### PR TITLE
CB-15680. Make cdp-usersync-internal group non-posix

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaGroupType.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaGroupType.java
@@ -1,0 +1,6 @@
+package com.sequenceiq.freeipa.client;
+
+public enum FreeIpaGroupType {
+    POSIX,
+    NONPOSIX
+}

--- a/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/operation/GroupAddOperationTest.java
+++ b/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/operation/GroupAddOperationTest.java
@@ -1,7 +1,10 @@
 package com.sequenceiq.freeipa.client.operation;
 
+import static com.sequenceiq.freeipa.client.FreeIpaGroupType.NONPOSIX;
+import static com.sequenceiq.freeipa.client.FreeIpaGroupType.POSIX;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -13,6 +16,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -35,7 +39,7 @@ public class GroupAddOperationTest {
     public void testInvokeWhenGroupProtected() {
         Map warnings = Maps.newHashMap();
         assertThrows(FreeIpaClientException.class, () ->
-                GroupAddOperation.create("admins", warnings::put).invoke(freeIpaClient));
+                GroupAddOperation.create("admins", POSIX, warnings::put).invoke(freeIpaClient));
         verifyNoInteractions(freeIpaClient);
     }
 
@@ -47,7 +51,7 @@ public class GroupAddOperationTest {
 
         when(freeIpaClient.invoke(any(), anyList(), any(), any())).thenReturn(rpcResponse);
 
-        GroupAddOperation.create(GROUP_NAME, warnings::put).invoke(freeIpaClient);
+        GroupAddOperation.create(GROUP_NAME, POSIX, warnings::put).invoke(freeIpaClient);
 
         verify(freeIpaClient).invoke(eq("group_add"), anyList(), any(), any());
     }
@@ -59,7 +63,7 @@ public class GroupAddOperationTest {
         when(freeIpaClient.invoke(any(), anyList(), any(), any())).thenThrow(
                 new FreeIpaClientException("error", new JsonRpcClientException(4002, "", null)));
 
-        GroupAddOperation.create(GROUP_NAME, warnings::put).invoke(freeIpaClient);
+        GroupAddOperation.create(GROUP_NAME, POSIX, warnings::put).invoke(freeIpaClient);
 
         verify(freeIpaClient).invoke(eq("group_add"), anyList(), any(), any());
         assertEquals(0, warnings.size());
@@ -72,10 +76,42 @@ public class GroupAddOperationTest {
         when(freeIpaClient.invoke(any(), anyList(), any(), any())).thenThrow(
                 new FreeIpaClientException("error", new JsonRpcClientException(5000, "", null)));
 
-        GroupAddOperation.create(GROUP_NAME, warnings::put).invoke(freeIpaClient);
+        GroupAddOperation.create(GROUP_NAME, POSIX, warnings::put).invoke(freeIpaClient);
 
         verify(freeIpaClient).invoke(eq("group_add"), anyList(), any(), any());
         assertEquals(1, warnings.size());
     }
 
+    @Test
+    public void testInvokePosix() throws FreeIpaClientException {
+        Map warnings = Maps.newHashMap();
+        RPCResponse<Object> rpcResponse = new RPCResponse<>();
+        rpcResponse.setResult(new Group());
+
+        when(freeIpaClient.invoke(any(), anyList(), any(), any())).thenReturn(rpcResponse);
+
+        GroupAddOperation.create(GROUP_NAME, POSIX, warnings::put).invoke(freeIpaClient);
+
+        ArgumentCaptor<Map<String, Object>> paramCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(freeIpaClient).invoke(eq("group_add"), anyList(), paramCaptor.capture(), any());
+        Map<String, Object> params = paramCaptor.getValue();
+        assertTrue(!params.containsKey("nonposix"));
+    }
+
+    @Test
+    public void testInvokeNonPosix() throws FreeIpaClientException {
+        Map warnings = Maps.newHashMap();
+        RPCResponse<Object> rpcResponse = new RPCResponse<>();
+        rpcResponse.setResult(new Group());
+
+        when(freeIpaClient.invoke(any(), anyList(), any(), any())).thenReturn(rpcResponse);
+
+        GroupAddOperation.create(GROUP_NAME, NONPOSIX, warnings::put).invoke(freeIpaClient);
+
+        ArgumentCaptor<Map<String, Object>> paramCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(freeIpaClient).invoke(eq("group_add"), anyList(), paramCaptor.capture(), any());
+        Map<String, Object> params = paramCaptor.getValue();
+        assertTrue(params.containsKey("nonposix"));
+        assertTrue((Boolean) params.get("nonposix"));
+    }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncConstants.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncConstants.java
@@ -1,15 +1,19 @@
 package com.sequenceiq.freeipa.service.freeipa.user;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
 
 import java.util.List;
+import java.util.Set;
 
 public final class UserSyncConstants {
 
     public static final String ADMINS_GROUP = "admins";
 
     public static final String CDP_USERSYNC_INTERNAL_GROUP = "cdp-usersync-internal";
+
+    public static final Set<String> NON_POSIX_GROUPS = ImmutableSet.of(CDP_USERSYNC_INTERNAL_GROUP);
 
     public static final String ACCESS_ENVIRONMENT =
             AuthorizationResourceAction.ACCESS_ENVIRONMENT.getRight();

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncService.java
@@ -18,6 +18,7 @@ import java.util.stream.Stream;
 
 import javax.inject.Inject;
 
+import com.sequenceiq.freeipa.client.FreeIpaGroupType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -550,12 +551,24 @@ public class UserSyncService {
 
     void addGroups(boolean fmsToFreeipaBatchCallEnabled, FreeIpaClient freeIpaClient, Set<FmsGroup> fmsGroups,
             BiConsumer<String, String> warnings) throws FreeIpaClientException {
-        List<GroupAddOperation> operations = Lists.newArrayList();
+        List<GroupAddOperation> posixOperations = Lists.newArrayList();
+        List<GroupAddOperation> nonPosixOperations = Lists.newArrayList();
         for (FmsGroup fmsGroup : fmsGroups) {
-            operations.add(GroupAddOperation.create(fmsGroup.getName(), warnings));
+            String groupName = fmsGroup.getName();
+            if (isNonPosixGroup(groupName)) {
+                nonPosixOperations.add(GroupAddOperation.create(groupName, FreeIpaGroupType.NONPOSIX, warnings));
+            } else {
+                posixOperations.add(GroupAddOperation.create(groupName, FreeIpaGroupType.POSIX, warnings));
+            }
         }
-        invokeOperation(operations, fmsToFreeipaBatchCallEnabled, freeIpaClient, warnings,
+        invokeOperation(posixOperations, fmsToFreeipaBatchCallEnabled, freeIpaClient, warnings,
                 Set.of(FreeIpaErrorCodes.DUPLICATE_ENTRY), false);
+        invokeOperation(nonPosixOperations, fmsToFreeipaBatchCallEnabled, freeIpaClient, warnings,
+                Set.of(FreeIpaErrorCodes.DUPLICATE_ENTRY), false);
+    }
+
+    private boolean isNonPosixGroup(String groupName) {
+        return UserSyncConstants.NON_POSIX_GROUPS.contains(groupName);
     }
 
     void addUsers(boolean fmsToFreeipaBatchCallEnabled, FreeIpaClient freeIpaClient, Set<FmsUser> fmsUsers,

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncServiceTest.java
@@ -220,7 +220,8 @@ class UserSyncServiceTest {
 
         underTest.applyStateDifferenceToIpa(ENV_CRN, freeIpaClient, usersStateDifference, warnings::put, true);
 
-        verify(freeIpaClient, times(8)).callBatch(any(), any(), any(), any());
+        // 9 times instead of 8 because non-posix groups are added in a separate batch
+        verify(freeIpaClient, times(9)).callBatch(any(), any(), any(), any());
 
         verifyNoMoreInteractions(freeIpaClient);
     }


### PR DESCRIPTION
It is significantly faster to add group members to non-posix
groups than to posix groups. The cdp-usersync-internal group
is only used by usersync and does not need to be a posix group.
This commit changes usersync to create cdp-usersync-internal
as non-posix. This will only affect new environments and not
existing cdp-usersync-internal groups.
