### PR TITLE
CB-15450. Patch FreeIPA commands to be more performant

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/operation/UserDisableOperation.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/operation/UserDisableOperation.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public class UserDisableOperation extends AbstractFreeipaOperation<Object> {
@@ -31,6 +32,11 @@ public class UserDisableOperation extends AbstractFreeipaOperation<Object> {
     @Override
     protected List<Object> getFlags() {
         return List.of(userUid);
+    }
+
+    @Override
+    protected Map<String, Object> getParams() {
+        return Map.of("skipcheck", "TRUE");
     }
 
     @Override

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/operation/UserRemoveOperation.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/operation/UserRemoveOperation.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.freeipa.client.operation;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.slf4j.Logger;
@@ -33,6 +34,11 @@ public class UserRemoveOperation extends AbstractFreeipaOperation<User> {
     @Override
     protected List<Object> getFlags() {
         return List.of(userUid);
+    }
+
+    @Override
+    protected Map<String, Object> getParams() {
+        return Map.of("skipcheck", "TRUE");
     }
 
     @Override

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/common-install.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/common-install.sls
@@ -37,6 +37,18 @@ add-httpd-x-cdp-trace-id:
     - source: salt://freeipa/scripts/getkeytab.py
     - onlyif: test -f /etc/ipa/default.conf
 
+/usr/lib/python2.7/site-packages/ipaserver/plugins/stageuser.py:
+  file.patch:
+    - source: salt://freeipa/scripts/stageuser.py.patch
+    - hash: md5=c34ee2a14a0480f07faef36507626bc6
+    - onlyif: test -f /etc/ipa/default.conf
+
+/usr/lib/python2.7/site-packages/ipaserver/plugins/user.py:
+  file.patch:
+    - source: salt://freeipa/scripts/user.py.patch
+    - hash: md5=ffa5662ae89286f27f5dc138a3c5316e
+    - onlyif: test -f /etc/ipa/default.conf
+
 restart_freeipa_after_plugin_change:
   service.running:
     - name: ipa
@@ -45,6 +57,8 @@ restart_freeipa_after_plugin_change:
     - watch:
       - file: /usr/lib/python2.7/site-packages/ipaserver/plugins/getkeytab.py
       - file: /usr/lib/python2.7/site-packages/ipaserver/rpcserver.py
+      - file: /usr/lib/python2.7/site-packages/ipaserver/plugins/stageuser.py
+      - file: /usr/lib/python2.7/site-packages/ipaserver/plugins/user.py
 
 set_number_of_krb5kdc_workers:
   file.replace:

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/stageuser.py.patch
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/stageuser.py.patch
@@ -1,0 +1,34 @@
+--- stageuser.py.orig	2022-01-31 13:33:25.989475331 -0600
++++ stageuser.py	2022-02-01 17:12:51.007022077 -0600
+@@ -727,26 +727,12 @@
+                              "active %s", active_dn)
+             raise
+ 
+-        # add the user we just created into the default primary group
+-        config = ldap.get_ipa_config()
+-        def_primary_group = config.get('ipadefaultprimarygroup')
+-        group_dn = self.api.Object['group'].get_dn(def_primary_group)
++        # Return an empty entity to avoid the performance penalty of retrieving
++        # the activated user
++        result = {}
++        result['result'] = {}
++        result['value'] = args[-1]
+ 
+-        # if the user is already a member of default primary group,
+-        # do not raise error
+-        # this can happen if automember rule or default group is set
+-        try:
+-            ldap.add_entry_to_group(active_dn, group_dn)
+-        except errors.AlreadyGroupMember:
+-            pass
+-
+-        # Now retrieve the activated entry
+-        result = self.api.Command.user_show(
+-            args[-1],
+-            all=options.get('all', False),
+-            raw=options.get('raw', False),
+-            version=options.get('version'),
+-        )
+         result['summary'] = unicode(
+             _('Stage user %s activated' % staging_dn[0].value))
+ 

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/user.py.patch
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/user.py.patch
@@ -1,0 +1,62 @@
+--- user.py.orig	2022-01-31 13:33:26.231995098 -0600
++++ user.py	2022-02-01 17:14:20.753236423 -0600
+@@ -589,18 +589,6 @@
+ 
+     def post_callback(self, ldap, dn, entry_attrs, *keys, **options):
+         assert isinstance(dn, DN)
+-        config = ldap.get_ipa_config()
+-        # add the user we just created into the default primary group
+-        def_primary_group = config.get('ipadefaultprimarygroup')
+-        group_dn = self.api.Object['group'].get_dn(def_primary_group)
+-
+-        # if the user is already a member of default primary group,
+-        # do not raise error
+-        # this can happen if automember rule or default group is set
+-        try:
+-            ldap.add_entry_to_group(dn, group_dn)
+-        except errors.AlreadyGroupMember:
+-            pass
+ 
+         # Fetch the entry again to update memberof, mep data, etc updated
+         # at the end of the transaction.
+@@ -639,6 +627,10 @@
+         Bool('preserve?',
+             exclude='cli',
+         ),
++        Flag('skipcheck',
++             cli_name='skipcheck',
++             doc=_('Skip check if user is last admin'),
++             ),
+     )
+ 
+     def _preserve_user(self, pkey, delete_container, **options):
+@@ -707,7 +699,8 @@
+         # delete user (delete container).
+         # If the target entry is a Delete entry, skip the orphaning/removal
+         # of OTP tokens.
+-        check_protected_member(keys[-1])
++        if options.get('skipcheck') is None:
++            check_protected_member(keys[-1])
+ 
+         if not options.get('preserve', False):
+             # Remove any ID overrides tied with this user
+@@ -1013,11 +1006,18 @@
+ 
+     has_output = output.standard_value
+     msg_summary = _('Disabled user account "%(value)s"')
++    takes_options = (
++        Flag('skipcheck',
++             cli_name='skipcheck',
++             doc=_('Skip check if user is last admin'),
++             ),
++    )
+ 
+     def execute(self, *keys, **options):
+         ldap = self.obj.backend
+ 
+-        check_protected_member(keys[-1])
++        if options.get('skipcheck') is None:
++            check_protected_member(keys[-1])
+ 
+         dn = self.obj.get_either_dn(*keys, **options)
+         ldap.deactivate_entry(dn)


### PR DESCRIPTION
This commit patches user and stageuser commands to skip some
behaviors that take a long time but are not needed for our use
case.

stageuser_activate has been modified to:
  - not add user to default group (ipausers)
  - not run a query to populate the return value

user_disable and user_del have been modified to:
  - not check whether the user being disabled/deleted is the
    last enabled member of a protected group (i.e., admins).
    This check was performed regardless of whether the user
    is a member of the admins group or not. Usersync has
    protections to not modify the admin user, so this check
    is extraneous. A flag was added to this check so that the
    default behavior is maintained for callers outside of
    usersync.

user_add has been modified to:
  - not add user to the default group (ipausers)
