### PR TITLE
CB-15847. Support freeipa diagnostics usage.

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/DiagnosticsFlowService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/DiagnosticsFlowService.java
@@ -119,6 +119,7 @@ public class DiagnosticsFlowService {
         setIfNotNull(eventBuilder::setAccountId, parameters.getAccountId());
         setIfNotNull(eventBuilder::setInputParameters, parameters.toMap().toString());
         setIfNotNull(eventBuilder::setResourceCrn, resourceCrn);
+        setIfNotNull(eventBuilder::setCaseNumber, parameters.getIssue());
         UsageProto.CDPVMDiagnosticsDestination.Value dest = convertUsageDestination(parameters.getDestination());
         setIfNotNull(eventBuilder::setDestination, dest);
         usageReporter.cdpVmDiagnosticsEvent(eventBuilder.build());

--- a/freeipa/build.gradle
+++ b/freeipa/build.gradle
@@ -127,6 +127,7 @@ dependencies {
   implementation project(':freeipa-api')
   implementation project(':freeipa-client')
   implementation project(':node-status-monitor-client')
+  implementation project(':usage-collection')
   implementation project(':common')
   implementation project(':core-api')
   implementation project(':databus-connector')

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/AbstractDiagnosticsCollectionActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/AbstractDiagnosticsCollectionActions.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.statemachine.StateContext;
 
+import com.cloudera.thunderhead.service.common.usage.UsageProto;
 import com.sequenceiq.cloudbreak.common.event.ResourceCrnPayload;
 import com.sequenceiq.cloudbreak.logger.MdcContext;
 import com.sequenceiq.common.model.diagnostics.DiagnosticParameters;
@@ -33,7 +34,8 @@ abstract class AbstractDiagnosticsCollectionActions<P extends ResourceCrnPayload
 
     @Override
     protected Object getFailurePayload(P payload, Optional<CommonContext> flowContext, Exception ex) {
-        return new DiagnosticsCollectionFailureEvent(payload.getResourceId(), ex, payload.getResourceCrn(), new DiagnosticParameters());
+        return new DiagnosticsCollectionFailureEvent(payload.getResourceId(), ex, payload.getResourceCrn(), new DiagnosticParameters(),
+                UsageProto.CDPVMDiagnosticsFailureType.Value.UNSET.name());
     }
 
     @Override

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/DiagnosticsCollectionActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/DiagnosticsCollectionActions.java
@@ -2,12 +2,15 @@ package com.sequenceiq.freeipa.flow.freeipa.diagnostics;
 
 import java.util.Map;
 
+import javax.inject.Inject;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.statemachine.action.Action;
 
+import com.cloudera.thunderhead.service.common.usage.UsageProto;
 import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
 import com.sequenceiq.cloudbreak.cloud.store.InMemoryStateStore;
 import com.sequenceiq.common.model.diagnostics.DiagnosticParameters;
@@ -21,6 +24,9 @@ import com.sequenceiq.freeipa.flow.freeipa.diagnostics.event.DiagnosticsCollecti
 public class DiagnosticsCollectionActions {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DiagnosticsCollectionActions.class);
+
+    @Inject
+    private DiagnosticsFlowService diagnosticsFlowService;
 
     @Bean(name = "DIAGNOSTICS_SALT_VALIDATION_STATE")
     public Action<?, ?> diagnosticsSaltValidateAction() {
@@ -199,6 +205,7 @@ public class DiagnosticsCollectionActions {
                         .withSelector(DiagnosticsCollectionStateSelectors.FINALIZE_DIAGNOSTICS_COLLECTION_EVENT.selector())
                         .withParameters(payload.getParameters())
                         .build();
+                diagnosticsFlowService.vmDiagnosticsReport(resourceCrn, payload.getParameters());
                 sendEvent(context, event);
             }
         };
@@ -222,6 +229,8 @@ public class DiagnosticsCollectionActions {
                         .withSelector(DiagnosticsCollectionStateSelectors.HANDLED_FAILED_DIAGNOSTICS_COLLECTION_EVENT.selector())
                         .withParameters(parameters)
                         .build();
+                diagnosticsFlowService.vmDiagnosticsReport(resourceCrn, payload.getParameters(),
+                        UsageProto.CDPVMDiagnosticsFailureType.Value.valueOf(payload.getFailureType()), payload.getException());
                 sendEvent(context, event);
             }
         };

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/DiagnosticsFlowService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/DiagnosticsFlowService.java
@@ -3,20 +3,26 @@ package com.sequenceiq.freeipa.flow.freeipa.diagnostics;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.cloudera.thunderhead.service.common.usage.UsageProto;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
 import com.sequenceiq.cloudbreak.orchestrator.host.TelemetryOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.orchestrator.model.Node;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryVersionConfiguration;
+import com.sequenceiq.cloudbreak.usage.UsageReporter;
+import com.sequenceiq.common.api.telemetry.model.DiagnosticsDestination;
+import com.sequenceiq.common.model.diagnostics.DiagnosticParameters;
 import com.sequenceiq.freeipa.entity.InstanceMetaData;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.orchestrator.StackBasedExitCriteriaModel;
@@ -29,6 +35,8 @@ import com.sequenceiq.freeipa.service.stack.instance.InstanceMetaDataService;
 public class DiagnosticsFlowService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DiagnosticsFlowService.class);
+
+    private static final Integer ERROR_MESSAGE_MAX_LENGTH = 1000;
 
     @Inject
     private StackService stackService;
@@ -47,6 +55,38 @@ public class DiagnosticsFlowService {
 
     @Inject
     private TelemetryVersionConfiguration telemetryVersionConfiguration;
+
+    @Inject
+    private UsageReporter usageReporter;
+
+    public void vmDiagnosticsReport(String resourceCrn, DiagnosticParameters parameters) {
+        vmDiagnosticsReport(resourceCrn, parameters, null, null);
+    }
+
+    public void vmDiagnosticsReport(String resourceCrn, DiagnosticParameters parameters, UsageProto.CDPVMDiagnosticsFailureType.Value failureType,
+            Exception exception) {
+        if (parameters == null) {
+            LOGGER.debug("Skip sending diagnostics report as diagnostic parameter input is empty.");
+            return;
+        }
+        UsageProto.CDPVMDiagnosticsEvent.Builder eventBuilder = UsageProto.CDPVMDiagnosticsEvent.newBuilder();
+        if (exception != null) {
+            eventBuilder.setFailureMessage(StringUtils.left(exception.getMessage(), ERROR_MESSAGE_MAX_LENGTH));
+            eventBuilder.setResult(UsageProto.CDPVMDiagnosticsResult.Value.FAILED);
+        } else {
+            eventBuilder.setResult(UsageProto.CDPVMDiagnosticsResult.Value.SUCCESSFUL);
+        }
+        setIfNotNull(eventBuilder::setFailureType, failureType);
+        setIfNotNull(eventBuilder::setUuid, parameters.getUuid());
+        setIfNotNull(eventBuilder::setDescription, parameters.getDescription());
+        setIfNotNull(eventBuilder::setAccountId, parameters.getAccountId());
+        setIfNotNull(eventBuilder::setInputParameters, parameters.toMap().toString());
+        setIfNotNull(eventBuilder::setCaseNumber, parameters.getIssue());
+        setIfNotNull(eventBuilder::setResourceCrn, resourceCrn);
+        UsageProto.CDPVMDiagnosticsDestination.Value dest = convertUsageDestination(parameters.getDestination());
+        setIfNotNull(eventBuilder::setDestination, dest);
+        usageReporter.cdpVmDiagnosticsEvent(eventBuilder.build());
+    }
 
     public Set<String> collectUnresponsiveNodes(Long stackId, Set<String> initialExcludeHosts)
             throws CloudbreakOrchestratorFailedException {
@@ -149,5 +189,26 @@ public class DiagnosticsFlowService {
         return CollectionUtils.isEmpty(initialExcludeHosts) || !(initialExcludeHosts.contains(node.getHostname())
                 || initialExcludeHosts.contains(node.getPublicIp())
                 || initialExcludeHosts.contains(node.getPrivateIp()));
+    }
+
+    private UsageProto.CDPVMDiagnosticsDestination.Value convertUsageDestination(DiagnosticsDestination destination) {
+        switch (destination) {
+            case LOCAL:
+                return UsageProto.CDPVMDiagnosticsDestination.Value.LOCAL;
+            case CLOUD_STORAGE:
+                return UsageProto.CDPVMDiagnosticsDestination.Value.CLOUD_STORAGE;
+            case SUPPORT:
+                return UsageProto.CDPVMDiagnosticsDestination.Value.SUPPORT;
+            case ENG:
+                return UsageProto.CDPVMDiagnosticsDestination.Value.ENGINEERING;
+            default:
+                return UsageProto.CDPVMDiagnosticsDestination.Value.UNSET;
+        }
+    }
+
+    private <T> void setIfNotNull(final Consumer<T> setter, final T value) {
+        if (value != null) {
+            setter.accept(value);
+        }
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/event/DiagnosticsCollectionFailureEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/event/DiagnosticsCollectionFailureEvent.java
@@ -9,9 +9,12 @@ public class DiagnosticsCollectionFailureEvent extends DiagnosticsCollectionEven
 
     private final Exception exception;
 
-    public DiagnosticsCollectionFailureEvent(Long resourceId, Exception exception, String resourceCrn, DiagnosticParameters parameters) {
+    private final String failureType;
+
+    public DiagnosticsCollectionFailureEvent(Long resourceId, Exception exception, String resourceCrn, DiagnosticParameters parameters, String failureType) {
         super(FAILED_DIAGNOSTICS_COLLECTION_EVENT.name(), resourceId, resourceCrn, parameters);
         this.exception = exception;
+        this.failureType = failureType;
     }
 
     @Override
@@ -21,6 +24,10 @@ public class DiagnosticsCollectionFailureEvent extends DiagnosticsCollectionEven
 
     public Exception getException() {
         return exception;
+    }
+
+    public String getFailureType() {
+        return failureType;
     }
 }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsCleanupHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsCleanupHandler.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.cloudera.thunderhead.service.common.usage.UsageProto;
 import com.sequenceiq.common.model.diagnostics.DiagnosticParameters;
 import com.sequenceiq.flow.reactor.api.event.EventSender;
 import com.sequenceiq.flow.reactor.api.handler.EventSenderAwareHandler;
@@ -55,7 +56,8 @@ public class DiagnosticsCleanupHandler extends EventSenderAwareHandler<Diagnosti
             eventSender().sendEvent(diagnosticsCollectionEvent, event.getHeaders());
         } catch (Exception e) {
             LOGGER.debug("Diagnostics cleanup failed. resourceCrn: '{}', parameters: '{}'.", resourceCrn, parameterMap, e);
-            DiagnosticsCollectionFailureEvent failureEvent = new DiagnosticsCollectionFailureEvent(resourceId, e, resourceCrn, parameters);
+            DiagnosticsCollectionFailureEvent failureEvent = new DiagnosticsCollectionFailureEvent(resourceId, e, resourceCrn, parameters,
+                    UsageProto.CDPVMDiagnosticsFailureType.Value.CLEANUP_FAILURE.name());
             eventBus.notify(failureEvent.selector(), new Event<>(event.getHeaders(), failureEvent));
         }
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsCollectionHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsCollectionHandler.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.cloudera.thunderhead.service.common.usage.UsageProto;
 import com.sequenceiq.common.model.diagnostics.DiagnosticParameters;
 import com.sequenceiq.flow.reactor.api.event.EventSender;
 import com.sequenceiq.flow.reactor.api.handler.EventSenderAwareHandler;
@@ -55,7 +56,8 @@ public class DiagnosticsCollectionHandler extends EventSenderAwareHandler<Diagno
             eventSender().sendEvent(diagnosticsCollectionEvent, event.getHeaders());
         } catch (Exception e) {
             LOGGER.debug("Diagnostics collection failed. resourceCrn: '{}', parameters: '{}'.", resourceCrn, parameterMap, e);
-            DiagnosticsCollectionFailureEvent failureEvent = new DiagnosticsCollectionFailureEvent(resourceId, e, resourceCrn, parameters);
+            DiagnosticsCollectionFailureEvent failureEvent = new DiagnosticsCollectionFailureEvent(resourceId, e, resourceCrn, parameters,
+                    UsageProto.CDPVMDiagnosticsFailureType.Value.COLLECTION_FAILURE.name());
             eventBus.notify(failureEvent.selector(), new Event<>(event.getHeaders(), failureEvent));
         }
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsEnsureMachineUserHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsEnsureMachineUserHandler.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.cloudera.thunderhead.service.common.usage.UsageProto;
 import com.sequenceiq.common.api.telemetry.model.DataBusCredential;
 import com.sequenceiq.common.api.telemetry.model.DiagnosticsDestination;
 import com.sequenceiq.common.model.diagnostics.DiagnosticParameters;
@@ -63,7 +64,8 @@ public class DiagnosticsEnsureMachineUserHandler extends EventSenderAwareHandler
             eventSender().sendEvent(diagnosticsCollectionEvent, event.getHeaders());
         } catch (Exception e) {
             LOGGER.debug("Diagnostics collection ensure machine user operation failed. resourceCrn: '{}', parameters: '{}'.", resourceCrn, parameterMap, e);
-            DiagnosticsCollectionFailureEvent failureEvent = new DiagnosticsCollectionFailureEvent(resourceId, e, resourceCrn, parameters);
+            DiagnosticsCollectionFailureEvent failureEvent = new DiagnosticsCollectionFailureEvent(resourceId, e, resourceCrn, parameters,
+                    UsageProto.CDPVMDiagnosticsFailureType.Value.UMS_RESOURCE_CHECK_FAILURE.name());
             eventBus.notify(failureEvent.selector(), new Event<>(event.getHeaders(), failureEvent));
         }
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsInitHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsInitHandler.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.cloudera.thunderhead.service.common.usage.UsageProto;
 import com.sequenceiq.common.model.diagnostics.DiagnosticParameters;
 import com.sequenceiq.flow.core.FlowConstants;
 import com.sequenceiq.flow.reactor.api.event.EventSender;
@@ -58,7 +59,8 @@ public class DiagnosticsInitHandler extends EventSenderAwareHandler<DiagnosticsC
             eventSender().sendEvent(diagnosticsCollectionEvent, event.getHeaders());
         } catch (Exception e) {
             LOGGER.debug("Diagnostics collection initialization failed. resourceCrn: '{}', parameters: '{}'.", resourceCrn, parameterMap, e);
-            DiagnosticsCollectionFailureEvent failureEvent = new DiagnosticsCollectionFailureEvent(resourceId, e, resourceCrn, parameters);
+            DiagnosticsCollectionFailureEvent failureEvent = new DiagnosticsCollectionFailureEvent(resourceId, e, resourceCrn, parameters,
+                    UsageProto.CDPVMDiagnosticsFailureType.Value.INITIALIZATION_FAILURE.name());
             eventBus.notify(failureEvent.selector(), new Event<>(event.getHeaders(), failureEvent));
         }
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsSaltValidationHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsSaltValidationHandler.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.cloudera.thunderhead.service.common.usage.UsageProto;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
 import com.sequenceiq.common.model.diagnostics.DiagnosticParameters;
 import com.sequenceiq.flow.reactor.api.event.EventSender;
@@ -72,7 +73,8 @@ public class DiagnosticsSaltValidationHandler extends EventSenderAwareHandler<Di
             eventSender().sendEvent(diagnosticsCollectionEvent, event.getHeaders());
         } catch (Exception e) {
             LOGGER.debug("Diagnostics salt validation failed. resourceCrn: '{}', parameters: '{}'.", resourceCrn, parameterMap, e);
-            DiagnosticsCollectionFailureEvent failureEvent = new DiagnosticsCollectionFailureEvent(resourceId, e, resourceCrn, parameters);
+            DiagnosticsCollectionFailureEvent failureEvent = new DiagnosticsCollectionFailureEvent(resourceId, e, resourceCrn, parameters,
+                    UsageProto.CDPVMDiagnosticsFailureType.Value.SALT_VALIDATION_FAILURE.name());
             eventBus.notify(failureEvent.selector(), new Event<>(event.getHeaders(), failureEvent));
         }
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsUpgradeTelemetryHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsUpgradeTelemetryHandler.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.cloudera.thunderhead.service.common.usage.UsageProto;
 import com.sequenceiq.common.model.diagnostics.DiagnosticParameters;
 import com.sequenceiq.flow.reactor.api.event.EventSender;
 import com.sequenceiq.flow.reactor.api.handler.EventSenderAwareHandler;
@@ -55,7 +56,8 @@ public class DiagnosticsUpgradeTelemetryHandler extends EventSenderAwareHandler<
             eventSender().sendEvent(diagnosticsCollectionEvent, event.getHeaders());
         } catch (Exception e) {
             LOGGER.debug("Diagnostics cdp-telemetry upgrade failed. resourceCrn: '{}', parameters: '{}'.", resourceCrn, parameterMap, e);
-            DiagnosticsCollectionFailureEvent failureEvent = new DiagnosticsCollectionFailureEvent(resourceId, e, resourceCrn, parameters);
+            DiagnosticsCollectionFailureEvent failureEvent = new DiagnosticsCollectionFailureEvent(resourceId, e, resourceCrn, parameters,
+                    UsageProto.CDPVMDiagnosticsFailureType.Value.UNSET.name());
             eventBus.notify(failureEvent.selector(), new Event<>(event.getHeaders(), failureEvent));
         }
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsUploadHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsUploadHandler.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.cloudera.thunderhead.service.common.usage.UsageProto;
 import com.sequenceiq.common.model.diagnostics.DiagnosticParameters;
 import com.sequenceiq.flow.reactor.api.event.EventSender;
 import com.sequenceiq.flow.reactor.api.handler.EventSenderAwareHandler;
@@ -55,7 +56,8 @@ public class DiagnosticsUploadHandler extends EventSenderAwareHandler<Diagnostic
             eventSender().sendEvent(diagnosticsCollectionEvent, event.getHeaders());
         } catch (Exception e) {
             LOGGER.debug("Diagnostics upload failed. resourceCrn: '{}', parameters: '{}'.", resourceCrn, parameterMap, e);
-            DiagnosticsCollectionFailureEvent failureEvent = new DiagnosticsCollectionFailureEvent(resourceId, e, resourceCrn, parameters);
+            DiagnosticsCollectionFailureEvent failureEvent = new DiagnosticsCollectionFailureEvent(resourceId, e, resourceCrn, parameters,
+                    UsageProto.CDPVMDiagnosticsFailureType.Value.UPLOAD_FAILURE.name());
             eventBus.notify(failureEvent.selector(), new Event<>(event.getHeaders(), failureEvent));
         }
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsVmPreFlightCheckHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsVmPreFlightCheckHandler.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.cloudera.thunderhead.service.common.usage.UsageProto;
 import com.sequenceiq.common.api.telemetry.model.DiagnosticsDestination;
 import com.sequenceiq.common.model.diagnostics.DiagnosticParameters;
 import com.sequenceiq.flow.reactor.api.event.EventSender;
@@ -58,7 +59,8 @@ public class DiagnosticsVmPreFlightCheckHandler extends EventSenderAwareHandler<
             eventSender().sendEvent(diagnosticsCollectionEvent, event.getHeaders());
         } catch (Exception e) {
             LOGGER.debug("Diagnostics collection VM PreFlight check failed. resourceCrn: '{}', parameters: '{}'.", resourceCrn, parameterMap, e);
-            DiagnosticsCollectionFailureEvent failureEvent = new DiagnosticsCollectionFailureEvent(resourceId, e, resourceCrn, parameters);
+            DiagnosticsCollectionFailureEvent failureEvent = new DiagnosticsCollectionFailureEvent(resourceId, e, resourceCrn, parameters,
+                    UsageProto.CDPVMDiagnosticsFailureType.Value.PREFLIGHT_VM_CHECK_FAILURE.name());
             eventBus.notify(failureEvent.selector(), new Event<>(event.getHeaders(), failureEvent));
         }
     }

--- a/usage-collection/src/main/proto/usage.proto
+++ b/usage-collection/src/main/proto/usage.proto
@@ -2425,6 +2425,8 @@ message CDPVMDiagnosticsEvent {
   string failureMessage = 8;
   // Input parameters of the diagnostics collections in string format.
   string inputParameters = 9;
+  // Identifier for the diagnostics bundle that can be a case number (for SUPPORT destination) or anything else like a Jira issue.
+  string caseNumber = 10;
 }
 
 // Destination of CDP VM diagnostics.


### PR DESCRIPTION
details:
- add usagecollection module to freeipa
- add usages around diagnostics steps (where it cannot be added - use UNSET types)
- update usage proto with case number (to be up to date, see: CB-15839)

See detailed description in the commit message.