### PR TITLE
CB-15837 Fix single resource group test teardown

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXEncryptedVolumeTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXEncryptedVolumeTest.java
@@ -113,11 +113,8 @@ public class DistroXEncryptedVolumeTest extends AbstractE2ETest {
         createDefaultCredential(testContext);
     }
 
-    @AfterMethod(onlyForGroups = { "azure_singlerg" })
-    public void tearDown(Object[] data) {
-        LOGGER.info("Tear down context");
-        ((TestContext) data[0]).cleanupTestContext();
-
+    @AfterMethod(onlyForGroups = { "azure_singlerg" }, dependsOnMethods = { "tearDown", "tearDownSpot" })
+    public void singleResourceGroupTearDown(Object[] data) {
         LOGGER.info("Delete the '{}' resource group after test has been done!", resourceGroupForTest);
         deleteResourceGroupCreatedForEnvironment(resourceGroupForTest);
     }


### PR DESCRIPTION
The recent changes of [CB-15688](https://jira.cloudera.com/browse/CB-15688) / [PR 12097](https://github.com/hortonworks/cloudbreak/pull/12097) override `DistroXEncryptedVolumeTest.tearDown()` in order to clean up Azure RG and tested resources.

The problem is, this method uses the:
```
onlyForGroups = { "azure_singlerg" }
```
condition and so it will not be invoked in case of AWS test case. Hence running that test class on AWS will likely leave behind cluster resources instead of cleaning them up.