### PR TITLE
CB-15503 Useful data is disappearing from EDH. With this commit we do…

### DIFF
--- a/core/src/test/java/com/sequenceiq/cloudbreak/structuredevent/converter/InstanceGroupToInstanceGroupDetailsConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/structuredevent/converter/InstanceGroupToInstanceGroupDetailsConverterTest.java
@@ -1,16 +1,14 @@
 package com.sequenceiq.cloudbreak.structuredevent.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.common.json.Json;
@@ -18,7 +16,6 @@ import com.sequenceiq.cloudbreak.domain.SecurityGroup;
 import com.sequenceiq.cloudbreak.domain.Template;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.structuredevent.event.InstanceGroupDetails;
-import com.sequenceiq.cloudbreak.structuredevent.event.SecurityGroupDetails;
 
 @ExtendWith(MockitoExtension.class)
 public class InstanceGroupToInstanceGroupDetailsConverterTest {
@@ -26,14 +23,10 @@ public class InstanceGroupToInstanceGroupDetailsConverterTest {
     @InjectMocks
     private InstanceGroupToInstanceGroupDetailsConverter underTest;
 
-    @Mock
-    private SecurityGroupToSecurityGroupDetailsConverter securityGroupToSecurityGroupDetailsConverter;
-
     @Test
     void convertEmptyNoNullPointer() {
         InstanceGroup instanceGroup = new InstanceGroup();
         instanceGroup.setSecurityGroup(new SecurityGroup());
-        when(securityGroupToSecurityGroupDetailsConverter.convert(any())).thenReturn(new SecurityGroupDetails());
 
         InstanceGroupDetails instanceGroupDetails = underTest.convert(instanceGroup);
 
@@ -45,13 +38,16 @@ public class InstanceGroupToInstanceGroupDetailsConverterTest {
         InstanceGroupDetails instanceGroupDetails = underTest.convert(createInstanceGroup());
 
         assertEquals("ATTACHED_VOLUMES", instanceGroupDetails.getTemporaryStorage());
+        // keep only encryted
         assertEquals(Boolean.TRUE, instanceGroupDetails.getAttributes().get("encrypted"));
+        // remove everything else
+        assertNull(instanceGroupDetails.getAttributes().get("everything-else"));
     }
 
     private InstanceGroup createInstanceGroup() {
         InstanceGroup instanceGroup = new InstanceGroup();
         Template template = new Template();
-        Map<String, Object> attributes = Map.of("encrypted", Boolean.TRUE);
+        Map<String, Object> attributes = Map.of("encrypted", Boolean.TRUE, "everything-else", Boolean.TRUE);
         template.setAttributes(new Json(attributes));
         template.setCloudPlatform("AWS");
         instanceGroup.setTemplate(template);

--- a/structuredevent-model/src/main/java/com/sequenceiq/cloudbreak/structuredevent/event/InstanceGroupDetails.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/cloudbreak/structuredevent/event/InstanceGroupDetails.java
@@ -20,8 +20,6 @@ public class InstanceGroupDetails implements Serializable {
 
     private List<VolumeDetails> volumes;
 
-    private SecurityGroupDetails securityGroup;
-
     private String temporaryStorage;
 
     private Integer rootVolumeSize;
@@ -66,14 +64,6 @@ public class InstanceGroupDetails implements Serializable {
 
     public void setVolumes(List<VolumeDetails> volumes) {
         this.volumes = volumes;
-    }
-
-    public SecurityGroupDetails getSecurityGroup() {
-        return securityGroup;
-    }
-
-    public void setSecurityGroup(SecurityGroupDetails securityGroup) {
-        this.securityGroup = securityGroup;
     }
 
     public String getTemporaryStorage() {

--- a/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StructuredEventToClusterShapeConverter.java
+++ b/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StructuredEventToClusterShapeConverter.java
@@ -25,7 +25,7 @@ public class StructuredEventToClusterShapeConverter {
 
     private static final int DEFAULT_INTEGER_VALUE = -1;
 
-    private static final int MAX_STRING_LENGTH = 3000;
+    private static final int MAX_STRING_LENGTH = 4000;
 
     public UsageProto.CDPClusterShape convert(StructuredFlowEvent structuredFlowEvent) {
         UsageProto.CDPClusterShape.Builder cdpClusterShape = UsageProto.CDPClusterShape.newBuilder();

--- a/structuredevent-service-legacy/src/test/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StructuredEventToClusterShapeConverterTest.java
+++ b/structuredevent-service-legacy/src/test/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StructuredEventToClusterShapeConverterTest.java
@@ -144,7 +144,7 @@ class StructuredEventToClusterShapeConverterTest {
         Assertions.assertTrue(definitionLength >= 0 && definitionLength <= 3000);
 
         master = createInstanceGroupDetails("master", 2, null);
-        stackDetails.setInstanceGroups(Collections.nCopies(100, master));
+        stackDetails.setInstanceGroups(Collections.nCopies(110, master));
         structuredFlowEvent.setStack(stackDetails);
 
         flowClusterShape = underTest.convert(structuredFlowEvent);


### PR DESCRIPTION
… a targeted reduction of data, in order to ensure that we  stay in the 12k size limit that is set today on fluentd.

See detailed description in the commit message.