### PR TITLE
CB-16208 datalake resize test need to be disabled 

### DIFF
--- a/integration-test/src/main/resources/testsuites/e2e/aws-longrunning-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/aws-longrunning-e2e-tests.yaml
@@ -10,4 +10,5 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.ephemeral.DistroXRepairTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.ephemeral.DistroXUpgradeTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRepairTests
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxResizeTests
+      #disable cause constant timeouts. need to be investigated before reenablement
+      #- name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxResizeTests


### PR DESCRIPTION
- until investigation is done on why it times out