### PR TITLE
CB-14916 Ignore DataHub Upgrade test with ephemeral caching on

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/ephemeral/DistroXUpgradeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/ephemeral/DistroXUpgradeTests.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
@@ -56,6 +57,7 @@ public class DistroXUpgradeTests extends AbstractE2ETest {
         createEnvironmentWithFreeIpa(testContext);
     }
 
+    @Ignore("Yarn config verification is not working, because CM responds with a server error")
     @Test(dataProvider = TEST_CONTEXT)
     @UseSpotInstances
     @Description(given = "there is a running Cloudbreak, and an environment with SDX and DistroX cluster in available state",

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/clouderamanager/action/ClouderaManagerClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/clouderamanager/action/ClouderaManagerClientActions.java
@@ -63,8 +63,10 @@ public class ClouderaManagerClientActions extends ClouderaManagerClient {
                 throw new TestFailException("IDBroker mappings are NOT exist!");
             }
         } catch (ApiException e) {
-            LOGGER.error("Exception when calling UsersResourceApi#readUsers2", e);
-            throw new TestFailException("Exception when calling UsersResourceApi#readUsers2 at " + apiClient.getBasePath(), e);
+            LOGGER.error("Exception when calling RoleConfigGroupsResourceApi#readConfig. Response: {}", e.getResponseBody(), e);
+            String message = format("Exception when calling RoleConfigGroupsResourceApi#readConfig at %s. Response: %s",
+                    apiClient.getBasePath(), e.getResponseBody());
+            throw new TestFailException(message, e);
         } catch (Exception e) {
             LOGGER.error("Can't get users' list at: '{}'!", apiClient.getBasePath());
             throw new TestFailException("Can't get users' list at: " + apiClient.getBasePath(), e);
@@ -99,11 +101,13 @@ public class ClouderaManagerClientActions extends ClouderaManagerClient {
                 throw new TestFailException("Nodemanager mappings are NOT exist!");
             }
         } catch (ApiException e) {
-            LOGGER.error("Exception when calling UsersResourceApi#readUsers2", e);
-            throw new TestFailException("Exception when calling UsersResourceApi#readUsers2 at " + apiClient.getBasePath(), e);
+            LOGGER.error("Exception when calling RoleConfigGroupsResourceApi#readConfig. Response: {}", e.getResponseBody(), e);
+            String message = format("Exception when calling RoleConfigGroupsResourceApi#readConfig at %s. Response: %s",
+                    apiClient.getBasePath(), e.getResponseBody());
+            throw new TestFailException(message, e);
         } catch (Exception e) {
-            LOGGER.error("Can't get users' list at: '{}'!", apiClient.getBasePath());
-            throw new TestFailException("Can't get users' list at: " + apiClient.getBasePath(), e);
+            LOGGER.error("Can't get role configs at: '{}'!", apiClient.getBasePath());
+            throw new TestFailException("Can't get role configs at: " + apiClient.getBasePath(), e);
         }
         return testDto;
     }
@@ -137,8 +141,10 @@ public class ClouderaManagerClientActions extends ClouderaManagerClient {
                 throw new TestFailException("Namenode mappings are NOT exist!");
             }
         } catch (ApiException e) {
-            LOGGER.error("Exception when calling RoleConfigGroupsResourceApi#readConfig", e);
-            throw new TestFailException("Exception when calling RoleConfigGroupsResourceApi#readConfig at " + apiClient.getBasePath(), e);
+            LOGGER.error("Exception when calling RoleConfigGroupsResourceApi#readConfig. Response: {}", e.getResponseBody(), e);
+            String message = format("Exception when calling RoleConfigGroupsResourceApi#readConfig at %s. Response: %s",
+                    apiClient.getBasePath(), e.getResponseBody());
+            throw new TestFailException(message, e);
         } catch (Exception e) {
             LOGGER.error("Can't read config at: '{}'!", apiClient.getBasePath());
             throw new TestFailException("Can't read config at: " + apiClient.getBasePath(), e);
@@ -175,8 +181,10 @@ public class ClouderaManagerClientActions extends ClouderaManagerClient {
                 throw new TestFailException("Datanode mappings are NOT exist!");
             }
         } catch (ApiException e) {
-            LOGGER.error("Exception when calling RoleConfigGroupsResourceApi#readConfig", e);
-            throw new TestFailException("Exception when calling RoleConfigGroupsResourceApi#readConfig at " + apiClient.getBasePath(), e);
+            LOGGER.error("Exception when calling RoleConfigGroupsResourceApi#readConfig. Response: {}", e.getResponseBody(), e);
+            String message = format("Exception when calling RoleConfigGroupsResourceApi#readConfig at %s. Response: %s",
+                    apiClient.getBasePath(), e.getResponseBody());
+            throw new TestFailException(message, e);
         } catch (Exception e) {
             LOGGER.error("Can't read config at: '{}'!", apiClient.getBasePath());
             throw new TestFailException("Can't read config at: " + apiClient.getBasePath(), e);


### PR DESCRIPTION
CM responds with a server error, when the test attempts to verify Yarn configs.
Putting the test on ignore, while this issue is fixed.
Added response body to error logs in the e2e CM client.

See detailed description in the commit message.