### PR TITLE
CB-14189 fix the AWS Native related ephemeral block device mapping creation

### DIFF
--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/resource/VolumeBuilderUtil.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/resource/VolumeBuilderUtil.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.cloud.aws.common.resource;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -23,25 +24,22 @@ import com.sequenceiq.cloudbreak.cloud.model.Volume;
 @Component
 public class VolumeBuilderUtil {
 
-    public BlockDeviceMapping getEphemeral(AwsInstanceView awsInstanceView) {
+    public List<BlockDeviceMapping> getEphemeral(AwsInstanceView awsInstanceView) {
         Long ephemeralCount = getEphemeralCount(awsInstanceView);
-        BlockDeviceMapping ephemeral = null;
+        List<BlockDeviceMapping> ephemeralBlockDeviceMappings = new ArrayList<>();
         if (ephemeralCount != 0) {
             List<String> seq = List.of("b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x",
                     "y", "z");
             int xIndex = 0;
-            while (xIndex < seq.size() && ephemeral == null) {
-                // we need to decrease the ephemeralCount, otherwise the 0 index will be never selected
-                if (xIndex == ephemeralCount - 1) {
-                    String x = seq.get(xIndex);
-                    ephemeral = new BlockDeviceMapping()
-                            .withDeviceName("/dev/xvd" + x)
-                            .withVirtualName("ephemeral" + xIndex);
-                }
+            while (xIndex < seq.size() && ephemeralBlockDeviceMappings.size() < ephemeralCount) {
+                String blockDeviceNameIndex = seq.get(xIndex);
+                ephemeralBlockDeviceMappings.add(new BlockDeviceMapping()
+                        .withDeviceName("/dev/xvd" + blockDeviceNameIndex)
+                        .withVirtualName("ephemeral" + xIndex));
                 xIndex++;
             }
         }
-        return ephemeral;
+        return ephemeralBlockDeviceMappings;
     }
 
     private Long getEphemeralCount(AwsInstanceView awsInstanceView) {

--- a/cloud-aws-native/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/resource/instance/AwsNativeInstanceResourceBuilder.java
+++ b/cloud-aws-native/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/resource/instance/AwsNativeInstanceResourceBuilder.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
@@ -163,9 +164,9 @@ public class AwsNativeInstanceResourceBuilder extends AbstractAwsNativeComputeBu
         AwsInstanceView awsInstanceView = new AwsInstanceView(group.getReferenceInstanceTemplate());
         List<BlockDeviceMapping> blocks = new ArrayList<>();
         blocks.add(volumeBuilderUtil.getRootVolume(awsInstanceView, group, cloudStack, ac));
-        BlockDeviceMapping ephemeral = volumeBuilderUtil.getEphemeral(awsInstanceView);
-        if (ephemeral != null) {
-            blocks.add(ephemeral);
+        List<BlockDeviceMapping> ephemeralBockDeviceMappings = volumeBuilderUtil.getEphemeral(awsInstanceView);
+        if (CollectionUtils.isNotEmpty(ephemeralBockDeviceMappings)) {
+            blocks.addAll(ephemeralBockDeviceMappings);
         }
         return blocks;
     }

--- a/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/resource/instance/AwsNativeInstanceResourceBuilderTest.java
+++ b/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/resource/instance/AwsNativeInstanceResourceBuilderTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -378,6 +379,32 @@ public class AwsNativeInstanceResourceBuilderTest {
         when(volumeBuilderUtil.getRootVolume(any(AwsInstanceView.class), eq(group), eq(cloudStack), eq(ac))).thenReturn(root);
         Collection<BlockDeviceMapping> actual = underTest.blocks(group, cloudStack, ac);
         Assertions.assertEquals(1, actual.size());
+    }
+
+    @Test
+    public void testBlocksWhenEphemeralBlockDeviceMappingsListIsEmpty() {
+        BlockDeviceMapping root = new BlockDeviceMapping();
+        when(group.getReferenceInstanceTemplate()).thenReturn(instanceTemplate);
+        when(volumeBuilderUtil.getEphemeral(any())).thenReturn(new ArrayList<>());
+        when(volumeBuilderUtil.getRootVolume(any(AwsInstanceView.class), eq(group), eq(cloudStack), eq(ac))).thenReturn(root);
+        Collection<BlockDeviceMapping> actual = underTest.blocks(group, cloudStack, ac);
+        Assertions.assertEquals(1, actual.size());
+    }
+
+    @Test
+    public void testBlocksWhenEphemeralBlockDeviceMappingsListIsNotEmpty() {
+        BlockDeviceMapping root = new BlockDeviceMapping();
+        BlockDeviceMapping ephemeralBlockDevice1 = new BlockDeviceMapping()
+                .withDeviceName("/dev/xvdb")
+                .withVirtualName("ephemeral0");
+        BlockDeviceMapping ephemeralBlockDevice2 = new BlockDeviceMapping()
+                .withDeviceName("/dev/xvdc")
+                .withVirtualName("ephemeral1");
+        when(group.getReferenceInstanceTemplate()).thenReturn(instanceTemplate);
+        when(volumeBuilderUtil.getEphemeral(any())).thenReturn(List.of(ephemeralBlockDevice1, ephemeralBlockDevice2));
+        when(volumeBuilderUtil.getRootVolume(any(AwsInstanceView.class), eq(group), eq(cloudStack), eq(ac))).thenReturn(root);
+        Collection<BlockDeviceMapping> actual = underTest.blocks(group, cloudStack, ac);
+        Assertions.assertEquals(3, actual.size());
     }
 
     @Test


### PR DESCRIPTION
… to have the accurate number of devices instead of creating only one
