### PR TITLE
CB-15311 Additional measurements when creating new flow

### DIFF
--- a/flow/src/main/java/com/sequenceiq/flow/core/Flow2Handler.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/Flow2Handler.java
@@ -35,6 +35,7 @@ import com.sequenceiq.cloudbreak.common.service.TransactionService.TransactionEx
 import com.sequenceiq.cloudbreak.common.service.TransactionService.TransactionRuntimeExecutionException;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.cloudbreak.service.flowlog.FlowLogUtil;
+import com.sequenceiq.cloudbreak.util.Benchmark;
 import com.sequenceiq.cloudbreak.util.NullUtil;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.flow.api.model.FlowType;
@@ -309,8 +310,8 @@ public class Flow2Handler implements Consumer<Event<? extends Payload>> {
         try {
             flow.initialize(contextParams);
             runningFlows.put(flow, flowChainId);
-            flowStatCache.put(flowId, flowChainId, payload.getResourceId(),
-                    flowConfig.getFlowOperationType().name(), flow.getFlowConfigClass(), false);
+            Benchmark.measure(() -> flowStatCache.put(flowId, flowChainId, payload.getResourceId(),
+                    flowConfig.getFlowOperationType().name(), flow.getFlowConfigClass(), false), LOGGER, "Creating flow stat took {}ms");
             transactionService.required(() -> {
                 flowLogService.save(flowParameters, flowChainId, key, payload, null, flowConfig.getClass(), flow.getCurrentState());
                 if (flowChainId != null) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/FreeIpaFlowInformation.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/FreeIpaFlowInformation.java
@@ -50,6 +50,8 @@ public class FreeIpaFlowInformation implements ApplicationFlowInformation {
             StackTerminationEvent.TERMINATION_EVENT.event(),
             CreateBindUserFlowEvent.CREATE_BIND_USER_EVENT.event());
 
+    private static final List<Class<? extends FlowConfiguration<?>>> TERMINATION_FLOWS = List.of(StackTerminationFlowConfig.class);
+
     @Override
     public List<Class<? extends FlowConfiguration<?>>> getRestartableFlows() {
         return RESTARTABLE_FLOWS;
@@ -62,6 +64,6 @@ public class FreeIpaFlowInformation implements ApplicationFlowInformation {
 
     @Override
     public List<Class<? extends FlowConfiguration<?>>> getTerminationFlow() {
-        return List.of(StackTerminationFlowConfig.class);
+        return TERMINATION_FLOWS;
     }
 }


### PR DESCRIPTION
In FMS we have seen it could take 15sec to accept a flow. To identify the root cause and narrow down where the time is spent 2 new measurements introduced:
- measure fething pending flows for resource from the database
- measure creating flow stats entry

See detailed description in the commit message.