### PR TITLE
CB-15582 Freeipa upscale/downscale e2e test

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/FreeIpaClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/FreeIpaClient.java
@@ -24,9 +24,12 @@ import com.sequenceiq.it.cloudbreak.actor.CloudbreakUser;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.EnvironmentAware;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaChildEnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaDownscaleTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaOperationStatusTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaUpscaleTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaUserSyncStatusDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaUserSyncTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeipaChangeImageCatalogTestDto;
@@ -79,9 +82,9 @@ public class FreeIpaClient<E extends Enum<E>> extends MicroserviceClient<com.seq
                     testContext.get(EnvironmentTestDto.class).getResponse().getCrn(), (OperationState) desiredStatuses.get("status"),
                     (Set<OperationState>) ignoredFailedStatuses);
         } else {
-            FreeIpaTestDto freeIpaTestDto = (FreeIpaTestDto) entity;
-            return new FreeIpaWaitObject(this, entity.getName(), freeIpaTestDto.getResponse().getEnvironmentCrn(), (Status) desiredStatuses.get("status"),
-                    (Set<Status>) ignoredFailedStatuses);
+            EnvironmentAware environmentAware = (EnvironmentAware) entity;
+            return new FreeIpaWaitObject(this, entity.getName(), environmentAware.getEnvironmentCrn(), (Status) desiredStatuses.get("status"),
+                (Set<Status>) ignoredFailedStatuses);
         }
     }
 
@@ -123,7 +126,9 @@ public class FreeIpaClient<E extends Enum<E>> extends MicroserviceClient<com.seq
                 FreeIpaUserSyncStatusDto.class.getSimpleName(),
                 FreeipaUsedImagesTestDto.class.getSimpleName(),
                 FreeIpaOperationStatusTestDto.class.getSimpleName(),
-                FreeipaChangeImageCatalogTestDto.class.getSimpleName());
+                FreeipaChangeImageCatalogTestDto.class.getSimpleName(),
+                FreeIpaUpscaleTestDto.class.getSimpleName(),
+                FreeIpaDownscaleTestDto.class.getSimpleName());
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaDownscaleAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaDownscaleAction.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.it.cloudbreak.action.freeipa;
+
+import static java.lang.String.format;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.scale.DownscaleRequest;
+import com.sequenceiq.it.cloudbreak.FreeIpaClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaDownscaleTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+
+public class FreeIpaDownscaleAction implements Action<FreeIpaDownscaleTestDto, FreeIpaClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FreeIpaDownscaleAction.class);
+
+    @Override
+    public FreeIpaDownscaleTestDto action(TestContext testContext, FreeIpaDownscaleTestDto testDto, FreeIpaClient client) throws Exception {
+        Log.whenJson(LOGGER, format(" FreeIPA downscale request:%n"), testDto.getRequest());
+        DownscaleRequest downscaleRequest = new DownscaleRequest();
+        downscaleRequest.setEnvironmentCrn(testDto.getRequest().getEnvironmentCrn());
+        downscaleRequest.setTargetFormFactor(testDto.getRequest().getTargetFormFactor());
+        testDto.setResponse(client.getDefaultClient()
+                .getFreeIpaV1Endpoint()
+                .downscale(downscaleRequest));
+        testDto.setFlow("FreeIPA downscale",  testDto.getResponse().getFlowIdentifier());
+        testDto.setOperationId(testDto.getResponse().getOperationId());
+        Log.whenJson(LOGGER, format(" FreeIPA downscale started: %n"), testDto.getResponse());
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaUpscaleAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaUpscaleAction.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.it.cloudbreak.action.freeipa;
+
+import static java.lang.String.format;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.scale.UpscaleRequest;
+import com.sequenceiq.it.cloudbreak.FreeIpaClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaUpscaleTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+
+public class FreeIpaUpscaleAction implements Action<FreeIpaUpscaleTestDto, FreeIpaClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FreeIpaUpscaleAction.class);
+
+    @Override
+    public FreeIpaUpscaleTestDto action(TestContext testContext, FreeIpaUpscaleTestDto testDto, FreeIpaClient client) throws Exception {
+        Log.whenJson(LOGGER, format(" FreeIPA upscale request:%n"), testDto.getRequest());
+        UpscaleRequest upscaleRequest = new UpscaleRequest();
+        upscaleRequest.setEnvironmentCrn(testDto.getRequest().getEnvironmentCrn());
+        upscaleRequest.setTargetFormFactor(testDto.getRequest().getTargetFormFactor());
+        testDto.setResponse(client.getDefaultClient()
+                .getFreeIpaV1Endpoint()
+                .upscale(upscaleRequest));
+        testDto.setFlow("FreeIPA upscale",  testDto.getResponse().getFlowIdentifier());
+        testDto.setOperationId(testDto.getResponse().getOperationId());
+        Log.whenJson(LOGGER, format(" FreeIPA upscale started: %n"), testDto.getResponse());
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/FreeIpaTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/FreeIpaTestClient.java
@@ -2,7 +2,6 @@ package com.sequenceiq.it.cloudbreak.client;
 
 import java.util.Set;
 
-import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaRebuildAction;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceMetadataType;
@@ -15,10 +14,12 @@ import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaCreateAction;
 import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaDeleteAction;
 import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaDescribeAction;
 import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaDetachChildEnvironmentAction;
+import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaDownscaleAction;
 import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaFindGroupsAction;
 import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaFindUsersAction;
 import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaFindUsersInGroupAction;
 import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaGetLastSyncOperationStatus;
+import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaRebuildAction;
 import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaRefreshAction;
 import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaRepairAction;
 import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaSetPasswordAction;
@@ -27,10 +28,13 @@ import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaStopAction;
 import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaSynchronizeAllUsersAction;
 import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaSynchronizeAllUsersInternalAction;
 import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaUpgradeAction;
+import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaUpscaleAction;
 import com.sequenceiq.it.cloudbreak.action.freeipa.FreeipaUsedImagesAction;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaChildEnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaDiagnosticsTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaDownscaleTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaUpscaleTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaUserSyncTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeipaChangeImageCatalogTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeipaUsedImagesTestDto;
@@ -121,4 +125,13 @@ public class FreeIpaTestClient {
     public Action<FreeipaChangeImageCatalogTestDto, FreeIpaClient> changeImageCatalog() {
         return new FreeIpaChangeImageCatalogAction();
     }
+
+    public Action<FreeIpaUpscaleTestDto, FreeIpaClient> upscale() {
+        return new FreeIpaUpscaleAction();
+    }
+
+    public Action<FreeIpaDownscaleTestDto, FreeIpaClient> downscale() {
+        return new FreeIpaDownscaleAction();
+    }
+
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.it.cloudbreak.cloud.v4.azure;
 
-import static com.sequenceiq.it.cloudbreak.ResourceGroupTest.AZURE_RESOURCE_GROUP_USAGE_SINGLE;
 import static java.lang.String.format;
 
 import java.util.List;
@@ -319,9 +318,7 @@ public class AzureCloudProvider extends AbstractCloudProvider {
 
     @Override
     public EnvironmentTestDto withResourceGroup(EnvironmentTestDto environmentTestDto, String resourceGroupUsageString, String resourceGroupName) {
-        ResourceGroupUsage resourceGroupUsage = AZURE_RESOURCE_GROUP_USAGE_SINGLE.equals(resourceGroupUsageString)
-                ? ResourceGroupUsage.SINGLE
-                : ResourceGroupUsage.MULTIPLE;
+        ResourceGroupUsage resourceGroupUsage = ResourceGroupUsage.valueOf(resourceGroupUsageString);
 
         if (environmentTestDto.getAzure() == null) {
             environmentTestDto.setAzure(AzureEnvironmentParameters.builder().build());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/EnvironmentAware.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/EnvironmentAware.java
@@ -1,0 +1,6 @@
+package com.sequenceiq.it.cloudbreak.dto.freeipa;
+
+public interface EnvironmentAware {
+
+    String getEnvironmentCrn();
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaDownscaleTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaDownscaleTestDto.java
@@ -1,0 +1,54 @@
+package com.sequenceiq.it.cloudbreak.dto.freeipa;
+
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.emptyRunningParameter;
+
+import java.util.Map;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.FormFactor;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.scale.DownscaleRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.scale.DownscaleResponse;
+import com.sequenceiq.it.cloudbreak.Prototype;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractFreeIpaTestDto;
+import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+
+@Prototype
+public class FreeIpaDownscaleTestDto extends AbstractFreeIpaTestDto<DownscaleRequest, DownscaleResponse, FreeIpaDownscaleTestDto>
+        implements EnvironmentAware {
+    protected FreeIpaDownscaleTestDto(TestContext testContext) {
+        super(new DownscaleRequest(), testContext);
+    }
+
+    @Override
+    public CloudbreakTestDto valid() {
+        return withEnvironmentCrn(getTestContext().given(EnvironmentTestDto.class).getCrn());
+
+    }
+
+    private FreeIpaDownscaleTestDto withEnvironmentCrn(String environmentCrn) {
+        getRequest().setEnvironmentCrn(environmentCrn);
+        return this;
+    }
+
+    public FreeIpaDownscaleTestDto withFormFactor(FormFactor formFactor) {
+        getRequest().setTargetFormFactor(formFactor);
+        return this;
+    }
+
+    @Override
+    public String getCrn() {
+        return getRequest().getEnvironmentCrn();
+    }
+
+    public FreeIpaDownscaleTestDto await(Status state) {
+        return getTestContext().await(this, Map.of("status", state), emptyRunningParameter());
+    }
+
+    @Override
+    public String getEnvironmentCrn() {
+        return getRequest().getEnvironmentCrn();
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaTestDto.java
@@ -69,7 +69,7 @@ import com.sequenceiq.it.cloudbreak.util.FreeIpaInstanceUtil;
 
 @Prototype
 public class FreeIpaTestDto extends AbstractFreeIpaTestDto<CreateFreeIpaRequest, DescribeFreeIpaResponse, FreeIpaTestDto>
-        implements Purgable<ListFreeIpaResponse, FreeIpaClient>, Searchable, Investigable {
+        implements Purgable<ListFreeIpaResponse, FreeIpaClient>, Searchable, Investigable, EnvironmentAware {
 
     private static final String FREEIPA_RESOURCE_NAME = "freeipaName";
 
@@ -419,5 +419,10 @@ public class FreeIpaTestDto extends AbstractFreeIpaTestDto<CreateFreeIpaRequest,
                 .flatMap(ig -> ig.getMetaData().stream())
                 .anyMatch(metadata -> InstanceStatus.DELETED_BY_PROVIDER == metadata.getInstanceStatus());
         return new Clue("FreeIpa", null, getResponse(), hasSpotTermination);
+    }
+
+    @Override
+    public String getEnvironmentCrn() {
+        return getResponse().getEnvironmentCrn();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaUpscaleTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaUpscaleTestDto.java
@@ -1,0 +1,54 @@
+package com.sequenceiq.it.cloudbreak.dto.freeipa;
+
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.emptyRunningParameter;
+
+import java.util.Map;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.FormFactor;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.scale.UpscaleRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.scale.UpscaleResponse;
+import com.sequenceiq.it.cloudbreak.Prototype;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractFreeIpaTestDto;
+import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+
+@Prototype
+public class FreeIpaUpscaleTestDto extends AbstractFreeIpaTestDto<UpscaleRequest, UpscaleResponse, FreeIpaUpscaleTestDto>
+        implements EnvironmentAware {
+    protected FreeIpaUpscaleTestDto(TestContext testContext) {
+        super(new UpscaleRequest(), testContext);
+    }
+
+    @Override
+    public CloudbreakTestDto valid() {
+        return withEnvironmentCrn(getTestContext().given(EnvironmentTestDto.class).getCrn());
+
+    }
+
+    private FreeIpaUpscaleTestDto withEnvironmentCrn(String environmentCrn) {
+        getRequest().setEnvironmentCrn(environmentCrn);
+        return this;
+    }
+
+    public FreeIpaUpscaleTestDto withFormFactor(FormFactor formFactor) {
+        getRequest().setTargetFormFactor(formFactor);
+        return this;
+    }
+
+    @Override
+    public String getCrn() {
+        return getRequest().getEnvironmentCrn();
+    }
+
+    public FreeIpaUpscaleTestDto await(Status state) {
+        return getTestContext().await(this, Map.of("status", state), emptyRunningParameter());
+    }
+
+    @Override
+    public String getEnvironmentCrn() {
+        return getRequest().getEnvironmentCrn();
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/freeipa/FreeIpaScalingTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/freeipa/FreeIpaScalingTests.java
@@ -1,0 +1,142 @@
+package com.sequenceiq.it.cloudbreak.testcase.e2e.freeipa;
+
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.FormFactor;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupResponse;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceMetaDataResponse;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceMetadataType;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.describe.DescribeFreeIpaResponse;
+import com.sequenceiq.it.cloudbreak.FreeIpaClient;
+import com.sequenceiq.it.cloudbreak.client.FreeIpaTestClient;
+import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaDownscaleTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaUpscaleTestDto;
+import com.sequenceiq.it.cloudbreak.dto.telemetry.TelemetryTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
+
+public class FreeIpaScalingTests extends AbstractE2ETest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FreeIpaScalingTests.class);
+
+    private static final Status FREEIPA_AVAILABLE = Status.AVAILABLE;
+
+    @Inject
+    private FreeIpaTestClient freeIpaTestClient;
+
+    @Test(dataProvider = TEST_CONTEXT)
+    @Description(
+            given = "there is a running cloudbreak",
+            when = "a valid stack create request is sent with 1 FreeIPA instance " +
+                    "AND the stack is scaled up to HA " +
+                    "AND the stack is scaled down to TWO_NODE_BASED " +
+                    "AND the stack is scaled up to HA ",
+            then = "the stack should be available AND deletable and have 3 nodes AND the primary gateway should not change")
+    public void testFreeIpaUpAndDownscale(TestContext testContext) {
+        String freeIpa = resourcePropertyProvider().getName();
+        Set<String> primaryGatewayInstanceId = new HashSet<>();
+
+        testContext
+                .given("telemetry", TelemetryTestDto.class)
+                .withLogging()
+                .withReportClusterLogs()
+                .given(freeIpa, FreeIpaTestDto.class)
+                .withTelemetry("telemetry")
+                .when(freeIpaTestClient.create(), key(freeIpa))
+                .await(FREEIPA_AVAILABLE)
+                .then((tc, testDto, client) -> {
+                    Set<InstanceMetaDataResponse> instanceMetaDataResponses = getInstanceMetaDataResponses(testDto.getRequest().getEnvironmentCrn(), client);
+                    primaryGatewayInstanceId.add(getPrimaryGatewayId(instanceMetaDataResponses));
+                    return testDto;
+                })
+
+                .given(FreeIpaUpscaleTestDto.class)
+                .withFormFactor(FormFactor.HA)
+                .when(freeIpaTestClient.upscale(), key(freeIpa))
+                .await(FREEIPA_AVAILABLE)
+                .then((tc, testDto, client) -> {
+                    Set<InstanceMetaDataResponse> instanceMetaDataResponses = getInstanceMetaDataResponses(testDto.getRequest().getEnvironmentCrn(), client);
+                    assertInstanceCount(testDto.getRequest().getTargetFormFactor(), instanceMetaDataResponses);
+                    assertPrimaryGatewayHasNotChanged(primaryGatewayInstanceId, instanceMetaDataResponses);
+                    return testDto;
+                })
+
+                .given(FreeIpaDownscaleTestDto.class)
+                .withFormFactor(FormFactor.TWO_NODE_BASED)
+                .when(freeIpaTestClient.downscale())
+                .await(FREEIPA_AVAILABLE)
+                .then((tc, testDto, client) -> {
+                    Set<InstanceMetaDataResponse> instanceMetaDataResponses = getInstanceMetaDataResponses(testDto.getRequest().getEnvironmentCrn(), client);
+                    assertInstanceCount(testDto.getRequest().getTargetFormFactor(), instanceMetaDataResponses);
+                    assertPrimaryGatewayHasNotChanged(primaryGatewayInstanceId, instanceMetaDataResponses);
+                    return testDto;
+                })
+
+                .given(FreeIpaUpscaleTestDto.class)
+                .withFormFactor(FormFactor.HA)
+                .when(freeIpaTestClient.upscale(), key(freeIpa))
+                .await(FREEIPA_AVAILABLE)
+                .then((tc, testDto, client) -> {
+                    Set<InstanceMetaDataResponse> instanceMetaDataResponses = getInstanceMetaDataResponses(testDto.getRequest().getEnvironmentCrn(), client);
+                    assertInstanceCount(testDto.getRequest().getTargetFormFactor(), instanceMetaDataResponses);
+                    assertPrimaryGatewayHasNotChanged(primaryGatewayInstanceId, instanceMetaDataResponses);
+                    return testDto;
+                })
+                .validate();
+    }
+
+    private String getPrimaryGatewayId(Set<InstanceMetaDataResponse> instanceMetaDataResponses) {
+        Optional<InstanceMetaDataResponse> primaryGatewayOptional = instanceMetaDataResponses.stream()
+                .filter(imd -> InstanceMetadataType.GATEWAY_PRIMARY.equals(imd.getInstanceType())).findFirst();
+        if (primaryGatewayOptional.isEmpty()) {
+            String message = "Freeipa does not have a primary gateway";
+            LOGGER.error(message);
+            throw new TestFailException(message);
+        }
+        return primaryGatewayOptional.get().getInstanceId();
+    }
+
+    private Set<InstanceMetaDataResponse> getInstanceMetaDataResponses(String environmentCrn, FreeIpaClient client) {
+        DescribeFreeIpaResponse describeFreeIpaResponse = client.getDefaultClient().getFreeIpaV1Endpoint().describe(environmentCrn);
+        Set<InstanceMetaDataResponse> instanceMetaDataResponses = describeFreeIpaResponse.getInstanceGroups().stream()
+                .map(InstanceGroupResponse::getMetaData)
+                .flatMap(Set::stream)
+                .collect(Collectors.toSet());
+        return instanceMetaDataResponses;
+    }
+
+    private void assertPrimaryGatewayHasNotChanged(Set<String> originalPrimaryGatewayInstanceId, Set<InstanceMetaDataResponse> instanceMetaDataResponses) {
+        String currentPrimaryGatewayInstanceId = getPrimaryGatewayId(instanceMetaDataResponses);
+        if (!originalPrimaryGatewayInstanceId.contains(currentPrimaryGatewayInstanceId)) {
+            String message = String.format("Freeipa primary gateway instance id has changed: %s => %s.",
+                    originalPrimaryGatewayInstanceId, currentPrimaryGatewayInstanceId);
+            LOGGER.error(message);
+            throw new TestFailException(message);
+        }
+    }
+
+    private void assertInstanceCount(FormFactor targetFormFactor, Set<InstanceMetaDataResponse> imd) {
+        if (targetFormFactor.getInstanceCount() != imd.size()) {
+            String message = String.format("Expected number of freeipa instances %s do not match the actual instance count %s ",
+                    targetFormFactor.getInstanceCount(), imd.size());
+            LOGGER.error(message);
+            throw new TestFailException(message);
+        }
+    }
+
+}

--- a/integration-test/src/main/resources/testsuites/e2e/aws-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/aws-e2e-tests.yaml
@@ -12,6 +12,7 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.NewNetworkWithNoInternetEnvironmentTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.freeipa.FreeIpaTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.freeipa.FreeIpaRebuildTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.freeipa.FreeIpaScalingTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXEncryptedVolumeTest
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXRepairTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXScaleTest

--- a/integration-test/src/main/resources/testsuites/e2e/azure-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/azure-e2e-tests.yaml
@@ -14,6 +14,7 @@ tests:
           - testCreateDistroXWithEncryptedVolumesInSingleRG
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXRepairTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXScaleTest
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.freeipa.FreeIpaScalingTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.imagevalidation.PrewarmImageValidatorE2ETest
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxImagesTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.AzureMarketplaceImageTest

--- a/integration-test/src/main/resources/testsuites/e2e/gcp-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/gcp-e2e-tests.yaml
@@ -10,6 +10,7 @@ tests:
     classes:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.NewNetworkEnvironmentTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.imagevalidation.PrewarmImageValidatorE2ETest
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.freeipa.FreeIpaScalingTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXRepairTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXScaleTest
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxImagesTests


### PR DESCRIPTION
An e2e test is added for freeipa scaling: it scales NON_HA -> HA -> TWO_NODE_BASED -> HA. At each step it checks from instanceMetaData:
- are the correct node numbers present
- the primary gateway has not changed
The test is only run for AWS currently, and takes ~1 hour.

See detailed description in the commit message.