### PR TITLE
CB-15467: Changed SdxUpgradeRequest field skipBackup to not have a isBackupSkipped field which was messing up Thunderhead generation.

### DIFF
--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxUpgradeRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxUpgradeRequest.java
@@ -59,8 +59,8 @@ public class SdxUpgradeRequest {
         this.dryRun = dryRun;
     }
 
-    public boolean isBackupSkipped() {
-        return Boolean.TRUE.equals(skipBackup);
+    public Boolean getSkipBackup() {
+        return skipBackup;
     }
 
     public void setSkipBackup(Boolean skipBackup) {

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/SdxRuntimeUpgradeService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/SdxRuntimeUpgradeService.java
@@ -164,7 +164,7 @@ public class SdxRuntimeUpgradeService {
     private SdxUpgradeResponse initSdxUpgrade(String userCrn, List<ImageInfoV4Response> upgradeCandidates, SdxUpgradeRequest request, SdxCluster cluster) {
         verifyPaywallAccess(userCrn, request);
         String imageId = determineImageId(request, upgradeCandidates);
-        boolean skipBackup = request != null && request.isBackupSkipped();
+        boolean skipBackup = request != null && Boolean.TRUE.equals(request.getSkipBackup());
         FlowIdentifier flowIdentifier = triggerDatalakeUpgradeFlow(imageId, cluster, shouldReplaceVmsAfterUpgrade(request), skipBackup);
         String message = getMessage(imageId);
         return new SdxUpgradeResponse(message, flowIdentifier);


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-15467

Thunderhead was naming the field `backupSkipped` instead of `skipBackup` which would result in issues once a request was sent by Thunderhead to CB.

This should fix it.