### PR TITLE
CB-15110 Adapt Kafka configs to multi AZ envs

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/StackToTemplatePreparationObjectConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/StackToTemplatePreparationObjectConverter.java
@@ -394,17 +394,14 @@ public class StackToTemplatePreparationObjectConverter {
 
     private GeneralClusterConfigs calculateGeneralClusterConfigs(Stack source, Cluster cluster) {
         GeneralClusterConfigs generalClusterConfigs = generalClusterConfigsProvider.generalClusterConfigs(source, cluster);
-        List<SdxClusterResponse> clients = sdxClientService.getByEnvironmentCrn(source.getEnvironmentCrn());
-        if (!clients.isEmpty()) {
-            boolean allInstanceGroupsHaveMultiAz = source.getInstanceGroups().stream().allMatch(ig -> {
-                boolean instanceGroupHasMultiAz = ((List<String>) ig.getInstanceGroupNetwork()
-                        .getAttributes()
-                        .getMap()
-                        .getOrDefault(NetworkConstants.SUBNET_IDS, new ArrayList<>())).size() > 1;
-                return instanceGroupHasMultiAz;
-            });
-            generalClusterConfigs.setMultiAzEnabled(allInstanceGroupsHaveMultiAz && clients.get(0).isEnableMultiAz());
-        }
+        boolean allInstanceGroupsHaveMultiAz = source.getInstanceGroups().stream().allMatch(ig -> {
+            boolean instanceGroupHasMultiAz = ((List<String>) ig.getInstanceGroupNetwork()
+                    .getAttributes()
+                    .getMap()
+                    .getOrDefault(NetworkConstants.SUBNET_IDS, new ArrayList<>())).size() > 1;
+            return instanceGroupHasMultiAz;
+        });
+        generalClusterConfigs.setMultiAzEnabled(allInstanceGroupsHaveMultiAz);
         if (source.getPrimaryGatewayInstance() != null) {
             if (StringUtils.isBlank(generalClusterConfigs.getClusterManagerIp())) {
                 String primaryGatewayIp = gatewayConfigService.getPrimaryGatewayIp(source);

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaAuthConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaAuthConfigProvider.java
@@ -17,14 +17,6 @@ import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 @Component
 public class KafkaAuthConfigProvider implements CmTemplateComponentConfigProvider {
 
-    private static final String LDAP_AUTH_URL = "ldap.auth.url";
-
-    private static final String LDAP_AUTH_USER_DN_TEMPLATE = "ldap.auth.user.dn.template";
-
-    private static final String LDAP_AUTH_ENABLE = "ldap.auth.enable";
-
-    private static final String SASL_AUTH_METHOD = "sasl.plain.auth";
-
     @Override
     public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject source) {
         KafkaConfigProviderUtils.KafkaAuthConfigType authType = KafkaConfigProviderUtils.getCdhVersionForStreaming(source).authType();
@@ -43,20 +35,20 @@ public class KafkaAuthConfigProvider implements CmTemplateComponentConfigProvide
 
     private List<ApiClusterTemplateConfig> ldapConfig(LdapView ldapView) {
         List<ApiClusterTemplateConfig> config = generalAuthConfig(ldapView);
-        config.add(config(LDAP_AUTH_ENABLE, "true"));
+        config.add(config(KafkaConfigs.LDAP_AUTH_ENABLE, "true"));
         return config;
     }
 
     private List<ApiClusterTemplateConfig> ldapAndPamConfig(LdapView ldapView) {
         List<ApiClusterTemplateConfig> config = generalAuthConfig(ldapView);
-        config.add(config(SASL_AUTH_METHOD, "PAM"));
+        config.add(config(KafkaConfigs.SASL_AUTH_METHOD, "PAM"));
         return config;
     }
 
     private List<ApiClusterTemplateConfig> generalAuthConfig(LdapView ldapView) {
         return Lists.newArrayList(
-                config(LDAP_AUTH_URL, ldapView.getConnectionURL()),
-                config(LDAP_AUTH_USER_DN_TEMPLATE, ldapView.getUserDnPattern()));
+                config(KafkaConfigs.LDAP_AUTH_URL, ldapView.getConnectionURL()),
+                config(KafkaConfigs.LDAP_AUTH_USER_DN_TEMPLATE, ldapView.getUserDnPattern()));
     }
 
     @Override

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaConfigProviderUtils.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaConfigProviderUtils.java
@@ -53,6 +53,11 @@ public class KafkaConfigProviderUtils {
         }
     }
 
+    static String getCdhVersion(TemplatePreparationObject source) {
+        return source.getBlueprintView().getProcessor().getStackVersion() == null ?
+                "" : source.getBlueprintView().getProcessor().getStackVersion();
+    }
+
     @VisibleForTesting
     static Optional<Integer> getCdhPatchVersion(TemplatePreparationObject source) {
         if (null != source.getProductDetailsView() && null != source.getProductDetailsView().getProducts()) {

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaConfigs.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaConfigs.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka;
+
+public class KafkaConfigs {
+
+    public static final String RANGER_PLUGIN_KAFKA_SERVICE_NAME = "ranger_plugin_kafka_service_name";
+
+    public static final String GENERATED_RANGER_SERVICE_NAME = "{{GENERATED_RANGER_SERVICE_NAME}}";
+
+    static final String DEFAULT_REPLICATION_FACTOR = "default.replication.factor";
+
+    static final String DELEGATION_TOKEN_ENABLE = "delegation.token.enable";
+
+    static final String ENABLE_RACK_AWARENESS = "enable.rack.awareness";
+
+    static final String KAFKA_DECOMMISSION_HOOK_ENABLED = "kafka.decommission.hook.enabled";
+
+    static final String LDAP_AUTH_ENABLE = "ldap.auth.enable";
+
+    static final String LDAP_AUTH_URL = "ldap.auth.url";
+
+    static final String LDAP_AUTH_USER_DN_TEMPLATE = "ldap.auth.user.dn.template";
+
+    static final String PRODUCER_METRICS_ENABLE = "producer.metrics.enable";
+
+    static final String SASL_AUTH_METHOD = "sasl.plain.auth";
+
+    private KafkaConfigs() { }
+}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaDatahubConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaDatahubConfigProvider.java
@@ -1,46 +1,39 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka;
 
+
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_0;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERA_STACK_VERSION_7_2_12;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaConfigProviderUtils.getCdhVersion;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateComponentConfigProvider;
 import org.springframework.stereotype.Component;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
 import com.google.common.collect.Lists;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
-import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateComponentConfigProvider;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 
 @Component
 public class KafkaDatahubConfigProvider implements CmTemplateComponentConfigProvider {
 
-    public static final String RANGER_PLUGIN_KAFKA_SERVICE_NAME = "ranger_plugin_kafka_service_name";
-
-    public static final String GENERATED_RANGER_SERVICE_NAME = "{{GENERATED_RANGER_SERVICE_NAME}}";
-
-    static final String PRODUCER_METRICS_ENABLE = "producer.metrics.enable";
-
-    static final String KAFKA_DECOMMISSION_HOOK_ENABLED = "kafka.decommission.hook.enabled";
-
     @Override
     public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject source) {
         ArrayList<ApiClusterTemplateConfig> configs = Lists.newArrayList();
-        String cdhVersion = source.getBlueprintView().getProcessor().getStackVersion() == null ?
-                "" : source.getBlueprintView().getProcessor().getStackVersion();
+        String cdhVersion = getCdhVersion(source);
         if (!isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERAMANAGER_VERSION_7_2_0)) {
-            configs.add(config(PRODUCER_METRICS_ENABLE, "true"));
+            configs.add(config(KafkaConfigs.PRODUCER_METRICS_ENABLE, "true"));
         }
         if (KafkaConfigProviderUtils.getCdhVersionForStreaming(source).supportsRangerServiceCreation()) {
-            configs.add(config(RANGER_PLUGIN_KAFKA_SERVICE_NAME, GENERATED_RANGER_SERVICE_NAME));
+            configs.add(config(KafkaConfigs.RANGER_PLUGIN_KAFKA_SERVICE_NAME, KafkaConfigs.GENERATED_RANGER_SERVICE_NAME));
         }
         if (isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERA_STACK_VERSION_7_2_12)) {
-            configs.add(config(KAFKA_DECOMMISSION_HOOK_ENABLED, "true"));
+            configs.add(config(KafkaConfigs.KAFKA_DECOMMISSION_HOOK_ENABLED, "true"));
         }
         return configs;
     }

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaDelegationTokenConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaDelegationTokenConfigProvider.java
@@ -14,13 +14,11 @@ import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 @Component
 public class KafkaDelegationTokenConfigProvider implements CmTemplateComponentConfigProvider {
 
-    private static final String CONFIG_NAME = "delegation.token.enable";
-
     private static final String CONFIG_VALUE = "true";
 
     @Override
     public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject source) {
-        return List.of(config(CONFIG_NAME, CONFIG_VALUE));
+        return List.of(config(KafkaConfigs.DELEGATION_TOKEN_ENABLE, CONFIG_VALUE));
     }
 
     @Override

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaMultiAzConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaMultiAzConfigProvider.java
@@ -1,0 +1,60 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.google.common.collect.Lists;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRoleConfigProvider;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERA_STACK_VERSION_7_2_14;
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaConfigProviderUtils.getCdhVersion;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaConfigs.DEFAULT_REPLICATION_FACTOR;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaConfigs.ENABLE_RACK_AWARENESS;
+
+@Component
+public class KafkaMultiAzConfigProvider extends AbstractRoleConfigProvider {
+
+    @Override
+    public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject source) {
+        ArrayList<ApiClusterTemplateConfig> configs = Lists.newArrayList();
+        String cdhVersion = getCdhVersion(source);
+        if (isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERA_STACK_VERSION_7_2_14)) {
+            configs.add(config(DEFAULT_REPLICATION_FACTOR, "3"));
+        }
+        return configs;
+    }
+
+    @Override
+    protected List<ApiClusterTemplateConfig> getRoleConfigs(String roleType, TemplatePreparationObject source) {
+        ArrayList<ApiClusterTemplateConfig> configs = Lists.newArrayList();
+        String cdhVersion = getCdhVersion(source);
+        if (isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERA_STACK_VERSION_7_2_14)) {
+            configs.add(config(ENABLE_RACK_AWARENESS, "true"));
+            return configs;
+        }
+        return List.of();
+    }
+
+    @Override
+    public List<String> getRoleTypes() {
+        return List.of(KafkaRoles.KAFKA_BROKER);
+    }
+
+    @Override
+    public String getServiceType() {
+        return KafkaRoles.KAFKA_SERVICE;
+    }
+
+    @Override
+    public boolean isConfigurationNeeded(CmTemplateProcessor cmTemplateProcessor, TemplatePreparationObject source) {
+        return (StackType.DATALAKE.equals(source.getStackType()) || StackType.WORKLOAD.equals(source.getStackType()))
+                && source.getGeneralClusterConfigs().isMultiAzEnabled();
+    }
+}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/schemaregistry/SchemaRegistryServiceConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/schemaregistry/SchemaRegistryServiceConfigProvider.java
@@ -3,7 +3,7 @@ package com.sequenceiq.cloudbreak.cmtemplate.configproviders.schemaregistry;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_0;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
-import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaDatahubConfigProvider.GENERATED_RANGER_SERVICE_NAME;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaConfigs.GENERATED_RANGER_SERVICE_NAME;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.schemaregistry.StreamingAppRdsRoleConfigProviderUtil.dataBaseTypeForCM;
 import static java.util.Collections.emptyList;
 

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/general/GeneralClusterConfigsProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/general/GeneralClusterConfigsProvider.java
@@ -19,8 +19,6 @@ public class GeneralClusterConfigsProvider {
 
     public static final String KAFKA_BROKER = "KAFKA_BROKER";
 
-    private static final int DEFAULT_REPLICATION_FACTOR = 3;
-
     private static final String PENDING_DEFAULT_VALUE = "pending...";
 
     public GeneralClusterConfigs generalClusterConfigs(Stack stack, Cluster cluster) {

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaDatahubConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaDatahubConfigProviderTest.java
@@ -2,10 +2,10 @@ package com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka;
 
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaConfigProviderUtilsTest.cdhParcelVersion;
-import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaDatahubConfigProvider.GENERATED_RANGER_SERVICE_NAME;
-import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaDatahubConfigProvider.PRODUCER_METRICS_ENABLE;
-import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaDatahubConfigProvider.RANGER_PLUGIN_KAFKA_SERVICE_NAME;
-import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaDatahubConfigProvider.KAFKA_DECOMMISSION_HOOK_ENABLED;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaConfigs.GENERATED_RANGER_SERVICE_NAME;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaConfigs.PRODUCER_METRICS_ENABLE;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaConfigs.RANGER_PLUGIN_KAFKA_SERVICE_NAME;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaConfigs.KAFKA_DECOMMISSION_HOOK_ENABLED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaMultiAzConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaMultiAzConfigProviderTest.java
@@ -1,0 +1,107 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.cloudbreak.template.model.GeneralClusterConfigs;
+import com.sequenceiq.cloudbreak.template.views.BlueprintView;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaConfigProviderUtilsTest.cdhParcelVersion;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaConfigs.DEFAULT_REPLICATION_FACTOR;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaConfigs.ENABLE_RACK_AWARENESS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class KafkaMultiAzConfigProviderTest {
+
+    private static final Set<ApiClusterTemplateConfig> SERVICE_CONFIG_WITH_KAFKA_7_2_14 = Set.of(
+            config(DEFAULT_REPLICATION_FACTOR, "3"));
+
+    private static final Set<ApiClusterTemplateConfig> ROLE_CONFIG_WITH_KAFKA_7_2_14 = Set.of(
+            config(ENABLE_RACK_AWARENESS, "true"));
+
+    @Mock
+    private CmTemplateProcessor cmTemplateProcessor;
+
+    @Mock
+    private BlueprintView blueprintView;
+
+    private KafkaMultiAzConfigProvider configProviderUnderTest;
+
+    @BeforeEach
+    void setUp() {
+        configProviderUnderTest = new KafkaMultiAzConfigProvider();
+    }
+
+    @ParameterizedTest
+    @MethodSource("testArgsForGetServiceConfigs")
+    void getServiceConfigs(String cdhMainVersion, String cdhParcelVersion, Collection<ApiClusterTemplateConfig> expectedConfigs) {
+        when(blueprintView.getProcessor()).thenReturn(cmTemplateProcessor);
+        when(cmTemplateProcessor.getStackVersion()).thenReturn(cdhMainVersion);
+        TemplatePreparationObject tpo = templatePreparationObject(StackType.DATALAKE, cdhParcelVersion);
+        List<ApiClusterTemplateConfig> serviceConfigs = configProviderUnderTest.getServiceConfigs(cmTemplateProcessor, tpo);
+        assertThat(serviceConfigs).as("Expected configs for cdh version: %s / %s", cdhMainVersion, cdhParcelVersion).hasSameElementsAs(expectedConfigs);
+    }
+
+    @ParameterizedTest
+    @MethodSource("testArgsForGetRoleConfigs")
+    void getRoleConfigs(String cdhMainVersion, String cdhParcelVersion, Collection<ApiClusterTemplateConfig> expectedConfigs) {
+        when(blueprintView.getProcessor()).thenReturn(cmTemplateProcessor);
+        when(cmTemplateProcessor.getStackVersion()).thenReturn(cdhMainVersion);
+        TemplatePreparationObject tpo = templatePreparationObject(StackType.DATALAKE, cdhParcelVersion);
+        List<ApiClusterTemplateConfig> serviceConfigs = configProviderUnderTest.getRoleConfigs(KafkaRoles.KAFKA_BROKER, tpo);
+        assertThat(serviceConfigs).as("Expected configs for cdh version: %s / %s", cdhMainVersion, cdhParcelVersion).hasSameElementsAs(expectedConfigs);
+    }
+
+    static Stream<Arguments> testArgsForGetServiceConfigs() {
+        return Stream.of(
+                Arguments.of("7.2.14", cdhParcelVersion("7.2.14", 0), SERVICE_CONFIG_WITH_KAFKA_7_2_14));
+    }
+
+    static Stream<Arguments> testArgsForGetRoleConfigs() {
+        return Stream.of(
+                Arguments.of("7.2.14", cdhParcelVersion("7.2.14", 0), ROLE_CONFIG_WITH_KAFKA_7_2_14));
+    }
+
+    @ParameterizedTest
+    @EnumSource(StackType.class)
+    void isConfigurationNeeded(StackType stackType) {
+        TemplatePreparationObject tpo = templatePreparationObject(stackType, null);
+        boolean expectedIsNeeded = stackType == StackType.DATALAKE || stackType == StackType.WORKLOAD;
+        assertThat(configProviderUnderTest.isConfigurationNeeded(null, tpo))
+                .as("Configuration should %sbe needed for stack type %s", expectedIsNeeded ? "" : "NOT ", stackType)
+                .isEqualTo(expectedIsNeeded);
+    }
+
+    private TemplatePreparationObject templatePreparationObject(StackType stackType, String cdhVersion) {
+        GeneralClusterConfigs configs = new GeneralClusterConfigs();
+        configs.setMultiAzEnabled(true);
+        TemplatePreparationObject.Builder builder = TemplatePreparationObject.Builder.builder()
+                .withBlueprintView(blueprintView)
+                .withStackType(stackType)
+                .withGeneralClusterConfigs(configs);
+        if (cdhVersion != null) {
+            List<ClouderaManagerProduct> products = KafkaConfigProviderUtilsTest.products("CDH=" + cdhVersion);
+            builder.withProductDetails(new ClouderaManagerRepo(), products);
+        }
+        return builder.build();
+    }
+}

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/schemaregistry/SchemaRegistryServiceConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/schemaregistry/SchemaRegistryServiceConfigProviderTest.java
@@ -1,7 +1,7 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.schemaregistry;
 
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
-import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaDatahubConfigProvider.GENERATED_RANGER_SERVICE_NAME;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaConfigs.GENERATED_RANGER_SERVICE_NAME;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.schemaregistry.SchemaRegistryServiceConfigProvider.RANGER_PLUGIN_SR_SERVICE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/model/GeneralClusterConfigs.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/model/GeneralClusterConfigs.java
@@ -47,6 +47,8 @@ public class GeneralClusterConfigs {
 
     private boolean enableRangerRaz;
 
+    private boolean multiAzEnabled;
+
     private Optional<String> loadBalancerGatewayFqdn = Optional.empty();
 
     private Optional<String> accountId = Optional.empty();
@@ -225,5 +227,13 @@ public class GeneralClusterConfigs {
 
     public void setAccountId(Optional<String> accountId) {
         this.accountId = accountId;
+    }
+
+    public boolean isMultiAzEnabled() {
+        return multiAzEnabled;
+    }
+
+    public void setMultiAzEnabled(boolean multiAzEnabled) {
+        this.multiAzEnabled = multiAzEnabled;
     }
 }


### PR DESCRIPTION
To make the multi AZ feature working well we need to change a few
Kafka configs in datalakes where the multi AZ feature is enabled
and also in Data Hubs.

1) We will enable rack awareness by setting the
   enable.rack.awareness CM config to true.
2) To make topics resilient we will set the default.replication.factor
   to 3 to increase some topics' replication factor which are created
   using the default replication factor. This will also make sure that
   users by default create resilient topics.

The change will create a new config provider called
KafkaMultiAzConfigProvider that covers any config changes needed on
Kafka.
It will also introduce the multiAzEnabled field and isMultiAzEnabled
method to GeneralClusterConfigs so that the newly created config
provider is able to detect if it is needed to be applied.

See detailed description in the commit message.