### PR TITLE
CB-14959 Add scheduled job to archive old, terminated InstanceMetaData

### DIFF
--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/instance/ArchivedInstanceMetaData.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/instance/ArchivedInstanceMetaData.java
@@ -1,0 +1,310 @@
+package com.sequenceiq.cloudbreak.domain.stack.instance;
+
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceLifeCycle;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceMetadataType;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.common.json.JsonToString;
+import com.sequenceiq.cloudbreak.domain.InstanceStatusConverter;
+import com.sequenceiq.cloudbreak.domain.ProvisionEntity;
+import com.sequenceiq.cloudbreak.domain.converter.InstanceLifeCycleConverter;
+import com.sequenceiq.cloudbreak.domain.converter.InstanceMetadataTypeConverter;
+
+@Entity
+public class ArchivedInstanceMetaData implements ProvisionEntity {
+    @Id
+    private Long id;
+
+    private Long privateId;
+
+    private String privateIp;
+
+    private String publicIp;
+
+    private Integer sshPort;
+
+    private String instanceId;
+
+    @Convert(converter = JsonToString.class)
+    @Column(columnDefinition = "TEXT")
+    private Json image;
+
+    private Boolean ambariServer;
+
+    private Boolean clusterManagerServer;
+
+    private String discoveryFQDN;
+
+    @Column(columnDefinition = "TEXT")
+    private String serverCert;
+
+    @Convert(converter = InstanceStatusConverter.class)
+    private InstanceStatus instanceStatus;
+
+    @Convert(converter = InstanceMetadataTypeConverter.class)
+    private InstanceMetadataType instanceMetadataType;
+
+    private String localityIndicator;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private InstanceGroup instanceGroup;
+
+    private Long startDate;
+
+    private Long terminationDate;
+
+    /**
+     * ID of the subnet (in a cloud platform specific format) the cloud instance is deployed in.
+     */
+    private String subnetId;
+
+    /**
+     * Name of the availability zone the cloud instance is deployed in. May be {@code null} if the cloud platform does not support this construct.
+     */
+    private String availabilityZone;
+
+    /**
+     * ID of the virtual network rack the cloud instance is deployed in. Interpretation and syntax are as per the
+     * <a href="https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/RackAwareness.html">Hadoop Rack Awareness</a> page.
+     */
+    @Column(columnDefinition = "TEXT")
+    private String rackId;
+
+    private String instanceName;
+
+    private String statusReason;
+
+    @Convert(converter = InstanceLifeCycleConverter.class)
+    private InstanceLifeCycle lifeCycle;
+
+    private String variant;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getPrivateId() {
+        return privateId;
+    }
+
+    public void setPrivateId(Long privateId) {
+        this.privateId = privateId;
+    }
+
+    public String getPrivateIp() {
+        return privateIp;
+    }
+
+    public void setPrivateIp(String privateIp) {
+        this.privateIp = privateIp;
+    }
+
+    public String getPublicIp() {
+        return publicIp;
+    }
+
+    public void setPublicIp(String publicIp) {
+        this.publicIp = publicIp;
+    }
+
+    public Integer getSshPort() {
+        return sshPort;
+    }
+
+    public void setSshPort(Integer sshPort) {
+        this.sshPort = sshPort;
+    }
+
+    public String getInstanceId() {
+        return instanceId;
+    }
+
+    public void setInstanceId(String instanceId) {
+        this.instanceId = instanceId;
+    }
+
+    public Json getImage() {
+        return image;
+    }
+
+    public void setImage(Json image) {
+        this.image = image;
+    }
+
+    public Boolean getAmbariServer() {
+        return ambariServer;
+    }
+
+    public void setAmbariServer(Boolean ambariServer) {
+        this.ambariServer = ambariServer;
+    }
+
+    public Boolean getClusterManagerServer() {
+        return clusterManagerServer;
+    }
+
+    public void setClusterManagerServer(Boolean clusterManagerServer) {
+        this.clusterManagerServer = clusterManagerServer;
+    }
+
+    public String getDiscoveryFQDN() {
+        return discoveryFQDN;
+    }
+
+    public void setDiscoveryFQDN(String discoveryFQDN) {
+        this.discoveryFQDN = discoveryFQDN;
+    }
+
+    public String getServerCert() {
+        return serverCert;
+    }
+
+    public void setServerCert(String serverCert) {
+        this.serverCert = serverCert;
+    }
+
+    public InstanceStatus getInstanceStatus() {
+        return instanceStatus;
+    }
+
+    public void setInstanceStatus(InstanceStatus instanceStatus) {
+        this.instanceStatus = instanceStatus;
+    }
+
+    public InstanceMetadataType getInstanceMetadataType() {
+        return instanceMetadataType;
+    }
+
+    public void setInstanceMetadataType(InstanceMetadataType instanceMetadataType) {
+        this.instanceMetadataType = instanceMetadataType;
+    }
+
+    public String getLocalityIndicator() {
+        return localityIndicator;
+    }
+
+    public void setLocalityIndicator(String localityIndicator) {
+        this.localityIndicator = localityIndicator;
+    }
+
+    public InstanceGroup getInstanceGroup() {
+        return instanceGroup;
+    }
+
+    public void setInstanceGroup(InstanceGroup instanceGroup) {
+        this.instanceGroup = instanceGroup;
+    }
+
+    public Long getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(Long startDate) {
+        this.startDate = startDate;
+    }
+
+    public Long getTerminationDate() {
+        return terminationDate;
+    }
+
+    public void setTerminationDate(Long terminationDate) {
+        this.terminationDate = terminationDate;
+    }
+
+    public String getSubnetId() {
+        return subnetId;
+    }
+
+    public void setSubnetId(String subnetId) {
+        this.subnetId = subnetId;
+    }
+
+    public String getAvailabilityZone() {
+        return availabilityZone;
+    }
+
+    public void setAvailabilityZone(String availabilityZone) {
+        this.availabilityZone = availabilityZone;
+    }
+
+    public String getRackId() {
+        return rackId;
+    }
+
+    public void setRackId(String rackId) {
+        this.rackId = rackId;
+    }
+
+    public String getInstanceName() {
+        return instanceName;
+    }
+
+    public void setInstanceName(String instanceName) {
+        this.instanceName = instanceName;
+    }
+
+    public String getStatusReason() {
+        return statusReason;
+    }
+
+    public void setStatusReason(String statusReason) {
+        this.statusReason = statusReason;
+    }
+
+    public InstanceLifeCycle getLifeCycle() {
+        return lifeCycle;
+    }
+
+    public void setLifeCycle(InstanceLifeCycle lifeCycle) {
+        this.lifeCycle = lifeCycle;
+    }
+
+    public String getVariant() {
+        return variant;
+    }
+
+    public void setVariant(String variant) {
+        this.variant = variant;
+    }
+
+    @Override
+    public String toString() {
+        return "ArchivedInstanceMetaData{" +
+                "id=" + id +
+                ", privateId=" + privateId +
+                ", privateIp='" + privateIp + '\'' +
+                ", publicIp='" + publicIp + '\'' +
+                ", sshPort=" + sshPort +
+                ", instanceId='" + instanceId + '\'' +
+                ", image=" + image +
+                ", ambariServer=" + ambariServer +
+                ", clusterManagerServer=" + clusterManagerServer +
+                ", discoveryFQDN='" + discoveryFQDN + '\'' +
+                ", serverCert='" + serverCert + '\'' +
+                ", instanceStatus=" + instanceStatus +
+                ", instanceMetadataType=" + instanceMetadataType +
+                ", localityIndicator='" + localityIndicator + '\'' +
+                ", instanceGroup=" + instanceGroup +
+                ", startDate=" + startDate +
+                ", terminationDate=" + terminationDate +
+                ", subnetId='" + subnetId + '\'' +
+                ", availabilityZone='" + availabilityZone + '\'' +
+                ", rackId='" + rackId + '\'' +
+                ", instanceName='" + instanceName + '\'' +
+                ", statusReason='" + statusReason + '\'' +
+                ", lifeCycle=" + lifeCycle +
+                ", variant='" + variant + '\'' +
+                '}';
+    }
+}

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -334,6 +334,7 @@ dependencies {
   testImplementation group: "org.yaml",          name: "snakeyaml"
   testImplementation group: 'org.hamcrest',      name: 'hamcrest',            version: hamcrestVersion
   testImplementation group: 'com.fasterxml.jackson.core',name: 'jackson-databind', version: jacksonVersion
+  testImplementation group: "com.openpojo",                  name: "openpojo",                       version: openPojoVersion
 }
 
 task execute(type: JavaExec) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/InstanceMetadataToArchivedInstanceMetadataConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/InstanceMetadataToArchivedInstanceMetadataConverter.java
@@ -1,0 +1,41 @@
+package com.sequenceiq.cloudbreak.converter;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.domain.stack.instance.ArchivedInstanceMetaData;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+
+@Component
+public class InstanceMetadataToArchivedInstanceMetadataConverter {
+
+    public ArchivedInstanceMetaData convert(InstanceMetaData instanceMetaData) {
+        ArchivedInstanceMetaData result = new ArchivedInstanceMetaData();
+
+        result.setInstanceGroup(instanceMetaData.getInstanceGroup());
+        result.setPrivateIp(instanceMetaData.getPrivateIp());
+        result.setPublicIp(instanceMetaData.getPublicIp());
+        result.setSshPort(instanceMetaData.getSshPort());
+        result.setId(instanceMetaData.getId());
+        result.setPrivateId(instanceMetaData.getPrivateId());
+        result.setInstanceId(instanceMetaData.getInstanceId());
+        result.setAmbariServer(instanceMetaData.getAmbariServer());
+        result.setClusterManagerServer(instanceMetaData.getClusterManagerServer());
+        result.setDiscoveryFQDN(instanceMetaData.getDiscoveryFQDN());
+        result.setInstanceStatus(instanceMetaData.getInstanceStatus());
+        result.setStartDate(instanceMetaData.getStartDate());
+        result.setTerminationDate(instanceMetaData.getTerminationDate());
+        result.setLocalityIndicator(instanceMetaData.getLocalityIndicator());
+        result.setInstanceMetadataType(instanceMetaData.getInstanceMetadataType());
+        result.setServerCert(instanceMetaData.getServerCert());
+        result.setSubnetId(instanceMetaData.getSubnetId());
+        result.setAvailabilityZone(instanceMetaData.getAvailabilityZone());
+        result.setRackId(instanceMetaData.getRackId());
+        result.setInstanceName(instanceMetaData.getInstanceName());
+        result.setImage(instanceMetaData.getImage());
+        result.setStatusReason(instanceMetaData.getStatusReason());
+        result.setLifeCycle(instanceMetaData.getLifeCycle());
+        result.setVariant(instanceMetaData.getVariant());
+
+        return result;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/ClusterCreationActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/ClusterCreationActions.java
@@ -20,6 +20,7 @@ import com.sequenceiq.cloudbreak.core.flow2.stack.provision.action.AbstractStack
 import com.sequenceiq.cloudbreak.core.flow2.stack.start.StackCreationContext;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.job.StackJobAdapter;
+import com.sequenceiq.cloudbreak.job.instancemetadata.ArchiveInstanceMetaDataJobService;
 import com.sequenceiq.cloudbreak.quartz.statuschecker.service.StatusCheckerJobService;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackFailureEvent;
@@ -103,6 +104,9 @@ public class ClusterCreationActions {
 
     @Inject
     private StatusCheckerJobService jobService;
+
+    @Inject
+    private ArchiveInstanceMetaDataJobService aimJobService;
 
     @Inject
     private StructuredSynchronizerJobService syncJobService;
@@ -646,6 +650,7 @@ public class ClusterCreationActions {
                 clusterCreationService.clusterInstallationFinished(context.getStack(), context.getProvisionType());
                 jobService.schedule(context.getStackId(), StackJobAdapter.class);
                 syncJobService.schedule(context.getStackId(), StructuredSynchronizerJobAdapter.class);
+                aimJobService.schedule(context.getStackId());
                 getMetricService().incrementMetricCounter(MetricType.CLUSTER_CREATION_SUCCESSFUL, context.getStack());
                 sendEvent(context);
             }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/instancemetadata/ArchiveInstanceMetaDataConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/instancemetadata/ArchiveInstanceMetaDataConfig.java
@@ -1,0 +1,47 @@
+package com.sequenceiq.cloudbreak.job.instancemetadata;
+
+import javax.annotation.PostConstruct;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ArchiveInstanceMetaDataConfig {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ArchiveInstanceMetaDataConfig.class);
+
+    @Value("${archiveinstancemetadata.intervalhours:24}")
+    private int intervalInHours;
+
+    @Value("${archiveinstancemetadata.archiveolderthanweeks:4}")
+    private int archiveOlderThanWeeks;
+
+    @Value("${archiveinstancemetadata.pageSize:400}")
+    private int pageSize;
+
+    @Value("${archiveinstancemetadata.enabled:true}")
+    private boolean archiveInstanceMetaDataEnabled;
+
+    @PostConstruct
+    void logEnablement() {
+        LOGGER.info("Archive InstanceMetaData is {}", archiveInstanceMetaDataEnabled ? "enabled" : "disabled");
+    }
+
+    public boolean isArchiveInstanceMetaDataEnabled() {
+        return archiveInstanceMetaDataEnabled;
+    }
+
+    public int getIntervalInHours() {
+        return intervalInHours;
+    }
+
+    public int getArchiveOlderThanWeeks() {
+        return archiveOlderThanWeeks;
+    }
+
+    public int getPageSize() {
+        return pageSize;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/instancemetadata/ArchiveInstanceMetaDataJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/instancemetadata/ArchiveInstanceMetaDataJob.java
@@ -1,0 +1,70 @@
+package com.sequenceiq.cloudbreak.job.instancemetadata;
+
+import javax.inject.Inject;
+
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
+import com.sequenceiq.cloudbreak.domain.view.StackView;
+import com.sequenceiq.cloudbreak.quartz.statuschecker.job.StatusCheckerJob;
+import com.sequenceiq.cloudbreak.service.stack.StackViewService;
+import com.sequenceiq.cloudbreak.service.stack.archive.ArchiveInstanceMetaDataException;
+import com.sequenceiq.cloudbreak.service.stack.archive.ArchiveInstanceMetaDataService;
+
+import io.opentracing.Tracer;
+
+@DisallowConcurrentExecution
+@Component
+public class ArchiveInstanceMetaDataJob extends StatusCheckerJob {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ArchiveInstanceMetaDataJob.class);
+
+    @Inject
+    private StackViewService stackViewService;
+
+    @Inject
+    private ArchiveInstanceMetaDataJobService jobService;
+
+    @Inject
+    private ArchiveInstanceMetaDataService archiveInstanceMetaDataService;
+
+    public ArchiveInstanceMetaDataJob(Tracer tracer) {
+        super(tracer, "Archive InstanceMetaData Job");
+    }
+
+    @Override
+    protected Object getMdcContextObject() {
+        return stackViewService.findById(getStackId()).orElseGet(StackView::new);
+    }
+
+    @Override
+    protected void executeTracedJob(JobExecutionContext context) throws JobExecutionException {
+        StackView stackView = stackViewService.findById(getStackId()).orElseGet(StackView::new);
+        Status stackStatus = stackView.getStatus();
+        if (!Status.getUnschedulableStatuses().contains(stackStatus)) {
+            archiveInstanceMetaDataOnStack(stackView);
+        } else {
+            LOGGER.debug("Existing stack InstanceMetaData archiving will be descheduled, because stack {} state is {}", stackView.getResourceCrn(), stackStatus);
+            jobService.unschedule(context.getJobDetail().getKey());
+        }
+    }
+
+    private void archiveInstanceMetaDataOnStack(StackView stackView) throws JobExecutionException {
+        try {
+            archiveInstanceMetaDataService.archive(stackView);
+        } catch (ArchiveInstanceMetaDataException e) {
+            LOGGER.error("Failed to archive terminated InstanceMetaData for stack: {}", stackView.getResourceCrn(), e);
+            throw new JobExecutionException(String.format("Failed to archive terminated InstanceMetaData for stack: %s, exception: %s",
+                    stackView.getResourceCrn(), e));
+        }
+    }
+
+    private Long getStackId() {
+        return Long.valueOf(getLocalId());
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/instancemetadata/ArchiveInstanceMetaDataJobAdapter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/instancemetadata/ArchiveInstanceMetaDataJobAdapter.java
@@ -1,0 +1,39 @@
+package com.sequenceiq.cloudbreak.job.instancemetadata;
+
+import org.quartz.Job;
+import org.springframework.context.ApplicationContext;
+
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
+import com.sequenceiq.cloudbreak.repository.StackRepository;
+
+public class ArchiveInstanceMetaDataJobAdapter extends JobResourceAdapter<Stack> {
+
+    public ArchiveInstanceMetaDataJobAdapter(Long id, ApplicationContext context) {
+        super(id, context);
+    }
+
+    public ArchiveInstanceMetaDataJobAdapter(Stack resource) {
+        super(resource);
+    }
+
+    @Override
+    public String getLocalId() {
+        return String.valueOf(getResource().getId());
+    }
+
+    @Override
+    public String getRemoteResourceId() {
+        return getResource().getResourceCrn();
+    }
+
+    @Override
+    public Class<? extends Job> getJobClassForResource() {
+        return ArchiveInstanceMetaDataJob.class;
+    }
+
+    @Override
+    public Class<StackRepository> getRepositoryClassForResource() {
+        return StackRepository.class;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/instancemetadata/ArchiveInstanceMetaDataJobInitializer.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/instancemetadata/ArchiveInstanceMetaDataJobInitializer.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.cloudbreak.job.instancemetadata;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.job.AbstractStackJobInitializer;
+
+@Component
+public class ArchiveInstanceMetaDataJobInitializer extends AbstractStackJobInitializer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ArchiveInstanceMetaDataJobInitializer.class);
+
+    @Inject
+    private ArchiveInstanceMetaDataConfig config;
+
+    @Inject
+    private ArchiveInstanceMetaDataJobService jobService;
+
+    @Override
+    public void initJobs() {
+        if (config.isArchiveInstanceMetaDataEnabled()) {
+            LOGGER.info("Scheduling archive InstanceMetaData jobs");
+            getAliveAndNotDeleteInProgressStacksStream()
+                    .forEach(s -> jobService.schedule(new ArchiveInstanceMetaDataJobAdapter(s)));
+        } else {
+            LOGGER.info("Skipping scheduling archive InstanceMetaData jobs, as they are disabled");
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/instancemetadata/ArchiveInstanceMetaDataJobService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/instancemetadata/ArchiveInstanceMetaDataJobService.java
@@ -1,0 +1,121 @@
+package com.sequenceiq.cloudbreak.job.instancemetadata;
+
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.SimpleScheduleBuilder;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.quartz.impl.matchers.GroupMatcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ArchiveInstanceMetaDataJobService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ArchiveInstanceMetaDataJobService.class);
+
+    private static final String JOB_GROUP = "archive-instancemetadata-jobs";
+
+    private static final String TRIGGER_GROUP = "archive-instancemetadata-triggers";
+
+    private static final Random RANDOM = new SecureRandom();
+
+    @Inject
+    private ArchiveInstanceMetaDataConfig properties;
+
+    @Inject
+    private Scheduler scheduler;
+
+    @Inject
+    private ApplicationContext applicationContext;
+
+    public void schedule(Long id) {
+        ArchiveInstanceMetaDataJobAdapter resourceAdapter = new ArchiveInstanceMetaDataJobAdapter(id, applicationContext);
+        JobDetail jobDetail = buildJobDetail(resourceAdapter);
+        Trigger trigger = buildJobTrigger(jobDetail);
+        schedule(resourceAdapter.getLocalId(), jobDetail, trigger);
+    }
+
+    public <T> void schedule(String id, JobDetail jobDetail, Trigger trigger) {
+        if (properties.isArchiveInstanceMetaDataEnabled()) {
+            try {
+                JobKey jobKey = JobKey.jobKey(id, JOB_GROUP);
+                if (scheduler.getJobDetail(jobKey) != null) {
+                    unschedule(jobKey);
+                }
+                scheduler.scheduleJob(jobDetail, trigger);
+            } catch (SchedulerException e) {
+                LOGGER.error(String.format("Error during scheduling quartz job: %s", id), e);
+            }
+        }
+    }
+
+    public void schedule(ArchiveInstanceMetaDataJobAdapter resource) {
+        JobDetail jobDetail = buildJobDetail(resource);
+        JobKey jobKey = jobDetail.getKey();
+        Trigger trigger = buildJobTrigger(jobDetail);
+        try {
+            if (scheduler.getJobDetail(jobKey) != null) {
+                unschedule(jobKey);
+            }
+            LOGGER.debug("Scheduling archive InstanceMetaData job for stack {}", resource.getRemoteResourceId());
+            scheduler.scheduleJob(jobDetail, trigger);
+        } catch (SchedulerException e) {
+            LOGGER.error(String.format("Error during scheduling archive InstanceMetaData job: %s", jobDetail), e);
+        }
+    }
+
+    public void unschedule(JobKey jobKey) {
+        try {
+            if (scheduler.getJobDetail(jobKey) != null) {
+                scheduler.deleteJob(jobKey);
+            }
+            if (scheduler.getJobKeys(GroupMatcher.groupEquals(JOB_GROUP)).isEmpty()) {
+                LOGGER.info("All terminated InstanceMetaData older than a week have been archived, hooray!");
+            }
+        } catch (SchedulerException e) {
+            LOGGER.error(String.format("Error during unscheduling quartz job: %s", jobKey), e);
+        }
+    }
+
+    private JobDetail buildJobDetail(ArchiveInstanceMetaDataJobAdapter resource) {
+        return JobBuilder.newJob(ArchiveInstanceMetaDataJob.class)
+                .withIdentity(resource.getLocalId(), JOB_GROUP)
+                .withDescription("Archiving InstanceMetadata for stack: " + resource.getRemoteResourceId())
+                .usingJobData(resource.toJobDataMap())
+                .storeDurably()
+                .build();
+    }
+
+    private Trigger buildJobTrigger(JobDetail jobDetail) {
+        return TriggerBuilder.newTrigger()
+                .forJob(jobDetail)
+                .withIdentity(jobDetail.getKey().getName(), TRIGGER_GROUP)
+                .withDescription("Trigger archiving InstanceMetaData for existing stack")
+                .startAt(delayedFirstStart())
+                .withSchedule(SimpleScheduleBuilder.simpleSchedule()
+                        .withIntervalInHours(properties.getIntervalInHours())
+                        .repeatForever()
+                        .withMisfireHandlingInstructionNextWithExistingCount())
+                .build();
+    }
+
+    private Date delayedFirstStart() {
+        int delayInMinutes = RANDOM.nextInt((int) TimeUnit.HOURS.toMinutes(properties.getIntervalInHours()));
+        return Date.from(ZonedDateTime.now().toInstant().plus(Duration.ofMinutes(delayInMinutes)));
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/ArchivedInstanceMetaDataRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/ArchivedInstanceMetaDataRepository.java
@@ -1,0 +1,14 @@
+package com.sequenceiq.cloudbreak.repository;
+
+import javax.transaction.Transactional;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.sequenceiq.cloudbreak.domain.stack.instance.ArchivedInstanceMetaData;
+import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
+
+@EntityType(entityClass = ArchivedInstanceMetaData.class)
+@Transactional(Transactional.TxType.REQUIRED)
+public interface ArchivedInstanceMetaDataRepository extends CrudRepository<ArchivedInstanceMetaData, Long> {
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceMetaDataRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceMetaDataRepository.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import javax.transaction.Transactional;
 import javax.transaction.Transactional.TxType;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
@@ -140,5 +141,10 @@ public interface InstanceMetaDataRepository extends CrudRepository<InstanceMetaD
             "WHERE id = :id AND instanceStatus <> 'TERMINATED'")
     int updateStatusIfNotTerminated(@Param("id") Long id, @Param("newInstanceStatus") InstanceStatus newInstanceStatus,
             @Param("newStatusReason") String newStatusReason);
+
+    @Query("SELECT i FROM InstanceMetaData i WHERE i.instanceStatus = 'TERMINATED' AND i.instanceGroup.stack.id= :stackId " +
+            "AND i.terminationDate < :thresholdTerminationDate ORDER BY i.terminationDate ASC")
+    Page<InstanceMetaData> findTerminatedInstanceMetadataByStackIdAndTerminatedBefore(@Param("stackId") Long stackId,
+            @Param("thresholdTerminationDate") Long thresholdTerminationDate, Pageable pageable);
 
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/InstanceMetaDataService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/InstanceMetaDataService.java
@@ -14,6 +14,7 @@ import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
@@ -318,6 +319,10 @@ public class InstanceMetaDataService {
         repository.delete(instanceMetaData);
     }
 
+    public void deleteAll(List<InstanceMetaData> instanceMetaData) {
+        repository.deleteAll(instanceMetaData);
+    }
+
     public Optional<InstanceMetaData> findNotTerminatedByPrivateAddress(Long stackId, String privateAddress) {
         return repository.findNotTerminatedByPrivateAddress(stackId, privateAddress);
     }
@@ -359,4 +364,7 @@ public class InstanceMetaDataService {
         return repository.findHostInStack(stackId, hostName);
     }
 
+    public Page<InstanceMetaData> getTerminatedInstanceMetaDataBefore(Long stackId, Long thresholdTerminationDate, PageRequest pageRequest) {
+        return repository.findTerminatedInstanceMetadataByStackIdAndTerminatedBefore(stackId, thresholdTerminationDate, pageRequest);
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/archive/ArchiveInstanceMetaDataException.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/archive/ArchiveInstanceMetaDataException.java
@@ -1,0 +1,12 @@
+package com.sequenceiq.cloudbreak.service.stack.archive;
+
+public class ArchiveInstanceMetaDataException extends Exception {
+
+    public ArchiveInstanceMetaDataException(String message) {
+        super(message);
+    }
+
+    public ArchiveInstanceMetaDataException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/archive/ArchiveInstanceMetaDataService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/archive/ArchiveInstanceMetaDataService.java
@@ -1,0 +1,150 @@
+package com.sequenceiq.cloudbreak.service.stack.archive;
+
+import static com.sequenceiq.cloudbreak.util.Benchmark.checkedMeasure;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.common.service.TransactionService;
+import com.sequenceiq.cloudbreak.converter.InstanceMetadataToArchivedInstanceMetadataConverter;
+import com.sequenceiq.cloudbreak.domain.stack.instance.ArchivedInstanceMetaData;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.domain.view.StackView;
+import com.sequenceiq.cloudbreak.job.instancemetadata.ArchiveInstanceMetaDataConfig;
+import com.sequenceiq.cloudbreak.repository.ArchivedInstanceMetaDataRepository;
+import com.sequenceiq.cloudbreak.service.stack.InstanceGroupService;
+import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
+import com.sequenceiq.flow.core.FlowLogService;
+import com.sequenceiq.flow.domain.FlowLog;
+import com.sequenceiq.flow.service.FlowRetryService;
+
+@Service
+public class ArchiveInstanceMetaDataService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ArchiveInstanceMetaDataService.class);
+
+    private static final int ZERO_PAGE_INDEX = 0;
+
+    @Inject
+    private InstanceMetaDataService instanceMetaDataService;
+
+    @Inject
+    private ArchivedInstanceMetaDataRepository archivedInstanceMetaDataRepository;
+
+    @Inject
+    private FlowLogService flowLogService;
+
+    @Inject
+    private FlowRetryService flowRetryService;
+
+    @Inject
+    private TransactionService transactionService;
+
+    @Inject
+    private ArchiveInstanceMetaDataConfig archiveInstanceMetaDataConfig;
+
+    @Inject
+    private InstanceGroupService instanceGroupService;
+
+    @Inject
+    private InstanceMetadataToArchivedInstanceMetadataConverter converter;
+
+    public void archive(StackView stack) throws ArchiveInstanceMetaDataException {
+        if (flowLogService.isOtherFlowRunning(stack.getId())) {
+            String message = String.format("Another flow is running for stack %s, skipping archiving terminated InstanceMetaData to let the flow finish",
+                    stack.getResourceCrn());
+            throw new ArchiveInstanceMetaDataException(message);
+        } else {
+            Optional<FlowLog> lastRetryableFailedFlow = flowRetryService.getLastRetryableFailedFlow(stack.getId());
+            if (lastRetryableFailedFlow.isEmpty()) {
+                try {
+                    LOGGER.info("Starting to archive terminated InstanceMetaData on stack {}", stack.getResourceCrn());
+                    checkedMeasure(() -> doArchive(stack), LOGGER, "Archiving terminated InstanceMetaData took {} ms for stack {}.",
+                            stack.getResourceCrn());
+                    LOGGER.info("InstanceMetaData archivation finished successfully for stack {}", stack.getResourceCrn());
+                } catch (ArchiveInstanceMetaDataException e) {
+                    throw e;
+                } catch (Exception e) {
+                    String message = String.format("Something unexpected went wrong with stack %s while archiving terminated InstanceMetaData",
+                            stack.getResourceCrn());
+                    throw new ArchiveInstanceMetaDataException(message, e);
+                }
+            } else {
+                String message = String.format("Stack %s has a retryable failed flow, " +
+                        "skipping archiving terminated InstanceMetaData to preserve possible retry", stack.getResourceCrn());
+                throw new ArchiveInstanceMetaDataException(message);
+            }
+        }
+    }
+
+    private void doArchive(StackView stack) throws ArchiveInstanceMetaDataException {
+        int archiveOlderThanWeeks = archiveInstanceMetaDataConfig.getArchiveOlderThanWeeks();
+        long thresholdTerminationDate = LocalDateTime.now().minusWeeks(archiveOlderThanWeeks).toInstant(ZoneOffset.UTC).toEpochMilli();
+
+        int pageSize = archiveInstanceMetaDataConfig.getPageSize();
+        PageRequest firstPageRequest = PageRequest.of(ZERO_PAGE_INDEX, pageSize);
+        int totalPages = archiveInstanceMetaDataPage(stack, thresholdTerminationDate, firstPageRequest);
+        for (int i = 1; i < totalPages; i++) {
+            PageRequest pageRequest = PageRequest.of(i, pageSize);
+            archiveInstanceMetaDataPage(stack, thresholdTerminationDate, pageRequest);
+        }
+    }
+
+    private int archiveInstanceMetaDataPage(StackView stack, long thresholdTerminationDate, PageRequest pageRequest) throws ArchiveInstanceMetaDataException {
+        int pageNumber = pageRequest.getPageNumber();
+        String stackResourceCrn = stack.getResourceCrn();
+        try {
+            return transactionService.required(() -> {
+                LOGGER.debug("Get batch #{} of terminated InstanceMetaData, that is oldar than {} week(s) (in epoch ms: {} ms) for stack {}",
+                        pageNumber, archiveInstanceMetaDataConfig.getArchiveOlderThanWeeks(), thresholdTerminationDate, stackResourceCrn);
+                Page<InstanceMetaData> page = instanceMetaDataService.getTerminatedInstanceMetaDataBefore(stack.getId(), thresholdTerminationDate, pageRequest);
+                if (0 == page.getTotalElements()) {
+                    LOGGER.debug("No InstanceMetaData with older termination date that {} found for stack: {}", thresholdTerminationDate, stackResourceCrn);
+                    return page.getTotalPages();
+                }
+                LOGGER.debug("Total number of InstanceMetaData to archive is {} for stack {}", page.getTotalElements(), stackResourceCrn);
+
+                List<ArchivedInstanceMetaData> archivedList = convertToArchived(page);
+                LOGGER.debug("Save batch #{} of ArchivedInstanceMetaData.", pageNumber);
+                archivedInstanceMetaDataRepository.saveAll(archivedList);
+                LOGGER.debug("Saved batch #{} of ArchivedInstanceMetaData. Deleting original InstanceMetaData.", pageNumber);
+                Set<InstanceGroup> instanceGroups = page.getContent().stream().map(InstanceMetaData::getInstanceGroup).collect(Collectors.toSet());
+                instanceGroups.forEach(ig -> {
+                    Set<Long> imIds = page.getContent().stream().map(InstanceMetaData::getId).collect(Collectors.toSet());
+                    LOGGER.debug("Removed InstanceMetaData ids in this batch: {}", imIds);
+                    ig.replaceInstanceMetadata(ig.getAllInstanceMetaData().stream().filter(im -> !imIds.contains(im.getId())).collect(Collectors.toSet()));
+                });
+                instanceGroupService.saveAll(instanceGroups);
+                LOGGER.debug("Removed batch #{} of the original InstanceMetaData from respective InstanceGroups.", pageNumber);
+                instanceMetaDataService.deleteAll(page.getContent());
+                LOGGER.debug("Deleted batch #{} of the original InstanceMetaData.", pageNumber);
+
+                return page.getTotalPages();
+            });
+        } catch (TransactionService.TransactionExecutionException e) {
+            String message = String.format("Failed to archive the batch #%d of terminated instancemetadata for stack %s", pageNumber, stackResourceCrn);
+            LOGGER.error(message);
+            throw new ArchiveInstanceMetaDataException(message, e);
+        }
+    }
+
+    private List<ArchivedInstanceMetaData> convertToArchived(Page<InstanceMetaData> page) {
+        LOGGER.trace("Converting {} InstanceMetaData to ArchivedInstanceMetaData", page.getNumberOfElements());
+        return page.stream()
+                .map(converter::convert)
+                .collect(Collectors.toList());
+    }
+}

--- a/core/src/main/resources/schema/app/20211206164956_CB-14959_Create_ArchivedInstanceMetaData_table.sql
+++ b/core/src/main/resources/schema/app/20211206164956_CB-14959_Create_ArchivedInstanceMetaData_table.sql
@@ -1,0 +1,40 @@
+-- // CB-14959 Create ArchivedInstanceMetaData table
+-- Migration SQL that makes the change goes here.
+
+CREATE TABLE IF NOT EXISTS archivedinstancemetadata
+(
+  variant                    varchar(255)                   NULL,
+  rackid                     text                           NULL,
+  availabilityzone           varchar(255)                   NULL,
+  lifecycle                  varchar(255)                   NULL,
+  clustermanagerserver       boolean                        NULL,
+  statusreason               text                           NULL,
+  image                      text                           NULL,
+  instancename               varchar(255)                   NULL,
+  subnetid                   varchar(255)                   NULL,
+  servercert                 text                           NULL,
+  instancemetadatatype       varchar(255)                   NULL,
+  sshport                    integer                        NULL,
+  localityindicator          varchar(255)                   NULL,
+  privateid                  bigint                         NULL,
+  instancegroup_id           bigint                         NULL,
+  terminationdate            bigint                         NULL,
+  startdate                  bigint                         NULL,
+  publicip                   varchar(255)                   NULL,
+  privateip                  varchar(255)                   NULL,
+  discoveryfqdn              varchar(255)                   NULL,
+  instancestatus             varchar(255)                   NULL,
+  instanceid                 varchar(255)                   NULL,
+  consulserver               boolean                        NULL,
+  ambariserver               boolean                        NULL,
+  id                         bigint                         NOT NULL
+);
+
+ALTER TABLE archivedinstancemetadata ADD CONSTRAINT archivedinstancemetadata_pkey PRIMARY KEY (id)
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+INSERT INTO instancemetadata SELECT * FROM archivedinstancemetadata;
+
+DROP TABLE IF EXISTS archivedinstancemetadata;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/InstanceMetadataToArchivedInstanceMetadataConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/InstanceMetadataToArchivedInstanceMetadataConverterTest.java
@@ -1,0 +1,58 @@
+package com.sequenceiq.cloudbreak.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.openpojo.random.RandomFactory;
+import com.openpojo.reflection.PojoClass;
+import com.openpojo.reflection.PojoField;
+import com.openpojo.reflection.impl.PojoClassFactory;
+import com.openpojo.validation.utils.ValidationHelper;
+import com.sequenceiq.cloudbreak.domain.stack.instance.ArchivedInstanceMetaData;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+
+class InstanceMetadataToArchivedInstanceMetadataConverterTest {
+
+    @Test
+    public void convert() throws Exception {
+        InstanceMetadataToArchivedInstanceMetadataConverter underTest = new InstanceMetadataToArchivedInstanceMetadataConverter();
+        InstanceMetaData instanceMetaData = generateInstanceMetaData();
+        ArchivedInstanceMetaData result = underTest.convert(instanceMetaData);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setVisibility(objectMapper.getSerializationConfig().getDefaultVisibilityChecker()
+                .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
+                .withIsGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withCreatorVisibility(JsonAutoDetect.Visibility.NONE));
+
+        String imJson = objectMapper.writeValueAsString(instanceMetaData);
+        String aimJson = objectMapper.writeValueAsString(result);
+        assertEquals(objectMapper.readTree(imJson), objectMapper.readTree(aimJson),
+                "Converted ArchivedInstanceMetaData should have the same fields and values.");
+    }
+
+    private InstanceMetaData generateInstanceMetaData() {
+        PojoClass pojoClass = PojoClassFactory.getPojoClass(InstanceMetaData.class);
+        final Object classInstance = ValidationHelper.getBasicInstance(pojoClass);
+        for (final PojoField fieldEntry : pojoClass.getPojoFields()) {
+            if (fieldEntry.hasGetter()) {
+                Object value = fieldEntry.get(classInstance);
+
+                if (!fieldEntry.isFinal()) {
+                    value = RandomFactory.getRandomValue(fieldEntry);
+                    fieldEntry.set(classInstance, value);
+                }
+
+            }
+        }
+
+        InstanceMetaData instanceMetaData = (InstanceMetaData) classInstance;
+        instanceMetaData.setServer(instanceMetaData.getClusterManagerServer());
+        return instanceMetaData;
+    }
+}


### PR DESCRIPTION
Terminated InstanceMetaData blows up many DB queries, due to our adhoc
entity relationship designs. These relationships have to be properly
revisited later, however to remedy the issue until the solution arrives,
this commit introduces a scheduled job to archive old, terminated
InstanceMetaData.

- new entity/table, called ArchivedInstanceMetaData, this will
  serve as a backup table for the imd
- scheduled job which runs daily, inserts all InstanceMetaData
  which were terminated at least a week ago to the back up table
