### PR TITLE
CB-14399 : Added a new flow chain for recovering from DL Resize failures.

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxReactorFlowManager.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxReactorFlowManager.java
@@ -5,6 +5,7 @@ import static com.sequenceiq.datalake.flow.datalake.recovery.DatalakeUpgradeReco
 import static com.sequenceiq.datalake.flow.datalake.upgrade.DatalakeUpgradeEvent.DATALAKE_UPGRADE_EVENT;
 import static com.sequenceiq.datalake.flow.delete.SdxDeleteEvent.SDX_DELETE_EVENT;
 import static com.sequenceiq.datalake.flow.detach.event.DatalakeResizeFlowChainStartEvent.SDX_RESIZE_FLOW_CHAIN_START_EVENT;
+import static com.sequenceiq.datalake.flow.detach.event.DatalakeResizeRecoveryFlowChainStartEvent.SDX_RESIZE_RECOVERY_FLOW_CHAIN_START_EVENT;
 import static com.sequenceiq.datalake.flow.diagnostics.SdxCmDiagnosticsEvent.SDX_CM_DIAGNOSTICS_COLLECTION_EVENT;
 import static com.sequenceiq.datalake.flow.diagnostics.SdxDiagnosticsEvent.SDX_DIAGNOSTICS_COLLECTION_EVENT;
 import static com.sequenceiq.datalake.flow.dr.backup.DatalakeBackupEvent.DATALAKE_DATABASE_BACKUP_EVENT;
@@ -45,6 +46,7 @@ import com.sequenceiq.datalake.flow.datalake.upgrade.event.DatalakeUpgradeFlowCh
 import com.sequenceiq.datalake.flow.datalake.upgrade.event.DatalakeUpgradeStartEvent;
 import com.sequenceiq.datalake.flow.delete.event.SdxDeleteStartEvent;
 import com.sequenceiq.datalake.flow.detach.event.DatalakeResizeFlowChainStartEvent;
+import com.sequenceiq.datalake.flow.detach.event.DatalakeResizeRecoveryFlowChainStartEvent;
 import com.sequenceiq.datalake.flow.diagnostics.event.SdxCmDiagnosticsCollectionEvent;
 import com.sequenceiq.datalake.flow.diagnostics.event.SdxDiagnosticsCollectionEvent;
 import com.sequenceiq.datalake.flow.dr.backup.event.DatalakeDatabaseBackupStartEvent;
@@ -111,6 +113,17 @@ public class SdxReactorFlowManager {
         );
         return notify(SDX_RESIZE_FLOW_CHAIN_START_EVENT, new DatalakeResizeFlowChainStartEvent(sdxClusterId, newSdxCluster, userId,
                 environmentClientService.getBackupLocation(newSdxCluster.getEnvCrn()), performBackup), newSdxCluster.getClusterName());
+    }
+
+    public FlowIdentifier triggerSdxResizeRecovery(SdxCluster oldSdxCluster, SdxCluster newSdxCluster) {
+        LOGGER.info("Triggering recovery for failed SDX resize with original cluster: {} and resized cluster: {}",
+                oldSdxCluster, newSdxCluster);
+        String userId = ThreadBasedUserCrnProvider.getUserCrn();
+        return notify(
+                SDX_RESIZE_RECOVERY_FLOW_CHAIN_START_EVENT,
+                new DatalakeResizeRecoveryFlowChainStartEvent(oldSdxCluster, newSdxCluster, userId),
+                oldSdxCluster.getClusterName()
+        );
     }
 
     public FlowIdentifier triggerSdxDeletion(SdxCluster cluster, boolean forced) {

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/chain/DatalakeResizeFlowEventChainFactory.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/chain/DatalakeResizeFlowEventChainFactory.java
@@ -38,9 +38,8 @@ public class DatalakeResizeFlowEventChainFactory implements FlowEventChainFactor
     public FlowTriggerEventQueue createFlowTriggerEventQueue(DatalakeResizeFlowChainStartEvent event) {
         Queue<Selectable> chain = new ConcurrentLinkedQueue<>();
 
-
         if (event.shouldTakeBackup()) {
-            //take a backup
+            // Take a backup
             chain.add(new DatalakeTriggerBackupEvent(DATALAKE_TRIGGER_BACKUP_EVENT.event(),
                     event.getResourceId(), event.getUserId(), event.getBackupLocation(), "resize" + System.currentTimeMillis(),
                     DatalakeBackupFailureReason.BACKUP_ON_RESIZE, event.accepted()));

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/chain/DatalakeResizeRecoveryFlowEventChainFactory.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/chain/DatalakeResizeRecoveryFlowEventChainFactory.java
@@ -1,0 +1,85 @@
+package com.sequenceiq.datalake.flow.chain;
+
+import static com.sequenceiq.datalake.flow.delete.SdxDeleteEvent.SDX_DELETE_EVENT;
+import static com.sequenceiq.datalake.flow.detach.SdxDetachEvent.SDX_DETACH_EVENT;
+import static com.sequenceiq.datalake.flow.detach.SdxDetachRecoveryEvent.SDX_DETACH_RECOVERY_EVENT;
+import static com.sequenceiq.datalake.flow.detach.event.DatalakeResizeRecoveryFlowChainStartEvent.SDX_RESIZE_RECOVERY_FLOW_CHAIN_START_EVENT;
+import static com.sequenceiq.datalake.flow.start.SdxStartEvent.SDX_START_EVENT;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.datalake.entity.SdxCluster;
+import com.sequenceiq.datalake.flow.delete.event.SdxDeleteStartEvent;
+import com.sequenceiq.datalake.flow.detach.event.DatalakeResizeRecoveryFlowChainStartEvent;
+import com.sequenceiq.datalake.flow.detach.event.SdxStartDetachEvent;
+import com.sequenceiq.datalake.flow.detach.event.SdxStartDetachRecoveryEvent;
+import com.sequenceiq.datalake.flow.start.event.SdxStartStartEvent;
+import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
+import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
+
+@Component
+public class DatalakeResizeRecoveryFlowEventChainFactory implements FlowEventChainFactory<DatalakeResizeRecoveryFlowChainStartEvent> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DatalakeResizeRecoveryFlowEventChainFactory.class);
+
+    @Inject
+    private SdxStatusService sdxStatusService;
+
+    @Override
+    public String initEvent() {
+        return SDX_RESIZE_RECOVERY_FLOW_CHAIN_START_EVENT;
+    }
+
+    @Override
+    public FlowTriggerEventQueue createFlowTriggerEventQueue(DatalakeResizeRecoveryFlowChainStartEvent event) {
+        Queue<Selectable> flowChain = new ConcurrentLinkedQueue<>();
+        if (event.getNewCluster() != null && event.getNewCluster().getDeleted() == null) {
+            flowChain.add(createDetachEventForNewCluster(event));
+            flowChain.add(createForcedDeleteStartEventForNewCluster(event));
+        }
+        if (event.getOldCluster().isDetached()) {
+            flowChain.add(createStartDetachRecoveryEventForOldCluster(event));
+        }
+        flowChain.add(createStartEventForOldCluster(event));
+        return new FlowTriggerEventQueue(getName(), event, flowChain);
+    }
+
+    private SdxStartDetachEvent createDetachEventForNewCluster(DatalakeResizeRecoveryFlowChainStartEvent event) {
+        SdxCluster fauxCluster = new SdxCluster();
+        fauxCluster.setClusterName(event.getNewCluster().getClusterName());
+
+        LOGGER.info("Generated a " + SDX_DETACH_EVENT.event() + " for the datalake resize recovery flow chain.");
+        SdxStartDetachEvent startDetachEvent = new SdxStartDetachEvent(
+                SDX_DETACH_EVENT.event(), event.getNewCluster().getId(), fauxCluster, event.getUserId(), event.accepted()
+        );
+        startDetachEvent.setDetachDuringRecovery(true);
+        return startDetachEvent;
+    }
+
+    private SdxDeleteStartEvent createForcedDeleteStartEventForNewCluster(DatalakeResizeRecoveryFlowChainStartEvent event) {
+        LOGGER.info("Generated a " + SDX_DELETE_EVENT.event() + " for the datalake resize recovery flow chain.");
+        return new SdxDeleteStartEvent(SDX_DELETE_EVENT.event(), event.getNewCluster().getId(), event.getUserId(), true);
+    }
+
+    private SdxStartDetachRecoveryEvent createStartDetachRecoveryEventForOldCluster(DatalakeResizeRecoveryFlowChainStartEvent event) {
+        LOGGER.info("Generated a " + SDX_DETACH_RECOVERY_EVENT.event() + " for the datalake resize recovery flow chain.");
+        return new SdxStartDetachRecoveryEvent(
+                SDX_DETACH_RECOVERY_EVENT.event(), event.getOldCluster().getId(), event.getUserId(), event.accepted()
+        );
+    }
+
+    private SdxStartStartEvent createStartEventForOldCluster(DatalakeResizeRecoveryFlowChainStartEvent event) {
+        LOGGER.info("Generated a " + SDX_START_EVENT.event() + " for the datalake resize recovery flow chain.");
+        return new SdxStartStartEvent(
+                SDX_START_EVENT.event(), event.getOldCluster().getId(), event.getUserId(), event.accepted()
+        );
+    }
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/detach/SdxDetachFlowConfig.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/detach/SdxDetachFlowConfig.java
@@ -21,10 +21,13 @@ import static com.sequenceiq.datalake.flow.detach.SdxDetachState.SDX_DETACH_EXTE
 import static com.sequenceiq.datalake.flow.detach.SdxDetachState.SDX_DETACH_FAILED_STATE;
 import static com.sequenceiq.datalake.flow.detach.SdxDetachState.SDX_DETACH_STACK_FAILED_STATE;
 import static com.sequenceiq.datalake.flow.detach.SdxDetachState.SDX_DETACH_STACK_STATE;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
 import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
 import com.sequenceiq.flow.core.config.RetryableFlowConfiguration;
-import java.util.List;
-import org.springframework.stereotype.Component;
 
 @Component
 public class SdxDetachFlowConfig extends AbstractFlowConfiguration<SdxDetachState, SdxDetachEvent> implements RetryableFlowConfiguration<SdxDetachEvent> {
@@ -32,6 +35,7 @@ public class SdxDetachFlowConfig extends AbstractFlowConfiguration<SdxDetachStat
     private static final List<Transition<SdxDetachState, SdxDetachEvent>> TRANSITIONS = new Transition.Builder<SdxDetachState, SdxDetachEvent>()
             .defaultFailureEvent(SDX_DETACH_FAILED_EVENT)
 
+            // Main flow.
             .from(INIT_STATE).to(SDX_DETACH_CLUSTER_STATE)
             .event(SDX_DETACH_EVENT).noFailureEvent()
 
@@ -63,10 +67,10 @@ public class SdxDetachFlowConfig extends AbstractFlowConfiguration<SdxDetachStat
             .event(SDX_ATTACH_NEW_CLUSTER_SUCCESS_EVENT)
             .failureState(SDX_ATTACH_NEW_CLUSTER_FAILED_STATE)
             .failureEvent(SDX_ATTACH_NEW_CLUSTER_FAILED_EVENT)
-
             .from(SDX_ATTACH_NEW_CLUSTER_FAILED_STATE).to(SDX_DETACH_FAILED_STATE)
             .event(SDX_DETACH_FAILED_EVENT).defaultFailureEvent()
 
+            // General failure configuration.
             .from(SDX_DETACH_FAILED_STATE).to(FINAL_STATE)
             .event(SDX_DETACH_FAILED_HANDLED_EVENT).noFailureEvent()
 
@@ -86,14 +90,14 @@ public class SdxDetachFlowConfig extends AbstractFlowConfiguration<SdxDetachStat
 
     @Override
     public SdxDetachEvent[] getInitEvents() {
-        return new SdxDetachEvent[]{
+        return new SdxDetachEvent[] {
                 SDX_DETACH_EVENT
         };
     }
 
     @Override
     public String getDisplayName() {
-        return "Sdx stop";
+        return "Sdx detach";
     }
 
     @Override

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/detach/SdxDetachRecoveryActions.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/detach/SdxDetachRecoveryActions.java
@@ -1,0 +1,101 @@
+package com.sequenceiq.datalake.flow.detach;
+
+import static com.sequenceiq.datalake.flow.detach.SdxDetachRecoveryEvent.SDX_DETACH_RECOVERY_FAILURE_HANDLED_EVENT;
+import static com.sequenceiq.datalake.flow.detach.SdxDetachRecoveryEvent.SDX_DETACH_RECOVERY_SUCCESS_EVENT;
+
+import java.util.Map;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.statemachine.StateContext;
+import org.springframework.statemachine.action.Action;
+
+import com.sequenceiq.datalake.entity.DatalakeStatusEnum;
+import com.sequenceiq.datalake.entity.SdxCluster;
+import com.sequenceiq.datalake.flow.SdxContext;
+import com.sequenceiq.datalake.flow.detach.event.SdxDetachRecoveryFailedEvent;
+import com.sequenceiq.datalake.flow.detach.event.SdxStartDetachRecoveryEvent;
+import com.sequenceiq.datalake.service.AbstractSdxAction;
+import com.sequenceiq.datalake.service.sdx.SdxService;
+import com.sequenceiq.datalake.service.sdx.attach.SdxAttachService;
+import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
+import com.sequenceiq.flow.core.FlowEvent;
+import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.flow.core.FlowState;
+
+@Configuration
+public class SdxDetachRecoveryActions {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxDetachRecoveryActions.class);
+
+    @Inject
+    private SdxService sdxService;
+
+    @Inject
+    private SdxAttachService sdxAttachService;
+
+    @Inject
+    private SdxStatusService sdxStatusService;
+
+    @Bean(name = "SDX_DETACH_RECOVERY_STATE")
+    public Action<?, ?> sdxDetachRecoveryAction() {
+        return new AbstractSdxAction<>(SdxStartDetachRecoveryEvent.class) {
+            @Override
+            protected SdxContext createFlowContext(FlowParameters flowParameters,
+                    StateContext<FlowState, FlowEvent> stateContext,
+                    SdxStartDetachRecoveryEvent payload) {
+                return SdxContext.from(flowParameters, payload);
+            }
+
+            @Override
+            protected void doExecute(SdxContext context, SdxStartDetachRecoveryEvent payload,
+                    Map<Object, Object> variables) throws Exception {
+                SdxCluster clusterToReattach = sdxService.getById(payload.getResourceId());
+                clusterToReattach = sdxAttachService.reattachDetachedSdxCluster(clusterToReattach);
+                LOGGER.info("Successfully restored detached SDX with ID {}.", clusterToReattach.getId());
+                sendEvent(context, SDX_DETACH_RECOVERY_SUCCESS_EVENT.event(), payload);
+            }
+
+            @Override
+            protected Object getFailurePayload(SdxStartDetachRecoveryEvent payload, Optional<SdxContext> flowContext,
+                    Exception e) {
+                LOGGER.error("Failed to recover from detach of SDX with ID {}.", payload.getResourceId());
+                return SdxDetachRecoveryFailedEvent.from(payload, e);
+            }
+        };
+    }
+
+    @Bean(name = "SDX_DETACH_RECOVERY_FAILED_STATE")
+    public Action<?, ?> failedAction() {
+        return new AbstractSdxAction<>(SdxDetachRecoveryFailedEvent.class) {
+            @Override
+            protected SdxContext createFlowContext(FlowParameters flowParameters,
+                    StateContext<FlowState, FlowEvent> stateContext,
+                    SdxDetachRecoveryFailedEvent payload) {
+                return SdxContext.from(flowParameters, payload);
+            }
+
+            @Override
+            protected void doExecute(SdxContext context, SdxDetachRecoveryFailedEvent payload, Map<Object, Object> variables) {
+                Exception exception = payload.getException();
+                LOGGER.error("Detach recovery of SDX cluster with ID {} and name {} failed with error {}.",
+                        payload.getResourceId(), payload.getSdxName(), exception.getMessage(), exception);
+                String statusReason = Optional.ofNullable(exception.getMessage()).orElse("SDX detach recovery failed");
+                sdxStatusService.setStatusForDatalakeAndNotify(DatalakeStatusEnum.STOPPED, statusReason, payload.getResourceId());
+                getFlow(context.getFlowParameters().getFlowId()).setFlowFailed(payload.getException());
+                sendEvent(context, SDX_DETACH_RECOVERY_FAILURE_HANDLED_EVENT.event(), payload);
+            }
+
+            @Override
+            protected Object getFailurePayload(SdxDetachRecoveryFailedEvent payload, Optional<SdxContext> flowContext,
+                    Exception e) {
+                LOGGER.error("Critical error in SdxDetachRecovery. Failure was not handled correctly.", e);
+                return null;
+            }
+        };
+    }
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/detach/SdxDetachRecoveryEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/detach/SdxDetachRecoveryEvent.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.datalake.flow.detach;
+
+import com.sequenceiq.datalake.flow.detach.event.SdxDetachRecoveryFailedEvent;
+import com.sequenceiq.flow.core.FlowEvent;
+import com.sequenceiq.flow.event.EventSelectorUtil;
+
+public enum SdxDetachRecoveryEvent implements FlowEvent {
+    SDX_DETACH_RECOVERY_EVENT(),
+    SDX_DETACH_RECOVERY_SUCCESS_EVENT(),
+    SDX_DETACH_RECOVERY_FAILED_EVENT(SdxDetachRecoveryFailedEvent.class),
+    SDX_DETACH_RECOVERY_FAILURE_HANDLED_EVENT();
+
+    private final String event;
+
+    SdxDetachRecoveryEvent() {
+        event = name();
+    }
+
+    SdxDetachRecoveryEvent(Class eventClass) {
+        event = EventSelectorUtil.selector(eventClass);
+    }
+
+    @Override
+    public String event() {
+        return event;
+    }
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/detach/SdxDetachRecoveryFlowConfig.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/detach/SdxDetachRecoveryFlowConfig.java
@@ -1,0 +1,72 @@
+package com.sequenceiq.datalake.flow.detach;
+
+import static com.sequenceiq.datalake.flow.detach.SdxDetachRecoveryEvent.SDX_DETACH_RECOVERY_EVENT;
+import static com.sequenceiq.datalake.flow.detach.SdxDetachRecoveryEvent.SDX_DETACH_RECOVERY_FAILED_EVENT;
+import static com.sequenceiq.datalake.flow.detach.SdxDetachRecoveryEvent.SDX_DETACH_RECOVERY_FAILURE_HANDLED_EVENT;
+import static com.sequenceiq.datalake.flow.detach.SdxDetachRecoveryEvent.SDX_DETACH_RECOVERY_SUCCESS_EVENT;
+import static com.sequenceiq.datalake.flow.detach.SdxDetachRecoveryState.SDX_DETACH_RECOVERY_FAILED_STATE;
+import static com.sequenceiq.datalake.flow.detach.SdxDetachRecoveryState.SDX_DETACH_RECOVERY_STATE;
+import static com.sequenceiq.datalake.flow.detach.SdxDetachRecoveryState.FINAL_STATE;
+import static com.sequenceiq.datalake.flow.detach.SdxDetachRecoveryState.INIT_STATE;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
+import com.sequenceiq.flow.core.config.AbstractFlowConfiguration.Transition.Builder;
+import com.sequenceiq.flow.core.config.RetryableFlowConfiguration;
+
+@Component
+public class SdxDetachRecoveryFlowConfig extends AbstractFlowConfiguration<SdxDetachRecoveryState, SdxDetachRecoveryEvent>
+        implements RetryableFlowConfiguration<SdxDetachRecoveryEvent> {
+    private static final List<Transition<SdxDetachRecoveryState, SdxDetachRecoveryEvent>> TRANSITIONS =
+        new Builder<SdxDetachRecoveryState, SdxDetachRecoveryEvent>()
+        .defaultFailureEvent(SDX_DETACH_RECOVERY_FAILED_EVENT)
+        .from(INIT_STATE).to(SDX_DETACH_RECOVERY_STATE)
+        .event(SDX_DETACH_RECOVERY_EVENT).noFailureEvent()
+        .from(SDX_DETACH_RECOVERY_STATE).to(FINAL_STATE)
+        .event(SDX_DETACH_RECOVERY_SUCCESS_EVENT).defaultFailureEvent()
+        .from(SDX_DETACH_RECOVERY_FAILED_STATE).to(FINAL_STATE)
+        .event(SDX_DETACH_RECOVERY_FAILURE_HANDLED_EVENT).noFailureEvent()
+        .build();
+
+    private static final FlowEdgeConfig<SdxDetachRecoveryState, SdxDetachRecoveryEvent> EDGE_CONFIG =
+            new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, SDX_DETACH_RECOVERY_FAILED_STATE, SDX_DETACH_RECOVERY_FAILURE_HANDLED_EVENT);
+
+    public SdxDetachRecoveryFlowConfig() {
+        super(SdxDetachRecoveryState.class, SdxDetachRecoveryEvent.class);
+    }
+
+    @Override
+    public SdxDetachRecoveryEvent[] getEvents() {
+        return SdxDetachRecoveryEvent.values();
+    }
+
+    @Override
+    public SdxDetachRecoveryEvent[] getInitEvents() {
+        return new SdxDetachRecoveryEvent[] {
+                SDX_DETACH_RECOVERY_EVENT
+        };
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Sdx detach recovery";
+    }
+
+    @Override
+    protected List<Transition<SdxDetachRecoveryState, SdxDetachRecoveryEvent>> getTransitions() {
+        return TRANSITIONS;
+    }
+
+    @Override
+    protected FlowEdgeConfig<SdxDetachRecoveryState, SdxDetachRecoveryEvent> getEdgeConfig() {
+        return EDGE_CONFIG;
+    }
+
+    @Override
+    public SdxDetachRecoveryEvent getRetryableEvent() {
+        return SDX_DETACH_RECOVERY_FAILURE_HANDLED_EVENT;
+    }
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/detach/SdxDetachRecoveryState.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/detach/SdxDetachRecoveryState.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.datalake.flow.detach;
+
+import com.sequenceiq.datalake.flow.FillInMemoryStateStoreRestartAction;
+import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
+import com.sequenceiq.flow.core.restart.DefaultRestartAction;
+
+public enum SdxDetachRecoveryState implements FlowState {
+    INIT_STATE,
+    SDX_DETACH_RECOVERY_STATE,
+    SDX_DETACH_RECOVERY_FAILED_STATE,
+    FINAL_STATE;
+
+    private Class<? extends DefaultRestartAction> restartAction = FillInMemoryStateStoreRestartAction.class;
+
+    SdxDetachRecoveryState() {
+    }
+
+    SdxDetachRecoveryState(Class<? extends DefaultRestartAction> restartAction) {
+        this.restartAction = restartAction;
+    }
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return restartAction;
+    }
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/detach/event/DatalakeResizeRecoveryFlowChainStartEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/detach/event/DatalakeResizeRecoveryFlowChainStartEvent.java
@@ -1,0 +1,47 @@
+package com.sequenceiq.datalake.flow.detach.event;
+
+import java.util.Objects;
+
+import com.sequenceiq.datalake.entity.SdxCluster;
+import com.sequenceiq.datalake.flow.SdxEvent;
+
+public class DatalakeResizeRecoveryFlowChainStartEvent extends SdxEvent {
+    public static final String SDX_RESIZE_RECOVERY_FLOW_CHAIN_START_EVENT = "DatalakeResizeRecoveryFlowChainStartEvent";
+
+    private final SdxCluster oldCluster;
+
+    private final SdxCluster newCluster;
+
+    public DatalakeResizeRecoveryFlowChainStartEvent(SdxCluster oldCluster, SdxCluster newCluster, String userId) {
+        super(oldCluster.getId(), userId);
+        this.oldCluster = oldCluster;
+        this.newCluster = newCluster;
+    }
+
+    public SdxCluster getOldCluster() {
+        return oldCluster;
+    }
+
+    public SdxCluster getNewCluster() {
+        return newCluster;
+    }
+
+    @Override
+    public String selector() {
+        return SDX_RESIZE_RECOVERY_FLOW_CHAIN_START_EVENT;
+    }
+
+    @Override
+    public boolean equalsEvent(SdxEvent other) {
+        return isClassAndEqualsEvent(DatalakeResizeRecoveryFlowChainStartEvent.class, other, event ->
+            Objects.equals(oldCluster, event.oldCluster) && Objects.equals(newCluster, event.newCluster)
+        );
+    }
+
+    @Override
+    public String toString() {
+        return selector() + '{' +
+                "oldCluster: '" + oldCluster.toString() + "'," +
+                "newCluster: '" + (newCluster == null ? "null" : newCluster.toString()) + "'}";
+    }
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/detach/event/SdxDetachRecoveryFailedEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/detach/event/SdxDetachRecoveryFailedEvent.java
@@ -1,0 +1,14 @@
+package com.sequenceiq.datalake.flow.detach.event;
+
+import com.sequenceiq.datalake.flow.SdxEvent;
+import com.sequenceiq.datalake.flow.SdxFailedEvent;
+
+public class SdxDetachRecoveryFailedEvent extends SdxFailedEvent {
+    public SdxDetachRecoveryFailedEvent(Long sdxId, String userId, Exception exception) {
+        super(sdxId, userId, exception);
+    }
+
+    public static SdxDetachRecoveryFailedEvent from(SdxEvent event, Exception exception) {
+        return new SdxDetachRecoveryFailedEvent(event.getResourceId(), event.getUserId(), exception);
+    }
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/detach/event/SdxStartDetachEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/detach/event/SdxStartDetachEvent.java
@@ -2,20 +2,38 @@ package com.sequenceiq.datalake.flow.detach.event;
 
 import java.util.Objects;
 
+import com.sequenceiq.cloudbreak.common.event.AcceptResult;
 import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.flow.SdxEvent;
+
+import reactor.rx.Promise;
 
 public class SdxStartDetachEvent extends SdxEvent {
 
     private final SdxCluster sdxCluster;
+
+    private boolean detachDuringRecovery;
 
     public SdxStartDetachEvent(String selector, Long sdxId, SdxCluster newSdxCluster, String userId) {
         super(selector, sdxId, userId);
         sdxCluster = newSdxCluster;
     }
 
+    public SdxStartDetachEvent(String selector, Long sdxId, SdxCluster newSdxCluster, String userId, Promise<AcceptResult> accepted) {
+        super(selector, sdxId, userId, accepted);
+        sdxCluster = newSdxCluster;
+    }
+
     public SdxCluster getSdxCluster() {
         return sdxCluster;
+    }
+
+    public void setDetachDuringRecovery(boolean detachDuringRecovery) {
+        this.detachDuringRecovery = detachDuringRecovery;
+    }
+
+    public boolean isDetachDuringRecovery() {
+        return detachDuringRecovery;
     }
 
     @Override

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/detach/event/SdxStartDetachRecoveryEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/detach/event/SdxStartDetachRecoveryEvent.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.datalake.flow.detach.event;
+
+import java.util.Objects;
+
+import com.sequenceiq.cloudbreak.common.event.AcceptResult;
+import com.sequenceiq.datalake.flow.SdxEvent;
+
+import reactor.rx.Promise;
+
+public class SdxStartDetachRecoveryEvent extends SdxEvent {
+    public SdxStartDetachRecoveryEvent(String selector, Long detachedSdxId, String userId, Promise<AcceptResult> accepted) {
+        super(selector, detachedSdxId, userId, accepted);
+    }
+
+    @Override
+    public boolean equalsEvent(SdxEvent other) {
+        return isClassAndEqualsEvent(SdxStartDetachRecoveryEvent.class, other,
+                event -> Objects.equals(event.getResourceId(), other.getResourceId()));
+    }
+
+    @Override
+    public String toString() {
+        return selector() + '{' + "detachedSdxId: '" + getResourceId() + "'}";
+    }
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/start/event/SdxStartStartEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/start/event/SdxStartStartEvent.java
@@ -1,6 +1,9 @@
 package com.sequenceiq.datalake.flow.start.event;
 
+import com.sequenceiq.cloudbreak.common.event.AcceptResult;
 import com.sequenceiq.datalake.flow.SdxEvent;
+
+import reactor.rx.Promise;
 
 public class SdxStartStartEvent extends SdxEvent {
 
@@ -8,9 +11,8 @@ public class SdxStartStartEvent extends SdxEvent {
         super(selector, sdxId, userId);
     }
 
-    @Override
-    public String selector() {
-        return "SdxStartStartEvent";
+    public SdxStartStartEvent(String selector, Long sdxId, String userId, Promise<AcceptResult> accepted) {
+        super(selector, sdxId, userId, accepted);
     }
 
     @Override

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/attach/SdxAttachDetachUtils.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/attach/SdxAttachDetachUtils.java
@@ -21,13 +21,14 @@ public class SdxAttachDetachUtils {
         sdxCluster.setClusterName(newName);
         sdxCluster.setOriginalCrn(sdxCluster.getCrn());
         sdxCluster.setCrn(newCrn);
+        sdxCluster.setStackCrn(newCrn);
     }
 
-    public void updateStack(SdxCluster cluster, String originalName) {
+    public void updateStack(String originalName, String newName, String newCrn) {
         String initiatorUserCrn = ThreadBasedUserCrnProvider.getUserCrn();
         ThreadBasedUserCrnProvider.doAsInternalActor(() ->
                 stackV4Endpoint.updateNameAndCrn(
-                        0L, originalName, initiatorUserCrn, cluster.getClusterName(), cluster.getCrn()
+                        0L, originalName, initiatorUserCrn, newName, newCrn
                 )
         );
     }

--- a/datalake/src/test/java/com/sequenceiq/datalake/flow/chain/DatalakeResizeRecoveryFlowEventChainTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/flow/chain/DatalakeResizeRecoveryFlowEventChainTest.java
@@ -1,0 +1,142 @@
+package com.sequenceiq.datalake.flow.chain;
+
+import static com.sequenceiq.datalake.flow.delete.SdxDeleteEvent.SDX_DELETE_EVENT;
+import static com.sequenceiq.datalake.flow.detach.SdxDetachEvent.SDX_DETACH_EVENT;
+import static com.sequenceiq.datalake.flow.detach.SdxDetachRecoveryEvent.SDX_DETACH_RECOVERY_EVENT;
+import static com.sequenceiq.datalake.flow.start.SdxStartEvent.SDX_START_EVENT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Queue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.datalake.entity.SdxCluster;
+import com.sequenceiq.datalake.flow.delete.event.SdxDeleteStartEvent;
+import com.sequenceiq.datalake.flow.detach.event.DatalakeResizeRecoveryFlowChainStartEvent;
+import com.sequenceiq.datalake.flow.detach.event.SdxStartDetachEvent;
+import com.sequenceiq.datalake.flow.detach.event.SdxStartDetachRecoveryEvent;
+import com.sequenceiq.datalake.flow.start.event.SdxStartStartEvent;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
+
+public class DatalakeResizeRecoveryFlowEventChainTest {
+    private static final String USER_CRN = "crn:cdp:iam:us-west-1:1234:user:1";
+
+    private static final long OLD_CLUSTER_SDX_ID = 1L;
+
+    private static final long NEW_CLUSTER_SDX_ID = 2L;
+
+    @InjectMocks
+    private DatalakeResizeRecoveryFlowEventChainFactory factory;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void chainCreationTestAllEvents() {
+        SdxCluster oldCluster = new SdxCluster();
+        oldCluster.setId(OLD_CLUSTER_SDX_ID);
+        oldCluster.setDetached(true);
+        SdxCluster newCluster = new SdxCluster();
+        newCluster.setId(NEW_CLUSTER_SDX_ID);
+
+        DatalakeResizeRecoveryFlowChainStartEvent event = new DatalakeResizeRecoveryFlowChainStartEvent(
+                oldCluster, newCluster, USER_CRN
+        );
+        FlowTriggerEventQueue flowTriggerEventQueue = factory.createFlowTriggerEventQueue(event);
+        assertEquals(4, flowTriggerEventQueue.getQueue().size());
+
+        Queue<Selectable> flowQueue = flowTriggerEventQueue.getQueue();
+        checkEventIsDetach(flowQueue.remove());
+        checkEventIsDeletion(flowQueue.remove());
+        checkEventIsDetachRecovery(flowQueue.remove());
+        checkEventIsStart(flowQueue.remove());
+    }
+
+    @Test
+    public void chainCreationTestNewDLAlreadyDeleted() {
+        SdxCluster oldCluster = new SdxCluster();
+        oldCluster.setId(OLD_CLUSTER_SDX_ID);
+        oldCluster.setDetached(true);
+        SdxCluster newCluster = new SdxCluster();
+        newCluster.setDeleted(1L);
+
+        DatalakeResizeRecoveryFlowChainStartEvent event = new DatalakeResizeRecoveryFlowChainStartEvent(
+                oldCluster, newCluster, USER_CRN
+        );
+        FlowTriggerEventQueue flowTriggerEventQueue = factory.createFlowTriggerEventQueue(event);
+        assertEquals(2, flowTriggerEventQueue.getQueue().size());
+
+        Queue<Selectable> flowQueue = flowTriggerEventQueue.getQueue();
+        checkEventIsDetachRecovery(flowQueue.remove());
+        checkEventIsStart(flowQueue.remove());
+    }
+
+    @Test
+    public void chainCreationTestNewDLNull() {
+        SdxCluster oldCluster = new SdxCluster();
+        oldCluster.setId(OLD_CLUSTER_SDX_ID);
+        oldCluster.setDetached(true);
+
+        DatalakeResizeRecoveryFlowChainStartEvent event = new DatalakeResizeRecoveryFlowChainStartEvent(
+                oldCluster, null, USER_CRN
+        );
+        FlowTriggerEventQueue flowTriggerEventQueue = factory.createFlowTriggerEventQueue(event);
+        assertEquals(2, flowTriggerEventQueue.getQueue().size());
+
+        Queue<Selectable> flowQueue = flowTriggerEventQueue.getQueue();
+        checkEventIsDetachRecovery(flowQueue.remove());
+        checkEventIsStart(flowQueue.remove());
+    }
+
+    @Test
+    public void chainCreationTestNewDLAlreadyDeletedAndOldDLNotDetached() {
+        SdxCluster oldCluster = new SdxCluster();
+        oldCluster.setId(OLD_CLUSTER_SDX_ID);
+        oldCluster.setDetached(false);
+        SdxCluster newCluster = new SdxCluster();
+        newCluster.setDeleted(1L);
+
+        DatalakeResizeRecoveryFlowChainStartEvent event = new DatalakeResizeRecoveryFlowChainStartEvent(
+                oldCluster, newCluster, USER_CRN
+        );
+        FlowTriggerEventQueue flowTriggerEventQueue = factory.createFlowTriggerEventQueue(event);
+        assertEquals(1, flowTriggerEventQueue.getQueue().size());
+
+        Queue<Selectable> flowQueue = flowTriggerEventQueue.getQueue();
+        checkEventIsStart(flowQueue.remove());
+    }
+
+    private void checkEventIsDetach(Selectable event) {
+        assertEquals(SDX_DETACH_EVENT.selector(), event.selector());
+        assertTrue(event instanceof SdxStartDetachEvent);
+        assertEquals(NEW_CLUSTER_SDX_ID, event.getResourceId());
+        assertTrue(((SdxStartDetachEvent) event).isDetachDuringRecovery());
+    }
+
+    private void checkEventIsDeletion(Selectable event) {
+        assertEquals(SDX_DELETE_EVENT.selector(), event.selector());
+        assertTrue(event instanceof SdxDeleteStartEvent);
+        assertEquals(NEW_CLUSTER_SDX_ID, event.getResourceId());
+        SdxDeleteStartEvent sdxDeleteStartEvent = (SdxDeleteStartEvent) event;
+        assertTrue(sdxDeleteStartEvent.isForced());
+    }
+
+    private void checkEventIsDetachRecovery(Selectable event) {
+        assertEquals(SDX_DETACH_RECOVERY_EVENT.selector(), event.selector());
+        assertTrue(event instanceof SdxStartDetachRecoveryEvent);
+        assertEquals(OLD_CLUSTER_SDX_ID, event.getResourceId());
+    }
+
+    private void checkEventIsStart(Selectable event) {
+        assertEquals(SDX_START_EVENT.selector(), event.selector());
+        assertTrue(event instanceof SdxStartStartEvent);
+        assertEquals(OLD_CLUSTER_SDX_ID, event.getResourceId());
+    }
+}

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/attach/SdxAttachServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/attach/SdxAttachServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.MockitoAnnotations;
 
 import com.sequenceiq.authorization.service.OwnerAssignmentService;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.StackV4Endpoint;
+import com.sequenceiq.cloudbreak.quartz.statuschecker.service.StatusCheckerJobService;
 import com.sequenceiq.datalake.entity.DatalakeStatusEnum;
 import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.service.sdx.SdxService;
@@ -24,7 +25,6 @@ import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.DatabaseServerV4Endpoint;
 import com.sequenceiq.sdx.api.model.SdxDatabaseAvailabilityType;
 
-@SuppressWarnings("unchecked")
 public class SdxAttachServiceTest {
     private static final String TEST_CLUSTER_ENV_CRN = "envCrn";
 
@@ -59,6 +59,9 @@ public class SdxAttachServiceTest {
 
     @Mock
     private SdxStatusService mockSdxStatusService;
+
+    @Mock
+    private StatusCheckerJobService mockJobService;
 
     @InjectMocks
     private SdxAttachDetachUtils mockSdxAttachDetachUtils = spy(SdxAttachDetachUtils.class);

--- a/flow/src/main/java/com/sequenceiq/flow/reactor/eventbus/ConsumerCheckerEventBus.java
+++ b/flow/src/main/java/com/sequenceiq/flow/reactor/eventbus/ConsumerCheckerEventBus.java
@@ -22,7 +22,7 @@ public class ConsumerCheckerEventBus extends EventBus {
         try {
             getConsumerRegistry().select(event.getKey());
         } catch (ConsumerNotFoundException e) {
-            LOGGER.error("Can not found consumer for event: " + e.getEvent(), e);
+            LOGGER.error("Could not find consumer for event: " + e.getEvent(), e);
             throw new EventCanNotBeDeliveredException(event);
         }
         super.accept(event);

--- a/flow/src/test/java/com/sequenceiq/flow/core/AbstractActionTestSupport.java
+++ b/flow/src/test/java/com/sequenceiq/flow/core/AbstractActionTestSupport.java
@@ -2,6 +2,7 @@ package com.sequenceiq.flow.core;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.springframework.statemachine.StateContext;
 
@@ -65,6 +66,17 @@ public class AbstractActionTestSupport<S extends FlowState, E extends FlowEvent,
      */
     public C createFlowContext(FlowParameters flowParameters, StateContext<S, E> stateContext, P payload) {
         return action.createFlowContext(flowParameters, stateContext, payload);
+    }
+
+    /**
+     * Delegates to {@link AbstractAction#getFailurePayload(Payload, Optional, Exception)}.
+     * @param payload request event payload
+     * @param flowContext optional containing the flow context
+     * @param ex failure exception
+     * @return payload for the failure
+     */
+    public Object getFailurePayload(P payload, Optional<C> flowContext, Exception ex) {
+        return action.getFailurePayload(payload, flowContext, ex);
     }
 
 }


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-14399

This change is focused on introducing a new flow chain for recovering from DL resize failures. In creating this change I also fixed existing bugs which caused recovery to fail due to the way in which the detach logic functioned.

**Recovery Flow**

1. Detach the DL to be deleted.
2. Delete the DL.
3. Re-attach the old DL that has to be recovered.
4. Start the DL

There are therefore three main parts to this change:

- Creation of the DL Resize Recovery flow chain
     - Involves the new chain, new events, a trigger method, and a new flow within the existing SDX Detach flow (primarily in DetachActions)
- Modifying the SdxClusterStatusCheckerJob to work when a cluster's stack's CRN is modified (otherwise this would mark the cluster as failed during recovery)
- Modifying the Stack DB to have a constraint on unique (CRN, Terminated) pairs instead of just CRN (otherwise recovery would fail as both the resized DL and the old one have the same CRN)

I have tested this by running both my own unit tests, existing mock tests, and locally setting up a DL, resizing it, and then recovering it.