### PR TITLE
CB-16066 Upgrade related flows should be able to start while bind use… 

### DIFF
--- a/flow/src/main/java/com/sequenceiq/flow/core/Flow2Handler.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/Flow2Handler.java
@@ -278,9 +278,7 @@ public class Flow2Handler implements Consumer<Event<? extends Payload>> {
     private AcceptResult handleFlowConflict(String key, Payload payload, String flowChainId, Set<FlowLogIdWithTypeAndTimestamp> flowLogItems) {
         AcceptResult acceptResult = null;
         Optional<FlowLog> initFlowLog = flowLogService.findAllByFlowIdOrderByCreatedDesc(flowLogItems.iterator().next().getFlowId())
-                .stream()
-                .sorted(Comparator.comparing(FlowLog::getCreated))
-                .findFirst();
+                .stream().min(Comparator.comparing(FlowLog::getCreated));
         if (initFlowLog.isPresent()) {
             LOGGER.info("Found previous init flow log: {}", initFlowLog.get());
             if (NullUtil.allNotNull(initFlowLog.get().getFlowChainId(), flowChainId)) {

--- a/flow/src/main/java/com/sequenceiq/flow/domain/FlowLogIdWithTypeAndTimestamp.java
+++ b/flow/src/main/java/com/sequenceiq/flow/domain/FlowLogIdWithTypeAndTimestamp.java
@@ -7,4 +7,5 @@ public interface FlowLogIdWithTypeAndTimestamp {
     ClassValue getFlowType();
 
     Long getCreated();
+
 }

--- a/flow/src/test/java/com/sequenceiq/flow/service/FlowNameFormatServiceTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/service/FlowNameFormatServiceTest.java
@@ -11,7 +11,6 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import com.sequenceiq.flow.domain.ClassValue;
 import com.sequenceiq.flow.domain.FlowLogIdWithTypeAndTimestamp;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -81,27 +80,4 @@ public class FlowNameFormatServiceTest {
 
     }
 
-    private static class TestFlowView implements FlowLogIdWithTypeAndTimestamp {
-
-        private Class flowType;
-
-        TestFlowView(Class flowType) {
-            this.flowType = flowType;
-        }
-
-        @Override
-        public String getFlowId() {
-            return "1";
-        }
-
-        @Override
-        public ClassValue getFlowType() {
-            return ClassValue.of(flowType);
-        }
-
-        @Override
-        public Long getCreated() {
-            return 1L;
-        }
-    }
 }

--- a/flow/src/test/java/com/sequenceiq/flow/service/TestFlowView.java
+++ b/flow/src/test/java/com/sequenceiq/flow/service/TestFlowView.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.flow.service;
+
+import com.sequenceiq.flow.domain.ClassValue;
+import com.sequenceiq.flow.domain.FlowLogIdWithTypeAndTimestamp;
+
+public class TestFlowView implements FlowLogIdWithTypeAndTimestamp {
+
+    private final Class<?> flowType;
+
+    public TestFlowView(Class<?> flowType) {
+        this.flowType = flowType;
+    }
+
+    @Override
+    public String getFlowId() {
+        return "1";
+    }
+
+    @Override
+    public ClassValue getFlowType() {
+        return ClassValue.of(flowType);
+    }
+
+    @Override
+    public Long getCreated() {
+        return 1L;
+    }
+
+    @Override
+    public String toString() {
+        return "TestFlowView{" +
+                "flowType=" + flowType +
+                '}';
+    }
+}

--- a/freeipa/build.gradle
+++ b/freeipa/build.gradle
@@ -150,6 +150,7 @@ dependencies {
   testImplementation project(path: ':authorization-common', configuration: 'tests')
   testImplementation project(path: ':common', configuration: 'tests')
   testImplementation project(path: ':secret-engine', configuration: 'tests')
+  testImplementation project(path: ':flow', configuration: 'tests')
 
   testImplementation group: 'com.hubspot.jinjava',         name: 'jinjava',                        version: jinjavaVersion
   testImplementation group: 'net.sf.json-lib',             name: 'json-lib',                       version: '2.4',              classifier: 'jdk15'

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/FreeIpaFlowInformation.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/FreeIpaFlowInformation.java
@@ -12,12 +12,17 @@ import com.sequenceiq.freeipa.flow.freeipa.cleanup.FreeIpaCleanupEvent;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.FreeIpaCleanupFlowConfig;
 import com.sequenceiq.freeipa.flow.freeipa.diagnostics.config.DiagnosticsCollectionFlowConfig;
 import com.sequenceiq.freeipa.flow.freeipa.downscale.DownscaleFlowConfig;
+import com.sequenceiq.freeipa.flow.freeipa.downscale.DownscaleFlowEvent;
 import com.sequenceiq.freeipa.flow.freeipa.provision.FreeIpaProvisionFlowConfig;
 import com.sequenceiq.freeipa.flow.freeipa.repair.changeprimarygw.ChangePrimaryGatewayFlowConfig;
+import com.sequenceiq.freeipa.flow.freeipa.repair.changeprimarygw.ChangePrimaryGatewayFlowEvent;
+import com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateEvent;
 import com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateFlowConfig;
 import com.sequenceiq.freeipa.flow.freeipa.upscale.UpscaleFlowConfig;
+import com.sequenceiq.freeipa.flow.freeipa.upscale.UpscaleFlowEvent;
 import com.sequenceiq.freeipa.flow.instance.reboot.RebootFlowConfig;
 import com.sequenceiq.freeipa.flow.stack.image.change.ImageChangeFlowConfig;
+import com.sequenceiq.freeipa.flow.stack.image.change.event.ImageChangeEvents;
 import com.sequenceiq.freeipa.flow.stack.provision.StackProvisionFlowConfig;
 import com.sequenceiq.freeipa.flow.stack.start.StackStartFlowConfig;
 import com.sequenceiq.freeipa.flow.stack.stop.StackStopFlowConfig;
@@ -48,7 +53,12 @@ public class FreeIpaFlowInformation implements ApplicationFlowInformation {
     private static final List<String> PARALLEL_FLOWS = List.of(
             FreeIpaCleanupEvent.CLEANUP_EVENT.event(),
             StackTerminationEvent.TERMINATION_EVENT.event(),
-            CreateBindUserFlowEvent.CREATE_BIND_USER_EVENT.event());
+            CreateBindUserFlowEvent.CREATE_BIND_USER_EVENT.event(),
+            SaltUpdateEvent.SALT_UPDATE_EVENT.event(),
+            ImageChangeEvents.IMAGE_CHANGE_EVENT.event(),
+            UpscaleFlowEvent.UPSCALE_EVENT.event(),
+            DownscaleFlowEvent.DOWNSCALE_EVENT.event(),
+            ChangePrimaryGatewayFlowEvent.CHANGE_PRIMARY_GATEWAY_EVENT.event());
 
     private static final List<Class<? extends FlowConfiguration<?>>> TERMINATION_FLOWS = List.of(StackTerminationFlowConfig.class);
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/cloud/PlatformParameterService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/cloud/PlatformParameterService.java
@@ -55,7 +55,7 @@ public class PlatformParameterService {
                 .build();
         CloudCredential cloudCredential = credentialConverter.convert(credential);
         PlatformParameterRequest parameterRequest = new PlatformParameterRequest(cloudContext, cloudCredential);
-        freeIpaFlowManager.notify(parameterRequest);
+        freeIpaFlowManager.notifyNonFlowEvent(parameterRequest);
         try {
             PlatformParameterResult res = parameterRequest.await();
             LOGGER.debug("Platform parameter result: {}", res);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaParallelFlowValidator.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaParallelFlowValidator.java
@@ -1,0 +1,75 @@
+package com.sequenceiq.freeipa.service.freeipa.flow;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.exception.FlowsAlreadyRunningException;
+import com.sequenceiq.cloudbreak.util.Benchmark;
+import com.sequenceiq.flow.core.FlowLogService;
+import com.sequenceiq.flow.domain.FlowLogIdWithTypeAndTimestamp;
+import com.sequenceiq.flow.service.FlowNameFormatService;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.CreateBindUserFlowConfig;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserFlowEvent;
+import com.sequenceiq.freeipa.flow.freeipa.cleanup.FreeIpaCleanupEvent;
+import com.sequenceiq.freeipa.flow.freeipa.cleanup.FreeIpaCleanupFlowConfig;
+import com.sequenceiq.freeipa.flow.stack.termination.StackTerminationEvent;
+
+@Component
+public class FreeIpaParallelFlowValidator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FreeIpaParallelFlowValidator.class);
+
+    private static final Set<Class<?>> IGNORED_ALREADY_RUNNING_PARALLEL_FLOWS = Set.of(
+            CreateBindUserFlowConfig.class,
+            FreeIpaCleanupFlowConfig.class);
+
+    private static final Set<String> ALLOWED_NEW_PARALLEL_FLOWS = Set.of(
+            FreeIpaCleanupEvent.CLEANUP_EVENT.event(),
+            StackTerminationEvent.TERMINATION_EVENT.event(),
+            CreateBindUserFlowEvent.CREATE_BIND_USER_EVENT.event());
+
+    @Inject
+    private FlowLogService flowLogService;
+
+    @Inject
+    private FlowNameFormatService flowNameFormatService;
+
+    public void checkFlowAllowedToStart(String selector, Long stackId) {
+        Benchmark.measure(() -> checkFlowAllowedToStartForBenchmark(selector, stackId),
+                LOGGER, "Checking flow for parallel run took {}ms");
+    }
+
+    private void checkFlowAllowedToStartForBenchmark(String selector, Long stackId) {
+        if (!isNewFlowAllowedToRunParallelToAnyFlows(selector)) {
+            checkRunningFlowsSupportParallelRun(stackId);
+        }
+    }
+
+    private boolean isNewFlowAllowedToRunParallelToAnyFlows(String selector) {
+        if (ALLOWED_NEW_PARALLEL_FLOWS.contains(selector)) {
+            LOGGER.info("{} is allowed to run parallel next to any flows", selector);
+            return true;
+        } else {
+            LOGGER.info("{} is not allowed to run parallel next to any flows", selector);
+            return false;
+        }
+    }
+
+    private void checkRunningFlowsSupportParallelRun(Long stackId) {
+        Set<FlowLogIdWithTypeAndTimestamp> runningNotAllowedFlows = flowLogService.findAllRunningNonTerminationFlowsByResourceId(stackId).stream()
+                .filter(flow -> !IGNORED_ALREADY_RUNNING_PARALLEL_FLOWS.contains(flow.getFlowType().getClassValue()))
+                .collect(Collectors.toSet());
+        LOGGER.info("Running flows which forbids triggering new flow: {}. Starting flow is {}", flowNameFormatService.formatFlows(runningNotAllowedFlows),
+                runningNotAllowedFlows.isEmpty() ? "PERMITTED" : "FORBIDDEN");
+        if (!runningNotAllowedFlows.isEmpty()) {
+            throw new FlowsAlreadyRunningException(String.format("Request not allowed, freeipa cluster already has a running operation. " +
+                            "Running operation(s): [%s]",
+                    flowNameFormatService.formatFlows(runningNotAllowedFlows)));
+        }
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/PasswordService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/PasswordService.java
@@ -206,7 +206,7 @@ public class PasswordService {
     private SetPasswordRequest triggerSetPassword(Stack stack, String environment, String username, String userCrn,
             String password, Optional<Instant> expirationInstant) {
         SetPasswordRequest request = new SetPasswordRequest(stack.getId(), environment, username, userCrn, password, expirationInstant);
-        freeIpaFlowManager.notify(request);
+        freeIpaFlowManager.notifyNonFlowEvent(request);
         return request;
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaCreationService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaCreationService.java
@@ -150,7 +150,7 @@ public class FreeIpaCreationService {
 
         fillInstanceMetadata(stack, environment);
 
-        String template = templateService.waitGetTemplate(stack, getPlatformTemplateRequest);
+        String template = templateService.waitGetTemplate(getPlatformTemplateRequest);
         stack.setTemplate(template);
         SecurityConfig securityConfig = tlsSecurityService.generateSecurityKeys(accountId);
         multiAzValidator.validateMultiAzForStack(stack.getPlatformvariant(), stack.getInstanceGroups());

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackTemplateService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackTemplateService.java
@@ -47,11 +47,11 @@ public class StackTemplateService {
                 .build();
         CloudCredential cloudCredential = credentialConverter.convert(credential);
         GetPlatformTemplateRequest getPlatformTemplateRequest = new GetPlatformTemplateRequest(cloudContext, cloudCredential);
-        freeIpaFlowManager.notify(getPlatformTemplateRequest);
+        freeIpaFlowManager.notifyNonFlowEvent(getPlatformTemplateRequest);
         return getPlatformTemplateRequest;
     }
 
-    public String waitGetTemplate(Stack stack, GetPlatformTemplateRequest getPlatformTemplateRequest) {
+    public String waitGetTemplate(GetPlatformTemplateRequest getPlatformTemplateRequest) {
         try {
             GetPlatformTemplateResult res = getPlatformTemplateRequest.await();
             LOGGER.debug("Get template result: {}", res);

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaParallelFlowValidatorTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaParallelFlowValidatorTest.java
@@ -1,0 +1,148 @@
+package com.sequenceiq.freeipa.service.freeipa.flow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.reflections.Reflections;
+import org.reflections.scanners.SubTypesScanner;
+
+import com.sequenceiq.cloudbreak.exception.FlowsAlreadyRunningException;
+import com.sequenceiq.flow.core.FlowLogService;
+import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
+import com.sequenceiq.flow.domain.FlowLogIdWithTypeAndTimestamp;
+import com.sequenceiq.flow.service.FlowNameFormatService;
+import com.sequenceiq.flow.service.TestFlowView;
+import com.sequenceiq.freeipa.FreeIpaFlowInformation;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.CreateBindUserFlowConfig;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserFlowEvent;
+import com.sequenceiq.freeipa.flow.freeipa.cleanup.FreeIpaCleanupEvent;
+import com.sequenceiq.freeipa.flow.freeipa.cleanup.FreeIpaCleanupFlowConfig;
+import com.sequenceiq.freeipa.flow.freeipa.downscale.DownscaleFlowEvent;
+import com.sequenceiq.freeipa.flow.freeipa.repair.changeprimarygw.ChangePrimaryGatewayFlowEvent;
+import com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateEvent;
+import com.sequenceiq.freeipa.flow.freeipa.upscale.UpscaleFlowConfig;
+import com.sequenceiq.freeipa.flow.freeipa.upscale.UpscaleFlowEvent;
+import com.sequenceiq.freeipa.flow.stack.image.change.event.ImageChangeEvents;
+import com.sequenceiq.freeipa.flow.stack.termination.StackTerminationEvent;
+
+@ExtendWith(MockitoExtension.class)
+class FreeIpaParallelFlowValidatorTest {
+
+    private static final Set<Class<?>> ALLOWED_PARALLEL_FLOW_CONFIG = Set.of(
+            CreateBindUserFlowConfig.class,
+            FreeIpaCleanupFlowConfig.class);
+
+    private static final Long STACK_ID = 1L;
+
+    private static final String COMMON_FLOW_EVENT = "testEvent";
+
+    @Mock
+    private FlowLogService flowLogService;
+
+    @Mock
+    private FlowNameFormatService flowNameFormatService;
+
+    @InjectMocks
+    private FreeIpaParallelFlowValidator underTest;
+
+    @ParameterizedTest
+    @MethodSource
+    public void testFlowAllowed(String selector, Set<FlowLogIdWithTypeAndTimestamp> runningFlows) {
+        lenient().when(flowLogService.findAllRunningNonTerminationFlowsByResourceId(STACK_ID)).thenReturn(runningFlows);
+
+        underTest.checkFlowAllowedToStart(selector, STACK_ID);
+    }
+
+    private static Stream<Arguments> testFlowAllowed() {
+        Stream<Arguments> dynamicFlowConfigTest = getAllFlowConfig().stream().flatMap(flowConfig ->
+                Stream.of(Arguments.of(FreeIpaCleanupEvent.CLEANUP_EVENT.event(), createFromFlowConfig(Set.of(flowConfig))),
+                        Arguments.of(StackTerminationEvent.TERMINATION_EVENT.event(), createFromFlowConfig(Set.of(flowConfig))),
+                        Arguments.of(CreateBindUserFlowEvent.CREATE_BIND_USER_EVENT.event(), createFromFlowConfig(Set.of(flowConfig))))
+        );
+        Stream<Arguments> staticFlowConfigTest = Stream.of(
+                Arguments.of(FreeIpaCleanupEvent.CLEANUP_EVENT.event(), createFromFlowConfig(Set.of(UpscaleFlowConfig.class))),
+                Arguments.of(StackTerminationEvent.TERMINATION_EVENT.event(), createFromFlowConfig(Set.of(UpscaleFlowConfig.class))),
+                Arguments.of(CreateBindUserFlowEvent.CREATE_BIND_USER_EVENT.event(), createFromFlowConfig(Set.of(UpscaleFlowConfig.class))),
+                Arguments.of(COMMON_FLOW_EVENT, createFromFlowConfig(Set.of(CreateBindUserFlowConfig.class))),
+                Arguments.of(COMMON_FLOW_EVENT, createFromFlowConfig(Set.of(FreeIpaCleanupFlowConfig.class))),
+                Arguments.of(COMMON_FLOW_EVENT, createFromFlowConfig(Set.of(CreateBindUserFlowConfig.class, FreeIpaCleanupFlowConfig.class))),
+                Arguments.of(COMMON_FLOW_EVENT, createFromFlowConfig(Set.of()))
+        );
+        return Stream.concat(staticFlowConfigTest, dynamicFlowConfigTest);
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void testFlowNotAllowed(String selector, Set<FlowLogIdWithTypeAndTimestamp> runningFlows) {
+        lenient().when(flowLogService.findAllRunningNonTerminationFlowsByResourceId(STACK_ID)).thenReturn(runningFlows);
+        when(flowNameFormatService.formatFlows(anySet())).thenReturn("ForbiddenFlow");
+
+        assertThrows(FlowsAlreadyRunningException.class, () -> underTest.checkFlowAllowedToStart(selector, STACK_ID));
+
+        verify(flowNameFormatService, never()).formatFlowName(any());
+    }
+
+    private static Stream<Arguments> testFlowNotAllowed() {
+        Stream<Arguments> dynamicFlowConfigTest = getAllFlowConfig().stream()
+                .filter(config -> !ALLOWED_PARALLEL_FLOW_CONFIG.contains(config))
+                .map(config -> Arguments.of(COMMON_FLOW_EVENT, createFromFlowConfig(Set.of(config))));
+        Stream<Arguments> staticFlowConfigTest = Stream.of(
+                Arguments.of(COMMON_FLOW_EVENT, createFromFlowConfig(Set.of(CreateBindUserFlowConfig.class, UpscaleFlowConfig.class))),
+                Arguments.of(COMMON_FLOW_EVENT, createFromFlowConfig(Set.of(FreeIpaCleanupFlowConfig.class, UpscaleFlowConfig.class))),
+                Arguments.of(COMMON_FLOW_EVENT, createFromFlowConfig(Set.of(CreateBindUserFlowConfig.class, FreeIpaCleanupFlowConfig.class,
+                        UpscaleFlowConfig.class)))
+        );
+        return Stream.concat(staticFlowConfigTest, dynamicFlowConfigTest);
+    }
+
+    private static Set<Class<? extends AbstractFlowConfiguration>> getAllFlowConfig() {
+        Reflections reflections = new Reflections("com.sequenceiq.freeipa.flow", new SubTypesScanner());
+        return reflections.getSubTypesOf(AbstractFlowConfiguration.class);
+    }
+
+    private static Set<FlowLogIdWithTypeAndTimestamp> createFromFlowConfig(Collection<Class<?>> clazz) {
+        return clazz.stream().map(FreeIpaParallelFlowValidatorTest::createFromFlowConfig).collect(Collectors.toSet());
+    }
+
+    private static FlowLogIdWithTypeAndTimestamp createFromFlowConfig(Class<?> clazz) {
+        return new TestFlowView(clazz);
+    }
+
+    @Test
+    public void testNewParallelFlows() {
+        List<String> allowedParallelFlows = new FreeIpaFlowInformation().getAllowedParallelFlows();
+        assertEquals(8, allowedParallelFlows.size(),
+                "You have changed parallel flows for FreeIPA. Please make sure 'FreeIpaParallelFlowValidator' is adjusted if necessary");
+        assertTrue(Set.of(
+                        FreeIpaCleanupEvent.CLEANUP_EVENT.event(),
+                        StackTerminationEvent.TERMINATION_EVENT.event(),
+                        CreateBindUserFlowEvent.CREATE_BIND_USER_EVENT.event(),
+                        SaltUpdateEvent.SALT_UPDATE_EVENT.event(),
+                        ImageChangeEvents.IMAGE_CHANGE_EVENT.event(),
+                        UpscaleFlowEvent.UPSCALE_EVENT.event(),
+                        DownscaleFlowEvent.DOWNSCALE_EVENT.event(),
+                        ChangePrimaryGatewayFlowEvent.CHANGE_PRIMARY_GATEWAY_EVENT.event()).containsAll(allowedParallelFlows),
+                "You have changed parallel flows for FreeIPA. Please make sure 'FreeIpaParallelFlowValidator' is adjusted if necessary");
+    }
+}


### PR DESCRIPTION
…r creation or cleanup is running

As BindUserCreate and Cleanup flow could be started any time during an FreeIPA upgrade all upgrade related flow in the flowchain should be able to run in parallel.
Flow engine doesn't support fine grain restrictions regarding when a flow can start next to another one, it's either permitted or forbidden.
In this commit all flows used in `UpgradeFlowEventChainFactory` is added to the `PARALLEL_FLOWS` in `FreeIpaFlowInformation`
To ensure they cannot be started next to other flows, `FreeIpaParallelFlowValidator` was introduced and it's now hooked into `FreeIpaFlowManager` right
before triggering any flows.
This validator ensures that only BindUserCreate, Cleanup and Termination flows could be started next to other running flows, while the flowchain can trigger
the upgrade related flows any time, as those triggers does go through only the Flow engine's validation.