### PR TITLE
CB-15394 Data Hub upgrade candidates will only check for existing pre…

### DIFF
--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/CsdLocationFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/CsdLocationFilterTest.java
@@ -68,10 +68,10 @@ public class CsdLocationFilterTest {
     }
 
     @Test
-    public void testFilterImageShouldReturnFalseWhenTheImageDoesNotContainsCsdFromTheStackRelatedParcels() {
+    public void testFilterImageShouldReturnTrueWhenTheImageDoesNotContainsCsdFromTheStackRelatedParcels() {
         List<String> preWarmCsd = List.of(ARCHIVE_URL);
         Image image = createImage(preWarmCsd);
-        assertFalse(underTest.filterImage(image, null, createImageFilterParams(Map.of("spark", ""))));
+        assertTrue(underTest.filterImage(image, null, createImageFilterParams(Map.of("spark", ""))));
     }
 
     @Test
@@ -96,10 +96,10 @@ public class CsdLocationFilterTest {
     }
 
     @Test
-    public void testFilterImageShouldReturnFalseWhenThereAreNoCsdAvailableForAllRequiresParcels() {
+    public void testFilterImageShouldReturnTrueWhenThereAreNoCsdAvailableForAllRequiresParcels() {
         List<String> preWarmCsd = List.of(ARCHIVE_URL);
         Image image = createImage(preWarmCsd);
-        assertFalse(underTest.filterImage(image, null, createImageFilterParams(Map.of("parcel1", "", "spark", ""))));
+        assertTrue(underTest.filterImage(image, null, createImageFilterParams(Map.of("parcel1", "", "spark", ""))));
     }
 
     private Image createImage(List<String> preWarmCsd) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/PreWarmParcelLocationFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/PreWarmParcelLocationFilterTest.java
@@ -55,6 +55,13 @@ public class PreWarmParcelLocationFilterTest {
     }
 
     @Test
+    public void testFilterImageShouldReturnTrueWhenSomePreWarmParcelsListElementsAreNull() {
+        List<List<String>> preWarmParcels = List.of(Arrays.asList("parcel1", ARCHIVE_URL), Arrays.asList(null, null));
+        Image image = createImage(preWarmParcels);
+        assertTrue(underTest.filterImage(image, null, createImageFilterParams(Map.of("parcel1", "", "parcel2", ""))));
+    }
+
+    @Test
     public void testFilterImageShouldReturnFalseWhenThePreWarmParcelsListElementsAreNull() {
         List<List<String>> preWarmParcels = List.of(Arrays.asList("parcel1", null), Arrays.asList(null, null));
         Image image = createImage(preWarmParcels);
@@ -76,10 +83,10 @@ public class PreWarmParcelLocationFilterTest {
     }
 
     @Test
-    public void testFilterImageShouldReturnFalseWhenThePreWarmParcelsAreNotEligibleForUpgrade() {
+    public void testFilterImageShouldReturnTrueWhenThePreWarmParcelsAreNotEligibleForUpgrade() {
         List<List<String>> preWarmParcels = List.of(List.of("parcel", RANDOM_URL));
         Image image = createImage(preWarmParcels);
-        assertFalse(underTest.filterImage(image, null, createImageFilterParams(Map.of("parcel1", "", "parcel2", ""))));
+        assertTrue(underTest.filterImage(image, null, createImageFilterParams(Map.of("parcel1", "", "parcel2", ""))));
     }
 
     @Test
@@ -90,10 +97,10 @@ public class PreWarmParcelLocationFilterTest {
     }
 
     @Test
-    public void testFilterImageShouldReturnFalseWhenTheImageDoesNotContainsPreWarmParcelFromTheStackRelatedParcels() {
+    public void testFilterImageShouldReturnTrueWhenTheImageDoesNotContainsPreWarmParcelFromTheStackRelatedParcels() {
         List<List<String>> preWarmParcels = List.of(List.of("parcel1", RANDOM_URL), List.of("parcel2", ARCHIVE_URL));
         Image image = createImage(preWarmParcels);
-        assertFalse(underTest.filterImage(image, null, createImageFilterParams(Map.of("spark", ""))));
+        assertTrue(underTest.filterImage(image, null, createImageFilterParams(Map.of("spark", ""))));
     }
 
     @Test
@@ -118,10 +125,10 @@ public class PreWarmParcelLocationFilterTest {
     }
 
     @Test
-    public void testFilterImageShouldReturnFalseWhenThereAreNoPreWarmParcelAvailableForAllRequiresParcels() {
+    public void testFilterImageShouldReturnTrueWhenThereAreNoPreWarmParcelAvailableForAllRequiresParcels() {
         List<List<String>> preWarmParcels = List.of(List.of("parcel", ARCHIVE_URL));
         Image image = createImage(preWarmParcels);
-        assertFalse(underTest.filterImage(image, null, createImageFilterParams(Map.of("parcel", "", "spark", ""))));
+        assertTrue(underTest.filterImage(image, null, createImageFilterParams(Map.of("parcel", "", "spark", ""))));
     }
 
     private Image createImage(List<List<String>> preWarmParcels) {


### PR DESCRIPTION
…-warm parcels and CSDs

Prior to this change, all the required pre-warm parcels and CSDs must exist on the target
image as well with a correct archive.cloudera.com URL. However, in recent CDP releases some of
the services have been moved to different parcels, like Spark -> CDH and Profiler -> CDH. This
resulted that the new releases were not showing up as upgrade candidates as we expected that the
Spark parcel is still available on the new image. To fix this from now on we will only check the
URL if it's available on the image. This means the following scenarios on a 7.2.11 -> 7.2.12 upgrade:

- Spark parcel is present on the 7.2.12 image, but with a non-archive URL -> image will be filtered
- Spark parcel is present on the 7.2.12 image with archive URL -> image will be shown as a valid candidate
- Spark parcel is missing on the 7.2.12 image -> image will be shown as a valid candidate

The same rules apply to the pre-warm CSDs as well, that we only validate the URLs if they are present on
the target image.

