### PR TITLE
CB-16352 Restore the SdxBackupRestoreTest after fixing wrong http for Solr service port

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxBackupAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxBackupAction.java
@@ -33,7 +33,7 @@ public class SdxBackupAction implements Action<SdxTestDto, SdxClient> {
     public SdxTestDto action(TestContext testContext, SdxTestDto testDto, SdxClient client) throws Exception {
         String sdxName = testDto.getName();
 
-        testContext.waitingFor(Duration.ofMinutes(5), "Waiting for CM services to be synchronized has been interrupted");
+        testContext.waitingFor(Duration.ofMinutes(2), "Waiting for CM services to be synchronized has been interrupted");
 
         Log.when(LOGGER, format(" SDX '%s' backup has been started to '%s' by name '%s'... ", sdxName, backupLocation, backupName));
         Log.whenJson(LOGGER, " SDX backup request: ", testDto.getRequest());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxBackupInternalAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxBackupInternalAction.java
@@ -33,7 +33,7 @@ public class SdxBackupInternalAction implements Action<SdxInternalTestDto, SdxCl
     public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
         String sdxName = testDto.getName();
 
-        testContext.waitingFor(Duration.ofMinutes(5), "Waiting for CM services to be synchronized has been interrupted");
+        testContext.waitingFor(Duration.ofMinutes(2), "Waiting for CM services to be synchronized has been interrupted");
 
         Log.when(LOGGER, format(" Internal SDX '%s' backup has been started to '%s' by name '%s'... ", sdxName, backupLocation, backupName));
         Log.whenJson(LOGGER, " Internal SDX backup request: ", testDto.getRequest());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRestoreInternalAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRestoreInternalAction.java
@@ -33,7 +33,7 @@ public class SdxRestoreInternalAction implements Action<SdxInternalTestDto, SdxC
     public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
         String sdxName = testDto.getName();
 
-        testContext.waitingFor(Duration.ofMinutes(5), "Waiting for CM services to be synchronized has been interrupted");
+        testContext.waitingFor(Duration.ofMinutes(2), "Waiting for CM services to be synchronized has been interrupted");
 
         Log.when(LOGGER, format(" Internal SDX '%s' restore has been started to '%s' ", sdxName, backupLocation));
         Log.whenJson(LOGGER, " Internal SDX restore request: ", testDto.getRequest());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxSyncAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxSyncAction.java
@@ -23,7 +23,7 @@ public class SdxSyncAction implements Action<SdxTestDto, SdxClient> {
     public SdxTestDto action(TestContext testContext, SdxTestDto testDto, SdxClient client) throws Exception {
         String sdxName = testDto.getName();
 
-        testContext.waitingFor(Duration.ofMinutes(4), "Waiting for CM services to be synchronized has been interrupted");
+        testContext.waitingFor(Duration.ofMinutes(1), "Waiting for CM services to be synchronized has been interrupted");
 
         Log.when(LOGGER, format(" SDX '%s' sync has been started... ", sdxName));
         Log.whenJson(LOGGER, " SDX sync request: ", testDto.getRequest());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxSyncInternalAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxSyncInternalAction.java
@@ -23,7 +23,7 @@ public class SdxSyncInternalAction implements Action<SdxInternalTestDto, SdxClie
     public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
         String sdxName = testDto.getName();
 
-        testContext.waitingFor(Duration.ofMinutes(4), "Waiting for CM services to be synchronized has been interrupted");
+        testContext.waitingFor(Duration.ofMinutes(1), "Waiting for CM services to be synchronized has been interrupted");
 
         Log.when(LOGGER, format(" Internal SDX '%s' sync has been started... ", sdxName));
         Log.whenJson(LOGGER, " Internal SDX sync request: ", testDto.getRequest());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/SdxBackupRestoreTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/SdxBackupRestoreTest.java
@@ -45,7 +45,7 @@ public class SdxBackupRestoreTest extends PreconditionSdxE2ETest {
         createEnvironmentWithFreeIpaAndDatalake(testContext);
     }
 
-    @Test(dataProvider = TEST_CONTEXT, description = "IGNORED: CB-14825 SDX backup flow has been finalised with failed status")
+    @Test(dataProvider = TEST_CONTEXT)
     @UseSpotInstances
     @Description(
             given = "there is a running Manowar SDX cluster in available state",

--- a/integration-test/src/main/resources/testsuites/e2e/l0promotion/sdx-backup-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/l0promotion/sdx-backup-tests.yaml
@@ -3,6 +3,3 @@ tests:
   - name: "sdx_backup_restore_e2e_tests"
     classes:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.l0promotion.SdxBackupRestoreTest
-        excludedMethods:
-          # CB-14825 SDX backup flow has been finalised with failed status
-          - testSDXBackupRestoreCanBeSuccessful


### PR DESCRIPTION
After [CB-16095: Wrong http for Solr service port in Knox topology. #12268](https://github.com/hortonworks/cloudbreak/pull/12268) has been merged, we can restore the related test case as well with name `SdxBackupRestoreTest`. Beyond this we can rewind the modified wait times in the related test actions as well.