### PR TITLE
CB-15434 Fix testCreateDistroXWithEphemeralTemporayStorage timeout is…

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/ephemeral/DistroXStopStartTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/ephemeral/DistroXStopStartTest.java
@@ -52,7 +52,7 @@ public class DistroXStopStartTest extends AbstractE2ETest {
         createEnvironmentWithFreeIpaAndDatalake(testContext);
     }
 
-    @Test(dataProvider = TEST_CONTEXT, description = "IGNORED: CB-15434 CM API calls fail on Azure with SocketTimeoutException")
+    @Test(dataProvider = TEST_CONTEXT)
     @UseSpotInstances
     @Description(
             given = "there is a running cloudbreak",

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/clouderamanager/action/ClouderaManagerClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/clouderamanager/action/ClouderaManagerClientActions.java
@@ -76,13 +76,13 @@ public class ClouderaManagerClientActions extends ClouderaManagerClient {
 
     public DistroXTestDto checkCmYarnNodemanagerRoleConfigGroups(DistroXTestDto testDto, String user, String password) {
         String serverIp = testDto.getResponse().getCluster().getServerIp();
-        ApiClient apiClient = getCmApiClient(serverIp, testDto.getName(), V_43, user, password);
+        ApiClient apiClient = getCmApiClientWithTimeoutDisabled(serverIp, testDto.getName(), V_43, user, password);
         // CHECKSTYLE:OFF
         RoleConfigGroupsResourceApi roleConfigGroupsResourceApi = new RoleConfigGroupsResourceApi(apiClient);
         // CHECKSTYLE:ON
         try {
             ApiConfigList knoxConfigs = roleConfigGroupsResourceApi.readConfig(testDto.getName(), "yarn-NODEMANAGER-BASE",
-                    "yarn", "summary");
+                    "yarn", "full");
             knoxConfigs.getItems().stream()
                     .forEach(knoxConfig -> {
                         String knoxConfigName = knoxConfig.getName();
@@ -114,7 +114,7 @@ public class ClouderaManagerClientActions extends ClouderaManagerClient {
 
     public DistroXTestDto checkCmHdfsNamenodeRoleConfigGroups(DistroXTestDto testDto, String user, String password, Set<String> mountPoints) {
         String serverIp = testDto.getResponse().getCluster().getServerIp();
-        ApiClient apiClient = getCmApiClient(serverIp, testDto.getName(), V_43, user, password);
+        ApiClient apiClient = getCmApiClientWithTimeoutDisabled(serverIp, testDto.getName(), V_43, user, password);
         // CHECKSTYLE:OFF
         RoleConfigGroupsResourceApi roleConfigGroupsResourceApi = new RoleConfigGroupsResourceApi(apiClient);
         // CHECKSTYLE:ON
@@ -125,7 +125,7 @@ public class ClouderaManagerClientActions extends ClouderaManagerClient {
                     .forEach(config -> {
                         String hdfsConfigName = config.getName();
                         String mappingsFromHdfsConfig = config.getValue();
-                        if ("dfs_data_dir_list".equalsIgnoreCase(hdfsConfigName)) {
+                        if ("dfs_name_dir_list".equalsIgnoreCase(hdfsConfigName)) {
                             if (mountPoints.stream().anyMatch(mappingsFromHdfsConfig::startsWith)) {
                                 LOGGER.error("{} contains ephemeral volume mapping '{}'!", hdfsConfigName, mappingsFromHdfsConfig);
                                 throw new TestFailException(String.format("%s contains ephemeral volume mapping '%s'!", hdfsConfigName,
@@ -154,7 +154,7 @@ public class ClouderaManagerClientActions extends ClouderaManagerClient {
 
     public DistroXTestDto checkCmHdfsDatanodeRoleConfigGroups(DistroXTestDto testDto, String user, String password, Set<String> mountPoints) {
         String serverIp = testDto.getResponse().getCluster().getServerIp();
-        ApiClient apiClient = getCmApiClient(serverIp, testDto.getName(), V_43, user, password);
+        ApiClient apiClient = getCmApiClientWithTimeoutDisabled(serverIp, testDto.getName(), V_43, user, password);
         // CHECKSTYLE:OFF
         RoleConfigGroupsResourceApi roleConfigGroupsResourceApi = new RoleConfigGroupsResourceApi(apiClient);
         // CHECKSTYLE:ON

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/clouderamanager/client/ClouderaManagerClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/clouderamanager/client/ClouderaManagerClient.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.it.cloudbreak.util.clouderamanager.client;
 
+import java.util.concurrent.TimeUnit;
+
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
@@ -28,6 +30,13 @@ public class ClouderaManagerClient {
         cmClient.setVerifyingSsl(false);
         cmClient.getHttpClient().interceptors().add(cmRequestIdProviderInterceptor);
         LOGGER.info(String.format("Cloudera Manager Base Path: %s", cmClient.getBasePath()));
+        return cmClient;
+    }
+
+    public ApiClient getCmApiClientWithTimeoutDisabled(String serverFqdn, String clusterName, String apiVersion, String cmUser, String cmPassword) {
+        ApiClient cmClient = getCmApiClient(serverFqdn, clusterName, apiVersion, cmUser, cmPassword);
+        cmClient.setConnectTimeout(0);
+        cmClient.getHttpClient().setReadTimeout(0, TimeUnit.MILLISECONDS);
         return cmClient;
     }
 }

--- a/integration-test/src/main/resources/testsuites/e2e/azure-longrunning-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/azure-longrunning-e2e-tests.yaml
@@ -11,8 +11,5 @@ tests:
           # CB-15466 Azure FreeIPA Upgrade operation has been timed out with no error message
           - testHAFreeIpaInstanceUpgrade
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.ephemeral.DistroXStopStartTest
-        excludedMethods:
-          # CB-15434 CM API calls fail on Azure with SocketTimeoutException
-          - testCreateDistroXWithEphemeralTemporaryStorage
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.ephemeral.DistroXRepairTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.ephemeral.DistroXUpgradeTests


### PR DESCRIPTION
…sue and reenable test.

The SocketTimeoutException was caused by the HTTP client that the CM API client uses. That HTTP client had a 10s default timeout and NGINX has a higher timeout so it was not reported as a server issue. The fix diasbles the timeout for the HTTP client, as the NGINX alreay has a timeout. After disabling it the longest CM call was successful in 12s. The commit also reenables the e2e test.

See detailed description in the commit message.