### PR TITLE
CB-16012: Set encryption key for an existing env that does not yet have encryption enabled

### DIFF
--- a/authorization-common-api/src/main/java/com/sequenceiq/authorization/info/model/RightV4.java
+++ b/authorization-common-api/src/main/java/com/sequenceiq/authorization/info/model/RightV4.java
@@ -27,6 +27,7 @@ public enum RightV4 {
     DH_CREATE(AuthorizationResourceAction.ENVIRONMENT_CREATE_DATAHUB),
     UPDATE_AZURE_ENCRYPTION_RESOURCES(AuthorizationResourceAction.UPDATE_AZURE_ENCRYPTION_RESOURCES),
     UPDATE_AWS_DISK_ENCRYPTION_PARAMETERS(AuthorizationResourceAction.UPDATE_AWS_DISK_ENCRYPTION_PARAMETERS),
+    UPDATE_GCP_ENCRYPTION_RESOURCES(AuthorizationResourceAction.UPDATE_GCP_ENCRYPTION_RESOURCES),
     // dh level
     DH_START(AuthorizationResourceAction.START_DATAHUB),
     DH_STOP(AuthorizationResourceAction.STOP_DATAHUB),

--- a/authorization-common-api/src/main/java/com/sequenceiq/authorization/resource/AuthorizationResourceAction.java
+++ b/authorization-common-api/src/main/java/com/sequenceiq/authorization/resource/AuthorizationResourceAction.java
@@ -97,6 +97,7 @@ public enum AuthorizationResourceAction {
     STRUCTURED_EVENTS_READ("structured_events/read", AuthorizationResourceType.STRUCTURED_EVENT),
     UPDATE_AZURE_ENCRYPTION_RESOURCES("environments/updateAzureEncryptionResources", AuthorizationResourceType.ENVIRONMENT),
     UPDATE_AWS_DISK_ENCRYPTION_PARAMETERS("environments/updateAwsDiskEncryptionParameters", AuthorizationResourceType.ENVIRONMENT),
+    UPDATE_GCP_ENCRYPTION_RESOURCES("environments/updateGcpEncryptionResources", AuthorizationResourceType.ENVIRONMENT),
     ENVIRONMENT_CHANGE_FREEIPA_IMAGE("environments/changeFreeipaImageCatalog", AuthorizationResourceType.ENVIRONMENT),
     // deprecated actions, please do not use them
     ENVIRONMENT_READ("environments/read", AuthorizationResourceType.ENVIRONMENT),

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentOpDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentOpDescription.java
@@ -37,6 +37,8 @@ public class EnvironmentOpDescription {
     public static final String UPDATE_AZURE_ENCRYPTION_RESOURCES_BY_CRN = "Updates the Customer managed key of the Azure environment of a given CRN.";
     public static final String UPDATE_AWS_DISK_ENCRYPTION_PARAMETERS_BY_NAME = "Updates the Customer managed key of the AWS environment of a given name.";
     public static final String UPDATE_AWS_DISK_ENCRYPTION_PARAMETERS_BY_CRN = "Updates the Customer managed key of the AWS environment of a given CRN.";
+    public static final String UPDATE_GCP_ENCRYPTION_RESOURCES_BY_NAME = "Updates the Customer managed key of the GCP environment of a given name.";
+    public static final String UPDATE_GCP_ENCRYPTION_RESOURCES_BY_CRN = "Updates the Customer managed key of the GCP environment of a given CRN.";
     public static final String UPGRADE_CCM = "Initiates the CCM tunnel type upgrade to the latest available version";
 
     private EnvironmentOpDescription() {

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/endpoint/EnvironmentEndpoint.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/endpoint/EnvironmentEndpoint.java
@@ -35,6 +35,7 @@ import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentLo
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.UpdateAwsDiskEncryptionParametersRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.UpdateAzureResourceEncryptionParametersRequest;
+import com.sequenceiq.environment.api.v1.environment.model.request.gcp.UpdateGcpResourceEncryptionParametersRequest;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentCrnResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.SimpleEnvironmentResponse;
@@ -318,5 +319,21 @@ public interface EnvironmentEndpoint {
     @ApiOperation(value = EnvironmentOpDescription.UPGRADE_CCM, produces = MediaType.APPLICATION_JSON, notes = ENVIRONMENT_NOTES,
             nickname = "upgradeCcmByEnvironmentCrnV1")
     void upgradeCcmByCrn(@ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT) @PathParam("crn") String crn);
+
+    @PUT
+    @Path("/name/{name}/update_gcp_encryption_resources")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = EnvironmentOpDescription.UPDATE_GCP_ENCRYPTION_RESOURCES_BY_NAME, produces = MediaType.APPLICATION_JSON, notes = ENVIRONMENT_NOTES,
+            nickname = "UpdateGcpResourceEncryptionParametersV1")
+    DetailedEnvironmentResponse updateGcpResourceEncryptionParametersByEnvironmentName(@PathParam("name") String environmentName,
+            @Valid UpdateGcpResourceEncryptionParametersRequest request);
+
+    @PUT
+    @Path("/crn/{crn}/update_gcp_encryption_resources")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = EnvironmentOpDescription.UPDATE_GCP_ENCRYPTION_RESOURCES_BY_CRN, produces = MediaType.APPLICATION_JSON, notes = ENVIRONMENT_NOTES,
+            nickname = "UpdateGcpResourceEncryptionParametersV1ByCrn")
+    DetailedEnvironmentResponse updateGcpResourceEncryptionParametersByEnvironmentCrn(@ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT)
+    @PathParam("crn") String crn, @Valid UpdateGcpResourceEncryptionParametersRequest request);
 
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/EnvironmentController.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/EnvironmentController.java
@@ -52,6 +52,7 @@ import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentLo
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.UpdateAwsDiskEncryptionParametersRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.UpdateAzureResourceEncryptionParametersRequest;
+import com.sequenceiq.environment.api.v1.environment.model.request.gcp.UpdateGcpResourceEncryptionParametersRequest;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentCrnResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.SimpleEnvironmentResponse;
@@ -472,5 +473,25 @@ public class EnvironmentController implements EnvironmentEndpoint {
     @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.EDIT_ENVIRONMENT /*for now*/)
     public void upgradeCcmByCrn(@ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT) @ResourceCrn String crn) {
         upgradeCcmService.upgradeCcmByCrn(crn);
+    }
+
+    @Override
+    @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.UPDATE_GCP_ENCRYPTION_RESOURCES)
+    public DetailedEnvironmentResponse updateGcpResourceEncryptionParametersByEnvironmentCrn(@ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT)
+    @ResourceCrn String crn, @RequestObject @Valid UpdateGcpResourceEncryptionParametersRequest request) {
+        String accountId = ThreadBasedUserCrnProvider.getAccountId();
+        EnvironmentDto result = environmentModificationService.updateGcpResourceEncryptionParametersByEnvironmentCrn(accountId, crn,
+                environmentApiConverter.convertUpdateGcpResourceEncryptionDto(request));
+        return environmentResponseConverter.dtoToDetailedResponse(result);
+    }
+
+    @Override
+    @CheckPermissionByResourceName(action = AuthorizationResourceAction.UPDATE_GCP_ENCRYPTION_RESOURCES)
+    public DetailedEnvironmentResponse updateGcpResourceEncryptionParametersByEnvironmentName(@ResourceName String environmentName,
+            @RequestObject @Valid UpdateGcpResourceEncryptionParametersRequest request) {
+        String accountId = ThreadBasedUserCrnProvider.getAccountId();
+        EnvironmentDto result = environmentModificationService.updateGcpResourceEncryptionParametersByEnvironmentName(accountId, environmentName,
+                environmentApiConverter.convertUpdateGcpResourceEncryptionDto(request));
+        return environmentResponseConverter.dtoToDetailedResponse(result);
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverter.java
@@ -45,6 +45,7 @@ import com.sequenceiq.environment.api.v1.environment.model.request.azure.Resourc
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.UpdateAzureResourceEncryptionParametersRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.gcp.GcpEnvironmentParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.gcp.GcpResourceEncryptionParameters;
+import com.sequenceiq.environment.api.v1.environment.model.request.gcp.UpdateGcpResourceEncryptionParametersRequest;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentCrnResponse;
 import com.sequenceiq.environment.credential.service.CredentialService;
 import com.sequenceiq.environment.credential.v1.converter.TunnelConverter;
@@ -59,6 +60,7 @@ import com.sequenceiq.environment.environment.dto.LocationDto;
 import com.sequenceiq.environment.environment.dto.SecurityAccessDto;
 import com.sequenceiq.environment.environment.dto.UpdateAwsDiskEncryptionParametersDto;
 import com.sequenceiq.environment.environment.dto.UpdateAzureResourceEncryptionDto;
+import com.sequenceiq.environment.environment.dto.UpdateGcpResourceEncryptionDto;
 import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentFeatures;
 import com.sequenceiq.environment.network.dto.NetworkDto;
 import com.sequenceiq.environment.parameter.dto.AwsDiskEncryptionParametersDto;
@@ -403,6 +405,13 @@ public class EnvironmentApiConverter {
         return UpdateAwsDiskEncryptionParametersDto.builder()
                 .withAwsDiskEncryptionParametersDto(
                         awsDiskEncryptionParametersToAwsDiskEncryptionParametersDto(request.getAwsDiskEncryptionParameters()))
+                .build();
+    }
+
+    public UpdateGcpResourceEncryptionDto convertUpdateGcpResourceEncryptionDto(UpdateGcpResourceEncryptionParametersRequest request) {
+        return UpdateGcpResourceEncryptionDto.builder()
+                .withGcpResourceEncryptionParametersDto(
+                        gcpResourceEncryptionParametersToGcpEncryptionParametersDto(request.getGcpResourceEncryptionParameters()))
                 .build();
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/EnvironmentValidatorService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/EnvironmentValidatorService.java
@@ -2,9 +2,7 @@ package com.sequenceiq.environment.environment.validation;
 
 import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AWS;
 import static com.sequenceiq.cloudbreak.util.SecurityGroupSeparator.getSecurityGroupIds;
-import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.GCP;
 import static com.sequenceiq.common.model.CredentialType.ENVIRONMENT;
-
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 import java.util.HashSet;
@@ -304,22 +302,16 @@ public class EnvironmentValidatorService {
         return resultBuilder.build();
     }
 
-    public ValidationResult validateEncryptionKey(EnvironmentCreationDto creationDto) {
+    public ValidationResult validateEncryptionKey(String encryptionKey, String accountId) {
         ValidationResultBuilder resultBuilder = ValidationResult.builder();
-        if (GCP.name().equalsIgnoreCase(creationDto.getCloudPlatform())) {
-            String encryptionKey = Optional.ofNullable(creationDto.getParameters())
-                    .map(parametersDto -> parametersDto.getGcpParametersDto())
-                    .map(gcpParametersDto -> gcpParametersDto.getGcpResourceEncryptionParametersDto())
-                    .map(gcpREParamsDto -> gcpREParamsDto.getEncryptionKey()).orElse(null);
-            if (StringUtils.isNotEmpty(encryptionKey)) {
-                if (!entitlementService.isGcpDiskEncryptionWithCMEKEnabled(creationDto.getAccountId())) {
-                    resultBuilder.error(String.format("You have specified encryption-key to enable encryption for GCP resources with CMEK "
-                            + "but that feature is currently not enabled for this account."
-                            + " Please get 'CDP_CB_GCP_DISK_ENCRYPTION_WITH_CMEK' enabled for this account."));
-                } else {
-                    ValidationResult validationResult = encryptionKeyValidator.validateEncryptionKey(encryptionKey);
-                    resultBuilder.merge(validationResult);
-                }
+        if (StringUtils.isNotEmpty(encryptionKey)) {
+            if (!entitlementService.isGcpDiskEncryptionWithCMEKEnabled(accountId)) {
+                resultBuilder.error(String.format("You have specified encryption-key to enable encryption for GCP resources with CMEK "
+                        + "but that feature is currently not enabled for this account."
+                        + " Please get 'CDP_CB_GCP_DISK_ENCRYPTION_WITH_CMEK' enabled for this account."));
+            } else {
+                ValidationResult validationResult = encryptionKeyValidator.validateEncryptionKey(encryptionKey);
+                resultBuilder.merge(validationResult);
             }
         }
         return resultBuilder.build();

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverterTest.java
@@ -57,6 +57,7 @@ import com.sequenceiq.environment.api.v1.environment.model.request.azure.Resourc
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.UpdateAzureResourceEncryptionParametersRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.gcp.GcpEnvironmentParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.gcp.GcpResourceEncryptionParameters;
+import com.sequenceiq.environment.api.v1.environment.model.request.gcp.UpdateGcpResourceEncryptionParametersRequest;
 import com.sequenceiq.environment.credential.service.CredentialService;
 import com.sequenceiq.environment.credential.v1.converter.TunnelConverter;
 import com.sequenceiq.environment.environment.domain.ExperimentalFeatures;
@@ -70,6 +71,7 @@ import com.sequenceiq.environment.environment.dto.LocationDto;
 import com.sequenceiq.environment.environment.dto.SecurityAccessDto;
 import com.sequenceiq.environment.environment.dto.UpdateAwsDiskEncryptionParametersDto;
 import com.sequenceiq.environment.environment.dto.UpdateAzureResourceEncryptionDto;
+import com.sequenceiq.environment.environment.dto.UpdateGcpResourceEncryptionDto;
 import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentTelemetry;
 import com.sequenceiq.environment.network.dto.NetworkDto;
 import com.sequenceiq.environment.parameter.dto.ParametersDto;
@@ -412,6 +414,18 @@ public class EnvironmentApiConverterTest {
                 .build();
         UpdateAwsDiskEncryptionParametersDto actual = underTest.convertUpdateAwsDiskEncryptionParametersDto(request);
         assertEquals(ENCRYPTION_KEY_ARN, actual.getAwsDiskEncryptionParametersDto().getEncryptionKeyArn());
+    }
+
+    @Test
+    void testConvertUpdateGcpResourceEncryptionDto() {
+        UpdateGcpResourceEncryptionParametersRequest request = UpdateGcpResourceEncryptionParametersRequest.builder()
+                .withGcpResourceEncryptionParameters(GcpResourceEncryptionParameters.builder()
+                        .withEncryptionKey(KEY_URL)
+                        .build())
+                .build();
+        UpdateGcpResourceEncryptionDto actual = underTest.convertUpdateGcpResourceEncryptionDto(request);
+
+        assertEquals(KEY_URL, actual.getGcpResourceEncryptionParametersDto().getEncryptionKey());
     }
 
     private void assertLocation(LocationRequest request, LocationDto actual) {

--- a/environment/src/test/java/com/sequenceiq/environment/environment/validation/EnvironmentValidatorServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/validation/EnvironmentValidatorServiceTest.java
@@ -34,7 +34,6 @@ import com.sequenceiq.environment.credential.service.CredentialService;
 import com.sequenceiq.environment.environment.EnvironmentStatus;
 import com.sequenceiq.environment.environment.domain.Environment;
 import com.sequenceiq.environment.environment.dto.AuthenticationDto;
-import com.sequenceiq.environment.environment.dto.EnvironmentCreationDto;
 import com.sequenceiq.environment.environment.dto.EnvironmentEditDto;
 import com.sequenceiq.environment.environment.dto.FreeIpaCreationAwsParametersDto;
 import com.sequenceiq.environment.environment.dto.FreeIpaCreationAwsSpotParametersDto;
@@ -47,9 +46,6 @@ import com.sequenceiq.environment.environment.validation.validators.EncryptionKe
 import com.sequenceiq.environment.environment.validation.validators.NetworkCreationValidator;
 import com.sequenceiq.environment.environment.validation.validators.PublicKeyValidator;
 import com.sequenceiq.environment.environment.validation.validators.TagValidator;
-import com.sequenceiq.environment.parameter.dto.GcpParametersDto;
-import com.sequenceiq.environment.parameter.dto.GcpResourceEncryptionParametersDto;
-import com.sequenceiq.environment.parameter.dto.ParametersDto;
 import com.sequenceiq.environment.platformresource.PlatformParameterService;
 
 @ExtendWith(MockitoExtension.class)
@@ -418,76 +414,33 @@ class EnvironmentValidatorServiceTest {
 
     @Test
     void shouldFailIfGcpEncryptionKeySpecifiedAndEntitlementAndWrongFormat() {
-        EnvironmentCreationDto creationDto = EnvironmentCreationDto.builder()
-                .withAccountId(ACCOUNT_ID)
-                .withCloudPlatform("GCP")
-                .withParameters(ParametersDto.builder()
-                        .withGcpParameters(GcpParametersDto.builder()
-                                .withEncryptionParameters(GcpResourceEncryptionParametersDto.builder()
-                                        .withEncryptionKey("project/Wrong-dummy-key-format")
-                                        .build())
-                                .build())
-                        .build())
-                .build();
-
+        String encryptionKey = "project/Wrong-dummy-key-format";
         ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
         validationResultBuilder.error("error");
         when(encryptionKeyValidator.validateEncryptionKey(any())).thenReturn(validationResultBuilder.build());
         when(entitlementService.isGcpDiskEncryptionWithCMEKEnabled(any())).thenReturn(true);
-        ValidationResult validationResult = underTest.validateEncryptionKey(creationDto);
+        ValidationResult validationResult = underTest.validateEncryptionKey(encryptionKey, ACCOUNT_ID);
         assertTrue(validationResult.hasError());
     }
 
     @Test
     void shouldFailIfGcpEncryptionKeySpecifiedAndNotEntitlement() {
-        EnvironmentCreationDto creationDto = EnvironmentCreationDto.builder()
-                .withAccountId(ACCOUNT_ID)
-                .withCloudPlatform("GCP")
-                .withParameters(ParametersDto.builder()
-                        .withGcpParameters(GcpParametersDto.builder()
-                                .withEncryptionParameters(GcpResourceEncryptionParametersDto.builder()
-                                        .withEncryptionKey("project/Wrong-dummy-key-format")
-                                        .build())
-                                .build())
-                        .build())
-                .build();
-
+        String encryptionKey = "project/Wrong-dummy-key-format";
         when(entitlementService.isGcpDiskEncryptionWithCMEKEnabled(any())).thenReturn(false);
-        ValidationResult validationResult = underTest.validateEncryptionKey(creationDto);
+        ValidationResult validationResult = underTest.validateEncryptionKey(encryptionKey, ACCOUNT_ID);
 
         assertTrue(validationResult.hasError());
     }
 
     @Test
-    void testValidateGcpEncryptionKeyNotSpecified() {
-        EnvironmentCreationDto creationDto = EnvironmentCreationDto.builder()
-                .withAccountId(ACCOUNT_ID)
-                .withCloudPlatform("GCP")
-                .build();
-        ValidationResult validationResult = underTest.validateEncryptionKey(creationDto);
-        assertFalse(validationResult.hasError());
-    }
-
-    @Test
     void testValidateGcpEncryptionKeySpecifiedAndEntitlement() {
-        EnvironmentCreationDto creationDto = EnvironmentCreationDto.builder()
-                .withAccountId(ACCOUNT_ID)
-                .withCloudPlatform("GCP")
-                .withParameters(ParametersDto.builder()
-                        .withGcpParameters(GcpParametersDto.builder()
-                                .withEncryptionParameters(GcpResourceEncryptionParametersDto.builder()
-                                        .withEncryptionKey("projects/dummy-project/locations/us-west2/keyRings/dummy-ring/cryptoKeys/dummy-key")
-                                        .build())
-                                .build())
-                        .build())
-                .build();
-
+        String encryptionKey = "projects/dummy-project/locations/us-west2/keyRings/dummy-ring/cryptoKeys/dummy-key";
         ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
 
         when(encryptionKeyValidator.validateEncryptionKey(any())).thenReturn(validationResultBuilder.build());
         when(entitlementService.isGcpDiskEncryptionWithCMEKEnabled(any())).thenReturn(true);
 
-        ValidationResult validationResult = underTest.validateEncryptionKey(creationDto);
+        ValidationResult validationResult = underTest.validateEncryptionKey(encryptionKey, ACCOUNT_ID);
         assertFalse(validationResult.hasError());
     }
 


### PR DESCRIPTION
CB-16012: Set encryption key for an existing env that does not yet have encryption enabled

CB-10502 introduced the encryption of Gcp Managed disks using Customer Managed Key. This feature is behind an entitlement "CDP_CB_GCP_DISK_ENCRYPTION_WITH_CMEK" and can be used for new environments.
This PR allows to set the encryption key for existing environments such that the new disks launched as part of new Datahubs will be encrypted with Customer Managed Key. All the previously launched disks/resources would remain unencrypted.

Validated these changes with :

    Existing environment
        Using wrong key url
        Using disabled key
        Using enabled key valid url
    Non - Existing environement

See detailed description in the commit message.