### PR TITLE
CB-16164 Stack patcher error handling improvements

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/AbstractTelemetryPatchService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/AbstractTelemetryPatchService.java
@@ -9,7 +9,6 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
-import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,20 +33,14 @@ public abstract class AbstractTelemetryPatchService extends ExistingStackPatchSe
     @Inject
     private ClusterComponentConfigProvider clusterComponentConfigProvider;
 
-    protected Set<Node> getAvailableNodes(String stackName, Set<InstanceMetaData> instanceMetaDataSet, List<GatewayConfig> gatewayConfigs,
+    protected Set<Node> getAvailableNodes(Set<InstanceMetaData> instanceMetaDataSet, List<GatewayConfig> gatewayConfigs,
             ClusterDeletionBasedExitCriteriaModel exitModel) throws CloudbreakOrchestratorFailedException, ExistingStackPatchApplyException {
         Set<Node> allNodes = getNodes(instanceMetaDataSet);
         Set<Node> unresponsiveNodes = telemetryOrchestrator.collectUnresponsiveNodes(gatewayConfigs, allNodes, exitModel);
         Set<String> unresponsiveHostnames = unresponsiveNodes.stream().map(Node::getHostname).collect(Collectors.toSet());
-        Set<Node> availableNodes = allNodes.stream()
+        return allNodes.stream()
                 .filter(n -> !unresponsiveHostnames.contains(n.getHostname()))
                 .collect(Collectors.toSet());
-        if (CollectionUtils.isEmpty(availableNodes)) {
-            String message = "Not found any available nodes for patch, stack: " + stackName;
-            LOGGER.info(message);
-            throw new ExistingStackPatchApplyException(message);
-        }
-        return availableNodes;
     }
 
     protected Set<Node> getNodes(Set<InstanceMetaData> instanceMetaDataSet) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/MeteringAzureMetadataPatchService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/MeteringAzureMetadataPatchService.java
@@ -10,6 +10,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -82,10 +83,10 @@ public class MeteringAzureMetadataPatchService extends AbstractTelemetryPatchSer
     }
 
     @Override
-    void doApply(Stack stack) throws ExistingStackPatchApplyException {
+    boolean doApply(Stack stack) throws ExistingStackPatchApplyException {
         if (isPrimaryGatewayReachable(stack)) {
             try {
-                upgradeMeteringOnNodes(stack);
+                return upgradeMeteringOnNodes(stack);
             } catch (ExistingStackPatchApplyException e) {
                 throw e;
             } catch (Exception e) {
@@ -94,11 +95,11 @@ public class MeteringAzureMetadataPatchService extends AbstractTelemetryPatchSer
         } else {
             String message = "Salt partial update and metering upgrade cannot run, because primary gateway is unreachable of stack: " + stack.getResourceCrn();
             LOGGER.info(message);
-            throw new ExistingStackPatchApplyException(message);
+            return false;
         }
     }
 
-    private void upgradeMeteringOnNodes(Stack stack) throws ExistingStackPatchApplyException, IOException, CloudbreakOrchestratorFailedException {
+    private boolean upgradeMeteringOnNodes(Stack stack) throws ExistingStackPatchApplyException, IOException, CloudbreakOrchestratorFailedException {
         byte[] currentSaltState = getCurrentSaltStateStack(stack);
         List<String> saltStateDefinitions = Arrays.asList("salt-common", "salt");
         List<String> meteringSaltStateDef = List.of("/salt/metering");
@@ -109,14 +110,21 @@ public class MeteringAzureMetadataPatchService extends AbstractTelemetryPatchSer
             List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
             ClusterDeletionBasedExitCriteriaModel exitModel = ClusterDeletionBasedExitCriteriaModel.nonCancellableModel();
             getTelemetryOrchestrator().updateMeteringSaltDefinition(meteringSaltStateConfig, gatewayConfigs, exitModel);
-            Set<Node> availableNodes = getAvailableNodes(stack.getName(), instanceMetaDataSet, gatewayConfigs, exitModel);
-            getTelemetryOrchestrator().upgradeMetering(gatewayConfigs, availableNodes, exitModel,
-                    meteringAzureMetadataPatchConfig.getDateBefore(), meteringAzureMetadataPatchConfig.getCustomRpmUrl());
-            byte[] newFullSaltState = compressUtil.updateCompressedOutputFolders(saltStateDefinitions, meteringSaltStateDef, currentSaltState);
-            clusterBootstrapper.updateSaltComponent(stack, newFullSaltState);
-            LOGGER.debug("Metering partial salt refresh successfully finished for stack {}", stack.getName());
+            Set<Node> availableNodes = getAvailableNodes(instanceMetaDataSet, gatewayConfigs, exitModel);
+            if (CollectionUtils.isEmpty(availableNodes)) {
+                LOGGER.info("Not found any available nodes for patch, stack: " + stack.getName());
+                return false;
+            } else {
+                getTelemetryOrchestrator().upgradeMetering(gatewayConfigs, availableNodes, exitModel,
+                        meteringAzureMetadataPatchConfig.getDateBefore(), meteringAzureMetadataPatchConfig.getCustomRpmUrl());
+                byte[] newFullSaltState = compressUtil.updateCompressedOutputFolders(saltStateDefinitions, meteringSaltStateDef, currentSaltState);
+                clusterBootstrapper.updateSaltComponent(stack, newFullSaltState);
+                LOGGER.debug("Metering partial salt refresh successfully finished for stack {}", stack.getName());
+                return true;
+            }
         } else {
             LOGGER.debug("Metering partial salt refresh is not required for stack {}", stack.getName());
+            return true;
         }
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/StackPatchUsageReporterService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/StackPatchUsageReporterService.java
@@ -44,6 +44,8 @@ public class StackPatchUsageReporterService {
         String message = Objects.requireNonNullElse(optionalMessage, "");
         try {
             Objects.requireNonNull(eventType);
+            LOGGER.info("Reporting stack patch event with resource crn {}, stack patch type {}, event type {} and message {}",
+                            resourceCrn, stackPatchType, eventType, message);
             UsageProto.CDPStackPatchEvent cdpStackPatchEvent = UsageProto.CDPStackPatchEvent.newBuilder()
                     .setResourceCrn(resourceCrn)
                     .setStackPatchType(stackPatchTypeName)

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/UnboundRestartPatchService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/UnboundRestartPatchService.java
@@ -78,10 +78,10 @@ public class UnboundRestartPatchService extends ExistingStackPatchService {
     }
 
     @Override
-    void doApply(Stack stack) throws ExistingStackPatchApplyException {
+    boolean doApply(Stack stack) throws ExistingStackPatchApplyException {
         if (isCmServerReachable(stack)) {
             FlowIdentifier flowIdentifier = ThreadBasedUserCrnProvider.doAs(
-                    internalCrnModifier.getInternalCrnWithAccountId(Crn.fromString(stack.getResourceCrn()).getAccountId()),
+                    internalCrnModifier.getInternalCrnWithAccountId(Crn.safeFromString(stack.getResourceCrn()).getAccountId()),
                     () -> clusterOperationService.updateSalt(stack));
             LOGGER.debug("Starting update salt for stack {} with flow {}", stack.getResourceCrn(), flowIdentifier.getPollableId());
             Boolean success = Polling.waitPeriodly(1, TimeUnit.MINUTES)
@@ -91,10 +91,10 @@ public class UnboundRestartPatchService extends ExistingStackPatchService {
                 LOGGER.warn(message);
                 throw new ExistingStackPatchApplyException(message);
             }
+            return true;
         } else {
-            String message = "Salt update cannot run, because CM server is unreachable of stack: " + stack.getResourceCrn();
-            LOGGER.info(message);
-            throw new ExistingStackPatchApplyException(message);
+            LOGGER.info("Salt update cannot run, because CM server is unreachable of stack: " + stack.getResourceCrn());
+            return false;
         }
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJobTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJobTest.java
@@ -133,6 +133,17 @@ class ExistingStackPatcherJobTest {
 
         underTest.executeTracedJob(context);
 
+        verify(existingStackPatchService).apply(stack);
+        verify(stackPatchUsageReporterService).reportAffected(stack, STACK_PATCH_TYPE);
+    }
+
+    @Test
+    void shouldUnscheduleWhenSuccessfullyApplied() throws JobExecutionException, ExistingStackPatchApplyException {
+        when(existingStackPatchService.isAffected(stack)).thenReturn(true);
+        when(existingStackPatchService.apply(stack)).thenReturn(true);
+
+        underTest.executeTracedJob(context);
+
         verifyUnschedule();
         verify(existingStackPatchService).apply(stack);
         verify(stackPatchUsageReporterService).reportAffected(stack, STACK_PATCH_TYPE);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stackpatch/LoggingAgentAutoRestartPatchServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stackpatch/LoggingAgentAutoRestartPatchServiceTest.java
@@ -195,9 +195,9 @@ public class LoggingAgentAutoRestartPatchServiceTest {
         given(compressUtil.generateCompressedOutputFromFolders(any(), any())).willReturn(fluentConfig);
         given(compressUtil.compareCompressedContent(any(), any(), any())).willReturn(false);
         // WHEN
-        ExistingStackPatchApplyException exception = assertThrows(ExistingStackPatchApplyException.class, () -> underTest.doApply(createStack()));
+        boolean result = underTest.doApply(createStack());
         // THEN
-        assertTrue(exception.getMessage().contains("Not found any available nodes"));
+        assertFalse(result);
 
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stackpatch/MeteringAzureMetadataPatchServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stackpatch/MeteringAzureMetadataPatchServiceTest.java
@@ -176,9 +176,9 @@ public class MeteringAzureMetadataPatchServiceTest {
         given(compressUtil.generateCompressedOutputFromFolders(any(), any())).willReturn(meteringConfig);
         given(compressUtil.compareCompressedContent(any(), any(), any())).willReturn(false);
         // WHEN
-        ExistingStackPatchApplyException exception = assertThrows(ExistingStackPatchApplyException.class, () -> underTest.doApply(createStack()));
+        boolean result = underTest.doApply(createStack());
         // THEN
-        assertTrue(exception.getMessage().contains("Not found any available nodes"));
+        assertFalse(result);
 
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stackpatch/UnboundRestartPatchServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stackpatch/UnboundRestartPatchServiceTest.java
@@ -111,9 +111,9 @@ class UnboundRestartPatchServiceTest {
     void unreachableCmServerFailsToApply() {
         setCmServerReachability(false);
 
-        assertThatThrownBy(() -> underTest.doApply(stack))
-                .isInstanceOf(ExistingStackPatchApplyException.class)
-                .hasMessageStartingWith("Salt update cannot run, because CM server is unreachable of stack");
+        boolean result = underTest.isAffected(stack);
+
+        assertThat(result).isFalse();
     }
 
     @Test


### PR DESCRIPTION
With monitoring in EDH and Datadog, stack patchers should only fail in unexpected cases. So when a stack is simply not in correct state for the patch to apply, no error should be reported.

See detailed description in the commit message.