### PR TITLE
CB-15383 increase google image copy timeout. Current azure poller is …

### DIFF
--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/setup/GcpProvisionSetup.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/setup/GcpProvisionSetup.java
@@ -45,7 +45,7 @@ public class GcpProvisionSetup implements Setup {
 
     private static final String READY = "READY";
 
-    private static final int ATTEMPT_COUNT = 300;
+    private static final int ATTEMPT_COUNT = 600;
 
     private static final int SLEEPTIME = 20;
 


### PR DESCRIPTION
…infinite so I did not set this to infinite

See detailed description in the commit message.