### PR TITLE
CB-15553: Fix constraint violation during root cert creation

### DIFF
--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/config/RootCertRegisterServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/config/RootCertRegisterServiceTest.java
@@ -4,7 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -49,6 +53,34 @@ class RootCertRegisterServiceTest {
             + "cSQj9z09/bLeGI/9RUiMvEJ5Bvg=\n"
             + "-----END CERTIFICATE-----";
 
+    private static final String OLD_EXPECTED_CERT = "-----BEGIN CERTIFICATE-----\n"
+            + "MIIEowIBAAKCAQEAv/iPGukH2DfwgWOjcxPAra3dKxKs3et1PER+cZgPc4g8B+AW\n"
+            + "yewgdmhDXEjJpbbMgKxiu2bfM+qmTB5I5ceSN34TMv4v7GdQvZ17suOoEhULEqMF\n"
+            + "NQ0UM238vMXLI+6NduM725Rr03QFAhS4s1LKuBbVfMJE8QB9bsB9Keqa+/Q66Jp9\n"
+            + "QddQ41IMCQ3vWrphQ2oIB+2/6qik4rd90DJnpcpi6gT3jnR3DAaDX3CSw2PBQVAc\n"
+            + "Wan0qPDb0HCN4ppFElLjJ5k218u1SIxH6Aqd21V+wWpcOdnunmrzfkOfs6PhHVe+\n"
+            + "6Y8jA81Tza15bWCgiCJQ14plfU3HqmGM8pkPPwIBJQKCAQEAsGfdcqyfbL3IP4v9\n"
+            + "+ws7byolLn/dHvQK3W9fb011+3ZFAFFhDJPKzavq3y4hFNF9pqw/DRJsPYuEDphe\n"
+            + "qaKiCXrFiM3m2TxYCC/Zc/PK4C8DQY7iML/pDKpCMO0biM1fZlRE150k0CVsYsbu\n"
+            + "6fkNTzeTvsBbBvmIBOg7qfotjZK6UECJa69FLhgL5yQYkwsS/7WK02n/dcDbKEi0\n"
+            + "S5rJRWkxYnEn2EktkX8iysUX1fwc0uD+De9mgVriAu2RXNXeYoB96gxYiGeFL/W8\n"
+            + "hqAER5tz2x6hRf+bF9D27JscVVTYJRjLRSAnvIUIS6BEpESBuGn1LEHF2kzyxZ+A\n"
+            + "KyK7TQKBgQDh5LBLOoQKcbgh/phKG18un2LPRDcbUgLpCz13r+Ufd5Cs858JAe2q\n"
+            + "cm7aWF//jPPa4fCIrNhM3TGQurP/AYAj3ziJEGE3zJu3ApAJEM/w5nmjgnI6VnO1\n"
+            + "1Hfc39+eAhJ637byCN6zeeLQFtAjqiWKUsAXVWm//mdy6HrnZ0i2FwKBgQDZjnbJ\n"
+            + "qLov3Y7OB2Tz6qH4UYVs+8NK1L1F0UkFr+iaU6GWzwjo1dzPt34/ZqOAzZI/eeMz\n"
+            + "6PLHTgmRXdglZXyvMVJJiXXa7zfPN3DTkAUCpu7sOe1jU3W1qICgfspEvh57BjL+\n"
+            + "uxyAiA5zKFSSl/+YGd/b4QY/IGVqrpr0a25RGQKBgQCShoAwzAKe/afesvr/ow1O\n"
+            + "rJMeqMnMiDk9N7krCk9uW2TDNj2k+lT48Efnk0UwJBPMP4dD5by8PHMtci+QpwcC\n"
+            + "gvQ9Ow6gvBH6Kyz+9iYECx535ek6mPEb/3BX6ylD5asfRQELsrn34FvFPzrms434\n"
+            + "27res/GRSxKrZl2PLj0AfQKBgFJRlLsBko6m3BabA5qQIZw6hYMu1EXT9Jb1PjmA\n"
+            + "1I1rwJnteP4naE6YdPVlG0V+N1ZJy5cZ31JU4QaSNhv84xHbT5FySEUAkahaKrDq\n"
+            + "YsK7tFliBsujCfG1YRoiIwVBBJ1Anax+JnXSna8IV1oP/9iv2CmvFx7N/NxCER42\n"
+            + "fMS9AoGBAOBaoUdij3AYpNXNbu3WgFwkkzxwiPdziwYiV81xv2jVg/JhWn34sUZT\n"
+            + "8WltJh0VP1vW/zt3+Ay8TB08/lnOhCHzZGIVfqBvJXti4o4nK2bEylhZJBsvDFHW\n"
+            + "phdH5oSG4alEPBxqoKJpeo+3KaApEEVXUjTqQPfFXvpoCebPc36i\n"
+            + "-----END CERTIFICATE-----";
+
     private static final String INPUT_CERT = "MIID0DCCArigAwIBAgIBATANBgkqhkiG9w0BAQsFADBNMSswKQYDVQQKDCJNTU9M"
             + "TkFSLlhDVTItOFk4WC5XTC5DTE9VREVSQS5TSVRFMR4wHAYDVQQDDBVDZXJ0aWZp"
             + "Y2F0ZSBBdXRob3JpdHkwHhcNMjAxMTI0MTY0NjIyWhcNNDAxMTI0MTY0NjIyWjBN"
@@ -71,6 +103,12 @@ class RootCertRegisterServiceTest {
             + "VQVOdUfPDN5FeHnS0/ixoOtNQG7YdmIp+ZaCmerpJnAFOGEgs+vj51eX8omH0jhn"
             + "cSQj9z09/bLeGI/9RUiMvEJ5Bvg=";
 
+    private static final long STACK_ID = 1L;
+
+    private static final String ENV_CRN = "env-crn";
+
+    private static final long CERT_ID = 2L;
+
     @Mock
     private FreeIpaClientFactory clientFactory;
 
@@ -83,9 +121,10 @@ class RootCertRegisterServiceTest {
     @InjectMocks
     private RootCertRegisterService underTest;
 
+    private final Stack stack = createStack();
+
     @Test
     public void testDeleteNotFoundHandled() {
-        Stack stack = new Stack();
         doThrow(new NotFoundException("asdgf")).when(rootCertService).deleteByStack(stack);
 
         underTest.delete(stack);
@@ -93,16 +132,15 @@ class RootCertRegisterServiceTest {
 
     @Test
     public void testRegisterByStackId() throws FreeIpaClientException {
-        Stack stack = new Stack();
-        stack.setEnvironmentCrn("ENV");
-        when(stackService.getStackById(1L)).thenReturn(stack);
+        when(stackService.getStackById(STACK_ID)).thenReturn(stack);
         FreeIpaClient freeIpaClient = mock(FreeIpaClient.class);
         when(clientFactory.getFreeIpaClientForStack(stack)).thenReturn(freeIpaClient);
         when(freeIpaClient.getRootCertificate()).thenReturn(INPUT_CERT);
         ArgumentCaptor<RootCert> certArgumentCaptor = ArgumentCaptor.forClass(RootCert.class);
+        when(rootCertService.findByStackId(STACK_ID)).thenReturn(Optional.empty());
         when(rootCertService.save(certArgumentCaptor.capture())).thenReturn(new RootCert());
 
-        underTest.register(1L);
+        underTest.register(STACK_ID);
 
         RootCert result = certArgumentCaptor.getValue();
         assertEquals(stack.getEnvironmentCrn(), result.getEnvironmentCrn());
@@ -112,11 +150,10 @@ class RootCertRegisterServiceTest {
 
     @Test
     public void testRegisterByStack() throws FreeIpaClientException {
-        Stack stack = new Stack();
-        stack.setEnvironmentCrn("ENV");
         FreeIpaClient freeIpaClient = mock(FreeIpaClient.class);
         when(clientFactory.getFreeIpaClientForStack(stack)).thenReturn(freeIpaClient);
         when(freeIpaClient.getRootCertificate()).thenReturn(INPUT_CERT);
+        when(rootCertService.findByStackId(STACK_ID)).thenReturn(Optional.empty());
 
         when(rootCertService.save(any(RootCert.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -125,6 +162,61 @@ class RootCertRegisterServiceTest {
         assertEquals(stack.getEnvironmentCrn(), result.getEnvironmentCrn());
         assertEquals(stack, result.getStack());
         assertEquals(EXPECTED_CERT, result.getCert());
+    }
+
+    @Test
+    public void testRegisterByStackShouldNotSaveTheRootCertWhenTheCurrentCertAvailableWithSameRootCertificate() throws FreeIpaClientException {
+        FreeIpaClient freeIpaClient = mock(FreeIpaClient.class);
+        RootCert currentRootCert = createRootCert(EXPECTED_CERT);
+        when(clientFactory.getFreeIpaClientForStack(stack)).thenReturn(freeIpaClient);
+        when(freeIpaClient.getRootCertificate()).thenReturn(INPUT_CERT);
+        when(rootCertService.findByStackId(STACK_ID)).thenReturn(Optional.of(currentRootCert));
+
+        RootCert result = underTest.register(stack);
+
+        assertEquals(stack.getEnvironmentCrn(), result.getEnvironmentCrn());
+        assertEquals(stack, result.getStack());
+        assertEquals(EXPECTED_CERT, result.getCert());
+        assertEquals(CERT_ID, result.getId());
+        verify(clientFactory).getFreeIpaClientForStack(stack);
+        verify(rootCertService).findByStackId(STACK_ID);
+        verifyNoMoreInteractions(rootCertService);
+    }
+
+    @Test
+    public void testRegisterByStackShouldSaveTheRootCertWhenTheCurrentCertAvailableWithOldRootCertificate() throws FreeIpaClientException {
+        FreeIpaClient freeIpaClient = mock(FreeIpaClient.class);
+        RootCert currentRootCert = createRootCert(OLD_EXPECTED_CERT);
+        when(clientFactory.getFreeIpaClientForStack(stack)).thenReturn(freeIpaClient);
+        when(freeIpaClient.getRootCertificate()).thenReturn(INPUT_CERT);
+        when(rootCertService.findByStackId(STACK_ID)).thenReturn(Optional.of(currentRootCert));
+        when(rootCertService.save(any(RootCert.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        RootCert result = underTest.register(stack);
+
+        assertEquals(stack.getEnvironmentCrn(), result.getEnvironmentCrn());
+        assertEquals(stack, result.getStack());
+        assertEquals(EXPECTED_CERT, result.getCert());
+        assertEquals(CERT_ID, result.getId());
+        verify(clientFactory).getFreeIpaClientForStack(stack);
+        verify(rootCertService).findByStackId(STACK_ID);
+        verify(rootCertService).save(result);
+    }
+
+    private RootCert createRootCert(String certificate) {
+        RootCert rootCert = new RootCert();
+        rootCert.setId(CERT_ID);
+        rootCert.setStack(stack);
+        rootCert.setEnvironmentCrn(ENV_CRN);
+        rootCert.setCert(certificate);
+        return rootCert;
+    }
+
+    private Stack createStack() {
+        Stack stack = new Stack();
+        stack.setId(STACK_ID);
+        stack.setEnvironmentCrn(ENV_CRN);
+        return stack;
     }
 
 }


### PR DESCRIPTION
During the environment creation, it's possible that we're trying to create and save the RootCert entity multiple times in the Freeipa management service, this can occur a ConstraintViolationException.
In this fix, we're trying to retrieve the current RootCert for the stack.
- If the RootCert is present with the new certificate not necessary to save it again.
- If the RootCert is present with an old certificate we're updating the entity.
- If the RootCert is not present, then we're creating a new entity and save to the database.