### PR TITLE
CB-15117 disable unbound elimination in mock since repair/upgrade ope…

### DIFF
--- a/mock-thunderhead/src/main/resources/application.yml
+++ b/mock-thunderhead/src/main/resources/application.yml
@@ -82,6 +82,7 @@ auth:
     ephemeral.disks.for.temp.data.enable: true
     ui:
       edp.progress.bar.enable: true
+    unbound.elimination.enable: false
 
 crn:
   partition: cdp


### PR DESCRIPTION
…rations take too long caused by unbound change

See detailed description in the commit message.