### PR TITLE
CB-16051 Can't stop the environment if DL has Node failure

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
@@ -814,6 +814,7 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
         ClustersResourceApi apiInstance = clouderaManagerApiFactory.getClustersResourceApi(apiClient);
         String clusterName = cluster.getName();
         LOGGER.debug("Starting all services for cluster.");
+        configService.enableKnoxAutorestartIfCmVersionAtLeast(CLOUDERAMANAGER_VERSION_7_1_0, apiClient, stack.getName());
         eventService
                 .fireCloudbreakEvent(stack.getId(), UPDATE_IN_PROGRESS.name(), CLUSTER_CM_CLUSTER_SERVICES_STARTING);
         Collection<ApiService> apiServices = readServices(stack);

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Stack.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Stack.java
@@ -699,7 +699,8 @@ public class Stack implements ProvisionEntity, WorkspaceAwareResource, Orchestra
                 || STOPPED.equals(getStatus())
                 || STOP_REQUESTED.equals(getStatus())
                 || STOP_IN_PROGRESS.equals(getStatus())
-                || EXTERNAL_DATABASE_STOP_FINISHED.equals(getStatus());
+                || EXTERNAL_DATABASE_STOP_FINISHED.equals(getStatus())
+                || NODE_FAILURE.equals(getStatus());
     }
 
     public boolean isExternalDatabaseStopped() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterStopHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterStopHandler.java
@@ -44,7 +44,7 @@ public class ClusterStopHandler implements EventHandler<ClusterStopRequest> {
             Stack stack = stackService.getByIdWithListsInTransaction(request.getResourceId());
             boolean clusterManagerRunning = apiConnectors.getConnector(stack).clusterStatusService().isClusterManagerRunning();
             if (clusterManagerRunning) {
-                apiConnectors.getConnector(stack).stopCluster(false);
+                apiConnectors.getConnector(stack).stopCluster(true);
             } else {
                 LOGGER.info("Cluster manager isn't running, cannot stop it.");
             }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
@@ -421,7 +421,8 @@ public class StackOperationService {
         } else if (reason != StopRestrictionReason.NONE) {
             throw new BadRequestException(
                     format("Cannot stop a stack '%s'. Reason: %s", stack.getName(), reason.getReason()));
-        } else if (!stack.isAvailable() && !stack.isStopFailed() && !stack.isAvailableWithStoppedInstances()) {
+        } else if (!stack.isAvailable() && !stack.isStopFailed()
+                && !stack.isAvailableWithStoppedInstances() && !stack.hasNodeFailure()) {
             throw NotAllowedStatusUpdate
                     .stack(stack)
                     .to(STOPPED)


### PR DESCRIPTION
Allowing DH and DL to be stopped even if they have node-failures.