### PR TITLE
CB-15530 Fix missing delete telemetry events.

### DIFF
--- a/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/mapper/ClusterUseCaseMapper.java
+++ b/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/mapper/ClusterUseCaseMapper.java
@@ -34,6 +34,8 @@ public class ClusterUseCaseMapper {
         firstStepUseCaseMap.put(Pair.of("ProvisionFlowEventChainFactory", "CloudConfigValidationFlowConfig"), UsageProto.CDPClusterStatus.Value.CREATE_STARTED);
         firstStepUseCaseMap.put(Pair.of("ProperTerminationFlowEventChainFactory", "ClusterTerminationFlowConfig"),
                 UsageProto.CDPClusterStatus.Value.DELETE_STARTED);
+        firstStepUseCaseMap.put(Pair.of("TerminationFlowEventChainFactory", "ClusterTerminationFlowConfig"),
+                UsageProto.CDPClusterStatus.Value.DELETE_STARTED);
         firstStepUseCaseMap.put(Pair.of("UpscaleFlowEventChainFactory", "StackUpscaleConfig"), UsageProto.CDPClusterStatus.Value.UPSCALE_STARTED);
         firstStepUseCaseMap.put(Pair.of("MultiHostgroupDownscaleFlowEventChainFactory", "FlowChainInitFlowConfig"),
                 UsageProto.CDPClusterStatus.Value.DOWNSCALE_STARTED);
@@ -83,6 +85,7 @@ public class ClusterUseCaseMapper {
                     useCase = getClusterStatus(nextFlowState, "CLUSTER_CREATION_FINISHED_STATE",
                             UsageProto.CDPClusterStatus.Value.CREATE_FINISHED, UsageProto.CDPClusterStatus.Value.CREATE_FAILED);
                     break;
+                case "TerminationFlowEventChainFactory":
                 case "ProperTerminationFlowEventChainFactory":
                     useCase = getClusterStatus(nextFlowState, "TERMINATION_FINISHED_STATE",
                             UsageProto.CDPClusterStatus.Value.DELETE_FINISHED, UsageProto.CDPClusterStatus.Value.DELETE_FAILED);


### PR DESCRIPTION
There was a change in cluster delete handling that moved the deletion of stopped clusters to a different flow chain. This flow chain was not handled in the mapping logic that maps flows to telemetry events. This commit adds the other flow chain to the mapping logic so it can start generating delete events again for stopped clusters. Tested by creating an environment, stopping, then deleting it and checking if the mapper logic correctly generated the expected DELETE_STARTED and DELETE_FINISHED events.