### PR TITLE
CB-16354 Bring your own DNS zone - Environment PlatformResources: add…

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/PlatformResources.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/PlatformResources.java
@@ -16,6 +16,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudVmTypes;
 import com.sequenceiq.cloudbreak.cloud.model.ExtendedCloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.Region;
 import com.sequenceiq.cloudbreak.cloud.model.database.CloudDatabaseServerSslCertificates;
+import com.sequenceiq.cloudbreak.cloud.model.dns.CloudPrivateDnsZones;
 import com.sequenceiq.cloudbreak.cloud.model.nosql.CloudNoSqlTables;
 import com.sequenceiq.cloudbreak.cloud.model.resourcegroup.CloudResourceGroups;
 
@@ -128,7 +129,22 @@ public interface PlatformResources {
      */
     CloudNoSqlTables noSqlTables(ExtendedCloudCredential cloudCredential, Region region, Map<String, String> filters);
 
+    /**
+     * Returns the list of resource groups
+     * @param cloudCredential credentials to connect to the cloud provider
+     * @param region region of resources - on some providers, resource groups of all regions are returned
+     * @param filters not used (reserved)
+     * @return the {@link CloudResourceGroups} contains all the resource groups
+     */
     CloudResourceGroups resourceGroups(ExtendedCloudCredential cloudCredential, Region region, Map<String, String> filters);
+
+    /**
+     * Returns the list of private DNS zones
+     * @param cloudCredential credentials to connect to the cloud provider
+     * @param filters not used (reserved)
+     * @return the {@link CloudPrivateDnsZones} contains all the private DNS zones
+     */
+    CloudPrivateDnsZones privateDnsZones(ExtendedCloudCredential cloudCredential, Map<String, String> filters);
 
     default boolean regionMatch(Region actualRegion, Region expectedRegion) {
         return expectedRegion == null || Strings.isNullOrEmpty(expectedRegion.value()) || actualRegion.value().equals(expectedRegion.value());

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/dns/CloudPrivateDnsZone.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/dns/CloudPrivateDnsZone.java
@@ -1,0 +1,47 @@
+package com.sequenceiq.cloudbreak.cloud.model.dns;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+public class CloudPrivateDnsZone {
+
+    private String privateDnsZoneId;
+
+    public CloudPrivateDnsZone(String privateDnsZoneId) {
+        this.privateDnsZoneId = privateDnsZoneId;
+    }
+
+    public String getPrivateDnsZoneId() {
+        return privateDnsZoneId;
+    }
+
+    public void setPrivateDnsZoneId(String privateDnsZoneId) {
+        this.privateDnsZoneId = privateDnsZoneId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CloudPrivateDnsZone that = (CloudPrivateDnsZone) o;
+
+        return new EqualsBuilder().append(getPrivateDnsZoneId(), that.getPrivateDnsZoneId()).isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37).append(getPrivateDnsZoneId()).toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "CloudPrivateDnsZone{" +
+                "privateDnsZoneId='" + privateDnsZoneId + '\'' +
+                '}';
+    }
+
+}

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/dns/CloudPrivateDnsZones.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/dns/CloudPrivateDnsZones.java
@@ -1,0 +1,53 @@
+package com.sequenceiq.cloudbreak.cloud.model.dns;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CloudPrivateDnsZones {
+
+    private List<CloudPrivateDnsZone> privateDnsZones = new ArrayList<>();
+
+    public CloudPrivateDnsZones() {
+    }
+
+    public CloudPrivateDnsZones(List<CloudPrivateDnsZone> privateDnsZones) {
+        this.privateDnsZones = privateDnsZones;
+    }
+
+    public List<CloudPrivateDnsZone> getPrivateDnsZones() {
+        return privateDnsZones;
+    }
+
+    public void setPrivateDnsZones(List<CloudPrivateDnsZone> privateDnsZones) {
+        this.privateDnsZones = privateDnsZones;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        CloudPrivateDnsZones that = (CloudPrivateDnsZones) o;
+
+        return getPrivateDnsZones() != null
+                ? getPrivateDnsZones().equals(that.getPrivateDnsZones())
+                : that.getPrivateDnsZones() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return getPrivateDnsZones() != null ? getPrivateDnsZones().hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "CloudPrivateDnsZones{" +
+                "privateDnsZones=" + privateDnsZones +
+                '}';
+    }
+
+}

--- a/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/PlatformResourcesTest.java
+++ b/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/PlatformResourcesTest.java
@@ -21,6 +21,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudSshKeys;
 import com.sequenceiq.cloudbreak.cloud.model.CloudVmTypes;
 import com.sequenceiq.cloudbreak.cloud.model.ExtendedCloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.Region;
+import com.sequenceiq.cloudbreak.cloud.model.dns.CloudPrivateDnsZones;
 import com.sequenceiq.cloudbreak.cloud.model.nosql.CloudNoSqlTables;
 import com.sequenceiq.cloudbreak.cloud.model.resourcegroup.CloudResourceGroups;
 
@@ -96,6 +97,11 @@ class PlatformResourcesTest {
 
         @Override
         public CloudResourceGroups resourceGroups(ExtendedCloudCredential cloudCredential, Region region, Map<String, String> filters) {
+            return null;
+        }
+
+        @Override
+        public CloudPrivateDnsZones privateDnsZones(ExtendedCloudCredential cloudCredential, Map<String, String> filters) {
             return null;
         }
 

--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/AwsPlatformResources.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/AwsPlatformResources.java
@@ -139,6 +139,7 @@ import com.sequenceiq.cloudbreak.cloud.model.VolumeParameterType;
 import com.sequenceiq.cloudbreak.cloud.model.database.CloudDatabaseServerSslCertificate;
 import com.sequenceiq.cloudbreak.cloud.model.database.CloudDatabaseServerSslCertificateType;
 import com.sequenceiq.cloudbreak.cloud.model.database.CloudDatabaseServerSslCertificates;
+import com.sequenceiq.cloudbreak.cloud.model.dns.CloudPrivateDnsZones;
 import com.sequenceiq.cloudbreak.cloud.model.nosql.CloudNoSqlTable;
 import com.sequenceiq.cloudbreak.cloud.model.nosql.CloudNoSqlTables;
 import com.sequenceiq.cloudbreak.cloud.model.resourcegroup.CloudResourceGroups;
@@ -917,6 +918,11 @@ public class AwsPlatformResources implements PlatformResources {
     @Override
     public CloudResourceGroups resourceGroups(ExtendedCloudCredential cloudCredential, Region region, Map<String, String> filters) {
         return new CloudResourceGroups();
+    }
+
+    @Override
+    public CloudPrivateDnsZones privateDnsZones(ExtendedCloudCredential cloudCredential, Map<String, String> filters) {
+        return new CloudPrivateDnsZones();
     }
 
     @Override

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePlatformResources.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePlatformResources.java
@@ -33,6 +33,7 @@ import com.microsoft.azure.management.msi.Identity;
 import com.microsoft.azure.management.network.Network;
 import com.microsoft.azure.management.network.NetworkSecurityGroup;
 import com.microsoft.azure.management.network.Subnet;
+import com.microsoft.azure.management.privatedns.v2018_09_01.PrivateZone;
 import com.microsoft.azure.management.resources.ResourceGroup;
 import com.sequenceiq.cloudbreak.cloud.PlatformResources;
 import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
@@ -60,6 +61,8 @@ import com.sequenceiq.cloudbreak.cloud.model.VmType;
 import com.sequenceiq.cloudbreak.cloud.model.VmTypeMeta.VmTypeMetaBuilder;
 import com.sequenceiq.cloudbreak.cloud.model.VolumeParameterConfig;
 import com.sequenceiq.cloudbreak.cloud.model.VolumeParameterType;
+import com.sequenceiq.cloudbreak.cloud.model.dns.CloudPrivateDnsZone;
+import com.sequenceiq.cloudbreak.cloud.model.dns.CloudPrivateDnsZones;
 import com.sequenceiq.cloudbreak.cloud.model.nosql.CloudNoSqlTables;
 import com.sequenceiq.cloudbreak.cloud.model.resourcegroup.CloudResourceGroup;
 import com.sequenceiq.cloudbreak.cloud.model.resourcegroup.CloudResourceGroups;
@@ -341,6 +344,15 @@ public class AzurePlatformResources implements PlatformResources {
         resourceGroupPagedList.loadAll();
         List<CloudResourceGroup> resourceGroups = resourceGroupPagedList.stream().map(rg -> new CloudResourceGroup(rg.name())).collect(Collectors.toList());
         return new CloudResourceGroups(resourceGroups);
+    }
+
+    @Override
+    public CloudPrivateDnsZones privateDnsZones(ExtendedCloudCredential cloudCredential, Map<String, String> filters) {
+        List<PrivateZone> azurePrivateDnsZones = azureClientService.getClient(cloudCredential).getPrivateDnsZoneListFromAllSubscriptions();
+        List<CloudPrivateDnsZone> cloudPrivateDnsZoneList = azurePrivateDnsZones.stream()
+                .map(pdz -> new CloudPrivateDnsZone(pdz.id())).collect(Collectors.toList());
+        LOGGER.debug("Found private DNS zones are: {}", cloudPrivateDnsZoneList);
+        return new CloudPrivateDnsZones(cloudPrivateDnsZoneList);
     }
 
     public InstanceStoreMetadata collectInstanceStorageCount(AuthenticatedContext ac, List<String> instanceTypes) {

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
@@ -863,6 +863,21 @@ public class AzureClient {
         return privatednsManager.privateZones().list();
     }
 
+    public List<PrivateZone> getPrivateDnsZoneListFromAllSubscriptions() {
+        PagedList<Subscription> subscriptions = azure.subscriptions().list();
+        subscriptions.loadAll();
+        return subscriptions.stream().map(s -> getPrivateDnsZones(s.subscriptionId()))
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+    }
+
+    private PagedList<PrivateZone> getPrivateDnsZones(String subscriptionId) {
+        privatednsManager dnsManager = azureClientCredentials.getPrivateDnsManagerWithAnotherSubscription(subscriptionId);
+        PagedList<PrivateZone> privateDnsZones = dnsManager.privateZones().list();
+        privateDnsZones.loadAll();
+        return privateDnsZones;
+    }
+
     public ValidationResult validateNetworkLinkExistenceForDnsZones(String networkLinkId, List<AzurePrivateDnsZoneServiceEnum> services,
             String resourceGroupName) {
         ValidationResultBuilder resultBuilder = new ValidationResultBuilder();

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClientCredentials.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClientCredentials.java
@@ -63,6 +63,10 @@ public class AzureClientCredentials {
         return privatednsManager.authenticate(azureClientCredentials, credentialView.getSubscriptionId());
     }
 
+    public privatednsManager getPrivateDnsManagerWithAnotherSubscription(String subscriptionId) {
+        return privatednsManager.authenticate(azureClientCredentials, subscriptionId);
+    }
+
     public ComputeManager getComputeManager() {
         return ComputeManager.authenticate(azureClientCredentials, credentialView.getSubscriptionId());
     }

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpPlatformResources.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpPlatformResources.java
@@ -79,6 +79,7 @@ import com.sequenceiq.cloudbreak.cloud.model.RegionCoordinateSpecifications;
 import com.sequenceiq.cloudbreak.cloud.model.VmType;
 import com.sequenceiq.cloudbreak.cloud.model.VmTypeMeta;
 import com.sequenceiq.cloudbreak.cloud.model.VmTypeMeta.VmTypeMetaBuilder;
+import com.sequenceiq.cloudbreak.cloud.model.dns.CloudPrivateDnsZones;
 import com.sequenceiq.cloudbreak.cloud.model.nosql.CloudNoSqlTables;
 import com.sequenceiq.cloudbreak.cloud.model.resourcegroup.CloudResourceGroups;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
@@ -531,6 +532,11 @@ public class GcpPlatformResources implements PlatformResources {
     @Override
     public CloudResourceGroups resourceGroups(ExtendedCloudCredential cloudCredential, Region region, Map<String, String> filters) {
         return new CloudResourceGroups();
+    }
+
+    @Override
+    public CloudPrivateDnsZones privateDnsZones(ExtendedCloudCredential cloudCredential, Map<String, String> filters) {
+        return new CloudPrivateDnsZones();
     }
 
     private List<KeyRing> getKeyRingList(CloudKMS cloudKMS, String projectId, String regionName) {

--- a/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockPlatformResources.java
+++ b/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockPlatformResources.java
@@ -44,6 +44,7 @@ import com.sequenceiq.cloudbreak.cloud.model.VmType;
 import com.sequenceiq.cloudbreak.cloud.model.VmTypeMeta;
 import com.sequenceiq.cloudbreak.cloud.model.VolumeParameterConfig;
 import com.sequenceiq.cloudbreak.cloud.model.VolumeParameterType;
+import com.sequenceiq.cloudbreak.cloud.model.dns.CloudPrivateDnsZones;
 import com.sequenceiq.cloudbreak.cloud.model.nosql.CloudNoSqlTables;
 import com.sequenceiq.cloudbreak.cloud.model.resourcegroup.CloudResourceGroups;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
@@ -234,6 +235,11 @@ public class MockPlatformResources implements PlatformResources {
     @Override
     public CloudResourceGroups resourceGroups(ExtendedCloudCredential cloudCredential, Region region, Map<String, String> filters) {
         return new CloudResourceGroups();
+    }
+
+    @Override
+    public CloudPrivateDnsZones privateDnsZones(ExtendedCloudCredential cloudCredential, Map<String, String> filters) {
+        return new CloudPrivateDnsZones();
     }
 
     private Region getRegionByName(String name) {

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/platform/GetPlatformPrivateDnsZonesRequest.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/platform/GetPlatformPrivateDnsZonesRequest.java
@@ -1,0 +1,42 @@
+package com.sequenceiq.cloudbreak.cloud.event.platform;
+
+import java.util.Map;
+
+import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformRequest;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.ExtendedCloudCredential;
+
+public class GetPlatformPrivateDnsZonesRequest extends CloudPlatformRequest<GetPlatformPrivateDnsZonesResult> {
+
+    private final String variant;
+
+    private final ExtendedCloudCredential extendedCloudCredential;
+
+    private final Map<String, String> filters;
+
+    public GetPlatformPrivateDnsZonesRequest(CloudCredential cloudCredential, ExtendedCloudCredential extendedCloudCredential, String variant,
+            Map<String, String> filters) {
+        super(null, cloudCredential);
+        this.variant = variant;
+        this.extendedCloudCredential = extendedCloudCredential;
+        this.filters = filters;
+    }
+
+    public String getVariant() {
+        return variant;
+    }
+
+    public ExtendedCloudCredential getExtendedCloudCredential() {
+        return extendedCloudCredential;
+    }
+
+    public Map<String, String> getFilters() {
+        return filters;
+    }
+
+    @Override
+    public String toString() {
+        return "GetPlatformPrivateDnsZonesRequest{}";
+    }
+
+}

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/platform/GetPlatformPrivateDnsZonesResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/platform/GetPlatformPrivateDnsZonesResult.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.cloudbreak.cloud.event.platform;
+
+import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
+import com.sequenceiq.cloudbreak.cloud.model.dns.CloudPrivateDnsZones;
+
+public class GetPlatformPrivateDnsZonesResult extends CloudPlatformResult {
+
+    private CloudPrivateDnsZones privateDnsZones;
+
+    public GetPlatformPrivateDnsZonesResult(Long resourceId, CloudPrivateDnsZones privateDnsZones) {
+        super(resourceId);
+        this.privateDnsZones = privateDnsZones;
+    }
+
+    public GetPlatformPrivateDnsZonesResult(String statusReason, Exception errorDetails, Long resourceId) {
+        super(statusReason, errorDetails, resourceId);
+    }
+
+    public CloudPrivateDnsZones getPrivateDnsZones() {
+        return privateDnsZones;
+    }
+
+}

--- a/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/handler/GetPlatformPrivateDnsZonesHandler.java
+++ b/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/handler/GetPlatformPrivateDnsZonesHandler.java
@@ -1,0 +1,50 @@
+package com.sequenceiq.cloudbreak.cloud.handler;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.event.platform.GetPlatformPrivateDnsZonesRequest;
+import com.sequenceiq.cloudbreak.cloud.event.platform.GetPlatformPrivateDnsZonesResult;
+import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
+import com.sequenceiq.cloudbreak.cloud.model.CloudPlatformVariant;
+import com.sequenceiq.cloudbreak.cloud.model.Platform;
+import com.sequenceiq.cloudbreak.cloud.model.Variant;
+import com.sequenceiq.cloudbreak.cloud.model.dns.CloudPrivateDnsZones;
+
+import reactor.bus.Event;
+
+@Component
+public class GetPlatformPrivateDnsZonesHandler implements CloudPlatformEventHandler<GetPlatformPrivateDnsZonesRequest> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(GetPlatformPrivateDnsZonesHandler.class);
+
+    @Inject
+    private CloudPlatformConnectors cloudPlatformConnectors;
+
+    @Override
+    public Class<GetPlatformPrivateDnsZonesRequest> type() {
+        return GetPlatformPrivateDnsZonesRequest.class;
+    }
+
+    @Override
+    public void accept(Event<GetPlatformPrivateDnsZonesRequest> event) {
+        LOGGER.debug("Received event to retrieve private DNS zones: {}", event);
+        GetPlatformPrivateDnsZonesRequest request = event.getData();
+
+        try {
+            CloudPlatformVariant cloudPlatformVariant = new CloudPlatformVariant(
+                    Platform.platform(request.getExtendedCloudCredential().getCloudPlatform()),
+                    Variant.variant(request.getVariant()));
+            CloudPrivateDnsZones privateDnsZones = cloudPlatformConnectors.get(cloudPlatformVariant)
+                    .platformResources().privateDnsZones(request.getExtendedCloudCredential(), request.getFilters());
+            GetPlatformPrivateDnsZonesResult result = new GetPlatformPrivateDnsZonesResult(request.getResourceId(), privateDnsZones);
+            request.getResult().onNext(result);
+            LOGGER.debug("Query platform private DNS zones finished.");
+        } catch (RuntimeException e) {
+            request.getResult().onNext(new GetPlatformPrivateDnsZonesResult(e.getMessage(), e, request.getResourceId()));
+        }
+    }
+
+}

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnPlatformResources.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnPlatformResources.java
@@ -32,6 +32,7 @@ import com.sequenceiq.cloudbreak.cloud.model.ExtendedCloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.Region;
 import com.sequenceiq.cloudbreak.cloud.model.RegionCoordinateSpecification;
 import com.sequenceiq.cloudbreak.cloud.model.RegionCoordinateSpecifications;
+import com.sequenceiq.cloudbreak.cloud.model.dns.CloudPrivateDnsZones;
 import com.sequenceiq.cloudbreak.cloud.model.nosql.CloudNoSqlTables;
 import com.sequenceiq.cloudbreak.cloud.model.resourcegroup.CloudResourceGroups;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
@@ -131,4 +132,10 @@ public class YarnPlatformResources implements PlatformResources {
     public CloudResourceGroups resourceGroups(ExtendedCloudCredential cloudCredential, Region region, Map<String, String> filters) {
         return new CloudResourceGroups();
     }
+
+    @Override
+    public CloudPrivateDnsZones privateDnsZones(ExtendedCloudCredential cloudCredential, Map<String, String> filters) {
+        return new CloudPrivateDnsZones();
+    }
+
 }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/platformresource/CredentialPlatformResourceEndpoint.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/platformresource/CredentialPlatformResourceEndpoint.java
@@ -22,6 +22,7 @@ import com.sequenceiq.environment.api.v1.platformresource.model.PlatformGateways
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformIpPoolsResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformNetworksResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformNoSqlTablesResponse;
+import com.sequenceiq.environment.api.v1.platformresource.model.PlatformPrivateDnsZonesResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformResourceGroupsResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformSecurityGroupsResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformSshKeysResponse;
@@ -191,4 +192,15 @@ public interface CredentialPlatformResourceEndpoint {
             @QueryParam("region") String region,
             @QueryParam("platformVariant") String platformVariant,
             @QueryParam("availabilityZone") String availabilityZone);
+
+    @GET
+    @Path("private_dns_zones")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = OpDescription.GET_PRIVATE_DNS_ZONES, produces = MediaType.APPLICATION_JSON, notes = CONNECTOR_NOTES,
+            nickname = "getPrivateDnsZones")
+    PlatformPrivateDnsZonesResponse getPrivateDnsZones(
+            @QueryParam("credentialName") String credentialName,
+            @QueryParam("credentialCrn") String credentialCrn,
+            @QueryParam("platformVariant") String platformVariant);
+
 }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/platformresource/EnvironmentPlatformResourceEndpoint.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/platformresource/EnvironmentPlatformResourceEndpoint.java
@@ -21,6 +21,7 @@ import com.sequenceiq.environment.api.v1.platformresource.model.PlatformGateways
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformIpPoolsResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformNetworksResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformNoSqlTablesResponse;
+import com.sequenceiq.environment.api.v1.platformresource.model.PlatformPrivateDnsZonesResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformResourceGroupsResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformSecurityGroupsResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformSshKeysResponse;
@@ -162,4 +163,14 @@ public interface EnvironmentPlatformResourceEndpoint {
             @QueryParam("region") String region,
             @QueryParam("platformVariant") String platformVariant,
             @QueryParam("availabilityZone") String availabilityZone);
+
+    @GET
+    @Path("private_dns_zones")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = OpEnvDescription.GET_PRIVATE_DNS_ZONES, produces = MediaType.APPLICATION_JSON, notes = CONNECTOR_NOTES,
+            nickname = "getPrivateDnsZonesByEnv")
+    PlatformPrivateDnsZonesResponse getPrivateDnsZones(
+            @QueryParam("environmentCrn") @NotEmpty String environmentCrn,
+            @QueryParam("platformVariant") String platformVariant);
+
 }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/platformresource/PlatformResourceModelDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/platformresource/PlatformResourceModelDescription.java
@@ -34,6 +34,7 @@ public class PlatformResourceModelDescription {
         public static final String GET_ENCRYPTIONKEYS = "retrieve encryption keys with properties";
         public static final String GET_NOSQL_TABLES = "retrieve nosql tables";
         public static final String GET_RESOURCE_GROUPS = "retrieve resource groups";
+        public static final String GET_PRIVATE_DNS_ZONES = "retrieve private DNS zones";
     }
 
     public static class OpEnvDescription {
@@ -51,6 +52,7 @@ public class PlatformResourceModelDescription {
         public static final String GET_ENCRYPTIONKEYS = "retrieve encryption keys with properties by environment";
         public static final String GET_NOSQL_TABLES = "retrieve nosql tables by environment";
         public static final String GET_RESOURCE_GROUPS = "retrieve resource groups by environment";
+        public static final String GET_PRIVATE_DNS_ZONES = "retrieve private DNS zones by environment";
     }
 
 }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/platformresource/model/PlatformPrivateDnsZoneResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/platformresource/model/PlatformPrivateDnsZoneResponse.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.environment.api.v1.platformresource.model;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import io.swagger.annotations.ApiModel;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PlatformPrivateDnsZoneResponse implements Serializable {
+
+    private String id;
+
+    public PlatformPrivateDnsZoneResponse() {
+    }
+
+    public PlatformPrivateDnsZoneResponse(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public String toString() {
+        return "PlatformPrivateDnsZoneResponse{" +
+                "id='" + id + '\'' +
+                '}';
+    }
+
+}

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/platformresource/model/PlatformPrivateDnsZonesResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/platformresource/model/PlatformPrivateDnsZonesResponse.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.environment.api.v1.platformresource.model;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PlatformPrivateDnsZonesResponse implements Serializable {
+
+    private List<PlatformPrivateDnsZoneResponse> privateDnsZoneResponses = new ArrayList<>();
+
+    public PlatformPrivateDnsZonesResponse() {
+    }
+
+    public PlatformPrivateDnsZonesResponse(@NotNull List<PlatformPrivateDnsZoneResponse> privateDnsZoneResponses) {
+        this.privateDnsZoneResponses = privateDnsZoneResponses;
+    }
+
+    public List<PlatformPrivateDnsZoneResponse> getPrivateDnsZoneResponses() {
+        return privateDnsZoneResponses;
+    }
+
+    public void setPrivateDnsZoneResponses(List<PlatformPrivateDnsZoneResponse> privateDnsZoneResponses) {
+        this.privateDnsZoneResponses = privateDnsZoneResponses;
+    }
+
+    @Override
+    public String toString() {
+        return "PlatformPrivateDnsZonesResponse{" +
+                "privateDnsZoneResponses=" + privateDnsZoneResponses +
+                '}';
+    }
+
+}

--- a/environment/src/main/java/com/sequenceiq/environment/platformresource/PlatformParameterService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/platformresource/PlatformParameterService.java
@@ -29,6 +29,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudSshKeys;
 import com.sequenceiq.cloudbreak.cloud.model.CloudVmTypes;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
 import com.sequenceiq.cloudbreak.cloud.model.PlatformDisks;
+import com.sequenceiq.cloudbreak.cloud.model.dns.CloudPrivateDnsZones;
 import com.sequenceiq.cloudbreak.cloud.model.nosql.CloudNoSqlTables;
 import com.sequenceiq.cloudbreak.cloud.model.resourcegroup.CloudResourceGroups;
 import com.sequenceiq.cloudbreak.cloud.service.CloudParameterService;
@@ -51,6 +52,41 @@ public class PlatformParameterService {
 
     @Inject
     private CredentialToExtendedCloudCredentialConverter extendedCloudCredentialConverter;
+
+    public PlatformResourceRequest getPlatformResourceRequestByEnvironment(
+            String accountId,
+            String environmentCrn,
+            String platformVariant,
+            String sharedProjectId) {
+        return getPlatformResourceRequestByEnvironment(
+                accountId,
+                environmentCrn,
+                null,
+                platformVariant,
+                null,
+                sharedProjectId,
+                null,
+                CdpResourceType.DEFAULT);
+    }
+
+    public PlatformResourceRequest getPlatformResourceRequest(
+            String accountId,
+            String credentialName,
+            String credentialCrn,
+            String platformVariant,
+            CdpResourceType cdpResourceType) {
+        return getPlatformResourceRequest(
+                accountId,
+                credentialName,
+                credentialCrn,
+                null,
+                platformVariant,
+                null,
+                null,
+                new HashMap<>(),
+                null,
+                cdpResourceType);
+    }
 
     public PlatformResourceRequest getPlatformResourceRequest(
             String accountId,
@@ -326,6 +362,11 @@ public class PlatformParameterService {
 
     public CloudResourceGroups getResourceGroups(PlatformResourceRequest request) {
         return cloudParameterService.getResourceGroups(extendedCloudCredentialConverter.convert(request.getCredential()), request.getRegion(),
+                request.getPlatformVariant(), request.getFilters());
+    }
+
+    public CloudPrivateDnsZones getPrivateDnsZones(PlatformResourceRequest request) {
+        return cloudParameterService.getPrivateDnsZones(extendedCloudCredentialConverter.convert(request.getCredential()),
                 request.getPlatformVariant(), request.getFilters());
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/platformresource/v1/CredentialPlatformResourceController.java
+++ b/environment/src/main/java/com/sequenceiq/environment/platformresource/v1/CredentialPlatformResourceController.java
@@ -35,6 +35,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudSshKeys;
 import com.sequenceiq.cloudbreak.cloud.model.CloudVmTypes;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
 import com.sequenceiq.cloudbreak.cloud.model.PlatformDisks;
+import com.sequenceiq.cloudbreak.cloud.model.dns.CloudPrivateDnsZones;
 import com.sequenceiq.cloudbreak.cloud.model.nosql.CloudNoSqlTables;
 import com.sequenceiq.cloudbreak.cloud.model.resourcegroup.CloudResourceGroups;
 import com.sequenceiq.cloudbreak.common.network.NetworkConstants;
@@ -48,6 +49,8 @@ import com.sequenceiq.environment.api.v1.platformresource.model.PlatformGateways
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformIpPoolsResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformNetworksResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformNoSqlTablesResponse;
+import com.sequenceiq.environment.api.v1.platformresource.model.PlatformPrivateDnsZoneResponse;
+import com.sequenceiq.environment.api.v1.platformresource.model.PlatformPrivateDnsZonesResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformResourceGroupResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformResourceGroupsResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformSecurityGroupsResponse;
@@ -429,6 +432,30 @@ public class CredentialPlatformResourceController implements CredentialPlatformR
                 .collect(Collectors.toList());
         PlatformResourceGroupsResponse response = new PlatformResourceGroupsResponse(platformResourceGroups);
         LOGGER.info("Resp /platform_resources/resource_groups, request: {}, resourceGroups: {}, response: {}", request, resourceGroups, response);
+        return response;
+    }
+
+    @Override
+    @CustomPermissionCheck
+    public PlatformPrivateDnsZonesResponse getPrivateDnsZones(
+            String credentialName,
+            String credentialCrn,
+            String platformVariant) {
+        CustomCheckUtil.run(() -> permissionCheckByCredential(credentialName, credentialCrn));
+        String accountId = getAccountId();
+        PlatformResourceRequest request = platformParameterService.getPlatformResourceRequest(
+                accountId,
+                credentialName,
+                credentialCrn,
+                platformVariant,
+                CdpResourceType.DEFAULT);
+        LOGGER.debug("Get /platform_resources/private_dns_zones, request: {}", request);
+        CloudPrivateDnsZones privateDnsZones = platformParameterService.getPrivateDnsZones(request);
+        List<PlatformPrivateDnsZoneResponse> platformPrivateDnsZones = privateDnsZones.getPrivateDnsZones().stream()
+                .map(pdz -> new PlatformPrivateDnsZoneResponse(pdz.getPrivateDnsZoneId()))
+                .collect(Collectors.toList());
+        PlatformPrivateDnsZonesResponse response = new PlatformPrivateDnsZonesResponse(platformPrivateDnsZones);
+        LOGGER.debug("Resp /platform_resources/private_dns_zones, request: {}, privateDnsZones: {}, response: {}", request, privateDnsZones, response);
         return response;
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/platformresource/v1/EnvironmentPlatformResourceController.java
+++ b/environment/src/main/java/com/sequenceiq/environment/platformresource/v1/EnvironmentPlatformResourceController.java
@@ -27,6 +27,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudRegions;
 import com.sequenceiq.cloudbreak.cloud.model.CloudSecurityGroups;
 import com.sequenceiq.cloudbreak.cloud.model.CloudSshKeys;
 import com.sequenceiq.cloudbreak.cloud.model.CloudVmTypes;
+import com.sequenceiq.cloudbreak.cloud.model.dns.CloudPrivateDnsZones;
 import com.sequenceiq.cloudbreak.cloud.model.nosql.CloudNoSqlTables;
 import com.sequenceiq.cloudbreak.cloud.model.resourcegroup.CloudResourceGroups;
 import com.sequenceiq.common.api.type.CdpResourceType;
@@ -38,6 +39,8 @@ import com.sequenceiq.environment.api.v1.platformresource.model.PlatformGateways
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformIpPoolsResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformNetworksResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformNoSqlTablesResponse;
+import com.sequenceiq.environment.api.v1.platformresource.model.PlatformPrivateDnsZoneResponse;
+import com.sequenceiq.environment.api.v1.platformresource.model.PlatformPrivateDnsZonesResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformResourceGroupResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformResourceGroupsResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformSecurityGroupsResponse;
@@ -359,6 +362,28 @@ public class EnvironmentPlatformResourceController implements EnvironmentPlatfor
                 .collect(Collectors.toList());
         PlatformResourceGroupsResponse response = new PlatformResourceGroupsResponse(platformResourceGroups);
         LOGGER.info("Resp /platform_resources/resource_groups, request: {}, resourceGroups: {}, response: {}", request, resourceGroups, response);
+        return response;
+    }
+
+    @Override
+    @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.DESCRIBE_ENVIRONMENT)
+    public PlatformPrivateDnsZonesResponse getPrivateDnsZones(
+            @ResourceCrn String environmentCrn,
+            String platformVariant) {
+        String accountId = getAccountId();
+        validateEnvironmentCrnPattern(environmentCrn);
+        PlatformResourceRequest request = platformParameterService.getPlatformResourceRequestByEnvironment(
+                accountId,
+                environmentCrn,
+                platformVariant,
+                null);
+        LOGGER.debug("Get /platform_resources/private_dns_zones, request: {}", request);
+        CloudPrivateDnsZones privateDnsZones = platformParameterService.getPrivateDnsZones(request);
+        List<PlatformPrivateDnsZoneResponse> platformPrivateDnsZones = privateDnsZones.getPrivateDnsZones().stream()
+                .map(pdz -> new PlatformPrivateDnsZoneResponse(pdz.getPrivateDnsZoneId()))
+                .collect(Collectors.toList());
+        PlatformPrivateDnsZonesResponse response = new PlatformPrivateDnsZonesResponse(platformPrivateDnsZones);
+        LOGGER.debug("Resp /platform_resources/private_dns_zones, request: {}, privateDnsZones: {}, response: {}", request, privateDnsZones, response);
         return response;
     }
 


### PR DESCRIPTION
… endpoint to return private DNS zones

An endpoint is needed that returns all private DNS zones, so that the UI can list available private DNS zones in the environment creation wizard.

See detailed description in the commit message.