### PR TITLE
CB-15602 Refactor ClouderaManagerParcelDecommissionService

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/model/ParcelOperationStatus.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/model/ParcelOperationStatus.java
@@ -39,8 +39,18 @@ public class ParcelOperationStatus {
         successful.put(parcelName, parcelVersion);
     }
 
+    public ParcelOperationStatus withSuccesful(String parcelName, String parcelVersion) {
+        successful.put(parcelName, parcelVersion);
+        return this;
+    }
+
     public void addFailed(String parcelName, String parcelVersion) {
         failed.put(parcelName, parcelVersion);
+    }
+
+    public ParcelOperationStatus withFailed(String parcelName, String parcelVersion) {
+        failed.put(parcelName, parcelVersion);
+        return this;
     }
 
     public ParcelOperationStatus merge(ParcelOperationStatus operationStatus) {

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ParcelCommand.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ParcelCommand.java
@@ -1,0 +1,9 @@
+package com.sequenceiq.cloudbreak.cm;
+
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.model.ApiCommand;
+
+@FunctionalInterface
+public interface ParcelCommand {
+    ApiCommand apply(String clusterName, String product, String version) throws ApiException;
+}


### PR DESCRIPTION
Before fixing the issue the class needed some refactor and extra unit test:
- getting rid of a bunch of code duplication by creating new parametrized methods under `ClouderaManagerParcelDecommissionService#removeUnusedParcelVersions`
- moving `getClouderaManagerParcelsByStatus` and `getClouderaManagerParcels` to `ClouderaManagerParcelManagementService` from `ClouderaManagerParcelDecommissionService` to make testing easier
- added unit test for `ClouderaManagerParcelDecommissionService#removeUnusedParcelVersions`

See detailed description in the commit message.