### PR TITLE
CB-15782 Cleanup every resources in case of Jenkins Abort

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/util/cleanup/CleanupUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/util/cleanup/CleanupUtil.java
@@ -49,11 +49,14 @@ public class CleanupUtil extends CleanupClientUtil {
     @Value("${integrationtest.outputdir:.}")
     private String outputDirectory;
 
+    @Value("${integrationtest.cleanup.afterAbort:false}")
+    private boolean cleanupAfterAbort;
+
     @Inject
     private CleanupWaitUtil waitUtil;
 
     public void cleanupAllResources() {
-        if (resourceFilesArePresent()) {
+        if (resourceFilesArePresent() && !cleanupAfterAbort) {
             cleanupDistroxes();
             cleanupSdxes();
             cleanupEnvironments();


### PR DESCRIPTION
In case of an E2E Jenkins build has been aborted (by user or by Time-out strategy), the test project teardown won't be invoked furthermore the [api-cleanup-app](http://ci-cloudbreak.eng.hortonworks.com/job/api-cleanup-app/) related build won't delete all the created resources if a test case resource file could not be generated by the `afterInvocation` listener.