### PR TITLE
Revert "CB-13414: Add e2e tests for re-sizing of the datalake with fixes."

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxResizeTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxResizeTestDto.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.it.cloudbreak.dto.sdx;
 
-import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.AbstractSdxTestDto;
@@ -26,13 +25,8 @@ public class SdxResizeTestDto extends AbstractSdxTestDto<SdxClusterResizeRequest
 
     @Override
     public SdxResizeTestDto valid() {
-        if (CloudPlatform.MOCK.equals(getCloudPlatform())) {
-            return withEnvironmentName(getTestContext().get(EnvironmentTestDto.class).getResponse().getName())
-                    .withClusterShape(getCloudProvider().getClusterShape());
-        } else {
-            return withEnvironmentName(getTestContext().get(EnvironmentTestDto.class).getResponse().getName())
-                    .withClusterShape(SdxClusterShape.MEDIUM_DUTY_HA);
-        }
+        return withEnvironmentName(getTestContext().get(EnvironmentTestDto.class).getResponse().getName())
+                .withClusterShape(getCloudProvider().getClusterShape());
     }
 
     public SdxResizeTestDto withEnvironmentName(String environment) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxResizeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxResizeTests.java
@@ -21,8 +21,6 @@ import com.sequenceiq.it.cloudbreak.util.SdxUtil;
 import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
 import com.sequenceiq.sdx.api.model.SdxClusterShape;
 import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
-import com.sequenceiq.sdx.api.model.SdxDatabaseAvailabilityType;
-import com.sequenceiq.sdx.api.model.SdxDatabaseRequest;
 
 public class SdxResizeTests extends PreconditionSdxE2ETest {
 
@@ -43,20 +41,16 @@ public class SdxResizeTests extends PreconditionSdxE2ETest {
     )
     public void testSDXResize(TestContext testContext) {
         String sdx = resourcePropertyProvider().getName();
+        AtomicReference<String> expectedShape = new AtomicReference<>();
         AtomicReference<String> expectedCrn = new AtomicReference<>();
         AtomicReference<String> expectedName = new AtomicReference<>();
-        SdxDatabaseRequest sdxDatabaseRequest = new SdxDatabaseRequest();
-        sdxDatabaseRequest.setAvailabilityType(SdxDatabaseAvailabilityType.NONE);
-
         testContext
                 .given(sdx, SdxInternalTestDto.class)
-                .withDatabase(sdxDatabaseRequest)
-                .withCloudStorage(getCloudStorageRequest(testContext))
-                .withClusterShape(SdxClusterShape.CUSTOM)
                 .when(sdxTestClient.createInternal(), key(sdx))
                 .await(SdxClusterStatusResponse.RUNNING, key(sdx))
                 .awaitForHealthyInstances()
                 .then((tc, testDto, client) -> {
+                    expectedShape.set(sdxUtil.getShape(testDto, client));
                     expectedCrn.set(sdxUtil.getCrn(testDto, client));
                     expectedName.set(sdx);
                     return testDto;
@@ -68,7 +62,7 @@ public class SdxResizeTests extends PreconditionSdxE2ETest {
                 .awaitForHealthyInstances()
                 .then((tc, dto, client) -> validateStackCrn(expectedCrn, dto))
                 .then((tc, dto, client) -> validateCrn(expectedCrn, dto))
-                .then((tc, dto, client) -> validateShape(dto))
+                .then((tc, dto, client) -> validateShape(expectedShape, dto))
                 .then((tc, dto, client) -> validateClusterName(expectedName, dto))
                 .validate();
     }
@@ -91,7 +85,7 @@ public class SdxResizeTests extends PreconditionSdxE2ETest {
         return dto;
     }
 
-    private SdxInternalTestDto validateShape(SdxInternalTestDto dto) {
+    private SdxInternalTestDto validateShape(AtomicReference<String> originalCrn, SdxInternalTestDto dto) {
         SdxClusterShape newShape = dto.getResponse().getClusterShape();
         Log.log(LOGGER, format(" New shape: %s ", newShape.name()));
         if (!SdxClusterShape.MEDIUM_DUTY_HA.equals(newShape)) {

--- a/integration-test/src/main/resources/testsuites/e2e/aws-longrunning-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/aws-longrunning-e2e-tests.yaml
@@ -10,4 +10,3 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.ephemeral.DistroXRepairTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.ephemeral.DistroXUpgradeTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRepairTests
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxResizeTests

--- a/integration-test/src/main/resources/testsuites/e2e/sdx-resize-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/sdx-resize-tests.yaml
@@ -1,5 +1,0 @@
-name: "sdx-recovery-tests"
-tests:
-  - name: "sdx_e2e_recovery_tests"
-    classes:
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxResizeTests


### PR DESCRIPTION
Reverts hortonworks/cloudbreak#12166