### PR TITLE
CB-15552 - Environment Provision Failed - resource cannot be created …

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureManagedImageService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureManagedImageService.java
@@ -1,13 +1,18 @@
 package com.sequenceiq.cloudbreak.cloud.azure.image;
 
+import static com.microsoft.azure.management.compute.ExecutionState.FAILED;
+import static com.microsoft.azure.management.compute.ExecutionState.SUCCEEDED;
+
 import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.microsoft.azure.management.compute.ExecutionState;
 import com.microsoft.azure.management.compute.VirtualMachineCustomImage;
 import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 
 @Service
 public class AzureManagedImageService {
@@ -18,11 +23,24 @@ public class AzureManagedImageService {
         String imageName = azureImageInfo.getImageNameWithRegion();
         String resourceGroup = azureImageInfo.getResourceGroup();
         VirtualMachineCustomImage image = client.findImage(resourceGroup, imageName);
-        if (image != null) {
-            LOGGER.debug("Custom image {} is present in resource group {}", imageName, resourceGroup);
-            return Optional.of(image);
+        if (image != null && image.inner() != null) {
+            return getImageByState(imageName, resourceGroup, image);
         } else {
             LOGGER.debug("Custom image {} is not present in resource group {}", imageName, resourceGroup);
+            return Optional.empty();
+        }
+    }
+
+    private Optional<VirtualMachineCustomImage> getImageByState(String imageName, String resourceGroup, VirtualMachineCustomImage image) {
+        ExecutionState creationState = ExecutionState.fromString(image.inner().provisioningState());
+        if (creationState == SUCCEEDED) {
+            LOGGER.debug("Custom image {} is present in resource group {}", imageName, resourceGroup);
+            return Optional.of(image);
+        } else if (creationState == FAILED) {
+            throw new CloudConnectorException(
+                    String.format("Image (%s/%s) creation failed in Azure, please check the reason on Azure Portal!", resourceGroup, imageName));
+        } else {
+            LOGGER.debug("Custom image {} in resource group {} has non final status {}", imageName, resourceGroup, creationState.toString());
             return Optional.empty();
         }
     }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureManagedImageServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureManagedImageServiceTest.java
@@ -2,22 +2,25 @@ package com.sequenceiq.cloudbreak.cloud.azure.image;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.microsoft.azure.management.compute.VirtualMachineCustomImage;
+import com.microsoft.azure.management.compute.implementation.ImageInner;
 import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
 import com.sequenceiq.cloudbreak.cloud.azure.util.AzureAuthExceptionHandler;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AzureManagedImageServiceTest {
@@ -38,15 +41,49 @@ public class AzureManagedImageServiceTest {
     private final AzureAuthExceptionHandler azureAuthExceptionHandler = new AzureAuthExceptionHandler();
 
     @Test
-    public void testGetVirtualMachineCustomImageShouldReturnTheImageWhenExistsOnProviderSide() {
+    public void testGetVirtualMachineCustomImageShouldReturnTheImageWhenSucceededOnProviderSide() {
         AzureImageInfo azureImageInfo = new AzureImageInfo(IMAGE_NAME_WITH_REGION, IMAGE_NAME, "imageId", "region", RESOURCE_GROUP);
-        VirtualMachineCustomImage image = Mockito.mock(VirtualMachineCustomImage.class);
+        VirtualMachineCustomImage image = mock(VirtualMachineCustomImage.class);
         when(azureClient.findImage(RESOURCE_GROUP, IMAGE_NAME_WITH_REGION)).thenReturn(image);
+        ImageInner imageInner = mock(ImageInner.class);
+        when(image.inner()).thenReturn(imageInner);
+        when(imageInner.provisioningState()).thenReturn("Succeeded");
 
         Optional<VirtualMachineCustomImage> actual = underTest.findVirtualMachineCustomImage(azureImageInfo, azureClient);
 
         assertTrue(actual.isPresent());
         assertEquals(image, actual.get());
+        verify(azureClient).findImage(RESOURCE_GROUP, IMAGE_NAME_WITH_REGION);
+    }
+
+    @Test
+    public void testGetVirtualMachineCustomImageShouldReturnTheImageWhenUnknownOnProviderSide() {
+        AzureImageInfo azureImageInfo = new AzureImageInfo(IMAGE_NAME_WITH_REGION, IMAGE_NAME, "imageId", "region", RESOURCE_GROUP);
+        VirtualMachineCustomImage image = mock(VirtualMachineCustomImage.class);
+        when(azureClient.findImage(RESOURCE_GROUP, IMAGE_NAME_WITH_REGION)).thenReturn(image);
+        ImageInner imageInner = mock(ImageInner.class);
+        when(image.inner()).thenReturn(imageInner);
+        when(imageInner.provisioningState()).thenReturn("Unknown");
+
+        Optional<VirtualMachineCustomImage> actual = underTest.findVirtualMachineCustomImage(azureImageInfo, azureClient);
+
+        assertTrue(actual.isEmpty());
+        verify(azureClient).findImage(RESOURCE_GROUP, IMAGE_NAME_WITH_REGION);
+    }
+
+    @Test
+    public void testGetVirtualMachineCustomImageShouldReturnTheImageWhenFailedOnProviderSide() {
+        AzureImageInfo azureImageInfo = new AzureImageInfo(IMAGE_NAME_WITH_REGION, IMAGE_NAME, "imageId", "region", RESOURCE_GROUP);
+        VirtualMachineCustomImage image = mock(VirtualMachineCustomImage.class);
+        when(azureClient.findImage(RESOURCE_GROUP, IMAGE_NAME_WITH_REGION)).thenReturn(image);
+        ImageInner imageInner = mock(ImageInner.class);
+        when(image.inner()).thenReturn(imageInner);
+        when(imageInner.provisioningState()).thenReturn("Failed");
+
+        CloudConnectorException actual = Assertions.assertThrows(CloudConnectorException.class, () ->
+                underTest.findVirtualMachineCustomImage(azureImageInfo, azureClient));
+
+        assertEquals("Image (resource-group/image-name-with-region) creation failed in Azure, please check the reason on Azure Portal!", actual.getMessage());
         verify(azureClient).findImage(RESOURCE_GROUP, IMAGE_NAME_WITH_REGION);
     }
 


### PR DESCRIPTION
…from Image

The symptom:
 `The resource 'freeipa51002m0' cannot be created from Image '/subscriptions/94359766-1315-49e2-b5da-xxxxxxxxx/resourceGroups/cloudbreak-images/providers/Microsoft.Compute/images/freeipa-cdh--1638437403.vhd-westus2' until Image has been successfully created`

The issue:
 - Even though we poll for the image not being null before submitting the ARM template, it seems there might be an edge case where it is still not successfully provisioned.

This commit:
 - adds extra validation for managed image provisioning status

