### PR TITLE
CB-15638 Disable flaky AzureEnvironmentWithCustomerManagedKeyTests

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/AzureEnvironmentWithCustomerManagedKeyTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/AzureEnvironmentWithCustomerManagedKeyTests.java
@@ -77,7 +77,7 @@ public class AzureEnvironmentWithCustomerManagedKeyTests extends AbstractE2ETest
     }
 
     @Test(dataProvider = TEST_CONTEXT, groups = { "withrg" }, description = "Creating a resource group for this test case. " +
-            "Disk encryption set(DES) is created in this newly created RG, as cloud-daily RG has locks which prevents cleanup of DES.")
+            "Disk encryption set(DES) is created in this newly created RG, as cloud-daily RG has locks which prevents cleanup of DES.", enabled = false)
     @UseSpotInstances
     @Description(
             given = "there is a running cloudbreak",
@@ -126,7 +126,7 @@ public class AzureEnvironmentWithCustomerManagedKeyTests extends AbstractE2ETest
     }
 
     @Test(dataProvider = TEST_CONTEXT, groups = { "norg" }, description = "Environment's Resource Group is not specified, in this case all the" +
-            " resources create their own resource groups.")
+            " resources create their own resource groups.", enabled = false)
     @UseSpotInstances
     @Description(
             given = "there is a running cloudbreak",

--- a/integration-test/src/main/resources/testsuites/e2e/azure-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/azure-e2e-tests.yaml
@@ -15,4 +15,3 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.imagevalidation.PrewarmImageValidatorE2ETest
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxImagesTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.AzureMarketplaceImageTest
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.AzureEnvironmentWithCustomerManagedKeyTests


### PR DESCRIPTION
`AzureEnvironmentWithCustomerManagedKeyTests` has two test cases, `testWithEnvironmentResourceGroup` and `testWithEncryptionKeyResourceGroup`. There are hardly any green runs of this class, one of the methods fails most of the time. Disabling both test cases & removing the test class from `azure-e2e-tests.yaml` until they can be sufficiently stabilized.