### PR TITLE
CB-15730 - CM server moved during upgrade to another node

### DIFF
--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsMetadataCollector.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsMetadataCollector.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -81,8 +82,8 @@ public class AwsMetadataCollector implements MetadataCollector {
                 ac.getCloudContext().getName(), resources.size(), vms.size(), allInstances.size());
         try {
             List<String> knownInstanceIdList = allInstances.stream()
-                    .filter(cloudInstance -> cloudInstance.getInstanceId() != null)
                     .map(CloudInstance::getInstanceId)
+                    .filter(Objects::nonNull)
                     .collect(Collectors.toList());
 
             return collectCloudVmMetaDataStatuses(ac, vms, resources, knownInstanceIdList);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapper.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapper.java
@@ -306,7 +306,9 @@ public class ClusterBootstrapper {
         Set<String> clusterNodeNames = stack.getNotTerminatedInstanceMetaDataList().stream()
                 .map(InstanceMetaData::getShortHostname).collect(Collectors.toSet());
 
-        Set<InstanceMetaData> notDeletedInstanceMetaDataSet = instanceMetaDataService.getNotDeletedInstanceMetadataByStackId(stack.getId());
+        // Ordered list of metadata to guarantee consistent hostname generation across multiple cluster recoveries
+        List<InstanceMetaData> notDeletedInstanceMetaDataSet = instanceMetaDataService.findNotTerminatedAsOrderedListForStack(stack.getId());
+        LOGGER.debug("There are the following available instances: {}", notDeletedInstanceMetaDataSet);
         for (InstanceMetaData im : notDeletedInstanceMetaDataSet) {
             if (im.getPrivateIp() == null && im.getPublicIpWrapper() == null) {
                 LOGGER.debug("Skipping instance metadata because the public ip and private ips are null '{}'.", im);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceMetaDataRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceMetaDataRepository.java
@@ -36,6 +36,15 @@ public interface InstanceMetaDataRepository extends CrudRepository<InstanceMetaD
             "AND i.instanceStatus <> 'DELETED_BY_PROVIDER'")
     Set<InstanceMetaData> findNotTerminatedForStack(@Param("stackId") Long stackId);
 
+    @EntityGraph(value = "InstanceMetaData.instanceGroup", type = EntityGraphType.LOAD)
+    @Query("SELECT i FROM InstanceMetaData i " +
+            "WHERE i.instanceGroup.stack.id= :stackId " +
+            "AND i.instanceStatus <> 'TERMINATED' " +
+            "AND i.instanceStatus <> 'DELETED_ON_PROVIDER_SIDE' " +
+            "AND i.instanceStatus <> 'DELETED_BY_PROVIDER' " +
+            "ORDER BY i.privateId")
+    List<InstanceMetaData> findNotTerminatedAsOrderedListForStack(@Param("stackId") Long stackId);
+
     @Query("SELECT i FROM InstanceMetaData i " +
             "WHERE i.instanceGroup.stack.id= :stackId " +
             "AND i.instanceStatus <> 'TERMINATED' " +
@@ -90,6 +99,9 @@ public interface InstanceMetaDataRepository extends CrudRepository<InstanceMetaD
 
     @EntityGraph(value = "InstanceMetaData.instanceGroup", type = EntityGraphType.LOAD)
     List<InstanceMetaData> findAllByInstanceGroupAndInstanceStatus(InstanceGroup instanceGroup, InstanceStatus status);
+
+    @EntityGraph(value = "InstanceMetaData.instanceGroup", type = EntityGraphType.LOAD)
+    List<InstanceMetaData> findAllByInstanceGroupAndInstanceStatusOrderByPrivateIdAsc(InstanceGroup instanceGroup, InstanceStatus status);
 
     @Query("SELECT i.serverCert FROM InstanceMetaData i WHERE i.instanceGroup.stack.id= :stackId AND i.instanceMetadataType = 'GATEWAY_PRIMARY' "
             + "AND i.instanceStatus <> 'TERMINATED'")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/MetadataSetupService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/MetadataSetupService.java
@@ -293,7 +293,10 @@ public class MetadataSetupService {
                 .findFirst();
 
         if (gwInstanceGroup.isPresent()) {
-            List<InstanceMetaData> gwInstances = instanceMetaDataService.findAllByInstanceGroupAndInstanceStatus(gwInstanceGroup.get(), InstanceStatus.CREATED);
+            // Ordered list of metadata to guarantee consistent primary gateway generation across multiple cluster recoveries
+            List<InstanceMetaData> gwInstances = instanceMetaDataService.findAllByInstanceGroupAndInstanceStatusOrdered(
+                    gwInstanceGroup.get(), InstanceStatus.CREATED);
+            LOGGER.debug("Found Gateway instances {}", gwInstances);
             Optional<InstanceMetaData> gwInstance = gwInstances.stream().findFirst();
             if (gwInstance.isPresent()) {
                 LOGGER.info("We were able to select primary GW from GW instances: {}", gwInstance);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/MetadataSetupServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/MetadataSetupServiceTest.java
@@ -510,7 +510,7 @@ public class MetadataSetupServiceTest {
         workerInstanceGroup.setInstanceMetaData(Set.of(workerInstanceMetadata3));
 
         when(instanceGroupService.findByStackId(1L)).thenReturn(Set.of(gwInstanceGroup, workerInstanceGroup));
-        when(instanceMetaDataService.findAllByInstanceGroupAndInstanceStatus(gwInstanceGroup,
+        when(instanceMetaDataService.findAllByInstanceGroupAndInstanceStatusOrdered(gwInstanceGroup,
                 com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus.CREATED)).thenReturn(List.of(gwInstanceMetadata1, gwInstanceMetadata2));
         when(instanceMetaDataService.findNotTerminatedForStack(1L)).thenReturn(Set.of(gwInstanceMetadata1, gwInstanceMetadata2, workerInstanceMetadata3));
         underTest.saveInstanceMetaData(stack, cloudVmMetaDataStatuses, CREATED);


### PR DESCRIPTION
This commit introduces consistent hostname generation and consistent primary gateway selection logic across multiple recoveries, meaning:
- it is guaranteed that
    - the instanceId-s remain the same
    - the privateId allocation remains the same
    - primary gateways remain the same

