### PR TITLE
CB-15491 make log4j as an illegal import in Cloudbreak. Sometimes we …

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/AzureIDBrokerObjectStorageValidator.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/AzureIDBrokerObjectStorageValidator.java
@@ -21,7 +21,6 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -169,7 +168,7 @@ public class AzureIDBrokerObjectStorageValidator {
 
     private void validateLog(AzureClient client, Identity identity, String logsLocationBase, ValidationResultBuilder resultBuilder) {
         LOGGER.debug(String.format("Validating logger identity %s", identity.principalId()));
-        if (Strings.isNotEmpty(logsLocationBase)) {
+        if (StringUtils.isNotEmpty(logsLocationBase)) {
             validateStorageAccount(client, Set.of(identity), logsLocationBase, LOG, resultBuilder);
         } else {
             LOGGER.debug("There is no storage location set for logger identity, this should not happen!");

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -186,8 +186,12 @@
             <property name="illegalClassNames" value="" />
         </module>
         <module name="IllegalImport">
+            <!-- no sun dependency, use java.lang -->
+            <property name="illegalPkgs" value="sun" />
+        </module>
+        <module name="IllegalImport">
             <!-- use org.slf4j -->
-            <property name="illegalPkgs" value="sun, org.apache.commons.logging, org.apache.log4j, java.util.logging" />
+            <property name="illegalPkgs" value="org.apache.logging, org.apache.commons.logging, org.apache.log4j, java.util.logging" />
         </module>
         <module name="IllegalImport">
             <!-- use org.junit -->

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/delete/handler/RdsDeletionHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/delete/handler/RdsDeletionHandler.java
@@ -2,7 +2,7 @@ package com.sequenceiq.datalake.flow.delete.handler;
 
 import javax.inject.Inject;
 
-import org.apache.logging.log4j.util.Strings;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -65,7 +65,7 @@ public class RdsDeletionHandler extends ExceptionCatcherEventHandler<RdsDeletion
         Selectable response;
         try {
             sdxClusterRepository.findById(sdxId).ifPresent(sdxCluster -> {
-                if (sdxCluster.hasExternalDatabase() && Strings.isNotEmpty(sdxCluster.getDatabaseCrn())) {
+                if (sdxCluster.hasExternalDatabase() && StringUtils.isNotEmpty(sdxCluster.getDatabaseCrn())) {
                     LOGGER.debug("start polling database termination for sdx: {}", sdxId);
                     databaseService.terminate(sdxCluster, rdsWaitRequest.isForced());
                 } else {

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/imagecatalog/ImageCatalogService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/imagecatalog/ImageCatalogService.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 
 import javax.inject.Inject;
 
-import org.apache.logging.log4j.util.Strings;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -59,7 +59,7 @@ public class ImageCatalogService implements ResourcePropertyProvider {
                     imageSettingsV4Request.getCatalog(), imageSettingsV4Request.getId());
             ImagesV4Response imagesV4Response = null;
             try {
-                if (Strings.isBlank(imageSettingsV4Request.getCatalog())) {
+                if (StringUtils.isBlank(imageSettingsV4Request.getCatalog())) {
                     imagesV4Response = imageCatalogV4Endpoint.getImageByImageId(SdxService.WORKSPACE_ID_DEFAULT, imageSettingsV4Request.getId(), accountId);
                 } else {
                     imagesV4Response = imageCatalogV4Endpoint.getImageByCatalogNameAndImageId(SdxService.WORKSPACE_ID_DEFAULT,

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/pause/DatabasePauseSupportService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/pause/DatabasePauseSupportService.java
@@ -1,14 +1,15 @@
 package com.sequenceiq.datalake.service.pause;
 
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.datalake.configuration.PlatformConfig;
 import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.service.EnvironmentClientService;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
-import org.apache.logging.log4j.util.Strings;
-import org.springframework.stereotype.Component;
-
-import javax.inject.Inject;
 
 @Component
 public class DatabasePauseSupportService {
@@ -20,7 +21,7 @@ public class DatabasePauseSupportService {
     private PlatformConfig platformConfig;
 
     public boolean isDatabasePauseSupported(SdxCluster sdxCluster) {
-        if (sdxCluster.hasExternalDatabase() && Strings.isNotEmpty(sdxCluster.getDatabaseCrn())) {
+        if (sdxCluster.hasExternalDatabase() && StringUtils.isNotEmpty(sdxCluster.getDatabaseCrn())) {
             DetailedEnvironmentResponse environment = environmentClientService.getByCrn(sdxCluster.getEnvCrn());
 
             return platformConfig.isExternalDatabasePauseSupportedFor(CloudPlatform.valueOf(environment.getCloudPlatform()));

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -32,7 +32,6 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.logging.log4j.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -471,7 +470,7 @@ public class SdxService implements ResourceIdProvider, ResourcePropertyProvider,
         newSdxCluster.setTags(sdxCluster.getTags());
         newSdxCluster.setCrn(sdxCluster.getCrn());
         CloudPlatform cloudPlatform = CloudPlatform.valueOf(environment.getCloudPlatform());
-        if (!Strings.isBlank(sdxCluster.getCloudStorageBaseLocation())) {
+        if (!StringUtils.isBlank(sdxCluster.getCloudStorageBaseLocation())) {
             newSdxCluster.setCloudStorageBaseLocation(sdxCluster.getCloudStorageBaseLocation());
             newSdxCluster.setCloudStorageFileSystemType(sdxCluster.getCloudStorageFileSystemType());
         } else if (!CloudPlatform.YARN.equalsIgnoreCase(cloudPlatform.name()) &&
@@ -492,7 +491,7 @@ public class SdxService implements ResourceIdProvider, ResourcePropertyProvider,
         prepareCloudStorageForStack(stackRequest, stackV4Response, newSdxCluster, environment);
         prepareDefaultSecurityConfigs(null, stackRequest, cloudPlatform);
         try {
-            if (!Strings.isBlank(sdxCluster.getStackRequestToCloudbreak())) {
+            if (!StringUtils.isBlank(sdxCluster.getStackRequestToCloudbreak())) {
                 StackV4Request stackV4RequestOrig = JsonUtil.readValue(sdxCluster.getStackRequestToCloudbreak(), StackV4Request.class);
                 stackRequest.setImage(stackV4RequestOrig.getImage());
             }
@@ -1086,7 +1085,7 @@ public class SdxService implements ResourceIdProvider, ResourcePropertyProvider,
     }
 
     private void checkIfSdxIsDeletable(SdxCluster sdxCluster, boolean forced) {
-        if (!forced && sdxCluster.hasExternalDatabase() && Strings.isEmpty(sdxCluster.getDatabaseCrn())) {
+        if (!forced && sdxCluster.hasExternalDatabase() && StringUtils.isEmpty(sdxCluster.getDatabaseCrn())) {
             throw new BadRequestException(String.format("Can not find external database for Data Lake, but it was requested: %s. Please use force delete.",
                     sdxCluster.getClusterName()));
         }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/database/DatabaseService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/database/DatabaseService.java
@@ -12,7 +12,6 @@ import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,8 +21,8 @@ import com.dyngr.Polling;
 import com.dyngr.core.AttemptResults;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.database.StackDatabaseServerResponse;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
-import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.cloud.VersionComparator;
 import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
@@ -130,7 +129,7 @@ public class DatabaseService {
     }
 
     private boolean dbHasBeenCreatedPreviously(SdxCluster sdxCluster) {
-        return Strings.isNotEmpty(sdxCluster.getDatabaseCrn());
+        return StringUtils.isNotEmpty(sdxCluster.getDatabaseCrn());
     }
 
     public void terminate(SdxCluster sdxCluster, boolean forced) {

--- a/datalake/src/main/java/com/sequenceiq/datalake/settings/SdxRepairSettings.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/settings/SdxRepairSettings.java
@@ -8,7 +8,6 @@ import java.util.stream.Stream;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.util.Strings;
 
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.sdx.api.model.SdxRepairRequest;
@@ -36,7 +35,7 @@ public class SdxRepairSettings {
                     ", or nodes ('nodesIds').");
         }
         SdxRepairSettings settings = new SdxRepairSettings();
-        if (Strings.isNotEmpty(request.getHostGroupName())) {
+        if (StringUtils.isNotEmpty(request.getHostGroupName())) {
             settings.hostGroupNames.add(request.getHostGroupName());
         } else if (CollectionUtils.isNotEmpty(request.getHostGroupNames())) {
             settings.hostGroupNames.addAll(request.getHostGroupNames());

--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/EnvironmentValidatorService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/EnvironmentValidatorService.java
@@ -6,7 +6,6 @@ import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.GCP;
 import static com.sequenceiq.common.model.CredentialType.ENVIRONMENT;
 
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
-import static org.apache.logging.log4j.util.Strings.isEmpty;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -235,11 +234,11 @@ public class EnvironmentValidatorService {
     }
 
     private boolean isAnySecurityGroupMissing(SecurityAccessDto securityAccessDto) {
-        return isEmpty(securityAccessDto.getDefaultSecurityGroupId()) || isEmpty(securityAccessDto.getSecurityGroupIdForKnox());
+        return StringUtils.isEmpty(securityAccessDto.getDefaultSecurityGroupId()) || StringUtils.isEmpty(securityAccessDto.getSecurityGroupIdForKnox());
     }
 
     private boolean isAllSecurityGroupMissing(SecurityAccessDto securityAccessDto) {
-        return isEmpty(securityAccessDto.getDefaultSecurityGroupId()) && isEmpty(securityAccessDto.getSecurityGroupIdForKnox());
+        return StringUtils.isEmpty(securityAccessDto.getDefaultSecurityGroupId()) && StringUtils.isEmpty(securityAccessDto.getSecurityGroupIdForKnox());
     }
 
     private boolean platformEnabled(Set<String> cloudPlatforms, String cloudPlatform) {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/cloudstorage/EnvironmentStorageConfigurationValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/cloudstorage/EnvironmentStorageConfigurationValidator.java
@@ -1,6 +1,6 @@
 package com.sequenceiq.environment.environment.validation.cloudstorage;
 
-import org.apache.logging.log4j.util.Strings;
+import org.apache.commons.lang3.StringUtils;
 
 import com.sequenceiq.cloudbreak.common.type.CloudConstants;
 import com.sequenceiq.cloudbreak.util.DocumentationLinkProvider;
@@ -10,7 +10,7 @@ import com.sequenceiq.environment.environment.domain.Environment;
 public abstract class EnvironmentStorageConfigurationValidator {
 
     protected void validateGcsConfig(Environment environment, ValidationResult.ValidationResultBuilder resultBuilder, String serviceAccountEmail) {
-        if (Strings.isNotBlank(serviceAccountEmail)) {
+        if (StringUtils.isNotBlank(serviceAccountEmail)) {
             if (!serviceAccountEmail.contains(".iam.gserviceaccount.com")) {
                 resultBuilder.error("Must be a full valid google service account in the format of " +
                         "[service-account-name]@[project-name].iam.gserviceaccount.com." +
@@ -23,7 +23,7 @@ public abstract class EnvironmentStorageConfigurationValidator {
     }
 
     protected void validateAdlsGen2Config(Environment environment, ValidationResult.ValidationResultBuilder resultBuilder, String managedIdentity) {
-        if (Strings.isNotBlank(managedIdentity)) {
+        if (StringUtils.isNotBlank(managedIdentity)) {
             if (!managedIdentity.matches("^/subscriptions/[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}/"
                     + "(resourceGroups|resourcegroups)/[-\\w._()]+/providers/Microsoft.ManagedIdentity/userAssignedIdentities/[A-Za-z0-9-_]*$")) {
                 resultBuilder.error("Must be a full valid managed identity resource ID in the format of /subscriptions/[your-subscription-id]/resourceGroups/" +
@@ -37,7 +37,7 @@ public abstract class EnvironmentStorageConfigurationValidator {
     }
 
     protected void validateS3Config(Environment environment, ValidationResult.ValidationResultBuilder resultBuilder, String instanceProfile) {
-        if (Strings.isNotBlank(instanceProfile)) {
+        if (StringUtils.isNotBlank(instanceProfile)) {
             if (!instanceProfile.startsWith("arn:aws:iam::") || !(instanceProfile.contains(":instance-profile/"))) {
                 resultBuilder.error("Must be a full valid amazon instance profile in the format of arn:aws:iam::[account-id]:instance-profile/[role-name]." +
                         getDocLink(environment.getCloudPlatform()));

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/kerberos/v1/KerberosConfigToCreateKerberosConfigRequestConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/kerberos/v1/KerberosConfigToCreateKerberosConfigRequestConverter.java
@@ -1,6 +1,6 @@
 package com.sequenceiq.freeipa.kerberos.v1;
 
-import org.apache.logging.log4j.util.Strings;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.freeipa.api.v1.kerberos.model.create.ActiveDirectoryKerberosDescriptor;
@@ -87,7 +87,7 @@ public class KerberosConfigToCreateKerberosConfigRequestConverter {
     }
 
     private String getFakeSecretIfNotNull(String value, String postfix) {
-        if (Strings.isNotBlank(value)) {
+        if (StringUtils.isNotBlank(value)) {
             String postString = postfix != null ? postfix : "secret";
             return "fake-" + postString;
         }


### PR DESCRIPTION
…have imported log4j in some of our class classes, these were always accidental imports. We shall ensure through checkstyle that we are not doing it.

This is not related to the log4j vulnerability, this is more like a code hygiene issue.

See detailed description in the commit message.