### PR TITLE
CB-13786: Implement controller to return all the data lake events.

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/events/EventV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/events/EventV4Endpoint.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.api.endpoint.v4.events;
 
+import java.util.List;
+
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -43,6 +45,17 @@ public interface EventV4Endpoint {
     @ApiOperation(value = EventOpDescription.GET_BY_NAME, produces = MediaType.APPLICATION_JSON, notes = Notes.EVENT_NOTES,
             nickname = "getEventsByStackNameInWorkspace")
     Page<CloudbreakEventV4Response> getCloudbreakEventsByStack(
+            @PathParam("name") String name,
+            @QueryParam("page") @DefaultValue("0") Integer page,
+            @QueryParam("size") @DefaultValue("100") Integer size,
+            @AccountId @QueryParam("accountId") String accountId);
+
+    @GET
+    @Path("{name}/list")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = EventOpDescription.GET_BY_NAME, produces = MediaType.APPLICATION_JSON, notes = Notes.EVENT_NOTES,
+            nickname = "getCloudbreakEventsListByStack")
+    List<CloudbreakEventV4Response> getPagedCloudbreakEventListByStack(
             @PathParam("name") String name,
             @QueryParam("page") @DefaultValue("0") Integer page,
             @QueryParam("size") @DefaultValue("100") Integer size,

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/client/internal/CloudbreakApiClientConfig.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/client/internal/CloudbreakApiClientConfig.java
@@ -10,6 +10,7 @@ import com.sequenceiq.cloudbreak.api.CoreApi;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.ClusterTemplateV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.DatabaseConfigV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.diagnostics.DiagnosticsV4Endpoint;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.events.EventV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.filesystems.FileSystemV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.ImageCatalogV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.operation.OperationV4Endpoint;
@@ -74,6 +75,12 @@ public class CloudbreakApiClientConfig {
     @ConditionalOnBean(name = "cloudbreakApiClientWebTarget")
     StackV4Endpoint stackV4Endpoint(WebTarget cloudbreakApiClientWebTarget) {
         return new WebTargetEndpointFactory().createEndpoint(cloudbreakApiClientWebTarget, StackV4Endpoint.class);
+    }
+
+    @Bean
+    @ConditionalOnBean(name = "cloudbreakApiClientWebTarget")
+    EventV4Endpoint eventV4Endpoint(WebTarget cloudbreakApiClientWebTarget) {
+        return new WebTargetEndpointFactory().createEndpoint(cloudbreakApiClientWebTarget, EventV4Endpoint.class);
     }
 
     @Bean

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/EventV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/EventV4Controller.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.controller.v4;
 
 import static com.sequenceiq.cloudbreak.common.exception.NotFoundException.notFound;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -62,6 +63,12 @@ public class EventV4Controller implements EventV4Endpoint {
         PageRequest pageable = PageRequest.of(page, size, Sort.by("timestamp").descending());
         StackView stackView = getStackViewIfAvailable(name);
         return cloudbreakEventsFacade.retrieveEventsByStack(stackView.getId(), stackView.getType(), pageable);
+    }
+
+    @Override
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.POWERUSER_ONLY)
+    public List<CloudbreakEventV4Response> getPagedCloudbreakEventListByStack(String name, Integer page, Integer size, @AccountId String accountId) {
+        return getCloudbreakEventsByStack(name, page, size, accountId).getContent();
     }
 
     private StackView getStackViewIfAvailable(String name) {

--- a/datalake-api/build.gradle
+++ b/datalake-api/build.gradle
@@ -10,6 +10,7 @@ dependencies {
   implementation project(':core-api')
   implementation project(':authorization-common-api')
   implementation project(":structuredevent-api-cdp")
+  implementation project(':structuredevent-model')
 
   implementation     group: 'io.opentracing.contrib',        name: 'opentracing-jaxrs2',             version: opentracingJaxrs2Version
 }

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxEventEndpoint.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxEventEndpoint.java
@@ -1,0 +1,43 @@
+package com.sequenceiq.sdx.api.endpoint;
+
+import static com.sequenceiq.cloudbreak.structuredevent.rest.endpoint.CDPStructuredEventOperationDescriptions.AUDIT_EVENTS_NOTES;
+import static com.sequenceiq.cloudbreak.structuredevent.rest.endpoint.CDPStructuredEventOperationDescriptions.AuditOpDescription.LIST_FOR_RESOURCE;
+
+import java.util.List;
+
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import org.springframework.validation.annotation.Validated;
+
+import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
+import com.sequenceiq.cloudbreak.structuredevent.event.StructuredEventType;
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPStructuredEvent;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
+@Validated
+@Path("/sdx")
+@RetryAndMetrics
+@Consumes(MediaType.APPLICATION_JSON)
+@Api(value = "/sdx", protocols = "http,https", consumes = MediaType.APPLICATION_JSON)
+public interface SdxEventEndpoint {
+
+    @GET
+    @Path("/structured_events")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = LIST_FOR_RESOURCE, produces = MediaType.APPLICATION_JSON, notes = AUDIT_EVENTS_NOTES,
+            nickname = "getCDPAuditEventsForResource")
+    List<CDPStructuredEvent> getAuditEvents(
+            @QueryParam("environmentCrn") @NotNull(message = "The 'environmentCrn' query parameter must be specified.") String environmentCrn,
+            @QueryParam("types") List<StructuredEventType> types,
+            @QueryParam("page") @DefaultValue("0") Integer page,
+            @QueryParam("size") @DefaultValue("100") Integer size);
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/configuration/EndpointConfig.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/configuration/EndpointConfig.java
@@ -16,6 +16,7 @@ import com.sequenceiq.authorization.controller.AuthorizationInfoController;
 import com.sequenceiq.authorization.info.AuthorizationUtilEndpoint;
 import com.sequenceiq.cloudbreak.exception.mapper.DefaultExceptionMapper;
 import com.sequenceiq.cloudbreak.structuredevent.rest.controller.CDPStructuredEventV1Controller;
+import com.sequenceiq.datalake.controller.SdxEventController;
 import com.sequenceiq.datalake.controller.diagnostics.DiagnosticsController;
 import com.sequenceiq.datalake.controller.mapper.WebApplicaitonExceptionMapper;
 import com.sequenceiq.datalake.controller.operation.OperationController;
@@ -62,7 +63,8 @@ public class EndpointConfig extends ResourceConfig {
             SdxRestoreController.class,
             SdxRecipeController.class,
             CDPStructuredEventV1Controller.class,
-            SdxRecoveryController.class
+            SdxRecoveryController.class,
+            SdxEventController.class
     );
 
     @Value("${info.app.version:unspecified}")
@@ -82,10 +84,6 @@ public class EndpointConfig extends ResourceConfig {
 
     @PostConstruct
     private void init() {
-        // todo: uncomment me for CB-13786
-//        if (auditEnabled) {
-//            register(CDPStructuredEventFilter.class);
-//        }
         registerEndpoints();
         registerExceptionMappers();
         register(serverTracingDynamicFeature);

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/SdxEventController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/SdxEventController.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.datalake.controller;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Controller;
+
+import com.sequenceiq.authorization.annotation.CheckPermissionByAccount;
+import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
+import com.sequenceiq.cloudbreak.structuredevent.event.StructuredEventType;
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPStructuredEvent;
+import com.sequenceiq.datalake.service.SdxEventsService;
+import com.sequenceiq.sdx.api.endpoint.SdxEventEndpoint;
+
+@Controller
+public class SdxEventController implements SdxEventEndpoint {
+
+    @Inject
+    private SdxEventsService sdxEventsService;
+
+    /**
+     * Retrieves audit events for the provided Environment CRN.
+     *
+     * @param environmentCrn a Environment CRN
+     * @param types          types of structured events to retrieve
+     * @return structured events gathered from datalake and cloudbreak services.
+     */
+    @Override
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.DESCRIBE_DATALAKE)
+    public List<CDPStructuredEvent> getAuditEvents(String environmentCrn, List<StructuredEventType> types, Integer page, Integer size) {
+        return sdxEventsService.getDatalakeAuditEvents(environmentCrn, types, page, size);
+    }
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/repository/SdxClusterRepository.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/repository/SdxClusterRepository.java
@@ -43,6 +43,8 @@ public interface SdxClusterRepository extends AccountAwareResourceRepository<Sdx
 
     Optional<SdxCluster> findByAccountIdAndEnvCrnAndDeletedIsNullAndDetachedIsTrue(@Param("accountId") String accountId, @Param("crn") String crn);
 
+    List<SdxCluster> findByAccountIdAndEnvCrn(@Param("accountId") String accountId, @Param("envcrn") String envcrn);
+
     @Query("SELECT s.envCrn FROM SdxCluster s WHERE s.accountId = :accountId AND s.crn = :crn AND s.deleted is null AND s.detached = false")
     Optional<String> findEnvCrnByAccountIdAndCrnAndDeletedIsNullAndDetachedIsFalse(@Param("accountId") String accountId, @Param("crn") String crn);
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/SdxEventsService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/SdxEventsService.java
@@ -1,0 +1,163 @@
+package com.sequenceiq.datalake.service;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.events.EventV4Endpoint;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.events.responses.CloudbreakEventV4Response;
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
+import com.sequenceiq.cloudbreak.auth.crn.CrnParseException;
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
+import com.sequenceiq.cloudbreak.structuredevent.event.StructuredEventType;
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPOperationDetails;
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPStructuredEvent;
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPStructuredNotificationEvent;
+import com.sequenceiq.cloudbreak.structuredevent.service.db.CDPStructuredEventDBService;
+import com.sequenceiq.datalake.entity.SdxCluster;
+import com.sequenceiq.datalake.repository.SdxClusterRepository;
+import com.sequenceiq.datalake.service.sdx.SdxService;
+
+@Service
+public class SdxEventsService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxEventsService.class);
+
+    @Inject
+    private SdxClusterRepository sdxClusterRepository;
+
+    @Inject
+    private SdxService sdxService;
+
+    @Inject
+    private CDPStructuredEventDBService cdpStructuredEventDBService;
+
+    @Inject
+    private EventV4Endpoint eventV4Endpoint;
+
+    public List<CDPStructuredEvent> getDatalakeAuditEvents(String environmentCrn, List<StructuredEventType> types, Integer page, Integer size) {
+        List<CDPStructuredEvent> dlEvents;
+        List<CDPStructuredEvent> cbEvents;
+
+        PageRequest pageable = PageRequest.of(page, size, Sort.by("timestamp").descending());
+        SdxCluster sdxCluster = getDatalake(environmentCrn);
+        if (sdxCluster == null) {
+            LOGGER.error("Datalake not found for environment with Crn:{}", environmentCrn);
+            return List.of();
+        }
+
+        List<String> datalakeCrns = getDatalakeCrns(environmentCrn);
+        dlEvents = retrieveDatalakeServiceEvents(types, datalakeCrns, pageable);
+        cbEvents = retrieveCloudbreakServiceEvents(sdxCluster, page, size);
+
+        List<CDPStructuredEvent> combinedEvents = new ArrayList<>();
+        combinedEvents.addAll(cbEvents);
+        combinedEvents.addAll(dlEvents);
+
+        if (combinedEvents.isEmpty()) {
+            LOGGER.info("No events from datalake and cloudbreak service");
+            return List.of();
+        }
+        return sortAndFilterBasedOnPageSize(combinedEvents, size);
+    }
+
+    private List<CDPStructuredEvent> retrieveDatalakeServiceEvents(List<StructuredEventType> types, List<String> datalakeCrns, PageRequest pageable) {
+        Page<CDPStructuredEvent> pagedResponse = cdpStructuredEventDBService.getPagedEventsOfResources(types, datalakeCrns, pageable);
+        if (pagedResponse != null && pagedResponse.getContent() != null && pagedResponse.getContent().size() > 0) {
+            return pagedResponse.getContent();
+        } else {
+            LOGGER.info("No events from datalake service");
+            return List.of();
+        }
+    }
+
+    private List<CDPStructuredEvent> retrieveCloudbreakServiceEvents(SdxCluster sdxCluster, Integer page, Integer size) {
+        List<CloudbreakEventV4Response> cloudbreakEventV4Responses = null;
+        try {
+            cloudbreakEventV4Responses = eventV4Endpoint.getPagedCloudbreakEventListByStack(sdxCluster.getName(), page, size,
+                    getAccountId(sdxCluster.getEnvCrn()));
+        } catch (Exception exception) {
+            cloudbreakEventV4Responses = List.of();
+        }
+        // Translate the cloudbreak events
+        return cloudbreakEventV4Responses.stream().map(entry -> convert(entry, sdxCluster.getCrn())).collect(Collectors.toList());
+    }
+
+    private List<CDPStructuredEvent> sortAndFilterBasedOnPageSize(List<CDPStructuredEvent> eventList, Integer size) {
+        return eventList.stream().sorted(Comparator.comparingLong(f -> f.getOperation().getTimestamp())).collect(Collectors.toList())
+                .subList(0, (eventList.size() > size) ? size : eventList.size());
+    }
+
+    private String getAccountId(String crnString) {
+        try {
+            Crn crn = Crn.safeFromString(crnString);
+            return crn.getAccountId();
+        } catch (NullPointerException | CrnParseException e) {
+            throw new BadRequestException("Can not parse CRN to find account ID: " + crnString);
+        }
+    }
+
+    /**
+     * Get datalake CRNs that are or were provisioned within the environment identified by the provided CRN.
+     *
+     * @param environmentCrn an environment CRN
+     * @return a list of Data Lake CRNs related to the environment
+     */
+    private List<String> getDatalakeCrns(String environmentCrn) {
+        return sdxClusterRepository.findByAccountIdAndEnvCrn(getAccountId(environmentCrn), environmentCrn).stream()
+                .map(SdxCluster::getCrn)
+                .collect(toList());
+    }
+
+    /**
+     * Get SdxCluster that is provisioned within the environment that is non-deleted and non-detached.
+     *
+     * @param environmentCrn an environment CRN
+     * @return SdxCluster related to the environment.
+     */
+    private SdxCluster getDatalake(String environmentCrn) {
+        LOGGER.info("Looking for datalake associated with environment Crn {}", environmentCrn);
+        List<SdxCluster> sdxClusters = sdxService.listSdxByEnvCrn(environmentCrn);
+        sdxClusters.stream().forEach(sdxCluster -> LOGGER.info("Found SDX cluster {}", sdxCluster));
+        if (!sdxClusters.isEmpty()) {
+            return sdxClusters.get(0);
+        }
+        return null;
+    }
+
+    /**
+     * Converts a collection of {@code CloudbreakEventV4Response} to {@code CDPStructuredEvent}.
+     *
+     * @param cloudbreakEventV4Response Event response from cloudbreak.
+     * @param datalakeCrn               Crn of data lake.
+     * @return CDP structured Event
+     */
+    private CDPStructuredEvent convert(CloudbreakEventV4Response cloudbreakEventV4Response, String datalakeCrn) {
+        CDPStructuredNotificationEvent cdpStructuredNotificationEvent = new CDPStructuredNotificationEvent();
+        CDPOperationDetails cdpOperationDetails = new CDPOperationDetails();
+        cdpOperationDetails.setTimestamp(cloudbreakEventV4Response.getEventTimestamp());
+        cdpOperationDetails.setEventType(StructuredEventType.NOTIFICATION);
+        cdpOperationDetails.setResourceName(cloudbreakEventV4Response.getClusterName());
+        cdpOperationDetails.setResourceId(cloudbreakEventV4Response.getClusterId());
+        cdpOperationDetails.setResourceCrn(datalakeCrn);
+        cdpOperationDetails.setResourceType(CloudbreakEventService.DATALAKE_RESOURCE_TYPE);
+
+        cdpStructuredNotificationEvent.setOperation(cdpOperationDetails);
+        cdpStructuredNotificationEvent.setStatusReason(cloudbreakEventV4Response.getEventMessage());
+
+        return cdpStructuredNotificationEvent;
+    }
+}

--- a/datalake/src/test/java/com/sequenceiq/datalake/controller/SdxEventControllerTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/controller/SdxEventControllerTest.java
@@ -1,0 +1,105 @@
+package com.sequenceiq.datalake.controller;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+
+import com.sequenceiq.cloudbreak.structuredevent.event.StructuredEventType;
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPOperationDetails;
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPStructuredEvent;
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPStructuredFlowEvent;
+import com.sequenceiq.cloudbreak.structuredevent.service.db.CDPStructuredEventDBService;
+import com.sequenceiq.datalake.entity.SdxCluster;
+import com.sequenceiq.datalake.repository.SdxClusterRepository;
+import com.sequenceiq.datalake.service.SdxEventsService;
+
+class SdxEventControllerTest {
+
+    private static final Integer TEST_PAGE = 1;
+
+    private static final Integer TEST_SIZE = 10;
+
+    private static final String RESOURCE_CRN = "crn:cdp:environments:us-west-1:460c0d8f-ae8e-4dce-9cd7-2351762eb9ac:environment:" +
+            "6b2b1600-8ac6-4c26-aa34-dab36f4bd243";
+
+    private static final List<StructuredEventType> TEST_EVENT_TYPES = List.of(StructuredEventType.FLOW, StructuredEventType.NOTIFICATION);
+
+    @Mock
+    private CDPStructuredEventDBService mockCdpStructuredEventDBService;
+
+    @Mock
+    private SdxClusterRepository mockSdxClusterRepository;
+
+    @Mock
+    private SdxEventsService sdxEventsService;
+
+    @InjectMocks
+    private SdxEventController datalakeEventController;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        SdxCluster sdxCluster = new SdxCluster();
+        sdxCluster.setCrn(RESOURCE_CRN);
+        when(mockSdxClusterRepository.findByAccountIdAndEnvCrn(any(), any())).thenReturn(List.of(sdxCluster));
+    }
+
+    @Test
+    void testNoAuthorizationWhenEventsReturnedIsEmpty() {
+        when(mockCdpStructuredEventDBService.getPagedEventsOfResources(eq(TEST_EVENT_TYPES), any(), any()))
+                .thenReturn(Page.empty());
+        when(sdxEventsService.getDatalakeAuditEvents(any(), eq(TEST_EVENT_TYPES), any(), any()))
+                .thenReturn(Collections.emptyList());
+        List<CDPStructuredEvent> result = datalakeEventController.getAuditEvents(RESOURCE_CRN, TEST_EVENT_TYPES, TEST_PAGE, TEST_SIZE);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testNoAuthorizationWhenEventsReturnedIsNotEmpty() {
+        when(mockCdpStructuredEventDBService.getPagedEventsOfResources(eq(TEST_EVENT_TYPES), any(), any()))
+                .thenReturn(Page.empty());
+        when(sdxEventsService.getDatalakeAuditEvents(any(), eq(TEST_EVENT_TYPES), any(), any()))
+                .thenReturn(Collections.singletonList(createCDPStructuredFlowEvent(1L)));
+        List<CDPStructuredEvent> result = datalakeEventController.getAuditEvents(RESOURCE_CRN, TEST_EVENT_TYPES, TEST_PAGE, TEST_SIZE);
+
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+    }
+
+    private CDPStructuredEvent createCDPStructuredFlowEvent(Long timestamp) {
+        CDPOperationDetails operationDetails = new CDPOperationDetails();
+        operationDetails.setResourceCrn("someCrn");
+        operationDetails.setResourceType("datalake");
+        operationDetails.setTimestamp(timestamp);
+        operationDetails.setEventType(StructuredEventType.FLOW);
+
+        CDPStructuredFlowEvent cdpStructuredEvent = new CDPStructuredFlowEvent() {
+            @Override
+            public String getStatus() {
+                return SENT;
+            }
+
+            @Override
+            public Long getDuration() {
+                return 1L;
+            }
+        };
+        cdpStructuredEvent.setOperation(operationDetails);
+        return cdpStructuredEvent;
+    }
+}

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxEventsServiceTests.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxEventsServiceTests.java
@@ -1,0 +1,217 @@
+package com.sequenceiq.datalake.service.sdx;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.events.EventV4Endpoint;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.events.responses.CloudbreakEventV4Response;
+import com.sequenceiq.cloudbreak.structuredevent.event.StructuredEventType;
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPOperationDetails;
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPStructuredEvent;
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPStructuredFlowEvent;
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPStructuredNotificationEvent;
+import com.sequenceiq.cloudbreak.structuredevent.service.db.CDPStructuredEventDBService;
+import com.sequenceiq.datalake.entity.SdxCluster;
+import com.sequenceiq.datalake.repository.SdxClusterRepository;
+import com.sequenceiq.datalake.service.SdxEventsService;
+
+public class SdxEventsServiceTests {
+
+    private static final Integer TEST_PAGE = 1;
+
+    private static final Integer TEST_SIZE = 10;
+
+    private static final String ENVIRONMENT_CRN = "crn:cdp:environments:us-west-1:460c0d8f-ae8e-4dce-9cd7-2351762eb9ac:environment:" +
+            "6b2b1600-8ac6-4c26-aa34-dab36f4bd243";
+
+    private static final String DATALAKE_CRN = "crn:cdp:environments:us-west-1:460c0d8f-ae8e-4dce-9cd7-2351762eb9ac:environment:" +
+            "6b2b1600-8ac6-4c26-aa34-dab36f4bd243";
+
+    private static final List<StructuredEventType> TEST_EVENT_TYPES = List.of(StructuredEventType.FLOW, StructuredEventType.NOTIFICATION);
+
+    @Mock
+    private CDPStructuredEventDBService mockCdpStructuredEventDBService;
+
+    @Mock
+    private EventV4Endpoint eventV4Endpoint;
+
+    @Mock
+    private SdxClusterRepository mockSdxClusterRepository;
+
+    @Mock
+    private SdxService sdxService;
+
+    @InjectMocks
+    private SdxEventsService sdxEventsService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        SdxCluster sdxCluster = new SdxCluster();
+        sdxCluster.setCrn(DATALAKE_CRN);
+        sdxCluster.setEnvCrn(ENVIRONMENT_CRN);
+        when(mockSdxClusterRepository.findByAccountIdAndEnvCrn(any(), any())).thenReturn(List.of(sdxCluster));
+        when(sdxService.listSdxByEnvCrn(any())).thenReturn(List.of(sdxCluster));
+    }
+
+    @Test
+    void testGetAuditEventsWhenNotEmptyPageComingBackFromDbServiceThenAuthzHappens() {
+        Page<CDPStructuredEvent> mockPage = mock(Page.class);
+
+        when(mockPage.getContent()).thenReturn(List.of(createTestCDPStructuredEvent(StructuredEventType.NOTIFICATION),
+                createTestCDPStructuredEvent(StructuredEventType.FLOW)));
+        when(mockCdpStructuredEventDBService.getPagedEventsOfResources(eq(TEST_EVENT_TYPES), any(), any()))
+                .thenReturn(mockPage);
+
+        List<CDPStructuredEvent> result = sdxEventsService.getDatalakeAuditEvents(DATALAKE_CRN, TEST_EVENT_TYPES, TEST_PAGE, TEST_SIZE);
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+
+    }
+
+    @Test
+    void testGetAuditEventsWhenTypeIsProvided() {
+        Page<CDPStructuredEvent> mockPage = mock(Page.class);
+
+        when(mockPage.getContent()).thenReturn(List.of(createTestCDPStructuredEvent(StructuredEventType.NOTIFICATION)));
+        when(mockCdpStructuredEventDBService.getPagedEventsOfResources(eq(List.of(StructuredEventType.NOTIFICATION)), any(), any()))
+                .thenReturn(mockPage);
+        when(eventV4Endpoint.getPagedCloudbreakEventListByStack(any(), any(), any(), any())).thenReturn(Collections.EMPTY_LIST);
+
+        List<CDPStructuredEvent> result = sdxEventsService.getDatalakeAuditEvents(DATALAKE_CRN,
+                Collections.singletonList(StructuredEventType.NOTIFICATION), TEST_PAGE, TEST_SIZE);
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals(result.get(0).getOperation().getEventType(), StructuredEventType.NOTIFICATION);
+    }
+
+    @Test
+    void testGetAuditEventsWithCBAndDlEvents() {
+        Page<CDPStructuredEvent> mockPage = mock(Page.class);
+
+        when(mockPage.getContent()).thenReturn(List.of(createTestCDPStructuredEvent(StructuredEventType.NOTIFICATION)));
+        when(mockCdpStructuredEventDBService.getPagedEventsOfResources(eq(List.of(StructuredEventType.NOTIFICATION)), any(), any()))
+                .thenReturn(mockPage);
+        when(eventV4Endpoint.getPagedCloudbreakEventListByStack(any(), any(), any(), any()))
+                .thenReturn(List.of(createCloudbreakEventV4Response()));
+
+        List<CDPStructuredEvent> result = sdxEventsService.getDatalakeAuditEvents(DATALAKE_CRN,
+                Collections.singletonList(StructuredEventType.NOTIFICATION), TEST_PAGE, TEST_SIZE);
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals(2, result.stream().filter(notification -> notification.getOperation().getEventType().equals(StructuredEventType.NOTIFICATION)).count());
+    }
+
+    @Test
+    void testGetAuditEventsWithCBAndDlEventsSort() {
+        Page<CDPStructuredEvent> mockPage = mock(Page.class);
+
+        when(mockPage.getContent()).thenReturn(List.of(createTestCDPStructuredEvent(StructuredEventType.NOTIFICATION, 5L),
+                createTestCDPStructuredEvent(StructuredEventType.NOTIFICATION, 2L)));
+        when(mockCdpStructuredEventDBService.getPagedEventsOfResources(eq(List.of(StructuredEventType.NOTIFICATION)), any(), any()))
+                .thenReturn(mockPage);
+        when(eventV4Endpoint.getPagedCloudbreakEventListByStack(any(), any(), any(), any()))
+                .thenReturn(List.of(createCloudbreakEventV4Response(1L)));
+
+        List<CDPStructuredEvent> result = sdxEventsService.getDatalakeAuditEvents(DATALAKE_CRN,
+                Collections.singletonList(StructuredEventType.NOTIFICATION), TEST_PAGE, TEST_SIZE);
+
+        assertNotNull(result);
+        assertEquals(3, result.size());
+        assertEquals(3, result.stream().filter(notification -> notification.getOperation().getEventType().equals(StructuredEventType.NOTIFICATION)).count());
+        assertTrue(result.get(0).getOperation().getTimestamp() < result.get(1).getOperation().getTimestamp());
+        assertTrue(result.get(1).getOperation().getTimestamp() < result.get(2).getOperation().getTimestamp());
+    }
+
+    private CloudbreakEventV4Response createCloudbreakEventV4Response() {
+        return createCloudbreakEventV4Response(1L);
+    }
+
+    private CloudbreakEventV4Response createCloudbreakEventV4Response(Long timestamp) {
+        CloudbreakEventV4Response cloudbreakEventV4Response = new CloudbreakEventV4Response();
+        cloudbreakEventV4Response.setEventTimestamp(timestamp);
+        cloudbreakEventV4Response.setClusterName("somename");
+        cloudbreakEventV4Response.setEventMessage("testing");
+        return cloudbreakEventV4Response;
+    }
+
+    private CDPStructuredEvent createTestCDPStructuredEvent(StructuredEventType type) {
+        if (type.equals(StructuredEventType.NOTIFICATION)) {
+            return createCDPStructuredNotificationEvent(0L);
+        } else {
+            return createCDPStructuredFlowEvent(0L);
+        }
+
+    }
+
+    private CDPStructuredEvent createTestCDPStructuredEvent(StructuredEventType type, Long timestamp) {
+        if (type.equals(StructuredEventType.NOTIFICATION)) {
+            return createCDPStructuredNotificationEvent(timestamp);
+        } else {
+            return createCDPStructuredFlowEvent(timestamp);
+        }
+
+    }
+
+    private CDPStructuredEvent createCDPStructuredNotificationEvent(Long timestamp) {
+        CDPOperationDetails operationDetails = new CDPOperationDetails();
+        operationDetails.setResourceCrn("someCrn");
+        operationDetails.setResourceType("datalake");
+        operationDetails.setTimestamp(timestamp);
+        operationDetails.setEventType(StructuredEventType.NOTIFICATION);
+
+        CDPStructuredNotificationEvent cdpStructuredEvent = new CDPStructuredNotificationEvent() {
+            @Override
+            public String getStatus() {
+                return SENT;
+            }
+
+            @Override
+            public Long getDuration() {
+                return 1L;
+            }
+        };
+        cdpStructuredEvent.setOperation(operationDetails);
+        return cdpStructuredEvent;
+    }
+
+    private CDPStructuredEvent createCDPStructuredFlowEvent(Long timestamp) {
+        CDPOperationDetails operationDetails = new CDPOperationDetails();
+        operationDetails.setResourceCrn("someCrn");
+        operationDetails.setResourceType("datalake");
+        operationDetails.setTimestamp(timestamp);
+        operationDetails.setEventType(StructuredEventType.FLOW);
+
+        CDPStructuredFlowEvent cdpStructuredEvent = new CDPStructuredFlowEvent() {
+            @Override
+            public String getStatus() {
+                return SENT;
+            }
+
+            @Override
+            public Long getDuration() {
+                return 1L;
+            }
+        };
+        cdpStructuredEvent.setOperation(operationDetails);
+        return cdpStructuredEvent;
+    }
+}

--- a/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/repository/CDPPagingStructuredEventRepository.java
+++ b/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/repository/CDPPagingStructuredEventRepository.java
@@ -21,4 +21,6 @@ public interface CDPPagingStructuredEventRepository extends PagingAndSortingRepo
     Page<CDPStructuredEventEntity> findByEventTypeAndResourceCrn(StructuredEventType eventType, String resourceCrn, Pageable pageable);
 
     Page<CDPStructuredEventEntity> findByEventTypeInAndResourceCrn(List<StructuredEventType> eventType, String resourceCrn, Pageable pageable);
+
+    Page<CDPStructuredEventEntity> findByEventTypeInAndResourceCrnIn(List<StructuredEventType> eventType, List<String> resourceCrn, Pageable pageable);
 }

--- a/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/rest/filter/CDPStructuredEventFilter.java
+++ b/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/rest/filter/CDPStructuredEventFilter.java
@@ -27,11 +27,11 @@ import com.sequenceiq.cloudbreak.structuredevent.rest.urlparser.CDPRestUrlParser
 
 /**
  * Inspects all requests to a service and determines if it should mark the request or response up with additional Structured Event metadata.
- *
+ * <p>
  * Uses implementations of {@code CDPRestUrlParser} to determine if additional actions should be taken on a request.
- *
+ * <p>
  * Activation of this filter is controlled by the {@code contentLogging} configuration value.
- *
+ * <p>
  * To use this class, it should be registered in an {@code EndpointConfig}.
  */
 @Component
@@ -64,6 +64,12 @@ public class CDPStructuredEventFilter implements WriterInterceptor, ContainerReq
     @Autowired
     private List<CDPRestUrlParser> cdpRestUrlParsers;
 
+    /**
+     * Add structured event parameters to the properties to the request context.
+     *
+     * @param requestContext the context on which to attach additional properties.
+     * @throws IOException if the request entity stream cannot be read correctly.
+     */
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
         boolean loggingEnabled = isLoggingEnabled(requestContext);
@@ -78,6 +84,15 @@ public class CDPStructuredEventFilter implements WriterInterceptor, ContainerReq
         }
     }
 
+    /**
+     * On response, attaches a logging stream to the request context, or sends a structured event.
+     * <p>
+     * The filter essentially helps send a structured event or sends it itself.
+     * <ul>
+     *     <li>When there is a response entity, {@code LoggingStream} is attached and used in {@code aroundWriteTo} to send a structured event.</li>
+     *     <li>When there isn't a response entity, send a structured event directly.</li>
+     * </ul>
+     */
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
         if (BooleanUtils.isTrue((Boolean) requestContext.getProperty(LOGGING_ENABLED_PROPERTY))) {
@@ -119,7 +134,7 @@ public class CDPStructuredEventFilter implements WriterInterceptor, ContainerReq
 
     /**
      * Iterates through implementations of {@code CDPRestUrlParser} to extract URL parameters if possible.
-     *
+     * <p>
      * The list of URL parsers is autowired by Spring.
      *
      * @param requestContext the source of URL parameters, parseable by one of the REST URL parsers

--- a/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/CDPStructuredEventService.java
+++ b/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/CDPStructuredEventService.java
@@ -14,4 +14,6 @@ public interface CDPStructuredEventService extends CDPStructuredEventSenderServi
     <T extends CDPStructuredEvent> Page<T> getPagedEventsOfResource(List<StructuredEventType> eventType, String resourceCrn, Pageable pageable);
 
     <T extends CDPStructuredEvent> List<T> getEventsOfResource(List<StructuredEventType> eventTypes, String resourceCrn);
+
+    <T extends CDPStructuredEvent> Page<T> getPagedEventsOfResources(List<StructuredEventType> eventTypes, List<String> resourceCrns, Pageable pageable);
 }

--- a/structuredevent-service-cdp/src/test/java/com/sequenceiq/cloudbreak/structuredevent/rest/controller/CDPStructuredEventV1ControllerTest.java
+++ b/structuredevent-service-cdp/src/test/java/com/sequenceiq/cloudbreak/structuredevent/rest/controller/CDPStructuredEventV1ControllerTest.java
@@ -1,0 +1,116 @@
+package com.sequenceiq.cloudbreak.structuredevent.rest.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import javax.ws.rs.core.Response;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import com.sequenceiq.cloudbreak.structuredevent.event.StructuredEventType;
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPOperationDetails;
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPStructuredEvent;
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPStructuredNotificationEvent;
+import com.sequenceiq.cloudbreak.structuredevent.service.db.CDPStructuredEventDBService;
+
+class CDPStructuredEventV1ControllerTest {
+
+    private static final String RESOURCE_CRN = "crn:cdp:environments:us-west-1:460c0d8f-ae8e-4dce-9cd7-2351762eb9ac:environment:6b2b1600-" +
+            "8ac6-4c26-aa34-dab36f4bd243";
+
+    private static final List<StructuredEventType> TEST_EVENT_TYPES = List.of(StructuredEventType.REST);
+
+    private static final Integer TEST_PAGE = 1;
+
+    private static final Integer TEST_SIZE = 1;
+
+    private static final String EXPECTED_ZIP_HEADER_KEY = "content-disposition";
+
+    private static final String EXPECTED_ZIP_HEADER_VALUE = "[attachment; filename = audit-environment.zip]";
+
+    @Mock
+    private CDPStructuredEventDBService mockStructuredEventDBService;
+
+    @InjectMocks
+    private CDPStructuredEventV1Controller underTest;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testGetAuditEventsWhenEmptyPageComingBackFromDbServiceThenNoAuthzHappens() {
+        when(mockStructuredEventDBService.getPagedEventsOfResource(eq(TEST_EVENT_TYPES), eq(RESOURCE_CRN), any(PageRequest.class)))
+                .thenReturn(Page.empty());
+
+        List<CDPStructuredEvent> result = underTest.getAuditEvents(RESOURCE_CRN, TEST_EVENT_TYPES, TEST_PAGE, TEST_SIZE);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testGetAuditEventsWhenNotEmptyPageComingBackFromDbServiceThenAuthzHappens() {
+        Page<CDPStructuredEvent> mockPage = mock(Page.class);
+        when(mockPage.getContent()).thenReturn(List.of(createTestCDPStructuredEvent()));
+        when(mockStructuredEventDBService.getPagedEventsOfResource(eq(TEST_EVENT_TYPES), eq(RESOURCE_CRN), any(PageRequest.class))).thenReturn(mockPage);
+
+        List<CDPStructuredEvent> result = underTest.getAuditEvents(RESOURCE_CRN, TEST_EVENT_TYPES, TEST_PAGE, TEST_SIZE);
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void testGetAuditEventsZipWhenNotEmptyPageComingBackFromDbServiceThenZipHeaderShouldBeInResponse() {
+        when(mockStructuredEventDBService.getEventsOfResource(eq(TEST_EVENT_TYPES), eq(RESOURCE_CRN))).thenReturn(List.of(createTestCDPStructuredEvent()));
+
+        Response response = underTest.getAuditEventsZip(RESOURCE_CRN, TEST_EVENT_TYPES);
+
+        assertNotNull(response);
+        assertFalse(response.getHeaders().isEmpty());
+        assertTrue(response.getHeaders().containsKey(EXPECTED_ZIP_HEADER_KEY));
+        assertEquals(EXPECTED_ZIP_HEADER_VALUE, response.getHeaders().get(EXPECTED_ZIP_HEADER_KEY).toString());
+    }
+
+    private CDPStructuredEvent createTestCDPStructuredEvent() {
+        CDPOperationDetails operationDetails = new CDPOperationDetails();
+        operationDetails.setResourceCrn("someCrn");
+        operationDetails.setResourceType("environment");
+        CDPStructuredEvent cdpStructuredEvent = new CDPStructuredEvent() {
+            @Override
+            public String getStatus() {
+                return SENT;
+            }
+
+            @Override
+            public Long getDuration() {
+                return 1L;
+            }
+        };
+        cdpStructuredEvent.setOperation(operationDetails);
+        return cdpStructuredEvent;
+    }
+
+    private CDPStructuredNotificationEvent createCDPStructuredNotificationEvent() {
+        CDPStructuredNotificationEvent event = new CDPStructuredNotificationEvent();
+        event.setOperation(createTestCDPStructuredEvent().getOperation());
+        return event;
+    }
+
+}

--- a/structuredevent-service-cdp/src/test/java/com/sequenceiq/cloudbreak/structuredevent/service/db/CDPStructuredEventDBServiceTest.java
+++ b/structuredevent-service-cdp/src/test/java/com/sequenceiq/cloudbreak/structuredevent/service/db/CDPStructuredEventDBServiceTest.java
@@ -97,7 +97,7 @@ public class CDPStructuredEventDBServiceTest {
     public void testCreateWhenResourceCrnIsNotEmpty() {
         CDPStructuredEvent event = new CDPStructuredRestCallEvent();
         CDPOperationDetails operation = new CDPOperationDetails();
-        operation.setResourceCrn("crn");
+        operation.setResourceCrn("crn:cdp:cloudbreak:us-west-1:someone:stack:12345");
         event.setOperation(operation);
         CDPStructuredEventEntity entity = new CDPStructuredEventEntity();
         when(cdpStructuredEventToCDPStructuredEventEntityConverter.convert(event)).thenReturn(entity);


### PR DESCRIPTION
The intent of the code is to add a controller in the datalake service that can provide all the events generated from datalake and cloud break services.

Functionality is added to fetch the notifications from the datalake service and cloudbreak service and perform necessary translations and sort them before serving the requests for notifications.