### PR TITLE
CB-15119: Handle null ApiRoleState when trying to retrieve CM status

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusService.java
@@ -393,7 +393,7 @@ public class ClouderaManagerClusterStatusService implements ClusterStatusService
         return services.stream()
                 .flatMap(service -> readRoles(api, stack, service))
                 .filter(role -> !IGNORED_ROLE_STATES.contains(role.getRoleState()))
-                .collect(groupingBy(role -> toClusterStatus(role.getRoleState()),
+                .collect(groupingBy(role -> toClusterStatus(Optional.ofNullable(role.getRoleState()).orElse(ApiRoleState.UNKNOWN)),
                         mapping(ApiRole::getName, toList())));
     }
 

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusServiceTest.java
@@ -164,6 +164,25 @@ public class ClouderaManagerClusterStatusServiceTest {
     }
 
     @Test
+    public void reportsClusterUnknownWhenARoleStateIsNull() throws ApiException {
+        cmIsReachable();
+        servicesAre(
+                new ApiService().name("service1").serviceState(ApiServiceState.STARTED),
+                new ApiService().name("service2").serviceState(ApiServiceState.STARTED)
+        );
+        rolesAre("service1",
+                new ApiRole().name("role 1.1").roleState(ApiRoleState.STARTED),
+                new ApiRole().name("role 1.2").roleState(ApiRoleState.STARTED)
+        );
+        rolesAre("service2",
+                new ApiRole().name("role 2.1").roleState(null),
+                new ApiRole().name("role 2.2").roleState(ApiRoleState.STARTED)
+        );
+
+        assertEquals(ClusterStatus.UNKNOWN, subject.getStatus(true).getClusterStatus());
+    }
+
+    @Test
     public void ignoresServicesNA() throws ApiException {
         cmIsReachable();
         servicesAre(


### PR DESCRIPTION
There were some cases when the CM readRoles API call returned roled with null ApiRoleState and this caused a NullPointerException when we tried to convert the value of the ApiRoleState to an internal status.
This case has covered with an improvement to convert the null value into an ApiRoleState.UNKNOWN status.