### PR TITLE
CB-15984. Remove additional Status, DetailedStackStatus introduced as

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ClusterStatusSyncHandler.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ClusterStatusSyncHandler.java
@@ -43,18 +43,16 @@ public class ClusterStatusSyncHandler implements ApplicationListener<ClusterStat
         StackStatusV4Response statusResponse = cloudbreakCommunicator.getStackStatusByCrn(cluster.getStackCrn());
 
         boolean clusterAvailable;
-        boolean clusterWithStoppedNodes = false;
         if (Boolean.TRUE.equals(cluster.isStopStartScalingEnabled())) {
             clusterAvailable = Optional.ofNullable(statusResponse.getStatus()).map(Status::isAvailable).orElse(false);
-            clusterWithStoppedNodes =
-                    Optional.ofNullable(statusResponse.getStatus()).map(s -> s == Status.AVAILABLE_WITH_STOPPED_INSTANCES).orElse(false);
-            clusterAvailable |= clusterWithStoppedNodes;
+            // TODO CB-15146: This may need to change depending on the final form of how we check which operations are to be allowed
+            //  when there are some STOPPED instances
         } else {
             clusterAvailable = Optional.ofNullable(statusResponse.getStatus()).map(Status::isAvailable).orElse(false)
             && Optional.ofNullable(statusResponse.getClusterStatus()).map(Status::isAvailable).orElse(false);
         }
 
-        LOGGER.info("Computed clusterAvailable: {}, clusterWithStoppedNodes: {}", clusterAvailable, clusterWithStoppedNodes);
+        LOGGER.info("Computed clusterAvailable: {}", clusterAvailable);
         LOGGER.info("Analysing CBCluster Status '{}' for Cluster '{}. Available(Determined)={}' ", statusResponse, cluster.getStackCrn(), clusterAvailable);
 
         if (DELETE_COMPLETED.equals(statusResponse.getStatus())) {

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/handler/ClusterStatusSyncHandlerTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/handler/ClusterStatusSyncHandlerTest.java
@@ -203,11 +203,12 @@ public class ClusterStatusSyncHandlerTest {
 
     @Test
     public void testOnApplicationEventWhenStopStartScalingEnabledAndClusterIsScaledDown() {
-        // Scale down with StopStart results in AVAILABLE_WITH_STOPPED_INSTANCES Stack status, but Periscope shouldn't mark the cluster as SUSPENDED.
+        // At the moment, there's no good way to determine if the cluster is scaled down,
+        //  so this test essentially exercises existing flow with the stopStartMechanism enabled.
         Cluster cluster = getACluster(ClusterState.RUNNING);
         cluster.setStopStartScalingEnabled(Boolean.TRUE);
         when(clusterService.findById(anyLong())).thenReturn(cluster);
-        when(cloudbreakCommunicator.getStackStatusByCrn(anyString())).thenReturn(getStackResponse(Status.AVAILABLE_WITH_STOPPED_INSTANCES));
+        when(cloudbreakCommunicator.getStackStatusByCrn(anyString())).thenReturn(getStackResponse(Status.AVAILABLE));
 
         underTest.onApplicationEvent(new ClusterStatusSyncEvent(AUTOSCALE_CLUSTER_ID));
 

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/common/DetailedStackStatus.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/common/DetailedStackStatus.java
@@ -71,7 +71,7 @@ public enum DetailedStackStatus {
     ROLLING_BACK(Status.UPDATE_IN_PROGRESS),
     // The stack is available
     AVAILABLE(Status.AVAILABLE),
-    AVAILABLE_WITH_STOPPED_INSTANCES(Status.AVAILABLE_WITH_STOPPED_INSTANCES),
+    AVAILABLE_WITH_STOPPED_INSTANCES(Status.AVAILABLE),
     // Instance removing status
     REMOVE_INSTANCE(Status.UPDATE_IN_PROGRESS),
     // Cluster operation is in progress

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/common/Status.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/common/Status.java
@@ -14,7 +14,6 @@ public enum Status {
     REQUESTED(StatusKind.PROGRESS),
     CREATE_IN_PROGRESS(StatusKind.PROGRESS),
     AVAILABLE(StatusKind.FINAL),
-    AVAILABLE_WITH_STOPPED_INSTANCES(StatusKind.FINAL),
     UPDATE_IN_PROGRESS(StatusKind.PROGRESS),
     UPDATE_REQUESTED(StatusKind.PROGRESS),
     UPDATE_FAILED(StatusKind.FINAL),
@@ -103,8 +102,7 @@ public enum Status {
 
     public boolean isRemovableStatus() {
         return EnumSet.of(AVAILABLE, UPDATE_FAILED, RECOVERY_FAILED, CREATE_FAILED, ENABLE_SECURITY_FAILED, DELETE_FAILED,
-                DELETE_COMPLETED, DELETED_ON_PROVIDER_SIDE, STOPPED, START_FAILED, STOP_FAILED, UPGRADE_CCM_FAILED,
-                AVAILABLE_WITH_STOPPED_INSTANCES).contains(this);
+                DELETE_COMPLETED, DELETED_ON_PROVIDER_SIDE, STOPPED, START_FAILED, STOP_FAILED, UPGRADE_CCM_FAILED).contains(this);
     }
 
     public boolean isAvailable() {

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/InstanceStatus.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/InstanceStatus.java
@@ -10,7 +10,6 @@ public enum InstanceStatus {
     SERVICES_UNHEALTHY,
     WAITING_FOR_REPAIR,
     STOPPED,
-    STARTED,
     DELETED_ON_PROVIDER_SIDE,
     DELETED_BY_PROVIDER,
     DELETE_REQUESTED,
@@ -31,8 +30,6 @@ public enum InstanceStatus {
                 return "WAITING_FOR_REPAIR";
             case SERVICES_RUNNING:
                 return "RUNNING";
-            case STARTED:
-                return "STARTED";
             default:
                 return "UNKNOWN";
         }

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Stack.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Stack.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.cloudbreak.domain.stack;
 
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.AVAILABLE;
-import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.AVAILABLE_WITH_STOPPED_INSTANCES;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.CREATE_IN_PROGRESS;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.DELETE_COMPLETED;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.DELETE_FAILED;
@@ -636,7 +635,9 @@ public class Stack implements ProvisionEntity, WorkspaceAwareResource {
     }
 
     public boolean isAvailableWithStoppedInstances() {
-        return AVAILABLE_WITH_STOPPED_INSTANCES.equals(getStatus());
+        // TODO CB-15146: This may need to change depending on the final form of how we check which operations are to be allowed
+        //  when there are some STOPPED instances. The entire method may be removed.
+        return isAvailable();
     }
 
     public boolean hasNodeFailure() {
@@ -669,7 +670,6 @@ public class Stack implements ProvisionEntity, WorkspaceAwareResource {
 
     public boolean isReadyForStop() {
         return AVAILABLE.equals(getStatus())
-                || AVAILABLE_WITH_STOPPED_INSTANCES.equals(getStatus())
                 || STOPPED.equals(getStatus())
                 || STOP_REQUESTED.equals(getStatus())
                 || STOP_IN_PROGRESS.equals(getStatus())

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/instance/InstanceMetaData.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/instance/InstanceMetaData.java
@@ -261,8 +261,7 @@ public class InstanceMetaData implements ProvisionEntity {
     public boolean isRunning() {
         return !isTerminated() && (InstanceStatus.CREATED.equals(instanceStatus) || InstanceStatus.SERVICES_RUNNING.equals(instanceStatus)
                 || InstanceStatus.DECOMMISSIONED.equals(instanceStatus) || InstanceStatus.DECOMMISSION_FAILED.equals(instanceStatus)
-                || InstanceStatus.SERVICES_HEALTHY.equals(instanceStatus) || InstanceStatus.SERVICES_UNHEALTHY.equals(instanceStatus)
-                || InstanceStatus.STARTED.equals(instanceStatus));
+                || InstanceStatus.SERVICES_HEALTHY.equals(instanceStatus) || InstanceStatus.SERVICES_UNHEALTHY.equals(instanceStatus));
     }
 
     public boolean isAttached() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/InstanceMetaDataToCloudInstanceConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/InstanceMetaDataToCloudInstanceConverter.java
@@ -81,11 +81,12 @@ public class InstanceMetaDataToCloudInstanceConverter {
                 return InstanceStatus.CREATE_REQUESTED;
             case CREATED:
                 return InstanceStatus.CREATED;
-            case STARTED:
             case SERVICES_RUNNING:
             case SERVICES_HEALTHY:
             case SERVICES_UNHEALTHY:
                 return InstanceStatus.STARTED;
+            // TODO ZZZ: Using DECOMMISSIONED is a bad idea based on this conversion. DECOMMISSIONED somehow means DELETE_REQUESTED, which
+            //  is going to cause chaos on the user side. SERVICES_RUNNING is just an extremely STUPID state.
             case DECOMMISSIONED:
             case DELETE_REQUESTED:
                 return InstanceStatus.DELETE_REQUESTED;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartds/StopStartDownscaleFlowService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartds/StopStartDownscaleFlowService.java
@@ -102,7 +102,7 @@ public class StopStartDownscaleFlowService {
     public void clusterDownscaleFinished(Long stackId, String hostGroupName, List<InstanceMetaData> instancesStopped) {
         stackUpdater.updateStackStatus(
                 stackId,
-                DetailedStackStatus.AVAILABLE_WITH_STOPPED_INSTANCES,
+                DetailedStackStatus.AVAILABLE,
                 "Instances: " + instancesStopped.size() + " stopped successfully.");
         flowMessageService.fireEventAndLog(stackId, AVAILABLE.name(), CLUSTER_SCALING_STOPSTART_DOWNSCALE_FINISHED,
                 hostGroupName, String.valueOf(instancesStopped.size()),

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartus/StopStartUpscaleActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartus/StopStartUpscaleActions.java
@@ -200,22 +200,8 @@ public class StopStartUpscaleActions {
                         .filter(i -> payload.getSuccessfullyCommissionedFqdns().contains(i.getDiscoveryFQDN()))
                         .collect(Collectors.toList());
 
-                // Is there any stopped instance in the actionable group
-                Optional<InstanceMetaData> instanceInStoppedState = notDeletedInstanceMetaDataList.stream()
-                        .filter(i -> context.getHostGroupName().equals(i.getInstanceGroupName()))
-                        .filter(i -> !payload.getSuccessfullyCommissionedFqdns().contains(i.getDiscoveryFQDN()))
-                        .filter(i -> i.getInstanceStatus().equals(STOPPED))
-                        .findFirst();
-
-                DetailedStackStatus finalStackStatus;
-                if (instanceInStoppedState.isEmpty()) {
-                    finalStackStatus = DetailedStackStatus.AVAILABLE;
-                } else {
-                    finalStackStatus = DetailedStackStatus.AVAILABLE_WITH_STOPPED_INSTANCES;
-                }
-
                 clusterUpscaleFlowService.clusterUpscaleFinished(context.getStackView(), context.getHostGroupName(),
-                        instancesCommissioned, finalStackStatus);
+                        instancesCommissioned, DetailedStackStatus.AVAILABLE);
 
                 sendEvent(context, STOPSTART_UPSCALE_FINALIZED_EVENT.event(), payload);
             }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartus/StopStartUpscaleFlowService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartus/StopStartUpscaleFlowService.java
@@ -54,7 +54,7 @@ class StopStartUpscaleFlowService {
     }
 
     void instancesStarted(long stackId, List<InstanceMetaData> instancesStarted) {
-        instancesStarted.stream().forEach(x -> instanceMetaDataService.updateInstanceStatus(x, InstanceStatus.STARTED));
+        instancesStarted.stream().forEach(x -> instanceMetaDataService.updateInstanceStatus(x, InstanceStatus.SERVICES_RUNNING));
         stackUpdater.updateStackStatus(stackId, DetailedStackStatus.STARTING_CLUSTER_MANAGER_SERVICES,
                 "Instances: " + instancesStarted.size() + " started successfully.");
         flowMessageService.fireEventAndLog(stackId, UPDATE_IN_PROGRESS.name(), CLUSTER_SCALING_STOPSTART_UPSCALE_NODES_STARTED,

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJob.java
@@ -201,7 +201,6 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
     Set<Status> syncableStates() {
         return EnumSet.of(
                 Status.AVAILABLE,
-                Status.AVAILABLE_WITH_STOPPED_INSTANCES,
                 Status.UPDATE_FAILED,
                 Status.ENABLE_SECURITY_FAILED,
                 Status.START_FAILED,
@@ -274,7 +273,9 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
                 Set<String> computeGroups = getComputeHostGroups(stack.getCluster());
                 boolean stoppedComputeOnly = stoppedInstances.stream().map(im -> im.getInstanceGroup().getGroupName()).allMatch(computeGroups::contains);
                 if (stoppedInstancesCount > 0 && stoppedComputeOnly && stoppedInstancesCount == failedInstances.size()) {
-                    clusterService.updateClusterStatusByStackId(stack.getId(), DetailedStackStatus.AVAILABLE_WITH_STOPPED_INSTANCES);
+                    // TODO CB-15146: This may need to change depending on the final form of how we check which operations are to be allowed
+                    //  when there are some STOPPED instances
+                    clusterService.updateClusterStatusByStackId(stack.getId(), DetailedStackStatus.AVAILABLE);
                 } else {
                     LOGGER.debug("WithStopStartEntitlement, putting cluster into NODE_FAILURE. Counts: stoppedInstanceCount={}, failedInstanceCount={}",
                             stoppedInstancesCount, failedInstances.size());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/nodestatus/NodeStatusCheckerJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/nodestatus/NodeStatusCheckerJob.java
@@ -228,7 +228,6 @@ public class NodeStatusCheckerJob extends StatusCheckerJob {
     private boolean checkableStates(Status status) {
         return EnumSet.of(
                 Status.AVAILABLE,
-                Status.AVAILABLE_WITH_STOPPED_INSTANCES,
                 Status.AMBIGUOUS,
                 Status.MAINTENANCE_MODE_ENABLED,
                 Status.UPDATE_REQUESTED,

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackSyncService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackSyncService.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.cloudbreak.service.stack.flow;
 
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.AVAILABLE;
-import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.AVAILABLE_WITH_STOPPED_INSTANCES;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.DELETE_FAILED;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.NODE_FAILURE;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.STOPPED;
@@ -28,7 +27,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
@@ -214,38 +212,21 @@ public class StackSyncService {
         }
     }
 
-    @VisibleForTesting
     void handleSyncResult(Stack stack, Map<InstanceSyncState, Integer> instanceStateCounts, SyncConfig syncConfig,
             Set<InstanceMetaData> instances) {
         Status status = stack.getStatus();
-        if (isAllStopped(instanceStateCounts, instances.size())) {
-            checkAndUpdateStackStatus(stack, status, STOPPED, DetailedStackStatus.STOPPED, SYNC_STATUS_REASON);
-            return;
-        }
-        if (isAllDeletedOnProvider(instanceStateCounts, instances.size())) {
-            checkAndUpdateStackStatus(stack, status, DELETE_FAILED, DetailedStackStatus.DELETED_ON_PROVIDER_SIDE, SYNC_STATUS_REASON);
-            return;
-        }
         if (instanceStateCounts.get(InstanceSyncState.RUNNING) > 0) {
-            if (!syncConfig.isCmServerRunning()) {
-                checkAndUpdateStackStatus(stack, status, UNREACHABLE, DetailedStackStatus.CLUSTER_MANAGER_NOT_RESPONDING, CM_SERVER_NOT_RESPONDING);
-                return;
+            if (syncConfig.isCmServerRunning()) {
+                if (status != AVAILABLE && status != NODE_FAILURE) {
+                    updateStackStatus(stack.getId(), DetailedStackStatus.AVAILABLE, SYNC_STATUS_REASON);
+                }
+            } else if (status != UNREACHABLE) {
+                updateStackStatus(stack.getId(), DetailedStackStatus.CLUSTER_MANAGER_NOT_RESPONDING, CM_SERVER_NOT_RESPONDING);
             }
-            if (status == NODE_FAILURE) {
-                return;
-            }
-            if (instanceStateCounts.get(InstanceSyncState.STOPPED) > 0) {
-                checkAndUpdateStackStatus(
-                        stack, status, AVAILABLE_WITH_STOPPED_INSTANCES, DetailedStackStatus.AVAILABLE_WITH_STOPPED_INSTANCES, SYNC_STATUS_REASON);
-                return;
-            }
-            checkAndUpdateStackStatus(stack, status, AVAILABLE, DetailedStackStatus.AVAILABLE, SYNC_STATUS_REASON);
-        }
-    }
-
-    private void checkAndUpdateStackStatus(Stack stack, Status currentStatus, Status excludedStatus, DetailedStackStatus newStatus, String syncStatusReason) {
-        if (currentStatus != excludedStatus) {
-            updateStackStatus(stack.getId(), newStatus, syncStatusReason);
+        } else if (isAllStopped(instanceStateCounts, instances.size()) && status != STOPPED) {
+            updateStackStatus(stack.getId(), DetailedStackStatus.STOPPED, SYNC_STATUS_REASON);
+        } else if (isAllDeletedOnProvider(instanceStateCounts, instances.size()) && status != DELETE_FAILED) {
+            updateStackStatus(stack.getId(), DetailedStackStatus.DELETED_ON_PROVIDER_SIDE, SYNC_STATUS_REASON);
         }
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartus/StopStartUpscaleActionsTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartus/StopStartUpscaleActionsTest.java
@@ -398,7 +398,7 @@ public class StopStartUpscaleActionsTest {
 
         verify(stopStartUpscaleFlowService).logInstancesFailedToCommission(eq(STACK_ID), eq(notCommissionedFqdns));
         verify(stopStartUpscaleFlowService).clusterUpscaleFinished(
-                any(), eq(INSTANCE_GROUP_NAME_ACTIONABLE), eq(startedInstances), eq(DetailedStackStatus.AVAILABLE_WITH_STOPPED_INSTANCES));
+                any(), eq(INSTANCE_GROUP_NAME_ACTIONABLE), eq(startedInstances), eq(DetailedStackStatus.AVAILABLE));
         ArgumentCaptor<Object> argumentCaptor = ArgumentCaptor.forClass(Object.class);
         verify(reactorEventFactory).createEvent(anyMap(), argumentCaptor.capture());
         verify(eventBus).notify("STOPSTART_UPSCALE_FINALIZED_EVENT", event);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJobTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJobTest.java
@@ -248,7 +248,7 @@ public class StackStatusCheckerJobTest {
 
     @Test
     public void testInstanceSyncCMRunningNodeStoppedAndStopStartEnabledInstanceStopped() throws JobExecutionException {
-        internalTestInstanceSyncStopStart("compute", InstanceStatus.STOPPED, DetailedStackStatus.AVAILABLE_WITH_STOPPED_INSTANCES);
+        internalTestInstanceSyncStopStart("compute", InstanceStatus.STOPPED, DetailedStackStatus.AVAILABLE);
     }
 
     @Test

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/StopStartUpscaleCommissionViaCMHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/StopStartUpscaleCommissionViaCMHandlerTest.java
@@ -278,7 +278,7 @@ public class StopStartUpscaleCommissionViaCMHandlerTest {
         for (int i = 0; i < count; i++) {
             InstanceMetaData instanceMetaData = new InstanceMetaData();
             instanceMetaData.setInstanceId(INSTANCE_ID_PREFIX + i);
-            instanceMetaData.setInstanceStatus(InstanceStatus.STARTED);
+            instanceMetaData.setInstanceStatus(InstanceStatus.SERVICES_RUNNING);
             instanceMetaData.setInstanceGroup(instanceGroup);
             instanceMetaData.setDiscoveryFQDN(INSTANCE_ID_PREFIX + i);
             instances.add(instanceMetaData);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationServiceTest.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.cloudbreak.service.stack.flow;
 
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus.AVAILABLE;
-import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus.AVAILABLE_WITH_STOPPED_INSTANCES;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus.CLUSTER_UPGRADE_FAILED;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus.STOPPED;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus.STOP_FAILED;
@@ -346,7 +345,6 @@ public class StackOperationServiceTest {
     public static Stream<Arguments> stackStatusForUpdateNodeCount() {
         return Stream.of(
                 Arguments.of("Stack is available", AVAILABLE),
-                Arguments.of("Stack has stopped instances", AVAILABLE_WITH_STOPPED_INSTANCES),
                 Arguments.of("Stack upgrade failure", CLUSTER_UPGRADE_FAILED)
         );
     }
@@ -354,8 +352,7 @@ public class StackOperationServiceTest {
     public static Stream<Arguments> stackStatusForStop() {
         return Stream.of(
                 Arguments.of("Stack is available", AVAILABLE),
-                Arguments.of("Stack failed to stop", STOP_FAILED),
-                Arguments.of("Stack is available with stopped instances", AVAILABLE_WITH_STOPPED_INSTANCES)
+                Arguments.of("Stack failed to stop", STOP_FAILED)
         );
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/StackSyncServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/StackSyncServiceTest.java
@@ -2,7 +2,6 @@ package com.sequenceiq.cloudbreak.service.stack.flow;
 
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus.CLUSTER_MANAGER_NOT_RESPONDING;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.AVAILABLE;
-import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.AVAILABLE_WITH_STOPPED_INSTANCES;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.NODE_FAILURE;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
@@ -69,7 +68,11 @@ class StackSyncServiceTest {
             if (expectedStatus == CLUSTER_MANAGER_NOT_RESPONDING) {
                 statusReason = "Cloudera Manager server not responding.";
             }
-            verify(stackUpdater).updateStackStatus(1L, expectedStatus, statusReason);
+            if (!currentStatus.equals(expectedStatus.getStatus())) {
+                verify(stackUpdater).updateStackStatus(1L, expectedStatus, statusReason);
+            } else {
+                verifyNoInteractions(stackUpdater);
+            }
         } else {
             verifyNoInteractions(stackUpdater);
         }
@@ -85,7 +88,7 @@ class StackSyncServiceTest {
                         1,
                         0,
                         new SyncConfig(true, true),
-                        DetailedStackStatus.AVAILABLE_WITH_STOPPED_INSTANCES
+                        null
                         ),
                 Arguments.of(
                         "Stack was available and now all stopped",
@@ -119,7 +122,7 @@ class StackSyncServiceTest {
                         ),
                 Arguments.of(
                         "Stack was running with 1 node stopped and now available",
-                        AVAILABLE_WITH_STOPPED_INSTANCES,
+                        AVAILABLE,
                         5,
                         5,
                         0,
@@ -129,7 +132,7 @@ class StackSyncServiceTest {
                 ),
                 Arguments.of(
                         "Stack was running with 1 node stopped and still running with 1 node stopped",
-                        AVAILABLE_WITH_STOPPED_INSTANCES,
+                        AVAILABLE,
                         5,
                         4,
                         1,
@@ -139,7 +142,7 @@ class StackSyncServiceTest {
                 ),
                 Arguments.of(
                         "Stack was running with 1 node stopped and now running CM is not running",
-                        AVAILABLE_WITH_STOPPED_INSTANCES,
+                        AVAILABLE,
                         5,
                         4,
                         1,

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/UpdateNodeCountValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/UpdateNodeCountValidatorTest.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.cloudbreak.service.stack.flow;
 
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.AVAILABLE;
-import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.AVAILABLE_WITH_STOPPED_INSTANCES;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.NODE_FAILURE;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -116,9 +115,6 @@ public class UpdateNodeCountValidatorTest {
         if (status == AVAILABLE) {
             when(stack.isAvailable()).thenReturn(true);
             when(stack.isAvailableWithStoppedInstances()).thenReturn(false);
-        } else if (status == AVAILABLE_WITH_STOPPED_INSTANCES) {
-            when(stack.isAvailable()).thenReturn(false);
-            when(stack.isAvailableWithStoppedInstances()).thenReturn(true);
         } else {
             when(stack.isAvailable()).thenReturn(false);
             when(stack.isAvailableWithStoppedInstances()).thenReturn(false);
@@ -136,12 +132,12 @@ public class UpdateNodeCountValidatorTest {
     private void checkExecutableThrowsException(Optional<String> errorMessageSegment, Stack stack, Executable executable) {
         BadRequestException badRequestException = assertThrows(BadRequestException.class, executable);
         Assert.assertEquals(errorMessageSegment.get(), badRequestException.getMessage());
+        Assert.assertTrue(badRequestException.getMessage().contains(errorMessageSegment.get()));
     }
 
     private static Stream<Arguments> testValidateStatusForStartHostGroupData() {
         return Stream.of(
                 Arguments.of(AVAILABLE, NO_ERROR),
-                Arguments.of(AVAILABLE_WITH_STOPPED_INSTANCES, NO_ERROR),
                 Arguments.of(NODE_FAILURE,
                         Optional.of("Data Hub 'master-stack' has 'NODE_FAILURE' state." +
                                 " Node group start operation is not allowed for this state."))


### PR DESCRIPTION
part of CB-14929 (before merge of the branch to master).
Also removes the STARTED InstanceStatus for now.
Impact on the CB-14929 stop-start based scaling is that all operations
will at least be attempted even if the cluster has STOPPED instances.
These will likely end up failing. Blocking specific operations is now
part of CB-15146, which mentions potential alternate mechanisms which
could be used to control these operations.

See detailed description in the commit message.