### PR TITLE
CB-15397: Add FMS API for listing prior clusters

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
@@ -91,6 +91,22 @@ public interface FreeIpaV1Endpoint {
     DescribeFreeIpaResponse describeInternal(@QueryParam("environment") String environmentCrn, @QueryParam("accountId") @AccountId String accountId);
 
     @GET
+    @Path("/all")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = FreeIpaOperationDescriptions.GET_ALL_BY_ENVID, produces = MediaType.APPLICATION_JSON, notes = FreeIpaNotes.FREEIPA_NOTES,
+            nickname = "getAllFreeIpaByEnvironmentV1")
+    List<DescribeFreeIpaResponse> describeAll(@QueryParam("environment") @NotEmpty String environmentCrn);
+
+    @GET
+    @Path("internal/all")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = FreeIpaOperationDescriptions.INTERNAL_GET_ALL_BY_ENVID, produces = MediaType.APPLICATION_JSON, notes = FreeIpaNotes.FREEIPA_NOTES,
+            nickname = "internalGetAllFreeIpaByEnvironmentV1")
+    List<DescribeFreeIpaResponse> describeAllInternal(
+            @QueryParam("environment") String environmentCrn,
+            @QueryParam("accountId") @AccountId String accountId);
+
+    @GET
     @Path("/list")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = FreeIpaOperationDescriptions.LIST_BY_ACCOUNT, produces = MediaType.APPLICATION_JSON, notes = FreeIpaNotes.FREEIPA_NOTES,

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaOperationDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaOperationDescriptions.java
@@ -5,6 +5,8 @@ public final class FreeIpaOperationDescriptions {
     public static final String REGISTER_CHILD_ENVIRONMENT = "Register a child environment";
     public static final String DEREGISTER_CHILD_ENVIRONMENT = "Deregister a child environment";
     public static final String GET_BY_ENVID = "Get FreeIPA stack by envid";
+    public static final String GET_ALL_BY_ENVID = "Get all FreeIPA stacks by envid";
+    public static final String INTERNAL_GET_ALL_BY_ENVID = "Get all FreeIPA stacks by envid";
     public static final String INTERNAL_GET_BY_ENVID_AND_ACCOUNTID = "Get FreeIPA stack by envid and account id";
     public static final String LIST_BY_ACCOUNT = "List all FreeIPA stacks by account";
     public static final String INTERNAL_LIST_BY_ACCOUNT = "List all FreeIPA stacks by account using the internal actor";

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaV1Controller.java
@@ -196,6 +196,19 @@ public class FreeIpaV1Controller implements FreeIpaV1Endpoint {
     }
 
     @Override
+    @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.DESCRIBE_ENVIRONMENT)
+    public List<DescribeFreeIpaResponse> describeAll(@ResourceCrn String environmentCrn) {
+        String accountId = crnService.getCurrentAccountId();
+        return freeIpaDescribeService.describeAll(environmentCrn, accountId);
+    }
+
+    @Override
+    @InternalOnly
+    public List<DescribeFreeIpaResponse> describeAllInternal(@ResourceCrn String environmentCrn, @AccountId String accountId) {
+        return freeIpaDescribeService.describeAll(environmentCrn, accountId);
+    }
+
+    @Override
     @FilterListBasedOnPermissions
     public List<ListFreeIpaResponse> list() {
         return freeIpaFiltering.filterFreeIpas(AuthorizationResourceAction.DESCRIBE_ENVIRONMENT);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/instance/InstanceGroupToInstanceGroupResponseConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/instance/InstanceGroupToInstanceGroupResponseConverter.java
@@ -1,20 +1,21 @@
 package com.sequenceiq.freeipa.converter.instance;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import javax.inject.Inject;
 
-import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupResponse;
 import com.sequenceiq.freeipa.converter.instance.template.TemplateToInstanceTemplateResponseConverter;
 import com.sequenceiq.freeipa.entity.InstanceGroup;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
 
 @Component
-public class InstanceGroupToInstanceGroupResponseConverter implements Converter<InstanceGroup, InstanceGroupResponse> {
+public class InstanceGroupToInstanceGroupResponseConverter {
 
     @Inject
     private TemplateToInstanceTemplateResponseConverter templateResponseConverter;
@@ -28,14 +29,14 @@ public class InstanceGroupToInstanceGroupResponseConverter implements Converter<
     @Inject
     private InstanceMetaDataToInstanceMetaDataResponseConverter metaDataConverter;
 
-    @Override
-    public InstanceGroupResponse convert(InstanceGroup source) {
+    public InstanceGroupResponse convert(InstanceGroup source, Boolean includeAllInstances) {
         InstanceGroupResponse instanceGroupResponse = new InstanceGroupResponse();
         instanceGroupResponse.setName(source.getGroupName());
         if (source.getTemplate() != null) {
             instanceGroupResponse.setInstanceTemplate(templateResponseConverter.convert(source.getTemplate()));
         }
-        instanceGroupResponse.setMetaData(metaDataConverter.convert(source.getNotTerminatedInstanceMetaDataSet()));
+        Set<InstanceMetaData> metaDataSet = includeAllInstances ? source.getInstanceMetaDataSet() : source.getNotTerminatedInstanceMetaDataSet();
+        instanceGroupResponse.setMetaData(metaDataConverter.convert(metaDataSet));
         if (source.getSecurityGroup() != null) {
             instanceGroupResponse.setSecurityGroup(securityGroupConverter.convert(source.getSecurityGroup()));
         }
@@ -47,7 +48,7 @@ public class InstanceGroupToInstanceGroupResponseConverter implements Converter<
         return instanceGroupResponse;
     }
 
-    public List<InstanceGroupResponse> convert(Iterable<InstanceGroup> source) {
-        return StreamSupport.stream(source.spliterator(), false).map(this::convert).collect(Collectors.toList());
+    public List<InstanceGroupResponse> convert(Iterable<InstanceGroup> source, Boolean includeAllInstances) {
+        return StreamSupport.stream(source.spliterator(), false).map(s -> convert(s, includeAllInstances)).collect(Collectors.toList());
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/StackToDescribeFreeIpaResponseConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/StackToDescribeFreeIpaResponseConverter.java
@@ -64,7 +64,7 @@ public class StackToDescribeFreeIpaResponseConverter {
     @Inject
     private StackToAvailabilityStatusConverter stackToAvailabilityStatusConverter;
 
-    public DescribeFreeIpaResponse convert(Stack stack, ImageEntity image, FreeIpa freeIpa, UserSyncStatus userSyncStatus) {
+    public DescribeFreeIpaResponse convert(Stack stack, ImageEntity image, FreeIpa freeIpa, UserSyncStatus userSyncStatus, Boolean includeAllInstances) {
         DescribeFreeIpaResponse describeFreeIpaResponse = new DescribeFreeIpaResponse();
         describeFreeIpaResponse.setName(stack.getName());
         describeFreeIpaResponse.setEnvironmentCrn(stack.getEnvironmentCrn());
@@ -77,7 +77,7 @@ public class StackToDescribeFreeIpaResponseConverter {
         describeFreeIpaResponse.setNetwork(networkResponseConverter.convert(stack));
         describeFreeIpaResponse.setPlacement(convertToPlacementResponse(stack));
         describeFreeIpaResponse.setTunnel(stack.getTunnel());
-        describeFreeIpaResponse.setInstanceGroups(instanceGroupConverter.convert(stack.getInstanceGroups()));
+        describeFreeIpaResponse.setInstanceGroups(instanceGroupConverter.convert(stack.getInstanceGroups(), includeAllInstances));
         describeFreeIpaResponse.setAvailabilityStatus(stackToAvailabilityStatusConverter.convert(stack));
         describeFreeIpaResponse.setStatus(stack.getStackStatus().getStatus());
         describeFreeIpaResponse.setStatusString(stack.getStackStatus().getStatusString());

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/events/FreeIpaCustomCrnOrNameProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/events/FreeIpaCustomCrnOrNameProvider.java
@@ -17,6 +17,6 @@ public class FreeIpaCustomCrnOrNameProvider extends AbstractCustomCrnOrNameProvi
 
     @Override
     protected List<? extends AccountAwareResource> getResource(String environmentCrn, String accountId) {
-        return stackService.getMultipleByEnvironmentCrnAndAccountIdEvenIfTerminated(environmentCrn, accountId);
+        return stackService.findMultipleByEnvironmentCrnAndAccountIdEvenIfTerminated(environmentCrn, accountId);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/repository/ChildEnvironmentRepository.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/repository/ChildEnvironmentRepository.java
@@ -23,6 +23,14 @@ public interface ChildEnvironmentRepository extends CrudRepository<ChildEnvironm
             @Param("childEnvironmentCrn") String childEnvironmentCrn,
             @Param("accountId") String accountId);
 
+    @Query("SELECT c.stack FROM ChildEnvironment c "
+            + "LEFT JOIN FETCH c.stack.instanceGroups ig "
+            + "LEFT JOIN FETCH ig.instanceMetaData "
+            + "WHERE c.environmentCrn = :childEnvironmentCrn AND c.stack.accountId = :accountId")
+    List<Stack> findMultipleParentByEnvironmentCrnEvenIfTerminatedWithList(
+            @Param("childEnvironmentCrn") String childEnvironmentCrn,
+            @Param("accountId") String accountId);
+
     @Query("SELECT c.stack FROM ChildEnvironment c LEFT JOIN FETCH c.stack.instanceGroups ig LEFT JOIN FETCH ig.instanceMetaData "
             + "WHERE c.environmentCrn = :childEnvironmentCrn AND c.stack.accountId = :accountId AND c.stack.resourceCrn = :resourceCrn")
     Optional<Stack> findParentByEnvironmentCrnAndCrnWthListsEvenIfTerminated(

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/repository/StackRepository.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/repository/StackRepository.java
@@ -59,6 +59,14 @@ public interface StackRepository extends AccountAwareResourceRepository<Stack, L
     @Query("SELECT s FROM Stack s WHERE s.accountId = :accountId AND s.environmentCrn = :environmentCrn")
     List<Stack> findMultipleByEnvironmentCrnAndAccountIdEvenIfTerminated(@Param("environmentCrn") String environmentCrn, @Param("accountId") String accountId);
 
+    @Query("SELECT s FROM Stack s "
+            + "LEFT JOIN FETCH s.instanceGroups ig "
+            + "LEFT JOIN FETCH ig.instanceMetaData "
+            + "WHERE s.accountId = :accountId AND s.environmentCrn = :environmentCrn")
+    List<Stack> findMultipleByEnvironmentCrnAndAccountIdEvenIfTerminatedWithList(
+            @Param("environmentCrn") String environmentCrn,
+            @Param("accountId") String accountId);
+
     @Query("SELECT s FROM Stack s LEFT JOIN ChildEnvironment c ON c.stack.id = s.id WHERE s.accountId = :accountId "
             + "AND (s.environmentCrn IN :environmentCrns OR c.environmentCrn IN :environmentCrns) AND s.terminated = -1")
     List<Stack> findMultipleByEnvironmentCrnOrChildEnvironmentCrnAndAccountId(

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/ChildEnvironmentService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/ChildEnvironmentService.java
@@ -40,6 +40,10 @@ public class ChildEnvironmentService {
         return repository.findMultipleParentByEnvironmentCrnEvenIfTerminated(environmentCrn, accountId);
     }
 
+    public List<Stack> findMultipleParentStackByChildEnvironmentCrnEvenIfTerminatedWithList(String environmentCrn, String accountId) {
+        return repository.findMultipleParentByEnvironmentCrnEvenIfTerminatedWithList(environmentCrn, accountId);
+    }
+
     public Optional<Stack> findParentStackByChildEnvironmentCrnAndCrnWithListsEvenIfTerminated(String environmentCrn, String accountId, String crn) {
         return repository.findParentByEnvironmentCrnAndCrnWthListsEvenIfTerminated(environmentCrn, accountId, crn);
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaCreationService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaCreationService.java
@@ -168,7 +168,7 @@ public class FreeIpaCreationService {
                     new StackEvent(FlowChainTriggers.PROVISION_TRIGGER_EVENT, stackImageFreeIpaTuple.getLeft().getId()));
             InMemoryStateStore.putStack(stack.getId(), PollGroup.POLLABLE);
             return stackToDescribeFreeIpaResponseConverter
-                    .convert(stackImageFreeIpaTuple.getLeft(), stackImageFreeIpaTuple.getMiddle(), stackImageFreeIpaTuple.getRight(), null);
+                    .convert(stackImageFreeIpaTuple.getLeft(), stackImageFreeIpaTuple.getMiddle(), stackImageFreeIpaTuple.getRight(), null, false);
         } catch (TransactionService.TransactionExecutionException e) {
             LOGGER.error("Creation of FreeIPA failed", e);
             throw new BadRequestException("Creation of FreeIPA failed: " + e.getCause().getMessage(), e);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
@@ -101,18 +101,18 @@ public class StackService implements ResourcePropertyProvider {
                 .or(() -> childEnvironmentService.findParentStackByChildEnvironmentCrnAndCrnWithListsEvenIfTerminated(environmentCrn, accountId, crn));
     }
 
-    public List<Stack> getMultipleByEnvironmentCrnAndAccountIdEvenIfTerminated(String environmentCrn, String accountId) {
-        List<Stack> stacks = findMultipleByEnvironmentCrnAndAccountIdEvenIfTerminated(environmentCrn, accountId);
-        if (stacks.isEmpty()) {
-                throw new NotFoundException(String.format("FreeIPA stack by environment [%s] not found", environmentCrn));
-        }
-        return stacks;
-    }
-
     public List<Stack> findMultipleByEnvironmentCrnAndAccountIdEvenIfTerminated(String environmentCrn, String accountId) {
         List<Stack> stacks = stackRepository.findMultipleByEnvironmentCrnAndAccountIdEvenIfTerminated(environmentCrn, accountId);
         if (stacks.isEmpty()) {
             stacks = childEnvironmentService.findMultipleParentStackByChildEnvironmentCrnEvenIfTerminated(environmentCrn, accountId);
+        }
+        return stacks;
+    }
+
+    public List<Stack> findMultipleByEnvironmentCrnAndAccountIdEvenIfTerminatedWithList(String environmentCrn, String accountId) {
+        List<Stack> stacks = stackRepository.findMultipleByEnvironmentCrnAndAccountIdEvenIfTerminatedWithList(environmentCrn, accountId);
+        if (stacks.isEmpty()) {
+            stacks = childEnvironmentService.findMultipleParentStackByChildEnvironmentCrnEvenIfTerminatedWithList(environmentCrn, accountId);
         }
         return stacks;
     }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/controller/FreeIpaV1ControllerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/controller/FreeIpaV1ControllerTest.java
@@ -3,6 +3,7 @@ package com.sequenceiq.freeipa.controller;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -16,7 +17,6 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.rebuild.RebuildRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,9 +30,11 @@ import com.sequenceiq.cloudbreak.validation.ValidationResult;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.FreeIpaServerBase;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.attachchildenv.AttachChildEnvironmentRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.create.CreateFreeIpaRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.describe.DescribeFreeIpaResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.detachchildenv.DetachChildEnvironmentRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.list.ListFreeIpaResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.reboot.RebootInstancesRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.rebuild.RebuildRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.repair.RepairInstancesRequest;
 import com.sequenceiq.freeipa.authorization.FreeIpaFiltering;
 import com.sequenceiq.freeipa.client.FreeIpaClientException;
@@ -165,6 +167,21 @@ class FreeIpaV1ControllerTest {
     @Test
     void describe() {
         assertNull(underTest.describe(ENVIRONMENT_CRN));
+    }
+
+    @Test
+    void describeAll() {
+        List<DescribeFreeIpaResponse> response = List.of(new DescribeFreeIpaResponse());
+        when(describeService.describeAll(anyString(), anyString())).thenReturn(response);
+        assertEquals(response, underTest.describeAll(ENVIRONMENT_CRN));
+    }
+
+    @Test
+    void describeAllInternal() {
+        List<DescribeFreeIpaResponse> response = List.of(new DescribeFreeIpaResponse());
+        when(describeService.describeAll(anyString(), anyString())).thenReturn(response);
+        assertEquals(response, underTest.describeAllInternal(ENVIRONMENT_CRN, ACCOUNT_ID));
+        verify(describeService).describeAll(ENVIRONMENT_CRN, ACCOUNT_ID);
     }
 
     @Test

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/stack/StackToDescribeFreeIpaResponseConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/stack/StackToDescribeFreeIpaResponseConverterTest.java
@@ -132,12 +132,12 @@ class StackToDescribeFreeIpaResponseConverterTest {
         when(authenticationResponseConverter.convert(stack.getStackAuthentication())).thenReturn(STACK_AUTHENTICATION_RESPONSE);
         when(imageSettingsResponseConverter.convert(image)).thenReturn(IMAGE_SETTINGS_RESPONSE);
         when(freeIpaServerResponseConverter.convert(freeIpa)).thenReturn(freeIpaServerResponse);
-        when(instanceGroupConverter.convert(stack.getInstanceGroups())).thenReturn(INSTANCE_GROUP_RESPONSES);
+        when(instanceGroupConverter.convert(stack.getInstanceGroups(), true)).thenReturn(INSTANCE_GROUP_RESPONSES);
         when(userSyncStatusConverter.convert(userSyncStatus)).thenReturn(USERSYNC_STATUS_RESPONSE);
         when(balancedDnsAvailabilityChecker.isBalancedDnsAvailable(stack)).thenReturn(true);
         when(stackToAvailabilityStatusConverter.convert(stack)).thenReturn(AvailabilityStatus.AVAILABLE);
 
-        DescribeFreeIpaResponse result = underTest.convert(stack, image, freeIpa, userSyncStatus);
+        DescribeFreeIpaResponse result = underTest.convert(stack, image, freeIpa, userSyncStatus, true);
 
         assertThat(result)
                 .returns(NAME, DescribeFreeIpaResponse::getName)

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/events/FreeIpaCustomCrnOrNameProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/events/FreeIpaCustomCrnOrNameProviderTest.java
@@ -71,7 +71,7 @@ public class FreeIpaCustomCrnOrNameProviderTest {
         stack.setResourceCrn("stackCrn");
         stack.setId(2922L);
 
-        when(stackService.getMultipleByEnvironmentCrnAndAccountIdEvenIfTerminated("env-crn", "acc")).thenReturn(List.of(stack));
+        when(stackService.findMultipleByEnvironmentCrnAndAccountIdEvenIfTerminated("env-crn", "acc")).thenReturn(List.of(stack));
 
         Map<String, String> restParams = new HashMap<>();
         Map<String, String> expected = ThreadBasedUserCrnProvider.doAs(userCrn, () -> underTest.provide(restCallDetails, null, restParams, "name", "crn"));

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/ChildEnvironmentServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/ChildEnvironmentServiceTest.java
@@ -73,6 +73,16 @@ class ChildEnvironmentServiceTest {
     }
 
     @Test
+    void findMultipleParentStackByChildEnvironmentCrnWithListsEvenIfTerminatedWithLIst() {
+        List<Stack> stackList = List.of(new Stack());
+        when(repository.findMultipleParentByEnvironmentCrnEvenIfTerminatedWithList(ENVIRONMENT_CRN, ACCOUNT_ID)).thenReturn(stackList);
+
+        List<Stack> result = underTest.findMultipleParentStackByChildEnvironmentCrnEvenIfTerminatedWithList(ENVIRONMENT_CRN, ACCOUNT_ID);
+
+        assertEquals(stackList, result);
+    }
+
+    @Test
     void findParentStackByChildEnvironmentCrnAndCrnWithListsEvenIfTerminated() {
         Optional<Stack> stack = Optional.of(new Stack());
         when(repository.findParentByEnvironmentCrnAndCrnWthListsEvenIfTerminated(ENVIRONMENT_CRN, ACCOUNT_ID, FREEIPA_CRN)).thenReturn(stack);

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaDescribeServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaDescribeServiceTest.java
@@ -1,0 +1,86 @@
+package com.sequenceiq.freeipa.service.stack;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.describe.DescribeFreeIpaResponse;
+import com.sequenceiq.freeipa.converter.stack.StackToDescribeFreeIpaResponseConverter;
+import com.sequenceiq.freeipa.entity.FreeIpa;
+import com.sequenceiq.freeipa.entity.ImageEntity;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.entity.StackStatus;
+import com.sequenceiq.freeipa.entity.UserSyncStatus;
+import com.sequenceiq.freeipa.service.freeipa.FreeIpaService;
+import com.sequenceiq.freeipa.service.freeipa.user.UserSyncStatusService;
+import com.sequenceiq.freeipa.service.image.ImageService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FreeIpaDescribeServiceTest {
+
+    private static final String ENVIRONMENT_CRN = "test:environment:crn";
+
+    private static final Long STACK_ID = 1L;
+
+    private static final String STACK_NAME = "stack-name";
+
+    private static final String ACCOUNT_ID = "account:id";
+
+    @InjectMocks
+    private FreeIpaDescribeService underTest;
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private ImageService imageService;
+
+    @Mock
+    private FreeIpaService freeIpaService;
+
+    @Mock
+    private UserSyncStatusService userSyncStatusService;
+
+    @Mock
+    private StackToDescribeFreeIpaResponseConverter stackToDescribeFreeIpaResponseConverter;
+
+    private Stack stack;
+
+    @BeforeEach
+    void setUp() {
+        stack = new Stack();
+        stack.setId(STACK_ID);
+        stack.setName(STACK_NAME);
+        StackStatus stackStatus = new StackStatus();
+        stackStatus.setStatus(Status.AVAILABLE);
+        stack.setStackStatus(stackStatus);
+    }
+
+    @Test
+    void describeAll() {
+        DescribeFreeIpaResponse describeResponse = mock(DescribeFreeIpaResponse.class);
+        ImageEntity image = mock(ImageEntity.class);
+        FreeIpa freeIpa = mock(FreeIpa.class);
+        UserSyncStatus userSyncStatus = mock(UserSyncStatus.class);
+        when(stackService.findMultipleByEnvironmentCrnAndAccountIdEvenIfTerminatedWithList(eq(ENVIRONMENT_CRN), eq(ACCOUNT_ID)))
+                .thenReturn(Collections.singletonList(stack));
+        when(imageService.getByStack(any())).thenReturn(image);
+        when(freeIpaService.findByStackId(any())).thenReturn(freeIpa);
+        when(userSyncStatusService.findByStack(any())).thenReturn(userSyncStatus);
+        when(stackToDescribeFreeIpaResponseConverter.convert(any(), any(), any(), any(), any())).thenReturn(describeResponse);
+
+        assertEquals(List.of(describeResponse), underTest.describeAll(ENVIRONMENT_CRN, ACCOUNT_ID));
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/StackServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/StackServiceTest.java
@@ -208,19 +208,11 @@ class StackServiceTest {
     }
 
     @Test
-    void getMultipleByEnvironmentCrnAndAccountIdEvenIfTerminated() {
-        when(stackRepository.findMultipleByEnvironmentCrnAndAccountIdEvenIfTerminated(ENVIRONMENT_CRN, ACCOUNT_ID)).thenReturn(List.of(stack));
-        List<Stack> results = underTest.getMultipleByEnvironmentCrnAndAccountIdEvenIfTerminated(ENVIRONMENT_CRN, ACCOUNT_ID);
+    void findMultipleByEnvironmentCrnAndAccountIdEvenIfTerminatedWithList() {
+        when(stackRepository.findMultipleByEnvironmentCrnAndAccountIdEvenIfTerminatedWithList(ENVIRONMENT_CRN, ACCOUNT_ID)).thenReturn(List.of(stack));
+        List<Stack> results = underTest.findMultipleByEnvironmentCrnAndAccountIdEvenIfTerminatedWithList(ENVIRONMENT_CRN, ACCOUNT_ID);
 
         assertEquals(List.of(stack), results);
-    }
-
-    @Test
-    void getMultipleByEnvironmentCrnAndAccountIdEvenIfTerminatedThrowsWhenCrnDoesNotExist() {
-        when(stackRepository.findMultipleByEnvironmentCrnAndAccountIdEvenIfTerminated(ENVIRONMENT_CRN, ACCOUNT_ID)).thenReturn(List.of());
-        NotFoundException notFoundException =
-                assertThrows(NotFoundException.class, () -> underTest.getMultipleByEnvironmentCrnAndAccountIdEvenIfTerminated(ENVIRONMENT_CRN, ACCOUNT_ID));
-        assertEquals("FreeIPA stack by environment [" + ENVIRONMENT_CRN + "] not found", notFoundException.getMessage());
     }
 
     @Test


### PR DESCRIPTION
Add new API to list all clusters including prior deleted clusters.
This is useful for obtaining a list of which CRN to use when
rebuilding FreeIPA clusters.

This was tested with unit tests and also with a local deployment of
cloudbreak.

See detailed description in the commit message.