### PR TITLE
CB-15721: Verify that DES SP access grant to Key Vault was indeed suc…

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureEncryptionResources.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureEncryptionResources.java
@@ -26,6 +26,7 @@ import com.sequenceiq.cloudbreak.cloud.azure.task.diskencryptionset.DiskEncrypti
 import com.sequenceiq.cloudbreak.cloud.azure.task.diskencryptionset.DiskEncryptionSetCreationPoller;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
 import com.sequenceiq.cloudbreak.cloud.model.Variant;
@@ -272,6 +273,9 @@ public class AzureEncryptionResources implements EncryptionResources {
             try {
                 LOGGER.info("Granting {}.", description);
                 azureClient.grantKeyVaultAccessPolicyToServicePrincipal(vaultResourceGroupName, vaultName, desPrincipalObjectId);
+                if (!azureClient.checkKeyVaultAccessPolicyForServicePrincipal(vaultResourceGroupName, vaultName, desPrincipalObjectId)) {
+                    throw new CloudConnectorException(String.format("Access policy has not been granted to object Id: %s, Retrying ...", desPrincipalObjectId));
+                }
                 LOGGER.info("Granted {}.", description);
                 return true;
             } catch (Exception e) {

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
@@ -56,6 +56,8 @@ import com.microsoft.azure.management.compute.implementation.DiskInner;
 import com.microsoft.azure.management.graphrbac.RoleAssignment;
 import com.microsoft.azure.management.graphrbac.RoleAssignments;
 import com.microsoft.azure.management.graphrbac.implementation.RoleAssignmentInner;
+import com.microsoft.azure.management.keyvault.AccessPolicy;
+import com.microsoft.azure.management.keyvault.AccessPolicyEntry;
 import com.microsoft.azure.management.keyvault.KeyPermissions;
 import com.microsoft.azure.management.keyvault.Vault;
 import com.microsoft.azure.management.marketplaceordering.v2015_06_01.AgreementTerms;
@@ -1004,6 +1006,29 @@ public class AzureClient {
                     .attach()
                     .apply();
         });
+    }
+
+    public boolean checkKeyVaultAccessPolicyForServicePrincipal(String resourceGroupName, String vaultName, String principalObjectId) {
+        return handleAuthException(() -> {
+            List<AccessPolicy> accessPolicies = azure.vaults()
+                    .getByResourceGroup(resourceGroupName, vaultName)
+                    .accessPolicies();
+            return checkKeyVaultAccessPolicyListForServicePrincipal(accessPolicies, principalObjectId);
+        });
+    }
+
+    @VisibleForTesting
+    boolean checkKeyVaultAccessPolicyListForServicePrincipal(List<AccessPolicy> accessPolicies, String principalObjectId) {
+        if (accessPolicies != null) {
+            for (int i = accessPolicies.size() - 1; i >= 0; i--) {
+                AccessPolicyEntry accessPolicyEntry = accessPolicies.get(i).inner();
+                if (principalObjectId.equals(accessPolicyEntry.objectId())) {
+                    return accessPolicyEntry.permissions().keys()
+                            .containsAll(List.of(KeyPermissions.WRAP_KEY, KeyPermissions.UNWRAP_KEY, KeyPermissions.GET));
+                }
+            }
+        }
+        return false;
     }
 
     public void removeKeyVaultAccessPolicyFromServicePrincipal(String resourceGroupName, String vaultName, String principalObjectId) {


### PR DESCRIPTION
CB-15721: Verify that DES SP access grant to Key Vault was indeed successful

1. It is tested that multiple attempts to the same principalId using "grantKeyVaultAccessPolicyToServicePrincipal" doesn't error out by Azure. The call is successful even if the grant is already present.
2. "checkKeyVaultAccessPolicyForServicePrincipal" checks if the accesspolicies are granted to the Disk encryption set principalId. The check is iterated backwards, as it is observed during testing that for the policies recently added, gets added to last.
3. Unit tests are updated.

