### PR TITLE
CB-15796. Move flow related migration scripts under flow module.

### DIFF
--- a/datalake/src/main/resources/schema/app/20210217140634_CB-11220_introduce_flowChainType_into_the_flowChainLog_table.sql
+++ b/datalake/src/main/resources/schema/app/20210217140634_CB-11220_introduce_flowChainType_into_the_flowChainLog_table.sql
@@ -1,9 +1,0 @@
--- // CB-11220 introduce flowChainType into the flowChainLog table
--- Migration SQL that makes the change goes here.
-
-ALTER TABLE flowchainlog ADD COLUMN flowchaintype CHARACTER VARYING (255);
-
--- //@UNDO
--- SQL to undo the change goes here.
-
-ALTER TABLE flowchainlog DROP COLUMN IF EXISTS flowchaintype;

--- a/environment/src/main/resources/schema/app/20210217140634_CB-11220_introduce_flowChainType_into_the_flowChainLog_table.sql
+++ b/environment/src/main/resources/schema/app/20210217140634_CB-11220_introduce_flowChainType_into_the_flowChainLog_table.sql
@@ -1,9 +1,0 @@
--- // CB-11220 introduce flowChainType into the flowChainLog table
--- Migration SQL that makes the change goes here.
-
-ALTER TABLE flowchainlog ADD COLUMN flowchaintype CHARACTER VARYING (255);
-
--- //@UNDO
--- SQL to undo the change goes here.
-
-ALTER TABLE flowchainlog DROP COLUMN IF EXISTS flowchaintype;

--- a/flow/src/main/resources/schema/flow/20210217140634_CB-11220_introduce_flowChainType_into_the_flowChainLog_table.sql
+++ b/flow/src/main/resources/schema/flow/20210217140634_CB-11220_introduce_flowChainType_into_the_flowChainLog_table.sql
@@ -1,7 +1,7 @@
 -- // CB-11220 introduce flowChainType into the flowChainLog table
 -- Migration SQL that makes the change goes here.
 
-ALTER TABLE flowchainlog ADD COLUMN flowchaintype CHARACTER VARYING (255);
+ALTER TABLE flowchainlog ADD COLUMN IF NOT EXISTS flowchaintype CHARACTER VARYING (255);
 
 -- //@UNDO
 -- SQL to undo the change goes here.

--- a/flow/src/test/resources/schema/flow_test/20210818140529_CB-13731_add_flow_chain_type.sql
+++ b/flow/src/test/resources/schema/flow_test/20210818140529_CB-13731_add_flow_chain_type.sql
@@ -1,7 +1,7 @@
 -- // CB-13731 introduce flowChainType into the flowChainLog table
 -- Migration SQL that makes the change goes here.
 
-ALTER TABLE flowchainlog ADD COLUMN flowchaintype CHARACTER VARYING (255);
+ALTER TABLE flowchainlog ADD COLUMN IF NOT EXISTS flowchaintype CHARACTER VARYING (255);
 
 -- //@UNDO
 -- SQL to undo the change goes here.

--- a/freeipa/src/main/resources/schema/app/20210217140634_CB-11220_introduce_flowChainType_into_the_flowChainLog_table.sql
+++ b/freeipa/src/main/resources/schema/app/20210217140634_CB-11220_introduce_flowChainType_into_the_flowChainLog_table.sql
@@ -1,9 +1,0 @@
--- // CB-11220 introduce flowChainType into the flowChainLog table
--- Migration SQL that makes the change goes here.
-
-ALTER TABLE flowchainlog ADD COLUMN flowchaintype CHARACTER VARYING (255);
-
--- //@UNDO
--- SQL to undo the change goes here.
-
-ALTER TABLE flowchainlog DROP COLUMN IF EXISTS flowchaintype;

--- a/redbeams/src/main/resources/schema/app/20210217140634_CB-11220_introduce_flowChainType_into_the_flowChainLog_table.sql
+++ b/redbeams/src/main/resources/schema/app/20210217140634_CB-11220_introduce_flowChainType_into_the_flowChainLog_table.sql
@@ -1,9 +1,0 @@
--- // CB-11220 introduce flowChainType into the flowChainLog table
--- Migration SQL that makes the change goes here.
-
-ALTER TABLE flowchainlog ADD COLUMN flowchaintype CHARACTER VARYING (255);
-
--- //@UNDO
--- SQL to undo the change goes here.
-
-ALTER TABLE flowchainlog DROP COLUMN IF EXISTS flowchaintype;


### PR DESCRIPTION
details:
- db migration can fail if flowchainlog does not exist at that time when this specific sql is running
- order of the migration scripts (per module) is decided based on the order of the SchemaLocationProvider implementations
- can differ for different projects + jdks -> can lead to migration failure

See detailed description in the commit message.