### PR TITLE
CB-15578 CM server and agent packages not upgraded if CentOS repos no…

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/upgrade.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/upgrade.sls
@@ -71,6 +71,7 @@ upgrade-cloudera-agent:
         - cloudera-manager-agent
         - cloudera-manager-daemons
     - refresh: True
+    - fromrepo: cloudera-manager
     - failhard: True
     - require:
         - sls: cloudera.repo

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/upgrade.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/upgrade.sls
@@ -37,6 +37,7 @@ upgrade-cloudera-server:
         - cloudera-manager-server
         - cloudera-manager-daemons
     - refresh: True
+    - fromrepo: cloudera-manager
     - failhard: True
     - require:
         - sls: cloudera.repo


### PR DESCRIPTION
…t available

CM server and agent upgrade salt state looks like:

```
upgrade-cloudera-server:
  pkg.latest:
    - pkgs:
        - cloudera-manager-server
        - cloudera-manager-daemons
    - refresh: True
    - failhard: True
    - require:
        - sls: cloudera.repo
```

The `refresh: True` ensures that yum would try to update the repo cache before trying to upgrade the package.
Issue is the result of this update is ignored, so if any of the repositories fail before updating the cloudera's repo,
then it won't be refreshed and salt would report that the package is up-to-date.

The exact repo for the state is defined, then only the defined repo would be updated, which solves this issue.

See detailed description in the commit message.