### PR TITLE
CB-15761 Fix java.lang.StringIndexOutOfBoundsException at AzureCloudBlobClientActions.getContainerName

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurecloudblob/action/AzureCloudBlobClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurecloudblob/action/AzureCloudBlobClientActions.java
@@ -91,14 +91,14 @@ public class AzureCloudBlobClientActions extends AzureCloudBlobClient {
     }
 
     private String getContainerName(String baseLocation) {
-        final String containerName = baseLocation.substring(baseLocation.lastIndexOf("/") + 1, baseLocation.lastIndexOf("@"));
+        final String containerName = baseLocation.substring(baseLocation.lastIndexOf("//") + 1, baseLocation.lastIndexOf("@"));
         LOGGER.info("Container Name: {} at Base Location: {}", containerName, baseLocation);
         return containerName;
     }
 
     private String getContainerName() {
         String fullPath = azureProperties.getCloudStorage().getBaseLocation();
-        final String containerName = fullPath.substring(fullPath.lastIndexOf("/") + 1, fullPath.lastIndexOf("@"));
+        final String containerName = fullPath.substring(fullPath.lastIndexOf("//") + 1, fullPath.lastIndexOf("@"));
         LOGGER.info("Container Name: {} at Path: {}", containerName, fullPath);
         return containerName;
     }
@@ -289,6 +289,7 @@ public class AzureCloudBlobClientActions extends AzureCloudBlobClient {
 
         Log.log(LOGGER, format(" Azure Blob Storage URI: %s", cloudBlobContainer.getStorageUri()));
         Log.log(LOGGER, format(" Azure Blob Container: %s", cloudBlobContainer.getName()));
+        Log.log(LOGGER, format(" Azure Blob Location: %s", baseLocation));
 
         try {
             for (ListBlobItem blob : cloudBlobContainer.listBlobs()) {


### PR DESCRIPTION
Azure E2E Build 1496--2.52.0-b59-AZURE (21-Jan-2022 03:01:21) [SdxRepairTests.testSDXRepairMasterAndIDBRokerWithStoppedEC2Instance](http://ci-cloudbreak.eng.hortonworks.com/job/api-longrunning-e2e-azure/1496/artifact/suites_log/SdxRepairTests.testSDXRepairMasterAndIDBRokerWithStoppedEC2Instance-20220121.log) is failing, because of:
```
2022-01-21 03:18:50,732 [TestNG-test=azure-longrunning-e2e-tests-8] ERROR c.s.i.cloudbreak.context.TestContext [SdxRepairTests.testSDXRepairMasterAndIDBRokerWithStoppedEC2Instance] - then [SdxRepairTests$$Lambda$1043/0x0000000800f1bc40] assertion is failed: begin 55, end 18, length 94, name: azure-test-c200430b
java.lang.StringIndexOutOfBoundsException: begin 55, end 18, length 94
	at java.base/java.lang.String.checkBoundsBeginEnd(String.java:3319)
	at java.base/java.lang.String.substring(String.java:1874)
	at com.sequenceiq.it.cloudbreak.util.azure.azurecloudblob.action.AzureCloudBlobClientActions.getContainerName(AzureCloudBlobClientActions.java:94)
```
where the 
```
final String containerName = baseLocation.substring(baseLocation.lastIndexOf("/") + 1, baseLocation.lastIndexOf("@"));
```
the new base location: `abfs://autotesting@autotestingapi.dfs.core.windows.net/apitest52d89e22729e462cac2541a33e462726`
So we need to fix the `containerName` based on the new base location string.
