### PR TITLE
CB-15932 wait 2 mins before trigger start in Environment stop-start tests

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
@@ -7,6 +7,7 @@ import static com.sequenceiq.it.cloudbreak.context.RunningParameter.emptyRunning
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
 import static java.util.Objects.isNull;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -447,5 +448,10 @@ public class EnvironmentTestDto
         } else if (flowIdentifier.getType() == FlowType.FLOW_CHAIN) {
             setLastKnownFlowChainId(flowIdentifier.getPollableId());
         }
+    }
+
+    public EnvironmentTestDto waitingFor(Duration duration, String interruptedMessage) {
+        getTestContext().waitingFor(duration, interruptedMessage);
+        return this;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/EnvironmentStopStartTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/EnvironmentStopStartTests.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.it.cloudbreak.testcase.e2e.environment;
 
+import java.time.Duration;
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -111,6 +112,8 @@ public class EnvironmentStopStartTests extends AbstractE2ETest {
                 .given(EnvironmentTestDto.class)
                 .when(environmentTestClient.stop())
                 .await(EnvironmentStatus.ENV_STOPPED)
+                //TODO workaround until CB-15932 has not been implemented
+                .waitingFor(Duration.ofMinutes(2), "Waiting for FreeIpa nodes to really be stopped on Gcp too has been interrupted")
                 .given(EnvironmentTestDto.class)
                 .when(environmentTestClient.start())
                 .await(EnvironmentStatus.AVAILABLE)


### PR DESCRIPTION
More details could be found in the related JIRA item CB-15932 with a root cause analysis why the GCP based environment stop-start tests are failing.
A `TODO` has been added and this commit will be reverted with the permanent fix.