### PR TITLE
Revert "CB-15182 Update E2E tests to configure the instance group net…

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/FetchPreferredSubnetForInstanceNetworkIfMultiAzEnabledAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/FetchPreferredSubnetForInstanceNetworkIfMultiAzEnabledAction.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.it.cloudbreak.action.v1.distrox;
+
+import java.util.ArrayList;
+
+import com.sequenceiq.distrox.api.v1.distrox.model.network.InstanceGroupNetworkV1Request;
+import com.sequenceiq.distrox.api.v1.distrox.model.network.aws.InstanceGroupAwsNetworkV1Parameters;
+import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
+import com.sequenceiq.it.cloudbreak.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.EnvironmentClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
+
+public class FetchPreferredSubnetForInstanceNetworkIfMultiAzEnabledAction implements Action<DistroXTestDto, CloudbreakClient> {
+
+    @Override
+    public DistroXTestDto action(TestContext testContext, DistroXTestDto testDto, CloudbreakClient client) throws Exception {
+        if ("AWS_NATIVE".equals(testDto.getRequest().getVariant())) {
+            EnvironmentClient envClient = testContext.getMicroserviceClient(EnvironmentClient.class);
+            DetailedEnvironmentResponse envResponse = envClient.getDefaultClient()
+                    .environmentV1Endpoint()
+                    .getByName(testDto.getRequest().getEnvironmentName());
+            InstanceGroupNetworkV1Request instanceGroupNetworkV1Request = new InstanceGroupNetworkV1Request();
+            InstanceGroupAwsNetworkV1Parameters awsNetworkV1Parameters = new InstanceGroupAwsNetworkV1Parameters();
+            awsNetworkV1Parameters.setSubnetIds(new ArrayList<>(envResponse.getNetwork().getPreferedSubnetIds()));
+            instanceGroupNetworkV1Request.setAws(awsNetworkV1Parameters);
+            testDto.getRequest().getInstanceGroups().forEach(s -> s.setNetwork(instanceGroupNetworkV1Request));
+        }
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/DistroXTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/DistroXTestClient.java
@@ -22,6 +22,7 @@ import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXShowBlueprintAction
 import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXStartAction;
 import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXStopAction;
 import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXUpgradeAction;
+import com.sequenceiq.it.cloudbreak.action.v1.distrox.FetchPreferredSubnetForInstanceNetworkIfMultiAzEnabledAction;
 import com.sequenceiq.it.cloudbreak.action.v4.util.RenewDistroXCertificateAction;
 import com.sequenceiq.it.cloudbreak.cloud.HostGroupType;
 import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
@@ -33,6 +34,10 @@ public class DistroXTestClient {
 
     public Action<DistroXTestDto, CloudbreakClient> create() {
         return new DistroXCreateAction();
+    }
+
+    public Action<DistroXTestDto, CloudbreakClient> fetchPreferredSubnetForInstanceNetworkIfMultiAzEnabled() {
+        return new FetchPreferredSubnetForInstanceNetworkIfMultiAzEnabledAction();
     }
 
     public Action<DistroXTestDto, CloudbreakClient> createInternal() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDto.java
@@ -47,7 +47,6 @@ import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
 import com.sequenceiq.it.cloudbreak.dto.clustertemplate.ClusterTemplateTestDto;
 import com.sequenceiq.it.cloudbreak.dto.distrox.cluster.DistroXUpgradeTestDto;
-import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.exception.TestFailException;
 import com.sequenceiq.it.cloudbreak.search.Searchable;
 import com.sequenceiq.it.cloudbreak.util.AuditUtil;
@@ -78,12 +77,7 @@ public class DistroXTestDto extends DistroXTestDtoBase<DistroXTestDto> implement
 
     @Override
     public DistroXTestDtoBase<DistroXTestDto> valid() {
-        DistroXTestDtoBase<DistroXTestDto> valid = super.valid();
-        EnvironmentTestDto environmentTestDto = getTestContext().get(EnvironmentTestDto.class);
-        if (environmentTestDto != null && environmentTestDto.getResponse() != null) {
-            valid.withEnvironmentName(environmentTestDto.getName());
-        }
-        return valid;
+        return super.valid().withEnvironment();
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDtoBase.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDtoBase.java
@@ -1,23 +1,15 @@
 package com.sequenceiq.it.cloudbreak.dto.distrox;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import org.apache.commons.lang3.StringUtils;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 import com.sequenceiq.distrox.api.v1.distrox.model.AwsDistroXV1Parameters;
 import com.sequenceiq.distrox.api.v1.distrox.model.AzureDistroXV1Parameters;
 import com.sequenceiq.distrox.api.v1.distrox.model.DistroXV1Request;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.InstanceGroupV1Request;
-import com.sequenceiq.distrox.api.v1.distrox.model.network.InstanceGroupNetworkV1Request;
-import com.sequenceiq.distrox.api.v1.distrox.model.network.aws.InstanceGroupAwsNetworkV1Parameters;
 import com.sequenceiq.distrox.api.v1.distrox.model.sharedservice.SdxV1Request;
-import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
-import com.sequenceiq.it.cloudbreak.EnvironmentClient;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
 import com.sequenceiq.it.cloudbreak.dto.distrox.cluster.DistroXClusterTestDto;
@@ -27,7 +19,6 @@ import com.sequenceiq.it.cloudbreak.dto.distrox.instancegroup.DistroXInstanceGro
 import com.sequenceiq.it.cloudbreak.dto.distrox.instancegroup.DistroXNetworkTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
-import com.sequenceiq.it.cloudbreak.exception.TestFailException;
 
 public class DistroXTestDtoBase<T extends DistroXTestDtoBase> extends AbstractCloudbreakTestDto<DistroXV1Request, StackV4Response, T> {
 
@@ -58,13 +49,11 @@ public class DistroXTestDtoBase<T extends DistroXTestDtoBase> extends AbstractCl
 
     public DistroXTestDtoBase<T> withEnvironmentKey(String environmentKey) {
         EnvironmentTestDto env = getTestContext().get(environmentKey);
-        if (env == null) {
-            throw new IllegalArgumentException("Env is null with given key: " + environmentKey);
+        DistroXTestDtoBase<T> ret = this;
+        if (env != null && env.getResponse() != null) {
+            ret = withEnvironmentName(env.getResponse().getName());
         }
-        if (env.getResponse() == null) {
-            throw new IllegalArgumentException("Env response is null with given key: " + environmentKey);
-        }
-        return withEnvironmentName(env.getResponse().getName());
+        return ret;
     }
 
     public DistroXTestDtoBase<T> withName(String name) {
@@ -171,33 +160,4 @@ public class DistroXTestDtoBase<T extends DistroXTestDtoBase> extends AbstractCl
         getRequest().setExternalDatabase(externalDatabaseDto.getRequest());
         return this;
     }
-
-    public DistroXTestDtoBase<T> withPreferredSubnetsForInstanceNetworkIfMultiAzEnabledOrJustFirst() {
-        if (StringUtils.isEmpty(getRequest().getEnvironmentName())) {
-            throw new TestFailException("Cannot fetch the preferred subnet without env name, please add it");
-        }
-        try {
-            EnvironmentClient envClient = getTestContext().getMicroserviceClient(EnvironmentClient.class);
-            DetailedEnvironmentResponse envResponse = envClient.getDefaultClient()
-                    .environmentV1Endpoint()
-                    .getByName(getRequest().getEnvironmentName());
-            InstanceGroupNetworkV1Request instanceGroupNetworkV1Request = new InstanceGroupNetworkV1Request();
-            InstanceGroupAwsNetworkV1Parameters awsNetworkV1Parameters = new InstanceGroupAwsNetworkV1Parameters();
-            if ("AWS_NATIVE".equals(getRequest().getVariant())) {
-                awsNetworkV1Parameters.setSubnetIds(new ArrayList<>(envResponse.getNetwork().getPreferedSubnetIds()));
-            } else {
-                String preferredSubnetId = envResponse.getNetwork().getPreferedSubnetIds().stream()
-                        .filter(s -> !s.equals(envResponse.getNetwork().getPreferedSubnetId()))
-                        .findFirst().get();
-                awsNetworkV1Parameters.setSubnetIds(List.of(preferredSubnetId));
-            }
-            instanceGroupNetworkV1Request.setAws(awsNetworkV1Parameters);
-            getRequest().getInstanceGroups().forEach(s -> s.setNetwork(instanceGroupNetworkV1Request));
-        } catch (Exception e) {
-            String message = "Cannot fetch preferred subnets from " + getRequest().getEnvironmentName();
-            throw new TestFailException(message, e);
-        }
-        return this;
-    }
-
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXRepairTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXRepairTests.java
@@ -55,7 +55,7 @@ public class DistroXRepairTests extends AbstractE2ETest {
 
         testContext
                 .given(distrox, DistroXTestDto.class)
-                .withPreferredSubnetsForInstanceNetworkIfMultiAzEnabledOrJustFirst()
+                .when(distroXTestClient.fetchPreferredSubnetForInstanceNetworkIfMultiAzEnabled())
                 .when(distroXTestClient.create(), key(distrox))
                 .await(STACK_AVAILABLE)
                 .awaitForHealthyInstances()

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXUpgradeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXUpgradeTests.java
@@ -61,7 +61,7 @@ public class DistroXUpgradeTests extends AbstractE2ETest {
         testContext
                 .given(distroXName, DistroXTestDto.class)
                 .withTemplate(String.format(commonClusterManagerProperties.getInternalDistroXBlueprintType(), currentRuntimeVersion))
-                .withPreferredSubnetsForInstanceNetworkIfMultiAzEnabledOrJustFirst()
+                .when(distroXTestClient.fetchPreferredSubnetForInstanceNetworkIfMultiAzEnabled())
                 .when(distroXTestClient.create(), key(distroXName))
                 .await(STACK_AVAILABLE)
                 .awaitForHealthyInstances()


### PR DESCRIPTION
…work for the not multi-az compatible clusters"

This reverts commit e1da83af0234ebf2b66b166122baca5adc51e194.

See detailed description in the commit message.