### PR TITLE
CB-15602 Fix ClouderaManagerParcelDecommissionService can't handle if…

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/model/ParcelOperationStatus.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/model/ParcelOperationStatus.java
@@ -1,45 +1,48 @@
 package com.sequenceiq.cloudbreak.cluster.model;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.StringJoiner;
 
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+
 public class ParcelOperationStatus {
 
-    private Map<String, String> successful = new HashMap<>();
+    private Multimap<String, String> successful = HashMultimap.create();
 
-    private Map<String, String> failed = new HashMap<>();
+    private Multimap<String, String> failed = HashMultimap.create();
 
     public ParcelOperationStatus() {
     }
 
     public ParcelOperationStatus(Map<String, String> successful, Map<String, String> failed) {
-        this.successful = new HashMap<>(successful);
-        this.failed = new HashMap<>(failed);
+        this.successful = successful.entrySet().stream().collect(Multimaps.toMultimap(Map.Entry::getKey, Map.Entry::getValue, HashMultimap::create));
+        this.failed = failed.entrySet().stream().collect(Multimaps.toMultimap(Map.Entry::getKey, Map.Entry::getValue, HashMultimap::create));
     }
 
-    public Map<String, String> getSuccessful() {
+    public Multimap<String, String> getSuccessful() {
         return successful;
     }
 
-    public void setSuccessful(Map<String, String> successful) {
+    public void setSuccessful(Multimap<String, String> successful) {
         this.successful = successful;
     }
 
-    public Map<String, String> getFailed() {
+    public Multimap<String, String> getFailed() {
         return failed;
     }
 
-    public void setFailed(Map<String, String> failed) {
+    public void setFailed(Multimap<String, String> failed) {
         this.failed = failed;
     }
 
-    public void addSuccesful(String parcelName, String parcelVersion) {
+    public void addSuccessful(String parcelName, String parcelVersion) {
         successful.put(parcelName, parcelVersion);
     }
 
-    public ParcelOperationStatus withSuccesful(String parcelName, String parcelVersion) {
+    public ParcelOperationStatus withSuccessful(String parcelName, String parcelVersion) {
         successful.put(parcelName, parcelVersion);
         return this;
     }
@@ -56,7 +59,7 @@ public class ParcelOperationStatus {
     public ParcelOperationStatus merge(ParcelOperationStatus operationStatus) {
         successful.putAll(operationStatus.successful);
         failed.putAll(operationStatus.failed);
-        successful.entrySet().removeIf(entry -> failed.containsKey(entry.getKey()));
+        operationStatus.failed.forEach((key, value) -> successful.remove(key, value));
         return this;
     }
 

--- a/cluster-api/src/test/java/com/sequenceiq/cloudbreak/cluster/model/ParcelOperationStatusTest.java
+++ b/cluster-api/src/test/java/com/sequenceiq/cloudbreak/cluster/model/ParcelOperationStatusTest.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.cluster.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 
@@ -17,9 +18,9 @@ public class ParcelOperationStatusTest {
         ParcelOperationStatus result = status1.merge(status2).merge(status3);
 
         assertEquals(1, result.getSuccessful().size());
-        assertEquals("v3", result.getSuccessful().get("parcel3"));
+        assertTrue(result.getSuccessful().containsEntry("parcel3", "v3"));
         assertEquals(2, result.getFailed().size());
-        assertEquals("v1", result.getFailed().get("parcel1"));
-        assertEquals("v2", result.getFailed().get("parcel2"));
+        assertTrue(result.getFailed().containsEntry("parcel1", "v1"));
+        assertTrue(result.getFailed().containsEntry("parcel2", "v2"));
     }
 }

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerParcelDecommissionService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerParcelDecommissionService.java
@@ -7,7 +7,6 @@ import static java.util.stream.Collectors.toMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.function.Predicate;
 
 import javax.inject.Inject;
 
@@ -20,6 +19,9 @@ import com.cloudera.api.swagger.ParcelsResourceApi;
 import com.cloudera.api.swagger.client.ApiClient;
 import com.cloudera.api.swagger.client.ApiException;
 import com.cloudera.api.swagger.model.ApiParcel;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
 import com.sequenceiq.cloudbreak.cloud.scheduler.CancellationException;
 import com.sequenceiq.cloudbreak.cluster.model.ParcelOperationStatus;
@@ -54,7 +56,7 @@ class ClouderaManagerParcelDecommissionService {
     public ParcelOperationStatus deactivateUnusedParcels(ParcelsResourceApi parcelsResourceApi, ParcelResourceApi parcelResourceApi, String stackName,
             Set<String> usedParcelComponentNames, Set<String> parcelNamesFromImage) {
         Map<String, String> activeParcels = getParcelsInStatus(parcelsResourceApi, stackName, ParcelStatus.ACTIVATED);
-        Map<String, String> parcelsToDeactivate = getUnusedParcels(activeParcels, usedParcelComponentNames, parcelNamesFromImage);
+        Multimap<String, String> parcelsToDeactivate = getUnusedParcels(activeParcels, usedParcelComponentNames, parcelNamesFromImage);
         LOGGER.debug("The following parcels will be deactivated: {}", parcelsToDeactivate);
         return deactivateParcels(parcelResourceApi, stackName, parcelsToDeactivate);
     }
@@ -62,7 +64,7 @@ class ClouderaManagerParcelDecommissionService {
     public ParcelOperationStatus undistributeUnusedParcels(ApiClient apiClient, ParcelsResourceApi parcelsResourceApi, ParcelResourceApi parcelResourceApi,
             Stack stack, Set<String> usedParcelComponentNames, Set<String> parcelNamesFromImage) {
         Map<String, String> distributedParcels = getParcelsInStatus(parcelsResourceApi, stack.getName(), ParcelStatus.DISTRIBUTED);
-        Map<String, String> parcelsToUndistribute = getUnusedParcels(distributedParcels, usedParcelComponentNames, parcelNamesFromImage);
+        Multimap<String, String> parcelsToUndistribute = getUnusedParcels(distributedParcels, usedParcelComponentNames, parcelNamesFromImage);
         LOGGER.debug("The following parcels will be undistributed: {}", parcelsToUndistribute);
         return undistributeParcels(apiClient, parcelResourceApi, stack, parcelsToUndistribute);
     }
@@ -70,7 +72,7 @@ class ClouderaManagerParcelDecommissionService {
     public ParcelOperationStatus removeUnusedParcels(ApiClient apiClient, ParcelsResourceApi parcelsResourceApi, ParcelResourceApi parcelResourceApi,
             Stack stack, Set<String> usedParcelComponentNames, Set<String> parcelNamesFromImage) {
         Map<String, String> downloadedParcels = getParcelsInStatus(parcelsResourceApi, stack.getName(), ParcelStatus.DOWNLOADED);
-        Map<String, String> parcelsToRemove = getUnusedParcels(downloadedParcels, usedParcelComponentNames, parcelNamesFromImage);
+        Multimap<String, String> parcelsToRemove = getUnusedParcels(downloadedParcels, usedParcelComponentNames, parcelNamesFromImage);
         LOGGER.debug("The following parcels will be removed: {}", parcelsToRemove);
         return removeParcels(apiClient, parcelResourceApi, stack, parcelsToRemove);
     }
@@ -83,55 +85,44 @@ class ClouderaManagerParcelDecommissionService {
 
     private void removeDownloadedUnusedParcels(ApiClient apiClient, ParcelsResourceApi parcelsResourceApi, ParcelResourceApi parcelResourceApi, Stack stack,
             ClouderaManagerProduct product) throws ApiException {
-        Map<String, String> unusedDownloadedParcelVersions =
+        Multimap<String, String> unusedDownloadedParcelVersions =
                 getParcelVersionsByStatusNameAndVersion(parcelsResourceApi, stack, product, ParcelStatus.DOWNLOADED);
         removeParcels(apiClient, parcelResourceApi, stack, unusedDownloadedParcelVersions);
     }
 
     private void undistributeUnusedDistributedParcels(ApiClient apiClient, ParcelsResourceApi parcelsResourceApi, ParcelResourceApi parcelResourceApi,
             Stack stack, ClouderaManagerProduct product) throws ApiException {
-        Map<String, String> unusedDistributedParcelVersions =
+        Multimap<String, String> unusedDistributedParcelVersions =
                 getParcelVersionsByStatusNameAndVersion(parcelsResourceApi, stack, product, ParcelStatus.DISTRIBUTED);
         undistributeParcels(apiClient, parcelResourceApi, stack, unusedDistributedParcelVersions);
     }
 
-    private Map<String, String> getParcelVersionsByStatusNameAndVersion(ParcelsResourceApi parcelsResourceApi, Stack stack, ClouderaManagerProduct product,
+    private Multimap<String, String> getParcelVersionsByStatusNameAndVersion(ParcelsResourceApi parcelsResourceApi, Stack stack, ClouderaManagerProduct product,
             ParcelStatus parcelStatus) throws ApiException {
         return parcelManagementService.getClouderaManagerParcelsByStatus(parcelsResourceApi, stack.getName(), parcelStatus)
                 .stream()
                 .filter(apiParcel -> apiParcel.getProduct().equals(product.getName()) && !apiParcel.getVersion().equals(product.getVersion()))
-                .collect(toMap(ApiParcel::getProduct, ApiParcel::getVersion));
+                .collect(Multimaps.toMultimap(ApiParcel::getProduct, ApiParcel::getVersion, HashMultimap::create));
     }
 
-    private Map<String, String> getUnusedParcels(Map<String, String> activeParcels, Set<String> usedParcelComponentNames, Set<String> parcelsFromImage) {
+    private Multimap<String, String> getUnusedParcels(Map<String, String> activeParcels, Set<String> usedParcelComponentNames, Set<String> parcelsFromImage) {
         return activeParcels.entrySet().stream()
                 .filter(entry -> !usedParcelComponentNames.contains(entry.getKey()) && parcelsFromImage.contains(entry.getKey()))
-                .collect(toMap(Entry::getKey, Entry::getValue));
+                .collect(Multimaps.toMultimap(Entry::getKey, Entry::getValue, HashMultimap::create));
     }
 
-    private ParcelOperationStatus deactivateParcels(ParcelResourceApi parcelResourceApi, String stackName, Map<String, String> activeParcels) {
-        ParcelOperationStatus deactivateStatus = new ParcelOperationStatus();
-        for (Entry<String, String> activeParcel : activeParcels.entrySet()) {
-            Parcel parcel = new Parcel(activeParcel.getKey(), activeParcel.getValue());
-            try {
-                LOGGER.debug("Deactivating {} parcel", parcel);
-                parcelResourceApi.deactivateCommand(stackName, parcel.getName(), parcel.getVersion());
-                deactivateStatus.addSuccesful(parcel.getName(), parcel.getVersion());
-                LOGGER.info("Successfully deactivated parcel: {}", parcel);
-            } catch (ApiException e) {
-                LOGGER.info(String.format("Unable to deactivate parcel: %s", parcel), e);
-                deactivateStatus.addFailed(parcel.getName(), parcel.getVersion());
-            }
-        }
-        return deactivateStatus;
+    private ParcelOperationStatus deactivateParcels(ParcelResourceApi parcelResourceApi, String stackName, Multimap<String, String> activeParcels) {
+        return activeParcels.entries().stream()
+                .map(parcel -> runSingleParcelCommand("DEACTIVATE", stackName, parcel, parcelResourceApi::deactivateCommand))
+                .reduce(new ParcelOperationStatus(), ParcelOperationStatus::merge);
     }
 
-    private ParcelOperationStatus undistributeParcels(ApiClient apiClient, ParcelResourceApi parcelResourceApi, Stack stack, Map<String, String> parcels) {
-        ParcelOperationStatus undistributeStatus = parcels.entrySet().stream()
-                .map(parcel -> runSingleParcelCommand("UNDISTRIBUTE", stack, parcel, parcelResourceApi::startRemovalOfDistributionCommand))
+    private ParcelOperationStatus undistributeParcels(ApiClient apiClient, ParcelResourceApi parcelResourceApi, Stack stack, Multimap<String, String> parcels) {
+        ParcelOperationStatus undistributeStatus = parcels.entries().stream()
+                .map(parcel -> runSingleParcelCommand("UNDISTRIBUTE", stack.getName(), parcel, parcelResourceApi::startRemovalOfDistributionCommand))
                 .reduce(new ParcelOperationStatus(), ParcelOperationStatus::merge);
 
-        Map<String, String> pollableParcels = filterForPollableParcels(parcels, undistributeStatus);
+        Multimap<String, String> pollableParcels = filterForPollableParcels(parcels, undistributeStatus);
         PollingResult pollingResult = clouderaManagerPollingServiceProvider.startPollingCmParcelStatus(stack, apiClient, pollableParcels,
                 ParcelStatus.DOWNLOADED);
         if (isExited(pollingResult)) {
@@ -142,31 +133,31 @@ class ClouderaManagerParcelDecommissionService {
         return undistributeStatus;
     }
 
-    private Map<String, String> filterForPollableParcels(Map<String, String> parcels, ParcelOperationStatus parcelOperationStatus) {
-        return parcels.entrySet().stream()
-                .filter(filterParcels(parcelOperationStatus.getSuccessful().keySet()))
-                .collect(toMap(Entry::getKey, Entry::getValue));
+    private Multimap<String, String> filterForPollableParcels(Multimap<String, String> parcels, ParcelOperationStatus parcelOperationStatus) {
+        return parcels.entries().stream()
+                .filter(entry -> parcelOperationStatus.getSuccessful().containsEntry(entry.getKey(), entry.getValue()))
+                .collect(Multimaps.toMultimap(Entry::getKey, Entry::getValue, HashMultimap::create));
     }
 
-    private ParcelOperationStatus runSingleParcelCommand(String commandName, Stack stack, Entry<String, String> distributedParcel,
+    private ParcelOperationStatus runSingleParcelCommand(String commandName, String stackName, Entry<String, String> parcelForCommand,
             ParcelCommand parcelCommand) {
-        Parcel parcel = new Parcel(distributedParcel.getKey(), distributedParcel.getValue());
+        Parcel parcel = new Parcel(parcelForCommand.getKey(), parcelForCommand.getValue());
         try {
             LOGGER.debug("[{}] Start for {} parcel", commandName, parcel);
-            parcelCommand.apply(stack.getName(), parcel.getName(), parcel.getVersion());
+            parcelCommand.apply(stackName, parcel.getName(), parcel.getVersion());
             LOGGER.info("[{}] Successful for parcel: {}", commandName, parcel);
-            return new ParcelOperationStatus().withSuccesful(parcel.getName(), parcel.getVersion());
+            return new ParcelOperationStatus().withSuccessful(parcel.getName(), parcel.getVersion());
         } catch (ApiException e) {
             LOGGER.info(String.format("[%s] Failed for parcel: %s", commandName, parcel), e);
             return new ParcelOperationStatus().withFailed(parcel.getName(), parcel.getVersion());
         }
     }
 
-    private ParcelOperationStatus removeParcels(ApiClient apiClient, ParcelResourceApi parcelResourceApi, Stack stack, Map<String, String> parcels) {
-        ParcelOperationStatus removalStatus = parcels.entrySet().stream()
-                .map(parcel -> runSingleParcelCommand("REMOVE", stack, parcel, parcelResourceApi::removeDownloadCommand))
+    private ParcelOperationStatus removeParcels(ApiClient apiClient, ParcelResourceApi parcelResourceApi, Stack stack, Multimap<String, String> parcels) {
+        ParcelOperationStatus removalStatus = parcels.entries().stream()
+                .map(parcel -> runSingleParcelCommand("REMOVE", stack.getName(), parcel, parcelResourceApi::removeDownloadCommand))
                 .reduce(new ParcelOperationStatus(), ParcelOperationStatus::merge);
-        Map<String, String> pollableParcels = filterForPollableParcels(parcels, removalStatus);
+        Multimap<String, String> pollableParcels = filterForPollableParcels(parcels, removalStatus);
         PollingResult pollingResult = clouderaManagerPollingServiceProvider.startPollingCmParcelDelete(stack, apiClient, pollableParcels);
         if (isExited(pollingResult)) {
             throw new CancellationException("Cluster was terminated while waiting for parcels deletion");
@@ -174,10 +165,6 @@ class ClouderaManagerParcelDecommissionService {
             throw new ClouderaManagerOperationFailedException("Timeout while Cloudera Manager deletes parcels.");
         }
         return removalStatus;
-    }
-
-    private Predicate<Entry<String, String>> filterParcels(Set<String> parcels) {
-        return parcel -> parcels.contains(parcel.getKey());
     }
 
     private static class Parcel {

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/ClouderaManagerPollingServiceProvider.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/ClouderaManagerPollingServiceProvider.java
@@ -2,7 +2,6 @@ package com.sequenceiq.cloudbreak.cm.polling;
 
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
@@ -12,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.cloudera.api.swagger.client.ApiClient;
+import com.google.common.collect.Multimap;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterEventService;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
@@ -121,7 +121,7 @@ public class ClouderaManagerPollingServiceProvider {
                 new ClouderaManagerSingleParcelActivationListenerTask(clouderaManagerApiPojoFactory, clusterEventService, product));
     }
 
-    public PollingResult startPollingCmParcelStatus(Stack stack, ApiClient apiClient, Map<String, String> parcelVersions,
+    public PollingResult startPollingCmParcelStatus(Stack stack, ApiClient apiClient, Multimap<String, String> parcelVersions,
             ParcelStatus parcelStatus) {
         LOGGER.debug("Waiting for Cloudera Manager parcels {} to become to status [{}]. [Server address: {}]", parcelVersions, parcelStatus,
                 stack.getClusterManagerIp());
@@ -129,7 +129,7 @@ public class ClouderaManagerPollingServiceProvider {
                 new ClouderaManagerParcelStatusListenerTask(clouderaManagerApiPojoFactory, clusterEventService, parcelVersions, parcelStatus));
     }
 
-    public PollingResult startPollingCmParcelDelete(Stack stack, ApiClient apiClient, Map<String, String> parcelVersions) {
+    public PollingResult startPollingCmParcelDelete(Stack stack, ApiClient apiClient, Multimap<String, String> parcelVersions) {
         LOGGER.debug("Waiting for Cloudera Manager parcels {} to be deleted. [Server address: {}]", parcelVersions,
                 stack.getClusterManagerIp());
         return pollCommandWithTimeListener(stack, apiClient, BigDecimal.ZERO, POLL_FOR_ONE_HOUR,

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerParcelDeletedListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerParcelDeletedListenerTask.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.cloudbreak.cm.polling.task;
 
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -13,6 +12,7 @@ import com.cloudera.api.swagger.client.ApiClient;
 import com.cloudera.api.swagger.client.ApiException;
 import com.cloudera.api.swagger.model.ApiParcel;
 import com.cloudera.api.swagger.model.ApiParcelList;
+import com.google.common.collect.Multimap;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterEventService;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
 import com.sequenceiq.cloudbreak.cm.model.ParcelStatus;
@@ -22,10 +22,10 @@ import com.sequenceiq.cloudbreak.domain.stack.Stack;
 public class ClouderaManagerParcelDeletedListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
     private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerParcelDeletedListenerTask.class);
 
-    private Map<String, String> parcelVersions;
+    private final Multimap<String, String> parcelVersions;
 
     public ClouderaManagerParcelDeletedListenerTask(ClouderaManagerApiPojoFactory clouderaManagerApiPojoFactory,
-            ClusterEventService clusterEventService, Map<String, String> parcelVersions) {
+            ClusterEventService clusterEventService, Multimap<String, String> parcelVersions) {
         super(clouderaManagerApiPojoFactory, clusterEventService);
         this.parcelVersions = parcelVersions;
     }
@@ -37,7 +37,7 @@ public class ClouderaManagerParcelDeletedListenerTask extends AbstractClouderaMa
         ApiParcelList parcels = getClouderaManagerParcels(apiClient, stack.getName());
         List<ApiParcel> existedParcels = collectExistingParcels(parcels);
         if (existedParcels.isEmpty()) {
-            LOGGER.debug("Parcels are deleted succesfully.");
+            LOGGER.debug("Parcels are deleted successfully.");
             return true;
         } else {
             LOGGER.debug("Some parcels are not yet deleted: [{}].", getJoinedParcelStages(existedParcels));
@@ -58,7 +58,7 @@ public class ClouderaManagerParcelDeletedListenerTask extends AbstractClouderaMa
     }
 
     private boolean isMatchingParcel(ApiParcel parcel) {
-        return parcelVersions.containsKey(parcel.getProduct()) && parcelVersions.get(parcel.getProduct()).equals(parcel.getVersion());
+        return parcelVersions.containsEntry(parcel.getProduct(), parcel.getVersion());
     }
 
     private String getJoinedParcelStages(List<ApiParcel> notActivated) {

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerParcelStatusListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerParcelStatusListenerTask.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.cloudbreak.cm.polling.task;
 
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -13,6 +12,7 @@ import com.cloudera.api.swagger.client.ApiClient;
 import com.cloudera.api.swagger.client.ApiException;
 import com.cloudera.api.swagger.model.ApiParcel;
 import com.cloudera.api.swagger.model.ApiParcelList;
+import com.google.common.collect.Multimap;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterEventService;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
 import com.sequenceiq.cloudbreak.cm.model.ParcelStatus;
@@ -22,12 +22,12 @@ import com.sequenceiq.cloudbreak.domain.stack.Stack;
 public class ClouderaManagerParcelStatusListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
     private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerParcelStatusListenerTask.class);
 
-    private Map<String, String> parcelVersions;
+    private final Multimap<String, String> parcelVersions;
 
-    private ParcelStatus parcelStatus;
+    private final ParcelStatus parcelStatus;
 
     public ClouderaManagerParcelStatusListenerTask(ClouderaManagerApiPojoFactory clouderaManagerApiPojoFactory,
-            ClusterEventService clusterEventService, Map<String, String> parcelVersions, ParcelStatus parcelStatus) {
+            ClusterEventService clusterEventService, Multimap<String, String> parcelVersions, ParcelStatus parcelStatus) {
         super(clouderaManagerApiPojoFactory, clusterEventService);
         this.parcelVersions = parcelVersions;
         this.parcelStatus = parcelStatus;
@@ -55,8 +55,7 @@ public class ClouderaManagerParcelStatusListenerTask extends AbstractClouderaMan
 
     private List<ApiParcel> getNotInProperStateParcels(ApiParcelList parcels) {
         return parcels.getItems().stream()
-                .filter(parcel -> parcelVersions.containsKey(parcel.getProduct()))
-                .filter(parcel -> parcelVersions.get(parcel.getProduct()).equals(parcel.getVersion()))
+                .filter(parcel -> parcelVersions.containsEntry(parcel.getProduct(), parcel.getVersion()))
                 .filter(parcel -> !parcelStatus.name().equals(parcel.getStage()))
                 .collect(Collectors.toList());
     }

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationServiceTest.java
@@ -1069,7 +1069,7 @@ class ClouderaManagerModificationServiceTest {
     }
 
     @Test
-    void testDeployConfigAndRefreshCMStaleServicesWhenRefreshFailAndForcedIsFalseFail() throws CloudbreakException, ApiException {
+    void testDeployConfigAndRefreshCMStaleServicesWhenRefreshFailAndForcedIsFalseFail() throws ApiException {
         ApiService apiService = new ApiService().configStalenessStatus(ApiConfigStalenessStatus.STALE)
                 .clientConfigStalenessStatus(ApiConfigStalenessStatus.FRESH);
         List<ApiService> apiServices = List.of(apiService);
@@ -1156,10 +1156,10 @@ class ClouderaManagerModificationServiceTest {
         verify(clouderaManagerParcelDecommissionService, times(1)).removeUnusedParcels(apiClientMock, parcelsResourceApi, parcelResourceApi, stack,
                 usedParcelComponentNames, parcelNamesFromImage);
         assertEquals(1, operationStatus.getSuccessful().size());
-        assertEquals("version5", operationStatus.getSuccessful().get("product5"));
+        assertTrue(operationStatus.getSuccessful().containsEntry("product5", "version5"));
         assertEquals(2, operationStatus.getFailed().size());
-        assertEquals("version3", operationStatus.getFailed().get("spark3"));
-        assertEquals("version4", operationStatus.getFailed().get("product4"));
+        assertTrue(operationStatus.getFailed().containsEntry("spark3", "version3"));
+        assertTrue(operationStatus.getFailed().containsEntry("product4", "version4"));
     }
 
     @Test

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterUpscaleServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterUpscaleServiceTest.java
@@ -128,7 +128,7 @@ class ClusterUpscaleServiceTest {
 
         CloudbreakException exception = assertThrows(CloudbreakException.class, () -> underTest.installServicesOnNewHosts(1L, "master", true, true));
 
-        assertEquals("Failed to remove the following parcels: {parcel=parcel}", exception.getMessage());
+        assertEquals("Failed to remove the following parcels: {parcel=[parcel]}", exception.getMessage());
         verify(parcelService).removeUnusedParcelComponents(stack);
     }
 


### PR DESCRIPTION
… there are more than 2 parcel  for same product

- switched from `Map` to `Multimap` so one product can have multiple versions
- `HashMultimap` is used everywhere to avoid having multiple of the same versions

See detailed description in the commit message.