### PR TITLE
CB-15341 Fix an end-to-end test during scale up

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ClusterStatusSyncHandler.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ClusterStatusSyncHandler.java
@@ -46,7 +46,7 @@ public class ClusterStatusSyncHandler implements ApplicationListener<ClusterStat
         boolean clusterNodesUnhealthy = false;
         if (cluster.isStopStartScalingEnabled()) {
             clusterAvailable = Optional.ofNullable(statusResponse.getStatus()).map(Status::isAvailable).orElse(false);
-            clusterNodesUnhealthy = Optional.ofNullable(statusResponse.getStatus()).map(s -> s == Status.NODE_FAILURE).orElse(false);
+            clusterNodesUnhealthy = Optional.ofNullable(statusResponse.getStatus()).map(s -> s == Status.AVAILABLE_WITH_STOPPED_INSTANCES).orElse(false);
             clusterAvailable |= clusterNodesUnhealthy;
         } else {
             clusterAvailable = Optional.ofNullable(statusResponse.getStatus()).map(Status::isAvailable).orElse(false)

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/handler/ClusterStatusSyncHandlerTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/handler/ClusterStatusSyncHandlerTest.java
@@ -203,11 +203,11 @@ public class ClusterStatusSyncHandlerTest {
 
     @Test
     public void testOnApplicationEventWhenStopStartScalingEnabledAndClusterIsScaledDown() {
-        // Scale down with StopStart results in NODE_FAILURE Stack status, but Periscope shouldn't mark the cluster as SUSPENDED.
+        // Scale down with StopStart results in AVAILABLE_WITH_STOPPED_INSTANCES Stack status, but Periscope shouldn't mark the cluster as SUSPENDED.
         Cluster cluster = getACluster(ClusterState.RUNNING);
         cluster.setStopStartScalingEnabled(Boolean.TRUE);
         when(clusterService.findById(anyLong())).thenReturn(cluster);
-        when(cloudbreakCommunicator.getStackStatusByCrn(anyString())).thenReturn(getStackResponse(Status.NODE_FAILURE));
+        when(cloudbreakCommunicator.getStackStatusByCrn(anyString())).thenReturn(getStackResponse(Status.AVAILABLE_WITH_STOPPED_INSTANCES));
 
         underTest.onApplicationEvent(new ClusterStatusSyncEvent(AUTOSCALE_CLUSTER_ID));
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/UpdateNodeCountValidator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/UpdateNodeCountValidator.java
@@ -96,7 +96,7 @@ public class UpdateNodeCountValidator {
     }
 
     public void validateStackStatusForStartHostGroup(Stack stack) {
-        if (!(stack.isAvailable() || stack.hasNodeFailure())) {
+        if (!(stack.isAvailable() || stack.isAvailableWithStoppedInstances())) {
             throw new BadRequestException(format("Data Hub '%s' has '%s' state. Node group start operation is not allowed for this state.",
                     stack.getName(), stack.getStatus()));
         }
@@ -137,7 +137,7 @@ public class UpdateNodeCountValidator {
 
     public void validateClusterStatusForStartHostGroup(Stack stack) {
         Cluster cluster = stack.getCluster();
-        if (cluster != null && !(stack.isAvailable() || stack.hasNodeFailure())) {
+        if (cluster != null && !(stack.isAvailable() || stack.isAvailableWithStoppedInstances())) {
             throw new BadRequestException(format("Data Hub '%s' has '%s' state. Node group start operation is not allowed for this state.",
                     cluster.getName(), stack.getStatus()));
         }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationServiceTest.java
@@ -3,7 +3,6 @@ package com.sequenceiq.cloudbreak.service.stack.flow;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus.AVAILABLE;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus.AVAILABLE_WITH_STOPPED_INSTANCES;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus.CLUSTER_UPGRADE_FAILED;
-import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus.NODE_FAILURE;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus.STOPPED;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus.STOP_FAILED;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus.STOP_REQUESTED;
@@ -117,9 +116,6 @@ public class StackOperationServiceTest {
 
     @Mock
     private TargetedUpscaleSupportService targetedUpscaleSupportService;
-
-    @Mock
-    private UpdateNodeCountValidator updateNodeCountValidator;
 
     @Spy
     private UpdateNodeCountValidator updateNodeCountValidator = new UpdateNodeCountValidator();
@@ -350,7 +346,7 @@ public class StackOperationServiceTest {
     public static Stream<Arguments> stackStatusForUpdateNodeCount() {
         return Stream.of(
                 Arguments.of("Stack is available", AVAILABLE),
-                Arguments.of("Stack has node failure", NODE_FAILURE),
+                Arguments.of("Stack has stopped instances", AVAILABLE_WITH_STOPPED_INSTANCES),
                 Arguments.of("Stack upgrade failure", CLUSTER_UPGRADE_FAILED)
         );
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/UpdateNodeCountValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/UpdateNodeCountValidatorTest.java
@@ -1,7 +1,7 @@
 package com.sequenceiq.cloudbreak.service.stack.flow;
 
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.AVAILABLE;
-import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.DELETE_IN_PROGRESS;
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.AVAILABLE_WITH_STOPPED_INSTANCES;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.NODE_FAILURE;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -115,13 +115,13 @@ public class UpdateNodeCountValidatorTest {
         when(cluster.getName()).thenReturn("master-stack");
         if (status == AVAILABLE) {
             when(stack.isAvailable()).thenReturn(true);
-            when(stack.hasNodeFailure()).thenReturn(false);
-        } else if (status == NODE_FAILURE) {
+            when(stack.isAvailableWithStoppedInstances()).thenReturn(false);
+        } else if (status == AVAILABLE_WITH_STOPPED_INSTANCES) {
             when(stack.isAvailable()).thenReturn(false);
-            when(stack.hasNodeFailure()).thenReturn(true);
+            when(stack.isAvailableWithStoppedInstances()).thenReturn(true);
         } else {
             when(stack.isAvailable()).thenReturn(false);
-            when(stack.hasNodeFailure()).thenReturn(false);
+            when(stack.isAvailableWithStoppedInstances()).thenReturn(false);
         }
 
         if (errorMessageSegment.isPresent()) {
@@ -141,9 +141,9 @@ public class UpdateNodeCountValidatorTest {
     private static Stream<Arguments> testValidateStatusForStartHostGroupData() {
         return Stream.of(
                 Arguments.of(AVAILABLE, NO_ERROR),
-                Arguments.of(NODE_FAILURE, NO_ERROR),
-                Arguments.of(DELETE_IN_PROGRESS,
-                        Optional.of("Data Hub 'master-stack' has 'DELETE_IN_PROGRESS' state." +
+                Arguments.of(AVAILABLE_WITH_STOPPED_INSTANCES, NO_ERROR),
+                Arguments.of(NODE_FAILURE,
+                        Optional.of("Data Hub 'master-stack' has 'NODE_FAILURE' state." +
                                 " Node group start operation is not allowed for this state."))
         );
     }


### PR DESCRIPTION
1. To allow the clusters to stop we introduced a new state.
2. This state needs to be allowed in scale up via start mode.

See detailed description in the commit message.