### PR TITLE
CB-15821 [E2E] Optimize `DistroXUpgradeTests#testDistroXEphemeralUpgrade` to reduce runtime

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/ephemeral/DistroXUpgradeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/ephemeral/DistroXUpgradeTests.java
@@ -21,13 +21,11 @@ import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
 import com.sequenceiq.it.cloudbreak.dto.distrox.cluster.DistroXUpgradeTestDto;
 import com.sequenceiq.it.cloudbreak.dto.distrox.instancegroup.DistroXInstanceGroupsBuilder;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
-import com.sequenceiq.it.cloudbreak.dto.sdx.SdxUpgradeTestDto;
 import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
 import com.sequenceiq.it.cloudbreak.util.clouderamanager.ClouderaManagerUtil;
 import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
 import com.sequenceiq.it.cloudbreak.util.ssh.action.SshJClientActions;
 import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
-import com.sequenceiq.sdx.api.model.SdxUpgradeReplaceVms;
 
 public class DistroXUpgradeTests extends AbstractE2ETest {
 
@@ -88,32 +86,6 @@ public class DistroXUpgradeTests extends AbstractE2ETest {
                 .when(distroXTestClient.create(), key(distroXName))
                 .await(STACK_AVAILABLE)
                 .awaitForHealthyInstances()
-                .then((tc, testDto, client) -> {
-                    verifyMountPointsUsedForTemporalDisks(testDto, "ephfs", "ephfs1");
-                    return testDto;
-                })
-                .then((tc, testDto, client) -> clouderaManagerUtil.checkClouderaManagerYarnNodemanagerRoleConfigGroupsDirect(testDto, sanitizedUserName,
-                        MOCK_UMS_PASSWORD))
-                .validate();
-        testContext
-                .given(distroXName, DistroXTestDto.class)
-                .when(distroXTestClient.stop(), key(distroXName))
-                .await(STACK_STOPPED)
-                .validate();
-        testContext
-                .given(SdxUpgradeTestDto.class)
-                .withReplaceVms(SdxUpgradeReplaceVms.DISABLED)
-                .withRuntime(targetRuntimeVersion)
-                .given(sdxName, SdxTestDto.class)
-                .when(sdxTestClient.upgrade(), key(sdxName))
-                .await(SdxClusterStatusResponse.DATALAKE_UPGRADE_IN_PROGRESS, key(sdxName).withWaitForFlow(Boolean.FALSE))
-                .await(SdxClusterStatusResponse.RUNNING, key(sdxName))
-                .awaitForHealthyInstances()
-                .validate();
-        testContext
-                .given(distroXName, DistroXTestDto.class)
-                .when(distroXTestClient.start(), key(distroXName))
-                .await(STACK_AVAILABLE)
                 .validate();
         testContext
                 .given(DistroXUpgradeTestDto.class)


### PR DESCRIPTION
- removed DL upgrade (~50min)
- removed ephemeral mount related validation after provision, as this is covered in other tests (~20min)
- removed DH stop-start as DL upgrade is removed (~15min)

See detailed description in the commit message.