### PR TITLE
CB-14883 mount-instance-storage service no longer mounts volumes twice

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/disks/service/scripts/mount-instance-storage.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/disks/service/scripts/mount-instance-storage.j2
@@ -225,6 +225,20 @@ find_format_and_mount_ephemeral_storage_aws() {
     return $((return_code))
 }
 
+is_there_a_volume_to_mount() {
+    not_mounted_volume_names=$(lsblk_command | grep -v / | grep ^[a-z] | cut -f1 -d' ')
+    root_disk=$(get_root_disk)
+    for volume in $not_mounted_volume_names; do
+      uuid=$(get_disk_uuid "/dev/$volume")
+      if [[ $root_disk != "/dev/$volume" && "$uuid" = ""  ]]; then
+        log $LOG_FILE "Found at least one volume which is not mounted."
+        return
+      fi
+    done
+    log $LOG_FILE "All volumes are mounted. Exiting"
+    exit_with_code $LOG_FILE 0 "script 'mount-instance-storage' ended"
+}
+
 main () {
     log $LOG_FILE "script 'instance-storage-format-and-mount' starts"
     sleep 1
@@ -235,8 +249,9 @@ main () {
         return_code=$?
         log $LOG_FILE result of remounting Azure temporary storage device: $return_code
         [[ ! $return_code -eq 0 ]] && exit_with_code $LOG_FILE $return_code "Error remounting Azure temporary storage device"
-    elif [[ "$CLOUD_PLATFORM" == "AWS" ]]; then
+    elif [[ "$CLOUD_PLATFORM" == "AWS" && "$TEMPORARY_STORAGE" != "EPHEMERAL_VOLUMES_ONLY" ]]; then
         log $LOG_FILE "Starting to remount AWS ephemeral devices"
+        is_there_a_volume_to_mount
         find_format_and_mount_ephemeral_storage_aws
         return_code=$?
         log $LOG_FILE result of remounting AWS ephemeral devices: $return_code


### PR DESCRIPTION
Added a check to skip the script, of all volumes are mounted already.
The mount-instance-storage scripts purpuse is to remount ephemeral volumes
after the cluster was stopped then started. However during cluster
deployment, the script ran, even when every disk was mounted and it could
happend that an ephemeral volume mounted /hadoopfs/fs1 also got mounted
on the next available path, eg. /haddopfs/fs3

See detailed description in the commit message.