### PR TITLE
CB-15924 Adjust SdxRangerRazEnabled E2E tests to use prewarmed images

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxEnableRangerRazAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxEnableRangerRazAction.java
@@ -6,14 +6,14 @@ import org.slf4j.LoggerFactory;
 import com.sequenceiq.it.cloudbreak.SdxClient;
 import com.sequenceiq.it.cloudbreak.action.Action;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
-import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
 
-public class SdxEnableRangerRazAction implements Action<SdxInternalTestDto, SdxClient> {
+public class SdxEnableRangerRazAction implements Action<SdxTestDto, SdxClient> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SdxEnableRangerRazAction.class);
 
     @Override
-    public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
+    public SdxTestDto action(TestContext testContext, SdxTestDto testDto, SdxClient client) throws Exception {
         client.getDefaultClient().sdxEndpoint().enableRangerRazByCrn(testDto.getCrn());
         return testDto;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/SdxTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/SdxTestClient.java
@@ -197,7 +197,7 @@ public class SdxTestClient {
         return new SdxChangeImageCatalogAction();
     }
 
-    public Action<SdxInternalTestDto, SdxClient> enableRangerRaz() {
+    public Action<SdxTestDto, SdxClient> enableRangerRaz() {
         return new SdxEnableRangerRazAction();
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
@@ -215,6 +215,11 @@ public class SdxTestDto extends AbstractSdxTestDto<SdxClusterRequest, SdxCluster
         return this;
     }
 
+    public SdxTestDto withRangerRazEnabled(boolean rangerRazEnabled) {
+        getRequest().setEnableRangerRaz(rangerRazEnabled);
+        return this;
+    }
+
     public SdxTestDto withTags(Map<String, String> tags) {
         getRequest().addTags(tags);
         return this;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxRangerRazEnabledTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxRangerRazEnabledTests.java
@@ -11,7 +11,7 @@ import org.testng.annotations.Test;
 import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
-import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
 import com.sequenceiq.it.cloudbreak.exception.TestFailException;
 import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 import com.sequenceiq.sdx.api.model.SdxDatabaseAvailabilityType;
@@ -34,10 +34,10 @@ public class SdxRangerRazEnabledTests extends PreconditionSdxE2ETest {
         sdxDatabaseRequest.setAvailabilityType(SdxDatabaseAvailabilityType.NONE);
 
         testContext
-                .given(SdxInternalTestDto.class)
-                .withDatabase(sdxDatabaseRequest)
+                .given(SdxTestDto.class)
+                .withExternalDatabase(sdxDatabaseRequest)
                 .withCloudStorage(getCloudStorageRequest(testContext))
-                .when(sdxTestClient.createInternal(), key(sdx))
+                .when(sdxTestClient.create(), key(sdx))
                 .await(SdxClusterStatusResponse.RUNNING)
                 .awaitForHealthyInstances()
                 .whenException(sdxTestClient.enableRangerRaz(), BadRequestException.class)
@@ -56,11 +56,11 @@ public class SdxRangerRazEnabledTests extends PreconditionSdxE2ETest {
         sdxDatabaseRequest.setAvailabilityType(SdxDatabaseAvailabilityType.NONE);
 
         testContext
-                .given(SdxInternalTestDto.class)
-                .withDatabase(sdxDatabaseRequest)
+                .given(SdxTestDto.class)
+                .withExternalDatabase(sdxDatabaseRequest)
                 .withCloudStorage(getCloudStorageRequest(testContext))
                 .withRangerRazEnabled(Boolean.TRUE)
-                .when(sdxTestClient.createInternal(), key(sdx))
+                .when(sdxTestClient.create(), key(sdx))
                 .await(SdxClusterStatusResponse.RUNNING)
                 .awaitForHealthyInstances()
                 .when(sdxTestClient.enableRangerRaz())


### PR DESCRIPTION
- Replaced `SdxInternalTestDto` with `SdxTestDto`
- Ran the E2E test to verify that prewarmed images were used.
<img width="726" alt="Screenshot 2022-02-03 at 11 19 42 PM" src="https://user-images.githubusercontent.com/30623280/152400812-5e04e47f-dd4b-4188-8d15-e4f4447fe666.png">
<img width="592" alt="Screenshot 2022-02-03 at 11 20 23 PM" src="https://user-images.githubusercontent.com/30623280/152400835-289f67b5-e945-44f9-877b-aaf9ac22323c.png">



See detailed description in the commit message.