### PR TITLE
Cb 15528 - E2E test for upgrade with custom catalog on Data Hub cluster

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CommonClusterManagerProperties.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CommonClusterManagerProperties.java
@@ -48,8 +48,7 @@ public class CommonClusterManagerProperties {
     }
 
     public String getInternalSdxBlueprintName() {
-        return String.format(internalSdxBlueprintName, runtimeVersion);
-    }
+        return String.format(internalSdxBlueprintName, runtimeVersion); }
 
     public void setInternalSdxBlueprintName(String internalSdxBlueprintName) {
         this.internalSdxBlueprintName = internalSdxBlueprintName;
@@ -119,6 +118,12 @@ public class CommonClusterManagerProperties {
 
         private String distroXUpgradeTargetVersion;
 
+        private String imageCatalogUrl3rdParty;
+
+        private String distroXUpgrade3rdPartyCurrentVersion;
+
+        private String distroXUpgrade3rdPartyTargetVersion;
+
         public String getCurrentHARuntimeVersion() {
             return currentHARuntimeVersion;
         }
@@ -157,6 +162,30 @@ public class CommonClusterManagerProperties {
 
         public void setDistroXUpgradeTargetVersion(String distroXUpgradeTargetVersion) {
             this.distroXUpgradeTargetVersion = distroXUpgradeTargetVersion;
+        }
+
+        public String getImageCatalogUrl3rdParty() {
+            return imageCatalogUrl3rdParty;
+        }
+
+        public void setImageCatalogUrl3rdParty(String imageCatalogUrl3rdParty) {
+            this.imageCatalogUrl3rdParty = imageCatalogUrl3rdParty;
+        }
+
+        public String getDistroXUpgrade3rdPartyCurrentVersion() {
+            return distroXUpgrade3rdPartyCurrentVersion;
+        }
+
+        public void setDistroXUpgrade3rdPartyCurrentVersion(String distroXUpgrade3rdPartyCurrentVersion) {
+            this.distroXUpgrade3rdPartyCurrentVersion = distroXUpgrade3rdPartyCurrentVersion;
+        }
+
+        public String getDistroXUpgrade3rdPartyTargetVersion() {
+            return distroXUpgrade3rdPartyTargetVersion;
+        }
+
+        public void setDistroXUpgrade3rdPartyTargetVersion(String distroXUpgrade3rdPartyTargetVersion) {
+            this.distroXUpgrade3rdPartyTargetVersion = distroXUpgrade3rdPartyTargetVersion;
         }
 
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXUpgradeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXUpgradeTests.java
@@ -4,22 +4,28 @@ import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
 
 import javax.inject.Inject;
 
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
 import org.testng.annotations.Test;
 
 import com.sequenceiq.it.cloudbreak.assertion.distrox.AwsAvailabilityZoneAssertion;
 import com.sequenceiq.it.cloudbreak.client.DistroXTestClient;
+import com.sequenceiq.it.cloudbreak.client.ImageCatalogTestClient;
 import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
 import com.sequenceiq.it.cloudbreak.cloud.v4.CommonClusterManagerProperties;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
 import com.sequenceiq.it.cloudbreak.dto.distrox.cluster.DistroXUpgradeTestDto;
+import com.sequenceiq.it.cloudbreak.dto.distrox.image.DistroXImageTestDto;
+import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxUpgradeTestDto;
 import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
 import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
 import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 import com.sequenceiq.sdx.api.model.SdxUpgradeReplaceVms;
+
+import java.util.concurrent.atomic.AtomicReference;
 
 public class DistroXUpgradeTests extends AbstractE2ETest {
 
@@ -28,6 +34,9 @@ public class DistroXUpgradeTests extends AbstractE2ETest {
 
     @Inject
     private DistroXTestClient distroXTestClient;
+
+    @Inject
+    private ImageCatalogTestClient imageCatalogTest;
 
     @Inject
     private CommonClusterManagerProperties commonClusterManagerProperties;
@@ -40,20 +49,38 @@ public class DistroXUpgradeTests extends AbstractE2ETest {
         createEnvironmentWithFreeIpa(testContext);
     }
 
+    protected String getUuid(TestContext testContext, String prodCatalogName, String currentRuntimeVersion3rdParty) {
+        testContext
+                .given(ImageCatalogTestDto.class).withName(prodCatalogName)
+                .when(imageCatalogTest.getV4(true));
+        ImageCatalogTestDto dto = testContext.get(ImageCatalogTestDto.class);
+        return dto.getResponse().getImages().getCdhImages().stream()
+                .filter(img -> img.getVersion().equals(currentRuntimeVersion3rdParty) && img.getImageSetsByProvider().keySet().stream().iterator().next()
+                        .equals(testContext.commonCloudProperties().getCloudProvider().toLowerCase())).iterator().next().getUuid();
+    }
+
     @Test(dataProvider = TEST_CONTEXT)
     @UseSpotInstances
-    @Description(given = "there is a running Cloudbreak, and an environment with SDX and DistroX cluster in available state",
-            when = "upgrade called on the DistroX cluster", then = "DistroX upgrade should be successful, the cluster should be up and running")
-    public void testDistroXUpgrade(TestContext testContext) {
-
-        String sdxName = resourcePropertyProvider().getName();
-        String distroXName = resourcePropertyProvider().getName();
+    @Description(
+            given = "there is a running Cloudbreak, and an environment with SDX and two DistroX clusters in " +
+            "available state, one cluster created with deafult catalog and one cluster created with production catalog",
+            when = "upgrade called on both DistroX clusters",
+            then = "Both DistroX upgrade should be successful," + " the clusters should be up and running")
+    public void testDistroXUpgrades(TestContext testContext) {
+        String imageSettings = resourcePropertyProvider().getName();
         String currentRuntimeVersion = commonClusterManagerProperties.getUpgrade().getDistroXUpgradeCurrentVersion();
         String targetRuntimeVersion = commonClusterManagerProperties.getUpgrade().getDistroXUpgradeTargetVersion();
+        String currentRuntimeVersion3rdParty = commonClusterManagerProperties.getUpgrade().getDistroXUpgrade3rdPartyCurrentVersion();
+        String targetRuntimeVersion3rdParty = commonClusterManagerProperties.getUpgrade().getDistroXUpgrade3rdPartyTargetVersion();
+        String sdxName = resourcePropertyProvider().getName();
+        String distroXName = resourcePropertyProvider().getName();
+        String distroX3rdPartyName = resourcePropertyProvider().getName();
+        String thirdPartyCatalogName = resourcePropertyProvider().getName();
+        AtomicReference<String> uuid = new AtomicReference<>();
         testContext
                 .given(sdxName, SdxTestDto.class)
-                .withCloudStorage()
                 .withRuntimeVersion(currentRuntimeVersion)
+                .withCloudStorage(getCloudStorageRequest(testContext))
                 .when(sdxTestClient.create(), key(sdxName))
                 .await(SdxClusterStatusResponse.RUNNING, key(sdxName))
                 .awaitForHealthyInstances()
@@ -63,14 +90,34 @@ public class DistroXUpgradeTests extends AbstractE2ETest {
                 .withTemplate(String.format(commonClusterManagerProperties.getInternalDistroXBlueprintType(), currentRuntimeVersion))
                 .withPreferredSubnetsForInstanceNetworkIfMultiAzEnabledOrJustFirst()
                 .when(distroXTestClient.create(), key(distroXName))
-                .await(STACK_AVAILABLE)
+                .validate();
+        createImageValidationSourceCatalog(testContext, commonClusterManagerProperties.getUpgrade()
+                .getImageCatalogUrl3rdParty(), thirdPartyCatalogName);
+        uuid.set(getUuid(testContext, thirdPartyCatalogName, currentRuntimeVersion3rdParty));
+        testContext
+                .given(imageSettings, DistroXImageTestDto.class).withImageCatalog(thirdPartyCatalogName)
+                .withImageId(uuid.get())
+                .given(distroX3rdPartyName, DistroXTestDto.class)
+                .withTemplate(String.format(commonClusterManagerProperties.getInternalDistroXBlueprintType(), currentRuntimeVersion3rdParty))
+                .withPreferredSubnetsForInstanceNetworkIfMultiAzEnabledOrJustFirst()
+                .withImageSettings(imageSettings)
+                .when(distroXTestClient.create(), key(distroX3rdPartyName))
+                .await(STACK_AVAILABLE, key(distroX3rdPartyName))
+                .awaitForHealthyInstances()
+                .then((tc, testDto, client) -> checkImageId(testDto, uuid.get()))
+                .given(distroXName, DistroXTestDto.class)
+                .await(STACK_AVAILABLE, key(distroXName))
                 .awaitForHealthyInstances()
                 .then(new AwsAvailabilityZoneAssertion())
                 .validate();
         testContext
                 .given(distroXName, DistroXTestDto.class)
                 .when(distroXTestClient.stop(), key(distroXName))
-                .await(STACK_STOPPED)
+                .given(distroX3rdPartyName, DistroXTestDto.class)
+                .when(distroXTestClient.stop(), key(distroX3rdPartyName))
+                .await(STACK_STOPPED, key(distroX3rdPartyName))
+                .given(distroXName, DistroXTestDto.class)
+                .await(STACK_STOPPED, key(distroXName))
                 .validate();
         testContext
                 .given(SdxUpgradeTestDto.class)
@@ -85,16 +132,38 @@ public class DistroXUpgradeTests extends AbstractE2ETest {
         testContext
                 .given(distroXName, DistroXTestDto.class)
                 .when(distroXTestClient.start(), key(distroXName))
-                .await(STACK_AVAILABLE)
+                .given(distroX3rdPartyName, DistroXTestDto.class)
+                .when(distroXTestClient.start(), key(distroX3rdPartyName))
+                .await(STACK_AVAILABLE, key(distroX3rdPartyName))
+                .awaitForHealthyInstances()
+                .given(distroXName, DistroXTestDto.class)
+                .await(STACK_AVAILABLE, key(distroXName))
+                .awaitForHealthyInstances()
                 .validate();
         testContext
                 .given(DistroXUpgradeTestDto.class)
                 .withRuntime(targetRuntimeVersion)
                 .given(distroXName, DistroXTestDto.class)
                 .when(distroXTestClient.upgrade(), key(distroXName))
+                .given(DistroXUpgradeTestDto.class)
+                .withRuntime(targetRuntimeVersion3rdParty)
+                .given(distroX3rdPartyName, DistroXTestDto.class)
+                .when(distroXTestClient.upgrade(), key(distroX3rdPartyName))
+                .await(STACK_AVAILABLE, key(distroX3rdPartyName))
+                .awaitForHealthyInstances()
+                .given(distroXName, DistroXTestDto.class)
                 .await(STACK_AVAILABLE, key(distroXName))
                 .awaitForHealthyInstances()
                 .then(new AwsAvailabilityZoneAssertion())
                 .validate();
+    }
+
+    private DistroXTestDto checkImageId(DistroXTestDto testDto, String expectedImageId) {
+        String currentImageId = testDto.getResponse().getImage().getId();
+        if (!currentImageId.equals(expectedImageId)) {
+            throw new TestFailException("The selected image ID is: " + currentImageId + " instead of: "
+                    + expectedImageId);
+        }
+        return testDto;
     }
 }

--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -88,6 +88,9 @@ integrationtest:
     targetRuntimeVersion: 7.2.14
     distroXUpgradeCurrentVersion: 7.2.7
     distroXUpgradeTargetVersion: 7.2.14
+    distroXUpgrade3rdPartyCurrentVersion: 7.2.7
+    distroXUpgrade3rdPartyTargetVersion: 7.2.12
+    imageCatalogUrl3rdParty: https://cloudbreak-imagecatalog.s3.amazonaws.com/v3-prod-cb-image-catalog.json
   privateEndpointEnabled: false
 
   spot:


### PR DESCRIPTION
See detailed description in the commit message.Today we have a single DistroX upgrade test for CDP upgrade http://ci-cloudbreak.eng.hortonworks.com/job/api-longrunning-e2e-aws/1389/testngreports/com.sequenceiq.it.cloudbreak.testcase.e2e.distrox/DistroXUpgradeTests/testDistroXUpgrade/ . We need to extend our testing to 3rd party image catalogs as well.

We should use the prod catalog for this purpose to avoid maintaining a new catalog. Prod catalog can be found here: https://cloudbreak-imagecatalog.s3.amazonaws.com/v3-prod-cb-image-catalog.json. Let's use this in the test with a random name and initiate an upgrade from any to any version using this catalog.
Jira link:
[https://jira.cloudera.com/browse/CB-15528](url)