### PR TITLE
CB-16272: Fixed SDX authorization via env CRN for detached DLs in order to allow detached DLs to be deleted via environment deletion.

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/repository/SdxClusterRepository.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/repository/SdxClusterRepository.java
@@ -50,8 +50,8 @@ public interface SdxClusterRepository extends AccountAwareResourceRepository<Sdx
 
     List<SdxCluster> findByAccountIdAndEnvCrn(@Param("accountId") String accountId, @Param("envcrn") String envcrn);
 
-    @Query("SELECT s.envCrn FROM SdxCluster s WHERE s.accountId = :accountId AND s.crn = :crn AND s.deleted is null AND s.detached = false")
-    Optional<String> findEnvCrnByAccountIdAndCrnAndDeletedIsNullAndDetachedIsFalse(@Param("accountId") String accountId, @Param("crn") String crn);
+    @Query("SELECT s.envCrn FROM SdxCluster s WHERE s.accountId = :accountId AND s.crn = :crn AND s.deleted is null")
+    Optional<String> findEnvCrnByAccountIdAndCrnAndDeletedIsNull(@Param("accountId") String accountId, @Param("crn") String crn);
 
     @Query("SELECT s FROM SdxCluster s WHERE s.accountId = :accountId AND s.crn IN (:crns) AND s.deleted is null AND s.detached = false")
     List<SdxCluster> findAllByAccountIdAndCrnAndDeletedIsNullAndDetachedIsFalse(@Param("accountId") String accountId, @Param("crns") Set<String> crns);

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -309,7 +309,7 @@ public class SdxService implements ResourceIdProvider, PayloadContextProvider, H
     public String getEnvCrnByCrn(String userCrn, String clusterCrn) {
         LOGGER.info("Searching for SDX cluster by crn {}", clusterCrn);
         String accountIdFromCrn = getAccountIdFromCrn(userCrn);
-        Optional<String> envCrn = sdxClusterRepository.findEnvCrnByAccountIdAndCrnAndDeletedIsNullAndDetachedIsFalse(accountIdFromCrn, clusterCrn);
+        Optional<String> envCrn = sdxClusterRepository.findEnvCrnByAccountIdAndCrnAndDeletedIsNull(accountIdFromCrn, clusterCrn);
         if (envCrn.isPresent()) {
             return envCrn.get();
         } else {


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-16272

This is focused on fixing an issue noticed when trying to delete an environment (even with the force flag) which had live detached DLs. Specifically, authorization would fail since the detached DLs could not be found and matched.

This should fix this.