### PR TITLE
CB-15368 Enable FreeIPA HA upgrade

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/handler/RemoveReplicationAgreementsHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/handler/RemoveReplicationAgreementsHandler.java
@@ -25,14 +25,10 @@ import com.sequenceiq.freeipa.service.freeipa.flow.FreeIpaTopologyService;
 import com.sequenceiq.freeipa.service.stack.StackService;
 
 import reactor.bus.Event;
-import reactor.bus.EventBus;
 
 @Component
 public class RemoveReplicationAgreementsHandler extends ExceptionCatcherEventHandler<RemoveReplicationAgreementsRequest> {
     private static final Logger LOGGER = LoggerFactory.getLogger(RemoveReplicationAgreementsHandler.class);
-
-    @Inject
-    private EventBus eventBus;
 
     @Inject
     private StackService stackService;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/upgrade/UpgradeValidationService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/upgrade/UpgradeValidationService.java
@@ -22,6 +22,8 @@ public class UpgradeValidationService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UpgradeValidationService.class);
 
+    private static final int MAX_NUMBER_OF_INSTANCES_FOR_UPGRADE = 3;
+
     @Inject
     private EntitlementService entitlementService;
 
@@ -29,9 +31,9 @@ public class UpgradeValidationService {
         if (allInstances.isEmpty()) {
             LOGGER.warn("Instances are empty for stack.");
             throw new BadRequestException("There are no instances available for upgrade!");
-        } else if (allInstances.size() > 2) {
+        } else if (allInstances.size() > MAX_NUMBER_OF_INSTANCES_FOR_UPGRADE) {
             LOGGER.warn("FreeIPA instance count is bigger then allowed. Size: [{}]", allInstances.size());
-            throw new BadRequestException("Upgrade currently only available for FreeIPA installation with 1 or 2 instances");
+            throw new BadRequestException("Upgrade currently only available for FreeIPA installation with 1 to 3 instances");
         } else if (isAnyInstanceInNotAvailableState(allInstances)) {
             throwErrorForNotAvailableInstances(allInstances);
         } else if (!stack.isAvailable()) {

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/upgrade/UpgradeValidationServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/upgrade/UpgradeValidationServiceTest.java
@@ -39,6 +39,12 @@ class UpgradeValidationServiceTest {
         Set<InstanceMetaData> allInstances = Set.of(createAvailableInstance("im1"), createAvailableInstance("im2"));
 
         underTest.validateStackForUpgrade(allInstances, stack);
+
+        allInstances = Set.of(createAvailableInstance("im1"), createAvailableInstance("im2"), createAvailableInstance("im3"));
+        underTest.validateStackForUpgrade(allInstances, stack);
+
+        allInstances = Set.of(createAvailableInstance("im1"));
+        underTest.validateStackForUpgrade(allInstances, stack);
     }
 
     @Test
@@ -50,9 +56,10 @@ class UpgradeValidationServiceTest {
     }
 
     @Test
-    public void testMoreThanTwoInstances() {
+    public void testMoreThanThreeInstances() {
         Stack stack = mock(Stack.class);
-        Set<InstanceMetaData> allInstances = Set.of(createAvailableInstance("im1"), createAvailableInstance("im2"), createAvailableInstance("im2"));
+        Set<InstanceMetaData> allInstances = Set.of(createAvailableInstance("im1"), createAvailableInstance("im2"), createAvailableInstance("im3"),
+                createAvailableInstance("im4"));
 
         assertThrows(BadRequestException.class, () -> underTest.validateStackForUpgrade(allInstances, stack));
     }


### PR DESCRIPTION
- modified validation to allow upgrade up to 3 instances
- refactored `FreeIpaTopologyService`

Tested upgrade for FreeIPA with 3 instances, and validated topology is fine when 4 instances are present. Also started DL after upgrade.

See detailed description in the commit message.