### PR TITLE
CB-15932 eliminate workaround from environment stop-start tests.

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/EnvironmentStopStartTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/EnvironmentStopStartTests.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.it.cloudbreak.testcase.e2e.environment;
 
-import java.time.Duration;
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -112,8 +111,6 @@ public class EnvironmentStopStartTests extends AbstractE2ETest {
                 .given(EnvironmentTestDto.class)
                 .when(environmentTestClient.stop())
                 .await(EnvironmentStatus.ENV_STOPPED)
-                //TODO workaround until CB-15932 has not been implemented
-                .waitingFor(Duration.ofMinutes(2), "Waiting for FreeIpa nodes to really be stopped on Gcp too has been interrupted")
                 .given(EnvironmentTestDto.class)
                 .when(environmentTestClient.start())
                 .await(EnvironmentStatus.AVAILABLE)


### PR DESCRIPTION
Additional waiter logic has been introduced between stop and start to let the VMs stop on GCP while the real fix hasn't  been implemented.

This PR is depends on [PR-12376](https://github.com/hortonworks/cloudbreak/pull/12376)