### PR TITLE
CB-15142 Fix cluster max size checks when making use of stop/start scaling

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/load/YarnLoadEvaluator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/load/YarnLoadEvaluator.java
@@ -142,7 +142,13 @@ public class YarnLoadEvaluator extends EvaluatorExecutor {
 
         if (yarnRecommendedScaleUpCount > 0 && isCoolDownTimeElapsed(cluster.getStackCrn(), "scaled-up",
                 loadAlertConfiguration.getScaleUpCoolDownMillis(), cluster.getLastScalingActivity()))  {
-            sendScaleUpEvent(stackV4Response.getNodeCount(), existingHostGroupSize, yarnRecommendedScaleUpCount);
+            if (Boolean.TRUE.equals(cluster.isStopStartScalingEnabled())) {
+                Integer existingClusterNodeCount = stackV4Response.getNodeCount() -
+                        stackResponseUtils.getStoppedInstanceCountInHostGroup(stackV4Response, policyHostGroup);
+                sendScaleUpEvent(existingClusterNodeCount, existingHostGroupSize, yarnRecommendedScaleUpCount);
+            } else {
+                sendScaleUpEvent(stackV4Response.getNodeCount(), existingHostGroupSize, yarnRecommendedScaleUpCount);
+            }
         } else if (!yarnRecommendedDecommissionHosts.isEmpty() && isCoolDownTimeElapsed(cluster.getStackCrn(), "scaled-down",
                 loadAlertConfiguration.getScaleDownCoolDownMillis(), cluster.getLastScalingActivity()))  {
             sendScaleDownEvent(existingHostGroupSize, yarnRecommendedDecommissionHosts);

--- a/autoscale/src/main/java/com/sequenceiq/periscope/utils/StackResponseUtils.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/utils/StackResponseUtils.java
@@ -38,6 +38,16 @@ public class StackResponseUtils {
                         InstanceMetaDataV4Response::getInstanceId));
     }
 
+    public Integer getStoppedInstanceCountInHostGroup(StackV4Response stackV4Response, String policyHostGroup) {
+        return stackV4Response.getInstanceGroups().stream()
+                .filter(instanceGroupV4Response -> instanceGroupV4Response.getName().equalsIgnoreCase(policyHostGroup))
+                .flatMap(instanceGroupV4Response -> instanceGroupV4Response.getMetadata().stream())
+                .filter(instanceMetaData -> instanceMetaData.getDiscoveryFQDN() != null)
+                .filter(instanceMetaData -> InstanceStatus.STOPPED.equals(instanceMetaData.getInstanceStatus()))
+                .collect(Collectors.counting())
+                .intValue();
+    }
+
     public Integer getNodeCountForHostGroup(StackV4Response stackResponse, String hostGroup) {
         return stackResponse.getInstanceGroups().stream()
                 .filter(instanceGroupV4Response -> instanceGroupV4Response.getName().equalsIgnoreCase(hostGroup))

--- a/autoscale/src/test/java/com/sequenceiq/periscope/utils/StackResponseUtilsTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/utils/StackResponseUtilsTest.java
@@ -48,6 +48,17 @@ public class StackResponseUtilsTest {
     }
 
     @Test
+    public void testGetStoppedInstanceCountInHostGroup() {
+        String hostGroup = "compute";
+        Integer runningHostGroupCount = 1;
+        Integer stoppedHostGroupCount = 3;
+
+        Integer stoppedInstanceCount = underTest.getStoppedInstanceCountInHostGroup(getMockStackV4ResponseForStopStart(hostGroup,
+                runningHostGroupCount, stoppedHostGroupCount), hostGroup);
+        assertEquals("Stopped instance count should match", Integer.valueOf(3), stoppedInstanceCount);
+    }
+
+    @Test
     public void testGetNodeCountForHostGroup() {
         String hostGroup = "compute";
 
@@ -102,6 +113,11 @@ public class StackResponseUtilsTest {
     private StackV4Response getMockStackV4Response(String hostGroup, boolean withUnhealthyInstances) {
         return MockStackResponseGenerator
                 .getMockStackV4Response("test-crn", hostGroup, "test_fqdn", 3, withUnhealthyInstances);
+    }
+
+    private StackV4Response getMockStackV4ResponseForStopStart(String hostGroup, int runningHostGroupCount, int stoppedHostGroupCount) {
+        return MockStackResponseGenerator
+                .getMockStackV4Response("test-crn", hostGroup, "test-fqdn", runningHostGroupCount, stoppedHostGroupCount);
     }
 
     private String getTestBP() throws IOException {


### PR DESCRIPTION
 - Changes to exclude stopped nodes in clusterNodeCount if stopStart scaling is enabled
 - Unit tests for StackResponseUtils, YarnLoadEvaluator

See detailed description in the commit message.