### PR TITLE
CB-15715: Make backup-restore flows retryable.

### DIFF
--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxRetryServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxRetryServiceTest.java
@@ -2,7 +2,10 @@ package com.sequenceiq.datalake.service.sdx;
 
 import static com.sequenceiq.datalake.flow.create.SdxCreateEvent.SDX_STACK_CREATION_IN_PROGRESS_EVENT;
 import static com.sequenceiq.datalake.flow.create.SdxCreateEvent.STORAGE_VALIDATION_WAIT_EVENT;
+import static com.sequenceiq.datalake.flow.create.SdxCreateState.INIT_STATE;
 import static com.sequenceiq.datalake.flow.create.SdxCreateState.SDX_CREATION_WAIT_RDS_STATE;
+import static com.sequenceiq.datalake.flow.dr.restore.DatalakeRestoreEvent.DATALAKE_TRIGGER_RESTORE_EVENT;
+import static com.sequenceiq.datalake.flow.dr.backup.DatalakeBackupEvent.DATALAKE_TRIGGER_BACKUP_EVENT;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -10,6 +13,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.function.Consumer;
 
@@ -22,7 +26,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.StackV4Endpoint;
 import com.sequenceiq.datalake.entity.SdxCluster;
+import com.sequenceiq.datalake.flow.create.SdxCreateFlowConfig;
+import com.sequenceiq.datalake.flow.dr.restore.DatalakeRestoreFlowConfig;
 import com.sequenceiq.flow.core.Flow2Handler;
+import com.sequenceiq.flow.domain.ClassValue;
 import com.sequenceiq.flow.domain.FlowLog;
 import com.sequenceiq.flow.domain.StateStatus;
 
@@ -50,10 +57,12 @@ public class SdxRetryServiceTest {
         successfulFlowLog.setNextEvent(STORAGE_VALIDATION_WAIT_EVENT.name());
         successfulFlowLog.setCreated(1L);
         successfulFlowLog.setCurrentState(SDX_CREATION_WAIT_RDS_STATE.name());
+        successfulFlowLog.setFlowType(ClassValue.of(SdxCreateFlowConfig.class));
         doAnswer(invocation -> {
             ((Consumer<FlowLog>) invocation.getArgument(1)).accept(successfulFlowLog);
             return null;
         }).when(flow2Handler).retryLastFailedFlow(anyLong(), any());
+        when(flow2Handler.getFirstStateLogfromLatestFlow(anyLong())).thenReturn(successfulFlowLog);
 
         sdxRetryService.retrySdx(sdxCluster);
 
@@ -72,15 +81,51 @@ public class SdxRetryServiceTest {
         successfulFlowLog.setNextEvent(SDX_STACK_CREATION_IN_PROGRESS_EVENT.name());
         successfulFlowLog.setCreated(1L);
         successfulFlowLog.setCurrentState(SDX_CREATION_WAIT_RDS_STATE.name());
-
+        successfulFlowLog.setFlowType(ClassValue.of(SdxCreateFlowConfig.class));
         doAnswer(invocation -> {
             ((Consumer<FlowLog>) invocation.getArgument(1)).accept(successfulFlowLog);
             return null;
         }).when(flow2Handler).retryLastFailedFlow(anyLong(), any());
-
+        when(flow2Handler.getFirstStateLogfromLatestFlow(anyLong())).thenReturn(successfulFlowLog);
         sdxRetryService.retrySdx(sdxCluster);
 
         verify(stackV4Endpoint, times(1)).retry(any(), eq("sdxclustername"), anyString());
     }
 
+    @Test
+    public void retryOnBackupRestoreFailure() {
+        SdxCluster sdxCluster = new SdxCluster();
+        sdxCluster.setId(1L);
+        sdxCluster.setClusterName("sdxclustername");
+        FlowLog successfulFlowLog = new FlowLog();
+        successfulFlowLog.setFlowId("FLOW_ID_1");
+        successfulFlowLog.setStateStatus(StateStatus.SUCCESSFUL);
+        successfulFlowLog.setNextEvent(DATALAKE_TRIGGER_RESTORE_EVENT.name());
+        successfulFlowLog.setCreated(1L);
+        successfulFlowLog.setCurrentState(INIT_STATE.name());
+        successfulFlowLog.setFlowType(ClassValue.of(DatalakeRestoreFlowConfig.class));
+        when(flow2Handler.getFirstStateLogfromLatestFlow(anyLong())).thenReturn(successfulFlowLog);
+
+        sdxRetryService.retrySdx(sdxCluster);
+
+        verify(flow2Handler, times(1)).retryLastFailedFlowFromStart(any());
+    }
+
+    @Test
+    public void retryOnBackupBackupFailure() {
+        SdxCluster sdxCluster = new SdxCluster();
+        sdxCluster.setId(1L);
+        sdxCluster.setClusterName("sdxclustername");
+        FlowLog successfulFlowLog = new FlowLog();
+        successfulFlowLog.setFlowId("FLOW_ID_1");
+        successfulFlowLog.setStateStatus(StateStatus.SUCCESSFUL);
+        successfulFlowLog.setNextEvent(DATALAKE_TRIGGER_BACKUP_EVENT.name());
+        successfulFlowLog.setCreated(1L);
+        successfulFlowLog.setCurrentState(INIT_STATE.name());
+        successfulFlowLog.setFlowType(ClassValue.of(DatalakeRestoreFlowConfig.class));
+        when(flow2Handler.getFirstStateLogfromLatestFlow(anyLong())).thenReturn(successfulFlowLog);
+
+        sdxRetryService.retrySdx(sdxCluster);
+        verify(flow2Handler, times(1)).retryLastFailedFlowFromStart(any());
+    }
 }

--- a/flow/src/main/java/com/sequenceiq/cloudbreak/service/flowlog/FlowLogUtil.java
+++ b/flow/src/main/java/com/sequenceiq/cloudbreak/service/flowlog/FlowLogUtil.java
@@ -22,6 +22,13 @@ public class FlowLogUtil {
     private FlowLogUtil() {
     }
 
+    public static FlowLog getFirstStateLog(List<FlowLog> flowLogs) {
+        List<FlowLog> reversedOrderedFlowLog = flowLogs.stream()
+                .sorted(Comparator.comparing(FlowLog::getCreated))
+                .collect(Collectors.toList());
+        return reversedOrderedFlowLog.get(0);
+    }
+
     public static FlowLog getLastSuccessfulStateLog(String failedState, List<FlowLog> flowLogs) {
         List<FlowLog> reversedOrderedFlowLog = flowLogs.stream()
                 .sorted(Comparator.comparing(FlowLog::getCreated).reversed())


### PR DESCRIPTION
Currently, there is no retry mechanism for backup-restore flows when they fail.

Let's say datalake backup or restore flow failed in the resize flow chain, there is no way to trigger a retry of backup/restore flows again.

Retrying from the failed state does not work for backup restore flows so added implementation to retry the complete flow.


Made sure that retry for start/stop/backup/restore/create flows work.