### PR TITLE
CB-16295 Disallow combinations of the stop / start scaling mechanism …

### DIFF
--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/common/MessageCode.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/common/MessageCode.java
@@ -40,6 +40,8 @@ public class MessageCode {
 
     public static final String VALIDATION_LOAD_HOST_GROUP_DUPLICATE_CONFIG = "autoscale.validation.load.duplicate.config";
 
+    public static final String VALIDATION_TIME_STOP_START_UNSUPPORTED = "autoscale.validation.time.stopstart.not.allowed";
+
     public static final String CLUSTER_SCALING_FAILED = "autoscale.cluster.scaling.failed";
 
     public static final String CLUSTER_UPDATE_IN_PROGRESS = "autoscale.cluster.update.in.progress";

--- a/autoscale-api/src/main/resources/messages/messages.properties
+++ b/autoscale-api/src/main/resources/messages/messages.properties
@@ -20,6 +20,7 @@ autoscale.activity.success=''{0}'' Autoscaling triggered for Host Group ''{1}'' 
 autoscale.activity.not.required=''{0}'' Autoscaling not required for config ''{1}''; Host Group  ''{2}'' node count is ''{3}''.
 
 autoscale.validation.single.type=Cluster can be configured with only one type of autoscaling.
+autoscale.validation.time.stopstart.not.allowed=Schedule-Based Autoscaling does not support the stop / start scaling mechanism.
 autoscale.validation.load.single.hostgroup=Load-Based Autoscaling is supported for only one HostGroup in a Cluster.
 autoscale.validation.load.unsupported.adjustment=Load-Based Autoscaling does not support AdjustmentType of type ''{0}''.
 autoscale.validation.load.duplicate.config=Hostgroup(s) ''{0}'' is configured with multiple Load-Based Autoscaling Configurations.

--- a/autoscale/src/main/java/com/sequenceiq/periscope/cache/AccountEntitlementCacheStopStart.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/cache/AccountEntitlementCacheStopStart.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.periscope.cache;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cache.common.AbstractCacheDefinition;
+
+@Component
+public class AccountEntitlementCacheStopStart extends AbstractCacheDefinition {
+
+    public static final String CACHE_NAME = "accountEntitlementCacheStopStart";
+
+    private static final long MAX_ENTRIES = 500L;
+
+    private static final int TTL_IN_MINUTES = 5;
+
+    @Override
+    protected String getName() {
+        return CACHE_NAME;
+    }
+
+    @Override
+    protected long getMaxEntries() {
+        return MAX_ENTRIES;
+    }
+
+    @Override
+    protected long getTimeToLiveSeconds() {
+        return TimeUnit.MINUTES.toSeconds(TTL_IN_MINUTES);
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/controller/DistroXAutoScaleClusterV1Controller.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/controller/DistroXAutoScaleClusterV1Controller.java
@@ -142,6 +142,7 @@ public class DistroXAutoScaleClusterV1Controller implements DistroXAutoScaleClus
         if (Boolean.TRUE.equals(autoscaleState.getUseStopStartMechanism())) {
             alertValidator.validateStopStartEntitlementAndDisableIfNotEntitled(cluster);
         }
+        alertValidator.validateScheduleWithStopStart(cluster, autoscaleState);
         try {
             transactionService.required(() -> asClusterCommonService.setAutoscaleState(cluster.getId(), autoscaleState));
         } catch (TransactionService.TransactionExecutionException e) {
@@ -160,7 +161,7 @@ public class DistroXAutoScaleClusterV1Controller implements DistroXAutoScaleClus
         if (Boolean.TRUE.equals(autoscaleClusterRequest.getUseStopStartMechanism())) {
             alertValidator.validateStopStartEntitlementAndDisableIfNotEntitled(cluster);
         }
-
+        alertValidator.validateScheduleWithStopStart(cluster, autoscaleClusterRequest);
         try {
             transactionService.required(() -> {
                 clusterService.deleteAlertsForCluster(cluster.getId());

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/EntitlementValidationService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/EntitlementValidationService.java
@@ -33,7 +33,7 @@ public class EntitlementValidationService {
         return entitled;
     }
 
-    @Cacheable(cacheNames = "accountEntitlementCache", key = "{#accountId,#cloudPlatform}")
+    @Cacheable(cacheNames = "accountEntitlementCacheStopStart", key = "{#accountId,#cloudPlatform}")
     public boolean stopStartAutoscalingEntitlementEnabled(String accountId, String cloudPlatform) {
         boolean entitled = autoscalingEntitlementEnabled(accountId, cloudPlatform);
         if (!entitled) {


### PR DESCRIPTION
…and schedule based autoscaling.

### Changes
 - Added methods to AlertValidator to disable stop/start scaling if schedule based policies are active.
 - Added a separate cache for checking the stop/start scaling entitlement.

### Testing
 - Endpoint tests for various scenarios related to enabling stop / start scaling and creating schedule based policies.
 - Unit tests for AlertValidator, to ensure exceptions are thrown at the appropriate points.

See detailed description in the commit message.