### PR TITLE
CB-15745. Generalize some telemetry and stack pacher configs

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/orchestrator/TelemetrySaltRetryConfig.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/orchestrator/TelemetrySaltRetryConfig.java
@@ -1,0 +1,70 @@
+package com.sequenceiq.cloudbreak.telemetry.orchestrator;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties("telemetry.salt.retry")
+public class TelemetrySaltRetryConfig {
+
+    private int cloudStorageValidation;
+
+    private int loggingAgentStop;
+
+    private int nodeStatusCollect;
+
+    private int diagnosticsCollect;
+
+    private int meteringUpgrade;
+
+    public int getCloudStorageValidation() {
+        return cloudStorageValidation;
+    }
+
+    public void setCloudStorageValidation(int cloudStorageValidation) {
+        this.cloudStorageValidation = cloudStorageValidation;
+    }
+
+    public int getLoggingAgentStop() {
+        return loggingAgentStop;
+    }
+
+    public void setLoggingAgentStop(int loggingAgentStop) {
+        this.loggingAgentStop = loggingAgentStop;
+    }
+
+    public int getNodeStatusCollect() {
+        return nodeStatusCollect;
+    }
+
+    public void setNodeStatusCollect(int nodeStatusCollect) {
+        this.nodeStatusCollect = nodeStatusCollect;
+    }
+
+    public int getDiagnosticsCollect() {
+        return diagnosticsCollect;
+    }
+
+    public void setDiagnosticsCollect(int diagnosticsCollect) {
+        this.diagnosticsCollect = diagnosticsCollect;
+    }
+
+    public int getMeteringUpgrade() {
+        return meteringUpgrade;
+    }
+
+    public void setMeteringUpgrade(int meteringUpgrade) {
+        this.meteringUpgrade = meteringUpgrade;
+    }
+
+    @Override
+    public String toString() {
+        return "TelemetrySaltRetryConfig{" +
+                "cloudStorageValidation=" + cloudStorageValidation +
+                ", loggingAgentStop=" + loggingAgentStop +
+                ", nodeStatusCollect=" + nodeStatusCollect +
+                ", diagnosticsCollect=" + diagnosticsCollect +
+                ", meteringUpgrade=" + meteringUpgrade +
+                '}';
+    }
+}

--- a/common/src/main/resources/common-config.yml
+++ b/common/src/main/resources/common-config.yml
@@ -31,3 +31,10 @@ telemetry:
         - key: "@cluster"
           value: dps
       forceLogging: false
+  salt:
+    retry:
+      cloud-storage-validation: 3
+      logging-agent-stop: 5
+      node-status-collect: 3
+      diagnostics-collect: 360
+      metering-upgrade: 5

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/config/LoggingAgentAutoRestartPatchConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/config/LoggingAgentAutoRestartPatchConfig.java
@@ -1,0 +1,39 @@
+package com.sequenceiq.cloudbreak.service.stackpatch.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties("existingstackpatcher.active-patches.logging-agent-auto-restart")
+public class LoggingAgentAutoRestartPatchConfig {
+
+    private String affectedVersionFrom;
+
+    private String dateAfter;
+
+    private String dateBefore;
+
+    public String getAffectedVersionFrom() {
+        return affectedVersionFrom;
+    }
+
+    public void setAffectedVersionFrom(String affectedVersionFrom) {
+        this.affectedVersionFrom = affectedVersionFrom;
+    }
+
+    public String getDateAfter() {
+        return dateAfter;
+    }
+
+    public void setDateAfter(String dateAfter) {
+        this.dateAfter = dateAfter;
+    }
+
+    public String getDateBefore() {
+        return dateBefore;
+    }
+
+    public void setDateBefore(String dateBefore) {
+        this.dateBefore = dateBefore;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/config/MeteringAzureMetadataPatchConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/config/MeteringAzureMetadataPatchConfig.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.cloudbreak.service.stackpatch.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties("existingstackpatcher.active-patches.metering-azure-metadata")
+public class MeteringAzureMetadataPatchConfig {
+
+    private String dateBefore;
+
+    private String customRpmUrl;
+
+    public String getDateBefore() {
+        return dateBefore;
+    }
+
+    public void setDateBefore(String dateBefore) {
+        this.dateBefore = dateBefore;
+    }
+
+    public String getCustomRpmUrl() {
+        return customRpmUrl;
+    }
+
+    public void setCustomRpmUrl(String customRpmUrl) {
+        this.customRpmUrl = customRpmUrl;
+    }
+}

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -854,14 +854,14 @@ existingstackpatcher:
   intervalhours: 24
   maxInitialStartDelayInHours: 2
   enabled: true
-  activePatches:
-    meteringAzureMetadata:
-      dateBefore: 2022-01-18
-      customRpmUrl: https://archive.cloudera.com/cp_clients/thunderhead-metering-heartbeat-application-0.1-SNAPSHOT.x86_64.rpm
-    loggingAgentAutoRestart:
-      affectedVersionFrom: 0.2.13
-      dateAfter: 2019-11-24
-      dateBefore: 2022-01-18
+  active-patches:
+    metering-azure-metadata:
+      date-before: 2022-01-18
+      custom-rpm-url: https://archive.cloudera.com/cp_clients/thunderhead-metering-heartbeat-application-0.1-SNAPSHOT.x86_64.rpm
+    logging-agent-auto-restart:
+      affected-version-from: 0.2.13
+      date-after: 2019-11-24
+      date-before: 2022-01-18
 
 clusterdns:
   host: localhost

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltTelemetryOrchestratorTest.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltTelemetryOrchestratorTest.java
@@ -17,37 +17,28 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.orchestrator.OrchestratorBootstrap;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.orchestrator.model.Node;
-import com.sequenceiq.cloudbreak.orchestrator.salt.client.SaltConnector;
 import com.sequenceiq.cloudbreak.orchestrator.salt.poller.SaltJobIdTracker;
 import com.sequenceiq.cloudbreak.orchestrator.salt.poller.checker.ConcurrentParameterizedStateRunner;
 import com.sequenceiq.cloudbreak.orchestrator.salt.runner.SaltRunner;
-import com.sequenceiq.cloudbreak.orchestrator.state.ExitCriteria;
 import com.sequenceiq.cloudbreak.orchestrator.state.ExitCriteriaModel;
+import com.sequenceiq.cloudbreak.telemetry.orchestrator.TelemetrySaltRetryConfig;
 
+@ExtendWith(MockitoExtension.class)
 class SaltTelemetryOrchestratorTest {
 
-    private static final int MAX_TELEMETRY_STOP_RETRY = 5;
-
-    private static final int MAX_NODESTATUS_COLLECT_RETRY = 3;
-
     private static final int MAX_DIAGNOSTICS_COLLECTION_RETRY = 360;
-
-    private static final int MAX_METERING_UPGRADE_RETRY = 360;
-
-    private final ExitCriteria exitCriteria = Mockito.mock(ExitCriteria.class);
-
-    private final SaltService saltService = Mockito.mock(SaltService.class);
-
-    private final SaltRunner saltRunner = Mockito.mock(SaltRunner.class);
-
-    private final SaltConnector saltConnector = Mockito.mock(SaltConnector.class);
 
     private final GatewayConfig gatewayConfig = new GatewayConfig("1.1.1.1", "10.0.0.1", "172.16.252.43", "10-0-0-1", 9443,
             "instanceid", "servercert", "clientcert", "clientkey", "saltpasswd", "saltbootpassword",
@@ -67,13 +58,25 @@ class SaltTelemetryOrchestratorTest {
     private final ExitCriteriaModel exitCriteriaModel = new ExitCriteriaModel() {
     };
 
-    private SaltTelemetryOrchestrator underTest = new SaltTelemetryOrchestrator(exitCriteria, saltService, saltRunner,
-            MAX_TELEMETRY_STOP_RETRY, MAX_NODESTATUS_COLLECT_RETRY, MAX_DIAGNOSTICS_COLLECTION_RETRY, MAX_METERING_UPGRADE_RETRY);
+    @Mock
+    private SaltService saltService;
+
+    @Mock
+    private SaltRunner saltRunner;
+
+    @Mock
+    private TelemetrySaltRetryConfig telemetrySaltRetryConfig;
+
+    @InjectMocks
+    private SaltTelemetryOrchestrator underTest;
 
     @BeforeEach
     void setupTest() throws CloudbreakOrchestratorFailedException {
+        underTest = new SaltTelemetryOrchestrator();
+        MockitoAnnotations.openMocks(this);
+        when(telemetrySaltRetryConfig.getDiagnosticsCollect()).thenReturn(MAX_DIAGNOSTICS_COLLECTION_RETRY);
         when(saltService.getPrimaryGatewayConfig(gatewayConfigs)).thenReturn(gatewayConfig);
-        when(saltService.createSaltConnector(gatewayConfig)).thenReturn(saltConnector);
+        when(saltService.createSaltConnector(gatewayConfig)).thenReturn(null);
         when(saltRunner.runner(orchestratorBootstrapArgumentCaptor.capture(), any(), any(), anyInt(), anyBoolean()))
                 .thenReturn(callable);
     }
@@ -104,6 +107,9 @@ class SaltTelemetryOrchestratorTest {
         Assertions.assertTrue(CollectionUtils.isEqualCollection(targets, saltJobRunner.getAllNode()));
         assertEquals(SaltTelemetryOrchestrator.FILECOLLECTOR_COLLECT, saltJobRunner.getState());
         verify(callable, Mockito.times(1)).call();
+        verify(saltService, Mockito.times(1)).getPrimaryGatewayConfig(gatewayConfigs);
+        verify(saltRunner, Mockito.times(1)).runner(any(), any(), any(), anyInt(), anyBoolean());
+        verify(telemetrySaltRetryConfig, Mockito.times(1)).getDiagnosticsCollect();
     }
 
     @Test


### PR DESCRIPTION
details:
- create object for salt retry configs for salt telemetry orchestrator (remove contructor params)
- rename configs for stack patcher (with "-" separator as spring recommends that and does not allow to use upper case as name in @ConfigurationProperty) and move them to an object as well (so constructor params can be removed here as well)
- refactor: move stack based image operations from ExistingStackPatchService to StackImageService

See detailed description in the commit message.