### PR TITLE
CB-16019 - Kafka's config provider doesn't set ranger repo for Kafka …

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaConnectDatahubConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaConnectDatahubConfigProvider.java
@@ -1,0 +1,53 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERA_STACK_VERSION_7_2_14;
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.google.common.collect.Lists;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRoleConfigProvider;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+
+@Component
+public class KafkaConnectDatahubConfigProvider extends AbstractRoleConfigProvider {
+
+    public static final String RANGER_PLUGIN_KAFKA_CONNECT_SERVICE_NAME_CONFIG = "ranger_plugin_kafka_connect_service_name";
+
+    @Override
+    protected List<ApiClusterTemplateConfig> getRoleConfigs(String roleType, TemplatePreparationObject source) {
+        ArrayList<ApiClusterTemplateConfig> configs = Lists.newArrayList();
+        String cdpVersion = source.getBlueprintView().getProcessor().getStackVersion() == null ?
+                "" : source.getBlueprintView().getProcessor().getStackVersion();
+
+        if (isVersionNewerOrEqualThanLimited(cdpVersion, CLOUDERA_STACK_VERSION_7_2_14) && KafkaRoles.KAFKA_CONNECT.equals(roleType)) {
+            configs.add(config(RANGER_PLUGIN_KAFKA_CONNECT_SERVICE_NAME_CONFIG, KafkaConfigs.GENERATED_RANGER_SERVICE_NAME));
+            return configs;
+        }
+
+        return List.of();
+    }
+
+    @Override
+    public List<String> getRoleTypes() {
+        return List.of(KafkaRoles.KAFKA_CONNECT);
+    }
+
+    @Override
+    public String getServiceType() {
+        return KafkaRoles.KAFKA_SERVICE;
+    }
+
+    @Override
+    public boolean isConfigurationNeeded(CmTemplateProcessor cmTemplateProcessor, TemplatePreparationObject source) {
+        return StackType.WORKLOAD.equals(source.getStackType());
+    }
+}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaRoles.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaRoles.java
@@ -6,6 +6,8 @@ public class KafkaRoles {
 
     public static final String KAFKA_BROKER = "KAFKA_BROKER";
 
+    public static final String KAFKA_CONNECT = "KAFKA_CONNECT";
+
     private KafkaRoles() {
     }
 

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaConnectDataHubConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaConnectDataHubConfigProviderTest.java
@@ -1,0 +1,102 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.cloudbreak.template.views.BlueprintView;
+import com.sequenceiq.cloudbreak.template.views.HostgroupView;
+
+@ExtendWith(MockitoExtension.class)
+public class KafkaConnectDataHubConfigProviderTest {
+
+    @Mock
+    private BlueprintView blueprintView;
+
+    @Mock
+    private CmTemplateProcessor processor;
+
+    private final KafkaConnectDatahubConfigProvider provider = new KafkaConnectDatahubConfigProvider();
+
+    @ParameterizedTest
+    @MethodSource("validConfigurationParameters")
+    void testRoleConfigsReturnedWithValidParameters(String cdhVersion, String roleType) {
+        cdpMainVersionIs(cdhVersion);
+        HostgroupView hostGroup = new HostgroupView("test");
+        assertEquals(expectedConfigWithConnectAndCdhAtLeast7214(),
+                provider.getRoleConfigs(roleType, getTemplatePreparationObject(hostGroup)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidConfigurationParameters")
+    void testEmptyListReturnedWithInvalidParameters(String cdhVersion, String roleType) {
+        cdpMainVersionIs(cdhVersion);
+        HostgroupView hostGroup = new HostgroupView("test");
+        assertEquals(List.of(),
+                provider.getRoleConfigs(roleType, getTemplatePreparationObject(hostGroup)));
+    }
+
+    @ParameterizedTest
+    @EnumSource(StackType.class)
+    void testIsConfigurationNeeded(StackType stackType) {
+        TemplatePreparationObject tpo = TemplatePreparationObject.Builder.builder()
+                .withBlueprintView(blueprintView)
+                .withStackType(stackType).build();
+        boolean expectedIsNeeded = stackType == StackType.WORKLOAD;
+        assertThat(provider.isConfigurationNeeded(null, tpo)).isEqualTo(expectedIsNeeded);
+    }
+
+    private static Stream<Arguments> validConfigurationParameters() {
+        return Stream.of(
+                Arguments.of("7.2.14", KafkaRoles.KAFKA_CONNECT),
+                Arguments.of("7.2.15", KafkaRoles.KAFKA_CONNECT),
+                Arguments.of("7.2.16", KafkaRoles.KAFKA_CONNECT)
+        );
+    }
+
+    private static Stream<Arguments> invalidConfigurationParameters() {
+        return Stream.of(
+                Arguments.of("7.2.12", KafkaRoles.KAFKA_CONNECT),
+                Arguments.of("7.2.13", KafkaRoles.KAFKA_CONNECT),
+                Arguments.of("7.2.12", KafkaRoles.KAFKA_BROKER),
+                Arguments.of("7.2.14", KafkaRoles.KAFKA_BROKER),
+                Arguments.of("7.2.15", KafkaRoles.KAFKA_BROKER)
+        );
+    }
+
+    private void cdpMainVersionIs(String version) {
+        when(blueprintView.getProcessor()).thenReturn(processor);
+        when(processor.getStackVersion()).thenReturn(version);
+    }
+
+    private TemplatePreparationObject getTemplatePreparationObject(HostgroupView hostGroup) {
+        TemplatePreparationObject preparationObject = TemplatePreparationObject.Builder.builder()
+                .withHostgroupViews(Set.of(hostGroup))
+                .withBlueprintView(blueprintView)
+                .build();
+        return preparationObject;
+    }
+
+    private List<ApiClusterTemplateConfig> expectedConfigWithConnectAndCdhAtLeast7214() {
+        return List.of(
+                config(KafkaConnectDatahubConfigProvider.RANGER_PLUGIN_KAFKA_CONNECT_SERVICE_NAME_CONFIG, KafkaConfigs.GENERATED_RANGER_SERVICE_NAME)
+        );
+    }
+}


### PR DESCRIPTION
…Connect

With this commit, we explicitly set the ranger_plugin_kafka_connect_service_name property for Kafka Connect if it is present in the cluster, and CDH >= 7.2.14.

Tested: Unit tests + manually on provisioned cluster
