### PR TITLE
CB-15341 Successful scale up final status should be based on the numb…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartus/StopStartUpscaleFlowService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartus/StopStartUpscaleFlowService.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.stopstartus;
 
-import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.AVAILABLE;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.UPDATE_FAILED;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.UPDATE_IN_PROGRESS;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALING_STOPSTART_UPSCALE_COMMISSIONING;
@@ -104,13 +103,11 @@ class StopStartUpscaleFlowService {
                 String.valueOf(notCommissionedFqdns.size()), notCommissionedFqdns.stream().collect(Collectors.joining(", ")));
     }
 
-    void clusterUpscaleFinished(StackView stackView, String hostgroupName, List<InstanceMetaData> commissioned) {
-        // TODO CB-14929: CB-15341 follow up. The DetailedStackStatus here needs to be updated based on the number of instances.
-        //  That determines AVAILABLE vs AVAILABLE_WITH_STOPPED_INSTANCES
+    void clusterUpscaleFinished(StackView stackView, String hostgroupName, List<InstanceMetaData> commissioned, DetailedStackStatus finalStackStatus) {
         LOGGER.debug("StopStart upscale finished successfully. CommissionedCount={}", commissioned.size());
         commissioned.stream().forEach(x -> instanceMetaDataService.updateInstanceStatus(x, InstanceStatus.SERVICES_HEALTHY));
-        stackUpdater.updateStackStatus(stackView.getId(), DetailedStackStatus.AVAILABLE, String.format("finished starting nodes"));
-        flowMessageService.fireEventAndLog(stackView.getId(), AVAILABLE.name(), CLUSTER_SCALING_STOPSTART_UPSCALE_FINISHED,
+        stackUpdater.updateStackStatus(stackView.getId(), finalStackStatus, String.format("finished starting nodes"));
+        flowMessageService.fireEventAndLog(stackView.getId(), finalStackStatus.getStatus().name(), CLUSTER_SCALING_STOPSTART_UPSCALE_FINISHED,
                 hostgroupName, String.valueOf(commissioned.size()),
                 commissioned.stream().map(i -> i.getDiscoveryFQDN()).collect(Collectors.joining(", ")));
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartus/StopStartUpscaleActionsTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartus/StopStartUpscaleActionsTest.java
@@ -33,6 +33,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.statemachine.action.Action;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.event.instance.StopStartUpscaleStartInstancesRequest;
@@ -325,7 +326,7 @@ public class StopStartUpscaleActionsTest {
                 = (AbstractStopStartUpscaleActions<StopStartUpscaleCommissionViaCMResult>) underTest.upscaleFinishedAction();
         initActionPrivateFields(action);
 
-        int adjustment = 5;
+        int adjustment = 10;
 
         StopStartUpscaleContext stopStartUpscaleContext = createContext(adjustment);
 
@@ -352,7 +353,8 @@ public class StopStartUpscaleActionsTest {
 
         new AbstractActionTestSupport<>(action).doExecute(stopStartUpscaleContext, payload, Collections.emptyMap());
 
-        verify(stopStartUpscaleFlowService).clusterUpscaleFinished(any(), eq(INSTANCE_GROUP_NAME_ACTIONABLE), eq(startedInstances));
+        verify(stopStartUpscaleFlowService).clusterUpscaleFinished(
+                any(), eq(INSTANCE_GROUP_NAME_ACTIONABLE), eq(startedInstances), eq(DetailedStackStatus.AVAILABLE));
         ArgumentCaptor<Object> argumentCaptor = ArgumentCaptor.forClass(Object.class);
         verify(reactorEventFactory).createEvent(anyMap(), argumentCaptor.capture());
         verify(eventBus).notify("STOPSTART_UPSCALE_FINALIZED_EVENT", event);
@@ -395,7 +397,8 @@ public class StopStartUpscaleActionsTest {
         new AbstractActionTestSupport<>(action).doExecute(stopStartUpscaleContext, payload, Collections.emptyMap());
 
         verify(stopStartUpscaleFlowService).logInstancesFailedToCommission(eq(STACK_ID), eq(notCommissionedFqdns));
-        verify(stopStartUpscaleFlowService).clusterUpscaleFinished(any(), eq(INSTANCE_GROUP_NAME_ACTIONABLE), eq(startedInstances));
+        verify(stopStartUpscaleFlowService).clusterUpscaleFinished(
+                any(), eq(INSTANCE_GROUP_NAME_ACTIONABLE), eq(startedInstances), eq(DetailedStackStatus.AVAILABLE_WITH_STOPPED_INSTANCES));
         ArgumentCaptor<Object> argumentCaptor = ArgumentCaptor.forClass(Object.class);
         verify(reactorEventFactory).createEvent(anyMap(), argumentCaptor.capture());
         verify(eventBus).notify("STOPSTART_UPSCALE_FINALIZED_EVENT", event);


### PR DESCRIPTION
…er of instances started

1. We introduced a new state for stop/start scaling.
2. This state is used when scale down successfully stops some nodes in the hostgroup.
3. The same state needs to be used when not all the instances are started during the scale up by start action.

See detailed description in the commit message.