### PR TITLE
CB-15396 Fix TagsUtil applied length restrictions for Azure and AWS

### DIFF
--- a/config/idea/inspections.xml
+++ b/config/idea/inspections.xml
@@ -1,5 +1,5 @@
 <profile version="1.0">
-  <option name="myName" value="Default" />
+  <option name="myName" value="CloudbreakDefault" />
   <inspection_tool class="AbstractClassNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
   <inspection_tool class="AbstractClassNeverImplemented" enabled="true" level="WARNING" enabled_by_default="true" />
   <inspection_tool class="AbstractMethodOverridesAbstractMethod" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -460,7 +460,16 @@
   <inspection_tool class="MultipleTopLevelClassesInFile" enabled="true" level="WARNING" enabled_by_default="true" />
   <inspection_tool class="MultipleTypedDeclaration" enabled="true" level="WARNING" enabled_by_default="true" />
   <inspection_tool class="NakedNotify" enabled="true" level="WARNING" enabled_by_default="true" />
-  <inspection_tool class="NativeMethodNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="NewMethodNamingConvention" enabled="true" level="ERROR" enabled_by_default="true">
+    <extension name="JUnit3MethodNamingConvention" enabled="true" />
+    <extension name="JUnit4MethodNamingConvention" enabled="true" />
+    <extension name="NativeMethodNamingConvention" enabled="true" />
+    <extension name="TestNGMethodNamingConvention" enabled="true">
+      <option name="m_regex" value="[a-z][A-Za-z_\d]*" />
+      <option name="m_minLength" value="4" />
+      <option name="m_maxLength" value="63" />
+    </extension>
+  </inspection_tool>
   <inspection_tool class="NegatedConditional" enabled="true" level="WARNING" enabled_by_default="true">
     <option name="m_ignoreNegatedNullComparison" value="true" />
   </inspection_tool>

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/E2ETestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/E2ETestContext.java
@@ -21,10 +21,7 @@ public class E2ETestContext extends TestContext {
     public <O extends CloudbreakTestDto> O init(Class<O> clss, CloudPlatform cloudPlatform) {
         O bean = super.init(clss, cloudPlatform);
         String testName = getTestMethodName().orElseThrow(TestMethodNameMissingException::new);
-        if  (cloudPlatform == CloudPlatform.GCP) {
-            testName = testName.toLowerCase();
-        }
-        tagsUtil.addTestNameTag(getCloudProvider().getCloudPlatform(), bean, testName);
+        tagsUtil.addTestNameTag(cloudPlatform, bean, testName);
         return bean;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/E2ETestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/E2ETestContext.java
@@ -24,7 +24,7 @@ public class E2ETestContext extends TestContext {
         if  (cloudPlatform == CloudPlatform.GCP) {
             testName = testName.toLowerCase();
         }
-        tagsUtil.addTestNameTag(bean, testName);
+        tagsUtil.addTestNameTag(getCloudProvider().getCloudPlatform(), bean, testName);
         return bean;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/MeasuredTestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/MeasuredTestContext.java
@@ -277,6 +277,11 @@ public class MeasuredTestContext extends MockedTestContext {
     }
 
     @Override
+    public CloudPlatform getCloudPlatform() {
+        return wrappedTestContext.getCloudPlatform();
+    }
+
+    @Override
     protected <T extends CloudbreakTestDto, U extends MicroserviceClient>
     T doAction(T entity, Class<? extends MicroserviceClient> clientClass, Action<T, U> action, String who) throws Exception {
         PerformanceIndicator pi = new PerformanceIndicator(action.getClass().getSimpleName());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
@@ -553,8 +553,8 @@ public abstract class TestContext implements ApplicationContextAware {
      * by `useRealUmsUser(testContext, AuthUserKeys.ACCOUNT_ADMIN)`
      */
     private Optional<String> getRealUMSUserName() {
-        if (Crn.isCrn(getActingUser().getCrn())) {
-            return Optional.of(Objects.requireNonNull(Crn.fromString(getActingUser().getCrn())).getUserId());
+        if (getRealUMSUserCrn().isPresent()) {
+            return Optional.of(getActingUser().getDisplayName());
         }
         return Optional.empty();
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
@@ -678,7 +678,7 @@ public abstract class TestContext implements ApplicationContextAware {
     }
 
     public <O extends CloudbreakTestDto> O init(Class<O> clss) {
-        return init(clss, CloudPlatform.valueOf(commonCloudProperties.getCloudProvider()));
+        return init(clss, getCloudPlatform());
     }
 
     public <O extends CloudbreakTestDto> O init(Class<O> clss, CloudPlatform cloudPlatform) {
@@ -707,7 +707,7 @@ public abstract class TestContext implements ApplicationContextAware {
     }
 
     public <O extends CloudbreakTestDto> O given(String key, Class<O> clss) {
-        return given(key, clss, CloudPlatform.valueOf(commonCloudProperties.getCloudProvider()));
+        return given(key, clss, getCloudPlatform());
     }
 
     public <O extends CloudbreakTestDto> O given(String key, Class<O> clss, CloudPlatform cloudPlatform) {
@@ -1211,6 +1211,10 @@ public abstract class TestContext implements ApplicationContextAware {
 
     public CloudProviderProxy getCloudProvider() {
         return cloudProvider;
+    }
+
+    public CloudPlatform getCloudPlatform() {
+        return CloudPlatform.valueOf(commonCloudProperties.getCloudProvider());
     }
 
     public void waitingFor(Duration duration, String interruptedMessage) {

--- a/integration-test/src/main/java/com/sequenceiq/it/util/TagsUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/util/TagsUtil.java
@@ -16,6 +16,7 @@ import org.testng.asserts.SoftAssert;
 import com.google.common.base.Objects;
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.cloud.gcp.util.GcpLabelUtil;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.common.api.tag.request.TaggableRequest;
 import com.sequenceiq.common.api.tag.response.TaggedResponse;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
@@ -43,18 +44,18 @@ public class TagsUtil {
 
     static final String TEST_NAME_TAG_VALUE_FAILURE_PATTERN = "Test name tag: [%s] value is: [%s] NOT equals [%s] test method name!";
 
-    private static final int GCP_TAG_MAX_LENGTH = 63;
+    private static final int TAGS_MAX_LENGTH = 128;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TagsUtil.class);
 
     @Inject
     private GcpLabelUtil gcpLabelUtil;
 
-    public void addTestNameTag(CloudbreakTestDto testDto, String testName) {
+    public void addTestNameTag(CloudPlatform cloudPlatform, CloudbreakTestDto testDto, String testName) {
         if (testDto instanceof AbstractTestDto) {
             Object request = ((AbstractTestDto<?, ?, ?, ?>) testDto).getRequest();
             if (request instanceof TaggableRequest) {
-                addTags((TaggableRequest) request, TEST_NAME_TAG, testName);
+                addTags(cloudPlatform, (TaggableRequest) request, TEST_NAME_TAG, testName);
             }
         }
     }
@@ -91,45 +92,28 @@ public class TagsUtil {
                     if (StringUtils.isEmpty(tagValue)) {
                         tagValue = response.getTagValue(tag.toLowerCase());
                     }
-                    Log.log(LOGGER, format(" Default tag: [%s] value is: [%s] Not Null! ", tag, tagValue));
-                    softAssert.assertNotNull(tagValue, String.format(MISSING_DEFAULT_TAG, tag));
+                    Log.log(LOGGER, format(" PASSED:: Default tag: [%s] value is: [%s] present! ", tag, tagValue));
+                    softAssert.assertNotNull(tagValue, format(MISSING_DEFAULT_TAG, tag));
                 }
             });
             softAssert.assertAll();
         } catch (NullPointerException e) {
             LOGGER.error("Tag validation is not possible, because of response: {} throws: {}!", response, e.getMessage(), e);
-            throw new TestFailException(String.format(" Tag validation is not possible, because of response: %s", response), e);
+            throw new TestFailException(format(" Tag validation is not possible, because of response: %s", response), e);
         }
     }
 
-    private void addTags(TaggableRequest taggableRequest, String tagKey, String tagValue) {
-        tagKey = applyLengthRestrictions(tagKey);
-        tagValue = applyLengthRestrictions(tagValue);
+    private void addTags(CloudPlatform cloudPlatform, TaggableRequest taggableRequest, String tagKey, String tagValue) {
+        tagKey = applyLengthRestrictions(cloudPlatform, tagKey);
+        tagValue = applyLengthRestrictions(cloudPlatform, tagValue);
         taggableRequest.addTag(tagKey, tagValue);
     }
 
-    private String applyLengthRestrictions(String tag) {
-        if (tag.length() > GCP_TAG_MAX_LENGTH) {
-            tag = tag.substring(0, GCP_TAG_MAX_LENGTH - 1);
+    private String applyLengthRestrictions(CloudPlatform cloudPlatform, String tag) {
+        if (CloudPlatform.GCP.equals(cloudPlatform) || tag.length() > TAGS_MAX_LENGTH) {
+            tag = gcpLabelUtil.transformLabelKeyOrValue(tag);
         }
         return tag;
-    }
-
-    private void validateOwnerTag(TaggedResponse response, String tag, TestContext testContext) {
-        String tagValue = response.getTagValue(tag);
-        if (StringUtils.isNotEmpty(tagValue)) {
-            if (tagValue.equals(testContext.getActingUserName()) || tagValue.equals(sanitize(testContext.getActingUserName()))) {
-                Log.log(LOGGER, format("Default tag: [%s] value is: [%s] equals [%s] acting user name! ", tag, tagValue,
-                        testContext.getActingUserName()));
-            } else if (gcpLabelTransformedValue(tagValue, testContext.getActingUserName())) {
-                Log.log(LOGGER, format("Default tag: [%s] value is: [%s] equals [%s] acting user name transformed to a GCP label value! ", tag,
-                        tagValue, testContext.getActingUserName()));
-            }
-        } else {
-            String message = format(ACTING_USER_NAME_VALUE_FAILURE_PATTERN, tag, tagValue, testContext.getActingUserName());
-            LOGGER.error(message);
-            throw new TestFailException(message);
-        }
     }
 
     private String sanitize(String value) {
@@ -140,46 +124,78 @@ public class TagsUtil {
         return tagValue.equals(gcpLabelUtil.transformLabelKeyOrValue(rawValue));
     }
 
-    private void validateClouderaCreatorResourceNameTag(TaggedResponse response, String tag, TestContext testContext) {
-        Crn actingUserCrn = testContext.getActingUserCrn();
-
+    private void validateOwnerTag(TaggedResponse response, String tag, TestContext testContext) {
         String tagValue = response.getTagValue(tag);
-        if (StringUtils.isEmpty(tagValue)) {
-            tagValue = response.getTagValue(tag.toLowerCase());
-        }
-        if (actingUserCrn != null && gcpLabelTransformedValue(tagValue, actingUserCrn.toString())) {
-            Log.log(LOGGER, format(" Default tag: [%s] value is: [%s] equals [%s] acting user CRN transformed to a GCP label value! ", tag, tagValue,
-                    actingUserCrn));
-        } else {
-            Crn creatorResourceNameTag = Crn.fromString(tagValue);
+        String actingUserName = testContext.getActingUserName();
 
-            if (actingUserCrn != null && creatorResourceNameTag != null && crnEqualsWithoutConsideringPartition(actingUserCrn, creatorResourceNameTag)) {
-                Log.log(LOGGER, format(" Default tag: [%s] value is: [%s] equals [%s] acting user CRN! ", tag, creatorResourceNameTag, actingUserCrn));
+        if (StringUtils.isNotEmpty(tagValue)) {
+            if (tagValue.equals(actingUserName) || tagValue.equals(sanitize(actingUserName))) {
+                Log.log(LOGGER, format(" PASSED:: Default tag: [%s] value: [%s] equals [%s] acting user name! ", tag, tagValue, actingUserName));
+            } else if (gcpLabelTransformedValue(tagValue, actingUserName)) {
+                Log.log(LOGGER, format(" PASSED:: Default tag: [%s] value: [%s] equals [%s] acting user name transformed to a GCP label value! ", tag,
+                        tagValue, actingUserName));
             } else {
-                String message = format(ACTING_USER_CRN_VALUE_FAILURE_PATTERN, tag, creatorResourceNameTag, actingUserCrn);
+                String message = format(ACTING_USER_NAME_VALUE_FAILURE_PATTERN, tag, tagValue, actingUserName);
                 LOGGER.error(message);
                 throw new TestFailException(message);
             }
+        } else {
+            throw new TestFailException(format("[%s] tag validation is not possible, because of the tag value is empty or null!", tag));
+        }
+    }
+
+    private void validateClouderaCreatorResourceNameTag(TaggedResponse response, String tag, TestContext testContext) {
+        String tagValue = response.getTagValue(tag);
+        String actingUser = testContext.getActingUserCrn().toString();
+
+        if (StringUtils.isNotEmpty(tagValue)) {
+            if (tagValue.equals(actingUser)) {
+                Log.log(LOGGER, format(" PASSED:: Default tag: [%s] value: [%s] equals [%s] acting user CRN! ", tag, tagValue, actingUser));
+            } else if (gcpLabelTransformedValue(tagValue, actingUser)) {
+                Log.log(LOGGER, format(" PASSED:: Default tag: [%s] value: [%s] equals [%s] acting user CRN transformed to a GCP label value! ", tag, tagValue,
+                        actingUser));
+            } else {
+                Crn actingUserCrn = java.util.Objects.requireNonNull(Crn.fromString(actingUser));
+                Crn creatorCrn = java.util.Objects.requireNonNull(Crn.fromString(tagValue));
+
+                if (crnEqualsWithoutConsideringPartition(actingUserCrn, creatorCrn)) {
+                    Log.log(LOGGER, format(" PASSED:: Default tag: [%s] value: [%s] equals [%s] acting user CRN partitions! ", tag, creatorCrn,
+                            actingUserCrn));
+                } else {
+                    String message = format(ACTING_USER_CRN_VALUE_FAILURE_PATTERN, tag, tagValue, actingUserCrn);
+                    LOGGER.error(message);
+                    throw new TestFailException(message);
+                }
+            }
+        } else {
+            throw new TestFailException(format("[%s] tag validation is not possible, because of the tag value is empty or null!", tag));
         }
     }
 
     private void validateTestNameTag(TaggedResponse response, TestContext testContext) {
-        String testNameTagValue = response.getTagValue(TEST_NAME_TAG);
-        if (StringUtils.isNotEmpty(testNameTagValue) && testNameTagValue.toLowerCase().equals(testContext.getTestMethodName().get().toLowerCase())) {
-            Log.log(LOGGER, format("Test name tag: [%s] value is: [%s] equals [%s] test method name! ", TEST_NAME_TAG, testNameTagValue,
-                    testContext.getTestMethodName().get()));
+        String tagValue = response.getTagValue(TEST_NAME_TAG);
+        String testName = testContext.getTestMethodName().orElseThrow(() -> new TestFailException("Test method name cannot be found for tag validation!"));
+
+        if (StringUtils.isNotEmpty(tagValue)) {
+            testName = applyLengthRestrictions(testContext.getCloudProvider().getCloudPlatform(), testName);
+
+            if (tagValue.equalsIgnoreCase(testName)) {
+                Log.log(LOGGER, format(" PASSED:: [%s] tag value: [%s] equals [%s] test method name! ", TEST_NAME_TAG, tagValue, testName));
+            } else {
+                String message = format(TEST_NAME_TAG_VALUE_FAILURE_PATTERN, TEST_NAME_TAG, tagValue, testName);
+                LOGGER.error(message);
+                throw new TestFailException(message);
+            }
         } else {
-            String message = format(TEST_NAME_TAG_VALUE_FAILURE_PATTERN, TEST_NAME_TAG, testNameTagValue, testContext.getTestMethodName().get());
-            LOGGER.error(message);
-            throw new TestFailException(message);
+            throw new TestFailException(format("[%s] tag validation is not possible, because of the tag value is empty or null!", TEST_NAME_TAG));
         }
     }
 
-    private boolean crnEqualsWithoutConsideringPartition(Crn actingUserCrn, Crn creatorResourceNameTag) {
-        return Objects.equal(actingUserCrn.getService(), creatorResourceNameTag.getService())
-                && Objects.equal(actingUserCrn.getRegion(), creatorResourceNameTag.getRegion())
-                && Objects.equal(actingUserCrn.getAccountId(), creatorResourceNameTag.getAccountId())
-                && Objects.equal(actingUserCrn.getResourceType(), creatorResourceNameTag.getResourceType())
-                && Objects.equal(actingUserCrn.getResource(), creatorResourceNameTag.getResource());
+    private boolean crnEqualsWithoutConsideringPartition(Crn actingUserCrn, Crn creatorCrn) {
+        return Objects.equal(actingUserCrn.getService(), creatorCrn.getService())
+                && Objects.equal(actingUserCrn.getRegion(), creatorCrn.getRegion())
+                && Objects.equal(actingUserCrn.getAccountId(), creatorCrn.getAccountId())
+                && Objects.equal(actingUserCrn.getResourceType(), creatorCrn.getResourceType())
+                && Objects.equal(actingUserCrn.getResource(), creatorCrn.getResource());
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/util/TagsUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/util/TagsUtil.java
@@ -44,6 +44,8 @@ public class TagsUtil {
 
     static final String TEST_NAME_TAG_VALUE_FAILURE_PATTERN = "Test name tag: [%s] value is: [%s] NOT equals [%s] test method name!";
 
+    static final String TAG_VALUE_IS_NULL_FAILURE_PATTERN = "[%s] tag validation is not possible, because of the tag value is empty or null!";
+
     private static final int TAGS_MAX_LENGTH = 128;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TagsUtil.class);
@@ -54,6 +56,9 @@ public class TagsUtil {
     public void addTestNameTag(CloudPlatform cloudPlatform, CloudbreakTestDto testDto, String testName) {
         if (testDto instanceof AbstractTestDto) {
             Object request = ((AbstractTestDto<?, ?, ?, ?>) testDto).getRequest();
+            if (CloudPlatform.GCP.equals(cloudPlatform)) {
+                testName = testName.toLowerCase();
+            }
             if (request instanceof TaggableRequest) {
                 addTags(cloudPlatform, (TaggableRequest) request, TEST_NAME_TAG, testName);
             }
@@ -140,15 +145,16 @@ public class TagsUtil {
                 throw new TestFailException(message);
             }
         } else {
-            throw new TestFailException(format("[%s] tag validation is not possible, because of the tag value is empty or null!", tag));
+            String message = format(TAG_VALUE_IS_NULL_FAILURE_PATTERN, tag);
+            throw new TestFailException(message);
         }
     }
 
     private void validateClouderaCreatorResourceNameTag(TaggedResponse response, String tag, TestContext testContext) {
         String tagValue = response.getTagValue(tag);
-        String actingUser = testContext.getActingUserCrn().toString();
+        String actingUser = getActingUser(testContext);
 
-        if (StringUtils.isNotEmpty(tagValue)) {
+        if (StringUtils.isNotEmpty(tagValue) && StringUtils.isNotEmpty(actingUser)) {
             if (tagValue.equals(actingUser)) {
                 Log.log(LOGGER, format(" PASSED:: Default tag: [%s] value: [%s] equals [%s] acting user CRN! ", tag, tagValue, actingUser));
             } else if (gcpLabelTransformedValue(tagValue, actingUser)) {
@@ -168,7 +174,8 @@ public class TagsUtil {
                 }
             }
         } else {
-            throw new TestFailException(format("[%s] tag validation is not possible, because of the tag value is empty or null!", tag));
+            throw new TestFailException(format("[%s] tag validation is not possible, because of either the tag value [%s] or acting user Crn [%s]" +
+                            " is empty or null!", tag, tagValue, actingUser));
         }
     }
 
@@ -177,7 +184,7 @@ public class TagsUtil {
         String testName = testContext.getTestMethodName().orElseThrow(() -> new TestFailException("Test method name cannot be found for tag validation!"));
 
         if (StringUtils.isNotEmpty(tagValue)) {
-            testName = applyLengthRestrictions(testContext.getCloudProvider().getCloudPlatform(), testName);
+            testName = applyLengthRestrictions(testContext.getCloudPlatform(), testName);
 
             if (tagValue.equalsIgnoreCase(testName)) {
                 Log.log(LOGGER, format(" PASSED:: [%s] tag value: [%s] equals [%s] test method name! ", TEST_NAME_TAG, tagValue, testName));
@@ -187,7 +194,8 @@ public class TagsUtil {
                 throw new TestFailException(message);
             }
         } else {
-            throw new TestFailException(format("[%s] tag validation is not possible, because of the tag value is empty or null!", TEST_NAME_TAG));
+            String message = format(TAG_VALUE_IS_NULL_FAILURE_PATTERN, TEST_NAME_TAG);
+            throw new TestFailException(message);
         }
     }
 
@@ -197,5 +205,13 @@ public class TagsUtil {
                 && Objects.equal(actingUserCrn.getAccountId(), creatorCrn.getAccountId())
                 && Objects.equal(actingUserCrn.getResourceType(), creatorCrn.getResourceType())
                 && Objects.equal(actingUserCrn.getResource(), creatorCrn.getResource());
+    }
+
+    private String getActingUser(TestContext testContext) {
+        try {
+            return testContext.getActingUserCrn().toString();
+        } catch (NullPointerException e) {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
`test-name` tag value has been limited to 63 characters long in case of every tests. This is not appropriate, because of the Azure tags' keys are limited to 128 characters not 63 and the same is true for AWS as well. Tag key and value length limitation is only required for [GCP cloud labels](https://cloud.google.com/resource-manager/docs/creating-managing-labels#requirements).

One of our E2E test case name was too long: `testEnvironmentWithCustomerManagedKeyAndEncryptionKeyResourceGroupSpecified`, because of this the `test-name` tag validation is failing, because of splitting at 63 character.

So I've introduced a new IDE inspection rule for test method names. Furthermore I've refactored the [TagsUtil](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/src/main/java/com/sequenceiq/it/util/TagsUtil.java) to deal with long keys and values (TestNG test names, machine user crns). 