### PR TITLE
CB-15894: E2E SdxResizeTests.testSDXResize failed because the referenced flow didn't belong to the referenced resource

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/repository/SdxClusterRepository.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/repository/SdxClusterRepository.java
@@ -39,6 +39,8 @@ public interface SdxClusterRepository extends AccountAwareResourceRepository<Sdx
 
     Optional<SdxCluster> findByAccountIdAndCrnAndDeletedIsNull(String accountId, String crn);
 
+    Optional<SdxCluster> findByAccountIdAndOriginalCrnAndDeletedIsNull(String accountId, String crn);
+
     Optional<SdxCluster> findByCrnAndDeletedIsNull(String crn);
 
     Optional<SdxCluster> findByAccountIdAndEnvCrnAndDeletedIsNullAndDetachedIsTrue(@Param("accountId") String accountId, @Param("crn") String crn);

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -8,6 +8,7 @@ import static com.sequenceiq.sdx.api.model.SdxClusterShape.CUSTOM;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -256,6 +257,26 @@ public class SdxService implements ResourceIdProvider, ResourcePropertyProvider,
             return sdxCluster.get();
         } else {
             throw notFound("SDX cluster", clusterCrn).get();
+        }
+    }
+
+    public List<SdxCluster> getSdxClustersByCrn(String userCrn, String clusterCrn) {
+        LOGGER.info("Searching for SDX cluster by crn {}", clusterCrn);
+        List<SdxCluster> sdxClusterList = new ArrayList<>();
+        String accountIdFromCrn = getAccountIdFromCrn(userCrn);
+        Optional<SdxCluster> sdxCluster = sdxClusterRepository.findByAccountIdAndCrnAndDeletedIsNull(accountIdFromCrn, clusterCrn);
+        if (sdxCluster.isPresent()) {
+            sdxClusterList.add(sdxCluster.get());
+            sdxCluster = sdxClusterRepository.findByAccountIdAndOriginalCrnAndDeletedIsNull(accountIdFromCrn, clusterCrn);
+            if (sdxCluster.isPresent()) {
+                LOGGER.info("Found a detached data lake associated with crn:{}", clusterCrn);
+                sdxClusterList.add(sdxCluster.get());
+            }
+        }
+        if (sdxClusterList.isEmpty()) {
+            throw notFound("SDX cluster", clusterCrn).get();
+        } else {
+            return sdxClusterList;
         }
     }
 
@@ -738,6 +759,12 @@ public class SdxService implements ResourceIdProvider, ResourcePropertyProvider,
     public Long getResourceIdByResourceCrn(String resourceCrn) {
         String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
         return getByCrn(userCrn, resourceCrn).getId();
+    }
+
+    @Override
+    public List<Long> getResourceIdsByResourceCrn(String resourceCrn) {
+        String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
+        return getSdxClustersByCrn(userCrn, resourceCrn).stream().map(cluster -> cluster.getId()).collect(Collectors.toList());
     }
 
     @Override

--- a/flow/src/main/java/com/sequenceiq/flow/core/ResourceIdProvider.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/ResourceIdProvider.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.flow.core;
 
+import java.util.List;
+
 import org.apache.commons.lang3.NotImplementedException;
 
 public interface ResourceIdProvider {
@@ -11,6 +13,11 @@ public interface ResourceIdProvider {
 
     default Long getResourceIdByResourceName(String resourceName) {
         throw new NotImplementedException("You have to implement getResourceIdByResourceName for your resource "
+                + "to be able to use Flow API endpoints using resource name!");
+    }
+
+    default List<Long> getResourceIdsByResourceCrn(String resourceName) {
+        throw new NotImplementedException("You have to implement getResourceIdsByResourceCrn for your resource "
                 + "to be able to use Flow API endpoints using resource name!");
     }
 }

--- a/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowLogDBService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowLogDBService.java
@@ -304,6 +304,14 @@ public class FlowLogDBService implements FlowLogService {
         return resourceIdProvider.getResourceIdByResourceName(resource);
     }
 
+    public List<Long> getResourceIdsByCrn(String resource) {
+        if (Crn.isCrn(resource)) {
+            return resourceIdProvider.getResourceIdsByResourceCrn(resource);
+        } else {
+            return Collections.EMPTY_LIST;
+        }
+    }
+
     public FlowLog getLastFlowLogByResourceCrnOrName(String resource) {
         Long resourceId = getResourceIdByCrnOrName(resource);
         Iterator<FlowLog> iterator = findAllForLastFlowIdByResourceIdOrderByCreatedDesc(resourceId).iterator();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxResizeTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxResizeTestDto.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.it.cloudbreak.dto.sdx;
 
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.AbstractSdxTestDto;
@@ -25,8 +26,13 @@ public class SdxResizeTestDto extends AbstractSdxTestDto<SdxClusterResizeRequest
 
     @Override
     public SdxResizeTestDto valid() {
-        return withEnvironmentName(getTestContext().get(EnvironmentTestDto.class).getResponse().getName())
-                .withClusterShape(getCloudProvider().getClusterShape());
+        if (CloudPlatform.MOCK.equals(getCloudPlatform())) {
+            return withEnvironmentName(getTestContext().get(EnvironmentTestDto.class).getResponse().getName())
+                    .withClusterShape(getCloudProvider().getClusterShape());
+        } else {
+            return withEnvironmentName(getTestContext().get(EnvironmentTestDto.class).getResponse().getName())
+                    .withClusterShape(SdxClusterShape.MEDIUM_DUTY_HA);
+        }
     }
 
     public SdxResizeTestDto withEnvironmentName(String environment) {

--- a/integration-test/src/main/resources/testsuites/e2e/aws-longrunning-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/aws-longrunning-e2e-tests.yaml
@@ -10,3 +10,4 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.ephemeral.DistroXRepairTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.ephemeral.DistroXUpgradeTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRepairTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxResizeTests


### PR DESCRIPTION
Original PR was https://github.com/hortonworks/cloudbreak/pull/12011.

This change was reverted as it was flaky.
Summary of changes
1. As the datalake is detached, there will be a very small interval before resized Dl is created. During this interval, DL with the CRN will not be found. That is exactly what was happening. I have included some failures handling the flow until code to address this situation.
2. When the datalake is resized datalake ID will change. The current validation would fail. Made changes to skip the validation for resizing.

See detailed description in the commit message.