### PR TITLE
CB-15759 Create test for cluster stop start with external database

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDto.java
@@ -28,9 +28,11 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 import com.sequenceiq.distrox.api.v1.distrox.endpoint.DistroXV1Endpoint;
 import com.sequenceiq.distrox.api.v1.distrox.model.DistroXV1Request;
+import com.sequenceiq.distrox.api.v1.distrox.model.database.DistroXDatabaseRequest;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.InstanceGroupV1Request;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.AwsInstanceTemplateV1Parameters;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.AwsInstanceTemplateV1SpotParameters;
@@ -285,6 +287,13 @@ public class DistroXTestDto extends DistroXTestDtoBase<DistroXTestDto> implement
 
     public DistroXTestDto withInitiatorUserCrn(String initiatorUserCrn) {
         this.initiatorUserCrn = initiatorUserCrn;
+        return this;
+    }
+
+    public DistroXTestDto withExternalDatabaseOnAws(DistroXDatabaseRequest database) {
+        if (CloudPlatform.AWS.equals(getCloudPlatform())) {
+            getRequest().setExternalDatabase(database);
+        }
         return this;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/clouderamanager/ClouderaManagerUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/clouderamanager/ClouderaManagerUtil.java
@@ -38,4 +38,8 @@ public class ClouderaManagerUtil {
     public DistroXTestDto checkClouderaManagerHdfsDatanodeRoleConfigGroups(DistroXTestDto testDto, String user, String password, Set<String> mountPoints) {
         return clouderaManagerClientActions.checkCmHdfsDatanodeRoleConfigGroups(testDto, user, password, mountPoints);
     }
+
+    public DistroXTestDto checkCmServicesStartedSuccessfully(DistroXTestDto testDto, String user, String password) {
+        return clouderaManagerClientActions.checkCmServicesStartedSuccessfully(testDto, user, password);
+    }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/clouderamanager/action/ClouderaManagerClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/clouderamanager/action/ClouderaManagerClientActions.java
@@ -1,18 +1,26 @@
 package com.sequenceiq.it.cloudbreak.util.clouderamanager.action;
 
 import static java.lang.String.format;
+import static org.apache.commons.collections4.ListUtils.emptyIfNull;
 
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import com.cloudera.api.swagger.HostsResourceApi;
 import com.cloudera.api.swagger.RoleConfigGroupsResourceApi;
 import com.cloudera.api.swagger.client.ApiClient;
 import com.cloudera.api.swagger.client.ApiException;
 import com.cloudera.api.swagger.model.ApiConfigList;
+import com.cloudera.api.swagger.model.ApiHost;
+import com.cloudera.api.swagger.model.ApiRoleRef;
+import com.cloudera.api.swagger.model.ApiRoleState;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
 import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.exception.TestFailException;
@@ -23,6 +31,8 @@ import com.sequenceiq.it.cloudbreak.util.clouderamanager.client.ClouderaManagerC
 public class ClouderaManagerClientActions extends ClouderaManagerClient {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerClientActions.class);
+
+    private static final Set<String> REQUIRED_SERVICES = Set.of("hive", "ranger", "atlas");
 
     private static final String V_43 = "/v43";
 
@@ -200,5 +210,48 @@ public class ClouderaManagerClientActions extends ClouderaManagerClient {
             throw new TestFailException("Can't get role configs at: " + apiClient.getBasePath(), e);
         }
         return testDto;
+    }
+
+    public DistroXTestDto checkCmServicesStartedSuccessfully(DistroXTestDto testDto, String user, String password) {
+        String serverIp = testDto.getResponse().getCluster().getServerIp();
+        ApiClient apiClient = getCmApiClientWithTimeoutDisabledDirect(serverIp, testDto.getName(), V_43, user, password);
+        // CHECKSTYLE:OFF
+        HostsResourceApi hostsResourceApi = new HostsResourceApi(apiClient);
+        // CHECKSTYLE:ON
+        try {
+            Set<String> masterHostnames = testDto.getResponse().getInstanceGroups()
+                    .stream()
+                    .filter(ig -> "master".equals(ig.getName()))
+                    .flatMap(ig -> ig.getMetadata().stream())
+                    .map(InstanceMetaDataV4Response::getDiscoveryFQDN)
+                    .collect(Collectors.toSet());
+            List<ApiHost> apiHosts = hostsResourceApi.readHosts(null, null, "FULL_WITH_HEALTH_CHECK_EXPLANATION").getItems();
+            Set<String> servicesNotStarted = apiHosts.stream()
+                    .filter(apiHost -> masterHostnames.contains(apiHost.getHostname()))
+                    .flatMap(apiHost -> collectNotStartedServicesOnHost(apiHost).stream())
+                    .filter(serviceName -> REQUIRED_SERVICES.contains(serviceName))
+                    .collect(Collectors.toSet());
+
+            if (!servicesNotStarted.isEmpty()) {
+                LOGGER.error("There are not started required services: {}", servicesNotStarted);
+                throw new TestFailException(String.format("There are not started required services: %s", servicesNotStarted));
+            }
+        } catch (ApiException e) {
+            LOGGER.error("Exception when calling HostsResourceApi#readHosts. Response: {}", e.getResponseBody(), e);
+            String message = format("Exception when calling HostsResourceApi#readHosts at %s. Response: %s",
+                    apiClient.getBasePath(), e.getResponseBody());
+            throw new TestFailException(message, e);
+        } catch (Exception e) {
+            LOGGER.error("Can't read host statuses at: '{}'!", apiClient.getBasePath());
+            throw new TestFailException("Can't read host statuses at: " + apiClient.getBasePath(), e);
+        }
+        return testDto;
+    }
+
+    private static Set<String> collectNotStartedServicesOnHost(ApiHost host) {
+        return emptyIfNull(host.getRoleRefs()).stream()
+                .filter(roleRef -> !ApiRoleState.STARTED.equals(roleRef.getRoleStatus()))
+                .map(ApiRoleRef::getServiceName)
+                .collect(Collectors.toSet());
     }
 }


### PR DESCRIPTION
Required CM services should be in running state (cluster start command should be issued) during cluster start.

See detailed description in the commit message.