### PR TITLE
CB-15909 Change rootVolume to 100GB for all types of nodes. Updated r…

### DIFF
--- a/core/src/main/resources/defaults/clustertemplates/7.2.14/yarn/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.14/yarn/flow-management-small.json
@@ -15,7 +15,7 @@
         "recoveryMode": "MANUAL",
         "template": {
           "rootVolume": {
-            "size": 50
+            "size": 100
           },
           "yarn": {
             "cpus": 4,
@@ -30,7 +30,7 @@
         "recoveryMode": "MANUAL",
         "template": {
           "rootVolume": {
-            "size": 50
+            "size": 100
           },
           "yarn": {
             "cpus": 4,
@@ -45,7 +45,7 @@
         "recoveryMode": "MANUAL",
         "template": {
           "rootVolume": {
-            "size": 50
+            "size": 100
           },
           "yarn": {
             "cpus": 4,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.14/yarn/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.14/yarn/flow-management.json
@@ -14,7 +14,7 @@
         "type": "GATEWAY",
         "template": {
           "rootVolume": {
-            "size": 50
+            "size": 100
           },
           "yarn": {
             "cpus": 4,
@@ -29,7 +29,7 @@
         "recoveryMode": "MANUAL",
         "template": {
           "rootVolume": {
-            "size": 50
+            "size": 100
           },
           "yarn": {
             "cpus": 4,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.15/yarn/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.15/yarn/flow-management-small.json
@@ -15,7 +15,7 @@
         "recoveryMode": "MANUAL",
         "template": {
           "rootVolume": {
-            "size": 50
+            "size": 100
           },
           "yarn": {
             "cpus": 4,
@@ -30,7 +30,7 @@
         "recoveryMode": "MANUAL",
         "template": {
           "rootVolume": {
-            "size": 50
+            "size": 100
           },
           "yarn": {
             "cpus": 4,
@@ -45,7 +45,7 @@
         "recoveryMode": "MANUAL",
         "template": {
           "rootVolume": {
-            "size": 50
+            "size": 100
           },
           "yarn": {
             "cpus": 4,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.15/yarn/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.15/yarn/flow-management.json
@@ -14,7 +14,7 @@
         "type": "GATEWAY",
         "template": {
           "rootVolume": {
-            "size": 50
+            "size": 100
           },
           "yarn": {
             "cpus": 4,
@@ -29,7 +29,7 @@
         "recoveryMode": "MANUAL",
         "template": {
           "rootVolume": {
-            "size": 50
+            "size": 100
           },
           "yarn": {
             "cpus": 4,


### PR DESCRIPTION
…ootVolume from 50 GB to 100 GB for Yarn to unblock tests. If rootVolume lower than 100 GB then cluster deploy fails.

See detailed description in the commit message.