### PR TITLE
CB-15820 Shorten FreeIPA statusReason field

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/healthcheckmodel/CheckResult.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/healthcheckmodel/CheckResult.java
@@ -54,8 +54,8 @@ public class CheckResult {
     @Override
     public String toString() {
         return "CheckResult{"
-                + "status='" + status + "\',"
-                + "host='" + host + "\',"
+                + "status='" + status + "',"
+                + "host='" + host + "',"
                 + "checks={" + StringUtils.join(checks, ",") + "},"
                 + "plugin_stat={" + StringUtils.join(pluginStat, ",") +  "}"
                 + '}';


### PR DESCRIPTION
Currently we store the whole freeipa healthcheck result in the statusreason field instead of storing the unhealthy part.
After the change only some main info and unhealthy checks would be present:
```
FreeIpa is AVAILABLE, node health check: {"status":"HEALTHY","host":"ipaserver0.mmolnar.xcu2-8y8x.wl.cloudera.site","checks":[],"pluginStats":[],"plugin_stat":[]}, node health check: {"status":"HEALTHY","host":"ipaserver1.mmolnar.xcu2-8y8x.wl.cloudera.site","checks":[],"pluginStats":[],"plugin_stat":[]}
```

See detailed description in the commit message.