### PR TITLE
Revert "CB-15396 Fix TagsUtil applied length restrictions for Azure and AWS"

### DIFF
--- a/config/idea/inspections.xml
+++ b/config/idea/inspections.xml
@@ -1,5 +1,5 @@
 <profile version="1.0">
-  <option name="myName" value="CloudbreakDefault" />
+  <option name="myName" value="Default" />
   <inspection_tool class="AbstractClassNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
   <inspection_tool class="AbstractClassNeverImplemented" enabled="true" level="WARNING" enabled_by_default="true" />
   <inspection_tool class="AbstractMethodOverridesAbstractMethod" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -460,16 +460,7 @@
   <inspection_tool class="MultipleTopLevelClassesInFile" enabled="true" level="WARNING" enabled_by_default="true" />
   <inspection_tool class="MultipleTypedDeclaration" enabled="true" level="WARNING" enabled_by_default="true" />
   <inspection_tool class="NakedNotify" enabled="true" level="WARNING" enabled_by_default="true" />
-  <inspection_tool class="NewMethodNamingConvention" enabled="true" level="ERROR" enabled_by_default="true">
-    <extension name="JUnit3MethodNamingConvention" enabled="true" />
-    <extension name="JUnit4MethodNamingConvention" enabled="true" />
-    <extension name="NativeMethodNamingConvention" enabled="true" />
-    <extension name="TestNGMethodNamingConvention" enabled="true">
-      <option name="m_regex" value="[a-z][A-Za-z_\d]*" />
-      <option name="m_minLength" value="4" />
-      <option name="m_maxLength" value="63" />
-    </extension>
-  </inspection_tool>
+  <inspection_tool class="NativeMethodNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
   <inspection_tool class="NegatedConditional" enabled="true" level="WARNING" enabled_by_default="true">
     <option name="m_ignoreNegatedNullComparison" value="true" />
   </inspection_tool>

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/E2ETestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/E2ETestContext.java
@@ -21,7 +21,10 @@ public class E2ETestContext extends TestContext {
     public <O extends CloudbreakTestDto> O init(Class<O> clss, CloudPlatform cloudPlatform) {
         O bean = super.init(clss, cloudPlatform);
         String testName = getTestMethodName().orElseThrow(TestMethodNameMissingException::new);
-        tagsUtil.addTestNameTag(cloudPlatform, bean, testName);
+        if  (cloudPlatform == CloudPlatform.GCP) {
+            testName = testName.toLowerCase();
+        }
+        tagsUtil.addTestNameTag(getCloudProvider().getCloudPlatform(), bean, testName);
         return bean;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/E2ETestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/E2ETestContext.java
@@ -24,7 +24,7 @@ public class E2ETestContext extends TestContext {
         if  (cloudPlatform == CloudPlatform.GCP) {
             testName = testName.toLowerCase();
         }
-        tagsUtil.addTestNameTag(getCloudProvider().getCloudPlatform(), bean, testName);
+        tagsUtil.addTestNameTag(bean, testName);
         return bean;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/MeasuredTestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/MeasuredTestContext.java
@@ -277,11 +277,6 @@ public class MeasuredTestContext extends MockedTestContext {
     }
 
     @Override
-    public CloudPlatform getCloudPlatform() {
-        return wrappedTestContext.getCloudPlatform();
-    }
-
-    @Override
     protected <T extends CloudbreakTestDto, U extends MicroserviceClient>
     T doAction(T entity, Class<? extends MicroserviceClient> clientClass, Action<T, U> action, String who) throws Exception {
         PerformanceIndicator pi = new PerformanceIndicator(action.getClass().getSimpleName());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
@@ -553,8 +553,8 @@ public abstract class TestContext implements ApplicationContextAware {
      * by `useRealUmsUser(testContext, AuthUserKeys.ACCOUNT_ADMIN)`
      */
     private Optional<String> getRealUMSUserName() {
-        if (getRealUMSUserCrn().isPresent()) {
-            return Optional.of(getActingUser().getDisplayName());
+        if (Crn.isCrn(getActingUser().getCrn())) {
+            return Optional.of(Objects.requireNonNull(Crn.fromString(getActingUser().getCrn())).getUserId());
         }
         return Optional.empty();
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
@@ -678,7 +678,7 @@ public abstract class TestContext implements ApplicationContextAware {
     }
 
     public <O extends CloudbreakTestDto> O init(Class<O> clss) {
-        return init(clss, getCloudPlatform());
+        return init(clss, CloudPlatform.valueOf(commonCloudProperties.getCloudProvider()));
     }
 
     public <O extends CloudbreakTestDto> O init(Class<O> clss, CloudPlatform cloudPlatform) {
@@ -707,7 +707,7 @@ public abstract class TestContext implements ApplicationContextAware {
     }
 
     public <O extends CloudbreakTestDto> O given(String key, Class<O> clss) {
-        return given(key, clss, getCloudPlatform());
+        return given(key, clss, CloudPlatform.valueOf(commonCloudProperties.getCloudProvider()));
     }
 
     public <O extends CloudbreakTestDto> O given(String key, Class<O> clss, CloudPlatform cloudPlatform) {
@@ -1211,10 +1211,6 @@ public abstract class TestContext implements ApplicationContextAware {
 
     public CloudProviderProxy getCloudProvider() {
         return cloudProvider;
-    }
-
-    public CloudPlatform getCloudPlatform() {
-        return CloudPlatform.valueOf(commonCloudProperties.getCloudProvider());
     }
 
     public void waitingFor(Duration duration, String interruptedMessage) {

--- a/integration-test/src/test/java/com/sequenceiq/it/util/TagsUtilTest.java
+++ b/integration-test/src/test/java/com/sequenceiq/it/util/TagsUtilTest.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import org.mockito.Mockito;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -19,7 +20,6 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.tags.TagsV4Response;
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.cloud.gcp.util.GcpLabelUtil;
-import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.AbstractTestDto;
@@ -47,8 +47,6 @@ public class TagsUtilTest {
             "Cloudera-Resource-Name", "whatever"
     );
 
-    private CloudPlatform cloudPlatform;
-
     private TagsUtil underTest;
 
     private MockedTestContext testContext;
@@ -58,9 +56,8 @@ public class TagsUtilTest {
     @BeforeMethod
     public void setUp() {
         underTest = new TagsUtil();
-        testContext = mock(MockedTestContext.class);
-        gcpLabelUtil = mock(GcpLabelUtil.class);
-        cloudPlatform = testContext.getCloudProvider().getCloudPlatform();
+        testContext = Mockito.mock(MockedTestContext.class);
+        gcpLabelUtil = Mockito.mock(GcpLabelUtil.class);
         ReflectionTestUtils.setField(underTest, "gcpLabelUtil", gcpLabelUtil);
         when(testContext.getTestMethodName()).thenReturn(Optional.of(TEST_NAME));
         when(testContext.getActingUserName()).thenReturn(ACTING_USER_NAME);
@@ -71,15 +68,15 @@ public class TagsUtilTest {
     void addTestNameTagShouldNotFailWhenTestDtoIsNotAbstractTestDto() {
         CloudbreakTestDto testDto = mock(CloudbreakTestDto.class);
 
-        assertThatCode(() -> underTest.addTestNameTag(cloudPlatform, testDto, TEST_NAME))
+        assertThatCode(() -> underTest.addTestNameTag(testDto, TEST_NAME))
                 .doesNotThrowAnyException();
     }
 
     @Test
-    void addTestNameTagShouldNotFailWhenTestDtoDoesNotHaveTaggedRequest() {
+    void addTestNameTagShouldNotFailWhenTestDtoDoesNotHaveTaggableRequest() {
         CloudbreakTestDto testDto = mock(AbstractTestDto.class);
 
-        assertThatCode(() -> underTest.addTestNameTag(cloudPlatform, testDto, TEST_NAME))
+        assertThatCode(() -> underTest.addTestNameTag(testDto, TEST_NAME))
                 .doesNotThrowAnyException();
     }
 
@@ -89,7 +86,7 @@ public class TagsUtilTest {
         SdxClusterRequest request = new SdxClusterRequest();
         testDto.setRequest(request);
 
-        underTest.addTestNameTag(cloudPlatform, testDto, TEST_NAME);
+        underTest.addTestNameTag(testDto, TEST_NAME);
 
         assertThat(request.getTags().get(TagsUtil.TEST_NAME_TAG))
                 .isEqualTo(TEST_NAME);
@@ -127,7 +124,7 @@ public class TagsUtilTest {
     }
 
     @Test
-    void verifyShouldFailAbstractTestDtoDoesNotHaveAllNeededTags() {
+    void verifyTagsShouldFailWhenAbstractTestDtoWithTaggedResponseDoesNotHaveAllNeededTags() {
         DistroXTestDto testDto = new DistroXTestDto(mock(TestContext.class));
         StackV4Response response = new StackV4Response();
         TagsV4Response tags = new TagsV4Response();
@@ -146,7 +143,7 @@ public class TagsUtilTest {
     }
 
     @Test
-    void verifyShouldFailTestContextHasNullAsActingUserCrn() {
+    void verifyTagsShouldFailWhenTestContextHasNullAsActingCrn() {
         DistroXTestDto testDto = new DistroXTestDto(mock(TestContext.class));
         StackV4Response response = new StackV4Response();
         TagsV4Response tags = new TagsV4Response();
@@ -163,7 +160,7 @@ public class TagsUtilTest {
     }
 
     @Test
-    void verifyShouldFailAbstractTestDtoDoesNotHaveAnyNeededTags() {
+    void verifyTagsShouldFailWhenAbstractTestDtoWithTaggedResponseDoesNotHaveAnyNeededTags() {
         DistroXTestDto testDto = new DistroXTestDto(mock(TestContext.class));
         testDto.setResponse(new StackV4Response());
 
@@ -173,7 +170,7 @@ public class TagsUtilTest {
     }
 
     @Test
-    void verifyCreatorTagWithAltusCrnButTestContextHasCdpCrn() {
+    void verifyTagsShouldVerifyTagWithTaggedResponseWhenTagsResponseContainCreatorWithAltusPartitionedCrnButTestContextHasCdpPartitionedCrn() {
         DistroXTestDto testDto = new DistroXTestDto(mock(TestContext.class));
         StackV4Response response = new StackV4Response();
         TagsV4Response tags = new TagsV4Response();
@@ -190,7 +187,7 @@ public class TagsUtilTest {
     }
 
     @Test
-    void verifyCreatorTagWithCdpCrnButTestContextHasAltusCrn() {
+    void verifyTagsShouldVerifyTagWithTaggedResponseWhenTagsResponseContainCreatorWithCdpPartitionedCrnButTestContextHasAltusPartitionedCrn() {
         DistroXTestDto testDto = new DistroXTestDto(mock(TestContext.class));
         StackV4Response response = new StackV4Response();
         TagsV4Response tags = new TagsV4Response();
@@ -206,7 +203,7 @@ public class TagsUtilTest {
     }
 
     @Test
-    void verifyCreatorTagAsGcpLabelTransformedValue() {
+    void verifyTagsShouldVerifyTagWithTaggedResponseWhenTagsResponseContainsCreatorAsGcpLabelTransformedValue() {
         DistroXTestDto testDto = new DistroXTestDto(mock(TestContext.class));
         StackV4Response response = new StackV4Response();
         TagsV4Response tags = new TagsV4Response();

--- a/integration-test/src/test/java/com/sequenceiq/it/util/TagsUtilTest.java
+++ b/integration-test/src/test/java/com/sequenceiq/it/util/TagsUtilTest.java
@@ -47,6 +47,8 @@ public class TagsUtilTest {
             "Cloudera-Resource-Name", "whatever"
     );
 
+    private CloudPlatform cloudPlatform;
+
     private TagsUtil underTest;
 
     private MockedTestContext testContext;
@@ -58,6 +60,7 @@ public class TagsUtilTest {
         underTest = new TagsUtil();
         testContext = mock(MockedTestContext.class);
         gcpLabelUtil = mock(GcpLabelUtil.class);
+        cloudPlatform = testContext.getCloudProvider().getCloudPlatform();
         ReflectionTestUtils.setField(underTest, "gcpLabelUtil", gcpLabelUtil);
         when(testContext.getTestMethodName()).thenReturn(Optional.of(TEST_NAME));
         when(testContext.getActingUserName()).thenReturn(ACTING_USER_NAME);
@@ -67,18 +70,16 @@ public class TagsUtilTest {
     @Test
     void addTestNameTagShouldNotFailWhenTestDtoIsNotAbstractTestDto() {
         CloudbreakTestDto testDto = mock(CloudbreakTestDto.class);
-        when(testDto.getCloudPlatform()).thenReturn(CloudPlatform.MOCK);
 
-        assertThatCode(() -> underTest.addTestNameTag(testDto.getCloudPlatform(), testDto, TEST_NAME))
+        assertThatCode(() -> underTest.addTestNameTag(cloudPlatform, testDto, TEST_NAME))
                 .doesNotThrowAnyException();
     }
 
     @Test
     void addTestNameTagShouldNotFailWhenTestDtoDoesNotHaveTaggedRequest() {
         CloudbreakTestDto testDto = mock(AbstractTestDto.class);
-        when(testDto.getCloudPlatform()).thenReturn(CloudPlatform.MOCK);
 
-        assertThatCode(() -> underTest.addTestNameTag(testDto.getCloudPlatform(), testDto, TEST_NAME))
+        assertThatCode(() -> underTest.addTestNameTag(cloudPlatform, testDto, TEST_NAME))
                 .doesNotThrowAnyException();
     }
 
@@ -87,9 +88,8 @@ public class TagsUtilTest {
         SdxTestDto testDto = new SdxTestDto(mock(TestContext.class));
         SdxClusterRequest request = new SdxClusterRequest();
         testDto.setRequest(request);
-        when(testContext.getCloudPlatform()).thenReturn(CloudPlatform.MOCK);
 
-        underTest.addTestNameTag(testContext.getCloudPlatform(), testDto, TEST_NAME);
+        underTest.addTestNameTag(cloudPlatform, testDto, TEST_NAME);
 
         assertThat(request.getTags().get(TagsUtil.TEST_NAME_TAG))
                 .isEqualTo(TEST_NAME);
@@ -138,7 +138,7 @@ public class TagsUtilTest {
         response.setTags(tags);
         testDto.setResponse(response);
 
-        String expectedMsg = String.format(TagsUtil.TAG_VALUE_IS_NULL_FAILURE_PATTERN, OWNER_TAG_KEY);
+        String expectedMsg = String.format(TagsUtil.ACTING_USER_NAME_VALUE_FAILURE_PATTERN, OWNER_TAG_KEY, "null", ACTING_USER_NAME);
         assertThatThrownBy(() -> underTest.verifyTags(testDto, testContext))
                 .hasMessageContaining(expectedMsg)
                 .matches(e -> !e.getMessage().contains(TagsUtil.MISSING_TEST_NAME_TAG_MESSAGE))
@@ -156,8 +156,7 @@ public class TagsUtilTest {
         testDto.setResponse(response);
         when(testContext.getActingUserCrn()).thenReturn(null);
 
-        String expectedMsg = String.format("[%s] tag validation is not possible, because of either the tag value [%s] or acting user Crn [%s]" +
-                        " is empty or null!", CLOUDERA_CREATOR_RESOURCE_NAME_TAG_KEY, ACTING_USER_CRN, "null");
+        String expectedMsg = String.format(TagsUtil.ACTING_USER_CRN_VALUE_FAILURE_PATTERN, CLOUDERA_CREATOR_RESOURCE_NAME_TAG_KEY, ACTING_USER_CRN, "null");
         assertThatThrownBy(() -> underTest.verifyTags(testDto, testContext))
                 .hasMessageContaining(expectedMsg)
                 .matches(e -> !e.getMessage().contains(TagsUtil.MISSING_TEST_NAME_TAG_MESSAGE));
@@ -168,7 +167,7 @@ public class TagsUtilTest {
         DistroXTestDto testDto = new DistroXTestDto(mock(TestContext.class));
         testDto.setResponse(new StackV4Response());
 
-        String expectedMessage = String.format(TagsUtil.TAG_VALUE_IS_NULL_FAILURE_PATTERN, TagsUtil.TEST_NAME_TAG);
+        String expectedMessage = String.format(TagsUtil.TEST_NAME_TAG_VALUE_FAILURE_PATTERN, TagsUtil.TEST_NAME_TAG, "null", TEST_NAME);
         assertThatThrownBy(() -> underTest.verifyTags(testDto, testContext))
                 .hasMessageContaining(expectedMessage);
     }


### PR DESCRIPTION
This reverts [92238c686e](https://github.com/hortonworks/cloudbreak/commit/92238c686e953bf8c3bd7f6021e075fa687ec3ab) and [335592b531](https://github.com/hortonworks/cloudbreak/commit/335592b531adb1603df4a17166d8a6e55e2a2230)