### PR TITLE
CB-15829 - Freeipa scaling: failed flow not detected as penultimate s…

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/action/FreeIpaDownscaleActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/action/FreeIpaDownscaleActions.java
@@ -444,7 +444,7 @@ public class FreeIpaDownscaleActions {
                 if (payload.getFailureDetails() != null) {
                     failureDetails.getAdditionalDetails().putAll(payload.getFailureDetails());
                 }
-                String errorReason = payload.getException() == null ? "Unknown error" : payload.getException().getMessage();
+                String errorReason = getErrorReason(payload.getException());
                 stackUpdater.updateStackStatus(context.getStack().getId(), getFailedStatus(variables), errorReason);
                 operationService.failOperation(stack.getAccountId(), getOperationId(variables), message, List.of(successDetails), List.of(failureDetails));
                 enableStatusChecker(stack, "Failed downscaling FreeIPA");

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/provision/action/FreeIpaProvisionActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/provision/action/FreeIpaProvisionActions.java
@@ -198,7 +198,7 @@ public class FreeIpaProvisionActions {
 
             @Override
             protected void doExecute(StackFailureContext context, StackFailureEvent payload, Map<Object, Object> variables) {
-                String errorReason = payload.getException() == null ? "Unknown error" : payload.getException().getMessage();
+                String errorReason = getErrorReason(payload.getException());
                 stackUpdater.updateStackStatus(context.getStack().getId(), DetailedStackStatus.PROVISION_FAILED, errorReason);
                 metricService.incrementMetricCounter(MetricType.FREEIPA_CREATION_FAILED, context.getStack(), payload.getException());
                 sendEvent(context);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/repair/changeprimarygw/action/ChangePrimaryGatewayActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/repair/changeprimarygw/action/ChangePrimaryGatewayActions.java
@@ -214,7 +214,7 @@ public class ChangePrimaryGatewayActions {
                 if (payload.getFailureDetails() != null) {
                     failureDetails.getAdditionalDetails().putAll(payload.getFailureDetails());
                 }
-                String errorReason = payload.getException() == null ? "Unknown error" : payload.getException().getMessage();
+                String errorReason = getErrorReason(payload.getException());
                 stackUpdater.updateStackStatus(context.getStack().getId(), DetailedStackStatus.REPAIR_FAILED, errorReason);
                 operationService.failOperation(stack.getAccountId(), getOperationId(variables), message, List.of(successDetails), List.of(failureDetails));
                 LOGGER.info("Enabling the status checker for stack ID {} after failing repairing", stack.getId());

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/action/FreeIpaUpscaleActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/action/FreeIpaUpscaleActions.java
@@ -616,7 +616,7 @@ public class FreeIpaUpscaleActions {
                 if (payload.getFailureDetails() != null) {
                     failureDetails.getAdditionalDetails().putAll(payload.getFailureDetails());
                 }
-                String errorReason = payload.getException() == null ? "Unknown error" : payload.getException().getMessage();
+                String errorReason = getErrorReason(payload.getException());
                 stackUpdater.updateStackStatus(context.getStack().getId(), getFailedStatus(variables), errorReason);
                 operationService.failOperation(stack.getAccountId(), getOperationId(variables), message, List.of(successDetails), List.of(failureDetails));
                 enableStatusChecker(stack, "Failed upscaling FreeIPA");

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/AbstractStackAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/AbstractStackAction.java
@@ -19,4 +19,8 @@ public abstract class AbstractStackAction<S extends FlowState, E extends FlowEve
     public void init() {
         super.init();
     }
+
+    protected String getErrorReason(Exception payloadException) {
+        return (payloadException == null || payloadException.getMessage() == null) ? "Unknown error" : payloadException.getMessage();
+    }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/ServiceStatusRawMessageTransformer.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/ServiceStatusRawMessageTransformer.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.freeipa.service.stack;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.common.api.type.Tunnel;
@@ -10,7 +11,9 @@ public class ServiceStatusRawMessageTransformer {
     public String transformMessage(String rawNewStatusReason, Tunnel tunnel) {
         // TODO Needs to be deprecated after cluster proxy team introduce the new cluster-proxy.ccmv2.endpoint-unavailable status
         if (!tunnel.useCcmV1()) {
-            return rawNewStatusReason.replaceAll(".ccm.", ".ccmv2.");
+            return StringUtils.isNotEmpty(rawNewStatusReason)
+                    ? rawNewStatusReason.replaceAll(".ccm.", ".ccmv2.")
+                    : rawNewStatusReason;
         }
         return rawNewStatusReason;
     }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/ServiceStatusRawMessageTransformerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/ServiceStatusRawMessageTransformerTest.java
@@ -1,6 +1,6 @@
 package com.sequenceiq.freeipa.service.stack;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -17,12 +17,18 @@ public class ServiceStatusRawMessageTransformerTest {
     @Test
     public void testMessageTransformWhenCcmV2() {
         String message = underTest.transformMessage("cluster-proxy.ccm.endpoint-unavailable", Tunnel.CCMV2);
-        Assert.assertEquals("cluster-proxy.ccmv2.endpoint-unavailable", message);
+        Assertions.assertEquals("cluster-proxy.ccmv2.endpoint-unavailable", message);
+    }
+
+    @Test
+    public void testNullMessageTransformWhenCcmV2() {
+        String message = underTest.transformMessage(null, Tunnel.CCMV2);
+        Assertions.assertEquals(null, message);
     }
 
     @Test
     public void testMessageTransformWhenCcmV1() {
         String message = underTest.transformMessage("cluster-proxy.ccm.endpoint-unavailable", Tunnel.CCM);
-        Assert.assertEquals("cluster-proxy.ccm.endpoint-unavailable", message);
+        Assertions.assertEquals("cluster-proxy.ccm.endpoint-unavailable", message);
     }
 }


### PR DESCRIPTION
…tep is not the fail handled step

This commit
  - fixes the NPE in `ServiceStatusRawMessageTransformer`
  - handles the case when the exception's message is null -> error is set to "Unknown"

