### PR TITLE
CB-16023: Support automatic backup of DL as part of upgrade and resize workflows on RAZ enabled environments.

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxReactorFlowManager.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxReactorFlowManager.java
@@ -159,10 +159,7 @@ public class SdxReactorFlowManager {
     private boolean shouldSdxBackupBePerformed(SdxCluster cluster) {
         boolean retVal = true;
         String reason = null;
-        if (cluster.isRangerRazEnabled()) {
-            retVal = false;
-            reason = "RAZ is enabled";
-        } else if (isVersionOlderThan(cluster, "7.2.1")) {
+        if (isVersionOlderThan(cluster, "7.2.1")) {
             retVal = false;
             reason = "Unsupported runtime: " + cluster.getRuntime();
         } else if (cluster.getCloudStorageFileSystemType() == null) {

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/chain/DatalakeResizeFlowEventChainFactory.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/chain/DatalakeResizeFlowEventChainFactory.java
@@ -58,7 +58,7 @@ public class DatalakeResizeFlowEventChainFactory implements FlowEventChainFactor
         // Create new
         chain.add(new SdxEvent(STORAGE_VALIDATION_WAIT_EVENT.event(), event.getResourceId(), event.getSdxCluster().getClusterName(), event.getUserId()));
 
-        if (event.shouldTakeBackup()) {
+        if (event.shouldTakeBackup() && !event.getSdxCluster().isRangerRazEnabled()) {
             //restore the new cluster
             chain.add(new DatalakeTriggerRestoreEvent(DATALAKE_TRIGGER_RESTORE_EVENT.event(), event.getResourceId(), event.getSdxCluster().getClusterName(),
                     event.getUserId(), null, event.getBackupLocation(), null, DatalakeRestoreFailureReason.RESTORE_ON_RESIZE));


### PR DESCRIPTION
But the restore is not performed automatically when RAZ is enabled.

Made sure that Backup is triggered when resizing and upgrading RAZ-enabled datalake.
