### PR TITLE
CB-16107 Change the DBStack's resourceCrn type in the entity. We use …

### DIFF
--- a/redbeams/src/main/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverter.java
@@ -160,7 +160,7 @@ public class AllocateDatabaseServerV4RequestToDBStackConverter {
 
         Instant now = clock.getCurrentInstant();
         dbStack.setDBStackStatus(new DBStackStatus(dbStack, DetailedDBStackStatus.PROVISION_REQUESTED, now.toEpochMilli()));
-        dbStack.setResourceCrn(crnService.createCrn(dbStack));
+        dbStack.setResourceCrn(crnService.createCrn(dbStack).toString());
         dbStack.setTags(getTags(dbStack, source, environment));
         dbStack.setSslConfig(getSslConfig(source, dbStack));
         return dbStack;
@@ -272,7 +272,7 @@ public class AllocateDatabaseServerV4RequestToDBStackConverter {
                 .withEnvironmentCrn(dbStack.getEnvironmentId())
                 .withPlatform(dbStack.getCloudPlatform())
                 .withAccountId(dbStack.getAccountId())
-                .withResourceCrn(dbStack.getResourceCrn().toString())
+                .withResourceCrn(dbStack.getResourceCrn())
                 .withIsInternalTenant(internalTenant)
                 .withUserName(dbStack.getUserName())
                 .withAccountTags(accountTagService.list())

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/converter/v4/databaseserver/DBStackToDatabaseServerStatusV4ResponseConverter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/converter/v4/databaseserver/DBStackToDatabaseServerStatusV4ResponseConverter.java
@@ -12,7 +12,7 @@ public class DBStackToDatabaseServerStatusV4ResponseConverter {
         DatabaseServerStatusV4Response response = new DatabaseServerStatusV4Response();
         response.setName(source.getName());
         response.setEnvironmentCrn(source.getEnvironmentId());
-        response.setResourceCrn(source.getResourceCrn().toString());
+        response.setResourceCrn(source.getResourceCrn());
 
         response.setStatus(source.getStatus());
         response.setStatusReason(source.getStatusReason());

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/domain/stack/DBStack.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/domain/stack/DBStack.java
@@ -38,9 +38,8 @@ public class DBStack {
     @SequenceGenerator(name = "dbstack_generator", sequenceName = "dbstack_id_seq", allocationSize = 1)
     private Long id;
 
-    @Convert(converter = CrnConverter.class)
     @Column(nullable = false)
-    private Crn resourceCrn;
+    private String resourceCrn;
 
     private String name;
 
@@ -232,11 +231,11 @@ public class DBStack {
         this.userName = userName;
     }
 
-    public Crn getResourceCrn() {
+    public String getResourceCrn() {
         return resourceCrn;
     }
 
-    public void setResourceCrn(Crn resourceCrn) {
+    public void setResourceCrn(String resourceCrn) {
         this.resourceCrn = resourceCrn;
     }
 
@@ -286,7 +285,7 @@ public class DBStack {
                 + "',platformVariant='" + platformVariant
                 + "',environmentId='" + environmentId
                 + "',ownerCrn='" + (ownerCrn != null ? ownerCrn.toString() : "null")
-                + "',resourceCrn='" + (resourceCrn != null ? resourceCrn.toString() : "null")
+                + "',resourceCrn='" + (resourceCrn != null ? resourceCrn : "null")
                 + '}';
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/AbstractRedbeamsProvisionAction.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/AbstractRedbeamsProvisionAction.java
@@ -69,7 +69,7 @@ public abstract class AbstractRedbeamsProvisionAction<P extends Payload>
         CloudContext cloudContext = CloudContext.Builder.builder()
                 .withId(dbStack.getId())
                 .withName(dbStack.getName())
-                .withCrn(dbStack.getResourceCrn().toString())
+                .withCrn(dbStack.getResourceCrn())
                 .withPlatform(dbStack.getCloudPlatform())
                 .withVariant(dbStack.getPlatformVariant())
                 .withLocation(location)

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/handler/UpdateDatabaseServerRegistrationHandler.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/handler/UpdateDatabaseServerRegistrationHandler.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.transform.CloudResourceHelper;
@@ -61,7 +62,7 @@ public class UpdateDatabaseServerRegistrationHandler extends ExceptionCatcherEve
 
         Selectable response;
         try {
-            DatabaseServerConfig dbServerConfig = databaseServerConfigService.getByCrn(dbStack.getResourceCrn())
+            DatabaseServerConfig dbServerConfig = databaseServerConfigService.getByCrn(Crn.safeFromString(dbStack.getResourceCrn()))
                     .orElseThrow(() -> new IllegalStateException("Cannot find database server " + dbStack.getResourceCrn()));
             CloudResource dbHostname = cloudResourceHelper.getResourceTypeFromList(ResourceType.RDS_HOSTNAME, dbResources)
                     .orElseThrow(() -> new IllegalStateException("DB hostname not found for allocated database."));

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/start/actions/AbstractRedbeamsStartAction.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/start/actions/AbstractRedbeamsStartAction.java
@@ -71,7 +71,7 @@ public abstract class AbstractRedbeamsStartAction<P extends Payload>
         CloudContext cloudContext = CloudContext.Builder.builder()
                 .withId(dbStack.getId())
                 .withName(dbStack.getName())
-                .withCrn(dbStack.getResourceCrn().toString())
+                .withCrn(dbStack.getResourceCrn())
                 .withPlatform(dbStack.getCloudPlatform())
                 .withVariant(dbStack.getPlatformVariant())
                 .withLocation(location)

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/stop/actions/AbstractRedbeamsStopAction.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/stop/actions/AbstractRedbeamsStopAction.java
@@ -71,7 +71,7 @@ public abstract class AbstractRedbeamsStopAction<P extends Payload>
         CloudContext cloudContext = CloudContext.Builder.builder()
                 .withId(dbStack.getId())
                 .withName(dbStack.getName())
-                .withCrn(dbStack.getResourceCrn().toString())
+                .withCrn(dbStack.getResourceCrn())
                 .withPlatform(dbStack.getCloudPlatform())
                 .withVariant(dbStack.getPlatformVariant())
                 .withLocation(location)

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/termination/AbstractRedbeamsTerminationAction.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/termination/AbstractRedbeamsTerminationAction.java
@@ -90,7 +90,7 @@ public abstract class AbstractRedbeamsTerminationAction<P extends RedbeamsEvent>
             cloudContext = CloudContext.Builder.builder()
                     .withId(dbStack.getId())
                     .withName(dbStack.getName())
-                    .withCrn(dbStack.getResourceCrn().toString())
+                    .withCrn(dbStack.getResourceCrn())
                     .withPlatform(dbStack.getCloudPlatform())
                     .withVariant(dbStack.getPlatformVariant())
                     .withUserName(userName)

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/termination/handler/DeregisterDatabaseServerHandler.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/termination/handler/DeregisterDatabaseServerHandler.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
@@ -50,7 +51,7 @@ public class DeregisterDatabaseServerHandler extends ExceptionCatcherEventHandle
         DBStack dbStack = request.getDbStack();
 
         try {
-            databaseServerConfigService.getByCrn(dbStack.getResourceCrn())
+            databaseServerConfigService.getByCrn(Crn.safeFromString(dbStack.getResourceCrn()))
                     .ifPresent(dsc -> databaseServerConfigService.delete(dsc));
             return response;
         } catch (Exception e) {

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/repository/DBStackRepository.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/repository/DBStackRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.redbeams.api.model.common.Status;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
 
@@ -18,7 +17,7 @@ public interface DBStackRepository extends JpaRepository<DBStack, Long> {
 
     Optional<DBStack> findByNameAndEnvironmentId(String name, String environmentId);
 
-    Optional<DBStack> findByResourceCrn(Crn crn);
+    Optional<DBStack> findByResourceCrn(String crn);
 
     @Query("SELECT d.id FROM DBStack d LEFT JOIN d.dbStackStatus dss WHERE dss.status IN :statuses")
     Set<Long> findAllByStatusIn(@Param("statuses") Set<Status> statuses);

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/DBStackService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/DBStackService.java
@@ -8,7 +8,6 @@ import javax.transaction.Transactional;
 
 import org.springframework.stereotype.Service;
 
-import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.common.event.PayloadContext;
 import com.sequenceiq.flow.core.PayloadContextProvider;
 import com.sequenceiq.redbeams.api.model.common.Status;
@@ -41,12 +40,8 @@ public class DBStackService implements PayloadContextProvider {
     }
 
     public DBStack getByCrn(String crn) {
-        return getByCrn(Crn.safeFromString(crn))
+        return dbStackRepository.findByResourceCrn(crn)
                 .orElseThrow(() -> new NotFoundException(String.format("Stack with crn [%s] not found", crn)));
-    }
-
-    public Optional<DBStack> getByCrn(Crn crn) {
-        return dbStackRepository.findByResourceCrn(crn);
     }
 
     public Set<Long> findAllDeleting() {
@@ -70,7 +65,7 @@ public class DBStackService implements PayloadContextProvider {
         Optional<DBStack> dbStackOpt = findById(resourceId);
         if (dbStackOpt.isPresent()) {
             DBStack dbStack = dbStackOpt.get();
-            return PayloadContext.create(dbStack.getResourceCrn().toString(), dbStack.getCloudPlatform());
+            return PayloadContext.create(dbStack.getResourceCrn(), dbStack.getCloudPlatform());
         }
         return null;
     }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/RedbeamsCreationService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/RedbeamsCreationService.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.cloud.CloudConnector;
 import com.sequenceiq.cloudbreak.cloud.exception.TemplatingNotSupportedException;
 import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
@@ -141,7 +142,7 @@ public class RedbeamsCreationService {
         dbServerConfig.setDatabaseVendor(databaseServer.getDatabaseVendor());
         dbServerConfig.setDbStack(dbStack);
         // host and port are set after allocation is complete, so leave as null
-        dbServerConfig.setResourceCrn(dbStack.getResourceCrn());
+        dbServerConfig.setResourceCrn(Crn.safeFromString(dbStack.getResourceCrn()));
         dbServerConfig.setClusterCrn(clusterCrn);
 
         databaseServerConfigService.create(dbServerConfig, DEFAULT_WORKSPACE, false);

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/sync/DBStackJobAdapter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/sync/DBStackJobAdapter.java
@@ -25,7 +25,7 @@ public class DBStackJobAdapter extends JobResourceAdapter<DBStack> {
 
     @Override
     public String getRemoteResourceId() {
-        return getResource().getResourceCrn().toString();
+        return getResource().getResourceCrn();
     }
 
     @Override

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/sync/DBStackStatusSyncService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/sync/DBStackStatusSyncService.java
@@ -107,7 +107,7 @@ public class DBStackStatusSyncService {
             CloudContext cloudContext = CloudContext.Builder.builder()
                     .withId(dbStack.getId())
                     .withName(dbStack.getName())
-                    .withCrn(dbStack.getResourceCrn().toString())
+                    .withCrn(dbStack.getResourceCrn())
                     .withPlatform(dbStack.getCloudPlatform())
                     .withVariant(dbStack.getPlatformVariant())
                     .withLocation(location)

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/provision/AbstractRedbeamsProvisionActionTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/provision/AbstractRedbeamsProvisionActionTest.java
@@ -74,7 +74,7 @@ public class AbstractRedbeamsProvisionActionTest {
         dbStack.setResourceCrn(CrnTestUtil.getDatabaseServerCrnBuilder()
                 .setAccountId("acc")
                 .setResource("resource")
-                .build());
+                .build().toString());
         dbStack.setName("mystack");
         dbStack.setRegion("us-east-1");
         dbStack.setAvailabilityZone("us-east-1b");

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/provision/handler/UpdateDatabaseServerRegistrationHandlerTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/provision/handler/UpdateDatabaseServerRegistrationHandlerTest.java
@@ -261,7 +261,7 @@ class UpdateDatabaseServerRegistrationHandlerTest {
         DBStack dbStack = new DBStack();
         dbStack.setName(DB_STACK_NAME);
         dbStack.setEnvironmentId(ENVIRONMENT_CRN);
-        dbStack.setResourceCrn(CRN);
+        dbStack.setResourceCrn(CRN.toString());
         return dbStack;
     }
 

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/start/actions/StartDatabaseServerFailedActionTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/start/actions/StartDatabaseServerFailedActionTest.java
@@ -155,7 +155,7 @@ public class StartDatabaseServerFailedActionTest {
         when(dbStack.getResourceCrn()).thenReturn(CrnTestUtil.getDatabaseServerCrnBuilder()
                 .setAccountId("acc")
                 .setResource("resource")
-                .build());
+                .build().toString());
         when(ownerCrn.getUserId()).thenReturn(USER_NAME);
         when(ownerCrn.getAccountId()).thenReturn(ACCOUNT_ID);
         when(credentialService.getCredentialByEnvCrn(DB_STACK_ENV_ID)).thenReturn(credential);

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/stop/actions/StopDatabaseServerFailedActionTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/stop/actions/StopDatabaseServerFailedActionTest.java
@@ -155,7 +155,7 @@ public class StopDatabaseServerFailedActionTest {
         when(dbStack.getResourceCrn()).thenReturn(CrnTestUtil.getDatabaseServerCrnBuilder()
                         .setAccountId("acc")
                         .setResource("resource")
-                        .build());
+                        .build().toString());
         when(ownerCrn.getUserId()).thenReturn(USER_NAME);
         when(ownerCrn.getAccountId()).thenReturn(ACCOUNT_ID);
         when(credentialService.getCredentialByEnvCrn(DB_STACK_ENV_ID)).thenReturn(credential);

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/termination/AbstractRedbeamsTerminationActionTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/termination/AbstractRedbeamsTerminationActionTest.java
@@ -79,7 +79,7 @@ public class AbstractRedbeamsTerminationActionTest {
         dbStack.setResourceCrn(CrnTestUtil.getDatabaseCrnBuilder()
                 .setAccountId("acc")
                 .setResource("resource")
-                .build());
+                .build().toString());
 
         credential = new Credential("userId", null, "userCrn");
 

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/service/stack/RedbeamsCreationServiceTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/service/stack/RedbeamsCreationServiceTest.java
@@ -97,7 +97,7 @@ class RedbeamsCreationServiceTest {
         dbStack.setPlatformVariant(PLATFORM_VARIANT);
         dbStack.setUserName("username");
         dbStack.setOwnerCrn(Crn.fromString("crn:cdp:iam:us-west-1:1234:user:234123"));
-        dbStack.setResourceCrn(Crn.fromString("crn:cdp:iam:us-west-1:1234:database:2312312"));
+        dbStack.setResourceCrn("crn:cdp:iam:us-west-1:1234:database:2312312");
         DatabaseServer databaseServer = new DatabaseServer();
         dbStack.setDatabaseServer(databaseServer);
         databaseServer.setAccountId(ACCOUNT_ID);
@@ -122,7 +122,7 @@ class RedbeamsCreationServiceTest {
         assertThat(launchedStack).isEqualTo(dbStack);
         verify(dbStackService).save(dbStack);
 
-        assertThat(dbStack.getResourceCrn()).isEqualTo(crn);
+        assertThat(dbStack.getResourceCrn()).isEqualTo(crn.toString());
         assertThat(dbStack.getTemplate()).isEqualTo(TEMPLATE);
 
         ArgumentCaptor<DatabaseServerConfig> databaseServerConfigCaptor = ArgumentCaptor.forClass(DatabaseServerConfig.class);

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/sync/DBStackStatusSyncServiceTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/sync/DBStackStatusSyncServiceTest.java
@@ -121,7 +121,7 @@ public class DBStackStatusSyncServiceTest {
         when(dbStack.getResourceCrn()).thenReturn(CrnTestUtil.getDatabaseServerCrnBuilder()
                 .setAccountId("acc")
                 .setResource("resource")
-                .build());
+                .build().toString());
         when(credentialService.getCredentialByEnvCrn(ENVIRONMENT_ID)).thenReturn(credential);
         when(credentialConverter.convert(credential)).thenReturn(cloudCredential);
         when(cloudPlatformConnectors.get(any())).thenReturn(cloudConnector);


### PR DESCRIPTION
…the Crn object in the DBStack entity but it unnecessary because we almost everytime parse it before and after to a string

See detailed description in the commit message.