### PR TITLE
CB-15751 - Remove CM DB during upgrade

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/repo/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/repo/init.sls
@@ -1,15 +1,11 @@
 {%- set configure_remote_db = salt['pillar.get']('postgres:configure_remote_db', 'None') %}
 
-
-{% if 'None' != configure_remote_db %}
-
-# Ensure that we remove the unnecessary db backage if embedded db is not used, to avoid upgrade issues
+# Ensure that we remove the unnecessary db package to avoid upgrade issues
 cloudera-manager-server-db-2:
   pkg.removed
 
-{% else %}
-
 # In case of Embedded database we just need to upgrade the database to the right version
+{% if 'None' == configure_remote_db %}
 
 {% if grains['os_family'] == 'RedHat' %}
 


### PR DESCRIPTION
7.1.0->7.2.13 upgrade fails with no external db setup due to the presence of package cloudera-manager-server-db-2.
This commit removes the condition to only remove this package in case of external RDS setup.

Tested with the following:
- 7.1.0 -> 7.2.13
- 7.1.0 -> 7.2.14
- 7.2.13 -> 7.2.14

