### PR TITLE
CB-15981 HA Datahubs fail in localdev -> Load Balancer A record is no…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/publicendpoint/FreeIPAEndpointManagementService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/publicendpoint/FreeIPAEndpointManagementService.java
@@ -116,11 +116,9 @@ public class FreeIPAEndpointManagementService extends BasePublicEndpointManageme
     }
 
     private Optional<LoadBalancer> getLoadBalancer(Long stackId) {
-        if (manageCertificateAndDnsInPem()) {
-            Set<LoadBalancer> loadBalancers = loadBalancerPersistenceService.findByStackId(stackId);
-            if (!loadBalancers.isEmpty()) {
-                return loadBalancerConfigService.selectLoadBalancer(loadBalancers, LoadBalancerType.PRIVATE);
-            }
+        Set<LoadBalancer> loadBalancers = loadBalancerPersistenceService.findByStackId(stackId);
+        if (!loadBalancers.isEmpty()) {
+            return loadBalancerConfigService.selectLoadBalancer(loadBalancers, LoadBalancerType.PRIVATE);
         }
         return Optional.empty();
     }


### PR DESCRIPTION
…t registered to ipa if PEM is not enabled

Remove the check that the PEM service is enabled before adding the load balancer DNS record to
FreeIPA. This will ensure that the LB is registered with FreeIPA in local dev environments.

Tested by creating a datalake and an HA datahub, and verifying both were created successfully and
the LB DNS records existed in FreeIPA.