### PR TITLE
CB-14916 Use direct connection to CM in ephemeral upgrade test

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/ephemeral/DistroXUpgradeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/ephemeral/DistroXUpgradeTests.java
@@ -6,7 +6,6 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
@@ -57,7 +56,6 @@ public class DistroXUpgradeTests extends AbstractE2ETest {
         createEnvironmentWithFreeIpa(testContext);
     }
 
-    @Ignore("Yarn config verification is not working, because CM responds with a server error")
     @Test(dataProvider = TEST_CONTEXT)
     @UseSpotInstances
     @Description(given = "there is a running Cloudbreak, and an environment with SDX and DistroX cluster in available state",
@@ -94,7 +92,7 @@ public class DistroXUpgradeTests extends AbstractE2ETest {
                     verifyMountPointsUsedForTemporalDisks(testDto, "ephfs", "ephfs1");
                     return testDto;
                 })
-                .then((tc, testDto, client) -> clouderaManagerUtil.checkClouderaManagerYarnNodemanagerRoleConfigGroups(testDto, sanitizedUserName,
+                .then((tc, testDto, client) -> clouderaManagerUtil.checkClouderaManagerYarnNodemanagerRoleConfigGroupsDirect(testDto, sanitizedUserName,
                         MOCK_UMS_PASSWORD))
                 .validate();
         testContext
@@ -128,7 +126,7 @@ public class DistroXUpgradeTests extends AbstractE2ETest {
                     verifyMountPointsUsedForTemporalDisks(testDto, "ephfs", "ephfs1");
                     return testDto;
                 })
-                .then((tc, testDto, client) -> clouderaManagerUtil.checkClouderaManagerYarnNodemanagerRoleConfigGroups(testDto, sanitizedUserName,
+                .then((tc, testDto, client) -> clouderaManagerUtil.checkClouderaManagerYarnNodemanagerRoleConfigGroupsDirect(testDto, sanitizedUserName,
                         MOCK_UMS_PASSWORD))
                 .validate();
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/clouderamanager/ClouderaManagerUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/clouderamanager/ClouderaManagerUtil.java
@@ -27,6 +27,10 @@ public class ClouderaManagerUtil {
         return clouderaManagerClientActions.checkCmYarnNodemanagerRoleConfigGroups(testDto, user, password);
     }
 
+    public DistroXTestDto checkClouderaManagerYarnNodemanagerRoleConfigGroupsDirect(DistroXTestDto testDto, String user, String password) {
+        return clouderaManagerClientActions.checkCmYarnNodemanagerRoleConfigGroupsDirect(testDto, user, password);
+    }
+
     public DistroXTestDto checkClouderaManagerHdfsNamenodeRoleConfigGroups(DistroXTestDto testDto, String user, String password, Set<String> mountPoints) {
         return clouderaManagerClientActions.checkCmHdfsNamenodeRoleConfigGroups(testDto, user, password, mountPoints);
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/clouderamanager/client/ClouderaManagerClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/clouderamanager/client/ClouderaManagerClient.java
@@ -22,9 +22,19 @@ public class ClouderaManagerClient {
     }
 
     public ApiClient getCmApiClient(String serverFqdn, String clusterName, String apiVersion, String cmUser, String cmPassword) {
+        String basePath = "https://" + serverFqdn + "/" + clusterName + "/cdp-proxy-api/cm-api" + apiVersion;
+        return getApiClient(serverFqdn, cmUser, cmPassword, basePath);
+    }
+
+    public ApiClient getCmApiClientDirect(String serverFqdn, String clusterName, String apiVersion, String cmUser, String cmPassword) {
+        String basePath = "https://" + serverFqdn + "/clouderamanager/api/" + apiVersion;
+        return getApiClient(serverFqdn, cmUser, cmPassword, basePath);
+    }
+
+    private ApiClient getApiClient(String serverFqdn, String cmUser, String cmPassword, String basePath) {
         LOGGER.info(String.format("Cloudera Manager Server access details: %nserverFqdn: %s %ncmUser: %s %ncmPassword: %s", serverFqdn, cmUser, cmPassword));
         ApiClient cmClient = new ApiClient();
-        cmClient.setBasePath("https://" + serverFqdn + "/" + clusterName + "/cdp-proxy-api/cm-api" + apiVersion);
+        cmClient.setBasePath(basePath);
         cmClient.setUsername(cmUser);
         cmClient.setPassword(cmPassword);
         cmClient.setVerifyingSsl(false);
@@ -35,6 +45,13 @@ public class ClouderaManagerClient {
 
     public ApiClient getCmApiClientWithTimeoutDisabled(String serverFqdn, String clusterName, String apiVersion, String cmUser, String cmPassword) {
         ApiClient cmClient = getCmApiClient(serverFqdn, clusterName, apiVersion, cmUser, cmPassword);
+        cmClient.setConnectTimeout(0);
+        cmClient.getHttpClient().setReadTimeout(0, TimeUnit.MILLISECONDS);
+        return cmClient;
+    }
+
+    public ApiClient getCmApiClientWithTimeoutDisabledDirect(String serverFqdn, String clusterName, String apiVersion, String cmUser, String cmPassword) {
+        ApiClient cmClient = getCmApiClientDirect(serverFqdn, clusterName, apiVersion, cmUser, cmPassword);
         cmClient.setConnectTimeout(0);
         cmClient.getHttpClient().setReadTimeout(0, TimeUnit.MILLISECONDS);
         return cmClient;


### PR DESCRIPTION
REST calls towards CM did not work through knox in the case of
ephemeral upgrade e2e tests. Changed the test to utilize direct
connection, while we figure out why does knox respond with ssl
error, when the SDX is created through the public API for the test.

See detailed description in the commit message.