### PR TITLE
CB-16194. Increase the allowed time-out while waiting for instances to

### DIFF
--- a/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/handler/StopStartDownscaleStopInstancesHandler.java
+++ b/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/handler/StopStartDownscaleStopInstancesHandler.java
@@ -27,7 +27,7 @@ public class StopStartDownscaleStopInstancesHandler implements CloudPlatformEven
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StopStartDownscaleStopInstancesHandler.class);
 
-    private static final Long STOP_POLL_TIMEBOUND_MS = 300_000L;
+    private static final Long STOP_POLL_TIMEBOUND_MS = 600_000L;
 
     @Inject
     private CloudPlatformConnectors cloudPlatformConnectors;

--- a/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/handler/StopStartUpscaleStartInstancesHandler.java
+++ b/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/handler/StopStartUpscaleStartInstancesHandler.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.dyngr.exception.PollerStoppedException;
 import com.sequenceiq.cloudbreak.cloud.CloudConnector;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
@@ -20,6 +21,7 @@ import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudVmInstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
+import com.sequenceiq.cloudbreak.service.CloudbreakRuntimeException;
 
 import reactor.bus.Event;
 import reactor.bus.EventBus;
@@ -29,7 +31,7 @@ public class StopStartUpscaleStartInstancesHandler implements CloudPlatformEvent
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StopStartUpscaleStartInstancesHandler.class);
 
-    private static final Long START_POLL_TIMEBOUND_MS = 300_000L;
+    private static final Long START_POLL_TIMEBOUND_MS = 600_000L;
 
     @Inject
     private CloudPlatformConnectors cloudPlatformConnectors;
@@ -76,14 +78,21 @@ public class StopStartUpscaleStartInstancesHandler implements CloudPlatformEvent
                 stoppedInstancesOnCloudProvider = collectStoppedInstancesFromCloudProvider(connector, ac, request.getAllInstancesInHg());
                 instancesToStart = getInstancesToStart(stoppedInstancesInCbHg, stoppedInstancesOnCloudProvider, request.getHostGroupName(), numInstancesToStart);
             } else {
-                // TODO CB-15132: Potentially validate against the cloud-provider to make sure these instances are actually in STOPPED state.
-                // Try starting the required instances based on CB state.
+                // Filter based on CB state, but confirm against the cloud provider. It is OK to start fewer instances than requested.
+                // TODO CB-15132: We could go back to the cloud provider and try finding additional stopped instances.
                 instancesToStart = stoppedInstancesInCbHg.subList(0, numInstancesToStart);
-                // TODO CB-15132: If there's a failure on this particular operation - go back to the cloud provider to try finding additional STOPPED instances,
-                // and try STARTING these as well.
+                stoppedInstancesOnCloudProvider = collectStoppedInstancesFromCloudProvider(connector, ac, instancesToStart);
+                Set<CloudInstance> stoppedInstancesOnCloudProviderSet =
+                        stoppedInstancesOnCloudProvider.stream().map(CloudVmInstanceStatus::getCloudInstance).collect(Collectors.toUnmodifiableSet());
+                instancesToStart = instancesToStart.stream()
+                        .filter(i -> stoppedInstancesOnCloudProviderSet.contains(i))
+                        .collect(Collectors.toList());
             }
-            LOGGER.info("Requested instances to start={}, actual instances being started={}, numInstancesWithServicesNotRunning={}",
-                    request.getNumInstancesToStart(), instancesToStart.size(), request.getStartedInstancesWithServicesNotRunning().size());
+
+            LOGGER.info("Requested instances to start={}, actual instances being started={}, numInstancesWithServicesNotRunning={}" +
+                    ", numStoppedInstanceCountInCbHg={}, numStoppedInstancesOnCloudProvider(subset)={}",
+                    request.getNumInstancesToStart(), instancesToStart.size(), request.getStartedInstancesWithServicesNotRunning().size(),
+                    stoppedInstancesInCbHg.size(), stoppedInstancesOnCloudProvider.size());
 
             LOGGER.debug("Attempting to start instances. count={}, instanceIds={}",
                     instancesToStart.size(), instancesToStart.stream().map(i -> i.getInstanceId()).collect(Collectors.toList()));
@@ -114,7 +123,30 @@ public class StopStartUpscaleStartInstancesHandler implements CloudPlatformEvent
             CloudConnector<?> connector, AuthenticatedContext ac, List<CloudInstance> instancesToStart) {
         // Note: This timebound can apply thrice along with some delays, given how retries on this API are currently configured for AWS.
         //  The rest of the cloud providers is an UNKNOWN.
-        return connector.instances().startWithLimitedRetry(ac, null, instancesToStart, START_POLL_TIMEBOUND_MS);
+        try {
+            return connector.instances().startWithLimitedRetry(ac, null, instancesToStart, START_POLL_TIMEBOUND_MS);
+        } catch (PollerStoppedException p) {
+            // We exceeded the time-bound on the polling. Try getting the status for all the instances that we attempted to start.
+            LOGGER.warn("Timed out while attempting to start instances. Attempting to get states for attempted nodes", p);
+            return getInstanceStatusOnStartError(connector, ac, instancesToStart, p);
+        } catch (Exception e) {
+            // Some other error while attempting to startInstances. Try getting the status for all the instances that we attempted to start.
+            LOGGER.warn("Exception while attempting to start instances. Attempting to get states for attempted nodes", e);
+            return getInstanceStatusOnStartError(connector, ac, instancesToStart, e);
+        }
+    }
+
+    private List<CloudVmInstanceStatus> getInstanceStatusOnStartError(CloudConnector<?> connector, AuthenticatedContext ac,
+            List<CloudInstance> instancesToStart, Exception originalException) {
+        try {
+            return connector.instances().checkWithoutRetry(ac, instancesToStart);
+        } catch (Exception e) {
+            LOGGER.warn("Error while trying to get instance status after start failure. Propagating original error from the start attempt", e);
+            // The PollerStoppedException is too verbose for the console.
+            String message = originalException instanceof PollerStoppedException ? "Timed out while waiting for instances to start" :
+                    "Error while attempting to start instances";
+            throw new CloudbreakRuntimeException(message, originalException);
+        }
     }
 
     private List<CloudVmInstanceStatus> collectStoppedInstancesFromCloudProvider(

--- a/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/StopStartDownscaleStopInstancesHandlerTest.java
+++ b/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/StopStartDownscaleStopInstancesHandlerTest.java
@@ -45,7 +45,7 @@ public class StopStartDownscaleStopInstancesHandlerTest {
 
     private static final String MOCK_INSTANCEID_PREFIX = "i-";
 
-    private static final Long EXPECTED_STOP_POLL_TIMEBOUND_MS = 300_000L;
+    private static final Long EXPECTED_STOP_POLL_TIMEBOUND_MS = 600_000L;
 
     @Mock
     private CloudPlatformConnectors cloudPlatformConnectors;

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/ClouderaManagerPollingServiceProvider.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/ClouderaManagerPollingServiceProvider.java
@@ -177,7 +177,7 @@ public class ClouderaManagerPollingServiceProvider {
 
     public ExtendedPollingResult startPollingCmHostsRecommission(Stack stack, ApiClient apiClient, BigDecimal commandId) {
         LOGGER.debug("Waiting for Cloudera Manager to re-commission host with commandId: {}. [Server address: {}]", commandId, stack.getClusterManagerIp());
-        long timeout = POLL_FOR_5_MINUTES;
+        long timeout = POLL_FOR_10_MINUTES;
         return pollCommandWithTimeListener(stack, apiClient, commandId, timeout,
                 new NoExceptionOnTimeoutClouderaManagerListenerTask(clouderaManagerApiPojoFactory, clusterEventService, "RecommissionHosts"));
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartus/StopStartUpscaleFlowService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartus/StopStartUpscaleFlowService.java
@@ -68,8 +68,8 @@ class StopStartUpscaleFlowService {
         flowMessageService.fireEventAndLog(stackId, UPDATE_FAILED.name(), CLUSTER_SCALING_STOPSTART_UPSCALE_NODES_NOT_STARTED,
                 String.valueOf(notStartedIntances.size()),
                         notStartedIntances.stream()
-                                .map(x -> x.getCloudInstance().getInstanceId())
-                                .collect(Collectors.joining(", ")));
+                                .map(x -> String.format("{%s : %s}", x.getCloudInstance().getInstanceId(), x.getStatus()))
+                                .collect(Collectors.joining(", ", "{", "}")));
     }
 
     void warnNotEnoughInstances(long stackId, String hostGroupName, int desiredCount, int addedCount) {


### PR DESCRIPTION
start (via the stopstart scaling mechanism).
- Increases the allowed time for both stop and start to 10 minutes. This
  combined with the 10m for the CM operations means that a
  scale-up/scale-down, if it were to fail, should fail within 20
  minutes.
- If a timeout is hit, proceed with the nodes which we were able to
  start.
- While determining which nodes to upscale, added an additional check
  to get state from the cloud-provider as well.
- Reduces verbosity of one of the console error messages which was
  otherwise logging CloudVmInstanceStatus for all nodes which were being
  started.

See detailed description in the commit message.