### PR TITLE
CB-16333 adding an internalonly api for getting distrox status. Usage…

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/StatusCrnsV4Request.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/StatusCrnsV4Request.java
@@ -1,0 +1,24 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.sequenceiq.cloudbreak.doc.ModelDescriptions;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+public class StatusCrnsV4Request {
+
+    @ApiModelProperty(ModelDescriptions.CRNS)
+    private List<String> crns = new ArrayList<>();
+
+    public List<String> getCrns() {
+        return crns;
+    }
+
+    public void setCrns(List<String> crns) {
+        this.crns = crns;
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/StackStatusV4Responses.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/StackStatusV4Responses.java
@@ -1,0 +1,17 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response;
+
+import java.util.List;
+import java.util.Set;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.responses.GeneralCollectionV4Response;
+
+public class StackStatusV4Responses extends GeneralCollectionV4Response<StackStatusV4Response> {
+
+    public StackStatusV4Responses(Set<StackStatusV4Response> responses) {
+        super(responses);
+    }
+
+    public StackStatusV4Responses() {
+        super(List.of());
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
@@ -17,6 +17,7 @@ public class ModelDescriptions {
     public static final String WORKSPACE_OF_THE_RESOURCE = "workspace of the resource";
     public static final String CREATOR = "the creator of the resource";
     public static final String CRN = "the unique crn of the resource";
+    public static final String CRNS = "the unique crns of the resource";
     public static final String USER_ID = "User ID in the new authorization model";
     public static final String WORKSPACE_ID = "Workspace ID of the resource";
     public static final String PREINSTALLED = "Denotes that the image is prewarmed or base image.";

--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/doc/DistroXOpDescription.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/doc/DistroXOpDescription.java
@@ -13,6 +13,7 @@ public class DistroXOpDescription {
     public static final String GET_BY_NAME = "get stack by name";
     public static final String GET_BY_CRN = "get stack by crn";
     public static final String GET_BY_CRN_INTERNAL = "get stack by crn (for internal user)";
+    public static final String GET_BY_CRNS_INTERNAL = "get stack by crns (for internal user)";
     public static final String CREATE = "create stack";
     public static final String DELETE_BY_NAME = "delete stack by name";
     public static final String DELETE_BY_CRN = "delete stack by crn";

--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/endpoint/DistroXInternalV1Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/endpoint/DistroXInternalV1Endpoint.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.distrox.api.v1.distrox.endpoint;
 
+import static com.sequenceiq.distrox.api.v1.distrox.doc.DistroXOpDescription.GET_BY_CRNS_INTERNAL;
 import static com.sequenceiq.distrox.api.v1.distrox.doc.DistroXOpDescription.GET_BY_CRN_INTERNAL;
 import static com.sequenceiq.distrox.api.v1.distrox.doc.DistroXOpDescription.RENEW_CERTIFICATE_INTERNAL;
 
@@ -11,6 +12,8 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StatusCrnsV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackStatusV4Responses;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Response;
 import com.sequenceiq.cloudbreak.doc.Notes;
 import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
@@ -32,6 +35,12 @@ public interface DistroXInternalV1Endpoint {
     @ApiOperation(value = GET_BY_CRN_INTERNAL, produces = MediaType.APPLICATION_JSON, notes = Notes.STACK_NOTES,
             nickname = "getDistroXInternalV1ByCrn")
     StackViewV4Response getByCrn(@PathParam("crn") String crn);
+
+    @POST
+    @Path("crn/status")
+    @ApiOperation(value = GET_BY_CRNS_INTERNAL, produces = MediaType.APPLICATION_JSON, notes = Notes.STACK_NOTES,
+            nickname = "getDistroXStatusInternalV1ByCrns")
+    StackStatusV4Responses getStatusByCrns(StatusCrnsV4Request request);
 
     @POST
     @Path("crn/{crn}/renew_certificate")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackClusterStatusViewToStatusConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackClusterStatusViewToStatusConverter.java
@@ -1,8 +1,12 @@
 package com.sequenceiq.cloudbreak.converter.v4.stacks;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackStatusV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackStatusV4Responses;
 import com.sequenceiq.cloudbreak.domain.projection.StackClusterStatusView;
 
 @Component
@@ -18,5 +22,13 @@ public class StackClusterStatusViewToStatusConverter {
         response.setClusterStatusReason(source.getClusterStatusReason());
         response.setCertExpirationState(source.getCertExpirationState());
         return response;
+    }
+
+    public StackStatusV4Responses convert(Iterable<StackClusterStatusView> sources) {
+        Set<StackStatusV4Response> jsons = new HashSet<>();
+        for (StackClusterStatusView source : sources) {
+            jsons.add(convert(source));
+        }
+        return new StackStatusV4Responses(jsons);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
@@ -168,6 +168,19 @@ public interface StackRepository extends WorkspaceResourceRepository<Stack, Long
             + "FROM Stack s "
             + "LEFT JOIN s.cluster c "
             + "LEFT JOIN s.stackStatus ss "
+            + "WHERE s.resourceCrn in :crns AND (s.type IS null OR s.type = :stackType)")
+    List<StackClusterStatusView> getStatusByCrnsInternal(@Param("crns") List<String> crns, @Param("stackType") StackType stackType);
+
+    @Query("SELECT s.id as id, "
+            + "s.resourceCrn as crn, "
+            + "ss.status as status, "
+            + "ss.statusReason as statusReason, "
+            + "c.status as clusterStatus, "
+            + "c.statusReason as clusterStatusReason, "
+            + "c.certExpirationState as certExpirationState "
+            + "FROM Stack s "
+            + "LEFT JOIN s.cluster c "
+            + "LEFT JOIN s.stackStatus ss "
             + "WHERE s.name = :name AND s.workspace.id= :workspaceId")
     Optional<StackClusterStatusView> getStatusByNameAndWorkspace(@Param("name") String name, @Param("workspaceId") Long workspaceId);
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
@@ -336,6 +336,10 @@ public class StackService implements ResourceIdProvider, ResourcePropertyProvide
         return foundStack.orElseThrow(() -> new NotFoundException(String.format(STACK_NOT_FOUND_BY_NAME_OR_CRN_EXCEPTION_MESSAGE, nameOrCrn)));
     }
 
+    public List<StackClusterStatusView> getStatusesByCrnsInternal(List<String> crns, StackType stackType) {
+        return stackRepository.getStatusByCrnsInternal(crns, stackType);
+    }
+
     public Set<AutoscaleStackV4Response> getAllForAutoscale() {
         try {
             return transactionService.required(() -> {

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
@@ -38,6 +38,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.recipe.UpdateRec
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.CertificatesRotationV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.GeneratedBlueprintV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackStatusV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackStatusV4Responses;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Responses;
@@ -211,6 +212,13 @@ public class StackOperations implements ResourcePropertyProvider {
         LOGGER.info("Adding environment name to the response.");
         environmentServiceDecorator.prepareEnvironment(stackViewV4Response);
         return stackViewV4Response;
+    }
+
+    public StackStatusV4Responses getStatusForInternalCrns(List<String> crns, StackType stackType) {
+        LOGGER.info("Get stackstatuses against internal user.");
+        List<StackClusterStatusView> statuses = stackService.getStatusesByCrnsInternal(crns, stackType);
+        LOGGER.info("Query Stack (status) successfully finished with crns {}", crns);
+        return stackClusterStatusViewToStatusConverter.convert(statuses);
     }
 
     public FlowIdentifier deleteInstance(@NotNull NameOrCrn nameOrCrn, Long workspaceId, boolean forced, String instanceId) {

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXInternalV1Controller.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXInternalV1Controller.java
@@ -4,11 +4,15 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Controller;
 
+import com.sequenceiq.authorization.annotation.AccountIdNotNeeded;
 import com.sequenceiq.authorization.annotation.CheckPermissionByAccount;
 import com.sequenceiq.authorization.annotation.InternalOnly;
+import com.sequenceiq.authorization.annotation.RequestObject;
 import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StatusCrnsV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackStatusV4Responses;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Response;
 import com.sequenceiq.cloudbreak.auth.security.internal.TenantAwareParam;
 import com.sequenceiq.cloudbreak.service.stack.flow.StackOperationService;
@@ -29,6 +33,13 @@ public class DistroXInternalV1Controller implements DistroXInternalV1Endpoint {
     @CheckPermissionByAccount(action = AuthorizationResourceAction.DATAHUB_READ)
     public StackViewV4Response getByCrn(@TenantAwareParam String crn) {
         return stackOperations.getForInternalCrn(NameOrCrn.ofCrn(crn), StackType.WORKLOAD);
+    }
+
+    @Override
+    @AccountIdNotNeeded
+    @InternalOnly
+    public StackStatusV4Responses getStatusByCrns(@RequestObject StatusCrnsV4Request request) {
+        return stackOperations.getStatusForInternalCrns(request.getCrns(), StackType.WORKLOAD);
     }
 
     @Override


### PR DESCRIPTION
… curl -v -k -X POST -H 'Content-Type: application/json' -H "x-cdp-actor-crn: crn:altus:iam:us-west-1:altus:user:__internal__actor__" http://localhost:9091/cb/api/v1/internal/distrox/crn/status -d '{"crns":["crn1", "crn2"]}'

See detailed description in the commit message.