### PR TITLE
CB-15306 Enable unbound elimination in mock since TTL issue of freeip…

### DIFF
--- a/mock-thunderhead/src/main/resources/application.yml
+++ b/mock-thunderhead/src/main/resources/application.yml
@@ -82,7 +82,7 @@ auth:
     ephemeral.disks.for.temp.data.enable: true
     ui:
       edp.progress.bar.enable: true
-    unbound.elimination.enable: false
+    unbound.elimination.enable: true
 
 crn:
   partition: cdp


### PR DESCRIPTION
…a and unbound is fixed

See detailed description in the commit message.