### PR TITLE
CB-16109 Hostgroup check for stop / start instances API

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
@@ -161,10 +161,13 @@ public class StackOperationService {
         if (instanceIdsByHostgroupMap.size() > 1) {
             throw new BadRequestException("Downscale via Instance Stop cannot process more than one host group");
         }
+        updateNodeCountValidator.validateInstanceGroup(stack, instanceIdsByHostgroupMap.keySet().iterator().next());
         LOGGER.info("InstanceIds without metadata: [{}]", instanceIdsWithoutMetadata);
         updateNodeCountValidator.validateServiceRoles(stack, instanceIdsByHostgroupMap.entrySet()
                 .stream()
                 .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().size() * -1)));
+        updateNodeCountValidator.validateInstanceGroupForStopStart(stack, instanceIdsByHostgroupMap.keySet().iterator().next(),
+                instanceIdsByHostgroupMap.entrySet().iterator().next().getValue().size() * -1);
         LOGGER.info("Stopping the following instances: {}", instanceIdsByHostgroupMap);
         if (!forced) {
             for (Entry<String, Set<Long>> entry : instanceIdsByHostgroupMap.entrySet()) {
@@ -296,6 +299,8 @@ public class StackOperationService {
                 updateNodeCountValidator.validateServiceRoles(stackWithLists, instanceGroupAdjustmentJson);
                 updateNodeCountValidator.validateStackStatusForStartHostGroup(stackWithLists);
                 updateNodeCountValidator.validateInstanceGroup(stackWithLists, instanceGroupAdjustmentJson.getInstanceGroup());
+                updateNodeCountValidator.validateInstanceGroupForStopStart(stackWithLists,
+                        instanceGroupAdjustmentJson.getInstanceGroup(), instanceGroupAdjustmentJson.getScalingAdjustment());
                 updateNodeCountValidator.validateScalabilityOfInstanceGroup(stackWithLists, instanceGroupAdjustmentJson);
                 updateNodeCountValidator.validateScalingAdjustment(instanceGroupAdjustmentJson, stackWithLists);
                 if (withClusterEvent) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/UpdateNodeCountValidator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/UpdateNodeCountValidator.java
@@ -5,6 +5,7 @@ import static java.lang.String.format;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -16,9 +17,12 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceMetadataTyp
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.HostGroupAdjustmentV4Request;
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessorFactory;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateValidator;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
+import com.sequenceiq.cloudbreak.common.type.Versioned;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
@@ -43,6 +47,9 @@ public class UpdateNodeCountValidator {
 
     @Inject
     private CmTemplateValidator cmTemplateValidator;
+
+    @Inject
+    private CmTemplateProcessorFactory cmTemplateProcessorFactory;
 
     @Inject
     private InstanceGroupService instanceGroupService;
@@ -170,6 +177,19 @@ public class UpdateNodeCountValidator {
                 instanceGroup);
     }
 
+    public void validateInstanceGroupForStopStart(Stack stack, String instanceGroupName, int scalingAdjustment) {
+        Set<String> computeGroups = getComputeHostGroup(stack);
+        if (!computeGroups.contains(instanceGroupName)) {
+            if (upscaleEvent(scalingAdjustment)) {
+                throw new BadRequestException(format("Start instances operation is not allowed for %s host group.", instanceGroupName));
+            } else if (downScaleEvent(scalingAdjustment)) {
+                throw new BadRequestException(format("Stop instances operation is not allowed for %s host group.", instanceGroupName));
+            } else {
+                throw new BadRequestException(format("Zero Scaling adjustment detected for %s host group.", instanceGroupName));
+            }
+        }
+    }
+
     private void validateGroupAdjustment(Stack stack, Integer scalingAdjustment, InstanceGroup instanceGroup) {
         if (upscaleEvent(scalingAdjustment)) {
             if (nodeCountIsLowerThanMinimalNodeCountAfterTheScalingEvent(instanceGroup, scalingAdjustment)) {
@@ -210,6 +230,13 @@ public class UpdateNodeCountValidator {
 
     private int getNodeCountAfterScaling(InstanceGroup instanceGroup, Integer scalingAdjustment) {
         return instanceGroup.getNodeCount() + scalingAdjustment.intValue();
+    }
+
+    private Set<String> getComputeHostGroup(Stack stack) {
+        String blueprintText = stack.getCluster().getBlueprint().getBlueprintText();
+        CmTemplateProcessor templateProcessor = cmTemplateProcessorFactory.get(blueprintText);
+        Versioned version = () -> templateProcessor.getVersion().get();
+        return templateProcessor.getComputeHostGroups(version);
     }
 
     private boolean nodeCountIsLowerThanMinimalNodeCountAfterTheScalingEvent(InstanceGroup instanceGroup,

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/StackCommonServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/StackCommonServiceTest.java
@@ -70,6 +70,8 @@ class StackCommonServiceTest {
 
     private static final String SUBNET_ID = "aSubnetId";
 
+    private static final String HOST_GROUP = "compute";
+
     @Mock
     private ImageCatalogService imageCatalogService;
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/UpdateNodeCountValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/UpdateNodeCountValidatorTest.java
@@ -2,28 +2,37 @@ package com.sequenceiq.cloudbreak.service.stack.flow;
 
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.AVAILABLE;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.NODE_FAILURE;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.junit.Assert;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.InstanceGroupAdjustmentV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessorFactory;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
@@ -32,6 +41,10 @@ import com.sequenceiq.common.api.type.ScalabilityOption;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class UpdateNodeCountValidatorTest {
+
+    private static final String TEST_COMPUTE_GROUP = "compute";
+
+    private static final String TEST_BLUEPRINT_TEXT = "blueprintText";
 
     private static final Optional<String> FORBIDDEN_DOWN = Optional.of("Requested scaling down is forbidden");
 
@@ -43,6 +56,9 @@ public class UpdateNodeCountValidatorTest {
 
     @InjectMocks
     public UpdateNodeCountValidator underTest;
+
+    @Mock
+    private CmTemplateProcessorFactory cmTemplateProcessorFactory;
 
     @ParameterizedTest(name = "The master node count is {0} this will be scaled with {2} " +
             "node and the minimum is {1} the ScalabilityOption is {3}.")
@@ -142,5 +158,51 @@ public class UpdateNodeCountValidatorTest {
                         Optional.of("Data Hub 'master-stack' has 'NODE_FAILURE' state." +
                                 " Node group start operation is not allowed for this state."))
         );
+    }
+
+    @Test
+    public void testValidateInstanceGroupForStopStartIsSuccessful() {
+        Stack stack = mock(Stack.class);
+        setupMocksForStopStartInstanceGroupValidation(stack);
+        assertDoesNotThrow(() -> underTest.validateInstanceGroupForStopStart(stack, "compute", 5));
+    }
+
+    @Test
+    public void testValidateInstanceGroupForStopStartThrowsExceptionForUpscale() {
+        Stack stack = mock(Stack.class);
+        setupMocksForStopStartInstanceGroupValidation(stack);
+        assertThatThrownBy(() -> underTest.validateInstanceGroupForStopStart(stack, "worker", 2))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("Start instances operation is not allowed for worker host group.");
+    }
+
+    @Test
+    public void testValidateInstanceGroupForStopStartThrowsExceptionForDownscale() {
+        Stack stack = mock(Stack.class);
+        setupMocksForStopStartInstanceGroupValidation(stack);
+        assertThatThrownBy(() -> underTest.validateInstanceGroupForStopStart(stack, "worker", -1))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("Stop instances operation is not allowed for worker host group.");
+    }
+
+    @Test
+    public void testValidateInstanceGroupForStopStartThrowsExceptionForZeroScalingAdjustment() {
+        Stack stack = mock(Stack.class);
+        setupMocksForStopStartInstanceGroupValidation(stack);
+        assertThatThrownBy(() -> underTest.validateInstanceGroupForStopStart(stack, "worker", 0))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("Zero Scaling adjustment detected for worker host group.");
+    }
+
+    private void setupMocksForStopStartInstanceGroupValidation(Stack stack) {
+        CmTemplateProcessor cmTemplateProcessor = mock(CmTemplateProcessor.class);
+        Cluster cluster = mock(Cluster.class);
+        Blueprint blueprint = mock(Blueprint.class);
+
+        when(stack.getCluster()).thenReturn(cluster);
+        when(cluster.getBlueprint()).thenReturn(blueprint);
+        when(blueprint.getBlueprintText()).thenReturn(TEST_BLUEPRINT_TEXT);
+        when(cmTemplateProcessorFactory.get(anyString())).thenReturn(cmTemplateProcessor);
+        when(cmTemplateProcessor.getComputeHostGroups(any())).thenReturn(Set.of(TEST_COMPUTE_GROUP));
     }
 }


### PR DESCRIPTION
### Changes
 - Added logic to detect compute like host groups
 - Validation to ensure that the stop / start operations can be invoked only for the applicable host group

### Testing
 - UTs for stop / start hostGroup validation in UpdateNodeCountValidatorTest

See detailed description in the commit message.