### PR TITLE
CB-15587 Cannot find attached volume Ids for FreeIPA

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazonec2/AmazonEC2Util.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazonec2/AmazonEC2Util.java
@@ -18,11 +18,11 @@ public class AmazonEC2Util {
     }
 
     public List<String> listInstanceVolumeIds(List<String> instanceIds) {
-        return ec2ClientActions.getInstanceVolumeIds(instanceIds);
+        return ec2ClientActions.getInstanceVolumeIds(instanceIds, false);
     }
 
     public List<String> listVolumeKmsKeyIds(List<String> instanceIds) {
-        return ec2ClientActions.getVolumesKmsKeys(instanceIds);
+        return ec2ClientActions.getRootVolumesKmsKeys(instanceIds);
     }
 
     public Map<String, Map<String, String>> listTagsByInstanceId(List<String> instanceIds) {


### PR DESCRIPTION
[testEnvironmentWithCustomerManagedKey](http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-aws/3959/testngreports/com.sequenceiq.it.cloudbreak.testcase.e2e.environment/AwsEnvironmentWithCustomerManagedKeyTests/testEnvironmentWithCustomerManagedKey/) is failing, because of:
```
Attached volume IDs are [] for [i-05fc54266345c8719] EC2 instance 
Attached volume IDs are [] for [i-05fc54266345c8719] EC2 instance 
Attached volume IDs are [] for [i-05fc54266345c8719] EC2 instance 
Attached volume IDs are [] for [i-05fc54266345c8719] EC2 instance 
Attached volume IDs are [] for [i-05fc54266345c8719] EC2 instance 
...
java.lang.NullPointerException
at java.base/java.util.Objects.requireNonNull(Objects.java:221)
at java.base/java.util.stream.Collectors.lambda$uniqKeysMapAccumulator$1(Collectors.java:178)
at java.base/java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169)
at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1654)
at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
at com.sequenceiq.it.cloudbreak.util.aws.amazonec2.action.EC2ClientActions.getVolumesKmsKeys(EC2ClientActions.java:200)
at com.sequenceiq.it.cloudbreak.util.aws.amazonec2.AmazonEC2Util.listVolumeKmsKeyIds(AmazonEC2Util.java:25)
at com.sequenceiq.it.cloudbreak.util.aws.AwsCloudFunctionality.listVolumeEncryptionKeyIds(AwsCloudFunctionality.java:36)
at com.sequenceiq.it.cloudbreak.util.aws.AwsCloudFunctionality$$FastClassBySpringCGLIB$$d17fdb6f.invoke()
...etc.
```

[EC2ClientActions.getVolumesKmsKeys](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazonec2/action/EC2ClientActions.java#L194-L204) throws `NullPointerException`, because of cannot find any volume Id for the FreeIPA.

So I've introduced a new parameter for the [getInstanceVolumeIds](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazonec2/action/EC2ClientActions.java#L59-L81) to can get root volume Ids as well.