### PR TITLE
CB-15416: Fix the flaky DL resize tests.

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
@@ -115,6 +115,9 @@ public abstract class TestContext implements ApplicationContextAware {
     @Value("#{'${integrationtest.cloudProvider}'.equals('MOCK') ? 300 : ${integrationtest.testsuite.maxRetry:2700}}")
     private int maxRetry;
 
+    @Value("#{'${integrationtest.cloudProvider}'.equals('MOCK') ? 3 : ${integrationtest.testsuite.maxRetryCount:3}}")
+    private int maxRetryCount;
+
     @Value("${integrationtest.ums.host:localhost}")
     private String umsHost;
 
@@ -969,7 +972,7 @@ public abstract class TestContext implements ApplicationContextAware {
             LOGGER.info("Resource Crn is not available for: {}", awaitEntity.getName());
         }
 
-        resourceAwait.await(awaitEntity, desiredStatuses, ignoredFailedStatuses, getTestContext(), runningParameter, pollingInterval, maxRetry);
+        resourceAwait.await(awaitEntity, desiredStatuses, ignoredFailedStatuses, getTestContext(), runningParameter, pollingInterval, maxRetry, maxRetryCount);
         return entity;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxResizeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxResizeTests.java
@@ -49,7 +49,7 @@ public class MockSdxResizeTests extends AbstractMockTest {
                 .validate();
     }
 
-    @Test(enabled = false, dataProvider = TEST_CONTEXT_WITH_MOCK)
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
     @Description(
             given = "there is a running Cloudbreak",
             when = "a valid SDX Internal Create request is sent",

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxUpgradeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxUpgradeTests.java
@@ -34,6 +34,7 @@ import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.dto.stack.StackTestDto;
 import com.sequenceiq.redbeams.api.model.common.Status;
+import com.sequenceiq.sdx.api.model.SdxClusterShape;
 import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 
 public class MockSdxUpgradeTests extends AbstractMockTest {
@@ -198,59 +199,59 @@ public class MockSdxUpgradeTests extends AbstractMockTest {
                 .validate();
     }
 
-//    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
-//    @Description(
-//            given = "there is a running Cloudbreak",
-//            when = "start an sdx cluster without attached disk on gateway, but disk attachment is supported on cloud provider side",
-//            then = "Upgrade option should be presented"
-//    )
-//    public void testSdxUpgradeAfterResize(MockedTestContext testContext) {
-//        String upgradeImageCatalogName = resourcePropertyProvider().getName();
-//        createImageCatalogForOsUpgrade(testContext, upgradeImageCatalogName);
-//        String sdxInternal = resourcePropertyProvider().getName();
-//        String stack = resourcePropertyProvider().getName();
-//        String cluster = "cmcluster";
-//        String imageSettings = "imageSettingsUpgrade";
-//        String networkKey = "someOtherNetwork";
-//
-//        testContext
-//                .given(networkKey, EnvironmentNetworkTestDto.class)
-//                .withMock(new EnvironmentNetworkMockParams())
-//                .given(EnvironmentTestDto.class)
-//                .withNetwork(networkKey)
-//                .withCreateFreeIpa(Boolean.TRUE)
-//                .withName(resourcePropertyProvider().getEnvironmentName())
-//                .withBackup("location/of/the/backup")
-//                .when(getEnvironmentTestClient().create())
-//                .await(EnvironmentStatus.AVAILABLE)
-//                .given(FreeIpaTestDto.class)
-//                .when(freeIpaTestClient.create())
-//                .await(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)
-//                .given(cluster, ClusterTestDto.class)
-//                .given(imageSettings, ImageSettingsTestDto.class)
-//                .withImageId("aaa778fc-7f17-4535-9021-515351df3691")
-//                .withImageCatalog(upgradeImageCatalogName)
-//                .given("NoAttachedDisksTemplate", InstanceTemplateV4TestDto.class)
-//                .withAttachedVolume(testContext.init(VolumeV4TestDto.class).withCount(0))
-//                .given("InstanceGroupWithoutAttachedDisk", InstanceGroupTestDto.class)
-//                .withHostGroup(HostGroupType.MASTER)
-//                .withTemplate("NoAttachedDisksTemplate")
-//                .given(stack, StackTestDto.class)
-//                .withCluster(cluster)
-//                .withImageSettings(imageSettings)
-//                .replaceInstanceGroups("InstanceGroupWithoutAttachedDisk")
-//                .given(sdxInternal, SdxInternalTestDto.class)
-//                .withStackRequest(key(cluster), key(stack))
-//                .when(sdxTestClient.createInternal(), key(sdxInternal))
-//                .await(SdxClusterStatusResponse.RUNNING)
-//                .when(sdxTestClient.resize(), key(sdxInternal))
-//                .await(SdxClusterStatusResponse.STOP_IN_PROGRESS, key(sdxInternal).withWaitForFlow(Boolean.FALSE))
-//                .await(SdxClusterStatusResponse.STACK_CREATION_IN_PROGRESS, key(sdxInternal).withWaitForFlow(Boolean.FALSE))
-//                .await(SdxClusterStatusResponse.RUNNING, key(sdxInternal).withWaitForFlow(Boolean.FALSE))
-//                .withClusterShape(SdxClusterShape.MEDIUM_DUTY_HA)
-//                .then(SdxUpgradeTestAssertion.validateSuccessfulUpgrade())
-//                .validate();
-//    }
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
+    @Description(
+            given = "there is a running Cloudbreak",
+            when = "start an sdx cluster without attached disk on gateway, but disk attachment is supported on cloud provider side",
+            then = "Upgrade option should be presented"
+    )
+    public void testSdxUpgradeAfterResize(MockedTestContext testContext) {
+        String upgradeImageCatalogName = resourcePropertyProvider().getName();
+        createImageCatalogForOsUpgrade(testContext, upgradeImageCatalogName);
+        String sdxInternal = resourcePropertyProvider().getName();
+        String stack = resourcePropertyProvider().getName();
+        String cluster = "cmcluster";
+        String imageSettings = "imageSettingsUpgrade";
+        String networkKey = "someOtherNetwork";
+
+        testContext
+                .given(networkKey, EnvironmentNetworkTestDto.class)
+                .withMock(new EnvironmentNetworkMockParams())
+                .given(EnvironmentTestDto.class)
+                .withNetwork(networkKey)
+                .withCreateFreeIpa(Boolean.TRUE)
+                .withName(resourcePropertyProvider().getEnvironmentName())
+                .withBackup("location/of/the/backup")
+                .when(getEnvironmentTestClient().create())
+                .await(EnvironmentStatus.AVAILABLE)
+                .given(FreeIpaTestDto.class)
+                .when(freeIpaTestClient.create())
+                .await(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)
+                .given(cluster, ClusterTestDto.class)
+                .given(imageSettings, ImageSettingsTestDto.class)
+                .withImageId("aaa778fc-7f17-4535-9021-515351df3691")
+                .withImageCatalog(upgradeImageCatalogName)
+                .given("NoAttachedDisksTemplate", InstanceTemplateV4TestDto.class)
+                .withAttachedVolume(testContext.init(VolumeV4TestDto.class).withCount(0))
+                .given("InstanceGroupWithoutAttachedDisk", InstanceGroupTestDto.class)
+                .withHostGroup(HostGroupType.MASTER)
+                .withTemplate("NoAttachedDisksTemplate")
+                .given(stack, StackTestDto.class)
+                .withCluster(cluster)
+                .withImageSettings(imageSettings)
+                .replaceInstanceGroups("InstanceGroupWithoutAttachedDisk")
+                .given(sdxInternal, SdxInternalTestDto.class)
+                .withStackRequest(key(cluster), key(stack))
+                .when(sdxTestClient.createInternal(), key(sdxInternal))
+                .await(SdxClusterStatusResponse.RUNNING)
+                .when(sdxTestClient.resize(), key(sdxInternal))
+                .await(SdxClusterStatusResponse.STOP_IN_PROGRESS, key(sdxInternal).withWaitForFlow(Boolean.FALSE))
+                .await(SdxClusterStatusResponse.STACK_CREATION_IN_PROGRESS, key(sdxInternal).withWaitForFlow(Boolean.FALSE))
+                .await(SdxClusterStatusResponse.RUNNING, key(sdxInternal).withWaitForFlow(Boolean.FALSE))
+                .withClusterShape(SdxClusterShape.MEDIUM_DUTY_HA)
+                .then(SdxUpgradeTestAssertion.validateSuccessfulUpgrade())
+                .validate();
+    }
 
     protected ImageCatalogTestDto createImageCatalogForOsUpgrade(MockedTestContext testContext, String name) {
         return testContext

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/ResourceAwait.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/ResourceAwait.java
@@ -21,7 +21,7 @@ public class ResourceAwait {
     private static final Logger LOGGER = LoggerFactory.getLogger(ResourceAwait.class);
 
     public <E extends Enum<E>> CloudbreakTestDto await(CloudbreakTestDto entity, Map<String, E> desiredStatuses, Set<E> ignoredFailedStatuses,
-            TestContext testContext, RunningParameter runningParameter, Duration pollingInterval, int maxRetry) {
+            TestContext testContext, RunningParameter runningParameter, Duration pollingInterval, int maxRetry, int maxRetryCount) {
         try {
             if (entity == null) {
                 throw new RuntimeException("Cloudbreak key has been provided but no result in resource map!");
@@ -32,12 +32,12 @@ public class ResourceAwait {
             String name = entity.getName();
             WaitObject waitObject = client.waitObject(entity, name, desiredStatuses, testContext, ignoredFailedStatuses);
             if (waitObject.isDeletionCheck()) {
-                client.waiterService().waitObject(new WaitTerminationChecker<>(), waitObject, testContext, pollingInterval, maxRetry, 1);
+                client.waiterService().waitObject(new WaitTerminationChecker<>(), waitObject, testContext, pollingInterval, maxRetry, maxRetryCount);
             } else if (waitObject.isFailedCheck()) {
-                client.waiterService().waitObject(new WaitFailedChecker<>(), waitObject, testContext, pollingInterval, maxRetry, 1);
+                client.waiterService().waitObject(new WaitFailedChecker<>(), waitObject, testContext, pollingInterval, maxRetry, maxRetryCount);
                 entity.refresh();
             } else {
-                client.waiterService().waitObject(new WaitOperationChecker<>(), waitObject, testContext, pollingInterval, maxRetry, 1);
+                client.waiterService().waitObject(new WaitOperationChecker<>(), waitObject, testContext, pollingInterval, maxRetry, maxRetryCount);
                 entity.refresh();
             }
         } catch (Exception e) {


### PR DESCRIPTION
**Root cause:** While performing DL resize there will be a brief period of time where there will not be any DL for a given environment.
This could result in a 404 error when the tests are polling for the status of the datalake for a sort interval.

Made necessary changes to test framework to perform retries when there are failures. Even these retries would be limited by the total timeout that is configured.