### PR TITLE
CB-15436 - CVE - Mock containers are still relying on legacy horton b…

### DIFF
--- a/mock-infrastructure/Dockerfile
+++ b/mock-infrastructure/Dockerfile
@@ -1,4 +1,4 @@
-FROM hortonworks/hwx_openjdk:11.0-jdk-slim
+FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.6-cldr1-jdk-slim-buster
 MAINTAINER info@hortonworks.com
 
 # REPO URL to download jar

--- a/mock-thunderhead/Dockerfile
+++ b/mock-thunderhead/Dockerfile
@@ -1,4 +1,4 @@
-FROM hortonworks/hwx_openjdk:11.0-jdk-slim
+FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.6-cldr1-jdk-slim-buster
 MAINTAINER info@hortonworks.com
 
 # REPO URL to download jar


### PR DESCRIPTION
…ase images, therefore this commit updates them to  docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.6-cldr1-jdk-slim-buster which is used in every other Dockerfile.

See detailed description in the commit message.