### PR TITLE
CB-14421 Implement targeted salt highstate during Upscale operation

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerSetupService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerSetupService.java
@@ -360,7 +360,8 @@ public class ClouderaManagerSetupService implements ClusterSetupService {
         } catch (ClouderaManagerClientInitException e) {
             throw new ClusterClientInitException(e);
         }
-        clouderaManagerPollingServiceProvider.startPollingCmHostStatus(stack, client);
+        List<String> privateIps = hostsInCluster.stream().map(InstanceMetaData::getPrivateIp).collect(Collectors.toList());
+        clouderaManagerPollingServiceProvider.startPollingCmHostStatus(stack, client, privateIps);
     }
 
     @Override

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/ClouderaManagerPollingServiceProvider.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/ClouderaManagerPollingServiceProvider.java
@@ -6,11 +6,13 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.cloudera.api.swagger.client.ApiClient;
+import com.google.common.base.Joiner;
 import com.google.common.collect.Multimap;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterEventService;
@@ -79,6 +81,13 @@ public class ClouderaManagerPollingServiceProvider {
         LOGGER.debug("Waiting for Cloudera Manager hosts to connect. [Server address: {}]", stack.getClusterManagerIp());
         return pollCommandWithTimeListener(stack, apiClient, null, POLL_FOR_ONE_HOUR,
                 new ClouderaManagerHostStatusChecker(clouderaManagerApiPojoFactory, clusterEventService));
+    }
+
+    public PollingResult startPollingCmHostStatus(Stack stack, ApiClient apiClient, List<String> targets) {
+        LOGGER.debug("Waiting for Cloudera Manager hosts to connect. [Server address: {}, target hosts: {}]",
+                stack.getClusterManagerIp(), Joiner.on(",").join(CollectionUtils.emptyIfNull(targets)));
+        return pollCommandWithTimeListener(stack, apiClient, null, POLL_FOR_ONE_HOUR,
+                new ClouderaManagerHostStatusChecker(clouderaManagerApiPojoFactory, clusterEventService, targets));
     }
 
     public PollingResult startPollingCmTemplateInstallation(Stack stack, ApiClient apiClient, BigDecimal commandId) {

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerHostStatusChecker.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerHostStatusChecker.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,10 +27,20 @@ public class ClouderaManagerHostStatusChecker extends AbstractClouderaManagerCom
 
     private final Instant start;
 
+    private final List<String> targets;
+
+    public ClouderaManagerHostStatusChecker(ClouderaManagerApiPojoFactory clouderaManagerApiPojoFactory,
+            ClusterEventService clusterEventService, List<String> targets) {
+        super(clouderaManagerApiPojoFactory, clusterEventService);
+        start = Instant.now();
+        this.targets = targets;
+    }
+
     public ClouderaManagerHostStatusChecker(ClouderaManagerApiPojoFactory clouderaManagerApiPojoFactory,
             ClusterEventService clusterEventService) {
         super(clouderaManagerApiPojoFactory, clusterEventService);
         start = Instant.now();
+        this.targets = List.of();
     }
 
     @Override
@@ -48,6 +59,7 @@ public class ClouderaManagerHostStatusChecker extends AbstractClouderaManagerCom
         return pollerObject.getStack().getInstanceMetaDataAsList().stream()
                 .filter(metaData -> metaData.getDiscoveryFQDN() != null)
                 .filter(InstanceMetaData::isReachable)
+                .filter(md -> CollectionUtils.isEmpty(targets) || targets.contains(md.getPrivateIp()))
                 .filter(metaData -> !hostIpsFromManager.contains(metaData.getPrivateIp()))
                 .collect(Collectors.toList());
     }

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerSetupServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerSetupServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
@@ -624,15 +625,13 @@ public class ClouderaManagerSetupServiceTest {
 
         when(clouderaManagerApiClientProvider.getV31Client(anyInt(), anyString(), anyString(), any(HttpClientConfig.class)))
                 .thenReturn(apiClient);
-        when(clouderaManagerPollingServiceProvider.startPollingCmHostStatus(any(Stack.class), any(ApiClient.class)))
+        when(clouderaManagerPollingServiceProvider.startPollingCmHostStatus(any(Stack.class), any(ApiClient.class), anyList()))
                 .thenReturn(PollingResult.EXIT);
 
         underTest.waitForHosts(Set.of());
 
         verify(clouderaManagerPollingServiceProvider, times(1)).startPollingCmHostStatus(
-                any(Stack.class),
-                any(ApiClient.class)
-        );
+                any(Stack.class), any(ApiClient.class), anyList());
     }
 
     @Test

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterServiceRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterServiceRunner.java
@@ -55,7 +55,7 @@ public class ClusterServiceRunner {
     @Inject
     private GatewayService gatewayService;
 
-    public void runAmbariServices(Long stackId) throws CloudbreakException {
+    public void runAmbariServices(Long stackId) {
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
         Cluster cluster = clusterService.getById(stack.getCluster().getId());
 
@@ -83,13 +83,6 @@ public class ClusterServiceRunner {
         HttpClientConfig ambariClientConfig = buildAmbariClientConfig(stack, gatewayIp);
         Cluster updatedCluster = clusterService.updateAmbariClientConfig(cluster.getId(), ambariClientConfig);
         stack.setCluster(updatedCluster);
-    }
-
-    public void updateSaltState(Long stackId) {
-        Stack stack = stackService.getByIdWithListsInTransaction(stackId);
-        Cluster cluster = clusterService.retrieveClusterByStackIdWithoutAuth(stack.getId())
-                .orElseThrow(NotFoundException.notFound("cluster", stack.getId()));
-        hostRunner.runClusterServices(stack, cluster, Map.of());
     }
 
     public void redeployGatewayCertificate(Long stackId) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
@@ -35,6 +35,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.Account;
+import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ExecutorType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
@@ -87,6 +88,7 @@ import com.sequenceiq.cloudbreak.orchestrator.host.GrainOperation;
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.host.OrchestratorGrainRunnerParams;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.cloudbreak.orchestrator.model.GrainProperties;
 import com.sequenceiq.cloudbreak.orchestrator.model.Node;
 import com.sequenceiq.cloudbreak.orchestrator.model.SaltConfig;
 import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
@@ -110,6 +112,7 @@ import com.sequenceiq.cloudbreak.service.sharedservice.DatalakeService;
 import com.sequenceiq.cloudbreak.service.stack.InstanceGroupService;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.service.stack.TargetedUpscaleSupportService;
 import com.sequenceiq.cloudbreak.service.stack.flow.MountDisks;
 import com.sequenceiq.cloudbreak.template.kerberos.KerberosDetailService;
 import com.sequenceiq.cloudbreak.template.views.RdsView;
@@ -242,24 +245,16 @@ public class ClusterHostServiceRunner {
     @Inject
     private FreeIpaConfigProvider freeIpaConfigProvider;
 
+    @Inject
+    private TargetedUpscaleSupportService targetedUpscaleSupportService;
+
     public void runClusterServices(@Nonnull Stack stack, @Nonnull Cluster cluster, Map<String, String> candidateAddresses) {
         try {
             Set<Node> allNodes = stackUtil.collectNodes(stack);
             Set<Node> reachableNodes = stackUtil.collectAndCheckReachableNodes(stack, candidateAddresses.keySet());
-            GatewayConfig primaryGatewayConfig = gatewayConfigService.getPrimaryGatewayConfig(stack);
             List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
-            SaltConfig saltConfig = createSaltConfig(stack, cluster, primaryGatewayConfig, gatewayConfigs, allNodes, reachableNodes);
-            ExitCriteriaModel exitCriteriaModel = clusterDeletionBasedModel(stack.getId(), cluster.getId());
-            modifyStartupMountRole(stack, reachableNodes, GrainOperation.ADD);
-            hostOrchestrator.initServiceRun(gatewayConfigs, allNodes, reachableNodes, saltConfig, exitCriteriaModel, stack.getCloudPlatform());
-            if (CollectionUtils.isEmpty(candidateAddresses)) {
-                mountDisks.mountAllDisks(stack.getId());
-            } else {
-                mountDisks.mountDisksOnNewNodes(stack.getId(), new HashSet<>(candidateAddresses.values()), allNodes);
-            }
-            recipeEngine.executePreClusterManagerRecipes(stack, hostGroupService.getByClusterWithRecipes(cluster.getId()));
-            hostOrchestrator.runService(gatewayConfigs, reachableNodes, saltConfig, exitCriteriaModel);
-            modifyStartupMountRole(stack, reachableNodes, GrainOperation.REMOVE);
+            List<GrainProperties> grainsProperties = grainPropertiesService.createGrainProperties(gatewayConfigs, cluster, reachableNodes);
+            executeRunClusterServices(stack, cluster, candidateAddresses, allNodes, reachableNodes, gatewayConfigs, grainsProperties);
         } catch (CloudbreakOrchestratorCancelledException e) {
             throw new CancellationException(e.getMessage());
         } catch (CloudbreakOrchestratorException | IOException | CloudbreakException e) {
@@ -272,13 +267,82 @@ public class ClusterHostServiceRunner {
         }
     }
 
+    public void runTargetedClusterServices(@Nonnull Stack stack, @Nonnull Cluster cluster, Map<String, String> candidateAddresses) {
+        try {
+            Set<Node> reachableCandidates = getReachableCandidates(stack, candidateAddresses);
+            List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
+            List<GrainProperties> grainsProperties = grainPropertiesService
+                    .createGrainProperties(gatewayConfigs, cluster, reachableCandidates);
+            Set<String> reachableCandidateHostNames = org.apache.commons.collections4.CollectionUtils.emptyIfNull(reachableCandidates)
+                    .stream().map(Node::getHostname).collect(Collectors.toSet());
+            LOGGER.debug("We are about to execute cluster services (salt highstate, pre cluster manager recipe execution, mount disks, etc.) " +
+                    "for reachable candidates (targeted operation): {}", Joiner.on(",").join(reachableCandidateHostNames));
+            executeRunClusterServices(stack, cluster, candidateAddresses, reachableCandidates, reachableCandidates, gatewayConfigs, grainsProperties);
+        } catch (CloudbreakOrchestratorCancelledException e) {
+            throw new CancellationException(e.getMessage());
+        } catch (CloudbreakOrchestratorException | IOException | CloudbreakException e) {
+            throw new CloudbreakServiceException(e.getMessage(), e);
+        }
+    }
+
+    private void executeRunClusterServices(Stack stack, Cluster cluster, Map<String, String> candidateAddresses,
+            Set<Node> allNodes, Set<Node> reachableNodes, List<GatewayConfig> gatewayConfigs, List<GrainProperties> grainsProperties)
+            throws IOException, CloudbreakOrchestratorException, CloudbreakException {
+        SaltConfig saltConfig = createSaltConfig(stack, cluster, grainsProperties);
+        ExitCriteriaModel exitCriteriaModel = clusterDeletionBasedModel(stack.getId(), cluster.getId());
+        modifyStartupMountRole(stack, reachableNodes, GrainOperation.ADD);
+        hostOrchestrator.initServiceRun(gatewayConfigs, allNodes, reachableNodes, saltConfig, exitCriteriaModel, stack.getCloudPlatform());
+        mountDisks(stack, candidateAddresses, allNodes);
+        recipeEngine.executePreClusterManagerRecipes(stack, hostGroupService.getByClusterWithRecipes(cluster.getId()));
+        hostOrchestrator.runService(gatewayConfigs, reachableNodes, saltConfig, exitCriteriaModel);
+        modifyStartupMountRole(stack, reachableNodes, GrainOperation.REMOVE);
+    }
+
+    public Set<Node> getReachableCandidates(Stack stack, Map<String, String> candidateAddresses) {
+        InstanceMetaData primaryGwImd = stack.getPrimaryGatewayInstance();
+        try {
+            Set<Node> reachableNodes = stackUtil.collectAndCheckReachableNodes(stack, candidateAddresses.keySet());
+            Set<Node> reachableCandidates = reachableNodes.stream().filter(node ->
+                    candidateAddresses.containsKey(node.getHostname())).collect(Collectors.toSet());
+            addPrimaryGatewayToCandidatesIfNeeded(primaryGwImd, reachableCandidates);
+            return reachableCandidates;
+        } catch (NodesUnreachableException e) {
+            String errorMessage = "Can not run cluster services on new nodes because the configuration management service is not responding on these nodes: "
+                    + e.getUnreachableNodes();
+            LOGGER.error(errorMessage);
+            throw new CloudbreakServiceException(errorMessage, e);
+        }
+    }
+
+    private void addPrimaryGatewayToCandidatesIfNeeded(InstanceMetaData primaryGwImd, Set<Node> reachableCandidates) {
+        boolean candidatesMissingPrimaryGateway = reachableCandidates.stream().noneMatch(node ->
+                StringUtils.equals(node.getHostname(), primaryGwImd.getDiscoveryFQDN()));
+        if (candidatesMissingPrimaryGateway) {
+            Node primaryGatewayNode = new Node(primaryGwImd.getPrivateIp(), primaryGwImd.getPublicIp(), primaryGwImd.getInstanceId(),
+                    primaryGwImd.getInstanceGroup().getTemplate().getInstanceType(), primaryGwImd.getDiscoveryFQDN(),
+                    primaryGwImd.getInstanceGroupName());
+            // in case of upscale we should add primary gateway to candidates
+            reachableCandidates.add(primaryGatewayNode);
+            LOGGER.debug("{} gateway node has been added to targets of targeted operation, since we need that to update certain pillars and configurations.",
+                    primaryGatewayNode.getHostname());
+        }
+    }
+
+    private void mountDisks(Stack stack, Map<String, String> candidateAddresses, Set<Node> allNodes) throws CloudbreakException {
+        if (CollectionUtils.isEmpty(candidateAddresses)) {
+            mountDisks.mountAllDisks(stack.getId());
+        } else {
+            mountDisks.mountDisksOnNewNodes(stack.getId(), new HashSet<>(candidateAddresses.values()), allNodes);
+        }
+    }
+
     public void updateClusterConfigs(@Nonnull Stack stack, @Nonnull Cluster cluster) {
         try {
             Set<Node> allNodes = stackUtil.collectNodes(stack);
             Set<Node> reachableNodes = stackUtil.collectReachableNodesByInstanceStates(stack);
-            GatewayConfig primaryGatewayConfig = gatewayConfigService.getPrimaryGatewayConfig(stack);
             List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
-            SaltConfig saltConfig = createSaltConfig(stack, cluster, primaryGatewayConfig, gatewayConfigs, allNodes, reachableNodes);
+            List<GrainProperties> grainsProperties = grainPropertiesService.createGrainProperties(gatewayConfigs, cluster, reachableNodes);
+            SaltConfig saltConfig = createSaltConfig(stack, cluster, grainsProperties);
             ExitCriteriaModel exitCriteriaModel = clusterDeletionBasedModel(stack.getId(), cluster.getId());
             hostOrchestrator.initSaltConfig(gatewayConfigs, allNodes, saltConfig, exitCriteriaModel);
             hostOrchestrator.runService(gatewayConfigs, reachableNodes, saltConfig, exitCriteriaModel);
@@ -292,7 +356,12 @@ public class ClusterHostServiceRunner {
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
         Cluster cluster = stack.getCluster();
         candidates = collectUpscaleCandidates(cluster.getId(), hostGroupName, scalingAdjustment);
-        runClusterServices(stack, cluster, candidates);
+        if (!candidates.keySet().contains(stack.getPrimaryGatewayInstance().getDiscoveryFQDN())
+            && targetedUpscaleSupportService.targetedUpscaleOperationSupported(stack)) {
+            runTargetedClusterServices(stack, cluster, candidates);
+        } else {
+            runClusterServices(stack, cluster, candidates);
+        }
         return candidates;
     }
 
@@ -319,9 +388,9 @@ public class ClusterHostServiceRunner {
         try {
             Set<Node> allNodes = stackUtil.collectNodes(stack);
             Set<Node> reachableNodes = stackUtil.collectReachableNodes(stack);
-            GatewayConfig primaryGatewayConfig = gatewayConfigService.getPrimaryGatewayConfig(stack);
             List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
-            SaltConfig saltConfig = createSaltConfig(stack, cluster, primaryGatewayConfig, gatewayConfigs, allNodes, reachableNodes);
+            List<GrainProperties> grainsProperties = grainPropertiesService.createGrainProperties(gatewayConfigs, cluster, reachableNodes);
+            SaltConfig saltConfig = createSaltConfig(stack, cluster, grainsProperties);
             ExitCriteriaModel exitCriteriaModel = clusterDeletionBasedModel(stack.getId(), cluster.getId());
             hostOrchestrator.uploadGatewayPillar(gatewayConfigs, allNodes, exitCriteriaModel, saltConfig);
             hostOrchestrator.runService(gatewayConfigs, reachableNodes, saltConfig, exitCriteriaModel);
@@ -332,15 +401,16 @@ public class ClusterHostServiceRunner {
         }
     }
 
-    private SaltConfig createSaltConfig(Stack stack, Cluster cluster, GatewayConfig primaryGatewayConfig, Iterable<GatewayConfig> gatewayConfigs,
-            Set<Node> allNodes, Set<Node> reachableNodes) throws IOException, CloudbreakOrchestratorException {
+    private SaltConfig createSaltConfig(Stack stack, Cluster cluster, List<GrainProperties> grainsProperties)
+            throws IOException, CloudbreakOrchestratorException {
+        GatewayConfig primaryGatewayConfig = gatewayConfigService.getPrimaryGatewayConfig(stack);
         ClouderaManagerRepo clouderaManagerRepo = clusterComponentConfigProvider.getClouderaManagerRepoDetails(cluster.getId());
         Map<String, SaltPillarProperties> servicePillar = new HashMap<>();
         KerberosConfig kerberosConfig = kerberosConfigService.get(stack.getEnvironmentCrn(), stack.getName()).orElse(null);
         saveCustomNameservers(stack, kerberosConfig, servicePillar);
         servicePillar.putAll(createUnboundEliminationPillar(Crn.safeFromString(stack.getResourceCrn()).getAccountId()));
         addKerberosConfig(servicePillar, kerberosConfig);
-        servicePillar.putAll(hostAttributeDecorator.createHostAttributePillars(stack, allNodes));
+        servicePillar.putAll(hostAttributeDecorator.createHostAttributePillars(stack));
         servicePillar.put("discovery", new SaltPillarProperties("/discovery/init.sls", singletonMap("platform", stack.cloudPlatform())));
         String virtualGroupsEnvironmentCrn = environmentConfigProvider.getParentEnvironmentCrn(stack.getEnvironmentCrn());
         boolean deployedInChildEnvironment = !virtualGroupsEnvironmentCrn.equals(stack.getEnvironmentCrn());
@@ -382,7 +452,7 @@ public class ClusterHostServiceRunner {
 
         decoratePillarWithJdbcConnectors(cluster, servicePillar);
 
-        return new SaltConfig(servicePillar, grainPropertiesService.createGrainProperties(gatewayConfigs, cluster, reachableNodes));
+        return new SaltConfig(servicePillar, grainsProperties);
     }
 
     private String getMountPath(InstanceGroup group) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/HostAttributeDecorator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/HostAttributeDecorator.java
@@ -19,6 +19,7 @@ import com.sequenceiq.cloudbreak.orchestrator.model.Node;
 import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
 import com.sequenceiq.cloudbreak.template.model.ServiceAttributes;
 import com.sequenceiq.cloudbreak.template.processor.BlueprintTextProcessor;
+import com.sequenceiq.cloudbreak.util.StackUtil;
 
 @Component
 public class HostAttributeDecorator {
@@ -27,11 +28,15 @@ public class HostAttributeDecorator {
 
     private final CmTemplateProcessorFactory cmTemplateProcessorFactory;
 
-    public HostAttributeDecorator(CmTemplateProcessorFactory cmTemplateProcessorFactory) {
+    private final StackUtil stackUtil;
+
+    public HostAttributeDecorator(CmTemplateProcessorFactory cmTemplateProcessorFactory, StackUtil stackUtil) {
         this.cmTemplateProcessorFactory = cmTemplateProcessorFactory;
+        this.stackUtil = stackUtil;
     }
 
-    public Map<String, SaltPillarProperties> createHostAttributePillars(Stack stack, Set<Node> nodes) {
+    public Map<String, SaltPillarProperties> createHostAttributePillars(Stack stack) {
+        Set<Node> allNodes = stackUtil.collectNodes(stack);
         stack.getCluster().getBlueprint().getBlueprintText();
         BlueprintTextProcessor blueprintTextProcessor = cmTemplateProcessorFactory.get(stack.getCluster().getBlueprint().getBlueprintText());
         Versioned blueprintVersion = () -> blueprintTextProcessor.getVersion().get();
@@ -39,7 +44,7 @@ public class HostAttributeDecorator {
         Map<String, Map<String, ServiceAttributes>> serviceAttributes = blueprintTextProcessor.getHostGroupBasedServiceAttributes(blueprintVersion);
 
         Map<String, Map<String, Object>> attributes = new HashMap<>();
-        for (Node node : nodes) {
+        for (Node node : allNodes) {
             Map<String, Map<String, String>> hgAttributes = getAttributesForHostGroup(node.getHostGroup(), serviceAttributes);
             Map<String, Object> hostAttributes = new HashMap<>();
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpscaleService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpscaleService.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -16,9 +18,12 @@ import com.sequenceiq.cloudbreak.cluster.service.ClusterClientInitException;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterServiceRunner;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.ClusterHostServiceRunner;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.orchestrator.model.Node;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.service.stack.TargetedUpscaleSupportService;
 
 @Service
 public class ClusterManagerUpscaleService {
@@ -40,6 +45,9 @@ public class ClusterManagerUpscaleService {
     @Inject
     private ClusterApiConnectors clusterApiConnectors;
 
+    @Inject
+    private TargetedUpscaleSupportService targetedUpscaleSupportService;
+
     public void upscaleClusterManager(Long stackId, String hostGroupName, Integer scalingAdjustment, boolean primaryGatewayChanged)
             throws ClusterClientInitException {
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
@@ -59,6 +67,15 @@ public class ClusterManagerUpscaleService {
         clusterService.updateInstancesToRunning(stack.getCluster().getId(), hostsPerHostGroup);
 
         ClusterApi connector = clusterApiConnectors.getConnector(stack);
-        connector.waitForHosts(stackService.getByIdWithListsInTransaction(stackId).getRunningInstanceMetaDataSet());
+        if (!primaryGatewayChanged && targetedUpscaleSupportService.targetedUpscaleOperationSupported(stack)) {
+            Set<Node> reachableCandidates = hostRunner.getReachableCandidates(stack, hosts);
+            List<String> reachableCandidatesHostname = reachableCandidates.stream().map(Node::getHostname).collect(Collectors.toList());
+            Set<InstanceMetaData> reachableInstances = stack.getNotDeletedInstanceMetaDataSet().stream()
+                    .filter(md -> reachableCandidatesHostname.contains(md.getDiscoveryFQDN()))
+                    .collect(Collectors.toSet());
+            connector.waitForHosts(reachableInstances);
+        } else {
+            connector.waitForHosts(stackService.getByIdWithListsInTransaction(stackId).getRunningInstanceMetaDataSet());
+        }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/TargetedUpscaleCache.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/TargetedUpscaleCache.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.cloudbreak.service.stack;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cache.common.AbstractCacheDefinition;
+
+@Service
+public class TargetedUpscaleCache extends AbstractCacheDefinition {
+
+    private static final Long MAX_ENTRIES = 1000L;
+
+    @Value("${cb.upscale.targeted.cache.ttl}")
+    private long ttlMinutes;
+
+    @Override
+    protected String getName() {
+        return "targetedUpscaleCache";
+    }
+
+    @Override
+    protected long getMaxEntries() {
+        return MAX_ENTRIES;
+    }
+
+    @Override
+    protected long getTimeToLiveSeconds() {
+        return ttlMinutes == 0L ? TimeUnit.MINUTES.toSeconds(2) : TimeUnit.MINUTES.toSeconds(ttlMinutes);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/TargetedUpscaleSupportService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/TargetedUpscaleSupportService.java
@@ -1,0 +1,68 @@
+package com.sequenceiq.cloudbreak.service.stack;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.cloudbreak.orchestrator.model.Node;
+import com.sequenceiq.cloudbreak.service.GatewayConfigService;
+import com.sequenceiq.cloudbreak.util.StackUtil;
+
+@Service
+public class TargetedUpscaleSupportService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TargetedUpscaleSupportService.class);
+
+    @Inject
+    private GatewayConfigService gatewayConfigService;
+
+    @Inject
+    private EntitlementService entitlementService;
+
+    @Inject
+    private HostOrchestrator hostOrchestrator;
+
+    @Inject
+    private StackUtil stackUtil;
+
+    @Cacheable(cacheNames = "targetedUpscaleCache", key = "{ #stack.resourceCrn }")
+    public boolean targetedUpscaleOperationSupported(Stack stack) {
+        try {
+            return isUnboundEliminationSupported(stack) && isUnboundClusterConfigRemoved(stack);
+        } catch (Exception e) {
+            LOGGER.error("Error occurred during checking if targeted upscale supported, thus assuming it is not enabled, cause: ", e);
+            return false;
+        }
+    }
+
+    private boolean isUnboundClusterConfigRemoved(Stack stack) {
+        GatewayConfig primaryGatewayConfig = gatewayConfigService.getPrimaryGatewayConfig(stack);
+        Set<Node> reachableNodes = stackUtil.collectReachableNodes(stack);
+        Set<String> reachableHostnames = reachableNodes.stream().map(Node::getHostname).collect(Collectors.toSet());
+        boolean unboundClusterConfigPresentOnAnyNodes = hostOrchestrator.unboundClusterConfigPresentOnAnyNodes(primaryGatewayConfig, reachableHostnames);
+        LOGGER.info("Result of check whether unbound config is present on nodes of stack [{}] is: {}",
+                stack.getResourceCrn(), unboundClusterConfigPresentOnAnyNodes);
+        return !unboundClusterConfigPresentOnAnyNodes;
+    }
+
+    private boolean isUnboundEliminationSupported(Stack stack) {
+        String accountId = Crn.safeFromString(stack.getResourceCrn()).getAccountId();
+        if (entitlementService.isUnboundEliminationSupported(accountId)) {
+            LOGGER.info("Unbound elimination is disabled for account {}, thus targeted upscale is not supported!", accountId);
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/util/StackUtil.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/util/StackUtil.java
@@ -113,8 +113,8 @@ public class StackUtil {
         if (unReachableCandidateNodes.isEmpty()) {
             return reachableNodes;
         } else {
-            LOGGER.error("Some nodes are unreachable: {}", unReachableCandidateNodes);
-            throw new NodesUnreachableException("Some nodes are unreachable", unReachableCandidateNodes);
+            LOGGER.error("Some of necessary nodes are unreachable: {}", unReachableCandidateNodes);
+            throw new NodesUnreachableException("Some of necessary nodes are unreachable", unReachableCandidateNodes);
         }
     }
 

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -740,6 +740,7 @@ cb:
         interrupt.timeout.seconds: 120
 
   workspace.service.cache.ttl: 15
+  upscale.targeted.cache.ttl: 5
 
   structuredevent:
     rest:

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunnerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunnerTest.java
@@ -1,7 +1,9 @@
 package com.sequenceiq.cloudbreak.core.bootstrap.service.host;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -13,19 +15,23 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import com.google.common.collect.Sets;
 import com.sequenceiq.cloudbreak.api.service.ExposedService;
 import com.sequenceiq.cloudbreak.api.service.ExposedServiceCollector;
 import com.sequenceiq.cloudbreak.auth.CMLicenseParser;
@@ -49,9 +55,12 @@ import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.kerberos.KerberosConfigService;
 import com.sequenceiq.cloudbreak.ldap.LdapConfigService;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.cloudbreak.orchestrator.model.Node;
+import com.sequenceiq.cloudbreak.orchestrator.model.SaltConfig;
 import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
 import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
 import com.sequenceiq.cloudbreak.service.DefaultClouderaManagerRepoService;
@@ -290,7 +299,35 @@ public class ClusterHostServiceRunnerTest {
     }
 
     @Test
-    public void testDecoratePillarWithMountInfo() {
+    public void testDecoratePillarWithMountInfoAndTargetedSaltCall() throws CloudbreakOrchestratorException, NodesUnreachableException {
+        setupMocksForRunClusterServices();
+        underTest.runTargetedClusterServices(stack, cluster, Map.of("fqdn3", "1.1.1.1"));
+
+        ArgumentCaptor<Set<Node>> reachableCandidates = ArgumentCaptor.forClass(Set.class);
+        ArgumentCaptor<SaltConfig> saltConfig = ArgumentCaptor.forClass(SaltConfig.class);
+        verify(hostOrchestrator).runService(any(), reachableCandidates.capture(), saltConfig.capture(), any());
+        assertTrue(reachableCandidates.getValue().stream().anyMatch(node -> StringUtils.equals("gateway1", node.getHostname())));
+        assertTrue(reachableCandidates.getValue().stream().anyMatch(node -> StringUtils.equals("fqdn3", node.getHostname())));
+        assertFalse(reachableCandidates.getValue().stream().anyMatch(node -> StringUtils.equals("fqdn1", node.getHostname())));
+        assertFalse(reachableCandidates.getValue().stream().anyMatch(node -> StringUtils.equals("fqdn2", node.getHostname())));
+        assertTrue(saltConfig.getValue().getServicePillarConfig().keySet().stream().allMatch(Objects::nonNull));
+    }
+
+    @Test
+    public void testDecoratePillarWithMountInfo() throws CloudbreakOrchestratorException, NodesUnreachableException {
+        setupMocksForRunClusterServices();
+        underTest.runClusterServices(stack, cluster, Map.of());
+
+        ArgumentCaptor<Set<Node>> reachableCandidates = ArgumentCaptor.forClass(Set.class);
+        ArgumentCaptor<SaltConfig> saltConfig = ArgumentCaptor.forClass(SaltConfig.class);
+        verify(hostOrchestrator).runService(any(), reachableCandidates.capture(), saltConfig.capture(), any());
+        assertTrue(reachableCandidates.getValue().stream().anyMatch(node -> StringUtils.equals("gateway1", node.getHostname())));
+        assertTrue(reachableCandidates.getValue().stream().anyMatch(node -> StringUtils.equals("fqdn1", node.getHostname())));
+        assertTrue(reachableCandidates.getValue().stream().anyMatch(node -> StringUtils.equals("fqdn2", node.getHostname())));
+        assertTrue(saltConfig.getValue().getServicePillarConfig().keySet().stream().allMatch(Objects::nonNull));
+    }
+
+    private void setupMocksForRunClusterServices() throws NodesUnreachableException {
         when(stack.getCluster()).thenReturn(cluster);
         when(stack.getTunnel()).thenReturn(Tunnel.DIRECT);
         when(stack.getCloudPlatform()).thenReturn(CloudPlatform.AWS.name());
@@ -313,36 +350,44 @@ public class ClusterHostServiceRunnerTest {
         when(cmExposedService.getServiceName()).thenReturn("CM");
         when(exposedServiceCollector.getClouderaManagerService()).thenReturn(cmExposedService);
 
-        Set<InstanceGroup> instanceGroups = new HashSet<>();
-        InstanceGroup workerInstanceGroup = new InstanceGroup();
         Template template = new Template();
         template.setTemporaryStorage(TemporaryStorage.EPHEMERAL_VOLUMES);
-        workerInstanceGroup.setTemplate(template);
 
-        Set<InstanceMetaData> workerInstanceMetaDatas = new HashSet<>();
-        InstanceMetaData worker1 = new InstanceMetaData();
-        worker1.setDiscoveryFQDN("fqdn1");
-        workerInstanceMetaDatas.add(worker1);
-        InstanceMetaData worker2 = new InstanceMetaData();
-        worker2.setDiscoveryFQDN(null);
-        workerInstanceMetaDatas.add(worker2);
-        workerInstanceGroup.setInstanceMetaData(workerInstanceMetaDatas);
-        instanceGroups.add(workerInstanceGroup);
+        Set<InstanceGroup> instanceGroups = new HashSet<>();
+        createInstanceGroup(template, instanceGroups, "fqdn1", null, "1.1.1.1", "1.1.1.2");
+        createInstanceGroup(template, instanceGroups, "fqdn2", null, "1.1.2.1", "1.1.2.2");
+        InstanceGroup gwIg = createInstanceGroup(template, instanceGroups, "gateway1", "gateway2", "1.1.3.1", "1.1.3.2");
 
-        InstanceGroup computeInstanceGroup = new InstanceGroup();
-        computeInstanceGroup.setTemplate(template);
-
-        Set<InstanceMetaData> computeInstanceMetaDatas = new HashSet<>();
-        InstanceMetaData compute1 = new InstanceMetaData();
-        compute1.setDiscoveryFQDN("fqdn2");
-        computeInstanceMetaDatas.add(compute1);
-        InstanceMetaData compute2 = new InstanceMetaData();
-        compute2.setDiscoveryFQDN(null);
-        computeInstanceMetaDatas.add(compute2);
-        computeInstanceGroup.setInstanceMetaData(computeInstanceMetaDatas);
-        instanceGroups.add(computeInstanceGroup);
+        when(stack.getPrimaryGatewayInstance()).thenReturn(
+                gwIg.getInstanceMetaDataSet().stream().filter(imd -> StringUtils.equals(imd.getDiscoveryFQDN(), "gateway1")).findFirst().get());
+        when(stackUtil.collectAndCheckReachableNodes(any(), any())).thenReturn(Sets.newHashSet(node("fqdn1"), node("fqdn2"), node("fqdn3"),
+                node("gateway1"), node("gateway3")));
 
         when(stack.getInstanceGroups()).thenReturn(instanceGroups);
-        underTest.runClusterServices(stack, cluster, Map.of());
+    }
+
+    private InstanceGroup createInstanceGroup(Template template, Set<InstanceGroup> instanceGroups, String fqdn1, String fqdn2,
+            String privateIp1, String privateIp2) {
+        InstanceGroup instanceGroup = new InstanceGroup();
+        instanceGroup.setTemplate(template);
+        instanceGroup.setGroupName("group");
+        Set<InstanceMetaData> instanceMetaDataSet = new HashSet<>();
+        instanceMetaDataSet.add(createInstanceMetadata(fqdn1, instanceGroup, privateIp1));
+        instanceMetaDataSet.add(createInstanceMetadata(fqdn2, instanceGroup, privateIp2));
+        instanceGroup.setInstanceMetaData(instanceMetaDataSet);
+        instanceGroups.add(instanceGroup);
+        return instanceGroup;
+    }
+
+    private InstanceMetaData createInstanceMetadata(String fqdn, InstanceGroup instanceGroup, String privateIp) {
+        InstanceMetaData imd1 = new InstanceMetaData();
+        imd1.setDiscoveryFQDN(fqdn);
+        imd1.setInstanceGroup(instanceGroup);
+        imd1.setPrivateIp(privateIp);
+        return imd1;
+    }
+
+    private Node node(String fqdn) {
+        return new Node(null, null, null, null, fqdn, null);
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpscaleServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpscaleServiceTest.java
@@ -1,0 +1,103 @@
+package com.sequenceiq.cloudbreak.core.cluster;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
+import com.sequenceiq.cloudbreak.cluster.service.ClusterClientInitException;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterServiceRunner;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.host.ClusterHostServiceRunner;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.service.stack.TargetedUpscaleSupportService;
+
+@ExtendWith(MockitoExtension.class)
+public class ClusterManagerUpscaleServiceTest {
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private ClusterHostServiceRunner clusterHostServiceRunner;
+
+    @Mock
+    private ClusterServiceRunner clusterServiceRunner;
+
+    @Mock
+    private ClusterService clusterService;
+
+    @Mock
+    private ClusterApiConnectors clusterApiConnectors;
+
+    @Mock
+    private ClusterApi clusterApi;
+
+    @Mock
+    private TargetedUpscaleSupportService targetedUpscaleSupportService;
+
+    @InjectMocks
+    private ClusterManagerUpscaleService underTest;
+
+    @Test
+    public void testUpscaleIfTargetedUpscaleNotSupportedOrPrimaryGatewayChanged() throws ClusterClientInitException {
+        when(stackService.getByIdWithListsInTransaction(any())).thenReturn(getStack());
+        when(clusterHostServiceRunner.addClusterServices(any(), any(), any())).thenReturn(Map.of());
+        doNothing().when(clusterServiceRunner).updateAmbariClientConfig(any(), any());
+        doNothing().when(clusterService).updateInstancesToRunning(any(), any());
+        when(clusterApiConnectors.getConnector(any(Stack.class))).thenReturn(clusterApi);
+
+        underTest.upscaleClusterManager(1L, "hg", 1, true);
+
+        verifyNoInteractions(targetedUpscaleSupportService);
+
+        when(targetedUpscaleSupportService.targetedUpscaleOperationSupported(any())).thenReturn(Boolean.FALSE);
+
+        underTest.upscaleClusterManager(1L, "hg", 1, false);
+
+        verifyNoMoreInteractions(clusterServiceRunner);
+        verify(clusterHostServiceRunner, times(0)).getReachableCandidates(any(), any());
+        verify(clusterApi, times(2)).waitForHosts(any());
+    }
+
+    @Test
+    public void testUpscaleIfTargetedUpscaleSupported() throws ClusterClientInitException {
+        when(stackService.getByIdWithListsInTransaction(any())).thenReturn(getStack());
+        when(clusterHostServiceRunner.addClusterServices(any(), any(), any())).thenReturn(Map.of());
+        doNothing().when(clusterService).updateInstancesToRunning(any(), any());
+        when(clusterApiConnectors.getConnector(any(Stack.class))).thenReturn(clusterApi);
+        when(targetedUpscaleSupportService.targetedUpscaleOperationSupported(any())).thenReturn(Boolean.TRUE);
+        when(clusterHostServiceRunner.getReachableCandidates(any(), any())).thenReturn(Set.of());
+
+        underTest.upscaleClusterManager(1L, "hg", 1, false);
+
+        verifyNoInteractions(clusterServiceRunner);
+        verify(clusterApi).waitForHosts(any());
+    }
+
+    private Stack getStack() {
+        Stack stack = new Stack();
+        Cluster cluster = new Cluster();
+        cluster.setId(1L);
+        stack.setCluster(cluster);
+        return stack;
+
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/TargetedUpscaleSupportServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/TargetedUpscaleSupportServiceTest.java
@@ -1,0 +1,80 @@
+package com.sequenceiq.cloudbreak.service.stack;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import javax.ws.rs.InternalServerErrorException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.cloudbreak.service.GatewayConfigService;
+import com.sequenceiq.cloudbreak.util.StackUtil;
+
+@ExtendWith(MockitoExtension.class)
+public class TargetedUpscaleSupportServiceTest {
+
+    private static final String DATAHUB_CRN = "crn:cdp:datahub:eu-1:1234:user:91011";
+
+    @Mock
+    private EntitlementService entitlementService;
+
+    @Mock
+    private GatewayConfigService gatewayConfigService;
+
+    @Mock
+    private HostOrchestrator hostOrchestrator;
+
+    @Mock
+    private StackUtil stackUtil;
+
+    @InjectMocks
+    private TargetedUpscaleSupportService underTest;
+
+    @Test
+    public void testIfEntitlementDisabled() {
+        when(entitlementService.isUnboundEliminationSupported(any())).thenReturn(Boolean.FALSE);
+        assertFalse(underTest.targetedUpscaleOperationSupported(getStack()));
+    }
+
+    @Test
+    public void testIfUnboundConfigPresent() {
+        when(entitlementService.isUnboundEliminationSupported(any())).thenReturn(Boolean.TRUE);
+        when(gatewayConfigService.getPrimaryGatewayConfig(any())).thenReturn(new GatewayConfig(null, null, null, null, null, null));
+        when(stackUtil.collectReachableNodes(any())).thenReturn(Set.of());
+        when(hostOrchestrator.unboundClusterConfigPresentOnAnyNodes(any(), any())).thenReturn(Boolean.TRUE);
+        assertFalse(underTest.targetedUpscaleOperationSupported(getStack()));
+    }
+
+    @Test
+    public void testIfUnboundConfigNotPresent() {
+        when(entitlementService.isUnboundEliminationSupported(any())).thenReturn(Boolean.TRUE);
+        when(gatewayConfigService.getPrimaryGatewayConfig(any())).thenReturn(new GatewayConfig(null, null, null, null, null, null));
+        when(stackUtil.collectReachableNodes(any())).thenReturn(Set.of());
+        when(hostOrchestrator.unboundClusterConfigPresentOnAnyNodes(any(), any())).thenReturn(Boolean.FALSE);
+        assertTrue(underTest.targetedUpscaleOperationSupported(getStack()));
+    }
+
+    @Test
+    public void testIfThereIsAnyError() {
+        when(entitlementService.isUnboundEliminationSupported(any())).thenThrow(new InternalServerErrorException("error"));
+        assertFalse(underTest.targetedUpscaleOperationSupported(getStack()));
+    }
+
+    private Stack getStack() {
+        Stack stack = new Stack();
+        stack.setResourceCrn(DATAHUB_CRN);
+        return stack;
+    }
+}

--- a/mock-infrastructure/src/main/java/com/sequenceiq/mock/salt/response/FileExistsSaltResponse.java
+++ b/mock-infrastructure/src/main/java/com/sequenceiq/mock/salt/response/FileExistsSaltResponse.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.mock.salt.response;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.google.common.collect.Maps;
+import com.sequenceiq.cloudbreak.orchestrator.salt.domain.PingResponse;
+import com.sequenceiq.mock.salt.SaltResponse;
+
+@Component
+public class FileExistsSaltResponse implements SaltResponse {
+
+    @Override
+    public Object run(String mockUuid, Map<String, List<String>> params) throws Exception {
+        List<String> targets = params.get("tgt");
+        PingResponse pingResponse = new PingResponse();
+        List<Map<String, Boolean>> result = new ArrayList<>();
+        Map<String, Boolean> hostMap = Maps.newHashMap();
+        targets.stream().forEach(target -> hostMap.put(target, false));
+        result.add(hostMap);
+        pingResponse.setResult(result);
+        return pingResponse;
+    }
+
+    @Override
+    public String cmd() {
+        return "file.file_exists";
+    }
+}

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
@@ -123,4 +123,6 @@ public interface HostOrchestrator extends HostRecipeExecutor {
     Map<String, String> getFreeDiskSpaceByNodes(Set<Node> nodes, List<GatewayConfig> gatewayConfigs);
 
     void removeDeadSaltMinions(GatewayConfig gatewayConfig) throws CloudbreakOrchestratorFailedException;
+
+    boolean unboundClusterConfigPresentOnAnyNodes(GatewayConfig primaryGateway, Set<String> nodes);
 }

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
@@ -1174,6 +1174,12 @@ public class SaltOrchestrator implements HostOrchestrator {
         }
     }
 
+    @Override
+    public boolean unboundClusterConfigPresentOnAnyNodes(GatewayConfig primaryGateway, Set<String> nodes) {
+        SaltConnector saltConnector = saltService.createSaltConnector(primaryGateway);
+        return SaltStates.unboundClusterConfigPresentOnAnyNodes(saltConnector, new HostList(nodes));
+    }
+
     private StateRunner createStateRunner(OrchestratorStateParams stateParams) {
         if (stateParams.isParameterized()) {
             if (stateParams.isConcurrent()) {

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStates.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStates.java
@@ -407,4 +407,10 @@ public class SaltStates {
         }
         return versionCommandOutput;
     }
+
+    public static boolean unboundClusterConfigPresentOnAnyNodes(SaltConnector sc, Target<String> target) {
+        return measure(() -> sc.run(target, "file.file_exists", LOCAL, PingResponse.class, "/etc/unbound/conf.d/00-cluster.conf"), LOGGER,
+                "Getting information about existence of unbound config took {}ms").getResult().stream()
+                .anyMatch(map -> map.values().stream().anyMatch(Boolean::booleanValue));
+    }
 }


### PR DESCRIPTION
CB-14421 Implement targeted salt highstate during Upscale operation

- during upscale we will execute highstate against only new nodes and gateway nodes (since several files should be updated on gateway nodes)
- host status checking should be done against only affected nodes
- node health validation is checking only nodes of affected hostgroup
- several logics have been separated in order to do targeted operations if operation is upscale
- targeted highstate operation depends on unbound elimination thus we are checking if unbound elimination is enabled and related conf is removed from all reachable nodes of the cluster

Tested locally:
- DH worker group upscale (before that, a compute node were killed on provider side)
- light duty DL master repair
- medium duty DL gateway repair