### PR TITLE
CB-14847 Implement partial failure/zombie instance filtering logic du…

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/InstanceStatus.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/InstanceStatus.java
@@ -11,7 +11,8 @@ public enum InstanceStatus {
     UNKNOWN(StatusGroup.PERMANENT),
     CREATE_REQUESTED(StatusGroup.PERMANENT),
     DELETE_REQUESTED(StatusGroup.PERMANENT),
-    IN_PROGRESS(StatusGroup.TRANSIENT);
+    IN_PROGRESS(StatusGroup.TRANSIENT),
+    ZOMBIE(StatusGroup.PERMANENT);
 
     private final StatusGroup statusGroup;
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerCommissioner.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerCommissioner.java
@@ -134,7 +134,7 @@ public class ClouderaManagerCommissioner {
     }
 
     public Map<String, InstanceMetaData> collectHostsToCommission(Stack stack, HostGroup hostGroup, Set<String> hostNames, ApiClient client) {
-        Set<InstanceMetaData> hostsInHostGroup = hostGroup.getInstanceGroup().getNotTerminatedInstanceMetaDataSet();
+        Set<InstanceMetaData> hostsInHostGroup = hostGroup.getInstanceGroup().getNotTerminatedAndNotZombieInstanceMetaDataSet();
         Map<String, InstanceMetaData> hostsToCommission = hostsInHostGroup.stream()
                 .filter(hostMetadata -> hostNames.contains(hostMetadata.getDiscoveryFQDN()))
                 // TODO CB-15132: Add additional checks to make sure the hosts are in the expected state. Even better,

--- a/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
@@ -367,6 +367,7 @@ public enum ResourceEvent {
     CLUSTER_SCALED_DOWN("cluster.scaled.down"),
     CLUSTER_SCALED_DOWN_NONE("cluster.scaled.down.none"),
     CLUSTER_SCALING_FAILED("cluster.scaling.failed"),
+    CLUSTER_SCALING_PARTIALLY_FAILED("cluster.scaling.partially.failed"),
     CLUSTER_DECOMMISSION_FAILED_FORCE_DELETE_CONTINUE("cluster.decommission.failed.force.delete.continue"),
     CLUSTER_STOP_MANAGEMENT_SERVER_STARTED("cluster.stop.management.server.started"),
     CLUSTER_STOP_COMPONENTS_STARTED("cluster.stop.components.started"),

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -153,6 +153,7 @@ cluster.stop.failed=Cluster could not be stopped. Reason: {0}
 cluster.create.failed={0}
 ambari.cluster.configure.security.failed=Failed to enable security on Cloudera Manager cluster. Reason: {0}
 cluster.scaling.failed=New node(s) could not be {0} the cluster. Reason {1}
+cluster.scaling.partially.failed=Scaling up was not fully successful. Some of the new node(s) could not be {0} the cluster. Reason {1}
 ambari.cluster.mr.smoke.failed=Warning: MapReduce smoke test failed, check your cluster''s configurations!
 ambari.cluster.install.failed=Cluster installation failed to complete, please check the Cloudera Manager UI for more details. You can try to reinstall the cluster with a different cluster definition or fix the failures in Cloudera Manager and sync the cluster with Cloudbreak later.
 ambari.cluster.upscale.failed=Cluster upscale failed to complete, please check the Cloudera Manager UI for more details. You can try to fix the failures in Cloudera Manager and sync the cluster with Cloudbreak later.

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/InstanceStatus.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/InstanceStatus.java
@@ -15,7 +15,8 @@ public enum InstanceStatus {
     DELETE_REQUESTED,
     DECOMMISSIONED,
     DECOMMISSION_FAILED,
-    TERMINATED;
+    TERMINATED,
+    ZOMBIE;
 
     public String getAsHostState() {
         switch (this) {

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Stack.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Stack.java
@@ -513,14 +513,32 @@ public class Stack implements ProvisionEntity, WorkspaceAwareResource, Orchestra
         return nodeCount;
     }
 
+    public Set<InstanceMetaData> getNotTerminatedAndNotZombieInstanceMetaDataSet() {
+        return instanceGroups.stream()
+                .flatMap(instanceGroup -> instanceGroup.getNotTerminatedAndNotZombieInstanceMetaDataSet().stream())
+                .collect(Collectors.toSet());
+    }
+
     public Set<InstanceMetaData> getNotTerminatedInstanceMetaDataSet() {
         return instanceGroups.stream()
                 .flatMap(instanceGroup -> instanceGroup.getNotTerminatedInstanceMetaDataSet().stream())
                 .collect(Collectors.toSet());
     }
 
-    public List<InstanceMetaData> getNotTerminatedInstanceMetaDataList() {
-        return new ArrayList<>(getNotTerminatedInstanceMetaDataSet());
+    public List<InstanceMetaData> getNotTerminatedAndNotZombieInstanceMetaDataList() {
+        return new ArrayList<>(getNotTerminatedAndNotZombieInstanceMetaDataSet());
+    }
+
+    public Set<InstanceMetaData> getNotDeletedAndNotZombieInstanceMetaDataSet() {
+        return instanceGroups.stream()
+                .flatMap(instanceGroup -> instanceGroup.getNotDeletedAndNotZombieInstanceMetaDataSet().stream())
+                .collect(Collectors.toSet());
+    }
+
+    public Set<InstanceMetaData> getZombieInstanceMetaDataSet() {
+        return instanceGroups.stream()
+                .flatMap(instanceGroup -> instanceGroup.getZombieInstanceMetaDataSet().stream())
+                .collect(Collectors.toSet());
     }
 
     public Set<InstanceMetaData> getNotDeletedInstanceMetaDataSet() {
@@ -541,8 +559,8 @@ public class Stack implements ProvisionEntity, WorkspaceAwareResource, Orchestra
                 .collect(Collectors.toSet());
     }
 
-    public List<InstanceMetaData> getNotDeletedInstanceMetaDataList() {
-        return new ArrayList<>(getNotDeletedInstanceMetaDataSet());
+    public List<InstanceMetaData> getNotDeletedAndNotZombieInstanceMetaDataList() {
+        return new ArrayList<>(getNotDeletedAndNotZombieInstanceMetaDataSet());
     }
 
     public List<InstanceMetaData> getInstanceMetaDataAsList() {
@@ -583,6 +601,13 @@ public class Stack implements ProvisionEntity, WorkspaceAwareResource, Orchestra
         this.parameters = parameters;
     }
 
+    public List<InstanceMetaData> getNotTerminatedAndNotZombieGatewayInstanceMetadata() {
+        return instanceGroups.stream()
+                .filter(ig -> InstanceGroupType.GATEWAY.equals(ig.getInstanceGroupType()))
+                .flatMap(ig -> ig.getNotTerminatedAndNotZombieInstanceMetaDataSet().stream())
+                .collect(Collectors.toList());
+    }
+
     public List<InstanceMetaData> getNotTerminatedGatewayInstanceMetadata() {
         return instanceGroups.stream()
                 .filter(ig -> InstanceGroupType.GATEWAY.equals(ig.getInstanceGroupType()))
@@ -598,7 +623,7 @@ public class Stack implements ProvisionEntity, WorkspaceAwareResource, Orchestra
     }
 
     public InstanceMetaData getPrimaryGatewayInstance() {
-        Optional<InstanceMetaData> metaData = getNotTerminatedGatewayInstanceMetadata().stream()
+        Optional<InstanceMetaData> metaData = getNotTerminatedAndNotZombieGatewayInstanceMetadata().stream()
                 .filter(im -> InstanceMetadataType.GATEWAY_PRIMARY.equals(im.getInstanceMetadataType())).findFirst();
         return metaData.orElse(null);
     }
@@ -939,7 +964,7 @@ public class Stack implements ProvisionEntity, WorkspaceAwareResource, Orchestra
     @Override
     public Set<InstanceMetaData> getAllNodesForOrchestration() {
         return instanceGroups.stream()
-                .flatMap(ig -> ig.getNotDeletedInstanceMetaDataSet().stream())
+                .flatMap(ig -> ig.getNotDeletedAndNotZombieInstanceMetaDataSet().stream())
                 .filter(im -> StringUtils.isNotBlank(im.getDiscoveryFQDN()))
                 .collect(Collectors.toSet());
     }

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/instance/InstanceGroup.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/instance/InstanceGroup.java
@@ -142,15 +142,33 @@ public class InstanceGroup implements ProvisionEntity, Comparable<InstanceGroup>
         return this;
     }
 
+    public Set<InstanceMetaData> getNotTerminatedAndNotZombieInstanceMetaDataSet() {
+        return instanceMetaData.stream()
+                .filter(metaData -> !metaData.isTerminated() && !metaData.isZombie())
+                .collect(Collectors.toSet());
+    }
+
     public Set<InstanceMetaData> getNotTerminatedInstanceMetaDataSet() {
         return instanceMetaData.stream()
                 .filter(metaData -> !metaData.isTerminated())
                 .collect(Collectors.toSet());
     }
 
+    public Set<InstanceMetaData> getNotDeletedAndNotZombieInstanceMetaDataSet() {
+        return instanceMetaData.stream()
+                .filter(metaData -> !metaData.isTerminated() && !metaData.isDeletedOnProvider() && !metaData.isZombie())
+                .collect(Collectors.toSet());
+    }
+
     public Set<InstanceMetaData> getNotDeletedInstanceMetaDataSet() {
         return instanceMetaData.stream()
                 .filter(metaData -> !metaData.isTerminated() && !metaData.isDeletedOnProvider())
+                .collect(Collectors.toSet());
+    }
+
+    public Set<InstanceMetaData> getZombieInstanceMetaDataSet() {
+        return instanceMetaData.stream()
+                .filter(metaData -> metaData.isZombie())
                 .collect(Collectors.toSet());
     }
 

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/instance/InstanceMetaData.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/instance/InstanceMetaData.java
@@ -229,7 +229,7 @@ public class InstanceMetaData implements ProvisionEntity, OrchestrationNode {
 
     public boolean isFailed() {
         return instanceStatus == InstanceStatus.FAILED || instanceStatus == InstanceStatus.ORCHESTRATION_FAILED
-                || instanceStatus == InstanceStatus.DECOMMISSION_FAILED;
+                || instanceStatus == InstanceStatus.DECOMMISSION_FAILED || instanceStatus == InstanceStatus.ZOMBIE;
     }
 
     public boolean isStopped() {
@@ -243,6 +243,7 @@ public class InstanceMetaData implements ProvisionEntity, OrchestrationNode {
     public boolean isReachable() {
         return !isTerminated()
                 && !isDeletedOnProvider()
+                && !InstanceStatus.ZOMBIE.equals(instanceStatus)
                 && !InstanceStatus.ORCHESTRATION_FAILED.equals(instanceStatus)
                 && !InstanceStatus.FAILED.equals(instanceStatus)
                 && !InstanceStatus.STOPPED.equals(instanceStatus);
@@ -250,6 +251,10 @@ public class InstanceMetaData implements ProvisionEntity, OrchestrationNode {
 
     public boolean isDeletedOnProvider() {
         return InstanceStatus.DELETED_ON_PROVIDER_SIDE.equals(instanceStatus) || InstanceStatus.DELETED_BY_PROVIDER.equals(instanceStatus);
+    }
+
+    public boolean isZombie() {
+        return InstanceStatus.ZOMBIE.equals(instanceStatus);
     }
 
     public boolean isHealthy() {

--- a/core-model/src/test/java/com/sequenceiq/cloudbreak/domain/stack/instance/InstanceMetaDataReachableTest.java
+++ b/core-model/src/test/java/com/sequenceiq/cloudbreak/domain/stack/instance/InstanceMetaDataReachableTest.java
@@ -32,7 +32,8 @@ public class InstanceMetaDataReachableTest {
                 InstanceStatus.DELETED_BY_PROVIDER,
                 InstanceStatus.FAILED,
                 InstanceStatus.ORCHESTRATION_FAILED,
-                InstanceStatus.STOPPED);
+                InstanceStatus.STOPPED,
+                InstanceStatus.ZOMBIE);
 
         return Arrays.stream(InstanceStatus.values())
                 .map(status -> {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/conclusion/step/VmStatusCheckerConclusionStep.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/conclusion/step/VmStatusCheckerConclusionStep.java
@@ -57,7 +57,7 @@ public class VmStatusCheckerConclusionStep extends ConclusionStep {
     public Conclusion check(Long resourceId) {
         Stack stack = stackService.getById(resourceId);
         ClusterApi connector = clusterApiConnectors.getConnector(stack);
-        Set<InstanceMetaData> runningInstances = instanceMetaDataService.findNotTerminatedForStack(stack.getId());
+        Set<InstanceMetaData> runningInstances = instanceMetaDataService.findNotTerminatedAndNotZombieForStack(stack.getId());
         if (isClusterManagerRunning(stack, connector)) {
             return checkCMForInstanceStatuses(connector, runningInstances, stack.getCluster().getId());
         } else {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/CloudInstanceIdToInstanceMetaDataConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/CloudInstanceIdToInstanceMetaDataConverter.java
@@ -12,8 +12,8 @@ import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 @Component
 public class CloudInstanceIdToInstanceMetaDataConverter {
 
-    public List<InstanceMetaData> getNotDeletedInstances(Stack stack, String hostGroupname, Set<String> cloudInstanceIds) {
-        return stack.getInstanceGroupByInstanceGroupName(hostGroupname).getNotDeletedInstanceMetaDataSet().stream()
+    public List<InstanceMetaData> getNotDeletedAndNotZombieInstances(Stack stack, String hostGroupname, Set<String> cloudInstanceIds) {
+        return stack.getInstanceGroupByInstanceGroupName(hostGroupname).getNotDeletedAndNotZombieInstanceMetaDataSet().stream()
                 .filter(im -> im.getInstanceId() == null ? false : cloudInstanceIds.contains(im.getInstanceId()))
                 .collect(Collectors.toList());
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackScaleV4RequestToUpdateClusterV4RequestConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackScaleV4RequestToUpdateClusterV4RequestConverter.java
@@ -1,18 +1,19 @@
 package com.sequenceiq.cloudbreak.converter.v4.stacks;
 
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.HostGroupAdjustmentV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackScaleV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.UpdateClusterV4Request;
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
 import com.sequenceiq.cloudbreak.common.service.TransactionService.TransactionExecutionException;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
-import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.service.blueprint.BlueprintTextProcessorFactory;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.template.processor.BlueprintTextProcessor;
-import org.springframework.stereotype.Component;
-
-import javax.inject.Inject;
 
 @Component
 public class StackScaleV4RequestToUpdateClusterV4RequestConverter {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpscaleService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpscaleService.java
@@ -13,16 +13,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterClientInitException;
-import com.sequenceiq.cloudbreak.common.orchestration.Node;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterServiceRunner;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.ClusterHostServiceRunner;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.orchestrator.model.NodeReachabilityResult;
 import com.sequenceiq.cloudbreak.polling.ExtendedPollingResult;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
+import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.service.stack.TargetedUpscaleSupportService;
 
@@ -49,17 +51,20 @@ public class ClusterManagerUpscaleService {
     @Inject
     private TargetedUpscaleSupportService targetedUpscaleSupportService;
 
-    public void upscaleClusterManager(Long stackId, String hostGroupName, Integer scalingAdjustment, boolean primaryGatewayChanged)
+    @Inject
+    private InstanceMetaDataService instanceMetaDataService;
+
+    public void upscaleClusterManager(Long stackId, String hostGroupName, Integer scalingAdjustment, boolean primaryGatewayChanged, boolean repair)
             throws ClusterClientInitException {
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
         LOGGER.debug("Adding {} new nodes for host group {}", scalingAdjustment, hostGroupName);
         Map<String, List<String>> hostsPerHostGroup = new HashMap<>();
 
-        Map<String, String> hosts = hostRunner.addClusterServices(stackId, hostGroupName, scalingAdjustment);
+        NodeReachabilityResult nodeReachabilityResult = hostRunner.addClusterServices(stackId, hostGroupName, scalingAdjustment, repair);
         if (primaryGatewayChanged) {
             clusterServiceRunner.updateAmbariClientConfig(stack, stack.getCluster());
         }
-        for (String hostName : hosts.keySet()) {
+        for (String hostName : nodeReachabilityResult.getReachableHosts()) {
             if (!hostsPerHostGroup.containsKey(hostGroupName)) {
                 hostsPerHostGroup.put(hostGroupName, new ArrayList<>());
             }
@@ -67,13 +72,14 @@ public class ClusterManagerUpscaleService {
         }
         clusterService.updateInstancesToRunning(stack.getCluster().getId(), hostsPerHostGroup);
 
+        clusterService.updateInstancesToZombie(stackId, nodeReachabilityResult.getUnreachableNodes());
+
         ClusterApi connector = clusterApiConnectors.getConnector(stack);
         ExtendedPollingResult result;
-        if (!primaryGatewayChanged && targetedUpscaleSupportService.targetedUpscaleOperationSupported(stack)) {
-            Set<Node> reachableCandidates = hostRunner.getReachableCandidates(stack, hosts);
-            List<String> reachableCandidatesHostname = reachableCandidates.stream().map(Node::getHostname).collect(Collectors.toList());
-            Set<InstanceMetaData> reachableInstances = stack.getNotDeletedInstanceMetaDataSet().stream()
-                    .filter(md -> reachableCandidatesHostname.contains(md.getDiscoveryFQDN()))
+        if (!repair && !primaryGatewayChanged && targetedUpscaleSupportService.targetedUpscaleOperationSupported(stack)) {
+            Set<String> reachableHosts = nodeReachabilityResult.getReachableHosts();
+            Set<InstanceMetaData> reachableInstances = stack.getNotDeletedAndNotZombieInstanceMetaDataSet().stream()
+                    .filter(md -> reachableHosts.contains(md.getDiscoveryFQDN()))
                     .collect(Collectors.toSet());
             result = connector.waitForHosts(reachableInstances);
         } else {
@@ -81,8 +87,8 @@ public class ClusterManagerUpscaleService {
         }
         if (result != null && result.isTimeout()) {
             LOGGER.info("Upscaling cluster manager were not successful for nodes: {}", result.getFailedInstanceIds());
-            //instanceMetaDataService.updateInstanceStatus(result.getFailedInstanceIds(), InstanceStatus.ZOMBIE,
-            //        "Upscaling cluster manager were not successful.";
+            instanceMetaDataService.updateInstanceStatus(result.getFailedInstanceIds(), InstanceStatus.ZOMBIE,
+                    "Upscaling cluster manager were not successful.");
         }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterUpscaleService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterUpscaleService.java
@@ -110,7 +110,7 @@ public class ClusterUpscaleService {
     }
 
     private boolean shouldRestartServices(Boolean repair, Boolean restartServices, Stack stack) {
-        return repair && restartServices && stack.getNotTerminatedInstanceMetaDataList().size() == stack.getRunningInstanceMetaDataSet().size();
+        return repair && restartServices && stack.getNotTerminatedAndNotZombieInstanceMetaDataList().size() == stack.getRunningInstanceMetaDataSet().size();
     }
 
     public void executePostRecipesOnNewHosts(Long stackId) throws CloudbreakException {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/ClusterCreationActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/ClusterCreationActions.java
@@ -222,7 +222,7 @@ public class ClusterCreationActions {
 
             @Override
             protected Selectable createRequest(StackCreationContext context) {
-                Set<InstanceMetaData> instanceMetaData = instanceMetaDataService.findNotTerminatedForStack(context.getStack().getId());
+                Set<InstanceMetaData> instanceMetaData = instanceMetaDataService.findNotTerminatedAndNotZombieForStack(context.getStack().getId());
                 Set<String> hostNames = instanceMetadataProcessor.extractFqdn(instanceMetaData);
                 Set<String> ips = instanceMetadataProcessor.extractIps(instanceMetaData);
                 return new CleanupFreeIpaEvent(context.getStack().getId(), hostNames, ips, false);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/service/ClusterProxyService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/service/ClusterProxyService.java
@@ -163,7 +163,7 @@ public class ClusterProxyService {
     }
 
     private List<ClusterServiceConfig> getClusterServiceConfigsForGWs(Stack stack, boolean preferPrivateIp) {
-        List<InstanceMetaData> gatewayInstanceMetadatas = stack.getNotTerminatedGatewayInstanceMetadata();
+        List<InstanceMetaData> gatewayInstanceMetadatas = stack.getNotTerminatedAndNotZombieGatewayInstanceMetadata();
         return gatewayInstanceMetadatas.stream()
                 .map(gatewayInstanceMetadata -> createClusterServiceConfigFromGWMetadata(stack, gatewayInstanceMetadata, preferPrivateIp))
                 .collect(Collectors.toList());
@@ -182,7 +182,7 @@ public class ClusterProxyService {
 
     private List<TunnelEntry> tunnelEntries(Stack stack) {
         List<TunnelEntry> entries = new ArrayList<>();
-        stack.getNotTerminatedGatewayInstanceMetadata().forEach(md -> {
+        stack.getNotTerminatedAndNotZombieGatewayInstanceMetadata().forEach(md -> {
             String gatewayIp = md.getPrivateIp();
             TunnelEntry gatewayTunnel = new TunnelEntry(md.getInstanceId(), KnownServiceIdentifier.GATEWAY.name(),
                     gatewayIp, ServiceFamilies.GATEWAY.getDefaultPort(), stack.getMinaSshdServiceId());
@@ -196,7 +196,7 @@ public class ClusterProxyService {
     }
 
     private List<CcmV2Config> ccmV2Configs(Stack stack) {
-        return stack.getNotTerminatedGatewayInstanceMetadata().stream()
+        return stack.getNotTerminatedAndNotZombieGatewayInstanceMetadata().stream()
                 .map(instanceMetaData -> new CcmV2Config(
                         stack.getCcmV2AgentCrn(),
                         instanceMetaData.getPrivateIp(),

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/repair/master/ha/ChangePrimaryGatewayService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/repair/master/ha/ChangePrimaryGatewayService.java
@@ -73,7 +73,7 @@ public class ChangePrimaryGatewayService {
 
     public void primaryGatewayChanged(long stackId, String newPrimaryGatewayFQDN) throws CloudbreakException, TransactionExecutionException {
         LOGGER.info("Update primary gateway ip");
-        Set<InstanceMetaData> imds = instanceMetaDataService.findNotTerminatedForStack(stackId);
+        Set<InstanceMetaData> imds = instanceMetaDataService.findNotTerminatedAndNotZombieForStack(stackId);
         Optional<InstanceMetaData> formerPrimaryGateway = imds.stream()
                 .filter(imd -> imd.getInstanceMetadataType() == InstanceMetadataType.GATEWAY_PRIMARY)
                 .findFirst();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/start/ClusterStartService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/start/ClusterStartService.java
@@ -94,7 +94,7 @@ public class ClusterStartService {
     private void updateInstancesToHealthy(StackView stack) {
         try {
             transactionService.required(() -> {
-                Set<InstanceMetaData> instances = instanceMetaDataService.findNotTerminatedForStack(stack.getId());
+                Set<InstanceMetaData> instances = instanceMetaDataService.findNotTerminatedAndNotZombieForStack(stack.getId());
                 for (InstanceMetaData metaData : instances) {
                     metaData.setInstanceStatus(com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus.SERVICES_HEALTHY);
                 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartds/StopStartDownscaleActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartds/StopStartDownscaleActions.java
@@ -117,9 +117,9 @@ public class StopStartDownscaleActions {
 
 
                 Set<Long> instancesToStop = stackService.getPrivateIdsForHostNames(
-                        stack.getNotDeletedInstanceMetaDataList(), payload.getDecommissionedHostFqdns());
+                        stack.getNotDeletedAndNotZombieInstanceMetaDataList(), payload.getDecommissionedHostFqdns());
 
-                List<InstanceMetaData> instanceMetaDataList = stack.getNotDeletedInstanceMetaDataList();
+                List<InstanceMetaData> instanceMetaDataList = stack.getNotDeletedAndNotZombieInstanceMetaDataList();
                 List<InstanceMetaData> instanceMetaDataForHg = instanceMetaDataList.stream().filter(
                         x -> x.getInstanceGroupName().equals(context.getHostGroupName())).collect(Collectors.toList());
 
@@ -159,7 +159,7 @@ public class StopStartDownscaleActions {
                         .filter(x -> x.getStatus() == InstanceStatus.STOPPED)
                         .map(x -> x.getCloudInstance().getInstanceId())
                         .collect(Collectors.toUnmodifiableSet());
-                List<InstanceMetaData> stoppedInstanceMetadata = cloudInstanceIdToInstanceMetaDataConverter.getNotDeletedInstances(
+                List<InstanceMetaData> stoppedInstanceMetadata = cloudInstanceIdToInstanceMetaDataConverter.getNotDeletedAndNotZombieInstances(
                         context.getStack(), context.getHostGroupName(), cloudInstanceIdsStopped);
                 stopStartDownscaleFlowService.instancesStopped(context.getStack().getId(), stoppedInstanceMetadata);
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartus/StopStartUpscaleActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartus/StopStartUpscaleActions.java
@@ -92,7 +92,7 @@ public class StopStartUpscaleActions {
             @Override
             protected Selectable createRequest(StopStartUpscaleContext context) {
                 Stack stack = context.getStack();
-                List<InstanceMetaData> instanceMetaDataList = stack.getNotDeletedInstanceMetaDataList();
+                List<InstanceMetaData> instanceMetaDataList = stack.getNotDeletedAndNotZombieInstanceMetaDataList();
 
                 List<InstanceMetaData> instanceMetaDataForHg = instanceMetaDataList.stream().filter(
                         x -> x.getInstanceGroupName().equals(context.getHostGroupName())).collect(Collectors.toList());
@@ -129,7 +129,7 @@ public class StopStartUpscaleActions {
                         .filter(x -> x.getStatus() == InstanceStatus.STARTED)
                         .map(x -> x.getCloudInstance().getInstanceId())
                         .collect(Collectors.toUnmodifiableSet());
-                List<InstanceMetaData> startedInstancesMetaData = cloudInstanceIdToInstanceMetaDataConverter.getNotDeletedInstances(
+                List<InstanceMetaData> startedInstancesMetaData = cloudInstanceIdToInstanceMetaDataConverter.getNotDeletedAndNotZombieInstances(
                         context.getStack(), context.getHostGroupName(), cloudInstanceIdsStarted);
                 clusterUpscaleFlowService.instancesStarted(context.getStack().getId(), startedInstancesMetaData);
 
@@ -138,7 +138,7 @@ public class StopStartUpscaleActions {
                 // This list is currently empty. It could be populated later in another flow-step by querying CM to get service health.
                 // Meant to be a mechanism which detects cloud instances which are RUNNING, but not being utilized (likely due to previous failures)
                 List<CloudInstance> instancesWithServicesNotRunning = payload.getStartInstanceRequest().getStartedInstancesWithServicesNotRunning();
-                List<InstanceMetaData> metaDataWithServicesNotRunning = cloudInstanceIdToInstanceMetaDataConverter.getNotDeletedInstances(
+                List<InstanceMetaData> metaDataWithServicesNotRunning = cloudInstanceIdToInstanceMetaDataConverter.getNotDeletedAndNotZombieInstances(
                         context.getStack(),
                         context.getHostGroupName(),
                         instancesWithServicesNotRunning.stream().map(i -> i.getInstanceId()).collect(Collectors.toUnmodifiableSet()));
@@ -195,7 +195,7 @@ public class StopStartUpscaleActions {
 
                 logInstancesNotCommissioned(context, payload.getNotRecommissionedFqdns());
 
-                List<InstanceMetaData> notDeletedInstanceMetaDataList = context.getStack().getNotDeletedInstanceMetaDataList();
+                List<InstanceMetaData> notDeletedInstanceMetaDataList = context.getStack().getNotDeletedAndNotZombieInstanceMetaDataList();
                 List<InstanceMetaData> instancesCommissioned = notDeletedInstanceMetaDataList.stream()
                         .filter(i -> payload.getSuccessfullyCommissionedFqdns().contains(i.getDiscoveryFQDN()))
                         .collect(Collectors.toList());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/upscale/ClusterUpscaleActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/upscale/ClusterUpscaleActions.java
@@ -148,7 +148,7 @@ public class ClusterUpscaleActions {
             @Override
             protected Selectable createRequest(ClusterUpscaleContext context) {
                 return new UpscaleClusterManagerRequest(context.getStackId(), context.getHostGroupName(), context.getAdjustment(),
-                        context.isSinglePrimaryGateway());
+                        context.isSinglePrimaryGateway(), context.isRepair());
             }
 
         };
@@ -385,7 +385,7 @@ public class ClusterUpscaleActions {
 
             @Override
             protected void doExecute(ClusterUpscaleContext context, UpscalePostRecipesResult payload, Map<Object, Object> variables) {
-                clusterUpscaleFlowService.clusterUpscaleFinished(context.getStack(), payload.getHostGroupName());
+                clusterUpscaleFlowService.clusterUpscaleFinished(context.getStack(), payload.getHostGroupName(), context.isRepair());
                 getMetricService().incrementMetricCounter(MetricType.CLUSTER_UPSCALE_SUCCESSFUL, context.getStack());
                 sendEvent(context, FINALIZED_EVENT.event(), payload);
             }
@@ -479,8 +479,8 @@ public class ClusterUpscaleActions {
             return (Boolean) variables.get(KERBEROS_SECURED);
         }
 
-        Boolean isRepair(Map<Object, Object> variables) {
-            return (Boolean) variables.get(REPAIR);
+        private boolean isRepair(Map<Object, Object> variables) {
+            return variables.get(REPAIR) != null && (Boolean) variables.get(REPAIR);
         }
 
         Boolean isRestartServices(Map<Object, Object> variables) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/upscale/ClusterUpscaleFlowService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/upscale/ClusterUpscaleFlowService.java
@@ -10,6 +10,7 @@ import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_RESTART_ALL_
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_RE_REGISTER_WITH_CLUSTER_PROXY;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALED_UP;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALING_FAILED;
+import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALING_PARTIALLY_FAILED;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALING_UP;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SINGLE_MASTER_REPAIR_FINISHED;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SINGLE_MASTER_REPAIR_STARTED;
@@ -35,6 +36,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
 import com.sequenceiq.cloudbreak.core.flow2.stack.CloudbreakFlowMessageService;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.domain.view.StackView;
 import com.sequenceiq.cloudbreak.event.ResourceEvent;
@@ -115,17 +117,17 @@ class ClusterUpscaleFlowService {
         flowMessageService.fireEventAndLog(stackId, UPDATE_IN_PROGRESS.name(), resourceEvent);
     }
 
-    void clusterUpscaleFinished(StackView stackView, String hostgroupName) {
-        int numOfFailedHosts = updateMetadata(stackView, hostgroupName);
+    void clusterUpscaleFinished(StackView stackView, String hostgroupName, boolean repair) {
+        int numOfFailedHosts = updateMetadata(stackView, hostgroupName, repair);
         boolean success = numOfFailedHosts == 0;
         if (success) {
             LOGGER.debug("Cluster upscaled successfully");
             clusterService.updateClusterStatusByStackId(stackView.getId(), DetailedStackStatus.AVAILABLE);
             flowMessageService.fireEventAndLog(stackView.getId(), AVAILABLE.name(), CLUSTER_SCALED_UP, hostgroupName);
         } else {
-            LOGGER.debug("Cluster upscale failed. {} hosts failed to upscale", numOfFailedHosts);
+            LOGGER.debug("Cluster upscale (partially) failed. {} hosts failed to upscale", numOfFailedHosts);
             clusterService.updateClusterStatusByStackId(stackView.getId(), DetailedStackStatus.UPSCALE_FAILED);
-            flowMessageService.fireEventAndLog(stackView.getId(), UPDATE_FAILED.name(), CLUSTER_SCALING_FAILED, "added to",
+            flowMessageService.fireEventAndLog(stackView.getId(), UPDATE_FAILED.name(), CLUSTER_SCALING_PARTIALLY_FAILED, "added to",
                     String.format("Cluster upscale operation failed on %d node(s).", numOfFailedHosts));
         }
     }
@@ -137,28 +139,34 @@ class ClusterUpscaleFlowService {
         flowMessageService.fireEventAndLog(stackId, UPDATE_FAILED.name(), CLUSTER_SCALING_FAILED, "added to", errorDetails.getMessage());
     }
 
-    private int updateMetadata(StackView stackView, String hostGroupName) {
+    private int updateMetadata(StackView stackView, String hostGroupName, boolean repair) {
         LOGGER.info("Start update metadata");
         Optional<HostGroup> hostGroupOptional = hostGroupService.getByClusterIdAndName(stackView.getClusterView().getId(), hostGroupName);
         if (hostGroupOptional.isPresent()) {
-            Set<InstanceMetaData> notDeletedInstanceMetaDataSet = hostGroupOptional.get().getInstanceGroup().getNotDeletedInstanceMetaDataSet();
-            return updateFailedHostMetaData(notDeletedInstanceMetaDataSet);
+            InstanceGroup instanceGroup = hostGroupOptional.get().getInstanceGroup();
+            Set<InstanceMetaData> notDeletedInstanceMetaDataSet = instanceGroup.getNotDeletedAndNotZombieInstanceMetaDataSet();
+            return updateMissingHostsMetaDatas(notDeletedInstanceMetaDataSet, instanceGroup, repair);
         } else {
             return 0;
         }
     }
 
-    private int updateFailedHostMetaData(Collection<InstanceMetaData> instanceMetaData) {
+    private int updateMissingHostsMetaDatas(Collection<InstanceMetaData> instanceMetaData, InstanceGroup instanceGroup, boolean repair) {
         List<String> upscaleHostNames = getHostNames(instanceMetaData);
         Collection<String> successHosts = new HashSet<>(upscaleHostNames);
-        return updateFailedHostMetaData(successHosts, instanceMetaData);
+        if (repair) {
+            return updateMissingHostMetaDatas(successHosts, instanceMetaData, InstanceStatus.ORCHESTRATION_FAILED);
+        } else {
+            updateMissingHostMetaDatas(successHosts, instanceMetaData, InstanceStatus.ZOMBIE);
+            return instanceGroup.getZombieInstanceMetaDataSet().size();
+        }
     }
 
-    private int updateFailedHostMetaData(Collection<String> successHosts, Iterable<InstanceMetaData> instanceMetaDatas) {
+    private int updateMissingHostMetaDatas(Collection<String> successHosts, Iterable<InstanceMetaData> instanceMetaDatas, InstanceStatus instanceStatus) {
         int failedHosts = 0;
         for (InstanceMetaData metaData : instanceMetaDatas) {
             if (!successHosts.contains(metaData.getDiscoveryFQDN())) {
-                instanceMetaDataService.updateInstanceStatus(metaData, InstanceStatus.ORCHESTRATION_FAILED,
+                instanceMetaDataService.updateInstanceStatus(metaData, instanceStatus,
                         "Cluster upscale failed. Host does not have fqdn.");
                 failedHosts++;
             }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/DiagnosticsFlowService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/DiagnosticsFlowService.java
@@ -175,7 +175,7 @@ public class DiagnosticsFlowService {
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
         String primaryGatewayIp = gatewayConfigService.getPrimaryGatewayIp(stack);
         Set<String> hosts = new HashSet<>(Arrays.asList(primaryGatewayIp));
-        Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedForStack(stackId);
+        Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedAndNotZombieForStack(stackId);
         List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
         Set<Node> allNodes = getNodes(instanceMetaDataSet, hosts, new HashSet<>(), new HashSet<>());
         ClusterDeletionBasedExitCriteriaModel exitModel = new ClusterDeletionBasedExitCriteriaModel(stackId, stack.getCluster().getId());
@@ -189,7 +189,7 @@ public class DiagnosticsFlowService {
     public Set<String> collectUnresponsiveNodes(Long stackId, Set<String> hosts, Set<String> hostGroups, Set<String> initialExcludeHosts)
             throws CloudbreakOrchestratorFailedException {
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
-        Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedForStack(stackId);
+        Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedAndNotZombieForStack(stackId);
         List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
         Set<Node> allNodes = getNodes(instanceMetaDataSet, new HashSet<>(), new HashSet<>(), new HashSet<>());
         ClusterDeletionBasedExitCriteriaModel exitModel = new ClusterDeletionBasedExitCriteriaModel(stackId, stack.getCluster().getId());
@@ -277,7 +277,7 @@ public class DiagnosticsFlowService {
     public void init(Long stackId, Map<String, Object> parameters, Set<String> hosts, Set<String> hostGroups, Set<String> excludeHosts)
             throws CloudbreakOrchestratorFailedException {
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
-        Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedForStack(stackId);
+        Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedAndNotZombieForStack(stackId);
         List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
         Set<Node> allNodes = getNodes(instanceMetaDataSet, hosts, hostGroups, excludeHosts);
         LOGGER.debug("Starting diagnostics init. resourceCrn: '{}'", stack.getResourceCrn());
@@ -292,7 +292,7 @@ public class DiagnosticsFlowService {
     public void telemetryUpgrade(Long stackId, Map<String, Object> parameters, Set<String> hosts, Set<String> hostGroups, Set<String> excludeHosts,
             boolean skipComponentRestart) throws CloudbreakOrchestratorFailedException {
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
-        Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedForStack(stackId);
+        Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedAndNotZombieForStack(stackId);
         List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
         Set<Node> allNodes = getNodes(instanceMetaDataSet, hosts, hostGroups, excludeHosts);
         LOGGER.debug("Starting cdp-telemetry upgrade for diagnostics. resourceCrn: '{}'", stack.getResourceCrn());
@@ -308,7 +308,7 @@ public class DiagnosticsFlowService {
     public void vmPreFlightCheck(Long stackId, Map<String, Object> parameters, Set<String> hosts, Set<String> hostGroups, Set<String> excludeHosts)
             throws CloudbreakOrchestratorFailedException {
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
-        Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedForStack(stackId);
+        Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedAndNotZombieForStack(stackId);
         List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
         Set<Node> allNodes = getNodes(instanceMetaDataSet, hosts, hostGroups, excludeHosts);
         LOGGER.debug("Starting diagnostics VM preflight check. resourceCrn: '{}'", stack.getResourceCrn());
@@ -323,7 +323,7 @@ public class DiagnosticsFlowService {
     public void collect(Long stackId, Map<String, Object> parameters, Set<String> hosts, Set<String> hostGroups, Set<String> excludeHosts)
             throws CloudbreakOrchestratorFailedException {
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
-        Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedForStack(stackId);
+        Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedAndNotZombieForStack(stackId);
         List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
         Set<Node> allNodes = getNodes(instanceMetaDataSet, hosts, hostGroups, excludeHosts);
         LOGGER.debug("Starting diagnostics collection. resourceCrn: '{}'", stack.getResourceCrn());
@@ -346,7 +346,7 @@ public class DiagnosticsFlowService {
     public void upload(Long stackId, Map<String, Object> parameters, Set<String> hosts, Set<String> hostGroups, Set<String> excludeHosts)
             throws CloudbreakOrchestratorFailedException {
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
-        Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedForStack(stackId);
+        Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedAndNotZombieForStack(stackId);
         List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
         Set<Node> allNodes = getNodes(instanceMetaDataSet, hosts, hostGroups, excludeHosts);
         LOGGER.debug("Starting diagnostics upload. resourceCrn: '{}'", stack.getResourceCrn());
@@ -369,7 +369,7 @@ public class DiagnosticsFlowService {
     public void cleanup(Long stackId, Map<String, Object> parameters, Set<String> hosts, Set<String> hostGroups, Set<String> excludeHosts)
             throws CloudbreakOrchestratorFailedException {
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
-        Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedForStack(stackId);
+        Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedAndNotZombieForStack(stackId);
         List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
         Set<Node> allNodes = getNodes(instanceMetaDataSet, hosts, hostGroups, excludeHosts);
         LOGGER.debug("Starting diagnostics cleanup. resourceCrn: '{}'", stack.getResourceCrn());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/image/update/StackImageUpdateService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/image/update/StackImageUpdateService.java
@@ -137,7 +137,7 @@ public class StackImageUpdateService {
     }
 
     public CheckResult checkPackageVersions(Stack stack, StatedImage newImage) {
-        Set<InstanceMetaData> instanceMetaDataSet = stack.getNotDeletedInstanceMetaDataSet();
+        Set<InstanceMetaData> instanceMetaDataSet = stack.getNotDeletedAndNotZombieInstanceMetaDataSet();
 
         CheckResult instanceHaveMultipleVersionResult = packageVersionChecker.checkInstancesHaveMultiplePackageVersions(instanceMetaDataSet);
         if (instanceHaveMultipleVersionResult.getStatus() == EventStatus.FAILED) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/service/StackCreationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/service/StackCreationService.java
@@ -245,7 +245,7 @@ public class StackCreationService {
 
     public void setupTls(StackContext context) throws CloudbreakException {
         Stack stack = context.getStack();
-        for (InstanceMetaData gwInstance : stack.getNotTerminatedGatewayInstanceMetadata()) {
+        for (InstanceMetaData gwInstance : stack.getNotTerminatedAndNotZombieGatewayInstanceMetadata()) {
             tlsSetupService.setupTls(stack, gwInstance);
         }
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/start/StackStartActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/start/StackStartActions.java
@@ -78,7 +78,7 @@ public class StackStartActions {
             protected Selectable createRequest(StackStartStopContext context) {
                 Stack stack = context.getStack();
                 LOGGER.debug("Assembling start request for stack: {}", stack);
-                List<CloudInstance> cloudInstances = instanceMetaDataToCloudInstanceConverter.convert(stack.getNotDeletedInstanceMetaDataList(),
+                List<CloudInstance> cloudInstances = instanceMetaDataToCloudInstanceConverter.convert(stack.getNotDeletedAndNotZombieInstanceMetaDataList(),
                         stack.getEnvironmentCrn(), stack.getStackAuthentication());
                 List<CloudResource> resources = stack.getResources().stream()
                         .map(s -> resourceToCloudResourceConverter.convert(s))
@@ -170,7 +170,7 @@ public class StackStartActions {
             Stack stack = stackService.getByIdWithListsInTransaction(stackId);
             stack.setResources(new HashSet<>(resourceService.getAllByStackId(payload.getResourceId())));
             MDCBuilder.buildMdcContext(stack);
-            List<InstanceMetaData> instances = new ArrayList<>(instanceMetaDataService.findNotTerminatedForStack(stackId));
+            List<InstanceMetaData> instances = new ArrayList<>(instanceMetaDataService.findNotTerminatedAndNotZombieForStack(stackId));
             Location location = location(region(stack.getRegion()), availabilityZone(stack.getAvailabilityZone()));
             CloudContext cloudContext = CloudContext.Builder.builder()
                     .withId(stack.getId())

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/start/StackStartStopService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/start/StackStartStopService.java
@@ -113,7 +113,7 @@ public class StackStartStopService {
     }
 
     private void updateInstancesToStopped(Stack stack, Collection<CloudVmInstanceStatus> instanceStatuses) {
-        Set<InstanceMetaData> allInstanceMetadataSet = instanceMetaDataService.getAllInstanceMetadataByStackId(stack.getId());
+        Set<InstanceMetaData> allInstanceMetadataSet = instanceMetaDataService.getNotDeletedAndNotZombieInstanceMetadataByStackId(stack.getId());
         for (InstanceMetaData metaData : allInstanceMetadataSet) {
             Optional<CloudVmInstanceStatus> status = instanceStatuses.stream()
                     .filter(is -> is != null && is.getCloudInstance().getInstanceId() != null

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/stop/StackStopActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/stop/StackStopActions.java
@@ -143,7 +143,7 @@ public class StackStopActions {
             Stack stack = stackService.getByIdWithListsInTransaction(stackId);
             stack.setResources(new HashSet<>(resourceService.getAllByStackId(payload.getResourceId())));
             MDCBuilder.buildMdcContext(stack);
-            List<InstanceMetaData> instances = new ArrayList<>(instanceMetaDataService.findNotTerminatedForStack(stackId));
+            List<InstanceMetaData> instances = new ArrayList<>(instanceMetaDataService.findNotTerminatedAndNotZombieForStack(stackId));
             Location location = location(region(stack.getRegion()), availabilityZone(stack.getAvailabilityZone()));
             CloudContext cloudContext = CloudContext.Builder.builder()
                     .withId(stack.getId())

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/sync/StackSyncActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/sync/StackSyncActions.java
@@ -152,7 +152,7 @@ public class StackSyncActions {
                     .withAccountId(stack.getTenant().getId())
                     .build();
             CloudCredential cloudCredential = stackUtil.getCloudCredential(stack);
-            return new StackSyncContext(flowParameters, stack, stack.getNotTerminatedInstanceMetaDataList(), cloudContext, cloudCredential,
+            return new StackSyncContext(flowParameters, stack, stack.getNotTerminatedAndNotZombieInstanceMetaDataList(), cloudContext, cloudCredential,
                     isStatusUpdateEnabled(variables));
         }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleActions.java
@@ -330,7 +330,7 @@ public class StackUpscaleActions {
 
             @Override
             protected void doExecute(StackScalingFlowContext context, ExtendHostMetadataResult payload, Map<Object, Object> variables) {
-                Set<InstanceMetaData> instanceMetaData = instanceMetaDataService.findNotTerminatedForStack(context.getStack().getId());
+                Set<InstanceMetaData> instanceMetaData = instanceMetaDataService.findNotTerminatedAndNotZombieForStack(context.getStack().getId());
                 Set<String> ips = payload.getRequest().getUpscaleCandidateAddresses();
                 Set<String> hostNames = instanceMetaData.stream()
                         .filter(im -> ips.contains(im.getPrivateIp()))
@@ -351,7 +351,7 @@ public class StackUpscaleActions {
                 final Stack stack = context.getStack();
                 stackUpscaleService.finishExtendHostMetadata(stack);
                 final Set<String> newAddresses = payload.getIps();
-                final Map<String, String> newAddressesByFqdn = stack.getNotDeletedInstanceMetaDataSet().stream()
+                final Map<String, String> newAddressesByFqdn = stack.getNotDeletedAndNotZombieInstanceMetaDataSet().stream()
                         .filter(instanceMetaData -> newAddresses.contains(instanceMetaData.getPrivateIp()))
                         .filter(instanceMetaData -> instanceMetaData.getDiscoveryFQDN() != null)
                         .collect(Collectors.toMap(InstanceMetaData::getDiscoveryFQDN, InstanceMetaData::getPublicIpWrapper));

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleService.java
@@ -139,7 +139,7 @@ public class StackUpscaleService {
 
     public void setupTls(StackContext context) throws CloudbreakException {
         Stack stack = context.getStack();
-        for (InstanceMetaData gwInstance : stack.getNotTerminatedGatewayInstanceMetadata()) {
+        for (InstanceMetaData gwInstance : stack.getNotTerminatedAndNotZombieGatewayInstanceMetadata()) {
             if (!stack.getTunnel().useCcm() && CREATED.equals(gwInstance.getInstanceStatus())) {
                 tlsSetupService.setupTls(stack, gwInstance);
             }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJob.java
@@ -229,7 +229,7 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
 
     private void doSync(Stack stack) {
         ClusterApi connector = clusterApiConnectors.getConnector(stack);
-        Set<InstanceMetaData> runningInstances = instanceMetaDataService.findNotTerminatedForStack(stack.getId());
+        Set<InstanceMetaData> runningInstances = instanceMetaDataService.findNotTerminatedAndNotZombieForStack(stack.getId());
         try {
             if (isClusterManagerRunning(stack, connector)) {
                 ExtendedHostStatuses extendedHostStatuses = connector.clusterStatusService().getExtendedHostStatuses(
@@ -350,6 +350,7 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
                 .collect(Collectors.toMap(e -> e.getKey().value(), e -> Optional.ofNullable(hostStatuses.statusReasonForHost(e.getKey()))));
         Set<String> noReportHosts = runningInstances.stream()
                 .filter(instanceMetaData -> instanceMetaData.getDiscoveryFQDN() != null)
+                .filter(instanceMetaData -> !instanceMetaData.isZombie())
                 .map(InstanceMetaData::getDiscoveryFQDN)
                 .filter(discoveryFQDN -> hostStatuses.getHostsHealth().get(hostName(discoveryFQDN)) == null)
                 .collect(toSet());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/UpscaleClusterManagerRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/UpscaleClusterManagerRequest.java
@@ -8,10 +8,13 @@ public class UpscaleClusterManagerRequest extends AbstractClusterScaleRequest {
 
     private final boolean primaryGatewayChanged;
 
-    public UpscaleClusterManagerRequest(Long stackId, String hostGroupName, Integer scalingAdjustment, boolean primaryGatewayChanged) {
+    private final boolean repair;
+
+    public UpscaleClusterManagerRequest(Long stackId, String hostGroupName, Integer scalingAdjustment, boolean primaryGatewayChanged, boolean repair) {
         super(stackId, hostGroupName);
         this.scalingAdjustment = scalingAdjustment;
         this.primaryGatewayChanged = primaryGatewayChanged;
+        this.repair = repair;
     }
 
     public Integer getScalingAdjustment() {
@@ -21,4 +24,9 @@ public class UpscaleClusterManagerRequest extends AbstractClusterScaleRequest {
     public boolean isPrimaryGatewayChanged() {
         return primaryGatewayChanged;
     }
+
+    public boolean isRepair() {
+        return repair;
+    }
+
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/UpscaleClusterManagerHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/UpscaleClusterManagerHandler.java
@@ -33,7 +33,7 @@ public class UpscaleClusterManagerHandler implements EventHandler<UpscaleCluster
         UpscaleClusterManagerResult result;
         try {
             clusterManagerUpscaleService.upscaleClusterManager(request.getResourceId(), request.getHostGroupName(),
-                    request.getScalingAdjustment(), request.isPrimaryGatewayChanged());
+                    request.getScalingAdjustment(), request.isPrimaryGatewayChanged(), request.isRepair());
             result = new UpscaleClusterManagerResult(request);
         } catch (Exception e) {
             result = new UpscaleClusterManagerResult(e.getMessage(), e, request);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/orchestration/RemoveHostsHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/orchestration/RemoveHostsHandler.java
@@ -90,7 +90,7 @@ public class RemoveHostsHandler implements EventHandler<RemoveHostsRequest> {
         LOGGER.debug("Remove hosts from orchestrator: {}", hostNames);
         try {
             Map<String, String> removeNodePrivateIPsByFQDN = new HashMap<>();
-            stack.getNotTerminatedInstanceMetaDataList().stream()
+            stack.getNotTerminatedInstanceMetaDataSet().stream()
                     .filter(instanceMetaData -> instanceMetaData.getDiscoveryFQDN() != null)
                     .filter(instanceMetaData ->
                             hostNames.stream()

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceMetaDataRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceMetaDataRepository.java
@@ -40,6 +40,15 @@ public interface InstanceMetaDataRepository extends CrudRepository<InstanceMetaD
     @Query("SELECT i FROM InstanceMetaData i " +
             "WHERE i.instanceGroup.stack.id= :stackId " +
             "AND i.instanceStatus <> 'TERMINATED' " +
+            "AND i.instanceStatus <> 'ZOMBIE' " +
+            "AND i.instanceStatus <> 'DELETED_ON_PROVIDER_SIDE' " +
+            "AND i.instanceStatus <> 'DELETED_BY_PROVIDER'")
+    Set<InstanceMetaData> findNotTerminatedAndNotZombieForStack(@Param("stackId") Long stackId);
+
+    @EntityGraph(value = "InstanceMetaData.instanceGroup", type = EntityGraphType.LOAD)
+    @Query("SELECT i FROM InstanceMetaData i " +
+            "WHERE i.instanceGroup.stack.id= :stackId " +
+            "AND i.instanceStatus <> 'TERMINATED' " +
             "AND i.instanceStatus <> 'DELETED_ON_PROVIDER_SIDE' " +
             "AND i.instanceStatus <> 'DELETED_BY_PROVIDER' " +
             "ORDER BY i.privateId")
@@ -48,9 +57,10 @@ public interface InstanceMetaDataRepository extends CrudRepository<InstanceMetaD
     @Query("SELECT i FROM InstanceMetaData i " +
             "WHERE i.instanceGroup.stack.id= :stackId " +
             "AND i.instanceStatus <> 'TERMINATED' " +
+            "AND i.instanceStatus <> 'ZOMBIE' " +
             "AND i.instanceStatus <> 'DELETED_ON_PROVIDER_SIDE' " +
             "AND i.instanceStatus <> 'DELETED_BY_PROVIDER'")
-    Set<InstanceMetaData> findNotTerminatedForStackWithoutInstanceGroups(@Param("stackId") Long stackId);
+    Set<InstanceMetaData> findNotTerminatedAndNotZombieForStackWithoutInstanceGroups(@Param("stackId") Long stackId);
 
     @EntityGraph(value = "InstanceMetaData.instanceGroup", type = EntityGraphType.LOAD)
     @Query("SELECT i FROM InstanceMetaData i WHERE i.instanceGroup.stack.id= :stackId")
@@ -90,7 +100,7 @@ public interface InstanceMetaDataRepository extends CrudRepository<InstanceMetaD
 
     @EntityGraph(value = "InstanceMetaData.instanceGroup", type = EntityGraphType.LOAD)
     @Query("SELECT i FROM InstanceMetaData i WHERE i.instanceGroup.stack.id= :stackId AND i.instanceGroup.groupName= :groupName "
-            + "AND i.instanceStatus in ('CREATED', 'SERVICES_RUNNING', 'DECOMMISSIONED', 'FAILED', 'STOPPED')")
+            + "AND i.instanceStatus in ('CREATED', 'SERVICES_RUNNING', 'DECOMMISSIONED', 'FAILED', 'STOPPED', 'ZOMBIE')")
     Set<InstanceMetaData> findRemovableInstances(@Param("stackId") Long stackId, @Param("groupName") String groupName);
 
     @EntityGraph(value = "InstanceMetaData.instanceGroup", type = EntityGraphType.LOAD)

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterRepairService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterRepairService.java
@@ -318,7 +318,7 @@ public class ClusterRepairService {
                 .filter(instanceSelectors.getLeft())
                 .map(hostGroup -> Map.entry(hostGroupName(hostGroup.getName()), hostGroup
                         .getInstanceGroup()
-                        .getNotTerminatedInstanceMetaDataSet()
+                        .getNotTerminatedAndNotZombieInstanceMetaDataSet()
                         .stream()
                         .filter(instanceMetaData -> instanceMetaData.getDiscoveryFQDN() != null)
                         .filter(instanceSelectors.getRight())

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/InstanceMetadataUpdater.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/InstanceMetadataUpdater.java
@@ -82,7 +82,7 @@ public class InstanceMetadataUpdater {
                 updateInstanceMetaDataIfVersionQueryFailed(packageVersionsByNameByHost, stack);
         notifyIfVersionsCannotBeQueried(stack, failedVersionQueriesByHost);
 
-        Set<InstanceMetaData> instanceMetaDataSet = stack.getNotDeletedInstanceMetaDataSet();
+        Set<InstanceMetaData> instanceMetaDataSet = stack.getNotDeletedAndNotZombieInstanceMetaDataSet();
 
         updateInstanceMetaDataWithPackageVersions(packageVersionsByNameByHost, instanceMetaDataSet);
 
@@ -99,7 +99,7 @@ public class InstanceMetadataUpdater {
 
     private List<String> updateInstanceMetaDataIfVersionQueryFailed(Map<String, Map<String, String>> packageVersionsByNameByHost,
             Stack stack) throws IOException {
-        Set<InstanceMetaData> instanceMetaDataSet = stack.getNotDeletedInstanceMetaDataSet();
+        Set<InstanceMetaData> instanceMetaDataSet = stack.getNotDeletedAndNotZombieInstanceMetaDataSet();
 
         List<String> failedVersionQueriesByHost = Lists.newArrayList();
         for (InstanceMetaData im : instanceMetaDataSet) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/ClusterOperationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/ClusterOperationService.java
@@ -392,7 +392,7 @@ public class ClusterOperationService {
 
     private Collection<InstanceMetaData> collectChangedHosts(Cluster cluster, Map<String, Optional<String>> hostNamesWithReason,
             Set<InstanceStatus> expectedState, InstanceStatus newState, ResourceEvent hostEvent) {
-        return instanceMetaDataService.findNotTerminatedForStack(cluster.getStack().getId()).stream()
+        return instanceMetaDataService.findNotTerminatedAndNotZombieForStack(cluster.getStack().getId()).stream()
                 .filter(host -> expectedState.contains(host.getInstanceStatus()) && hostNamesWithReason.containsKey(host.getDiscoveryFQDN()))
                 .map(host -> updateHostStatus(hostNamesWithReason, newState, hostEvent, host))
                 .collect(Collectors.toSet());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/UpdateHostsValidator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/UpdateHostsValidator.java
@@ -78,7 +78,7 @@ public class UpdateHostsValidator {
                 throw new BadRequestException(String.format("Can't find instancegroup for hostgroup: %s", hostGroupName));
             } else {
                 InstanceGroup instanceGroup = hostGroup.getInstanceGroup();
-                int hostsCount = instanceGroup.getNotDeletedInstanceMetaDataSet().size();
+                int hostsCount = instanceGroup.getNotDeletedAndNotZombieInstanceMetaDataSet().size();
                 int adjustment = Math.abs(hostGroupAdjustment.getScalingAdjustment());
                 Boolean validateNodeCount = hostGroupAdjustment.getValidateNodeCount();
                 if (validateNodeCount == null || validateNodeCount) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/recipe/OrchestratorRecipeExecutor.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/recipe/OrchestratorRecipeExecutor.java
@@ -191,7 +191,7 @@ class OrchestratorRecipeExecutor {
     private Set<Node> collectNodes(Stack stack, Set<String> hostNames) {
         Set<Node> agents = new HashSet<>();
         for (InstanceGroup instanceGroup : stack.getInstanceGroups()) {
-            for (InstanceMetaData im : instanceGroup.getNotDeletedInstanceMetaDataSet()) {
+            for (InstanceMetaData im : instanceGroup.getNotDeletedAndNotZombieInstanceMetaDataSet()) {
                 if (hostNames.contains(im.getDiscoveryFQDN())) {
                     String instanceId = im.getInstanceId();
                     String instanceType = instanceGroup.getTemplate().getInstanceType();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/telemetry/ClusterMonitoringEngine.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/telemetry/ClusterMonitoringEngine.java
@@ -38,7 +38,7 @@ public class ClusterMonitoringEngine {
         if (telemetry != null && telemetry.isMonitoringFeatureEnabled()) {
             try {
                 LOGGER.info("Install and start monitoring for CM server.");
-                Set<InstanceMetaData> instanceMetaDataSet = stack.getNotDeletedInstanceMetaDataSet();
+                Set<InstanceMetaData> instanceMetaDataSet = stack.getNotDeletedAndNotZombieInstanceMetaDataSet();
                 List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
                 Set<Node> allNodes = instanceMetaDataSet.stream()
                         .map(im -> new Node(im.getPrivateIp(), im.getPublicIp(), im.getInstanceId(),

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/CurrentImageUsageCondition.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/CurrentImageUsageCondition.java
@@ -33,7 +33,7 @@ public class CurrentImageUsageCondition {
     }
 
     private Set<Image> getImagesFromInstanceMetadata(Long stackId) {
-        return instanceMetaDataService.getNotDeletedInstanceMetadataByStackId(stackId)
+        return instanceMetaDataService.getNotDeletedAndNotZombieInstanceMetadataByStackId(stackId)
                 .stream()
                 .map(InstanceMetaData::getImage)
                 .filter(json -> !json.getMap().isEmpty())

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/multiaz/MultiAzCalculatorService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/multiaz/MultiAzCalculatorService.java
@@ -84,7 +84,7 @@ public class MultiAzCalculatorService {
         collectCurrentSubnetUsage(instanceGroup, subnetUsage);
 
         if (!subnetIds.isEmpty() && multiAzValidator.supportedForInstanceMetadataGeneration(instanceGroup)) {
-            for (InstanceMetaData instanceMetaData : instanceGroup.getNotDeletedInstanceMetaDataSet()) {
+            for (InstanceMetaData instanceMetaData : instanceGroup.getNotDeletedAndNotZombieInstanceMetaDataSet()) {
                 if (isNullOrEmpty(instanceMetaData.getSubnetId())) {
                     Integer numberOfInstanceInASubnet = searchTheSmallestInstanceCountForUsage(subnetUsage);
                     String leastUsedSubnetId = searchTheSmallestUsedID(subnetUsage, numberOfInstanceInASubnet);
@@ -139,7 +139,7 @@ public class MultiAzCalculatorService {
     }
 
     private void collectCurrentAzUsage(InstanceGroup instanceGroup, Map<String, Integer> azUsage, Map<String, String> subnetAzPairs) {
-        for (InstanceMetaData instanceMetaData : instanceGroup.getNotDeletedInstanceMetaDataSet()) {
+        for (InstanceMetaData instanceMetaData : instanceGroup.getNotDeletedAndNotZombieInstanceMetaDataSet()) {
             String subnetId = instanceMetaData.getSubnetId();
             if (!isNullOrEmpty(subnetId)) {
                 String az = subnetAzPairs.get(subnetId);
@@ -177,7 +177,7 @@ public class MultiAzCalculatorService {
 
     private void collectCurrentSubnetUsage(InstanceGroup instanceGroup, Map<String, Integer> subnetUsage) {
 
-        for (InstanceMetaData instanceMetaData : instanceGroup.getNotDeletedInstanceMetaDataSet()) {
+        for (InstanceMetaData instanceMetaData : instanceGroup.getNotDeletedAndNotZombieInstanceMetaDataSet()) {
             String subnetId = instanceMetaData.getSubnetId();
             if (!isNullOrEmpty(subnetId)) {
                 Integer countOfInstances = subnetUsage.get(subnetId);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/publicendpoint/dns/AllHostPublicDnsEntryService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/publicendpoint/dns/AllHostPublicDnsEntryService.java
@@ -29,7 +29,7 @@ public class AllHostPublicDnsEntryService extends BaseDnsEntryService {
             LOGGER.info("No running gateway or all node is terminated, we skip the dns entry deletion.");
         } else {
             InstanceMetaData primaryGatewayInstance = gateway.get();
-            Map<String, List<String>> hostnamesByInstanceGroupName = stack.getNotTerminatedInstanceMetaDataList()
+            Map<String, List<String>> hostnamesByInstanceGroupName = stack.getNotTerminatedGatewayInstanceMetadata()
                     .stream()
                     .filter(im -> StringUtils.isNoneEmpty(im.getDiscoveryFQDN()) && !im.getDiscoveryFQDN().equals(primaryGatewayInstance.getDiscoveryFQDN()))
                     .collect(groupingBy(InstanceMetaData::getInstanceGroupName, mapping(InstanceMetaData::getDiscoveryFQDN, toList())));

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/publicendpoint/dns/BaseDnsEntryService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/publicendpoint/dns/BaseDnsEntryService.java
@@ -71,7 +71,7 @@ public abstract class BaseDnsEntryService extends BasePublicEndpointManagementSe
 
     private Map<String, String> getCandidateIpsByFqdn(Stack stack) {
         Map<String, List<String>> componentLocation = getComponentLocation(stack);
-        final Set<InstanceMetaData> runningInstanceMetaData = stack.getNotDeletedInstanceMetaDataSet();
+        final Set<InstanceMetaData> runningInstanceMetaData = stack.getNotDeletedAndNotZombieInstanceMetaDataSet();
         final InstanceMetaData primaryGatewayInstanceMetadata = stack.getPrimaryGatewayInstance();
         return componentLocation
                 .values()

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/sharedservice/DatalakeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/sharedservice/DatalakeService.java
@@ -163,8 +163,9 @@ public class DatalakeService {
     private String getDatalakeClusterManagerFqdn(Stack datalakeStack) {
         String fqdn;
         try {
-            fqdn = transactionService.required(() -> datalakeStack.getNotTerminatedGatewayInstanceMetadata().isEmpty()
-                    ? datalakeStack.getClusterManagerIp() : datalakeStack.getNotTerminatedGatewayInstanceMetadata().iterator().next().getDiscoveryFQDN());
+            fqdn = transactionService.required(() -> datalakeStack.getNotTerminatedAndNotZombieGatewayInstanceMetadata().isEmpty()
+                    ? datalakeStack.getClusterManagerIp()
+                    : datalakeStack.getNotTerminatedAndNotZombieGatewayInstanceMetadata().iterator().next().getDiscoveryFQDN());
         } catch (Exception ignored) {
             LOGGER.debug("Get instance metadata transaction failed, giving back IP as FQDN");
             fqdn = datalakeStack.getClusterManagerIp();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/InstanceGroupService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/InstanceGroupService.java
@@ -55,6 +55,20 @@ public class InstanceGroupService {
         return viewRepository.findInstanceGroupsInStack(stackId);
     }
 
+    public Set<InstanceGroup> findNotTerminatedAndNotZombieByStackId(Long stackId) {
+        try {
+            return transactionService.required(() -> {
+                Set<InstanceGroup> instanceGroups = repository.findByStackId(stackId);
+                instanceGroups.forEach(
+                        ig -> ig.replaceInstanceMetadata(ig.getNotTerminatedAndNotZombieInstanceMetaDataSet())
+                );
+                return instanceGroups;
+            });
+        } catch (TransactionService.TransactionExecutionException e) {
+            throw new CloudbreakServiceException("Can't load instance groups for stack ID.", e);
+        }
+    }
+
     public Set<InstanceGroup> findNotTerminatedByStackId(Long stackId) {
         try {
             return transactionService.required(() -> {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/InstanceMetaDataService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/InstanceMetaDataService.java
@@ -249,6 +249,13 @@ public class InstanceMetaDataService {
         return repository.findAllInStack(stackId);
     }
 
+    public Set<InstanceMetaData> getNotDeletedAndNotZombieInstanceMetadataByStackId(Long stackId) {
+        return repository.findAllInStack(stackId)
+                .stream()
+                .filter(metaData -> !metaData.isTerminated() && !metaData.isDeletedOnProvider() && !metaData.isZombie())
+                .collect(Collectors.toSet());
+    }
+
     public Set<InstanceMetaData> getNotDeletedInstanceMetadataByStackId(Long stackId) {
         return repository.findAllInStack(stackId)
                 .stream()
@@ -309,6 +316,10 @@ public class InstanceMetaDataService {
         return repository.findNotTerminatedForStack(stackId);
     }
 
+    public Set<InstanceMetaData> findNotTerminatedAndNotZombieForStack(Long stackId) {
+        return repository.findNotTerminatedAndNotZombieForStack(stackId);
+    }
+
     public List<InstanceMetaData> findNotTerminatedAsOrderedListForStack(Long stackId) {
         return repository.findNotTerminatedAsOrderedListForStack(stackId);
     }
@@ -317,8 +328,8 @@ public class InstanceMetaDataService {
         return repository.save(instanceMetaData);
     }
 
-    public Set<InstanceMetaData> findNotTerminatedForStackWithoutInstanceGroups(Long stackId) {
-        return repository.findNotTerminatedForStackWithoutInstanceGroups(stackId);
+    public Set<InstanceMetaData> findNotTerminatedAndNotZombieForStackWithoutInstanceGroups(Long stackId) {
+        return repository.findNotTerminatedAndNotZombieForStackWithoutInstanceGroups(stackId);
     }
 
     public Optional<InstanceMetaData> findByStackIdAndInstanceId(Long stackId, String instanceId) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/HostMetadataSetup.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/HostMetadataSetup.java
@@ -50,7 +50,7 @@ public class HostMetadataSetup {
             transactionService.required(() -> {
                 LOGGER.debug("Setting up host metadata for the cluster.");
                 Stack stack = stackService.getByIdWithListsInTransaction(stackId);
-                Set<InstanceMetaData> allInstanceMetadataByStackId = instanceMetaDataService.getNotDeletedInstanceMetadataByStackId(stackId);
+                Set<InstanceMetaData> allInstanceMetadataByStackId = instanceMetaDataService.getNotDeletedAndNotZombieInstanceMetadataByStackId(stackId);
                 updateWithHostData(stack, allInstanceMetadataByStackId);
                 instanceMetaDataService.saveAll(allInstanceMetadataByStackId);
             });
@@ -64,7 +64,7 @@ public class HostMetadataSetup {
             transactionService.required(() -> {
                 LOGGER.info("Extending host metadata: {}", newAddresses);
                 Stack stack = stackService.getByIdWithListsInTransaction(stackId);
-                Set<InstanceMetaData> newInstanceMetadata = instanceMetaDataService.getNotDeletedInstanceMetadataByStackId(stackId).stream()
+                Set<InstanceMetaData> newInstanceMetadata = instanceMetaDataService.getNotDeletedAndNotZombieInstanceMetadataByStackId(stackId).stream()
                         .filter(instanceMetaData -> newAddresses.contains(instanceMetaData.getPrivateIp()))
                         .collect(Collectors.toSet());
                 updateWithHostData(stack, newInstanceMetadata);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/InstanceSyncState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/InstanceSyncState.java
@@ -9,7 +9,8 @@ public enum InstanceSyncState {
     RUNNING,
     STOPPED,
     IN_PROGRESS,
-    UNKNOWN;
+    UNKNOWN,
+    ZOMBIE;
 
     public static InstanceSyncState getInstanceSyncState(InstanceStatus instanceStatus) {
         switch (instanceStatus) {
@@ -27,6 +28,8 @@ public enum InstanceSyncState {
                 return DELETED_ON_PROVIDER_SIDE;
             case TERMINATED_BY_PROVIDER:
                 return DELETED_BY_PROVIDER;
+            case ZOMBIE:
+                return ZOMBIE;
             default:
                 return UNKNOWN;
         }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/MetadataSetupService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/MetadataSetupService.java
@@ -214,7 +214,7 @@ public class MetadataSetupService {
                 }
                 instanceMetaDataEntry.setLifeCycle(InstanceLifeCycle.fromCloudInstanceLifeCycle(md.getLifeCycle()));
                 primaryIgSelected = setupInstanceMetaDataType(primaryIgSelected, terminatedPrimaryGwWhichShouldBeRestored, instanceMetaDataEntry, ig);
-                if (status != null) {
+                if (status != null && instanceMetaDataEntry.getInstanceStatus() != InstanceStatus.ZOMBIE) {
                     if (cloudVmMetaDataStatus.getCloudVmInstanceStatus().getStatus() == TERMINATED) {
                         instanceMetaDataEntry.setInstanceStatus(InstanceStatus.TERMINATED);
                     } else {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackSyncService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackSyncService.java
@@ -207,7 +207,7 @@ public class StackSyncService {
 
     private void handleSyncResult(Stack stack, Map<InstanceSyncState, Integer> instanceStateCounts, SyncConfig syncConfig) {
         if (syncConfig.isStackStatusUpdateEnabled()) {
-            Set<InstanceMetaData> instances = instanceMetaDataService.findNotTerminatedForStackWithoutInstanceGroups(stack.getId());
+            Set<InstanceMetaData> instances = instanceMetaDataService.findNotTerminatedAndNotZombieForStackWithoutInstanceGroups(stack.getId());
             handleSyncResult(stack, instanceStateCounts, syncConfig, instances);
         }
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/LoggingAgentAutoRestartPatchService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/LoggingAgentAutoRestartPatchService.java
@@ -105,7 +105,7 @@ public class LoggingAgentAutoRestartPatchService extends AbstractTelemetryPatchS
                 byte[] fluentSaltStateConfig = compressUtil.generateCompressedOutputFromFolders(saltStateDefinitions, loggingAgentSaltStateDef);
                 boolean loggingAgentContentMatches = compressUtil.compareCompressedContent(currentSaltState, fluentSaltStateConfig, loggingAgentSaltStateDef);
                 if (!loggingAgentContentMatches) {
-                    Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedForStack(stack.getId());
+                    Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedAndNotZombieForStack(stack.getId());
                     List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
                     ClusterDeletionBasedExitCriteriaModel exitModel = ClusterDeletionBasedExitCriteriaModel.nonCancellableModel();
                     Set<Node> availableNodes = getAvailableNodes(stack.getName(), instanceMetaDataSet, gatewayConfigs, exitModel);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/MeteringAzureMetadataPatchService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/MeteringAzureMetadataPatchService.java
@@ -105,7 +105,7 @@ public class MeteringAzureMetadataPatchService extends AbstractTelemetryPatchSer
         byte[] meteringSaltStateConfig = compressUtil.generateCompressedOutputFromFolders(saltStateDefinitions, meteringSaltStateDef);
         boolean meteringContentMatches = compressUtil.compareCompressedContent(currentSaltState, meteringSaltStateConfig, meteringSaltStateDef);
         if (!meteringContentMatches) {
-            Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedForStack(stack.getId());
+            Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedAndNotZombieForStack(stack.getId());
             List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
             ClusterDeletionBasedExitCriteriaModel exitModel = ClusterDeletionBasedExitCriteriaModel.nonCancellableModel();
             getTelemetryOrchestrator().updateMeteringSaltDefinition(meteringSaltStateConfig, gatewayConfigs, exitModel);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/DiskSpaceValidationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/DiskSpaceValidationService.java
@@ -57,7 +57,8 @@ public class DiskSpaceValidationService {
         long requiredFreeSpace = parcelSizeService.getRequiredFreeSpace(targetImage, stack);
         Map<String, String> freeDiskSpaceByNodes = getFreeDiskSpaceByNodes(stack);
         LOGGER.debug("Required free space for parcels {} KB. Free space by nodes in KB: {}", requiredFreeSpace, freeDiskSpaceByNodes);
-        Map<String, String> notEligibleNodes = getNotEligibleNodes(freeDiskSpaceByNodes, requiredFreeSpace, stack.getNotTerminatedGatewayInstanceMetadata());
+        Map<String, String> notEligibleNodes = getNotEligibleNodes(freeDiskSpaceByNodes, requiredFreeSpace,
+                stack.getNotTerminatedAndNotZombieGatewayInstanceMetadata());
         if (!notEligibleNodes.isEmpty()) {
             throw new UpgradeValidationFailedException(String.format(
                     "There is not enough free space on the nodes to perform upgrade operation. The required free space by nodes: %s",

--- a/core/src/main/java/com/sequenceiq/cloudbreak/util/StackUtil.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/util/StackUtil.java
@@ -45,6 +45,7 @@ import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.domain.view.StackView;
 import com.sequenceiq.cloudbreak.dto.credential.Credential;
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.orchestrator.model.NodeReachabilityResult;
 import com.sequenceiq.cloudbreak.service.GatewayConfigService;
 import com.sequenceiq.cloudbreak.service.LoadBalancerConfigService;
 import com.sequenceiq.cloudbreak.service.environment.credential.CredentialClientService;
@@ -80,7 +81,20 @@ public class StackUtil {
     private EntitlementService entitlementService;
 
     public Set<Node> collectNodes(Stack stack) {
-        return stack.getAllNodes();
+        Set<Node> agents = new HashSet<>();
+        for (InstanceGroup instanceGroup : stack.getInstanceGroups()) {
+            if (instanceGroup.getNodeCount() != 0) {
+                for (InstanceMetaData im : instanceGroup.getNotDeletedInstanceMetaDataSet()) {
+                    if (im.getDiscoveryFQDN() != null) {
+                        String instanceId = im.getInstanceId();
+                        String instanceType = instanceGroup.getTemplate().getInstanceType();
+                        agents.add(new Node(im.getPrivateIp(), im.getPublicIp(), instanceId, instanceType,
+                                im.getDiscoveryFQDN(), im.getInstanceGroupName()));
+                    }
+                }
+            }
+        }
+        return agents;
     }
 
     public Set<Node> collectReachableNodesByInstanceStates(Stack stack) {
@@ -98,6 +112,23 @@ public class StackUtil {
                 .collect(Collectors.toSet());
     }
 
+    public NodeReachabilityResult collectReachableAndUnreachableCandidateNodes(Stack stack, Collection<String> necessaryNodes) {
+        NodeReachabilityResult nodeReachabilityResult = collectReachableAndUnreachableNodes(stack);
+        Set<Node> reachableCandidateNodes = nodeReachabilityResult.getReachableNodes().stream()
+                .filter(node -> necessaryNodes.contains(node.getHostname()))
+                .collect(Collectors.toSet());
+        Set<Node> unreachableCandidateNodes = nodeReachabilityResult.getUnreachableNodes().stream()
+                .filter(node -> necessaryNodes.contains(node.getHostname()))
+                .collect(Collectors.toSet());
+
+        NodeReachabilityResult nodeReachabilityResultWithCandidates = new NodeReachabilityResult(reachableCandidateNodes, unreachableCandidateNodes);
+        if (!unreachableCandidateNodes.isEmpty()) {
+            LOGGER.warn("Some candidate nodes are unreachable: {}", nodeReachabilityResultWithCandidates.getUnreachableHosts());
+        }
+        LOGGER.debug("Candidate node reachability result: {}", nodeReachabilityResultWithCandidates);
+        return nodeReachabilityResultWithCandidates;
+    }
+
     public Set<Node> collectAndCheckReachableNodes(Stack stack, Collection<String> necessaryNodes) throws NodesUnreachableException {
         Set<Node> reachableNodes = collectReachableNodes(stack);
         Set<String> reachableAddresses = reachableNodes.stream().map(Node::getHostname).collect(Collectors.toSet());
@@ -112,7 +143,14 @@ public class StackUtil {
     }
 
     public Set<Node> collectReachableNodes(Stack stack) {
-        return hostOrchestrator.getResponsiveNodes(collectNodes(stack), gatewayConfigService.getPrimaryGatewayConfig(stack));
+        return hostOrchestrator.getResponsiveNodes(collectNodes(stack), gatewayConfigService.getPrimaryGatewayConfig(stack)).getReachableNodes();
+    }
+
+    public NodeReachabilityResult collectReachableAndUnreachableNodes(Stack stack) {
+        NodeReachabilityResult nodeReachabilityResult = hostOrchestrator.getResponsiveNodes(collectNodes(stack),
+                gatewayConfigService.getPrimaryGatewayConfig(stack));
+        LOGGER.debug("Node reachability result: {}", nodeReachabilityResult);
+        return nodeReachabilityResult;
     }
 
     public Set<Node> collectNodesFromHostnames(Stack stack, Set<String> hostnames) {
@@ -142,7 +180,7 @@ public class StackUtil {
         Map<String, Map<String, Object>> instanceToVolumeInfoMap = createInstanceToVolumeInfoMap(volumeSets);
         for (InstanceGroup instanceGroup : stack.getInstanceGroups()) {
             if (instanceGroup.getNodeCount() != 0) {
-                for (InstanceMetaData im : instanceGroup.getNotDeletedInstanceMetaDataSet()) {
+                for (InstanceMetaData im : instanceGroup.getNotDeletedAndNotZombieInstanceMetaDataSet()) {
                     if (im.getDiscoveryFQDN() != null && (newNodeAddresses.isEmpty() || newNodeAddresses.contains(im.getPrivateIp()))) {
                         String instanceId = im.getInstanceId();
                         String instanceType = instanceGroup.getTemplate().getInstanceType();

--- a/core/src/test/java/com/sequenceiq/cloudbreak/conclusion/step/VmStatusCheckerConclusionStepTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/conclusion/step/VmStatusCheckerConclusionStepTest.java
@@ -89,7 +89,7 @@ class VmStatusCheckerConclusionStepTest {
     @Test
     public void checkShouldBeSuccessfulIfCMIsRunningAndAllInstanceIsHealthy() {
         when(clusterStatusService.isClusterManagerRunningQuickCheck()).thenReturn(Boolean.TRUE);
-        when(instanceMetaDataService.findNotTerminatedForStack(anyLong()))
+        when(instanceMetaDataService.findNotTerminatedAndNotZombieForStack(anyLong()))
                 .thenReturn(Set.of(createInstanceMetadata("host1"), createInstanceMetadata("host2")));
         when(clusterStatusService.getExtendedHostStatuses(any())).thenReturn(createExtendedHostStatuses(true));
 
@@ -103,7 +103,7 @@ class VmStatusCheckerConclusionStepTest {
     @Test
     public void checkShouldFailIfCMIsRunningAndUnhealthyOrUnknownInstanceExists() {
         when(clusterStatusService.isClusterManagerRunningQuickCheck()).thenReturn(Boolean.TRUE);
-        when(instanceMetaDataService.findNotTerminatedForStack(anyLong()))
+        when(instanceMetaDataService.findNotTerminatedAndNotZombieForStack(anyLong()))
                 .thenReturn(Set.of(createInstanceMetadata("host1"), createInstanceMetadata("host2"), createInstanceMetadata("host3")));
         when(clusterStatusService.getExtendedHostStatuses(any())).thenReturn(createExtendedHostStatuses(false));
 
@@ -119,7 +119,7 @@ class VmStatusCheckerConclusionStepTest {
     @Test
     public void checkShouldBeSuccessfulIfCMIsNotRunningAndAllInstanceIsHealthy() {
         when(clusterStatusService.isClusterManagerRunningQuickCheck()).thenReturn(Boolean.FALSE);
-        when(instanceMetaDataService.findNotTerminatedForStack(anyLong()))
+        when(instanceMetaDataService.findNotTerminatedAndNotZombieForStack(anyLong()))
                 .thenReturn(Set.of(createInstanceMetadata("host1"), createInstanceMetadata("host2")));
         when(stackInstanceStatusChecker.queryInstanceStatuses(any(), anyList()))
                 .thenReturn(List.of(createCloudVmInstanceStatus("host1", true), createCloudVmInstanceStatus("host2", true)));
@@ -134,7 +134,7 @@ class VmStatusCheckerConclusionStepTest {
     @Test
     public void checkShouldFailIfCMIsNotRunningAndUnhealthyInstanceExists() {
         when(clusterStatusService.isClusterManagerRunningQuickCheck()).thenReturn(Boolean.FALSE);
-        when(instanceMetaDataService.findNotTerminatedForStack(anyLong()))
+        when(instanceMetaDataService.findNotTerminatedAndNotZombieForStack(anyLong()))
                 .thenReturn(Set.of(createInstanceMetadata("host1"), createInstanceMetadata("host2")));
         when(stackInstanceStatusChecker.queryInstanceStatuses(any(), anyList()))
                 .thenReturn(List.of(createCloudVmInstanceStatus("host1", false), createCloudVmInstanceStatus("host2", false)));
@@ -153,7 +153,7 @@ class VmStatusCheckerConclusionStepTest {
         when(clusterStatusService.isClusterManagerRunningQuickCheck()).thenReturn(Boolean.FALSE);
         InstanceMetaData instanceMetaData = new InstanceMetaData();
         instanceMetaData.setInstanceId("1");
-        when(instanceMetaDataService.findNotTerminatedForStack(anyLong())).thenReturn(Set.of(instanceMetaData));
+        when(instanceMetaDataService.findNotTerminatedAndNotZombieForStack(anyLong())).thenReturn(Set.of(instanceMetaData));
         when(stackInstanceStatusChecker.queryInstanceStatuses(any(), anyList()))
                 .thenReturn(List.of(createCloudVmInstanceStatus("1", false)));
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapperErrorHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapperErrorHandlerTest.java
@@ -88,7 +88,7 @@ public class ClusterBootstrapperErrorHandlerTest {
         when(instanceMetaDataService.findNotTerminatedByPrivateAddress(anyLong(), anyString())).thenAnswer((Answer<Optional<InstanceMetaData>>) invocation -> {
             Object[] args = invocation.getArguments();
             String ip = (String) args[1];
-            for (InstanceMetaData instanceMetaData : stack.getNotDeletedInstanceMetaDataSet()) {
+            for (InstanceMetaData instanceMetaData : stack.getNotDeletedAndNotZombieInstanceMetaDataSet()) {
                 if (instanceMetaData.getPrivateIp().equals(ip)) {
                     return Optional.of(instanceMetaData);
                 }
@@ -99,7 +99,7 @@ public class ClusterBootstrapperErrorHandlerTest {
                 .thenAnswer((Answer<Optional<InstanceGroup>>) invocation -> {
                     Object[] args = invocation.getArguments();
                     String name = (String) args[1];
-                    for (InstanceMetaData instanceMetaData : stack.getNotDeletedInstanceMetaDataSet()) {
+                    for (InstanceMetaData instanceMetaData : stack.getNotDeletedAndNotZombieInstanceMetaDataSet()) {
                         if (instanceMetaData.getInstanceGroup().getGroupName().equals(name)) {
                             InstanceGroup instanceGroup = instanceMetaData.getInstanceGroup();
                             instanceGroup.getInstanceMetaDataSet().forEach(im -> im.setInstanceStatus(InstanceStatus.TERMINATED));
@@ -130,7 +130,7 @@ public class ClusterBootstrapperErrorHandlerTest {
         when(instanceMetaDataService.findNotTerminatedByPrivateAddress(anyLong(), anyString())).thenAnswer((Answer<Optional<InstanceMetaData>>) invocation -> {
             Object[] args = invocation.getArguments();
             String ip = (String) args[1];
-            for (InstanceMetaData instanceMetaData : stack.getNotDeletedInstanceMetaDataSet()) {
+            for (InstanceMetaData instanceMetaData : stack.getNotDeletedAndNotZombieInstanceMetaDataSet()) {
                 if (instanceMetaData.getPrivateIp().equals(ip)) {
                     return Optional.of(instanceMetaData);
                 }
@@ -141,7 +141,7 @@ public class ClusterBootstrapperErrorHandlerTest {
                 .thenAnswer((Answer<Optional<InstanceGroup>>) invocation -> {
                     Object[] args = invocation.getArguments();
                     String name = (String) args[1];
-                    for (InstanceMetaData instanceMetaData : stack.getNotDeletedInstanceMetaDataSet()) {
+                    for (InstanceMetaData instanceMetaData : stack.getNotDeletedAndNotZombieInstanceMetaDataSet()) {
                         if (instanceMetaData.getInstanceGroup().getGroupName().equals(name)) {
                             return Optional.ofNullable(instanceMetaData.getInstanceGroup());
                         }
@@ -163,7 +163,7 @@ public class ClusterBootstrapperErrorHandlerTest {
 
     private Set<Node> prepareNodes(Stack stack) {
         Set<Node> nodes = new HashSet<>();
-        for (InstanceMetaData instanceMetaData : stack.getNotDeletedInstanceMetaDataSet()) {
+        for (InstanceMetaData instanceMetaData : stack.getNotDeletedAndNotZombieInstanceMetaDataSet()) {
             nodes.add(new Node(instanceMetaData.getPrivateIp(), instanceMetaData.getPublicIpWrapper(), null, null));
         }
         return nodes;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterNodeNameGeneratorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterNodeNameGeneratorTest.java
@@ -143,7 +143,7 @@ public class ClusterNodeNameGeneratorTest {
     }
 
     private void testHostNameGenerationForStack(Stack underTestStack, Set<String> expectedNodeNames) {
-        Set<InstanceMetaData> testInstanceMetadata = underTestStack.getNotTerminatedInstanceMetaDataSet();
+        Set<InstanceMetaData> testInstanceMetadata = underTestStack.getNotTerminatedAndNotZombieInstanceMetaDataSet();
         Map<String, AtomicLong> hostGroupNodeCount = new HashMap<>();
         underTestStack.getInstanceGroups().stream().forEach(
                 instanceGroup -> hostGroupNodeCount.put(instanceGroup.getGroupName(), new AtomicLong(0L)));

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpscaleServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpscaleServiceTest.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.core.cluster;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -8,7 +9,6 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import java.util.Map;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -23,6 +23,7 @@ import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterServiceRunner;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.ClusterHostServiceRunner;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.orchestrator.model.NodeReachabilityResult;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
@@ -58,34 +59,32 @@ public class ClusterManagerUpscaleServiceTest {
     @Test
     public void testUpscaleIfTargetedUpscaleNotSupportedOrPrimaryGatewayChanged() throws ClusterClientInitException {
         when(stackService.getByIdWithListsInTransaction(any())).thenReturn(getStack());
-        when(clusterHostServiceRunner.addClusterServices(any(), any(), any())).thenReturn(Map.of());
+        when(clusterHostServiceRunner.addClusterServices(any(), any(), any(), anyBoolean())).thenReturn(new NodeReachabilityResult(Set.of(), Set.of()));
         doNothing().when(clusterServiceRunner).updateAmbariClientConfig(any(), any());
         doNothing().when(clusterService).updateInstancesToRunning(any(), any());
         when(clusterApiConnectors.getConnector(any(Stack.class))).thenReturn(clusterApi);
 
-        underTest.upscaleClusterManager(1L, "hg", 1, true);
+        underTest.upscaleClusterManager(1L, "hg", 1, true, false);
 
         verifyNoInteractions(targetedUpscaleSupportService);
 
         when(targetedUpscaleSupportService.targetedUpscaleOperationSupported(any())).thenReturn(Boolean.FALSE);
 
-        underTest.upscaleClusterManager(1L, "hg", 1, false);
+        underTest.upscaleClusterManager(1L, "hg", 1, false, false);
 
         verifyNoMoreInteractions(clusterServiceRunner);
-        verify(clusterHostServiceRunner, times(0)).getReachableCandidates(any(), any());
         verify(clusterApi, times(2)).waitForHosts(any());
     }
 
     @Test
     public void testUpscaleIfTargetedUpscaleSupported() throws ClusterClientInitException {
         when(stackService.getByIdWithListsInTransaction(any())).thenReturn(getStack());
-        when(clusterHostServiceRunner.addClusterServices(any(), any(), any())).thenReturn(Map.of());
+        when(clusterHostServiceRunner.addClusterServices(any(), any(), any(), anyBoolean())).thenReturn(new NodeReachabilityResult(Set.of(), Set.of()));
         doNothing().when(clusterService).updateInstancesToRunning(any(), any());
         when(clusterApiConnectors.getConnector(any(Stack.class))).thenReturn(clusterApi);
         when(targetedUpscaleSupportService.targetedUpscaleOperationSupported(any())).thenReturn(Boolean.TRUE);
-        when(clusterHostServiceRunner.getReachableCandidates(any(), any())).thenReturn(Set.of());
 
-        underTest.upscaleClusterManager(1L, "hg", 1, false);
+        underTest.upscaleClusterManager(1L, "hg", 1, false, false);
 
         verifyNoInteractions(clusterServiceRunner);
         verify(clusterApi).waitForHosts(any());

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartds/StopStartDownscaleActionsTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartds/StopStartDownscaleActionsTest.java
@@ -418,7 +418,7 @@ public class StopStartDownscaleActionsTest {
                 Stream.of(instancesActionableStarted, instancesActionableNotStarted, instancesRandomStarted, instancesRandomNotStarted)
                         .flatMap(Collection::stream).collect(Collectors.toList());
 
-        lenient().when(stack.getNotDeletedInstanceMetaDataList()).thenReturn(combined);
+        lenient().when(stack.getNotDeletedAndNotZombieInstanceMetaDataList()).thenReturn(combined);
 
         InstanceGroup instanceGroup = new InstanceGroup();
         instanceGroup.setGroupName(INSTANCE_GROUP_NAME_ACTIONABLE);
@@ -426,7 +426,7 @@ public class StopStartDownscaleActionsTest {
         lenient().when(stack.getInstanceGroupByInstanceGroupName(eq(INSTANCE_GROUP_NAME_ACTIONABLE))).thenReturn(instanceGroup);
 
         lenient().when(stackService.getPrivateIdsForHostNames(any(), any())).thenCallRealMethod();
-        lenient().when(cloudInstanceIdToInstanceMetaDataConverter.getNotDeletedInstances(any(), anyString(), any())).thenCallRealMethod();
+        lenient().when(cloudInstanceIdToInstanceMetaDataConverter.getNotDeletedAndNotZombieInstances(any(), anyString(), any())).thenCallRealMethod();
     }
 
     private List<CloudInstance> mockInstanceMetadataToCloudInstanceConverter(List<InstanceMetaData> src) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartus/StopStartUpscaleActionsTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartus/StopStartUpscaleActionsTest.java
@@ -417,7 +417,7 @@ public class StopStartUpscaleActionsTest {
         List<InstanceMetaData> combined =
                 Stream.of(instancesActionableNotStopped, instancesActionableStopped, instancesRandomNotStopped, instancesRandomStopped)
                 .flatMap(Collection::stream).collect(Collectors.toList());
-        lenient().when(stack.getNotDeletedInstanceMetaDataList()).thenReturn(combined);
+        lenient().when(stack.getNotDeletedAndNotZombieInstanceMetaDataList()).thenReturn(combined);
         lenient().when(stack.getEnvironmentCrn()).thenReturn(ENV_CRN);
         lenient().when(stack.getStackAuthentication()).thenReturn(stackAuthentication);
         lenient().when(stack.getId()).thenReturn(STACK_ID);
@@ -437,7 +437,7 @@ public class StopStartUpscaleActionsTest {
         lenient().when(instanceMetaDataToCloudInstanceConverter.convert(any(), anyString(), any(StackAuthentication.class)))
                 .thenReturn(cloudInstancesActionableStopped, cloudInstancesActionableAll);
 
-        lenient().when(cloudInstanceIdToInstanceMetaDataConverter.getNotDeletedInstances(any(), any(), any())).thenCallRealMethod();
+        lenient().when(cloudInstanceIdToInstanceMetaDataConverter.getNotDeletedAndNotZombieInstances(any(), any(), any())).thenCallRealMethod();
     }
 
     private List<InstanceMetaData> generateInstances(int count, int startIndex,

--- a/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJobTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJobTest.java
@@ -317,13 +317,13 @@ public class StackStatusCheckerJobTest {
                 new HealthCheck(HealthCheckType.CERT, HealthCheckResult.UNHEALTHY, Optional.empty()));
         ExtendedHostStatuses extendedHostStatuses = new ExtendedHostStatuses(Map.of(HostName.hostName("host1"), healthChecks));
         when(clusterStatusService.getExtendedHostStatuses(any())).thenReturn(extendedHostStatuses);
-        when(instanceMetaDataService.findNotTerminatedForStack(anyLong())).thenReturn(Set.of(instanceMetaData));
+        when(instanceMetaDataService.findNotTerminatedAndNotZombieForStack(anyLong())).thenReturn(Set.of(instanceMetaData));
         when(instanceMetaData.getInstanceStatus()).thenReturn(InstanceStatus.SERVICES_HEALTHY);
     }
 
     private void setupForCMNotAccessible() {
         setStackStatus(DetailedStackStatus.STOPPED);
-        when(instanceMetaDataService.findNotTerminatedForStack(anyLong())).thenReturn(Set.of(instanceMetaData));
+        when(instanceMetaDataService.findNotTerminatedAndNotZombieForStack(anyLong())).thenReturn(Set.of(instanceMetaData));
     }
 
     private void setStackStatus(DetailedStackStatus detailedStackStatus) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusIntegrationTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusIntegrationTest.java
@@ -203,8 +203,8 @@ class StackStatusIntegrationTest {
         stack.setWorkspace(workspace);
 
         when(stackService.get(STACK_ID)).thenReturn(stack);
-        when(instanceMetaDataService.findNotTerminatedForStack(STACK_ID)).thenReturn(runningInstances);
-        when(instanceMetaDataService.findNotTerminatedForStackWithoutInstanceGroups(STACK_ID)).thenReturn(runningInstances);
+        when(instanceMetaDataService.findNotTerminatedAndNotZombieForStack(STACK_ID)).thenReturn(runningInstances);
+        when(instanceMetaDataService.findNotTerminatedAndNotZombieForStackWithoutInstanceGroups(STACK_ID)).thenReturn(runningInstances);
     }
 
     private void setUpClusterApi() {
@@ -291,7 +291,7 @@ class StackStatusIntegrationTest {
         setUpCloudVmInstanceStatuses(Map.of(
                 INSTANCE_1, com.sequenceiq.cloudbreak.cloud.model.InstanceStatus.TERMINATED_BY_PROVIDER,
                 INSTANCE_2, com.sequenceiq.cloudbreak.cloud.model.InstanceStatus.TERMINATED_BY_PROVIDER));
-        when(instanceMetaDataService.findNotTerminatedForStackWithoutInstanceGroups(STACK_ID)).thenReturn(Set.of());
+        when(instanceMetaDataService.findNotTerminatedAndNotZombieForStackWithoutInstanceGroups(STACK_ID)).thenReturn(Set.of());
 
         underTest.executeTracedJob(jobExecutionContext);
 
@@ -323,7 +323,7 @@ class StackStatusIntegrationTest {
         setUpCloudVmInstanceStatuses(Map.of(
                 INSTANCE_1, com.sequenceiq.cloudbreak.cloud.model.InstanceStatus.TERMINATED_BY_PROVIDER,
                 INSTANCE_2, com.sequenceiq.cloudbreak.cloud.model.InstanceStatus.TERMINATED_BY_PROVIDER));
-        when(instanceMetaDataService.findNotTerminatedForStackWithoutInstanceGroups(STACK_ID)).thenReturn(Set.of());
+        when(instanceMetaDataService.findNotTerminatedAndNotZombieForStackWithoutInstanceGroups(STACK_ID)).thenReturn(Set.of());
 
         underTest.executeTracedJob(jobExecutionContext);
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ClusterServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ClusterServiceTest.java
@@ -214,7 +214,7 @@ class ClusterServiceTest {
         instanceMetadata.setDiscoveryFQDN(FQDN1);
         instanceMetadata.setInstanceStatus(InstanceStatus.SERVICES_RUNNING);
         instanceMetadata.setStatusReason(STATUS_REASON_ORIGINAL);
-        when(instanceMetaDataService.findNotTerminatedForStack(stack.getId())).thenReturn(Set.of(instanceMetadata));
+        when(instanceMetaDataService.findNotTerminatedAndNotZombieForStack(stack.getId())).thenReturn(Set.of(instanceMetadata));
     }
 
     private void setupClusterApi(Stack stack, HealthCheckResult healthCheckResult, String statusReason) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/flow/ClusterOperationServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/flow/ClusterOperationServiceTest.java
@@ -185,7 +185,7 @@ public class ClusterOperationServiceTest {
 
         HostGroup hostGroup = getHostGroup(host1, RecoveryMode.AUTO);
         when(instanceMetaDataService.getAllInstanceMetadataByStackId(eq(stack.getId()))).thenReturn(Set.of(host1, host2));
-        when(instanceMetaDataService.findNotTerminatedForStack(eq(stack.getId()))).thenReturn(Set.of(host1, host2));
+        when(instanceMetaDataService.findNotTerminatedAndNotZombieForStack(eq(stack.getId()))).thenReturn(Set.of(host1, host2));
         when(hostGroupService.findHostGroupsInCluster(stack.getCluster().getId())).thenReturn(Set.of(hostGroup, getHostGroup(host2, RecoveryMode.MANUAL)));
 
         underTest.reportHealthChange(STACK_CRN, Map.of("host1", Optional.empty(), "host2", Optional.empty()), Set.of());
@@ -252,7 +252,7 @@ public class ClusterOperationServiceTest {
 
         InstanceMetaData host1 = getHost("host1", "master", InstanceStatus.SERVICES_UNHEALTHY, InstanceGroupType.GATEWAY);
 
-        when(instanceMetaDataService.findNotTerminatedForStack(eq(stack.getId()))).thenReturn(new HashSet<>(Arrays.asList(host1)));
+        when(instanceMetaDataService.findNotTerminatedAndNotZombieForStack(eq(stack.getId()))).thenReturn(new HashSet<>(Arrays.asList(host1)));
 
         when(cloudbreakMessagesService.getMessage(any(), anyCollection())).thenReturn("recovery detected");
 
@@ -293,7 +293,7 @@ public class ClusterOperationServiceTest {
 
         InstanceMetaData instanceWithoutFqdn = getHost(null, "master", InstanceStatus.SERVICES_UNHEALTHY, InstanceGroupType.GATEWAY);
 
-        when(instanceMetaDataService.findNotTerminatedForStack(eq(stack.getId()))).thenReturn(new HashSet<>(Arrays.asList(instanceWithoutFqdn)));
+        when(instanceMetaDataService.findNotTerminatedAndNotZombieForStack(eq(stack.getId()))).thenReturn(new HashSet<>(Arrays.asList(instanceWithoutFqdn)));
 
         when(cloudbreakMessagesService.getMessage(any(), anyCollection())).thenReturn("recovery detected");
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/CurrentImageUsageConditionTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/CurrentImageUsageConditionTest.java
@@ -39,21 +39,21 @@ public class CurrentImageUsageConditionTest {
     @Test
     public void testFilterCurrentImageShouldReturnTrueWhenThereAreInstanceWithOtherImage() {
         Set<InstanceMetaData> instanceMetaData = Set.of(createInstanceMetaData(NEW_IMAGE), createInstanceMetaData(OLD_IMAGE));
-        when(instanceMetaDataService.getNotDeletedInstanceMetadataByStackId(STACK_ID)).thenReturn(instanceMetaData);
+        when(instanceMetaDataService.getNotDeletedAndNotZombieInstanceMetadataByStackId(STACK_ID)).thenReturn(instanceMetaData);
 
         assertTrue(underTest.currentImageUsedOnInstances(STACK_ID, NEW_IMAGE));
 
-        verify(instanceMetaDataService).getNotDeletedInstanceMetadataByStackId(STACK_ID);
+        verify(instanceMetaDataService).getNotDeletedAndNotZombieInstanceMetadataByStackId(STACK_ID);
     }
 
     @Test
     public void testFilterCurrentImageShouldReturnTrueWhenThereAreNoInstanceWithOtherImage() {
         Set<InstanceMetaData> instanceMetaData = Set.of(createInstanceMetaData(NEW_IMAGE), createInstanceMetaData(NEW_IMAGE));
-        when(instanceMetaDataService.getNotDeletedInstanceMetadataByStackId(STACK_ID)).thenReturn(instanceMetaData);
+        when(instanceMetaDataService.getNotDeletedAndNotZombieInstanceMetadataByStackId(STACK_ID)).thenReturn(instanceMetaData);
 
         assertFalse(underTest.currentImageUsedOnInstances(STACK_ID, NEW_IMAGE));
 
-        verify(instanceMetaDataService).getNotDeletedInstanceMetadataByStackId(STACK_ID);
+        verify(instanceMetaDataService).getNotDeletedAndNotZombieInstanceMetadataByStackId(STACK_ID);
     }
 
     @Test
@@ -61,11 +61,11 @@ public class CurrentImageUsageConditionTest {
         InstanceMetaData nullImageInstanceMetadata = new InstanceMetaData();
         nullImageInstanceMetadata.setImage(new Json(null));
         Set<InstanceMetaData> instanceMetaData = Set.of(createInstanceMetaData(NEW_IMAGE), nullImageInstanceMetadata);
-        when(instanceMetaDataService.getNotDeletedInstanceMetadataByStackId(STACK_ID)).thenReturn(instanceMetaData);
+        when(instanceMetaDataService.getNotDeletedAndNotZombieInstanceMetadataByStackId(STACK_ID)).thenReturn(instanceMetaData);
 
         assertFalse(underTest.currentImageUsedOnInstances(STACK_ID, NEW_IMAGE));
 
-        verify(instanceMetaDataService).getNotDeletedInstanceMetadataByStackId(STACK_ID);
+        verify(instanceMetaDataService).getNotDeletedAndNotZombieInstanceMetadataByStackId(STACK_ID);
     }
 
     @Test
@@ -73,11 +73,11 @@ public class CurrentImageUsageConditionTest {
         InstanceMetaData nullImageInstanceMetadata = new InstanceMetaData();
         nullImageInstanceMetadata.setImage(new Json(null));
         Set<InstanceMetaData> instanceMetaData = Set.of(createInstanceMetaData(OLD_IMAGE), nullImageInstanceMetadata);
-        when(instanceMetaDataService.getNotDeletedInstanceMetadataByStackId(STACK_ID)).thenReturn(instanceMetaData);
+        when(instanceMetaDataService.getNotDeletedAndNotZombieInstanceMetadataByStackId(STACK_ID)).thenReturn(instanceMetaData);
 
         assertTrue(underTest.currentImageUsedOnInstances(STACK_ID, NEW_IMAGE));
 
-        verify(instanceMetaDataService).getNotDeletedInstanceMetadataByStackId(STACK_ID);
+        verify(instanceMetaDataService).getNotDeletedAndNotZombieInstanceMetadataByStackId(STACK_ID);
     }
 
     @Test
@@ -87,11 +87,11 @@ public class CurrentImageUsageConditionTest {
         InstanceMetaData nullImageInstanceMetadata2 = new InstanceMetaData();
         nullImageInstanceMetadata2.setImage(new Json(null));
         Set<InstanceMetaData> instanceMetaData = Set.of(nullImageInstanceMetadata, nullImageInstanceMetadata2);
-        when(instanceMetaDataService.getNotDeletedInstanceMetadataByStackId(STACK_ID)).thenReturn(instanceMetaData);
+        when(instanceMetaDataService.getNotDeletedAndNotZombieInstanceMetadataByStackId(STACK_ID)).thenReturn(instanceMetaData);
 
         assertFalse(underTest.currentImageUsedOnInstances(STACK_ID, NEW_IMAGE));
 
-        verify(instanceMetaDataService).getNotDeletedInstanceMetadataByStackId(STACK_ID);
+        verify(instanceMetaDataService).getNotDeletedAndNotZombieInstanceMetadataByStackId(STACK_ID);
     }
 
     private com.sequenceiq.cloudbreak.cloud.model.Image createImage(String imageId) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/publicendpoint/dns/AllHostPublicDnsEntryServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/publicendpoint/dns/AllHostPublicDnsEntryServiceTest.java
@@ -42,7 +42,7 @@ class AllHostPublicDnsEntryServiceTest {
         otherGatewayInstanceMetadata.setDiscoveryFQDN("something.new");
         otherGatewayInstanceMetadata.setInstanceGroup(gatewayInstanceGroup);
         otherGatewayInstanceMetadata.setInstanceStatus(InstanceStatus.SERVICES_RUNNING);
-        Set<InstanceMetaData> updatedIM = gatewayInstanceGroup.getNotTerminatedInstanceMetaDataSet();
+        Set<InstanceMetaData> updatedIM = gatewayInstanceGroup.getNotTerminatedAndNotZombieInstanceMetaDataSet();
         updatedIM.add(otherGatewayInstanceMetadata);
         gatewayInstanceGroup.replaceInstanceMetadata(updatedIM);
 
@@ -66,7 +66,7 @@ class AllHostPublicDnsEntryServiceTest {
     @Test
     void getComponentLocationWhenNodesDoesNotHaveDiscoveryFQDN() {
         Stack stack = TestUtil.stack();
-        stack.getNotTerminatedInstanceMetaDataList()
+        stack.getNotTerminatedAndNotZombieInstanceMetaDataList()
                 .forEach(im -> im.setDiscoveryFQDN(null));
 
         Map<String, List<String>> result = underTest.getComponentLocation(stack);
@@ -78,7 +78,7 @@ class AllHostPublicDnsEntryServiceTest {
     void getComponentLocationWhenTheGatewayNodeHaveOnlyDiscoveryFQDN() {
         Stack stack = TestUtil.stack();
         InstanceMetaData primaryGatewayInstance = stack.getPrimaryGatewayInstance();
-        stack.getNotTerminatedInstanceMetaDataList().stream()
+        stack.getNotTerminatedAndNotZombieInstanceMetaDataList().stream()
                 .filter(im -> !primaryGatewayInstance.getId().equals(im.getId()))
                 .forEach(im -> im.setDiscoveryFQDN(null));
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/rdsconfig/AbstractRdsConfigProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/rdsconfig/AbstractRdsConfigProviderTest.java
@@ -66,9 +66,9 @@ public class AbstractRdsConfigProviderTest {
     public void createServicePillarForLocalRdsConfig() {
         when(rdsConfigService.createIfNotExists(any(), any(), any())).thenAnswer(i -> i.getArguments()[1]);
         Stack testStack = TestUtil.stack();
-        InstanceMetaData metaData = testStack.getNotTerminatedGatewayInstanceMetadata().iterator().next();
+        InstanceMetaData metaData = testStack.getNotTerminatedAndNotZombieGatewayInstanceMetadata().iterator().next();
         metaData.setInstanceMetadataType(InstanceMetadataType.GATEWAY_PRIMARY);
-        testStack.getNotTerminatedGatewayInstanceMetadata().add(metaData);
+        testStack.getNotTerminatedAndNotZombieGatewayInstanceMetadata().add(metaData);
         Cluster testCluster = TestUtil.cluster();
 
         Map<String, Object> result = underTest.createServicePillarConfigMapIfNeeded(testStack, testCluster);
@@ -96,9 +96,9 @@ public class AbstractRdsConfigProviderTest {
         when(secretService.getByResponse(username)).thenReturn(REMOTE_ADMIN);
         when(secretService.getByResponse(password)).thenReturn(REMOTE_ADMIN_PASSWORD);
         Stack testStack = TestUtil.stack();
-        InstanceMetaData metaData = testStack.getNotTerminatedGatewayInstanceMetadata().iterator().next();
+        InstanceMetaData metaData = testStack.getNotTerminatedAndNotZombieGatewayInstanceMetadata().iterator().next();
         metaData.setInstanceMetadataType(InstanceMetadataType.GATEWAY_PRIMARY);
-        testStack.getNotTerminatedGatewayInstanceMetadata().add(metaData);
+        testStack.getNotTerminatedAndNotZombieGatewayInstanceMetadata().add(metaData);
         Cluster testCluster = TestUtil.cluster();
         testStack.setCluster(testCluster);
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/rdsconfig/RedbeamsDbServerConfigurerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/rdsconfig/RedbeamsDbServerConfigurerTest.java
@@ -157,9 +157,9 @@ public class RedbeamsDbServerConfigurerTest {
 
     private Stack createStack(Cluster testCluster) {
         Stack testStack = TestUtil.stack();
-        InstanceMetaData metaData = testStack.getNotTerminatedGatewayInstanceMetadata().iterator().next();
+        InstanceMetaData metaData = testStack.getNotTerminatedAndNotZombieGatewayInstanceMetadata().iterator().next();
         metaData.setInstanceMetadataType(InstanceMetadataType.GATEWAY_PRIMARY);
-        testStack.getNotTerminatedGatewayInstanceMetadata().add(metaData);
+        testStack.getNotTerminatedAndNotZombieGatewayInstanceMetadata().add(metaData);
         testStack.setCluster(testCluster);
         return testStack;
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/HostMetadataSetupTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/HostMetadataSetupTest.java
@@ -78,7 +78,7 @@ public class HostMetadataSetupTest {
         Stack stack = mock(Stack.class);
         InstanceMetaData im1 = createInstanceMetadata("id1", InstanceMetadataType.CORE, 1L, "10.0.0.1", "host1", false);
         InstanceMetaData im2 = createInstanceMetadata("id2", InstanceMetadataType.CORE, 2L, "10.0.0.2", "host2", false);
-        when(instanceMetaDataService.getNotDeletedInstanceMetadataByStackId(STACK_ID)).thenReturn(Set.of(im1, im2));
+        when(instanceMetaDataService.getNotDeletedAndNotZombieInstanceMetadataByStackId(STACK_ID)).thenReturn(Set.of(im1, im2));
         when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
         when(hostOrchestrator.getMembers(any(), any())).thenReturn(Map.of("10.0.0.1", "host1", "10.0.0.2", "host2"));
 
@@ -98,7 +98,7 @@ public class HostMetadataSetupTest {
     public void testSetupNewHostMetadataWithSingplePrimaryChange() throws CloudbreakException, CloudbreakOrchestratorException {
         Stack stack = mock(Stack.class);
         InstanceMetaData im1 = createInstanceMetadata("id1", InstanceMetadataType.GATEWAY_PRIMARY, 1L, "10.0.0.1", "host1", true);
-        when(instanceMetaDataService.getNotDeletedInstanceMetadataByStackId(STACK_ID)).thenReturn(Set.of(im1));
+        when(instanceMetaDataService.getNotDeletedAndNotZombieInstanceMetadataByStackId(STACK_ID)).thenReturn(Set.of(im1));
         when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
         when(hostOrchestrator.getMembers(any(), any())).thenReturn(Map.of("10.0.0.1", "host1"));
 
@@ -117,7 +117,7 @@ public class HostMetadataSetupTest {
         InstanceMetaData im1 = createInstanceMetadata("id1", InstanceMetadataType.GATEWAY, 1L, "10.0.0.1", "host1", false);
         InstanceMetaData im2 = createInstanceMetadata("id2", InstanceMetadataType.GATEWAY, 2L, "10.0.0.2", "host2", false);
         Set<InstanceMetaData> allNewInstances = Set.of(im1, im2);
-        when(instanceMetaDataService.getNotDeletedInstanceMetadataByStackId(STACK_ID)).thenReturn(allNewInstances);
+        when(instanceMetaDataService.getNotDeletedAndNotZombieInstanceMetadataByStackId(STACK_ID)).thenReturn(allNewInstances);
         when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
         when(hostOrchestrator.getMembers(any(), any())).thenReturn(Map.of("10.0.0.1", "host1", "10.0.0.2", "host2"));
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stackpatch/LoggingAgentAutoRestartPatchServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stackpatch/LoggingAgentAutoRestartPatchServiceTest.java
@@ -169,7 +169,7 @@ public class LoggingAgentAutoRestartPatchServiceTest {
         InstanceGroup instanceGroup = createInstanceGroup();
         instanceMetaData.setInstanceGroup(instanceGroup);
         Set<InstanceMetaData> instanceMetaDataSet = Set.of(instanceMetaData);
-        given(instanceMetaDataService.findNotTerminatedForStack(anyLong())).willReturn(instanceMetaDataSet);
+        given(instanceMetaDataService.findNotTerminatedAndNotZombieForStack(anyLong())).willReturn(instanceMetaDataSet);
         given(clusterComponentConfigProvider.getSaltStateComponent(anyLong())).willReturn(currentSaltState);
         given(compressUtil.generateCompressedOutputFromFolders(any(), any())).willReturn(fluentConfig);
         given(compressUtil.compareCompressedContent(any(), any(), any())).willReturn(false);
@@ -189,7 +189,7 @@ public class LoggingAgentAutoRestartPatchServiceTest {
         InstanceGroup instanceGroup = createInstanceGroup();
         instanceMetaData.setInstanceGroup(instanceGroup);
         Set<InstanceMetaData> instanceMetaDataSet = Set.of(instanceMetaData);
-        given(instanceMetaDataService.findNotTerminatedForStack(anyLong())).willReturn(instanceMetaDataSet);
+        given(instanceMetaDataService.findNotTerminatedAndNotZombieForStack(anyLong())).willReturn(instanceMetaDataSet);
         given(telemetryOrchestrator.collectUnresponsiveNodes(any(), any(), any())).willReturn(Set.of(new Node(null, null, null, null)));
         given(clusterComponentConfigProvider.getSaltStateComponent(anyLong())).willReturn(currentSaltState);
         given(compressUtil.generateCompressedOutputFromFolders(any(), any())).willReturn(fluentConfig);
@@ -235,7 +235,7 @@ public class LoggingAgentAutoRestartPatchServiceTest {
         InstanceGroup instanceGroup = createInstanceGroup();
         instanceMetaData.setInstanceGroup(instanceGroup);
         Set<InstanceMetaData> instanceMetaDataSet = Set.of(instanceMetaData);
-        given(instanceMetaDataService.findNotTerminatedForStack(anyLong())).willReturn(instanceMetaDataSet);
+        given(instanceMetaDataService.findNotTerminatedAndNotZombieForStack(anyLong())).willReturn(instanceMetaDataSet);
         given(clusterComponentConfigProvider.getSaltStateComponent(anyLong())).willReturn(currentSaltState);
         given(compressUtil.generateCompressedOutputFromFolders(any(), any())).willReturn(fluentConfig);
         given(compressUtil.compareCompressedContent(any(), any(), any())).willReturn(false);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stackpatch/MeteringAzureMetadataPatchServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stackpatch/MeteringAzureMetadataPatchServiceTest.java
@@ -148,7 +148,7 @@ public class MeteringAzureMetadataPatchServiceTest {
         InstanceGroup instanceGroup = createInstanceGroup();
         instanceMetaData.setInstanceGroup(instanceGroup);
         Set<InstanceMetaData> instanceMetaDataSet = Set.of(instanceMetaData);
-        given(instanceMetaDataService.findNotTerminatedForStack(anyLong())).willReturn(instanceMetaDataSet);
+        given(instanceMetaDataService.findNotTerminatedAndNotZombieForStack(anyLong())).willReturn(instanceMetaDataSet);
         given(clusterComponentConfigProvider.getSaltStateComponent(anyLong())).willReturn(currentSaltState);
         given(compressUtil.generateCompressedOutputFromFolders(any(), any())).willReturn(meteringConfig);
         given(compressUtil.compareCompressedContent(any(), any(), any())).willReturn(false);
@@ -169,7 +169,7 @@ public class MeteringAzureMetadataPatchServiceTest {
         InstanceGroup instanceGroup = createInstanceGroup();
         instanceMetaData.setInstanceGroup(instanceGroup);
         Set<InstanceMetaData> instanceMetaDataSet = Set.of(instanceMetaData);
-        given(instanceMetaDataService.findNotTerminatedForStack(anyLong())).willReturn(instanceMetaDataSet);
+        given(instanceMetaDataService.findNotTerminatedAndNotZombieForStack(anyLong())).willReturn(instanceMetaDataSet);
         given(telemetryOrchestrator.collectUnresponsiveNodes(any(), any(), any())).willReturn(
                 Set.of(new Node(null, null, null, null)));
         given(clusterComponentConfigProvider.getSaltStateComponent(anyLong())).willReturn(currentSaltState);
@@ -216,7 +216,7 @@ public class MeteringAzureMetadataPatchServiceTest {
         InstanceGroup instanceGroup = createInstanceGroup();
         instanceMetaData.setInstanceGroup(instanceGroup);
         Set<InstanceMetaData> instanceMetaDataSet = Set.of(instanceMetaData);
-        given(instanceMetaDataService.findNotTerminatedForStack(anyLong())).willReturn(instanceMetaDataSet);
+        given(instanceMetaDataService.findNotTerminatedAndNotZombieForStack(anyLong())).willReturn(instanceMetaDataSet);
         given(clusterComponentConfigProvider.getSaltStateComponent(anyLong())).willReturn(currentSaltState);
         given(compressUtil.generateCompressedOutputFromFolders(any(), any())).willReturn(meteringConfig);
         given(compressUtil.compareCompressedContent(any(), any(), any())).willReturn(false);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/util/StackUtilTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/util/StackUtilTest.java
@@ -41,6 +41,7 @@ import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.dto.credential.Credential;
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.orchestrator.model.NodeReachabilityResult;
 import com.sequenceiq.cloudbreak.service.GatewayConfigService;
 import com.sequenceiq.cloudbreak.service.environment.credential.CredentialClientService;
 import com.sequenceiq.common.api.type.ResourceType;
@@ -172,7 +173,7 @@ public class StackUtilTest {
         Set<Node> nodes = new HashSet<>();
         nodes.add(new Node("1.1.1.1", "1.1.1.1", "1", "m5.xlarge", "node1.example.com", "worker"));
         nodes.add(new Node("1.1.1.3", "1.1.1.3", "3", "m5.xlarge", "node3.example.com", "worker"));
-        when(hostOrchestrator.getResponsiveNodes(nodesCaptor.capture(), any())).thenReturn(nodes);
+        when(hostOrchestrator.getResponsiveNodes(nodesCaptor.capture(), any())).thenReturn(new NodeReachabilityResult(nodes, Set.of()));
 
         stackUtil.collectAndCheckReachableNodes(stack, necessaryNodes);
 
@@ -214,7 +215,7 @@ public class StackUtilTest {
 
         Set<Node> nodes = new HashSet<>();
         nodes.add(new Node("1.1.1.1", "1.1.1.1", "1", "m5.xlarge", "node1.example.com", "worker"));
-        when(hostOrchestrator.getResponsiveNodes(nodesCaptor.capture(), any())).thenReturn(nodes);
+        when(hostOrchestrator.getResponsiveNodes(nodesCaptor.capture(), any())).thenReturn(new NodeReachabilityResult(nodes, Set.of()));
 
         NodesUnreachableException nodesUnreachableException = Assertions.assertThrows(NodesUnreachableException.class,
                 () -> stackUtil.collectAndCheckReachableNodes(stack, necessaryNodes));
@@ -248,6 +249,11 @@ public class StackUtilTest {
         instanceGroup.setTemplate(template);
         instanceGroupSet.add(instanceGroup);
         stack.setInstanceGroups(instanceGroupSet);
+
+        Set<Node> nodes = new HashSet<>();
+        nodes.add(new Node("1.1.1.1", "1.1.1.1", "1", "m5.xlarge", "node1.example.com", "worker"));
+        when(hostOrchestrator.getResponsiveNodes(nodesCaptor.capture(), any())).thenReturn(new NodeReachabilityResult(nodes, Set.of()));
+
         stackUtil.collectReachableNodes(stack);
 
         verify(hostOrchestrator).getResponsiveNodes(nodesCaptor.capture(), any());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/cloudbreak/CloudbreakInstanceWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/cloudbreak/CloudbreakInstanceWaitObject.java
@@ -8,6 +8,7 @@ import static com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStat
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus.FAILED;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus.ORCHESTRATION_FAILED;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus.TERMINATED;
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus.ZOMBIE;
 
 import java.util.List;
 import java.util.Map;
@@ -25,12 +26,11 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.i
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.exception.TestFailException;
-import com.sequenceiq.it.cloudbreak.util.wait.service.instance.InstanceFailedChecker;
 import com.sequenceiq.it.cloudbreak.util.wait.service.instance.InstanceWaitObject;
 
 public class CloudbreakInstanceWaitObject implements InstanceWaitObject {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(InstanceFailedChecker.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CloudbreakInstanceWaitObject.class);
 
     private final String name;
 
@@ -103,7 +103,7 @@ public class CloudbreakInstanceWaitObject implements InstanceWaitObject {
 
     @Override
     public boolean isFailed() {
-        Set<InstanceStatus> failedStatuses = Set.of(FAILED, ORCHESTRATION_FAILED, DECOMMISSION_FAILED);
+        Set<InstanceStatus> failedStatuses = Set.of(FAILED, ORCHESTRATION_FAILED, DECOMMISSION_FAILED, ZOMBIE);
         return getInstanceStatuses().values().stream().anyMatch(failedStatuses::contains);
     }
 
@@ -114,7 +114,8 @@ public class CloudbreakInstanceWaitObject implements InstanceWaitObject {
 
     @Override
     public boolean isCreateFailed() {
-        return getInstanceStatuses().values().stream().anyMatch(ORCHESTRATION_FAILED::equals);
+        Set<InstanceStatus> failedStatuses = Set.of(ORCHESTRATION_FAILED, ZOMBIE);
+        return getInstanceStatuses().values().stream().anyMatch(failedStatuses::contains);
     }
 
     @Override
@@ -125,7 +126,7 @@ public class CloudbreakInstanceWaitObject implements InstanceWaitObject {
 
     @Override
     public boolean isFailedCheck() {
-        Set<InstanceStatus> failedStatuses = Set.of(FAILED, ORCHESTRATION_FAILED, DECOMMISSION_FAILED);
+        Set<InstanceStatus> failedStatuses = Set.of(FAILED, ORCHESTRATION_FAILED, DECOMMISSION_FAILED, ZOMBIE);
         return failedStatuses.contains(desiredStatus);
     }
 

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
@@ -15,6 +15,7 @@ import com.sequenceiq.cloudbreak.orchestrator.model.BootstrapParams;
 import com.sequenceiq.cloudbreak.orchestrator.model.CmAgentStopFlags;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.orchestrator.model.KeytabModel;
+import com.sequenceiq.cloudbreak.orchestrator.model.NodeReachabilityResult;
 import com.sequenceiq.cloudbreak.orchestrator.model.SaltConfig;
 import com.sequenceiq.cloudbreak.orchestrator.state.ExitCriteriaModel;
 
@@ -60,7 +61,7 @@ public interface HostOrchestrator extends HostRecipeExecutor {
 
     List<String> getAvailableNodes(GatewayConfig gatewayConfig, Set<Node> nodes);
 
-    Set<Node> getResponsiveNodes(Set<Node> nodes, GatewayConfig gatewayConfig);
+    NodeReachabilityResult getResponsiveNodes(Set<Node> nodes, GatewayConfig gatewayConfig);
 
     void tearDown(OrchestratorAware stack, List<GatewayConfig> allGatewayConfigs, Map<String, String> removeNodePrivateIPsByFQDN,
             Set<Node> remainingNodes, ExitCriteriaModel exitModel) throws CloudbreakOrchestratorException;

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/model/NodeReachabilityResult.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/model/NodeReachabilityResult.java
@@ -1,0 +1,51 @@
+package com.sequenceiq.cloudbreak.orchestrator.model;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.sequenceiq.cloudbreak.common.orchestration.Node;
+
+public class NodeReachabilityResult {
+
+    private Set<Node> reachableNodes = new HashSet<>();
+
+    private Set<Node> unreachableNodes = new HashSet<>();
+
+    public NodeReachabilityResult(Set<Node> reachableNodes, Set<Node> unreachableNodes) {
+        if (reachableNodes != null) {
+            this.reachableNodes = reachableNodes;
+        }
+        if (unreachableNodes != null) {
+            this.unreachableNodes = unreachableNodes;
+        }
+    }
+
+    public Set<Node> getReachableNodes() {
+        return reachableNodes;
+    }
+
+    public Set<Node> getUnreachableNodes() {
+        return unreachableNodes;
+    }
+
+    public Set<String> getReachableHosts() {
+        return reachableNodes.stream()
+                .map(node -> node.getHostname())
+                .collect(Collectors.toSet());
+    }
+
+    public Set<String> getUnreachableHosts() {
+        return unreachableNodes.stream()
+                .map(node -> node.getHostname())
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public String toString() {
+        return "NodeResult{" +
+                "reachableNodes=" + getReachableHosts() +
+                ", unreachableNodes=" + getUnreachableHosts() +
+                '}';
+    }
+}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/general/GeneralClusterConfigsProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/general/GeneralClusterConfigsProvider.java
@@ -25,7 +25,7 @@ public class GeneralClusterConfigsProvider {
         boolean gatewayInstanceMetadataPresented = false;
         boolean instanceMetadataPresented = false;
         if (stack.getInstanceGroups() != null && !stack.getInstanceGroups().isEmpty()) {
-            List<InstanceMetaData> gatewayInstanceMetadata = stack.getNotTerminatedGatewayInstanceMetadata();
+            List<InstanceMetaData> gatewayInstanceMetadata = stack.getNotTerminatedAndNotZombieGatewayInstanceMetadata();
             gatewayInstanceMetadataPresented = !gatewayInstanceMetadata.isEmpty()
                     && stack.getCluster().getGateway() != null;
             instanceMetadataPresented = true;


### PR DESCRIPTION
…ring upscale operation

We may lose some nodes from the original upscale request. We need to continue with the upscale operation.
- Mark nodes as Zombie that have been provisioned but not able to take part in the cluster
- Nodes can only go into Zombie state during upscale
- Syncer should skip these nodes
- Stop should be prohibited until Zombie nodes are terminated
- Zombie instances must be deleted by hand (or downscale)

See detailed description in the commit message.