### PR TITLE
CB-13330: Allow Datahub upgrade when ephemeral storage based instances are used

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
@@ -59,6 +59,7 @@ import com.sequenceiq.cloudbreak.service.stack.flow.StackOperationService;
 import com.sequenceiq.cloudbreak.structuredevent.CloudbreakRestRequestThreadLocalService;
 import com.sequenceiq.cloudbreak.workspace.controller.WorkspaceEntityType;
 import com.sequenceiq.distrox.v1.distrox.StackOperations;
+import com.sequenceiq.distrox.v1.distrox.StackUpgradeOperations;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.flow.api.model.RetryableFlowResponse;
 import com.sequenceiq.flow.api.model.RetryableFlowResponse.Builder;
@@ -69,6 +70,9 @@ public class StackV4Controller extends NotificationController implements StackV4
 
     @Inject
     private StackOperations stackOperations;
+
+    @Inject
+    private StackUpgradeOperations stackUpgradeOperations;
 
     @Inject
     private StackOperationService stackOperationService;
@@ -93,13 +97,13 @@ public class StackV4Controller extends NotificationController implements StackV4
     @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.POWERUSER_ONLY)
     public StackV4Response post(Long workspaceId, @Valid StackV4Request request, @AccountId String accountId) {
-        return stackOperations.post(restRequestThreadLocalService.getRequestedWorkspaceId(), request, false);
+        return stackOperations.post(restRequestThreadLocalService.getRequestedWorkspaceId(), restRequestThreadLocalService.getCloudbreakUser(), request, false);
     }
 
     @Override
     @InternalOnly
     public StackV4Response postInternal(Long workspaceId, @Valid StackV4Request request, @InitiatorUserCrn String initiatorUserCrn) {
-        return stackOperations.post(restRequestThreadLocalService.getRequestedWorkspaceId(), request, false);
+        return stackOperations.post(restRequestThreadLocalService.getRequestedWorkspaceId(), restRequestThreadLocalService.getCloudbreakUser(), request, false);
     }
 
     @Override
@@ -206,19 +210,20 @@ public class StackV4Controller extends NotificationController implements StackV4
     @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.POWERUSER_ONLY)
     public FlowIdentifier upgradeOs(Long workspaceId, String name, @AccountId String accountId) {
-        return stackOperations.upgradeOs(NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId());
+        return stackUpgradeOperations.upgradeOs(NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId());
     }
 
     @Override
     @InternalOnly
     public FlowIdentifier upgradeOsInternal(Long workspaceId, String name, @InitiatorUserCrn String initiatorUserCrn) {
-        return stackOperations.upgradeOs(NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId());
+        return stackUpgradeOperations.upgradeOs(NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId());
     }
 
     @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.POWERUSER_ONLY)
     public UpgradeOptionV4Response checkForOsUpgrade(Long workspaceId, String name, @AccountId String accountId) {
-        return stackOperations.checkForOsUpgrade(NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId());
+        return stackUpgradeOperations.checkForOsUpgrade(NameOrCrn.ofName(name), restRequestThreadLocalService.getCloudbreakUser(),
+                restRequestThreadLocalService.getRequestedWorkspaceId());
     }
 
     @Override
@@ -306,19 +311,20 @@ public class StackV4Controller extends NotificationController implements StackV4
     @CheckPermissionByAccount(action = AuthorizationResourceAction.POWERUSER_ONLY)
     public UpgradeV4Response checkForClusterUpgradeByName(Long workspaceId, String name, UpgradeV4Request request,
             @AccountId String accountId) {
-        return stackOperations.checkForClusterUpgrade(accountId, NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId(), request);
+        return stackUpgradeOperations.checkForClusterUpgrade(accountId, NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId(),
+                request);
     }
 
     @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.POWERUSER_ONLY)
     public FlowIdentifier upgradeClusterByName(Long workspaceId, String name, String imageId, @AccountId String accountId) {
-        return stackOperations.upgradeCluster(NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId(), imageId);
+        return stackUpgradeOperations.upgradeCluster(NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId(), imageId);
     }
 
     @Override
     @InternalOnly
     public FlowIdentifier upgradeClusterByNameInternal(Long workspaceId, String name, String imageId, @InitiatorUserCrn String initiatorUserCrn) {
-        return stackOperations.upgradeCluster(NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId(), imageId);
+        return stackUpgradeOperations.upgradeCluster(NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId(), imageId);
     }
 
     @Override
@@ -476,8 +482,8 @@ public class StackV4Controller extends NotificationController implements StackV4
     @Override
     @InternalOnly
     public GenerateImageCatalogV4Response generateImageCatalogInternal(Long workspaceId, String name, @InitiatorUserCrn String initiatorUserCrn) {
-        CloudbreakImageCatalogV3 imageCatalog
-                = stackOperations.generateImageCatalog(NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId());
+        CloudbreakImageCatalogV3 imageCatalog = stackOperations.generateImageCatalog(NameOrCrn.ofName(name),
+                restRequestThreadLocalService.getRequestedWorkspaceId());
         return new GenerateImageCatalogV4Response(imageCatalog);
     }
 }

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackUpgradeOperations.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackUpgradeOperations.java
@@ -1,0 +1,141 @@
+package com.sequenceiq.distrox.v1.distrox;
+
+import java.util.List;
+import java.util.Optional;
+
+import javax.inject.Inject;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.BadRequestException;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.tags.upgrade.UpgradeV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Responses;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.upgrade.UpgradeOptionV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.upgrade.UpgradeV4Response;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.common.user.CloudbreakUser;
+import com.sequenceiq.cloudbreak.conf.LimitConfiguration;
+import com.sequenceiq.cloudbreak.domain.projection.StackInstanceCount;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterDBValidationService;
+import com.sequenceiq.cloudbreak.service.stack.InstanceGroupService;
+import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.service.upgrade.ClusterUpgradeAvailabilityService;
+import com.sequenceiq.cloudbreak.service.upgrade.UpgradePreconditionService;
+import com.sequenceiq.cloudbreak.service.upgrade.UpgradeService;
+import com.sequenceiq.cloudbreak.service.user.UserService;
+import com.sequenceiq.cloudbreak.workspace.model.User;
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+
+@Service
+public class StackUpgradeOperations {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StackUpgradeOperations.class);
+
+    @Inject
+    private UserService userService;
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private UpgradeService upgradeService;
+
+    @Inject
+    private InstanceGroupService instanceGroupService;
+
+    @Inject
+    private InstanceMetaDataService instanceMetaDataService;
+
+    @Inject
+    private LimitConfiguration limitConfiguration;
+
+    @Inject
+    private ClusterUpgradeAvailabilityService clusterUpgradeAvailabilityService;
+
+    @Inject
+    private EntitlementService entitlementService;
+
+    @Inject
+    private UpgradePreconditionService upgradePreconditionService;
+
+    @Inject
+    private ClusterDBValidationService clusterDBValidationService;
+
+    @Inject
+    private StackOperations stackOperations;
+
+    public FlowIdentifier upgradeOs(@NotNull NameOrCrn nameOrCrn, Long workspaceId) {
+        LOGGER.debug("Starting to upgrade OS: " + nameOrCrn);
+        return upgradeService.upgradeOs(workspaceId, nameOrCrn);
+    }
+
+    public FlowIdentifier upgradeCluster(@NotNull NameOrCrn nameOrCrn, Long workspaceId, String imageId) {
+        LOGGER.debug("Starting to upgrade cluster: " + nameOrCrn);
+        return upgradeService.upgradeCluster(workspaceId, nameOrCrn, imageId);
+    }
+
+    public UpgradeOptionV4Response checkForOsUpgrade(@NotNull NameOrCrn nameOrCrn, CloudbreakUser cloudbreakUser, Long workspaceId) {
+        User user = userService.getOrCreate(cloudbreakUser);
+        if (nameOrCrn.hasName()) {
+            return upgradeService.getOsUpgradeOptionByStackNameOrCrn(workspaceId, nameOrCrn, user);
+        } else {
+            LOGGER.debug("No stack name provided for upgrade, found: " + nameOrCrn);
+            throw new BadRequestException("Please provide a stack name for upgrade");
+        }
+    }
+
+    public UpgradeV4Response checkForClusterUpgrade(String accountId, @NotNull NameOrCrn nameOrCrn, Long workspaceId, UpgradeV4Request request) {
+        return checkForClusterUpgrade(accountId, stackService.getByNameOrCrnInWorkspace(nameOrCrn, workspaceId), workspaceId, request);
+    }
+
+    public UpgradeV4Response checkForClusterUpgrade(String accountId, @NotNull Stack stack, Long workspaceId, UpgradeV4Request request) {
+        MDCBuilder.buildMdcContext(stack);
+        stack.setInstanceGroups(instanceGroupService.getByStackAndFetchTemplates(stack.getId()));
+        boolean osUpgrade = upgradeService.isOsUpgrade(request);
+        boolean replaceVms = determineReplaceVmsParameter(stack, request.getReplaceVms());
+        if (replaceVms) {
+            StackInstanceCount stackInstanceCount = instanceMetaDataService.countByStackId(stack.getId());
+            Integer upgradeNodeCountLimit = limitConfiguration.getUpgradeNodeCountLimit();
+            if (stackInstanceCount.getInstanceCount() > upgradeNodeCountLimit) {
+                throw new BadRequestException(
+                        String.format("There are %s nodes in the cluster. Upgrade has a limit of %s nodes, above the limit it is unstable. " +
+                                "Please downscale the cluster below the limit and retry the upgrade.",
+                                stackInstanceCount.getInstanceCount(), upgradeNodeCountLimit));
+            }
+        }
+        UpgradeV4Response upgradeResponse = clusterUpgradeAvailabilityService.checkForUpgradesByName(stack, osUpgrade, replaceVms,
+                request.getInternalUpgradeSettings());
+        if (CollectionUtils.isNotEmpty(upgradeResponse.getUpgradeCandidates())) {
+            clusterUpgradeAvailabilityService.filterUpgradeOptions(accountId, upgradeResponse, request, stack.isDatalake());
+        }
+        validateDatalakeHasNoRunningDatahub(accountId, workspaceId, stack, upgradeResponse);
+        return upgradeResponse;
+    }
+
+    private void validateDatalakeHasNoRunningDatahub(String accountId, Long workspaceId, Stack stack, UpgradeV4Response upgradeResponse) {
+        if (entitlementService.runtimeUpgradeEnabled(accountId) && StackType.DATALAKE == stack.getType()) {
+            LOGGER.info("Checking that the attached DataHubs of the Datalake are in stopped state only in case if Datalake runtime upgarda is enabled" +
+                    " in [{}] account on [{}] cluster.", accountId, stack.getName());
+            StackViewV4Responses stackViewV4Responses = stackOperations.listByEnvironmentCrn(workspaceId, stack.getEnvironmentCrn(),
+                    List.of(StackType.WORKLOAD));
+            upgradePreconditionService.checkForRunningAttachedClusters(stackViewV4Responses, upgradeResponse, stack);
+        }
+    }
+
+    private boolean determineReplaceVmsParameter(Stack stack, Boolean replaceVms) {
+        if (stack.isDatalake() || replaceVms != null) {
+            return Optional.ofNullable(replaceVms).orElse(Boolean.TRUE);
+        } else {
+            return upgradePreconditionService.notUsingEphemeralVolume(stack) && clusterDBValidationService.isGatewayRepairEnabled(stack.getCluster());
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/service/DistroXService.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/service/DistroXService.java
@@ -4,6 +4,8 @@ import static java.lang.String.format;
 
 import java.util.Optional;
 
+import javax.inject.Inject;
+
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
@@ -13,6 +15,7 @@ import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
 import com.sequenceiq.cloudbreak.service.freeipa.FreeipaClientService;
 import com.sequenceiq.cloudbreak.service.stack.StackViewService;
 import com.sequenceiq.cloudbreak.service.workspace.WorkspaceService;
+import com.sequenceiq.cloudbreak.structuredevent.CloudbreakRestRequestThreadLocalService;
 import com.sequenceiq.distrox.api.v1.distrox.model.DistroXV1Request;
 import com.sequenceiq.distrox.v1.distrox.StackOperations;
 import com.sequenceiq.distrox.v1.distrox.converter.DistroXV1RequestToStackV4RequestConverter;
@@ -22,32 +25,32 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.describe.DescribeFreeIp
 @Service
 public class DistroXService {
 
-    private final StackOperations stackOperations;
+    @Inject
+    private StackOperations stackOperations;
 
-    private final WorkspaceService workspaceService;
+    @Inject
+    private WorkspaceService workspaceService;
 
-    private final EnvironmentClientService environmentClientService;
+    @Inject
+    private EnvironmentClientService environmentClientService;
 
-    private final DistroXV1RequestToStackV4RequestConverter stackRequestConverter;
+    @Inject
+    private DistroXV1RequestToStackV4RequestConverter stackRequestConverter;
 
-    private final StackViewService stackViewService;
+    @Inject
+    private StackViewService stackViewService;
 
-    private final FreeipaClientService freeipaClientService;
+    @Inject
+    private FreeipaClientService freeipaClientService;
 
-    public DistroXService(EnvironmentClientService environmentClientService, StackOperations stackOperations, WorkspaceService workspaceService,
-            DistroXV1RequestToStackV4RequestConverter stackRequestConverter, StackViewService stackViewService, FreeipaClientService freeipaClientService) {
-        this.environmentClientService = environmentClientService;
-        this.stackRequestConverter = stackRequestConverter;
-        this.workspaceService = workspaceService;
-        this.stackOperations = stackOperations;
-        this.stackViewService = stackViewService;
-        this.freeipaClientService = freeipaClientService;
-    }
+    @Inject
+    private CloudbreakRestRequestThreadLocalService restRequestThreadLocalService;
 
     public StackV4Response post(DistroXV1Request request) {
         validate(request);
         return stackOperations.post(
                 workspaceService.getForCurrentUser().getId(),
+                restRequestThreadLocalService.getCloudbreakUser(),
                 stackRequestConverter.convert(request),
                 true);
     }

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/StackOperationsTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/StackOperationsTest.java
@@ -19,12 +19,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import javax.ws.rs.BadRequestException;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
 import org.junit.rules.ExpectedException;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -33,33 +30,26 @@ import org.mockito.MockitoAnnotations;
 import com.sequenceiq.cloudbreak.TestUtil;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.tags.upgrade.UpgradeV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Response;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakImageCatalogV3;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.user.CloudbreakUser;
-import com.sequenceiq.cloudbreak.conf.LimitConfiguration;
 import com.sequenceiq.cloudbreak.converter.v4.stacks.StackClusterStatusViewToStatusConverter;
 import com.sequenceiq.cloudbreak.converter.v4.stacks.UserNamePasswordV4RequestToUpdateClusterV4RequestConverter;
 import com.sequenceiq.cloudbreak.converter.v4.stacks.view.StackApiViewToStackViewV4ResponseConverter;
 import com.sequenceiq.cloudbreak.domain.projection.StackCrnView;
-import com.sequenceiq.cloudbreak.domain.projection.StackInstanceCount;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.view.StackApiView;
 import com.sequenceiq.cloudbreak.service.ClusterCommonService;
-import com.sequenceiq.cloudbreak.service.DefaultClouderaManagerRepoService;
 import com.sequenceiq.cloudbreak.service.StackCommonService;
 import com.sequenceiq.cloudbreak.service.image.GenerateImageCatalogService;
-import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.cloudbreak.service.stack.StackApiViewService;
 import com.sequenceiq.cloudbreak.service.stack.StackImageService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
-import com.sequenceiq.cloudbreak.service.upgrade.UpgradeService;
 import com.sequenceiq.cloudbreak.service.user.UserService;
 import com.sequenceiq.cloudbreak.service.workspace.WorkspaceService;
-import com.sequenceiq.cloudbreak.structuredevent.CloudbreakRestRequestThreadLocalService;
 import com.sequenceiq.cloudbreak.workspace.model.User;
 import com.sequenceiq.distrox.v1.distrox.service.EnvironmentServiceDecorator;
 import com.sequenceiq.distrox.v1.distrox.service.SdxServiceDecorator;
@@ -86,9 +76,6 @@ public class StackOperationsTest {
     private UserService userService;
 
     @Mock
-    private CloudbreakRestRequestThreadLocalService restRequestThreadLocalService;
-
-    @Mock
     private WorkspaceService workspaceService;
 
     @Mock
@@ -99,9 +86,6 @@ public class StackOperationsTest {
 
     @Mock
     private StackApiViewService stackApiViewService;
-
-    @Mock
-    private DefaultClouderaManagerRepoService defaultClouderaManagerRepoService;
 
     @Mock
     private EnvironmentServiceDecorator environmentServiceDecorator;
@@ -130,15 +114,6 @@ public class StackOperationsTest {
     @Mock
     private GenerateImageCatalogService generateImageCatalogService;
 
-    @Mock
-    private UpgradeService upgradeService;
-
-    @Mock
-    private InstanceMetaDataService instanceMetaDataService;
-
-    @Mock
-    private LimitConfiguration limitConfiguration;
-
     private Stack stack;
 
     private User user;
@@ -148,7 +123,6 @@ public class StackOperationsTest {
         MockitoAnnotations.initMocks(this);
         user = TestUtil.user(1L, "someUserId");
         stack = TestUtil.stack();
-        when(restRequestThreadLocalService.getCloudbreakUser()).thenReturn(cloudbreakUser);
         when(userService.getOrCreate(cloudbreakUser)).thenReturn(user);
     }
 
@@ -264,22 +238,6 @@ public class StackOperationsTest {
         CloudbreakImageCatalogV3 actual = underTest.generateImageCatalog(nameOrCrn, stack.getWorkspace().getId());
 
         assertEquals(imageCatalog, actual);
-    }
-
-    @Test
-    public void throwsBadRequestIfClusterHasMoreNodesThanTheLimit() {
-        UpgradeV4Request upgradeV4Request = new UpgradeV4Request();
-        upgradeV4Request.setReplaceVms(true);
-        StackInstanceCount stackInstanceCount = mock(StackInstanceCount.class);
-        when(stackInstanceCount.getInstanceCount()).thenReturn(201);
-        when(limitConfiguration.getUpgradeNodeCountLimit()).thenReturn(200);
-        when(instanceMetaDataService.countByStackId(any())).thenReturn(stackInstanceCount);
-
-        BadRequestException exception = Assertions.assertThrows(BadRequestException.class,
-                () -> underTest.checkForClusterUpgrade("accId", stack, stack.getWorkspace().getId(), upgradeV4Request));
-
-        assertEquals("There are 201 nodes in the cluster. Upgrade has a limit of 200 nodes, above the limit it is unstable. " +
-                "Please downscale the cluster below the limit and retry the upgrade.", exception.getMessage());
     }
 
     private StackV4Response stackResponse() {

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/StackUpgradeOperationsTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/StackUpgradeOperationsTest.java
@@ -1,0 +1,261 @@
+package com.sequenceiq.distrox.v1.distrox;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.ws.rs.BadRequestException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.InternalUpgradeSettings;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.tags.upgrade.UpgradeV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Responses;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.image.ImageInfoV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.upgrade.UpgradeV4Response;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.common.user.CloudbreakUser;
+import com.sequenceiq.cloudbreak.conf.LimitConfiguration;
+import com.sequenceiq.cloudbreak.domain.projection.StackInstanceCount;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterDBValidationService;
+import com.sequenceiq.cloudbreak.service.stack.InstanceGroupService;
+import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
+import com.sequenceiq.cloudbreak.service.upgrade.ClusterUpgradeAvailabilityService;
+import com.sequenceiq.cloudbreak.service.upgrade.UpgradePreconditionService;
+import com.sequenceiq.cloudbreak.service.upgrade.UpgradeService;
+import com.sequenceiq.cloudbreak.service.user.UserService;
+import com.sequenceiq.cloudbreak.workspace.model.User;
+
+@ExtendWith(MockitoExtension.class)
+class StackUpgradeOperationsTest {
+
+    private static final long STACK_ID = 1L;
+
+    private static final long WORKSPACE_ID = 2L;
+
+    private static final String ACCOUNT_ID = "account-id";
+
+    private static final String STACK_NAME = "stack-name";
+
+    private static final String IMAGE_ID = "image-id";
+
+    private static final int INSTANCE_COUNT = 10;
+
+    private static final int NODE_LIMIT = 15;
+
+    private static final String ENVIRONMENT_CRN = "env-crn";
+
+    @InjectMocks
+    private StackUpgradeOperations underTest;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private UpgradeService upgradeService;
+
+    @Mock
+    private InstanceGroupService instanceGroupService;
+
+    @Mock
+    private InstanceMetaDataService instanceMetaDataService;
+
+    @Mock
+    private LimitConfiguration limitConfiguration;
+
+    @Mock
+    private ClusterUpgradeAvailabilityService clusterUpgradeAvailabilityService;
+
+    @Mock
+    private EntitlementService entitlementService;
+
+    @Mock
+    private UpgradePreconditionService upgradePreconditionService;
+
+    @Mock
+    private ClusterDBValidationService clusterDBValidationService;
+
+    @Mock
+    private StackOperations stackOperations;
+
+    @Mock
+    private CloudbreakUser cloudbreakUser;
+
+    private NameOrCrn nameOrCrn;
+
+    @BeforeEach
+    void before() {
+        nameOrCrn = NameOrCrn.ofName(STACK_NAME);
+    }
+
+    @Test
+    void testUpgradeOsShouldCallUpgradeService() {
+        underTest.upgradeOs(nameOrCrn, WORKSPACE_ID);
+        verify(upgradeService).upgradeOs(WORKSPACE_ID, nameOrCrn);
+    }
+
+    @Test
+    void testUpgradeClusterShouldCallUpgradeService() {
+        underTest.upgradeCluster(nameOrCrn, WORKSPACE_ID, IMAGE_ID);
+        verify(upgradeService).upgradeCluster(WORKSPACE_ID, nameOrCrn, IMAGE_ID);
+    }
+
+    @Test
+    void testCheckForOsUpgradeShouldShouldCallUpgradeServiceWhenTheClusterNameIsAvailable() {
+        User user = new User();
+        when(userService.getOrCreate(cloudbreakUser)).thenReturn(user);
+
+        underTest.checkForOsUpgrade(nameOrCrn, cloudbreakUser, WORKSPACE_ID);
+
+        verify(userService).getOrCreate(cloudbreakUser);
+        verify(upgradeService).getOsUpgradeOptionByStackNameOrCrn(WORKSPACE_ID, nameOrCrn, user);
+    }
+
+    @Test
+    void testCheckForOsUpgradeShouldThrowExceptionWhenTheClusterNameIsNotAvailable() {
+        when(userService.getOrCreate(cloudbreakUser)).thenReturn(new User());
+
+        assertThrows(BadRequestException.class, () -> underTest.checkForOsUpgrade(NameOrCrn.ofCrn("crn"), cloudbreakUser, WORKSPACE_ID));
+
+        verify(userService).getOrCreate(cloudbreakUser);
+        verifyNoInteractions(upgradeService);
+    }
+
+    @Test
+    void throwsBadRequestIfClusterHasMoreNodesThanTheLimit() {
+        UpgradeV4Request request = createUpgradeRequest(true);
+        StackInstanceCount stackInstanceCount = mock(StackInstanceCount.class);
+        when(stackInstanceCount.getInstanceCount()).thenReturn(201);
+        when(limitConfiguration.getUpgradeNodeCountLimit()).thenReturn(200);
+        when(instanceMetaDataService.countByStackId(any())).thenReturn(stackInstanceCount);
+
+        BadRequestException exception = Assertions.assertThrows(BadRequestException.class,
+                () -> underTest.checkForClusterUpgrade("accId", new Stack(), WORKSPACE_ID, request));
+
+        assertEquals("There are 201 nodes in the cluster. Upgrade has a limit of 200 nodes, above the limit it is unstable. " +
+                "Please downscale the cluster below the limit and retry the upgrade.", exception.getMessage());
+    }
+
+    @Test
+    void testCheckForClusterUpgradeShouldReturnUpgradeCandidatesWhenTheUpgradeIsRuntimeUpgradeAndTheStackTypeIsWorkloadAndReplaceVmDisabled() {
+        Stack stack = createStack(StackType.WORKLOAD);
+        UpgradeV4Request request = createUpgradeRequest(null);
+        UpgradeV4Response upgradeResponse = new UpgradeV4Response();
+        upgradeResponse.setUpgradeCandidates(List.of(new ImageInfoV4Response()));
+        when(instanceGroupService.getByStackAndFetchTemplates(STACK_ID)).thenReturn(Collections.emptySet());
+        when(upgradeService.isOsUpgrade(request)).thenReturn(false);
+        when(upgradePreconditionService.notUsingEphemeralVolume(stack)).thenReturn(false);
+        when(clusterUpgradeAvailabilityService.checkForUpgradesByName(stack, false, false, request.getInternalUpgradeSettings())).thenReturn(upgradeResponse);
+        when(entitlementService.runtimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(true);
+
+        UpgradeV4Response actual = underTest.checkForClusterUpgrade(ACCOUNT_ID, stack, WORKSPACE_ID, request);
+
+        assertEquals(upgradeResponse, actual);
+        verify(instanceGroupService).getByStackAndFetchTemplates(STACK_ID);
+        verify(upgradeService).isOsUpgrade(request);
+        verify(upgradePreconditionService).notUsingEphemeralVolume(stack);
+        verify(clusterUpgradeAvailabilityService).checkForUpgradesByName(stack, false, false, request.getInternalUpgradeSettings());
+        verify(clusterUpgradeAvailabilityService).filterUpgradeOptions(ACCOUNT_ID, upgradeResponse, request, false);
+        verify(entitlementService).runtimeUpgradeEnabled(ACCOUNT_ID);
+        verifyNoInteractions(stackOperations);
+    }
+
+    @Test
+    void testCheckForClusterUpgradeShouldReturnUpgradeCandidatesWhenTheUpgradeIsRuntimeUpgradeAndTheStackTypeIsWorkloadAndReplaceVmEnabled() {
+        Stack stack = createStack(StackType.WORKLOAD);
+        UpgradeV4Request request = createUpgradeRequest(true);
+        UpgradeV4Response upgradeResponse = createUpgradeResponse();
+        when(instanceGroupService.getByStackAndFetchTemplates(STACK_ID)).thenReturn(Collections.emptySet());
+        when(upgradeService.isOsUpgrade(request)).thenReturn(false);
+        StackInstanceCount instanceCount = mock(StackInstanceCount.class);
+        when(instanceCount.getInstanceCount()).thenReturn(INSTANCE_COUNT);
+        when(instanceMetaDataService.countByStackId(STACK_ID)).thenReturn(instanceCount);
+        when(limitConfiguration.getUpgradeNodeCountLimit()).thenReturn(NODE_LIMIT);
+        when(clusterUpgradeAvailabilityService.checkForUpgradesByName(stack, false, true, request.getInternalUpgradeSettings())).thenReturn(upgradeResponse);
+        when(entitlementService.runtimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(true);
+
+        UpgradeV4Response actual = underTest.checkForClusterUpgrade(ACCOUNT_ID, stack, WORKSPACE_ID, request);
+
+        assertEquals(upgradeResponse, actual);
+        verify(instanceGroupService).getByStackAndFetchTemplates(STACK_ID);
+        verify(upgradeService).isOsUpgrade(request);
+        verify(instanceGroupService).getByStackAndFetchTemplates(STACK_ID);
+        verify(limitConfiguration).getUpgradeNodeCountLimit();
+        verify(clusterUpgradeAvailabilityService).checkForUpgradesByName(stack, false, true, request.getInternalUpgradeSettings());
+        verify(clusterUpgradeAvailabilityService).filterUpgradeOptions(ACCOUNT_ID, upgradeResponse, request, false);
+        verify(entitlementService).runtimeUpgradeEnabled(ACCOUNT_ID);
+        verifyNoInteractions(upgradePreconditionService);
+        verifyNoInteractions(clusterDBValidationService);
+        verifyNoInteractions(stackOperations);
+    }
+
+    @Test
+    void testCheckForClusterUpgradeShouldReturnUpgradeCandidatesWhenTheUpgradeIsRuntimeUpgradeAndTheStackTypeIsDataLakeAndReplaceVmEnabled() {
+        Stack stack = createStack(StackType.DATALAKE);
+        StackViewV4Responses stackViewV4Responses = new StackViewV4Responses();
+        UpgradeV4Request request = createUpgradeRequest(null);
+        UpgradeV4Response upgradeResponse = createUpgradeResponse();
+        when(instanceGroupService.getByStackAndFetchTemplates(STACK_ID)).thenReturn(Collections.emptySet());
+        when(upgradeService.isOsUpgrade(request)).thenReturn(false);
+        StackInstanceCount instanceCount = mock(StackInstanceCount.class);
+        when(instanceCount.getInstanceCount()).thenReturn(INSTANCE_COUNT);
+        when(instanceMetaDataService.countByStackId(STACK_ID)).thenReturn(instanceCount);
+        when(limitConfiguration.getUpgradeNodeCountLimit()).thenReturn(NODE_LIMIT);
+        when(clusterUpgradeAvailabilityService.checkForUpgradesByName(stack, false, true, request.getInternalUpgradeSettings())).thenReturn(upgradeResponse);
+        when(entitlementService.runtimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(true);
+        when(stackOperations.listByEnvironmentCrn(eq(WORKSPACE_ID), eq(ENVIRONMENT_CRN), any())).thenReturn(stackViewV4Responses);
+
+        UpgradeV4Response actual = underTest.checkForClusterUpgrade(ACCOUNT_ID, stack, WORKSPACE_ID, request);
+
+        assertEquals(upgradeResponse, actual);
+        verify(instanceGroupService).getByStackAndFetchTemplates(STACK_ID);
+        verify(upgradeService).isOsUpgrade(request);
+        verify(instanceGroupService).getByStackAndFetchTemplates(STACK_ID);
+        verify(limitConfiguration).getUpgradeNodeCountLimit();
+        verify(clusterUpgradeAvailabilityService).checkForUpgradesByName(stack, false, true, request.getInternalUpgradeSettings());
+        verify(clusterUpgradeAvailabilityService).filterUpgradeOptions(ACCOUNT_ID, upgradeResponse, request, true);
+        verify(entitlementService).runtimeUpgradeEnabled(ACCOUNT_ID);
+        verify(stackOperations).listByEnvironmentCrn(eq(WORKSPACE_ID), eq(ENVIRONMENT_CRN), any());
+        verify(upgradePreconditionService).checkForRunningAttachedClusters(stackViewV4Responses, upgradeResponse, stack);
+        verifyNoInteractions(clusterDBValidationService);
+    }
+
+    private UpgradeV4Response createUpgradeResponse() {
+        UpgradeV4Response upgradeResponse = new UpgradeV4Response();
+        upgradeResponse.setUpgradeCandidates(List.of(new ImageInfoV4Response()));
+        return upgradeResponse;
+    }
+
+    private UpgradeV4Request createUpgradeRequest(Boolean replaceVm) {
+        UpgradeV4Request upgradeRequest = new UpgradeV4Request();
+        upgradeRequest.setReplaceVms(replaceVm);
+        upgradeRequest.setInternalUpgradeSettings(new InternalUpgradeSettings(true, true, true));
+        return upgradeRequest;
+    }
+
+    private Stack createStack(StackType stackType) {
+        Stack stack = new Stack();
+        stack.setId(STACK_ID);
+        stack.setType(stackType);
+        stack.setEnvironmentCrn(ENVIRONMENT_CRN);
+        return stack;
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/service/upgrade/DistroXUpgradeAvailabilityServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/service/upgrade/DistroXUpgradeAvailabilityServiceTest.java
@@ -45,7 +45,7 @@ import com.sequenceiq.cloudbreak.service.stack.RuntimeVersionService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.service.stack.StackViewService;
 import com.sequenceiq.common.model.UpgradeShowAvailableImages;
-import com.sequenceiq.distrox.v1.distrox.StackOperations;
+import com.sequenceiq.distrox.v1.distrox.StackUpgradeOperations;
 
 @ExtendWith(MockitoExtension.class)
 public class DistroXUpgradeAvailabilityServiceTest {
@@ -66,7 +66,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
     private EntitlementService entitlementService;
 
     @Mock
-    private StackOperations stackOperations;
+    private StackUpgradeOperations stackUpgradeOperations;
 
     @Mock
     private StackService stackService;
@@ -112,7 +112,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         UpgradeV4Response response = new UpgradeV4Response();
         response.setUpgradeCandidates(List.of(mock(ImageInfoV4Response.class), mock(ImageInfoV4Response.class)));
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(STACK);
-        when(stackOperations.checkForClusterUpgrade(ACCOUNT_ID, STACK, WORKSPACE_ID, request)).thenReturn(response);
+        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, STACK, WORKSPACE_ID, request)).thenReturn(response);
 
         UpgradeV4Response result = underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN);
 
@@ -136,7 +136,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         when(entitlementService.datahubRuntimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(false);
         when(stackService.getByCrn(DATALAKE_CRN)).thenReturn(datalake);
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(STACK);
-        when(stackOperations.checkForClusterUpgrade(ACCOUNT_ID, STACK, WORKSPACE_ID, request)).thenReturn(response);
+        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, STACK, WORKSPACE_ID, request)).thenReturn(response);
         when(clusterService.getCluster(datalake)).thenReturn(datalakeCluster);
 
         BadRequestException exception = assertThrows(BadRequestException.class, () -> underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN));
@@ -161,7 +161,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         when(entitlementService.datahubRuntimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(false);
         when(stackService.getByCrn(DATALAKE_CRN)).thenReturn(datalake);
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(STACK);
-        when(stackOperations.checkForClusterUpgrade(ACCOUNT_ID, STACK, WORKSPACE_ID, request)).thenReturn(response);
+        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, STACK, WORKSPACE_ID, request)).thenReturn(response);
         when(clusterService.getCluster(datalake)).thenReturn(datalakeCluster);
 
         assertDoesNotThrow(() -> underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN));
@@ -181,7 +181,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         response.setCurrent(currentImage);
         when(entitlementService.datahubRuntimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(true);
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(STACK);
-        when(stackOperations.checkForClusterUpgrade(ACCOUNT_ID, STACK, WORKSPACE_ID, request)).thenReturn(response);
+        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, STACK, WORKSPACE_ID, request)).thenReturn(response);
 
         assertDoesNotThrow(() -> underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN));
 
@@ -201,7 +201,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         image3.setCreated(5L);
         response.setUpgradeCandidates(List.of(image1, image2, image3));
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(STACK);
-        when(stackOperations.checkForClusterUpgrade(ACCOUNT_ID, STACK, WORKSPACE_ID, request)).thenReturn(response);
+        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, STACK, WORKSPACE_ID, request)).thenReturn(response);
 
         UpgradeV4Response result = underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN);
 
@@ -225,7 +225,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         ImageInfoV4Response image9 = createImageResponse(6L, "C");
         response.setUpgradeCandidates(List.of(image1, image2, image3, image4, image5, image6, image7, image8, image9));
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(STACK);
-        when(stackOperations.checkForClusterUpgrade(ACCOUNT_ID, STACK, WORKSPACE_ID, request)).thenReturn(response);
+        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, STACK, WORKSPACE_ID, request)).thenReturn(response);
 
         UpgradeV4Response result = underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN);
 
@@ -257,7 +257,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         clusterView.setId(1L);
         ReflectionTestUtils.setField(stackView, "cluster", clusterView);
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(stackWithEnv);
-        when(stackOperations.checkForClusterUpgrade(ACCOUNT_ID, stackWithEnv, WORKSPACE_ID, request)).thenReturn(response);
+        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stackWithEnv, WORKSPACE_ID, request)).thenReturn(response);
         when(stackViewService.findDatalakeViewByEnvironmentCrn(stackWithEnv.getEnvironmentCrn())).thenReturn(Optional.of(stackView));
         when(runtimeVersionService.getRuntimeVersion(eq(clusterView.getId()))).thenReturn(Optional.of("C"));
         when(entitlementService.datahubRuntimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(true);
@@ -278,7 +278,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         Stack stackWithEnv = new Stack();
         stackWithEnv.setEnvironmentCrn("envcrn");
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(stackWithEnv);
-        when(stackOperations.checkForClusterUpgrade(ACCOUNT_ID, stackWithEnv, WORKSPACE_ID, request)).thenReturn(response);
+        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stackWithEnv, WORKSPACE_ID, request)).thenReturn(response);
 
         UpgradeV4Response result = underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN);
 
@@ -304,7 +304,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         clusterView.setId(1L);
         ReflectionTestUtils.setField(stackView, "cluster", clusterView);
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(stackWithEnv);
-        when(stackOperations.checkForClusterUpgrade(ACCOUNT_ID, stackWithEnv, WORKSPACE_ID, request)).thenReturn(response);
+        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stackWithEnv, WORKSPACE_ID, request)).thenReturn(response);
         when(stackViewService.findDatalakeViewByEnvironmentCrn(stackWithEnv.getEnvironmentCrn())).thenReturn(Optional.of(stackView));
         when(runtimeVersionService.getRuntimeVersion(eq(clusterView.getId()))).thenReturn(Optional.of("7.1.0"));
         when(entitlementService.isDifferentDataHubAndDataLakeVersionAllowed(anyString())).thenReturn(false);
@@ -336,7 +336,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         clusterView.setId(1L);
         ReflectionTestUtils.setField(stackView, "cluster", clusterView);
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(stackWithEnv);
-        when(stackOperations.checkForClusterUpgrade(ACCOUNT_ID, stackWithEnv, WORKSPACE_ID, request)).thenReturn(response);
+        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stackWithEnv, WORKSPACE_ID, request)).thenReturn(response);
         when(entitlementService.isDifferentDataHubAndDataLakeVersionAllowed(anyString())).thenReturn(true);
 
         UpgradeV4Response result = underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN);
@@ -363,7 +363,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         stackWithEnv.setEnvironmentCrn("envcrn");
         when(clusterService.getCluster(any())).thenReturn(datalakeCluster);
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(stackWithEnv);
-        when(stackOperations.checkForClusterUpgrade(ACCOUNT_ID, stackWithEnv, WORKSPACE_ID, request)).thenReturn(response);
+        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stackWithEnv, WORKSPACE_ID, request)).thenReturn(response);
         when(entitlementService.datahubRuntimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(false);
 
         UpgradeV4Response result = underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN);
@@ -392,7 +392,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         stackWithEnv.setEnvironmentCrn("envcrn");
         when(clusterService.getCluster(any())).thenReturn(datalakeCluster);
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(stackWithEnv);
-        when(stackOperations.checkForClusterUpgrade(ACCOUNT_ID, stackWithEnv, WORKSPACE_ID, request)).thenReturn(response);
+        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stackWithEnv, WORKSPACE_ID, request)).thenReturn(response);
         when(entitlementService.datahubRuntimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(false);
 
         UpgradeV4Response result = underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN);
@@ -425,7 +425,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         ReflectionTestUtils.setField(stackView, "cluster", clusterView);
         when(clusterService.getCluster(any())).thenReturn(datalakeCluster);
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(stackWithEnv);
-        when(stackOperations.checkForClusterUpgrade(ACCOUNT_ID, stackWithEnv, WORKSPACE_ID, request)).thenReturn(response);
+        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stackWithEnv, WORKSPACE_ID, request)).thenReturn(response);
         when(entitlementService.datahubRuntimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(false);
         when(entitlementService.isDifferentDataHubAndDataLakeVersionAllowed(anyString())).thenReturn(false);
         when(stackViewService.findDatalakeViewByEnvironmentCrn(stackWithEnv.getEnvironmentCrn())).thenReturn(Optional.of(stackView));


### PR DESCRIPTION
Testing steps
- Create an environment with DataLake 7.2.9
- Create a DataHub with `7.2.9 - Data Mart with Apache Impala and Hue` template.
- In the DataHub's `upgrade` tab the available upgrades should be listed.
- Runtime upgrade to 7.2.10 should be successful