### PR TITLE
CB-15963 - Handle dangling VolumeSets on Azure for MultiRG setup

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/VolumeSetAttributes.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/VolumeSetAttributes.java
@@ -106,6 +106,20 @@ public class VolumeSetAttributes {
         return discoveryFQDN;
     }
 
+    @Override
+    public String toString() {
+        return "VolumeSetAttributes{" +
+                "availabilityZone='" + availabilityZone + '\'' +
+                ", deleteOnTermination=" + deleteOnTermination +
+                ", fstab='" + fstab + '\'' +
+                ", volumes=" + volumes +
+                ", uuids='" + uuids + '\'' +
+                ", volumeSize=" + volumeSize +
+                ", volumeType='" + volumeType + '\'' +
+                ", discoveryFQDN='" + discoveryFQDN + '\'' +
+                '}';
+    }
+
     @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Volume {

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/ResourceUtil.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/ResourceUtil.java
@@ -1,0 +1,24 @@
+package com.sequenceiq.cloudbreak.domain.stack;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import com.sequenceiq.cloudbreak.domain.Resource;
+
+public class ResourceUtil {
+
+    private ResourceUtil() {
+    }
+
+    // CB-15963 - this is to ensure that we consider only the latest VolumeSet for each instance if there are more than 1
+    public static List<Resource> getLatestResourceByInstanceId(List<Resource> resourceList) {
+        return new ArrayList<>(resourceList.stream()
+                .collect(Collectors.toMap(Resource::getInstanceId, Function.identity(),
+                        BinaryOperator.maxBy(Comparator.comparing(Resource::getId))))
+                .values());
+    }
+}

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Stack.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Stack.java
@@ -444,7 +444,7 @@ public class Stack implements ProvisionEntity, WorkspaceAwareResource {
             case CloudConstants.GCP:
                 return getResourcesByType(ResourceType.GCP_ATTACHED_DISKSET);
             case CloudConstants.AZURE:
-                return getResourcesByType(ResourceType.AZURE_VOLUMESET);
+                return ResourceUtil.getLatestResourceByInstanceId(getResourcesByType(ResourceType.AZURE_VOLUMESET));
             default:
                 return List.of();
         }

--- a/core-model/src/test/java/com/sequenceiq/cloudbreak/domain/stack/ResourceUtilTest.java
+++ b/core-model/src/test/java/com/sequenceiq/cloudbreak/domain/stack/ResourceUtilTest.java
@@ -1,0 +1,60 @@
+package com.sequenceiq.cloudbreak.domain.stack;
+
+import static com.sequenceiq.cloudbreak.domain.stack.ResourceUtil.getLatestResourceByInstanceId;
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import com.sequenceiq.cloudbreak.cloud.model.VolumeSetAttributes;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.domain.Resource;
+import com.sequenceiq.common.api.type.ResourceType;
+
+public class ResourceUtilTest {
+
+    @Test
+    public void selectResourceWithLatestIdIfThereAreMultipleForGivenInstanceId() {
+        List<Resource> volumeSets = new ArrayList<>();
+        volumeSets.add(getVolumeSetResource("anInstanceId", 1L));
+        volumeSets.add(getVolumeSetResource("anInstanceId", 2L));
+        volumeSets.add(getVolumeSetResource("secInstanceId", 3L));
+        volumeSets.add(getVolumeSetResource("thirdInstanceId", 4L));
+        volumeSets.add(getVolumeSetResource("anInstanceId", 5L));
+        List<Resource> latestResourceByInstanceId = getLatestResourceByInstanceId(volumeSets);
+
+        assertEquals(3, latestResourceByInstanceId.size());
+        assertEquals(3, latestResourceByInstanceId.stream().map(Resource::getId).distinct().count());
+        assertEquals(Set.of(3L, 4L, 5L), latestResourceByInstanceId.stream().map(Resource::getId).collect(Collectors.toSet()));
+
+    }
+
+    @Test
+    public void selectAllResourcesIfThereAreOnlyOneForEachGivenInstanceId() {
+        List<Resource> volumeSets = new ArrayList<>();
+        volumeSets.add(getVolumeSetResource("anInstanceId", 1L));
+        volumeSets.add(getVolumeSetResource("secInstanceId", 2L));
+        volumeSets.add(getVolumeSetResource("thirdInstanceId", 3L));
+        List<Resource> latestResourceByInstanceId = getLatestResourceByInstanceId(volumeSets);
+
+        assertEquals(3, latestResourceByInstanceId.size());
+        assertEquals(3, latestResourceByInstanceId.stream().map(Resource::getId).distinct().count());
+        assertEquals(Set.of(1L, 2L, 3L), latestResourceByInstanceId.stream().map(Resource::getId).collect(Collectors.toSet()));
+    }
+
+    private Resource getVolumeSetResource(String instanceID, Long id) {
+        Resource resource = new Resource();
+        resource.setResourceType(ResourceType.AZURE_VOLUMESET);
+        resource.setInstanceId(instanceID);
+        resource.setId(id);
+        VolumeSetAttributes volumeSetAttributes = new VolumeSetAttributes.Builder()
+                .build();
+        resource.setAttributes(new Json(volumeSetAttributes));
+        return resource;
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/downscale/ClusterDownscaleService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/downscale/ClusterDownscaleService.java
@@ -65,7 +65,7 @@ public class ClusterDownscaleService {
             flowMessageService.fireInstanceGroupEventAndLog(stackId, Status.UPDATE_IN_PROGRESS.name(), hostGroupName, CLUSTER_REMOVING_NODE_FROM_HOSTGROUP,
                     String.valueOf(Math.abs(scalingAdjustment)), hostGroupName);
         } else if (!CollectionUtils.isEmpty(privateIds)) {
-            LOGGER.info("Decommissioning {} hosts from host group '{}'", privateIds, hostGroupName);
+            LOGGER.info("Decommissioning hosts with ids {} from host group '{}'", privateIds, hostGroupName);
             Stack stack = stackService.getByIdWithListsInTransaction(stackId);
             List<String> decomissionedHostNames = stackService.getHostNamesForPrivateIds(stack.getInstanceMetaDataAsList(), privateIds);
             ResourceEvent resourceEvent = details.isForced() ? CLUSTER_FORCE_REMOVING_NODE_FROM_HOSTGROUP : CLUSTER_REMOVING_NODE_FROM_HOSTGROUP;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/InstanceMetadataUpdater.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/InstanceMetadataUpdater.java
@@ -143,7 +143,7 @@ public class InstanceMetadataUpdater {
         if (!failedVersionQueryByHost.isEmpty()) {
             cloudbreakEventService.fireCloudbreakEvent(stack.getId(), UPDATE_FAILED.name(),
                     CLUSTER_PACKAGE_VERSION_CANNOT_BE_QUERIED,
-                    Collections.singletonList(failedVersionQueryByHost.stream().collect(Collectors.joining("\r\n"))));
+                    Collections.singletonList(String.join("\r\n", failedVersionQueryByHost)));
         }
     }
 


### PR DESCRIPTION
This commit ensures, that even if there are multiple volumeSets for a given instance (e.g. through recovery) we would only use the latest one and no more.

Fixing the termination/recovery leaving the VolumeSets would be a much larger change that would make less sense to implement as we are already phasing out Multi RG setup.