### PR TITLE
CB-16020 Add java.io.tmpdir property for NiFi. Added property java.ar…

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.15/cdp-flow-management-small.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.15/cdp-flow-management-small.bp
@@ -162,6 +162,10 @@
                 "value": "-Xms8g"
               },
               {
+                "name": "java.arg.7",
+                "value": "-Djava.io.tmpdir=${nifi.working.directory}/tmp"
+              },
+              {
                 "name": "nifi.registry.client.name",
                 "value": "Default NiFi Registry Client"
               },

--- a/core/src/main/resources/defaults/blueprints/7.2.15/cdp-flow-management.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.15/cdp-flow-management.bp
@@ -138,6 +138,10 @@
                 "value": "-Xms8g"
               },
               {
+                "name": "java.arg.7",
+                "value": "-Djava.io.tmpdir=${nifi.working.directory}/tmp"
+              },
+              {
                 "name": "nifi.registry.client.name",
                 "value": "Default NiFi Registry Client"
               },


### PR DESCRIPTION
…g.7, to set additional java argument java.io.tmpdir for NiFi process.

See detailed description in the commit message.