### PR TITLE
CB-11741: Nigthly e2e Azure tests should use encryption

### DIFF
--- a/integration-test/src/main/resources/testsuites/e2e/azure-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/azure-e2e-tests.yaml
@@ -16,4 +16,4 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxImagesTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRepairTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.AzureMarketplaceImageTest
-        name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.EnvironmentWithCustomerManagedKeyTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.EnvironmentWithCustomerManagedKeyTests


### PR DESCRIPTION
CB-11741: Nigthly e2e Azure tests should use encryption
This PR fixes the missing "-" for commit : https://github.com/hortonworks/cloudbreak/pull/11898/commits/85846c72e5d7c0e29aaf5109639eab8ff9459511
