### PR TITLE
CB-15688: [API E2E] Azure Customer Managed Key testWithEnvironmentResourceGroup creates resources as default settings

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureEncryptionResources.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureEncryptionResources.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -96,8 +97,8 @@ public class AzureEncryptionResources implements EncryptionResources {
             String vaultResourceGroupName = diskEncryptionSetCreationRequest.getEncryptionKeyResourceGroupName();
             String desResourceGroupName = diskEncryptionSetCreationRequest.getDiskEncryptionSetResourceGroupName();
 
-            if (desResourceGroupName == null) {
-                if (vaultResourceGroupName == null) {
+            if (StringUtils.isEmpty(desResourceGroupName)) {
+                if (StringUtils.isEmpty(vaultResourceGroupName)) {
                     throw new IllegalArgumentException("Encryption key resource group name should be present if resource group is not provided during " +
                             "environment creation. At least one of --resource-group-name or --encryption-key-resource-group-name should be specified.");
                 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
@@ -323,12 +323,16 @@ public class AzureCloudProvider extends AbstractCloudProvider {
                 ? ResourceGroupUsage.SINGLE
                 : ResourceGroupUsage.MULTIPLE;
 
-        return environmentTestDto.withAzure(AzureEnvironmentParameters.builder()
-                .withAzureResourceGroup(AzureResourceGroup.builder()
-                        .withResourceGroupUsage(resourceGroupUsage)
-                        .withName(resourceGroupName)
-                        .build())
+        if (environmentTestDto.getAzure() == null) {
+            environmentTestDto.setAzure(AzureEnvironmentParameters.builder().build());
+        }
+        AzureEnvironmentParameters azureEnvironmentParameters = environmentTestDto.getAzure();
+        azureEnvironmentParameters.setResourceGroup(AzureResourceGroup.builder()
+                .withResourceGroupUsage(resourceGroupUsage)
+                .withName(resourceGroupName)
                 .build());
+        environmentTestDto.setAzure(azureEnvironmentParameters);
+        return environmentTestDto;
     }
 
     @Override
@@ -476,12 +480,16 @@ public class AzureCloudProvider extends AbstractCloudProvider {
 
     @Override
     public EnvironmentTestDto withResourceEncryption(EnvironmentTestDto environmentTestDto) {
-        return environmentTestDto.withAzure(AzureEnvironmentParameters.builder()
-                .withResourceEncryptionParameters(AzureResourceEncryptionParameters.builder()
-                        .withEncryptionKeyResourceGroupName(getEncryptionResourceGroupName())
-                        .withEncryptionKeyUrl(getEncryptionKeyUrl())
-                        .build())
+        if (environmentTestDto.getAzure() == null) {
+            environmentTestDto.setAzure(AzureEnvironmentParameters.builder().build());
+        }
+        AzureEnvironmentParameters azureEnvironmentParameters = environmentTestDto.getAzure();
+        azureEnvironmentParameters.setResourceEncryptionParameters(AzureResourceEncryptionParameters.builder()
+                .withEncryptionKeyResourceGroupName(getEncryptionResourceGroupName())
+                .withEncryptionKeyUrl(getEncryptionKeyUrl())
                 .build());
+        environmentTestDto.setAzure(azureEnvironmentParameters);
+        return environmentTestDto;
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
@@ -98,6 +98,14 @@ public class EnvironmentTestDto
         return getRequest().getParentEnvironmentName();
     }
 
+    public AzureEnvironmentParameters getAzure() {
+        return getRequest().getAzure();
+    }
+
+    public void setAzure(AzureEnvironmentParameters azure) {
+        getRequest().setAzure(azure);
+    }
+
     @Override
     public EnvironmentTestDto valid() {
         return getCloudProvider()

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/AwsEnvironmentWithCustomerManagedKeyTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/AwsEnvironmentWithCustomerManagedKeyTests.java
@@ -131,7 +131,8 @@ public class AwsEnvironmentWithCustomerManagedKeyTests extends AbstractE2ETest {
         List<String> instanceIds = freeIpaInstanceUtil.getInstanceIds(testDto, freeIpaClient, MASTER.getName());
         String kmsKeyArn = awsProperties.getDiskEncryption().getEnvironmentKey();
 
-        List<String> volumeKmsKeyIds = new ArrayList<>(cloudFunctionality.listVolumeEncryptionKeyIds(testDto.getRequest().getName(), instanceIds));
+        List<String> volumeKmsKeyIds = new ArrayList<>(cloudFunctionality.listVolumeEncryptionKeyIds(testDto.getRequest().getName(), null,
+                instanceIds));
         if (volumeKmsKeyIds.stream().noneMatch(keyId -> keyId.equalsIgnoreCase(kmsKeyArn))) {
             LOGGER.error("FreeIpa volume has not been encrypted with [{}] KMS key!", kmsKeyArn);
             throw new TestFailException(format("FreeIpa volume has not been encrypted with [%s] KMS key!", kmsKeyArn));

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/CloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/CloudFunctionality.java
@@ -29,7 +29,7 @@ public interface CloudFunctionality {
             maxAttempts = ATTEMPTS,
             backoff = @Backoff(delay = DELAY, multiplier = MULTIPLIER, maxDelay = MAX_DELAY)
     )
-    List<String> listVolumeEncryptionKeyIds(String clusterName, List<String> instanceIds);
+    List<String> listVolumeEncryptionKeyIds(String clusterName, String resourceGroupName, List<String> instanceIds);
 
     @Retryable(
             maxAttempts = ATTEMPTS,
@@ -53,7 +53,7 @@ public interface CloudFunctionality {
             maxAttempts = ATTEMPTS,
             backoff = @Backoff(delay = DELAY, multiplier = MULTIPLIER, maxDelay = MAX_DELAY)
     )
-    ResourceGroup createResourceGroup(String resourceGroupName);
+    ResourceGroup createResourceGroup(String resourceGroupName, Map<String, String> tags);
 
     @Retryable(
             maxAttempts = ATTEMPTS,

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/AwsCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/AwsCloudFunctionality.java
@@ -32,7 +32,7 @@ public class AwsCloudFunctionality implements CloudFunctionality {
     }
 
     @Override
-    public List<String> listVolumeEncryptionKeyIds(String clusterName, List<String> instanceIds) {
+    public List<String> listVolumeEncryptionKeyIds(String clusterName, String resourceGroupName, List<String> instanceIds) {
         return amazonEC2Util.listVolumeKmsKeyIds(instanceIds);
     }
 
@@ -52,7 +52,7 @@ public class AwsCloudFunctionality implements CloudFunctionality {
     }
 
     @Override
-    public ResourceGroup createResourceGroup(String resourceGroupName) {
+    public ResourceGroup createResourceGroup(String resourceGroupName, Map<String, String> tags) {
         LOGGER.debug("createResourceGroup: nothing to do for AWS");
         throw new NotImplementedException("Resource group creation is not applicable for AWS!");
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/AzureCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/AzureCloudFunctionality.java
@@ -28,8 +28,8 @@ public class AzureCloudFunctionality implements CloudFunctionality {
     }
 
     @Override
-    public List<String> listVolumeEncryptionKeyIds(String clusterName, List<String> instanceIds) {
-        return azureClientActions.getVolumesDesId(clusterName, instanceIds);
+    public List<String> listVolumeEncryptionKeyIds(String clusterName, String resourceGroupName, List<String> instanceIds) {
+        return azureClientActions.getVolumesDesId(clusterName, resourceGroupName, instanceIds);
     }
 
     @Override
@@ -48,8 +48,8 @@ public class AzureCloudFunctionality implements CloudFunctionality {
     }
 
     @Override
-    public ResourceGroup createResourceGroup(String resourceGroupName) {
-        return azureClientActions.createResourceGroup(resourceGroupName);
+    public ResourceGroup createResourceGroup(String resourceGroupName, Map<String, String> tags) {
+        return azureClientActions.createResourceGroup(resourceGroupName, tags);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpCloudFunctionality.java
@@ -34,7 +34,7 @@ public class GcpCloudFunctionality implements CloudFunctionality {
     }
 
     @Override
-    public List<String> listVolumeEncryptionKeyIds(String clusterName, List<String> instanceIds) {
+    public List<String> listVolumeEncryptionKeyIds(String clusterName, String resourceGroupName, List<String> instanceIds) {
         throw new NotImplementedException("Not yet implemented on GCP");
     }
 
@@ -60,7 +60,7 @@ public class GcpCloudFunctionality implements CloudFunctionality {
     }
 
     @Override
-    public ResourceGroup createResourceGroup(String resourceGroupName) {
+    public ResourceGroup createResourceGroup(String resourceGroupName, Map<String, String> tags) {
         LOGGER.debug("createResourceGroup: nothing to do for GCP");
         throw new NotImplementedException("Resource group creation is not applicable for GCP!");
     }


### PR DESCRIPTION
CB-15688: [API E2E] Azure Customer Managed Key testWithEnvironmentResourceGroup creates resources as default settings

When I running [AzureEnvironmentWithCustomerManagedKeyTests suite testWithEnvironmentResourceGroup](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/AzureEnvironmentWithCustomerManagedKeyTests.java#L86) test case I've realised the created [resourceGroupForTest](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/AzureEnvironmentWithCustomerManagedKeyTests.java#L102) actually has not been used.

So the created resourceGroupForTest is empty and does not contain any resource during the entire test execution.



This commit has following fixes - 
1. "withResourceGroup" method sets the AzureEnvironmentParameters and so does "withResourceEncryption", As both of these methods sets AzureEnvironmentParameters without checking if it already exists, the resourceGroupForTest set by withResourceGroup gets overridden by withResourceEncryption method as it is called later. Existence of AzureEnvironmentParameters is checked before filling in the nested objects for it.

2. "resourceGroupForTest" now has required tags attached to it to prevent the deletion by cloud-haunter-app before the test finishes.

3. Few preventive checks are added to avoid exceptions in case of "resource group not found".