### PR TITLE
CB-15800 calculate availability zone and subnet usage in FreeIPA only when availability zone data exists

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/multiaz/MultiAzCalculatorService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/multiaz/MultiAzCalculatorService.java
@@ -42,11 +42,13 @@ public class MultiAzCalculatorService {
         if (environment != null && environment.getNetwork() != null && environment.getNetwork().getSubnetMetas() != null) {
             for (Map.Entry<String, CloudSubnet> entry : environment.getNetwork().getSubnetMetas().entrySet()) {
                 CloudSubnet value = entry.getValue();
-                if (!Strings.isNullOrEmpty(value.getName())) {
-                    subnetAzPairs.put(value.getName(), value.getAvailabilityZone());
-                }
-                if (!Strings.isNullOrEmpty(value.getId())) {
-                    subnetAzPairs.put(value.getId(), value.getAvailabilityZone());
+                if (value != null && value.getAvailabilityZone() != null) {
+                    if (!Strings.isNullOrEmpty(value.getName())) {
+                        subnetAzPairs.put(value.getName(), value.getAvailabilityZone());
+                    }
+                    if (!Strings.isNullOrEmpty(value.getId())) {
+                        subnetAzPairs.put(value.getId(), value.getAvailabilityZone());
+                    }
                 }
             }
         }
@@ -101,12 +103,16 @@ public class MultiAzCalculatorService {
             String subnetId = instanceMetaData.getSubnetId();
             if (!isNullOrEmpty(subnetId)) {
                 String az = subnetAzPairs.get(subnetId);
-                Integer countOfInstances = azUsage.get(az);
-                if (countOfInstances != null) {
-                    azUsage.put(az, countOfInstances + 1);
+                if (StringUtils.isNotEmpty(az)) {
+                    Integer countOfInstances = azUsage.get(az);
+                    if (countOfInstances != null) {
+                        azUsage.put(az, countOfInstances + 1);
+                    } else {
+                        LOGGER.warn("AZ with subnet ID {} is not present in the environment networks. Current usage: {}",
+                                subnetId, azUsage.keySet());
+                    }
                 } else {
-                    LOGGER.warn("AZ with subnet ID {} is not present in the environment networks. Current usage: {}",
-                            subnetId, azUsage.keySet());
+                    LOGGER.debug("There is no availability zone data for subnet id: '{}', It is normal on Azure for now", subnetId);
                 }
             }
         }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/instance/InstanceMetaDataService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/instance/InstanceMetaDataService.java
@@ -134,9 +134,11 @@ public class InstanceMetaDataService {
                     instanceMetaData.setInstanceStatus(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceStatus.REQUESTED);
                     instanceMetaData.setInstanceGroup(instanceGroup);
                     instanceMetaData.setDiscoveryFQDN(freeIpa.getHostname() + String.format("%d.", privateId) + freeIpa.getDomain());
-                    Map<String, String> filteredSubnetsByLeastUsedAz = multiAzCalculatorService.filterSubnetByLeastUsedAz(instanceGroup, subnetAzMap);
-                    multiAzCalculatorService.updateSubnetIdForSingleInstanceIfEligible(filteredSubnetsByLeastUsedAz, currentSubnetUsage, instanceMetaData,
-                            instanceGroup);
+                    if (!subnetAzMap.isEmpty()) {
+                        Map<String, String> filteredSubnetsByLeastUsedAz = multiAzCalculatorService.filterSubnetByLeastUsedAz(instanceGroup, subnetAzMap);
+                        multiAzCalculatorService.updateSubnetIdForSingleInstanceIfEligible(filteredSubnetsByLeastUsedAz, currentSubnetUsage, instanceMetaData,
+                                instanceGroup);
+                    }
                     instanceMetaDataRepository.save(instanceMetaData);
                     LOGGER.debug("Saved InstanceMetaData: {}", instanceMetaData);
                     instanceGroup.getInstanceMetaDataSet().add(instanceMetaData);


### PR DESCRIPTION
The following cURL has been created to test the upscale scenario of a FreeIPA cluster on Azure:
```
curl -X PUT -H "Content-Type: application/json" \
-H "x-cdp-actor-crn: crn:altus:iam:us-west-1:cloudera:user:t...@cloudera.com" \
-d '{"environmentCrn": "crn:cdp:environments:us-west-1:cloudera:environment:0...", "targetFormFactor": "HA"}' \
http://localhost:8090/freeipa/api/v1/freeipa/upscale
```
The previously problematic logic has been covered by UT and an AWS multi-AZ enabled FreeIPA cluster was also created as a sanity check of multi-AZ functionality.