### PR TITLE
CB-16271 Bring your own DNS zone - environment API + DB changes

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/network/NetworkResourcesCreationRequest.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/network/NetworkResourcesCreationRequest.java
@@ -3,6 +3,8 @@ package com.sequenceiq.cloudbreak.cloud.model.network;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.Region;
@@ -25,6 +27,8 @@ public class NetworkResourcesCreationRequest {
 
     private final boolean privateEndpointsEnabled;
 
+    private final String existingPrivateDnsZoneId;
+
     private final Map<String, String> tags;
 
     private NetworkResourcesCreationRequest(Builder builder) {
@@ -36,6 +40,7 @@ public class NetworkResourcesCreationRequest {
         region = builder.region;
         resourceGroup = builder.resourceGroup;
         privateEndpointsEnabled = builder.privateEndpointsEnabled;
+        existingPrivateDnsZoneId = builder.existingPrivateDnsZoneId;
         tags = builder.tags;
     }
 
@@ -71,6 +76,14 @@ public class NetworkResourcesCreationRequest {
         return privateEndpointsEnabled;
     }
 
+    public String getExistingPrivateDnsZoneId() {
+        return existingPrivateDnsZoneId;
+    }
+
+    public boolean isExistingPrivateDnsZone() {
+        return StringUtils.isNotEmpty(existingPrivateDnsZoneId);
+    }
+
     public Map<String, String> getTags() {
         return tags;
     }
@@ -92,6 +105,8 @@ public class NetworkResourcesCreationRequest {
         private String resourceGroup;
 
         private boolean privateEndpointsEnabled;
+
+        private String existingPrivateDnsZoneId;
 
         private Map<String, String> tags = new HashMap<>();
 
@@ -137,6 +152,11 @@ public class NetworkResourcesCreationRequest {
 
         public Builder withTags(Map<String, String> tags) {
             this.tags = tags;
+            return this;
+        }
+
+        public Builder withExistingPrivateDnsZone(String existingPrivateDnsZoneId) {
+            this.existingPrivateDnsZoneId = existingPrivateDnsZoneId;
             return this;
         }
 

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureNetworkConnector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureNetworkConnector.java
@@ -218,8 +218,10 @@ public class AzureNetworkConnector implements NetworkConnector {
 
     @Override
     public void createProviderSpecificNetworkResources(NetworkResourcesCreationRequest request) {
+        // TODO CB-16349 Currently the bring your own DNS zone is not yet ready: because of this, even if an existing DNS zone is provided,
+        //  CDP will create its own.
         if (request.isPrivateEndpointsEnabled()) {
-            LOGGER.debug("Private endpoints are enabled, checking the presence of DNS Zones and Network links..");
+            LOGGER.debug("Private endpoints are enabled, and DNS zone is managed by CDP. Checking the presence of DNS Zones and Network links..");
             AzureClient azureClient = azureClientService.getClient(request.getCloudCredential());
             String resourceGroup = request.getResourceGroup();
             AuthenticatedContext authenticatedContext = new AuthenticatedContext(request.getCloudContext(), request.getCloudCredential());
@@ -232,7 +234,11 @@ public class AzureNetworkConnector implements NetworkConnector {
             azureDnsZoneService.checkOrCreateDnsZones(authenticatedContext, azureClient, networkView, resourceGroup, tags);
             azureNetworkLinkService.checkOrCreateNetworkLinks(authenticatedContext, azureClient, networkView, resourceGroup, tags);
         } else {
-            LOGGER.debug("Private endpoints are disabled, nothing to do.");
+            if (request.isExistingPrivateDnsZone()) {
+                LOGGER.debug("The private DNS zone '{}' already exists, nothing to do. ", request.getExistingPrivateDnsZoneId());
+            } else {
+                LOGGER.debug("Private endpoints are disabled, nothing to do.");
+            }
         }
     }
 

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtils.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtils.java
@@ -72,6 +72,8 @@ public class AzureUtils {
 
     public static final String NETWORK_ID = "networkId";
 
+    public static final String PRIVATE_DNS_ZONE_ID = "privateDnsZoneId";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(AzureUtils.class);
 
     private static final String NO_PUBLIC_IP = "noPublicIp";
@@ -202,6 +204,10 @@ public class AzureUtils {
 
     public String getCustomNetworkId(Network network) {
         return network.getStringParameter(NETWORK_ID);
+    }
+
+    public String getPrivateDnsZoneId(Network network) {
+        return network.getStringParameter(PRIVATE_DNS_ZONE_ID);
     }
 
     public String getCustomResourceGroupName(Network network) {

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/network/AzureNetworkV4Parameters.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/network/AzureNetworkV4Parameters.java
@@ -30,6 +30,9 @@ public class AzureNetworkV4Parameters extends MappableBase implements JsonEntity
     @ApiModelProperty
     private String subnetId;
 
+    @ApiModelProperty
+    private String privateDnsZoneId;
+
     public Boolean getNoPublicIp() {
         return noPublicIp;
     }
@@ -62,6 +65,14 @@ public class AzureNetworkV4Parameters extends MappableBase implements JsonEntity
         this.subnetId = subnetId;
     }
 
+    public String getPrivateDnsZoneId() {
+        return privateDnsZoneId;
+    }
+
+    public void setPrivateDnsZoneId(String privateDnsZoneId) {
+        this.privateDnsZoneId = privateDnsZoneId;
+    }
+
     @Override
     public Map<String, Object> asMap() {
         Map<String, Object> map = super.asMap();
@@ -69,6 +80,7 @@ public class AzureNetworkV4Parameters extends MappableBase implements JsonEntity
         putIfValueNotNull(map, "resourceGroupName", resourceGroupName);
         putIfValueNotNull(map, "networkId", networkId);
         putIfValueNotNull(map, "subnetId", subnetId);
+        putIfValueNotNull(map, "privateDnsZoneId", privateDnsZoneId);
         return map;
     }
 
@@ -85,5 +97,6 @@ public class AzureNetworkV4Parameters extends MappableBase implements JsonEntity
         resourceGroupName = getParameterOrNull(parameters, "resourceGroupName");
         networkId = getParameterOrNull(parameters, "networkId");
         subnetId = getParameterOrNull(parameters, "subnetId");
+        privateDnsZoneId = getParameterOrNull(parameters, "privateDnsZoneId");
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/AzureEnvironmentNetworkConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/AzureEnvironmentNetworkConverter.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.converter.v4.environment.network;
 
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
@@ -23,7 +24,13 @@ public class AzureEnvironmentNetworkConverter extends EnvironmentBaseNetworkConv
         return Map.of(
                 "networkId", azure.getNetworkId(),
                 "resourceGroupName", azure.getResourceGroupName(),
-                "noPublicIp", azure.getNoPublicIp());
+                "noPublicIp", azure.getNoPublicIp(),
+                "privateDnsZoneId", getPrivateDnsZoneId(azure)
+        );
+    }
+
+    private String getPrivateDnsZoneId(EnvironmentNetworkAzureParams azure) {
+        return StringUtils.isNotEmpty(azure.getPrivateDnsZoneId()) ? azure.getPrivateDnsZoneId() : "";
     }
 
     @Override

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
@@ -37,6 +37,7 @@ public class EnvironmentModelDescription {
     public static final String GCP_NO_FIREWALL_RULES = "Gcp no firewall rules";
 
     public static final String AZURE_RESOURCE_GROUP_NAME = "Azure Resource Group Name of the specified network";
+    public static final String AZURE_PRIVATE_DNS_ZONE_ID = "Full resource id of an existing azure private DNS zone";
     public static final String AZURE_NETWORK_ID = "Azure Network ID of the specified network";
     public static final String AZURE_NO_PUBLIC_IP = "Azure Network is private if this flag is true";
 

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/EnvironmentNetworkAzureParams.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/EnvironmentNetworkAzureParams.java
@@ -24,6 +24,10 @@ public class EnvironmentNetworkAzureParams {
     @ApiModelProperty(value = EnvironmentModelDescription.AZURE_RESOURCE_GROUP_NAME, required = true)
     private String resourceGroupName;
 
+    @Size(max = 255)
+    @ApiModelProperty(value = EnvironmentModelDescription.AZURE_PRIVATE_DNS_ZONE_ID)
+    private String privateDnsZoneId;
+
     @NotNull
     @ApiModelProperty(EnvironmentModelDescription.AZURE_NO_PUBLIC_IP)
     private Boolean noPublicIp;
@@ -52,11 +56,20 @@ public class EnvironmentNetworkAzureParams {
         this.noPublicIp = noPublicIp;
     }
 
+    public String getPrivateDnsZoneId() {
+        return privateDnsZoneId;
+    }
+
+    public void setPrivateDnsZoneId(String privateDnsZoneId) {
+        this.privateDnsZoneId = privateDnsZoneId;
+    }
+
     @Override
     public String toString() {
         return "EnvironmentNetworkAzureParams{" +
                 "networkId='" + networkId + '\'' +
                 ", resourceGroupName='" + resourceGroupName + '\'' +
+                ", privateDnsZoneId='" + privateDnsZoneId + '\'' +
                 ", noPublicIp=" + noPublicIp +
                 '}';
     }
@@ -67,6 +80,8 @@ public class EnvironmentNetworkAzureParams {
         private String resourceGroupName;
 
         private Boolean noPublicIp;
+
+        private String privateDnsZoneId;
 
         private EnvironmentNetworkAzureParamsBuilder() {
         }
@@ -90,11 +105,17 @@ public class EnvironmentNetworkAzureParams {
             return this;
         }
 
+        public EnvironmentNetworkAzureParamsBuilder withPrivateDnsZoneId(String privateDnsZoneId) {
+            this.privateDnsZoneId = privateDnsZoneId;
+            return this;
+        }
+
         public EnvironmentNetworkAzureParams build() {
             EnvironmentNetworkAzureParams environmentNetworkAzureParams = new EnvironmentNetworkAzureParams();
             environmentNetworkAzureParams.setNetworkId(networkId);
             environmentNetworkAzureParams.setResourceGroupName(resourceGroupName);
             environmentNetworkAzureParams.setNoPublicIp(noPublicIp);
+            environmentNetworkAzureParams.setPrivateDnsZoneId(privateDnsZoneId);
             return environmentNetworkAzureParams;
         }
     }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/NetworkDtoToResponseConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/NetworkDtoToResponseConverter.java
@@ -59,6 +59,7 @@ public class NetworkDtoToResponseConverter {
                         .withNetworkId(p.getNetworkId())
                         .withResourceGroupName(p.getResourceGroupName())
                         .withNoPublicIp(p.isNoPublicIp())
+                        .withPrivateDnsZoneId(p.getPrivateDnsZoneId())
                         .build()))
                 .withGcp(getIfNotNull(network.getGcp(), p -> EnvironmentNetworkGcpParams.EnvironmentNetworkGcpParamsBuilder
                         .anEnvironmentNetworkGcpParamsBuilder()

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/NetworkRequestToDtoConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/NetworkRequestToDtoConverter.java
@@ -44,6 +44,7 @@ public class NetworkRequestToDtoConverter {
                     .withNetworkId(network.getAzure().getNetworkId())
                     .withNoPublicIp(Boolean.TRUE.equals(network.getAzure().getNoPublicIp()))
                     .withResourceGroupName(network.getAzure().getResourceGroupName())
+                    .withPrivateDnsZoneId(network.getAzure().getPrivateDnsZoneId())
                     .build();
             builder.withAzure(azureParams);
             builder.withNetworkId(network.getAzure().getNetworkId());

--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/network/azure/AzureEnvironmentNetworkValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/network/azure/AzureEnvironmentNetworkValidator.java
@@ -1,42 +1,28 @@
 package com.sequenceiq.environment.environment.validation.network.azure;
 
 import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AZURE;
-import static com.sequenceiq.common.api.type.ServiceEndpointCreation.ENABLED_PRIVATE_ENDPOINT;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.cloud.azure.AzureCloudSubnetParametersService;
-import com.sequenceiq.cloudbreak.cloud.azure.AzureNetworkLinkService;
-import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
-import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClientService;
-import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
-import com.sequenceiq.cloudbreak.util.NullUtil;
 import com.sequenceiq.cloudbreak.validation.ValidationResult.ValidationResultBuilder;
 import com.sequenceiq.common.api.type.ServiceEndpointCreation;
-import com.sequenceiq.environment.credential.v1.converter.CredentialToCloudCredentialConverter;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
 import com.sequenceiq.environment.environment.dto.EnvironmentValidationDto;
 import com.sequenceiq.environment.environment.validation.ValidationType;
 import com.sequenceiq.environment.environment.validation.network.EnvironmentNetworkValidator;
 import com.sequenceiq.environment.network.CloudNetworkService;
-import com.sequenceiq.environment.network.dao.domain.RegistrationType;
 import com.sequenceiq.environment.network.dto.AzureParams;
 import com.sequenceiq.environment.network.dto.NetworkDto;
-import com.sequenceiq.environment.parameter.dto.AzureParametersDto;
-import com.sequenceiq.environment.parameter.dto.AzureResourceGroupDto;
-import com.sequenceiq.environment.parameter.dto.ParametersDto;
-import com.sequenceiq.environment.parameter.dto.ResourceGroupUsagePattern;
 
 @Component
 public class AzureEnvironmentNetworkValidator implements EnvironmentNetworkValidator {
@@ -45,23 +31,12 @@ public class AzureEnvironmentNetworkValidator implements EnvironmentNetworkValid
 
     private final CloudNetworkService cloudNetworkService;
 
-    private final AzureCloudSubnetParametersService azureCloudSubnetParametersService;
+    private final AzurePrivateEndpointValidator azurePrivateEndpointValidator;
 
-    private final AzureNetworkLinkService azureNetworkLinkService;
-
-    private final AzureClientService azureClientService;
-
-    private final CredentialToCloudCredentialConverter credentialToCloudCredentialConverter;
-
-    public AzureEnvironmentNetworkValidator(CloudNetworkService cloudNetworkService, AzureCloudSubnetParametersService azureCloudSubnetParametersService,
-            AzureNetworkLinkService azureNetworkLinkService,
-            AzureClientService azureClientService,
-            CredentialToCloudCredentialConverter credentialToCloudCredentialConverter) {
+    public AzureEnvironmentNetworkValidator(CloudNetworkService cloudNetworkService,
+            AzurePrivateEndpointValidator azurePrivateEndpointValidator) {
         this.cloudNetworkService = cloudNetworkService;
-        this.azureCloudSubnetParametersService = azureCloudSubnetParametersService;
-        this.azureNetworkLinkService = azureNetworkLinkService;
-        this.azureClientService = azureClientService;
-        this.credentialToCloudCredentialConverter = credentialToCloudCredentialConverter;
+        this.azurePrivateEndpointValidator = azurePrivateEndpointValidator;
     }
 
     @Override
@@ -77,6 +52,7 @@ public class AzureEnvironmentNetworkValidator implements EnvironmentNetworkValid
         if (environmentValidationDto.getValidationType() == ValidationType.ENVIRONMENT_CREATION) {
             checkPrivateEndpointNetworkPoliciesWhenExistingNetwork(networkDto, cloudNetworks, resultBuilder);
             checkPrivateEndpointsWhenMultipleResourceGroup(resultBuilder, environmentDto, networkDto.getServiceEndpointCreation());
+            checkExistingPrivateDnsZoneWhenNotPrivateEndpoint(resultBuilder, networkDto);
             checkPrivateEndpointForExistingNetworkLink(resultBuilder, environmentDto, networkDto);
         } else {
             LOGGER.debug("Skipping Private Endpoint related validations as they have been validated before during env creation");
@@ -132,39 +108,11 @@ public class AzureEnvironmentNetworkValidator implements EnvironmentNetworkValid
 
     private void checkPrivateEndpointNetworkPoliciesWhenExistingNetwork(
             NetworkDto networkDto, Map<String, CloudSubnet> cloudNetworks, ValidationResultBuilder resultBuilder) {
-        if (!ENABLED_PRIVATE_ENDPOINT.equals(networkDto.getServiceEndpointCreation())) {
-            LOGGER.debug("No private endpoint network policies validation requested");
-            return;
-        }
-
-        if (RegistrationType.CREATE_NEW == networkDto.getRegistrationType()) {
-            LOGGER.debug("Using new network -- bypassing private endpoint network policies validation");
-            return;
-        }
-
-        boolean noSuitableSubnetPresent = cloudNetworks.values().stream().noneMatch(azureCloudSubnetParametersService::isPrivateEndpointNetworkPoliciesDisabled);
-        if (noSuitableSubnetPresent) {
-            String subnetsInVnet = cloudNetworks.values().stream().map(CloudSubnet::getName).collect(Collectors.joining(", "));
-            String errorMessage = String.format("It is not possible to create private endpoints for existing network with id '%s' in resource group '%s': " +
-                            "Azure requires at least one subnet with private endpoint network policies (eg. NSGs) disabled.  Please disable private endpoint " +
-                            "network policies in at least one of the following subnets and retry: '%s'. Refer to Microsoft documentation at: " +
-                            "https://docs.microsoft.com/en-us/azure/private-link/disable-private-endpoint-network-policy",
-                    networkDto.getNetworkId(), networkDto.getAzure().getResourceGroupName(), subnetsInVnet);
-            LOGGER.warn(errorMessage);
-            resultBuilder.error(errorMessage);
-        }
+        azurePrivateEndpointValidator.checkPrivateEndpointNetworkPoliciesWhenExistingNetwork(networkDto, cloudNetworks, resultBuilder);
     }
 
     private void checkPrivateEndpointForExistingNetworkLink(ValidationResultBuilder resultBuilder, EnvironmentDto environmentDto, NetworkDto networkDto) {
-        if (networkDto.getServiceEndpointCreation() ==  ServiceEndpointCreation.ENABLED_PRIVATE_ENDPOINT &&
-                ResourceGroupUsagePattern.USE_MULTIPLE != getResourceGroupUsagePattern(environmentDto)) {
-            CloudCredential cloudCredential = credentialToCloudCredentialConverter.convert(environmentDto.getCredential());
-            AzureClient azureClient = azureClientService.getClient(cloudCredential);
-            Optional<String> resourceGroupName = getAzureResourceGroupDto(environmentDto)
-                    .map(AzureResourceGroupDto::getName);
-            resourceGroupName.ifPresent(rgName -> NullUtil.doIfNotNull(
-                    azureNetworkLinkService.validateExistingNetworkLink(azureClient, networkDto.getAzure().getNetworkId(), rgName), resultBuilder::merge));
-        }
+        azurePrivateEndpointValidator.checkPrivateEndpointForExistingNetworkLink(resultBuilder, environmentDto, networkDto);
     }
 
     private void checkResourceGroupNameWhenExistingNetwork(ValidationResultBuilder resultBuilder, AzureParams azureParams) {
@@ -210,24 +158,11 @@ public class AzureEnvironmentNetworkValidator implements EnvironmentNetworkValid
 
     private void checkPrivateEndpointsWhenMultipleResourceGroup(ValidationResultBuilder resultBuilder, EnvironmentDto environmentDto,
             ServiceEndpointCreation serviceEndpointCreation) {
-        ResourceGroupUsagePattern resourceGroupUsagePattern = getResourceGroupUsagePattern(environmentDto);
-        if (resourceGroupUsagePattern == ResourceGroupUsagePattern.USE_MULTIPLE
-                && serviceEndpointCreation == ServiceEndpointCreation.ENABLED_PRIVATE_ENDPOINT) {
-            resultBuilder.error("Private endpoint creation is not supported for multiple resource group deployment model, "
-                    + "please use single single resource groups to be able to use private endpoints in Azure!");
-        }
+        azurePrivateEndpointValidator.checkPrivateEndpointsWhenMultipleResourceGroup(resultBuilder, environmentDto, serviceEndpointCreation);
     }
 
-    private ResourceGroupUsagePattern getResourceGroupUsagePattern(EnvironmentDto environmentDto) {
-        return getAzureResourceGroupDto(environmentDto)
-                .map(AzureResourceGroupDto::getResourceGroupUsagePattern)
-                .orElse(ResourceGroupUsagePattern.USE_MULTIPLE);
-    }
-
-    private Optional<AzureResourceGroupDto> getAzureResourceGroupDto(EnvironmentDto environmentDto) {
-        return Optional.ofNullable(environmentDto.getParameters())
-                .map(ParametersDto::azureParametersDto)
-                .map(AzureParametersDto::getAzureResourceGroupDto);
+    private void checkExistingPrivateDnsZoneWhenNotPrivateEndpoint(ValidationResultBuilder resultBuilder, NetworkDto networkDto) {
+        azurePrivateEndpointValidator.checkExistingPrivateDnsZoneWhenNotPrivateEndpoint(resultBuilder, networkDto);
     }
 
     @Override

--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/network/azure/AzurePrivateEndpointValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/network/azure/AzurePrivateEndpointValidator.java
@@ -1,0 +1,122 @@
+package com.sequenceiq.environment.environment.validation.network.azure;
+
+import static com.sequenceiq.common.api.type.ServiceEndpointCreation.ENABLED_PRIVATE_ENDPOINT;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.azure.AzureCloudSubnetParametersService;
+import com.sequenceiq.cloudbreak.cloud.azure.AzureNetworkLinkService;
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClientService;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
+import com.sequenceiq.cloudbreak.util.NullUtil;
+import com.sequenceiq.cloudbreak.validation.ValidationResult;
+import com.sequenceiq.common.api.type.ServiceEndpointCreation;
+import com.sequenceiq.environment.credential.v1.converter.CredentialToCloudCredentialConverter;
+import com.sequenceiq.environment.environment.dto.EnvironmentDto;
+import com.sequenceiq.environment.network.dao.domain.RegistrationType;
+import com.sequenceiq.environment.network.dto.NetworkDto;
+import com.sequenceiq.environment.parameter.dto.AzureParametersDto;
+import com.sequenceiq.environment.parameter.dto.AzureResourceGroupDto;
+import com.sequenceiq.environment.parameter.dto.ParametersDto;
+import com.sequenceiq.environment.parameter.dto.ResourceGroupUsagePattern;
+
+@Component
+public class AzurePrivateEndpointValidator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AzurePrivateEndpointValidator.class);
+
+    private final AzureCloudSubnetParametersService azureCloudSubnetParametersService;
+
+    private final AzureNetworkLinkService azureNetworkLinkService;
+
+    private final CredentialToCloudCredentialConverter credentialToCloudCredentialConverter;
+
+    private final AzureClientService azureClientService;
+
+    public AzurePrivateEndpointValidator(AzureCloudSubnetParametersService azureCloudSubnetParametersService, AzureNetworkLinkService azureNetworkLinkService,
+            CredentialToCloudCredentialConverter credentialToCloudCredentialConverter, AzureClientService azureClientService) {
+        this.azureCloudSubnetParametersService = azureCloudSubnetParametersService;
+        this.azureNetworkLinkService = azureNetworkLinkService;
+        this.credentialToCloudCredentialConverter = credentialToCloudCredentialConverter;
+        this.azureClientService = azureClientService;
+    }
+
+    public void checkPrivateEndpointNetworkPoliciesWhenExistingNetwork(
+            NetworkDto networkDto, Map<String, CloudSubnet> cloudNetworks, ValidationResult.ValidationResultBuilder resultBuilder) {
+        if (!ENABLED_PRIVATE_ENDPOINT.equals(networkDto.getServiceEndpointCreation())) {
+            LOGGER.debug("No private endpoint network policies validation requested");
+            return;
+        }
+
+        if (RegistrationType.CREATE_NEW == networkDto.getRegistrationType()) {
+            LOGGER.debug("Using new network -- bypassing private endpoint network policies validation");
+            return;
+        }
+
+        boolean noSuitableSubnetPresent = cloudNetworks.values().stream().noneMatch(azureCloudSubnetParametersService::isPrivateEndpointNetworkPoliciesDisabled);
+        if (noSuitableSubnetPresent) {
+            String subnetsInVnet = cloudNetworks.values().stream().map(CloudSubnet::getName).collect(Collectors.joining(", "));
+            String errorMessage = String.format("It is not possible to create private endpoints for existing network with id '%s' in resource group '%s': " +
+                            "Azure requires at least one subnet with private endpoint network policies (eg. NSGs) disabled.  Please disable private endpoint " +
+                            "network policies in at least one of the following subnets and retry: '%s'. Refer to Microsoft documentation at: " +
+                            "https://docs.microsoft.com/en-us/azure/private-link/disable-private-endpoint-network-policy",
+                    networkDto.getNetworkId(), networkDto.getAzure().getResourceGroupName(), subnetsInVnet);
+            LOGGER.warn(errorMessage);
+            resultBuilder.error(errorMessage);
+        }
+    }
+
+    public void checkPrivateEndpointsWhenMultipleResourceGroup(ValidationResult.ValidationResultBuilder resultBuilder, EnvironmentDto environmentDto,
+            ServiceEndpointCreation serviceEndpointCreation) {
+        ResourceGroupUsagePattern resourceGroupUsagePattern = getResourceGroupUsagePattern(environmentDto);
+        if (resourceGroupUsagePattern == ResourceGroupUsagePattern.USE_MULTIPLE
+                && serviceEndpointCreation == ServiceEndpointCreation.ENABLED_PRIVATE_ENDPOINT) {
+            resultBuilder.error("Private endpoint creation is not supported for multiple resource group deployment model, "
+                    + "please use single single resource groups to be able to use private endpoints in Azure!");
+        }
+    }
+
+    public void checkExistingPrivateDnsZoneWhenNotPrivateEndpoint(ValidationResult.ValidationResultBuilder resultBuilder, NetworkDto networkDto) {
+        if (StringUtils.isNotEmpty(networkDto.getAzure().getPrivateDnsZoneId())
+                && networkDto.getServiceEndpointCreation() != ServiceEndpointCreation.ENABLED_PRIVATE_ENDPOINT) {
+            resultBuilder.error("A private DNS zone is provided, but private endpoint creation is turned off. Please either turn on private endpoint creation"
+                    + " or do not specify the existing private DNS zone.");
+        }
+    }
+
+    public void checkPrivateEndpointForExistingNetworkLink(ValidationResult.ValidationResultBuilder resultBuilder, EnvironmentDto environmentDto,
+            NetworkDto networkDto) {
+        if (networkDto.getServiceEndpointCreation() == ServiceEndpointCreation.ENABLED_PRIVATE_ENDPOINT &&
+                ResourceGroupUsagePattern.USE_MULTIPLE != getResourceGroupUsagePattern(environmentDto) &&
+                StringUtils.isEmpty(networkDto.getAzure().getPrivateDnsZoneId())) {
+            CloudCredential cloudCredential = credentialToCloudCredentialConverter.convert(environmentDto.getCredential());
+            AzureClient azureClient = azureClientService.getClient(cloudCredential);
+            Optional<String> resourceGroupName = getAzureResourceGroupDto(environmentDto)
+                    .map(AzureResourceGroupDto::getName);
+            resourceGroupName.ifPresent(rgName -> NullUtil.doIfNotNull(
+                    azureNetworkLinkService.validateExistingNetworkLink(azureClient, networkDto.getAzure().getNetworkId(), rgName), resultBuilder::merge));
+        }
+    }
+
+    private ResourceGroupUsagePattern getResourceGroupUsagePattern(EnvironmentDto environmentDto) {
+        return getAzureResourceGroupDto(environmentDto)
+                .map(AzureResourceGroupDto::getResourceGroupUsagePattern)
+                .orElse(ResourceGroupUsagePattern.USE_MULTIPLE);
+    }
+
+    private Optional<AzureResourceGroupDto> getAzureResourceGroupDto(EnvironmentDto environmentDto) {
+        return Optional.ofNullable(environmentDto.getParameters())
+                .map(ParametersDto::azureParametersDto)
+                .map(AzureParametersDto::getAzureResourceGroupDto);
+    }
+
+}

--- a/environment/src/main/java/com/sequenceiq/environment/network/dao/domain/AzureNetwork.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/dao/domain/AzureNetwork.java
@@ -12,6 +12,8 @@ public class AzureNetwork extends BaseNetwork {
 
     private Boolean noPublicIp;
 
+    private String privateDnsZoneId;
+
     public String getNetworkId() {
         return networkId;
     }
@@ -36,12 +38,21 @@ public class AzureNetwork extends BaseNetwork {
         this.noPublicIp = noPublicIp;
     }
 
+    public String getPrivateDnsZoneId() {
+        return privateDnsZoneId;
+    }
+
+    public void setPrivateDnsZoneId(String privateDnsZoneId) {
+        this.privateDnsZoneId = privateDnsZoneId;
+    }
+
     @Override
     public String toString() {
-        return super.toString() + ", " + "AzureNetwork{" +
+        return "AzureNetwork{" +
                 "networkId='" + networkId + '\'' +
                 ", resourceGroupName='" + resourceGroupName + '\'' +
                 ", noPublicIp=" + noPublicIp +
-                '}';
+                ", privateDnsZoneId='" + privateDnsZoneId + '\'' +
+                "} " + super.toString();
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/network/service/NetworkCreationRequestFactory.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/service/NetworkCreationRequestFactory.java
@@ -16,12 +16,12 @@ import com.sequenceiq.cloudbreak.cloud.model.Region;
 import com.sequenceiq.cloudbreak.cloud.model.network.NetworkCreationRequest;
 import com.sequenceiq.cloudbreak.cloud.model.network.NetworkResourcesCreationRequest;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.converter.ServiceEndpointCreationToEndpointTypeConverter;
 import com.sequenceiq.cloudbreak.util.NullUtil;
-import com.sequenceiq.environment.api.v1.environment.model.base.PrivateSubnetCreation;
 import com.sequenceiq.common.api.type.ServiceEndpointCreation;
+import com.sequenceiq.environment.api.v1.environment.model.base.PrivateSubnetCreation;
 import com.sequenceiq.environment.credential.v1.converter.CredentialToCloudCredentialConverter;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
-import com.sequenceiq.cloudbreak.converter.ServiceEndpointCreationToEndpointTypeConverter;
 import com.sequenceiq.environment.environment.service.EnvironmentTagProvider;
 import com.sequenceiq.environment.network.dao.domain.AzureNetwork;
 import com.sequenceiq.environment.network.dao.domain.BaseNetwork;
@@ -97,6 +97,7 @@ public class NetworkCreationRequestFactory {
                 .withCloudContext(getCloudContext(environment))
                 .withRegion(Region.region(environment.getLocation().getName()))
                 .withPrivateEndpointsEnabled(ServiceEndpointCreation.ENABLED_PRIVATE_ENDPOINT == networkDto.getServiceEndpointCreation())
+                .withExistingPrivateDnsZone(networkDto.getAzure().getPrivateDnsZoneId())
                 .withTags(environmentTagProvider.getTags(environment, environment.getNetwork().getResourceCrn()));
                 getResourceGroupName(environment).ifPresent(builder::withResourceGroup);
         return builder.build();

--- a/environment/src/main/java/com/sequenceiq/environment/network/v1/converter/AzureEnvironmentNetworkConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/v1/converter/AzureEnvironmentNetworkConverter.java
@@ -1,18 +1,22 @@
 package com.sequenceiq.environment.network.v1.converter;
 
+import static com.sequenceiq.cloudbreak.cloud.azure.AzureUtils.NETWORK_ID;
+import static com.sequenceiq.cloudbreak.cloud.azure.AzureUtils.PRIVATE_DNS_ZONE_ID;
+import static com.sequenceiq.cloudbreak.cloud.azure.AzureUtils.RG_NAME;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.cloud.azure.AzureUtils;
 import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
 import com.sequenceiq.cloudbreak.cloud.model.Network;
 import com.sequenceiq.cloudbreak.cloud.model.network.CreatedCloudNetwork;
 import com.sequenceiq.cloudbreak.cloud.model.network.CreatedSubnet;
 import com.sequenceiq.cloudbreak.cloud.model.network.SubnetType;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.common.api.type.ServiceEndpointCreation;
 import com.sequenceiq.environment.environment.domain.EnvironmentViewConverter;
 import com.sequenceiq.environment.network.dao.domain.AzureNetwork;
 import com.sequenceiq.environment.network.dao.domain.BaseNetwork;
@@ -39,6 +43,9 @@ public class AzureEnvironmentNetworkConverter extends EnvironmentBaseNetworkConv
             azureNetwork.setNetworkId(azureParams.getNetworkId());
             azureNetwork.setResourceGroupName(azureParams.getResourceGroupName());
             azureNetwork.setNoPublicIp(azureParams.isNoPublicIp());
+            if (ServiceEndpointCreation.ENABLED_PRIVATE_ENDPOINT.equals(network.getServiceEndpointCreation())) {
+                azureNetwork.setPrivateDnsZoneId(azureParams.getPrivateDnsZoneId());
+            }
         }
         return azureNetwork;
     }
@@ -70,11 +77,12 @@ public class AzureEnvironmentNetworkConverter extends EnvironmentBaseNetworkConv
     NetworkDto setProviderSpecificFields(NetworkDto.Builder builder, BaseNetwork network) {
         AzureNetwork azureNetwork = (AzureNetwork) network;
         return builder.withAzure(
-                AzureParams.builder()
-                        .withNetworkId(azureNetwork.getNetworkId())
-                        .withResourceGroupName(azureNetwork.getResourceGroupName())
-                        .withNoPublicIp(azureNetwork.getNoPublicIp())
-                        .build())
+                        AzureParams.builder()
+                                .withNetworkId(azureNetwork.getNetworkId())
+                                .withResourceGroupName(azureNetwork.getResourceGroupName())
+                                .withNoPublicIp(azureNetwork.getNoPublicIp())
+                                .withPrivateDnsZoneId(azureNetwork.getPrivateDnsZoneId())
+                                .build())
                 .build();
     }
 
@@ -102,8 +110,9 @@ public class AzureEnvironmentNetworkConverter extends EnvironmentBaseNetworkConv
     public Network convertToNetwork(BaseNetwork baseNetwork) {
         AzureNetwork azureNetwork = (AzureNetwork) baseNetwork;
         Map<String, Object> param = new HashMap<>();
-        param.put(AzureUtils.RG_NAME, azureNetwork.getResourceGroupName());
-        param.put(AzureUtils.NETWORK_ID, azureNetwork.getNetworkId());
+        param.put(RG_NAME, azureNetwork.getResourceGroupName());
+        param.put(NETWORK_ID, azureNetwork.getNetworkId());
+        param.put(PRIVATE_DNS_ZONE_ID, azureNetwork.getPrivateDnsZoneId());
         return new Network(null, param);
     }
 }

--- a/environment/src/main/resources/schema/app/20220214071457_CB-16106_Bring_Your_Own_Private_DNS_Zone_(BYODZ).sql
+++ b/environment/src/main/resources/schema/app/20220214071457_CB-16106_Bring_Your_Own_Private_DNS_Zone_(BYODZ).sql
@@ -1,0 +1,10 @@
+-- // CB-16106 Bring Your Own Private DNS Zone (BYODZ)
+-- Migration SQL that makes the change goes here.
+ALTER TABLE environment_network ADD COLUMN IF NOT EXISTS privatednszoneid VARCHAR(255);
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+ALTER TABLE environment_network DROP COLUMN IF EXISTS privatednszoneid;
+
+

--- a/environment/src/test/java/com/sequenceiq/environment/environment/validation/network/azure/AzurePrivateEndpointValidatorTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/validation/network/azure/AzurePrivateEndpointValidatorTest.java
@@ -1,0 +1,256 @@
+package com.sequenceiq.environment.environment.validation.network.azure;
+
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cloud.azure.AzureCloudSubnetParametersService;
+import com.sequenceiq.cloudbreak.cloud.azure.AzureNetworkLinkService;
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClientService;
+import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
+import com.sequenceiq.cloudbreak.validation.ValidationResult;
+import com.sequenceiq.common.api.type.ServiceEndpointCreation;
+import com.sequenceiq.environment.credential.v1.converter.CredentialToCloudCredentialConverter;
+import com.sequenceiq.environment.environment.dto.EnvironmentDto;
+import com.sequenceiq.environment.environment.validation.network.NetworkTestUtils;
+import com.sequenceiq.environment.network.dao.domain.RegistrationType;
+import com.sequenceiq.environment.network.dto.AzureParams;
+import com.sequenceiq.environment.network.dto.NetworkDto;
+import com.sequenceiq.environment.parameter.dto.AzureParametersDto;
+import com.sequenceiq.environment.parameter.dto.AzureResourceGroupDto;
+import com.sequenceiq.environment.parameter.dto.ParametersDto;
+import com.sequenceiq.environment.parameter.dto.ResourceGroupUsagePattern;
+
+@ExtendWith(MockitoExtension.class)
+public class AzurePrivateEndpointValidatorTest {
+
+    private static final String MY_SINGLE_RG = "mySingleRg";
+
+    private static final String NETWORK_ID = "networkId";
+
+    private static final String EXISTING_PRIVATE_DNS_ZONE_ID = "existingPrivateDnsZoneId";
+
+    @Mock
+    private AzureCloudSubnetParametersService azureCloudSubnetParametersService;
+
+    @Mock
+    private AzureNetworkLinkService azureNetworkLinkService;
+
+    @Mock
+    private CredentialToCloudCredentialConverter credentialToCloudCredentialConverter;
+
+    @Mock
+    private AzureClientService azureClientService;
+
+    private AzurePrivateEndpointValidator underTest;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+        underTest = new AzurePrivateEndpointValidator(
+                azureCloudSubnetParametersService,
+                azureNetworkLinkService,
+                credentialToCloudCredentialConverter,
+                azureClientService
+        );
+    }
+
+    @Test
+    void testCheckPrivateEndpointNetworkPoliciesWhenExistingNetworkAndPrivateEndpointNetworkPoliciesEnabled() {
+        ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
+        AzureParams azureParams = getAzureParams();
+        NetworkDto networkDto = NetworkTestUtils.getNetworkDtoBuilder(azureParams, null, null, azureParams.getNetworkId(), null, 1, RegistrationType.EXISTING)
+                .withServiceEndpointCreation(ServiceEndpointCreation.ENABLED_PRIVATE_ENDPOINT)
+                .build();
+        when(azureCloudSubnetParametersService.isPrivateEndpointNetworkPoliciesDisabled(any())).thenCallRealMethod();
+
+        underTest.checkPrivateEndpointNetworkPoliciesWhenExistingNetwork(networkDto, getCloudSubnets(true), validationResultBuilder);
+
+        assertTrue(validationResultBuilder.build().hasError());
+        NetworkTestUtils.checkErrorsPresent(validationResultBuilder, List.of(
+                "It is not possible to create private endpoints for existing network with id 'networkId' in resource group 'networkResourceGroupName': " +
+                        "Azure requires at least one subnet with private endpoint network policies (eg. NSGs) disabled.  Please disable private endpoint " +
+                        "network policies in at least one of the following subnets and retry: 'subnet-one'. Refer to Microsoft documentation at: " +
+                        "https://docs.microsoft.com/en-us/azure/private-link/disable-private-endpoint-network-policy"));
+    }
+
+    @Test
+    void testCheckPrivateEndpointNetworkPoliciesWhenExistingNetworkAndPrivateEndpointNetworkPoliciesDisabled() {
+        ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
+        NetworkDto networkDto = getNetworkDto(getAzureParams());
+        when(azureCloudSubnetParametersService.isPrivateEndpointNetworkPoliciesDisabled(any())).thenCallRealMethod();
+
+        underTest.checkPrivateEndpointNetworkPoliciesWhenExistingNetwork(networkDto, getCloudSubnets(false), validationResultBuilder);
+
+        assertFalse(validationResultBuilder.build().hasError());
+    }
+
+    @Test
+    void testCheckPrivateEndpointForExistingNetworkLinkWhenLinkFromAnotherRG() {
+        ValidationResult.ValidationResultBuilder envValidationResultBuilder = new ValidationResult.ValidationResultBuilder();
+        ValidationResult.ValidationResultBuilder azureValidationResultBuilder = new ValidationResult.ValidationResultBuilder();
+        String message = "Network link for the network aNetworkLink already exists for Private DNS Zone "
+                + "privatelink.postgres.database.azure.com in resource group mySingleRg. Please ensure that there is no existing network link and try again!";
+
+        EnvironmentDto environmentDto = getEnvironmentDto(MY_SINGLE_RG, ResourceGroupUsagePattern.USE_SINGLE);
+        AzureParams azureParams = getAzureParams();
+        NetworkDto networkDto = getNetworkDto(azureParams);
+        when(azureNetworkLinkService.validateExistingNetworkLink(any(), any(), eq(MY_SINGLE_RG))).
+                thenReturn(azureValidationResultBuilder.error(message).build());
+
+        underTest.checkPrivateEndpointForExistingNetworkLink(envValidationResultBuilder, environmentDto, networkDto);
+
+        assertTrue(envValidationResultBuilder.build().hasError());
+        NetworkTestUtils.checkErrorsPresent(envValidationResultBuilder, List.of(message));
+    }
+
+    @Test
+    void testCheckPrivateEndpointForExistingNetworkLinkWhenNotExists() {
+        ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
+        EnvironmentDto environmentDto = getEnvironmentDto(MY_SINGLE_RG, ResourceGroupUsagePattern.USE_SINGLE);
+        AzureParams azureParams = getAzureParams();
+        when(azureNetworkLinkService.validateExistingNetworkLink(any(), any(), eq(MY_SINGLE_RG))).thenReturn(null);
+
+        underTest.checkPrivateEndpointForExistingNetworkLink(validationResultBuilder, environmentDto, getNetworkDto(azureParams));
+
+        verify(credentialToCloudCredentialConverter).convert(any());
+        verify(azureClientService).getClient(any());
+        verify(azureNetworkLinkService).validateExistingNetworkLink(any(), any(), any());
+        assertFalse(validationResultBuilder.build().hasError());
+    }
+
+    @Test
+    void testCheckPrivateEndpointForExistingNetworkLinkWhenServiceEndpoints() {
+        ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
+        EnvironmentDto environmentDto = getEnvironmentDto(MY_SINGLE_RG, ResourceGroupUsagePattern.USE_SINGLE);
+        AzureParams azureParams = getAzureParams();
+
+        underTest.checkPrivateEndpointForExistingNetworkLink(validationResultBuilder, environmentDto,
+                getNetworkDto(azureParams, ServiceEndpointCreation.ENABLED));
+
+        verify(credentialToCloudCredentialConverter, never()).convert(any());
+        verify(azureClientService, never()).getClient(any());
+        verify(azureNetworkLinkService, never()).validateExistingNetworkLink(any(), any(), any());
+        assertFalse(validationResultBuilder.build().hasError());
+    }
+
+    @Test
+    void testCheckPrivateEndpointForExistingNetworkLinkWhenMultipleRg() {
+        ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
+        EnvironmentDto environmentDto = getEnvironmentDto(MY_SINGLE_RG, ResourceGroupUsagePattern.USE_MULTIPLE);
+        AzureParams azureParams = getAzureParams();
+
+        underTest.checkPrivateEndpointForExistingNetworkLink(validationResultBuilder, environmentDto, getNetworkDto(azureParams));
+
+        verify(credentialToCloudCredentialConverter, never()).convert(any());
+        verify(azureClientService, never()).getClient(any());
+        verify(azureNetworkLinkService, never()).validateExistingNetworkLink(any(), any(), any());
+        assertFalse(validationResultBuilder.build().hasError());
+    }
+
+    @Test
+    void testCheckPrivateEndpointForExistingNetworkLinkWhenExistingDnsZone() {
+        ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
+        EnvironmentDto environmentDto = getEnvironmentDto(MY_SINGLE_RG, ResourceGroupUsagePattern.USE_SINGLE);
+        AzureParams azureParams = getAzureParams(EXISTING_PRIVATE_DNS_ZONE_ID);
+
+        underTest.checkPrivateEndpointForExistingNetworkLink(validationResultBuilder, environmentDto, getNetworkDto(azureParams));
+
+        verify(credentialToCloudCredentialConverter, never()).convert(any());
+        verify(azureClientService, never()).getClient(any());
+        verify(azureNetworkLinkService, never()).validateExistingNetworkLink(any(), any(), any());
+        assertFalse(validationResultBuilder.build().hasError());
+    }
+
+    @Test
+    void testCheckPrivateEndpointsWhenMultipleResourceGroupWhenMultipleRG() {
+        ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
+        EnvironmentDto environmentDto = getEnvironmentDto(null, ResourceGroupUsagePattern.USE_MULTIPLE);
+
+        underTest.checkPrivateEndpointsWhenMultipleResourceGroup(validationResultBuilder, environmentDto, ServiceEndpointCreation.ENABLED_PRIVATE_ENDPOINT);
+
+        assertTrue(validationResultBuilder.build().hasError());
+        NetworkTestUtils.checkErrorsPresent(validationResultBuilder, List.of(
+                "Private endpoint creation is not supported for multiple resource group deployment model, please use single single " +
+                        "resource groups to be able to use private endpoints in Azure!"));
+    }
+
+    @Test
+    void testCheckExistingPrivateDnsZoneWhenNotPrivateEndpoint() {
+        ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
+        AzureParams azureParams = getAzureParams(EXISTING_PRIVATE_DNS_ZONE_ID);
+        NetworkDto networkDto = getNetworkDto(azureParams, ServiceEndpointCreation.DISABLED);
+
+        underTest.checkExistingPrivateDnsZoneWhenNotPrivateEndpoint(validationResultBuilder, networkDto);
+
+        assertTrue(validationResultBuilder.build().hasError());
+        NetworkTestUtils.checkErrorsPresent(validationResultBuilder, List.of(
+                "A private DNS zone is provided, but private endpoint creation is turned off. Please either turn on private endpoint creation" +
+                        " or do not specify the existing private DNS zone."));
+    }
+
+    private AzureParams getAzureParams() {
+        return getAzureParams(null);
+    }
+
+    private AzureParams getAzureParams(String privateDnsZoneId) {
+        return AzureParams.builder()
+                .withNetworkId(AzurePrivateEndpointValidatorTest.NETWORK_ID)
+                .withResourceGroupName("networkResourceGroupName")
+                .withPrivateDnsZoneId(privateDnsZoneId)
+                .build();
+    }
+
+    private NetworkDto getNetworkDto(AzureParams azureParams) {
+        return getNetworkDto(azureParams, ServiceEndpointCreation.ENABLED_PRIVATE_ENDPOINT);
+    }
+
+    private NetworkDto getNetworkDto(AzureParams azureParams, ServiceEndpointCreation serviceEndpointCreation) {
+        return NetworkDto.builder()
+                .withId(1L)
+                .withName("networkName")
+                .withResourceCrn("aResourceCRN")
+                .withAzure(azureParams)
+                .withSubnetMetas(Map.of())
+                .withNetworkId("networkId")
+                .withServiceEndpointCreation(serviceEndpointCreation)
+                .build();
+    }
+
+    private EnvironmentDto getEnvironmentDto(String name, ResourceGroupUsagePattern resourceGroupUsagePattern) {
+        return EnvironmentDto.builder()
+                .withParameters(ParametersDto.builder()
+                        .withAzureParameters(
+                                AzureParametersDto.builder()
+                                        .withResourceGroup(AzureResourceGroupDto.builder()
+                                                .withName(name)
+                                                .withResourceGroupUsagePattern(resourceGroupUsagePattern)
+                                                .build())
+                                        .build()
+                        ).build())
+                .build();
+    }
+
+    private Map<String, CloudSubnet> getCloudSubnets(boolean privateEndpointNetworkPoliciesEnabled) {
+        CloudSubnet cloudSubnetOne = new CloudSubnet();
+        cloudSubnetOne.putParameter("privateEndpointNetworkPolicies", privateEndpointNetworkPoliciesEnabled ? "enabled" : "disabled");
+        cloudSubnetOne.setName("subnet-one");
+        return Map.of("subnet-one", cloudSubnetOne);
+    }
+
+}

--- a/structuredevent-model/src/main/java/com/sequenceiq/environment/network/dto/AzureParams.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/environment/network/dto/AzureParams.java
@@ -8,10 +8,13 @@ public class AzureParams {
 
     private boolean noPublicIp;
 
+    private String privateDnsZoneId;
+
     private AzureParams(Builder builder) {
         networkId = builder.networkId;
         resourceGroupName = builder.resourceGroupName;
         noPublicIp = builder.noPublicIp;
+        privateDnsZoneId = builder.privateDnsZoneId;
     }
 
     public String getNetworkId() {
@@ -38,12 +41,21 @@ public class AzureParams {
         this.noPublicIp = noPublicIp;
     }
 
+    public String getPrivateDnsZoneId() {
+        return privateDnsZoneId;
+    }
+
+    public void setPrivateDnsZoneId(String privateDnsZoneId) {
+        this.privateDnsZoneId = privateDnsZoneId;
+    }
+
     @Override
     public String toString() {
         return "AzureParams{" +
                 "networkId='" + networkId + '\'' +
                 ", resourceGroupName='" + resourceGroupName + '\'' +
                 ", noPublicIp=" + noPublicIp +
+                ", privateDnsZoneId='" + privateDnsZoneId + '\'' +
                 '}';
     }
 
@@ -57,6 +69,8 @@ public class AzureParams {
         private String resourceGroupName;
 
         private boolean noPublicIp;
+
+        private String privateDnsZoneId;
 
         private Builder() {
         }
@@ -73,6 +87,11 @@ public class AzureParams {
 
         public Builder withNoPublicIp(boolean noPublicIp) {
             this.noPublicIp = noPublicIp;
+            return this;
+        }
+
+        public Builder withPrivateDnsZoneId(String privateDnsZoneId) {
+            this.privateDnsZoneId = privateDnsZoneId;
             return this;
         }
 


### PR DESCRIPTION
As the first commit of Bring Your Own DNS Zone feature, it introduces API changes to environment service:
- in the request a new Azure related field, privateDnsZoneId in network request is introduced, it takes a full azure resource id
- the id is then saved into the environment_network table
- the response returns an additional field privateDnsZoneId

However, the functionality should not yet change: if serviceEndpointCreation is set to enabledPrivateEndpoint, then the private DNS zone is still created in the single RG.

See detailed description in the commit message.