### PR TITLE
CB-15417 - Generate a request id in Nginx for all requests going to Knox and log it in access.log

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/clouderamanager-ssl-user-facing.conf
+++ b/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/clouderamanager-ssl-user-facing.conf
@@ -3,6 +3,11 @@ map $http_upgrade $connection_upgrade {
         ''      close;
     }
 
+log_format main '$remote_addr - $remote_user [$time_local] '
+                               '"$request" $status $bytes_sent '
+                               '"$http_referer" "$http_user_agent" "$request_id"';
+access_log /var/log/nginx/access.log main;
+
 upstream knox {
     server 127.0.0.1:8443;
 }
@@ -73,6 +78,8 @@ server {
         proxy_set_header   X-Forwarded-Host $server_name;
         proxy_set_header   X-Forwarded-Proto $scheme;
         proxy_set_header   Expect $http_expect;
+        # Ensure request_id/trace_id gets passed down to Knox
+        proxy_set_header   X-Request-Id $request_id;
         # Ensure that websockets work
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/ssl-locations.d/knox.conf
+++ b/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/ssl-locations.d/knox.conf
@@ -13,6 +13,8 @@ location /knox/ {
   proxy_set_header   X-Forwarded-Host $server_name;
   proxy_set_header   X-Forwarded-Proto $scheme;
   proxy_set_header   Expect $http_expect;
+  # Ensure request_id/trace_id gets passed down to Knox
+  proxy_set_header   X-Request-Id $request_id;
   # Ensure that websockets work
   proxy_http_version 1.1;
   proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
**Describe the change you are making**
This PR adds two things to nginx config:
1. Generate a unique request id and pass it to Knox under `X-Request-Id` header
2. Log this request id in nginx access.log

**Why is this change needed**
This PR is a part of the effort to operationalize and instrument Knox (and other components). This is also part of OKR for Knox https://jira.cloudera.com/browse/CB-15417

**Side effects**
There should be no side effects. 

**Testing**
This was tested on a public cloud cluster by updating the `ssl-user-facing.conf` file. Following are the log snippets:

nginx log **before** the fix
```
10.19.15.62 - - [13/Jan/2022:19:40:04 +0000] "GET /dwx-o7p83q/cdp-proxy/atlas/js/templates/search/save/SaveSearchView_tmpl.html?bust=1640865545143 HTTP/1.1" 200 787 "https://dwx-o7p83q-gateway.dwx-o7p8.xcu2-8y8x.dev.cldr.work/dwx-o7p83q/cdp-proxy/atlas/index.html?action=timeout" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.71 Safari/537.36"
``` 
nginx log **after** the fix (notice the extra `f7c3ea4818dc061d7e80c71e252bb53e` at the end)
```
165.1.200.192 - - [19/Jan/2022:15:05:04 +0000] "GET /srm-dl/cdp-proxy/hbase/webui/static/css/bg.gif HTTP/1.1" 200 385 "https://srm-dl-gateway.srm-cb-1.xcu2-8y8x.dev.cldr.work/srm-dl/cdp-proxy/hbase/webui/static/css/hbase.css" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.71 Safari/537.36" "f7c3ea4818dc061d7e80c71e252bb53e"
```

Knox debug logs showing the `X-Request-Id` header with the same trace id (`f7c3ea4818dc061d7e80c71e252bb53e`)

```
2022-01-19 15:05:04,289 DEBUG http.wire (Wire.java:wire(73)) - http-outgoing-24 >> "GET /static/css/bg.gif?doAs=csso_smore_0 HTTP/1.1[\r][\n]"
2022-01-19 15:05:04,289 DEBUG http.wire (Wire.java:wire(73)) - http-outgoing-24 >> "X-Forwarded-For: 127.0.0.1[\r][\n]"
2022-01-19 15:05:04,290 DEBUG http.wire (Wire.java:wire(73)) - http-outgoing-24 >> "X-Forwarded-Proto: https[\r][\n]"
2022-01-19 15:05:04,290 DEBUG http.wire (Wire.java:wire(73)) - http-outgoing-24 >> "X-Forwarded-Port: 443[\r][\n]"
2022-01-19 15:05:04,290 DEBUG http.wire (Wire.java:wire(73)) - http-outgoing-24 >> "X-Forwarded-Host: srm-dl-gateway.srm-cb-1.xcu2-8y8x.dev.cldr.work[\r][\n]"
2022-01-19 15:05:04,290 DEBUG http.wire (Wire.java:wire(73)) - http-outgoing-24 >> "X-Forwarded-Server: srm-dl-gateway.srm-cb-1.xcu2-8y8x.dev.cldr.work[\r][\n]"
2022-01-19 15:05:04,291 DEBUG http.wire (Wire.java:wire(73)) - http-outgoing-24 >> "X-Forwarded-Context: /srm-dl/cdp-proxy[\r][\n]"
2022-01-19 15:05:04,291 DEBUG http.wire (Wire.java:wire(73)) - http-outgoing-24 >> "Cookie: pac4jCsrfToken=24631612-b382-4838-8eb2-aca5ffcb5e1d; hadoop-jwt= ........; ATLASSESSIONID=node03r5u3rt5m174ytrf3opntkwi347.node0; SESSION=NzgzZjQxMzktZTI0NC00NzBhLThkYzMtMDM2NTRhMWI0ZmJh[\r][\n]"
2022-01-19 15:05:04,291 DEBUG http.wire (Wire.java:wire(73)) - http-outgoing-24 >> "Accept: image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8[\r][\n]"
2022-01-19 15:05:04,291 DEBUG http.wire (Wire.java:wire(73)) - http-outgoing-24 >> "X-Request-Id: f7c3ea4818dc061d7e80c71e252bb53e[\r][\n]"
2022-01-19 15:05:04,292 DEBUG http.wire (Wire.java:wire(73)) - http-outgoing-24 >> "Referer: https://srm-dl-gateway.srm-cb-1.xcu2-8y8x.dev.cldr.work/[\r][\n]"
2022-01-19 15:05:04,292 DEBUG http.wire (Wire.java:wire(73)) - http-outgoing-24 >> "Connection: Upgrade[\r][\n]"
2022-01-19 15:05:04,292 DEBUG http.wire (Wire.java:wire(73)) - http-outgoing-24 >> "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.71 Safari/537.36[\r][\n]"
```
