### PR TITLE
CB-15474 removed ephemeral disk tests from azure-longrunning-e2e-tests

### DIFF
--- a/integration-test/src/main/resources/testsuites/e2e/azure-longrunning-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/azure-longrunning-e2e-tests.yaml
@@ -6,7 +6,4 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRecoveryTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.EnvironmentStopStartTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXUpgradeTests
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.ephemeral.DistroXStopStartTest
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.ephemeral.DistroXRepairTests
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.ephemeral.DistroXUpgradeTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRepairTests

--- a/integration-test/src/main/resources/testsuites/e2e/l0promotion/azure-ephemeral-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/l0promotion/azure-ephemeral-tests.yaml
@@ -1,0 +1,5 @@
+name: "azure-ephemeral-tests"
+tests:
+  - name: "azure-ephemeral-tests"
+    classes:
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.ephemeral.DistroXRepairTests


### PR DESCRIPTION
- added it mow-dev test suite
- azure can't provide Standard_L8s_v2 instance type reliably