### PR TITLE
CB-15359 Extend EDH sync report with database type

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/converter/StackToStackDetailsConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/converter/StackToStackDetailsConverter.java
@@ -12,11 +12,21 @@ import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
+import com.sequenceiq.cloudbreak.service.cluster.EmbeddedDatabaseService;
+import com.sequenceiq.cloudbreak.service.rdsconfig.RedbeamsDbServerConfigurer;
 import com.sequenceiq.cloudbreak.structuredevent.event.StackDetails;
 
 @Component
 public class StackToStackDetailsConverter {
     private static final Logger LOGGER = LoggerFactory.getLogger(StackToStackDetailsConverter.class);
+
+    private static final String UNKNONW = "UNKNOWN";
+
+    private static final String ON_ROOT_VOLUME = "ON_ROOT_VOLUME";
+
+    private static final String ON_ATTACHED_VOLUME = "ON_ATTACHED_VOLUME";
+
+    private static final String EXTERNAL_DB = "EXTERNAL_DB";
 
     @Inject
     private ComponentConfigProviderService componentConfigProviderService;
@@ -26,6 +36,12 @@ public class StackToStackDetailsConverter {
 
     @Inject
     private ImageToImageDetailsConverter imageToImageDetailsConverter;
+
+    @Inject
+    private RedbeamsDbServerConfigurer dbServerConfigurer;
+
+    @Inject
+    private EmbeddedDatabaseService embeddedDatabaseService;
 
     public StackDetails convert(Stack source) {
         StackDetails stackDetails = new StackDetails();
@@ -48,6 +64,7 @@ public class StackToStackDetailsConverter {
                         .collect(Collectors.toList()));
         stackDetails.setTags(source.getTags());
         convertComponents(stackDetails, source);
+        convertDatabaseType(stackDetails, source);
         return stackDetails;
     }
 
@@ -61,4 +78,20 @@ public class StackToStackDetailsConverter {
         }
     }
 
+    private void convertDatabaseType(StackDetails stackDetails, Stack stack) {
+        try {
+            if (dbServerConfigurer.isRemoteDatabaseNeeded(stack.getCluster())) {
+                stackDetails.setDatabaseType(EXTERNAL_DB);
+            } else {
+                if (embeddedDatabaseService.isAttachedDiskForEmbeddedDatabaseCreated(stack)) {
+                    stackDetails.setDatabaseType(ON_ATTACHED_VOLUME);
+                } else {
+                    stackDetails.setDatabaseType(ON_ROOT_VOLUME);
+                }
+            }
+        } catch (Exception ex) {
+            LOGGER.warn("Database type cannot be found", ex.getMessage());
+            stackDetails.setDatabaseType(UNKNONW);
+        }
+    }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/structuredevent/converter/StackToStackDetailsConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/structuredevent/converter/StackToStackDetailsConverterTest.java
@@ -1,0 +1,110 @@
+package com.sequenceiq.cloudbreak.structuredevent.converter;
+
+import java.util.HashSet;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.StackStatus;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
+import com.sequenceiq.cloudbreak.service.cluster.EmbeddedDatabaseService;
+import com.sequenceiq.cloudbreak.service.rdsconfig.RedbeamsDbServerConfigurer;
+import com.sequenceiq.cloudbreak.structuredevent.event.StackDetails;
+import com.sequenceiq.common.api.type.Tunnel;
+
+@ExtendWith(MockitoExtension.class)
+public class StackToStackDetailsConverterTest {
+    @Mock
+    private ComponentConfigProviderService componentConfigProviderService;
+
+    @Mock
+    private InstanceGroupToInstanceGroupDetailsConverter instanceGroupToInstanceGroupDetailsConverter;
+
+    @Mock
+    private ImageToImageDetailsConverter imageToImageDetailsConverter;
+
+    @Mock
+    private RedbeamsDbServerConfigurer dbServerConfigurer;
+
+    @Mock
+    private EmbeddedDatabaseService embeddedDatabaseService;
+
+    @InjectMocks
+    private StackToStackDetailsConverter underTest;
+
+    @Test
+    public void testConversion() {
+        // GIVEN
+        Stack stack = createStack();
+        // WHEN
+        StackDetails actual = underTest.convert(stack);
+        // THEN
+        Assertions.assertEquals(stack.getName(), actual.getName());
+        Assertions.assertEquals(stack.getTunnel().name(), actual.getTunnel());
+        Assertions.assertEquals(stack.getType().name(), actual.getType());
+        Assertions.assertEquals("ON_ROOT_VOLUME", actual.getDatabaseType());
+    }
+
+    @Test
+    public void testConversionExternalDB() {
+        // GIVEN
+        Stack stack = createStack();
+        Mockito.when(dbServerConfigurer.isRemoteDatabaseNeeded(stack.getCluster())).thenReturn(true);
+        // WHEN
+        StackDetails actual = underTest.convert(stack);
+        // THEN
+        Assertions.assertEquals("EXTERNAL_DB", actual.getDatabaseType());
+    }
+
+    @Test
+    public void testConversionWhenDBOnAttachedDisk() {
+        // GIVEN
+        Stack stack = createStack();
+        Mockito.when(embeddedDatabaseService.isAttachedDiskForEmbeddedDatabaseCreated(stack)).thenReturn(true);
+        // WHEN
+        StackDetails actual = underTest.convert(stack);
+        // THEN
+        Assertions.assertEquals("ON_ATTACHED_VOLUME", actual.getDatabaseType());
+    }
+
+    @Test
+    public void testConversionWhenDBTypeThrowsException() {
+        // GIVEN
+        Stack stack = createStack();
+        Mockito.when(embeddedDatabaseService.isAttachedDiskForEmbeddedDatabaseCreated(stack)).thenThrow(new RuntimeException());
+        // WHEN
+        StackDetails actual = underTest.convert(stack);
+        // THEN
+        Assertions.assertEquals("UNKNOWN", actual.getDatabaseType());
+    }
+
+    private Stack createStack() {
+        StackStatus status = new StackStatus();
+        status.setStatus(Status.AVAILABLE);
+
+        Stack stack = new Stack();
+        stack.setId(0L);
+        stack.setName("stack");
+        stack.setStackStatus(status);
+        stack.setTunnel(Tunnel.DIRECT);
+        stack.setType(StackType.WORKLOAD);
+        stack.setRegion("region");
+        stack.setAvailabilityZone("avzone");
+        stack.setDescription("description");
+        stack.setCloudPlatform("cloudplatform");
+        stack.setInstanceGroups(new HashSet<>());
+        stack.setTags(new Json(""));
+        stack.setCluster(new Cluster());
+        return stack;
+    }
+}

--- a/structuredevent-model/src/main/java/com/sequenceiq/cloudbreak/structuredevent/event/StackDetails.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/cloudbreak/structuredevent/event/StackDetails.java
@@ -101,6 +101,8 @@ public class StackDetails implements Serializable {
 
     private Json tags;
 
+    private String databaseType;
+
     public Long getId() {
         return id;
     }
@@ -307,5 +309,13 @@ public class StackDetails implements Serializable {
                     .orElse(new StackTags(new HashMap<>(), new HashMap<>(), new HashMap<>()));
         }
         return new StackTags(new HashMap<>(), new HashMap<>(), new HashMap<>());
+    }
+
+    public String getDatabaseType() {
+        return databaseType;
+    }
+
+    public void setDatabaseType(String databaseType) {
+        this.databaseType = databaseType;
     }
 }

--- a/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StructuredSyncEventToCDPSyncDetailsConverter.java
+++ b/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StructuredSyncEventToCDPSyncDetailsConverter.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 
 import com.cloudera.thunderhead.service.common.usage.UsageProto;
 import com.sequenceiq.cloudbreak.structuredevent.event.ClusterDetails;
+import com.sequenceiq.cloudbreak.structuredevent.event.StackDetails;
 import com.sequenceiq.cloudbreak.structuredevent.event.StructuredSyncEvent;
 
 @Component
@@ -17,6 +18,10 @@ public class StructuredSyncEventToCDPSyncDetailsConverter {
             if (clusterDetails != null) {
                 cdpSyncDetails.setClusterCreationStarted(clusterDetails.getCreationStarted() != null ? clusterDetails.getCreationStarted() : 0L);
                 cdpSyncDetails.setClusterCreationFinished(clusterDetails.getCreationFinished() != null ? clusterDetails.getCreationFinished() : 0L);
+            }
+            StackDetails stackDetails = structuredSyncEvent.getStack();
+            if (stackDetails != null) {
+                cdpSyncDetails.setDatabaseType(stackDetails.getDatabaseType() != null ? stackDetails.getDatabaseType() : "UNKNOWN");
             }
         }
 

--- a/structuredevent-service-legacy/src/test/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StructuredSyncEventToCDPSyncDetailsConverterTest.java
+++ b/structuredevent-service-legacy/src/test/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StructuredSyncEventToCDPSyncDetailsConverterTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import com.cloudera.thunderhead.service.common.usage.UsageProto;
 import com.sequenceiq.cloudbreak.structuredevent.event.ClusterDetails;
+import com.sequenceiq.cloudbreak.structuredevent.event.StackDetails;
 import com.sequenceiq.cloudbreak.structuredevent.event.StructuredSyncEvent;
 
 public class StructuredSyncEventToCDPSyncDetailsConverterTest {
@@ -47,4 +48,14 @@ public class StructuredSyncEventToCDPSyncDetailsConverterTest {
         Assert.assertEquals(0L, details.getClusterCreationFinished());
     }
 
+    @Test
+    public void testConversionWithEmptyStackDetails() {
+        StructuredSyncEvent structuredSyncEvent = new StructuredSyncEvent();
+        StackDetails stackDetails = new StackDetails();
+        structuredSyncEvent.setStack(stackDetails);
+
+        UsageProto.CDPSyncDetails details = underTest.convert(structuredSyncEvent);
+
+        Assert.assertEquals("UNKNOWN", details.getDatabaseType());
+    }
 }

--- a/usage-collection/src/main/proto/usage.proto
+++ b/usage-collection/src/main/proto/usage.proto
@@ -1219,6 +1219,8 @@ message CDPSyncDetails {
   uint64 clusterCreationStarted = 3;
   // The timestamp of the finish of the cluster creation
   uint64 clusterCreationFinished = 4;
+  // The database type of the cluster
+  string databaseType = 5;
 }
 
 // Generated periodically for Datalake clusters


### PR DESCRIPTION
Sync report is extended with database type in EDH report:
* new member in StackDetails: databaseType
* new member in usage proto: CDPSyncDetails.databaseType
* values: ON_ROOT_VOLUME, ON_ATTACHED_DISK, EXTERNAL_DB, UNKNOWN
* was tested on gcp, azure, aws; with root volume, attached disk and external db
