### PR TITLE
CB-15532 Azure load balancer Standard sku causing DL create failure

### DIFF
--- a/cloud-azure/src/main/resources/templates/arm-v2.ftl
+++ b/cloud-azure/src/main/resources/templates/arm-v2.ftl
@@ -212,7 +212,7 @@
                         </#list>
                      </#if>
                      },
-                   <#if loadBalancers?? && (loadBalancers?filter(loadBalancer -> loadBalancer.sku == "STANDARD")?size > 0)>
+                   <#if loadBalancerMapping[instance.groupName]?? && (loadBalancers?filter(loadBalancer -> loadBalancer.sku == "STANDARD")?size > 0)>
                      "sku": {
                          "name": "Standard",
                          "tier": "Regional"


### PR DESCRIPTION
When using a Standard SKU with the Azure load balancer, the publicIP of the instances being load
balanced must also have a Standard SKU, and the publicIPAllocationMethod must be "Static".
Previously the publicIP SKU was being set to match the load balancer SKU all instances, not just
the load balanced instances. This change adds a conditional to check if the instance is part
of the load balancer targets before setting the publicIP SKU.

Tested by creating a datalake with the change and verifying it was created successfully and that
the publicIP Standard SKU was only set for the target instances, and with a new unit test.