### PR TITLE
CB-15139 Modifications to make Periscope differentiate between the sc…

### DIFF
--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/AutoscaleClusterState.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/AutoscaleClusterState.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.periscope.api.model;
 
+import com.sequenceiq.periscope.doc.ApiDescription.ClusterStopStartScalingState;
 import com.sequenceiq.periscope.doc.ApiDescription.ClusterAutoscaleState;
 
 import io.swagger.annotations.ApiModel;
@@ -9,25 +10,48 @@ import io.swagger.annotations.ApiModelProperty;
 public class AutoscaleClusterState {
 
     @ApiModelProperty(ClusterAutoscaleState.ENABLE_AUTOSCALING)
-    private boolean enableAutoscaling;
+    private Boolean enableAutoscaling;
 
-    public boolean isEnableAutoscaling() {
+    @ApiModelProperty(ClusterStopStartScalingState.ENABLE_STOP_START_SCALING)
+    private Boolean useStopStartMechanism;
+
+    public Boolean isEnableAutoscaling() {
         return enableAutoscaling;
     }
 
-    public void setEnableAutoscaling(boolean enableAutoscaling) {
+    public void setEnableAutoscaling(Boolean enableAutoscaling) {
         this.enableAutoscaling = enableAutoscaling;
+    }
+
+    public Boolean getUseStopStartMechanism() {
+        return useStopStartMechanism;
+    }
+
+    public void setUseStopStartMechanism(Boolean useStopStartMechanism) {
+        this.useStopStartMechanism = useStopStartMechanism;
     }
 
     public static AutoscaleClusterState enable() {
         AutoscaleClusterState stateJson = new AutoscaleClusterState();
-        stateJson.enableAutoscaling = true;
+        stateJson.enableAutoscaling = Boolean.TRUE;
         return stateJson;
     }
 
     public static AutoscaleClusterState disable() {
         AutoscaleClusterState stateJson = new AutoscaleClusterState();
-        stateJson.enableAutoscaling = false;
+        stateJson.enableAutoscaling = Boolean.FALSE;
+        return stateJson;
+    }
+
+    public static AutoscaleClusterState enableStopStart() {
+        AutoscaleClusterState stateJson = enable();
+        stateJson.useStopStartMechanism = Boolean.TRUE;
+        return stateJson;
+    }
+
+    public static AutoscaleClusterState disableStopStart() {
+        AutoscaleClusterState stateJson = enable();
+        stateJson.useStopStartMechanism = Boolean.FALSE;
         return stateJson;
     }
 }

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/DistroXAutoscaleClusterRequest.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/DistroXAutoscaleClusterRequest.java
@@ -15,6 +15,9 @@ public class DistroXAutoscaleClusterRequest implements Json {
     @ApiModelProperty(ClusterJsonsProperties.ENABLE_AUTOSCALING)
     private @NotNull Boolean enableAutoscaling;
 
+    @ApiModelProperty(value = ClusterJsonsProperties.ENABLE_STOP_START_SCALING)
+    private Boolean useStopStartMechanism;
+
     @ApiModelProperty(ClusterJsonsProperties.TIME_ALERTS)
     private List<@Valid TimeAlertRequest> timeAlertRequests;
 
@@ -46,5 +49,13 @@ public class DistroXAutoscaleClusterRequest implements Json {
 
     public void setLoadAlertRequests(List<LoadAlertRequest> loadAlertRequests) {
         this.loadAlertRequests = loadAlertRequests;
+    }
+
+    public Boolean getUseStopStartMechanism() {
+        return useStopStartMechanism;
+    }
+
+    public void setUseStopStartMechanism(Boolean useStopStartMechanism) {
+        this.useStopStartMechanism = useStopStartMechanism;
     }
 }

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/DistroXAutoscaleClusterResponse.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/DistroXAutoscaleClusterResponse.java
@@ -26,6 +26,9 @@ public class DistroXAutoscaleClusterResponse implements Json {
     @ApiModelProperty(ClusterJsonsProperties.AUTOSCALING_ENABLED)
     private Boolean autoscalingEnabled;
 
+    @ApiModelProperty(ClusterJsonsProperties.STOP_START_SCALING_ENABLED)
+    private Boolean stopStartScalingEnabled;
+
     @ApiModelProperty(ClusterJsonsProperties.TIME_ALERTS)
     private List<TimeAlertResponse> timeAlerts;
 
@@ -97,5 +100,13 @@ public class DistroXAutoscaleClusterResponse implements Json {
 
     public void setStackCrn(String stackCrn) {
         this.stackCrn = stackCrn;
+    }
+
+    public Boolean isStopStartScalingEnabled() {
+        return stopStartScalingEnabled;
+    }
+
+    public void setStopStartScalingEnabled(Boolean stopStartScalingEnabled) {
+        this.stopStartScalingEnabled = stopStartScalingEnabled;
     }
 }

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/doc/ApiDescription.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/doc/ApiDescription.java
@@ -92,6 +92,7 @@ public class ApiDescription {
         public static final String CLUSTER_DELETE = "delete cluster";
         public static final String CLUSTER_SET_STATE = "set cluster state";
         public static final String CLUSTER_SET_AUTOSCALE_STATE = "enable or disable cluster's autoscale feature";
+        public static final String CLUSTER_SET_STOP_START_SCALING = "enable or disable cluster's stop start scaling feature";
         public static final String CLUSTER_UPDATE_AUTOSCALE_CONFIG = "update cluster's autoscale config";
         public static final String CLUSTER_DELETE_ALERTS = "delete a cluster's alerts";
     }
@@ -113,6 +114,8 @@ public class ApiDescription {
         public static final String STACK_CRN = "crn of the stack in Cloudbreak";
         public static final String ENABLE_AUTOSCALING = "Enable or Disable the Autoscaling feature set on the underlying Periscope cluster";
         public static final String AUTOSCALING_ENABLED = "Indicate that the Autoscaling feature set is Enabled or Disabled";
+        public static final String ENABLE_STOP_START_SCALING = "Enable or Disable the StopStart scaling feature set on the underlying Periscope cluster";
+        public static final String STOP_START_SCALING_ENABLED = "Indicates if stop start scaling feature is enabled or disabled";
         public static final String ID = "Id of the cluster";
         public static final String STACK_NAME = "Name of stack in Cloudbreak";
         public static final String STACK_TYPE = "Type of stack in Cloudbreak";
@@ -143,6 +146,10 @@ public class ApiDescription {
 
     public static class ClusterAutoscaleState {
         public static final String ENABLE_AUTOSCALING = "field to switch on or off autoscaling feature";
+    }
+
+    public static class ClusterStopStartScalingState {
+        public static final String ENABLE_STOP_START_SCALING = "field to switch on or off the stop start scaling feature.";
     }
 
     public static class TimeAlertJsonProperties {

--- a/autoscale/src/main/java/com/sequenceiq/periscope/controller/AutoScaleClusterCommonService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/controller/AutoScaleClusterCommonService.java
@@ -108,13 +108,23 @@ public class AutoScaleClusterCommonService implements ResourcePropertyProvider {
     }
 
     public Cluster setAutoscaleState(Long clusterId, AutoscaleClusterState autoscaleState) {
-        return setAutoscaleState(clusterId, autoscaleState.isEnableAutoscaling());
+        Cluster cluster = setAutoscaleState(clusterId, autoscaleState.isEnableAutoscaling());
+        return setStopStartScalingState(cluster.getId(), autoscaleState.getUseStopStartMechanism());
     }
 
     public Cluster setAutoscaleState(Long clusterId, Boolean enableAutoScaling) {
         Cluster cluster = clusterService.findById(clusterId);
-        if (!cluster.isAutoscalingEnabled().equals(enableAutoScaling)) {
+        if (enableAutoScaling != null && !cluster.isAutoscalingEnabled().equals(enableAutoScaling)) {
             cluster = clusterService.setAutoscaleState(clusterId, enableAutoScaling);
+            processAutoscalingStateChanged(cluster);
+        }
+        return cluster;
+    }
+
+    public Cluster setStopStartScalingState(Long clusterId, Boolean enableStopStartScaling) {
+        Cluster cluster = clusterService.findById(clusterId);
+        if (enableStopStartScaling != null && !cluster.isStopStartScalingEnabled().equals(enableStopStartScaling)) {
+            cluster = clusterService.setStopStartScalingState(cluster, enableStopStartScaling);
             processAutoscalingStateChanged(cluster);
         }
         return cluster;

--- a/autoscale/src/main/java/com/sequenceiq/periscope/converter/DistroXAutoscaleClusterResponseConverter.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/converter/DistroXAutoscaleClusterResponseConverter.java
@@ -30,6 +30,7 @@ public class DistroXAutoscaleClusterResponseConverter extends AbstractConverter<
                 source.getState());
 
         json.setStackType(source.getStackType());
+        json.setStopStartScalingEnabled(source.isStopStartScalingEnabled());
 
         List<TimeAlertResponse> timeAlertRequests =
                 timeAlertResponseConverter.convertAllToJson(new ArrayList<>(source.getTimeAlerts()));

--- a/autoscale/src/main/java/com/sequenceiq/periscope/domain/Cluster.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/domain/Cluster.java
@@ -64,6 +64,9 @@ public class Cluster implements Monitored, Clustered {
     @Column(name = "cooldown")
     private Integer coolDown = ScalingConstants.DEFAULT_CLUSTER_COOLDOWN_MINS;
 
+    @Column(name = "stop_start_enabled")
+    private Boolean stopStartScalingEnabled = ScalingConstants.STOP_START_SCALING_ENABLED;
+
     @Column(name = "cb_stack_crn")
     private String stackCrn;
 
@@ -314,6 +317,14 @@ public class Cluster implements Monitored, Clustered {
 
     public Boolean getAutoscalingEnabled() {
         return autoscalingEnabled;
+    }
+
+    public Boolean isStopStartScalingEnabled() {
+        return stopStartScalingEnabled;
+    }
+
+    public void setStopStartScalingEnabled(Boolean stopStartScalingEnabled) {
+        this.stopStartScalingEnabled = stopStartScalingEnabled;
     }
 }
 

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ScalingConstants.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ScalingConstants.java
@@ -18,6 +18,8 @@ public class ScalingConstants {
 
     public static final int DEFAULT_MAX_LOAD_BASED_AUTOSCALING_COOLDOWN_MINS = 180;
 
+    public static final boolean STOP_START_SCALING_ENABLED = Boolean.FALSE;
+
     private ScalingConstants() {
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/load/YarnLoadEvaluator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/load/YarnLoadEvaluator.java
@@ -113,12 +113,6 @@ public class YarnLoadEvaluator extends EvaluatorExecutor {
 
     protected void pollYarnMetricsAndScaleCluster() throws Exception {
         StackV4Response stackV4Response = cloudbreakCommunicator.getByCrn(cluster.getStackCrn());
-        // TODO CB-14929: This needs to be carefully handled. The filter for STOPPED instances, if it does not apply correctl (e.g. nodes
-        //  are in 'Services Starting' state, can result in upscale being skipped, or in some scenarios - unnecessary downscales.
-        //  Sample log for when this happened (downscale by 1 instead of upscale by 5).
-        //  (AS min set to 15, AS max set to 20: 15 nodes RUNNING. 5 nodes in SERVICE_STARTING state - ended up downscaling by 1)
-        //  Sample log: hostFqdnsToInstanceId=20, configMaxNodeCount=0, configMinNodeCount=1, maxAllowedUpScale=0, maxAllowedDownScale=1
-        //  At least protect against such unnecessary downscales.
         Map<String, String> hostFqdnsToInstanceId = stackResponseUtils.getCloudInstanceIdsForHostGroup(stackV4Response, policyHostGroup);
 
         int existingHostGroupSize = hostFqdnsToInstanceId.size();

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/CloudbreakCommunicator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/CloudbreakCommunicator.java
@@ -58,9 +58,13 @@ public class CloudbreakCommunicator {
     public void decommissionInstancesForCluster(Cluster cluster, List<String> decommissionNodeIds) {
         ScalingStrategy scalingStrategy = ScalingStrategy.STOPSTART;
         requestLogging.logResponseTime(() -> {
-            cloudbreakInternalCrnClient.withInternalCrn().autoscaleEndpoint()
-                    .stopInternalInstancesForClusterCrn(cluster.getStackCrn(), decommissionNodeIds, false, scalingStrategy);
-            // TODO CB-14929: Make Periscope scaling mechanism aware
+            if (cluster.isStopStartScalingEnabled()) {
+                cloudbreakInternalCrnClient.withInternalCrn()
+                        .autoscaleEndpoint().stopInternalInstancesForClusterCrn(cluster.getStackCrn(), decommissionNodeIds, false, scalingStrategy);
+            } else {
+                cloudbreakInternalCrnClient.withInternalCrn()
+                        .autoscaleEndpoint().decommissionInternalInstancesForClusterCrn(cluster.getStackCrn(), decommissionNodeIds, false);
+            }
             return Optional.empty();
         }, String.format("DecommissionInstancesForCluster query for cluster crn %s, Scaling strategy %s, NodeIds %s, Scaling Strategy %s",
                 scalingStrategy, cluster.getStackCrn(), scalingStrategy, decommissionNodeIds));

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ClusterStatusSyncHandler.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ClusterStatusSyncHandler.java
@@ -42,17 +42,18 @@ public class ClusterStatusSyncHandler implements ApplicationListener<ClusterStat
 
         StackStatusV4Response statusResponse = cloudbreakCommunicator.getStackStatusByCrn(cluster.getStackCrn());
 
-        // TODO CB-14929: cluster availability checks needs to be based on the scaling mechanism, and the eventual status of
-        // a cluster which has STOPPED instances.
-//        boolean clusterAvailable = Optional.ofNullable(statusResponse.getStatus()).map(Status::isAvailable).orElse(false)
-//                && Optional.ofNullable(statusResponse.getClusterStatus()).map(Status::isAvailable).orElse(false);
+        boolean clusterAvailable;
+        boolean clusterNodesUnhealthy = false;
+        if (cluster.isStopStartScalingEnabled()) {
+            clusterAvailable = Optional.ofNullable(statusResponse.getStatus()).map(Status::isAvailable).orElse(false);
+            clusterNodesUnhealthy = Optional.ofNullable(statusResponse.getStatus()).map(s -> s == Status.NODE_FAILURE).orElse(false);
+            clusterAvailable |= clusterNodesUnhealthy;
+        } else {
+            clusterAvailable = Optional.ofNullable(statusResponse.getStatus()).map(Status::isAvailable).orElse(false)
+            && Optional.ofNullable(statusResponse.getClusterStatus()).map(Status::isAvailable).orElse(false);
+        }
 
-        boolean clusterAvailable = Optional.ofNullable(statusResponse.getStatus()).map(Status::isAvailable).orElse(false);
-        boolean clusterNodesUnhealthy = Optional.ofNullable(statusResponse.getStatus()).map(s -> s == Status.NODE_FAILURE).orElse(false);
         LOGGER.info("ZZZ: Computed clusterAvailable: {}, clusterNodesUnhealthy: {}", clusterAvailable, clusterNodesUnhealthy);
-        clusterAvailable |= clusterNodesUnhealthy;
-
-
         LOGGER.debug("Analysing CBCluster Status '{}' for Cluster '{}. Available(Determined)={}' ", statusResponse, cluster.getStackCrn(), clusterAvailable);
         LOGGER.info("ZZZ: Analysing CBCluster Status '{}' for Cluster '{}. Available(Determined)={}' ",
                 statusResponse, cluster.getStackCrn(), clusterAvailable);

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/ClusterService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/ClusterService.java
@@ -203,6 +203,14 @@ public class ClusterService {
         return cluster;
     }
 
+    public Cluster setStopStartScalingState(Cluster cluster, Boolean enableStopStartScaling) {
+        LoggingUtils.buildMdcContext(cluster);
+        cluster.setStopStartScalingEnabled(enableStopStartScaling);
+        cluster = clusterRepository.save(cluster);
+        calculateClusterStateMetrics();
+        return cluster;
+    }
+
     public void setLastEvaluated(Long clusterId, Long lastEvaluated) {
         clusterRepository.setClusterLastEvaluated(clusterId, lastEvaluated);
     }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/utils/StackResponseUtils.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/utils/StackResponseUtils.java
@@ -33,9 +33,7 @@ public class StackResponseUtils {
                 .filter(instanceGroupV4Response -> instanceGroupV4Response.getName().equalsIgnoreCase(hostGroup))
                 .flatMap(instanceGroupV4Response -> instanceGroupV4Response.getMetadata().stream())
                 .filter(instanceMetaData -> instanceMetaData.getDiscoveryFQDN() != null)
-                // TODO CB-14929: the computation of host group counts depends on the scaling mechanism being used.
-                //  Even for STOPPED instances, this may require additional checks on status of the nodes.
-                .filter(instanceMetaData -> instanceMetaData.getInstanceStatus() != InstanceStatus.STOPPED)
+                .filter(instanceMetaData -> InstanceStatus.SERVICES_HEALTHY.equals(instanceMetaData.getInstanceStatus()))
                 .collect(Collectors.toMap(InstanceMetaDataV4Response::getDiscoveryFQDN,
                         InstanceMetaDataV4Response::getInstanceId));
     }

--- a/autoscale/src/main/resources/schema/app/20211220140443_CB-15139_Support_for_StopStart_scaling_in_periscope.sql
+++ b/autoscale/src/main/resources/schema/app/20211220140443_CB-15139_Support_for_StopStart_scaling_in_periscope.sql
@@ -1,0 +1,9 @@
+-- // CB-15139 Support for StopStart scaling in periscope
+-- Migration SQL that makes the change goes here.
+ALTER TABLE "cluster" ADD COLUMN IF NOT EXISTS "stop_start_enabled" boolean DEFAULT false;
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+ALTER TABLE "cluster" DROP COLUMN IF EXISTS "stop_start_enabled";
+

--- a/autoscale/src/test/java/com/sequenceiq/periscope/endpointtests/DistroXAutoScaleClusterV1EndpointTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/endpointtests/DistroXAutoScaleClusterV1EndpointTest.java
@@ -213,6 +213,45 @@ public class DistroXAutoScaleClusterV1EndpointTest {
     }
 
     @Test
+    public void testEnableStopStartScalingForClusterName() {
+        DistroXAutoscaleClusterResponse clusterResponse =
+                distroXAutoScaleClusterV1Endpoint.enableAutoscaleForClusterName(TEST_CLUSTER_NAME, AutoscaleClusterState.enableStopStart());
+        assertTrue("StopStart scaling should be enabled", clusterResponse.isStopStartScalingEnabled());
+
+        clusterResponse = distroXAutoScaleClusterV1Endpoint.enableAutoscaleForClusterName(TEST_CLUSTER_NAME, AutoscaleClusterState.disableStopStart());
+        assertFalse("StopStart scaling should be disabled", clusterResponse.isStopStartScalingEnabled());
+    }
+
+    @Test
+    public void testEnableStopStartScalingForClusterCrn() {
+        DistroXAutoscaleClusterResponse clusterResponse =
+                distroXAutoScaleClusterV1Endpoint.enableAutoscaleForClusterCrn(TEST_CLUSTER_CRN, AutoscaleClusterState.enableStopStart());
+        assertTrue("StopStart scaling should be enabled", clusterResponse.isStopStartScalingEnabled());
+
+        clusterResponse = distroXAutoScaleClusterV1Endpoint.enableAutoscaleForClusterCrn(TEST_CLUSTER_CRN, AutoscaleClusterState.disableStopStart());
+        assertFalse("StopStart scaling should be disabled", clusterResponse.isStopStartScalingEnabled());
+    }
+
+    @Test
+    public void testUpdateAutoscaleConfigByClusterCrnForEnableDisableStopStartScaling() {
+        DistroXAutoscaleClusterRequest clusterRequest = new DistroXAutoscaleClusterRequest();
+        clusterRequest.setEnableAutoscaling(true);
+
+        clusterRequest.setUseStopStartMechanism(null);
+        DistroXAutoscaleClusterResponse clusterResponse =
+                distroXAutoScaleClusterV1Endpoint.updateAutoscaleConfigByClusterCrn(TEST_CLUSTER_CRN, clusterRequest);
+        assertFalse("StopStart scaling should be disabled if not specified in reuqest", clusterResponse.isStopStartScalingEnabled());
+
+        clusterRequest.setUseStopStartMechanism(true);
+        clusterResponse = distroXAutoScaleClusterV1Endpoint.updateAutoscaleConfigByClusterCrn(TEST_CLUSTER_CRN, clusterRequest);
+        assertTrue("StopStart scaling should be enabled", clusterResponse.isStopStartScalingEnabled());
+
+        clusterRequest.setUseStopStartMechanism(false);
+        clusterResponse = distroXAutoScaleClusterV1Endpoint.updateAutoscaleConfigByClusterCrn(TEST_CLUSTER_CRN, clusterRequest);
+        assertFalse("StopStart scaling should be disabled", clusterResponse.isStopStartScalingEnabled());
+    }
+
+    @Test
     public void testUpdateAutoscaleConfigByClusterCrnForLoadAlerts() {
         List<LoadAlertRequest> loadAlertRequests = getLoadAlertRequests(1, List.of("compute"));
 

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/CronTimeEvaluatorTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/CronTimeEvaluatorTest.java
@@ -166,7 +166,7 @@ public class CronTimeEvaluatorTest {
 
         TimeAlert alert = getAAlert(desiredNodeCount);
         StackV4Response stackV4Response = MockStackResponseGenerator
-                .getMockStackV4Response(clusterCrn, testHostGroup, "testFqdn" + testHostGroup, currentHostGroupCount);
+                .getMockStackV4Response(clusterCrn, testHostGroup, "testFqdn" + testHostGroup, currentHostGroupCount, false);
 
         when(cloudbreakCommunicator.getByCrn(anyString())).thenReturn(stackV4Response);
         when(stackResponseUtils.getNodeCountForHostGroup(stackV4Response, testHostGroup)).thenCallRealMethod();

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/load/YarnLoadEvaluatorTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/load/YarnLoadEvaluatorTest.java
@@ -190,7 +190,7 @@ public class YarnLoadEvaluatorTest {
         Cluster cluster = getARunningCluster();
         String hostGroup = "compute";
         StackV4Response stackV4Response = MockStackResponseGenerator
-                .getMockStackV4Response(CLOUDBREAK_STACK_CRN, hostGroup, fqdnBase, currentHostGroupCount);
+                .getMockStackV4Response(CLOUDBREAK_STACK_CRN, hostGroup, fqdnBase, currentHostGroupCount, false);
 
         YarnScalingServiceV1Response upScale = getMockYarnScalingResponse(hostGroup, yarnUpScaleCount, yarnDownScaleCount);
 

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/handler/ClusterStatusSyncHandlerTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/handler/ClusterStatusSyncHandlerTest.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.periscope.monitor.handler;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -200,6 +201,36 @@ public class ClusterStatusSyncHandlerTest {
         verify(cloudbreakCommunicator).getStackStatusByCrn(CLOUDBREAK_STACK_CRN);
     }
 
+    @Test
+    public void testOnApplicationEventWhenStopStartScalingEnabledAndClusterIsScaledDown() {
+        // Scale down with StopStart results in NODE_FAILURE Stack status, but Periscope shouldn't mark the cluster as SUSPENDED.
+        Cluster cluster = getACluster(ClusterState.RUNNING);
+        cluster.setStopStartScalingEnabled(Boolean.TRUE);
+        when(clusterService.findById(anyLong())).thenReturn(cluster);
+        when(cloudbreakCommunicator.getStackStatusByCrn(anyString())).thenReturn(getStackResponse(Status.NODE_FAILURE));
+
+        underTest.onApplicationEvent(new ClusterStatusSyncEvent(AUTOSCALE_CLUSTER_ID));
+
+        assertEquals(ClusterState.RUNNING, cluster.getState());
+        verify(clusterService).findById(AUTOSCALE_CLUSTER_ID);
+        verify(clusterService, never()).setState(anyLong(), any(ClusterState.class));
+        verify(cloudbreakCommunicator).getStackStatusByCrn(CLOUDBREAK_STACK_CRN);
+    }
+
+    @Test
+    public void testOnApplicationEventWhenStopStartScalingEnabledAndClusterIsScaledUp() {
+        Cluster cluster = getACluster(ClusterState.RUNNING);
+        cluster.setStopStartScalingEnabled(Boolean.TRUE);
+        when(clusterService.findById(anyLong())).thenReturn(cluster);
+        when(cloudbreakCommunicator.getStackStatusByCrn(anyString())).thenReturn(getStackResponse(Status.AVAILABLE));
+
+        underTest.onApplicationEvent(new ClusterStatusSyncEvent(AUTOSCALE_CLUSTER_ID));
+
+        verify(clusterService).findById(AUTOSCALE_CLUSTER_ID);
+        verify(clusterService, never()).setState(anyLong(), any(ClusterState.class));
+        verify(cloudbreakCommunicator).getStackStatusByCrn(CLOUDBREAK_STACK_CRN);
+    }
+
     private StackStatusV4Response getStackResponse(Status clusterStatus) {
         StackStatusV4Response stackResponse = new StackStatusV4Response();
         stackResponse.setStatus(clusterStatus);
@@ -212,6 +243,7 @@ public class ClusterStatusSyncHandlerTest {
         cluster.setId(AUTOSCALE_CLUSTER_ID);
         cluster.setStackCrn(CLOUDBREAK_STACK_CRN);
         cluster.setState(clusterState);
+        cluster.setStopStartScalingEnabled(Boolean.FALSE);
 
         ClusterPertain clusterPertain = new ClusterPertain();
         cluster.setClusterPertain(clusterPertain);

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/handler/ScalingRequestTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/handler/ScalingRequestTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -107,11 +108,11 @@ public class ScalingRequestTest {
     @MethodSource("scaleUpNodeCountTesting")
     public void testScaleUpNodeCount(String testCase, int existingClusterNodeCount, int existingHostGroupNodeCount,
             int desiredHostGroupNodeCount, int expectedNodeCount) {
-        // TODO CB-14929: Test needs adjustment based on the scaling strategy being used
         ArgumentCaptor<UpdateStackV4Request> captor = ArgumentCaptor.forClass(UpdateStackV4Request.class);
 
         if (expectedNodeCount > 0) {
             initScaleUpMocks();
+            when(cluster.isStopStartScalingEnabled()).thenReturn(false);
             when(limitsConfigurationService.getMaxNodeCountLimit()).thenReturn(TEST_CLUSTER_MAX_NODE_COUNT);
             ScalingRequest scalingRequest = initializeTestRequest(existingClusterNodeCount, existingHostGroupNodeCount, desiredHostGroupNodeCount, List.of());
             scalingRequest.run();
@@ -124,13 +125,34 @@ public class ScalingRequestTest {
         }
     }
 
+    @ParameterizedTest(name = "{0}: With existingClusterNodeCount={1}, existingHostGroupNodeCount={2}, desiredHostGroupNodeCount ={3}, expectedNodeCount={4} ")
+    @MethodSource("scaleUpNodeCountTesting")
+    public void testScaleUpNodeCountWithStopStartScaling(String testCaseName, int existingClusterNodeCount, int existingHostGroupNodeCount,
+            int desiredHostGroupNodeCount, int expectedNodeCount) {
+        ArgumentCaptor<UpdateStackV4Request> captor = ArgumentCaptor.forClass(UpdateStackV4Request.class);
+
+        if (expectedNodeCount > 0) {
+            initScaleUpMocks();
+            when(cluster.isStopStartScalingEnabled()).thenReturn(true);
+            when(limitsConfigurationService.getMaxNodeCountLimit()).thenReturn(TEST_CLUSTER_MAX_NODE_COUNT);
+            ScalingRequest scalingRequest = initializeTestRequest(existingClusterNodeCount, existingHostGroupNodeCount, desiredHostGroupNodeCount, List.of());
+            scalingRequest.run();
+
+            verify(autoscaleV4Endpoint, times(1)).putStackStartInstances(anyString(), captor.capture());
+            UpdateStackV4Request request = captor.getValue();
+            assertEquals("Upscale nodecount should match", expectedNodeCount, request.getInstanceGroupAdjustment().getScalingAdjustment().intValue());
+        } else {
+            verify(autoscaleV4Endpoint, times(0)).putStackStartInstances(anyString(), captor.capture());
+        }
+    }
+
     private void initScaleUpMocks() {
         when(scalingHardLimitsService.isViolatingAutoscaleMaxStepInNodeCount(anyInt())).thenReturn(false);
         ClusterPertain cluterPertain = mock(ClusterPertain.class);
         when(cluster.getClusterPertain()).thenReturn(cluterPertain);
         when(cluster.getStackCrn()).thenReturn("testStackCrn");
         when(cluterPertain.getTenant()).thenReturn("testTenant");
-        when(cluterPertain.getUserId()).thenReturn("userId");
+        lenient().when(cluterPertain.getUserId()).thenReturn("userId");
 
         BaseAlert baseAlert = mock(BaseAlert.class);
         when(baseAlert.getAlertType()).thenReturn(AlertType.LOAD);

--- a/autoscale/src/test/java/com/sequenceiq/periscope/utils/MockStackResponseGenerator.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/utils/MockStackResponseGenerator.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
@@ -15,7 +16,8 @@ public class MockStackResponseGenerator {
     private MockStackResponseGenerator() {
     }
 
-    public static StackV4Response getMockStackV4Response(String clusterCrn, String hostGroup, String fqdnBase, int currentHostGroupCount) {
+    public static StackV4Response getMockStackV4Response(String clusterCrn, String hostGroup, String fqdnBase, int currentHostGroupCount,
+            boolean withUnhealthyInstances) {
         List<InstanceGroupV4Response> instanceGroupV4Responses = new ArrayList<>();
 
         InstanceMetaDataV4Response master1 = new InstanceMetaDataV4Response();
@@ -32,11 +34,32 @@ public class MockStackResponseGenerator {
         instanceGroupV4Responses.add(instanceGroup("worker", awsTemplate(), Set.of(worker1, worker2)));
 
         Set fqdnToInstanceIds = new HashSet();
-        for (int i = 1; i <= currentHostGroupCount; i++) {
-            InstanceMetaDataV4Response metadata1 = new InstanceMetaDataV4Response();
-            metadata1.setDiscoveryFQDN(fqdnBase + i);
-            metadata1.setInstanceId("test_instanceid_" + hostGroup + i);
-            fqdnToInstanceIds.add(metadata1);
+        if (!withUnhealthyInstances) {
+            for (int i = 1; i <= currentHostGroupCount; i++) {
+                InstanceMetaDataV4Response metadata1 = new InstanceMetaDataV4Response();
+                metadata1.setDiscoveryFQDN(fqdnBase + i);
+                metadata1.setInstanceId("test_instanceid_" + hostGroup + i);
+                metadata1.setInstanceStatus(InstanceStatus.SERVICES_HEALTHY);
+                fqdnToInstanceIds.add(metadata1);
+            }
+        } else {
+            // Add nodes with InstanceStatuses STOPPED and SERVICES_UNHEALTHY
+            List<InstanceStatus> unhealthyStatuses = List.of(InstanceStatus.STOPPED, InstanceStatus.SERVICES_UNHEALTHY);
+            for (InstanceStatus status: unhealthyStatuses) {
+                InstanceMetaDataV4Response metadataResponse = new InstanceMetaDataV4Response();
+                metadataResponse.setDiscoveryFQDN(fqdnBase + unhealthyStatuses.indexOf(status));
+                metadataResponse.setInstanceId("test_instanceid_" + hostGroup + unhealthyStatuses.indexOf(status));
+                metadataResponse.setInstanceStatus(status);
+                fqdnToInstanceIds.add(metadataResponse);
+            }
+            // Add remaining healthy instances
+            for (int i = unhealthyStatuses.size(); i < currentHostGroupCount; ++i) {
+                InstanceMetaDataV4Response metadataResponse = new InstanceMetaDataV4Response();
+                metadataResponse.setDiscoveryFQDN(fqdnBase + i);
+                metadataResponse.setInstanceId("test_instanceid_" + hostGroup + i);
+                metadataResponse.setInstanceStatus(InstanceStatus.SERVICES_HEALTHY);
+                fqdnToInstanceIds.add(metadataResponse);
+            }
         }
         instanceGroupV4Responses.add(instanceGroup(hostGroup, awsTemplate(), fqdnToInstanceIds));
 

--- a/autoscale/src/test/java/com/sequenceiq/periscope/utils/StackResponseUtilsTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/utils/StackResponseUtilsTest.java
@@ -25,7 +25,7 @@ public class StackResponseUtilsTest {
         String hostGroup = "compute";
 
         Map<String, String> instanceIdsForHostGroups = underTest
-                .getCloudInstanceIdsForHostGroup(getMockStackV4Response(hostGroup), hostGroup);
+                .getCloudInstanceIdsForHostGroup(getMockStackV4Response(hostGroup, false), hostGroup);
 
         assertEquals("Retrieved Instance Ids size should match", instanceIdsForHostGroups.size(), 3);
         assertEquals("Retrieved Instance Id should match",
@@ -37,11 +37,22 @@ public class StackResponseUtilsTest {
     }
 
     @Test
+    public void testGetCloudInstanceIdsForHostGroupWithUnhealthyInstances() {
+        String hostGroup = "compute";
+
+        Map<String, String> instanceIdsToHostGroup = underTest.
+                getCloudInstanceIdsForHostGroup(getMockStackV4Response(hostGroup, true), hostGroup);
+
+        assertEquals("Retrieved Instance Ids size should match", 1, instanceIdsToHostGroup.size());
+        assertEquals("Retrieved Instance Id should match", "test_instanceid_compute2", instanceIdsToHostGroup.get("test_fqdn2"));
+    }
+
+    @Test
     public void testGetNodeCountForHostGroup() {
         String hostGroup = "compute";
 
         Integer nodeCountForHostGroup = underTest
-                .getNodeCountForHostGroup(getMockStackV4Response(hostGroup), hostGroup);
+                .getNodeCountForHostGroup(getMockStackV4Response(hostGroup, false), hostGroup);
         assertEquals("Retrieved HostGroup Instance Count should match.", Integer.valueOf(3), nodeCountForHostGroup);
     }
 
@@ -88,9 +99,9 @@ public class StackResponseUtilsTest {
         assertEquals("RoleConfigName in template should match for HostGroup", expectedRoleConfigName, hostGroupRolename);
     }
 
-    private StackV4Response getMockStackV4Response(String hostGroup) {
+    private StackV4Response getMockStackV4Response(String hostGroup, boolean withUnhealthyInstances) {
         return MockStackResponseGenerator
-                .getMockStackV4Response("test-crn", hostGroup, "test_fqdn", 3);
+                .getMockStackV4Response("test-crn", hostGroup, "test_fqdn", 3, withUnhealthyInstances);
     }
 
     private String getTestBP() throws IOException {


### PR DESCRIPTION
…aling mechanism.

### Overview
- Schema change to accommodate stopStartScaling enabled flag for the periscope cluster.
- Changes to ScalingRequest and ClusterStatusSyncHandler to call relevant API based on scaling mechanism.
- **Added new required property to `DistroxAutoscaleClusterRequest` for enabling/disabling stopStart scaling**

### Testing
- Unit tests for the modified components.

### TODO:
- [x] Changes to YarnLoadEvaluator to filter out STOPPED or otherwise UNHEALTHY nodes.
- [x] Determine if the `stopStartScalingEnabled` flag must be exposed in the autoscale API, to toggle between normal autoscaling and StopStart scaling.
- [x] Tests for `DistroXAutoScaleClusterV1Endpoint`
- [ ] ~Add entitlement check for StopStart scaling~


See detailed description in the commit message.