### PR TITLE
CB-15622 Increase resourcereference length

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/resourcepersister/Resource.java
+++ b/environment/src/main/java/com/sequenceiq/environment/resourcepersister/Resource.java
@@ -35,8 +35,10 @@ public class Resource {
     @Convert(converter = CommonStatusConverter.class)
     private CommonStatus resourceStatus;
 
+    @Column(nullable = false)
     private String resourceName;
 
+    @Column(columnDefinition = "TEXT")
     private String resourceReference;
 
     public Resource() {

--- a/environment/src/main/resources/schema/app/20220107151846_CB-15622_Increase_resourcereference_length.sql
+++ b/environment/src/main/resources/schema/app/20220107151846_CB-15622_Increase_resourcereference_length.sql
@@ -1,0 +1,10 @@
+-- // CB-15622 Increase resourcereference length
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE IF EXISTS resource ALTER COLUMN resourcereference SET DATA TYPE TEXT;
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+-- Nothing to undo


### PR DESCRIPTION
* Change data type of `environmentdb.resource.resourcereference` from `VARCHAR(255)` to `TEXT`.
* Adjust entity `Resource` (`environment`):
  * `resourceName` is not `nullable` (see the former create script
    `20200930134106_CB-8867-Env_service_should_create_private_DNS_zone_privatelink.postgres.database.azure.com.sql`).
  * `resourceReference` shall have the right `columnDefinition`.
