### PR TITLE
CB-15915 - Add Kafka Connect to 7.2.15 Streams Messaging cluster temp…

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.15/cdp-streaming-small.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.15/cdp-streaming-small.bp
@@ -45,6 +45,11 @@
             "refName": "kafka-KAFKA_BROKER-BASE",
             "roleType": "KAFKA_BROKER",
             "base": true
+          },
+          {
+            "refName": "kafka-KAFKA_CONNECT-BASE",
+            "roleType": "KAFKA_CONNECT",
+            "base": true
           }
         ]
       },
@@ -118,7 +123,8 @@
           "zookeeper-SERVER-BASE",
           "streams_replication_manager-STREAMS_REPLICATION_MANAGER_DRIVER-BASE",
           "kafka-GATEWAY-BASE",
-          "kafka-KAFKA_BROKER-BASE"
+          "kafka-KAFKA_BROKER-BASE",
+          "kafka-KAFKA_CONNECT-BASE"
         ]
       },
       {
@@ -127,7 +133,8 @@
         "roleConfigGroupsRefNames": [
           "streams_replication_manager-STREAMS_REPLICATION_MANAGER_DRIVER-BASE",
           "kafka-GATEWAY-BASE",
-          "kafka-KAFKA_BROKER-BASE"
+          "kafka-KAFKA_BROKER-BASE",
+          "kafka-KAFKA_CONNECT-BASE"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/blueprints/7.2.15/cdp-streaming.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.15/cdp-streaming.bp
@@ -45,6 +45,11 @@
             "refName": "kafka-KAFKA_BROKER-BASE",
             "roleType": "KAFKA_BROKER",
             "base": true
+          },
+          {
+            "refName": "kafka-KAFKA_CONNECT-BASE",
+            "roleType": "KAFKA_CONNECT",
+            "base": true
           }
         ]
       },
@@ -148,6 +153,14 @@
         "roleConfigGroupsRefNames": [
           "streams_replication_manager-STREAMS_REPLICATION_MANAGER_SERVICE-BASE",
           "streams_replication_manager-STREAMS_REPLICATION_MANAGER_DRIVER-BASE"
+        ]
+      },
+      {
+        "refName": "connect",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "kafka-GATEWAY-BASE",
+          "kafka-KAFKA_CONNECT-BASE"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/clustertemplates/7.2.15/aws/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.15/aws/streaming.json
@@ -128,6 +128,27 @@
         "nodeCount": 0,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "connect",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "standard"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.15/azure/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.15/azure/streaming.json
@@ -121,6 +121,25 @@
         "nodeCount": 0,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "connect",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "Standard_LRS"
+            }
+          ],
+          "azure": {
+            "manageDisk": true
+          },
+          "instanceType": "Standard_D8_v3"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.15/gcp/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.15/gcp/streaming.json
@@ -112,6 +112,22 @@
         "nodeCount": 0,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "connect",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "pd-standard"
+            }
+          ],
+          "instanceType": "e2-standard-8"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.15/yarn/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.15/yarn/streaming.json
@@ -103,6 +103,21 @@
         "nodeCount": 0,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "connect",
+        "template": {
+          "yarn": {
+            "cpus": 4,
+            "memory": 16384
+          },
+          "rootVolume": {
+            "size": 50
+          }
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }


### PR DESCRIPTION
…lates

Kafka Connect in Public Cloud was introduced from CDH 7.2.14. This commit adds the Kafka Connect role to the 7.2.15 cluster templates.

Tested: Locally on provisioned cluster

As discussed under #12199, we need to backport this change to 2.52.0 branch as the master is already 2.53.0.