### PR TITLE
CB-15376. Move CM commissioning into CMCommissioner classeses.

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
@@ -147,5 +147,7 @@ public interface ClusterApi {
 
     ClusterDecomissionService clusterDecomissionService();
 
+    ClusterCommissionService clusterCommissionService();
+
     ClusterDiagnosticsService clusterDiagnosticsService();
 }

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterCommissionService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterCommissionService.java
@@ -1,0 +1,16 @@
+package com.sequenceiq.cloudbreak.cluster.api;
+
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Nonnull;
+
+import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+
+public interface ClusterCommissionService {
+
+    Map<String, InstanceMetaData> collectHostsToCommission(@Nonnull HostGroup hostGroup, Set<String> hostNames);
+
+    Set<String> recommissionClusterNodes(Map<String, InstanceMetaData> hostsToRecommission);
+}

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterDecomissionService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterDecomissionService.java
@@ -21,9 +21,6 @@ public interface ClusterDecomissionService {
 
     Set<String> decommissionClusterNodes(Map<String, InstanceMetaData> hostsToRemove);
 
-    // TODO CB-14929: Introduce a clusterRecommissionHandler and move this API out.
-    Set<String> recommissionClusterNodes(Map<String, InstanceMetaData> hostsToRecommission);
-
     void enterMaintenanceMode(Stack stack, Map<String, InstanceMetaData> hostList);
 
     void removeManagementServices();

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/exception/ClusterManagerCheckedException.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/exception/ClusterManagerCheckedException.java
@@ -1,0 +1,19 @@
+package com.sequenceiq.cloudbreak.cluster.exception;
+
+public class ClusterManagerCheckedException extends Exception {
+
+    // TODO CB-14929: Extend this with some kind of enums / codes to indicate types of errors.
+    //  - Example: Connectivity issues.
+
+    public ClusterManagerCheckedException(String message) {
+        super(message);
+    }
+
+    public ClusterManagerCheckedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ClusterManagerCheckedException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterCommissionService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterCommissionService.java
@@ -1,0 +1,68 @@
+package com.sequenceiq.cloudbreak.cm;
+
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Nonnull;
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.cloudera.api.swagger.client.ApiClient;
+import com.sequenceiq.cloudbreak.client.HttpClientConfig;
+import com.sequenceiq.cloudbreak.cluster.api.ClusterCommissionService;
+import com.sequenceiq.cloudbreak.cluster.service.ClusterClientInitException;
+import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiClientProvider;
+import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerClientInitException;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+
+@Service
+public class ClouderaManagerClusterCommissionService implements ClusterCommissionService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerClusterCommissionService.class);
+
+    private final Stack stack;
+
+    private final HttpClientConfig clientConfig;
+
+    @Inject
+    private ClouderaManagerApiClientProvider clouderaManagerApiClientProvider;
+
+    @Inject
+    private ClouderaManagerCommissioner clouderaManagerCommissioner;
+
+    private ApiClient client;
+
+    public ClouderaManagerClusterCommissionService(Stack stack, HttpClientConfig clientConfig) {
+        this.stack = stack;
+        this.clientConfig = clientConfig;
+    }
+
+    @PostConstruct
+    public void initApiClient() throws ClusterClientInitException {
+        Cluster cluster = stack.getCluster();
+        String user = cluster.getCloudbreakAmbariUser();
+        String password = cluster.getCloudbreakAmbariPassword();
+        try {
+            client = clouderaManagerApiClientProvider.getV31Client(stack.getGatewayPort(), user, password, clientConfig);
+        } catch (ClouderaManagerClientInitException e) {
+            throw new ClusterClientInitException(e);
+        }
+    }
+
+    @Override
+    public Map<String, InstanceMetaData> collectHostsToCommission(@Nonnull HostGroup hostGroup, Set<String> hostNames) {
+        return clouderaManagerCommissioner.collectHostsToCommission(stack, hostGroup, hostNames, client);
+    }
+
+    @Override
+    public Set<String> recommissionClusterNodes(Map<String, InstanceMetaData> hostsToRecommission) {
+        return clouderaManagerCommissioner.recommissionNodes(stack, hostsToRecommission, client);
+    }
+}

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterDecomissionService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterDecomissionService.java
@@ -91,11 +91,6 @@ public class ClouderaManagerClusterDecomissionService implements ClusterDecomiss
     }
 
     @Override
-    public Set<String> recommissionClusterNodes(Map<String, InstanceMetaData> hostsToRecommission) {
-        return clouderaManagerDecomissioner.recommissionNodes(stack, hostsToRecommission, client);
-    }
-
-    @Override
     public void enterMaintenanceMode(Stack stack, Map<String, InstanceMetaData> hostList) {
         clouderaManagerDecomissioner.enterMaintenanceMode(stack, hostList, client);
     }

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerCommissioner.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerCommissioner.java
@@ -1,0 +1,168 @@
+package com.sequenceiq.cloudbreak.cm;
+
+import static com.sequenceiq.cloudbreak.polling.PollingResult.isExited;
+import static com.sequenceiq.cloudbreak.polling.PollingResult.isTimeout;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.cloudera.api.swagger.ClouderaManagerResourceApi;
+import com.cloudera.api.swagger.CommandsResourceApi;
+import com.cloudera.api.swagger.HostsResourceApi;
+import com.cloudera.api.swagger.client.ApiClient;
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.model.ApiCommand;
+import com.cloudera.api.swagger.model.ApiHost;
+import com.cloudera.api.swagger.model.ApiHostList;
+import com.cloudera.api.swagger.model.ApiHostNameList;
+import com.google.common.collect.Sets;
+import com.sequenceiq.cloudbreak.cloud.scheduler.CancellationException;
+import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollingServiceProvider;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.polling.PollingResult;
+
+@Component
+public class ClouderaManagerCommissioner {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerCommissioner.class);
+
+    private static final String SUMMARY_REQUEST_VIEW = "SUMMARY";
+
+    @Inject
+    private ClouderaManagerApiFactory clouderaManagerApiFactory;
+
+    @Inject
+    private ClouderaManagerPollingServiceProvider clouderaManagerPollingServiceProvider;
+
+    /**
+     * Attempts to recommission the provided list of hosts
+     * @param stack the stack under consideration
+     * @param hostsToRecommission hosts to decommission
+     * @param client api client to communicate with ClouderaManager
+     * @return the hostnames for hosts which were successfully recommissioned
+     */
+    public Set<String> recommissionNodes(Stack stack, Map<String, InstanceMetaData> hostsToRecommission, ApiClient client) {
+
+        // TODO CB-14929: Check status of target nodes / previously issued commands - in case of pod restarts etc.
+        //  Ideally without needing to persist anything (commandId etc)
+        // TODO CB-14929: Deal with situations where CM itself is unavailable. Go back and STOP resources on the cloud-provider.
+        HostsResourceApi hostsResourceApi = clouderaManagerApiFactory.getHostsResourceApi(client);
+        try {
+            ApiHostList hostRefList = hostsResourceApi.readHosts(null, null, SUMMARY_REQUEST_VIEW);
+            // TODO CB-14929 Maybe move this to a trace level log.
+            LOGGER.debug("hostsAvailableFromCM: [{}]", hostRefList.getItems().stream().map(ApiHost::getHostname));
+
+            // Not considering the commission states of the nodes. Nodes could be COMMISSIONED with services in STOPPED state.
+            List<String> hostsAvailableForRecommission = hostRefList.getItems().stream()
+                    .filter(apiHostRef -> hostsToRecommission.containsKey(apiHostRef.getHostname()))
+                    .parallel()
+                    .map(ApiHost::getHostname)
+                    .collect(Collectors.toList());
+
+            Set<String> hostsAvailableForRecommissionSet = new HashSet<>(hostsAvailableForRecommission);
+            List<String> cmHostsUnavailableForRecommission = hostsToRecommission.keySet().stream()
+                    .filter(h -> !hostsAvailableForRecommissionSet.contains(h)).collect(Collectors.toList());
+
+            if (cmHostsUnavailableForRecommission.size() != 0) {
+                LOGGER.info("Some recommission targets are unavailable in CM: TotalRecommissionTargetCount={}, unavailableInCMCount={}, unavailableInCM=[{}]",
+                        hostsToRecommission.size(), cmHostsUnavailableForRecommission.size(), cmHostsUnavailableForRecommission);
+            }
+
+            ClouderaManagerResourceApi apiInstance = clouderaManagerApiFactory.getClouderaManagerResourceApi(client);
+
+            ApiHostNameList body = new ApiHostNameList().items(hostsAvailableForRecommission);
+
+            ApiCommand apiCommand = apiInstance.hostsRecommissionAndExitMaintenanceModeCommand("recommission_with_start", body);
+            PollingResult pollingResult = clouderaManagerPollingServiceProvider
+                    .startPollingCmHostsRecommission(stack, client, apiCommand.getId());
+            if (isExited(pollingResult)) {
+                throw new CancellationException("Cluster was terminated while waiting for host decommission");
+            } else if (isTimeout(pollingResult)) {
+                String warningMessage = "Cloudera Manager recommission host command {} polling timed out, " +
+                        "thus we are aborting the recommission operation.";
+                abortRecommissionWithWarnMessage(apiCommand, client, warningMessage);
+                // TODO CB-149292: What corrective action can be taken in this scenario? We have no idea whether any of the nodes
+                //  were recommissioned. Could try checking the status from CM, and take corrective action.
+                //  - Could collect list of nodes which are in the expected list and exclude them from corrective action.
+                //    (However, this is not trivial since the SERVICE needs to have the nodes recommissioned and that may have failed)
+                //  - We could go and STOP all instances, which essentially means re-trying the recommission the next time around.
+                throw new CloudbreakServiceException(
+                        String.format("Timeout while Cloudera Manager recommissioned hosts. CM command Id: %s", apiCommand.getId()));
+            }
+
+            return hostsAvailableForRecommission.stream()
+                    .map(hostsToRecommission::get)
+                    .map(InstanceMetaData::getDiscoveryFQDN)
+                    .collect(Collectors.toSet());
+        } catch (ApiException e) {
+            // TODO CB-14929: Evaluate whether it is possible to figure out if a partial commission succeeded.
+            //  Retry / STOP other nodes where it may have failed.
+            LOGGER.error("Failed to recommission hosts: {}", hostsToRecommission.keySet(), e);
+            throw new CloudbreakServiceException(e.getMessage(), e);
+        }
+    }
+
+    public Map<String, InstanceMetaData> collectHostsToCommission(Stack stack, HostGroup hostGroup, Set<String> hostNames, ApiClient client) {
+        Set<InstanceMetaData> hostsInHostGroup = hostGroup.getInstanceGroup().getNotTerminatedInstanceMetaDataSet();
+        Map<String, InstanceMetaData> hostsToCommission = hostsInHostGroup.stream()
+                .filter(hostMetadata -> hostNames.contains(hostMetadata.getDiscoveryFQDN()))
+                // TODO CB-14929: Add additional checks to make sure the hosts are in the expected state. Even better,
+                //  in addition to the incoming list, get additional hosts which may be in a 'strange' state in CM,
+                //  and see if these can be made part of the upscale operation.
+                .collect(Collectors.toMap(InstanceMetaData::getDiscoveryFQDN, hostMetadata -> hostMetadata));
+        if (hostsToCommission.size() != hostNames.size()) {
+            List<String> missingHosts = hostNames.stream().filter(h -> !hostsToCommission.containsKey(h)).collect(Collectors.toList());
+            LOGGER.debug("Not all requested hosts found in CB. MissingCount={}, missingHosts=[{}]. Requested hosts: [{}]",
+                    missingHosts.size(), missingHosts, hostNames);
+        }
+
+        HostsResourceApi hostsResourceApi = clouderaManagerApiFactory.getHostsResourceApi(client);
+        try {
+            ApiHostList hostRefList = hostsResourceApi.readHosts(null, null, SUMMARY_REQUEST_VIEW);
+            List<String> cmHostNames = hostRefList.getItems().stream()
+                    .map(ApiHost::getHostname)
+                    .collect(Collectors.toList());
+
+            List<String> matchingCmHosts = hostsToCommission.keySet().stream()
+                    .filter(hostName -> cmHostNames.contains(hostName))
+                    .collect(Collectors.toList());
+            Set<String> matchingCmHostSet = new HashSet<>(matchingCmHosts);
+
+            if (matchingCmHosts.size() != hostsToCommission.size()) {
+                List<String> missingHostsInCm = hostsToCommission.keySet().stream().filter(h -> !matchingCmHostSet.contains(h)).collect(Collectors.toList());
+
+                LOGGER.debug("Not all requested hosts found in CM. MissingCount={}, missingHosts=[{}]. Requested hosts: [{}]",
+                        missingHostsInCm.size(), missingHostsInCm, hostsToCommission.keySet());
+            }
+
+            Sets.newHashSet(hostsToCommission.keySet()).stream()
+                    .filter(hostName -> !matchingCmHostSet.contains(hostName))
+                    .forEach(hostsToCommission::remove);
+            LOGGER.debug("Collected hosts to commission: [{}]", hostsToCommission);
+            return hostsToCommission;
+        } catch (ApiException e) {
+            // TODO: CB-14929: This exception has to be handled properly. Situations where CM communications fails. There's no retries here right now.
+            LOGGER.error("Failed to get host list for cluster: {}", stack.getName(), e);
+            throw new CloudbreakServiceException(e.getMessage(), e);
+        }
+    }
+
+    private void abortRecommissionWithWarnMessage(ApiCommand apiCommand, ApiClient client, String warningMessage) throws ApiException {
+        LOGGER.warn(warningMessage, apiCommand.getId());
+        CommandsResourceApi commandsResourceApi = clouderaManagerApiFactory.getCommandsResourceApi(client);
+        commandsResourceApi.abortCommand(apiCommand.getId());
+    }
+}

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerConnector.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerConnector.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.client.HttpClientConfig;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
+import com.sequenceiq.cloudbreak.cluster.api.ClusterCommissionService;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterDecomissionService;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterDiagnosticsService;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterModificationService;
@@ -55,6 +56,11 @@ public class ClouderaManagerConnector implements ClusterApi {
     @Override
     public ClusterDecomissionService clusterDecomissionService() {
         return applicationContext.getBean(ClouderaManagerClusterDecomissionService.class, stack, clientConfig);
+    }
+
+    @Override
+    public ClusterCommissionService clusterCommissionService() {
+        return applicationContext.getBean(ClouderaManagerClusterCommissionService.class, stack, clientConfig);
     }
 
     @Override

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/ClouderaManagerPollingServiceProvider.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/ClouderaManagerPollingServiceProvider.java
@@ -35,6 +35,7 @@ import com.sequenceiq.cloudbreak.cm.polling.task.ClouderaManagerSyncApiCommandId
 import com.sequenceiq.cloudbreak.cm.polling.task.ClouderaManagerTemplateInstallationChecker;
 import com.sequenceiq.cloudbreak.cm.polling.task.ClouderaManagerUpgradeParcelDistributeListenerTask;
 import com.sequenceiq.cloudbreak.cm.polling.task.ClouderaManagerUpgradeParcelDownloadListenerTask;
+import com.sequenceiq.cloudbreak.cm.polling.task.NoExceptionOnTimeoutClouderaManagerListenerTask;
 import com.sequenceiq.cloudbreak.cm.polling.task.SilentCMDecommissionHostListenerTask;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.polling.PollingResult;
@@ -158,12 +159,10 @@ public class ClouderaManagerPollingServiceProvider {
     }
 
     public PollingResult startPollingCmHostsRecommission(Stack stack, ApiClient apiClient, BigDecimal commandId) {
-        LOGGER.debug("ZZZ: Waiting for Cloudera Manager to re-commission host. [Server address: {}]", stack.getClusterManagerIp());
+        LOGGER.debug("Waiting for Cloudera Manager to re-commission host with commandId: {}. [Server address: {}]", commandId, stack.getClusterManagerIp());
         long timeout = POLL_FOR_5_MINUTES;
-        LOGGER.info("Cloudera Manager re-commission hosts command will have {} minutes timeout, " +
-                "since all affected nodes are already deleted from provider side.", TimeUnit.SECONDS.toMinutes(timeout));
         return pollCommandWithTimeListener(stack, apiClient, commandId, timeout,
-                new SilentCMDecommissionHostListenerTask(clouderaManagerApiPojoFactory, clusterEventService));
+                new NoExceptionOnTimeoutClouderaManagerListenerTask(clouderaManagerApiPojoFactory, clusterEventService, "RecommissionHosts"));
     }
 
     public PollingResult startPollingCmHostDecommissioning(Stack stack, ApiClient apiClient, BigDecimal commandId,

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/NoExceptionOnTimeoutClouderaManagerListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/NoExceptionOnTimeoutClouderaManagerListenerTask.java
@@ -1,0 +1,22 @@
+package com.sequenceiq.cloudbreak.cm.polling.task;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.cluster.service.ClusterEventService;
+import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
+
+public class NoExceptionOnTimeoutClouderaManagerListenerTask extends ClouderaManagerDefaultListenerTask {
+    private static final Logger LOGGER = LoggerFactory.getLogger(NoExceptionOnTimeoutClouderaManagerListenerTask.class);
+
+    public NoExceptionOnTimeoutClouderaManagerListenerTask(ClouderaManagerApiPojoFactory clouderaManagerApiPojoFactory,
+            ClusterEventService clusterEventService, String commandDescription) {
+        super(clouderaManagerApiPojoFactory, clusterEventService, commandDescription);
+    }
+
+    @Override
+    public void handleTimeout(ClouderaManagerCommandPollerObject pollerObject) {
+        LOGGER.info("Timeout ignored for polling of command {}, commandDescription={}.", pollerObject.getId(), getCommandName());
+    }
+}

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/BaseClouderaManagerCommDecommTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/BaseClouderaManagerCommDecommTest.java
@@ -1,0 +1,68 @@
+package com.sequenceiq.cloudbreak.cm;
+
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.cloudera.api.swagger.HostsResourceApi;
+import com.cloudera.api.swagger.client.ApiClient;
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.model.ApiCommand;
+import com.cloudera.api.swagger.model.ApiHealthSummary;
+import com.cloudera.api.swagger.model.ApiHost;
+import com.cloudera.api.swagger.model.ApiHostList;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
+import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+
+public abstract class BaseClouderaManagerCommDecommTest {
+
+    protected ApiHost createGoodHealthApiHostRef(String instanceFqd) {
+        return createApiHostRef(instanceFqd, ApiHealthSummary.GOOD);
+    }
+
+    protected ApiHost createApiHostRef(String instanceFqd, ApiHealthSummary healthSummary) {
+        ApiHost instanceHostRef = new ApiHost();
+        instanceHostRef.setHostname(instanceFqd);
+        instanceHostRef.setHostId(instanceFqd);
+        instanceHostRef.setHealthSummary(healthSummary);
+        return instanceHostRef;
+    }
+
+    protected ApiHostList createGoodHealthApiHostList(Set<String> hostnames) {
+        List<ApiHost> apiHosts = hostnames.stream().map(h -> createGoodHealthApiHostRef(h)).collect(Collectors.toList());
+        ApiHostList apiHostList = new ApiHostList();
+        apiHostList.setItems(apiHosts);
+        return apiHostList;
+    }
+
+    protected void mockListClusterHosts(ApiHostList apiHostList, HostsResourceApi hostsResourceApi,
+            ClouderaManagerApiFactory clouderaManagerApiFactory, ApiClient client) throws ApiException {
+        when(hostsResourceApi.readHosts(null, null, "SUMMARY")).thenReturn(apiHostList);
+        when(clouderaManagerApiFactory.getHostsResourceApi(client)).thenReturn(hostsResourceApi);
+    }
+
+    protected InstanceMetaData createRunningInstanceMetadata(String fqdn, String groupName) {
+        return createInstanceMetadata(InstanceStatus.SERVICES_HEALTHY, fqdn, groupName);
+    }
+
+    protected ApiCommand getApiCommand(BigDecimal commandId) {
+        ApiCommand apiCommand = new ApiCommand();
+        apiCommand.setId(commandId);
+        return apiCommand;
+    }
+
+    private InstanceMetaData createInstanceMetadata(InstanceStatus servicesHealthy, String runningInstanceFqdn, String instanceGroupName) {
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+        instanceMetaData.setInstanceStatus(servicesHealthy);
+        instanceMetaData.setDiscoveryFQDN(runningInstanceFqdn);
+        InstanceGroup instanceGroup = new InstanceGroup();
+        instanceGroup.setGroupName(instanceGroupName);
+        instanceMetaData.setInstanceGroup(instanceGroup);
+        return instanceMetaData;
+    }
+}

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterCommissionServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterCommissionServiceTest.java
@@ -1,0 +1,116 @@
+package com.sequenceiq.cloudbreak.cm;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.cloudera.api.swagger.client.ApiClient;
+import com.sequenceiq.cloudbreak.client.HttpClientConfig;
+import com.sequenceiq.cloudbreak.cluster.service.ClusterClientInitException;
+import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiClientProvider;
+import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerClientInitException;
+import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClouderaManagerClusterCommissionServiceTest {
+
+    private static final int GATEWAY_PORT = 8080;
+
+    private static final String USER = "admin";
+
+    private static final String PASSWORD = "admin123";
+
+    @Mock
+    private ClouderaManagerApiClientProvider clouderaManagerApiClientProvider;
+
+    @Mock
+    private ClouderaManagerApiFactory clouderaManagerApiFactory;
+
+    @Mock
+    private ClouderaManagerCommissioner clouderaManagerCommissioner;
+
+    @Mock
+    private ApplicationContext applicationContext;
+
+    @Mock
+    private HttpClientConfig clientConfig;
+
+    @Mock
+    private ApiClient apiClient;
+
+    @InjectMocks
+    private ClouderaManagerClusterCommissionService underTest;
+
+    private Stack stack = createStack();
+
+    @Before
+    public void before() {
+        underTest = new ClouderaManagerClusterCommissionService(stack, clientConfig);
+        ReflectionTestUtils.setField(underTest, "clouderaManagerApiClientProvider", clouderaManagerApiClientProvider);
+        ReflectionTestUtils.setField(underTest, "clouderaManagerCommissioner", clouderaManagerCommissioner);
+        ReflectionTestUtils.setField(underTest, "client", apiClient);
+    }
+
+    @Test
+    public void testInitApiClientShouldCreateTheApiClient() throws ClusterClientInitException, ClouderaManagerClientInitException {
+        ReflectionTestUtils.setField(underTest, "client", null);
+        ApiClient client = Mockito.mock(ApiClient.class);
+        when(clouderaManagerApiClientProvider.getV31Client(GATEWAY_PORT, USER, PASSWORD, clientConfig)).thenReturn(client);
+
+        underTest.initApiClient();
+
+        assertEquals(client, ReflectionTestUtils.getField(underTest, "client"));
+        verify(clouderaManagerApiClientProvider).getV31Client(GATEWAY_PORT, USER, PASSWORD, clientConfig);
+    }
+
+    @Test
+    public void testCollectHostsToCommission() {
+        HostGroup hostGroup = mock(HostGroup.class);
+        Set<String> hostnames = mock(Set.class);
+        underTest.collectHostsToCommission(hostGroup, hostnames);
+        verify(clouderaManagerCommissioner).collectHostsToCommission(stack, hostGroup, hostnames, apiClient);
+    }
+
+    @Test
+    public void testRecommissionClusterNodes() {
+        Map<String, InstanceMetaData> hosts = mock(Map.class);
+        underTest.recommissionClusterNodes(hosts);
+        verify(clouderaManagerCommissioner).recommissionNodes(stack, hosts, apiClient);
+    }
+
+    private Stack createStack() {
+        Stack stack = new Stack();
+        stack.setCluster(createCluster());
+        stack.setGatewayPort(GATEWAY_PORT);
+        return stack;
+    }
+
+    private Cluster createCluster() {
+        Cluster cluster = new Cluster();
+        cluster.setCloudbreakUser(USER);
+        cluster.setCloudbreakPassword(PASSWORD);
+        return cluster;
+    }
+}
+
+
+
+

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerCommissionerTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerCommissionerTest.java
@@ -1,0 +1,245 @@
+package com.sequenceiq.cloudbreak.cm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.cloudera.api.swagger.ClouderaManagerResourceApi;
+import com.cloudera.api.swagger.ClustersResourceApi;
+import com.cloudera.api.swagger.CommandsResourceApi;
+import com.cloudera.api.swagger.HostsResourceApi;
+import com.cloudera.api.swagger.client.ApiClient;
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.model.ApiCommand;
+import com.cloudera.api.swagger.model.ApiHostList;
+import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollingServiceProvider;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.polling.PollingResult;
+
+@ExtendWith(MockitoExtension.class)
+public class ClouderaManagerCommissionerTest extends BaseClouderaManagerCommDecommTest {
+
+    private static final String STACK_NAME = "stack";
+
+    private static final String DELETED_INSTANCE_FQDN = "deletedInstance";
+
+    private static final String RUNNING_INSTANCE_FQDN = "runningInstance";
+
+    private static final String RUNNING_INSTANCE_FQDN_BASE = "runningInstance-";
+
+    private static final String HOSTGROUP_NAME_COMPUTE = "compute";
+
+    @InjectMocks
+    private ClouderaManagerCommissioner underTest;
+
+    @Mock
+    private ClouderaManagerApiFactory clouderaManagerApiFactory;
+
+    @Mock
+    private ApiClient client;
+
+    @Mock
+    private ClustersResourceApi clustersResourceApi;
+
+    @Mock
+    private HostsResourceApi hostsResourceApi;
+
+    @Mock
+    private ClouderaManagerResourceApi clouderaManagerResourceApi;
+
+    @Mock
+    private CommandsResourceApi commandsResourceApi;
+
+    @Mock
+    private ClouderaManagerPollingServiceProvider pollingServiceProvider;
+
+    @Test
+    public void testCollectHostsToCommissionAllFound() throws ApiException {
+        Set<String> hostNames = createHostnames(3);
+        ApiHostList apiHostList = createGoodHealthApiHostList(hostNames);
+        mockListClusterHosts(apiHostList);
+        HostGroup hostGroup = createHostGroup(hostNames);
+
+        Map<String, InstanceMetaData> result = underTest.collectHostsToCommission(getStack(), hostGroup, hostNames, client);
+
+        assertEquals(3, result.size());
+        assertEquals(hostNames, result.keySet());
+    }
+
+    @Test
+    public void testCollectHostsToCommissionMissingInCB() throws ApiException {
+        Set<String> hostNames = createHostnames(3);
+        ApiHostList apiHostList = createGoodHealthApiHostList(hostNames);
+        mockListClusterHosts(apiHostList);
+
+        Set<String> hostnamesKnownToCb = new HashSet<>(hostNames);
+        hostnamesKnownToCb.remove(hostNames.iterator().next());
+        HostGroup hostGroup = createHostGroup(hostnamesKnownToCb);
+
+        Map<String, InstanceMetaData> result = underTest.collectHostsToCommission(getStack(), hostGroup, hostNames, client);
+
+        assertEquals(2, result.size());
+        assertEquals(hostnamesKnownToCb, result.keySet());
+    }
+
+    @Test
+    public void testCollectHostsToCommissionMissingInCM() throws ApiException {
+        Set<String> hostNames = createHostnames(3);
+
+        Set<String> hostnamesKnownToCm = new HashSet<>(hostNames);
+        hostnamesKnownToCm.remove(hostNames.iterator().next());
+        ApiHostList apiHostList = createGoodHealthApiHostList(hostnamesKnownToCm);
+        mockListClusterHosts(apiHostList);
+
+        HostGroup hostGroup = createHostGroup(hostNames);
+
+        Map<String, InstanceMetaData> result = underTest.collectHostsToCommission(getStack(), hostGroup, hostNames, client);
+
+        assertEquals(2, result.size());
+        assertEquals(hostnamesKnownToCm, result.keySet());
+    }
+
+    @Test
+    public void testCollectHostsToCommissionMissingInCBAndCM() throws ApiException {
+        Set<String> hostNames = createHostnames(3);
+
+        Set<String> hostnamesKnownToCm = new HashSet<>(hostNames);
+        hostnamesKnownToCm.remove(hostNames.iterator().next());
+        ApiHostList apiHostList = createGoodHealthApiHostList(hostnamesKnownToCm);
+        mockListClusterHosts(apiHostList);
+
+        Set<String> hostnamesKnownToCb = new HashSet<>(hostNames);
+        hostnamesKnownToCb.remove(hostnamesKnownToCm.iterator().next());
+        HostGroup hostGroup = createHostGroup(hostnamesKnownToCb);
+
+        Map<String, InstanceMetaData> result = underTest.collectHostsToCommission(getStack(), hostGroup, hostNames, client);
+
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    public void testRecommissionNodesSuccess() throws ApiException {
+        Set<String> hostNames = createHostnames(3);
+        ApiHostList apiHostList = createGoodHealthApiHostList(hostNames);
+        mockListClusterHosts(apiHostList);
+
+        Map<String, InstanceMetaData> hostsToDecommission;
+        Set<InstanceMetaData> instanceMetaDataSet = createRunningInstanceMetadata(hostNames);
+        Map<String, InstanceMetaData> hostsToCommission = instanceMetaDataSet.stream().collect(Collectors.toMap(InstanceMetaData::getDiscoveryFQDN, e -> e));
+
+        mockCommissionAndExitMaintenanceMode(PollingResult.SUCCESS);
+        Set<String> result = underTest.recommissionNodes(getStack(), hostsToCommission, client);
+
+        assertEquals(3, result.size());
+        assertEquals(hostNames, result);
+    }
+
+    @Test
+    public void testRecommissionNodesSuccessMissingNodesInCm() throws ApiException {
+        Set<String> hostNames = createHostnames(3);
+        Set<String> hostnamesKnownToCm = new HashSet<>(hostNames);
+        hostnamesKnownToCm.remove(hostNames.iterator().next());
+        ApiHostList apiHostList = createGoodHealthApiHostList(hostnamesKnownToCm);
+        mockListClusterHosts(apiHostList);
+
+        Map<String, InstanceMetaData> hostsToDecommission;
+        Set<InstanceMetaData> instanceMetaDataSet = createRunningInstanceMetadata(hostNames);
+        Map<String, InstanceMetaData> hostsToCommission = instanceMetaDataSet.stream().collect(Collectors.toMap(InstanceMetaData::getDiscoveryFQDN, e -> e));
+
+        mockCommissionAndExitMaintenanceMode(PollingResult.SUCCESS);
+        Set<String> result = underTest.recommissionNodes(getStack(), hostsToCommission, client);
+
+        assertEquals(2, result.size());
+        assertEquals(hostnamesKnownToCm, result);
+    }
+
+    @Test
+    public void testRecommissionNodesTimeout() throws ApiException {
+        Set<String> hostNames = createHostnames(3);
+        ApiHostList apiHostList = createGoodHealthApiHostList(hostNames);
+        mockListClusterHosts(apiHostList);
+
+        Map<String, InstanceMetaData> hostsToDecommission;
+        Set<InstanceMetaData> instanceMetaDataSet = createRunningInstanceMetadata(hostNames);
+        Map<String, InstanceMetaData> hostsToCommission = instanceMetaDataSet.stream().collect(Collectors.toMap(InstanceMetaData::getDiscoveryFQDN, e -> e));
+
+        // TODO CB-14929: What are the other PollingResults that CM can return. How about entities like FAILURE?.
+        //  Is an explicit check for SUCCESS required?
+        mockCommissionAndExitMaintenanceMode(PollingResult.TIMEOUT);
+        mockAbortCommission();
+
+        assertThrows(CloudbreakServiceException.class, () -> underTest.recommissionNodes(getStack(), hostsToCommission, client));
+        verify(commandsResourceApi).abortCommand(eq(BigDecimal.valueOf(1)));
+    }
+
+    // TODO CB-14929: As error handling is improved, add tests to include
+    //  1. hosts which are not in the desired state.
+    //  2. Exceptions when communicating with CM endpoints.
+
+    private Set<String> createHostnames(int runningCount) {
+        Set<String> hostnames = new HashSet<>();
+        for (int i = 0; i < runningCount; i++) {
+            hostnames.add(RUNNING_INSTANCE_FQDN_BASE + i);
+        }
+        return hostnames;
+    }
+
+    private void mockListClusterHosts(ApiHostList apiHostList) throws ApiException {
+        mockListClusterHosts(apiHostList, hostsResourceApi, clouderaManagerApiFactory, client);
+    }
+
+    private void mockCommissionAndExitMaintenanceMode(PollingResult pollingResult) throws ApiException {
+        ApiCommand apiCommand = getApiCommand(BigDecimal.valueOf(1));
+        when(clouderaManagerApiFactory.getClouderaManagerResourceApi(eq(client))).thenReturn(clouderaManagerResourceApi);
+        when(clouderaManagerResourceApi.hostsRecommissionAndExitMaintenanceModeCommand(any(), any())).thenReturn(apiCommand);
+        when(pollingServiceProvider.startPollingCmHostsRecommission(any(), eq(client), eq(apiCommand.getId()))).thenReturn(pollingResult);
+    }
+
+    private void mockAbortCommission() {
+        when(clouderaManagerApiFactory.getCommandsResourceApi(eq(client))).thenReturn(commandsResourceApi);
+    }
+
+    private Set<InstanceMetaData> createRunningInstanceMetadata(Set<String> hosts) {
+        return hosts.stream().map(
+                h -> createRunningInstanceMetadata(h, HOSTGROUP_NAME_COMPUTE)).collect(Collectors.toUnmodifiableSet());
+    }
+
+    private HostGroup createHostGroup(Set<String> runningHostNames) {
+        HostGroup hostGroup = new HostGroup();
+        InstanceGroup instanceGroup = new InstanceGroup();
+
+        Set<InstanceMetaData> instanceMetaData = createRunningInstanceMetadata(runningHostNames);
+
+        instanceGroup.setInstanceMetaData(instanceMetaData);
+        instanceGroup.setGroupName(HOSTGROUP_NAME_COMPUTE);
+        hostGroup.setInstanceGroup(instanceGroup);
+        hostGroup.setName(HOSTGROUP_NAME_COMPUTE);
+        return hostGroup;
+    }
+
+    private Stack getStack() {
+        Stack stack = new Stack();
+        stack.setName(STACK_NAME);
+        return stack;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartds/StopStartDownscaleFlowService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartds/StopStartDownscaleFlowService.java
@@ -2,12 +2,12 @@ package com.sequenceiq.cloudbreak.core.flow2.cluster.stopstartds;
 
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.AVAILABLE;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.UPDATE_FAILED;
-import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALING_STOPSTART_DOWNSCALE_STARTING2;
-import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALING_STOPSTART_DOWNSCALE_STARTING;
+import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALING_FAILED;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALING_STOPSTART_DOWNSCALE_FINISHED;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALING_STOPSTART_DOWNSCALE_INIT;
-import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALING_FAILED;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALING_STOPSTART_DOWNSCALE_NODE_STOPPING;
+import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALING_STOPSTART_DOWNSCALE_STARTING;
+import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALING_STOPSTART_DOWNSCALE_STARTING2;
 
 import java.util.List;
 import java.util.Set;
@@ -25,7 +25,6 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
 import com.sequenceiq.cloudbreak.core.flow2.stack.CloudbreakFlowMessageService;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
-import com.sequenceiq.cloudbreak.domain.view.StackView;
 import com.sequenceiq.cloudbreak.service.StackUpdater;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
 import com.sequenceiq.cloudbreak.service.hostgroup.HostGroupService;
@@ -93,7 +92,6 @@ public class StopStartDownscaleFlowService {
     }
 
     public void clusterDownscaleFinished(Long stackId, @Nullable String hostGroupName, Set<InstanceMetaData> instancesStopped) {
-        StackView stackView = stackService.getViewByIdWithoutAuth(stackId);
         // TODO CB-14929: Make sure Database state updates are handled correctly.
         instancesStopped.stream().forEach(x -> instanceMetaDataService.updateInstanceStatus(x, InstanceStatus.STOPPED));
         stackUpdater.updateStackStatus(stackId, DetailedStackStatus.AVAILABLE, "Instances: " + instancesStopped.size() + " stopped successfully.");

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/StopStartUpscaleCommissionViaCMHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/StopStartUpscaleCommissionViaCMHandler.java
@@ -16,7 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.cluster.api.ClusterDecomissionService;
+import com.sequenceiq.cloudbreak.cluster.api.ClusterCommissionService;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterSetupService;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterClientInitException;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
@@ -85,7 +85,7 @@ public class StopStartUpscaleCommissionViaCMHandler implements EventHandler<Stop
             flowMessageService.fireEventAndLog(stack.getId(), UPDATE_IN_PROGRESS.name(), CLUSTER_SCALING_STOPSTART_UPSCALE_CMHOSTSSTARTED,
                     String.valueOf(request.getInstancesToCommission().size()));
 
-            ClusterDecomissionService clusterDecomissionService = clusterApiConnectors.getConnector(stack).clusterDecomissionService();
+            ClusterCommissionService clusterCommissionService = clusterApiConnectors.getConnector(stack).clusterCommissionService();
 
             // TODO CB-14929:  No null fqdn etc checking in place. Rant:  Java Streams are terrible to easily get things wrong,
             // and not think through what could potetntially braek. Not to mention the syntax..
@@ -95,7 +95,7 @@ public class StopStartUpscaleCommissionViaCMHandler implements EventHandler<Stop
             HostGroup hostGroup = hostGroupService.getByClusterIdAndName(cluster.getId(), request.getHostGroupName())
                     .orElseThrow(NotFoundException.notFound("hostgroup", request.getHostGroupName()));
 
-            Map<String, InstanceMetaData> hostsToRecommission = clusterDecomissionService.collectHostsToRemove(hostGroup, hostNames);
+            Map<String, InstanceMetaData> hostsToRecommission = clusterCommissionService.collectHostsToCommission(hostGroup, hostNames);
             LOGGER.info("ZZZ: hostNamesToRecommission after checking with CM: count={}, details={}", hostsToRecommission.size(), hostsToRecommission);
 
             // TODO CB-14929: Ensure CM, relevant services (YARN RM) are in a functional state - or fail/delay the operation
@@ -106,7 +106,7 @@ public class StopStartUpscaleCommissionViaCMHandler implements EventHandler<Stop
 
             Set<String> recommissionedHostnames = Collections.emptySet();
             if (hostsToRecommission.size() > 0) {
-                recommissionedHostnames = clusterDecomissionService.recommissionClusterNodes(hostsToRecommission);
+                recommissionedHostnames = clusterCommissionService.recommissionClusterNodes(hostsToRecommission);
             }
             LOGGER.info("ZZZ: hostsRecommissioned: count={}, hostNames={}", recommissionedHostnames.size(), recommissionedHostnames);
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationServiceTest.java
@@ -297,8 +297,6 @@ public class StackOperationServiceTest {
         cluster.setStatus(Status.AVAILABLE);
         stack.setCluster(cluster);
 
-        User user = new User();
-
         Collection<String> instanceIds = new LinkedList<>();
         InstanceMetaData im1 = createInstanceMetadataForTest(1L, "group1");
         InstanceMetaData im2 = createInstanceMetadataForTest(2L, "group1");
@@ -317,7 +315,7 @@ public class StackOperationServiceTest {
 
         // Verify non stop-start invocation
         capturedInstances = ArgumentCaptor.forClass(Map.class);
-        underTest.removeInstances(stack, 0L, instanceIds, false, user, null);
+        underTest.removeInstances(stack, instanceIds, false, null);
         verify(flowManager).triggerStackRemoveInstances(eq(stack.getId()), capturedInstances.capture(), eq(false));
         captured = capturedInstances.getValue();
         assertEquals(1, captured.size());
@@ -327,7 +325,7 @@ public class StackOperationServiceTest {
         // Verify stop-start invocation
         reset(flowManager);
         capturedInstances = ArgumentCaptor.forClass(Map.class);
-        underTest.removeInstances(stack, 0L, instanceIds, false, user, ScalingStrategy.STOPSTART);
+        underTest.removeInstances(stack, instanceIds, false, ScalingStrategy.STOPSTART);
         verify(flowManager).triggerStopStartStackDownscale(eq(stack.getId()), capturedInstances.capture(), eq(false));
         captured = capturedInstances.getValue();
         assertEquals(1, captured.size());
@@ -337,9 +335,9 @@ public class StackOperationServiceTest {
 
         // No requestIds sent - BadRequest (regular and stopstart)
         assertThrows(BadRequestException.class,
-                () -> underTest.removeInstances(stack, 0L, null, false, user, null));
+                () -> underTest.removeInstances(stack, null, false, null));
         assertThrows(BadRequestException.class,
-                () -> underTest.removeInstances(stack, 0L, null, false, user, ScalingStrategy.STOPSTART));
+                () -> underTest.removeInstances(stack, null, false, ScalingStrategy.STOPSTART));
 
         // stopstart supports a single hostGroup only
         reset(flowManager);
@@ -347,11 +345,11 @@ public class StackOperationServiceTest {
         when(updateNodeCountValidator.validateInstanceForDownscale(im4.getInstanceId(), stack)).thenReturn(im4);
         instanceIds.add("i4");
         assertThrows(BadRequestException.class,
-                () -> underTest.removeInstances(stack, 0L, instanceIds, false, user, ScalingStrategy.STOPSTART));
+                () -> underTest.removeInstances(stack, instanceIds, false, ScalingStrategy.STOPSTART));
 
         // regular scaling supports multiple hostgroups
         reset(flowManager);
-        underTest.removeInstances(stack, 0L, instanceIds, false, user, null);
+        underTest.removeInstances(stack, instanceIds, false, null);
         verify(flowManager).triggerStackRemoveInstances(eq(stack.getId()), capturedInstances.capture(), eq(false));
         captured = capturedInstances.getValue();
         assertEquals(2, captured.size());


### PR DESCRIPTION
- Moves temporary code from the decommissioner classes into commissioner
  classes, with some improvements.
- Adds unit tests for the same.

See detailed description in the commit message.