### PR TITLE
CB-15640 Use SHA2-512 for saltbootstrap password and salt password in cloudbreak-core and cloudbreak-freeipa

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/util/FreeIpaPasswordUtil.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/util/FreeIpaPasswordUtil.java
@@ -6,6 +6,11 @@ import java.util.List;
 
 import org.apache.commons.lang3.RandomStringUtils;
 
+/**
+ * @deprecated {@link RandomStringUtils} uses a global, predictable {@link java.util.Random} internally.
+ * Use {@link com.sequenceiq.cloudbreak.util.password.DefaultPasswordGenerator} instead.
+ */
+@Deprecated
 public class FreeIpaPasswordUtil {
 
     private static final int PWD_PREFIX_LENGTH = 3;

--- a/common/src/main/java/com/sequenceiq/cloudbreak/util/PasswordUtil.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/util/PasswordUtil.java
@@ -6,6 +6,11 @@ import java.security.NoSuchAlgorithmException;
 
 import org.apache.commons.lang3.RandomStringUtils;
 
+/**
+ * @deprecated {@link RandomStringUtils} uses a global, predictable {@link java.util.Random} internally.
+ * Use {@link com.sequenceiq.cloudbreak.util.password.DefaultPasswordGenerator} instead.
+ */
+@Deprecated
 public class PasswordUtil {
 
     private static final int PWD_LENGTH = 128;

--- a/common/src/main/java/com/sequenceiq/cloudbreak/util/password/CharSet.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/util/password/CharSet.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.cloudbreak.util.password;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.google.common.base.Preconditions;
+
+public class CharSet {
+
+    public static final CharSet ALPHABETIC_LOWER_CASE = fromString("abcdefghijklmnopqrstuvwxyz");
+
+    public static final CharSet ALPHABETIC_UPPER_CASE = fromString("ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+
+    public static final CharSet NUMERIC = fromString("0123456789");
+
+    public static final CharSet SAFE_SPECIAL_CHARACTERS = fromString("?.-_+");
+
+    private final List<Character> values;
+
+    public CharSet(Collection<Character> values) {
+        Preconditions.checkNotNull(values);
+        Preconditions.checkArgument(!values.isEmpty(), "Character set must contain at least one value.");
+        this.values = List.copyOf(new LinkedHashSet<>(values));
+    }
+
+    public static CharSet fromString(String characters) {
+        return new CharSet(characters.chars()
+                .mapToObj(c -> (char) c)
+                .collect(Collectors.toList()));
+    }
+
+    public List<Character> getValues() {
+        return values;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/util/password/DefaultPasswordGenerator.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/util/password/DefaultPasswordGenerator.java
@@ -1,0 +1,11 @@
+package com.sequenceiq.cloudbreak.util.password;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class DefaultPasswordGenerator {
+
+    public String generate() {
+        return PasswordGenerator.getDefault().generate();
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/util/password/PasswordGenerator.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/util/password/PasswordGenerator.java
@@ -1,0 +1,115 @@
+package com.sequenceiq.cloudbreak.util.password;
+
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.bouncycastle.crypto.digests.SHA512Digest;
+import org.bouncycastle.crypto.prng.SP800SecureRandomBuilder;
+
+public class PasswordGenerator {
+
+    private static final int PREFIX_LENGTH = 3;
+
+    private static final int PART_LENGTH = 8;
+
+    private static final PasswordGenerator DEFAULT_PASSWORD_GENERATOR = builder()
+            .prefix(CharSet.ALPHABETIC_LOWER_CASE, PREFIX_LENGTH)
+            .mandatoryCharacters(CharSet.SAFE_SPECIAL_CHARACTERS)
+            .bodyPart(CharSet.ALPHABETIC_LOWER_CASE, PART_LENGTH)
+            .bodyPart(CharSet.ALPHABETIC_UPPER_CASE, PART_LENGTH)
+            .bodyPart(CharSet.NUMERIC, PART_LENGTH)
+            .randomSupplier(() -> new SP800SecureRandomBuilder(new SecureRandom(), false)
+                    .setPersonalizationString(Long.toString(System.nanoTime()).getBytes())
+                    .buildHash(new SHA512Digest(), null, false))
+            .build();
+
+    private final Optional<PasswordPart> prefixPart;
+
+    private final List<PasswordPart> bodyParts;
+
+    private final Optional<CharSet> mandatoryCharacters;
+
+    private final Supplier<SecureRandom> randomSupplier;
+
+    private PasswordGenerator(
+            Optional<PasswordPart> prefixPart,
+            List<PasswordPart> bodyParts,
+            Optional<CharSet> mandatoryCharacters,
+            Supplier<SecureRandom> randomSupplier) {
+        this.prefixPart = prefixPart;
+        this.bodyParts = bodyParts;
+        this.mandatoryCharacters = mandatoryCharacters;
+        this.randomSupplier = randomSupplier;
+    }
+
+    public static PasswordGenerator getDefault() {
+        return DEFAULT_PASSWORD_GENERATOR;
+    }
+
+    public String generate() {
+        SecureRandom random = randomSupplier.get();
+        StringBuilder password = new StringBuilder();
+        if (prefixPart.isPresent()) {
+            prefixPart.get().generateRandomCharacters(random).forEach(password::append);
+        }
+        List<Character> body = new ArrayList<>();
+        if (mandatoryCharacters.isPresent()) {
+            body.addAll(mandatoryCharacters.get().getValues());
+        }
+        for (PasswordPart passwordPart : bodyParts) {
+            body.addAll(passwordPart.generateRandomCharacters(random));
+        }
+
+        Collections.shuffle(body, random);
+        body.forEach(password::append);
+        return password.toString();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private Optional<PasswordPart> prefixPart = Optional.empty();
+
+        private List<PasswordPart> bodyParts = new ArrayList<>();
+
+        private Optional<CharSet> mandatoryCharacters = Optional.empty();
+
+        private Supplier<SecureRandom> randomSupplier;
+
+        public Builder prefix(CharSet charSet, int length) {
+            prefixPart = Optional.of(new PasswordPart(charSet, length));
+            return this;
+        }
+
+        public Builder mandatoryCharacters(CharSet charSet) {
+            mandatoryCharacters = Optional.of(charSet);
+            return this;
+        }
+
+        public Builder bodyPart(CharSet charSet, int length) {
+            bodyParts.add(new PasswordPart(charSet, length));
+            return this;
+        }
+
+        public Builder randomSupplier(Supplier<SecureRandom> randomSupplier) {
+            this.randomSupplier = randomSupplier;
+            return this;
+        }
+
+        public PasswordGenerator build() {
+            return new PasswordGenerator(
+                    prefixPart,
+                    bodyParts,
+                    mandatoryCharacters,
+                    randomSupplier
+            );
+        }
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/util/password/PasswordPart.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/util/password/PasswordPart.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.cloudbreak.util.password;
+
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PasswordPart {
+
+    private final CharSet charSet;
+
+    private final int charSetLength;
+
+    private final int length;
+
+    public PasswordPart(CharSet charSet, int length) {
+        this.charSet = charSet;
+        charSetLength = charSet.getValues().size();
+        this.length = length;
+    }
+
+    public List<Character> generateRandomCharacters(SecureRandom random) {
+        List<Character> result = new ArrayList<>();
+        for (int i = 0; i < length; i++) {
+            result.add(charSet.getValues().get(random.nextInt(charSetLength)));
+        }
+        return result;
+    }
+}

--- a/common/src/test/java/com/sequenceiq/cloudbreak/util/password/CharSetTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/util/password/CharSetTest.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.cloudbreak.util.password;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+public class CharSetTest {
+
+    @Test
+    public void testNotContainsDuplicates() {
+        assertEquals(List.of('a', 'b', 'c'), CharSet.fromString("abac").getValues());
+    }
+
+    @Test
+    public void testEmptyIsNotAllowed() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> CharSet.fromString(""));
+        assertEquals("Character set must contain at least one value.", exception.getMessage());
+    }
+
+    @Test
+    public void testAllowOneElement() {
+        assertEquals(List.of('a'), CharSet.fromString("a").getValues());
+    }
+}

--- a/common/src/test/java/com/sequenceiq/cloudbreak/util/password/PasswordGeneratorTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/util/password/PasswordGeneratorTest.java
@@ -1,0 +1,106 @@
+package com.sequenceiq.cloudbreak.util.password;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.security.SecureRandom;
+
+import org.bouncycastle.crypto.digests.SHA512Digest;
+import org.bouncycastle.crypto.prng.SP800SecureRandomBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PasswordGeneratorTest {
+
+    @Spy
+    private SecureRandom secureRandom = new SecureRandom();
+
+    private PasswordGenerator underTest;
+
+    @Test
+    public void testRequiredEntropyIsNotTooBig() {
+        underTest.generate();
+
+        verify(secureRandom, times(1)).generateSeed(32);
+        verifyNoMoreInteractions(secureRandom);
+    }
+
+    @BeforeEach
+    public void setUp() {
+        underTest = PasswordGenerator.builder()
+                .prefix(CharSet.ALPHABETIC_LOWER_CASE, 3)
+                .mandatoryCharacters(CharSet.SAFE_SPECIAL_CHARACTERS)
+                .bodyPart(CharSet.ALPHABETIC_LOWER_CASE, 8)
+                .bodyPart(CharSet.ALPHABETIC_UPPER_CASE, 8)
+                .bodyPart(CharSet.NUMERIC, 8)
+                .randomSupplier(() -> new SP800SecureRandomBuilder(secureRandom, false)
+                        .setPersonalizationString(Long.toString(System.nanoTime()).getBytes())
+                        .buildHash(new SHA512Digest(), null, false))
+                .build();
+    }
+
+    @Test
+    public void testPasswordLength() {
+        String password = underTest.generate();
+
+        assertEquals(32, password.length());
+    }
+
+    @Test
+    public void testPasswordFormat() {
+        String password = underTest.generate();
+
+        assertFirstNCharacterInSet(password, CharSet.ALPHABETIC_LOWER_CASE, 3);
+
+        assertContainsCharactersFromSet(password, 3, 32, CharSet.NUMERIC, 8);
+        assertContainsCharactersFromSet(password, 3, 32, CharSet.ALPHABETIC_LOWER_CASE, 8);
+        assertContainsCharactersFromSet(password, 3, 32, CharSet.ALPHABETIC_UPPER_CASE, 8);
+
+        assertAllCharactersPresent(password, 3, 32, CharSet.SAFE_SPECIAL_CHARACTERS);
+    }
+
+    private void assertFirstNCharacterInSet(String password, CharSet charSet, int n) {
+        for (int i = 0; i < n; i++) {
+            assertTrue(charSet.getValues().contains(password.charAt(i)),
+                    "Password character at " + i + "th place must be one of the characters " + charSet.getValues() + " actual value is " + password.charAt(i));
+        }
+    }
+
+    private void assertContainsCharactersFromSet(String password, int start, int end, CharSet charSet, int requiredCount) {
+        int numberOfCharactersFromSet = getNumberOfCharactersFromSet(password, start, end, charSet);
+        String message = String.format("Password %s in range %s-%s must contain %s characters from values %s. Actual value: %s.",
+                password, start, end, requiredCount, charSet.getValues(), numberOfCharactersFromSet);
+        assertEquals(requiredCount, numberOfCharactersFromSet, message);
+    }
+
+    private void assertAllCharactersPresent(String password, int start, int end, CharSet charSet) {
+        String message = String.format("Password %s in range %s-%s must contain all characters %s.", password, start, end, charSet.getValues());
+        assertTrue(allCharactersIsPresent(password, start, end, charSet), message);
+    }
+
+    private int getNumberOfCharactersFromSet(String password, int start, int end, CharSet charSet) {
+        int result = 0;
+        for (int i = start; i < end; i++) {
+            if (charSet.getValues().contains(password.charAt(i))) {
+                result++;
+            }
+        }
+        return result;
+    }
+
+    private boolean allCharactersIsPresent(String password, int start, int end, CharSet charSet) {
+        for (char character : charSet.getValues()) {
+            if (!password.substring(start, end).contains(Character.toString(character))) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/TlsSecurityService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/TlsSecurityService.java
@@ -25,18 +25,18 @@ import com.sequenceiq.cloudbreak.client.HttpClientConfig;
 import com.sequenceiq.cloudbreak.client.SaltClientConfig;
 import com.sequenceiq.cloudbreak.clusterproxy.ClusterProxyConfiguration;
 import com.sequenceiq.cloudbreak.clusterproxy.ClusterProxyEnablementService;
+import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.provision.service.ClusterProxyService;
 import com.sequenceiq.cloudbreak.domain.SaltSecurityConfig;
 import com.sequenceiq.cloudbreak.domain.SecurityConfig;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
-import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.service.securityconfig.SecurityConfigService;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.util.FixedSizePreloadCache;
-import com.sequenceiq.cloudbreak.util.PasswordUtil;
+import com.sequenceiq.cloudbreak.util.password.DefaultPasswordGenerator;
 import com.sequenceiq.cloudbreak.workspace.model.Workspace;
 
 @Component
@@ -62,6 +62,9 @@ public class TlsSecurityService {
     @Inject
     private ClusterProxyService clusterProxyService;
 
+    @Inject
+    private DefaultPasswordGenerator passwordGenerator;
+
     @Value("${cb.security.keypair.cache.size:10}")
     private int keyPairCacheSize;
 
@@ -78,8 +81,8 @@ public class TlsSecurityService {
         securityConfig.setWorkspace(workspace);
         SaltSecurityConfig saltSecurityConfig = new SaltSecurityConfig();
         saltSecurityConfig.setWorkspace(workspace);
-        saltSecurityConfig.setSaltBootPassword(PasswordUtil.generatePassword());
-        saltSecurityConfig.setSaltPassword(PasswordUtil.generatePassword());
+        saltSecurityConfig.setSaltBootPassword(passwordGenerator.generate());
+        saltSecurityConfig.setSaltPassword(passwordGenerator.generate());
         securityConfig.setSaltSecurityConfig(saltSecurityConfig);
 
         setClientKeys(securityConfig, keyPairCache.pop(), keyPairCache.pop());

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/TlsSecurityService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/TlsSecurityService.java
@@ -16,7 +16,7 @@ import com.sequenceiq.cloudbreak.client.HttpClientConfig;
 import com.sequenceiq.cloudbreak.client.SaltClientConfig;
 import com.sequenceiq.cloudbreak.clusterproxy.ClusterProxyConfiguration;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
-import com.sequenceiq.cloudbreak.util.PasswordUtil;
+import com.sequenceiq.cloudbreak.util.password.DefaultPasswordGenerator;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceMetadataType;
 import com.sequenceiq.freeipa.entity.InstanceMetaData;
 import com.sequenceiq.freeipa.entity.SaltSecurityConfig;
@@ -43,6 +43,9 @@ public class TlsSecurityService {
 
     @Inject
     private StackService stackService;
+
+    @Inject
+    private DefaultPasswordGenerator passwordGenerator;
 
     public SecurityConfig generateSecurityKeys(String accountId) {
         SecurityConfig securityConfig = new SecurityConfig();
@@ -94,13 +97,13 @@ public class TlsSecurityService {
     }
 
     private void generateSaltBootPassword(SaltSecurityConfig saltSecurityConfig) {
-        String saltBootPassword = PasswordUtil.generatePassword();
+        String saltBootPassword = passwordGenerator.generate();
         saltSecurityConfig.setSaltBootPassword(saltBootPassword);
         saltSecurityConfig.setSaltBootPasswordVault(saltBootPassword);
     }
 
     private void generateSaltPassword(SaltSecurityConfig saltSecurityConfig) {
-        String saltPassword = PasswordUtil.generatePassword();
+        String saltPassword = passwordGenerator.generate();
         saltSecurityConfig.setSaltPassword(saltPassword);
         saltSecurityConfig.setSaltPasswordVault(saltPassword);
     }


### PR DESCRIPTION
Created password generator which uses cryptographically strong random generator. The default password format is the same as in `FreeIpaPasswordUtil` but `PasswordGenerator` provides a builder to support different formats. The default implementation (based on SHA-512 based DRBG) requires 256 bit entropy from the operating system.

The password format is the following:

```
PREFIX | shuffle( MANDATORY_CHARACTERS | X1 | X2 | ... | Xn )
```

where:
- __PREFIX:__ optional n length prefix randomly chosen from a specified character set,
- __MANDATORY_CHARACTERS:__ optional characters which must be included in the password in random order,
- __X1, X2, ..., Xn:__ parts from different character sets with different length.

__Note:__ 

- not all ASCII characters could be used because various scripts, yaml parsing ...etc. failed during cluster installation that is the reason behind the special format and why not we simply choose random values with equal probability from a huge enough set.
- previous implementation https://github.com/hortonworks/cloudbreak/pull/12094 used too much entropy (around 10000) because I used prediction resistant flag `true` which ended up reseeding the DRBG every time, this is not needed since we create a new DRBG for every password and the password is not long enough to predict one password based on some parts of it.