### PR TITLE
CB-15495 TestNg E2E tiemout validation if INTEGRATIONTEST_TIMEOUT_E2E_CHECK set

### DIFF
--- a/integration-test/scripts/check-results.sh
+++ b/integration-test/scripts/check-results.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 : ${INTEGRATIONTEST_MAX_PG_NETWORK_OUTPUT:="7.5GB"}
+: ${INTEGRATIONTEST_TIMEOUT_E2E_CHECK:="false"}
 
 status_code=0
 
@@ -27,6 +28,37 @@ if [[ "$CIRCLECI" ]]; then
     if [[ $(find suites_log -maxdepth 1 -name '*.log' | wc -l) -lt 3 ]]; then
         echo -e "\033[0;91m--- !!! NO TEST HAS BEEN LAUNCHED !!! ---\n";
         status_code=1;
+    fi
+
+    # Checking timed out tests
+    if [[ "${INTEGRATIONTEST_TIMEOUT_E2E_CHECK}" == "true" ]]; then
+      declare executed_tests=$(find suites_log -maxdepth 1 -name '*.test*.log' | wc -l)
+      declare generated_results=$(find . -maxdepth 1 -name 'resource_names_test*.json' | wc -l)
+      declare -i diff=$executed_tests-$generated_results
+      declare -a suite_logs
+      declare -a resource_files
+      declare -a timed_out_tests
+      if [[ $diff -gt 0 ]]; then
+          while IFS=  read -r -d $'\0'; do
+              REPLY=${REPLY#*.}; REPLY=${REPLY%-*}
+              suite_logs+=("$REPLY")
+          done < <(find suites_log -type f -name '*.test*.log' -print0)
+          while IFS=  read -r -d $'\0'; do
+              REPLY=${REPLY#*resource_names_}; REPLY=${REPLY%.json*}
+              resource_files+=("$REPLY")
+          done < <(find . -type f -name 'resource_names_test*.json' -print0)
+
+          for suite_log in "${suite_logs[@]}"; do
+            if [[ ! ${resource_files[*]} =~ $suite_log ]]; then
+              timed_out_tests+=("$suite_log")
+            fi
+          done
+
+          if [[ ! -z "${timed_out_tests[*]}" ]]; then
+            echo -e "\033[0;91m--- !!! ["${timed_out_tests[*]}"] TEST HAS BEEN TIMEDOUT !!! ---\n";
+            status_code=1;
+          fi
+      fi
     fi
 
     if [[ -z "${INTEGRATIONTEST_YARN_QUEUE}" ]] && [[ "$AWS" != true ]]; then


### PR DESCRIPTION
Our E2E tests are running in parallel by 8 threads (with the help of [TestNG parallel attribute](https://testng.org/doc/documentation-main.html#parallel-running)):
```
parallel="methods": TestNG will run all your test methods in separate threads. Dependent methods will also run in separate threads but they will respect the order that you specified.
```
This helps us to reduce the 'execution time' as tests are executed simultaneously in different threads.

Beyond this we applied a 100 minutes timeout for our test cases by default, on this way we can guarantees that none of the threads will block on a stuck test thread forever.

Unfortunately test case's thread is terminated if it takes longer than it's timeout setting. I found some similar issues at TestNG:
- [TestNg not generating reports in case of timeout #1215](https://github.com/cbeust/testng/issues/1215)
- [[selenium:testng] Total tests run: 0, Failures: 0, Skips: 0 on suite timeout with hardAssert? #669](https://github.com/cbeust/testng/issues/669)
- [Test Timeout not respected in parallel="methods" mode #2009](https://github.com/cbeust/testng/issues/2009)
- [timeout setting not working in parallel="tests" mode #811](https://github.com/cbeust/testng/issues/811)

For now we can introduce an extra validation in our [check-results.sh](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/scripts/check-results.sh) as a workaround for this.

This PR has precondition at [cloudbreak-ansible-playbooks#163](https://github.com/hortonworks/cloudbreak-ansible-playbooks/pull/163)