### PR TITLE
CB-14421 distrox scale test should ignore NODE_FAILURE status since a…

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXScaleTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXScaleTest.java
@@ -60,14 +60,14 @@ public class DistroXScaleTest extends AbstractE2ETest {
                     cloudFunctionality.deleteInstances(testDto.getName(), List.of(anInstanceToDelete.get()));
                     return testDto;
                 })
-                .await(STACK_AVAILABLE)
+                .awaitForFlow()
                 .when(distroXTestClient.scale(params.getHostGroup(), params.getScaleDownTarget()))
-                .await(STACK_AVAILABLE);
+                .awaitForFlow();
         IntStream.range(1, params.getTimes()).forEach(i -> testContext.given(DistroXTestDto.class)
                 .when(distroXTestClient.scale(params.getHostGroup(), params.getScaleUpTarget()))
-                .await(STACK_AVAILABLE)
+                .awaitForFlow()
                 .when(distroXTestClient.scale(params.getHostGroup(), params.getScaleDownTarget()))
-                .await(STACK_AVAILABLE));
+                .awaitForFlow());
         testContext.given(DistroXTestDto.class).validate();
     }
 


### PR DESCRIPTION
…n irrelevant node is deleted on purpose

See detailed description in the commit message.