### PR TITLE
CB-14700 Add host template name as tag to hosts after upgrade

### DIFF
--- a/client-cm/src/main/java/com/sequenceiq/cloudbreak/cm/client/ClouderaManagerApiClientProvider.java
+++ b/client-cm/src/main/java/com/sequenceiq/cloudbreak/cm/client/ClouderaManagerApiClientProvider.java
@@ -32,6 +32,8 @@ public class ClouderaManagerApiClientProvider {
 
     public static final String API_V_45 = API_ROOT + "/v45";
 
+    public static final String API_V_46 = API_ROOT + "/v46";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerApiClientProvider.class);
 
     @Value("${cb.cm.client.cluster.proxy.timeout}")
@@ -153,5 +155,9 @@ public class ClouderaManagerApiClientProvider {
 
     public ApiClient getV45Client(Integer gatewayPort, String user, String password, HttpClientConfig clientConfig) throws ClouderaManagerClientInitException {
         return getApiClientByApiVersion(gatewayPort, user, password, clientConfig, API_V_45);
+    }
+
+    public ApiClient getV46Client(Integer gatewayPort, String user, String password, HttpClientConfig clientConfig) throws ClouderaManagerClientInitException {
+        return getApiClientByApiVersion(gatewayPort, user, password, clientConfig, API_V_46);
     }
 }


### PR DESCRIPTION
Add services through the host template feature (OPSAPS-60099) in the public cloud needs CM to store the host and host template mapping. Because in public cloud roles and services are added into the cluster by adding role config group to host template and then reapplying host template on all the associated hosts.
So we are storing host templates and host mapping by adding CM tag on the host. Tag name will be _cldr_cm_host_template_name and value will be template name for the host i.e -> (Tag name =_cldr_cm_host_template_name, value = template name, entity_id = hostid ).

These tags will be automatically added when performing an apply host template. For new installations, these tags will be added while setting up a cluster using import cluster template API(as it performs apply host template cmd internally).

But for existing clusters, CM can't add these tags automatically as CM doesn't have info regarding the host template used by the host. For each host that is previously applied using a specific host template, these changes add a CM tag with a value equal to the host template name during the cluster upgrade process. The API to tag hosts is only available from CM version 7.6.0 and up.