### PR TITLE
CB-15721: Verify that DES SP access grant to Key Vault was indeed successful

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureEncryptionResources.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureEncryptionResources.java
@@ -272,6 +272,9 @@ public class AzureEncryptionResources implements EncryptionResources {
             try {
                 LOGGER.info("Granting {}.", description);
                 azureClient.grantKeyVaultAccessPolicyToServicePrincipal(vaultResourceGroupName, vaultName, desPrincipalObjectId);
+                if (!azureClient.checkKeyVaultAccessPolicyForServicePrincipal(vaultResourceGroupName, vaultName, desPrincipalObjectId)) {
+                    throw new RuntimeException(String.format("Access policy has not been granted to object Id: %s, Retrying ...", desPrincipalObjectId));
+                }
                 LOGGER.info("Granted {}.", description);
                 return true;
             } catch (Exception e) {

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
@@ -56,6 +56,7 @@ import com.microsoft.azure.management.compute.implementation.DiskInner;
 import com.microsoft.azure.management.graphrbac.RoleAssignment;
 import com.microsoft.azure.management.graphrbac.RoleAssignments;
 import com.microsoft.azure.management.graphrbac.implementation.RoleAssignmentInner;
+import com.microsoft.azure.management.keyvault.AccessPolicy;
 import com.microsoft.azure.management.keyvault.KeyPermissions;
 import com.microsoft.azure.management.keyvault.Vault;
 import com.microsoft.azure.management.marketplaceordering.v2015_06_01.AgreementTerms;
@@ -1003,6 +1004,20 @@ public class AzureClient {
                     .allowKeyPermissions(List.of(KeyPermissions.WRAP_KEY, KeyPermissions.UNWRAP_KEY, KeyPermissions.GET))
                     .attach()
                     .apply();
+        });
+    }
+
+    public boolean checkKeyVaultAccessPolicyForServicePrincipal(String resourceGroupName, String vaultName, String principalObjectId) {
+        return handleAuthException(() -> {
+            List<AccessPolicy> accessPolicies = azure.vaults()
+                    .getByResourceGroup(resourceGroupName, vaultName)
+                    .accessPolicies();
+            for (int i = accessPolicies.size() - 1; i >= 0; i--) {
+                if (accessPolicies.get(i).inner().objectId().equals(principalObjectId)) {
+                    return true;
+                }
+            }
+            return false;
         });
     }
 

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureEncryptionResourcesTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureEncryptionResourcesTest.java
@@ -296,6 +296,8 @@ public class AzureEncryptionResourcesTest {
         when(azureClient.getCurrentSubscription()).thenReturn(subscription);
         when(azureClient.getDiskEncryptionSetByName(any(String.class), any(String.class))).thenReturn(des);
         when(azureClient.keyVaultExists("dummyResourceGroup", "dummyVaultName")).thenReturn(Boolean.TRUE);
+        when(azureClient.checkKeyVaultAccessPolicyForServicePrincipal("dummyResourceGroup", "dummyVaultName", DES_PRINCIPAL_ID))
+                .thenReturn(true);
         initRetry();
         // Return the same DES instance to simulate that the poller checker task instantly completed
         when(diskEncryptionSetCreationPoller.startPolling(eq(authenticatedContext), any(DiskEncryptionSetCreationCheckerContext.class), eq(des)))
@@ -309,6 +311,7 @@ public class AzureEncryptionResourcesTest {
         verify(azureClient, never()).createDiskEncryptionSet(any(String.class), any(String.class), any(String.class),
                 any(String.class), any(String.class), any(Map.class));
         verify(azureClient).grantKeyVaultAccessPolicyToServicePrincipal("dummyResourceGroup", "dummyVaultName", DES_PRINCIPAL_ID);
+        verify(azureClient).checkKeyVaultAccessPolicyForServicePrincipal("dummyResourceGroup", "dummyVaultName", DES_PRINCIPAL_ID);
 
         verifyPersistedCloudResource();
     }
@@ -386,6 +389,8 @@ public class AzureEncryptionResourcesTest {
         when(authenticatedContext.getParameter(AzureClient.class)).thenReturn(azureClient);
         when(azureClient.getCurrentSubscription()).thenReturn(subscription);
         when(azureClient.getDiskEncryptionSetByName(any(String.class), any(String.class))).thenReturn(desInitial);
+        when(azureClient.checkKeyVaultAccessPolicyForServicePrincipal("dummyResourceGroup", "dummyVaultName", DES_PRINCIPAL_ID))
+                .thenReturn(true);
         initRetry();
         // Return a different DES instance to simulate that the poller checker task initially indicated incomplete, hence the final DES was obtained by the
         // scheduled execution of the poller
@@ -401,6 +406,7 @@ public class AzureEncryptionResourcesTest {
         verify(azureClient, never()).createDiskEncryptionSet(any(String.class), any(String.class), any(String.class),
                 any(String.class), any(String.class), any(Map.class));
         verify(azureClient).grantKeyVaultAccessPolicyToServicePrincipal("dummyResourceGroup", "dummyVaultName", DES_PRINCIPAL_ID);
+        verify(azureClient).checkKeyVaultAccessPolicyForServicePrincipal("dummyResourceGroup", "dummyVaultName", DES_PRINCIPAL_ID);
 
         verifyPersistedCloudResource();
     }
@@ -439,6 +445,8 @@ public class AzureEncryptionResourcesTest {
         when(azureClient.createDiskEncryptionSet(any(String.class), any(String.class), any(String.class),
                 any(String.class), any(String.class), any(Map.class))).thenReturn(des);
         when(azureClient.keyVaultExists("dummyResourceGroup", "dummyVaultName")).thenReturn(Boolean.TRUE);
+        when(azureClient.checkKeyVaultAccessPolicyForServicePrincipal("dummyResourceGroup", "dummyVaultName", DES_PRINCIPAL_ID))
+                .thenReturn(true);
         initRetry();
         // Return the same DES instance to simulate that the poller checker task instantly completed
         when(diskEncryptionSetCreationPoller.startPolling(eq(authenticatedContext), any(DiskEncryptionSetCreationCheckerContext.class), eq(des)))
@@ -449,6 +457,7 @@ public class AzureEncryptionResourcesTest {
         assertEquals(createdDes.getDiskEncryptionSetLocation(), "dummyRegion");
         assertEquals(createdDes.getDiskEncryptionSetResourceGroupName(), "dummyResourceGroup");
         verify(azureClient).grantKeyVaultAccessPolicyToServicePrincipal("dummyResourceGroup", "dummyVaultName", DES_PRINCIPAL_ID);
+        verify(azureClient).checkKeyVaultAccessPolicyForServicePrincipal("dummyResourceGroup", "dummyVaultName", DES_PRINCIPAL_ID);
 
         verifyPersistedCloudResource();
     }
@@ -534,6 +543,7 @@ public class AzureEncryptionResourcesTest {
         when(azureClient.getDiskEncryptionSetByName(any(String.class), any(String.class))).thenReturn(null);
         when(azureClient.createDiskEncryptionSet(any(String.class), any(String.class), any(String.class),
                 any(String.class), any(String.class), any(Map.class))).thenReturn(des);
+        when(azureClient.checkKeyVaultAccessPolicyForServicePrincipal(any(String.class), any(String.class), any(String.class))).thenReturn(true);
         initRetry();
         // Return the same DES instance to simulate that the poller checker task instantly completed
         when(diskEncryptionSetCreationPoller.startPolling(eq(authenticatedContext), any(DiskEncryptionSetCreationCheckerContext.class), eq(des)))
@@ -544,7 +554,7 @@ public class AzureEncryptionResourcesTest {
         assertEquals(createdDes.getDiskEncryptionSetLocation(), "dummyRegion");
         assertEquals(createdDes.getDiskEncryptionSetResourceGroupName(), "dummyResourceGroup");
         verify(azureClient).grantKeyVaultAccessPolicyToServicePrincipal("dummyVaultResourceGroup", "dummyVaultName", DES_PRINCIPAL_ID);
-
+        verify(azureClient).checkKeyVaultAccessPolicyForServicePrincipal("dummyVaultResourceGroup", "dummyVaultName", DES_PRINCIPAL_ID);
         verifyPersistedCloudResource();
     }
 
@@ -604,6 +614,8 @@ public class AzureEncryptionResourcesTest {
         when(azureClient.createDiskEncryptionSet(any(String.class), any(String.class), any(String.class),
                 any(String.class), any(String.class), any(Map.class))).thenReturn(des);
         when(azureClient.keyVaultExists("dummyResourceGroup", "dummyVaultName")).thenReturn(Boolean.TRUE);
+        when(azureClient.checkKeyVaultAccessPolicyForServicePrincipal("dummyResourceGroup", "dummyVaultName", DES_PRINCIPAL_ID))
+                .thenReturn(true);
         initRetry();
         // Return the same DES instance to simulate that the poller checker task instantly completed
         when(diskEncryptionSetCreationPoller.startPolling(eq(authenticatedContext), any(DiskEncryptionSetCreationCheckerContext.class), eq(des)))
@@ -614,6 +626,7 @@ public class AzureEncryptionResourcesTest {
         assertEquals(createdDes.getDiskEncryptionSetLocation(), "dummyRegion");
         assertEquals(createdDes.getDiskEncryptionSetResourceGroupName(), "envName-CDP_DES-uniqueId");
         verify(azureClient).grantKeyVaultAccessPolicyToServicePrincipal("dummyResourceGroup", "dummyVaultName", DES_PRINCIPAL_ID);
+        verify(azureClient).checkKeyVaultAccessPolicyForServicePrincipal("dummyResourceGroup", "dummyVaultName", DES_PRINCIPAL_ID);
         verify(azureClient).createResourceGroup(eq("envName-CDP_DES-uniqueId"), eq("dummyRegion"), any(HashMap.class));
         verifyPersistedResourceGroupAndDiskEncryptionSetCloudResource(resourceGroup.id());
     }


### PR DESCRIPTION
CB-15721: Verify that DES SP access grant to Key Vault was indeed successful

1. It is tested that multiple attempts to the same principalId using "grantKeyVaultAccessPolicyToServicePrincipal" doesn't error out by Azure. The call is successful even if the grant is already present.
2. "checkKeyVaultAccessPolicyForServicePrincipal" checks if the accesspolicies are granted to the Disk encryption set principalId. The check is iterated backwards, as it is observed during testing that for the policies recently added, gets added to last.
3. Unit tests are updated.

