### PR TITLE
CB-15762 Replace FreeIPA termination's `noFailureEvent`

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/StackTerminationFlowConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/StackTerminationFlowConfig.java
@@ -32,11 +32,11 @@ public class StackTerminationFlowConfig extends AbstractFlowConfiguration<StackT
     private static final List<Transition<StackTerminationState, StackTerminationEvent>> TRANSITIONS =
             new Builder<StackTerminationState, StackTerminationEvent>()
                     .defaultFailureEvent(TERMINATION_FAILED_EVENT)
-                    .from(INIT_STATE).to(STOP_TELEMETRY_AGENT_STATE).event(TERMINATION_EVENT).noFailureEvent()
-                    .from(STOP_TELEMETRY_AGENT_STATE).to(DEREGISTER_CLUSTERPROXY_STATE).event(STOP_TELEMETRY_AGENT_FINISHED_EVENT).noFailureEvent()
-                    .from(DEREGISTER_CLUSTERPROXY_STATE).to(DEREGISTER_CCMKEY_STATE).event(CLUSTER_PROXY_DEREGISTRATION_FINISHED_EVENT).noFailureEvent()
-                    .from(DEREGISTER_CCMKEY_STATE).to(REMOVE_MACHINE_USER_STATE).event(CCM_KEY_DEREGISTRATION_FINISHED_EVENT).noFailureEvent()
-                    .from(REMOVE_MACHINE_USER_STATE).to(TERMINATION_STATE).event(REMOVE_MACHINE_USER_FINISHED_EVENT).noFailureEvent()
+                    .from(INIT_STATE).to(STOP_TELEMETRY_AGENT_STATE).event(TERMINATION_EVENT).defaultFailureEvent()
+                    .from(STOP_TELEMETRY_AGENT_STATE).to(DEREGISTER_CLUSTERPROXY_STATE).event(STOP_TELEMETRY_AGENT_FINISHED_EVENT).defaultFailureEvent()
+                    .from(DEREGISTER_CLUSTERPROXY_STATE).to(DEREGISTER_CCMKEY_STATE).event(CLUSTER_PROXY_DEREGISTRATION_FINISHED_EVENT).defaultFailureEvent()
+                    .from(DEREGISTER_CCMKEY_STATE).to(REMOVE_MACHINE_USER_STATE).event(CCM_KEY_DEREGISTRATION_FINISHED_EVENT).defaultFailureEvent()
+                    .from(REMOVE_MACHINE_USER_STATE).to(TERMINATION_STATE).event(REMOVE_MACHINE_USER_FINISHED_EVENT).defaultFailureEvent()
                     .from(TERMINATION_STATE).to(TERMINATION_FINISHED_STATE).event(TERMINATION_FINISHED_EVENT).defaultFailureEvent()
                     .from(TERMINATION_FINISHED_STATE).to(FINAL_STATE).event(TERMINATION_FINALIZED_EVENT).defaultFailureEvent()
                     .build();


### PR DESCRIPTION
When an error happens during on action, and it's not handled inside the action, then
`AbstractAction` would send the failure event configure in the flow's configuration.
If it's set to `noFailureEvent`, then this cause an unhandled failure in the flow.
These configurations are now replaced to avoid such situations.
Also other flows in FMS were check, but those have no `noFailureEvent` except the first transition.

See detailed description in the commit message.