### PR TITLE
CB-15313: Enable patch upgrade for Flow Management templates from 7.2.13

### DIFF
--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -796,6 +796,8 @@ cb:
         LIVY_FOR_SPARK3: 7.2.9,
         OMID: 7.2.9,
         OOZIE: 7.2.9,
+        NIFI: 7.2.13,
+        NIFIREGISTRY: 7.2.13,
         PHOENIX: 7.2.9,
         QUEUEMANAGER: 7.2.9,
         SCHEMAREGISTRY: 7.2.9,

--- a/core/src/main/resources/defaults/blueprints/7.2.13/cdp-flow-management-small.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.13/cdp-flow-management-small.bp
@@ -3,6 +3,7 @@
   "blueprint": {
     "cdhVersion": "7.2.13",
     "displayName": "flow-management",
+    "blueprintUpgradeOption": "MAINTENANCE_UPGRADE_GA",
     "services": [
       {
         "refName": "core_settings",

--- a/core/src/main/resources/defaults/blueprints/7.2.13/cdp-flow-management.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.13/cdp-flow-management.bp
@@ -3,6 +3,7 @@
   "blueprint": {
     "cdhVersion": "7.2.13",
     "displayName": "flow-management",
+    "blueprintUpgradeOption": "MAINTENANCE_UPGRADE_GA",
     "services": [
       {
         "refName": "core_settings",

--- a/core/src/main/resources/defaults/blueprints/7.2.14/cdp-flow-management-small.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.14/cdp-flow-management-small.bp
@@ -3,6 +3,7 @@
   "blueprint": {
     "cdhVersion": "7.2.14",
     "displayName": "flow-management",
+    "blueprintUpgradeOption": "MAINTENANCE_UPGRADE_GA",
     "services": [
       {
         "refName": "core_settings",

--- a/core/src/main/resources/defaults/blueprints/7.2.14/cdp-flow-management.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.14/cdp-flow-management.bp
@@ -3,6 +3,7 @@
   "blueprint": {
     "cdhVersion": "7.2.14",
     "displayName": "flow-management",
+    "blueprintUpgradeOption": "MAINTENANCE_UPGRADE_GA",
     "services": [
       {
         "refName": "core_settings",


### PR DESCRIPTION
Testing steps

- Create an environment with DataLake 7.2.12
- Create a DataHub cluster with Flow Management 7.2.12 blueprint.
- CDP_RUNTIME_UPGRADE_DATAHUB entitlement is turned off
- On the DataHub's upgrade tab the upgrade candidates should not be available
----
- Create an environment with DataLake 7.2.13
- Create a DataHub cluster with Flow Management 7.2.13 blueprint.
- CDP_RUNTIME_UPGRADE_DATAHUB entitlement is turned off
- On the DataHub's upgrade tab the upgrade candidates should be available