### PR TITLE
CB-15434 Temporarily ignore testCreateDistroXWithEphemeralTemporarySt…

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/ephemeral/DistroXStopStartTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/ephemeral/DistroXStopStartTest.java
@@ -7,6 +7,7 @@ import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
@@ -52,6 +53,7 @@ public class DistroXStopStartTest extends AbstractE2ETest {
         createEnvironmentWithFreeIpaAndDatalake(testContext);
     }
 
+    @Ignore("Increase in CM API call fails with SocketTimeoutException")
     @Test(dataProvider = TEST_CONTEXT)
     @UseSpotInstances
     @Description(


### PR DESCRIPTION
…orage e2e test.

There is an increase of fails for this test because sometimes the CM API calls fail with java.net.SocketTimeoutException: timeout. Until further investigation and fix the e2e test is ignored.

See detailed description in the commit message.