### PR TITLE
DISTX-731 Propagate telemetry metrics for custom configurations

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/converter/CustomConfigurationsToCustomConfigurationsDetailsConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/converter/CustomConfigurationsToCustomConfigurationsDetailsConverter.java
@@ -1,0 +1,41 @@
+package com.sequenceiq.cloudbreak.structuredevent.converter;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.domain.CustomConfigurationProperty;
+import com.sequenceiq.cloudbreak.domain.CustomConfigurations;
+import com.sequenceiq.cloudbreak.structuredevent.event.CustomConfigurationsDetails;
+
+@Component
+public class CustomConfigurationsToCustomConfigurationsDetailsConverter {
+
+    public CustomConfigurationsDetails convert(CustomConfigurations customConfigurations) {
+        CustomConfigurationsDetails customConfigurationsDetails = new CustomConfigurationsDetails();
+        customConfigurationsDetails.setId(customConfigurations.getId());
+        customConfigurationsDetails.setCustomConfigurationsName(customConfigurations.getName());
+        if (customConfigurations.getConfigurations() != null) {
+            customConfigurationsDetails.setServices(getServicesList(customConfigurations.getConfigurations()));
+            customConfigurationsDetails.setRoles(getRolesList(customConfigurations.getConfigurations()));
+        }
+        customConfigurationsDetails.setRuntimeVersion(customConfigurations.getRuntimeVersion());
+        return customConfigurationsDetails;
+    }
+
+    private List<String> getServicesList(Collection<CustomConfigurationProperty> properties) {
+        return properties.stream()
+                .map(CustomConfigurationProperty::getServiceType)
+                .collect(Collectors.toList());
+    }
+
+    private List<String> getRolesList(Collection<CustomConfigurationProperty> properties) {
+            return properties.stream()
+                    .map(CustomConfigurationProperty::getRoleType)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/converter/StackToStackDetailsConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/converter/StackToStackDetailsConverter.java
@@ -41,6 +41,9 @@ public class StackToStackDetailsConverter {
     private ImageToImageDetailsConverter imageToImageDetailsConverter;
 
     @Inject
+    private CustomConfigurationsToCustomConfigurationsDetailsConverter customConfigurationsToCustomConfigurationsDetailsConverter;
+
+    @Inject
     private RedbeamsDbServerConfigurer dbServerConfigurer;
 
     @Inject
@@ -61,6 +64,10 @@ public class StackToStackDetailsConverter {
         stackDetails.setStatus(source.getStatus().name());
         if (source.getStackStatus() != null && source.getStackStatus().getDetailedStackStatus() != null) {
             stackDetails.setDetailedStatus(source.getStackStatus().getDetailedStackStatus().name());
+        }
+        if (source.getCluster() != null && source.getCluster().getCustomConfigurations() != null) {
+            stackDetails.setCustomConfigurations(
+                    customConfigurationsToCustomConfigurationsDetailsConverter.convert(source.getCluster().getCustomConfigurations()));
         }
         stackDetails.setStatusReason(source.getStatusReason());
         stackDetails.setInstanceGroups(

--- a/core/src/test/java/com/sequenceiq/cloudbreak/structuredevent/converter/CustomConfigurationsToCustomConfigurationsDetailsConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/structuredevent/converter/CustomConfigurationsToCustomConfigurationsDetailsConverterTest.java
@@ -1,0 +1,53 @@
+package com.sequenceiq.cloudbreak.structuredevent.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.sequenceiq.cloudbreak.domain.CustomConfigurationProperty;
+import com.sequenceiq.cloudbreak.domain.CustomConfigurations;
+import com.sequenceiq.cloudbreak.structuredevent.event.CustomConfigurationsDetails;
+
+@ExtendWith(MockitoExtension.class)
+class CustomConfigurationsToCustomConfigurationsDetailsConverterTest {
+
+    @InjectMocks
+    private CustomConfigurationsToCustomConfigurationsDetailsConverter underTest;
+
+    @Test
+    void testConvertEmptyNoNPE() {
+        CustomConfigurations customConfigurations = new CustomConfigurations();
+
+        CustomConfigurationsDetails customConfigurationsDetails = underTest.convert(customConfigurations);
+
+        assertThat(customConfigurationsDetails).isNotNull();
+    }
+
+    @Test
+    void testConvert() {
+        CustomConfigurations customConfigurations = new CustomConfigurations();
+        customConfigurations.setId(1L);
+        customConfigurations.setName("test-name");
+        customConfigurations.setConfigurations(Sets.newHashSet(
+                new CustomConfigurationProperty("property1", "value1", null, "service1"),
+                new CustomConfigurationProperty("property2", "value2", "role2", "service2"),
+                new CustomConfigurationProperty("property3", "value3", null, "service3"),
+                new CustomConfigurationProperty("property4", "value4", "role4", "service4")));
+        customConfigurations.setRuntimeVersion("test-runtime-version");
+
+        CustomConfigurationsDetails customConfigurationsDetails = underTest.convert(customConfigurations);
+
+        assertThat(customConfigurationsDetails).isNotNull();
+        assertThat(customConfigurationsDetails.getCustomConfigurationsName()).isEqualTo("test-name");
+        assertThat(customConfigurationsDetails.getId()).isEqualTo(1L);
+        assertThat(customConfigurationsDetails.getRuntimeVersion()).isEqualTo("test-runtime-version");
+        assertThat(customConfigurationsDetails.getRoles()).hasSameElementsAs(Lists.newArrayList("role2", "role4"));
+        assertThat(customConfigurationsDetails.getServices()).hasSameElementsAs(Lists.newArrayList("service1", "service2", "service3", "service4"));
+    }
+
+}

--- a/structuredevent-model/src/main/java/com/sequenceiq/cloudbreak/structuredevent/event/CustomConfigurationsDetails.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/cloudbreak/structuredevent/event/CustomConfigurationsDetails.java
@@ -1,0 +1,61 @@
+package com.sequenceiq.cloudbreak.structuredevent.event;
+
+import java.io.Serializable;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CustomConfigurationsDetails implements Serializable {
+    private Long id;
+
+    private String customConfigurationsName;
+
+    private List<String> services;
+
+    private List<String> roles;
+
+    private String runtimeVersion;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getCustomConfigurationsName() {
+        return customConfigurationsName;
+    }
+
+    public void setCustomConfigurationsName(String customConfigurationsName) {
+        this.customConfigurationsName = customConfigurationsName;
+    }
+
+    public List<String> getServices() {
+        return services;
+    }
+
+    public void setServices(List<String> services) {
+        this.services = services;
+    }
+
+    public List<String> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(List<String> roles) {
+        this.roles = roles;
+    }
+
+    public String getRuntimeVersion() {
+        return runtimeVersion;
+    }
+
+    public void setRuntimeVersion(String runtimeVersion) {
+        this.runtimeVersion = runtimeVersion;
+    }
+}

--- a/structuredevent-model/src/main/java/com/sequenceiq/cloudbreak/structuredevent/event/StackDetails.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/cloudbreak/structuredevent/event/StackDetails.java
@@ -105,6 +105,8 @@ public class StackDetails implements Serializable {
 
     private boolean multiAz;
 
+    private CustomConfigurationsDetails customConfigurations;
+
     public Long getId() {
         return id;
     }
@@ -327,5 +329,13 @@ public class StackDetails implements Serializable {
 
     public void setMultiAz(boolean multiAz) {
         this.multiAz = multiAz;
+    }
+
+    public CustomConfigurationsDetails getCustomConfigurations() {
+        return customConfigurations;
+    }
+
+    public void setCustomConfigurations(CustomConfigurationsDetails customConfigurations) {
+        this.customConfigurations = customConfigurations;
     }
 }

--- a/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StructuredEventToCDPClusterShapeConverter.java
+++ b/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StructuredEventToCDPClusterShapeConverter.java
@@ -82,6 +82,10 @@ public class StructuredEventToCDPClusterShapeConverter {
             Collections.sort(hostGroupNodeCount);
             cdpClusterShape.setHostGroupNodeCount(String.join(", ", hostGroupNodeCount));
             cdpClusterShape.setTemporaryStorageUsed(hostGroupTemporaryStorage.contains(TemporaryStorage.EPHEMERAL_VOLUMES.name()));
+            String customConfigurationsDetails = JsonUtil.writeValueAsStringSilentSafe(stackDetails.getCustomConfigurations());
+            if (StringUtils.length(customConfigurationsDetails) <= MAX_STRING_LENGTH) {
+                cdpClusterShape.setClusterTemplateOverridesDetails(customConfigurationsDetails);
+            }
             String definitionDetailsJsonString = JsonUtil.writeValueAsStringSilentSafe(stackDetails.getInstanceGroups());
             if (StringUtils.length(definitionDetailsJsonString) <= MAX_STRING_LENGTH) {
                 cdpClusterShape.setDefinitionDetails(definitionDetailsJsonString);

--- a/usage-collection/src/main/proto/usage.proto
+++ b/usage-collection/src/main/proto/usage.proto
@@ -1467,6 +1467,8 @@ message CDPClusterShape {
   bool temporaryStorageUsed = 5;
   // Cluster template details in JSON format
   string clusterTemplateDetails = 6;
+  // Cluster template overrides in JSON format
+  string clusterTemplateOverridesDetails = 7;
 }
 
 // The Shape of the Data lake.


### PR DESCRIPTION
#### Changes
 - Added new column to `CDPClusterShape` to determine the services and roles of custom configurations that were used for the DH cluster
 - New field `customConfigurations` in `StackDetails`

#### Testing
 - UT for the relevant converters.


See detailed description in the commit message.