### PR TITLE
CB-14421 distrox scale test should remove deleted instance before dow…

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXScaleTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXScaleTest.java
@@ -58,9 +58,13 @@ public class DistroXScaleTest extends AbstractE2ETest {
                                 "At least 1 instance needed from group %s to test delete it and test targeted upscale.", params.getIrrelevantHostGroup()));
                     }
                     cloudFunctionality.deleteInstances(testDto.getName(), List.of(anInstanceToDelete.get()));
+                    testDto.setRemovableInstanceId(anInstanceToDelete.get());
                     return testDto;
                 })
                 .awaitForFlow()
+                // removing deleted instance since downscale still validates if stack is available
+                .when(distroXTestClient.removeInstance())
+                .await(STACK_AVAILABLE)
                 .when(distroXTestClient.scale(params.getHostGroup(), params.getScaleDownTarget()))
                 .awaitForFlow();
         IntStream.range(1, params.getTimes()).forEach(i -> testContext.given(DistroXTestDto.class)


### PR DESCRIPTION
…nscale since downscale still validates if stack is available

See detailed description in the commit message.