### PR TITLE
CB-14926 [e2e] WaitObject: introduce ignoreFailedState -- phase II. o…

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/CloudbreakClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/CloudbreakClient.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.it.cloudbreak;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -48,12 +47,12 @@ import com.sequenceiq.it.cloudbreak.dto.util.RenewDistroXCertificateTestDto;
 import com.sequenceiq.it.cloudbreak.dto.util.StackMatrixTestDto;
 import com.sequenceiq.it.cloudbreak.dto.util.UsedImagesTestDto;
 import com.sequenceiq.it.cloudbreak.dto.util.VersionCheckTestDto;
-import com.sequenceiq.it.cloudbreak.util.wait.service.WaitObject;
 import com.sequenceiq.it.cloudbreak.util.wait.service.cloudbreak.CloudbreakWaitObject;
 import com.sequenceiq.it.cloudbreak.util.wait.service.instance.InstanceWaitObject;
 import com.sequenceiq.it.cloudbreak.util.wait.service.instance.cloudbreak.CloudbreakInstanceWaitObject;
 
-public class CloudbreakClient extends MicroserviceClient<com.sequenceiq.cloudbreak.client.CloudbreakClient, CloudbreakServiceCrnEndpoints> {
+public class CloudbreakClient extends MicroserviceClient<com.sequenceiq.cloudbreak.client.CloudbreakClient, CloudbreakServiceCrnEndpoints, Status,
+        CloudbreakWaitObject> {
     public static final String CLOUDBREAK_CLIENT = "CLOUDBREAK_CLIENT";
 
     private static com.sequenceiq.cloudbreak.client.CloudbreakClient singletonCloudbreakClient;
@@ -82,11 +81,9 @@ public class CloudbreakClient extends MicroserviceClient<com.sequenceiq.cloudbre
     }
 
     @Override
-    public <E extends Enum<E>, T extends WaitObject> T waitObject(CloudbreakTestDto entity, String name, Map<String, E> desiredStatuses,
-            TestContext testContext, Set<E> ignoredFailedStatuses) {
-        Map<String, Status> map = new HashMap<>();
-        desiredStatuses.forEach((key, v) -> map.put(key, (Status) v));
-        return (T) new CloudbreakWaitObject(this, name, map, testContext.getActingUserCrn().getAccountId(), (Set<Status>) ignoredFailedStatuses);
+    public CloudbreakWaitObject waitObject(CloudbreakTestDto entity, String name, Map<String, Status> desiredStatuses,
+            TestContext testContext, Set<Status> ignoredFailedStatuses) {
+        return new CloudbreakWaitObject(this, name, desiredStatuses, testContext.getActingUserCrn().getAccountId(), ignoredFailedStatuses);
     }
 
     @Override
@@ -200,8 +197,8 @@ public class CloudbreakClient extends MicroserviceClient<com.sequenceiq.cloudbre
     }
 
     @Override
-    public <E extends Enum<E>> InstanceWaitObject waitInstancesObject(CloudbreakTestDto entity, TestContext testContext,
-            List<String> instanceIds, E instanceStatus) {
+    public <O extends Enum<O>> InstanceWaitObject waitInstancesObject(CloudbreakTestDto entity, TestContext testContext,
+            List<String> instanceIds, O instanceStatus) {
         return new CloudbreakInstanceWaitObject(testContext, entity.getName(), instanceIds, (InstanceStatus) instanceStatus);
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/EnvironmentClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/EnvironmentClient.java
@@ -22,10 +22,10 @@ import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
 import com.sequenceiq.it.cloudbreak.dto.credential.CredentialTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.proxy.ProxyTestDto;
-import com.sequenceiq.it.cloudbreak.util.wait.service.WaitObject;
 import com.sequenceiq.it.cloudbreak.util.wait.service.environment.EnvironmentWaitObject;
 
-public class EnvironmentClient extends MicroserviceClient<com.sequenceiq.environment.client.EnvironmentClient, EnvironmentServiceCrnEndpoints> {
+public class EnvironmentClient extends MicroserviceClient<com.sequenceiq.environment.client.EnvironmentClient, EnvironmentServiceCrnEndpoints,
+        EnvironmentStatus, EnvironmentWaitObject> {
 
     public static final String ENVIRONMENT_CLIENT = "ENVIRONMENT_CLIENT";
 
@@ -51,9 +51,9 @@ public class EnvironmentClient extends MicroserviceClient<com.sequenceiq.environ
     }
 
     @Override
-    public <E extends Enum<E>, T extends WaitObject> T waitObject(CloudbreakTestDto entity, String name, Map<String, E> desiredStatuses,
-            TestContext testContext, Set<E> ignoredFailedStatuses) {
-        return (T) new EnvironmentWaitObject(this, entity.getName(), entity.getCrn(), (EnvironmentStatus) desiredStatuses.get("status"));
+    public EnvironmentWaitObject waitObject(CloudbreakTestDto entity, String name, Map<String, EnvironmentStatus> desiredStatuses,
+            TestContext testContext, Set<EnvironmentStatus> ignoredFailedStatuses) {
+        return new EnvironmentWaitObject(this, entity.getName(), entity.getCrn(), desiredStatuses.get("status"), ignoredFailedStatuses);
     }
 
     public static synchronized EnvironmentClient createProxyEnvironmentClient(TestParameter testParameter, CloudbreakUser cloudbreakUser) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/MicroserviceClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/MicroserviceClient.java
@@ -14,7 +14,7 @@ import com.sequenceiq.it.cloudbreak.util.wait.service.WaitObject;
 import com.sequenceiq.it.cloudbreak.util.wait.service.WaitService;
 import com.sequenceiq.it.cloudbreak.util.wait.service.instance.InstanceWaitObject;
 
-public abstract class MicroserviceClient<C, I> extends Entity {
+public abstract class MicroserviceClient<C, I, E extends Enum<E>, W extends WaitObject> extends Entity {
 
     protected static final int TIMEOUT = 60 * 1000;
 
@@ -47,11 +47,13 @@ public abstract class MicroserviceClient<C, I> extends Entity {
         return new WaitService<>();
     }
 
-    public abstract <E extends Enum<E>, W extends WaitObject> W waitObject(CloudbreakTestDto entity, String name, Map<String, E> desiredStatuses,
-            TestContext testContext, Set<E> ignoredFailedStatuses);
+    public W waitObject(CloudbreakTestDto entity, String name, Map<String, E> desiredStatuses,
+            TestContext testContext, Set<E> ignoredFailedStatuses) {
+        throw new TestFailException("Wait object is not supported by the client");
+    }
 
-    public <E extends Enum<E>> InstanceWaitObject waitInstancesObject(CloudbreakTestDto entity, TestContext testContext,
-            List<String> instanceIds, E instanceStatus) {
+    public <O extends Enum<O>>  InstanceWaitObject waitInstancesObject(CloudbreakTestDto entity, TestContext testContext,
+            List<String> instanceIds, O instanceStatus) {
         throw new TestFailException("Can't create waitInstanceWaitObject instances object");
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/RedbeamsClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/RedbeamsClient.java
@@ -14,12 +14,11 @@ import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
 import com.sequenceiq.it.cloudbreak.dto.database.RedbeamsDatabaseServerTestDto;
 import com.sequenceiq.it.cloudbreak.dto.database.RedbeamsDatabaseTestDto;
-import com.sequenceiq.it.cloudbreak.util.wait.service.WaitObject;
 import com.sequenceiq.it.cloudbreak.util.wait.service.redbeams.RedbeamsWaitObject;
 import com.sequenceiq.redbeams.api.model.common.Status;
 import com.sequenceiq.redbeams.client.RedbeamsApiKeyClient;
 
-public class RedbeamsClient extends MicroserviceClient<com.sequenceiq.redbeams.client.RedbeamsClient, Void> {
+public class RedbeamsClient extends MicroserviceClient<com.sequenceiq.redbeams.client.RedbeamsClient, Void, Status, RedbeamsWaitObject> {
 
     public static final String REDBEAMS_CLIENT = "REDBEAMS_CLIENT";
 
@@ -48,9 +47,9 @@ public class RedbeamsClient extends MicroserviceClient<com.sequenceiq.redbeams.c
     }
 
     @Override
-    public <E extends Enum<E>, W extends WaitObject> W waitObject(CloudbreakTestDto entity, String name, Map<String, E> desiredStatuses,
-            TestContext testContext, Set<E> ignoredFailedStatuses) {
-        return (W) new RedbeamsWaitObject(this, entity.getCrn(), (Status) desiredStatuses.get("status"));
+    public RedbeamsWaitObject waitObject(CloudbreakTestDto entity, String name, Map<String, Status> desiredStatuses,
+            TestContext testContext, Set<Status> ignoredFailedStatuses) {
+        return new RedbeamsWaitObject(this, entity.getCrn(), desiredStatuses.get("status"), ignoredFailedStatuses);
     }
 
     @Override
@@ -60,7 +59,8 @@ public class RedbeamsClient extends MicroserviceClient<com.sequenceiq.redbeams.c
 
     @Override
     public Set<String> supportedTestDtos() {
-        return Set.of(RedbeamsDatabaseServerTestDto.class.getSimpleName(),
+        return Set.of(
+                RedbeamsDatabaseServerTestDto.class.getSimpleName(),
                 RedbeamsDatabaseTestDto.class.getSimpleName());
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/SdxClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/SdxClient.java
@@ -18,7 +18,6 @@ import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCustomTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
 import com.sequenceiq.it.cloudbreak.dto.util.RenewDatalakeCertificateTestDto;
-import com.sequenceiq.it.cloudbreak.util.wait.service.WaitObject;
 import com.sequenceiq.it.cloudbreak.util.wait.service.datalake.DatalakeWaitObject;
 import com.sequenceiq.it.cloudbreak.util.wait.service.instance.InstanceWaitObject;
 import com.sequenceiq.it.cloudbreak.util.wait.service.instance.cloudbreak.CloudbreakInstanceWaitObject;
@@ -26,7 +25,7 @@ import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 import com.sequenceiq.sdx.client.SdxServiceApiKeyClient;
 import com.sequenceiq.sdx.client.SdxServiceApiKeyEndpoints;
 
-public class SdxClient extends MicroserviceClient<SdxServiceApiKeyEndpoints, Void> {
+public class SdxClient extends MicroserviceClient<SdxServiceApiKeyEndpoints, Void, SdxClusterStatusResponse, DatalakeWaitObject> {
     public static final String SDX_CLIENT = "SDX_CLIENT";
 
     private SdxServiceApiKeyEndpoints sdxClient;
@@ -41,10 +40,9 @@ public class SdxClient extends MicroserviceClient<SdxServiceApiKeyEndpoints, Voi
     }
 
     @Override
-    public <E extends Enum<E>, W extends WaitObject> W waitObject(CloudbreakTestDto entity, String name, Map<String, E> desiredStatuses,
-            TestContext testContext, Set<E> ignoredFailedStatuses) {
-        return (W) new DatalakeWaitObject(this, entity.getName(), (SdxClusterStatusResponse) desiredStatuses.get("status"),
-                (Set<SdxClusterStatusResponse>) ignoredFailedStatuses);
+    public DatalakeWaitObject waitObject(CloudbreakTestDto entity, String name, Map<String, SdxClusterStatusResponse> desiredStatuses,
+            TestContext testContext, Set<SdxClusterStatusResponse> ignoredFailedStatuses) {
+        return new DatalakeWaitObject(this, entity.getName(), desiredStatuses.get("status"), ignoredFailedStatuses);
     }
 
     @Override
@@ -76,8 +74,8 @@ public class SdxClient extends MicroserviceClient<SdxServiceApiKeyEndpoints, Voi
     }
 
     @Override
-    public <E extends Enum<E>> InstanceWaitObject waitInstancesObject(CloudbreakTestDto entity, TestContext testContext,
-            List<String> instanceIds, E instanceStatus) {
+    public <O extends Enum<O>> InstanceWaitObject waitInstancesObject(CloudbreakTestDto entity, TestContext testContext,
+            List<String> instanceIds, O instanceStatus) {
         return new CloudbreakInstanceWaitObject(testContext, entity.getName(), instanceIds, (InstanceStatus) instanceStatus);
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/UmsClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/UmsClient.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.it.cloudbreak;
 
 import java.lang.reflect.Field;
-import java.util.Map;
 import java.util.Set;
 
 import org.springframework.util.ReflectionUtils;
@@ -10,8 +9,6 @@ import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
 import com.sequenceiq.cloudbreak.auth.altus.config.UmsChannelConfig;
 import com.sequenceiq.cloudbreak.auth.altus.config.UmsClientConfig;
 import com.sequenceiq.flow.api.FlowPublicEndpoint;
-import com.sequenceiq.it.cloudbreak.context.TestContext;
-import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
 import com.sequenceiq.it.cloudbreak.dto.ums.UmsGroupTestDto;
 import com.sequenceiq.it.cloudbreak.dto.ums.UmsTestDto;
 import com.sequenceiq.it.cloudbreak.exception.TestFailException;
@@ -20,7 +17,7 @@ import com.sequenceiq.it.cloudbreak.util.wait.service.WaitService;
 
 import io.opentracing.Tracer;
 
-public class UmsClient extends MicroserviceClient<GrpcUmsClient, Void> {
+public class UmsClient<E extends Enum<E>, W extends WaitObject> extends MicroserviceClient<GrpcUmsClient, Void, E, W> {
 
     public static final String UMS_CLIENT = "UMS_CLIENT";
 
@@ -42,12 +39,6 @@ public class UmsClient extends MicroserviceClient<GrpcUmsClient, Void> {
     @Override
     public <T extends WaitObject> WaitService<T> waiterService() {
         throw new TestFailException("Wait service does not support by ums client");
-    }
-
-    @Override
-    public <E extends Enum<E>, W extends WaitObject> W waitObject(CloudbreakTestDto entity, String name, Map<String, E> desiredStatuses,
-            TestContext testContext, Set<E> ignoredFailedStatuses) {
-        throw new TestFailException("Wait object does not support by ums client");
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/cloudbreak/CloudbreakWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/cloudbreak/CloudbreakWaitObject.java
@@ -56,8 +56,7 @@ public class CloudbreakWaitObject implements WaitObject {
 
     private StackStatusV4Response stackStatus;
 
-    public CloudbreakWaitObject(CloudbreakClient client, String name, Map<String, Status> desiredStatuses, String accountId,
-            Set<Status> ignoredFailedStatuses) {
+    public CloudbreakWaitObject(CloudbreakClient client, String name, Map<String, Status> desiredStatuses, String accountId, Set<Status> ignoredFailedStatuses) {
         this.client = client;
         this.name = name;
         this.desiredStatuses = desiredStatuses;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/environment/EnvironmentWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/environment/EnvironmentWaitObject.java
@@ -5,6 +5,7 @@ import static com.sequenceiq.environment.api.v1.environment.model.response.Envir
 import static com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus.DELETE_FAILED;
 
 import java.util.Map;
+import java.util.Set;
 
 import com.sequenceiq.environment.api.v1.environment.endpoint.EnvironmentEndpoint;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
@@ -20,15 +21,19 @@ public class EnvironmentWaitObject implements WaitObject {
 
     private final EnvironmentStatus desiredStatus;
 
+    private final Set<EnvironmentStatus> ignoredFailedStatuses;
+
     private DetailedEnvironmentResponse environment;
 
     private final String name;
 
-    public EnvironmentWaitObject(EnvironmentClient environmentClient, String name, String environmentCrn, EnvironmentStatus desiredStatus) {
+    public EnvironmentWaitObject(EnvironmentClient environmentClient, String name, String environmentCrn, EnvironmentStatus desiredStatus,
+            Set<EnvironmentStatus> ignoredFailedStatuses) {
         this.client = environmentClient;
         this.crn = environmentCrn;
         this.name = name;
         this.desiredStatus = desiredStatus;
+        this.ignoredFailedStatuses = ignoredFailedStatuses;
     }
 
     public EnvironmentEndpoint getEndpoint() {
@@ -84,7 +89,7 @@ public class EnvironmentWaitObject implements WaitObject {
 
     @Override
     public boolean isFailedButIgnored() {
-        return false;
+        return ignoredFailedStatuses.contains(environment.getEnvironmentStatus());
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaOperationWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaOperationWaitObject.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.it.cloudbreak.util.wait.service.freeipa;
 
 import java.util.Map;
+import java.util.Set;
 
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
@@ -14,13 +15,16 @@ public class FreeIpaOperationWaitObject extends FreeIpaWaitObject {
 
     private final OperationState desiredOperationState;
 
+    private final Set<OperationState> ignoredFailedStatuses;
+
     private OperationStatus operationStatus;
 
     public FreeIpaOperationWaitObject(FreeIpaClient freeIpaClient, String operationId, String freeipaName, String environmentCrn,
-            OperationState desiredOperationState) {
+            OperationState desiredOperationState, Set<OperationState> ignoredFailedStatuses) {
         super(freeIpaClient, freeipaName, environmentCrn, Status.AVAILABLE);
         this.operationId = operationId;
         this.desiredOperationState = desiredOperationState;
+        this.ignoredFailedStatuses = ignoredFailedStatuses;
     }
 
     @Override
@@ -53,6 +57,11 @@ public class FreeIpaOperationWaitObject extends FreeIpaWaitObject {
     @Override
     public Map<String, String> getDesiredStatuses() {
         return Map.of(STATUS, desiredOperationState.name());
+    }
+
+    @Override
+    public boolean isFailedButIgnored() {
+        return ignoredFailedStatuses.contains(operationStatus.getStatus());
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaUserSyncWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaUserSyncWaitObject.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.it.cloudbreak.util.wait.service.freeipa;
 
 import java.util.Map;
+import java.util.Set;
 
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.EnvironmentUserSyncState;
@@ -11,12 +12,15 @@ public class FreeIpaUserSyncWaitObject extends FreeIpaWaitObject {
 
     private final UserSyncState desiredUserSyncState;
 
+    private Set<UserSyncState> ignoredFailedStatuses;
+
     private EnvironmentUserSyncState environmentUserSyncState;
 
     public FreeIpaUserSyncWaitObject(FreeIpaClient freeIpaClient, String freeipaName, String environmentCrn,
-            UserSyncState desiredUserSyncState) {
+            UserSyncState desiredUserSyncState, Set<UserSyncState> ignoredFailedStatuses) {
         super(freeIpaClient, freeipaName, environmentCrn, Status.AVAILABLE);
         this.desiredUserSyncState = desiredUserSyncState;
+        this.ignoredFailedStatuses = ignoredFailedStatuses;
     }
 
     @Override
@@ -38,6 +42,11 @@ public class FreeIpaUserSyncWaitObject extends FreeIpaWaitObject {
     @Override
     public Map<String, String> getDesiredStatuses() {
         return Map.of(STATUS, desiredUserSyncState.name());
+    }
+
+    @Override
+    public boolean isFailedButIgnored() {
+        return ignoredFailedStatuses.contains(environmentUserSyncState.getState());
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaWaitObject.java
@@ -5,6 +5,7 @@ import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.DE
 import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.DELETE_FAILED;
 
 import java.util.Map;
+import java.util.Set;
 
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.FreeIpaV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
@@ -20,15 +21,22 @@ public class FreeIpaWaitObject implements WaitObject {
 
     private final Status desiredStatus;
 
+    private final Set<Status> ignoredFailedStatuses;
+
     private final String name;
 
     private DescribeFreeIpaResponse freeIpa;
 
-    public FreeIpaWaitObject(FreeIpaClient freeIpaClient, String name, String environmentCrn, Status desiredStatus) {
+    public FreeIpaWaitObject(FreeIpaClient freeIpaClient, String name, String environmentCrn, Status desiredStatus, Set<Status> ignoredFailedStatuses) {
         this.client = freeIpaClient;
         this.environmentCrn = environmentCrn;
         this.desiredStatus = desiredStatus;
+        this.ignoredFailedStatuses = ignoredFailedStatuses;
         this.name = name;
+    }
+
+    protected FreeIpaWaitObject(FreeIpaClient freeIpaClient, String name, String environmentCrn, Status desiredStatus) {
+        this(freeIpaClient, name, environmentCrn, desiredStatus, Set.of());
     }
 
     public FreeIpaV1Endpoint getEndpoint() {
@@ -88,7 +96,7 @@ public class FreeIpaWaitObject implements WaitObject {
 
     @Override
     public boolean isFailedButIgnored() {
-        return false;
+        return ignoredFailedStatuses.contains(freeIpa.getStatus());
     }
 
     @Override


### PR DESCRIPTION
…f CB-14893

In CB-14893 the await method was further customized: it not only waits for an object to reach a status, but the test writer can specify to ignore some of the failure states, called ignoredFailedStatuses. CB-14893 gives explanation on the why. Also, that commit gave full implementation for SDXWaitObject only.

This commit extends ignoredFailedStatuses to all other WaitObjects. It is still used only in some SDX tests.

See detailed description in the commit message.