### PR TITLE
CB-15700. Implement metering client auto updated via StackPatcher logic

### DIFF
--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/StackPatchType.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/StackPatchType.java
@@ -3,5 +3,6 @@ package com.sequenceiq.cloudbreak.domain.stack;
 public enum StackPatchType {
     UNBOUND_RESTART,
     LOGGING_AGENT_AUTO_RESTART,
+    METERING_AZURE_METADATA,
     UNKNOWN
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherConfig.java
@@ -18,6 +18,9 @@ public class ExistingStackPatcherConfig {
     @Value("${existingstackpatcher.enabled}")
     private boolean existingStackPatcherEnabled;
 
+    @Value("${existingstackpatcher.maxInitialStartDelayInHours}")
+    private int maxInitialStartDelayInHours;
+
     @PostConstruct
     void logEnablement() {
         LOGGER.info("Existing stack patcher is {}", existingStackPatcherEnabled ? "enabled" : "disabled");
@@ -29,5 +32,9 @@ public class ExistingStackPatcherConfig {
 
     public int getIntervalInHours() {
         return intervalInHours;
+    }
+
+    public int getMaxInitialStartDelayInHours() {
+        return maxInitialStartDelayInHours;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJobService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJobService.java
@@ -90,7 +90,7 @@ public class ExistingStackPatcherJobService {
     }
 
     private Date delayedFirstStart() {
-        int delayInMinutes = RANDOM.nextInt((int) TimeUnit.HOURS.toMinutes(properties.getIntervalInHours()));
+        int delayInMinutes = RANDOM.nextInt((int) TimeUnit.HOURS.toMinutes(properties.getMaxInitialStartDelayInHours()));
         return Date.from(ZonedDateTime.now().toInstant().plus(Duration.ofMinutes(delayInMinutes)));
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogService.java
@@ -346,7 +346,7 @@ public class ImageCatalogService extends AbstractWorkspaceAwareResourceService<I
         }
     }
 
-    private boolean isCustomImageCatalog(ImageCatalog imageCatalog) {
+    public boolean isCustomImageCatalog(ImageCatalog imageCatalog) {
         return imageCatalog != null && Strings.isNullOrEmpty(imageCatalog.getImageCatalogUrl()) && imageCatalog.getCustomImages() != null;
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/AbstractTelemetryPatchService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/AbstractTelemetryPatchService.java
@@ -1,0 +1,77 @@
+package com.sequenceiq.cloudbreak.service.stackpatch;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterDeletionBasedExitCriteriaModel;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.orchestrator.host.TelemetryOrchestrator;
+import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.cloudbreak.orchestrator.model.Node;
+
+public abstract class AbstractTelemetryPatchService extends ExistingStackPatchService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractTelemetryPatchService.class);
+
+    private static final int DIVIDER = 1000;
+
+    @Inject
+    private TelemetryOrchestrator telemetryOrchestrator;
+
+    @Inject
+    private ClusterComponentConfigProvider clusterComponentConfigProvider;
+
+    protected Set<Node> getAvailableNodes(String stackName, Set<InstanceMetaData> instanceMetaDataSet, List<GatewayConfig> gatewayConfigs,
+            ClusterDeletionBasedExitCriteriaModel exitModel) throws CloudbreakOrchestratorFailedException, ExistingStackPatchApplyException {
+        Set<Node> allNodes = getNodes(instanceMetaDataSet);
+        Set<Node> unresponsiveNodes = telemetryOrchestrator.collectUnresponsiveNodes(gatewayConfigs, allNodes, exitModel);
+        Set<String> unresponsiveHostnames = unresponsiveNodes.stream().map(Node::getHostname).collect(Collectors.toSet());
+        Set<Node> availableNodes = allNodes.stream()
+                .filter(n -> !unresponsiveHostnames.contains(n.getHostname()))
+                .collect(Collectors.toSet());
+        if (CollectionUtils.isEmpty(availableNodes)) {
+            String message = "Not found any available nodes for patch, stack: " + stackName;
+            LOGGER.info(message);
+            throw new ExistingStackPatchApplyException(message);
+        }
+        return availableNodes;
+    }
+
+    protected Set<Node> getNodes(Set<InstanceMetaData> instanceMetaDataSet) {
+        return instanceMetaDataSet.stream()
+                .map(im -> new Node(im.getPrivateIp(), im.getPublicIp(), im.getInstanceId(),
+                        im.getInstanceGroup().getTemplate().getInstanceType(), im.getDiscoveryFQDN(), im.getInstanceGroup().getGroupName()))
+                .collect(Collectors.toSet());
+    }
+
+    protected byte[] getCurrentSaltStateStack(Stack stack) throws ExistingStackPatchApplyException {
+        byte[] currentSaltState = clusterComponentConfigProvider.getSaltStateComponent(stack.getCluster().getId());
+        if (currentSaltState == null) {
+            String message = "Salt state is empty for stack " + stack.getResourceCrn();
+            LOGGER.info(message);
+            throw new ExistingStackPatchApplyException(message);
+        }
+        return currentSaltState;
+    }
+
+    protected TelemetryOrchestrator getTelemetryOrchestrator() {
+        return telemetryOrchestrator;
+    }
+
+    protected long dateStringToTimestampForImage(String dateString) {
+        return Date.from(LocalDate.parse(dateString).atStartOfDay().toInstant(ZoneOffset.UTC)).getTime() / DIVIDER;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/ExistingStackPatchService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/ExistingStackPatchService.java
@@ -9,10 +9,19 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
+import com.sequenceiq.cloudbreak.auth.security.internal.InternalCrnModifier;
+import com.sequenceiq.cloudbreak.cloud.model.Image;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
+import com.sequenceiq.cloudbreak.domain.ImageCatalog;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.StackPatch;
 import com.sequenceiq.cloudbreak.domain.stack.StackPatchType;
 import com.sequenceiq.cloudbreak.repository.StackPatchRepository;
+import com.sequenceiq.cloudbreak.service.image.ImageCatalogService;
+import com.sequenceiq.cloudbreak.service.image.StatedImage;
+import com.sequenceiq.cloudbreak.service.stack.StackImageService;
 import com.sequenceiq.flow.core.FlowLogService;
 import com.sequenceiq.flow.domain.FlowLog;
 import com.sequenceiq.flow.service.FlowRetryService;
@@ -29,6 +38,15 @@ public abstract class ExistingStackPatchService {
 
     @Inject
     private FlowRetryService flowRetryService;
+
+    @Inject
+    private StackImageService stackImageService;
+
+    @Inject
+    private ImageCatalogService imageCatalogService;
+
+    @Inject
+    private InternalCrnModifier internalCrnModifier;
 
     public boolean isStackAlreadyFixed(Stack stack) {
         return stackPatchRepository.findByStackAndType(stack, getStackFixType()).isPresent();
@@ -65,6 +83,34 @@ public abstract class ExistingStackPatchService {
         return stack.getClusterManagerServer()
                 .orElseThrow(() -> new ExistingStackPatchApplyException("Could not find CM server for stack: " + stack.getResourceCrn()))
                 .isReachable();
+    }
+
+    protected StatedImage getStatedImage(Stack stack, Image image, ImageCatalog imageCatalog) {
+        return ThreadBasedUserCrnProvider.doAs(
+                internalCrnModifier.getInternalCrnWithAccountId(Crn.fromString(stack.getResourceCrn()).getAccountId()),
+                () -> {
+                    try {
+                        return imageCatalogService.getImageByCatalogName(stack.getWorkspace().getId(), image.getImageId(), imageCatalog.getName());
+                    } catch (Exception e) {
+                        return null;
+                    }
+                });
+    }
+
+    protected StatedImage getStatedImageForStack(Stack stack) throws CloudbreakImageNotFoundException {
+        Image image = getImageByStack(stack);
+        ImageCatalog imageCatalog = getImageCatalogFromStackAndImage(stack, image);
+        return getStatedImage(stack, image, imageCatalog);
+    }
+
+    protected ImageCatalog getImageCatalogFromStackAndImage(Stack stack, Image image) {
+        return ThreadBasedUserCrnProvider.doAs(
+                internalCrnModifier.getInternalCrnWithAccountId(Crn.fromString(stack.getResourceCrn()).getAccountId()),
+                () -> imageCatalogService.getImageCatalogByName(stack.getWorkspace().getId(), image.getImageCatalogName()));
+    }
+
+    protected Image getImageByStack(Stack stack) throws CloudbreakImageNotFoundException {
+        return stackImageService.getCurrentImage(stack);
     }
 
     /**

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/LoggingAgentAutoRestartPatchService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/LoggingAgentAutoRestartPatchService.java
@@ -5,49 +5,40 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
+import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
-import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.ImagePackageVersion;
-import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterBootstrapper;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterDeletionBasedExitCriteriaModel;
+import com.sequenceiq.cloudbreak.domain.ImageCatalog;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.StackPatchType;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
-import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
-import com.sequenceiq.cloudbreak.orchestrator.host.TelemetryOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.orchestrator.model.Node;
 import com.sequenceiq.cloudbreak.service.CloudbreakRuntimeException;
 import com.sequenceiq.cloudbreak.service.GatewayConfigService;
+import com.sequenceiq.cloudbreak.service.image.ImageCatalogService;
+import com.sequenceiq.cloudbreak.service.image.StatedImage;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
-import com.sequenceiq.cloudbreak.service.stack.StackImageService;
 import com.sequenceiq.cloudbreak.util.CompressUtil;
 
 @Service
-public class LoggingAgentAutoRestartPatchService extends ExistingStackPatchService {
+public class LoggingAgentAutoRestartPatchService extends AbstractTelemetryPatchService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LoggingAgentAutoRestartPatchService.class);
 
-    private static final String AFFECTED_CDP_LOGGING_AGENT_VERSION = "0.2.13";
-
     @Inject
     private CompressUtil compressUtil;
-
-    @Inject
-    private TelemetryOrchestrator telemetryOrchestrator;
-
-    @Inject
-    private StackImageService stackImageService;
 
     @Inject
     private InstanceMetaDataService instanceMetaDataService;
@@ -56,22 +47,52 @@ public class LoggingAgentAutoRestartPatchService extends ExistingStackPatchServi
     private GatewayConfigService gatewayConfigService;
 
     @Inject
-    private ClusterComponentConfigProvider clusterComponentConfigProvider;
+    private ClusterBootstrapper clusterBootstrapper;
 
     @Inject
-    private ClusterBootstrapper clusterBootstrapper;
+    private ImageCatalogService imageCatalogService;
+
+    private final String affectedVersionFrom;
+
+    private final String dateAfter;
+
+    private final String dateBefore;
+
+    private Version affectedVersion;
+
+    private Long dateAfterTimestamp;
+
+    private Long dateBeforeTimestamp;
+
+    public LoggingAgentAutoRestartPatchService(
+            @Value("${existingstackpatcher.activePatches.loggingAgentAutoRestart.affectedVersionFrom}") String affectedVersionFrom,
+            @Value("${existingstackpatcher.activePatches.loggingAgentAutoRestart.dateAfter}") String dateAfter,
+            @Value("${existingstackpatcher.activePatches.loggingAgentAutoRestart.dateBefore}") String dateBefore) {
+        this.affectedVersionFrom = affectedVersionFrom;
+        this.dateAfter = dateAfter;
+        this.dateBefore = dateBefore;
+    }
+
+    @PostConstruct
+    public void init() {
+        affectedVersion = Version.parse(affectedVersionFrom);
+        dateAfterTimestamp = dateStringToTimestampForImage(dateAfter);
+        dateBeforeTimestamp = dateStringToTimestampForImage(dateBefore);
+    }
 
     @Override
     public boolean isAffected(Stack stack) {
-        Version affectedVersion = Version.parse(AFFECTED_CDP_LOGGING_AGENT_VERSION);
         try {
             boolean affected = false;
             if (StackType.WORKLOAD.equals(stack.getType())) {
-                Image image = stackImageService.getCurrentImage(stack);
+                Image image = getImageByStack(stack);
                 Map<String, String> packageVersions = image.getPackageVersions();
-                if (packageVersions.containsKey(ImagePackageVersion.CDP_LOGGING_AGENT.getKey())
+                boolean hasCdpLoggingAgentPackageVersion = packageVersions.containsKey(ImagePackageVersion.CDP_LOGGING_AGENT.getKey());
+                if (hasCdpLoggingAgentPackageVersion
                         && Version.parse(packageVersions.get(ImagePackageVersion.CDP_LOGGING_AGENT.getKey())).compareTo(affectedVersion) <= 0) {
                     affected = true;
+                } else if (!hasCdpLoggingAgentPackageVersion) {
+                    affected = isAffectedByImageTimestamp(stack, image, dateAfterTimestamp, dateBeforeTimestamp);
                 }
             }
             return affected;
@@ -85,12 +106,7 @@ public class LoggingAgentAutoRestartPatchService extends ExistingStackPatchServi
     void doApply(Stack stack) throws ExistingStackPatchApplyException {
         if (isCmServerReachable(stack)) {
             try {
-                byte[] currentSaltState = clusterComponentConfigProvider.getSaltStateComponent(stack.getCluster().getId());
-                if (currentSaltState == null) {
-                    String message = "Salt state is empty for stack " + stack.getResourceCrn();
-                    LOGGER.info(message);
-                    throw new ExistingStackPatchApplyException(message);
-                }
+                byte[] currentSaltState = getCurrentSaltStateStack(stack);
                 List<String> saltStateDefinitions = Arrays.asList("salt-common", "salt");
                 List<String> loggingAgentSaltStateDef = List.of("/salt/fluent");
                 byte[] fluentSaltStateConfig = compressUtil.generateCompressedOutputFromFolders(saltStateDefinitions, loggingAgentSaltStateDef);
@@ -100,7 +116,7 @@ public class LoggingAgentAutoRestartPatchService extends ExistingStackPatchServi
                     List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
                     ClusterDeletionBasedExitCriteriaModel exitModel = ClusterDeletionBasedExitCriteriaModel.nonCancellableModel();
                     Set<Node> availableNodes = getAvailableNodes(stack.getName(), instanceMetaDataSet, gatewayConfigs, exitModel);
-                    telemetryOrchestrator.executeLoggingAgentDiagnostics(fluentSaltStateConfig, gatewayConfigs, availableNodes, exitModel);
+                    getTelemetryOrchestrator().executeLoggingAgentDiagnostics(fluentSaltStateConfig, gatewayConfigs, availableNodes, exitModel);
                     byte[] newFullSaltState = compressUtil.updateCompressedOutputFolders(saltStateDefinitions, loggingAgentSaltStateDef, currentSaltState);
                     clusterBootstrapper.updateSaltComponent(stack, newFullSaltState);
                     LOGGER.debug("Logging agent partial salt refresh and diagnostics successfully finished for stack {}", stack.getName());
@@ -119,31 +135,21 @@ public class LoggingAgentAutoRestartPatchService extends ExistingStackPatchServi
         }
     }
 
-    private Set<Node> getAvailableNodes(String stackName, Set<InstanceMetaData> instanceMetaDataSet, List<GatewayConfig> gatewayConfigs,
-            ClusterDeletionBasedExitCriteriaModel exitModel) throws CloudbreakOrchestratorFailedException, ExistingStackPatchApplyException {
-        Set<Node> allNodes = getNodes(instanceMetaDataSet);
-        Set<Node> unresponsiveNodes = telemetryOrchestrator.collectUnresponsiveNodes(gatewayConfigs, allNodes, exitModel);
-        Set<String> unresponsiveHostnames = unresponsiveNodes.stream().map(Node::getHostname).collect(Collectors.toSet());
-        Set<Node> availableNodes = allNodes.stream()
-                .filter(n -> !unresponsiveHostnames.contains(n.getHostname()))
-                .collect(Collectors.toSet());
-        if (CollectionUtils.isEmpty(availableNodes)) {
-            String message = "Not found any available nodes for logging-agent auto restart patch, stack: " + stackName;
-            LOGGER.info(message);
-            throw new ExistingStackPatchApplyException(message);
-        }
-        return availableNodes;
-    }
-
     @Override
     public StackPatchType getStackFixType() {
         return StackPatchType.LOGGING_AGENT_AUTO_RESTART;
     }
 
-    private Set<Node> getNodes(Set<InstanceMetaData> instanceMetaDataSet) {
-        return instanceMetaDataSet.stream()
-                .map(im -> new Node(im.getPrivateIp(), im.getPublicIp(), im.getInstanceId(),
-                        im.getInstanceGroup().getTemplate().getInstanceType(), im.getDiscoveryFQDN(), im.getInstanceGroup().getGroupName()))
-                .collect(Collectors.toSet());
+    private boolean isAffectedByImageTimestamp(Stack stack, Image image, long dateAfterTimestamp, long dateBeforeTimestamp) {
+        boolean affected = false;
+        ImageCatalog imageCatalog = getImageCatalogFromStackAndImage(stack, image);
+        if (!imageCatalogService.isCustomImageCatalog(imageCatalog)) {
+            StatedImage statedImage = getStatedImage(stack, image, imageCatalog);
+            if (statedImage == null || statedImage.getImage() == null || (dateAfterTimestamp <= statedImage.getImage().getCreated()
+                    && statedImage.getImage().getCreated() < dateBeforeTimestamp)) {
+                affected = true;
+            }
+        }
+        return affected;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/MeteringAzureMetadataPatchService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/MeteringAzureMetadataPatchService.java
@@ -1,0 +1,123 @@
+package com.sequenceiq.cloudbreak.service.stackpatch;
+
+import static com.sequenceiq.cloudbreak.domain.stack.StackPatchType.METERING_AZURE_METADATA;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterBootstrapper;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterDeletionBasedExitCriteriaModel;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.StackPatchType;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.cloudbreak.orchestrator.model.Node;
+import com.sequenceiq.cloudbreak.service.CloudbreakRuntimeException;
+import com.sequenceiq.cloudbreak.service.GatewayConfigService;
+import com.sequenceiq.cloudbreak.service.image.StatedImage;
+import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
+import com.sequenceiq.cloudbreak.util.CompressUtil;
+
+@Service
+public class MeteringAzureMetadataPatchService extends AbstractTelemetryPatchService  {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MeteringAzureMetadataPatchService.class);
+
+    @Inject
+    private CompressUtil compressUtil;
+
+    @Inject
+    private InstanceMetaDataService instanceMetaDataService;
+
+    @Inject
+    private GatewayConfigService gatewayConfigService;
+
+    @Inject
+    private ClusterBootstrapper clusterBootstrapper;
+
+    private final String dateBefore;
+
+    private final String customRpmUrl;
+
+    public MeteringAzureMetadataPatchService(@Value("${existingstackpatcher.activePatches.meteringAzureMetadata.dateBefore}") String dateBefore,
+            @Value("${existingstackpatcher.activePatches.meteringAzureMetadata.customRpmUrl}") String customRpmUrl) {
+        this.dateBefore = dateBefore;
+        this.customRpmUrl = customRpmUrl;
+    }
+
+    @Override
+    public boolean isAffected(Stack stack) {
+        try {
+            boolean affected = false;
+            if (StackType.WORKLOAD.equals(stack.getType())
+                    && CloudPlatform.AZURE.equalsIgnoreCase(stack.getCloudPlatform())) {
+                try {
+                    final Long dateBeforeTimestamp = dateStringToTimestampForImage(dateBefore);
+                    StatedImage statedImage = getStatedImageForStack(stack);
+                    if (statedImage == null || statedImage.getImage() == null || statedImage.getImage().getCreated() < dateBeforeTimestamp) {
+                        affected = true;
+                    }
+                } catch (Exception e) {
+                    String errorMessage = String.format("Cannot determine stack with crn %s is affected by azure metadata issue", stack.getResourceCrn());
+                    LOGGER.debug(errorMessage, e);
+                    throw new ExistingStackPatchApplyException(errorMessage, e);
+                }
+            }
+            return affected;
+        } catch (Exception e) {
+            LOGGER.warn("Error during obtaining image / catalog for stack " + stack.getResourceCrn(), e);
+            throw new CloudbreakRuntimeException("Error during obtaining image / catalog for stack " + stack.getResourceCrn(), e);
+        }
+    }
+
+    @Override
+    void doApply(Stack stack) throws ExistingStackPatchApplyException {
+        if (isCmServerReachable(stack)) {
+            try {
+                upgradeMeteringOnNodes(stack);
+            } catch (ExistingStackPatchApplyException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new ExistingStackPatchApplyException(e.getMessage(), e);
+            }
+        }
+    }
+
+    private void upgradeMeteringOnNodes(Stack stack) throws ExistingStackPatchApplyException, IOException, CloudbreakOrchestratorFailedException {
+        byte[] currentSaltState = getCurrentSaltStateStack(stack);
+        List<String> saltStateDefinitions = Arrays.asList("salt-common", "salt");
+        List<String> meteringSaltStateDef = List.of("/salt/metering");
+        byte[] meteringSaltStateConfig = compressUtil.generateCompressedOutputFromFolders(saltStateDefinitions, meteringSaltStateDef);
+        boolean meteringContentMatches = compressUtil.compareCompressedContent(currentSaltState, meteringSaltStateConfig, meteringSaltStateDef);
+        if (!meteringContentMatches) {
+            Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedForStack(stack.getId());
+            List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
+            ClusterDeletionBasedExitCriteriaModel exitModel = ClusterDeletionBasedExitCriteriaModel.nonCancellableModel();
+            getTelemetryOrchestrator().updateMeteringSaltDefinition(meteringSaltStateConfig, gatewayConfigs, exitModel);
+            Set<Node> availableNodes = getAvailableNodes(stack.getName(), instanceMetaDataSet, gatewayConfigs, exitModel);
+            getTelemetryOrchestrator().upgradeMetering(gatewayConfigs, availableNodes, exitModel, dateBefore, customRpmUrl);
+            byte[] newFullSaltState = compressUtil.updateCompressedOutputFolders(saltStateDefinitions, meteringSaltStateDef, currentSaltState);
+            clusterBootstrapper.updateSaltComponent(stack, newFullSaltState);
+            LOGGER.debug("Metering partial salt refresh successfully finished for stack {}", stack.getName());
+        } else {
+            LOGGER.debug("Metering partial salt refresh is not required for stack {}", stack.getName());
+        }
+    }
+
+    @Override
+    public StackPatchType getStackFixType() {
+        return METERING_AZURE_METADATA;
+    }
+}

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -832,7 +832,16 @@ crn:
 
 existingstackpatcher:
   intervalhours: 24
+  maxInitialStartDelayInHours: 2
   enabled: true
+  activePatches:
+    meteringAzureMetadata:
+      dateBefore: 2022-01-18
+      customRpmUrl: https://archive.cloudera.com/cp_clients/thunderhead-metering-heartbeat-application-0.1-SNAPSHOT.x86_64.rpm
+    loggingAgentAutoRestart:
+      affectedVersionFrom: 0.2.13
+      dateAfter: 2019-11-24
+      dateBefore: 2022-01-18
 
 clusterdns:
   host: localhost

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/TelemetryOrchestrator.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/TelemetryOrchestrator.java
@@ -47,4 +47,10 @@ public interface TelemetryOrchestrator {
 
     void executeLoggingAgentDiagnostics(byte[] loggingAgentSaltState, List<GatewayConfig> gatewayConfigs, Set<Node> allNodes, ExitCriteriaModel exitModel)
             throws CloudbreakOrchestratorFailedException;
+
+    void updateMeteringSaltDefinition(byte[] meteringSaltState, List<GatewayConfig> gatewayConfigs, ExitCriteriaModel exitModel)
+            throws CloudbreakOrchestratorFailedException;
+
+    void upgradeMetering(List<GatewayConfig> gatewayConfigs, Set<Node> nodes, ExitCriteriaModel exitModel, String upgradeFromDate, String customRpmUrl)
+            throws CloudbreakOrchestratorFailedException;
 }

--- a/orchestrator-salt/src/main/resources/salt/salt/metering/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/metering/init.sls
@@ -45,6 +45,12 @@ stop_metering_heartbeat_application_if_needed:
       - mode
 
 {% if metering.enabled %}
+
+{% if salt['pillar.get']('platform') == 'AZURE' %}
+include:
+  - metering.upgrade
+{% endif %}
+
 /etc/metering/generate_heartbeats.ini:
   file.managed:
     - source: salt://metering/template/generate_heartbeats.ini.j2

--- a/orchestrator-salt/src/main/resources/salt/salt/metering/scripts/metering_package_manager.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/metering/scripts/metering_package_manager.sh
@@ -1,0 +1,222 @@
+#!/bin/sh
+
+METERING_PACKAGE_NAME="thunderhead-metering-heartbeat-application"
+METERING_FILE_NAME="$METERING_PACKAGE_NAME-0.1-SNAPSHOT.x86_64.rpm"
+: ${METERING_ARCHIVE_URL:="https://archive.cloudera.com/cp_clients/$METERING_FILE_NAME"}
+: ${METERING_SERVICE_DELIVERY_URL:="https://cloudera-service-delivery-cache.s3.amazonaws.com/$METERING_PACKAGE_NAME/clients/$METERING_FILE_NAME"}
+: ${LOGFILE_FOLDER:="/var/log/metering-upgrade"}
+CURL_CONNECT_TIMEOUT=60
+MIN_BYTES=1000000
+
+print_help() {
+  cat << EOF
+   Usage: [<command>] [<arguments with flags>]
+   commands:
+     upgrade              download and upgrade metering heartbeat agent
+     help                 print usage
+   upgrade command arguments:
+     -d, --from-date      <yyyy-mm-dd>       Install RPM if the installation date is lower than this value.
+     -u, --custom-rpm-url <CUSTOM RPM URL>   Custom URL that will be used instead of the default archive URL
+EOF
+}
+
+do_exit() {
+  local code=$1
+  local message=$2
+  if [[ "$message" == "" ]]; then
+    info "Exit code: $code"
+  else
+    info "Exit code: $code, --- STATUS MESSAGE --- $message --- STATUS MESSAGE ---"
+  fi
+  exit $code
+}
+
+init_logfile() {
+  mkdir -p $LOGFILE_FOLDER
+  local timestamp=$(date +"%Y%m%d-%H%M%S")
+  LOGFILE="$LOGFILE_FOLDER/metering-upgrade-${timestamp}.log"
+  touch $LOGFILE
+  cleanup_old_logs
+  info "The following log file will be used: $LOGFILE"
+}
+
+cleanup_old_logs() {
+  ls -1tr $LOGFILE_FOLDER/metering-upgrade*.log | head -n -3 | xargs --no-run-if-empty rm
+}
+
+info() {
+  log "$1"
+}
+
+debug() {
+  log "$1" "true"
+}
+
+log() {
+  local timestamp=$(date +"%Y-%m-%dT%H:%M:%S.%3N%z")
+  local debug=$2
+  echo "$timestamp $1" >> $LOGFILE
+  if [[ "$2" == "" ]]; then
+    echo "$1"
+  fi
+}
+
+rpm_upgrade() {
+  local local_rpm_file=${1:?"usage: <local_rpm_file>"}
+  debug "Execute command: yum remove -y $METERING_PACKAGE_NAME && rpm -i $local_rpm_file"
+  yum remove -y $METERING_PACKAGE_NAME && rpm -i $local_rpm_file
+  local upgrade_result="$?"
+  if [[ "$upgrade_result" == 0 ]]; then
+    do_exit 0 "UPGRADE FINISHED."
+  else
+    do_exit 1 "UPGRADE FAILED WITH CODE: $upgrade_result."
+  fi
+}
+
+check_upgrade_by_date() {
+  local from_date="$FROM_DATE"
+  if [[ "$from_date" != "" ]]; then
+    debug "Check that upgrade is required by date: $from_date"
+    metering_package_date_unformatted=$(rpm -qa --last thunderhead-metering-heartbeat-application | cut -d " " -f 2-)
+    metering_package_date=$(date -d "$metering_package_date_unformatted" '+%Y-%m-%d')
+    if [[ "$from_date" < "$metering_package_date" ]]; then
+      do_exit 0 "NO UPGRADE REQUIRED"
+    fi
+  fi
+}
+
+check_download_rpm_by_size() {
+  local local_rpm_file=${1:?"usage: <local_rpm_file>"}
+  if [[ ! -f $local_rpm_file ]]; then
+    do_exit 1 "Cannot find file: $local_rpm_file"
+  fi
+  local rpm_file_size=$(du -sb $local_rpm_file | awk '{ print $1 }')
+  local rs=$(expr $rpm_file_size + 0)
+  local min=$(expr $MIN_BYTES + 0)
+  if [ "$min" -gt "$rs" ]; then
+    do_exit 1 "File $local_rpm_file is too small (bytes: $rs)"
+  fi
+}
+
+download() {
+  local local_rpm_file=${1:?"usage: <local_rpm_file>"}
+  local archive_url="$METERING_ARCHIVE_URL"
+  if [[ "$CUSTOM_RPM_URL" != "" ]]; then
+    debug "Found custom RPM URL: $CUSTOM_RPM_URL"
+    archive_url="$CUSTOM_RPM_URL"
+  fi
+  debug "Checking internet connection against url: $archive_url"
+  curl ${CURL_EXTRA_PARAMS} --head -s -k $archive_url
+  local archive_check_result="$?"
+  if [[ "$archive_check_result" == "0" ]]; then
+    download_binary "$archive_url" "$local_rpm_file" "true"
+  else
+    if [[ "$METERING_SERVICE_DELIVERY_URL" == "$METERING_ARCHIVE_URL" ]]; then
+      do_exit 1 "Cannot download Metering RPM file (from $archive_url)."
+    fi
+    debug "Internet connection failed against $archive_url"
+    debug "Checking internet connection against url: $METERING_SERVICE_DELIVERY_URL"
+    curl ${CURL_EXTRA_PARAMS} --head -s -k $METERING_SERVICE_DELIVERY_URL
+    local service_delivery_check_result="$?"
+    if [[ "$service_delivery_check_result" == "0" ]]; then
+      download_binary "$METERING_SERVICE_DELIVERY_URL" "$local_rpm_file" "true"
+    else
+      do_exit 1 "Cannot download Metering RPM file (from $archive_url or $METERING_SERVICE_DELIVERY_URL)."
+    fi
+  fi
+}
+
+download_binary() {
+    local rpm_url=${1:?"usage: <rpm_url>"}
+    local download_file_path=${2:?"usage: <download_file_path>"}
+    local override=${3}
+    if [[ -f $download_file_path && "$override" == "" ]]; then
+      log "RPM file '$download_file_path' already exists. Download will be skipped."
+      return
+    fi
+    log "Downloading $rpm_url"
+    content_length=$(curl ${CURL_EXTRA_PARAMS} -s --head -k -L "${rpm_url}" | grep -i Content-Length | awk '{print $2}' | tr -d '\r' | tr -d '\n')
+    log "Content length: ${content_length}"
+    free_space="$(df -B1 --output=avail "$WORKING_DIR" | grep -v Avail)"
+    log "Free space: ${free_space}"
+    local fs=$(expr $free_space + 0)
+    local cl=$(expr $content_length + 0)
+    if [ "$fs" -gt "$cl" ]; then
+      log "Have enough space for download the rpm from: $rpm_url"
+    else
+      do_exit 1 "Not enough space to download the rpm from: $rpm_url)"
+    fi
+    log "Run command: curl -k -L --output $download_file_path $rpm_url"
+    curl ${CURL_EXTRA_PARAMS} -k -L --output "$download_file_path" "$rpm_url"
+    if [[ ! -f $download_file_path ]]; then
+      do_exit 1 "RPM file was not downloaded: $download_file_path. Exiting ..."
+    fi
+}
+
+run_operation() {
+  while [[ $# -gt 0 ]]
+    do
+      key="$1"
+      case $key in
+        -d|--from-date)
+          FROM_DATE="$2"
+          shift 2
+        ;;
+        -u|--custom-rpm-url)
+          CUSTOM_RPM_URL="$2"
+          shift 2
+        ;;
+        -w|--working-dir)
+          WORKING_DIR="$2"
+          shift 2
+        ;;
+        *)
+          echo "Unknown option: $1"
+          do_exit 1
+        ;;
+      esac
+  done
+  init_logfile
+  if [[ "$WORKING_DIR" == "" ]]; then
+    WORKING_DIR="/tmp"
+  elif [[ ! -d "$WORKING_DIR" ]]; then
+    info "Working directory does not exists. Creating it..."
+    mkdir -p "$WORKING_DIR"
+    if [[ ! -d "$WORKING_DIR" ]]; then
+      do_exit 1 "Workdir cannot be created: $WORKING_DIR"
+    fi
+  fi
+  if [[ "$OPERATION_NAME" == "upgrade" ]]; then
+    if [[ "$HTTPS_PROXY" != "" ]]; then
+      export https_proxy="${HTTPS_PROXY}"
+      info "Found https_proxy settings."
+    fi
+    if [[ "$NO_PROXY" != "" ]]; then
+      export no_proxy="${NO_PROXY}"
+      info "Found no_proxy settings: $no_proxy"
+    fi
+    local local_rpm_file="$WORKING_DIR/$METERING_FILE_NAME"
+    check_upgrade_by_date
+    download "$local_rpm_file"
+    check_download_rpm_by_size "$local_rpm_file"
+    rpm_upgrade "$local_rpm_file"
+  fi
+}
+
+main() {
+  command="$1"
+  case $command in
+   "upgrade")
+      OPERATION_NAME="upgrade"
+      run_operation "${@:2}"
+   ;;
+   "help")
+      print_help
+    ;;
+   *)
+    echo "Available commands: (upgrade | help)"
+   ;;
+   esac
+}
+
+main ${1+"$@"}

--- a/orchestrator-salt/src/main/resources/salt/salt/metering/upgrade.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/metering/upgrade.sls
@@ -1,0 +1,40 @@
+{% set rpm_file_name = 'thunderhead-metering-heartbeat-application-0.1-SNAPSHOT.x86_64.rpm' %}
+{% set date_from = salt['pillar.get']('metering:upgradeDateFrom', '2022-01-18') %}
+{% set custom_rpm_url = salt['pillar.get']('metering:customRpmUrl', 'https://archive.cloudera.com/cp_clients/' + rpm_file_name) %}
+{% set fail_hard = salt['pillar.get']('metering:failHard') %}
+{% set proxy_full_url = None %}
+{% if salt['pillar.get']('proxy:host') %}
+  {% set proxy_host = salt['pillar.get']('proxy:host') %}
+  {% set proxy_port = salt['pillar.get']('proxy:port')|string %}
+  {% set proxy_protocol = salt['pillar.get']('proxy:protocol') %}
+  {% set proxy_url = proxy_protocol + "://" + proxy_host + ":" + proxy_port %}
+  {% if salt['pillar.get']('proxy:user') and salt['pillar.get']('proxy:password') %}
+    {% set proxy_user = salt['pillar.get']('proxy:user') %}
+    {% set proxy_password = salt['pillar.get']('proxy:password') %}
+    {% set proxy_full_url =  proxy_protocol + "://" + proxy_user + ":"+ proxy_password + "@" + proxy_host + ":" + proxy_port %}
+  {% else %}
+    {% set proxy_full_url = proxy_url %}
+  {% endif %}
+{% endif %}
+{% set no_proxy_hosts = salt['pillar.get']('proxy:noProxyHosts') %}
+
+/opt/salt/scripts/metering_package_manager.sh:
+  file.managed:
+    - user: root
+    - group: root
+    - mode: 700
+    - source: salt://metering/scripts/metering_package_manager.sh
+    - template: jinja
+
+execute_metering_binary_upgrade:
+  cmd.run:{% if fail_hard %}
+    - failHard: True{% endif %}
+    - name: "/opt/salt/scripts/metering_package_manager.sh upgrade{% if date_from %} -d {{ date_from }}{% endif %}{% if custom_rpm_url %} -u {{ custom_rpm_url }}{% endif %}{% if not fail_hard %}; exit 0{% endif %}"{% if proxy_full_url %}
+    - env:
+      - HTTPS_PROXY: {{ proxy_full_url }}{% if no_proxy_hosts %}
+      - NO_PROXY: {{ no_proxy_hosts }}{% endif %}{% endif %}
+
+remove_metering_tmp_rpm_file:
+  file.absent:
+    - name: /tmp/{{ rpm_file_name }}
+    - onlyif: test -f /tmp/{{ rpm_file_name }}

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltTelemetryOrchestratorTest.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltTelemetryOrchestratorTest.java
@@ -39,6 +39,8 @@ class SaltTelemetryOrchestratorTest {
 
     private static final int MAX_DIAGNOSTICS_COLLECTION_RETRY = 360;
 
+    private static final int MAX_METERING_UPGRADE_RETRY = 360;
+
     private final ExitCriteria exitCriteria = Mockito.mock(ExitCriteria.class);
 
     private final SaltService saltService = Mockito.mock(SaltService.class);
@@ -66,7 +68,7 @@ class SaltTelemetryOrchestratorTest {
     };
 
     private SaltTelemetryOrchestrator underTest = new SaltTelemetryOrchestrator(exitCriteria, saltService, saltRunner,
-            MAX_TELEMETRY_STOP_RETRY, MAX_NODESTATUS_COLLECT_RETRY, MAX_DIAGNOSTICS_COLLECTION_RETRY);
+            MAX_TELEMETRY_STOP_RETRY, MAX_NODESTATUS_COLLECT_RETRY, MAX_DIAGNOSTICS_COLLECTION_RETRY, MAX_METERING_UPGRADE_RETRY);
 
     @BeforeEach
     void setupTest() throws CloudbreakOrchestratorFailedException {


### PR DESCRIPTION
details:
- added new stack patcher implementation for fixing azure datahub nodes by upgrading old metering rpms
- stack patcher compares image creation dates in order to identify the stack that will need updates
- update logging auto restart stack patcher to update datahubs based on image timestamps as well (if those datahubs do not have a package version for cdp-logging-agent)
- added new metering_package_manager.sh script that can download/upgrade rpms (from 2 different places, first one can be provided by flags)
- script is used in upgrade.sls, init triggers that in failsafe mode, the stack patcher triggers that in fail hard mode
- add some refactoring & unit tests

See detailed description in the commit message.