### PR TITLE
CB-15425 Improve AWS Disk Encryption test with external parameters

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/AbstractCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/AbstractCloudProvider.java
@@ -25,6 +25,7 @@ import com.sequenceiq.it.cloudbreak.dto.ClusterTestDto;
 import com.sequenceiq.it.cloudbreak.dto.ImageSettingsTestDto;
 import com.sequenceiq.it.cloudbreak.dto.PlacementSettingsTestDto;
 import com.sequenceiq.it.cloudbreak.dto.SubnetId;
+import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDtoBase;
 import com.sequenceiq.it.cloudbreak.dto.distrox.cluster.DistroXClusterTestDto;
 import com.sequenceiq.it.cloudbreak.dto.distrox.image.DistroXImageTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentAuthenticationTestDto;
@@ -107,6 +108,16 @@ public abstract class AbstractCloudProvider implements CloudProvider {
     @Override
     public EnvironmentTestDto withResourceGroup(EnvironmentTestDto environmentTestDto, String resourceGroupUsage, String resourceGroupName) {
         return environmentTestDto;
+    }
+
+    @Override
+    public EnvironmentTestDto withResourceEncryption(EnvironmentTestDto environmentTestDto) {
+        return environmentTestDto;
+    }
+
+    @Override
+    public DistroXTestDtoBase withResourceEncryption(DistroXTestDtoBase distroXTestDtoBase) {
+        return distroXTestDtoBase;
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProvider.java
@@ -100,6 +100,10 @@ public interface CloudProvider {
 
     EnvironmentTestDto withResourceGroup(EnvironmentTestDto environmentTestDto, String resourceGroupUsage, String resourceGroupName);
 
+    EnvironmentTestDto withResourceEncryption(EnvironmentTestDto environmentTestDto);
+
+    DistroXTestDtoBase withResourceEncryption(DistroXTestDtoBase distroXTestDtoBase);
+
     StackTestDtoBase stack(StackTestDtoBase stack);
 
     ClusterTestDto cluster(ClusterTestDto cluster);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProviderProxy.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProviderProxy.java
@@ -244,6 +244,16 @@ public class CloudProviderProxy implements CloudProvider {
     }
 
     @Override
+    public EnvironmentTestDto withResourceEncryption(EnvironmentTestDto environmentTestDto) {
+        return delegate.withResourceEncryption(environmentTestDto);
+    }
+
+    @Override
+    public DistroXTestDtoBase withResourceEncryption(DistroXTestDtoBase distroXTestDtoBase) {
+        return delegate.withResourceEncryption(distroXTestDtoBase);
+    }
+
+    @Override
     public String getSubnetCIDR() {
         return delegate.getSubnetCIDR();
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProvider.java
@@ -37,6 +37,7 @@ import com.sequenceiq.environment.api.v1.credential.model.parameters.aws.KeyBase
 import com.sequenceiq.environment.api.v1.credential.model.parameters.aws.RoleBasedParameters;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkAwsParams;
 import com.sequenceiq.environment.api.v1.environment.model.request.AttachedFreeIpaRequest;
+import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsDiskEncryptionParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsEnvironmentParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsFreeIpaParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsFreeIpaSpotParameters;
@@ -513,5 +514,25 @@ public class AwsCloudProvider extends AbstractCloudProvider {
     @Override
     public String getFreeIpaUpgradeImageCatalog() {
         return awsProperties.getFreeipa().getUpgrade().getCatalog();
+    }
+
+    @Override
+    public EnvironmentTestDto withResourceEncryption(EnvironmentTestDto environmentTestDto) {
+        return environmentTestDto.withAws(AwsEnvironmentParameters.builder()
+                .withAwsDiskEncryptionParameters(AwsDiskEncryptionParameters.builder()
+                        .withEncryptionKeyArn(getEncryptionKeyArn(true))
+                        .build())
+                .build());
+    }
+
+    @Override
+    public DistroXTestDtoBase withResourceEncryption(DistroXTestDtoBase distroXTestDtoBase) {
+        return distroXTestDtoBase;
+    }
+
+    public String getEncryptionKeyArn(boolean environmentEncryption) {
+        return environmentEncryption
+                ? awsProperties.getDiskEncryption().getEnvironmentKey()
+                : awsProperties.getDiskEncryption().getDatahubKey();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsProperties.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsProperties.java
@@ -27,8 +27,6 @@ public class AwsProperties {
 
     private Boolean multiaz;
 
-    private String diskEncryptionKey;
-
     private final Instance instance = new Instance();
 
     private final Instance storageOptimizedInstance = new Instance();
@@ -38,6 +36,8 @@ public class AwsProperties {
     private final Baseimage baseimage = new Baseimage();
 
     private final Cloudstorage cloudstorage = new Cloudstorage();
+
+    private final DiskEncryption diskEncryption = new DiskEncryption();
 
     private FreeIpaProperties freeipa = new FreeIpaProperties();
 
@@ -63,14 +63,6 @@ public class AwsProperties {
 
     public void setRegion(String region) {
         this.region = region;
-    }
-
-    public String getDiskEncryptionKey() {
-        return diskEncryptionKey;
-    }
-
-    public void setDiskEncryptionKey(String diskEncryptionKey) {
-        this.diskEncryptionKey = diskEncryptionKey;
     }
 
     public Boolean getMultiaz() {
@@ -134,6 +126,10 @@ public class AwsProperties {
 
     public Cloudstorage getCloudStorage() {
         return cloudstorage;
+    }
+
+    public DiskEncryption getDiskEncryption() {
+        return diskEncryption;
     }
 
     public String getDynamoTableName() {
@@ -289,6 +285,29 @@ public class AwsProperties {
             public void setInstanceProfile(String instanceProfile) {
                 this.instanceProfile = instanceProfile;
             }
+        }
+    }
+
+    public static class DiskEncryption {
+
+        private String environmentKey;
+
+        private String datahubKey;
+
+        public String getEnvironmentKey() {
+            return environmentKey;
+        }
+
+        public void setEnvironmentKey(String environmentKey) {
+            this.environmentKey = environmentKey;
+        }
+
+        public String getDatahubKey() {
+            return datahubKey;
+        }
+
+        public void setDatahubKey(String datahubKey) {
+            this.datahubKey = datahubKey;
         }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
@@ -32,6 +32,7 @@ import com.sequenceiq.environment.api.v1.credential.model.parameters.azure.AppBa
 import com.sequenceiq.environment.api.v1.credential.model.parameters.azure.AzureCredentialRequestParameters;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkAzureParams;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureEnvironmentParameters;
+import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureResourceEncryptionParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureResourceGroup;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.ResourceGroupUsage;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.AzureNetworkParameters;
@@ -471,5 +472,32 @@ public class AzureCloudProvider extends AbstractCloudProvider {
     @Override
     public String getFreeIpaUpgradeImageCatalog() {
         return azureProperties.getFreeipa().getUpgrade().getCatalog();
+    }
+
+    @Override
+    public EnvironmentTestDto withResourceEncryption(EnvironmentTestDto environmentTestDto) {
+        return environmentTestDto.withAzure(AzureEnvironmentParameters.builder()
+                .withResourceEncryptionParameters(AzureResourceEncryptionParameters.builder()
+                        .withEncryptionKeyResourceGroupName(getEncryptionResourceGroupName(true))
+                        .withEncryptionKeyUrl(getEncryptionKeyUrl(true))
+                        .build())
+                .build());
+    }
+
+    @Override
+    public DistroXTestDtoBase withResourceEncryption(DistroXTestDtoBase distroXTestDtoBase) {
+        return distroXTestDtoBase;
+    }
+
+    public String getEncryptionResourceGroupName(boolean environmentEncryption) {
+        return environmentEncryption
+                ? azureProperties.getDiskEncryption().getEnvironmentKey().getResourceGroupName()
+                : azureProperties.getDiskEncryption().getDatahubKey().getResourceGroupName();
+    }
+
+    public String getEncryptionKeyUrl(boolean environmentEncryption) {
+        return environmentEncryption
+                ? azureProperties.getDiskEncryption().getEnvironmentKey().getEncryptionKeyUrl()
+                : azureProperties.getDiskEncryption().getDatahubKey().getEncryptionKeyUrl();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
@@ -478,8 +478,8 @@ public class AzureCloudProvider extends AbstractCloudProvider {
     public EnvironmentTestDto withResourceEncryption(EnvironmentTestDto environmentTestDto) {
         return environmentTestDto.withAzure(AzureEnvironmentParameters.builder()
                 .withResourceEncryptionParameters(AzureResourceEncryptionParameters.builder()
-                        .withEncryptionKeyResourceGroupName(getEncryptionResourceGroupName(true))
-                        .withEncryptionKeyUrl(getEncryptionKeyUrl(true))
+                        .withEncryptionKeyResourceGroupName(getEncryptionResourceGroupName())
+                        .withEncryptionKeyUrl(getEncryptionKeyUrl())
                         .build())
                 .build());
     }
@@ -489,15 +489,11 @@ public class AzureCloudProvider extends AbstractCloudProvider {
         return distroXTestDtoBase;
     }
 
-    public String getEncryptionResourceGroupName(boolean environmentEncryption) {
-        return environmentEncryption
-                ? azureProperties.getDiskEncryption().getEnvironmentKey().getResourceGroupName()
-                : azureProperties.getDiskEncryption().getDatahubKey().getResourceGroupName();
+    public String getEncryptionResourceGroupName() {
+        return azureProperties.getDiskEncryption().getResourceGroupName();
     }
 
-    public String getEncryptionKeyUrl(boolean environmentEncryption) {
-        return environmentEncryption
-                ? azureProperties.getDiskEncryption().getEnvironmentKey().getEncryptionKeyUrl()
-                : azureProperties.getDiskEncryption().getDatahubKey().getEncryptionKeyUrl();
+    public String getEncryptionKeyUrl() {
+        return azureProperties.getDiskEncryption().getEncryptionKeyUrl();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureProperties.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureProperties.java
@@ -335,62 +335,24 @@ public class AzureProperties {
 
     public static class DiskEncription {
 
-        private final EnvironmentKey environmentKey = new EnvironmentKey();
+        private String encryptionKeyUrl;
 
-        private final DatahubKey datahubKey = new DatahubKey();
+        private String resourceGroupName;
 
-        public EnvironmentKey getEnvironmentKey() {
-            return environmentKey;
-        }
-
-        public DatahubKey getDatahubKey() {
-            return datahubKey;
-        }
-
-        public static class EnvironmentKey {
-
-            private String encryptionKeyUrl;
-
-            private String resourceGroupName;
-
-            public String getEncryptionKeyUrl() {
+        public String getEncryptionKeyUrl() {
                 return encryptionKeyUrl;
             }
 
-            public void setEncryptionKeyUrl(String encryptionKeyUrl) {
+        public void setEncryptionKeyUrl(String encryptionKeyUrl) {
                 this.encryptionKeyUrl = encryptionKeyUrl;
             }
 
-            public String getResourceGroupName() {
+        public String getResourceGroupName() {
                 return resourceGroupName;
             }
 
-            public void setResourceGroupName(String resourceGroupName) {
+        public void setResourceGroupName(String resourceGroupName) {
                 this.resourceGroupName = resourceGroupName;
             }
-        }
-
-        public static class DatahubKey {
-
-            private String encryptionKeyUrl;
-
-            private String resourceGroupName;
-
-            public String getEncryptionKeyUrl() {
-                return encryptionKeyUrl;
-            }
-
-            public void setEncryptionKeyUrl(String encryptionKeyUrl) {
-                this.encryptionKeyUrl = encryptionKeyUrl;
-            }
-
-            public String getResourceGroupName() {
-                return resourceGroupName;
-            }
-
-            public void setResourceGroupName(String resourceGroupName) {
-                this.resourceGroupName = resourceGroupName;
-            }
-        }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureProperties.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureProperties.java
@@ -29,6 +29,8 @@ public class AzureProperties {
 
     private final Network network = new Network();
 
+    private final DiskEncription diskEncryption = new DiskEncription();
+
     private FreeIpaProperties freeipa = new FreeIpaProperties();
 
     public FreeIpaProperties getFreeipa() {
@@ -85,6 +87,10 @@ public class AzureProperties {
 
     public Network getNetwork() {
         return network;
+    }
+
+    public DiskEncription getDiskEncryption() {
+        return diskEncryption;
     }
 
     public static class Credential {
@@ -324,6 +330,67 @@ public class AzureProperties {
 
         public void setNoPublicIp(Boolean noPublicIp) {
             this.noPublicIp = noPublicIp;
+        }
+    }
+
+    public static class DiskEncription {
+
+        private final EnvironmentKey environmentKey = new EnvironmentKey();
+
+        private final DatahubKey datahubKey = new DatahubKey();
+
+        public EnvironmentKey getEnvironmentKey() {
+            return environmentKey;
+        }
+
+        public DatahubKey getDatahubKey() {
+            return datahubKey;
+        }
+
+        public static class EnvironmentKey {
+
+            private String encryptionKeyUrl;
+
+            private String resourceGroupName;
+
+            public String getEncryptionKeyUrl() {
+                return encryptionKeyUrl;
+            }
+
+            public void setEncryptionKeyUrl(String encryptionKeyUrl) {
+                this.encryptionKeyUrl = encryptionKeyUrl;
+            }
+
+            public String getResourceGroupName() {
+                return resourceGroupName;
+            }
+
+            public void setResourceGroupName(String resourceGroupName) {
+                this.resourceGroupName = resourceGroupName;
+            }
+        }
+
+        public static class DatahubKey {
+
+            private String encryptionKeyUrl;
+
+            private String resourceGroupName;
+
+            public String getEncryptionKeyUrl() {
+                return encryptionKeyUrl;
+            }
+
+            public void setEncryptionKeyUrl(String encryptionKeyUrl) {
+                this.encryptionKeyUrl = encryptionKeyUrl;
+            }
+
+            public String getResourceGroupName() {
+                return resourceGroupName;
+            }
+
+            public void setResourceGroupName(String resourceGroupName) {
+                this.resourceGroupName = resourceGroupName;
+            }
         }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpCloudProvider.java
@@ -30,6 +30,8 @@ import com.sequenceiq.environment.api.v1.credential.model.parameters.gcp.JsonPar
 import com.sequenceiq.environment.api.v1.credential.model.parameters.gcp.P12Parameters;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkGcpParams;
 import com.sequenceiq.environment.api.v1.environment.model.request.SecurityAccessRequest;
+import com.sequenceiq.environment.api.v1.environment.model.request.gcp.GcpEnvironmentParameters;
+import com.sequenceiq.environment.api.v1.environment.model.request.gcp.GcpResourceEncryptionParameters;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.GcpNetworkParameters;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.NetworkRequest;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
@@ -487,5 +489,25 @@ public class GcpCloudProvider extends AbstractCloudProvider {
     @Override
     public String getFreeIpaUpgradeImageCatalog() {
         return gcpProperties.getFreeipa().getUpgrade().getCatalog();
+    }
+
+    @Override
+    public EnvironmentTestDto withResourceEncryption(EnvironmentTestDto environmentTestDto) {
+        return environmentTestDto.withGcp(GcpEnvironmentParameters.builder()
+                .withResourceEncryptionParameters(GcpResourceEncryptionParameters.builder()
+                        .withEncryptionKey(getEncryptionKey(true))
+                        .build())
+                .build());
+    }
+
+    @Override
+    public DistroXTestDtoBase withResourceEncryption(DistroXTestDtoBase distroXTestDtoBase) {
+        return distroXTestDtoBase;
+    }
+
+    public String getEncryptionKey(boolean environmentEncryption) {
+        return environmentEncryption
+                ? gcpProperties.getDiskEncryption().getEnvironmentKey()
+                : gcpProperties.getDiskEncryption().getDatahubKey();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpProperties.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpProperties.java
@@ -31,6 +31,8 @@ public class GcpProperties {
 
     private final Network network = new Network();
 
+    private final DiskEncryption diskEncryption = new DiskEncryption();
+
     private FreeIpaProperties freeipa = new FreeIpaProperties();
 
     public FreeIpaProperties getFreeipa() {
@@ -98,6 +100,10 @@ public class GcpProperties {
 
     public Network getNetwork() {
         return network;
+    }
+
+    public DiskEncryption getDiskEncryption() {
+        return diskEncryption;
     }
 
     public static class Baseimage {
@@ -370,6 +376,29 @@ public class GcpProperties {
             public void setServiceAccountEmail(String serviceAccountEmail) {
                 this.serviceAccountEmail = serviceAccountEmail;
             }
+        }
+    }
+
+    public static class DiskEncryption {
+
+        private String environmentKey;
+
+        private String datahubKey;
+
+        public String getEnvironmentKey() {
+            return environmentKey;
+        }
+
+        public void setEnvironmentKey(String environmentKey) {
+            this.environmentKey = environmentKey;
+        }
+
+        public String getDatahubKey() {
+            return datahubKey;
+        }
+
+        public void setDatahubKey(String datahubKey) {
+            this.datahubKey = datahubKey;
         }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/mock/MockCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/mock/MockCloudProvider.java
@@ -48,6 +48,7 @@ import com.sequenceiq.it.cloudbreak.dto.distrox.instancegroup.DistroXNetworkTest
 import com.sequenceiq.it.cloudbreak.dto.distrox.instancegroup.DistroXRootVolumeTestDto;
 import com.sequenceiq.it.cloudbreak.dto.distrox.instancegroup.DistroXVolumeTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentNetworkTestDto;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCloudStorageTestDto;
@@ -435,5 +436,15 @@ public class MockCloudProvider extends AbstractCloudProvider {
         params.setInternetGatewayId(getInternetGatewayId());
         params.setVpcId(getVpcId());
         return params;
+    }
+
+    @Override
+    public EnvironmentTestDto withResourceEncryption(EnvironmentTestDto environmentTestDto) {
+        return environmentTestDto;
+    }
+
+    @Override
+    public DistroXTestDtoBase withResourceEncryption(DistroXTestDtoBase distroXTestDtoBase) {
+        return distroXTestDtoBase;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/mock/MockProperties.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/mock/MockProperties.java
@@ -32,6 +32,8 @@ public class MockProperties {
 
     private final Cloudstorage cloudstorage = new Cloudstorage();
 
+    private final DiskEncryption diskEncryption = new DiskEncryption();
+
     public String getAvailabilityZone() {
         return availabilityZone;
     }
@@ -94,6 +96,10 @@ public class MockProperties {
 
     public Cloudstorage getCloudStorage() {
         return cloudstorage;
+    }
+
+    public DiskEncryption getDiskEncryption() {
+        return diskEncryption;
     }
 
     public String getInternetGateway() {
@@ -313,6 +319,29 @@ public class MockProperties {
             public void setInstanceProfile(String instanceProfile) {
                 this.instanceProfile = instanceProfile;
             }
+        }
+    }
+
+    public static class DiskEncryption {
+
+        private String environmentKey;
+
+        private String datahubKey;
+
+        public String getEnvironmentKey() {
+            return environmentKey;
+        }
+
+        public void setEnvironmentKey(String environmentKey) {
+            this.environmentKey = environmentKey;
+        }
+
+        public String getDatahubKey() {
+            return datahubKey;
+        }
+
+        public void setDatahubKey(String datahubKey) {
+            this.datahubKey = datahubKey;
         }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/yarn/YarnCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/yarn/YarnCloudProvider.java
@@ -310,4 +310,14 @@ public class YarnCloudProvider extends AbstractCloudProvider {
     public String getInstanceProfile() {
         return null;
     }
+
+    @Override
+    public EnvironmentTestDto withResourceEncryption(EnvironmentTestDto environmentTestDto) {
+        return environmentTestDto;
+    }
+
+    @Override
+    public DistroXTestDtoBase withResourceEncryption(DistroXTestDtoBase distroXTestDtoBase) {
+        return distroXTestDtoBase;
+    }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/yarn/YarnProperties.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/yarn/YarnProperties.java
@@ -23,6 +23,8 @@ public class YarnProperties {
 
     private final Baseimage baseimage = new Baseimage();
 
+    private final DiskEncryption diskEncryption = new DiskEncryption();
+
     public String getAvailabilityZone() {
         return availabilityZone;
     }
@@ -73,6 +75,10 @@ public class YarnProperties {
 
     public Baseimage getBaseimage() {
         return baseimage;
+    }
+
+    public DiskEncryption getDiskEncryption() {
+        return diskEncryption;
     }
 
     public static class Credential {
@@ -148,6 +154,29 @@ public class YarnProperties {
 
         public void setImageId(String imageId) {
             this.imageId = imageId;
+        }
+    }
+
+    public static class DiskEncryption {
+
+        private String environmentKey;
+
+        private String datahubKey;
+
+        public String getEnvironmentKey() {
+            return environmentKey;
+        }
+
+        public void setEnvironmentKey(String environmentKey) {
+            this.environmentKey = environmentKey;
+        }
+
+        public String getDatahubKey() {
+            return datahubKey;
+        }
+
+        public void setDatahubKey(String datahubKey) {
+            this.datahubKey = datahubKey;
         }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDtoBase.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDtoBase.java
@@ -97,6 +97,10 @@ public class DistroXTestDtoBase<T extends DistroXTestDtoBase> extends AbstractCl
         return this;
     }
 
+    public DistroXTestDtoBase<T> withResourceEncryption() {
+        return getCloudProvider().withResourceEncryption(this);
+    }
+
     public DistroXTestDtoBase<T> withAzure(AzureDistroXV1Parameters azure) {
         getRequest().setAzure(azure);
         return this;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
@@ -32,10 +32,9 @@ import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentRe
 import com.sequenceiq.environment.api.v1.environment.model.request.FreeIpaImageRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.LocationRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.SecurityAccessRequest;
-import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsDiskEncryptionParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsEnvironmentParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureEnvironmentParameters;
-import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureResourceEncryptionParameters;
+import com.sequenceiq.environment.api.v1.environment.model.request.gcp.GcpEnvironmentParameters;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
 import com.sequenceiq.environment.api.v1.environment.model.response.SimpleEnvironmentResponse;
@@ -274,41 +273,22 @@ public class EnvironmentTestDto
         return getCloudProvider().withResourceGroup(this, resourceGroupUsage, resourceGroupName);
     }
 
-    public EnvironmentTestDto withAzureResourceEncryptionParameters(String encryptionKeyUrl, String resourceGroup) {
-        if (CloudPlatform.AZURE.equals(getTestContext().getCloudProvider().getCloudPlatform())) {
-            AzureResourceEncryptionParameters azureResourceEncryptionParameters = AzureResourceEncryptionParameters.builder()
-                    .withEncryptionKeyUrl(encryptionKeyUrl)
-                    .withEncryptionKeyResourceGroupName(resourceGroup)
-                    .build();
-            if (getRequest().getAzure() == null) {
-                getRequest().setAzure(AzureEnvironmentParameters.builder()
-                        .withResourceEncryptionParameters(azureResourceEncryptionParameters)
-                        .build());
-            } else {
-                getRequest().getAzure().setResourceEncryptionParameters(azureResourceEncryptionParameters);
-            }
-        }
-        return this;
-    }
-
-    public EnvironmentTestDto withAwsResourceEncryptionParameters(String encryptionKeyArn) {
-        if (CloudPlatform.AWS.equals(getTestContext().getCloudProvider().getCloudPlatform())) {
-            AwsDiskEncryptionParameters awsDiskEncryptionParameters = AwsDiskEncryptionParameters.builder()
-                    .withEncryptionKeyArn(encryptionKeyArn)
-                    .build();
-            if (getRequest().getAws() == null) {
-                getRequest().setAws(AwsEnvironmentParameters.builder()
-                        .withAwsDiskEncryptionParameters(awsDiskEncryptionParameters)
-                        .build());
-            } else {
-                getRequest().getAws().setAwsDiskEncryptionParameters(awsDiskEncryptionParameters);
-            }
-        }
-        return this;
+    public EnvironmentTestDto withResourceEncryption() {
+        return getCloudProvider().withResourceEncryption(this);
     }
 
     public EnvironmentTestDto withAws(AwsEnvironmentParameters awsEnvironmentParameters) {
         getRequest().setAws(awsEnvironmentParameters);
+        return this;
+    }
+
+    public EnvironmentTestDto withAzure(AzureEnvironmentParameters azureEnvironmentParameters) {
+        getRequest().setAzure(azureEnvironmentParameters);
+        return this;
+    }
+
+    public EnvironmentTestDto withGcp(GcpEnvironmentParameters gcpEnvironmentParameters) {
+        getRequest().setGcp(gcpEnvironmentParameters);
         return this;
     }
 
@@ -319,11 +299,6 @@ public class EnvironmentTestDto
         } else {
             LOGGER.info("S3guard is ignored on cloudplatform {}.", getTestContext().getCloudProvider().getCloudPlatform());
         }
-        return this;
-    }
-
-    public EnvironmentTestDto withAzure(AzureEnvironmentParameters azureEnvironmentParameters) {
-        getRequest().setAzure(azureEnvironmentParameters);
         return this;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaTestDto.java
@@ -76,6 +76,9 @@ public class FreeIpaTestDto extends AbstractFreeIpaTestDto<CreateFreeIpaRequest,
     @Inject
     private FreeIpaTestClient freeIpaTestClient;
 
+    @Inject
+    private FreeIpaInstanceUtil freeIpaInstanceUtil;
+
     public FreeIpaTestDto(TestContext testContext) {
         super(new CreateFreeIpaRequest(), testContext);
     }
@@ -335,7 +338,7 @@ public class FreeIpaTestDto extends AbstractFreeIpaTestDto<CreateFreeIpaRequest,
 
     public FreeIpaTestDto awaitForHealthyInstances() {
         Map<List<String>, com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceStatus> instanceStatusMap =
-                getInstanceStatusMapIfAvailableInResponse(() -> FreeIpaInstanceUtil.getInstanceStatusMap(getResponse()));
+                getInstanceStatusMapIfAvailableInResponse(() -> freeIpaInstanceUtil.getInstanceStatusMap(getResponse()));
         return awaitForFreeIpaInstance(instanceStatusMap);
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/AwsEnvironmentWithCustomerManagedKeyTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/AwsEnvironmentWithCustomerManagedKeyTests.java
@@ -1,27 +1,48 @@
 package com.sequenceiq.it.cloudbreak.testcase.e2e.environment;
 
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.MASTER;
+import static java.lang.String.format;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.inject.Inject;
 
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.common.api.type.Tunnel;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationState;
 import com.sequenceiq.it.cloudbreak.EnvironmentClient;
-import com.sequenceiq.it.cloudbreak.assertion.Assertion;
+import com.sequenceiq.it.cloudbreak.FreeIpaClient;
 import com.sequenceiq.it.cloudbreak.client.CredentialTestClient;
 import com.sequenceiq.it.cloudbreak.client.EnvironmentTestClient;
+import com.sequenceiq.it.cloudbreak.client.FreeIpaTestClient;
 import com.sequenceiq.it.cloudbreak.cloud.v4.aws.AwsProperties;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.credential.CredentialTestDto;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentNetworkTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaUserSyncTestDto;
 import com.sequenceiq.it.cloudbreak.dto.telemetry.TelemetryTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.it.cloudbreak.log.Log;
 import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
+import com.sequenceiq.it.cloudbreak.util.CloudFunctionality;
+import com.sequenceiq.it.cloudbreak.util.FreeIpaInstanceUtil;
 import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
 
 public class AwsEnvironmentWithCustomerManagedKeyTests extends AbstractE2ETest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsEnvironmentWithCustomerManagedKeyTests.class);
 
     @Inject
     private EnvironmentTestClient environmentTestClient;
@@ -32,8 +53,15 @@ public class AwsEnvironmentWithCustomerManagedKeyTests extends AbstractE2ETest {
     @Inject
     private AwsProperties awsProperties;
 
+    @Inject
+    private FreeIpaTestClient freeIpaTestClient;
+
+    @Inject
+    private FreeIpaInstanceUtil freeIpaInstanceUtil;
+
     @Override
     protected void setupTest(TestContext testContext) {
+        testContext.getCloudProvider().getCloudFunctionality().cloudStorageInitialize();
         checkCloudPlatform(CloudPlatform.AWS);
         createDefaultUser(testContext);
     }
@@ -42,37 +70,75 @@ public class AwsEnvironmentWithCustomerManagedKeyTests extends AbstractE2ETest {
     @UseSpotInstances
     @Description(
             given = "there is a running cloudbreak",
-            when = "create an Environment with encryption parameters",
+            when = "create an Environment with disk encryption",
             then = "should use encryption parameters for resource encryption.")
     public void testEnvironmentWithCustomerManagedKey(TestContext testContext) {
-        String encryptionKeyArn = awsProperties.getDiskEncryptionKey();
         testContext
                 .given(CredentialTestDto.class)
                 .when(credentialTestClient.create())
+                .given(EnvironmentNetworkTestDto.class)
                 .given("telemetry", TelemetryTestDto.class)
-                .withLogging()
-                .withReportClusterLogs()
+                    .withLogging()
+                    .withReportClusterLogs()
                 .given(EnvironmentTestDto.class)
-                .withNetwork()
-                .withAwsResourceEncryptionParameters(encryptionKeyArn)
-                .withTelemetry("telemetry")
-                .withCreateFreeIpa(Boolean.FALSE)
+                    .withNetwork()
+                    .withResourceEncryption()
+                    .withTelemetry("telemetry")
+                    .withTunnel(Tunnel.CLUSTER_PROXY)
+                    .withCreateFreeIpa(Boolean.FALSE)
                 .when(environmentTestClient.create())
                 .await(EnvironmentStatus.AVAILABLE)
-                .then((tc, testDto, cc) -> environmentTestClient.describe().action(tc, testDto, cc))
-                .then(verifyEncryptionParameters())
+                .given(FreeIpaTestDto.class)
+                    .withEnvironment()
+                    .withTelemetry("telemetry")
+                    .withCatalog(commonCloudProperties().getImageValidation().getFreeIpaImageCatalog(),
+                        commonCloudProperties().getImageValidation().getFreeIpaImageUuid())
+                .when(freeIpaTestClient.create())
+                .await(Status.AVAILABLE)
+                .awaitForHealthyInstances()
+                .given(FreeIpaUserSyncTestDto.class)
+                .when(freeIpaTestClient.getLastSyncOperationStatus())
+                .await(OperationState.COMPLETED)
+                .given(EnvironmentTestDto.class)
+                .when(environmentTestClient.describe())
+                .then(this::verifyEnvironmentResponseKMSParameters)
+                .given(FreeIpaTestDto.class)
+                .then(this::verifyFreeIPAEC2VolumeKMSKey)
                 .validate();
     }
 
-    private static Assertion<EnvironmentTestDto, EnvironmentClient> verifyEncryptionParameters() {
-        return (testContext, testDto, environmentClient) -> {
-            DetailedEnvironmentResponse environment = environmentClient.getDefaultClient().environmentV1Endpoint().getByName(testDto.getName());
-            if (CloudPlatform.AWS.name().equals(environment.getCloudPlatform())) {
-                if (StringUtils.isEmpty(environment.getAws().getAwsDiskEncryptionParameters().getEncryptionKeyArn())) {
-                    throw new IllegalArgumentException("Failed to get encryption key details");
-                }
+    private EnvironmentTestDto verifyEnvironmentResponseKMSParameters(TestContext testContext, EnvironmentTestDto testDto,
+            EnvironmentClient environmentClient) {
+        DetailedEnvironmentResponse environment = environmentClient.getDefaultClient().environmentV1Endpoint().getByName(testDto.getName());
+
+        if (CloudPlatform.AWS.name().equals(environment.getCloudPlatform())) {
+            String encryptionKey = environment.getAws().getAwsDiskEncryptionParameters().getEncryptionKeyArn();
+            String environmentName = testDto.getRequest().getName();
+
+            if (StringUtils.isEmpty(encryptionKey)) {
+                LOGGER.error(String.format("KMS key is not available for [%s] environment!", environmentName));
+                throw new TestFailException(format("KMS key is not available for [%s] environment!", environmentName));
+            } else {
+                LOGGER.info(String.format(" Environment [%s] create has been done with [%s] KMS key. ", environmentName, encryptionKey));
+                Log.then(LOGGER, format(" Environment '%s' create has been done with [%s] KMS key. ", environmentName, encryptionKey));
             }
-            return testDto;
-        };
+        }
+        return testDto;
+    }
+
+    private FreeIpaTestDto verifyFreeIPAEC2VolumeKMSKey(TestContext testContext, FreeIpaTestDto testDto, FreeIpaClient freeIpaClient) {
+        CloudFunctionality cloudFunctionality = testContext.getCloudProvider().getCloudFunctionality();
+        List<String> instanceIds = freeIpaInstanceUtil.getInstanceIds(testDto, freeIpaClient, MASTER.getName());
+        String kmsKeyArn = awsProperties.getDiskEncryption().getEnvironmentKey();
+
+        List<String> volumeKmsKeyIds = new ArrayList<>(cloudFunctionality.listVolumeKmsKeyIds(instanceIds));
+        if (volumeKmsKeyIds.stream().noneMatch(keyId -> keyId.equalsIgnoreCase(kmsKeyArn))) {
+            LOGGER.error("FreeIpa volume has not been encrypted with [{}] KMS key!", kmsKeyArn);
+            throw new TestFailException(format("FreeIpa volume has not been encrypted with [%s] KMS key!", kmsKeyArn));
+        } else {
+            LOGGER.info(String.format("FreeIpa volume has been encrypted with [%s] KMS key!", kmsKeyArn));
+            Log.then(LOGGER, format(" FreeIpa volume has not been encrypted with [%s] KMS key! ", kmsKeyArn));
+        }
+        return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/AwsEnvironmentWithCustomerManagedKeyTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/AwsEnvironmentWithCustomerManagedKeyTests.java
@@ -103,7 +103,7 @@ public class AwsEnvironmentWithCustomerManagedKeyTests extends AbstractE2ETest {
                 .when(environmentTestClient.describe())
                 .then(this::verifyEnvironmentResponseKMSParameters)
                 .given(FreeIpaTestDto.class)
-                .then(this::verifyFreeIPAEC2VolumeKMSKey)
+                .then(this::verifyFreeIpaEc2VolumeKMSKey)
                 .validate();
     }
 
@@ -126,12 +126,12 @@ public class AwsEnvironmentWithCustomerManagedKeyTests extends AbstractE2ETest {
         return testDto;
     }
 
-    private FreeIpaTestDto verifyFreeIPAEC2VolumeKMSKey(TestContext testContext, FreeIpaTestDto testDto, FreeIpaClient freeIpaClient) {
+    private FreeIpaTestDto verifyFreeIpaEc2VolumeKMSKey(TestContext testContext, FreeIpaTestDto testDto, FreeIpaClient freeIpaClient) {
         CloudFunctionality cloudFunctionality = testContext.getCloudProvider().getCloudFunctionality();
         List<String> instanceIds = freeIpaInstanceUtil.getInstanceIds(testDto, freeIpaClient, MASTER.getName());
         String kmsKeyArn = awsProperties.getDiskEncryption().getEnvironmentKey();
 
-        List<String> volumeKmsKeyIds = new ArrayList<>(cloudFunctionality.listVolumeKmsKeyIds(instanceIds));
+        List<String> volumeKmsKeyIds = new ArrayList<>(cloudFunctionality.listVolumeEncryptionKeyIds(testDto.getRequest().getName(), instanceIds));
         if (volumeKmsKeyIds.stream().noneMatch(keyId -> keyId.equalsIgnoreCase(kmsKeyArn))) {
             LOGGER.error("FreeIpa volume has not been encrypted with [{}] KMS key!", kmsKeyArn);
             throw new TestFailException(format("FreeIpa volume has not been encrypted with [%s] KMS key!", kmsKeyArn));

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/AzureEnvironmentWithCustomerManagedKeyTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/AzureEnvironmentWithCustomerManagedKeyTests.java
@@ -1,33 +1,53 @@
 package com.sequenceiq.it.cloudbreak.testcase.e2e.environment;
 
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.MASTER;
+import static java.lang.String.format;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.inject.Inject;
 
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
-import com.microsoft.azure.CloudException;
-import com.microsoft.azure.management.Azure;
 import com.microsoft.azure.management.resources.ResourceGroup;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.common.api.type.Tunnel;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationState;
 import com.sequenceiq.it.cloudbreak.EnvironmentClient;
-import com.sequenceiq.it.cloudbreak.assertion.Assertion;
+import com.sequenceiq.it.cloudbreak.FreeIpaClient;
+import com.sequenceiq.it.cloudbreak.ResourceGroupTest;
 import com.sequenceiq.it.cloudbreak.client.CredentialTestClient;
 import com.sequenceiq.it.cloudbreak.client.EnvironmentTestClient;
-import com.sequenceiq.it.cloudbreak.cloud.v4.CommonCloudProperties;
+import com.sequenceiq.it.cloudbreak.client.FreeIpaTestClient;
+import com.sequenceiq.it.cloudbreak.cloud.v4.azure.AzureCloudProvider;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.credential.CredentialTestDto;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentNetworkTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaUserSyncTestDto;
 import com.sequenceiq.it.cloudbreak.dto.telemetry.TelemetryTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.it.cloudbreak.log.Log;
 import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
+import com.sequenceiq.it.cloudbreak.util.CloudFunctionality;
+import com.sequenceiq.it.cloudbreak.util.FreeIpaInstanceUtil;
 import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
 
 public class AzureEnvironmentWithCustomerManagedKeyTests extends AbstractE2ETest {
 
-    private static final String RESOURCE_GROUP_FOR_TEST = "azure-test-des-rg";
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsEnvironmentWithCustomerManagedKeyTests.class);
+
+    private String resourceGroupForTest;
 
     @Inject
     private EnvironmentTestClient environmentTestClient;
@@ -36,10 +56,13 @@ public class AzureEnvironmentWithCustomerManagedKeyTests extends AbstractE2ETest
     private CredentialTestClient credentialTestClient;
 
     @Inject
-    private Azure azure;
+    private AzureCloudProvider azureCloudProvider;
 
     @Inject
-    private CommonCloudProperties commonCloudProperties;
+    private FreeIpaTestClient freeIpaTestClient;
+
+    @Inject
+    private FreeIpaInstanceUtil freeIpaInstanceUtil;
 
     @Override
     protected void setupTest(TestContext testContext) {
@@ -47,100 +70,150 @@ public class AzureEnvironmentWithCustomerManagedKeyTests extends AbstractE2ETest
         createDefaultUser(testContext);
     }
 
-    @AfterMethod
-    public void tearDownSpot() {
-        deleteResourceGroupCreatedForEnvironment(RESOURCE_GROUP_FOR_TEST);
+    @AfterMethod(onlyForGroups = { "withrg" })
+    public void tearDown() {
+        LOGGER.info("Delete the '{}' resource group after test has been done!", resourceGroupForTest);
+        deleteResourceGroupCreatedForEnvironment(resourceGroupForTest);
     }
 
-    @Test(dataProvider = TEST_CONTEXT, description = "Creating a resource group for this test case. Disk encryption set(DES)" +
-            " is created in this newly created RG, as cloud-daily RG has locks which prevents cleanup of DES.")
+    @Test(dataProvider = TEST_CONTEXT, groups = { "withrg" }, description = "Creating a resource group for this test case. " +
+            "Disk encryption set(DES) is created in this newly created RG, as cloud-daily RG has locks which prevents cleanup of DES.")
     @UseSpotInstances
     @Description(
             given = "there is a running cloudbreak",
             when = "create an Environment with disk encryption where key and environment are in same Resource groups",
             then = "should use encryption parameters for resource encryption.")
     public void testWithEnvironmentResourceGroup(TestContext testContext) {
-        createResourceGroupForEnvironment(RESOURCE_GROUP_FOR_TEST);
+        String environmentName = resourcePropertyProvider().getName();
+
+        resourceGroupForTest = resourcePropertyProvider().getName();
+        createResourceGroupForEnvironment(resourceGroupForTest);
 
         testContext
                 .given(CredentialTestDto.class)
                 .when(credentialTestClient.create())
+                .given(EnvironmentNetworkTestDto.class)
                 .given("telemetry", TelemetryTestDto.class)
                     .withLogging()
                     .withReportClusterLogs()
                 .given(EnvironmentTestDto.class)
-                    .withName("azure-test-des-1")
+                    .withName(environmentName)
                     .withNetwork()
-                    .withResourceGroup("SINGLE", RESOURCE_GROUP_FOR_TEST)
+                    .withResourceGroup(ResourceGroupTest.AZURE_RESOURCE_GROUP_USAGE_SINGLE, resourceGroupForTest)
                     .withResourceEncryption()
                     .withTelemetry("telemetry")
+                    .withTunnel(Tunnel.CLUSTER_PROXY)
+                    .withCreateFreeIpa(Boolean.FALSE)
                 .when(environmentTestClient.create())
                 .await(EnvironmentStatus.AVAILABLE)
-                .then((tc, testDto, cc) -> environmentTestClient.describe().action(tc, testDto, cc))
-                .then(verifyEncryptionParameters())
+                .given(FreeIpaTestDto.class)
+                    .withEnvironment()
+                    .withTelemetry("telemetry")
+                    .withCatalog(commonCloudProperties().getImageValidation().getFreeIpaImageCatalog(),
+                        commonCloudProperties().getImageValidation().getFreeIpaImageUuid())
+                .when(freeIpaTestClient.create())
+                .await(Status.AVAILABLE)
+                .awaitForHealthyInstances()
+                .given(FreeIpaUserSyncTestDto.class)
+                .when(freeIpaTestClient.getLastSyncOperationStatus())
+                .await(OperationState.COMPLETED)
+                .given(EnvironmentTestDto.class)
+                .when(environmentTestClient.describe())
+                .then(this::verifyEnvironmentResponseDesParameters)
+                .given(FreeIpaTestDto.class)
+                .then((context, testDto, testClient) -> verifyFreeIpaVolumeDesKey(context, testDto, testClient, environmentName))
                 .validate();
     }
 
-    @Test(dataProvider = TEST_CONTEXT, description = "Environment's Resource Group is not specified, in this case all the resources create their own" +
-            " resource groups.")
+    @Test(dataProvider = TEST_CONTEXT, groups = { "norg" }, description = "Environment's Resource Group is not specified, in this case all the" +
+            " resources create their own resource groups.")
     @UseSpotInstances
     @Description(
             given = "there is a running cloudbreak",
             when = "create an Environment with disk encryption where key and environment are in different Resource groups",
             then = "should use encryption parameters for resource encryption.")
     public void testWithEncryptionKeyResourceGroup(TestContext testContext) {
+        String environmentName = resourcePropertyProvider().getName();
+
         testContext
                 .given(CredentialTestDto.class)
                 .when(credentialTestClient.create())
+                .given(EnvironmentNetworkTestDto.class)
                 .given("telemetry", TelemetryTestDto.class)
                     .withLogging()
                     .withReportClusterLogs()
                 .given(EnvironmentTestDto.class)
-                    .withName("azure-test-des-2")
+                    .withName(environmentName)
                     .withNetwork()
-                    .withResourceGroup("USE_MULTIPLE", null)
                     .withResourceEncryption()
                     .withTelemetry("telemetry")
+                    .withTunnel(Tunnel.CLUSTER_PROXY)
+                    .withCreateFreeIpa(Boolean.FALSE)
                 .when(environmentTestClient.create())
                 .await(EnvironmentStatus.AVAILABLE)
-                .then((tc, testDto, cc) -> environmentTestClient.describe().action(tc, testDto, cc))
-                .then(verifyEncryptionParameters())
+                .given(FreeIpaTestDto.class)
+                    .withEnvironment()
+                    .withTelemetry("telemetry")
+                    .withCatalog(commonCloudProperties().getImageValidation().getFreeIpaImageCatalog(),
+                        commonCloudProperties().getImageValidation().getFreeIpaImageUuid())
+                .when(freeIpaTestClient.create())
+                .await(Status.AVAILABLE)
+                .awaitForHealthyInstances()
+                .given(FreeIpaUserSyncTestDto.class)
+                .when(freeIpaTestClient.getLastSyncOperationStatus())
+                .await(OperationState.COMPLETED)
+                .given(EnvironmentTestDto.class)
+                .when(environmentTestClient.describe())
+                .then(this::verifyEnvironmentResponseDesParameters)
+                .given(FreeIpaTestDto.class)
+                .then((context, testDto, testClient) -> verifyFreeIpaVolumeDesKey(context, testDto, testClient, environmentName))
                 .validate();
     }
 
     private ResourceGroup createResourceGroupForEnvironment(String resourceGroupName) {
-        return azure.resourceGroups().define(resourceGroupName)
-                .withRegion("West US 2")
-                .withTags(commonCloudProperties.getTags())
-                .create();
-    }
-
-    private boolean resourceGroupExists(String name) {
-        try {
-            return azure.resourceGroups().contain(name);
-        } catch (CloudException e) {
-            if (e.getMessage().contains("Status code 403")) {
-                return false;
-            }
-            throw e;
-        }
+        CloudFunctionality cloudFunctionality = azureCloudProvider.getCloudFunctionality();
+        return cloudFunctionality.createResourceGroup(resourceGroupName);
     }
 
     private void deleteResourceGroupCreatedForEnvironment(String resourceGroupName) {
-        if (resourceGroupExists(resourceGroupName)) {
-            azure.resourceGroups().deleteByName(resourceGroupName);
-        }
+        CloudFunctionality cloudFunctionality = azureCloudProvider.getCloudFunctionality();
+        cloudFunctionality.deleteResourceGroup(resourceGroupName);
     }
 
-    private static Assertion<EnvironmentTestDto, EnvironmentClient> verifyEncryptionParameters() {
-        return (testContext, testDto, environmentClient) -> {
-            DetailedEnvironmentResponse environment = environmentClient.getDefaultClient().environmentV1Endpoint().getByName(testDto.getName());
-            if (CloudPlatform.AZURE.name().equals(environment.getCloudPlatform())) {
-                if (StringUtils.isEmpty(environment.getAzure().getResourceEncryptionParameters().getDiskEncryptionSetId())) {
-                    throw new IllegalArgumentException("Failed to create disk encryption set.");
-                }
+    private EnvironmentTestDto verifyEnvironmentResponseDesParameters(TestContext testContext, EnvironmentTestDto testDto,
+            EnvironmentClient environmentClient) {
+        DetailedEnvironmentResponse environment = environmentClient.getDefaultClient().environmentV1Endpoint().getByName(testDto.getName());
+
+        if (CloudPlatform.AZURE.name().equals(environment.getCloudPlatform())) {
+            String encryptionKey = environment.getAzure().getResourceEncryptionParameters().getEncryptionKeyUrl();
+            String environmentName = testDto.getRequest().getName();
+
+            if (StringUtils.isEmpty(encryptionKey)) {
+                LOGGER.error(String.format("DES key is not available for '%s' environment!", environmentName));
+                throw new TestFailException(format("DES key is not available for '%s' environment!", environmentName));
+            } else {
+                LOGGER.info(String.format(" Environment '%s' create has been done with '%s' DES key. ", environmentName, encryptionKey));
+                Log.then(LOGGER, format(" Environment '%s' create has been done with '%s' DES key. ", environmentName, encryptionKey));
             }
-            return testDto;
-        };
+        }
+        return testDto;
+    }
+
+    private FreeIpaTestDto verifyFreeIpaVolumeDesKey(TestContext testContext, FreeIpaTestDto testDto, FreeIpaClient freeIpaClient, String environmentName) {
+        CloudFunctionality cloudFunctionality = testContext.getCloudProvider().getCloudFunctionality();
+        List<String> instanceIds = freeIpaInstanceUtil.getInstanceIds(testDto, freeIpaClient, MASTER.getName());
+        String desKeyUrl = azureCloudProvider.getEncryptionKeyUrl();
+
+        List<String> volumesDesId = new ArrayList<>(cloudFunctionality.listVolumeEncryptionKeyIds(testDto.getRequest().getName(), instanceIds));
+        volumesDesId.forEach(desId -> {
+            if (desId.contains("diskEncryptionSets/" + environmentName)) {
+                LOGGER.info(format("FreeIpa volume has been encrypted with '%s' DES key!", desId));
+                Log.then(LOGGER, format(" FreeIpa volume has not been encrypted with '%s' DES key! ", desId));
+            } else {
+                LOGGER.error(format("FreeIpa volume has not been encrypted with '%s' DES key!", desKeyUrl));
+                throw new TestFailException(format("FreeIpa volume has not been encrypted with '%s' DES key!", desKeyUrl));
+            }
+        });
+        return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/CloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/CloudFunctionality.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 
+import com.microsoft.azure.management.resources.ResourceGroup;
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
 
 public interface CloudFunctionality {
@@ -28,7 +29,7 @@ public interface CloudFunctionality {
             maxAttempts = ATTEMPTS,
             backoff = @Backoff(delay = DELAY, multiplier = MULTIPLIER, maxDelay = MAX_DELAY)
     )
-    List<String> listVolumeKmsKeyIds(List<String> instanceIds);
+    List<String> listVolumeEncryptionKeyIds(String clusterName, List<String> instanceIds);
 
     @Retryable(
             maxAttempts = ATTEMPTS,
@@ -47,6 +48,18 @@ public interface CloudFunctionality {
             backoff = @Backoff(delay = DELAY, multiplier = MULTIPLIER, maxDelay = MAX_DELAY)
     )
     void stopInstances(String clusterName, List<String> instanceIds);
+
+    @Retryable(
+            maxAttempts = ATTEMPTS,
+            backoff = @Backoff(delay = DELAY, multiplier = MULTIPLIER, maxDelay = MAX_DELAY)
+    )
+    ResourceGroup createResourceGroup(String resourceGroupName);
+
+    @Retryable(
+            maxAttempts = ATTEMPTS,
+            backoff = @Backoff(delay = DELAY, multiplier = MULTIPLIER, maxDelay = MAX_DELAY)
+    )
+    void deleteResourceGroup(String resourceGroupName);
 
     @Retryable(
             maxAttempts = ATTEMPTS,

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/CloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/CloudFunctionality.java
@@ -28,6 +28,12 @@ public interface CloudFunctionality {
             maxAttempts = ATTEMPTS,
             backoff = @Backoff(delay = DELAY, multiplier = MULTIPLIER, maxDelay = MAX_DELAY)
     )
+    List<String> listVolumeKmsKeyIds(List<String> instanceIds);
+
+    @Retryable(
+            maxAttempts = ATTEMPTS,
+            backoff = @Backoff(delay = DELAY, multiplier = MULTIPLIER, maxDelay = MAX_DELAY)
+    )
     Map<String, Map<String, String>> listTagsByInstanceId(String clusterName, List<String> instanceIds);
 
     @Retryable(

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/FreeIpaInstanceUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/FreeIpaInstanceUtil.java
@@ -5,23 +5,29 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.springframework.stereotype.Component;
+
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceMetaDataResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.describe.DescribeFreeIpaResponse;
+import com.sequenceiq.it.cloudbreak.FreeIpaClient;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 
+@Component
 public class FreeIpaInstanceUtil {
-    private FreeIpaInstanceUtil() {
-    }
 
-    public static List<String> getInstanceIds(List<InstanceGroupResponse> instanceGroupResponses, String hostGroupName) {
+    public List<String> getInstanceIds(FreeIpaTestDto freeIpaTestDto, FreeIpaClient freeIpaClient, String hostGroupName) {
+        DescribeFreeIpaResponse describeFreeIpaResponse = freeIpaClient.getDefaultClient()
+                .getFreeIpaV1Endpoint().describe(freeIpaTestDto.getRequest().getEnvironmentCrn());
+        List<InstanceGroupResponse> instanceGroupResponses = describeFreeIpaResponse.getInstanceGroups();
         InstanceGroupResponse instanceGroupResponse = instanceGroupResponses.stream().filter(instanceGroup ->
                 instanceGroup.getName().equals(hostGroupName)).findFirst().orElse(null);
         return Objects.requireNonNull(instanceGroupResponse).getMetaData()
                 .stream().map(InstanceMetaDataResponse::getInstanceId).collect(Collectors.toList());
     }
 
-    public static Map<List<String>, InstanceStatus> getInstanceStatusMap(DescribeFreeIpaResponse freeIpaResponse) {
+    public Map<List<String>, InstanceStatus> getInstanceStatusMap(DescribeFreeIpaResponse freeIpaResponse) {
         return freeIpaResponse.getInstanceGroups().stream()
                 .filter(instanceGroupResponse -> instanceGroupResponse.getMetaData().stream()
                         .anyMatch(instanceMetaDataResponse -> Objects.nonNull(instanceMetaDataResponse.getInstanceId())))

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/AwsCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/AwsCloudFunctionality.java
@@ -5,10 +5,12 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.microsoft.azure.management.resources.ResourceGroup;
 import com.sequenceiq.it.cloudbreak.util.CloudFunctionality;
 import com.sequenceiq.it.cloudbreak.util.aws.amazonec2.AmazonEC2Util;
 import com.sequenceiq.it.cloudbreak.util.aws.amazons3.AmazonS3Util;
@@ -30,7 +32,7 @@ public class AwsCloudFunctionality implements CloudFunctionality {
     }
 
     @Override
-    public List<String> listVolumeKmsKeyIds(List<String> instanceIds) {
+    public List<String> listVolumeEncryptionKeyIds(String clusterName, List<String> instanceIds) {
         return amazonEC2Util.listVolumeKmsKeyIds(instanceIds);
     }
 
@@ -47,6 +49,18 @@ public class AwsCloudFunctionality implements CloudFunctionality {
     @Override
     public void stopInstances(String clusterName, List<String> instanceIds) {
         amazonEC2Util.stopHostGroupInstances(instanceIds);
+    }
+
+    @Override
+    public ResourceGroup createResourceGroup(String resourceGroupName) {
+        LOGGER.debug("createResourceGroup: nothing to do for AWS");
+        throw new NotImplementedException("Resource group creation is not applicable for AWS!");
+    }
+
+    @Override
+    public void deleteResourceGroup(String resourceGroupName) {
+        LOGGER.debug("deleteResourceGroup: nothing to do for AWS");
+        throw new NotImplementedException("Resource group deletion is not applicable for AWS!");
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/AwsCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/AwsCloudFunctionality.java
@@ -30,6 +30,11 @@ public class AwsCloudFunctionality implements CloudFunctionality {
     }
 
     @Override
+    public List<String> listVolumeKmsKeyIds(List<String> instanceIds) {
+        return amazonEC2Util.listVolumeKmsKeyIds(instanceIds);
+    }
+
+    @Override
     public Map<String, Map<String, String>> listTagsByInstanceId(String clusterName, List<String> instanceIds) {
         return amazonEC2Util.listTagsByInstanceId(instanceIds);
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazonec2/AmazonEC2Util.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazonec2/AmazonEC2Util.java
@@ -21,6 +21,10 @@ public class AmazonEC2Util {
         return ec2ClientActions.getInstanceVolumeIds(instanceIds);
     }
 
+    public List<String> listVolumeKmsKeyIds(List<String> instanceIds) {
+        return ec2ClientActions.getVolumesKmsKeys(instanceIds);
+    }
+
     public Map<String, Map<String, String>> listTagsByInstanceId(List<String> instanceIds) {
         return ec2ClientActions.listTagsByInstanceId(instanceIds);
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/AzureCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/AzureCloudFunctionality.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.it.cloudbreak.util.CloudFunctionality;
@@ -24,6 +25,11 @@ public class AzureCloudFunctionality implements CloudFunctionality {
     @Override
     public List<String> listInstanceVolumeIds(String clusterName, List<String> instanceIds) {
         return azureClientActions.listInstanceVolumeIds(clusterName, instanceIds);
+    }
+
+    @Override
+    public List<String> listVolumeKmsKeyIds(List<String> instanceIds) {
+        throw new NotImplementedException("Not yet implemented on Azure");
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/AzureCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/AzureCloudFunctionality.java
@@ -6,9 +6,9 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.stereotype.Component;
 
+import com.microsoft.azure.management.resources.ResourceGroup;
 import com.sequenceiq.it.cloudbreak.util.CloudFunctionality;
 import com.sequenceiq.it.cloudbreak.util.azure.azurecloudblob.AzureCloudBlobUtil;
 import com.sequenceiq.it.cloudbreak.util.azure.azurevm.action.AzureClientActions;
@@ -28,8 +28,8 @@ public class AzureCloudFunctionality implements CloudFunctionality {
     }
 
     @Override
-    public List<String> listVolumeKmsKeyIds(List<String> instanceIds) {
-        throw new NotImplementedException("Not yet implemented on Azure");
+    public List<String> listVolumeEncryptionKeyIds(String clusterName, List<String> instanceIds) {
+        return azureClientActions.getVolumesDesId(clusterName, instanceIds);
     }
 
     @Override
@@ -45,6 +45,16 @@ public class AzureCloudFunctionality implements CloudFunctionality {
     @Override
     public void stopInstances(String clusterName, List<String> instanceIds) {
         azureClientActions.stopInstances(clusterName, instanceIds);
+    }
+
+    @Override
+    public ResourceGroup createResourceGroup(String resourceGroupName) {
+        return azureClientActions.createResourceGroup(resourceGroupName);
+    }
+
+    @Override
+    public void deleteResourceGroup(String resourceGroupName) {
+        azureClientActions.deleteResourceGroup(resourceGroupName);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpCloudFunctionality.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.microsoft.azure.management.resources.ResourceGroup;
 import com.sequenceiq.cloudbreak.cloud.gcp.util.GcpLabelUtil;
 import com.sequenceiq.it.cloudbreak.util.CloudFunctionality;
 
@@ -33,7 +34,7 @@ public class GcpCloudFunctionality implements CloudFunctionality {
     }
 
     @Override
-    public List<String> listVolumeKmsKeyIds(List<String> instanceIds) {
+    public List<String> listVolumeEncryptionKeyIds(String clusterName, List<String> instanceIds) {
         throw new NotImplementedException("Not yet implemented on GCP");
     }
 
@@ -56,6 +57,18 @@ public class GcpCloudFunctionality implements CloudFunctionality {
     @Override
     public void stopInstances(String clusterName, List<String> instanceIds) {
         gcpUtil.stopHostGroupInstances(instanceIds);
+    }
+
+    @Override
+    public ResourceGroup createResourceGroup(String resourceGroupName) {
+        LOGGER.debug("createResourceGroup: nothing to do for GCP");
+        throw new NotImplementedException("Resource group creation is not applicable for GCP!");
+    }
+
+    @Override
+    public void deleteResourceGroup(String resourceGroupName) {
+        LOGGER.debug("deleteResourceGroup: nothing to do for GCP");
+        throw new NotImplementedException("Resource group deletion is not applicable for GCP!");
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpCloudFunctionality.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -29,6 +30,11 @@ public class GcpCloudFunctionality implements CloudFunctionality {
     @Override
     public List<String> listInstanceVolumeIds(String clusterName, List<String> instanceIds) {
         return gcpUtil.listInstanceDiskNames(instanceIds);
+    }
+
+    @Override
+    public List<String> listVolumeKmsKeyIds(List<String> instanceIds) {
+        throw new NotImplementedException("Not yet implemented on GCP");
     }
 
     @Override

--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -194,12 +194,8 @@ integrationtest:
         imageId: dc277098-ea7c-48b7-b1a2-89950b989b6a
         catalog: https://cloudbreak-imagecatalog.s3.us-west-1.amazonaws.com/freeipa-upgrade-test-catalog.json
     diskEncryption:
-      environmentKey:
-        encryptionKeyUrl:
-        resourceGroupName:
-      datahubKey:
-        encryptionKeyUrl:
-        resourceGroupName:
+      encryptionKeyUrl:
+      resourceGroupName:
 
   # gcp parameters
   gcp:

--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -100,7 +100,6 @@ integrationtest:
     region: eu-central-1
     location: eu-central-1
     availabilityZone: eu-central-1a
-    diskEncryptionKey:
     vpcId: vpc-0fc0a422f82ea8eec
     subnetIds:
       - subnet-025e39ebeb6efeca8
@@ -137,6 +136,9 @@ integrationtest:
       upgrade:
         imageId: 9c1c8959-86a7-4b7d-af5a-be252f8b395d
         catalog: https://cloudbreak-imagecatalog.s3.us-west-1.amazonaws.com/freeipa-upgrade-test-catalog.json
+    diskEncryption:
+      environmentKey:
+      datahubKey:
 
   # azure parameters
   azure:
@@ -191,6 +193,13 @@ integrationtest:
       upgrade:
         imageId: dc277098-ea7c-48b7-b1a2-89950b989b6a
         catalog: https://cloudbreak-imagecatalog.s3.us-west-1.amazonaws.com/freeipa-upgrade-test-catalog.json
+    diskEncryption:
+      environmentKey:
+        encryptionKeyUrl:
+        resourceGroupName:
+      datahubKey:
+        encryptionKeyUrl:
+        resourceGroupName:
 
   # gcp parameters
   gcp:
@@ -232,6 +241,9 @@ integrationtest:
       upgrade:
         imageId: bbc059cd-d7c7-4938-bb34-5c7fc09f1204
         catalog: https://cloudbreak-imagecatalog.s3.us-west-1.amazonaws.com/freeipa-upgrade-test-catalog.json
+    diskEncryption:
+      environmentKey:
+      datahubKey:
 
   # yarn parameters
   yarn:
@@ -251,6 +263,9 @@ integrationtest:
     networkCidr: 172.27.0.0/16
     baseimage:
       imageId:
+    diskEncryption:
+      environmentKey:
+      datahubKey:
 
   # mock parameters
   mock:
@@ -283,6 +298,9 @@ integrationtest:
         instanceProfile: "arn:aws:iam::1234567890:instance-profile/mock.testing.instance.profile"
       baseLocation: "s3a://mock-test"
       fileSystemType: S3
+    diskEncryption:
+      environmentKey:
+      datahubKey:
 
   cleanup:
       retryCount: 3

--- a/integration-test/src/main/resources/testsuites/e2e/azure-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/azure-e2e-tests.yaml
@@ -15,4 +15,4 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.imagevalidation.PrewarmImageValidatorE2ETest
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxImagesTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.AzureMarketplaceImageTest
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.EnvironmentWithCustomerManagedKeyTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.AzureEnvironmentWithCustomerManagedKeyTests


### PR DESCRIPTION
We have hard-coded Azure disk encryption test parameters at [EnvironmentWithCustomerManagedKeyTests](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/EnvironmentWithCustomerManagedKeyTests.java#L30-L34). We can make this more secure. Furthermore can be troublesome if we'd like to change any of these parameter just for a Jenkins build.

Beyond this we already have external parameter for AWS at [application.yml](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/src/main/resources/application.yml#L103) as {{integrationtest.aws.diskEncryptionKey}}. However this was not introduced to [AwsCloudProvider](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProvider.java) and it's proxies to generally use in tests and utils as in case of other AWS parameters we do.

I've improved a little the `AwsEnvironmentWithCustomerManagedKeyTests`, because of the cloud provider side validation was not implemented there. I think that is also needed for us to can rest assured about the requested KMS encryption was applied correctly on the provider side.