### PR TITLE
CB-15709 Retry FreeIPA calls which fails with IOException

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientExceptionUtil.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientExceptionUtil.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -108,7 +109,8 @@ public class FreeIpaClientExceptionUtil {
 
     @VisibleForTesting
     static boolean isExceptionWithIOExceptionCause(FreeIpaClientException e) {
-        return Stream.of(getAncestorCauseBeforeFreeIpaClientExceptions(e))
+        return ExceptionUtils.getThrowableList(e)
+                .stream()
                 .anyMatch(IOException.class::isInstance);
     }
 

--- a/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/FreeIpaClientExceptionUtilV1Test.java
+++ b/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/FreeIpaClientExceptionUtilV1Test.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.freeipa.client;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -10,6 +11,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
 import com.googlecode.jsonrpc4j.JsonRpcClientException;
 
 public class FreeIpaClientExceptionUtilV1Test {
@@ -123,6 +126,9 @@ public class FreeIpaClientExceptionUtilV1Test {
                 new FreeIpaClientException(MESSAGE, new FreeIpaClientException(MESSAGE, new IOException()))));
         Assertions.assertFalse(FreeIpaClientExceptionUtil.isExceptionWithIOExceptionCause(
                 new FreeIpaClientException(MESSAGE, new FreeIpaClientException(MESSAGE, new IllegalStateException()))));
+        Assertions.assertTrue(FreeIpaClientExceptionUtil.isExceptionWithIOExceptionCause(
+                new FreeIpaClientException(MESSAGE, new FreeIpaClientException(MESSAGE,
+                        new RuntimeException("stream closed", new JsonParseException(mock(JsonParser.class), "stream closed"))))));
     }
 
     @Test

--- a/freeipa/build.gradle
+++ b/freeipa/build.gradle
@@ -75,7 +75,7 @@ dependencies {
   implementation     group: 'com.google.guava',          name: 'guava',                                version: guavaVersion
   implementation     group: 'org.apache.kerby',          name: 'kerb-util',                            version: '2.0.0'
 
-  implementation     group: 'com.github.briandilley.jsonrpc4j', name: 'jsonrpc4j',                     version: '1.5.3'
+  implementation     group: 'com.github.briandilley.jsonrpc4j', name: 'jsonrpc4j',                     version: '1.6'
   implementation     group: 'com.dyngr',                        name: 'polling',                       version: '1.1.3'
   implementation     group: 'org.freemarker',                   name: 'freemarker',                    version: freemarkerVersion
   testImplementation ('org.springframework.boot:spring-boot-starter-test') {

--- a/node-status-monitor-client/build.gradle
+++ b/node-status-monitor-client/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     exclude group: 'io.grpc', module: 'grpc-testing'
   }
   implementation     group: 'com.google.protobuf',              name: 'protobuf-java-util',          version: protobufVersion
-  implementation     group: 'com.github.briandilley.jsonrpc4j', name: 'jsonrpc4j',                   version: '1.5.3'
+  implementation     group: 'com.github.briandilley.jsonrpc4j', name: 'jsonrpc4j',                   version: '1.6'
   implementation     group: 'com.fasterxml.jackson.core',       name: 'jackson-databind',            version: jacksonVersion
   implementation     group: 'org.slf4j',                        name: 'slf4j-api',                   version: slf4jApiVersion
   implementation     group: 'org.apache.commons',               name: 'commons-lang3',               version: apacheCommonsLangVersion


### PR DESCRIPTION
Previously not the full stack trace was check for `IOException`. With this commit the whole stack trace causes would be checked.
This is necessary as `JsonRpcHttpClient` does some wrapping.

Bumped up `JsonRpcHttpClient` version in some gradle files where it was missing.

See detailed description in the commit message.