### PR TITLE
[CB-16028] /recoverable endpoint sometimes polls before flows have started

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxRetryService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxRetryService.java
@@ -48,7 +48,7 @@ public class SdxRetryService {
     private StackV4Endpoint stackV4Endpoint;
 
     public FlowIdentifier retrySdx(SdxCluster sdxCluster) {
-        FlowLog flowLog = flow2Handler.getFirstStateLogfromLatestFlow(sdxCluster.getId());
+        FlowLog flowLog = flow2Handler.getFirstRetryableStateLogfromLatestFlow(sdxCluster.getId());
         if (!flowLog.getFlowType().isOnClassPath()) {
             throw new InternalServerErrorException(String.format("Flow type %s is not on classpath", flowLog.getFlowType().getName()));
         }

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/resize/recovery/ResizeRecoveryServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/resize/recovery/ResizeRecoveryServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -83,7 +84,7 @@ public class ResizeRecoveryServiceTest {
                 .thenReturn(flowId);
         String flowChainId = "CHAIN";
         flowLog.setFlowChainId(flowChainId);
-        lenient().when(flow2Handler.getFirstStateLogfromLatestFlow(cluster.getId())).thenReturn(flowLog);
+        lenient().when(flow2Handler.getFirstStateLogfromLatestFlow(cluster.getId())).thenReturn(Optional.of(flowLog));
         lenient().when(flowChainLogService.getFlowChainType(flowChainId)).thenReturn(DatalakeResizeFlowEventChainFactory.class.getSimpleName());
     }
 
@@ -129,6 +130,14 @@ public class ResizeRecoveryServiceTest {
     }
 
     @Test
+    public void testEmptyFlowLogValidateNonRecoverable() {
+        lenient().when(flow2Handler.getFirstStateLogfromLatestFlow(cluster.getId())).thenReturn(Optional.empty());
+        sdxStatusEntity.setStatus(DatalakeStatusEnum.REQUESTED);
+        SdxRecoverableResponse sdxRecoverableResponse = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.validateRecovery(cluster));
+        assertEquals(RecoveryStatus.NON_RECOVERABLE, sdxRecoverableResponse.getStatus(), "No recent flowlog should be non-recoverable");
+    }
+
+    @Test
     public void testNoEntitlementValidate() {
         when(entitlementService.isDatalakeResizeRecoveryEnabled(anyString())).thenReturn(false);
 
@@ -139,6 +148,7 @@ public class ResizeRecoveryServiceTest {
         assertEquals("Resize Recovery entitlement not enabled", sdxRecoverableResponse.getReason());
     }
 
+    @Test
     public void testNoEntitlementTrigger() {
         when(entitlementService.isDatalakeResizeRecoveryEnabled(anyString())).thenReturn(false);
 

--- a/flow/src/main/java/com/sequenceiq/cloudbreak/service/flowlog/FlowLogUtil.java
+++ b/flow/src/main/java/com/sequenceiq/cloudbreak/service/flowlog/FlowLogUtil.java
@@ -22,11 +22,8 @@ public class FlowLogUtil {
     private FlowLogUtil() {
     }
 
-    public static FlowLog getFirstStateLog(List<FlowLog> flowLogs) {
-        List<FlowLog> reversedOrderedFlowLog = flowLogs.stream()
-                .sorted(Comparator.comparing(FlowLog::getCreated))
-                .collect(Collectors.toList());
-        return reversedOrderedFlowLog.get(0);
+    public static Optional<FlowLog> getFirstStateLog(List<FlowLog> flowLogs) {
+        return flowLogs.stream().min(Comparator.comparing(FlowLog::getCreated));
     }
 
     public static FlowLog getLastSuccessfulStateLog(String failedState, List<FlowLog> flowLogs) {


### PR DESCRIPTION

Now account for the chance that we might return no flows for a given
resourceId

