### PR TITLE
CB-15485 [log4j] Update JVM properties of the cloudera runtime via CB…

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/AbstractRoleConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/AbstractRoleConfigProvider.java
@@ -19,6 +19,8 @@ import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 
 public abstract class AbstractRoleConfigProvider implements CmTemplateComponentConfigProvider {
 
+    public static final String LOG4J2_FORMAT_MSG_NO_LOOKUPS = "-Dlog4j2.formatMsgNoLookups=True";
+
     private static final String PATCH_VERSION_REGEX = "\\.p([0-9]+)\\.";
 
     @Override

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/spark/Spark3OnYarnRoleConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/spark/Spark3OnYarnRoleConfigProvider.java
@@ -16,6 +16,12 @@ import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 @Component
 public class Spark3OnYarnRoleConfigProvider extends AbstractRoleConfigProvider {
 
+    public static final String SPARK_YARN_AM_EXTRA_JAVA_OPTIONS = "spark.yarn.am.extraJavaOptions";
+
+    public static final String SPARK_DRIVER_EXTRA_JAVA_OPTIONS = "spark.driver.extraJavaOptions";
+
+    public static final String SPARK_EXECUTOR_EXTRA_JAVA_OPTIONS = "spark.executor.extraJavaOptions";
+
     private static final String SPARK3_CONF_CLIENT_SAFETY_VALVE = "spark3-conf/spark-defaults.conf_client_config_safety_valve";
 
     private static final String SPARK3_YARN_ACCESS_DIR_PARAM = "spark.kerberos.access.hadoopFileSystems=";
@@ -27,7 +33,10 @@ public class Spark3OnYarnRoleConfigProvider extends AbstractRoleConfigProvider {
                 return ConfigUtils.getStorageLocationForServiceProperty(source, HMS_METASTORE_EXTERNAL_DIR)
                         .map(location -> ConfigUtils.getBasePathFromStorageLocation(location.getValue()))
                         .map(basePath -> List.of(config(SPARK3_CONF_CLIENT_SAFETY_VALVE,
-                                SPARK3_YARN_ACCESS_DIR_PARAM + basePath)))
+                                SPARK3_YARN_ACCESS_DIR_PARAM + basePath + '\n' +
+                                        SPARK_YARN_AM_EXTRA_JAVA_OPTIONS + '=' + LOG4J2_FORMAT_MSG_NO_LOOKUPS + '\n' +
+                                        SPARK_DRIVER_EXTRA_JAVA_OPTIONS + '=' + LOG4J2_FORMAT_MSG_NO_LOOKUPS + '\n' +
+                                        SPARK_EXECUTOR_EXTRA_JAVA_OPTIONS + '=' + LOG4J2_FORMAT_MSG_NO_LOOKUPS)))
                         .orElseGet(List::of);
             default:
                 return List.of();

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/spark/SparkOnYarnRoleConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/spark/SparkOnYarnRoleConfigProvider.java
@@ -2,6 +2,9 @@ package com.sequenceiq.cloudbreak.cmtemplate.configproviders.spark;
 
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive.HiveMetastoreCloudStorageServiceConfigProvider.HMS_METASTORE_EXTERNAL_DIR;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.spark.Spark3OnYarnRoleConfigProvider.SPARK_DRIVER_EXTRA_JAVA_OPTIONS;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.spark.Spark3OnYarnRoleConfigProvider.SPARK_EXECUTOR_EXTRA_JAVA_OPTIONS;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.spark.Spark3OnYarnRoleConfigProvider.SPARK_YARN_AM_EXTRA_JAVA_OPTIONS;
 
 import java.util.List;
 
@@ -27,7 +30,10 @@ public class SparkOnYarnRoleConfigProvider extends AbstractRoleConfigProvider {
                 return ConfigUtils.getStorageLocationForServiceProperty(source, HMS_METASTORE_EXTERNAL_DIR)
                         .map(location -> ConfigUtils.getBasePathFromStorageLocation(location.getValue()))
                         .map(basePath -> List.of(config(SPARK_CONF_CLIENT_SAFETY_VALVE,
-                                SPARK_YARN_ACCESS_DIR_PARAM + basePath)))
+                                SPARK_YARN_ACCESS_DIR_PARAM + basePath + '\n' +
+                                        SPARK_YARN_AM_EXTRA_JAVA_OPTIONS + '=' + LOG4J2_FORMAT_MSG_NO_LOOKUPS + '\n' +
+                                        SPARK_DRIVER_EXTRA_JAVA_OPTIONS + '=' + LOG4J2_FORMAT_MSG_NO_LOOKUPS + '\n' +
+                                        SPARK_EXECUTOR_EXTRA_JAVA_OPTIONS + '=' + LOG4J2_FORMAT_MSG_NO_LOOKUPS)))
                         .orElseGet(List::of);
             default:
                 return List.of();

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/yarn/YarnConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/yarn/YarnConfigProvider.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.yarn;
 
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRoleConfigProvider.LOG4J2_FORMAT_MSG_NO_LOOKUPS;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
 
 import java.util.List;
@@ -23,6 +24,10 @@ public class YarnConfigProvider implements CmTemplateComponentConfigProvider {
 
     private static final String YARN_SITE_SERVICE_SAFETY_VALVE = "yarn_service_config_safety_valve";
 
+    private static final String MAPREDUCE_MAP_JAVA_OPTS = "mapreduce_map_java_opts";
+
+    private static final String MAPREDUCE_REDUCE_JAVA_OPTS = "mapreduce_reduce_java_opts";
+
     @Inject
     private ExposedServiceCollector exposedServiceCollector;
 
@@ -32,6 +37,8 @@ public class YarnConfigProvider implements CmTemplateComponentConfigProvider {
         if (templateProcessor.getServiceByType(HiveRoles.HIVELLAP).isPresent()) {
             apiClusterTemplateConfigs.add(config(YARN_SITE_SERVICE_SAFETY_VALVE, getYarnSiteServiceValveValue()));
         }
+        apiClusterTemplateConfigs.add(config(MAPREDUCE_MAP_JAVA_OPTS, LOG4J2_FORMAT_MSG_NO_LOOKUPS));
+        apiClusterTemplateConfigs.add(config(MAPREDUCE_REDUCE_JAVA_OPTS, LOG4J2_FORMAT_MSG_NO_LOOKUPS));
         return apiClusterTemplateConfigs;
     }
 

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/spark/Spark3OnYarnRoleConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/spark/Spark3OnYarnRoleConfigProviderTest.java
@@ -63,7 +63,10 @@ public class Spark3OnYarnRoleConfigProviderTest {
 
         assertEquals(1, sparkOnYarnConfigs.size());
         assertEquals("spark3-conf/spark-defaults.conf_client_config_safety_valve", sparkOnYarnConfigs.get(0).getName());
-        assertEquals("spark.kerberos.access.hadoopFileSystems=" + clientConfigDirLocation, sparkOnYarnConfigs.get(0).getValue());
+        String log4j = "\nspark.yarn.am.extraJavaOptions=-Dlog4j2.formatMsgNoLookups=True\n" +
+                "spark.driver.extraJavaOptions=-Dlog4j2.formatMsgNoLookups=True\n" +
+                "spark.executor.extraJavaOptions=-Dlog4j2.formatMsgNoLookups=True";
+        assertEquals("spark.kerberos.access.hadoopFileSystems=" + clientConfigDirLocation + log4j, sparkOnYarnConfigs.get(0).getValue());
     }
 
     private TemplatePreparationObject getTemplatePreparationObject(String... locations) {

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/spark/SparkOnYarnRoleConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/spark/SparkOnYarnRoleConfigProviderTest.java
@@ -63,7 +63,10 @@ public class SparkOnYarnRoleConfigProviderTest {
 
         assertEquals(1, sparkOnYarnConfigs.size());
         assertEquals("spark-conf/spark-defaults.conf_client_config_safety_valve", sparkOnYarnConfigs.get(0).getName());
-        assertEquals("spark.yarn.access.hadoopFileSystems=" + clientConfigDirLocation, sparkOnYarnConfigs.get(0).getValue());
+        String log4j = "\nspark.yarn.am.extraJavaOptions=-Dlog4j2.formatMsgNoLookups=True\n" +
+                "spark.driver.extraJavaOptions=-Dlog4j2.formatMsgNoLookups=True\n" +
+                "spark.executor.extraJavaOptions=-Dlog4j2.formatMsgNoLookups=True";
+        assertEquals("spark.yarn.access.hadoopFileSystems=" + clientConfigDirLocation + log4j, sparkOnYarnConfigs.get(0).getValue());
     }
 
     private TemplatePreparationObject getTemplatePreparationObject(String... locations) {

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/yarn/YarnConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/yarn/YarnConfigProviderTest.java
@@ -32,16 +32,20 @@ public class YarnConfigProviderTest {
     public void testGetConfigsWhenLlapIsPresent() {
         when(cmTemplateProcessor.getServiceByType(eq(HiveRoles.HIVELLAP))).thenReturn(Optional.of(new ApiClusterTemplateService()));
         List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(cmTemplateProcessor, null);
-        assertEquals(1, serviceConfigs.size());
-        assertTrue(serviceConfigs.stream().anyMatch(sc -> StringUtils.equals(sc.getName(), "yarn_service_config_safety_valve")));
+        assertEquals(3, serviceConfigs.size());
+        assertTrue(serviceConfigs.stream().allMatch(sc -> StringUtils.equals(sc.getName(), "yarn_service_config_safety_valve") ||
+                                                            StringUtils.equals(sc.getName(), "mapreduce_map_java_opts") ||
+                                                            StringUtils.equals(sc.getName(), "mapreduce_reduce_java_opts")));
     }
 
     @Test
     public void testGetConfigsWhenLlapIsNotPresent() {
         when(cmTemplateProcessor.getServiceByType(eq(HiveRoles.HIVELLAP))).thenReturn(Optional.empty());
         List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(cmTemplateProcessor, null);
-        assertEquals(0, serviceConfigs.size());
+        assertEquals(2, serviceConfigs.size());
         assertFalse(serviceConfigs.stream().anyMatch(sc -> StringUtils.equals(sc.getName(), "yarn_service_config_safety_valve")));
+        assertTrue(serviceConfigs.stream().allMatch(sc -> StringUtils.equals(sc.getName(), "mapreduce_map_java_opts") ||
+                                                            StringUtils.equals(sc.getName(), "mapreduce_reduce_java_opts")));
     }
 
 }


### PR DESCRIPTION
… for additional protection

1. Spark and Yarn are covered.
2. Tez and other services are yet to be covered.
3. Only unit test done, end to end is pending.
4. Depending on component team commitment and QE teams commitment can add more services and testing

See detailed description in the commit message.