### PR TITLE
CB-16070 CCM Connector enhancements

### DIFF
--- a/ccm-connector/src/main/java/com/sequenceiq/cloudbreak/ccmimpl/ccmv2/GrpcCcmV2Client.java
+++ b/ccm-connector/src/main/java/com/sequenceiq/cloudbreak/ccmimpl/ccmv2/GrpcCcmV2Client.java
@@ -2,6 +2,10 @@ package com.sequenceiq.cloudbreak.ccmimpl.ccmv2;
 
 import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
@@ -14,10 +18,14 @@ import com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterC
 import com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.CreateOrGetInvertingProxyResponse;
 import com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxy;
 import com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent;
+import com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest;
+import com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest.Builder;
+import com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse;
 import com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.RegisterAgentRequest;
 import com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.RegisterAgentResponse;
 import com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.UnregisterAgentRequest;
 import com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.UnregisterAgentResponse;
+import com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken;
 import com.sequenceiq.cloudbreak.ccmimpl.ccmv2.config.GrpcCcmV2Config;
 import com.sequenceiq.cloudbreak.grpc.ManagedChannelWrapper;
 import com.sequenceiq.cloudbreak.grpc.altus.AltusMetadataInterceptor;
@@ -26,8 +34,6 @@ import com.sequenceiq.cloudbreak.grpc.util.GrpcUtil;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.opentracing.Tracer;
-
-import java.util.Optional;
 
 @Component
 public class GrpcCcmV2Client {
@@ -61,7 +67,7 @@ public class GrpcCcmV2Client {
                     .setAccountId(accountId)
                     .setDomainName(domainName)
                     .setKeyId(keyId);
-            environmentCrnOpt.ifPresent(environmentCrn -> registerAgentRequestBuilder.setEnvironmentCrn(environmentCrn));
+            environmentCrnOpt.ifPresent(registerAgentRequestBuilder::setEnvironmentCrn);
             RegisterAgentRequest registerAgentRequest = registerAgentRequestBuilder.build();
             LOGGER.debug("Calling registerAgent with params accountId: '{}', environmentCrnOpt: '{}', domainName: '{}', keyId:'{}' ",
                     accountId, environmentCrnOpt, domainName, keyId);
@@ -80,6 +86,30 @@ public class GrpcCcmV2Client {
             LOGGER.debug("Calling unRegisterAgent with params agentCrn: '{}'", agentCrn);
             return client.unregisterAgent(unregisterAgentRequest);
         }
+    }
+
+    public List<InvertingProxyAgent> listAgents(String requestId, String actorCrn, String accountId, Optional<String> environmentCrnOpt) {
+        List<InvertingProxyAgent> result = new ArrayList<>();
+        try (ManagedChannelWrapper channelWrapper = makeWrapper()) {
+            ClusterConnectivityManagementV2BlockingStub client = makeClient(channelWrapper.getChannel(), requestId, actorCrn);
+            Builder listAgentsRequestBuilder = ListAgentsRequest.newBuilder();
+            environmentCrnOpt.ifPresentOrElse(listAgentsRequestBuilder::setEnvironmentCrn, () -> listAgentsRequestBuilder.setAccountId(accountId));
+            ListAgentsRequest listAgentsRequest = listAgentsRequestBuilder.build();
+
+            PageToken nextPageToken = null;
+            int page = 0;
+            while (page == 0 || nextPageToken.getExclusiveStartKeyStringAttrsCount() > 0 || nextPageToken.getExclusiveStartKeyNumAttrsCount() > 0) {
+                ++page;
+                LOGGER.debug("Calling listAgents with params accountId: '{}', environment CRN: '{}', page: '{}'", accountId, environmentCrnOpt, page);
+                ListAgentsResponse listAgentsResponse = client.listAgents(listAgentsRequest);
+                result.addAll(listAgentsResponse.getAgentsList());
+
+                nextPageToken = listAgentsResponse.getNextPageToken();
+                listAgentsRequestBuilder.setPageToken(nextPageToken);
+                listAgentsRequest = listAgentsRequestBuilder.build();
+            }
+        }
+        return result;
     }
 
     private ManagedChannelWrapper makeWrapper() {

--- a/ccm-connector/src/main/java/com/sequenceiq/cloudbreak/ccmimpl/cloudinit/DefaultCcmV2JumpgateParameterSupplier.java
+++ b/ccm-connector/src/main/java/com/sequenceiq/cloudbreak/ccmimpl/cloudinit/DefaultCcmV2JumpgateParameterSupplier.java
@@ -29,10 +29,10 @@ public class DefaultCcmV2JumpgateParameterSupplier extends DefaultCcmV2Parameter
 
         LOGGER.debug("CcmV2JumpgateConfig successfully retrieved InvertingProxyHost: '{}', InvertingProxyStatus: '{}', InvertingProxyAgentCrn: '{}', " +
                         "EnvironmentCrnOpt: '{}'", invertingProxy.getHostname(), invertingProxy.getStatus(),
-                invertingProxyAgent.getAgentCrn(), Optional.of(invertingProxyAgent.getEnvironmentCrn()));
+                invertingProxyAgent.getAgentCrn(), invertingProxyAgent.getEnvironmentCrn());
 
         return new DefaultCcmV2JumpgateParameters(invertingProxy.getHostname(), invertingProxy.getCertificate(), invertingProxyAgent.getAgentCrn(), agentKeyId,
-                invertingProxyAgent.getEncipheredPrivateKey(), invertingProxyAgent.getCertificate(),
+                invertingProxyAgent.getEncipheredPrivateKey(), invertingProxyAgent.getCertificate(), invertingProxyAgent.getEnvironmentCrn(),
                 invertingProxyAgent.getAccessKeyId(), invertingProxyAgent.getEncipheredAccessKey());
     }
 }

--- a/ccm-connector/src/test/java/com/sequenceiq/cloudbreak/ccmimpl/ccmv2/CcmV2ManagementClientTest.java
+++ b/ccm-connector/src/test/java/com/sequenceiq/cloudbreak/ccmimpl/ccmv2/CcmV2ManagementClientTest.java
@@ -1,16 +1,18 @@
 package com.sequenceiq.cloudbreak.ccmimpl.ccmv2;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxy;
 import com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent;
@@ -19,8 +21,8 @@ import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.ccm.exception.CcmV2Exception;
 import com.sequenceiq.cloudbreak.ccmimpl.ccmv2.config.GrpcCcmV2Config;
 
-@RunWith(MockitoJUnitRunner.class)
-public class CcmV2ManagementClientTest {
+@ExtendWith(MockitoExtension.class)
+class CcmV2ManagementClientTest {
 
     private static final String TEST_ACCOUNT_ID = "us-west-1:e7b1345f-4ae1-4594-9113-fc91f22ef8bd";
 
@@ -41,14 +43,14 @@ public class CcmV2ManagementClientTest {
     @Mock
     private GrpcCcmV2Config grpcCcmV2Config;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         when(grpcCcmV2Config.getPollingIntervalMs()).thenReturn(10);
         when(grpcCcmV2Config.getTimeoutMs()).thenReturn(100);
     }
 
     @Test
-    public void testAwaitReadyInvertingProxyForAccountWhenInvertingProxyIsReady() {
+    void testAwaitReadyInvertingProxyForAccountWhenInvertingProxyIsReady() {
         InvertingProxy invertingProxy = InvertingProxy.newBuilder().setStatus(InvertingProxy.Status.READY).build();
         when(grpcCcmV2Client.getOrCreateInvertingProxy(TEST_REQUEST_ID, TEST_ACCOUNT_ID, TEST_USER_CRN)).thenReturn(invertingProxy);
         InvertingProxy retrievedProxy = ThreadBasedUserCrnProvider.doAs(TEST_USER_CRN,
@@ -56,22 +58,26 @@ public class CcmV2ManagementClientTest {
         assertEquals(InvertingProxy.Status.READY, retrievedProxy.getStatus(), "Inverting Proxy Status should be ready.");
     }
 
-    @Test(expected = CcmV2Exception.class)
-    public void testAwaitReadyInvertingProxyForAccountWhenInvertingProxyIsCreating() {
+    @Test
+    void testAwaitReadyInvertingProxyForAccountWhenInvertingProxyIsCreating() {
         InvertingProxy invertingProxy = InvertingProxy.newBuilder().setStatus(InvertingProxy.Status.CREATING).build();
         when(grpcCcmV2Client.getOrCreateInvertingProxy(TEST_REQUEST_ID, TEST_ACCOUNT_ID, TEST_USER_CRN)).thenReturn(invertingProxy);
-        ThreadBasedUserCrnProvider.doAs(TEST_USER_CRN, () -> underTest.awaitReadyInvertingProxyForAccount(TEST_REQUEST_ID, TEST_ACCOUNT_ID));
-    }
-
-    @Test(expected = CcmV2Exception.class)
-    public void testAwaitReadyInvertingProxyForAccountWhenInvertingProxyIsFailed() {
-        InvertingProxy invertingProxy = InvertingProxy.newBuilder().setStatus(InvertingProxy.Status.FAILED).build();
-        when(grpcCcmV2Client.getOrCreateInvertingProxy(TEST_REQUEST_ID, TEST_ACCOUNT_ID, TEST_USER_CRN)).thenReturn(invertingProxy);
-        ThreadBasedUserCrnProvider.doAs(TEST_USER_CRN, () -> underTest.awaitReadyInvertingProxyForAccount(TEST_REQUEST_ID, TEST_ACCOUNT_ID));
+        assertThatThrownBy(() ->
+                ThreadBasedUserCrnProvider.doAs(TEST_USER_CRN, () -> underTest.awaitReadyInvertingProxyForAccount(TEST_REQUEST_ID, TEST_ACCOUNT_ID)))
+                .isInstanceOf(CcmV2Exception.class);
     }
 
     @Test
-    public void testRegisterInvertingProxyAgent() {
+    void testAwaitReadyInvertingProxyForAccountWhenInvertingProxyIsFailed() {
+        InvertingProxy invertingProxy = InvertingProxy.newBuilder().setStatus(InvertingProxy.Status.FAILED).build();
+        when(grpcCcmV2Client.getOrCreateInvertingProxy(TEST_REQUEST_ID, TEST_ACCOUNT_ID, TEST_USER_CRN)).thenReturn(invertingProxy);
+        assertThatThrownBy(() ->
+                ThreadBasedUserCrnProvider.doAs(TEST_USER_CRN, () -> underTest.awaitReadyInvertingProxyForAccount(TEST_REQUEST_ID, TEST_ACCOUNT_ID)))
+                .isInstanceOf(CcmV2Exception.class);
+    }
+
+    @Test
+    void testRegisterInvertingProxyAgent() {
         String domain = "test.domain";
         String keyId = "keyId";
 
@@ -84,19 +90,20 @@ public class CcmV2ManagementClientTest {
         assertEquals(TEST_AGENT_CRN, registeredAgent.getAgentCrn(), "InvertingProxyAgent agentCrn  should match.");
     }
 
-    @Test(expected = CcmV2Exception.class)
-    public void testRegisterInvertingProxyAgentWhenException() {
+    @Test
+    void testRegisterInvertingProxyAgentWhenException() {
         String domain = "test.domain";
         String keyId = "keyId";
 
         when(grpcCcmV2Client.registerAgent(TEST_REQUEST_ID, TEST_ACCOUNT_ID, Optional.of(TEST_ENVIRONMENT_CRN), domain, keyId, TEST_USER_CRN))
                 .thenThrow(new RuntimeException());
-        ThreadBasedUserCrnProvider.doAs(TEST_USER_CRN,
-                () -> underTest.registerInvertingProxyAgent(TEST_REQUEST_ID, TEST_ACCOUNT_ID, Optional.of(TEST_ENVIRONMENT_CRN), domain, keyId));
+        assertThatThrownBy(() -> ThreadBasedUserCrnProvider.doAs(TEST_USER_CRN,
+                () -> underTest.registerInvertingProxyAgent(TEST_REQUEST_ID, TEST_ACCOUNT_ID, Optional.of(TEST_ENVIRONMENT_CRN), domain, keyId)))
+                .isInstanceOf(CcmV2Exception.class);
     }
 
     @Test
-    public void testUnRegisterAgent() {
+    void testUnRegisterAgent() {
         UnregisterAgentResponse mockResponse = UnregisterAgentResponse.newBuilder().build();
         when(grpcCcmV2Client.unRegisterAgent(TEST_REQUEST_ID, TEST_AGENT_CRN, TEST_USER_CRN)).thenReturn(mockResponse);
         UnregisterAgentResponse unregisterAgentResponse = ThreadBasedUserCrnProvider.doAs(TEST_USER_CRN,
@@ -104,9 +111,27 @@ public class CcmV2ManagementClientTest {
         assertEquals(unregisterAgentResponse, mockResponse, "UnregisterAgentResponse should match.");
     }
 
-    @Test(expected = CcmV2Exception.class)
-    public void testUnRegisterAgentWhenException() {
+    @Test
+    void testUnRegisterAgentWhenException() {
         when(grpcCcmV2Client.unRegisterAgent(TEST_REQUEST_ID, TEST_AGENT_CRN, TEST_USER_CRN)).thenThrow(new RuntimeException());
-        ThreadBasedUserCrnProvider.doAs(TEST_USER_CRN, () -> underTest.deregisterInvertingProxyAgent(TEST_REQUEST_ID, TEST_AGENT_CRN));
+        assertThatThrownBy(() -> ThreadBasedUserCrnProvider.doAs(TEST_USER_CRN, () -> underTest.deregisterInvertingProxyAgent(TEST_REQUEST_ID, TEST_AGENT_CRN)))
+                .isInstanceOf(CcmV2Exception.class);
+    }
+
+    @Test
+    void testListAgents() {
+        List<InvertingProxyAgent> mockResponse = List.of(InvertingProxyAgent.newBuilder().build());
+        when(grpcCcmV2Client.listAgents(TEST_REQUEST_ID, TEST_USER_CRN, TEST_ACCOUNT_ID, Optional.of(TEST_ENVIRONMENT_CRN))).thenReturn(mockResponse);
+        List<InvertingProxyAgent> listAgentsResponse = ThreadBasedUserCrnProvider.doAs(TEST_USER_CRN,
+                () -> underTest.listInvertingProxyAgents(TEST_REQUEST_ID, TEST_ACCOUNT_ID, Optional.of(TEST_ENVIRONMENT_CRN)));
+        assertEquals(listAgentsResponse, mockResponse, "List Agents Response should match.");
+    }
+
+    @Test
+    void testListAgentsWhenException() {
+        when(grpcCcmV2Client.listAgents(TEST_REQUEST_ID, TEST_USER_CRN, TEST_ACCOUNT_ID, Optional.of(TEST_ENVIRONMENT_CRN))).thenThrow(new RuntimeException());
+        assertThatThrownBy(() -> ThreadBasedUserCrnProvider.doAs(TEST_USER_CRN,
+                        () ->  underTest.listInvertingProxyAgents(TEST_REQUEST_ID, TEST_ACCOUNT_ID, Optional.of(TEST_ENVIRONMENT_CRN))))
+                .isInstanceOf(CcmV2Exception.class);
     }
 }

--- a/ccm-connector/src/test/java/com/sequenceiq/cloudbreak/ccmimpl/cloudinit/DefaultCcmV2JumpgateParameterSupplierTest.java
+++ b/ccm-connector/src/test/java/com/sequenceiq/cloudbreak/ccmimpl/cloudinit/DefaultCcmV2JumpgateParameterSupplierTest.java
@@ -61,10 +61,12 @@ class DefaultCcmV2JumpgateParameterSupplierTest {
                 Crn.fromString(TEST_CLUSTER_CRN).getResource());
         assertNotNull(resultParameters, "CCMV2 Jumpgate Parameters should not be null");
 
+        assertEquals(TEST_ENVIRONMENT_CRN, resultParameters.getEnvironmentCrn(), "EnvironmentCRN should match");
         assertEquals("invertingProxyAgentCrn", resultParameters.getAgentCrn(), "AgentCRN should match");
         assertEquals("invertingProxyHost", resultParameters.getInvertingProxyHost(), "InvertingProxyHost should match");
         assertEquals("invertingProxyCertificate", resultParameters.getInvertingProxyCertificate(), "InvertingProxyCertificate should match");
         assertEquals(TEST_RESOURCE_ID, resultParameters.getAgentKeyId(), "AgentKeyId should match");
+        assertAgentCertOrMachineUser(resultParameters, singleWayTls);
     }
 
     private void assertAgentCertOrMachineUser(CcmV2JumpgateParameters resultParameters, boolean singleWayTls) {

--- a/ccm-connector/src/test/java/com/sequenceiq/cloudbreak/ccmimpl/cloudinit/DefaultCcmV2ParameterSupplierTest.java
+++ b/ccm-connector/src/test/java/com/sequenceiq/cloudbreak/ccmimpl/cloudinit/DefaultCcmV2ParameterSupplierTest.java
@@ -1,11 +1,17 @@
 package com.sequenceiq.cloudbreak.ccmimpl.cloudinit;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -18,6 +24,7 @@ import com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterC
 import com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent;
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.ccm.cloudinit.CcmV2Parameters;
+import com.sequenceiq.cloudbreak.ccm.exception.CcmV2Exception;
 import com.sequenceiq.cloudbreak.ccmimpl.ccmv2.CcmV2ManagementClient;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,6 +40,10 @@ class DefaultCcmV2ParameterSupplierTest {
 
     private static final String TEST_ENVIRONMENT_CRN = String.format("crn:cdp:iam:us-west-1:%s:environment:%s", TEST_ACCOUNT_ID, TEST_ENVIRONMENT_ID);
 
+    private static final String TEST_GATEWAY_DOMAIN = "test.gateway.domain";
+
+    private static final String TEST_AGENT_CRN = String.format("crn:cdp:ccmv2:us-west-1:e7b1345f-4ae1-4594-9113-fc91f22ef8bd:agent:%s", TEST_RESOURCE_ID);
+
     @InjectMocks
     private DefaultCcmV2ParameterSupplier underTest;
 
@@ -41,7 +52,50 @@ class DefaultCcmV2ParameterSupplierTest {
 
     @Test
     void testGetCcmV2Parameter() {
-        String gatewayDomain = "test.gateway.domain";
+        setupRegisterInvertingProxyDetails();
+
+        CcmV2Parameters resultParameters = underTest.getCcmV2Parameters(TEST_ACCOUNT_ID, Optional.of(TEST_ENVIRONMENT_CRN), TEST_GATEWAY_DOMAIN,
+                Crn.fromString(TEST_CLUSTER_CRN).getResource());
+        assertResult(resultParameters);
+        verify(ccmV2Client).listInvertingProxyAgents(anyString(), eq(TEST_ACCOUNT_ID), eq(Optional.of(TEST_ENVIRONMENT_CRN)));
+        verify(ccmV2Client).registerInvertingProxyAgent(
+                anyString(), eq(TEST_ACCOUNT_ID), eq(Optional.of(TEST_ENVIRONMENT_CRN)), eq(TEST_GATEWAY_DOMAIN), eq(TEST_RESOURCE_ID));
+        verify(ccmV2Client, never()).deregisterInvertingProxyAgent(any(), any());
+    }
+
+    @Test
+    void unregisterAgentIsCalledWhenExisted() {
+        setupRegisterInvertingProxyDetails();
+        when(ccmV2Client.listInvertingProxyAgents(any(), any(), any()))
+                .thenReturn(List.of(InvertingProxyAgent.newBuilder().setAgentCrn(TEST_AGENT_CRN).build()));
+
+        CcmV2Parameters resultParameters = underTest.getCcmV2Parameters(TEST_ACCOUNT_ID, Optional.of(TEST_ENVIRONMENT_CRN), TEST_GATEWAY_DOMAIN,
+                Crn.fromString(TEST_CLUSTER_CRN).getResource());
+
+        assertResult(resultParameters);
+
+        verify(ccmV2Client).listInvertingProxyAgents(anyString(), eq(TEST_ACCOUNT_ID), eq(Optional.of(TEST_ENVIRONMENT_CRN)));
+        verify(ccmV2Client).registerInvertingProxyAgent(
+                anyString(), eq(TEST_ACCOUNT_ID), eq(Optional.of(TEST_ENVIRONMENT_CRN)), eq(TEST_GATEWAY_DOMAIN), eq(TEST_RESOURCE_ID));
+        verify(ccmV2Client).deregisterInvertingProxyAgent(any(), eq(TEST_AGENT_CRN));
+    }
+
+    @Test
+    void unregisterAgentRethrows() {
+        setupRegisterInvertingProxyDetails();
+        when(ccmV2Client.listInvertingProxyAgents(any(), any(), any()))
+                .thenThrow(new CcmV2Exception("internal error"));
+
+        assertThatThrownBy(() -> underTest.getCcmV2Parameters(TEST_ACCOUNT_ID, Optional.of(TEST_ENVIRONMENT_CRN), TEST_GATEWAY_DOMAIN,
+                Crn.fromString(TEST_CLUSTER_CRN).getResource())).hasMessageNotContaining("internal error").isInstanceOf(CcmV2Exception.class);
+
+        verify(ccmV2Client).listInvertingProxyAgents(anyString(), eq(TEST_ACCOUNT_ID), eq(Optional.of(TEST_ENVIRONMENT_CRN)));
+        verify(ccmV2Client, never()).registerInvertingProxyAgent(
+                anyString(), eq(TEST_ACCOUNT_ID), eq(Optional.of(TEST_ENVIRONMENT_CRN)), eq(TEST_GATEWAY_DOMAIN), eq(TEST_RESOURCE_ID));
+        verify(ccmV2Client, never()).deregisterInvertingProxyAgent(any(), eq(TEST_AGENT_CRN));
+    }
+
+    private void setupRegisterInvertingProxyDetails() {
         InvertingProxy mockInvertingProxy = InvertingProxy.newBuilder()
                 .setHostname("invertingProxyHost")
                 .setCertificate("invertingProxyCertificate")
@@ -52,13 +106,12 @@ class DefaultCcmV2ParameterSupplierTest {
                 .setCertificate("invertingProxyAgentCertificate")
                 .setEncipheredPrivateKey("invertingProxyAgentEncipheredKey")
                 .build();
-
         when(ccmV2Client.awaitReadyInvertingProxyForAccount(anyString(), anyString())).thenReturn(mockInvertingProxy);
-        when(ccmV2Client.registerInvertingProxyAgent(anyString(), anyString(), any(Optional.class), anyString(), anyString()))
+        lenient().when(ccmV2Client.registerInvertingProxyAgent(anyString(), anyString(), any(Optional.class), anyString(), anyString()))
                 .thenReturn(mockInvertingProxyAgent);
+    }
 
-        CcmV2Parameters resultParameters = underTest.getCcmV2Parameters(TEST_ACCOUNT_ID, Optional.of(TEST_ENVIRONMENT_CRN), gatewayDomain,
-                Crn.fromString(TEST_CLUSTER_CRN).getResource());
+    private void assertResult(CcmV2Parameters resultParameters) {
         assertNotNull(resultParameters, "CCMV2 Parameters should not be null");
 
         assertEquals("invertingProxyAgentCrn", resultParameters.getAgentCrn(), "AgentCRN should match");

--- a/common/src/main/java/com/sequenceiq/cloudbreak/auth/crn/Crn.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/auth/crn/Crn.java
@@ -173,7 +173,8 @@ public class Crn {
         ACCOUNTTAG("accounttag", NON_ADMIN_SERVICE),
         ACCOUNTTELEMETRY("accounttelemetry", NON_ADMIN_SERVICE),
         ML("ml", NON_ADMIN_SERVICE),
-        DF("df", NON_ADMIN_SERVICE);
+        DF("df", NON_ADMIN_SERVICE),
+        CCMV2("ccmv2", NON_ADMIN_SERVICE);
 
         private static final ImmutableMap<String, Service> FROM_STRING;
 
@@ -373,7 +374,8 @@ public class Crn {
         ACCOUNT_TELEMETRY("accountTelemetry"),
         DATAHUB_AUTOSCALE_CONFIG("datahubAutoscaleConfig"),
         PROXY_CONIFG("proxyConfig"),
-        SERVICE("service");
+        SERVICE("service"),
+        AGENT("agent");
 
         private static final ImmutableMap<String, ResourceType> FROM_STRING;
 

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/CcmV2JumpgateParameters.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/CcmV2JumpgateParameters.java
@@ -21,6 +21,8 @@ public interface CcmV2JumpgateParameters extends CcmV2Parameters {
         }
     }
 
+    String getEnvironmentCrn();
+
     String getAgentMachineUserAccessKey();
 
     String getAgentMachineUserEncipheredAccessKey();

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/CcmV2Parameters.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/CcmV2Parameters.java
@@ -30,5 +30,7 @@ public interface CcmV2Parameters {
 
     String getAgentCrn();
 
+    String getAgentBackendIdPrefix();
+
     void addToTemplateModel(@Nonnull Map<String, Object> model);
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/DefaultCcmV2JumpgateParameters.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/DefaultCcmV2JumpgateParameters.java
@@ -3,25 +3,34 @@ package com.sequenceiq.cloudbreak.ccm.cloudinit;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 import java.util.Map;
+import java.util.Objects;
 
 import javax.annotation.Nonnull;
 
 public class DefaultCcmV2JumpgateParameters extends DefaultCcmV2Parameters implements CcmV2JumpgateParameters {
+
+    private final String environmentCrn;
 
     private final String agentMachineUserAccessKey;
 
     private final String agentMachineUserEncipheredAccessKey;
 
     public DefaultCcmV2JumpgateParameters(@Nonnull String invertingProxyHost, @Nonnull String invertingProxyCertificate, @Nonnull String agentCrn,
-            @Nonnull String agentKeyId, String agentEncipheredPrivateKey, String agentCertificate,
+            @Nonnull String agentKeyId, String agentEncipheredPrivateKey, String agentCertificate, String environmentCrn,
             String agentMachineUserAccessKey, String agentMachineUserEncipheredAccessKey) {
         super(invertingProxyHost, invertingProxyCertificate, agentCrn, agentKeyId, agentEncipheredPrivateKey, agentCertificate);
-        this.agentMachineUserAccessKey = agentMachineUserAccessKey;
-        this.agentMachineUserEncipheredAccessKey = agentMachineUserEncipheredAccessKey;
+        this.environmentCrn = Objects.requireNonNullElse(environmentCrn, EMPTY);
+        this.agentMachineUserAccessKey = Objects.requireNonNullElse(agentMachineUserAccessKey, EMPTY);
+        this.agentMachineUserEncipheredAccessKey = Objects.requireNonNullElse(agentMachineUserEncipheredAccessKey, EMPTY);
     }
 
     public DefaultCcmV2JumpgateParameters() {
-        this(EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY);
+        this(EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY);
+    }
+
+    @Override
+    public String getEnvironmentCrn() {
+        return environmentCrn;
     }
 
     @Override

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/DefaultCcmV2Parameters.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/DefaultCcmV2Parameters.java
@@ -67,6 +67,13 @@ public class DefaultCcmV2Parameters implements CcmV2Parameters, Serializable {
     }
 
     @Override
+    public String getAgentBackendIdPrefix() {
+        return StringUtils.isNotBlank(getAgentCrn())
+                ? String.format(CCMV2_BACKEND_ID_FORMAT, getAgentCrn(), EMPTY)
+                : EMPTY;
+    }
+
+    @Override
     public void addToTemplateModel(@Nonnull Map<String, Object> model) {
         model.put(CcmV2ParameterConstants.CCMV2_INVERTING_PROXY_HOST, getInvertingProxyHost());
         model.put(CcmV2ParameterConstants.CCMV2_INVERTING_PROXY_CERTIFICATE, getInvertingProxyCertificate());
@@ -75,8 +82,6 @@ public class DefaultCcmV2Parameters implements CcmV2Parameters, Serializable {
         model.put(CcmV2ParameterConstants.CCMV2_AGENT_CRN, getAgentCrn());
         model.put(CcmV2ParameterConstants.CCMV2_AGENT_ENCIPHERED_KEY, getAgentEncipheredPrivateKey());
         model.put(CcmV2ParameterConstants.CCMV2_AGENT_CERTIFICATE, getAgentCertificate());
-        model.put(CcmV2ParameterConstants.CCMV2_AGENT_BACKEND_ID_PREFIX, StringUtils.isNotBlank(getAgentCrn())
-                ? String.format(CCMV2_BACKEND_ID_FORMAT, getAgentCrn(), EMPTY)
-                : EMPTY);
+        model.put(CcmV2ParameterConstants.CCMV2_AGENT_BACKEND_ID_PREFIX, getAgentBackendIdPrefix());
     }
 }

--- a/common/src/test/java/com/sequenceiq/cloudbreak/ccm/cloudinit/DefaultCcmV2JumpgateParametersTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/ccm/cloudinit/DefaultCcmV2JumpgateParametersTest.java
@@ -24,7 +24,7 @@ class DefaultCcmV2JumpgateParametersTest {
     @Test
     void testAddToTemplateModelFull() {
         underTest = new DefaultCcmV2JumpgateParameters("invertingProxyHost", "invertingProxyCertificate", "agentCrn",
-                "agentKeyId", "agentEncipheredPrivateKey", "agentCertificate",
+                "agentKeyId", "agentEncipheredPrivateKey", "agentCertificate", "environmentCrn",
                 "agentMachineUserAccessKey", "agentMachineUserEncipheredAccessKey");
 
         Map<String, Object> expectedParams = new HashMap<>();

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/userdata/UserDataBuilderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/userdata/UserDataBuilderTest.java
@@ -141,7 +141,7 @@ class UserDataBuilderTest {
     void testBuildUserDataWithCCMV2JumpgateParams(CcmV2TlsType ccmV2TlsType,
             boolean oneWayTlsEntitlementEnabled, String expectedContentFileName) throws IOException {
         CcmV2JumpgateParameters ccmV2JumpgateParameters = new DefaultCcmV2JumpgateParameters("invertingProxyHost", "invertingProxyCertificate",
-                "agentCrn", "agentKeyId", "agentEncipheredPrivateKey", "agentCertificate",
+                "agentCrn", "agentKeyId", "agentEncipheredPrivateKey", "agentCertificate", "environmentCrn",
                 "agentMachineUserAccessKeyId", "agentMachineUserEncipheredAccessKey");
         CcmConnectivityParameters ccmConnectivityParameters = new CcmConnectivityParameters(ccmV2JumpgateParameters);
 


### PR DESCRIPTION
There is an issue when trying to re-register an inverting proxy agent for the same cluster in the same environment, causing a unique constraint violation in the ccmv2 thunderhead service.

This is mitigated by first checking if an agent is already registered and if so, removing the registration.

The ccmv2 service was missing from the CRN enums, adding.

See detailed description in the commit message.