### PR TITLE
CB-15758 Better way to check if the nodegroup is only for compute for…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterStartHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterStartHandler.java
@@ -1,10 +1,12 @@
 package com.sequenceiq.cloudbreak.reactor.handler.cluster;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
+import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -12,12 +14,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessorFactory;
+import com.sequenceiq.cloudbreak.common.type.Versioned;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.container.postgres.PostgresConfigService;
 import com.sequenceiq.cloudbreak.core.cluster.ClusterBuilderService;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
@@ -115,13 +119,14 @@ public class ClusterStartHandler implements EventHandler<ClusterStartRequest> {
                     datalakeStack.isPresent(),
                     dlIsRebuild,
                     resizeEntitlementEnabled);
+            CmTemplateProcessor blueprintProcessor = getCmTemplateProcessor(stack.getCluster());
             if (clusterDataHub && datalakeStack.isPresent() &&
                     dlIsRebuild &&
                     resizeEntitlementEnabled) {
                 LOGGER.info("Triggering update of remote data context");
                 apiConnectors.getConnector(stack).startClusterMgmtServices();
                 clusterBuilderService.configureManagementServices(stack.getId());
-                if (shouldReloadDatabaseConfig(stack.getCluster())) {
+                if (shouldReloadDatabaseConfig(blueprintProcessor)) {
                     //Update Hive service database configuration
                     updateDatabaseConfiguration(datalakeStack, stack, HIVE_SERVICE, DatabaseType.HIVE);
                 } else {
@@ -131,19 +136,35 @@ public class ClusterStartHandler implements EventHandler<ClusterStartRequest> {
             } else {
                 requestId = apiConnectors.getConnector(stack).startCluster();
             }
-            if (stackUtil.stopStartScalingEntitlementEnabled(stack)) {
-                List<String> decommissionedHostsFromCM = apiConnectors.getConnector(stack).clusterStatusService().getDecommissionedHostsFromCM();
-                // TODO: CB-15341 Is this a sufficient check for compute hostgroup in the long run?
-                List<String> decommissionedComputeHosts = decommissionedHostsFromCM.stream().filter(h -> h.contains("compute")).collect(Collectors.toList());
-                if (!decommissionedComputeHosts.isEmpty()) {
-                    apiConnectors.getConnector(stack).clusterCommissionService().recommissionHosts(decommissionedComputeHosts);
-                }
-            }
+            handleStopStartScalingFeature(stack, blueprintProcessor);
             result = new ClusterStartResult(request, requestId);
         } catch (Exception e) {
             result = new ClusterStartResult(e.getMessage(), e, request);
         }
         eventBus.notify(result.selector(), new Event<>(event.getHeaders(), result));
+    }
+
+    @VisibleForTesting
+    void handleStopStartScalingFeature(Stack stack, CmTemplateProcessor blueprintProcessor) {
+        if (stackUtil.stopStartScalingEntitlementEnabled(stack)) {
+            List<String> decommissionedHostsFromCM = apiConnectors.getConnector(stack).clusterStatusService().getDecommissionedHostsFromCM();
+            Set<String> computeGroups = getComputeHostGroups(blueprintProcessor);
+            if (computeGroups.isEmpty() || decommissionedHostsFromCM.isEmpty()) {
+                return;
+            }
+            Set<String> decommissionedComputeHosts = new HashSet<>();
+            for (String group : computeGroups) {
+                String groupWithPrefix = '-' + group;
+                for (String hostName : decommissionedHostsFromCM) {
+                    if (hostName.contains(groupWithPrefix)) {
+                        decommissionedComputeHosts.add(hostName);
+                    }
+                }
+            }
+            if (!decommissionedComputeHosts.isEmpty()) {
+                apiConnectors.getConnector(stack).clusterCommissionService().recommissionHosts(new ArrayList<>(decommissionedComputeHosts));
+            }
+        }
     }
 
     private void updateDatabaseConfiguration(Optional<Stack> datalakeStack, Stack dataHubStack, String service, DatabaseType databaseType) {
@@ -179,9 +200,17 @@ public class ClusterStartHandler implements EventHandler<ClusterStartRequest> {
         return datalakeStack.getCreated() > dataHubStack.getCreated();
     }
 
-    private boolean shouldReloadDatabaseConfig(Cluster cluster) {
-        String blueprintText = cluster.getBlueprint().getBlueprintText();
-        CmTemplateProcessor blueprintProcessor = cmTemplateProcessorFactory.get(blueprintText);
+    private boolean shouldReloadDatabaseConfig(CmTemplateProcessor blueprintProcessor) {
         return blueprintProcessor.isCMComponentExistsInBlueprint("HIVEMETASTORE");
+    }
+
+    private CmTemplateProcessor getCmTemplateProcessor(Cluster cluster) {
+        String blueprintText = cluster.getBlueprint().getBlueprintText();
+        return cmTemplateProcessorFactory.get(blueprintText);
+    }
+
+    private Set<String> getComputeHostGroups(CmTemplateProcessor blueprintProcessor) {
+        Versioned blueprintVersion = () -> blueprintProcessor.getVersion().get();
+        return blueprintProcessor.getComputeHostGroups(blueprintVersion);
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJobTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJobTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -40,10 +41,13 @@ import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterStatusService;
 import com.sequenceiq.cloudbreak.cluster.status.ClusterStatusResult;
 import com.sequenceiq.cloudbreak.cluster.status.ExtendedHostStatuses;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessorFactory;
 import com.sequenceiq.cloudbreak.common.type.HealthCheck;
 import com.sequenceiq.cloudbreak.common.type.HealthCheckResult;
 import com.sequenceiq.cloudbreak.common.type.HealthCheckType;
 import com.sequenceiq.cloudbreak.converter.spi.InstanceMetaDataToCloudInstanceConverter;
+import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.StackStatus;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
@@ -67,6 +71,8 @@ import io.opentracing.Tracer;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StackStatusCheckerJobTest {
+
+    private static final String BLUEPRINT_TEXT = "blueprintText";
 
     @InjectMocks
     private StackStatusCheckerJob underTest;
@@ -131,6 +137,18 @@ public class StackStatusCheckerJobTest {
     @Mock
     private StackUtil stackUtil;
 
+    @Mock
+    private Cluster cluster;
+
+    @Mock
+    private Blueprint blueprint;
+
+    @Mock
+    private CmTemplateProcessorFactory cmTemplateProcessorFactory;
+
+    @Mock
+    private CmTemplateProcessor cmTemplateProcessor;
+
     @Before
     public void init() {
         Tracer tracer = Mockito.mock(Tracer.class);
@@ -146,7 +164,7 @@ public class StackStatusCheckerJobTest {
         workspace = new Workspace();
         workspace.setId(1L);
         stack.setWorkspace(workspace);
-        stack.setCluster(new Cluster());
+        stack.setCluster(cluster);
         user = new User();
         user.setUserId("1");
         stack.setCreator(user);
@@ -154,6 +172,12 @@ public class StackStatusCheckerJobTest {
 
         when(stackService.get(anyLong())).thenReturn(stack);
         when(jobExecutionContext.getMergedJobDataMap()).thenReturn(new JobDataMap());
+        when(cluster.getBlueprint()).thenReturn(blueprint);
+        when(blueprint.getBlueprintText()).thenReturn(BLUEPRINT_TEXT);
+        when(cmTemplateProcessorFactory.get(anyString())).thenReturn(cmTemplateProcessor);
+        Set<String> computeGroups = new HashSet<>();
+        computeGroups.add("compute");
+        when(cmTemplateProcessor.getComputeHostGroups(any())).thenReturn(computeGroups);
     }
 
     @After

--- a/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusIntegrationTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusIntegrationTest.java
@@ -49,6 +49,7 @@ import com.sequenceiq.cloudbreak.cluster.status.ClusterStatus;
 import com.sequenceiq.cloudbreak.cluster.status.ClusterStatusResult;
 import com.sequenceiq.cloudbreak.cluster.status.ExtendedHostStatuses;
 import com.sequenceiq.cloudbreak.cluster.util.ResourceAttributeUtil;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessorFactory;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
 import com.sequenceiq.cloudbreak.common.type.HealthCheck;
 import com.sequenceiq.cloudbreak.common.type.HealthCheckResult;
@@ -140,6 +141,9 @@ class StackStatusIntegrationTest {
 
     @MockBean
     private StackUtil stackUtil;
+
+    @MockBean
+    private CmTemplateProcessorFactory cmTemplateProcessorFactory;
 
     @MockBean
     private StackInstanceStatusChecker stackStatusChecker;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterStartHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterStartHandlerTest.java
@@ -1,0 +1,97 @@
+package com.sequenceiq.cloudbreak.reactor.handler.cluster;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
+import com.sequenceiq.cloudbreak.cluster.api.ClusterCommissionService;
+import com.sequenceiq.cloudbreak.cluster.api.ClusterStatusService;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
+import com.sequenceiq.cloudbreak.util.StackUtil;
+
+@ExtendWith(MockitoExtension.class)
+class ClusterStartHandlerTest {
+
+    @Mock
+    private CmTemplateProcessor cmTemplateProcessor;
+
+    @Mock
+    private StackUtil stackUtil;
+
+    @Mock
+    private ClusterApiConnectors apiConnectors;
+
+    @Mock
+    private ClusterApi connector;
+
+    @Mock
+    private ClusterStatusService clusterStatusService;
+
+    @Mock
+    private ClusterCommissionService clusterCommissionService;
+
+    @InjectMocks
+    private ClusterStartHandler underTest;
+
+    private Stack stack;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new ClusterStartHandler();
+        MockitoAnnotations.openMocks(this);
+
+        stack = new Stack();
+        stack.setCloudPlatform("AWS");
+
+        when(stackUtil.stopStartScalingEntitlementEnabled(any())).thenReturn(true);
+        when(apiConnectors.getConnector(any(Stack.class))).thenReturn(connector);
+        when(connector.clusterStatusService()).thenReturn(clusterStatusService);
+        lenient().when(connector.clusterCommissionService()).thenReturn(clusterCommissionService);
+        List<String> decommHosts = new ArrayList<>();
+        decommHosts.add("computing-computing0.foo.bar");
+        decommHosts.add("computing-compute0.foo.bar");
+        decommHosts.add("computing-working0.foo.bar");
+        when(clusterStatusService.getDecommissionedHostsFromCM()).thenReturn(decommHosts);
+        Set<String> computeGroups = new HashSet<>();
+        computeGroups.add("compute");
+        computeGroups.add("computing");
+        when(cmTemplateProcessor.getComputeHostGroups(any())).thenReturn(computeGroups);
+    }
+
+    @Test
+    void stopStartScalingFeatureShouldRecommissionComputeGroups() {
+        underTest.handleStopStartScalingFeature(stack, cmTemplateProcessor);
+        List<String> recommHosts = new ArrayList<>();
+        recommHosts.add("computing-computing0.foo.bar");
+        recommHosts.add("computing-compute0.foo.bar");
+        verify(clusterCommissionService, times(1)).recommissionHosts(eq(recommHosts));
+    }
+
+    @Test
+    void stopStartScalingFeatureShouldNotRecommissionNonComputeGroups() {
+        List<String> decommHosts = new ArrayList<>();
+        decommHosts.add("computing-working0.foo.bar");
+        when(clusterStatusService.getDecommissionedHostsFromCM()).thenReturn(decommHosts);
+        underTest.handleStopStartScalingFeature(stack, cmTemplateProcessor);
+        verify(clusterCommissionService, times(0)).recommissionHosts(any());
+    }
+}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessor.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessor.java
@@ -361,6 +361,15 @@ public class CmTemplateProcessor implements BlueprintTextProcessor {
         return result;
     }
 
+    @Override
+    public Set<String> getComputeHostGroups(Versioned version) {
+        Map<String, Set<String>> componentsByHostGroup = collectComponentsByHostGroupWithYarnNMs();
+        // Re-using the current LoadBasedAutoScaling recommendation to determine hostGroups which can be autoscaled
+        Set<String> computeHostGroups = getRecommendationByBlacklist(BlackListedLoadBasedAutoscaleRole.class,
+                true, componentsByHostGroup, version, List.of());
+        return computeHostGroups;
+    }
+
     private Map<String, Set<String>> collectComponentsByHostGroupWithYarnNMs() {
         Map<String, Set<ServiceComponent>> hgToNonGwServiceComponents = getNonGatewayServicesByHostGroup();
         Map<String, Set<ServiceComponent>> hgToNonGwServiceComponentsWithYarnNMs = hgToNonGwServiceComponents.entrySet().stream()

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessorTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessorTest.java
@@ -531,6 +531,14 @@ public class CmTemplateProcessorTest {
     }
 
     @Test
+    public void testGetComputeHostGroups() {
+        Versioned blueprintVersion = () -> "7.2.11";
+
+        underTest = new CmTemplateProcessor(getBlueprintText("input/custom-hostgroups-for-nms.bp"));
+        assertEquals(2, underTest.getComputeHostGroups(blueprintVersion).size());
+    }
+
+    @Test
     public void testYARNServiceAttributes() {
         Versioned blueprintVersion = () -> "7.2.11";
 

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/processor/BlueprintTextProcessor.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/processor/BlueprintTextProcessor.java
@@ -71,6 +71,8 @@ public interface BlueprintTextProcessor {
      */
     Map<String, Map<String, ServiceAttributes>> getHostGroupBasedServiceAttributes(Versioned version);
 
+    Set<String> getComputeHostGroups(Versioned version);
+
     String getStackVersion();
 
     List<String> getHostTemplateNames();


### PR DESCRIPTION
… recommissioning during stop start scaling cluster start

1. Re-used the same method used in autoscaling enablement for figuring out compute nodes, instead of relying on the name compute.
2. In ClusterStartHandler it uses the hostname pattern (<cluster-name>-<group-name><num>) to identify if it is compute hostname or not.
3. Added unit tests to make sure both the status syncer and cluster start works according to the expectation.

See detailed description in the commit message.