### PR TITLE
Revert "CB-15495 TestNg E2E tiemout validation if INTEGRATIONTEST_TIM…

### DIFF
--- a/integration-test/scripts/check-results.sh
+++ b/integration-test/scripts/check-results.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 : ${INTEGRATIONTEST_MAX_PG_NETWORK_OUTPUT:="7.5GB"}
-: ${INTEGRATIONTEST_TIMEOUT_E2E_CHECK:="false"}
 
 status_code=0
 
@@ -28,37 +27,6 @@ if [[ "$CIRCLECI" ]]; then
     if [[ $(find suites_log -maxdepth 1 -name '*.log' | wc -l) -lt 3 ]]; then
         echo -e "\033[0;91m--- !!! NO TEST HAS BEEN LAUNCHED !!! ---\n";
         status_code=1;
-    fi
-
-    # Checking timed out tests
-    if [[ "${INTEGRATIONTEST_TIMEOUT_E2E_CHECK}" == "true" ]]; then
-      declare executed_tests=$(find suites_log -maxdepth 1 -name '*.test*.log' | wc -l)
-      declare generated_results=$(find . -maxdepth 1 -name 'resource_names_test*.json' | wc -l)
-      declare -i diff=$executed_tests-$generated_results
-      declare -a suite_logs
-      declare -a resource_files
-      declare -a timed_out_tests
-      if [[ $diff -gt 0 ]]; then
-          while IFS=  read -r -d $'\0'; do
-              REPLY=${REPLY#*.}; REPLY=${REPLY%-*}
-              suite_logs+=("$REPLY")
-          done < <(find suites_log -type f -name '*.test*.log' -print0)
-          while IFS=  read -r -d $'\0'; do
-              REPLY=${REPLY#*resource_names_}; REPLY=${REPLY%.json*}
-              resource_files+=("$REPLY")
-          done < <(find . -type f -name 'resource_names_test*.json' -print0)
-
-          for suite_log in "${suite_logs[@]}"; do
-            if [[ ! ${resource_files[*]} =~ $suite_log ]]; then
-              timed_out_tests+=("$suite_log")
-            fi
-          done
-
-          if [[ ! -z "${timed_out_tests[*]}" ]]; then
-            echo -e "\033[0;91m--- !!! ["${timed_out_tests[*]}"] TEST HAS BEEN TIMEDOUT !!! ---\n";
-            status_code=1;
-          fi
-      fi
     fi
 
     if [[ -z "${INTEGRATIONTEST_YARN_QUEUE}" ]] && [[ "$AWS" != true ]]; then


### PR DESCRIPTION
This reverts commit [56ecabbd8dd0fc66630480ef2cd36425b7edf2cc](https://github.com/hortonworks/cloudbreak/commit/56ecabbd8dd0fc66630480ef2cd36425b7edf2cc).
I've moved this change to a much more appropriate script as a separate function at the [cloudbreak-ansible-playbooks  jenkins/build-scripts/cloudbreak-e2e-tests#9b521f97a4993a9a05b7d4517c15ae489b0d065f](https://github.com/hortonworks/cloudbreak-ansible-playbooks/commit/9b521f97a4993a9a05b7d4517c15ae489b0d065f). The new solution is much more reliable and stable.