### PR TITLE
CB-16102: Stopping the data lake is timing out when DH cluster are present.

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/DistroxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/DistroxService.java
@@ -39,7 +39,7 @@ public class DistroxService {
         START
     }
 
-    @Value("${dl.dh.polling.attempt:90}")
+    @Value("${dl.dh.polling.attempt:360}")
     private Integer attempt;
 
     @Value("${dl.dh.polling.sleep.time:5}")


### PR DESCRIPTION
When data lake in an environment with DH clusters is stopped, pooling internal to stop DH cluster is just 5-6 min which is short.

 Especially this is not sufficient for DH clusters that have external databases.

 Re-used the attempt count from DatahubPollerService.
