### PR TITLE
CB-15632 Mitigate FreeIPA System permission replication issue

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaPermissionService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaPermissionService.java
@@ -27,7 +27,9 @@ public class FreeIpaPermissionService {
     private static final String ENROLLMENT_ADMINISTRATOR_ROLE = "Enrollment Administrator";
 
     public void setPermissions(FreeIpaClient freeIpaClient) throws FreeIpaClientException {
-        freeIpaClient.addPermissionsToPrivilege(HOST_ENROLLMENT_PRIVILEGE, List.of(ADD_HOSTS_PERMISSION, REMOVE_HOSTS_PERMISSION, REMOVE_SERVICES_PERMISSION));
+        freeIpaClient.addPermissionsToPrivilege(HOST_ENROLLMENT_PRIVILEGE, List.of(ADD_HOSTS_PERMISSION));
+        freeIpaClient.addPermissionsToPrivilege(HOST_ENROLLMENT_PRIVILEGE, List.of(REMOVE_HOSTS_PERMISSION));
+        freeIpaClient.addPermissionsToPrivilege(HOST_ENROLLMENT_PRIVILEGE, List.of(REMOVE_SERVICES_PERMISSION));
         freeIpaClient.addRolePrivileges(ENROLLMENT_ADMINISTRATOR_ROLE, Set.of(DNS_ADMINISTRATORS_PRIVILEGE));
     }
 }


### PR DESCRIPTION
Adding 3 `System` permissions to `Host Enrollment` privilege is causing replication issues almost every time.
Sometimes the system can't get out of this and blocks every operation causing various issues during cluster operations.

The fix is simply to add the permissions in separate calls.

See detailed description in the commit message.