### PR TITLE
CB-15946 Eliminate N+1 queries during the autosyncable entity initali…

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/quartz/model/JobResource.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/quartz/model/JobResource.java
@@ -1,0 +1,10 @@
+package com.sequenceiq.cloudbreak.quartz.model;
+
+public interface JobResource {
+
+    String getLocalId();
+
+    String getRemoteResourceId();
+
+    String getName();
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/quartz/model/JobResourceAdapter.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/quartz/model/JobResourceAdapter.java
@@ -5,7 +5,6 @@ import java.util.Optional;
 import org.quartz.Job;
 import org.quartz.JobDataMap;
 import org.springframework.context.ApplicationContext;
-import org.springframework.data.repository.CrudRepository;
 
 public abstract class JobResourceAdapter<T> {
 
@@ -13,43 +12,39 @@ public abstract class JobResourceAdapter<T> {
 
     public static final String REMOTE_RESOURCE_CRN = "remoteResourceCrn";
 
-    private T resource;
+    private JobResource jobResource;
 
     public JobResourceAdapter(Long id, ApplicationContext context) {
         loadResource(id, context);
     }
 
-    public JobResourceAdapter(T resource) {
-        this.resource = resource;
+    public JobResourceAdapter(JobResource jobResource) {
+        this.jobResource = jobResource;
     }
 
-    public T getResource() {
-        return resource;
+    public JobResource getJobResource() {
+        return jobResource;
     }
 
     protected JobResourceAdapter<T> loadResource(Long id, ApplicationContext context) {
-        Optional<T> resource = find(id, context);
-        this.resource = resource.orElse(null);
+        Optional<JobResource> resource = find(id, context);
+        this.jobResource = resource.orElse(null);
         return this;
     }
 
-    public abstract String getLocalId();
-
-    public abstract String getRemoteResourceId();
-
-    private Optional<T> find(Long id, ApplicationContext context) {
-        CrudRepository<T, Long> repo = context.getBean(getRepositoryClassForResource());
-        return repo.findById(id);
+    private Optional<JobResource> find(Long id, ApplicationContext context) {
+        JobResourceRepository<T, Long> jobResourceRepository = context.getBean(getRepositoryClassForResource());
+        return jobResourceRepository.getJobResource(id);
     }
 
     public abstract Class<? extends Job> getJobClassForResource();
 
-    public abstract Class<? extends CrudRepository<T, Long>> getRepositoryClassForResource();
+    public abstract Class<? extends JobResourceRepository<T, Long>> getRepositoryClassForResource();
 
     public JobDataMap toJobDataMap() {
         JobDataMap jobDataMap = new JobDataMap();
-        jobDataMap.put(LOCAL_ID, getLocalId());
-        jobDataMap.put(REMOTE_RESOURCE_CRN, getRemoteResourceId());
+        jobDataMap.put(LOCAL_ID, getJobResource().getLocalId());
+        jobDataMap.put(REMOTE_RESOURCE_CRN, getJobResource().getRemoteResourceId());
         return jobDataMap;
     }
 

--- a/common/src/main/java/com/sequenceiq/cloudbreak/quartz/model/JobResourceRepository.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/quartz/model/JobResourceRepository.java
@@ -1,0 +1,11 @@
+package com.sequenceiq.cloudbreak.quartz.model;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.NoRepositoryBean;
+import org.springframework.data.repository.Repository;
+
+@NoRepositoryBean
+public interface JobResourceRepository<T, ID> extends Repository<T, ID> {
+    Optional<JobResource> getJobResource(ID resourceId);
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/quartz/statuschecker/job/StatusCheckerJob.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/quartz/statuschecker/job/StatusCheckerJob.java
@@ -29,4 +29,8 @@ public abstract class StatusCheckerJob extends TracedQuartzJob {
     public void setRemoteResourceCrn(String remoteResourceCrn) {
         this.remoteResourceCrn = remoteResourceCrn;
     }
+
+    protected Long getLocalIdAsLong() {
+        return Long.valueOf(getLocalId());
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/RescheduleStatusCheckChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/RescheduleStatusCheckChainFactory.java
@@ -7,9 +7,8 @@ import javax.inject.Inject;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
-import com.sequenceiq.cloudbreak.domain.view.StackView;
 import com.sequenceiq.cloudbreak.job.StackJobAdapter;
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
 import com.sequenceiq.cloudbreak.quartz.statuschecker.service.StatusCheckerJobService;
 import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.RescheduleStatusCheckTriggerEvent;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
@@ -35,17 +34,10 @@ public class RescheduleStatusCheckChainFactory implements FlowEventChainFactory<
 
     @Override
     public FlowTriggerEventQueue createFlowTriggerEventQueue(RescheduleStatusCheckTriggerEvent event) {
-        StackView stack = stackService.getViewByIdWithoutAuth(event.getResourceId());
-        if (stack != null && stack.isAvailable() && stack.getClusterView() != null) {
-            jobService.schedule(new StackJobAdapter(convertToStack(stack)), repairScheduleDelayInSeconds);
+        JobResource jobResource = stackService.getJobResource(event.getResourceId());
+        if (jobResource != null) {
+            jobService.schedule(new StackJobAdapter(jobResource), repairScheduleDelayInSeconds);
         }
         return new FlowTriggerEventQueue(getName(), event, new ConcurrentLinkedDeque<>());
-    }
-
-    private Stack convertToStack(StackView view) {
-        Stack result = new Stack();
-        result.setId(view.getId());
-        result.setResourceCrn(view.getResourceCrn());
-        return result;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/StackJobAdapter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/StackJobAdapter.java
@@ -4,6 +4,7 @@ import org.quartz.Job;
 import org.springframework.context.ApplicationContext;
 
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
 import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
 import com.sequenceiq.cloudbreak.repository.StackRepository;
 
@@ -13,18 +14,8 @@ public class StackJobAdapter extends JobResourceAdapter<Stack> {
         super(id, context);
     }
 
-    public StackJobAdapter(Stack resource) {
-        super(resource);
-    }
-
-    @Override
-    public String getLocalId() {
-        return String.valueOf(getResource().getId());
-    }
-
-    @Override
-    public String getRemoteResourceId() {
-        return getResource().getResourceCrn();
+    public StackJobAdapter(JobResource jobResource) {
+        super(jobResource);
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/StackJobInitializer.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/StackJobInitializer.java
@@ -14,7 +14,7 @@ public class StackJobInitializer extends AbstractStackJobInitializer {
 
     @Override
     public void initJobs() {
-        getAliveAndNotDeleteInProgressStacksStream()
+        getAliveJobResources()
                 .forEach(s -> jobService.schedule(new StackJobAdapter(s)));
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJob.java
@@ -138,7 +138,7 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
                 } else if (shouldSwitchToLongSyncJob(stackStatus, context)) {
                     LOGGER.debug("Stack sync will be scheduled to long polling, stack state is {}", stackStatus);
                     jobService.unschedule(getLocalId());
-                    jobService.scheduleLongIntervalCheck(new StackJobAdapter(stack));
+                    jobService.scheduleLongIntervalCheck(getStackId(), StackJobAdapter.class);
                 } else if (null == stackStatus || ignoredStates().contains(stackStatus)) {
                     LOGGER.debug("Stack sync is skipped, stack state is {}", stackStatus);
                 } else if (syncableStates().contains(stackStatus)) {
@@ -158,7 +158,7 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
             Stack stack = stackService.get(getStackId());
             Status stackStatus = stack.getStatus();
             if (!longSyncableStates().contains(stackStatus)) {
-                jobService.schedule(new StackJobAdapter(stack));
+                jobService.schedule(getStackId(), StackJobAdapter.class);
             }
         }
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/instancemetadata/ArchiveInstanceMetaDataJobAdapter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/instancemetadata/ArchiveInstanceMetaDataJobAdapter.java
@@ -4,6 +4,7 @@ import org.quartz.Job;
 import org.springframework.context.ApplicationContext;
 
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
 import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
 import com.sequenceiq.cloudbreak.repository.StackRepository;
 
@@ -13,18 +14,8 @@ public class ArchiveInstanceMetaDataJobAdapter extends JobResourceAdapter<Stack>
         super(id, context);
     }
 
-    public ArchiveInstanceMetaDataJobAdapter(Stack resource) {
-        super(resource);
-    }
-
-    @Override
-    public String getLocalId() {
-        return String.valueOf(getResource().getId());
-    }
-
-    @Override
-    public String getRemoteResourceId() {
-        return getResource().getResourceCrn();
+    public ArchiveInstanceMetaDataJobAdapter(JobResource jobResource) {
+        super(jobResource);
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/instancemetadata/ArchiveInstanceMetaDataJobInitializer.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/instancemetadata/ArchiveInstanceMetaDataJobInitializer.java
@@ -23,7 +23,7 @@ public class ArchiveInstanceMetaDataJobInitializer extends AbstractStackJobIniti
     public void initJobs() {
         if (config.isArchiveInstanceMetaDataEnabled()) {
             LOGGER.info("Scheduling archive InstanceMetaData jobs");
-            getAliveAndNotDeleteInProgressStacksStream()
+            getAliveJobResources()
                     .forEach(s -> jobService.schedule(new ArchiveInstanceMetaDataJobAdapter(s)));
         } else {
             LOGGER.info("Skipping scheduling archive InstanceMetaData jobs, as they are disabled");

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/instancemetadata/ArchiveInstanceMetaDataJobService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/instancemetadata/ArchiveInstanceMetaDataJobService.java
@@ -47,7 +47,7 @@ public class ArchiveInstanceMetaDataJobService {
         ArchiveInstanceMetaDataJobAdapter resourceAdapter = new ArchiveInstanceMetaDataJobAdapter(id, applicationContext);
         JobDetail jobDetail = buildJobDetail(resourceAdapter);
         Trigger trigger = buildJobTrigger(jobDetail);
-        schedule(resourceAdapter.getLocalId(), jobDetail, trigger);
+        schedule(resourceAdapter.getJobResource().getLocalId(), jobDetail, trigger);
     }
 
     public <T> void schedule(String id, JobDetail jobDetail, Trigger trigger) {
@@ -74,7 +74,7 @@ public class ArchiveInstanceMetaDataJobService {
             if (scheduler.getJobDetail(jobKey) != null) {
                 unschedule(jobKey);
             }
-            LOGGER.debug("Scheduling archive InstanceMetaData job for stack {}", resource.getRemoteResourceId());
+            LOGGER.debug("Scheduling archive InstanceMetaData job for stack {}", resource.getJobResource().getRemoteResourceId());
             scheduler.scheduleJob(jobDetail, trigger);
         } catch (SchedulerException e) {
             LOGGER.error(String.format("Error during scheduling archive InstanceMetaData job: %s", jobDetail), e);
@@ -96,8 +96,8 @@ public class ArchiveInstanceMetaDataJobService {
 
     private JobDetail buildJobDetail(ArchiveInstanceMetaDataJobAdapter resource) {
         return JobBuilder.newJob(ArchiveInstanceMetaDataJob.class)
-                .withIdentity(resource.getLocalId(), JOB_GROUP)
-                .withDescription("Archiving InstanceMetadata for stack: " + resource.getRemoteResourceId())
+                .withIdentity(resource.getJobResource().getLocalId(), JOB_GROUP)
+                .withDescription("Archiving InstanceMetadata for stack: " + resource.getJobResource().getRemoteResourceId())
                 .usingJobData(resource.toJobDataMap())
                 .storeDurably()
                 .build();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/nodestatus/NodeStatusCheckerJobInitializer.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/nodestatus/NodeStatusCheckerJobInitializer.java
@@ -14,7 +14,7 @@ public class NodeStatusCheckerJobInitializer extends AbstractStackJobInitializer
 
     @Override
     public void initJobs() {
-        getAliveAndNotDeleteInProgressStacksStream()
+        getAliveJobResources()
                 .forEach(s -> nodeStatusCheckerJobService.schedule(new NodeStatusJobAdapter(s)));
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/nodestatus/NodeStatusCheckerJobService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/nodestatus/NodeStatusCheckerJobService.java
@@ -49,13 +49,13 @@ public class NodeStatusCheckerJobService {
     public <T> void schedule(JobResourceAdapter<T> resource) {
         JobDetail jobDetail = buildJobDetail(resource);
         Trigger trigger = buildJobTrigger(jobDetail, RANDOM.nextInt(properties.getIntervalInSeconds()));
-        schedule(jobDetail, trigger, resource.getLocalId());
+        schedule(jobDetail, trigger, resource.getJobResource().getLocalId());
     }
 
     public <T> void schedule(JobResourceAdapter<T> resource, int delayInSeconds) {
         JobDetail jobDetail = buildJobDetail(resource);
         Trigger trigger = buildJobTrigger(jobDetail, delayInSeconds);
-        schedule(jobDetail, trigger, resource.getLocalId());
+        schedule(jobDetail, trigger, resource.getJobResource().getLocalId());
     }
 
     private void schedule(JobDetail jobDetail, Trigger trigger, String localId) {
@@ -104,7 +104,7 @@ public class NodeStatusCheckerJobService {
         JobDataMap jobDataMap = resource.toJobDataMap();
 
         return JobBuilder.newJob(resource.getJobClassForResource())
-                .withIdentity(resource.getLocalId(), JOB_GROUP)
+                .withIdentity(resource.getJobResource().getLocalId(), JOB_GROUP)
                 .withDescription("Checking stack nodestatus Job")
                 .usingJobData(jobDataMap)
                 .storeDurably()

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/nodestatus/NodeStatusJobAdapter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/nodestatus/NodeStatusJobAdapter.java
@@ -3,23 +3,14 @@ package com.sequenceiq.cloudbreak.job.nodestatus;
 import org.quartz.Job;
 
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
 import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
 import com.sequenceiq.cloudbreak.repository.StackRepository;
 
 public class NodeStatusJobAdapter extends JobResourceAdapter<Stack> {
 
-    public NodeStatusJobAdapter(Stack resource) {
-        super(resource);
-    }
-
-    @Override
-    public String getLocalId() {
-        return String.valueOf(getResource().getId());
-    }
-
-    @Override
-    public String getRemoteResourceId() {
-        return getResource().getResourceCrn();
+    public NodeStatusJobAdapter(JobResource jobResource) {
+        super(jobResource);
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJobAdapter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJobAdapter.java
@@ -5,6 +5,7 @@ import org.quartz.JobDataMap;
 import org.springframework.context.ApplicationContext;
 
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
 import com.sequenceiq.cloudbreak.domain.stack.StackPatchType;
 import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
 import com.sequenceiq.cloudbreak.repository.StackRepository;
@@ -19,19 +20,9 @@ public class ExistingStackPatcherJobAdapter extends JobResourceAdapter<Stack> {
         super(id, context);
     }
 
-    public ExistingStackPatcherJobAdapter(Stack resource, StackPatchType stackPatchType) {
-        super(resource);
+    public ExistingStackPatcherJobAdapter(JobResource jobResource, StackPatchType stackPatchType) {
+        super(jobResource);
         this.stackPatchType = stackPatchType;
-    }
-
-    @Override
-    public String getLocalId() {
-        return String.valueOf(getResource().getId());
-    }
-
-    @Override
-    public String getRemoteResourceId() {
-        return getResource().getResourceCrn();
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJobInitializer.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJobInitializer.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.job.stackpatcher;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -10,10 +11,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.StackPatchType;
 import com.sequenceiq.cloudbreak.job.AbstractStackJobInitializer;
 import com.sequenceiq.cloudbreak.job.stackpatcher.config.ExistingStackPatcherConfig;
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
 
 @Component
 public class ExistingStackPatcherJobInitializer extends AbstractStackJobInitializer {
@@ -31,7 +32,7 @@ public class ExistingStackPatcherJobInitializer extends AbstractStackJobInitiali
         Set<StackPatchType> enabledStackPatchTypes = getEnabledStackPatchTypes();
         LOGGER.info("Existing stack patch types enabled: {}", enabledStackPatchTypes);
 
-        Set<Stack> stacks = getAliveAndNotDeleteInProgressStacksStream().collect(Collectors.toSet());
+        List<JobResource> stacks = getAliveJobResources();
         enabledStackPatchTypes.forEach(stackPatchType -> {
             LOGGER.info("Scheduling stack patcher jobs for {}", stackPatchType);
             stacks.forEach(stack -> jobService.schedule(new ExistingStackPatcherJobAdapter(stack, stackPatchType)));

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJobService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJobService.java
@@ -73,8 +73,8 @@ public class ExistingStackPatcherJobService {
 
     private JobDetail buildJobDetail(ExistingStackPatcherJobAdapter resource) {
         return JobBuilder.newJob(ExistingStackPatcherJob.class)
-                .withIdentity(resource.getLocalId(), JOB_GROUP)
-                .withDescription("Patching existing stack: " + resource.getRemoteResourceId())
+                .withIdentity(resource.getJobResource().getLocalId(), JOB_GROUP)
+                .withDescription("Patching existing stack: " + resource.getJobResource().getRemoteResourceId())
                 .usingJobData(resource.toJobDataMap())
                 .storeDurably()
                 .build();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
@@ -30,13 +30,15 @@ import com.sequenceiq.cloudbreak.domain.projection.StackPlatformVariantView;
 import com.sequenceiq.cloudbreak.domain.projection.StackStatusView;
 import com.sequenceiq.cloudbreak.domain.projection.StackTtlView;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
+import com.sequenceiq.cloudbreak.quartz.model.JobResourceRepository;
 import com.sequenceiq.cloudbreak.workspace.model.Workspace;
 import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
 import com.sequenceiq.cloudbreak.workspace.repository.workspace.WorkspaceResourceRepository;
 
 @EntityType(entityClass = Stack.class)
 @Transactional(TxType.REQUIRED)
-public interface StackRepository extends WorkspaceResourceRepository<Stack, Long> {
+public interface StackRepository extends WorkspaceResourceRepository<Stack, Long>, JobResourceRepository<Stack, Long> {
 
     @Query("SELECT s.id as id, s.name as name, s.resourceCrn as crn from Stack s "
             + "WHERE s.cluster.clusterManagerIp= :clusterManagerIp AND s.terminated = null "
@@ -368,4 +370,17 @@ public interface StackRepository extends WorkspaceResourceRepository<Stack, Long
             "FROM Stack s " +
             "WHERE s.id = :id")
     Optional<PayloadContext> findStackAsPayloadContext(@Param("id") Long id);
+
+    @Query("SELECT s.id as localId, s.resourceCrn as remoteResourceId, s.name as name " +
+            "FROM Stack s " +
+            "WHERE s.id = :resourceId")
+    Optional<JobResource> getJobResource(@Param("resourceId") Long resourceId);
+
+    @Query("SELECT s.id as localId, s.resourceCrn as remoteResourceId, s.name as name " +
+            "FROM Stack s " +
+            "LEFT JOIN s.stackStatus ss " +
+            "WHERE s.terminated = null " +
+            "AND (s.type is not 'TEMPLATE' OR s.type is null) " +
+            "AND ss.status not in (:notInStatuses)")
+    List<JobResource> getJobResourcesNotIn(@Param("notInStatuses") Set<Status> notInStatuses);
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
@@ -96,6 +96,7 @@ import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.cloudbreak.orchestrator.container.ContainerOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
 import com.sequenceiq.cloudbreak.orchestrator.model.OrchestrationCredential;
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
 import com.sequenceiq.cloudbreak.repository.StackRepository;
 import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
@@ -990,5 +991,13 @@ public class StackService implements ResourceIdProvider, ResourcePropertyProvide
     public CloudPlatformVariant getPlatformVariantByStackId(Long resourceId) {
         StackPlatformVariantView variantView = stackRepository.findPlatformVariantAndCloudPlatformById(resourceId);
         return new CloudPlatformVariant(variantView.getCloudPlatform(), variantView.getPlatformVariant());
+    }
+
+    public List<JobResource> getAllAliveForAutoSync(Set<Status> statusesNotIn) {
+        return stackRepository.getJobResourcesNotIn(statusesNotIn);
+    }
+
+    public JobResource getJobResource(Long resourceId) {
+        return stackRepository.getJobResource(resourceId).orElseThrow(notFound("Stack", resourceId));
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/job/StructuredSynchronizerJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/job/StructuredSynchronizerJob.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
-import com.sequenceiq.cloudbreak.quartz.TracedQuartzJob;
+import com.sequenceiq.cloudbreak.quartz.statuschecker.job.StatusCheckerJob;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.structuredevent.LegacyDefaultStructuredEventClient;
 import com.sequenceiq.cloudbreak.structuredevent.StructuredSyncEventFactory;
@@ -25,11 +25,9 @@ import io.opentracing.Tracer;
 
 @DisallowConcurrentExecution
 @Component
-public class StructuredSynchronizerJob extends TracedQuartzJob {
+public class StructuredSynchronizerJob extends StatusCheckerJob {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StructuredSynchronizerJob.class);
-
-    private String localId;
 
     @Inject
     private StackService stackService;
@@ -49,49 +47,38 @@ public class StructuredSynchronizerJob extends TracedQuartzJob {
 
     @Override
     protected Object getMdcContextObject() {
-        return stackService.getById(getStackId());
+        return stackService.getById(getLocalIdAsLong());
     }
 
     @Override
     protected void executeTracedJob(JobExecutionContext context) throws JobExecutionException {
+        Long stackId = getLocalIdAsLong();
         try {
-            Stack stack = stackService.get(getStackId());
+            Stack stack = stackService.get(stackId);
             if (stack == null) {
-                LOGGER.debug("Stack not found with id {}, StructuredSynchronizerJob will be unscheduled.", getStackId());
-                syncJobService.unschedule(localId);
+                LOGGER.debug("Stack not found with id {}, StructuredSynchronizerJob will be unscheduled.", stackId);
+                syncJobService.unschedule(getLocalId());
             } else if (stack.getStatus() == null) {
-                LOGGER.debug("Stack state is null for stack {}. The event won't be stored!", getStackId());
-            } else if (unshedulableStates().contains(stack.getStatus())) {
-                LOGGER.debug("StructuredSynchronizerJob will be unscheduled for stack {}, stack state is {}", getStackId(), stack.getStatus());
-                syncJobService.unschedule(localId);
+                LOGGER.debug("Stack state is null for stack {}. The event won't be stored!", stackId);
+            } else if (unschedulableStates().contains(stack.getStatus())) {
+                LOGGER.debug("StructuredSynchronizerJob will be unscheduled for stack {}, stack state is {}", stackId, stack.getStatus());
+                syncJobService.unschedule(getLocalId());
             } else {
-                LOGGER.debug("StructuredSynchronizerJob is running for stack: '{}'", getStackId());
-                StructuredSyncEvent structuredEvent = structuredSyncEventFactory.createStructuredSyncEvent(getStackId());
+                LOGGER.debug("StructuredSynchronizerJob is running for stack: '{}'", stackId);
+                StructuredSyncEvent structuredEvent = structuredSyncEventFactory.createStructuredSyncEvent(stackId);
                 legacyDefaultStructuredEventClient.sendStructuredEvent(structuredEvent);
             }
         } catch (NotFoundException ex) {
-            LOGGER.debug("Stack not found with id {}, StructuredSynchronizerJob will be unscheduled.", getStackId());
-            syncJobService.unschedule(localId);
+            LOGGER.debug("Stack not found with id {}, StructuredSynchronizerJob will be unscheduled.", stackId);
+            syncJobService.unschedule(getLocalId());
         } catch (Exception ex) {
             LOGGER.error("Error happened during StructuredSyncEvent generation! The event won't be stored!", ex);
         }
     }
 
-    Set<Status> unshedulableStates() {
+    Set<Status> unschedulableStates() {
         return EnumSet.of(
                 Status.DELETE_COMPLETED
         );
-    }
-
-    private Long getStackId() {
-        return Long.valueOf(localId);
-    }
-
-    public String getLocalId() {
-        return localId;
-    }
-
-    public void setLocalId(String localId) {
-        this.localId = localId;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/job/StructuredSynchronizerJobAdapter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/job/StructuredSynchronizerJobAdapter.java
@@ -4,6 +4,7 @@ import org.quartz.Job;
 import org.springframework.context.ApplicationContext;
 
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
 import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
 import com.sequenceiq.cloudbreak.repository.StackRepository;
 
@@ -13,18 +14,8 @@ public class StructuredSynchronizerJobAdapter extends JobResourceAdapter<Stack> 
         super(id, context);
     }
 
-    public StructuredSynchronizerJobAdapter(Stack resource) {
-        super(resource);
-    }
-
-    @Override
-    public String getLocalId() {
-        return String.valueOf(getResource().getId());
-    }
-
-    @Override
-    public String getRemoteResourceId() {
-        return getResource().getResourceCrn();
+    public StructuredSynchronizerJobAdapter(JobResource jobResource) {
+        super(jobResource);
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/job/StructuredSynchronizerJobInitializer.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/job/StructuredSynchronizerJobInitializer.java
@@ -1,9 +1,12 @@
 package com.sequenceiq.cloudbreak.structuredevent.job;
 
+import java.util.Set;
+
 import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.job.AbstractStackJobInitializer;
 
 @Component
@@ -14,7 +17,7 @@ public class StructuredSynchronizerJobInitializer extends AbstractStackJobInitia
 
     @Override
     public void initJobs() {
-        getAliveStacksStream()
+        getJobResourcesNotIn(Set.of(Status.DELETE_COMPLETED))
                 .forEach(s -> jobService.scheduleWithDelay(new StructuredSynchronizerJobAdapter(s)));
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/job/StructuredSynchronizerJobService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/job/StructuredSynchronizerJobService.java
@@ -53,7 +53,7 @@ public class StructuredSynchronizerJobService {
             JobResourceAdapter<T> resourceAdapter = c.newInstance(id, applicationContext);
             JobDetail jobDetail = buildJobDetail(resourceAdapter);
             Trigger trigger = buildJobTrigger(jobDetail);
-            schedule(resourceAdapter.getLocalId(), jobDetail, trigger);
+            schedule(resourceAdapter.getJobResource().getLocalId(), jobDetail, trigger);
         } catch (NoSuchMethodException | IllegalAccessException | InstantiationException | InvocationTargetException e) {
             LOGGER.error(String.format("Error during scheduling quartz job: %s", id), e);
         }
@@ -62,7 +62,7 @@ public class StructuredSynchronizerJobService {
     public <T> void scheduleWithDelay(JobResourceAdapter<T> resource) {
         JobDetail jobDetail = buildJobDetail(resource);
         Trigger trigger = buildJobTriggerWithDelay(jobDetail);
-        schedule(resource.getLocalId(), jobDetail, trigger);
+        schedule(resource.getJobResource().getLocalId(), jobDetail, trigger);
     }
 
     public <T> void schedule(String id, JobDetail jobDetail, Trigger trigger) {
@@ -93,7 +93,7 @@ public class StructuredSynchronizerJobService {
 
     private <T> JobDetail buildJobDetail(JobResourceAdapter<T> resourceAdapter) {
         return JobBuilder.newJob(resourceAdapter.getJobClassForResource())
-                .withIdentity(resourceAdapter.getLocalId(), JOB_GROUP)
+                .withIdentity(resourceAdapter.getJobResource().getLocalId(), JOB_GROUP)
                 .withDescription("Creating Structured Synchronization Event")
                 .usingJobData(resourceAdapter.toJobDataMap())
                 .storeDurably()

--- a/core/src/test/java/com/sequenceiq/cloudbreak/structuredevent/job/StructuredSynchronizerJobTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/structuredevent/job/StructuredSynchronizerJobTest.java
@@ -6,14 +6,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 
@@ -28,7 +28,7 @@ import com.sequenceiq.cloudbreak.structuredevent.event.StructuredSyncEvent;
 
 import io.opentracing.Tracer;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class StructuredSynchronizerJobTest {
 
     @Mock
@@ -51,7 +51,7 @@ public class StructuredSynchronizerJobTest {
 
     private Stack stack;
 
-    @Before
+    @BeforeEach
     public void init() {
         Tracer tracer = Mockito.mock(Tracer.class);
         underTest = new StructuredSynchronizerJob(tracer);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/repair/SdxRepairActions.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/repair/SdxRepairActions.java
@@ -121,7 +121,7 @@ public class SdxRepairActions {
                 SdxCluster sdxCluster = sdxStatusService.setStatusForDatalakeAndNotify(DatalakeStatusEnum.RUNNING,
                         ResourceEvent.SDX_REPAIR_FINISHED, "Repair finished, Datalake is running", payload.getResourceId());
                 metricService.incrementMetricCounter(MetricType.SDX_REPAIR_FINISHED, sdxCluster);
-                jobService.schedule(new SdxClusterJobAdapter(sdxCluster));
+                jobService.schedule(sdxCluster.getId(), SdxClusterJobAdapter.class);
                 sendEvent(context, SDX_REPAIR_FINALIZED_EVENT.event(), payload);
             }
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/job/SdxClusterJobAdapter.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/job/SdxClusterJobAdapter.java
@@ -3,28 +3,19 @@ package com.sequenceiq.datalake.job;
 import org.quartz.Job;
 import org.springframework.context.ApplicationContext;
 
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
 import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
 import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.repository.SdxClusterRepository;
 
 public class SdxClusterJobAdapter extends JobResourceAdapter<SdxCluster> {
 
-    public SdxClusterJobAdapter(SdxCluster resource) {
-        super(resource);
+    public SdxClusterJobAdapter(JobResource jobResource) {
+        super(jobResource);
     }
 
     public SdxClusterJobAdapter(Long id, ApplicationContext context) {
         super(id, context);
-    }
-
-    @Override
-    public String getLocalId() {
-        return getResource().getId().toString();
-    }
-
-    @Override
-    public String getRemoteResourceId() {
-        return getResource().getStackCrn();
     }
 
     @Override

--- a/datalake/src/main/java/com/sequenceiq/datalake/job/SdxClusterJobInitializer.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/job/SdxClusterJobInitializer.java
@@ -4,11 +4,9 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.datalake.entity.SdxCluster;
-import com.sequenceiq.datalake.projection.SdxClusterIdView;
-import com.sequenceiq.datalake.repository.SdxClusterRepository;
 import com.sequenceiq.cloudbreak.quartz.model.JobInitializer;
 import com.sequenceiq.cloudbreak.quartz.statuschecker.service.StatusCheckerJobService;
+import com.sequenceiq.datalake.repository.SdxClusterRepository;
 
 @Component
 public class SdxClusterJobInitializer implements JobInitializer {
@@ -21,16 +19,6 @@ public class SdxClusterJobInitializer implements JobInitializer {
 
     @Override
     public void initJobs() {
-        sdxClusterRepository.findAllAliveView().stream()
-                .map(this::convertToSdx)
-                .forEach(s -> jobService.schedule(new SdxClusterJobAdapter(s)));
+        sdxClusterRepository.findAllAliveView().forEach(s -> jobService.schedule(new SdxClusterJobAdapter(s)));
     }
-
-    private SdxCluster convertToSdx(SdxClusterIdView view) {
-        SdxCluster result = new SdxCluster();
-        result.setId(view.getId());
-        result.setStackCrn(view.getStackCrn());
-        return result;
-    }
-
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/job/SdxClusterStatusCheckerJob.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/job/SdxClusterStatusCheckerJob.java
@@ -222,12 +222,12 @@ public class SdxClusterStatusCheckerJob extends StatusCheckerJob {
         } else if (DatalakeStatusEnum.DELETED_ON_PROVIDER_SIDE.equals(updatedStatus)) {
             if (!isLongSyncJob(context)) {
                 LOGGER.info("Sdx status is {}. Rescheduling sync job to long interval.", updatedStatus);
-                jobService.scheduleLongIntervalCheck(new SdxClusterJobAdapter(sdx));
+                jobService.scheduleLongIntervalCheck(sdx.getId(), SdxClusterJobAdapter.class);
             }
         } else {
             if (isLongSyncJob(context)) {
                 LOGGER.info("Sdx status is {}. Rescheduling sync job to short interval.", updatedStatus);
-                jobService.schedule(new SdxClusterJobAdapter(sdx));
+                jobService.schedule(sdx.getId(), SdxClusterJobAdapter.class);
             }
         }
     }

--- a/datalake/src/main/java/com/sequenceiq/datalake/repository/SdxClusterRepository.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/repository/SdxClusterRepository.java
@@ -15,25 +15,26 @@ import org.springframework.stereotype.Repository;
 
 import com.sequenceiq.authorization.service.list.ResourceWithId;
 import com.sequenceiq.authorization.service.model.projection.ResourceCrnAndNameView;
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
+import com.sequenceiq.cloudbreak.quartz.model.JobResourceRepository;
 import com.sequenceiq.cloudbreak.structuredevent.repository.AccountAwareResourceRepository;
 import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
 import com.sequenceiq.common.api.type.CertExpirationState;
 import com.sequenceiq.datalake.entity.SdxCluster;
-import com.sequenceiq.datalake.projection.SdxClusterIdView;
 
 @Repository
 @Transactional(TxType.REQUIRED)
 @EntityType(entityClass = SdxCluster.class)
-public interface SdxClusterRepository extends AccountAwareResourceRepository<SdxCluster, Long> {
+public interface SdxClusterRepository extends AccountAwareResourceRepository<SdxCluster, Long>, JobResourceRepository<SdxCluster, Long> {
 
     @Override
     List<SdxCluster> findAll();
 
-    @Query("SELECT s.id as id, s.stackCrn as stackCrn " +
+    @Query("SELECT s.id as localId, s.stackCrn as remoteResourceId, s.name as name " +
             "FROM SdxCluster s " +
             "WHERE s.deleted is null " +
             "AND s.stackCrn is not null")
-    List<SdxClusterIdView> findAllAliveView();
+    List<JobResource> findAllAliveView();
 
     Optional<SdxCluster> findByAccountIdAndClusterNameAndDeletedIsNullAndDetachedIsFalse(String accountId, String clusterName);
 
@@ -91,4 +92,9 @@ public interface SdxClusterRepository extends AccountAwareResourceRepository<Sdx
     @Query("SELECT new com.sequenceiq.authorization.service.list.ResourceWithId(s.id, s.crn, s.envCrn) FROM SdxCluster s " +
             "WHERE s.accountId = :accountId AND s.envCrn = :envCrn AND s.deleted IS NULL")
     List<ResourceWithId> findAuthorizationResourcesByAccountIdAndEnvCrn(@Param("accountId") String accountId, @Param("envCrn") String envCrn);
+
+    @Query("SELECT s.id as localId, s.stackCrn as remoteResourceId, s.name as name " +
+            "FROM SdxCluster s " +
+            "WHERE s.id = :resourceId")
+    Optional<JobResource> getJobResource(@Param("resourceId") Long resourceId);
 }

--- a/datalake/src/test/java/com/sequenceiq/datalake/job/SdxClusterStatusCheckerJobTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/job/SdxClusterStatusCheckerJobTest.java
@@ -174,7 +174,7 @@ class SdxClusterStatusCheckerJobTest {
                 eq(ResourceEvent.SDX_CLUSTER_DELETED_ON_PROVIDER_SIDE),
                 eq(""),
                 eq(sdxCluster));
-        verify(jobService, times(1)).scheduleLongIntervalCheck(any());
+        verify(jobService, times(1)).scheduleLongIntervalCheck(any(), any());
     }
 
     @Test
@@ -191,7 +191,7 @@ class SdxClusterStatusCheckerJobTest {
                 eq(Collections.singleton("data-lake-cluster")),
                 eq(""),
                 eq(sdxCluster));
-        verify(jobService, times(1)).schedule(any());
+        verify(jobService, times(1)).schedule(any(), any());
     }
 
     @Test

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/EnvCreationActions.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/EnvCreationActions.java
@@ -262,7 +262,7 @@ public class EnvCreationActions {
                             environment.setStatus(EnvironmentStatus.AVAILABLE);
                             environment.setStatusReason(null);
                             Environment result = environmentService.save(environment);
-                            environmentJobService.schedule(result);
+                            environmentJobService.schedule(result.getId());
                             EnvironmentDto environmentDto = environmentService.getEnvironmentDto(result);
                             metricService.incrementMetricCounter(MetricType.ENV_CREATION_FINISHED, environmentDto);
                             eventService.sendEventAndNotification(environmentDto, context.getFlowTriggerUserCrn(), ENVIRONMENT_CREATION_FINISHED);

--- a/environment/src/main/java/com/sequenceiq/environment/environment/repository/EnvironmentRepository.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/repository/EnvironmentRepository.java
@@ -14,6 +14,8 @@ import org.springframework.data.repository.query.Param;
 import com.sequenceiq.authorization.service.list.ResourceWithId;
 import com.sequenceiq.authorization.service.model.projection.ResourceCrnAndNameView;
 import com.sequenceiq.cloudbreak.common.event.PayloadContext;
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
+import com.sequenceiq.cloudbreak.quartz.model.JobResourceRepository;
 import com.sequenceiq.cloudbreak.structuredevent.repository.AccountAwareResourceRepository;
 import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
 import com.sequenceiq.environment.environment.EnvironmentStatus;
@@ -21,7 +23,7 @@ import com.sequenceiq.environment.environment.domain.Environment;
 
 @Transactional(TxType.REQUIRED)
 @EntityType(entityClass = Environment.class)
-public interface EnvironmentRepository extends AccountAwareResourceRepository<Environment, Long> {
+public interface EnvironmentRepository extends AccountAwareResourceRepository<Environment, Long>, JobResourceRepository<Environment, Long> {
 
     @Query("SELECT e FROM Environment e "
             + "LEFT JOIN FETCH e.network n "
@@ -90,8 +92,8 @@ public interface EnvironmentRepository extends AccountAwareResourceRepository<En
     List<Environment> findAllByAccountIdAndParentEnvIdAndArchivedIsFalse(@Param("accountId") String accountId,
             @Param("parentEnvironmentId") Long parentEnvironmentId);
 
-    @Query("SELECT e FROM Environment e WHERE e.archived = false and e.status in (:statuses)")
-    List<Environment> findAllRunningAndStatusIn(@Param("statuses") Collection<EnvironmentStatus> statuses);
+    @Query("SELECT e.resourceCrn as remoteResourceId, e.id as localId, e.name as name FROM Environment e WHERE e.archived = false and e.status in (:statuses)")
+    List<JobResource> findAllRunningAndStatusIn(@Param("statuses") Collection<EnvironmentStatus> statuses);
 
     @Query("SELECT new com.sequenceiq.authorization.service.list.ResourceWithId(e.id, e.resourceCrn) FROM Environment e " +
             "WHERE e.accountId = :accountId AND e.archived = false")
@@ -101,4 +103,8 @@ public interface EnvironmentRepository extends AccountAwareResourceRepository<En
             "FROM Environment e " +
             "WHERE e.id = :id")
     Optional<PayloadContext> findStackAsPayloadContext(@Param("id") Long id);
+
+    @Query("SELECT e.resourceCrn as remoteResourceId, e.id as localId, e.name as name " +
+            "FROM Environment e WHERE e.id = :resourceId")
+    Optional<JobResource> getJobResource(@Param("resourceId") Long resourceId);
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentDeletionService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentDeletionService.java
@@ -78,7 +78,7 @@ public class EnvironmentDeletionService {
         validateDeletion(environment, cascading);
         environment = updateEnvironmentDeletionType(environment, forced);
         LOGGER.debug("Deleting environment with name: {}", environment.getName());
-        environmentJobService.unschedule(environment);
+        environmentJobService.unschedule(environment.getId());
         if (cascading) {
             reactorFlowManager.triggerCascadingDeleteFlow(environment, userCrn, forced);
         } else {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentService.java
@@ -39,6 +39,7 @@ import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.cloudbreak.logger.MDCUtils;
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
 import com.sequenceiq.cloudbreak.structuredevent.repository.AccountAwareResourceRepository;
 import com.sequenceiq.cloudbreak.structuredevent.service.AbstractAccountAwareResourceService;
 import com.sequenceiq.environment.environment.EnvironmentDeletionType;
@@ -395,7 +396,7 @@ public class EnvironmentService extends AbstractAccountAwareResourceService<Envi
         }
     }
 
-    public List<Environment> findAllForAutoSync() {
+    public List<JobResource> findAllForAutoSync() {
         return environmentRepository.findAllRunningAndStatusIn(List.of(
                 EnvironmentStatus.AVAILABLE,
                 EnvironmentStatus.UPDATE_FAILED,

--- a/environment/src/main/java/com/sequenceiq/environment/environment/sync/EnvironmentJobAdapter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/sync/EnvironmentJobAdapter.java
@@ -2,11 +2,12 @@ package com.sequenceiq.environment.environment.sync;
 
 import org.quartz.Job;
 import org.springframework.context.ApplicationContext;
-import org.springframework.data.repository.CrudRepository;
 
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
+import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
+import com.sequenceiq.cloudbreak.quartz.model.JobResourceRepository;
 import com.sequenceiq.environment.environment.domain.Environment;
 import com.sequenceiq.environment.environment.repository.EnvironmentRepository;
-import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
 
 public class EnvironmentJobAdapter extends JobResourceAdapter<Environment> {
 
@@ -14,18 +15,8 @@ public class EnvironmentJobAdapter extends JobResourceAdapter<Environment> {
         super(id, context);
     }
 
-    public EnvironmentJobAdapter(Environment resource) {
+    public EnvironmentJobAdapter(JobResource resource) {
         super(resource);
-    }
-
-    @Override
-    public String getLocalId() {
-        return String.valueOf(getResource().getId());
-    }
-
-    @Override
-    public String getRemoteResourceId() {
-        return getResource().getResourceCrn();
     }
 
     @Override
@@ -34,7 +25,7 @@ public class EnvironmentJobAdapter extends JobResourceAdapter<Environment> {
     }
 
     @Override
-    public Class<? extends CrudRepository<Environment, Long>> getRepositoryClassForResource() {
+    public Class<? extends JobResourceRepository<Environment, Long>> getRepositoryClassForResource() {
         return EnvironmentRepository.class;
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/sync/EnvironmentJobInitializer.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/sync/EnvironmentJobInitializer.java
@@ -6,9 +6,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.environment.environment.domain.Environment;
-import com.sequenceiq.environment.environment.service.EnvironmentService;
 import com.sequenceiq.cloudbreak.quartz.model.JobInitializer;
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
+import com.sequenceiq.environment.environment.service.EnvironmentService;
 
 @Component
 public class EnvironmentJobInitializer implements JobInitializer {
@@ -26,10 +26,10 @@ public class EnvironmentJobInitializer implements JobInitializer {
 
     @Override
     public void initJobs() {
-        List<Environment> environments = environmentService.findAllForAutoSync();
-        for (Environment environment : environments) {
-            environmentJobService.schedule(environment);
+        List<JobResource> jobResources = environmentService.findAllForAutoSync();
+        for (JobResource jobResource : jobResources) {
+            environmentJobService.schedule(jobResource);
         }
-        LOGGER.info("Auto syncer is inited with {} environments on start", environments.size());
+        LOGGER.info("Auto syncer is inited with {} environments on start", jobResources.size());
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/sync/EnvironmentStatusCheckerJob.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/sync/EnvironmentStatusCheckerJob.java
@@ -53,12 +53,12 @@ public class EnvironmentStatusCheckerJob extends StatusCheckerJob {
 
     @Override
     protected Object getMdcContextObject() {
-        return environmentService.findEnvironmentById(getEnvId()).orElse(null);
+        return environmentService.findEnvironmentById(getLocalIdAsLong()).orElse(null);
     }
 
     @Override
     protected void executeTracedJob(JobExecutionContext context) throws JobExecutionException {
-        Long envId = getEnvId();
+        Long envId = getLocalIdAsLong();
         Optional<Environment> environmentOpt = environmentService.findEnvironmentById(envId);
         if (environmentOpt.isPresent()) {
             Environment environment = environmentOpt.get();
@@ -100,9 +100,5 @@ public class EnvironmentStatusCheckerJob extends StatusCheckerJob {
         } else {
             LOGGER.info("The environment status would be had to update from {} to {}", environment.getStatus(), status);
         }
-    }
-
-    private Long getEnvId() {
-        return Long.valueOf(getLocalId());
     }
 }

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentDeletionServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentDeletionServiceTest.java
@@ -1,22 +1,5 @@
 package com.sequenceiq.environment.environment.service;
 
-import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
-import com.sequenceiq.cloudbreak.util.TestConstants;
-import com.sequenceiq.environment.environment.domain.Environment;
-import com.sequenceiq.environment.environment.dto.EnvironmentDto;
-import com.sequenceiq.environment.environment.dto.EnvironmentDtoConverter;
-import com.sequenceiq.environment.environment.flow.EnvironmentReactorFlowManager;
-import com.sequenceiq.environment.environment.sync.EnvironmentJobService;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.Mockito;
-
-import javax.ws.rs.BadRequestException;
-import java.util.Optional;
-import java.util.Set;
-
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
@@ -30,6 +13,25 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.Set;
+
+import javax.ws.rs.BadRequestException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
+
+import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
+import com.sequenceiq.cloudbreak.util.TestConstants;
+import com.sequenceiq.environment.environment.domain.Environment;
+import com.sequenceiq.environment.environment.dto.EnvironmentDto;
+import com.sequenceiq.environment.environment.dto.EnvironmentDtoConverter;
+import com.sequenceiq.environment.environment.flow.EnvironmentReactorFlowManager;
+import com.sequenceiq.environment.environment.sync.EnvironmentJobService;
 
 public class EnvironmentDeletionServiceTest {
 
@@ -131,7 +133,7 @@ public class EnvironmentDeletionServiceTest {
         assertEquals(environmentDto, environmentDeletionServiceWired
                 .deleteByCrnAndAccountId(TestConstants.CRN, TestConstants.ACCOUNT_ID, TestConstants.USER, cascading, true));
         verify(environmentDeletionServiceWired).delete(eq(environment), eq(TestConstants.USER), anyBoolean(), anyBoolean());
-        verify(environmentJobService).unschedule(environment);
+        verify(environmentJobService).unschedule(any());
         if (cascading) {
             verify(reactorFlowManager).triggerCascadingDeleteFlow(eq(environment), eq(TestConstants.USER), eq(true));
             verify(reactorFlowManager, never()).triggerDeleteFlow(any(), any(), anyBoolean());

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/AbstractCommonChainAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/AbstractCommonChainAction.java
@@ -80,7 +80,7 @@ public abstract class AbstractCommonChainAction<S extends FlowState, E extends F
 
     protected void enableStatusChecker(Stack stack, String reason) {
         LOGGER.info("Enabling the status checker for stack ID {}. {}", stack.getId(), reason);
-        jobService.schedule(stack);
+        jobService.schedule(stack.getId());
     }
 
     protected boolean shouldCompleteOperation(Map<Object, Object> variables) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/provision/action/FreeIpaProvisionActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/provision/action/FreeIpaProvisionActions.java
@@ -180,7 +180,7 @@ public class FreeIpaProvisionActions {
             protected void doExecute(StackContext context, PostInstallFreeIpaSuccess payload, Map<Object, Object> variables) {
                 configRegisters.forEach(configProvider -> configProvider.register(context.getStack().getId()));
                 metricService.incrementMetricCounter(MetricType.FREEIPA_CREATION_FINISHED, context.getStack());
-                freeipaJobService.schedule(context.getStack());
+                freeipaJobService.schedule(context.getStack().getId());
                 stackUpdater.updateStackStatus(context.getStack().getId(), DetailedStackStatus.PROVISIONED, "FreeIPA installation finished");
                 sendEvent(context);
             }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/repository/StackRepository.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/repository/StackRepository.java
@@ -12,6 +12,8 @@ import org.springframework.data.repository.query.Param;
 
 import com.sequenceiq.authorization.service.model.projection.ResourceCrnAndNameView;
 import com.sequenceiq.cloudbreak.common.event.PayloadContext;
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
+import com.sequenceiq.cloudbreak.quartz.model.JobResourceRepository;
 import com.sequenceiq.cloudbreak.structuredevent.repository.AccountAwareResourceRepository;
 import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
@@ -22,13 +24,15 @@ import com.sequenceiq.freeipa.entity.Stack;
 
 @Transactional(Transactional.TxType.REQUIRED)
 @EntityType(entityClass = Stack.class)
-public interface StackRepository extends AccountAwareResourceRepository<Stack, Long> {
+public interface StackRepository extends AccountAwareResourceRepository<Stack, Long>, JobResourceRepository<Stack, Long> {
 
     @Query("SELECT s FROM Stack s WHERE s.terminated = -1")
     List<Stack> findAllRunning();
 
-    @Query("SELECT s FROM Stack s WHERE s.terminated = -1 and s.stackStatus.status in (:statuses)")
-    List<Stack> findAllRunningAndStatusIn(@Param("statuses") Collection<Status> statuses);
+    @Query("SELECT s.id as localId, s.resourceCrn as remoteResourceId, s.name as name " +
+            "FROM Stack s " +
+            "WHERE s.terminated = -1 and s.stackStatus.status in (:statuses)")
+    List<JobResource> findAllRunningAndStatusIn(@Param("statuses") Collection<Status> statuses);
 
     @Query("SELECT s FROM Stack s LEFT JOIN FETCH s.instanceGroups ig LEFT JOIN FETCH ig.instanceMetaData WHERE s.id= :id ")
     Optional<Stack> findOneWithLists(@Param("id") Long id);
@@ -130,4 +134,8 @@ public interface StackRepository extends AccountAwareResourceRepository<Stack, L
             "FROM Stack s " +
             "WHERE s.id = :id")
     Optional<PayloadContext> getStackAsPayloadContextById(@Param("id") Long id);
+
+    @Query("SELECT s.id as localId, s.resourceCrn as remoteResourceId, s.name as name FROM Stack s " +
+            "WHERE s.id = :resourceId")
+    Optional<JobResource> getJobResource(@Param("resourceId") Long resourceId);
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
@@ -28,6 +28,7 @@ import com.sequenceiq.cloudbreak.common.event.PayloadContext;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
 import com.sequenceiq.flow.core.PayloadContextProvider;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
@@ -54,7 +55,7 @@ public class StackService implements ResourcePropertyProvider, PayloadContextPro
         return stackRepository.findAllRunning();
     }
 
-    public List<Stack> findAllForAutoSync() {
+    public List<JobResource> findAllForAutoSync() {
         return stackRepository.findAllRunningAndStatusIn(List.of(
                 Status.AVAILABLE,
                 Status.UPDATE_FAILED,

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/FreeipaJobService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/FreeipaJobService.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.cloudbreak.quartz.statuschecker.service.StatusCheckerJobService;
 
@@ -20,15 +21,19 @@ public class FreeipaJobService {
     @Inject
     private StatusCheckerJobService jobService;
 
-    public void schedule(Stack stack) {
+    public void schedule(JobResource jobResource) {
         if (autoSyncConfig.isEnabled()) {
-            jobService.schedule(new StackJobAdapter(stack));
-            LOGGER.info("{} is scheduled for auto sync", stack.getName());
+            jobService.schedule(new StackJobAdapter(jobResource));
+        }
+    }
+
+    public void schedule(Long id) {
+        if (autoSyncConfig.isEnabled()) {
+            jobService.schedule(id, StackJobAdapter.class);
         }
     }
 
     public void unschedule(Stack stack) {
-        jobService.unschedule(new StackJobAdapter(stack).getLocalId());
-        LOGGER.info("{} is unscheduled, it will not auto sync anymore", stack.getName());
+        jobService.unschedule(String.valueOf(stack.getId()));
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/StackJobAdapter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/StackJobAdapter.java
@@ -2,11 +2,11 @@ package com.sequenceiq.freeipa.sync;
 
 import org.quartz.Job;
 import org.springframework.context.ApplicationContext;
-import org.springframework.data.repository.CrudRepository;
 
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
+import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.repository.StackRepository;
-import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
 
 public class StackJobAdapter extends JobResourceAdapter<Stack> {
 
@@ -14,18 +14,8 @@ public class StackJobAdapter extends JobResourceAdapter<Stack> {
         super(id, context);
     }
 
-    public StackJobAdapter(Stack resource) {
-        super(resource);
-    }
-
-    @Override
-    public String getLocalId() {
-        return String.valueOf(getResource().getId());
-    }
-
-    @Override
-    public String getRemoteResourceId() {
-        return getResource().getResourceCrn();
+    public StackJobAdapter(JobResource jobResource) {
+        super(jobResource);
     }
 
     @Override
@@ -34,7 +24,7 @@ public class StackJobAdapter extends JobResourceAdapter<Stack> {
     }
 
     @Override
-    public Class<? extends CrudRepository<Stack, Long>> getRepositoryClassForResource() {
+    public Class<StackRepository> getRepositoryClassForResource() {
         return StackRepository.class;
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/StackJobInitializer.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/StackJobInitializer.java
@@ -10,9 +10,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.freeipa.entity.Stack;
-import com.sequenceiq.freeipa.service.stack.StackService;
 import com.sequenceiq.cloudbreak.quartz.model.JobInitializer;
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
+import com.sequenceiq.freeipa.service.stack.StackService;
 
 @Component
 public class StackJobInitializer implements JobInitializer {
@@ -27,10 +27,10 @@ public class StackJobInitializer implements JobInitializer {
 
     @Override
     public void initJobs() {
-        List<Stack> stacks = checkedMeasure(() -> stackService.findAllForAutoSync(), LOGGER, ":::Auto sync::: stacks are fetched from db in {}ms");
-        for (Stack stack : stacks) {
-            freeipaJobService.schedule(stack);
+        List<JobResource> jobResources = checkedMeasure(() -> stackService.findAllForAutoSync(), LOGGER, ":::Auto sync::: Stacks are fetched from db in {}ms");
+        for (JobResource jobResource : jobResources) {
+            freeipaJobService.schedule(jobResource);
         }
-        LOGGER.info("Auto syncer is inited with {} stacks on start", stacks.size());
+        LOGGER.info("Auto syncer is inited with {} stacks on start", jobResources.size());
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/action/RedbeamsProvisionActions.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/action/RedbeamsProvisionActions.java
@@ -109,7 +109,7 @@ public class RedbeamsProvisionActions {
                 metricService.incrementMetricCounter(MetricType.DB_PROVISION_FINISHED, dbStack);
 
                 dbStack.ifPresentOrElse(
-                        db -> dbStackJobService.schedule(db),
+                        db -> dbStackJobService.schedule(db.getId()),
                         () -> LOGGER.info("DBStack was not present, could not start autosynch service")
                 );
             }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/termination/action/RedbeamsTerminationActions.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/termination/action/RedbeamsTerminationActions.java
@@ -66,7 +66,7 @@ public class RedbeamsTerminationActions {
 
             @Override
             protected Selectable createRequest(RedbeamsContext context) {
-                dbStackJobService.unschedule(context.getDBStack());
+                dbStackJobService.unschedule(context.getDBStack().getId(), context.getDBStack().getName());
                 return new DeregisterDatabaseServerRequest(context.getCloudContext(), context.getDatabaseStack(), context.getDBStack());
             }
 

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/repository/DBStackRepository.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/repository/DBStackRepository.java
@@ -9,11 +9,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
+import com.sequenceiq.cloudbreak.quartz.model.JobResourceRepository;
 import com.sequenceiq.redbeams.api.model.common.Status;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
 
 @Transactional(Transactional.TxType.REQUIRED)
-public interface DBStackRepository extends JpaRepository<DBStack, Long> {
+public interface DBStackRepository extends JpaRepository<DBStack, Long>, JobResourceRepository<DBStack, Long> {
 
     Optional<DBStack> findByNameAndEnvironmentId(String name, String environmentId);
 
@@ -25,6 +27,13 @@ public interface DBStackRepository extends JpaRepository<DBStack, Long> {
     @Query("SELECT d.id FROM DBStack d LEFT JOIN d.dbStackStatus dss WHERE d.id IN :dbStackIds AND dss.status IN :statuses")
     Set<Long> findAllByIdInAndStatusIn(@Param("dbStackIds") Set<Long> dbStackIds, @Param("statuses") Set<Status> statuses);
 
-    @Query("SELECT d FROM DBStack d LEFT JOIN d.dbStackStatus dss WHERE dss.status IN :statuses")
-    Set<DBStack> findAllDbStackByStatusIn(@Param("statuses") Set<Status> statuses);
+    @Query("SELECT d.id as localId, d.resourceCrn as remoteResourceId, d.name as name " +
+            "FROM DBStack d LEFT JOIN d.dbStackStatus dss " +
+            "WHERE dss.status IN :statuses")
+    Set<JobResource> findAllDbStackByStatusIn(@Param("statuses") Set<Status> statuses);
+
+    @Query("SELECT d.id as localId, d.resourceCrn as remoteResourceId, d.name as name " +
+            "FROM DBStack d " +
+            "WHERE d.id = :resourceId")
+    Optional<JobResource> getJobResource(@Param("resourceId") Long resourceId);
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/DBStackService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/DBStackService.java
@@ -9,6 +9,7 @@ import javax.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.common.event.PayloadContext;
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
 import com.sequenceiq.flow.core.PayloadContextProvider;
 import com.sequenceiq.redbeams.api.model.common.Status;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
@@ -52,7 +53,7 @@ public class DBStackService implements PayloadContextProvider {
         return dbStackRepository.findAllByIdInAndStatusIn(dbStackIds, Status.getDeletingStatuses());
     }
 
-    public Set<DBStack> findAllForAutoSync() {
+    public Set<JobResource> findAllForAutoSync() {
         return dbStackRepository.findAllDbStackByStatusIn(Status.getAutoSyncStatuses());
     }
 

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/sync/DBStackJobAdapter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/sync/DBStackJobAdapter.java
@@ -2,11 +2,12 @@ package com.sequenceiq.redbeams.sync;
 
 import org.quartz.Job;
 import org.springframework.context.ApplicationContext;
-import org.springframework.data.repository.CrudRepository;
 
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
+import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
+import com.sequenceiq.cloudbreak.quartz.model.JobResourceRepository;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
 import com.sequenceiq.redbeams.repository.DBStackRepository;
-import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
 
 public class DBStackJobAdapter extends JobResourceAdapter<DBStack> {
 
@@ -14,18 +15,8 @@ public class DBStackJobAdapter extends JobResourceAdapter<DBStack> {
         super(id, context);
     }
 
-    public DBStackJobAdapter(DBStack resource) {
-        super(resource);
-    }
-
-    @Override
-    public String getLocalId() {
-        return String.valueOf(getResource().getId());
-    }
-
-    @Override
-    public String getRemoteResourceId() {
-        return getResource().getResourceCrn();
+    public DBStackJobAdapter(JobResource jobResource) {
+        super(jobResource);
     }
 
     @Override
@@ -34,7 +25,7 @@ public class DBStackJobAdapter extends JobResourceAdapter<DBStack> {
     }
 
     @Override
-    public Class<? extends CrudRepository<DBStack, Long>> getRepositoryClassForResource() {
+    public Class<? extends JobResourceRepository<DBStack, Long>> getRepositoryClassForResource() {
         return DBStackRepository.class;
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/sync/DBStackJobInizializer.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/sync/DBStackJobInizializer.java
@@ -11,7 +11,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.quartz.model.JobInitializer;
-import com.sequenceiq.redbeams.domain.stack.DBStack;
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
 import com.sequenceiq.redbeams.service.stack.DBStackService;
 
 @Component
@@ -27,9 +27,9 @@ public class DBStackJobInizializer implements JobInitializer {
 
     @Override
     public void initJobs() {
-        Set<DBStack> dbStacks = checkedMeasure(() -> dbStackService.findAllForAutoSync(), LOGGER, ":::Auto sync::: db stacks are fetched from db in {}ms");
-        for (DBStack dbStack : dbStacks) {
-            dbStackJobService.schedule(dbStack);
+        Set<JobResource> dbStacks = checkedMeasure(() -> dbStackService.findAllForAutoSync(), LOGGER, ":::Auto sync::: db stacks are fetched from db in {}ms");
+        for (JobResource jobResource : dbStacks) {
+            dbStackJobService.schedule(jobResource);
         }
         LOGGER.info("Auto syncer is inited with {} db stacks on start", dbStacks.size());
     }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/sync/DBStackJobService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/sync/DBStackJobService.java
@@ -6,8 +6,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
 import com.sequenceiq.cloudbreak.quartz.statuschecker.service.StatusCheckerJobService;
-import com.sequenceiq.redbeams.domain.stack.DBStack;
 
 @Component
 public class DBStackJobService {
@@ -20,15 +20,20 @@ public class DBStackJobService {
     @Inject
     private StatusCheckerJobService jobService;
 
-    public void schedule(DBStack dbStack) {
+    public void schedule(JobResource jobResource) {
         if (autoSyncConfig.isEnabled()) {
-            jobService.schedule(new DBStackJobAdapter(dbStack));
-            LOGGER.info("{} is scheduled for auto sync", dbStack.getName());
+            jobService.schedule(new DBStackJobAdapter(jobResource));
         }
     }
 
-    public void unschedule(DBStack dbStack) {
-        jobService.unschedule(new DBStackJobAdapter(dbStack).getLocalId());
-        LOGGER.info("{} is unscheduled, it will not auto sync anymore", dbStack.getName());
+    public void schedule(Long id) {
+        if (autoSyncConfig.isEnabled()) {
+            jobService.schedule(id, DBStackJobAdapter.class);
+        }
+    }
+
+    public void unschedule(Long id, String name) {
+        jobService.unschedule(String.valueOf(id));
+        LOGGER.info("{} is unscheduled, it will not auto sync anymore", name);
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/sync/DBStackStatusSyncService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/sync/DBStackStatusSyncService.java
@@ -71,8 +71,7 @@ public class DBStackStatusSyncService {
 
         if (status != null && Status.getUnscheduleAutoSyncStatuses().contains(status)) {
             LOGGER.debug(":::Auto sync::: Unschedule DB Stack Status sync as the status is '{}'", status);
-
-            dbStackJobService.unschedule(dbStack);
+            dbStackJobService.unschedule(dbStack.getId(), dbStack.getName());
         }
     }
 

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/service/stack/DBStackServiceTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/service/stack/DBStackServiceTest.java
@@ -16,6 +16,7 @@ import org.junit.rules.ExpectedException;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
 import com.sequenceiq.redbeams.api.model.common.Status;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
 import com.sequenceiq.redbeams.exception.NotFoundException;
@@ -81,7 +82,7 @@ public class DBStackServiceTest {
 
     @Test
     public void testFindAllForAutoSync() {
-        Set<DBStack> expected = Collections.emptySet();
+        Set<JobResource> expected = Collections.emptySet();
         when(dbStackRepository.findAllDbStackByStatusIn(Status.getAutoSyncStatuses())).thenReturn(expected);
 
         assertEquals(expected, underTest.findAllForAutoSync());

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/sync/DBStackJobInizializerTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/sync/DBStackJobInizializerTest.java
@@ -1,19 +1,21 @@
 package com.sequenceiq.redbeams.sync;
 
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.Set;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.sequenceiq.redbeams.domain.stack.DBStack;
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
 import com.sequenceiq.redbeams.service.stack.DBStackService;
 
+@ExtendWith(MockitoExtension.class)
 public class DBStackJobInizializerTest {
 
     @Mock
@@ -25,20 +27,15 @@ public class DBStackJobInizializerTest {
     @InjectMocks
     private DBStackJobInizializer victim;
 
-    @BeforeEach
-    public void initTests() throws Exception {
-        initMocks(this);
-    }
-
     @Test
     public void shouldDeleteAllJobsAndScheduleNewOnesForDbStacks() {
-        DBStack dbStack = new DBStack();
-        Set<DBStack> dbStacks = Set.of(dbStack);
+        JobResource jobResource = mock(JobResource.class);
+        Set<JobResource> jobResources = Set.of(jobResource);
 
-        when(dbStackService.findAllForAutoSync()).thenReturn(dbStacks);
+        when(dbStackService.findAllForAutoSync()).thenReturn(jobResources);
 
         victim.initJobs();
 
-        verify(dbStackJobService).schedule(dbStack);
+        verify(dbStackJobService).schedule(jobResource);
     }
 }

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/sync/DBStackJobServiceTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/sync/DBStackJobServiceTest.java
@@ -1,19 +1,19 @@
 package com.sequenceiq.redbeams.sync;
 
-import com.sequenceiq.redbeams.domain.stack.DBStack;
-import com.sequenceiq.cloudbreak.quartz.statuschecker.service.StatusCheckerJobService;
-import org.junit.jupiter.api.BeforeEach;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import com.sequenceiq.cloudbreak.quartz.statuschecker.service.StatusCheckerJobService;
+import com.sequenceiq.redbeams.domain.stack.DBStack;
 
+@ExtendWith(MockitoExtension.class)
 public class DBStackJobServiceTest {
 
     private static final Long DB_STACK_ID = 123L;
@@ -30,38 +30,27 @@ public class DBStackJobServiceTest {
     @InjectMocks
     private DBStackJobService victim;
 
-    @BeforeEach
-    public void initTests() {
-        initMocks(this);
-    }
-
     @Test
     public void shouldScheduleJobWhenEnabled() {
         when(autoSyncConfig.isEnabled()).thenReturn(true);
 
-        victim.schedule(dbStack);
+        victim.schedule(DB_STACK_ID);
 
-        ArgumentCaptor<DBStackJobAdapter> dbStackJobAdapterArgumentCaptor = ArgumentCaptor.forClass(DBStackJobAdapter.class);
-
-        verify(jobService).schedule(dbStackJobAdapterArgumentCaptor.capture());
-
-        assertEquals(dbStack, dbStackJobAdapterArgumentCaptor.getValue().getResource());
+        verify(jobService).schedule(DB_STACK_ID, DBStackJobAdapter.class);
     }
 
     @Test
     public void shouldNotScheduleJobWhenDisabled() {
         when(autoSyncConfig.isEnabled()).thenReturn(false);
 
-        victim.schedule(dbStack);
+        victim.schedule(DB_STACK_ID);
 
-        verifyZeroInteractions(jobService);
+        verifyNoInteractions(jobService);
     }
 
     @Test
     public void shouldUnscheduleJob() {
-        when(dbStack.getId()).thenReturn(DB_STACK_ID);
-
-        victim.unschedule(dbStack);
+        victim.unschedule(DB_STACK_ID, "name");
 
         verify(jobService).unschedule(String.valueOf(DB_STACK_ID));
     }

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/sync/DBStackStatusSyncServiceTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/sync/DBStackStatusSyncServiceTest.java
@@ -45,6 +45,8 @@ public class DBStackStatusSyncServiceTest {
 
     private static final String ENVIRONMENT_ID = "environment id";
 
+    private static final String DB_NAME = "name";
+
     private static final Long DB_STACK_ID = 1234L;
 
     @Mock
@@ -157,10 +159,11 @@ public class DBStackStatusSyncServiceTest {
         when(dbStack.getId()).thenReturn(DB_STACK_ID);
         when(dbStack.getStatus()).thenReturn(Status.DELETE_IN_PROGRESS);
         when(dbStack.getOwnerCrn()).thenReturn(crn);
+        when(dbStack.getName()).thenReturn(DB_NAME);
 
         victim.sync(dbStack);
 
         verify(dbStackStatusUpdater).updateStatus(DB_STACK_ID, DetailedDBStackStatus.DELETE_COMPLETED);
-        verify(dbStackJobService).unschedule(dbStack);
+        verify(dbStackJobService).unschedule(DB_STACK_ID, DB_NAME);
     }
 }


### PR DESCRIPTION
…zation. We are fetching the pure entity but we only use the crn and id. Because of lazy/eager fetch, and toString combination we can fetch unnecesary relations. I have refactored in all services

See detailed description in the commit message.