### PR TITLE
CB-15341 Allow environment/cluster to be stopped when the nodes are i…

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
@@ -65,8 +65,11 @@ import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.CDP_USE_DAT
 import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.CDP_VM_DIAGNOSTICS;
 import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.CLOUDERA_INTERNAL_ACCOUNT;
 import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.DATAHUB_AWS_AUTOSCALING;
+import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.DATAHUB_AWS_STOP_START_SCALING;
 import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.DATAHUB_AZURE_AUTOSCALING;
+import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.DATAHUB_AZURE_STOP_START_SCALING;
 import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.DATAHUB_GCP_AUTOSCALING;
+import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.DATAHUB_GCP_STOP_START_SCALING;
 import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.DATA_LAKE_LIGHT_TO_MEDIUM_MIGRATION;
 import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.EPHEMERAL_DISKS_FOR_TEMP_DATA;
 import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.FMS_FREEIPA_BATCH_CALL;
@@ -268,12 +271,24 @@ public class EntitlementService {
         return isEntitlementRegistered(accountId, DATAHUB_AWS_AUTOSCALING);
     }
 
+    public boolean awsStopStartScalingEnabled(String accountId) {
+        return isEntitlementRegistered(accountId, DATAHUB_AWS_STOP_START_SCALING);
+    }
+
     public boolean azureAutoScalingEnabled(String accountId) {
         return isEntitlementRegistered(accountId, DATAHUB_AZURE_AUTOSCALING);
     }
 
+    public boolean azureStopStartScalingEnabled(String accountId) {
+        return isEntitlementRegistered(accountId, DATAHUB_AZURE_STOP_START_SCALING);
+    }
+
     public boolean gcpAutoScalingEnabled(String accountId) {
         return isEntitlementRegistered(accountId, DATAHUB_GCP_AUTOSCALING);
+    }
+
+    public boolean gcpStopStartScalingEnabled(String accountId) {
+        return isEntitlementRegistered(accountId, DATAHUB_GCP_STOP_START_SCALING);
     }
 
     public boolean ccmV2Enabled(String accountId) {

--- a/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementServiceTest.java
+++ b/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementServiceTest.java
@@ -140,6 +140,15 @@ class EntitlementServiceTest {
                 {"DATAHUB_GCP_AUTOSCALING", (EntitlementCheckFunction) EntitlementService::gcpAutoScalingEnabled, false},
                 {"DATAHUB_GCP_AUTOSCALING", (EntitlementCheckFunction) EntitlementService::gcpAutoScalingEnabled, true},
 
+                {"DATAHUB_AWS_STOP_START_SCALING", (EntitlementCheckFunction) EntitlementService::awsStopStartScalingEnabled, false},
+                {"DATAHUB_AWS_STOP_START_SCALING", (EntitlementCheckFunction) EntitlementService::awsStopStartScalingEnabled, true},
+
+                {"DATAHUB_AZURE_STOP_START_SCALING", (EntitlementCheckFunction) EntitlementService::azureStopStartScalingEnabled, false},
+                {"DATAHUB_AZURE_STOP_START_SCALING", (EntitlementCheckFunction) EntitlementService::azureStopStartScalingEnabled, true},
+
+                {"DATAHUB_GCP_STOP_START_SCALING", (EntitlementCheckFunction) EntitlementService::gcpStopStartScalingEnabled, false},
+                {"DATAHUB_GCP_STOP_START_SCALING", (EntitlementCheckFunction) EntitlementService::gcpStopStartScalingEnabled, true},
+
                 {"CDP_CB_DATABASE_WIRE_ENCRYPTION", (EntitlementCheckFunction) EntitlementService::databaseWireEncryptionEnabled, false},
                 {"CDP_CB_DATABASE_WIRE_ENCRYPTION", (EntitlementCheckFunction) EntitlementService::databaseWireEncryptionEnabled, true},
 

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/EntitlementValidationService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/EntitlementValidationService.java
@@ -31,4 +31,20 @@ public class EntitlementValidationService {
         }
         return entitled;
     }
+
+    @Cacheable(cacheNames = "accountEntitlementCache", key = "{#accountId,#cloudPlatform}")
+    public boolean stopStartAutoscalingEntitlementEnabled(String accountId, String cloudPlatform) {
+        boolean entitled = autoscalingEntitlementEnabled(accountId, cloudPlatform);
+        if (!entitled) {
+            return false;
+        }
+        if ("AWS".equalsIgnoreCase(cloudPlatform)) {
+            entitled = entitlementService.awsStopStartScalingEnabled(accountId);
+        } else if ("AZURE".equalsIgnoreCase(cloudPlatform)) {
+            entitled = entitlementService.azureStopStartScalingEnabled(accountId);
+        } else if ("GCP".equalsIgnoreCase(cloudPlatform)) {
+            entitled = entitlementService.gcpStopStartScalingEnabled(accountId);
+        }
+        return entitled;
+    }
 }

--- a/autoscale/src/test/java/com/sequenceiq/periscope/service/EntitlementValidationServiceTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/service/EntitlementValidationServiceTest.java
@@ -57,6 +57,32 @@ public class EntitlementValidationServiceTest {
     }
 
     @Test
+    public void testWhenAWSStopStartAndEntitled() {
+        when(entitlementService.awsAutoScalingEnabled(anyString())).thenReturn(true);
+        when(entitlementService.awsStopStartScalingEnabled(anyString())).thenReturn(true);
+
+        boolean entitled = underTest.stopStartAutoscalingEntitlementEnabled(TEST_ACCOUNT_ID, "AWS");
+        assertTrue("isEntitled should be true when entitlement found", entitled);
+    }
+
+    @Test
+    public void testWhenAWSStopStartAndNotEntitled() {
+        when(entitlementService.awsAutoScalingEnabled(anyString())).thenReturn(false);
+
+        boolean entitled = underTest.stopStartAutoscalingEntitlementEnabled(TEST_ACCOUNT_ID, "AWS");
+        assertFalse("isEntitled should be false when entitlement is not found", entitled);
+    }
+
+    @Test
+    public void testWhenAWSEntitledAndNotStopStart() {
+        when(entitlementService.awsAutoScalingEnabled(anyString())).thenReturn(true);
+        when(entitlementService.awsStopStartScalingEnabled(anyString())).thenReturn(false);
+
+        boolean entitled = underTest.stopStartAutoscalingEntitlementEnabled(TEST_ACCOUNT_ID, "AWS");
+        assertFalse("isEntitled should be false when entitlement is not found", entitled);
+    }
+
+    @Test
     public void testWhenAzureAndEntitled() {
         when(entitlementService.azureAutoScalingEnabled(anyString())).thenReturn(true);
 

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterCommissionService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterCommissionService.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.cluster.api;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -13,4 +14,6 @@ public interface ClusterCommissionService {
     Map<String, InstanceMetaData> collectHostsToCommission(@Nonnull HostGroup hostGroup, Set<String> hostNames);
 
     Set<String> recommissionClusterNodes(Map<String, InstanceMetaData> hostsToRecommission);
+
+    void recommissionHosts(List<String> hostsToRecommission);
 }

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterStatusService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterStatusService.java
@@ -17,6 +17,8 @@ public interface ClusterStatusService {
 
     ExtendedHostStatuses getExtendedHostStatuses(Optional<String> runtimeVersion);
 
+    List<String> getDecommissionedHostsFromCM();
+
     Map<HostName, String> getHostStatusesRaw();
 
     boolean isClusterManagerRunning();

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterCommissionService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterCommissionService.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.cm;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -66,5 +67,10 @@ public class ClouderaManagerClusterCommissionService implements ClusterCommissio
     @Override
     public Set<String> recommissionClusterNodes(Map<String, InstanceMetaData> hostsToRecommission) {
         return clouderaManagerCommissioner.recommissionNodes(stack, hostsToRecommission, client);
+    }
+
+    @Override
+    public void recommissionHosts(List<String> hostsToRecommission) {
+        clouderaManagerCommissioner.recommissionHosts(stack, client, hostsToRecommission);
     }
 }

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusService.java
@@ -79,6 +79,8 @@ public class ClouderaManagerClusterStatusService implements ClusterStatusService
 
     static final String FULL_WITH_EXPLANATION_VIEW = "FULL_WITH_HEALTH_CHECK_EXPLANATION";
 
+    static final String SUMMARY = "summary";
+
     private static final String DEFAULT_STATUS_REASON = "Cloudera Manager reported bad health for this host.";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerClusterStatusService.class);
@@ -260,6 +262,19 @@ public class ClouderaManagerClusterStatusService implements ClusterStatusService
         hostStates.entrySet().removeIf(entry -> entry.getValue().isEmpty());
         LOGGER.debug("Creating 'ExtendedHostStatuses' with {}", hostStates);
         return new ExtendedHostStatuses(hostStates);
+    }
+
+    @Override
+    public List<String> getDecommissionedHostsFromCM() {
+        HostsResourceApi api = clouderaManagerApiFactory.getHostsResourceApi(client);
+        try {
+            ApiHostList apiHostList = api.readHosts(null, null, SUMMARY);
+            LOGGER.trace("Response from CM for readHosts call: {}", apiHostList);
+            return apiHostList.getItems().stream().filter(ApiHost::getMaintenanceMode).map(ApiHost::getHostname).collect(toList());
+        } catch (ApiException e) {
+            LOGGER.info("Failed to get hosts from CM", e);
+            throw new RuntimeException("Failed to get hosts from CM due to: " + e.getMessage(), e);
+        }
     }
 
     private static Set<HealthCheck> getHealthChecks(ApiHost apiHost, boolean cmServicesHealthCheckAllowed) {

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterCommissionServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterCommissionServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -94,6 +95,13 @@ public class ClouderaManagerClusterCommissionServiceTest {
         Map<String, InstanceMetaData> hosts = mock(Map.class);
         underTest.recommissionClusterNodes(hosts);
         verify(clouderaManagerCommissioner).recommissionNodes(stack, hosts, apiClient);
+    }
+
+    @Test
+    public void testRecommissionClusterHosts() {
+        List<String> hosts = mock(List.class);
+        underTest.recommissionHosts(hosts);
+        verify(clouderaManagerCommissioner).recommissionHosts(stack, apiClient, hosts);
     }
 
     private Stack createStack() {

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusServiceTest.java
@@ -5,6 +5,7 @@ import static com.sequenceiq.cloudbreak.cm.ClouderaManagerClusterStatusService.F
 import static com.sequenceiq.cloudbreak.cm.ClouderaManagerClusterStatusService.FULL_WITH_EXPLANATION_VIEW;
 import static com.sequenceiq.cloudbreak.cm.ClouderaManagerClusterStatusService.HOST_AGENT_CERTIFICATE_EXPIRY;
 import static com.sequenceiq.cloudbreak.cm.ClouderaManagerClusterStatusService.HOST_SCM_HEALTH;
+import static com.sequenceiq.cloudbreak.cm.ClouderaManagerClusterStatusService.SUMMARY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -231,6 +232,18 @@ public class ClouderaManagerClusterStatusServiceTest {
     }
 
     @Test
+    public void getDecommissionedHostsFromCM() throws ApiException {
+        hostsAre(
+                new ApiHost().hostname("host1").maintenanceMode(true),
+                new ApiHost().hostname("host2").maintenanceMode(false)
+        );
+
+        List<String> hosts = subject.getDecommissionedHostsFromCM();
+        assertEquals(1, hosts.size());
+        assertEquals("host1", hosts.get(0));
+    }
+
+    @Test
     public void collectsExtendedHostHealthIfAvailable() throws ApiException {
         hostsAre(
                 new ApiHost().hostname("host1")
@@ -412,6 +425,7 @@ public class ClouderaManagerClusterStatusServiceTest {
         Arrays.stream(hosts).forEach(host -> host.addRoleRefsItem(roleRef(ApiHealthSummary.GOOD)));
         ApiHostList list = new ApiHostList().items(Arrays.asList(hosts));
         when(hostsApi.readHosts(null, null, FULL_VIEW)).thenReturn(list);
+        when(hostsApi.readHosts(null, null, SUMMARY)).thenReturn(list);
         when(hostsApi.readHosts(null, null, FULL_WITH_EXPLANATION_VIEW)).thenReturn(list);
     }
 

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/common/DetailedStackStatus.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/common/DetailedStackStatus.java
@@ -71,6 +71,7 @@ public enum DetailedStackStatus {
     ROLLING_BACK(Status.UPDATE_IN_PROGRESS),
     // The stack is available
     AVAILABLE(Status.AVAILABLE),
+    AVAILABLE_WITH_STOPPED_INSTANCES(Status.AVAILABLE_WITH_STOPPED_INSTANCES),
     // Instance removing status
     REMOVE_INSTANCE(Status.UPDATE_IN_PROGRESS),
     // Cluster operation is in progress

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/common/Status.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/common/Status.java
@@ -14,6 +14,7 @@ public enum Status {
     REQUESTED(StatusKind.PROGRESS),
     CREATE_IN_PROGRESS(StatusKind.PROGRESS),
     AVAILABLE(StatusKind.FINAL),
+    AVAILABLE_WITH_STOPPED_INSTANCES(StatusKind.FINAL),
     UPDATE_IN_PROGRESS(StatusKind.PROGRESS),
     UPDATE_REQUESTED(StatusKind.PROGRESS),
     UPDATE_FAILED(StatusKind.FINAL),
@@ -72,7 +73,7 @@ public enum Status {
 
     public boolean isRemovableStatus() {
         return Arrays.asList(AVAILABLE, UPDATE_FAILED, RECOVERY_FAILED, CREATE_FAILED, ENABLE_SECURITY_FAILED, DELETE_FAILED,
-                DELETE_COMPLETED, DELETED_ON_PROVIDER_SIDE, STOPPED, START_FAILED, STOP_FAILED).contains(valueOf(name()));
+                DELETE_COMPLETED, DELETED_ON_PROVIDER_SIDE, STOPPED, START_FAILED, STOP_FAILED, AVAILABLE_WITH_STOPPED_INSTANCES).contains(valueOf(name()));
     }
 
     public boolean isAvailable() {
@@ -121,6 +122,7 @@ public enum Status {
     static EnumSet<Status> notMappableToFailed() {
         return EnumSet.of(
                 AVAILABLE,
+                AVAILABLE_WITH_STOPPED_INSTANCES,
                 UPDATE_REQUESTED,
                 UPDATE_FAILED,
                 RECOVERY_REQUESTED,

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Stack.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Stack.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.domain.stack;
 
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.AVAILABLE;
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.AVAILABLE_WITH_STOPPED_INSTANCES;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.CREATE_IN_PROGRESS;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.DELETE_COMPLETED;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.DELETE_FAILED;
@@ -634,6 +635,10 @@ public class Stack implements ProvisionEntity, WorkspaceAwareResource {
         return AVAILABLE.equals(getStatus());
     }
 
+    public boolean isAvailableWithStoppedInstances() {
+        return AVAILABLE_WITH_STOPPED_INSTANCES.equals(getStatus());
+    }
+
     public boolean hasNodeFailure() {
         return NODE_FAILURE.equals(getStatus());
     }
@@ -664,6 +669,7 @@ public class Stack implements ProvisionEntity, WorkspaceAwareResource {
 
     public boolean isReadyForStop() {
         return AVAILABLE.equals(getStatus())
+                || AVAILABLE_WITH_STOPPED_INSTANCES.equals(getStatus())
                 || STOPPED.equals(getStatus())
                 || STOP_REQUESTED.equals(getStatus())
                 || STOP_IN_PROGRESS.equals(getStatus())

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartds/StopStartDownscaleFlowService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartds/StopStartDownscaleFlowService.java
@@ -85,7 +85,10 @@ public class StopStartDownscaleFlowService {
     public void clusterDownscaleFinished(Long stackId, @Nullable String hostGroupName, Set<InstanceMetaData> instancesStopped) {
         // TODO CB-14929: Make sure Database state updates are handled correctly.
         instancesStopped.stream().forEach(x -> instanceMetaDataService.updateInstanceStatus(x, InstanceStatus.STOPPED));
-        stackUpdater.updateStackStatus(stackId, DetailedStackStatus.AVAILABLE, "Instances: " + instancesStopped.size() + " stopped successfully.");
+        stackUpdater.updateStackStatus(
+                stackId,
+                DetailedStackStatus.AVAILABLE_WITH_STOPPED_INSTANCES,
+                "Instances: " + instancesStopped.size() + " stopped successfully.");
 
         flowMessageService.fireEventAndLog(stackId, AVAILABLE.name(), CLUSTER_SCALING_STOPSTART_DOWNSCALE_FINISHED,
                 hostGroupName == null ? "null" : hostGroupName);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJob.java
@@ -54,6 +54,7 @@ import com.sequenceiq.cloudbreak.service.stack.StackViewService;
 import com.sequenceiq.cloudbreak.service.stack.flow.InstanceSyncState;
 import com.sequenceiq.cloudbreak.service.stack.flow.StackSyncService;
 import com.sequenceiq.cloudbreak.service.stack.flow.SyncConfig;
+import com.sequenceiq.cloudbreak.util.StackUtil;
 import com.sequenceiq.flow.core.FlowLogService;
 
 import io.opentracing.Tracer;
@@ -101,6 +102,9 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
 
     @Inject
     private RuntimeVersionService runtimeVersionService;
+
+    @Inject
+    private StackUtil stackUtil;
 
     public StackStatusCheckerJob(Tracer tracer) {
         super(tracer, "Stack Status Checker Job");
@@ -190,6 +194,7 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
     Set<Status> syncableStates() {
         return EnumSet.of(
                 Status.AVAILABLE,
+                Status.AVAILABLE_WITH_STOPPED_INSTANCES,
                 Status.UPDATE_FAILED,
                 Status.ENABLE_SECURITY_FAILED,
                 Status.START_FAILED,
@@ -218,6 +223,7 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
         Set<InstanceMetaData> runningInstances = instanceMetaDataService.findNotTerminatedForStack(stack.getId());
         try {
             if (isClusterManagerRunning(stack, connector)) {
+                // TODO CB-15341 Node in maintenance mode does not get special treatment, should it?
                 ExtendedHostStatuses extendedHostStatuses = connector.clusterStatusService().getExtendedHostStatuses(
                         runtimeVersionService.getRuntimeVersion(stack.getCluster().getId()));
                 Map<HostName, Set<HealthCheck>> hostStatuses = extendedHostStatuses.getHostsHealth();
@@ -253,7 +259,17 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
         clusterService.updateClusterCertExpirationState(stack.getCluster(), hostCertExpiring);
         clusterOperationService.reportHealthChange(stack.getResourceCrn(), newFailedNodeNamesWithReason, newHealthyHostNames);
         if (!failedInstances.isEmpty()) {
-            clusterService.updateClusterStatusByStackId(stack.getId(), DetailedStackStatus.NODE_FAILURE);
+            if (stackUtil.stopStartScalingEntitlementEnabled(stack)) {
+                Set<InstanceMetaData> stoppedInstances = failedInstances.stream().filter(im -> im.getInstanceStatus().equals(STOPPED)).collect(toSet());
+                long stoppedInstancesCount = stoppedInstances.size();
+                // TODO: CB-15341 Is this a sufficient check for compute hostgroup in the long run?
+                boolean stoppedComputeOnly = stoppedInstances.stream().map(im -> im.getInstanceGroup().getGroupName()).allMatch(g -> g.contains("compute"));
+                if (stoppedComputeOnly && stoppedInstancesCount == failedInstances.size()) {
+                    clusterService.updateClusterStatusByStackId(stack.getId(), DetailedStackStatus.AVAILABLE_WITH_STOPPED_INSTANCES);
+                }
+            } else {
+                clusterService.updateClusterStatusByStackId(stack.getId(), DetailedStackStatus.NODE_FAILURE);
+            }
         } else if (statesFromAvailableAllowed().contains(stack.getStatus())) {
             clusterService.updateClusterStatusByStackId(stack.getId(), DetailedStackStatus.AVAILABLE);
         }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/nodestatus/NodeStatusCheckerJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/nodestatus/NodeStatusCheckerJob.java
@@ -228,6 +228,7 @@ public class NodeStatusCheckerJob extends StatusCheckerJob {
     private boolean checkableStates(Status status) {
         return EnumSet.of(
                 Status.AVAILABLE,
+                Status.AVAILABLE_WITH_STOPPED_INSTANCES,
                 Status.AMBIGUOUS,
                 Status.MAINTENANCE_MODE_ENABLED,
                 Status.UPDATE_REQUESTED,

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
@@ -375,7 +375,7 @@ public class StackOperationService {
         } else if (reason != StopRestrictionReason.NONE) {
             throw new BadRequestException(
                     format("Cannot stop a stack '%s'. Reason: %s", stack.getName(), reason.getReason()));
-        } else if (!stack.isAvailable() && !stack.isStopFailed()) {
+        } else if (!stack.isAvailable() && !stack.isStopFailed() && !stack.isAvailableWithStoppedInstances()) {
             throw NotAllowedStatusUpdate
                     .stack(stack)
                     .to(STOPPED)

--- a/core/src/main/java/com/sequenceiq/cloudbreak/util/StackUtil.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/util/StackUtil.java
@@ -25,6 +25,8 @@ import org.springframework.stereotype.Service;
 import com.google.common.annotations.VisibleForTesting;
 import com.gs.collections.impl.tuple.AbstractImmutableEntry;
 import com.gs.collections.impl.tuple.ImmutableEntry;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.CloudVolumeUsageType;
 import com.sequenceiq.cloudbreak.cloud.model.VolumeSetAttributes;
@@ -72,6 +74,9 @@ public class StackUtil {
 
     @Inject
     private GatewayConfigService gatewayConfigService;
+
+    @Inject
+    private EntitlementService entitlementService;
 
     public Set<Node> collectNodes(Stack stack) {
         Set<Node> agents = new HashSet<>();
@@ -247,5 +252,19 @@ public class StackUtil {
     public CloudCredential getCloudCredential(Stack stack) {
         Credential credential = credentialClientService.getByEnvironmentCrn(stack.getEnvironmentCrn());
         return credentialConverter.convert(credential);
+    }
+
+    public boolean stopStartScalingEntitlementEnabled(Stack stack) {
+        boolean entitled = false;
+        String accountId = Crn.safeFromString(stack.getResourceCrn()).getAccountId();
+        String cloudPlatform = stack.getCloudPlatform();
+        if ("AWS".equalsIgnoreCase(cloudPlatform)) {
+            entitled = entitlementService.awsStopStartScalingEnabled(accountId);
+        } else if ("AZURE".equalsIgnoreCase(cloudPlatform)) {
+            entitled = entitlementService.azureStopStartScalingEnabled(accountId);
+        } else if ("GCP".equalsIgnoreCase(cloudPlatform)) {
+            entitled = entitlementService.gcpStopStartScalingEnabled(accountId);
+        }
+        return entitled;
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/StackSyncServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/StackSyncServiceTest.java
@@ -1,0 +1,152 @@
+package com.sequenceiq.cloudbreak.service.stack.flow;
+
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus.CLUSTER_MANAGER_NOT_RESPONDING;
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.AVAILABLE;
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.AVAILABLE_WITH_STOPPED_INSTANCES;
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.NODE_FAILURE;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.cloudera.cdp.shaded.com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.service.StackUpdater;
+
+@ExtendWith(MockitoExtension.class)
+class StackSyncServiceTest {
+
+    @InjectMocks
+    private StackSyncService underTest;
+
+    @Mock
+    private Stack stack;
+
+    @Mock
+    private StackUpdater stackUpdater;
+
+    @ParameterizedTest(name = "{0}: currentStatus={1} and expectedStatus={6}")
+    @MethodSource("stackStatusForSync")
+    void handleSyncResult(
+            String methodName,
+            Status currentStatus,
+            int total,
+            int running,
+            int stopped,
+            int deleted,
+            SyncConfig syncConfig,
+            DetailedStackStatus expectedStatus) {
+        when(stack.getStatus()).thenReturn(currentStatus);
+        lenient().when(stack.getId()).thenReturn(1L);
+        Map<InstanceSyncState, Integer> instanceStateCounts = Maps.newHashMap();
+        instanceStateCounts.put(InstanceSyncState.STOPPED, stopped);
+        instanceStateCounts.put(InstanceSyncState.RUNNING, running);
+        instanceStateCounts.put(InstanceSyncState.DELETED_ON_PROVIDER_SIDE, deleted);
+        instanceStateCounts.put(InstanceSyncState.DELETED_BY_PROVIDER, 0);
+        Set<InstanceMetaData> instances = Sets.newHashSet();
+        for (int i = 0; i < total; i++) {
+            instances.add(new InstanceMetaData());
+        }
+        underTest.handleSyncResult(stack, instanceStateCounts, syncConfig, instances);
+        if (expectedStatus != null) {
+            String statusReason = "Synced instance states with the cloud provider.";
+            if (expectedStatus == CLUSTER_MANAGER_NOT_RESPONDING) {
+                statusReason = "Cloudera Manager server not responding.";
+            }
+            verify(stackUpdater).updateStackStatus(1L, expectedStatus, statusReason);
+        } else {
+            verifyNoInteractions(stackUpdater);
+        }
+    }
+
+    public static Stream<Arguments> stackStatusForSync() {
+        return Stream.of(
+                Arguments.of(
+                        "Stack was available and now 1 node stopped",
+                        AVAILABLE,
+                        5,
+                        4,
+                        1,
+                        0,
+                        new SyncConfig(true, true),
+                        DetailedStackStatus.AVAILABLE_WITH_STOPPED_INSTANCES
+                        ),
+                Arguments.of(
+                        "Stack was available and now all stopped",
+                        AVAILABLE,
+                        5,
+                        0,
+                        5,
+                        0,
+                        new SyncConfig(true, true),
+                        DetailedStackStatus.STOPPED
+                        ),
+                Arguments.of(
+                        "Stack was available and now all deleted",
+                        AVAILABLE,
+                        0,
+                        0,
+                        0,
+                        5,
+                        new SyncConfig(true, true),
+                        DetailedStackStatus.DELETED_ON_PROVIDER_SIDE
+                        ),
+                Arguments.of(
+                        "Stack was node failure and now 1 node stopped",
+                        NODE_FAILURE,
+                        5,
+                        3,
+                        1,
+                        1,
+                        new SyncConfig(true, true),
+                        null
+                        ),
+                Arguments.of(
+                        "Stack was running with 1 node stopped and now available",
+                        AVAILABLE_WITH_STOPPED_INSTANCES,
+                        5,
+                        5,
+                        0,
+                        0,
+                        new SyncConfig(true, true),
+                        DetailedStackStatus.AVAILABLE
+                ),
+                Arguments.of(
+                        "Stack was running with 1 node stopped and still running with 1 node stopped",
+                        AVAILABLE_WITH_STOPPED_INSTANCES,
+                        5,
+                        4,
+                        1,
+                        0,
+                        new SyncConfig(true, true),
+                        null
+                ),
+                Arguments.of(
+                        "Stack was running with 1 node stopped and now running CM is not running",
+                        AVAILABLE_WITH_STOPPED_INSTANCES,
+                        5,
+                        4,
+                        1,
+                        0,
+                        new SyncConfig(true, false),
+                        CLUSTER_MANAGER_NOT_RESPONDING
+                )
+        );
+    }
+}


### PR DESCRIPTION
…n stopped state

1. At the moment used the EntitlementService to check for the enablement of stop start scaling.
2. Implemented poor man's way finding stopped instances belong to compute hostgroup to set appropriate status
3. Now cluster start will recommission the services.
4. Need to add more unit test.