### PR TITLE
 CB-16060. Reduce the minimum cooldown configuration for AutoScale to 1

### DIFF
--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/LoadAlertConfigurationRequest.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/LoadAlertConfigurationRequest.java
@@ -28,19 +28,19 @@ public class LoadAlertConfigurationRequest implements Json {
     private @Valid Integer maxResourceValue;
 
     @ApiModelProperty(LoadAlertJsonProperties.LOAD_ALERT_CONFIGURATION_COOL_DOWN_MINS_VALUE)
-    @Min(value = 2)
+    @Min(value = 1)
     @Max(value = 180)
     @Digits(fraction = 0, integer = 3)
     private @Valid Integer coolDownMinutes;
 
     @ApiModelProperty(LoadAlertJsonProperties.LOAD_ALERT_CONFIGURATION_SCALE_UP_COOL_DOWN_MINS_VALUE)
-    @Min(value = 2)
+    @Min(value = 1)
     @Max(value = 180)
     @Digits(fraction = 0, integer = 3)
     private @Valid Integer scaleUpCoolDownMinutes;
 
     @ApiModelProperty(LoadAlertJsonProperties.LOAD_ALERT_CONFIGURATION_SCALE_DOWN_COOL_DOWN_MINS_VALUE)
-    @Min(value = 2)
+    @Min(value = 1)
     @Max(value = 180)
     @Digits(fraction = 0, integer = 3)
     private @Valid Integer scaleDownCoolDownMinutes;

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/ClusterStatusMonitor.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/ClusterStatusMonitor.java
@@ -21,7 +21,7 @@ public class ClusterStatusMonitor extends ClusterMonitor {
 
     @Override
     public String getTriggerExpression() {
-        return MonitorUpdateRate.EVERY_MIN_RATE_CRON;
+        return MonitorUpdateRate.CLUSTER_MONITOR_EVERY_MIN_RATE_CRON;
     }
 
     @Override

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/LoadMonitor.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/LoadMonitor.java
@@ -23,7 +23,7 @@ public class LoadMonitor extends ClusterMonitor {
 
     @Override
     public String getTriggerExpression() {
-        return MonitorUpdateRate.EVERY_TWO_MIN_RATE_CRON;
+        return MonitorUpdateRate.EVERY_MIN_RATE_CRON;
     }
 
     @Override

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/MonitorUpdateRate.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/MonitorUpdateRate.java
@@ -33,6 +33,11 @@ public final class MonitorUpdateRate {
     public static final String EVERY_MIN_RATE_CRON = "0 * * * * ?";
 
     /**
+     * Every minute, at the 50s mark.
+     */
+    public static final String CLUSTER_MONITOR_EVERY_MIN_RATE_CRON = "50 0/1 * * * ?";
+
+    /**
      * Every 2 minutes.
      */
     public static final String EVERY_TWO_MIN_RATE_CRON = "0 0/2 * * * ?";

--- a/autoscale/src/test/java/com/sequenceiq/periscope/domain/LoadAlertConfigurationTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/domain/LoadAlertConfigurationTest.java
@@ -22,8 +22,8 @@ public class LoadAlertConfigurationTest {
                 Arguments.of("POLLING_COOLDOWN_DEFINED2", 50, 10, 10, 10),
                 Arguments.of("POLLING_COOLDOWN_DEFINED2", 50, 10, 5, 5),
 
-                Arguments.of("POLLING_SCALEUP_DEFINED", -1, 10, -1, 2),
-                Arguments.of("POLLING_SCALEDOWN_DEFINED", -1, -1, 10, 2),
+                Arguments.of("POLLING_SCALEUP_DEFINED", -1, 10, -1, DEFAULT_LOAD_BASED_AUTOSCALING_COOLDOWN_MINS),
+                Arguments.of("POLLING_SCALEDOWN_DEFINED", -1, -1, 10, DEFAULT_LOAD_BASED_AUTOSCALING_COOLDOWN_MINS),
 
                 Arguments.of("POLLING_SCALEUP_SCALEDOWN_DEFINED1", -1, 10, 10, 10),
                 Arguments.of("POLLING_SCALEUP_SCALEDOWN_DEFINED2", -1, 5, 10, 5)


### PR DESCRIPTION
 minute.
- The default continues to be 2 minutes.
- The ClusterStatusSyncMonitor now runs every minute at the 50s mark.

See detailed description in the commit message.