### PR TITLE
CB-15932 refactor stop/start related GCP poller to be based on operations

### DIFF
--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceStateChecker.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceStateChecker.java
@@ -1,0 +1,143 @@
+package com.sequenceiq.cloudbreak.cloud.gcp.compute;
+
+import static com.sequenceiq.cloudbreak.cloud.gcp.service.checker.AbstractGcpComputeBaseResourceChecker.OPERATION_ID;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.http.HttpStatus;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.services.compute.model.Instance;
+import com.google.api.services.compute.model.Operation;
+import com.sequenceiq.cloudbreak.cloud.gcp.GcpResourceException;
+import com.sequenceiq.cloudbreak.cloud.gcp.context.GcpContext;
+import com.sequenceiq.cloudbreak.cloud.gcp.util.GcpStackUtil;
+import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
+import com.sequenceiq.cloudbreak.cloud.model.CloudVmInstanceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
+
+@Service
+public class GcpInstanceStateChecker {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GcpInstanceStateChecker.class);
+
+    private static final String ERROR_CODE = "code";
+
+    private final GcpStackUtil gcpStackUtil;
+
+    public GcpInstanceStateChecker(GcpStackUtil gcpStackUtil) {
+        this.gcpStackUtil = gcpStackUtil;
+    }
+
+    public List<CloudVmInstanceStatus> checkBasedOnOperation(GcpContext context, List<CloudInstance> instances) {
+        LOGGER.info("Checking instances('{}') states based on operation id if the operation couldn't be found then fall back to get the instance details.",
+                instances.stream().map(CloudInstance::getInstanceId).collect(Collectors.joining(",")));
+        List<CloudVmInstanceStatus> result = new ArrayList<>();
+        for (CloudInstance instance : instances) {
+            String operationName = instance.getStringParameter(OPERATION_ID);
+            String availabilityZone = instance.getAvailabilityZone();
+            String instanceId = instance.getInstanceId();
+            try {
+                LOGGER.debug("Get operations of instance('{}'), with operation id:'{}' in availability zone:'{}'", instanceId, operationName, availabilityZone);
+                Operation operation = gcpStackUtil.zoneOperation(context.getCompute(), context.getProjectId(), operationName, availabilityZone).execute();
+                InstanceStatus status = getInstanceStatusFromOperation(operation);
+                LOGGER.info("The status of the instance('{}') based on the related operation('{}') is: {}", instanceId, operationName, status.name());
+                result.add(new CloudVmInstanceStatus(instance, status));
+            } catch (GoogleJsonResponseException gJsonRespExc) {
+                if (resourceNotFoundException(gJsonRespExc)) {
+                    LOGGER.info("Operation '{}' could not be found for instance '{}'", operationName, instanceId);
+                    CloudVmInstanceStatus vmInstanceStatus = getInstanceStatusFromGcpInstance(context, instance);
+                    result.add(vmInstanceStatus);
+                } else {
+                    String message = String.format("Failed to check the '%s' operation on the instance '%s'.", operationName, instanceId);
+                    LOGGER.warn(message, gJsonRespExc);
+                    throw new GcpResourceException(message, gJsonRespExc);
+                }
+            } catch (Exception ex) {
+                String message = String.format("Failed to check the '%s' operation on the instance '%s'.", operationName, instanceId);
+                LOGGER.warn(message, ex);
+                throw new GcpResourceException(message, ex);
+            }
+        }
+        return result;
+    }
+
+    private InstanceStatus getInstanceStatusFromOperation(Operation operation) throws Exception {
+        InstanceStatus status;
+        if (gcpStackUtil.isOperationFinished(operation)) {
+            String operationType = operation.getOperationType();
+            switch (operationType) {
+                case "start":
+                    status = InstanceStatus.STARTED;
+                    break;
+                case "stop":
+                    status = InstanceStatus.STOPPED;
+                    break;
+                case "delete":
+                    status = InstanceStatus.TERMINATED;
+                    break;
+                default:
+                    throw new UnsupportedOperationException(String.format("Operation type '%s' is not supported by GCP related SPI code!", operationType));
+            }
+        } else {
+            status = InstanceStatus.IN_PROGRESS;
+        }
+        return status;
+    }
+
+    private CloudVmInstanceStatus getInstanceStatusFromGcpInstance(GcpContext context, CloudInstance instance) {
+        String instanceId = instance.getInstanceId();
+        String projectId = context.getProjectId();
+        String availabilityZone = instance.getAvailabilityZone();
+        InstanceStatus status;
+        try {
+            LOGGER.debug("Query instance('{}') details from GCP in availability zone: '{}'", instanceId, availabilityZone);
+            Instance gcpInstance = gcpStackUtil.getComputeInstanceWithId(context.getCompute(), projectId, availabilityZone, instanceId);
+            status = getInstanceStatusFromGcpInstance(gcpInstance);
+        } catch (GoogleJsonResponseException jsonExc) {
+            if (resourceNotFoundException(jsonExc)) {
+                LOGGER.info("Instance wit id '{}' could not be found", instanceId);
+                status = InstanceStatus.TERMINATED_BY_PROVIDER;
+            } else {
+                String message = String.format("Failed to fetch the details of the instance '%s' from GCP", instanceId);
+                LOGGER.warn(message, jsonExc);
+                throw new GcpResourceException(message, jsonExc);
+            }
+        } catch (IOException e) {
+            String message = String.format("Failed to fetch the details of the instance '%s' from GCP.", instanceId);
+            LOGGER.warn(message, e);
+            throw new GcpResourceException(message, e);
+        }
+        LOGGER.info("The status of the instance('{}') based on the instance details from GCP is: {}", instanceId, status.name());
+        return new CloudVmInstanceStatus(instance, status);
+    }
+
+    private boolean resourceNotFoundException(GoogleJsonResponseException ex) {
+        return ex.getDetails() != null
+                && ex.getDetails().containsKey(ERROR_CODE)
+                && (ex.getDetails().get(ERROR_CODE).equals(HttpStatus.SC_NOT_FOUND) || ex.getDetails().get(ERROR_CODE).equals(HttpStatus.SC_FORBIDDEN));
+    }
+
+    @NotNull
+    private InstanceStatus getInstanceStatusFromGcpInstance(Instance gcpInstance) {
+        InstanceStatus status;
+        switch (gcpInstance.getStatus()) {
+            case "RUNNING":
+                status = InstanceStatus.STARTED;
+                break;
+            case "TERMINATED":
+                status = InstanceStatus.STOPPED;
+                break;
+            default:
+                status = InstanceStatus.IN_PROGRESS;
+        }
+        return status;
+    }
+}

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/service/checker/GcpComputeResourceChecker.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/service/checker/GcpComputeResourceChecker.java
@@ -79,7 +79,7 @@ public class GcpComputeResourceChecker {
                 if (e1.getDetails().get("code").equals(HttpStatus.SC_NOT_FOUND) || e1.getDetails().get("code").equals(HttpStatus.SC_FORBIDDEN)) {
                     String availabilityZone = Strings.isNullOrEmpty(cloudResource.getAvailabilityZone())
                             ? location.getAvailabilityZone().value() : cloudResource.getAvailabilityZone();
-                    Operation execute = gcpStackUtil.zoneOperations(context.getCompute(), context.getProjectId(), operationId,
+                    Operation execute = gcpStackUtil.zoneOperation(context.getCompute(), context.getProjectId(), operationId,
                             availabilityZone).execute();
                     checkComputeOperationError(execute);
                     return execute;

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceStateCheckerTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceStateCheckerTest.java
@@ -1,0 +1,286 @@
+package com.sequenceiq.cloudbreak.cloud.gcp.compute;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.google.api.client.googleapis.json.GoogleJsonError;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpResponseException;
+import com.google.api.client.http.HttpStatusCodes;
+import com.google.api.services.compute.Compute;
+import com.google.api.services.compute.model.Instance;
+import com.google.api.services.compute.model.Operation;
+import com.sequenceiq.cloudbreak.cloud.gcp.GcpResourceException;
+import com.sequenceiq.cloudbreak.cloud.gcp.context.GcpContext;
+import com.sequenceiq.cloudbreak.cloud.gcp.service.checker.AbstractGcpComputeBaseResourceChecker;
+import com.sequenceiq.cloudbreak.cloud.gcp.util.GcpStackUtil;
+import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
+import com.sequenceiq.cloudbreak.cloud.model.CloudVmInstanceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
+
+@ExtendWith(MockitoExtension.class)
+class GcpInstanceStateCheckerTest {
+
+    private static final String PROJECT_ID = "aProjectId";
+
+    private static final String AVAILABILITY_ZONE = "anAzId";
+
+    private static final String OPERATION_ID = "anOperationIdentifier";
+
+    @Mock
+    private GcpStackUtil gcpStackUtil;
+
+    @Mock
+    private GcpContext gcpContext;
+
+    @Mock
+    private Compute gcpCompute;
+
+    @InjectMocks
+    private GcpInstanceStateChecker underTest;
+
+    @Test
+    void checkBasedOnOperationWhenNoInstancesSpecified() {
+        List<CloudVmInstanceStatus> actual = underTest.checkBasedOnOperation(gcpContext, List.of());
+
+        verifyNoInteractions(gcpStackUtil);
+        Assertions.assertTrue(actual.isEmpty());
+    }
+
+    @Test
+    void checkBasedOnOperationWhenGetOperationFailsWithIOException() throws IOException {
+        stubGcpContext();
+        CloudInstance cloudInstance = getCloudInstanceWithOperation(AVAILABILITY_ZONE, OPERATION_ID);
+        when(gcpStackUtil.zoneOperation(gcpCompute, PROJECT_ID, OPERATION_ID, AVAILABILITY_ZONE)).thenThrow(new IOException("Something went wrong!"));
+
+        Assertions.assertThrows(GcpResourceException.class, () -> underTest.checkBasedOnOperation(gcpContext, List.of(cloudInstance)));
+
+        verify(gcpStackUtil).zoneOperation(gcpCompute, PROJECT_ID, OPERATION_ID, AVAILABILITY_ZONE);
+    }
+
+    @Test
+    void checkBasedOnOperationWhenGetOperationFailsWithGoogleJsonExceptionWithoutErrorCode() throws IOException {
+        stubGcpContext();
+        CloudInstance cloudInstance = getCloudInstanceWithOperation(AVAILABILITY_ZONE, OPERATION_ID);
+        HttpResponseException.Builder builder = new HttpResponseException.Builder(HttpStatusCodes.STATUS_CODE_BAD_GATEWAY,
+                "Bad gateway: internal server error", new HttpHeaders());
+        GoogleJsonResponseException googleJsonResponseException = new GoogleJsonResponseException(builder, null);
+        when(gcpStackUtil.zoneOperation(gcpCompute, PROJECT_ID, OPERATION_ID, AVAILABILITY_ZONE)).thenThrow(googleJsonResponseException);
+
+        Assertions.assertThrows(GcpResourceException.class, () -> underTest.checkBasedOnOperation(gcpContext, List.of(cloudInstance)));
+
+        verify(gcpStackUtil).zoneOperation(gcpCompute, PROJECT_ID, OPERATION_ID, AVAILABILITY_ZONE);
+    }
+
+    @Test
+    void checkBasedOnOperationWhenGetOperationFailsWithGoogleJsonExceptionWithServiceUnavailableAsRelatedErrorCode() throws IOException {
+        stubGcpContext();
+        CloudInstance cloudInstance = getCloudInstanceWithOperation(AVAILABILITY_ZONE, OPERATION_ID);
+        HttpResponseException.Builder builder = new HttpResponseException.Builder(HttpStatusCodes.STATUS_CODE_BAD_GATEWAY,
+                "Bad gateway: internal server error", new HttpHeaders());
+        GoogleJsonError googleErrorDetail = new GoogleJsonError();
+        googleErrorDetail.setCode(HttpStatusCodes.STATUS_CODE_SERVICE_UNAVAILABLE);
+        GoogleJsonResponseException googleJsonResponseException = new GoogleJsonResponseException(builder, googleErrorDetail);
+        when(gcpStackUtil.zoneOperation(gcpCompute, PROJECT_ID, OPERATION_ID, AVAILABILITY_ZONE)).thenThrow(googleJsonResponseException);
+
+        Assertions.assertThrows(GcpResourceException.class, () -> underTest.checkBasedOnOperation(gcpContext, List.of(cloudInstance)));
+
+        verify(gcpStackUtil).zoneOperation(gcpCompute, PROJECT_ID, OPERATION_ID, AVAILABILITY_ZONE);
+    }
+
+    @Test
+    void checkBasedOnOperationWhenGetOperationSucceedsAndFinishedButTheOperationTypeIsNotSupported() throws Exception {
+        stubGcpContext();
+        CloudInstance cloudInstance = getCloudInstanceWithOperation(AVAILABILITY_ZONE, OPERATION_ID);
+        Compute.ZoneOperations.Get get = mock(Compute.ZoneOperations.Get.class);
+        Operation operation = getOperation(OPERATION_ID, "DONE", "UNKNOWN");
+        when(get.execute()).thenReturn(operation);
+        when(gcpStackUtil.zoneOperation(gcpCompute, PROJECT_ID, OPERATION_ID, AVAILABILITY_ZONE)).thenReturn(get);
+        when(gcpStackUtil.isOperationFinished(operation)).thenReturn(Boolean.TRUE);
+
+        Assertions.assertThrows(GcpResourceException.class, () -> underTest.checkBasedOnOperation(gcpContext, List.of(cloudInstance)));
+
+        verify(gcpStackUtil).zoneOperation(gcpCompute, PROJECT_ID, OPERATION_ID, AVAILABILITY_ZONE);
+    }
+
+    @ParameterizedTest(name = "checkBasedOnOperationWhenGetOperationReturns with operation status: {0}, type: {1} then the expected instance status is: {3}")
+    @MethodSource("checkBasedOnOperationWhenGetOperationReturnsData")
+    void checkBasedOnOperationWhenGetOperationReturns(String operationStatus, String operationType, boolean operationFinished,
+            InstanceStatus expectedInstanceStatus) throws Exception {
+        stubGcpContext();
+        CloudInstance cloudInstance = getCloudInstanceWithOperation(AVAILABILITY_ZONE, OPERATION_ID);
+        Compute.ZoneOperations.Get get = mock(Compute.ZoneOperations.Get.class);
+        Operation operation = getOperation(OPERATION_ID, operationStatus, operationType);
+        when(get.execute()).thenReturn(operation);
+        when(gcpStackUtil.zoneOperation(gcpCompute, PROJECT_ID, OPERATION_ID, AVAILABILITY_ZONE)).thenReturn(get);
+        when(gcpStackUtil.isOperationFinished(operation)).thenReturn(operationFinished);
+
+        List<CloudVmInstanceStatus> vmStatuses = underTest.checkBasedOnOperation(gcpContext, List.of(cloudInstance));
+
+        verify(gcpStackUtil).zoneOperation(gcpCompute, PROJECT_ID, OPERATION_ID, AVAILABILITY_ZONE);
+        assertFalse(vmStatuses.isEmpty());
+        assertTrue(vmStatuses.stream().allMatch(vmStatus -> expectedInstanceStatus.equals(vmStatus.getStatus())));
+    }
+
+    static Object[][] checkBasedOnOperationWhenGetOperationReturnsData() {
+        return new Object[][]{
+                // operationStatus, operationType, operationFinished, expectedInstanceStatus
+                {"RUNNING", "start", Boolean.FALSE, InstanceStatus.IN_PROGRESS},
+                {"RUNNING", "stop", Boolean.FALSE, InstanceStatus.IN_PROGRESS},
+                {"RUNNING", "delete", Boolean.FALSE, InstanceStatus.IN_PROGRESS},
+                {"DONE", "start", Boolean.TRUE, InstanceStatus.STARTED},
+                {"DONE", "stop", Boolean.TRUE, InstanceStatus.STOPPED},
+                {"DONE", "delete", Boolean.TRUE, InstanceStatus.TERMINATED},
+        };
+    }
+
+    @ParameterizedTest(name = "checkBasedOnOperation when operation get fails with {0} status code and GCP instance status: {1} "
+            + "and expected instance status: {2} ")
+    @MethodSource("checkBasedOnOperationWhenGetOperationFailsWithNotFoundGoogleJsonExceptionData")
+    void checkBasedOnOperationWhenGetOperationFailsWithNotFoundGoogleJsonExceptionAndInstanceCouldBeGet(int operationErrorStatusCode, String gcpInstanceStatus,
+            InstanceStatus expectedInstanceStatus) throws IOException {
+        stubGcpContext();
+        String instanceId = "instanceId";
+        CloudInstance cloudInstance = getCloudInstanceWithOperation(AVAILABILITY_ZONE, OPERATION_ID, instanceId);
+        HttpResponseException.Builder builder = new HttpResponseException.Builder(HttpStatusCodes.STATUS_CODE_BAD_GATEWAY,
+                "Bad gateway: internal server error", new HttpHeaders());
+        GoogleJsonError googleErrorDetail = new GoogleJsonError();
+        googleErrorDetail.setCode(operationErrorStatusCode);
+        GoogleJsonResponseException googleJsonResponseException = new GoogleJsonResponseException(builder, googleErrorDetail);
+        when(gcpStackUtil.zoneOperation(gcpCompute, PROJECT_ID, OPERATION_ID, AVAILABILITY_ZONE)).thenThrow(googleJsonResponseException);
+        Instance instance = new Instance();
+        instance.setStatus(gcpInstanceStatus);
+        when(gcpStackUtil.getComputeInstanceWithId(gcpCompute, PROJECT_ID, AVAILABILITY_ZONE, instanceId)).thenReturn(instance);
+
+        List<CloudVmInstanceStatus> vmStatuses = underTest.checkBasedOnOperation(gcpContext, List.of(cloudInstance));
+
+        verify(gcpStackUtil).zoneOperation(gcpCompute, PROJECT_ID, OPERATION_ID, AVAILABILITY_ZONE);
+        verify(gcpStackUtil).getComputeInstanceWithId(gcpCompute, PROJECT_ID, AVAILABILITY_ZONE, instanceId);
+        assertFalse(vmStatuses.isEmpty());
+        assertTrue(vmStatuses.stream().allMatch(vmStatus -> expectedInstanceStatus.equals(vmStatus.getStatus())));
+    }
+
+    static Object[][] checkBasedOnOperationWhenGetOperationFailsWithNotFoundGoogleJsonExceptionData() {
+        return new Object[][]{
+                // operationErrorStatusCode, gcpInstanceStatus, expectedInstanceStatus
+                {HttpStatusCodes.STATUS_CODE_NOT_FOUND, "IN_PROGRESS", InstanceStatus.IN_PROGRESS},
+                {HttpStatusCodes.STATUS_CODE_NOT_FOUND, "RUNNING", InstanceStatus.STARTED},
+                {HttpStatusCodes.STATUS_CODE_NOT_FOUND, "TERMINATED", InstanceStatus.STOPPED},
+                {HttpStatusCodes.STATUS_CODE_FORBIDDEN, "IN_PROGRESS", InstanceStatus.IN_PROGRESS},
+                {HttpStatusCodes.STATUS_CODE_FORBIDDEN, "RUNNING", InstanceStatus.STARTED},
+                {HttpStatusCodes.STATUS_CODE_FORBIDDEN, "TERMINATED", InstanceStatus.STOPPED},
+        };
+    }
+
+    @Test
+    void checkBasedOnOperationWhenGetOperationFailsWithGoogleJsonExceptionWithForbiddenAsRelatedErrorCodeAndInstanceGetFailsWithIOException()
+            throws IOException {
+        stubGcpContext();
+        String instanceId = "instanceId";
+        CloudInstance cloudInstance = getCloudInstanceWithOperation(AVAILABILITY_ZONE, OPERATION_ID, instanceId);
+        HttpResponseException.Builder builder = new HttpResponseException.Builder(HttpStatusCodes.STATUS_CODE_BAD_GATEWAY,
+                "Bad gateway: internal server error", new HttpHeaders());
+        GoogleJsonError googleErrorDetail = new GoogleJsonError();
+        googleErrorDetail.setCode(HttpStatusCodes.STATUS_CODE_FORBIDDEN);
+        GoogleJsonResponseException googleJsonResponseException = new GoogleJsonResponseException(builder, googleErrorDetail);
+        when(gcpStackUtil.zoneOperation(gcpCompute, PROJECT_ID, OPERATION_ID, AVAILABILITY_ZONE)).thenThrow(googleJsonResponseException);
+        when(gcpStackUtil.getComputeInstanceWithId(gcpCompute, PROJECT_ID, AVAILABILITY_ZONE, instanceId)).thenThrow(new IOException("something went wrong"));
+
+        Assertions.assertThrows(GcpResourceException.class, () -> underTest.checkBasedOnOperation(gcpContext, List.of(cloudInstance)));
+
+        verify(gcpStackUtil).zoneOperation(gcpCompute, PROJECT_ID, OPERATION_ID, AVAILABILITY_ZONE);
+        verify(gcpStackUtil).getComputeInstanceWithId(gcpCompute, PROJECT_ID, AVAILABILITY_ZONE, instanceId);
+    }
+
+    @Test
+    void checkBasedOnOperationWhenGetOperationFailsWithGoogleJsonExceptionWithForbiddenAsRelatedErrorCodeAndInstanceGetFailsWithInternalServerErrorGoogleExc()
+            throws IOException {
+        stubGcpContext();
+        String instanceId = "instanceId";
+        CloudInstance cloudInstance = getCloudInstanceWithOperation(AVAILABILITY_ZONE, OPERATION_ID, instanceId);
+        HttpResponseException.Builder builder = new HttpResponseException.Builder(HttpStatusCodes.STATUS_CODE_FORBIDDEN,
+                "Bad gateway: internal server error", new HttpHeaders());
+        GoogleJsonError googleErrorDetail = new GoogleJsonError();
+        googleErrorDetail.setCode(HttpStatusCodes.STATUS_CODE_FORBIDDEN);
+        when(gcpStackUtil.zoneOperation(gcpCompute, PROJECT_ID, OPERATION_ID, AVAILABILITY_ZONE))
+                .thenThrow(new GoogleJsonResponseException(builder, googleErrorDetail));
+
+        GoogleJsonError googleErrorDetail2 = new GoogleJsonError();
+        googleErrorDetail2.setCode(HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
+        when(gcpStackUtil.getComputeInstanceWithId(gcpCompute, PROJECT_ID, AVAILABILITY_ZONE, instanceId))
+                .thenThrow(new GoogleJsonResponseException(builder, googleErrorDetail2));
+
+        Assertions.assertThrows(GcpResourceException.class, () -> underTest.checkBasedOnOperation(gcpContext, List.of(cloudInstance)));
+
+        verify(gcpStackUtil).zoneOperation(gcpCompute, PROJECT_ID, OPERATION_ID, AVAILABILITY_ZONE);
+        verify(gcpStackUtil).getComputeInstanceWithId(gcpCompute, PROJECT_ID, AVAILABILITY_ZONE, instanceId);
+    }
+
+    @Test
+    void checkBasedOnOperationWhenGetOperationFailsWithGoogleJsonExceptionWithForbiddenAsRelatedErrorCodeAndInstanceGetFailsWithNotFoundErrorGoogleExc()
+            throws IOException {
+        stubGcpContext();
+        String instanceId = "instanceId";
+        CloudInstance cloudInstance = getCloudInstanceWithOperation(AVAILABILITY_ZONE, OPERATION_ID, instanceId);
+        HttpResponseException.Builder builder = new HttpResponseException.Builder(HttpStatusCodes.STATUS_CODE_FORBIDDEN,
+                "Bad gateway: internal server error", new HttpHeaders());
+        GoogleJsonError googleErrorDetail = new GoogleJsonError();
+        googleErrorDetail.setCode(HttpStatusCodes.STATUS_CODE_FORBIDDEN);
+        when(gcpStackUtil.zoneOperation(gcpCompute, PROJECT_ID, OPERATION_ID, AVAILABILITY_ZONE))
+                .thenThrow(new GoogleJsonResponseException(builder, googleErrorDetail));
+
+        GoogleJsonError googleErrorDetail2 = new GoogleJsonError();
+        googleErrorDetail2.setCode(HttpStatusCodes.STATUS_CODE_FORBIDDEN);
+        when(gcpStackUtil.getComputeInstanceWithId(gcpCompute, PROJECT_ID, AVAILABILITY_ZONE, instanceId))
+                .thenThrow(new GoogleJsonResponseException(builder, googleErrorDetail2));
+
+        List<CloudVmInstanceStatus> vmStatuses = underTest.checkBasedOnOperation(gcpContext, List.of(cloudInstance));
+
+        verify(gcpStackUtil).zoneOperation(gcpCompute, PROJECT_ID, OPERATION_ID, AVAILABILITY_ZONE);
+        verify(gcpStackUtil).getComputeInstanceWithId(gcpCompute, PROJECT_ID, AVAILABILITY_ZONE, instanceId);
+        assertFalse(vmStatuses.isEmpty());
+        assertTrue(vmStatuses.stream().allMatch(vmStatus -> InstanceStatus.TERMINATED_BY_PROVIDER.equals(vmStatus.getStatus())));
+    }
+
+    private CloudInstance getCloudInstanceWithOperation(String availabilityZone, String operationId) {
+        return getCloudInstanceWithOperation(availabilityZone, operationId, "instanceId");
+    }
+
+    private CloudInstance getCloudInstanceWithOperation(String availabilityZone, String operationId, String instanceId) {
+        CloudInstance cloudInstance = new CloudInstance(instanceId, null, null, "subnetId", availabilityZone);
+        cloudInstance.putParameter(AbstractGcpComputeBaseResourceChecker.OPERATION_ID, operationId);
+        return cloudInstance;
+    }
+
+    private void stubGcpContext() {
+        when(gcpContext.getProjectId()).thenReturn(PROJECT_ID);
+        when(gcpContext.getCompute()).thenReturn(gcpCompute);
+    }
+
+    @NotNull
+    private Operation getOperation(String anOperationIdentifier, String status, String operationType) {
+        Operation operation = new Operation();
+        operation.setName(anOperationIdentifier);
+        operation.setStatus(status);
+        operation.setOperationType(operationType);
+        return operation;
+    }
+}

--- a/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/scheduler/SyncPollingScheduler.java
+++ b/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/scheduler/SyncPollingScheduler.java
@@ -15,11 +15,11 @@ import com.sequenceiq.cloudbreak.cloud.task.PollTask;
 @Component
 public class SyncPollingScheduler<T> {
 
-    public static final int POLLING_INTERVAL = 1000;
+    public static final int POLLING_INTERVAL = 5000;
 
-    public static final int MAX_POLLING_ATTEMPT = 5000;
+    public static final int MAX_POLLING_ATTEMPT = 1000;
 
-    public static final int FAILURE_TOLERANT_ATTEMPT = 3;
+    public static final int FAILURE_TOLERANT_ATTEMPT = 5;
 
     public T schedule(PollTask<T> task) throws Exception {
         return schedule(task, POLLING_INTERVAL, MAX_POLLING_ATTEMPT, FAILURE_TOLERANT_ATTEMPT);


### PR DESCRIPTION

The original logic only checked the state of the instances and try to convert it to InstanceStatus, but in some cases this result in a situation where the stop poller exited immediately as the instance state were still permanent when the poller has started.