### PR TITLE
CB-11198 Use correct URL in mock-infrastructure to fetch CB version o…

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/ImageCatalogMockServerSetup.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/ImageCatalogMockServerSetup.java
@@ -54,7 +54,7 @@ public class ImageCatalogMockServerSetup {
     private String getCloudbreakUnderTestVersion(String cbServerAddress) {
         WebTarget target;
         Client client = RestClientUtil.get();
-        if (cbServerAddress.contains("dps.mow") || cbServerAddress.contains("cdp.mow")) {
+        if (cbServerAddress.contains("dps.mow") || cbServerAddress.contains("cdp.mow") || cbServerAddress.contains("cdp-priv.mow")) {
             target = client.target(defaultCloudbreakServer + "/cloud/cb/info");
         } else {
             target = client.target(cbServerAddress + "/info");


### PR DESCRIPTION
…n mow-priv clusters

The format of the mow-priv cluster url is: `https://XXXXX-console.cdp-priv.mow-dev.cloudera.com/cloud/cb/info`
mock-infrastructure should handle this url pattern and return the correct CB version based on the info endpoint. 

See detailed description in the commit message.