### PR TITLE
CB-16265 E2E tests for enabling skipBackup flag in sdx upgrade requests

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxUpgradeTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxUpgradeTestDto.java
@@ -30,7 +30,9 @@ public class SdxUpgradeTestDto extends AbstractSdxTestDto<SdxUpgradeRequest, Sdx
     @Override
     public SdxUpgradeTestDto valid() {
         return withRuntime(commonClusterManagerProperties.getUpgrade().getTargetRuntimeVersion())
-                .withReplaceVms(SdxUpgradeReplaceVms.ENABLED);
+                .withReplaceVms(SdxUpgradeReplaceVms.ENABLED)
+                .setSkipBackup(Boolean.TRUE);
+
     }
 
     public SdxUpgradeTestDto withRuntime(String runtime) {
@@ -40,6 +42,11 @@ public class SdxUpgradeTestDto extends AbstractSdxTestDto<SdxUpgradeRequest, Sdx
 
     public SdxUpgradeTestDto withReplaceVms(SdxUpgradeReplaceVms replaceVms) {
         getRequest().setReplaceVms(replaceVms);
+        return this;
+    }
+
+    public SdxUpgradeTestDto setSkipBackup(Boolean skipBackup) {
+        getRequest().setSkipBackup(skipBackup);
         return this;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/DistroXOSUpgradeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/DistroXOSUpgradeTests.java
@@ -86,6 +86,7 @@ public class DistroXOSUpgradeTests extends AbstractE2ETest {
                 .given(SdxUpgradeTestDto.class)
                     .withReplaceVms(SdxUpgradeReplaceVms.ENABLED)
                     .withRuntime(targetRuntimeVersion)
+                    .setSkipBackup(Boolean.TRUE)
                 .given(sdxName, SdxTestDto.class)
                 .when(sdxTestClient.upgrade(), key(sdxName))
                 .await(SdxClusterStatusResponse.DATALAKE_UPGRADE_IN_PROGRESS, key(sdxName).withWaitForFlow(Boolean.FALSE))


### PR DESCRIPTION
https://jira.cloudera.com/browse/CB-16265

skipBackup must be true in our E2E tests since we don't have the infrastructure to do backups.