### PR TITLE
CRB-1942 DataHub: Add support for GCP instances - n2d-highmem-32 and …

### DIFF
--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -687,6 +687,8 @@ cb:
         n2d-highcpu-8,
         n2d-highcpu-16,
         n2d-highcpu-32,
+        n2d-highmem-32,
+        n2d-highmem-64,
         e2-highmem-8,
         e2-highmem-16,
         e2-highcpu-8,


### PR DESCRIPTION
…n2d-highmem-64. Tested with custom shape cluster shape.

See detailed description in the commit message.