### PR TITLE
CB-15656 Services are not started (cluster start command is not issue…

### DIFF
--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/view/StackView.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/view/StackView.java
@@ -4,6 +4,7 @@ import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.AVAILABLE;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.CREATE_IN_PROGRESS;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.DELETE_COMPLETED;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.DELETE_IN_PROGRESS;
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.EXTERNAL_DATABASE_START_FINISHED;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.EXTERNAL_DATABASE_START_IN_PROGRESS;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.EXTERNAL_DATABASE_STOP_FINISHED;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.START_IN_PROGRESS;
@@ -132,7 +133,8 @@ public class StackView extends CompactView {
     }
 
     public boolean isStartInProgress() {
-        return START_IN_PROGRESS.equals(getStatus()) || START_REQUESTED.equals(getStatus()) || EXTERNAL_DATABASE_START_IN_PROGRESS.equals(getStatus());
+        return START_IN_PROGRESS.equals(getStatus()) || START_REQUESTED.equals(getStatus())
+                || EXTERNAL_DATABASE_START_IN_PROGRESS.equals(getStatus()) || EXTERNAL_DATABASE_START_FINISHED.equals(getStatus());
     }
 
     public boolean isStopInProgress() {


### PR DESCRIPTION
…d) upon DH with external database

Check for EXTERNAL_DATABASE_START_FINISHED state in cluster start trigger as well.

See detailed description in the commit message.