### PR TITLE
CB-15712 Create separate cloud storage base location for every Azure E2E test

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProvider.java
@@ -80,7 +80,7 @@ public class AwsCloudProvider extends AbstractCloudProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AwsCloudProvider.class);
 
-    private static final String DEFAULT_STORAGE_NAME = "testsdx" + UUID.randomUUID().toString().replaceAll("-", "");
+    private static final String DEFAULT_STORAGE_NAME = "apitest" + UUID.randomUUID().toString().replaceAll("-", "");
 
     private static final String KEY_BASED_CREDENTIAL = "key";
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
@@ -72,7 +72,7 @@ public class AzureCloudProvider extends AbstractCloudProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AzureCloudProvider.class);
 
-    private static final String DEFAULT_STORAGE_NAME = "testsdx" + UUID.randomUUID().toString().replaceAll("-", "");
+    private static final String DEFAULT_STORAGE_NAME = "apitest" + UUID.randomUUID().toString().replaceAll("-", "");
 
     @Inject
     private AzureProperties azureProperties;
@@ -376,7 +376,7 @@ public class AzureCloudProvider extends AbstractCloudProvider {
 
     @Override
     public String getBaseLocation() {
-        return azureProperties.getCloudStorage().getBaseLocation();
+        return String.join("/", azureProperties.getCloudStorage().getBaseLocation(), DEFAULT_STORAGE_NAME);
     }
 
     public String getAssumerIdentity() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpCloudProvider.java
@@ -72,7 +72,7 @@ public class GcpCloudProvider extends AbstractCloudProvider {
 
     private static final String JSON_CREDENTIAL_TYPE = "json";
 
-    private static final String DEFAULT_STORAGE_NAME = "testsdx" + UUID.randomUUID().toString().replaceAll("-", "");
+    private static final String DEFAULT_STORAGE_NAME = "apitest" + UUID.randomUUID().toString().replaceAll("-", "");
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GcpCloudProvider.class);
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/mock/MockCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/mock/MockCloudProvider.java
@@ -72,7 +72,7 @@ public class MockCloudProvider extends AbstractCloudProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MockCloudProvider.class);
 
-    private static final String DEFAULT_STORAGE_NAME = "testsdx" + UUID.randomUUID().toString().replaceAll("-", "");
+    private static final String DEFAULT_STORAGE_NAME = "apitest" + UUID.randomUUID().toString().replaceAll("-", "");
 
     @Value("${mock.infrastructure.host:localhost}")
     private String mockInfrastructureHost;


### PR DESCRIPTION
During the investigation of E2E test failures it turned out that all our E2E test on all environments are using the same cloud storage base location which is a dangerous practice and could be ended up with race condition in specific service when they would like to create the same subdirectory at the same time.

For example on Azure the main Datalake related service are configured to use the `abfs://autotesting@autotestingapi.dfs.core.windows.net/` cloud storage location which means that all the created Datalake's ranger services on different environments are writing to the `abfs://autotesting@autotestingapi.dfs.core.windows.net/ranger/audit/atlas` directory.

Relevant config from Ranger logs:
```
2022-01-15 02:40:11,910 INFO  - [main:] ~ AUDIT PROPERTY: xasecure.audit.destination.hdfs.dir=abfs://autotesting@autotestingapi.dfs.core.windows.net/ranger/audit/atlas (AuditProviderFactory:149)
```

It would be much safer to use a separate cloud storage base location for every Environment/Datalake creation in our E2E tests.