### PR TITLE
CB-15788: Database backup/restore has only 10 minute timeout.

### DIFF
--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
@@ -143,7 +143,7 @@ public class SaltOrchestrator implements HostOrchestrator {
     @Value("${cb.max.salt.recipe.execution.retry.forced:2}")
     private int maxRetryRecipeForced;
 
-    @Value("${cb.max.salt.database.dr.retry:60}")
+    @Value("${cb.max.salt.database.dr.retry:300}")
     private int maxDatabaseDrRetry;
 
     @Value("${cb.max.salt.database.dr.retry.onerror:5}")


### PR DESCRIPTION
Bumping it up the try count from 60 to 300 so that the total retry interval is going to be 50 min.
