### PR TITLE
CB-15731. Improvements to scale-down via instance stop.

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/InstanceConnector.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/InstanceConnector.java
@@ -54,6 +54,21 @@ public interface InstanceConnector {
     List<CloudVmInstanceStatus> stop(AuthenticatedContext authenticatedContext, List<CloudResource> resources, List<CloudInstance> vms);
 
     /**
+     * A version of instance stop which limits the retries that operation may normally perform.
+     *
+     * @param authenticatedContext the authenticated context which holds the client object
+     * @param resources            resources managed by Cloudbreak, can be used to figure out which resources are associated with the given VMs
+     *                             (e.g. floating IP) and they can be started as well
+     * @param vms                  VM instances to be stopped
+     * @param timeboundInMs        A timebound in ms for this call.
+     * @return status of instances
+     */
+    default List<CloudVmInstanceStatus> stopWithLimitedRetry(AuthenticatedContext authenticatedContext, List<CloudResource> resources,
+            List<CloudInstance> vms, Long timeboundInMs) {
+        return stop(authenticatedContext, resources, vms);
+    }
+
+    /**
      * Reboot instances. You can reboot instances through this method. It does not need to wait/block until the VM instances are rebooted, but it can return
      * immediately and the {@link #check(AuthenticatedContext, List)} method is invoked to check regularly whether the VM instances have already been started
      * after a reboot or not.

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/instance/StopStartDownscaleStopInstancesResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/instance/StopStartDownscaleStopInstancesResult.java
@@ -3,37 +3,26 @@ package com.sequenceiq.cloudbreak.cloud.event.instance;
 import java.util.List;
 
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
-import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudVmInstanceStatus;
 
 public class StopStartDownscaleStopInstancesResult extends CloudPlatformResult {
 
-    private final List<CloudInstance> cloudInstancesToStop;
+    private final StopStartDownscaleStopInstancesRequest stopInstancesRequest;
 
-    private final List<CloudVmInstanceStatus> cloudVmInstanceStatusesNoCheck;
+    private final List<CloudVmInstanceStatus> affectedInstanceStatuses;
 
-    public StopStartDownscaleStopInstancesResult(Long resourceId, List<CloudInstance> cloudInstancesToStop,
-            List<CloudVmInstanceStatus> cloudVmInstanceStatusesNoCheck) {
+    public StopStartDownscaleStopInstancesResult(Long resourceId, StopStartDownscaleStopInstancesRequest request,
+            List<CloudVmInstanceStatus> affectedInstanceStatuses) {
         super(resourceId);
-        this.cloudInstancesToStop = cloudInstancesToStop;
-        this.cloudVmInstanceStatusesNoCheck = cloudVmInstanceStatusesNoCheck;
+        this.stopInstancesRequest = request;
+        this.affectedInstanceStatuses = affectedInstanceStatuses;
     }
 
-    public List<CloudInstance> getCloudInstancesToStop() {
-        return cloudInstancesToStop;
+    public StopStartDownscaleStopInstancesRequest getStopInstancesRequest() {
+        return stopInstancesRequest;
     }
 
-    // TODO CB-14929: This should include information about the actual instances that were STOPPED.
-    //  The result needs to be filtered somewhewre for the actual status. Will evolve based on error handling.
-    public List<CloudVmInstanceStatus> getCloudVmInstanceStatusesNoCheck() {
-        return cloudVmInstanceStatusesNoCheck;
-    }
-
-    @Override
-    public String toString() {
-        return "StopStartDownscaleStopInstancesResult{" +
-                "cloudInstancesToStop=" + cloudInstancesToStop +
-                ", cloudVmInstanceStatusesNoCheck=" + cloudVmInstanceStatusesNoCheck +
-                '}';
+    public List<CloudVmInstanceStatus> getAffectedInstanceStatuses() {
+        return affectedInstanceStatuses;
     }
 }

--- a/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/handler/StopStartUpscaleStartInstancesHandler.java
+++ b/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/handler/StopStartUpscaleStartInstancesHandler.java
@@ -29,7 +29,7 @@ public class StopStartUpscaleStartInstancesHandler implements CloudPlatformEvent
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StopStartUpscaleStartInstancesHandler.class);
 
-    private static final Long START_POLL_TIMEBOUND_MS = 180_000L;
+    private static final Long START_POLL_TIMEBOUND_MS = 300_000L;
 
     @Inject
     private CloudPlatformConnectors cloudPlatformConnectors;

--- a/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/StopStartDownscaleStopInstancesHandlerTest.java
+++ b/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/StopStartDownscaleStopInstancesHandlerTest.java
@@ -1,0 +1,209 @@
+package com.sequenceiq.cloudbreak.cloud.handler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cloud.Authenticator;
+import com.sequenceiq.cloudbreak.cloud.CloudConnector;
+import com.sequenceiq.cloudbreak.cloud.InstanceConnector;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.event.instance.StopStartDownscaleStopInstancesRequest;
+import com.sequenceiq.cloudbreak.cloud.event.instance.StopStartDownscaleStopInstancesResult;
+import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
+import com.sequenceiq.cloudbreak.cloud.model.CloudPlatformVariant;
+import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.CloudVmInstanceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
+
+import reactor.bus.Event;
+import reactor.bus.EventBus;
+
+@ExtendWith(MockitoExtension.class)
+public class StopStartDownscaleStopInstancesHandlerTest {
+
+    private static final String MOCK_INSTANCEID_PREFIX = "i-";
+
+    private static final Long EXPECTED_STOP_POLL_TIMEBOUND_MS = 300_000L;
+
+    @Mock
+    private CloudPlatformConnectors cloudPlatformConnectors;
+
+    @Mock
+    private EventBus eventBus;
+
+    @InjectMocks
+    private StopStartDownscaleStopInstancesHandler underTest;
+
+    @Mock
+    private CloudConnector<Object> cloudConnector;
+
+    @Mock
+    private CloudContext cloudContext;
+
+    @Mock
+    private CloudCredential cloudCredential;
+
+    @Mock
+    private CloudStack cloudStack;
+
+    @Mock
+    private InstanceConnector instanceConnector;
+
+    @BeforeEach
+    public void setUp() {
+        Authenticator authenticator = mock(Authenticator.class);
+        AuthenticatedContext ac = mock(AuthenticatedContext.class);
+        CloudPlatformVariant cloudPlatformVariant = mock(CloudPlatformVariant.class);
+
+        reset(cloudContext);
+        reset(cloudPlatformConnectors);
+        reset(cloudConnector);
+
+        lenient().when(cloudContext.getPlatformVariant()).thenReturn(cloudPlatformVariant);
+        lenient().when(cloudPlatformConnectors.get(any(CloudPlatformVariant.class))).thenReturn(cloudConnector);
+        lenient().when(cloudConnector.authentication()).thenReturn(authenticator);
+        lenient().when(authenticator.authenticate(any(CloudContext.class), any(CloudCredential.class))).thenReturn(ac);
+        lenient().when(cloudConnector.instances()).thenReturn(instanceConnector);
+    }
+
+    @Test
+    void testType() {
+        assertEquals(StopStartDownscaleStopInstancesRequest.class, underTest.type());
+    }
+
+    @Test
+    void testAllSuccessfullyStopped() {
+        List<CloudInstance> cloudInstancesToStop = generateCloudInstances(5);
+        List<CloudVmInstanceStatus> stoppedInstanceStatusList = generateStoppedCloudInstances(cloudInstancesToStop);
+
+        testExpectedResultInernal(cloudInstancesToStop, stoppedInstanceStatusList);
+    }
+
+    @Test
+    void testSomeStopAttemptedInstancesInTerminalState() {
+        List<CloudInstance> cloudInstancesToStop = generateCloudInstances(5);
+        List<CloudVmInstanceStatus> stoppedInstanceStatusList = generateCloudVMInstanceStatusWithSomeInTerminalState(cloudInstancesToStop);
+        testExpectedResultInernal(cloudInstancesToStop, stoppedInstanceStatusList);
+    }
+
+    @Test
+    void testNoInstancesToStop() {
+        List<CloudInstance> cloudInstancesToStop = generateCloudInstances(0);
+        List<CloudVmInstanceStatus> stoppedInstanceStatusList = generateStoppedCloudInstances(cloudInstancesToStop);
+        testExpectedResultInernal(cloudInstancesToStop, stoppedInstanceStatusList, false);
+    }
+
+    @Test
+    void testFailureFromCloudProviderWhenStoppingInstances() {
+        List<CloudInstance> cloudInstancesToStop = generateCloudInstances(5);
+
+        when(instanceConnector.stopWithLimitedRetry(any(AuthenticatedContext.class), eq(null), eq(cloudInstancesToStop), any(Long.class)))
+                .thenThrow(new RuntimeException("CloudProviderStopError"));
+
+        StopStartDownscaleStopInstancesRequest request =
+                new StopStartDownscaleStopInstancesRequest(cloudContext, cloudCredential, cloudStack, cloudInstancesToStop);
+
+        Event event = new Event(request);
+        try {
+            underTest.accept(event);
+            Assert.fail("Expected an exception");
+        } catch (Exception expected) {
+            assertEquals("CloudProviderStopError", expected.getMessage());
+        }
+    }
+
+    private void testExpectedResultInernal(List<CloudInstance> cloudInstancesToStop, List<CloudVmInstanceStatus> cloudConnectoReturnList) {
+        testExpectedResultInernal(cloudInstancesToStop, cloudConnectoReturnList, true);
+    }
+
+    private void testExpectedResultInernal(List<CloudInstance> cloudInstancesToStop, List<CloudVmInstanceStatus> cloudConnectoReturnList,
+            boolean expectedCloudInteractions) {
+        StopStartDownscaleStopInstancesRequest request =
+                new StopStartDownscaleStopInstancesRequest(cloudContext, cloudCredential, cloudStack, cloudInstancesToStop);
+
+        lenient().when(instanceConnector.stopWithLimitedRetry(any(AuthenticatedContext.class), eq(null), eq(cloudInstancesToStop), any(Long.class)))
+                .thenReturn(cloudConnectoReturnList);
+
+        Event event = new Event(request);
+        underTest.accept(event);
+
+        ArgumentCaptor<Event> resultCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(eventBus).notify(any(Object.class), resultCaptor.capture());
+
+        if (expectedCloudInteractions) {
+            verify(instanceConnector).stopWithLimitedRetry(any(AuthenticatedContext.class), eq(null), eq(cloudInstancesToStop),
+                    eq(EXPECTED_STOP_POLL_TIMEBOUND_MS));
+        }
+        verifyNoMoreInteractions(instanceConnector);
+
+        assertEquals(1, resultCaptor.getAllValues().size());
+        Event resultEvent = resultCaptor.getValue();
+        assertEquals(StopStartDownscaleStopInstancesResult.class, resultEvent.getData().getClass());
+        StopStartDownscaleStopInstancesResult result = (StopStartDownscaleStopInstancesResult) resultEvent.getData();
+
+        assertEquals(cloudConnectoReturnList, result.getAffectedInstanceStatuses());
+    }
+
+    private List<CloudInstance> generateCloudInstances(int numInstances) {
+        List<CloudInstance> instances = new LinkedList<>();
+
+        for (int i = 0; i < numInstances; i++) {
+            CloudInstance cloudInstance = mock(CloudInstance.class);
+            lenient().when(cloudInstance.getInstanceId()).thenReturn(MOCK_INSTANCEID_PREFIX + i);
+            instances.add(cloudInstance);
+        }
+        return instances;
+    }
+
+    private List<CloudVmInstanceStatus> generateStoppedCloudInstances(List<CloudInstance> cloudInstances) {
+        List<CloudVmInstanceStatus> cloudVmInstanceStatusList = new LinkedList<>();
+        for (CloudInstance cloudInstance : cloudInstances) {
+            cloudVmInstanceStatusList.add(new CloudVmInstanceStatus(cloudInstance, InstanceStatus.STOPPED));
+        }
+        return cloudVmInstanceStatusList;
+    }
+
+    private List<CloudVmInstanceStatus> generateCloudVMInstanceStatusWithSomeInTerminalState(List<CloudInstance> cloudInstances) {
+        List<CloudVmInstanceStatus> cloudVmInstanceStatusList = new LinkedList<>();
+
+        int count = 0;
+        for (CloudInstance cloudInstance : cloudInstances) {
+            CloudVmInstanceStatus cloudVmInstanceStatus;
+            if (count == 0) {
+                cloudVmInstanceStatus = new CloudVmInstanceStatus(cloudInstance, InstanceStatus.TERMINATED);
+            } else if (count == 1) {
+                cloudVmInstanceStatus = new CloudVmInstanceStatus(cloudInstance, InstanceStatus.TERMINATED_BY_PROVIDER);
+            } else if (count == 2) {
+                cloudVmInstanceStatus = new CloudVmInstanceStatus(cloudInstance, InstanceStatus.DELETE_REQUESTED);
+            } else {
+                cloudVmInstanceStatus = new CloudVmInstanceStatus(cloudInstance, InstanceStatus.STOPPED);
+            }
+
+            count++;
+            cloudVmInstanceStatusList.add(cloudVmInstanceStatus);
+        }
+        return cloudVmInstanceStatusList;
+    }
+}

--- a/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/StopStartUpscaleStartInstancesHandlerTest.java
+++ b/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/StopStartUpscaleStartInstancesHandlerTest.java
@@ -86,7 +86,6 @@ public class StopStartUpscaleStartInstancesHandlerTest {
         lenient().when(cloudConnector.authentication()).thenReturn(authenticator);
         lenient().when(authenticator.authenticate(any(CloudContext.class), any(CloudCredential.class))).thenReturn(ac);
         lenient().when(cloudConnector.instances()).thenReturn(instanceConnector);
-
     }
 
     @Test

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterDecomissionService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterDecomissionService.java
@@ -21,7 +21,9 @@ public interface ClusterDecomissionService {
 
     Set<String> decommissionClusterNodes(Map<String, InstanceMetaData> hostsToRemove);
 
-    void enterMaintenanceMode(Stack stack, Map<String, InstanceMetaData> hostList);
+    Set<String> decommissionClusterNodesStopStart(Map<String, InstanceMetaData> hostsToRemove, long pollingTimeout);
+
+    void enterMaintenanceMode(Stack stack, Set<String> hostFqdnList);
 
     void removeManagementServices();
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterDecomissionService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterDecomissionService.java
@@ -91,8 +91,13 @@ public class ClouderaManagerClusterDecomissionService implements ClusterDecomiss
     }
 
     @Override
-    public void enterMaintenanceMode(Stack stack, Map<String, InstanceMetaData> hostList) {
-        clouderaManagerDecomissioner.enterMaintenanceMode(stack, hostList, client);
+    public Set<String> decommissionClusterNodesStopStart(Map<String, InstanceMetaData> hostsToRemove, long pollingTimeout) {
+        return clouderaManagerDecomissioner.decommissionNodesStopStart(stack, hostsToRemove, client, pollingTimeout);
+    }
+
+    @Override
+    public void enterMaintenanceMode(Stack stack, Set<String> hostFqdnList) {
+        clouderaManagerDecomissioner.enterMaintenanceMode(stack, hostFqdnList, client);
     }
 
     @Override

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerDecomissioner.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerDecomissioner.java
@@ -5,6 +5,7 @@ import static com.sequenceiq.cloudbreak.polling.PollingResult.isTimeout;
 
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -194,7 +195,9 @@ public class ClouderaManagerDecomissioner {
                 .filter(hostMetadata -> hostNames.contains(hostMetadata.getDiscoveryFQDN()))
                 .collect(Collectors.toMap(InstanceMetaData::getDiscoveryFQDN, hostMetadata -> hostMetadata));
         if (hostsToRemove.size() != hostNames.size()) {
-            LOGGER.debug("Not all hosts found in the given host group. [{}, {}]", hostGroup.getName(), hostNames);
+            List<String> missingHosts = hostNames.stream().filter(h -> !hostsToRemove.containsKey(h)).collect(Collectors.toList());
+            LOGGER.debug("Not all requested hosts found in CB for host group: {}. MissingCount={}, missingHosts=[{}]. Requested hosts: [{}]",
+                    hostGroup.getName(), missingHosts.size(), missingHosts, hostNames);
         }
         HostsResourceApi hostsResourceApi = clouderaManagerApiFactory.getHostsResourceApi(client);
         try {
@@ -203,8 +206,21 @@ public class ClouderaManagerDecomissioner {
                     .map(ApiHost::getHostname)
                     .collect(Collectors.toList());
             // TODO: what if i remove a node from CM manually?
+
+            List<String> matchingCmHosts = hostsToRemove.keySet().stream()
+                    .filter(hostName -> runningHosts.contains(hostName))
+                    .collect(Collectors.toList());
+            Set<String> matchingCmHostSet = new HashSet<>(matchingCmHosts);
+
+            if (matchingCmHosts.size() != hostsToRemove.size()) {
+                List<String> missingHostsInCm = hostsToRemove.keySet().stream().filter(h -> !matchingCmHostSet.contains(h)).collect(Collectors.toList());
+
+                LOGGER.debug("Not all requested hosts found in CM. MissingCount={}, missingHosts=[{}]. Requested hosts: [{}]",
+                        missingHostsInCm.size(), missingHostsInCm, hostsToRemove.keySet());
+            }
+
             Sets.newHashSet(hostsToRemove.keySet()).stream()
-                    .filter(hostName -> !runningHosts.contains(hostName))
+                    .filter(hostName -> !matchingCmHostSet.contains(hostName))
                     .forEach(hostsToRemove::remove);
             LOGGER.debug("Collected hosts to remove: [{}]", hostsToRemove);
             return hostsToRemove;
@@ -214,7 +230,7 @@ public class ClouderaManagerDecomissioner {
         }
     }
 
-    public void enterMaintenanceMode(Stack stack, Map<String, InstanceMetaData> hostList, ApiClient client) {
+    public void enterMaintenanceMode(Stack stack, Set<String> hostList, ApiClient client) {
         HostsResourceApi hostsResourceApi = clouderaManagerApiFactory.getHostsResourceApi(client);
         String currentHostId = null;
         int successCount = 0;
@@ -223,7 +239,7 @@ public class ClouderaManagerDecomissioner {
         try {
             ApiHostList hostRefList = hostsResourceApi.readHosts(null, null, SUMMARY_REQUEST_VIEW);
             availableHostsIdsFromCm = hostRefList.getItems().stream()
-                    .filter(apiHostRef -> hostList.containsKey(apiHostRef.getHostname()))
+                    .filter(apiHostRef -> hostList.contains(apiHostRef.getHostname()))
                     .parallel()
                     .map(ApiHost::getHostId)
                     .collect(Collectors.toList());
@@ -237,6 +253,54 @@ public class ClouderaManagerDecomissioner {
                     successCount, hostList == null ? 0 : hostList.size(), availableHostsIdsFromCm == null ? "null" : availableHostsIdsFromCm);
         } catch (ApiException e) {
             LOGGER.error("Failed while putting a node into maintenance mode. nodeId=" + currentHostId + ", successCount=" + successCount, e);
+            throw new CloudbreakServiceException(e.getMessage(), e);
+        }
+    }
+
+    public Set<String> decommissionNodesStopStart(Stack stack, Map<String, InstanceMetaData> hostsToRemove, ApiClient client, long pollingTimeout) {
+        HostsResourceApi hostsResourceApi = clouderaManagerApiFactory.getHostsResourceApi(client);
+        try {
+            ApiHostList hostRefList = hostsResourceApi.readHosts(null, null, SUMMARY_REQUEST_VIEW);
+            // TODO CB-14929 Maybe move this to a trace level log.
+            LOGGER.debug("Target decommissionNodes: count={}, hosts=[{}]", hostsToRemove.size(), hostsToRemove.keySet());
+            LOGGER.debug("hostsAvailableFromCM: count={}, hosts=[{}]", hostRefList.getItems().size(),
+                    hostRefList.getItems().stream().map(ApiHost::getHostname));
+            List<String> stillAvailableRemovableHosts = hostRefList.getItems().stream()
+                    .filter(apiHostRef -> hostsToRemove.containsKey(apiHostRef.getHostname()))
+                    .parallel()
+                    .map(ApiHost::getHostname)
+                    .collect(Collectors.toList());
+
+            Set<String> hostsAvailableForDecommissionSet = new HashSet<>(stillAvailableRemovableHosts);
+            List<String> cmHostsUnavailableForDecommission = hostsToRemove.keySet().stream()
+                    .filter(h -> !hostsAvailableForDecommissionSet.contains(h)).collect(Collectors.toList());
+            if (cmHostsUnavailableForDecommission.size() != 0) {
+                LOGGER.info("Some decommission targets are unavailable in CM: TotalDecommissionTargetCount={}, unavailableInCMCount={}, unavailableInCm=[{}]",
+                        hostsToRemove.size(), cmHostsUnavailableForDecommission.size(), cmHostsUnavailableForDecommission);
+            }
+
+            ClouderaManagerResourceApi apiInstance = clouderaManagerApiFactory.getClouderaManagerResourceApi(client);
+            ApiHostNameList body = new ApiHostNameList().items(stillAvailableRemovableHosts);
+            ApiCommand apiCommand = apiInstance.hostsDecommissionCommand(body);
+
+            PollingResult pollingResult = clouderaManagerPollingServiceProvider.startPollingCmHostsDecommission(
+                    stack, client, apiCommand.getId(), pollingTimeout);
+            if (isExited(pollingResult)) {
+                throw new CancellationException("Cluster was terminated while waiting for host decommission");
+            } else if (isTimeout(pollingResult)) {
+                String warningMessage = "Cloudera Manager decommission host command {} polling timed out, " +
+                        "thus we are aborting the decommission and we are retrying it for lost nodes once again.";
+                abortDecommissionWithWarningMessage(apiCommand, client, warningMessage);
+                throw new CloudbreakServiceException(
+                        String.format("Timeout while Cloudera Manager decommissioned host. CM command Id: %s", apiCommand.getId()));
+            }
+            return stillAvailableRemovableHosts.stream()
+                    .map(hostsToRemove::get)
+                    .filter(instanceMetaData -> instanceMetaData.getDiscoveryFQDN() != null)
+                    .map(InstanceMetaData::getDiscoveryFQDN)
+                    .collect(Collectors.toSet());
+        } catch (ApiException e) {
+            LOGGER.error("Failed to decommission hosts: {}", hostsToRemove.keySet(), e);
             throw new CloudbreakServiceException(e.getMessage(), e);
         }
     }

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/ClouderaManagerPollingServiceProvider.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/ClouderaManagerPollingServiceProvider.java
@@ -165,11 +165,16 @@ public class ClouderaManagerPollingServiceProvider {
                 new NoExceptionOnTimeoutClouderaManagerListenerTask(clouderaManagerApiPojoFactory, clusterEventService, "RecommissionHosts"));
     }
 
+    public PollingResult startPollingCmHostsDecommission(Stack stack, ApiClient apiClient, BigDecimal commandId, long pollingTimeout) {
+        LOGGER.debug("Waiting for Cloudera Manager to decommission host. [Server address: {}]", stack.getClusterManagerIp());
+        return pollCommandWithTimeListener(stack, apiClient, commandId, pollingTimeout,
+                new NoExceptionOnTimeoutClouderaManagerListenerTask(clouderaManagerApiPojoFactory, clusterEventService, "DecommissionHosts"));
+    }
+
     public PollingResult startPollingCmHostDecommissioning(Stack stack, ApiClient apiClient, BigDecimal commandId,
             boolean onlyLostNodesAffected, int removableHostsCount) {
         LOGGER.debug("Waiting for Cloudera Manager to decommission host. [Server address: {}]", stack.getClusterManagerIp());
         if (onlyLostNodesAffected) {
-            // TODO CB-14929: not exactly CB-14929. Seems incorrect to include 5 minutes per host being removed.
             long timeout = POLL_FOR_10_MINUTES + removableHostsCount * POLL_FOR_5_MINUTES;
             LOGGER.info("Cloudera Manager decommission host command will have {} minutes timeout, " +
                     "since all affected nodes are already deleted from provider side.", TimeUnit.SECONDS.toMinutes(timeout));

--- a/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
@@ -298,9 +298,6 @@ public enum ResourceEvent {
     CLUSTER_UPGRADE_VALIDATION_FAILED("cluster.upgrade.validation.failed"),
     CLUSTER_PROVISION_CLOUD_STORAGE_VALIDATION_ON_IDBROKER_FAILED("cluster.provision.idbrokerhost.cloudstorage.vmvalidation.failed"),
 
-    // TODO CB-14929: Add additional messsages here, especially for the partial operations.
-    // TODO CB-14929: hostnames vs instanceIds when logging requests
-    // TODO CB-14929: Requests must include instanceCounts (Ideally change this for the current scaling operations as well)
     CLUSTER_SCALING_STOPSTART_UPSCALE_INIT("cluster.scaling.stopstart.upscale.init"),
     CLUSTER_SCALING_STOPSTART_UPSCALE_NODES_STARTED("cluster.scaling.stopstart.upscale.nodes.started"),
     CLUSTER_SCALING_STOPSTART_UPSCALE_NODES_NOT_STARTED("cluster.scaling.stopstart.upscale.nodes.notstarted"),
@@ -315,11 +312,14 @@ public enum ResourceEvent {
 
     CLUSTER_SCALING_STOPSTART_DOWNSCALE_INIT("cluster.scaling.stopstart.downscale.init"),
     CLUSTER_SCALING_STOPSTART_DOWNSCALE_STARTING("cluster.scaling.stopstart.downscale.starting"),
-    CLUSTER_SCALING_STOPSTART_DOWNSCALE_STARTING2("cluster.scaling.stopstart.downscale.starting2"),
+    CLUSTER_SCALING_STOPSTART_DOWNSCALE_COULDNOTDECOMMISSION("cluster.scaling.stopstart.downscale.couldnotdecommission"),
     CLUSTER_SCALING_STOPSTART_DOWNSCALE_ENTERINGCMMAINTMODE("cluster.scaling.stopstart.downscale.enteringcmmaintmode"),
     CLUSTER_SCALING_STOPSTART_DOWNSCALE_ENTEREDCMMAINTMODE("cluster.scaling.stopstart.downscale.enteredcmmaintmode"),
     CLUSTER_SCALING_STOPSTART_DOWNSCALE_NODE_STOPPING("cluster.scaling.stopstart.downscale.nodes.stopping"),
+    CLUSTER_SCALING_STOPSTART_DOWNSCALE_NODES_STOPPED("cluster.scaling.stopstart.downscale.nodes.stopped"),
+    CLUSTER_SCALING_STOPSTART_DOWNSCALE_NODES_NOT_STOPPED("cluster.scaling.stopstart.downscale.nodes.notstopped"),
     CLUSTER_SCALING_STOPSTART_DOWNSCALE_FINISHED("cluster.scaling.stopstart.downscale.finished"),
+    CLUSTER_SCALING_STOPSTART_DOWNSCALE_FAILED("cluster.scaling.stopstart.downscale.failed"),
 
 
     CLUSTER_SALT_UPDATE_STARTED("cluster.salt.update.started"),

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -102,24 +102,27 @@ cluster.manager.server.restarting=Restarting Cluster Manager Server
 cluster.services.restarting=Restarting Cluster services
 
 cluster.scaling.stopstart.upscale.init=Scaling up (via instance start) for host group: {0}. Starting {1} node(s)
-cluster.scaling.stopstart.upscale.nodes.started=Started Instances: count={0}, instanceId(s):{1}
-cluster.scaling.stopstart.upscale.nodes.notstarted=Some instances did not reach the desired state, and may need attention: count={0}, instanceId(s): {1}
+cluster.scaling.stopstart.upscale.nodes.started=Started Instances: count={0}, instanceId(s): [{1}]
+cluster.scaling.stopstart.upscale.nodes.notstarted=Some instances did not reach the desired 'STARTED' state, and may need attention: count={0}, instanceId(s): [{1}]
 cluster.scaling.stopstart.upscale.inadequate.nodes=Could not find adequate nodes to upscale(start) in hostGroup: {0}. Additional nodes may need to be added to the cluster. DesiredCount={1}, UpscaleCount={2}
 cluster.scaling.stopstart.upscale.commissioning=Commissioning services. Host group: {0}, InstanceCount={1}, hostname(s): {2}
 cluster.scaling.stopstart.upscale.commissioning2=Commissioning services. Host group: {0}, startedInstanceCount={1}, hostname(s): {2} existingInstanceCount={3}, hostname(s): {4}
-cluster.scaling.stopstart.upscale.couldnotcommission=Could not commission services on all nodes. Some nodes may need attention: instanceCount={1}, hostname(s): {2}
+cluster.scaling.stopstart.upscale.couldnotcommission=Could not commission services on all nodes. Some nodes may need attention: instanceCount={0}, hostname(s): [{1}]
 cluster.scaling.stopstart.upscale.waiting.hoststart=Waiting for {0} cm-host(s) to start before commissioning services
 cluster.scaling.stopstart.upscale.cmhostsstarted={0} cm-host(s) started
 cluster.scaling.stopstart.upscale.finished=Scaled up (via instance start) host group: {0}. Instance details: count={1}, hostname(s): {2}
-cluster.scaling.stopstart.upscale.failed=Failed to upscale (via instance start). Reason: {1}
-cluster.scaling.stopstart.downscale.init=Scaling down (via instance stop) host group: {0}
-cluster.scaling.stopstart.downscale.starting=Scaling down (via instance stop) {0} node(s) from the host group {1}
-cluster.scaling.stopstart.downscale.starting2=Scaling down (via instance stop) {0} node(s) from host group: {1}. Hosts: {2}
+cluster.scaling.stopstart.upscale.failed=Failed to upscale (via instance start). Reason: {0}
+
+cluster.scaling.stopstart.downscale.init=Scaling down (via instance stop) for host group: {0}
+cluster.scaling.stopstart.downscale.starting=Scaling down (via instance stop) {0} node(s) from host group: {1}. Decommissioning services on hosts: [{2}]
+cluster.scaling.stopstart.downscale.couldnotdecommission=Could not decommission services on all nodes. Some nodes may need attention: instanceCount={0}, hostname(s): [{1}]
 cluster.scaling.stopstart.downscale.enteringcmmaintmode=Putting {0} cm-host(s) into maintenance mode
 cluster.scaling.stopstart.downscale.enteredcmmaintmode=Finished putting {0} cm-host(s) into maintenance mode
-cluster.scaling.stopstart.downscale.nodes.stopping=Stopping {0} node(s) from host group {1}. Hosts: {2}
-cluster.scaling.stopstart.downscale.finished=Scaled down (via instance stop) host group: {0}
-
+cluster.scaling.stopstart.downscale.nodes.stopping=Stopping {0} node(s) from host group {1}. Hosts: [{2}]
+cluster.scaling.stopstart.downscale.nodes.stopped=Stopped Instances: count={0}, instanceId(s): [{1}]
+cluster.scaling.stopstart.downscale.nodes.notstopped=Some instances did not reach the desired 'STOPPED' state, and may need attention: count={0}, instanceId(s): [{1}]
+cluster.scaling.stopstart.downscale.finished=Scaled down (via instance stop) host group: {0}. Instance details: count={1}, instance(s): {2}
+cluster.scaling.stopstart.downscale.failed=Failed to downscale (via instance stop). Reason: {0}
 
 cluster.scaling.up=Scaling up host group: {0}
 cluster.re.register.with.cluster.proxy=Re-registering with Cluster Proxy service

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/StopStartDownscaleFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/StopStartDownscaleFlowEventChainFactory.java
@@ -46,17 +46,12 @@ public class StopStartDownscaleFlowEventChainFactory implements FlowEventChainFa
         HostGroup hostGroup = hostGroupService.getByClusterIdAndName(clusterView.getId(), event.getHostGroupName())
                 .orElseThrow(NotFoundException.notFound("hostgroup", event.getHostGroupName()));
 
-
-
         StopStartDownscaleTriggerEvent te = new StopStartDownscaleTriggerEvent(
                 StopStartDownscaleEvent.STOPSTART_DOWNSCALE_TRIGGER_EVENT.event(),
                 stackView.getId(),
                 hostGroup.getName(),
-                event.getAdjustment(),
-                // TODO CB-14929: This seems sub-optimal. Will need to lookup the hostnames again in a subsequent operation.
                 Sets.newHashSet(event.getPrivateIds()),
                 event.isSinglePrimaryGateway(),
-                event.isRestartServices(),
                 event.getClusterManagerType()
         );
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartds/StopStartDownscaleContext.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartds/StopStartDownscaleContext.java
@@ -15,31 +15,24 @@ public class StopStartDownscaleContext extends StackContext {
 
     private final String hostGroupName;
 
-    // TODO CB-14929: One of the below 2 should be present. i.e. stop a random set of nodes, OR stop a specific set of nodes. Add validations.
     private final Set<Long> hostIdsToRemove;
-
-    private final Integer adjustment;
 
     private final Boolean singlePrimaryGateway;
 
     private final ClusterManagerType clusterManagerType;
 
-    private final Boolean restartServices;
-
     private final StackView stackView;
 
     public StopStartDownscaleContext(FlowParameters flowParameters, Stack stack, StackView stackView,
             CloudContext cloudContext, CloudCredential cloudCredential, CloudStack cloudStack,
-            String hostGroupName, Set<Long> hostIdsToRemove, Integer adjustment,
+            String hostGroupName, Set<Long> hostIdsToRemove,
             Boolean singlePrimaryGateway,
-            ClusterManagerType clusterManagerType, Boolean restartServices) {
+            ClusterManagerType clusterManagerType) {
         super(flowParameters, stack, cloudContext, cloudCredential, cloudStack);
         this.hostGroupName = hostGroupName;
         this.hostIdsToRemove = hostIdsToRemove;
-        this.adjustment = adjustment;
         this.singlePrimaryGateway = singlePrimaryGateway;
         this.clusterManagerType = clusterManagerType;
-        this.restartServices = restartServices;
         this.stackView = stackView;
     }
 
@@ -51,20 +44,13 @@ public class StopStartDownscaleContext extends StackContext {
         return hostIdsToRemove;
     }
 
-    public Integer getAdjustment() {
-        return adjustment;
-    }
-
+    // TODO CB-14929: Is this ever used? / is this needed in mutli-CM instances?
     public Boolean getSinglePrimaryGateway() {
         return singlePrimaryGateway;
     }
 
     public ClusterManagerType getClusterManagerType() {
         return clusterManagerType;
-    }
-
-    public Boolean getRestartServices() {
-        return restartServices;
     }
 
     public StackView getStackView() {
@@ -76,10 +62,8 @@ public class StopStartDownscaleContext extends StackContext {
         return "StopStartDownscaleContext{" +
                 "hostGroupName='" + hostGroupName + '\'' +
                 ", hostIdsToRemove=" + hostIdsToRemove +
-                ", adjustment=" + adjustment +
                 ", singlePrimaryGateway=" + singlePrimaryGateway +
                 ", clusterManagerType=" + clusterManagerType +
-                ", restartServices=" + restartServices +
                 ", stackView=" + stackView +
                 '}';
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartds/StopStartDownscaleEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartds/StopStartDownscaleEvent.java
@@ -14,8 +14,6 @@ public enum StopStartDownscaleEvent implements FlowEvent {
     STOPSTART_DOWNSCALE_FAILURE_EVENT("STOPSTART_DOWNSCALE_FAILURE_EVENT"),
     STOPSTART_DOWNSCALE_FAIL_HANDLE_EVENT("STOPSTART_DOWNSCALE_FAIL_HANDLE_EVENT");
 
-
-
     private final String event;
 
     StopStartDownscaleEvent(String event) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartds/StopStartDownscaleFlowConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartds/StopStartDownscaleFlowConfig.java
@@ -36,10 +36,16 @@ public class StopStartDownscaleFlowConfig extends AbstractFlowConfiguration<Stop
                 .to(STOPSTART_DOWNSCALE_STOP_INSTANCE_STATE)
                 .event(STOPSTART_DOWNSCALE_CLUSTER_MANAGER_DECOMMISSIONED_EVENT)
                 .defaultFailureEvent()
+                // TODO CB-14929: Error handling. Add a failureState() + failureEvent() transition - for any repair action that may be necessary.
+                // This likely involves adding a new set of transitions from this failure state to the final failed state
+                //  (i.e. STOPSTART_DOWNSCALE_FAILED_STATE)
             .from(STOPSTART_DOWNSCALE_STOP_INSTANCE_STATE)
                 .to(STOPSTART_DOWNSCALE_FINALIZE_STATE)
                 .event(STOPSTART_DOWNSCALE_INSTANCES_STOPPED_EVENT)
                 .defaultFailureEvent()
+                // TODO CB-14929: Error handling. Add a failureState() + failureEvent() transition - for any repair action that may be necessary.
+                // This likely involves adding a new set of transitions from this failure state to the final failed state
+                //  (i.e. STOPSTART_DOWNSCALE_FAILED_STATE)
             .from(STOPSTART_DOWNSCALE_FINALIZE_STATE)
                 .to(FINAL_STATE)
                 .event(STOPSTART_DOWNSCALE_FINALIZED_EVENT)

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartds/StopStartDownscaleFlowService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartds/StopStartDownscaleFlowService.java
@@ -2,26 +2,30 @@ package com.sequenceiq.cloudbreak.core.flow2.cluster.stopstartds;
 
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.AVAILABLE;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.UPDATE_FAILED;
-import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALING_FAILED;
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.UPDATE_IN_PROGRESS;
+import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALING_STOPSTART_DOWNSCALE_COULDNOTDECOMMISSION;
+import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALING_STOPSTART_DOWNSCALE_FAILED;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALING_STOPSTART_DOWNSCALE_FINISHED;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALING_STOPSTART_DOWNSCALE_INIT;
+import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALING_STOPSTART_DOWNSCALE_NODES_NOT_STOPPED;
+import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALING_STOPSTART_DOWNSCALE_NODES_STOPPED;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALING_STOPSTART_DOWNSCALE_NODE_STOPPING;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALING_STOPSTART_DOWNSCALE_STARTING;
-import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALING_STOPSTART_DOWNSCALE_STARTING2;
 
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-import org.springframework.util.CollectionUtils;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.CloudVmInstanceStatus;
 import com.sequenceiq.cloudbreak.core.flow2.stack.CloudbreakFlowMessageService;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
@@ -29,7 +33,6 @@ import com.sequenceiq.cloudbreak.service.StackUpdater;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
-import com.sun.istack.Nullable;
 
 @Component
 public class StopStartDownscaleFlowService {
@@ -51,53 +54,63 @@ public class StopStartDownscaleFlowService {
     @Inject
     private InstanceMetaDataService instanceMetaDataService;
 
-    public void clusterDownscaleStarted(long stackId, String hostGroupName, Integer scalingAdjustment, Set<Long> privateIds) {
-        flowMessageService.fireEventAndLog(stackId, Status.UPDATE_IN_PROGRESS.name(), CLUSTER_SCALING_STOPSTART_DOWNSCALE_INIT, hostGroupName);
+    public void clusterDownscaleStarted(long stackId, String hostGroupName, Set<Long> privateIds) {
         clusterService.updateClusterStatusByStackId(stackId, DetailedStackStatus.DOWNSCALE_BY_STOP_IN_PROGRESS);
-        // TODO CB-14929: rationalize instanceIds vs hostnames. stackService.getHostNamesForPrivateIds seems to return instanceIds instead of hostnames.
+        flowMessageService.fireEventAndLog(stackId, Status.UPDATE_IN_PROGRESS.name(), CLUSTER_SCALING_STOPSTART_DOWNSCALE_INIT, hostGroupName);
 
-        // TODO CB-14929: Implement the adjustment where a list of hosts is not provided in the request.
-        if (scalingAdjustment != null && scalingAdjustment != 0) {
-            LOGGER.info("ZZZ: stopstart scaling Decommissioning {} hosts from host group '{}'", Math.abs(scalingAdjustment), hostGroupName);
-            flowMessageService.fireInstanceGroupEventAndLog(stackId, Status.UPDATE_IN_PROGRESS.name(), hostGroupName,
-                    CLUSTER_SCALING_STOPSTART_DOWNSCALE_STARTING,
-                    String.valueOf(Math.abs(scalingAdjustment)), hostGroupName);
-        } else if (!CollectionUtils.isEmpty(privateIds)) {
-            LOGGER.info("ZZZ: stopstart scaling Decommissioning {} hosts from host group '{}'", privateIds, hostGroupName);
-            Stack stack = stackService.getByIdWithListsInTransaction(stackId);
-            List<String> decomissionedHostNames = stackService.getHostNamesForPrivateIds(stack.getInstanceMetaDataAsList(), privateIds);
-            LOGGER.info("ZZZ: Scaling down hostnames: {}", decomissionedHostNames);
-            flowMessageService.fireInstanceGroupEventAndLog(stackId, Status.UPDATE_IN_PROGRESS.name(), hostGroupName,
-                    CLUSTER_SCALING_STOPSTART_DOWNSCALE_STARTING2,
-                    String.valueOf(decomissionedHostNames.size()), hostGroupName, String.join(",", decomissionedHostNames));
-        }
-    }
-
-    public void clusterDownscalingStoppingInstances(long stackId, String hostGroupName, Set<Long> privateIds) {
-        LOGGER.info("ZZZ: Attempting to stop nodes (stopstart) {} from host group {}", privateIds, hostGroupName);
+        // TODO CB-15153: Change the message once an adjustment based downscale is supported.
+        LOGGER.debug("stopstart scaling Decommissioning from group: {}, privateIds: [{}]", hostGroupName, privateIds);
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
         List<String> decomissionedHostNames = stackService.getHostNamesForPrivateIds(stack.getInstanceMetaDataAsList(), privateIds);
+        LOGGER.debug("stopstart scaling Decommissioning from group: {}, hostnames: [{}]", hostGroupName, decomissionedHostNames);
         flowMessageService.fireInstanceGroupEventAndLog(stackId, Status.UPDATE_IN_PROGRESS.name(), hostGroupName,
-                CLUSTER_SCALING_STOPSTART_DOWNSCALE_NODE_STOPPING,
+                CLUSTER_SCALING_STOPSTART_DOWNSCALE_STARTING,
                 String.valueOf(decomissionedHostNames.size()), hostGroupName, String.join(",", decomissionedHostNames));
     }
 
-    public void clusterDownscaleFinished(Long stackId, @Nullable String hostGroupName, Set<InstanceMetaData> instancesStopped) {
-        // TODO CB-14929: Make sure Database state updates are handled correctly.
+    public void logCouldNotDecommission(long stackId, List<String> notDecommissionedFqdns) {
+        // TODO CB-14929: CB-15418 This needs to be an orange message (i.e. not success, not failure). Need to figure out how the UI
+        //  processes these and applies icons.
+        flowMessageService.fireEventAndLog(stackId, UPDATE_FAILED.name(), CLUSTER_SCALING_STOPSTART_DOWNSCALE_COULDNOTDECOMMISSION,
+                String.valueOf(notDecommissionedFqdns.size()), notDecommissionedFqdns.stream().collect(Collectors.joining(", ")));
+    }
+
+    public void clusterDownscalingStoppingInstances(long stackId, String hostGroupName, Set<String> decommissionedFqdns) {
+        flowMessageService.fireInstanceGroupEventAndLog(stackId, Status.UPDATE_IN_PROGRESS.name(), hostGroupName,
+                CLUSTER_SCALING_STOPSTART_DOWNSCALE_NODE_STOPPING,
+                String.valueOf(decommissionedFqdns.size()), hostGroupName, String.join(",", decommissionedFqdns));
+    }
+
+    public void instancesStopped(long stackId, List<InstanceMetaData> instancesStopped) {
         instancesStopped.stream().forEach(x -> instanceMetaDataService.updateInstanceStatus(x, InstanceStatus.STOPPED));
+        flowMessageService.fireEventAndLog(stackId, UPDATE_IN_PROGRESS.name(), CLUSTER_SCALING_STOPSTART_DOWNSCALE_NODES_STOPPED,
+                String.valueOf(instancesStopped.size()), instancesStopped.stream().map(x -> x.getInstanceId()).collect(Collectors.joining(", ")));
+    }
+
+    public void logInstancesFailedToStop(long stackId, List<CloudVmInstanceStatus> notStoppedInstances) {
+        // TODO CB-14929: CB-15418 This needs to be an orange message (i.e. not success, not failure). Need to figure out how the UI
+        //  processes these and applies icons.
+        flowMessageService.fireEventAndLog(stackId, UPDATE_FAILED.name(), CLUSTER_SCALING_STOPSTART_DOWNSCALE_NODES_NOT_STOPPED,
+                String.valueOf(notStoppedInstances.size()),
+                        notStoppedInstances.stream().map(x -> x.getCloudInstance().getInstanceId()).collect(Collectors.toList()).toString());
+    }
+
+    public void clusterDownscaleFinished(Long stackId, String hostGroupName, List<InstanceMetaData> instancesStopped) {
         stackUpdater.updateStackStatus(
                 stackId,
                 DetailedStackStatus.AVAILABLE_WITH_STOPPED_INSTANCES,
                 "Instances: " + instancesStopped.size() + " stopped successfully.");
-
         flowMessageService.fireEventAndLog(stackId, AVAILABLE.name(), CLUSTER_SCALING_STOPSTART_DOWNSCALE_FINISHED,
-                hostGroupName == null ? "null" : hostGroupName);
+                hostGroupName, String.valueOf(instancesStopped.size()),
+                instancesStopped.stream().map(InstanceMetaData::getDiscoveryFQDN).collect(Collectors.joining(", ")));
     }
 
     public void handleClusterDownscaleFailure(long stackId, Exception errorDetails) {
         LOGGER.info("Error during stopstart downscale flow: " + errorDetails.getMessage(), errorDetails);
         stackUpdater.updateStackStatus(stackId, DetailedStackStatus.DOWNSCALE_BY_STOP_FAILED,
                 String.format("New node(s) (stopstart) could not be removed from the cluster: %s", errorDetails));
-        flowMessageService.fireEventAndLog(stackId, UPDATE_FAILED.name(), CLUSTER_SCALING_FAILED, "removed to", errorDetails.getMessage());
+
+        // TODO CB-14929: Error handling. In case of a failure - should the status of the instances be moved to something like ORCHESTRATOR_FAILED?
+        flowMessageService.fireEventAndLog(stackId, UPDATE_FAILED.name(), CLUSTER_SCALING_STOPSTART_DOWNSCALE_FAILED, errorDetails.getMessage());
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartds/StopStartDownscaleState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartds/StopStartDownscaleState.java
@@ -13,6 +13,8 @@ enum StopStartDownscaleState implements FlowState {
     STOPSTART_DOWNSCALE_FAILED_STATE,
     FINAL_STATE;
 
+    // TODO CB-14929: Error handling: Additional states as part of improved error handling
+
     private final Class<? extends RestartAction> restartAction = FillInMemoryStateStoreRestartAction.class;
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartus/StopStartUpscaleEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartus/StopStartUpscaleEvent.java
@@ -14,7 +14,6 @@ public enum StopStartUpscaleEvent implements FlowEvent {
     STOPSTART_UPSCALE_FAILURE_EVENT("STOPSTART_UPSCALE_FAILURE_EVENT"),
     STOPSTART_UPSCALE_FAIL_HANDLED_EVENT("STOPSTART_UPSCALE_FAIL_HANDLED_EVENT");
 
-
     private final String event;
 
     StopStartUpscaleEvent(String event) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartus/StopStartUpscaleState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartus/StopStartUpscaleState.java
@@ -11,9 +11,9 @@ enum StopStartUpscaleState implements FlowState {
     STOPSTART_UPSCALE_HOSTS_COMMISSION_STATE,
     STOPSTART_UPSCALE_FINALIZE_STATE,
     STOPSTART_UPSCALE_FAILED_STATE,
-    STOPSTART_UPSCALE_HOSTS_COMMISSION_FAILED_STATE,
     FINAL_STATE;
 
+    // TODO CB-14929: Error handling: Additional states as part of improved error handling
 
     private final Class<? extends RestartAction> restartAction = FillInMemoryStateStoreRestartAction.class;
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/StopStartDownscaleTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/StopStartDownscaleTriggerEvent.java
@@ -10,34 +10,24 @@ public class StopStartDownscaleTriggerEvent extends StackEvent implements HostGr
 
     private final String hostGroup;
 
-    private final Integer adjustment;
-
     private final Set<Long> hostIds;
 
     private final boolean singlePrimaryGateway;
 
-    private final boolean restartServices;
-
     private final ClusterManagerType clusterManagerType;
 
-    public StopStartDownscaleTriggerEvent(String selector, Long stackId, String hostGroup, Integer adjustment, Set<Long> hostIds, boolean singlePrimaryGateway,
-            boolean restartServices, ClusterManagerType clusterManagerType) {
+    public StopStartDownscaleTriggerEvent(String selector, Long stackId, String hostGroup, Set<Long> hostIds, boolean singlePrimaryGateway,
+            ClusterManagerType clusterManagerType) {
         super(selector, stackId);
         this.hostGroup = hostGroup;
-        this.adjustment = adjustment == null ? Integer.valueOf(0) : adjustment;
         this.hostIds = hostIds;
         this.singlePrimaryGateway = singlePrimaryGateway;
-        this.restartServices = restartServices;
         this.clusterManagerType = ClusterManagerType.CLOUDERA_MANAGER;
     }
 
     @Override
     public String getHostGroupName() {
         return hostGroup;
-    }
-
-    public Integer getAdjustment() {
-        return adjustment;
     }
 
     public Set<Long> getHostIds() {
@@ -48,10 +38,6 @@ public class StopStartDownscaleTriggerEvent extends StackEvent implements HostGr
         return singlePrimaryGateway;
     }
 
-    public boolean isRestartServices() {
-        return restartServices;
-    }
-
     public ClusterManagerType getClusterManagerType() {
         return clusterManagerType;
     }
@@ -60,10 +46,8 @@ public class StopStartDownscaleTriggerEvent extends StackEvent implements HostGr
     public String toString() {
         return "StopStartDownscaleTriggerEvent{" +
                 "hostGroup='" + hostGroup + '\'' +
-                ", adjustment=" + adjustment +
                 ", hostIds=" + hostIds +
                 ", singlePrimaryGateway=" + singlePrimaryGateway +
-                ", restartServices=" + restartServices +
                 ", clusterManagerType=" + clusterManagerType +
                 '}';
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/StopStartDownscaleDecommissionViaCMResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/StopStartDownscaleDecommissionViaCMResult.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.orchestration;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.StopStartDownscaleDecommissionViaCMRequest;
@@ -9,19 +11,28 @@ public class StopStartDownscaleDecommissionViaCMResult extends AbstractClusterSc
 
     private final Set<String> decommissionedHostFqdns;
 
-    public StopStartDownscaleDecommissionViaCMResult(StopStartDownscaleDecommissionViaCMRequest request, Set<String> decommissionedHostFqdns) {
+    private final List<String> notDecommissionedHostFqdns;
+
+    public StopStartDownscaleDecommissionViaCMResult(StopStartDownscaleDecommissionViaCMRequest request, Set<String> decommissionedHostFqdns,
+            List<String> notDecommissionedHostFqdns) {
         super(request);
         this.decommissionedHostFqdns = decommissionedHostFqdns;
+        this.notDecommissionedHostFqdns = notDecommissionedHostFqdns == null ? Collections.emptyList() : notDecommissionedHostFqdns;
     }
 
     public Set<String> getDecommissionedHostFqdns() {
         return decommissionedHostFqdns;
     }
 
+    public List<String> getNotDecommissionedHostFqdns() {
+        return notDecommissionedHostFqdns;
+    }
+
     @Override
     public String toString() {
         return "StopStartDownscaleDecommissionViaCMResult{" +
                 "decommissionedHostFqdns=" + decommissionedHostFqdns +
+                ", notDecommissionedHostFqdns=" + notDecommissionedHostFqdns +
                 '}';
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/StopStartDownscaleDecommissionViaCMHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/StopStartDownscaleDecommissionViaCMHandler.java
@@ -4,11 +4,13 @@ import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.UPDATE_IN_
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALING_STOPSTART_DOWNSCALE_ENTEREDCMMAINTMODE;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALING_STOPSTART_DOWNSCALE_ENTERINGCMMAINTMODE;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -20,12 +22,15 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterDecomissionService;
+import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.stopstartds.StopStartDownscaleEvent;
 import com.sequenceiq.cloudbreak.core.flow2.stack.CloudbreakFlowMessageService;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.reactor.api.event.StackFailureEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.StopStartDownscaleDecommissionViaCMRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.StopStartDownscaleDecommissionViaCMResult;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
@@ -33,18 +38,17 @@ import com.sequenceiq.cloudbreak.service.hostgroup.HostGroupService;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.flow.event.EventSelectorUtil;
-import com.sequenceiq.flow.reactor.api.handler.EventHandler;
+import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
-import reactor.bus.EventBus;
 
 @Component
-public class StopStartDownscaleDecommissionViaCMHandler implements EventHandler<StopStartDownscaleDecommissionViaCMRequest> {
+public class StopStartDownscaleDecommissionViaCMHandler extends ExceptionCatcherEventHandler<StopStartDownscaleDecommissionViaCMRequest> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StopStartDownscaleDecommissionViaCMHandler.class);
 
-    @Inject
-    private EventBus eventBus;
+    private static final long POLL_FOR_10_MINUTES = TimeUnit.MINUTES.toSeconds(10);
 
     @Inject
     private ClusterApiConnectors clusterApiConnectors;
@@ -58,7 +62,6 @@ public class StopStartDownscaleDecommissionViaCMHandler implements EventHandler<
     @Inject
     private InstanceMetaDataService instanceMetaDataService;
 
-    // TODO CB-14929: Should flowMessageService be used inside a hnadler to write messages to the activity log, etc.
     @Inject
     private CloudbreakFlowMessageService flowMessageService;
 
@@ -68,9 +71,14 @@ public class StopStartDownscaleDecommissionViaCMHandler implements EventHandler<
     }
 
     @Override
-    public void accept(Event<StopStartDownscaleDecommissionViaCMRequest> event) {
+    protected Selectable defaultFailureEvent(Long resourceId, Exception e, Event<StopStartDownscaleDecommissionViaCMRequest> event) {
+        return new StackFailureEvent(StopStartDownscaleEvent.STOPSTART_DOWNSCALE_FAIL_HANDLE_EVENT.event(), resourceId, e);
+    }
+
+    @Override
+    protected Selectable doAccept(HandlerEvent<StopStartDownscaleDecommissionViaCMRequest> event) {
         StopStartDownscaleDecommissionViaCMRequest request = event.getData();
-        LOGGER.info("StopStartDownscaleDecommissionViaCMHandler for: {}, {}", event.getData().getResourceId(), event);
+        LOGGER.info("StopStartDownscaleDecommissionViaCMHandler for: {}, {}", event.getData().getResourceId(), event.getData());
 
         try {
             Stack stack = request.getStack();
@@ -78,59 +86,99 @@ public class StopStartDownscaleDecommissionViaCMHandler implements EventHandler<
             ClusterDecomissionService clusterDecomissionService = clusterApiConnectors.getConnector(stack).clusterDecomissionService();
 
             Set<String> hostNames = getHostNamesForPrivateIds(request.getInstanceIdsToDecommission(), stack);
-            LOGGER.info("ZZZ: hostNamesToDecommission: count={}, hostNames={}", hostNames.size(), hostNames);
+            LOGGER.debug("Attempting to decommission hosts. count={}, hostnames={}", hostNames.size(), hostNames);
 
             HostGroup hostGroup = hostGroupService.getByClusterIdAndName(cluster.getId(), request.getHostGroupName())
                     .orElseThrow(NotFoundException.notFound("hostgroup", request.getHostGroupName()));
 
             Map<String, InstanceMetaData> hostsToRemove = clusterDecomissionService.collectHostsToRemove(hostGroup, hostNames);
-            LOGGER.info("ZZZ: hostNamesToDecommission after checking with CM: count={}, details={}", hostsToRemove.size(), hostsToRemove);
+            List<String> missingHostsInCm = Collections.emptyList();
+            if (hostNames.size() != hostsToRemove.size()) {
+                missingHostsInCm = hostNames.stream()
+                        .filter(h -> !hostsToRemove.containsKey(h))
+                        .collect(Collectors.toList());
+                LOGGER.info("Found fewer instances in CM to decommission, as compared to initial ask. foundCount={}, initialCount={}, missingHostsInCm={}",
+                        hostsToRemove.size(), hostNames.size(), missingHostsInCm);
+            }
 
             // TODO CB-14929: Potentially put the nodes into maintenance mode before decommissioning?
 
-            // TODO CB-14929: Time bound commission. Potentially poll for nodes which do not reach the desired state within a time bound.
+            // TODO CB-15132: Eventually, try parsing the results of the CM decommission, and see if a partial decommission went through in the
+            //  timebound specified.
             Set<String> decommissionedHostNames = Collections.emptySet();
             if (hostsToRemove.size() > 0) {
-                updateInstanceStatuses(hostsToRemove.values(), InstanceStatus.DECOMMISSIONED, "decommission requested for instance");
-                decommissionedHostNames = clusterDecomissionService.decommissionClusterNodes(hostsToRemove);
+                decommissionedHostNames = clusterDecomissionService.decommissionClusterNodesStopStart(hostsToRemove, POLL_FOR_10_MINUTES);
+                updateInstanceStatuses(hostsToRemove, decommissionedHostNames,
+                        InstanceStatus.DECOMMISSIONED, "decommission requested for instances");
+                // TODO CB-14929: Error Handling: In case of failures, figure out whcih nodes need to be moved into what is likely to be the
+                //  ORCHESTRATION_FAILED state. This will likely be done in
             }
-            LOGGER.info("ZZZ: hostsDecommissioned: count={}, hostNames={}", decommissionedHostNames.size(), decommissionedHostNames);
 
-            LOGGER.info("ZZZ: Attempting to put hosts into maintenance mode");
-            flowMessageService.fireEventAndLog(stack.getId(), UPDATE_IN_PROGRESS.name(), CLUSTER_SCALING_STOPSTART_DOWNSCALE_ENTERINGCMMAINTMODE,
-                    String.valueOf(hostsToRemove.size()));
+            // This doesn't handle failures. It handles scenarios where CM list APIs don't have the necessary hosts available.
+            List<String> allMissingHostnames = null;
+            if (missingHostsInCm.size() > 0) {
+                allMissingHostnames = new LinkedList<>(missingHostsInCm);
+            }
+            if (hostsToRemove.size() != decommissionedHostNames.size()) {
+                Set<String> finalDecommissionedHostnames = decommissionedHostNames;
+                List<String> additionalMissingDecommissionHostnames = hostsToRemove.keySet().stream()
+                        .filter(h -> !finalDecommissionedHostnames.contains(h))
+                        .collect(Collectors.toList());
+                LOGGER.info("Decommissioned fewer instances than requested. decommissionedCount={}, expectedCount={}, initialCount={}, notDecommissioned=[{}]",
+                        decommissionedHostNames.size(), hostsToRemove.size(), hostNames.size(), additionalMissingDecommissionHostnames);
+                if (allMissingHostnames == null) {
+                    allMissingHostnames = new LinkedList<>();
+                }
+                allMissingHostnames.addAll(additionalMissingDecommissionHostnames);
+            }
 
-            clusterDecomissionService.enterMaintenanceMode(stack, hostsToRemove);
+            LOGGER.info("hostsDecommissioned: count={}, hostNames={}", decommissionedHostNames.size(), decommissionedHostNames);
 
-            flowMessageService.fireEventAndLog(stack.getId(), UPDATE_IN_PROGRESS.name(), CLUSTER_SCALING_STOPSTART_DOWNSCALE_ENTEREDCMMAINTMODE,
-                    String.valueOf(hostsToRemove.size()));
-            LOGGER.info("ZZZ: Nodes moved to maintenance mode");
+            if (decommissionedHostNames.size() > 0) {
+                LOGGER.debug("Attempting to put decommissioned hosts into maintenance mode. count={}", decommissionedHostNames.size());
+                flowMessageService.fireEventAndLog(stack.getId(), UPDATE_IN_PROGRESS.name(), CLUSTER_SCALING_STOPSTART_DOWNSCALE_ENTERINGCMMAINTMODE,
+                        String.valueOf(decommissionedHostNames.size()));
 
+                clusterDecomissionService.enterMaintenanceMode(stack, decommissionedHostNames);
 
-            // TODO CB-14929: Maybe consider a CM API to propaget a node decommission timeout -
+                flowMessageService.fireEventAndLog(stack.getId(), UPDATE_IN_PROGRESS.name(), CLUSTER_SCALING_STOPSTART_DOWNSCALE_ENTEREDCMMAINTMODE,
+                        String.valueOf(decommissionedHostNames.size()));
+                LOGGER.debug("Successfully put decommissioned hosts into maintenance mode. count={}", decommissionedHostNames.size());
+            } else {
+                LOGGER.debug("No nodes decommissioned, hence no nodes being put into maintenance mode");
+            }
+
+            // TODO CB-15132: Maybe consider a CM API to propaget a node decommission timeout -
             //  separation between a forced downscale (random nodes), and a specified list of nodes
             //  The main differentiation is whether the nodes are expected to be running 'old' work,
             //  or are safe to remove fast (i.e. AutoScale downscale - race could only put 20-30s odd worth of work on the new nodes).
-            // TODO CB-14929: Populate the status of the nodes which were stopped successfully, those which failed/timed out, etc.
-            StopStartDownscaleDecommissionViaCMResult result = new StopStartDownscaleDecommissionViaCMResult(request, decommissionedHostNames);
-            eventBus.notify(result.selector(), new Event<>(event.getHeaders(), result));
-        } finally {
-            LOGGER.debug("ZZZ: Remove this. Added for checkstyles");
-            // TODO CB-14929: Proper exception handling in a catch block
+
+            StopStartDownscaleDecommissionViaCMResult result =
+                    new StopStartDownscaleDecommissionViaCMResult(request, decommissionedHostNames, allMissingHostnames);
+            return result;
+        } catch (Exception e) {
+            // TODO CB-15132: This can be improved based on where and when the Exception occurred to potentially rollback certain aspects.
+            // ClusterClientInitException is one which is explicitly thrown.
+            return new StackFailureEvent(StopStartDownscaleEvent.STOPSTART_DOWNSCALE_FAIL_HANDLE_EVENT.event(), request.getResourceId(), e);
         }
     }
 
     private Set<String> getHostNamesForPrivateIds(Set<Long> hostIdsToRemove, Stack stack) {
-        // List<String> decomissionedHostNames = stackService.getHostNamesForPrivateIds(stack.getInstanceMetaDataAsList(),
-        // request.getInstanceIdsToDecommission());
         return hostIdsToRemove.stream().map(privateId -> {
             Optional<InstanceMetaData> instanceMetadata = stackService.getInstanceMetadata(stack.getInstanceMetaDataAsList(), privateId);
             return instanceMetadata.map(InstanceMetaData::getDiscoveryFQDN).orElse(null);
         }).filter(StringUtils::isNotEmpty).collect(Collectors.toSet());
     }
 
-    private void updateInstanceStatuses(Collection<InstanceMetaData> instanceMetadatas, InstanceStatus instanceStatus, String statusReason) {
-        for (InstanceMetaData instanceMetaData : instanceMetadatas) {
+    private void updateInstanceStatuses(Map<String, InstanceMetaData> instanceMetadataMap, Set<String> fqdnsRemoved,
+            InstanceStatus instanceStatus, String statusReason) {
+        for (String fqdn : fqdnsRemoved) {
+            InstanceMetaData instanceMetaData = instanceMetadataMap.get(fqdn);
+            if (instanceMetaData == null) {
+                throw new RuntimeException(
+                        String.format("Unexpected fqdn decommissioned. Not present in requsted list. unexpected fqdn=[%s], ExpectedSet=[%s]",
+                                fqdn, instanceMetadataMap));
+            }
             instanceMetaDataService.updateInstanceStatus(instanceMetaData, instanceStatus, statusReason);
         }
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/StopStartUpscaleCommissionViaCMHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/StopStartUpscaleCommissionViaCMHandler.java
@@ -126,7 +126,7 @@ public class StopStartUpscaleCommissionViaCMHandler extends ExceptionCatcherEven
                 List<String> additionalMissingRecommissionHostnames = hostsToRecommission.keySet().stream()
                         .filter(h -> !finalRecommissionedHostnames.contains(h))
                         .collect(Collectors.toList());
-                LOGGER.info("Recommissioned fewer instances then requested. recommissionedCount={}, expectedCount={}, initialCount={}, notRecommissioned={}",
+                LOGGER.info("Recommissioned fewer instances than requested. recommissionedCount={}, expectedCount={}, initialCount={}, notRecommissioned=[{}]",
                         recommissionedHostnames.size(), hostsToRecommission.size(), hostNames.size(), additionalMissingRecommissionHostnames);
                 if (allMissingRecommissionHostnames == null) {
                     allMissingRecommissionHostnames = new LinkedList<>();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
@@ -820,10 +820,9 @@ public class StackService implements ResourceIdProvider, ResourcePropertyProvide
         });
     }
 
-    // TODO CB-14929:  This method is named incorrectly. It returns instanceIds instead of hostNames
     public List<String> getHostNamesForPrivateIds(List<InstanceMetaData> instanceMetaDataList, Collection<Long> privateIds) {
         return getInstanceMetaDataForPrivateIdsWithoutTerminatedInstances(instanceMetaDataList, privateIds).stream()
-                .map(InstanceMetaData::getInstanceId)
+                .map(InstanceMetaData::getDiscoveryFQDN)
                 .collect(Collectors.toList());
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartds/StopStartDownscaleActionsTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartds/StopStartDownscaleActionsTest.java
@@ -1,0 +1,463 @@
+package com.sequenceiq.cloudbreak.core.flow2.cluster.stopstartds;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNotNull;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.statemachine.action.Action;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.event.instance.StopStartDownscaleStopInstancesRequest;
+import com.sequenceiq.cloudbreak.cloud.event.instance.StopStartDownscaleStopInstancesResult;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
+import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.CloudVmInstanceStatus;
+import com.sequenceiq.cloudbreak.common.metrics.MetricService;
+import com.sequenceiq.cloudbreak.common.type.ClusterManagerType;
+import com.sequenceiq.cloudbreak.converter.CloudInstanceIdToInstanceMetaDataConverter;
+import com.sequenceiq.cloudbreak.converter.spi.InstanceMetaDataToCloudInstanceConverter;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.stopstartds.StopStartDownscaleActions.AbstractStopStartDownscaleActions;
+import com.sequenceiq.cloudbreak.core.flow2.event.StopStartDownscaleTriggerEvent;
+import com.sequenceiq.cloudbreak.domain.StackAuthentication;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.domain.view.StackView;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.StopStartDownscaleDecommissionViaCMRequest;
+import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.StopStartDownscaleDecommissionViaCMResult;
+import com.sequenceiq.cloudbreak.service.metrics.CloudbreakMetricService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.flow.core.AbstractActionTestSupport;
+import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.flow.core.FlowRegister;
+import com.sequenceiq.flow.reactor.ErrorHandlerAwareReactorEventFactory;
+
+import reactor.bus.Event;
+import reactor.bus.EventBus;
+
+@ExtendWith(MockitoExtension.class)
+public class StopStartDownscaleActionsTest {
+
+    private static final String INSTANCE_GROUP_NAME_ACTIONABLE = "compute";
+
+    private static final String INSTANCE_GROUP_NAME_RANDOM = "other";
+
+    private static final String SELECTOR = "dontcareforthistest";
+
+    private static final Long STACK_ID = 100L;
+
+    private static final String INSTANCE_ID_PREFIX = "i-";
+
+    private static final String ENV_CRN = "envCrn";
+
+    @Mock
+    private StopStartDownscaleFlowService stopStartDownscaleFlowService;
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private InstanceMetaDataToCloudInstanceConverter instanceMetaDataToCloudInstanceConverter;
+
+    @Mock
+    private CloudInstanceIdToInstanceMetaDataConverter cloudInstanceIdToInstanceMetaDataConverter;
+
+    @InjectMocks
+    private StopStartDownscaleActions underTest;
+
+    @Mock
+    private FlowParameters flowParameters;
+
+    @Mock
+    private Stack stack;
+
+    @Mock
+    private StackView stackView;
+
+    @Mock
+    private CloudContext cloudContext;
+
+    @Mock
+    private CloudCredential cloudCredential;
+
+    @Mock
+    private CloudStack cloudStack;
+
+    @Mock
+    private StackAuthentication stackAuthentication;
+
+    @Mock
+    private FlowRegister runningFlows;
+
+    @Mock
+    private EventBus eventBus;
+
+    @Mock
+    private ErrorHandlerAwareReactorEventFactory reactorEventFactory;
+
+    @Mock
+    private Event<Object> event;
+
+    @Mock
+    private CloudbreakMetricService metricService;
+
+    @Test
+    void testDecommissionViaCmAction() throws Exception {
+        AbstractStopStartDownscaleActions<StopStartDownscaleTriggerEvent> action =
+                (AbstractStopStartDownscaleActions<StopStartDownscaleTriggerEvent>) underTest.decommissionViaCmAction();
+        initActionPrivateFields(action);
+
+        List<InstanceMetaData> instancesActionableStarted = generateInstances(10, 100, InstanceStatus.SERVICES_HEALTHY, INSTANCE_GROUP_NAME_ACTIONABLE);
+        Set<Long> instanceIdsToRemove = instancesActionableStarted.stream().limit(5).map(InstanceMetaData::getId).collect(Collectors.toUnmodifiableSet());
+
+        StopStartDownscaleContext stopStartDownscaleContext = createContext(instanceIdsToRemove);
+        StopStartDownscaleTriggerEvent payload = new StopStartDownscaleTriggerEvent(SELECTOR, STACK_ID, INSTANCE_GROUP_NAME_ACTIONABLE,
+                instanceIdsToRemove, true, ClusterManagerType.CLOUDERA_MANAGER);
+
+        mockStackEtc();
+        when(reactorEventFactory.createEvent(anyMap(), isNotNull())).thenReturn(event);
+
+        new AbstractActionTestSupport<>(action).doExecute(stopStartDownscaleContext, payload, Collections.emptyMap());
+
+        verify(stopStartDownscaleFlowService).clusterDownscaleStarted(eq(STACK_ID), eq(INSTANCE_GROUP_NAME_ACTIONABLE), eq(instanceIdsToRemove));
+        verifyNoMoreInteractions(stopStartDownscaleFlowService);
+        ArgumentCaptor<Object> argumentCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(reactorEventFactory).createEvent(anyMap(), argumentCaptor.capture());
+        verify(eventBus).notify("STOPSTARTDOWNSCALEDECOMMISSIONVIACMREQUEST", event);
+        assertThat(argumentCaptor.getValue()).isInstanceOf(StopStartDownscaleDecommissionViaCMRequest.class);
+
+        StopStartDownscaleDecommissionViaCMRequest req = (StopStartDownscaleDecommissionViaCMRequest) argumentCaptor.getValue();
+        Assert.assertEquals(instanceIdsToRemove, req.getInstanceIdsToDecommission());
+        Assert.assertEquals(INSTANCE_GROUP_NAME_ACTIONABLE, req.getHostGroupName());
+    }
+
+    @Test
+    void testStopInstancesActionAllDecommissioned() throws Exception {
+        AbstractStopStartDownscaleActions<StopStartDownscaleDecommissionViaCMResult> action =
+                (AbstractStopStartDownscaleActions<StopStartDownscaleDecommissionViaCMResult>) underTest.stopInstancesAction();
+        initActionPrivateFields(action);
+
+        List<InstanceMetaData> instancesActionableStarted = generateInstances(10, 100, InstanceStatus.SERVICES_HEALTHY, INSTANCE_GROUP_NAME_ACTIONABLE);
+        List<InstanceMetaData> instancesActionableNotStarted = generateInstances(5, 200, InstanceStatus.STOPPED, INSTANCE_GROUP_NAME_ACTIONABLE);
+        List<InstanceMetaData> instancesRandomStarted = generateInstances(8, 300, InstanceStatus.SERVICES_HEALTHY, INSTANCE_GROUP_NAME_RANDOM);
+        List<InstanceMetaData> instancesRandomNotStarted = generateInstances(3, 400, InstanceStatus.STOPPED, INSTANCE_GROUP_NAME_RANDOM);
+
+        List<InstanceMetaData> expectedToBeStopped = instancesActionableStarted.stream().limit(5).collect(Collectors.toList());
+        Set<Long> instanceIdsToRemove = expectedToBeStopped.stream().map(InstanceMetaData::getId).collect(Collectors.toUnmodifiableSet());
+
+        Set<String> decommissionedHostsFqdns =
+                expectedToBeStopped.stream().map(InstanceMetaData::getDiscoveryFQDN).collect(Collectors.toUnmodifiableSet());
+
+        StopStartDownscaleContext stopStartDownscaleContext = createContext(instanceIdsToRemove);
+        StopStartDownscaleDecommissionViaCMRequest r =
+                new StopStartDownscaleDecommissionViaCMRequest(stack, INSTANCE_GROUP_NAME_ACTIONABLE, instanceIdsToRemove);
+        StopStartDownscaleDecommissionViaCMResult payload = new StopStartDownscaleDecommissionViaCMResult(r, decommissionedHostsFqdns, Collections.emptyList());
+
+        mockStackEtc(instancesActionableStarted, instancesActionableNotStarted, instancesRandomStarted, instancesRandomNotStarted);
+        List<CloudInstance> expectedCloudInstances = mockInstanceMetadataToCloudInstanceConverter(expectedToBeStopped);
+        when(reactorEventFactory.createEvent(anyMap(), isNotNull())).thenReturn(event);
+
+        new AbstractActionTestSupport<>(action).doExecute(stopStartDownscaleContext, payload, Collections.emptyMap());
+
+        verify(instanceMetaDataToCloudInstanceConverter).convert(eq(expectedToBeStopped), anyString(), any(StackAuthentication.class));
+        verify(stopStartDownscaleFlowService).
+                clusterDownscalingStoppingInstances(eq(STACK_ID), eq(INSTANCE_GROUP_NAME_ACTIONABLE), eq(decommissionedHostsFqdns));
+        verifyNoMoreInteractions(stopStartDownscaleFlowService);
+        ArgumentCaptor<Object> argumentCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(reactorEventFactory).createEvent(anyMap(), argumentCaptor.capture());
+        verify(eventBus).notify("STOPSTARTDOWNSCALESTOPINSTANCESREQUEST", event);
+        assertThat(argumentCaptor.getValue()).isInstanceOf(StopStartDownscaleStopInstancesRequest.class);
+
+        StopStartDownscaleStopInstancesRequest req = (StopStartDownscaleStopInstancesRequest) argumentCaptor.getValue();
+        Assert.assertEquals(expectedCloudInstances, req.getCloudInstancesToStop());
+    }
+
+    @Test
+    void testStopInstancesActionNotAllDecommissioned() throws Exception {
+        AbstractStopStartDownscaleActions<StopStartDownscaleDecommissionViaCMResult> action =
+                (AbstractStopStartDownscaleActions<StopStartDownscaleDecommissionViaCMResult>) underTest.stopInstancesAction();
+        initActionPrivateFields(action);
+
+        List<InstanceMetaData> instancesActionableStarted = generateInstances(10, 100, InstanceStatus.SERVICES_HEALTHY, INSTANCE_GROUP_NAME_ACTIONABLE);
+        List<InstanceMetaData> instancesActionableNotStarted = generateInstances(5, 200, InstanceStatus.STOPPED, INSTANCE_GROUP_NAME_ACTIONABLE);
+        List<InstanceMetaData> instancesRandomStarted = generateInstances(8, 300, InstanceStatus.SERVICES_HEALTHY, INSTANCE_GROUP_NAME_RANDOM);
+        List<InstanceMetaData> instancesRandomNotStarted = generateInstances(3, 400, InstanceStatus.STOPPED, INSTANCE_GROUP_NAME_RANDOM);
+
+        Set<Long> instanceIdsToRemove = instancesActionableStarted.stream().limit(6).map(InstanceMetaData::getId).collect(Collectors.toUnmodifiableSet());
+        List<InstanceMetaData> expectedToBeStopped = instancesActionableStarted.stream().limit(4).collect(Collectors.toList());
+        Set<String> decommissionedHostsFqdns =
+                expectedToBeStopped.stream().map(InstanceMetaData::getDiscoveryFQDN).collect(Collectors.toUnmodifiableSet());
+
+        List<InstanceMetaData> notDecommissioned = instancesActionableStarted.subList(4, 6);
+        List<String> notDecommissionedFqdns = notDecommissioned.stream().map(InstanceMetaData::getDiscoveryFQDN).collect(Collectors.toUnmodifiableList());
+
+        StopStartDownscaleContext stopStartDownscaleContext = createContext(instanceIdsToRemove);
+        StopStartDownscaleDecommissionViaCMRequest r =
+                new StopStartDownscaleDecommissionViaCMRequest(stack, INSTANCE_GROUP_NAME_ACTIONABLE, instanceIdsToRemove);
+        StopStartDownscaleDecommissionViaCMResult payload = new StopStartDownscaleDecommissionViaCMResult(r, decommissionedHostsFqdns, notDecommissionedFqdns);
+
+        mockStackEtc(instancesActionableStarted, instancesActionableNotStarted, instancesRandomStarted, instancesRandomNotStarted);
+        List<CloudInstance> expectedCloudInstances = mockInstanceMetadataToCloudInstanceConverter(expectedToBeStopped);
+        when(reactorEventFactory.createEvent(anyMap(), isNotNull())).thenReturn(event);
+
+        new AbstractActionTestSupport<>(action).doExecute(stopStartDownscaleContext, payload, Collections.emptyMap());
+
+        verify(instanceMetaDataToCloudInstanceConverter).convert(eq(expectedToBeStopped), anyString(), any(StackAuthentication.class));
+        verify(stopStartDownscaleFlowService).logCouldNotDecommission(eq(STACK_ID), eq(notDecommissionedFqdns));
+        verify(stopStartDownscaleFlowService).
+                clusterDownscalingStoppingInstances(eq(STACK_ID), eq(INSTANCE_GROUP_NAME_ACTIONABLE), eq(decommissionedHostsFqdns));
+        verifyNoMoreInteractions(stopStartDownscaleFlowService);
+        ArgumentCaptor<Object> argumentCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(reactorEventFactory).createEvent(anyMap(), argumentCaptor.capture());
+        verify(eventBus).notify("STOPSTARTDOWNSCALESTOPINSTANCESREQUEST", event);
+        assertThat(argumentCaptor.getValue()).isInstanceOf(StopStartDownscaleStopInstancesRequest.class);
+
+        StopStartDownscaleStopInstancesRequest req = (StopStartDownscaleStopInstancesRequest) argumentCaptor.getValue();
+        Assert.assertEquals(expectedCloudInstances, req.getCloudInstancesToStop());
+    }
+
+    @Test
+    void testStopInstancesActionNoneDecommissioned() throws Exception {
+        // This behaviour is not ideal. Letting 0 stopped flow through the actual state machine instead of short-circuiting it.
+        AbstractStopStartDownscaleActions<StopStartDownscaleDecommissionViaCMResult> action =
+                (AbstractStopStartDownscaleActions<StopStartDownscaleDecommissionViaCMResult>) underTest.stopInstancesAction();
+        initActionPrivateFields(action);
+
+        List<InstanceMetaData> instancesActionableStarted = generateInstances(10, 100, InstanceStatus.SERVICES_HEALTHY, INSTANCE_GROUP_NAME_ACTIONABLE);
+        List<InstanceMetaData> instancesActionableNotStarted = generateInstances(5, 200, InstanceStatus.STOPPED, INSTANCE_GROUP_NAME_ACTIONABLE);
+        List<InstanceMetaData> instancesRandomStarted = generateInstances(8, 300, InstanceStatus.SERVICES_HEALTHY, INSTANCE_GROUP_NAME_RANDOM);
+        List<InstanceMetaData> instancesRandomNotStarted = generateInstances(3, 400, InstanceStatus.STOPPED, INSTANCE_GROUP_NAME_RANDOM);
+
+        Set<Long> instanceIdsToRemove = instancesActionableStarted.stream().limit(6).map(InstanceMetaData::getId).collect(Collectors.toUnmodifiableSet());
+        List<InstanceMetaData> expectedToBeStopped = Collections.emptyList();
+        Set<String> decommissionedHostsFqdns = Collections.emptySet();
+
+        List<InstanceMetaData> notDecommissioned = instancesActionableStarted.subList(0, 6);
+        List<String> notDecommissionedFqdns = notDecommissioned.stream().map(InstanceMetaData::getDiscoveryFQDN).collect(Collectors.toUnmodifiableList());
+
+        StopStartDownscaleContext stopStartDownscaleContext = createContext(instanceIdsToRemove);
+        StopStartDownscaleDecommissionViaCMRequest r =
+                new StopStartDownscaleDecommissionViaCMRequest(stack, INSTANCE_GROUP_NAME_ACTIONABLE, instanceIdsToRemove);
+        StopStartDownscaleDecommissionViaCMResult payload = new StopStartDownscaleDecommissionViaCMResult(r, decommissionedHostsFqdns, notDecommissionedFqdns);
+
+        mockStackEtc(instancesActionableStarted, instancesActionableNotStarted, instancesRandomStarted, instancesRandomNotStarted);
+        List<CloudInstance> expectedCloudInstances = mockInstanceMetadataToCloudInstanceConverter(expectedToBeStopped);
+        when(reactorEventFactory.createEvent(anyMap(), isNotNull())).thenReturn(event);
+
+        new AbstractActionTestSupport<>(action).doExecute(stopStartDownscaleContext, payload, Collections.emptyMap());
+
+        verify(instanceMetaDataToCloudInstanceConverter).convert(eq(expectedToBeStopped), anyString(), any(StackAuthentication.class));
+        verify(stopStartDownscaleFlowService).logCouldNotDecommission(eq(STACK_ID), eq(notDecommissionedFqdns));
+        verify(stopStartDownscaleFlowService).
+                clusterDownscalingStoppingInstances(eq(STACK_ID), eq(INSTANCE_GROUP_NAME_ACTIONABLE), eq(decommissionedHostsFqdns));
+        verifyNoMoreInteractions(stopStartDownscaleFlowService);
+        ArgumentCaptor<Object> argumentCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(reactorEventFactory).createEvent(anyMap(), argumentCaptor.capture());
+        verify(eventBus).notify("STOPSTARTDOWNSCALESTOPINSTANCESREQUEST", event);
+        assertThat(argumentCaptor.getValue()).isInstanceOf(StopStartDownscaleStopInstancesRequest.class);
+
+        StopStartDownscaleStopInstancesRequest req = (StopStartDownscaleStopInstancesRequest) argumentCaptor.getValue();
+        Assert.assertEquals(expectedCloudInstances, req.getCloudInstancesToStop());
+    }
+
+    @Test
+    void testDownscaleFinishedActionAllStopped() throws Exception {
+        AbstractStopStartDownscaleActions<StopStartDownscaleStopInstancesResult> action =
+                (AbstractStopStartDownscaleActions<StopStartDownscaleStopInstancesResult>) underTest.downscaleFinishedAction();
+        initActionPrivateFields(action);
+
+        List<InstanceMetaData> instancesActionableStarted = generateInstances(10, 100, InstanceStatus.SERVICES_HEALTHY, INSTANCE_GROUP_NAME_ACTIONABLE);
+        List<InstanceMetaData> instancesActionableNotStarted = generateInstances(5, 200, InstanceStatus.STOPPED, INSTANCE_GROUP_NAME_ACTIONABLE);
+        List<InstanceMetaData> instancesRandomStarted = generateInstances(8, 300, InstanceStatus.SERVICES_HEALTHY, INSTANCE_GROUP_NAME_RANDOM);
+        List<InstanceMetaData> instancesRandomNotStarted = generateInstances(3, 400, InstanceStatus.STOPPED, INSTANCE_GROUP_NAME_RANDOM);
+
+        List<InstanceMetaData> expectedToBeStopped = instancesActionableStarted.stream().limit(5).collect(Collectors.toList());
+        Set<Long> instanceIdsToRemove = expectedToBeStopped.stream().map(InstanceMetaData::getId).collect(Collectors.toUnmodifiableSet());
+
+        StopStartDownscaleContext stopStartDownscaleContext = createContext(instanceIdsToRemove);
+
+        mockStackEtc(instancesActionableStarted, instancesActionableNotStarted, instancesRandomStarted, instancesRandomNotStarted);
+        List<CloudInstance> expectedCloudInstances = mockInstanceMetadataToCloudInstanceConverter(expectedToBeStopped);
+        List<CloudVmInstanceStatus> cloudVmInstanceStatusList = constructStoppedCloudVmInstanceStatus(expectedCloudInstances);
+        when(reactorEventFactory.createEvent(anyMap(), isNotNull())).thenReturn(event);
+
+        StopStartDownscaleStopInstancesResult payload =
+                new StopStartDownscaleStopInstancesResult(STACK_ID, mock(StopStartDownscaleStopInstancesRequest.class), cloudVmInstanceStatusList);
+
+        new AbstractActionTestSupport<>(action).doExecute(stopStartDownscaleContext, payload, Collections.emptyMap());
+
+        ArgumentCaptor<List> listCap = ArgumentCaptor.forClass(List.class);
+        verify(stopStartDownscaleFlowService).instancesStopped(eq(STACK_ID), listCap.capture());
+        assertThat(new HashSet<>(listCap.getValue())).isEqualTo(new HashSet<>(expectedToBeStopped));
+        verify(stopStartDownscaleFlowService).clusterDownscaleFinished(eq(STACK_ID), eq(INSTANCE_GROUP_NAME_ACTIONABLE), listCap.capture());
+        assertThat(new HashSet<>(listCap.getValue())).isEqualTo(new HashSet<>(expectedToBeStopped));
+        verifyNoMoreInteractions(stopStartDownscaleFlowService);
+        ArgumentCaptor<Object> argumentCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(reactorEventFactory).createEvent(anyMap(), argumentCaptor.capture());
+        verify(eventBus).notify("STOPSTART_DOWNSCALE_FINALIZED_EVENT", event);
+        assertThat(argumentCaptor.getValue()).isInstanceOf(StopStartDownscaleStopInstancesResult.class);
+    }
+
+    @Test
+    void testDownscaleFinishedActionNotAllStopped() throws Exception {
+        AbstractStopStartDownscaleActions<StopStartDownscaleStopInstancesResult> action =
+                (AbstractStopStartDownscaleActions<StopStartDownscaleStopInstancesResult>) underTest.downscaleFinishedAction();
+        initActionPrivateFields(action);
+
+        List<InstanceMetaData> instancesActionableStarted = generateInstances(10, 100, InstanceStatus.SERVICES_HEALTHY, INSTANCE_GROUP_NAME_ACTIONABLE);
+        List<InstanceMetaData> instancesActionableNotStarted = generateInstances(5, 200, InstanceStatus.STOPPED, INSTANCE_GROUP_NAME_ACTIONABLE);
+        List<InstanceMetaData> instancesRandomStarted = generateInstances(8, 300, InstanceStatus.SERVICES_HEALTHY, INSTANCE_GROUP_NAME_RANDOM);
+        List<InstanceMetaData> instancesRandomNotStarted = generateInstances(3, 400, InstanceStatus.STOPPED, INSTANCE_GROUP_NAME_RANDOM);
+
+        List<InstanceMetaData> expectedToBeStopped = instancesActionableStarted.stream().limit(5).collect(Collectors.toList());
+        Set<Long> instanceIdsToRemove = expectedToBeStopped.stream().map(InstanceMetaData::getId).collect(Collectors.toUnmodifiableSet());
+
+        StopStartDownscaleContext stopStartDownscaleContext = createContext(instanceIdsToRemove);
+
+        mockStackEtc(instancesActionableStarted, instancesActionableNotStarted, instancesRandomStarted, instancesRandomNotStarted);
+        List<CloudInstance> expectedCloudInstances = mockInstanceMetadataToCloudInstanceConverter(expectedToBeStopped);
+        List<CloudVmInstanceStatus> cloudVmInstanceStatusList = constructMixedCloudVmInstanceStatus(expectedCloudInstances);
+        when(reactorEventFactory.createEvent(anyMap(), isNotNull())).thenReturn(event);
+
+        StopStartDownscaleStopInstancesResult payload =
+                new StopStartDownscaleStopInstancesResult(STACK_ID, mock(StopStartDownscaleStopInstancesRequest.class), cloudVmInstanceStatusList);
+
+        new AbstractActionTestSupport<>(action).doExecute(stopStartDownscaleContext, payload, Collections.emptyMap());
+
+        ArgumentCaptor<List> listCap = ArgumentCaptor.forClass(List.class);
+        verify(stopStartDownscaleFlowService).instancesStopped(eq(STACK_ID), listCap.capture());
+        assertThat(new HashSet<>(listCap.getValue())).isEqualTo(new HashSet<>(expectedToBeStopped.subList(1, 5)));
+        verify(stopStartDownscaleFlowService).clusterDownscaleFinished(eq(STACK_ID), eq(INSTANCE_GROUP_NAME_ACTIONABLE), listCap.capture());
+        assertThat(new HashSet<>(listCap.getValue())).isEqualTo(new HashSet<>(expectedToBeStopped.subList(1, 5)));
+        verify(stopStartDownscaleFlowService).logInstancesFailedToStop(eq(STACK_ID), eq(cloudVmInstanceStatusList.subList(0, 1)));
+        verifyNoMoreInteractions(stopStartDownscaleFlowService);
+        ArgumentCaptor<Object> argumentCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(reactorEventFactory).createEvent(anyMap(), argumentCaptor.capture());
+        verify(eventBus).notify("STOPSTART_DOWNSCALE_FINALIZED_EVENT", event);
+        assertThat(argumentCaptor.getValue()).isInstanceOf(StopStartDownscaleStopInstancesResult.class);
+    }
+
+    private StopStartDownscaleContext createContext(Set<Long> instanceIdsToRemove) {
+        return new StopStartDownscaleContext(flowParameters, stack, stackView,
+                cloudContext, cloudCredential, cloudStack, INSTANCE_GROUP_NAME_ACTIONABLE,
+                instanceIdsToRemove, true, ClusterManagerType.CLOUDERA_MANAGER);
+    }
+
+    private void mockStackEtc() {
+        lenient().when(stack.getId()).thenReturn(STACK_ID);
+        lenient().when(stack.getStackAuthentication()).thenReturn(stackAuthentication);
+        lenient().when(stack.getEnvironmentCrn()).thenReturn(ENV_CRN);
+
+        lenient().when(stackView.getId()).thenReturn(STACK_ID);
+    }
+
+    private void mockStackEtc(List<InstanceMetaData> instancesActionableStarted, List<InstanceMetaData> instancesActionableNotStarted,
+            List<InstanceMetaData> instancesRandomStarted, List<InstanceMetaData> instancesRandomNotStarted) {
+        mockStackEtc();
+
+        List<InstanceMetaData> combined =
+                Stream.of(instancesActionableStarted, instancesActionableNotStarted, instancesRandomStarted, instancesRandomNotStarted)
+                        .flatMap(Collection::stream).collect(Collectors.toList());
+
+        lenient().when(stack.getNotDeletedInstanceMetaDataList()).thenReturn(combined);
+
+        InstanceGroup instanceGroup = new InstanceGroup();
+        instanceGroup.setGroupName(INSTANCE_GROUP_NAME_ACTIONABLE);
+        instanceGroup.setInstanceMetaData(new HashSet<>(combined));
+        lenient().when(stack.getInstanceGroupByInstanceGroupName(eq(INSTANCE_GROUP_NAME_ACTIONABLE))).thenReturn(instanceGroup);
+
+        lenient().when(stackService.getPrivateIdsForHostNames(any(), any())).thenCallRealMethod();
+        lenient().when(cloudInstanceIdToInstanceMetaDataConverter.getNotDeletedInstances(any(), anyString(), any())).thenCallRealMethod();
+    }
+
+    private List<CloudInstance> mockInstanceMetadataToCloudInstanceConverter(List<InstanceMetaData> src) {
+        List<CloudInstance> result = convertToCloudInstance(src);
+        lenient().when(instanceMetaDataToCloudInstanceConverter.convert(eq(src), anyString(), any(StackAuthentication.class)))
+                .thenReturn(result);
+        return result;
+    }
+
+    private List<CloudInstance> convertToCloudInstance(List<InstanceMetaData> instances) {
+        List<CloudInstance> cloudInstances = new LinkedList<>();
+        for (InstanceMetaData im : instances) {
+            CloudInstance cloudInstance = new CloudInstance(im.getInstanceId(), null, null, "blah", "blah");
+            cloudInstances.add(cloudInstance);
+        }
+        return cloudInstances;
+    }
+
+    private List<InstanceMetaData> generateInstances(int count, int startIndex,
+            com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus instanceStatus, String instanceGroupName) {
+        List<InstanceMetaData> instances = new ArrayList<>(count);
+        InstanceGroup instanceGroup = new InstanceGroup();
+        instanceGroup.setGroupName(instanceGroupName);
+        for (int i = 0; i < count; i++) {
+            InstanceMetaData instanceMetaData = new InstanceMetaData();
+            instanceMetaData.setPrivateId((long) (startIndex + i));
+            instanceMetaData.setId((long) (startIndex + i));
+            instanceMetaData.setInstanceId(INSTANCE_ID_PREFIX + (startIndex + i));
+            instanceMetaData.setInstanceStatus(instanceStatus);
+            instanceMetaData.setInstanceGroup(instanceGroup);
+            instanceMetaData.setDiscoveryFQDN(INSTANCE_ID_PREFIX + (startIndex + i));
+            instances.add(instanceMetaData);
+        }
+        return instances;
+    }
+
+    private List<CloudVmInstanceStatus> constructStoppedCloudVmInstanceStatus(List<CloudInstance> cloudInstances) {
+        List<CloudVmInstanceStatus> cloudVmInstanceStatusList = new LinkedList<>();
+        for (CloudInstance cloudInstance : cloudInstances) {
+            cloudVmInstanceStatusList.add(new CloudVmInstanceStatus(cloudInstance, com.sequenceiq.cloudbreak.cloud.model.InstanceStatus.STOPPED));
+        }
+        return cloudVmInstanceStatusList;
+    }
+
+    private List<CloudVmInstanceStatus> constructMixedCloudVmInstanceStatus(List<CloudInstance> cloudInstances) {
+        List<CloudVmInstanceStatus> cloudVmInstanceStatusList = new LinkedList<>();
+        for (int i = 0; i < cloudInstances.size(); i++) {
+            com.sequenceiq.cloudbreak.cloud.model.InstanceStatus expStatus;
+            if (i == 0) {
+                expStatus = com.sequenceiq.cloudbreak.cloud.model.InstanceStatus.TERMINATED;
+            } else {
+                expStatus = com.sequenceiq.cloudbreak.cloud.model.InstanceStatus.STOPPED;
+            }
+            cloudVmInstanceStatusList.add(new CloudVmInstanceStatus(cloudInstances.get(i), expStatus));
+        }
+        return cloudVmInstanceStatusList;
+    }
+
+    private void initActionPrivateFields(Action<?, ?> action) {
+        ReflectionTestUtils.setField(action, null, runningFlows, FlowRegister.class);
+        ReflectionTestUtils.setField(action, null, eventBus, EventBus.class);
+        ReflectionTestUtils.setField(action, null, reactorEventFactory, ErrorHandlerAwareReactorEventFactory.class);
+        ReflectionTestUtils.setField(action, null, metricService, MetricService.class);
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/StopStartDownscaleDecommissionViaCMHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/StopStartDownscaleDecommissionViaCMHandlerTest.java
@@ -1,0 +1,390 @@
+package com.sequenceiq.cloudbreak.reactor.handler.cluster;
+
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.UPDATE_IN_PROGRESS;
+import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALING_STOPSTART_DOWNSCALE_ENTEREDCMMAINTMODE;
+import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALING_STOPSTART_DOWNSCALE_ENTERINGCMMAINTMODE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
+import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
+import com.sequenceiq.cloudbreak.cluster.api.ClusterDecomissionService;
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.core.flow2.stack.CloudbreakFlowMessageService;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.reactor.api.event.StackFailureEvent;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.StopStartDownscaleDecommissionViaCMRequest;
+import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.StopStartDownscaleDecommissionViaCMResult;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
+import com.sequenceiq.cloudbreak.service.hostgroup.HostGroupService;
+import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
+
+import reactor.bus.Event;
+
+@ExtendWith(MockitoExtension.class)
+public class StopStartDownscaleDecommissionViaCMHandlerTest {
+
+    private static final String INSTANCE_GROUP_NAME = "compute";
+
+    private static final Long STACK_ID = 100L;
+
+    private static final Long CLUSTER_ID = 101L;
+
+    private static final String INSTANCE_ID_PREFIX = "i-";
+
+    @Mock
+    private ClusterApiConnectors clusterApiConnectors;
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private HostGroupService hostGroupService;
+
+    @Mock
+    private InstanceMetaDataService instanceMetaDataService;
+
+    @Mock
+    private CloudbreakFlowMessageService flowMessageService;
+
+    @InjectMocks
+    private StopStartDownscaleDecommissionViaCMHandler underTest;
+
+    @Mock
+    private Stack stack;
+
+    @Mock
+    private Cluster cluster;
+
+    @Mock
+    private ClusterApi clusterApi;
+
+    @Mock
+    private ClusterDecomissionService clusterDecomissionService;
+
+    @BeforeEach
+    void setUp() {
+        setupBasicMocks();
+    }
+
+    @Test
+    void testAllDecommissioned() {
+        testCollectDecommissionCombinationsInternal(5, 5, 5);
+    }
+
+    @Test
+    void testCmHasMissingNodes() {
+        testCollectDecommissionCombinationsInternal(5, 4, 4);
+    }
+
+    @Test
+    void testCollectAndDecommissionReturnFewerNodes() {
+        testCollectDecommissionCombinationsInternal(5, 4, 3);
+    }
+
+    @Test
+    void testDecommissionReturnsFewerNodes() {
+        testCollectDecommissionCombinationsInternal(5, 5, 3);
+    }
+
+    @Test
+    void testNoNodesAvailableInCm() {
+        int instancesToDecommissionCount = 5;
+        int expcetedInstanceToCollectCount = 0;
+        int expectedInstancesDecommissionedCount = 0;
+        List<InstanceMetaData> instancesToDecommission = getInstancesToDecommission(instancesToDecommissionCount);
+        HostGroup hostGroup = createHostGroup(instancesToDecommission);
+        Map<String, InstanceMetaData> collected =
+                instancesToDecommission.stream().limit(expcetedInstanceToCollectCount).collect(Collectors.toMap(i -> i.getDiscoveryFQDN(), i -> i));
+        List<InstanceMetaData> decommissionedMetadataList =
+                collected.values().stream().limit(expectedInstancesDecommissionedCount).collect(Collectors.toList());
+        Set<String> fqdnsDecommissioned = decommissionedMetadataList.stream().map(InstanceMetaData::getDiscoveryFQDN).collect(Collectors.toUnmodifiableSet());
+
+        setupAdditionalMocks(hostGroup, instancesToDecommission, collected, fqdnsDecommissioned);
+
+        Set<Long> instanceIdsToDecommission = instancesToDecommission.stream().map(InstanceMetaData::getPrivateId).collect(Collectors.toUnmodifiableSet());
+        Set<String> hostnamesToDecommission = instancesToDecommission.stream().map(InstanceMetaData::getDiscoveryFQDN).collect(Collectors.toUnmodifiableSet());
+
+        StopStartDownscaleDecommissionViaCMRequest request =
+                new StopStartDownscaleDecommissionViaCMRequest(stack, INSTANCE_GROUP_NAME, instanceIdsToDecommission);
+        HandlerEvent handlerEvent = new HandlerEvent(Event.wrap(request));
+        Selectable selectable = underTest.doAccept(handlerEvent);
+
+        assertThat(selectable).isInstanceOf(StopStartDownscaleDecommissionViaCMResult.class);
+
+        StopStartDownscaleDecommissionViaCMResult result = (StopStartDownscaleDecommissionViaCMResult) selectable;
+        assertThat(result.getDecommissionedHostFqdns()).hasSize(expectedInstancesDecommissionedCount);
+        assertThat(result.getNotDecommissionedHostFqdns()).hasSize(instancesToDecommissionCount - expectedInstancesDecommissionedCount);
+
+        verifyNoMoreInteractions(instanceMetaDataService);
+
+        verify(clusterDecomissionService).collectHostsToRemove(eq(hostGroup), eq(hostnamesToDecommission));
+        verifyNoMoreInteractions(flowMessageService);
+        verifyNoMoreInteractions(clusterDecomissionService);
+    }
+
+    @Test
+    void testNoNodesFromCMDecommission() {
+        int instancesToDecommissionCount = 5;
+        int expcetedInstanceToCollectCount = 4;
+        int expectedInstancesDecommissionedCount = 0;
+        List<InstanceMetaData> instancesToDecommission = getInstancesToDecommission(instancesToDecommissionCount);
+        HostGroup hostGroup = createHostGroup(instancesToDecommission);
+        Map<String, InstanceMetaData> collected =
+                instancesToDecommission.stream().limit(expcetedInstanceToCollectCount).collect(Collectors.toMap(i -> i.getDiscoveryFQDN(), i -> i));
+        List<InstanceMetaData> decommissionedMetadataList =
+                collected.values().stream().limit(expectedInstancesDecommissionedCount).collect(Collectors.toList());
+        Set<String> fqdnsDecommissioned = decommissionedMetadataList.stream().map(InstanceMetaData::getDiscoveryFQDN).collect(Collectors.toUnmodifiableSet());
+
+        setupAdditionalMocks(hostGroup, instancesToDecommission, collected, fqdnsDecommissioned);
+
+        Set<Long> instanceIdsToDecommission = instancesToDecommission.stream().map(InstanceMetaData::getPrivateId).collect(Collectors.toUnmodifiableSet());
+        Set<String> hostnamesToDecommission = instancesToDecommission.stream().map(InstanceMetaData::getDiscoveryFQDN).collect(Collectors.toUnmodifiableSet());
+
+        StopStartDownscaleDecommissionViaCMRequest request =
+                new StopStartDownscaleDecommissionViaCMRequest(stack, INSTANCE_GROUP_NAME, instanceIdsToDecommission);
+        HandlerEvent handlerEvent = new HandlerEvent(Event.wrap(request));
+        Selectable selectable = underTest.doAccept(handlerEvent);
+
+        assertThat(selectable).isInstanceOf(StopStartDownscaleDecommissionViaCMResult.class);
+
+        StopStartDownscaleDecommissionViaCMResult result = (StopStartDownscaleDecommissionViaCMResult) selectable;
+        assertThat(result.getDecommissionedHostFqdns()).hasSize(expectedInstancesDecommissionedCount);
+        assertThat(result.getNotDecommissionedHostFqdns()).hasSize(instancesToDecommissionCount - expectedInstancesDecommissionedCount);
+
+        verifyNoMoreInteractions(instanceMetaDataService);
+
+        verify(clusterDecomissionService).collectHostsToRemove(eq(hostGroup), eq(hostnamesToDecommission));
+        verify(clusterDecomissionService).decommissionClusterNodesStopStart(eq(collected), anyLong());
+        verifyNoMoreInteractions(flowMessageService);
+        verifyNoMoreInteractions(clusterDecomissionService);
+    }
+
+    @Test
+    void testNoNodesInInitialDecommissionRequest() {
+        int instancesToDecommissionCount = 0;
+        int expcetedInstanceToCollectCount = 0;
+        int expectedInstancesDecommissionedCount = 0;
+        List<InstanceMetaData> instancesToDecommission = getInstancesToDecommission(instancesToDecommissionCount);
+        HostGroup hostGroup = createHostGroup(instancesToDecommission);
+        Map<String, InstanceMetaData> collected =
+                instancesToDecommission.stream().limit(expcetedInstanceToCollectCount).collect(Collectors.toMap(i -> i.getDiscoveryFQDN(), i -> i));
+        List<InstanceMetaData> decommissionedMetadataList =
+                collected.values().stream().limit(expectedInstancesDecommissionedCount).collect(Collectors.toList());
+        Set<String> fqdnsDecommissioned = decommissionedMetadataList.stream().map(InstanceMetaData::getDiscoveryFQDN).collect(Collectors.toUnmodifiableSet());
+
+        setupAdditionalMocks(hostGroup, instancesToDecommission, collected, fqdnsDecommissioned);
+
+        Set<Long> instanceIdsToDecommission = instancesToDecommission.stream().map(InstanceMetaData::getPrivateId).collect(Collectors.toUnmodifiableSet());
+        Set<String> hostnamesToDecommission = instancesToDecommission.stream().map(InstanceMetaData::getDiscoveryFQDN).collect(Collectors.toUnmodifiableSet());
+
+        StopStartDownscaleDecommissionViaCMRequest request =
+                new StopStartDownscaleDecommissionViaCMRequest(stack, INSTANCE_GROUP_NAME, instanceIdsToDecommission);
+        HandlerEvent handlerEvent = new HandlerEvent(Event.wrap(request));
+        Selectable selectable = underTest.doAccept(handlerEvent);
+
+        assertThat(selectable).isInstanceOf(StopStartDownscaleDecommissionViaCMResult.class);
+
+        StopStartDownscaleDecommissionViaCMResult result = (StopStartDownscaleDecommissionViaCMResult) selectable;
+        assertThat(result.getDecommissionedHostFqdns()).hasSize(expectedInstancesDecommissionedCount);
+        assertThat(result.getNotDecommissionedHostFqdns()).hasSize(instancesToDecommissionCount - expectedInstancesDecommissionedCount);
+
+        verify(clusterDecomissionService).collectHostsToRemove(eq(hostGroup), eq(hostnamesToDecommission));
+        verifyNoMoreInteractions(instanceMetaDataService);
+        verifyNoMoreInteractions(flowMessageService);
+        verifyNoMoreInteractions(clusterDecomissionService);
+    }
+
+    @Test
+    void testErrorFromCmHostCollection() {
+        int instancesToDecommissionCount = 5;
+        int expcetedInstanceToCollectCount = 5;
+        int expectedInstancesDecommissionedCount = 5;
+        List<InstanceMetaData> instancesToDecommission = getInstancesToDecommission(instancesToDecommissionCount);
+        HostGroup hostGroup = createHostGroup(instancesToDecommission);
+        Map<String, InstanceMetaData> collected =
+                instancesToDecommission.stream().limit(expcetedInstanceToCollectCount).collect(Collectors.toMap(i -> i.getDiscoveryFQDN(), i -> i));
+        List<InstanceMetaData> decommissionedMetadataList =
+                collected.values().stream().limit(expectedInstancesDecommissionedCount).collect(Collectors.toList());
+        Set<String> fqdnsDecommissioned = decommissionedMetadataList.stream().map(InstanceMetaData::getDiscoveryFQDN).collect(Collectors.toUnmodifiableSet());
+
+        Set<Long> instanceIdsToDecommission = instancesToDecommission.stream().map(InstanceMetaData::getPrivateId).collect(Collectors.toUnmodifiableSet());
+        Set<String> hostnamesToDecommission = instancesToDecommission.stream().map(InstanceMetaData::getDiscoveryFQDN).collect(Collectors.toUnmodifiableSet());
+
+        setupAdditionalMocks(hostGroup, instancesToDecommission, collected, fqdnsDecommissioned);
+        when(clusterDecomissionService.collectHostsToRemove(eq(hostGroup), eq(hostnamesToDecommission)))
+                .thenThrow(new RuntimeException("collectHostsToDecommissionError"));
+
+        StopStartDownscaleDecommissionViaCMRequest request =
+                new StopStartDownscaleDecommissionViaCMRequest(stack, INSTANCE_GROUP_NAME, instanceIdsToDecommission);
+        HandlerEvent handlerEvent = new HandlerEvent(Event.wrap(request));
+        Selectable selectable = underTest.doAccept(handlerEvent);
+        verify(clusterDecomissionService).collectHostsToRemove(eq(hostGroup), eq(hostnamesToDecommission));
+
+        assertThat(selectable).isInstanceOf(StackFailureEvent.class);
+
+        StackFailureEvent result = (StackFailureEvent) selectable;
+        assertThat(result.getException().getMessage()).isEqualTo("collectHostsToDecommissionError");
+
+        verifyNoMoreInteractions(instanceMetaDataService);
+        verifyNoMoreInteractions(flowMessageService);
+        verifyNoMoreInteractions(clusterDecomissionService);
+    }
+
+    @Test
+    void testErrorFromCmCommission() {
+        int instancesToDecommissionCount = 5;
+        int expcetedInstanceToCollectCount = 5;
+        int expectedInstancesDecommissionedCount = 5;
+        List<InstanceMetaData> instancesToDecommission = getInstancesToDecommission(instancesToDecommissionCount);
+        HostGroup hostGroup = createHostGroup(instancesToDecommission);
+        Map<String, InstanceMetaData> collected =
+                instancesToDecommission.stream().limit(expcetedInstanceToCollectCount).collect(Collectors.toMap(i -> i.getDiscoveryFQDN(), i -> i));
+        List<InstanceMetaData> decommissionedMetadataList =
+                collected.values().stream().limit(expectedInstancesDecommissionedCount).collect(Collectors.toList());
+        Set<String> fqdnsDecommissioned = decommissionedMetadataList.stream().map(InstanceMetaData::getDiscoveryFQDN).collect(Collectors.toUnmodifiableSet());
+
+        Set<Long> instanceIdsToDecommission = instancesToDecommission.stream().map(InstanceMetaData::getPrivateId).collect(Collectors.toUnmodifiableSet());
+        Set<String> hostnamesToDecommission = instancesToDecommission.stream().map(InstanceMetaData::getDiscoveryFQDN).collect(Collectors.toUnmodifiableSet());
+
+        setupAdditionalMocks(hostGroup, instancesToDecommission, collected, fqdnsDecommissioned);
+        when(clusterDecomissionService.decommissionClusterNodesStopStart(eq(collected), anyLong()))
+                .thenThrow(new RuntimeException("decommissionHostsError"));
+
+        StopStartDownscaleDecommissionViaCMRequest request =
+                new StopStartDownscaleDecommissionViaCMRequest(stack, INSTANCE_GROUP_NAME, instanceIdsToDecommission);
+        HandlerEvent handlerEvent = new HandlerEvent(Event.wrap(request));
+        Selectable selectable = underTest.doAccept(handlerEvent);
+        verify(clusterDecomissionService).collectHostsToRemove(eq(hostGroup), eq(hostnamesToDecommission));
+        verify(clusterDecomissionService).decommissionClusterNodesStopStart(eq(collected), anyLong());
+
+        assertThat(selectable).isInstanceOf(StackFailureEvent.class);
+
+        StackFailureEvent result = (StackFailureEvent) selectable;
+        assertThat(result.getException().getMessage()).isEqualTo("decommissionHostsError");
+
+        verifyNoMoreInteractions(instanceMetaDataService);
+        verifyNoMoreInteractions(flowMessageService);
+        verifyNoMoreInteractions(clusterDecomissionService);
+    }
+
+    private void testCollectDecommissionCombinationsInternal(int instancesToDecommissionCount, int expcetedInstanceToCollectCount,
+            int expectedInstancesDecommissionedCount) {
+        List<InstanceMetaData> instancesToDecommission = getInstancesToDecommission(instancesToDecommissionCount);
+        HostGroup hostGroup = createHostGroup(instancesToDecommission);
+        Map<String, InstanceMetaData> collected =
+                instancesToDecommission.stream().limit(expcetedInstanceToCollectCount).collect(Collectors.toMap(i -> i.getDiscoveryFQDN(), i -> i));
+        List<InstanceMetaData> decommissionedMetadataList =
+                collected.values().stream().limit(expectedInstancesDecommissionedCount).collect(Collectors.toList());
+        Set<String> fqdnsDecommissioned = decommissionedMetadataList.stream().map(InstanceMetaData::getDiscoveryFQDN).collect(Collectors.toUnmodifiableSet());
+
+        setupAdditionalMocks(hostGroup, instancesToDecommission, collected, fqdnsDecommissioned);
+
+        Set<Long> instanceIdsToDecommission = instancesToDecommission.stream().map(InstanceMetaData::getPrivateId).collect(Collectors.toUnmodifiableSet());
+        Set<String> hostnamesToDecommission = instancesToDecommission.stream().map(InstanceMetaData::getDiscoveryFQDN).collect(Collectors.toUnmodifiableSet());
+
+        StopStartDownscaleDecommissionViaCMRequest request =
+                new StopStartDownscaleDecommissionViaCMRequest(stack, INSTANCE_GROUP_NAME, instanceIdsToDecommission);
+        HandlerEvent handlerEvent = new HandlerEvent(Event.wrap(request));
+        Selectable selectable = underTest.doAccept(handlerEvent);
+
+        assertThat(selectable).isInstanceOf(StopStartDownscaleDecommissionViaCMResult.class);
+
+        StopStartDownscaleDecommissionViaCMResult result = (StopStartDownscaleDecommissionViaCMResult) selectable;
+        assertThat(result.getDecommissionedHostFqdns()).hasSize(expectedInstancesDecommissionedCount);
+        assertThat(result.getNotDecommissionedHostFqdns()).hasSize(instancesToDecommissionCount - expectedInstancesDecommissionedCount);
+
+        for (InstanceMetaData instanceMetaData : decommissionedMetadataList) {
+            verify(instanceMetaDataService).updateInstanceStatus(eq(instanceMetaData), eq(InstanceStatus.DECOMMISSIONED), anyString());
+        }
+        verifyNoMoreInteractions(instanceMetaDataService);
+
+        verify(clusterDecomissionService).collectHostsToRemove(eq(hostGroup), eq(hostnamesToDecommission));
+        verify(clusterDecomissionService).decommissionClusterNodesStopStart(eq(collected), anyLong());
+
+        verify(flowMessageService).fireEventAndLog(eq(STACK_ID), eq(UPDATE_IN_PROGRESS.name()),
+                eq(CLUSTER_SCALING_STOPSTART_DOWNSCALE_ENTERINGCMMAINTMODE), eq(String.valueOf(fqdnsDecommissioned.size())));
+        verify(clusterDecomissionService).enterMaintenanceMode(eq(stack), eq(fqdnsDecommissioned));
+        verify(flowMessageService).fireEventAndLog(eq(STACK_ID), eq(UPDATE_IN_PROGRESS.name()),
+                eq(CLUSTER_SCALING_STOPSTART_DOWNSCALE_ENTEREDCMMAINTMODE), eq(String.valueOf(fqdnsDecommissioned.size())));
+        verifyNoMoreInteractions(flowMessageService);
+        verifyNoMoreInteractions(clusterDecomissionService);
+    }
+
+    private void setupBasicMocks() {
+        lenient().when(stack.getId()).thenReturn(STACK_ID);
+        lenient().when(stack.getCluster()).thenReturn(cluster);
+        lenient().when(cluster.getId()).thenReturn(CLUSTER_ID);
+
+        lenient().when(clusterApiConnectors.getConnector(any(Stack.class))).thenReturn(clusterApi);
+        lenient().when(clusterApi.clusterDecomissionService()).thenReturn(clusterDecomissionService);
+    }
+
+    private void setupAdditionalMocks(HostGroup hostGroup, List<InstanceMetaData> allInstanceMetadata,
+            Map<String, InstanceMetaData> collectedInstances, Set<String> decommissionedInstances) {
+        lenient().when(stack.getInstanceMetaDataAsList()).thenReturn(allInstanceMetadata);
+        lenient().when(stackService.getInstanceMetadata(any(), any())).thenCallRealMethod();
+
+        lenient().when(hostGroupService.getByClusterIdAndName(eq(CLUSTER_ID), eq(INSTANCE_GROUP_NAME))).thenReturn(Optional.of(hostGroup));
+
+        Set<String> hostnames = allInstanceMetadata.stream().map(InstanceMetaData::getDiscoveryFQDN).collect(Collectors.toUnmodifiableSet());
+
+        lenient().when(clusterDecomissionService.collectHostsToRemove(eq(hostGroup), eq(hostnames))).thenReturn(collectedInstances);
+
+        lenient().when(clusterDecomissionService.decommissionClusterNodesStopStart(eq(collectedInstances), anyLong())).thenReturn(decommissionedInstances);
+    }
+
+    private List<InstanceMetaData> getInstancesToDecommission(int count) {
+        List<InstanceMetaData> instances = new ArrayList<>(count);
+        InstanceGroup instanceGroup = new InstanceGroup();
+        instanceGroup.setGroupName(INSTANCE_GROUP_NAME);
+        for (int i = 0; i < count; i++) {
+            InstanceMetaData instanceMetaData = new InstanceMetaData();
+            instanceMetaData.setInstanceId(INSTANCE_ID_PREFIX + i);
+            instanceMetaData.setInstanceStatus(InstanceStatus.SERVICES_HEALTHY);
+            instanceMetaData.setInstanceGroup(instanceGroup);
+            instanceMetaData.setDiscoveryFQDN(INSTANCE_ID_PREFIX + i);
+            instanceMetaData.setPrivateId((long) i);
+            instances.add(instanceMetaData);
+        }
+        return instances;
+    }
+
+    private HostGroup createHostGroup(List<InstanceMetaData> instancesToDecommission) {
+        HostGroup hostGroup = new HostGroup();
+        hostGroup.setName(INSTANCE_GROUP_NAME);
+        InstanceGroup instanceGroup = new InstanceGroup();
+        instanceGroup.setGroupName(INSTANCE_GROUP_NAME);
+        instanceGroup.setInstanceMetaData(new HashSet<>(instancesToDecommission));
+        hostGroup.setInstanceGroup(instanceGroup);
+        return hostGroup;
+    }
+}


### PR DESCRIPTION
- Limit some retries and time spent on retries.
- Additional state checks on cloud instances to handle terminated, etc
  instances.
- Enhanced information propagation between the various flow actions.
- Log actvity information between discrepencies in requested node count, and
  achieved scale-down.
- Cleanup/improved comments, logging, some method and class names from POC.
- Tests for the various downscale actions and handlers.

See detailed description in the commit message.