### PR TITLE
CB-15783 UMS mock tests should clean up resources correctly

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
@@ -925,7 +925,19 @@ public abstract class TestContext implements ApplicationContextAware {
         return await(entity, desiredStatuses, emptyRunningParameter());
     }
 
+    public <T extends CloudbreakTestDto, E extends Enum<E>> T awaitWithClient(T entity, Map<String, E> desiredStatuses, MicroserviceClient client) {
+        return awaitWithClient(entity, desiredStatuses, emptyRunningParameter(), client);
+    }
+
     public <T extends CloudbreakTestDto, E extends Enum<E>> T await(T entity, Map<String, E> desiredStatuses, RunningParameter runningParameter) {
+        MicroserviceClient client = getTestContext().getMicroserviceClient(entity.getClass(), getTestContext().setActingUser(runningParameter)
+                .getAccessKey());
+
+        return awaitWithClient(entity, desiredStatuses, runningParameter, client);
+    }
+
+    private <T extends CloudbreakTestDto, E extends Enum<E>> T awaitWithClient(T entity, Map<String, E> desiredStatuses, RunningParameter runningParameter,
+            MicroserviceClient client) {
         checkShutdown();
         if (!getExceptionMap().isEmpty() && runningParameter.isSkipOnFail()) {
             Log.await(LOGGER, String.format("Cloudbreak await should be skipped because of previous error. await [%s]", desiredStatuses));
@@ -948,7 +960,7 @@ public abstract class TestContext implements ApplicationContextAware {
         }
 
         resourceAwait.await(awaitEntity, desiredStatuses, getTestContext(), runningParameter,
-                flowUtilSingleStatus.getPollingDurationOrTheDefault(runningParameter), maxRetry, maxRetryCount);
+                flowUtilSingleStatus.getPollingDurationOrTheDefault(runningParameter), maxRetry, maxRetryCount, client);
         return entity;
     }
 
@@ -1167,8 +1179,10 @@ public abstract class TestContext implements ApplicationContextAware {
         List<CloudbreakTestDto> orderedTestDtos = testDtos.stream().sorted(new CompareByOrder()).collect(Collectors.toList());
         for (CloudbreakTestDto testDto : orderedTestDtos) {
             try {
-                testDto.cleanUp(this, getAdminMicroserviceClient(testDto.getClass(), Objects.requireNonNull(Crn.fromString(testDto.getCrn())).
-                        getAccountId()));
+                LOGGER.info("Starting to clean up {} {}", testDto.getClass().getSimpleName(), testDto.getName());
+                String accountId = Objects.requireNonNull(Crn.fromString(testDto.getCrn())).getAccountId();
+                MicroserviceClient adminMicroserviceClient = getAdminMicroserviceClient(testDto.getClass(), accountId);
+                testDto.cleanUp(adminMicroserviceClient);
             } catch (Exception e) {
                 LOGGER.info("Cleaning up of tests context with {} resource is failing, because of: {}", testDto.getName(), e.getMessage());
             }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractSdxTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractSdxTestDto.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
+import javax.ws.rs.NotFoundException;
 
 import org.apache.commons.lang3.NotImplementedException;
 
@@ -115,7 +116,13 @@ public abstract class AbstractSdxTestDto<R, S, T extends CloudbreakTestDto> exte
                 runningParameters.get(runningParameters.size() - 1));
     }
 
-    public FlowUtil getFlowUtil() {
-        return flowUtil;
+    @Override
+    public void deleteForCleanup(SdxClient client) {
+        try {
+            setFlow("SDX deletion", client.getDefaultClient().sdxEndpoint().deleteByCrn(getCrn(), true));
+            awaitForFlow();
+        } catch (NotFoundException nfe) {
+            LOGGER.info("resource not found, thus cleanup not needed.");
+        }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractTestDto.java
@@ -40,7 +40,7 @@ import com.sequenceiq.it.cloudbreak.finder.Finder;
 import com.sequenceiq.it.cloudbreak.log.Log;
 import com.sequenceiq.it.cloudbreak.mock.ExecuteQueryToMockInfrastructure;
 
-public abstract class AbstractTestDto<R, S, T extends CloudbreakTestDto, U extends MicroserviceClient> extends Entity implements CloudbreakTestDto {
+public abstract class AbstractTestDto<R, S, T extends CloudbreakTestDto, U extends MicroserviceClient> extends Entity implements CloudbreakTestDto<U> {
 
     @Inject
     private TestParameter testParameter;
@@ -250,6 +250,10 @@ public abstract class AbstractTestDto<R, S, T extends CloudbreakTestDto, U exten
 
     public T await(Map<String, Status> statuses) {
         return await(statuses, emptyRunningParameter());
+    }
+
+    public T awaitWithClient(Map<String, Status> statuses, U client) {
+        return getTestContext().awaitWithClient((T) this, statuses, client);
     }
 
     public T await(Map<String, Status> statuses, RunningParameter runningParameter) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/CloudbreakTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/CloudbreakTestDto.java
@@ -11,9 +11,8 @@ import com.sequenceiq.it.cloudbreak.MicroserviceClient;
 import com.sequenceiq.it.cloudbreak.assign.Assignable;
 import com.sequenceiq.it.cloudbreak.context.Orderable;
 import com.sequenceiq.it.cloudbreak.context.RunningParameter;
-import com.sequenceiq.it.cloudbreak.context.TestContext;
 
-public interface CloudbreakTestDto extends Orderable, Assignable {
+public interface CloudbreakTestDto<U extends MicroserviceClient> extends Orderable, Assignable {
 
     Logger LOGGER = LoggerFactory.getLogger(CloudbreakTestDto.class);
 
@@ -31,8 +30,16 @@ public interface CloudbreakTestDto extends Orderable, Assignable {
 
     CloudPlatform getCloudPlatform();
 
-    default void cleanUp(TestContext context, MicroserviceClient client) {
-        LOGGER.warn(String.format("Cleanup WARN: 'cleanUp' is not implemented for TestDto: %s with name: %s", getClass().getSimpleName(), getName()));
+    default void cleanUp(U client) {
+        try {
+            deleteForCleanup(client);
+        } catch (Exception ignore) {
+            LOGGER.error(String.format("%s cleanup failed because: ", getClass().getSimpleName()), ignore);
+        }
+    }
+
+    default void deleteForCleanup(U client) {
+        LOGGER.warn("cleanUp logic is not implemented for TestDto: {}", getClass().getSimpleName());
     }
 
     default CloudbreakTestDto refresh() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/blueprint/BlueprintTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/blueprint/BlueprintTestDto.java
@@ -1,26 +1,19 @@
 package com.sequenceiq.it.cloudbreak.dto.blueprint;
 
-import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import javax.inject.Inject;
-
 import com.sequenceiq.cloudbreak.api.endpoint.v4.blueprint.requests.BlueprintV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.blueprint.responses.BlueprintV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.blueprint.responses.BlueprintV4ViewResponse;
-import com.sequenceiq.it.cloudbreak.MicroserviceClient;
+import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
-import com.sequenceiq.it.cloudbreak.client.BlueprintTestClient;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
 
 @Prototype
 public class BlueprintTestDto extends AbstractCloudbreakTestDto<BlueprintV4Request, BlueprintV4Response, BlueprintTestDto> {
-
-    public static final String BLUEPRINT = "BLUEPRINT";
 
     private static final String BLUEPRINT_RESOURCE_NAME = "blueprintName";
 
@@ -28,21 +21,13 @@ public class BlueprintTestDto extends AbstractCloudbreakTestDto<BlueprintV4Reque
 
     private String accountId;
 
-    @Inject
-    private BlueprintTestClient blueprintTestClient;
-
     public BlueprintTestDto(TestContext testContext) {
         super(new BlueprintV4Request(), testContext);
     }
 
     @Override
-    public void cleanUp(TestContext context, MicroserviceClient cloudbreakClient) {
-        LOGGER.info("Cleaning up blueprint with name: {}", getName());
-        if (getResponse() != null) {
-            when(blueprintTestClient.deleteV4(), key("delete-blueprint-" + getName()).withSkipOnFail(false));
-        } else {
-            LOGGER.info("Blueprint: {} response is null!", getName());
-        }
+    public void deleteForCleanup(CloudbreakClient cloudbreakClient) {
+        cloudbreakClient.getDefaultClient().blueprintV4Endpoint().deleteByCrn(0L, getCrn());
     }
 
     public BlueprintTestDto valid() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/clustertemplate/ClusterTemplateTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/clustertemplate/ClusterTemplateTestDto.java
@@ -1,19 +1,13 @@
 package com.sequenceiq.it.cloudbreak.dto.clustertemplate;
 
-import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
-
 import java.util.Collection;
-
-import javax.inject.Inject;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.ClusterTemplateV4Type;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.requests.ClusterTemplateV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.responses.ClusterTemplateV4Response;
 import com.sequenceiq.distrox.api.v1.distrox.model.DistroXV1Request;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
-import com.sequenceiq.it.cloudbreak.MicroserviceClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
-import com.sequenceiq.it.cloudbreak.client.ClusterTemplateTestClient;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.DeletableTestDto;
 import com.sequenceiq.it.cloudbreak.dto.distrox.cluster.clouderamanager.DistroXClouderaManagerTestDto;
@@ -25,9 +19,6 @@ import com.sequenceiq.it.cloudbreak.util.ResponseUtil;
 @Prototype
 public class ClusterTemplateTestDto extends DeletableTestDto<ClusterTemplateV4Request, ClusterTemplateV4Response,
         ClusterTemplateTestDto, ClusterTemplateV4Response> {
-
-    @Inject
-    private ClusterTemplateTestClient clusterTemplateTestClient;
 
     public ClusterTemplateTestDto(TestContext testContext) {
         super(new ClusterTemplateV4Request(), testContext);
@@ -85,11 +76,6 @@ public class ClusterTemplateTestDto extends DeletableTestDto<ClusterTemplateV4Re
         return this;
     }
 
-    public ClusterTemplateTestDto withGatewayPort(Integer gatewayPort) {
-        getRequest().getDistroXTemplate().setGatewayPort(gatewayPort);
-        return this;
-    }
-
     public ClusterTemplateTestDto withCM(String key) {
         DistroXClouderaManagerTestDto clouderaManagerTestDto = getTestContext().get(key);
         getRequest().getDistroXTemplate().getCluster().setCm(clouderaManagerTestDto.getRequest());
@@ -116,13 +102,8 @@ public class ClusterTemplateTestDto extends DeletableTestDto<ClusterTemplateV4Re
     }
 
     @Override
-    public void cleanUp(TestContext context, MicroserviceClient client) {
-        LOGGER.info("Cleaning up cluster template with name: {}", getName());
-        if (getResponse() != null) {
-            when(clusterTemplateTestClient.deleteV4(), key("delete-clustertemplate-" + getName()).withSkipOnFail(false));
-        } else {
-            LOGGER.info("Cluster template: {} response is null!", getName());
-        }
+    public void deleteForCleanup(CloudbreakClient client) {
+        client.getDefaultClient().clusterTemplateV4EndPoint().deleteByCrn(0L, getCrn());
     }
 
     public Long count() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/credential/CredentialTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/credential/CredentialTestDto.java
@@ -1,10 +1,6 @@
 package com.sequenceiq.it.cloudbreak.dto.credential;
 
-import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
-
 import java.util.Collection;
-
-import javax.inject.Inject;
 
 import com.sequenceiq.environment.api.v1.credential.model.parameters.aws.AwsCredentialParameters;
 import com.sequenceiq.environment.api.v1.credential.model.parameters.azure.AzureCredentialRequestParameters;
@@ -15,9 +11,7 @@ import com.sequenceiq.environment.api.v1.credential.model.request.CredentialRequ
 import com.sequenceiq.environment.api.v1.credential.model.request.EditCredentialRequest;
 import com.sequenceiq.environment.api.v1.credential.model.response.CredentialResponse;
 import com.sequenceiq.it.cloudbreak.EnvironmentClient;
-import com.sequenceiq.it.cloudbreak.MicroserviceClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
-import com.sequenceiq.it.cloudbreak.client.CredentialTestClient;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.DeletableEnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.util.ResponseUtil;
@@ -28,9 +22,6 @@ public class CredentialTestDto extends DeletableEnvironmentTestDto<CredentialReq
     public static final String CREDENTIAL = "CREDENTIAL";
 
     private static final String CREDENTIAL_RESOURCE_NAME = "credentialName";
-
-    @Inject
-    private CredentialTestClient credentialTestClient;
 
     public CredentialTestDto(TestContext testContext) {
         super(new CredentialRequest(), testContext);
@@ -110,13 +101,8 @@ public class CredentialTestDto extends DeletableEnvironmentTestDto<CredentialReq
     }
 
     @Override
-    public void cleanUp(TestContext context, MicroserviceClient client) {
-        LOGGER.info("Cleaning up credential with name: {}", getName());
-        if (getResponse() != null) {
-            when(credentialTestClient.delete(), key("delete-credential-" + getName()).withSkipOnFail(false));
-        } else {
-            LOGGER.info("Credential: {} response is null!", getName());
-        }
+    public void deleteForCleanup(EnvironmentClient client) {
+        client.getDefaultClient().credentialV1Endpoint().deleteByResourceCrn(getCrn());
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/customconfigs/CustomConfigurationsTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/customconfigs/CustomConfigurationsTestDto.java
@@ -3,16 +3,12 @@ package com.sequenceiq.it.cloudbreak.dto.customconfigs;
 import java.util.Collection;
 import java.util.Set;
 
-import javax.inject.Inject;
-
 import com.sequenceiq.cloudbreak.api.endpoint.v4.requests.CustomConfigurationsV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.responses.CustomConfigurationsV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.responses.CustomConfigurationsV4Responses;
 import com.sequenceiq.cloudbreak.api.model.CustomConfigurationPropertyParameters;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
-import com.sequenceiq.it.cloudbreak.MicroserviceClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
-import com.sequenceiq.it.cloudbreak.client.CustomConfigurationsTestClient;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.DeletableTestDto;
 import com.sequenceiq.it.cloudbreak.util.ResponseUtil;
@@ -29,9 +25,6 @@ public class CustomConfigurationsTestDto extends
                     "<property><name>fs.s3a.fast.upload.buffer</name><value>disk</value></property>", null, "hdfs"));
 
     private CustomConfigurationsV4Responses customConfigsResponses;
-
-    @Inject
-    private CustomConfigurationsTestClient customConfigurationsTestClient;
 
     protected CustomConfigurationsTestDto(TestContext testContext) {
         super(new CustomConfigurationsV4Request(), testContext);
@@ -68,13 +61,8 @@ public class CustomConfigurationsTestDto extends
     }
 
     @Override
-    public void cleanUp(TestContext context, MicroserviceClient client) {
-        LOGGER.info("Cleaning up custom configurations: ");
-        try {
-            customConfigurationsTestClient.deleteV4();
-        } catch (Exception e) {
-            LOGGER.warn("Something went wrong while deleting CustomConfigurations: {}, because of {}", getName(), e.getMessage(), e);
-        }
+    public void deleteForCleanup(CloudbreakClient client) {
+        client.getDefaultClient().customConfigurationsV4Endpoint().deleteByCrn(getCrn());
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
@@ -11,14 +11,13 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
+import javax.ws.rs.NotFoundException;
 
 import org.testng.util.Strings;
 
-import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.common.api.backup.request.BackupRequest;
 import com.sequenceiq.common.api.telemetry.request.TelemetryRequest;
 import com.sequenceiq.common.api.type.Tunnel;
@@ -41,12 +40,10 @@ import com.sequenceiq.environment.api.v1.environment.model.response.SimpleEnviro
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.flow.api.model.FlowType;
 import com.sequenceiq.it.cloudbreak.EnvironmentClient;
-import com.sequenceiq.it.cloudbreak.MicroserviceClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.ResourceGroupTest;
 import com.sequenceiq.it.cloudbreak.assign.Assignable;
 import com.sequenceiq.it.cloudbreak.client.EnvironmentTestClient;
-import com.sequenceiq.it.cloudbreak.cloud.v4.aws.AwsProperties;
 import com.sequenceiq.it.cloudbreak.context.Clue;
 import com.sequenceiq.it.cloudbreak.context.Investigable;
 import com.sequenceiq.it.cloudbreak.context.RunningParameter;
@@ -70,9 +67,6 @@ public class EnvironmentTestDto
 
     @Inject
     private EnvironmentTestClient environmentTestClient;
-
-    @Inject
-    private AwsProperties awsProperties;
 
     private Collection<SimpleEnvironmentResponse> simpleResponses;
 
@@ -215,12 +209,6 @@ public class EnvironmentTestDto
         return this;
     }
 
-    public EnvironmentTestDto withAuthentication() {
-        EnvironmentAuthenticationTestDto authenticationTestDto = getTestContext().get(EnvironmentAuthenticationTestDto.class);
-        getRequest().setAuthentication(authenticationTestDto.getRequest());
-        return this;
-    }
-
     public EnvironmentTestDto withSecurityAccess() {
         EnvironmentSecurityAccessTestDto securityAccessTestDto = getTestContext().get(EnvironmentSecurityAccessTestDto.class);
         getRequest().setSecurityAccess(securityAccessTestDto.getRequest());
@@ -272,11 +260,6 @@ public class EnvironmentTestDto
         return withNetwork(environmentNetwork.getRequest());
     }
 
-    public EnvironmentTestDto withS3Guard(String tableName) {
-        getCloudProvider().setS3Guard(this, tableName);
-        return this;
-    }
-
     public EnvironmentTestDto withResourceGroup(String resourceGroupUsage, String resourceGroupName) {
         return getCloudProvider().withResourceGroup(this, resourceGroupUsage, resourceGroupName);
     }
@@ -290,23 +273,8 @@ public class EnvironmentTestDto
         return this;
     }
 
-    public EnvironmentTestDto withAzure(AzureEnvironmentParameters azureEnvironmentParameters) {
-        getRequest().setAzure(azureEnvironmentParameters);
-        return this;
-    }
-
     public EnvironmentTestDto withGcp(GcpEnvironmentParameters gcpEnvironmentParameters) {
         getRequest().setGcp(gcpEnvironmentParameters);
-        return this;
-    }
-
-    public EnvironmentTestDto withS3Guard() {
-        if (CloudPlatform.AWS.equals(getTestContext().getCloudProvider().getCloudPlatform())) {
-            String tableName = awsProperties.getDynamoTableName() + '-' + UUID.randomUUID().toString();
-            return withS3Guard(tableName);
-        } else {
-            LOGGER.info("S3guard is ignored on cloudplatform {}.", getTestContext().getCloudProvider().getCloudPlatform());
-        }
         return this;
     }
 
@@ -343,10 +311,6 @@ public class EnvironmentTestDto
         this.simpleResponses = simpleResponses;
     }
 
-    public SimpleEnvironmentResponse getResponseSimpleEnv() {
-        return simpleResponse;
-    }
-
     public void setResponseSimpleEnv(SimpleEnvironmentResponse simpleResponse) {
         this.simpleResponse = simpleResponse;
     }
@@ -375,13 +339,12 @@ public class EnvironmentTestDto
     }
 
     @Override
-    public void cleanUp(TestContext context, MicroserviceClient client) {
-        LOGGER.info("Cleaning up environment with name: {}", getName());
-        if (getResponse() != null) {
-            when(environmentTestClient.cascadingDelete(), key("delete-environment-" + getName()).withSkipOnFail(false));
-            await(ARCHIVED, new RunningParameter().withSkipOnFail(true));
-        } else {
-            LOGGER.info("Environment: {} response is null!", getName());
+    public void deleteForCleanup(EnvironmentClient client) {
+        try {
+            client.getDefaultClient().environmentV1Endpoint().deleteByCrn(getCrn(), true, false);
+            getTestContext().awaitWithClient(this, Map.of("status", ARCHIVED), client);
+        } catch (NotFoundException nfe) {
+            LOGGER.info("resource not found, thus cleanup not needed.");
         }
     }
 
@@ -468,13 +431,6 @@ public class EnvironmentTestDto
             throw new IllegalStateException("Environment response hasn't been set, therefore 'getResourceCrn' cannot be fulfilled.");
         }
         return getResponse().getCrn();
-    }
-
-    public String getParentEnvironmentCrn() {
-        if (getResponse() == null) {
-            throw new IllegalStateException("Environment response hasn't been set, therefore 'getParentEnvironmentCrn' cannot be fulfilled.");
-        }
-        return getResponse().getParentEnvironmentCrn();
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/imagecatalog/ImageCatalogTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/imagecatalog/ImageCatalogTestDto.java
@@ -1,18 +1,12 @@
 package com.sequenceiq.it.cloudbreak.dto.imagecatalog;
 
-import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
-
 import java.util.Collection;
-
-import javax.inject.Inject;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.requests.ImageCatalogV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImageCatalogV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImagesV4Response;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
-import com.sequenceiq.it.cloudbreak.MicroserviceClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
-import com.sequenceiq.it.cloudbreak.client.ImageCatalogTestClient;
 import com.sequenceiq.it.cloudbreak.context.Purgable;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
@@ -24,16 +18,11 @@ public class ImageCatalogTestDto extends AbstractCloudbreakTestDto<ImageCatalogV
 
     public static final String IMAGE_CATALOG = "IMAGE_CATALOG";
 
-    public static final String IMAGE_CATALOG_URL = "IMAGE_CATALOG_URL";
-
     private static final String IMAGECATALOG_RESOURCE_NAME = "imagecatalogName";
 
     private ImagesV4Response imagesV4Response;
 
     private Boolean skipCleanup = Boolean.FALSE;
-
-    @Inject
-    private ImageCatalogTestClient imageCatalogTestClient;
 
     public ImageCatalogTestDto(TestContext testContext) {
         super(new ImageCatalogV4Request(), testContext);
@@ -86,14 +75,9 @@ public class ImageCatalogTestDto extends AbstractCloudbreakTestDto<ImageCatalogV
     }
 
     @Override
-    public void cleanUp(TestContext context, MicroserviceClient client) {
+    public void deleteForCleanup(CloudbreakClient client) {
         if (!skipCleanup) {
-            LOGGER.info("Cleaning up image catalog with name: {}", getName());
-            if (getResponse() != null) {
-                when(imageCatalogTestClient.deleteV4(), key("delete-imagecatalog-" + getName()).withSkipOnFail(false));
-            } else {
-                LOGGER.info("Image catalog: {} response is null!", getName());
-            }
+            client.getDefaultClient().imageCatalogV4Endpoint().deleteByCrn(0L, getCrn());
         }
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/kerberos/KerberosTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/kerberos/KerberosTestDto.java
@@ -1,15 +1,9 @@
 package com.sequenceiq.it.cloudbreak.dto.kerberos;
 
-import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
-
-import javax.inject.Inject;
-import javax.ws.rs.WebApplicationException;
-
 import com.sequenceiq.freeipa.api.v1.kerberos.model.create.CreateKerberosConfigRequest;
 import com.sequenceiq.freeipa.api.v1.kerberos.model.describe.DescribeKerberosConfigResponse;
-import com.sequenceiq.it.cloudbreak.MicroserviceClient;
+import com.sequenceiq.it.cloudbreak.FreeIpaClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
-import com.sequenceiq.it.cloudbreak.client.KerberosTestClient;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.AbstractFreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
@@ -17,27 +11,13 @@ import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 @Prototype
 public class KerberosTestDto extends AbstractFreeIpaTestDto<CreateKerberosConfigRequest, DescribeKerberosConfigResponse, KerberosTestDto> {
 
-    public static final String DEFAULT_MASTERKEY = "masterkey";
-
-    public static final String DEFAULT_ADMIN_USER = "admin";
-
-    public static final String DEFAULT_ADMIN_PASSWORD = "password";
-
-    @Inject
-    private KerberosTestClient kerberosTestClient;
-
     public KerberosTestDto(TestContext testContext) {
         super(new CreateKerberosConfigRequest(), testContext);
     }
 
     @Override
-    public void cleanUp(TestContext context, MicroserviceClient client) {
-        LOGGER.info("Cleaning up kerberos config with name: {}", getName());
-        try {
-            when(kerberosTestClient.deleteV1(), key("delete-kerberos-" + getName()).withSkipOnFail(false));
-        } catch (WebApplicationException ignore) {
-            LOGGER.warn("Something went wrong during {} kerberos config delete, because of: {}", getName(), ignore.getMessage(), ignore);
-        }
+    public void deleteForCleanup(FreeIpaClient client) {
+        client.getDefaultClient().getKerberosConfigV1Endpoint().delete(getResponse().getEnvironmentCrn());
     }
 
     @Override
@@ -94,18 +74,8 @@ public class KerberosTestDto extends AbstractFreeIpaTestDto<CreateKerberosConfig
         return this;
     }
 
-    public KerberosTestDto withActiveDirectoryDescriptor(ActiveDirectoryKerberosDescriptorTestDto activeDirectoryDescriptor) {
-        getRequest().setActiveDirectory(activeDirectoryDescriptor.getRequest());
-        return this;
-    }
-
     public KerberosTestDto withFreeIpaDescriptor() {
         getRequest().setFreeIpa(getTestContext().get(FreeIpaKerberosDescriptorTestDto.class).getRequest());
-        return this;
-    }
-
-    public KerberosTestDto withFreeIpaDescriptor(FreeIpaKerberosDescriptorTestDto freeIpaDescriptor) {
-        getRequest().setFreeIpa(freeIpaDescriptor.getRequest());
         return this;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/ldap/LdapTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/ldap/LdapTestDto.java
@@ -1,16 +1,10 @@
 package com.sequenceiq.it.cloudbreak.dto.ldap;
 
-import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
-
-import javax.inject.Inject;
-import javax.ws.rs.WebApplicationException;
-
 import com.sequenceiq.freeipa.api.v1.ldap.model.DirectoryType;
 import com.sequenceiq.freeipa.api.v1.ldap.model.create.CreateLdapConfigRequest;
 import com.sequenceiq.freeipa.api.v1.ldap.model.describe.DescribeLdapConfigResponse;
-import com.sequenceiq.it.cloudbreak.MicroserviceClient;
+import com.sequenceiq.it.cloudbreak.FreeIpaClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
-import com.sequenceiq.it.cloudbreak.client.LdapTestClient;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.AbstractFreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
@@ -20,21 +14,13 @@ public class LdapTestDto extends AbstractFreeIpaTestDto<CreateLdapConfigRequest,
 
     private static final String LDAP_RESOURCE_NAME = "ldapName";
 
-    @Inject
-    private LdapTestClient ldapTestClient;
-
     public LdapTestDto(TestContext testContext) {
         super(new CreateLdapConfigRequest(), testContext);
     }
 
     @Override
-    public void cleanUp(TestContext context, MicroserviceClient client) {
-        LOGGER.info("Cleaning up LDAP config with name: {}", getName());
-        try {
-            when(ldapTestClient.deleteV1(), key("delete-ldap-" + getName()).withSkipOnFail(false));
-        } catch (WebApplicationException ignore) {
-            LOGGER.warn("Something went wrong during {} LDAP config delete, because of: {}", getName(), ignore.getMessage(), ignore);
-        }
+    public void deleteForCleanup(FreeIpaClient client) {
+        client.getDefaultClient().getLdapConfigV1Endpoint().delete(getResponse().getEnvironmentCrn());
     }
 
     public String getName() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/recipe/RecipeTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/recipe/RecipeTestDto.java
@@ -1,13 +1,8 @@
 package com.sequenceiq.it.cloudbreak.dto.recipe;
 
-import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
-
 import java.util.Base64;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import javax.inject.Inject;
-import javax.ws.rs.WebApplicationException;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.recipes.RecipeV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.recipes.requests.RecipeV4Request;
@@ -16,9 +11,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.recipes.responses.RecipeV4Respo
 import com.sequenceiq.cloudbreak.api.endpoint.v4.recipes.responses.RecipeViewV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.recipes.responses.RecipeViewV4Responses;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
-import com.sequenceiq.it.cloudbreak.MicroserviceClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
-import com.sequenceiq.it.cloudbreak.client.RecipeTestClient;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.DeletableTestDto;
 import com.sequenceiq.it.cloudbreak.util.ResponseUtil;
@@ -30,9 +23,6 @@ public class RecipeTestDto extends DeletableTestDto<RecipeV4Request, RecipeV4Res
 
     private RecipeViewV4Responses simpleResponses;
 
-    @Inject
-    private RecipeTestClient recipeTestClient;
-
     private String accountId;
 
     public RecipeTestDto(TestContext testContext) {
@@ -40,13 +30,8 @@ public class RecipeTestDto extends DeletableTestDto<RecipeV4Request, RecipeV4Res
     }
 
     @Override
-    public void cleanUp(TestContext context, MicroserviceClient cloudbreakClient) {
-        LOGGER.info("Cleaning up recipe with name: {}", getName());
-        try {
-            when(recipeTestClient.deleteV4(), key("delete-recipe-" + getName()).withSkipOnFail(false));
-        } catch (WebApplicationException ignore) {
-            LOGGER.warn("Something went wrong during {} recipe delete, because of: {}", getName(), ignore.getMessage(), ignore);
-        }
+    public void deleteForCleanup(CloudbreakClient cloudbreakClient) {
+        cloudbreakClient.getDefaultClient().recipeV4Endpoint().deleteByCrn(0L, getCrn());
     }
 
     @Override
@@ -133,6 +118,6 @@ public class RecipeTestDto extends DeletableTestDto<RecipeV4Request, RecipeV4Res
 
     @Override
     public int order() {
-        return 500;
+        return 600;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxCustomTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxCustomTestDto.java
@@ -16,7 +16,6 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.image.ImageSettingsV4Request;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
-import com.sequenceiq.it.cloudbreak.MicroserviceClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.ResourcePropertyProvider;
 import com.sequenceiq.it.cloudbreak.SdxClient;
@@ -108,11 +107,6 @@ public class SdxCustomTestDto extends AbstractSdxTestDto<SdxCustomClusterRequest
         return this;
     }
 
-    public SdxCustomTestDto addTags(Map<String, String> tags) {
-        getRequest().addTags(tags);
-        return this;
-    }
-
     public SdxCustomTestDto withTags(Map<String, String> tags) {
         getRequest().addTags(tags);
         return this;
@@ -131,22 +125,10 @@ public class SdxCustomTestDto extends AbstractSdxTestDto<SdxCustomClusterRequest
         return withEnvironmentName(environment.getResponse().getName());
     }
 
-    private SdxCustomTestDto withEnvironmentDto(EnvironmentTestDto environmentTestDto) {
-        return withEnvironmentName(environmentTestDto.getResponse().getName());
-    }
-
     public SdxCustomTestDto withEnvironmentClass(Class<EnvironmentTestDto> environmentClass) {
         EnvironmentTestDto environment = getTestContext().get(environmentClass.getSimpleName());
         if (environment == null) {
             throw new IllegalArgumentException(String.format("Environment has not been provided for this Sdx: '%s' response!", getName()));
-        }
-        return withEnvironmentName(environment.getResponse().getName());
-    }
-
-    public SdxCustomTestDto withEnvironmentKey(RunningParameter key) {
-        EnvironmentTestDto environment = getTestContext().get(key.getKey());
-        if (environment == null) {
-            throw new IllegalArgumentException(String.format("Environment has not been provided for this internal Sdx: '%s' response!", getName()));
         }
         return withEnvironmentName(environment.getResponse().getName());
     }
@@ -191,14 +173,6 @@ public class SdxCustomTestDto extends AbstractSdxTestDto<SdxCustomClusterRequest
         return getTestContext().awaitForFlow(this, runningParameter);
     }
 
-    public SdxCustomTestDto awaitForInstance(Map<List<String>, InstanceStatus> statuses) {
-        return awaitForInstance(statuses, emptyRunningParameter());
-    }
-
-    public SdxCustomTestDto awaitForInstance(SdxCustomTestDto entity, Map<String, InstanceStatus> statuses, RunningParameter runningParameter) {
-        return getTestContext().await(entity, statuses, runningParameter);
-    }
-
     public SdxCustomTestDto awaitForInstance(Map<List<String>, InstanceStatus> statuses, RunningParameter runningParameter) {
         return getTestContext().awaitForInstance(this, statuses, runningParameter);
     }
@@ -207,17 +181,6 @@ public class SdxCustomTestDto extends AbstractSdxTestDto<SdxCustomClusterRequest
     public CloudbreakTestDto refresh() {
         LOGGER.info("Refresh SDX with name: {}", getName());
         return when(sdxTestClient.refreshCustom(), key("refresh-sdx-" + getName()));
-    }
-
-    @Override
-    public void cleanUp(TestContext context, MicroserviceClient client) {
-        LOGGER.info("Cleaning up sdx internal with name: {}", getName());
-        if (getResponse() != null) {
-            when(sdxTestClient.forceDeleteCustom(), key("delete-sdx-" + getName()));
-            await(DELETED, new RunningParameter().withSkipOnFail(true));
-        } else {
-            LOGGER.info("Sdx internal: {} response is null!", getName());
-        }
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxInternalTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxInternalTestDto.java
@@ -28,13 +28,11 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.image.ImageSetti
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
-import com.sequenceiq.it.cloudbreak.MicroserviceClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.SdxClient;
 import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
 import com.sequenceiq.it.cloudbreak.cloud.v4.CommonCloudProperties;
 import com.sequenceiq.it.cloudbreak.cloud.v4.CommonClusterManagerProperties;
-import com.sequenceiq.it.cloudbreak.cloud.v4.mock.MockCloudProvider;
 import com.sequenceiq.it.cloudbreak.context.Clue;
 import com.sequenceiq.it.cloudbreak.context.Investigable;
 import com.sequenceiq.it.cloudbreak.context.Purgable;
@@ -49,7 +47,6 @@ import com.sequenceiq.it.cloudbreak.dto.PlacementSettingsTestDto;
 import com.sequenceiq.it.cloudbreak.dto.StackAuthenticationTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.stack.StackTestDto;
-import com.sequenceiq.it.cloudbreak.dto.stack.StackTestDtoBase;
 import com.sequenceiq.it.cloudbreak.search.Searchable;
 import com.sequenceiq.it.cloudbreak.util.AuditUtil;
 import com.sequenceiq.it.cloudbreak.util.InstanceUtil;
@@ -209,12 +206,6 @@ public class SdxInternalTestDto extends AbstractSdxTestDto<SdxInternalClusterReq
         return this;
     }
 
-    public SdxInternalTestDto withClusterTemplateName(String template) {
-        ClusterTestDto cluster = getTestContext().given(ClusterTestDto.class);
-        cluster.withBlueprintName(template);
-        return this;
-    }
-
     public SdxInternalTestDto withTemplate(JSONObject templateJson) {
         StackTestDto stack = getTestContext().given(StackTestDto.class);
         ClusterTestDto cluster = getTestContext().given(ClusterTestDto.class);
@@ -257,10 +248,6 @@ public class SdxInternalTestDto extends AbstractSdxTestDto<SdxInternalClusterReq
             throw new IllegalArgumentException(String.format("Environment has not been provided for this internal Sdx: '%s' response!", getName()));
         }
         return withEnvironmentName(environment.getResponse().getName());
-    }
-
-    private SdxInternalTestDto withEnvironmentDto(EnvironmentTestDto environmentTestDto) {
-        return withEnvironmentName(environmentTestDto.getResponse().getName());
     }
 
     public SdxInternalTestDto withEnvironmentClass(Class<EnvironmentTestDto> environmentClass) {
@@ -383,17 +370,6 @@ public class SdxInternalTestDto extends AbstractSdxTestDto<SdxInternalClusterReq
     }
 
     @Override
-    public void cleanUp(TestContext context, MicroserviceClient client) {
-        LOGGER.info("Cleaning up sdx internal with name: {}", getName());
-        if (getResponse() != null) {
-            when(sdxTestClient.forceDeleteInternal(), key("delete-sdx-" + getName()));
-            await(DELETED, new RunningParameter().withSkipOnFail(true));
-        } else {
-            LOGGER.info("Sdx internal: {} response is null!", getName());
-        }
-    }
-
-    @Override
     public List<SdxClusterResponse> getAll(SdxClient client) {
         SdxEndpoint sdxEndpoint = client.getDefaultClient().sdxEndpoint();
         return sdxEndpoint.list(null, false).stream()
@@ -443,16 +419,6 @@ public class SdxInternalTestDto extends AbstractSdxTestDto<SdxInternalClusterReq
         } catch (JSONException e) {
             LOGGER.error("Cannot get Authentication from template: {}", templateJson, e);
             return getCloudProvider().stackAuthentication(getTestContext().get(StackAuthenticationTestDto.class));
-        }
-    }
-
-    private Integer getGatewayPort(StackTestDtoBase stack, JSONObject templateJson) {
-        try {
-            return Integer.parseInt(templateJson.getString("gatewayPort"));
-        } catch (JSONException e) {
-            LOGGER.error("Cannot get Gateway Port from template: {}", templateJson, e);
-            MockCloudProvider mock = new MockCloudProvider();
-            return mock.gatewayPort(stack);
         }
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
@@ -28,7 +28,6 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.I
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
-import com.sequenceiq.it.cloudbreak.MicroserviceClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.SdxClient;
 import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
@@ -49,7 +48,6 @@ import com.sequenceiq.sdx.api.model.SdxAwsSpotParameters;
 import com.sequenceiq.sdx.api.model.SdxCloudStorageRequest;
 import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
 import com.sequenceiq.sdx.api.model.SdxClusterRequest;
-import com.sequenceiq.sdx.api.model.SdxClusterResizeRequest;
 import com.sequenceiq.sdx.api.model.SdxClusterResponse;
 import com.sequenceiq.sdx.api.model.SdxClusterShape;
 import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
@@ -87,17 +85,6 @@ public class SdxTestDto extends AbstractSdxTestDto<SdxClusterRequest, SdxCluster
                 .withTags(getCloudProvider().getTags())
                 .withRuntimeVersion(commonClusterManagerProperties.getRuntimeVersion());
         return getCloudProvider().sdx(this);
-    }
-
-    @Override
-    public void cleanUp(TestContext context, MicroserviceClient client) {
-        LOGGER.info("Cleaning up sdx with name: {}", getName());
-        if (getResponse() != null) {
-            when(sdxTestClient.forceDelete(), key("delete-sdx-" + getName()).withSkipOnFail(false));
-            await(DELETED, new RunningParameter().withSkipOnFail(true));
-        } else {
-            LOGGER.info("Sdx: {} response is null!", getName());
-        }
     }
 
     @Override
@@ -211,10 +198,6 @@ public class SdxTestDto extends AbstractSdxTestDto<SdxClusterRequest, SdxCluster
         return awaitForInstance(statuses, emptyRunningParameter());
     }
 
-    public SdxTestDto awaitForInstance(SdxTestDto entity, Map<List<String>, InstanceStatus> statuses, RunningParameter runningParameter) {
-        return getTestContext().awaitForInstance(entity, statuses, runningParameter);
-    }
-
     public SdxTestDto awaitForInstance(Map<List<String>, InstanceStatus> statuses, RunningParameter runningParameter) {
         return getTestContext().awaitForInstance(this, statuses, runningParameter);
     }
@@ -274,18 +257,6 @@ public class SdxTestDto extends AbstractSdxTestDto<SdxClusterRequest, SdxCluster
             throw new IllegalArgumentException(String.format("Environment has not been provided for this Sdx: '%s' response!", getName()));
         }
         return withEnvironmentName(environment.getResponse().getName());
-    }
-
-    private SdxTestDto withEnvironmentDto(EnvironmentTestDto environmentTestDto) {
-        return withEnvironmentName(environmentTestDto.getResponse().getName());
-    }
-
-    public SdxTestDto withEnvironmentKey(RunningParameter environmentKey) {
-        EnvironmentTestDto env = getTestContext().get(environmentKey.getKey());
-        if (env == null) {
-            throw new IllegalArgumentException(String.format("Environment has not been provided for this Sdx: '%s' response!", getName()));
-        }
-        return withEnvironmentName(env.getResponse().getName());
     }
 
     public SdxTestDto withEnvironmentName(String environmentName) {
@@ -351,14 +322,6 @@ public class SdxTestDto extends AbstractSdxTestDto<SdxClusterRequest, SdxCluster
             throw new IllegalArgumentException("SDX Recovery does not exist!");
         }
         return recovery.getRequest();
-    }
-
-    public SdxClusterResizeRequest getSdxResizeRequest() {
-        SdxResizeTestDto resize = given(SdxResizeTestDto.class);
-        if (resize == null) {
-            throw new IllegalArgumentException("SDX Resize does not exist!");
-        }
-        return resize.getRequest();
     }
 
     public SdxTestDto withRuntimeVersion(String runtimeVersion) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/util/CheckResourceRightTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/util/CheckResourceRightTestDto.java
@@ -5,7 +5,6 @@ import java.util.Map;
 
 import com.sequenceiq.authorization.info.model.CheckResourceRightsV4Response;
 import com.sequenceiq.authorization.info.model.RightV4;
-import com.sequenceiq.it.cloudbreak.MicroserviceClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
@@ -31,11 +30,6 @@ public class CheckResourceRightTestDto extends AbstractCloudbreakTestDto<Object,
     public CheckResourceRightTestDto withRightsToCheck(Map<String, List<RightV4>> rightsToCheck) {
         this.rightsToCheck = rightsToCheck;
         return this;
-    }
-
-    @Override
-    public void cleanUp(TestContext context, MicroserviceClient client) {
-        LOGGER.debug("this entry point does not have any clean up operation");
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/util/CheckRightTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/util/CheckRightTestDto.java
@@ -5,7 +5,6 @@ import java.util.List;
 import com.google.common.collect.Lists;
 import com.sequenceiq.authorization.info.model.CheckRightV4Response;
 import com.sequenceiq.authorization.info.model.RightV4;
-import com.sequenceiq.it.cloudbreak.MicroserviceClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
@@ -31,11 +30,6 @@ public class CheckRightTestDto extends AbstractCloudbreakTestDto<Object, CheckRi
     public CheckRightTestDto withRightsToCheck(List<RightV4> rightsToCheck) {
         this.rightsToCheck = rightsToCheck;
         return this;
-    }
-
-    @Override
-    public void cleanUp(TestContext context, MicroserviceClient client) {
-        LOGGER.debug("this entry point does not have any clean up operation");
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/ResourceAwait.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/ResourceAwait.java
@@ -20,14 +20,12 @@ public class ResourceAwait {
     private static final Logger LOGGER = LoggerFactory.getLogger(ResourceAwait.class);
 
     public <E extends Enum<E>> CloudbreakTestDto await(CloudbreakTestDto entity, Map<String, E> desiredStatuses,
-            TestContext testContext, RunningParameter runningParameter, Duration pollingInterval, int maxRetry, int maxRetryCount) {
+            TestContext testContext, RunningParameter runningParameter, Duration pollingInterval, int maxRetry, int maxRetryCount, MicroserviceClient client) {
         try {
             if (entity == null) {
                 throw new RuntimeException("Cloudbreak key has been provided but no result in resource map!");
             }
             Log.await(LOGGER, String.format("%s for %s", entity.getName(), desiredStatuses));
-            MicroserviceClient client = testContext.getMicroserviceClient(entity.getClass(), testContext.setActingUser(runningParameter)
-                    .getAccessKey());
             String name = entity.getName();
             WaitObject waitObject = client.waitObject(entity, name, desiredStatuses, testContext, runningParameter.getIgnoredStatuses());
             if (waitObject.isDeletionCheck()) {


### PR DESCRIPTION
- cleanup method is simplified now and using admin client from method parameter
- cleanup of affected classes regarding unused code