### PR TITLE
CB-13425.. Addendum: put back cdp-logging-agent manual install.

### DIFF
--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/cdp-logging-agent-init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/cdp-logging-agent-init.sls
@@ -4,6 +4,27 @@
 {% set dbus_lock_exists = salt['file.file_exists' ]('/etc/cdp-logging-agent/databus_bundle.lock') %}
 {% set restart_sleep_time = 1200 %}
 
+{% if fluent.uninstallTdAgent %}
+td_agent_stop:
+  service.dead:
+    - enable: False
+    - name: td-agent
+uninstall_td_agent:
+  pkg.purged:
+    - name: td-agent
+{% endif %}
+{% if not fluent.cdpLoggingAgentInstalled %}
+{% if os == "RedHat" or os == "CentOS" %}
+install_cdp_logging_agent:
+  cmd.run:
+    - name: rpm -i {{ fluent.cdpLoggingAgentRpm }}
+{% else %}
+install_cdp_logging_agent_warning:
+  cmd.run:
+    - name: echo "CDP logging agent cannot be installed to {{ os }}"
+{% endif %}
+{% endif %}
+
 /etc/cdp-logging-agent/post-start.sh:
   file.managed:
     - source: salt://fluent/template/post-start.sh.j2

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
@@ -4,6 +4,8 @@
 {% else %}
     {% set fluent_enabled = False %}
 {% endif %}
+{% set cdp_logging_agent_version = '0.2.16' %}
+{% set cdp_logging_agent_rpm = 'https://cloudera-service-delivery-cache.s3.amazonaws.com/telemetry/cdp-logging-agent/' + cdp_logging_agent_version + '/cdp_logging_agent-'+ cdp_logging_agent_version + '.x86_64.rpm' %}
 {% if salt['pillar.get']('fluent:cloudStorageLoggingEnabled') %}
     {% set cloud_storage_logging_enabled = True %}
 {% else %}
@@ -216,10 +218,15 @@
 {% endif %}
 {% set td_agent_installed = salt['file.directory_exists' ]('/etc/td-agent') %}
 {% set cdp_logging_agent_installed = salt['file.directory_exists' ]('/etc/cdp-logging-agent') %}
-{% if td_agent_installed and not cdp_logging_agent_installed %}
+{% if td_agent_installed and cdp_logging_agent_installed %}
+  {% set binary = 'cdp-logging-agent' %}
+  {% set uninstall_td_agent = True %}
+{% elif td_agent_installed %}
   {% set binary = 'td-agent' %}
+  {% set uninstall_td_agent = False %}
 {% else %}
   {% set binary = 'cdp-logging-agent' %}
+  {% set uninstall_td_agent = False %}
 {% endif %}
 {% do fluent.update({
     "enabled": fluent_enabled,
@@ -283,5 +290,8 @@
     "proxyFullUrl": proxy_full_url,
     "noProxyHosts": no_proxy_hosts,
     "binary": binary,
-    "fluentVersion": fluent_version
+    "fluentVersion": fluent_version,
+    "cdpLoggingAgentInstalled": cdp_logging_agent_installed,
+    "cdpLoggingAgentRpm": cdp_logging_agent_rpm,
+    "uninstallTdAgent": uninstall_td_agent
 }) %}


### PR DESCRIPTION
details:
- for ycloud, logging agents are not installed by default, this code installs rpm manually from s3
- this code is needed for tests, so just putting back as is, we will need to figure it out a better way for the upgrade

See detailed description in the commit message.