### PR TITLE
CB-15619 Fix root disk detection logic in mount-instance-storage service

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/disks/service/scripts/mount-instance-storage.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/disks/service/scripts/mount-instance-storage.j2
@@ -169,6 +169,15 @@ find_format_and_mount_tempstorage_azure() {
       return $((return_value))
 }
 
+get_root_disk() {
+    root_partition=$(lsblk | grep /$ | cut -f1 -d' ' )
+    if [[ $root_partition =~ "nvme" ]]; then
+        echo "/dev/$(lsblk | grep /$ | cut -f1 -d' ' | sed 's/p\w//g' | cut -c 3-)"
+    else
+        echo "/dev/$(lsblk | grep /$ | cut -f1 -d' ' | sed 's/[0-9]//g' | cut -c 3-)"
+    fi
+}
+
 find_format_and_mount_ephemeral_storage_aws() {
     declare -a devices_arr
     declare -a inst_storage_devices_arr
@@ -186,11 +195,12 @@ find_format_and_mount_ephemeral_storage_aws() {
         devices_log=$(printf '%s ' "${devices_arr[@]}")
         log $LOG_FILE "All devices: $devices_log"
 
+        root_disk=$(get_root_disk)
         for device in "${devices_arr[@]}"; do
             path="/dev/$device"
             if [[ $path == $root_disk* ]]; then
                 log $LOG_FILE "skipping root disk/partition: $path"
-            else [[ -z $(grep "$path" /proc/mounts | cut -d ' ' -f1) ]]
+            elif [[ -z $(grep "$path" /proc/mounts | cut -d ' ' -f1) ]]; then
                 log $LOG_FILE "device '$path' is not mounted. Adding to devices to format and mount."
                 inst_storage_devices_arr+=($path)
             fi


### PR DESCRIPTION
Root disk was improperly detected by the service responsible for
mounting instance storage after cluster stop/start. Also
there was a semantic error in an if statement determining if the
device is already mounted or not.

See detailed description in the commit message.