### PR TITLE
CB-15837 Fix Azure encryption test single resource group test teardown

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/AzureEnvironmentWithCustomerManagedKeyTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/AzureEnvironmentWithCustomerManagedKeyTests.java
@@ -73,11 +73,8 @@ public class AzureEnvironmentWithCustomerManagedKeyTests extends AbstractE2ETest
         createDefaultUser(testContext);
     }
 
-    @AfterMethod(onlyForGroups = { "withrg" })
-    public void tearDown(Object[] data) {
-        LOGGER.info("Tear down context");
-        ((TestContext) data[0]).cleanupTestContext();
-
+    @AfterMethod(onlyForGroups = { "withrg" }, dependsOnMethods = { "tearDown", "tearDownSpot" })
+    public void singleResourceGroupTearDown() {
         LOGGER.info("Delete the '{}' resource group after test has been done!", resourceGroupForTest);
         deleteResourceGroupCreatedForEnvironment(resourceGroupForTest);
     }
@@ -224,7 +221,7 @@ public class AzureEnvironmentWithCustomerManagedKeyTests extends AbstractE2ETest
         volumesDesId.forEach(desId -> {
             if (desId.contains("diskEncryptionSets/" + testContext.given(EnvironmentTestDto.class).getRequest().getName())) {
                 LOGGER.info(format("FreeIpa volume has been encrypted with '%s' DES key!", desId));
-                Log.then(LOGGER, format(" FreeIpa volume has not been encrypted with '%s' DES key! ", desId));
+                Log.then(LOGGER, format(" FreeIpa volume has been encrypted with '%s' DES key! ", desId));
             } else {
                 LOGGER.error(format("FreeIpa volume has not been encrypted with '%s' DES key!", desKeyUrl));
                 throw new TestFailException(format("FreeIpa volume has not been encrypted with '%s' DES key!", desKeyUrl));


### PR DESCRIPTION
The recent changes of [CB-15688](https://jira.cloudera.com/browse/CB-15688) / [PR 12073](https://github.com/hortonworks/cloudbreak/pull/12073) override `AzureEnvironmentWithCustomerManagedKeyTests.tearDown()` in order to clean up Azure RG and tested resources.

The problem is, this method uses the:
```
onlyForGroups = { "withrg" }
```
condition and so it will not be invoked in case of `testWithEncryptionKeyResourceGroup` test case. So cluster resources are going to be left behind for this test.