### PR TITLE
CB-15763 Optimisticlockexception in StackUpdater caused termination f…

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/action/DeregisterCcmKeyAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/action/DeregisterCcmKeyAction.java
@@ -30,7 +30,7 @@ public class DeregisterCcmKeyAction extends AbstractStackTerminationAction<Termi
     protected void doExecute(StackTerminationContext context, TerminationEvent payload, Map<Object, Object> variables) {
         Stack stack = context.getStack();
 
-        stackUpdater.updateStackStatus(stack.getId(), DetailedStackStatus.DEREGISTERING_CCM_KEY,
+        stackUpdater.updateStackStatusWithRetry(stack.getId(), DetailedStackStatus.DEREGISTERING_CCM_KEY,
                 "Deregistering CCM key.");
 
         String userCrn = ThreadBasedUserCrnProvider.getUserCrn();

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/action/DeregisterClusterProxyAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/action/DeregisterClusterProxyAction.java
@@ -24,7 +24,7 @@ public class DeregisterClusterProxyAction extends AbstractStackTerminationAction
 
     @Override
     protected void doExecute(StackTerminationContext context, TerminationEvent payload, Map<Object, Object> variables) {
-        stackUpdater.updateStackStatus(context.getStack().getId(), DetailedStackStatus.DEREGISTERING_WITH_CLUSTERPROXY,
+        stackUpdater.updateStackStatusWithRetry(context.getStack().getId(), DetailedStackStatus.DEREGISTERING_WITH_CLUSTERPROXY,
                 "Deregistering FreeIPA from Cluster Proxy.");
         ClusterProxyDeregistrationRequest clusterProxyDeregistrationRequest =
                 new ClusterProxyDeregistrationRequest(payload.getResourceId(), payload.getForced());

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/action/StackTerminationAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/action/StackTerminationAction.java
@@ -29,7 +29,8 @@ public class StackTerminationAction extends AbstractStackTerminationAction<Termi
 
     @Override
     protected void doExecute(StackTerminationContext context, TerminationEvent payload, Map<Object, Object> variables) {
-        stackUpdater.updateStackStatus(context.getStack().getId(), DetailedStackStatus.DELETE_IN_PROGRESS, "Terminating FreeIPA and its infrastructure.");
+        stackUpdater.updateStackStatusWithRetry(context.getStack().getId(), DetailedStackStatus.DELETE_IN_PROGRESS,
+                "Terminating FreeIPA and its infrastructure.");
         TerminateStackRequest<?> terminateRequest = createRequest(context);
         sendEvent(context, terminateRequest.selector(), terminateRequest);
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/action/StackTerminationService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/action/StackTerminationService.java
@@ -33,7 +33,7 @@ public class StackTerminationService {
         if (!forced) {
             Exception errorDetails = payload.getException();
             String stackUpdateMessage = "Termination failed: " + errorDetails.getMessage();
-            stackUpdater.updateStackStatus(stack.getId(), DetailedStackStatus.DELETE_FAILED, stackUpdateMessage);
+            stackUpdater.updateStackStatusWithRetry(stack.getId(), DetailedStackStatus.DELETE_FAILED, stackUpdateMessage);
             LOGGER.debug("Error during stack termination flow: ", errorDetails);
         } else {
             terminationService.finalizeTermination(stack.getId());

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/action/TerminationService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/action/TerminationService.java
@@ -75,7 +75,7 @@ public class TerminationService {
         stack.setTerminated(currentTimeMillis);
         terminateMetaDataInstances(stack, null);
         cleanupVault(stack);
-        stackUpdater.updateStackStatus(stack, DetailedStackStatus.DELETE_COMPLETED, "Stack was terminated successfully.");
+        stackUpdater.updateStackStatusWithRetry(stack.getId(), DetailedStackStatus.DELETE_COMPLETED, "Stack was terminated successfully.");
         stackService.save(stack);
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackStatusUpdater.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackStatusUpdater.java
@@ -1,0 +1,87 @@
+package com.sequenceiq.freeipa.service.stack;
+
+import java.util.Objects;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
+import com.sequenceiq.cloudbreak.cloud.store.InMemoryStateStore;
+import com.sequenceiq.cloudbreak.message.StackStatusMessageTransformator;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.entity.StackStatus;
+
+@Service
+public class StackStatusUpdater {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StackStatusUpdater.class);
+
+    @Inject
+    private StackStatusMessageTransformator stackStatusMessageTransformator;
+
+    @Inject
+    private ServiceStatusRawMessageTransformer serviceStatusRawMessageTransformer;
+
+    @Inject
+    private StackService stackService;
+
+    public Stack update(Stack stack, DetailedStackStatus newDetailedStatus, String rawNewStatusReason) {
+        StackStatus stackStatus = stack.getStackStatus();
+        if (!Status.DELETE_COMPLETED.equals(stackStatus.getStatus())) {
+            rawNewStatusReason = serviceStatusRawMessageTransformer.transformMessage(rawNewStatusReason, stack.getTunnel());
+            String transformedNewStatusReason = stackStatusMessageTransformator.transformMessage(rawNewStatusReason);
+            if (isStatusChanged(stack, newDetailedStatus, transformedNewStatusReason)) {
+                stack = handleStatusChange(stack, stackStatus, newDetailedStatus, transformedNewStatusReason);
+            } else {
+                LOGGER.debug("Statuses are the same, it will not update");
+                updateInMemoryStoreIfStackIsMissing(stack, newDetailedStatus.getStatus());
+            }
+        }
+        return stack;
+    }
+
+    private Stack updateStatus(Stack stackOriginal, DetailedStackStatus newDetailedStatus, String newStatusReason, StackStatus stackStatus) {
+        Stack stack = stackService.getStackById(stackOriginal.getId());
+        Status newStatus = newDetailedStatus.getStatus();
+        LOGGER.debug("Updated: status from {} to {} - detailed status from {} to {} - reason from {} to {}",
+                stackStatus.getStatus(), newStatus, stackStatus.getDetailedStackStatus(), newDetailedStatus,
+                stackStatus.getStatusReason(), newStatusReason);
+        stack.setStackStatus(new StackStatus(stack, newStatus, newStatusReason, newDetailedStatus));
+        stack = stackService.save(stack);
+        return stack;
+    }
+
+    private void updateInMemoryStoreIfStackIsMissing(Stack stack, Status newStatus) {
+        if (InMemoryStateStore.getStack(stack.getId()) == null) {
+            LOGGER.debug("Although status hasn't changed, the stack is missing from 'InMemoryStateStore'. Updating 'InMemoryStateStore'");
+            updateInMemoryStore(stack, newStatus);
+        }
+    }
+
+    private Stack handleStatusChange(Stack stack, StackStatus stackStatus, DetailedStackStatus newDetailedStatus, String newStatusReason) {
+        stack = updateStatus(stack, newDetailedStatus, newStatusReason, stackStatus);
+        updateInMemoryStore(stack, newDetailedStatus.getStatus());
+        return stack;
+    }
+
+    private void updateInMemoryStore(Stack stack, Status newStatus) {
+        if (newStatus.isRemovableStatus()) {
+            InMemoryStateStore.deleteStack(stack.getId());
+        } else {
+            PollGroup pollGroup = Status.DELETE_COMPLETED.equals(newStatus) ? PollGroup.CANCELLED : PollGroup.POLLABLE;
+            InMemoryStateStore.putStack(stack.getId(), pollGroup);
+        }
+    }
+
+    private boolean isStatusChanged(Stack stack, DetailedStackStatus newDetailedStatus, String newStatusReason) {
+        return newDetailedStatus.getStatus() != stack.getStackStatus().getStatus()
+                || !newDetailedStatus.equals(stack.getStackStatus().getDetailedStackStatus())
+                || !Objects.equals(newStatusReason, stack.getStackStatus().getStatusReason());
+    }
+
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackUpdater.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackUpdater.java
@@ -1,21 +1,18 @@
 package com.sequenceiq.freeipa.service.stack;
 
-import java.util.Objects;
-
 import javax.inject.Inject;
+import javax.persistence.OptimisticLockException;
 
+import org.hibernate.StaleObjectStateException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
-import com.sequenceiq.cloudbreak.cloud.store.InMemoryStateStore;
-import com.sequenceiq.cloudbreak.message.StackStatusMessageTransformator;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.entity.SecurityConfig;
 import com.sequenceiq.freeipa.entity.Stack;
-import com.sequenceiq.freeipa.entity.StackStatus;
 import com.sequenceiq.freeipa.service.SecurityConfigService;
 
 @Component
@@ -30,17 +27,21 @@ public class StackUpdater {
     private SecurityConfigService securityConfigService;
 
     @Inject
-    private StackStatusMessageTransformator stackStatusMessageTransformator;
-
-    @Inject
-    private ServiceStatusRawMessageTransformer serviceStatusRawMessageTransformer;
+    private StackStatusUpdater stackStatusUpdater;
 
     public Stack updateStackStatus(Long stackId, DetailedStackStatus detailedStatus, String statusReason) {
-        return doUpdateStackStatus(stackId, detailedStatus, statusReason);
+        Stack stack = stackService.getStackById(stackId);
+        return updateStackStatus(stack, detailedStatus, statusReason);
+    }
+
+    @Retryable(value = {OptimisticLockException.class, StaleObjectStateException.class}, backoff = @Backoff(value = 1000), maxAttempts = 4)
+    public Stack updateStackStatusWithRetry(Long stackId, DetailedStackStatus detailedStatus, String statusReason) {
+        Stack stack = stackService.getStackById(stackId);
+        return updateStackStatus(stack, detailedStatus, statusReason);
     }
 
     public Stack updateStackStatus(Stack stack, DetailedStackStatus detailedStatus, String statusReason) {
-        return doUpdateStackStatus(stack, detailedStatus, statusReason);
+        return stackStatusUpdater.update(stack, detailedStatus, statusReason);
     }
 
     public Stack updateStackSecurityConfig(Stack stack, SecurityConfig securityConfig) {
@@ -54,61 +55,4 @@ public class StackUpdater {
         return stackService.save(stack);
     }
 
-    private Stack doUpdateStackStatus(Long stackId, DetailedStackStatus detailedStatus, String statusReason) {
-        Stack stack = stackService.getStackById(stackId);
-        return doUpdateStackStatus(stack, detailedStatus, statusReason);
-    }
-
-    private Stack doUpdateStackStatus(Stack stack, DetailedStackStatus newDetailedStatus, String rawNewStatusReason) {
-        Status newStatus = newDetailedStatus.getStatus();
-        StackStatus stackStatus = stack.getStackStatus();
-        if (!Status.DELETE_COMPLETED.equals(stackStatus.getStatus())) {
-            rawNewStatusReason = serviceStatusRawMessageTransformer.transformMessage(rawNewStatusReason, stack.getTunnel());
-            String transformedStatusReason = stackStatusMessageTransformator.transformMessage(rawNewStatusReason);
-            if (isStatusChanged(stack, newDetailedStatus, transformedStatusReason, newStatus)) {
-                stack = handleStatusChange(stack, newDetailedStatus, transformedStatusReason, newStatus, stackStatus);
-            } else {
-                LOGGER.debug("Statuses are the same, it will not update");
-                updateInMemoryStoreIfStackIsMissing(stack, newStatus);
-            }
-        }
-        return stack;
-    }
-
-    private void updateInMemoryStoreIfStackIsMissing(Stack stack, Status newStatus) {
-        if (InMemoryStateStore.getStack(stack.getId()) == null) {
-            LOGGER.debug("Although status hasn't changed, the stack is missing from 'InMemoryStateStore'. Updating 'InMemoryStateStore'");
-            updateInMemoryStore(stack, newStatus);
-        }
-    }
-
-    private Stack handleStatusChange(Stack stack, DetailedStackStatus newDetailedStatus, String newStatusReason, Status newStatus, StackStatus stackStatus) {
-        stack = saveStackNewStatus(stack, newDetailedStatus, newStatusReason, newStatus, stackStatus);
-        updateInMemoryStore(stack, newStatus);
-        return stack;
-    }
-
-    private void updateInMemoryStore(Stack stack, Status newStatus) {
-        if (newStatus.isRemovableStatus()) {
-            InMemoryStateStore.deleteStack(stack.getId());
-        } else {
-            PollGroup pollGroup = Status.DELETE_COMPLETED.equals(newStatus) ? PollGroup.CANCELLED : PollGroup.POLLABLE;
-            InMemoryStateStore.putStack(stack.getId(), pollGroup);
-        }
-    }
-
-    private Stack saveStackNewStatus(Stack stack, DetailedStackStatus newDetailedStatus, String newStatusReason, Status newStatus, StackStatus stackStatus) {
-        LOGGER.debug("Updated: status from {} to {} - detailed status from {} to {} - reason from {} to {}",
-                stackStatus.getStatus(), newStatus, stackStatus.getDetailedStackStatus(), newDetailedStatus,
-                stackStatus.getStatusReason(), newStatusReason);
-        stack.setStackStatus(new StackStatus(stack, newStatus, newStatusReason, newDetailedStatus));
-        stack = stackService.save(stack);
-        return stack;
-    }
-
-    private boolean isStatusChanged(Stack stack, DetailedStackStatus detailedStatus, String statusReason, Status status) {
-        return status != stack.getStackStatus().getStatus()
-                || !detailedStatus.equals(stack.getStackStatus().getDetailedStackStatus())
-                || !Objects.equals(statusReason, stack.getStackStatus().getStatusReason());
-    }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/termination/action/TerminationServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/termination/action/TerminationServiceTest.java
@@ -32,6 +32,8 @@ class TerminationServiceTest {
 
     private static final String STACK_NAME = "freeipa-cluster";
 
+    private static final long STACK_ID = 1L;
+
     @Mock
     private StackService stackService;
 
@@ -108,18 +110,19 @@ class TerminationServiceTest {
     }
 
     @Test
-    void testfinalizeTerminationTransaction() throws Exception {
+    void testFinalizeTerminationTransaction() throws Exception {
         Stack stack = mock(Stack.class);
+        when(stack.getId()).thenReturn(STACK_ID);
 
-        when(stackService.getByIdWithListsInTransaction(1L)).thenReturn(stack);
+        when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
         when(stack.getName()).thenReturn(STACK_NAME);
 
-        underTest.finalizeTerminationTransaction(1L);
+        underTest.finalizeTerminationTransaction(STACK_ID);
 
         verify(stack).setName(anyString());
         verify(stack).setTerminated(any());
         verify(keytabCleanupService).cleanupByEnvironment(any(), any());
-        verify(stackUpdater).updateStackStatus(eq(stack),
+        verify(stackUpdater).updateStackStatusWithRetry(eq(STACK_ID),
                 eq(DetailedStackStatus.DELETE_COMPLETED),
                 eq("Stack was terminated successfully."));
         verify(stackService).save(eq(stack));

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/StackStatusUpdaterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/StackStatusUpdaterTest.java
@@ -1,0 +1,133 @@
+package com.sequenceiq.freeipa.service.stack;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
+import com.sequenceiq.cloudbreak.cloud.store.InMemoryStateStore;
+import com.sequenceiq.cloudbreak.message.StackStatusMessageTransformator;
+import com.sequenceiq.common.api.type.Tunnel;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.entity.StackStatus;
+
+@ExtendWith(MockitoExtension.class)
+public class StackStatusUpdaterTest {
+
+    private static final long STACK_ID = 1234L;
+
+    private static final String REASON = "myReason";
+
+    private static final String TRANSFORMED_REASON = "transform2";
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private StackStatusMessageTransformator stackStatusMessageTransformator;
+
+    @Mock
+    private ServiceStatusRawMessageTransformer serviceStatusRawMessageTransformer;
+
+    @Mock
+    private StackStatusUpdater stackStatusUpdater;
+
+    @InjectMocks
+    private StackStatusUpdater underTest;
+
+    @Test
+    void testDoUpdateStackStatusWhenNoStatusChange() {
+        Stack stack = getStack(DetailedStackStatus.AVAILABLE, TRANSFORMED_REASON);
+        DetailedStackStatus newStackStatus = DetailedStackStatus.AVAILABLE;
+        InMemoryStateStore.putStack(stack.getId(), PollGroup.POLLABLE);
+        when(serviceStatusRawMessageTransformer.transformMessage(eq(REASON), any(Tunnel.class))).thenReturn("transform1");
+        when(stackStatusMessageTransformator.transformMessage("transform1")).thenReturn(TRANSFORMED_REASON);
+
+        underTest.update(stack, newStackStatus, REASON);
+
+        verify(stackService, never()).save(stack);
+        assertThat(InMemoryStateStore.getAllStackId()).contains(STACK_ID);
+    }
+
+    @Test
+    void testDoUpdateStackStatusWhenStatusIsDeleteCompleted() {
+        Stack stack = getStack(DetailedStackStatus.DELETE_COMPLETED, "deleteReason");
+        DetailedStackStatus newStackStatus = DetailedStackStatus.AVAILABLE;
+
+        underTest.update(stack, newStackStatus, REASON);
+
+        verify(serviceStatusRawMessageTransformer, never()).transformMessage(any(), any());
+        verify(stackStatusMessageTransformator, never()).transformMessage(any());
+        verify(stackService, never()).save(stack);
+        assertThat(InMemoryStateStore.getStack(STACK_ID)).isNull();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = DetailedStackStatus.class, names = {"AVAILABLE", "DELETE_FAILED", "DELETE_COMPLETED", "STOPPED", "START_FAILED",
+            "STOP_FAILED", "REPAIR_FAILED", "UPSCALE_FAILED", "DOWNSCALE_FAILED", "PROVISIONED", "SALT_STATE_UPDATE_FAILED", "REPAIR_COMPLETED",
+            "DOWNSCALE_COMPLETED", "UPSCALE_COMPLETED", "STARTED", "PROVISION_FAILED"})
+    void testDoUpdateStackStatusWhenRemovableState(DetailedStackStatus detailedStackStatus) {
+        Stack stack = getStack(DetailedStackStatus.CREATING_INFRASTRUCTURE, "oldReason");
+        InMemoryStateStore.putStack(stack.getId(), PollGroup.POLLABLE);
+        when(serviceStatusRawMessageTransformer.transformMessage(eq(REASON), any(Tunnel.class))).thenReturn("transform1");
+        when(stackStatusMessageTransformator.transformMessage("transform1")).thenReturn(TRANSFORMED_REASON);
+        when(stackService.getStackById(STACK_ID)).thenReturn(stack);
+        when(stackService.save(stack)).thenReturn(stack);
+
+        underTest.update(stack, detailedStackStatus, REASON);
+
+        assertNewStatusIsSaved(detailedStackStatus);
+        assertThat(InMemoryStateStore.getStack(STACK_ID)).isNull();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = DetailedStackStatus.class, names = {"AVAILABLE", "DELETE_FAILED", "DELETE_COMPLETED", "STOPPED", "START_FAILED",
+            "STOP_FAILED", "REPAIR_FAILED", "UPSCALE_FAILED", "DOWNSCALE_FAILED", "PROVISIONED", "SALT_STATE_UPDATE_FAILED", "REPAIR_COMPLETED",
+            "DOWNSCALE_COMPLETED", "UPSCALE_COMPLETED", "STARTED", "PROVISION_FAILED"}, mode = EnumSource.Mode.EXCLUDE)
+    void testDoUpdateStackStatusWhenNotRemovableState(DetailedStackStatus detailedStackStatus) {
+        Stack stack = getStack(DetailedStackStatus.AVAILABLE, "oldReason");
+        when(serviceStatusRawMessageTransformer.transformMessage(eq(REASON), any(Tunnel.class))).thenReturn("transform1");
+        when(stackStatusMessageTransformator.transformMessage("transform1")).thenReturn(TRANSFORMED_REASON);
+        when(stackService.getStackById(STACK_ID)).thenReturn(stack);
+        when(stackService.save(stack)).thenReturn(stack);
+
+        underTest.update(stack, detailedStackStatus, REASON);
+
+        assertNewStatusIsSaved(detailedStackStatus);
+        assertThat(InMemoryStateStore.getAllStackId()).contains(STACK_ID);
+    }
+
+    private void assertNewStatusIsSaved(DetailedStackStatus newDetailedStackStatus) {
+        ArgumentCaptor<Stack> captor = ArgumentCaptor.forClass(Stack.class);
+        verify(stackService).save(captor.capture());
+        StackStatus savedStackStatus = captor.getValue().getStackStatus();
+        assertEquals(savedStackStatus.getDetailedStackStatus(), newDetailedStackStatus);
+        assertEquals(TRANSFORMED_REASON, savedStackStatus.getStatusReason());
+    }
+
+    private Stack getStack(DetailedStackStatus originalStatus, String statusReason) {
+        Stack stack = new Stack();
+        stack.setId(STACK_ID);
+        StackStatus stackStatus = new StackStatus();
+        stackStatus.setDetailedStackStatus(originalStatus);
+        stackStatus.setStatus(originalStatus.getStatus());
+        stackStatus.setStatusReason(statusReason);
+        stack.setStackStatus(stackStatus);
+        return stack;
+    }
+
+}


### PR DESCRIPTION
…low interrupt

In some cases there might be parallel flows. In that case updating the stack status might happen at the same time, causing OptimisticLockException or StaleObjectStateExceptions.
This commit applies a retry logic around reading the Stack, updating and saving it.

See detailed description in the commit message.