### PR TITLE
CB-15991 Eliminate 'mine.get' from  metadata settings.sls

### DIFF
--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeServiceTest.java
@@ -87,7 +87,7 @@ public class ClusterManagerUpgradeServiceTest {
         verify(hostOrchestrator, times(1)).upgradeClusterManager(any(), any(), any(), any(), any());
         verify(clusterApi).stopCluster(true);
         verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerRepo(any(), any(), any());
-        verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerSettings(any(), any(), any());
+        verify(clusterHostServiceRunner, times(1)).createPillarWithClouderaManagerSettings(any(), any(), any());
         verify(clusterApi).startCluster();
     }
 
@@ -102,7 +102,7 @@ public class ClusterManagerUpgradeServiceTest {
         verify(hostOrchestrator, times(1)).upgradeClusterManager(any(), any(), any(), any(), any());
         verify(clusterApi).stopCluster(true);
         verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerRepo(any(), any(), any());
-        verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerSettings(any(), any(), any());
+        verify(clusterHostServiceRunner, times(1)).createPillarWithClouderaManagerSettings(any(), any(), any());
         verify(clusterApi, never()).startCluster();
     }
 
@@ -118,7 +118,7 @@ public class ClusterManagerUpgradeServiceTest {
         verify(hostOrchestrator, times(1)).upgradeClusterManager(any(), any(), any(), any(), any());
         verify(clusterApi).stopCluster(true);
         verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerRepo(any(), any(), any());
-        verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerSettings(any(), any(), any());
+        verify(clusterHostServiceRunner, times(1)).createPillarWithClouderaManagerSettings(any(), any(), any());
         verify(clusterApi).startCluster();
         verify(csdParcelDecorator, times(1)).decoratePillarWithCsdParcels(any(), any());
     }
@@ -135,7 +135,7 @@ public class ClusterManagerUpgradeServiceTest {
         verify(hostOrchestrator, times(1)).upgradeClusterManager(any(), any(), any(), any(), any());
         verify(clusterApi).stopCluster(true);
         verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerRepo(any(), any(), any());
-        verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerSettings(any(), any(), any());
+        verify(clusterHostServiceRunner, times(1)).createPillarWithClouderaManagerSettings(any(), any(), any());
         verify(clusterApi).startCluster();
         verify(csdParcelDecorator, times(1)).decoratePillarWithCsdParcels(any(), any());
     }

--- a/orchestrator-salt/src/main/resources/salt/salt/metadata/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/metadata/settings.sls
@@ -1,12 +1,4 @@
-{% set server_address = [] %}
-{%- for host, host_ips in salt['mine.get']('G@roles:manager_server', 'network.ipaddrs', tgt_type = 'compound').items() %}
-  {%- for ip, args in pillar.get('hosts', {}).items() %}
-    {% if ip in host_ips %}
-      {% do server_address.append(ip) %}
-    {% endif %}
-  {%- endfor %}
-{%- endfor %}
-{% set server_address = server_address[0] %}
+{% set server_address = salt['pillar.get']('cloudera-manager:address') %}
 {% set platform = salt['pillar.get']('platform') %}
 {% set clusterName = salt['pillar.get']('cluster:name') %}
 {% set cluster_domain = salt['pillar.get']('hosts')[server_address]['domain'] %}


### PR DESCRIPTION
- Instead of the mine.get the primary gateway's private IP is stored in `cloudera-manager:address` field in
`/cloudera-manager/settings.sls` pillar. This is available from all nodes.
- Removed condition which persisted CM related pillar only if it's a CM cluster based on blueprint.
As we do not support Ambari anymore, and every cluster is CM based, it doesn't make any sense.
- Adjusted unit test, and smaller refactor of gateway pillar code for readability.

Tested:
- DH and DL provision
- DH and DL upgrade, DL medium duty upgrade
- DH upscale

Example pillar file:
```
cat cloudera-manager/settings.sls 
#!json
{
	"cloudera-manager": {
		"address": "10.112.22.209",
		"mgmt_service_directories": [
			"/hadoopfs/fs1/cloudera-scm-headlamp",
			"/hadoopfs/fs1/cloudera-scm-eventserver",
			"/hadoopfs/fs1/cloudera-service-monitor",
			"/hadoopfs/fs1/cloudera-host-monitor"
		],
		"settings": {
			"cloudera_scm_sudo_access": false,
			"deterministic_uid_gid": true,
			"disable_auto_bundle_collection": false,
			"heartbeat_interval": "3",
			"missed_heartbeat_interval": "30",
			"set_cdp_env": true
		}
	}
}
```