### PR TITLE
CB-15695 Fix workloadUsername for testEphemeralDistroXMasterRepairWithTerminatedEC2Instances

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/DistroXRepairTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/DistroXRepairTests.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.ephemeral;
+package com.sequenceiq.it.cloudbreak.testcase.e2e.l0promotion;
 
 import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.MASTER;
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
@@ -8,20 +8,24 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
-import com.sequenceiq.cloudbreak.util.SanitizerUtil;
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationState;
 import com.sequenceiq.it.cloudbreak.client.DistroXTestClient;
+import com.sequenceiq.it.cloudbreak.client.FreeIpaTestClient;
+import com.sequenceiq.it.cloudbreak.client.UmsTestClient;
 import com.sequenceiq.it.cloudbreak.cloud.HostGroupType;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
 import com.sequenceiq.it.cloudbreak.dto.distrox.instancegroup.DistroXInstanceGroupsBuilder;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaUserSyncTestDto;
+import com.sequenceiq.it.cloudbreak.dto.ums.UmsTestDto;
 import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
 import com.sequenceiq.it.cloudbreak.util.CloudFunctionality;
 import com.sequenceiq.it.cloudbreak.util.DistroxUtil;
@@ -31,13 +35,11 @@ import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
 import com.sequenceiq.it.cloudbreak.util.ssh.action.SshJClientActions;
 
 /**
- * Since [CB-15474 removed ephemeral disk tests from azure-longrunning-e2e-tests] this test suite is
- * only supported with AWS provider.
+ * Based on the [CB-15474 removed ephemeral disk tests from azure-longrunning-e2e-tests]:
+ *  Mitigation plan is to have only 1 testcase with this type of instance (preferably repair due to mounting)
+ *  and move it to the mow-dev test suite which will only run once a week.
  */
 public class DistroXRepairTests extends AbstractE2ETest {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DistroXRepairTests.class);
-
-    private static final String MOCK_UMS_PASSWORD = "Password123!";
 
     @Inject
     private DistroXTestClient distroXTestClient;
@@ -51,9 +53,15 @@ public class DistroXRepairTests extends AbstractE2ETest {
     @Inject
     private SshJClientActions sshJClientActions;
 
+    @Inject
+    private UmsTestClient umsTestClient;
+
+    @Inject
+    private FreeIpaTestClient freeIpaTestClient;
+
     @Override
     protected void setupTest(TestContext testContext) {
-        assertSupportedCloudPlatform(CloudPlatform.AWS);
+        assertSupportedCloudPlatform(CloudPlatform.AZURE);
         createDefaultUser(testContext);
         createDefaultCredential(testContext);
         initializeDefaultBlueprints(testContext);
@@ -63,19 +71,34 @@ public class DistroXRepairTests extends AbstractE2ETest {
     @Test(dataProvider = TEST_CONTEXT)
     @UseSpotInstances
     @Description(
-            given = "there is a running Cloudbreak, and an environment with SDX and DistroX cluster in available state",
-            when = "recovery called on the MASTER host group of DistroX cluster, where the EC2 instance had been terminated",
-            then = "DistroX recovery should be successful, the cluster should be up and running"
+            given = "there is a running environment with FreeIPA and SDX in available state",
+            when = "a new DistroX should be created",
+                and = "MASTER host group should be recovered, where the instance had been terminated",
+            then = "DistroX recovery should be successful, the cluster should be up and running with same volumes"
     )
-    public void testEphemeralDistroXMasterRepairWithTerminatedEC2Instances(TestContext testContext) {
+    public void testEphemeralDistroXMasterRepairWithTerminatedInstances(TestContext testContext) {
         String distrox = resourcePropertyProvider().getName();
         List<String> actualVolumeIds = new ArrayList<>();
         List<String> expectedVolumeIds = new ArrayList<>();
-
-        String username = testContext.getActingUserCrn().getResource();
-        String sanitizedUserName = SanitizerUtil.sanitizeWorkloadUsername(username);
+        String newWorkloadPassword = "Admin@123";
+        String userCrn = testContext.getActingUserCrn().toString();
+        String workloadUsername = testContext
+                .given(UmsTestDto.class)
+                .assignTarget(EnvironmentTestDto.class.getSimpleName())
+                .when(umsTestClient.getUserDetails(userCrn))
+                .getResponse().getWorkloadUsername();
 
         testContext
+                .given(FreeIpaTestDto.class)
+                .when(freeIpaTestClient.describe())
+                .given(FreeIpaUserSyncTestDto.class)
+                .when(freeIpaTestClient.getLastSyncOperationStatus())
+                .await(OperationState.COMPLETED)
+                .given(UmsTestDto.class).assignTarget(EnvironmentTestDto.class.getSimpleName())
+                .when(umsTestClient.setWorkloadPassword(newWorkloadPassword))
+                .given(FreeIpaUserSyncTestDto.class)
+                .when(freeIpaTestClient.syncAll())
+                .await(OperationState.COMPLETED)
                 .given(distrox, DistroXTestDto.class)
                 .withInstanceGroupsEntity(new DistroXInstanceGroupsBuilder(testContext)
                         .defaultHostGroup()
@@ -103,8 +126,8 @@ public class DistroXRepairTests extends AbstractE2ETest {
                     verifyMountPointsUsedForTemporalDisks(testDto, "ephfs", "ephfs1");
                     return testDto;
                 })
-                .then((tc, testDto, client) -> clouderaManagerUtil.checkClouderaManagerYarnNodemanagerRoleConfigGroups(testDto, sanitizedUserName,
-                        MOCK_UMS_PASSWORD))
+                .then((tc, testDto, client) -> clouderaManagerUtil.checkClouderaManagerYarnNodemanagerRoleConfigGroups(testDto, workloadUsername,
+                        newWorkloadPassword))
                 .then((tc, testDto, client) -> {
                     CloudFunctionality cloudFunctionality = tc.getCloudProvider().getCloudFunctionality();
                     List<String> instanceIds = distroxUtil.getInstanceIds(testDto, client, MASTER.getName());

--- a/integration-test/src/main/resources/testsuites/e2e/l0promotion/azure-ephemeral-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/l0promotion/azure-ephemeral-tests.yaml
@@ -2,4 +2,4 @@ name: "azure-ephemeral-tests"
 tests:
   - name: "azure-ephemeral-tests"
     classes:
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.ephemeral.DistroXRepairTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.l0promotion.DistroXRepairTests


### PR DESCRIPTION
MOW-Dev 2.52.0-b30 [mow-api-longrunning-azure DistroXRepairTests testEphemeralDistroXMasterRepairWithTerminatedEC2Instances](http://ci-cloudbreak.eng.hortonworks.com/job/mow-api-longrunning-azure/2/artifact/suites_log/DistroXRepairTests.testEphemeralDistroXMasterRepairWithTerminatedEC2Instances-20220116.log) is failing because of
```2022-01-16 16:50:50,578 [TestNG-test=azure-ephemeral-tests-1] INFO  c.s.i.c.u.c.c.ClouderaManagerClient [DistroXRepairTests.testEphemeralDistroXMasterRepairWithTerminatedEC2Instances] - Cloudera Manager Base Path: https://10.124.218.60/azure-test-a058/cdp-proxy-api/cm-api/v43
2022-01-16 16:50:53,838 [TestNG-test=azure-ephemeral-tests-1] ERROR c.s.i.c.u.c.a.ClouderaManagerClientActions [DistroXRepairTests.testEphemeralDistroXMasterRepairWithTerminatedEC2Instances] - Exception when calling RoleConfigGroupsResourceApi#readConfig. Response: 
com.cloudera.api.swagger.client.ApiException: Unauthorized
	at com.cloudera.api.swagger.client.ApiClient.handleResponse(ApiClient.java:1074)
	at com.cloudera.api.swagger.client.ApiClient.execute(ApiClient.java:990)
	at com.cloudera.api.swagger.RoleConfigGroupsResourceApi.readConfigWithHttpInfo(RoleConfigGroupsResourceApi.java:749)
	at com.cloudera.api.swagger.RoleConfigGroupsResourceApi.readConfig(RoleConfigGroupsResourceApi.java:732)
	at com.sequenceiq.it.cloudbreak.util.clouderamanager.action.ClouderaManagerClientActions.checkCmYarnNodemanagerRoleConfigGroups(ClouderaManagerClientActions.java:84)
	at com.sequenceiq.it.cloudbreak.util.clouderamanager.ClouderaManagerUtil.checkClouderaManagerYarnNodemanagerRoleConfigGroups(ClouderaManagerUtil.java:27)
	at com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.ephemeral.DistroXRepairTests.lambda$testEphemeralDistroXMasterRepairWithTerminatedEC2Instances$3(DistroXRepairTests.java:101)
	at com.sequenceiq.it.cloudbreak.context.TestContext.then(TestContext.java:377)
	at com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto.then(AbstractCloudbreakTestDto.java:87)
	at com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto.then(AbstractCloudbreakTestDto.java:82)
	at com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.ephemeral.DistroXRepairTests.testEphemeralDistroXMasterRepairWithTerminatedEC2Instances(DistroXRepairTests.java:101)
```
CM user and password:
```
2022-01-16 16:50:50,521 [TestNG-test=azure-ephemeral-tests-1] INFO  c.s.i.c.u.c.c.ClouderaManagerClient [DistroXRepairTests.testEphemeralDistroXMasterRepairWithTerminatedEC2Instances] - Cloudera Manager Server access details: 
serverFqdn: 10.124.218.60 
cmUser: 55b3f799fe63475282fc1150d448be3d 
cmPassword: Password123!
```
Here we need to change to get the Mow-Dev account workload user and it's password:
```
String workloadUsername = testContext.given(UmsTestDto.class).assignTarget(EnvironmentTestDto.class.getSimpleName())
        .when(umsTestClient.getUserDetails(userCrn)).getResponse().getWorkloadUsername();
```
instead of
```
String username = testContext.getActingUserCrn().getResource();
String sanitizedUserName = SanitizerUtil.sanitizeWorkloadUsername(username);
```
and along with these changes need to sync the FreeIPA with the new workload user and it's password as well.