### PR TITLE
CB-14961 Have a mock test for a large cluster

### DIFF
--- a/integration-test/src/main/resources/testsuites/v4/mock/longrunning-mock.yaml
+++ b/integration-test/src/main/resources/testsuites/v4/mock/longrunning-mock.yaml
@@ -1,10 +1,7 @@
 name: "mock-tests"
 tests:
-  - name: "newway mock testcases"
-    packages:
-      - com.sequenceiq.it.cloudbreak.testcase.mock.*
+  - name: "long running mock testcases"
     classes:
       - name: com.sequenceiq.it.cloudbreak.testcase.mock.DistroXClusterUpscaleDownscaleTest
-        excludedMethods:
+        includedMethods:
           - testScaleDownAndUpManyTimes
-


### PR DESCRIPTION
Recently there was a production outage caused by large memory demand, that in turn was caused by DB queries with many (~3500) terminated instancemetadata (imd) entries. Terminated imds were left in place by downscale. Frequent scaling activities thus led to the accumulation of many imds, that increased the memory pressure. In production the cloudbreak container has ~2G of memory, and that is easily exhausted by a query with several 1000 imds.

This commit introduces a mock test with a large number of scaling, to test that cloudbreak will not run out of memory, even if more than 10.000 imd is accumulated for a cluster in cbdb imd table. Currently memory pressure is not measured, the test relies on the test environment maximizing cloudbreak memory in the same amount that is available on prod. The expectation is that the mock test runs through.

See detailed description in the commit message.