### PR TITLE
CB-12322 we are ensuring with swagger compatibility tests that we are…

### DIFF
--- a/common-model/src/main/java/com/sequenceiq/common/api/util/versionchecker/ClientVersionUtil.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/util/versionchecker/ClientVersionUtil.java
@@ -20,7 +20,7 @@ public class ClientVersionUtil {
             }
             String[] serverParts = removeStartingV(server).split("\\.");
             String[] clientParts = removeStartingV(client).split("\\.");
-            if (serverParts[0].equals(clientParts[0]) && serverParts[1].equals(clientParts[1])) {
+            if (serverParts[0].equals(clientParts[0])) {
                 return true;
             }
         } catch (ArrayIndexOutOfBoundsException | NullPointerException ignore) {

--- a/common-model/src/test/java/com/sequenceiq/common/api/util/versionchecker/ClientVersionUtilTest.java
+++ b/common-model/src/test/java/com/sequenceiq/common/api/util/versionchecker/ClientVersionUtilTest.java
@@ -7,49 +7,43 @@ import org.junit.jupiter.api.Test;
 class ClientVersionUtilTest {
     @Test
     void checkVersionOk() {
-        boolean result = ClientVersionUtil.checkVersion("2.4.0-dev.250", "2.4.0-rc.14");
+        boolean result = ClientVersionUtil.checkVersion("2.4.0-b250", "2.4.0-b14");
         Assertions.assertTrue(result);
     }
 
     @Test
-    void checkVersionOkWithV() {
-        boolean result = ClientVersionUtil.checkVersion("2.4.0-dev.250", "v2.4.0-rc.14");
+    void checkVersionOkMinorDifference() {
+        boolean result = ClientVersionUtil.checkVersion("2.50.0-b250", "2.4.0-b14");
         Assertions.assertTrue(result);
     }
 
     @Test
-    void checkVersionNok() {
-        boolean result = ClientVersionUtil.checkVersion("2.5.0-dev.250", "2.4.0-rc.14");
-        Assertions.assertFalse(result);
-    }
-
-    @Test
-    void checkVersionNokTooShort() {
-        boolean result = ClientVersionUtil.checkVersion("2", "2.4.0-rc.14");
+    void checkVersionNokMajorDifference() {
+        boolean result = ClientVersionUtil.checkVersion("3.5.0-b250", "2.4.0-b14");
         Assertions.assertFalse(result);
     }
 
     @Test
     void checkVersionNokUndefined() {
-        boolean result = ClientVersionUtil.checkVersion("undefined", "2.4.0-rc.14");
+        boolean result = ClientVersionUtil.checkVersion("undefined", "2.4.0-b14");
         Assertions.assertFalse(result);
     }
 
     @Test
     void checkVersionNokEmpty() {
-        boolean result = ClientVersionUtil.checkVersion("", "2.4.0-rc.14");
+        boolean result = ClientVersionUtil.checkVersion("", "2.4.0-b14");
         Assertions.assertFalse(result);
     }
 
     @Test
     void checkVersionNokNull() {
-        boolean result = ClientVersionUtil.checkVersion(null, "2.4.0-rc.14");
+        boolean result = ClientVersionUtil.checkVersion(null, "2.4.0-b14");
         Assertions.assertFalse(result);
     }
 
     @Test
     void checkVersionOkSnapshotGoesThrough() {
-        boolean result = ClientVersionUtil.checkVersion("2.5.0-dev.250", "snapshot-2.4.0-rc.14");
+        boolean result = ClientVersionUtil.checkVersion("2.5.0-b250", "snapshot-2021-03-11T09:42:59");
         Assertions.assertTrue(result);
     }
 }


### PR DESCRIPTION
… fully backward compatible, therefore forcefully breaking the CLI in every two weeks (in every minor release) is not justified. Starting from this commit the version check will verify the major version only for compatibility change.

See detailed description in the commit message.