### PR TITLE
CB-16388 RDSConfig calculation take long time, refactor the RdsConfig select by clusterId

### DIFF
--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/view/RdsConfigWithoutCluster.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/view/RdsConfigWithoutCluster.java
@@ -1,0 +1,41 @@
+package com.sequenceiq.cloudbreak.domain.view;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ResourceStatus;
+import com.sequenceiq.cloudbreak.domain.RdsSslMode;
+import com.sequenceiq.cloudbreak.service.secret.domain.Secret;
+
+public interface RdsConfigWithoutCluster {
+    Long getId();
+
+    String getName();
+
+    String getDescription();
+
+    String getConnectionURL();
+
+    RdsSslMode getSslMode();
+
+    DatabaseVendor getDatabaseEngine();
+
+    String getConnectionDriver();
+
+    Long getCreationDate();
+
+    String getStackVersion();
+
+    ResourceStatus getStatus();
+
+    String getType();
+
+    String getConnectorJarUrl();
+
+    boolean isArchived();
+
+    Long getDeletionTimestamp();
+
+    Secret getConnectionUserName();
+
+    Secret getConnectionPassword();
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/StackCreatorService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/StackCreatorService.java
@@ -288,7 +288,7 @@ public class StackCreatorService {
             if (e.getCause() instanceof DataIntegrityViolationException) {
                 String msg = String.format("Error with resource [%s], error: [%s]", APIResourceType.STACK,
                         getProperSqlErrorMessage((DataIntegrityViolationException) e.getCause()));
-                throw new BadRequestException(msg);
+                throw new BadRequestException(msg, e.getCause());
             }
             throw new TransactionRuntimeExecutionException(e);
         }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/RdsConfigWithoutClusterRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/RdsConfigWithoutClusterRepository.java
@@ -1,0 +1,69 @@
+package com.sequenceiq.cloudbreak.repository;
+
+import java.util.List;
+import java.util.Set;
+
+import javax.transaction.Transactional;
+import javax.transaction.Transactional.TxType;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ResourceStatus;
+import com.sequenceiq.cloudbreak.domain.RDSConfig;
+import com.sequenceiq.cloudbreak.domain.view.RdsConfigWithoutCluster;
+import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
+
+@EntityType(entityClass = RDSConfig.class)
+@Transactional(TxType.REQUIRED)
+public interface RdsConfigWithoutClusterRepository extends CrudRepository<RDSConfig, Long> {
+
+    String PROJECTION = "r.id as id, " +
+            "r.name as name, " +
+            "r.description as description, " +
+            "r.connectionURL as connectionURL," +
+            "r.sslMode as sslMode," +
+            "r.databaseEngine as databaseEngine," +
+            "r.connectionDriver as connectionDriver," +
+            "r.creationDate as creationDate," +
+            "r.stackVersion as stackVersion," +
+            "r.status as status," +
+            "r.type as type," +
+            "r.connectorJarUrl as connectorJarUrl," +
+            "r.archived as archived," +
+            "r.deletionTimestamp as deletionTimestamp," +
+            "r.connectionUserName as connectionUserName," +
+            "r.connectionPassword as connectionPassword ";
+
+    @Query("SELECT " + PROJECTION +
+            "FROM RDSConfig r " +
+            "INNER JOIN r.clusters c " +
+            "WHERE c.id= :clusterId " +
+            "AND r.status <> 'DEFAULT_DELETED' AND r.type= :type")
+    RdsConfigWithoutCluster findByClusterIdAndType(@Param("clusterId") Long clusterId, @Param("type") String type);
+
+    @Query("SELECT " + PROJECTION +
+            "FROM RDSConfig r " +
+            "INNER JOIN r.clusters c " +
+            "WHERE c.id = :clusterId")
+    Set<RdsConfigWithoutCluster> findByClusterId(@Param("clusterId") Long clusterId);
+
+    @Query("SELECT DISTINCT COUNT(r) FROM RDSConfig r " +
+            "INNER JOIN r.clusters c " +
+            "WHERE c.id= :clusterId " +
+            "AND r.type in (:databaseTypes) " +
+            "AND r.status in (:statuses)")
+    long countByClusterIdAndStatusAndTypeIn(@Param("clusterId") Long id,
+            @Param("statuses") Set<ResourceStatus> statuses,
+            @Param("databaseTypes") Set<String> databaseTypes);
+
+    @Query("SELECT DISTINCT " + PROJECTION + " FROM RDSConfig r " +
+            "INNER JOIN r.clusters c " +
+            "WHERE c.id= :clusterId " +
+            "AND r.type in (:databaseTypes) " +
+            "AND r.status in (:statuses)")
+    List<RdsConfigWithoutCluster> findByClusterIdAndStatusInAndTypeIn(@Param("clusterId") Long id,
+            @Param("statuses") Set<ResourceStatus> statuses,
+            @Param("databaseTypes") Set<String> databaseTypes);
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/GatewayConfigService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/GatewayConfigService.java
@@ -57,7 +57,7 @@ public class GatewayConfigService {
     }
 
     public GatewayConfig getGatewayConfig(Stack stack, InstanceMetaData gatewayInstance, Boolean knoxGatewayEnabled) {
-        return tlsSecurityService.buildGatewayConfig(stack.getId(), gatewayInstance, stack.getGatewayPort(), getSaltClientConfig(stack), knoxGatewayEnabled);
+        return tlsSecurityService.buildGatewayConfig(stack, gatewayInstance, stack.getGatewayPort(), getSaltClientConfig(stack), knoxGatewayEnabled);
     }
 
     public String getPrimaryGatewayIp(Stack stack) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/TlsSecurityService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/TlsSecurityService.java
@@ -116,12 +116,12 @@ public class TlsSecurityService {
         saltSecurityConfig.setSaltSignPrivateKey(BaseEncoding.base64().encode(keyPair.getKey().getBytes()));
     }
 
-    public GatewayConfig buildGatewayConfig(Long stackId, InstanceMetaData gatewayInstance, Integer gatewayPort,
+    public GatewayConfig buildGatewayConfig(Stack stack, InstanceMetaData gatewayInstance, Integer gatewayPort,
             SaltClientConfig saltClientConfig, Boolean knoxGatewayEnabled) {
+        Long stackId = stack.getId();
         LOGGER.info("Build gateway config for stack with id: {}, gatewayInstance: {}, gatewayPort: {}, knoxGatewayEnabled: {}",
                 stackId, gatewayInstance, gatewayPort, knoxGatewayEnabled);
         SecurityConfig securityConfig = getSecurityConfigByStackIdOrThrowNotFound(stackId);
-        Stack stack = stackService.getById(stackId);
         String connectionIp = getGatewayIp(securityConfig, gatewayInstance, stack);
         HttpClientConfig conf = buildTLSClientConfig(stackId, stack.getCloudPlatform(), connectionIp, gatewayInstance);
         SaltSecurityConfig saltSecurityConfig = securityConfig.getSaltSecurityConfig();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/RdsConfigService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/RdsConfigService.java
@@ -138,13 +138,4 @@ public class RdsConfigService extends AbstractWorkspaceAwareResourceService<RDSC
     public Set<Cluster> getClustersUsingResource(RDSConfig rdsConfig) {
         return clusterService.findByRdsConfig(rdsConfig.getId());
     }
-
-    public RDSConfig resolveVaultValues(RDSConfig config) {
-        String username = config.getConnectionUserName();
-        String password = config.getConnectionPassword();
-        config.setConnectionUserName(username);
-        config.setConnectionPassword(password);
-        return config;
-    }
-
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/RdsConfigWithoutClusterService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/RdsConfigWithoutClusterService.java
@@ -1,0 +1,39 @@
+package com.sequenceiq.cloudbreak.service.rdsconfig;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ResourceStatus;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
+import com.sequenceiq.cloudbreak.domain.view.RdsConfigWithoutCluster;
+import com.sequenceiq.cloudbreak.repository.RdsConfigWithoutClusterRepository;
+
+@Component
+public class RdsConfigWithoutClusterService {
+
+    @Inject
+    private RdsConfigWithoutClusterRepository rdsConfigWithoutClusterRepository;
+
+    public RdsConfigWithoutCluster findByClusterIdAndType(Long clusterId, DatabaseType databaseType) {
+        return rdsConfigWithoutClusterRepository.findByClusterIdAndType(clusterId, databaseType.name());
+    }
+
+    public Set<RdsConfigWithoutCluster> findByClusterId(Long clusterId) {
+        return rdsConfigWithoutClusterRepository.findByClusterId(clusterId);
+    }
+
+    public long countByClusterIdAndStatusInAndTypeIn(Long id, Set<ResourceStatus> statuses, Set<DatabaseType> databaseTypes) {
+        return rdsConfigWithoutClusterRepository.countByClusterIdAndStatusAndTypeIn(id, statuses,
+                databaseTypes.stream().map(Enum::name).collect(Collectors.toSet()));
+    }
+
+    public List<RdsConfigWithoutCluster> findByClusterIdAndStatusInAndTypeIn(Long id, Set<ResourceStatus> statuses, Set<DatabaseType> databaseTypes) {
+        return rdsConfigWithoutClusterRepository.findByClusterIdAndStatusInAndTypeIn(id, statuses,
+                databaseTypes.stream().map(Enum::name).collect(Collectors.toSet()));
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/converter/StackToStackDetailsConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/converter/StackToStackDetailsConverter.java
@@ -82,9 +82,11 @@ public class StackToStackDetailsConverter {
     }
 
     private List<String> getSubnetIds(com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup e) {
-        Json attributes = e.getInstanceGroupNetwork().getAttributes();
-        if (attributes != null && attributes.getMap() != null) {
-            return (List<String>) attributes.getMap().getOrDefault(NetworkConstants.SUBNET_IDS, List.of());
+        if (e.getInstanceGroupNetwork() != null) {
+            Json attributes = e.getInstanceGroupNetwork().getAttributes();
+            if (attributes != null && attributes.getMap() != null) {
+                return (List<String>) attributes.getMap().getOrDefault(NetworkConstants.SUBNET_IDS, List.of());
+            }
         }
         return List.of();
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpscaleServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpscaleServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.Optional;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -59,8 +60,10 @@ public class ClusterManagerUpscaleServiceTest {
 
     @Test
     public void testUpscaleIfTargetedUpscaleNotSupportedOrPrimaryGatewayChanged() throws ClusterClientInitException {
-        when(stackService.getByIdWithListsInTransaction(any())).thenReturn(getStack());
-        when(clusterHostServiceRunner.addClusterServices(any(), any(), anyBoolean())).thenReturn(new NodeReachabilityResult(Set.of(), Set.of()));
+        Stack stack = getStack();
+        when(stackService.getByIdWithListsInTransaction(any())).thenReturn(stack);
+        when(clusterService.findOneWithLists(1L)).thenReturn(Optional.of(stack.getCluster()));
+        when(clusterHostServiceRunner.addClusterServices(any(), any(), any(), anyBoolean())).thenReturn(new NodeReachabilityResult(Set.of(), Set.of()));
         doNothing().when(clusterServiceRunner).updateAmbariClientConfig(any(), any());
         doNothing().when(clusterService).updateInstancesToRunning(any(), any());
         when(clusterApiConnectors.getConnector(any(Stack.class))).thenReturn(clusterApi);
@@ -79,8 +82,10 @@ public class ClusterManagerUpscaleServiceTest {
 
     @Test
     public void testUpscaleIfTargetedUpscaleSupported() throws ClusterClientInitException {
-        when(stackService.getByIdWithListsInTransaction(any())).thenReturn(getStack());
-        when(clusterHostServiceRunner.addClusterServices(any(), any(), anyBoolean())).thenReturn(new NodeReachabilityResult(Set.of(), Set.of()));
+        Stack stack = getStack();
+        when(stackService.getByIdWithListsInTransaction(any())).thenReturn(stack);
+        when(clusterService.findOneWithLists(1L)).thenReturn(Optional.of(stack.getCluster()));
+        when(clusterHostServiceRunner.addClusterServices(any(), any(), any(), anyBoolean())).thenReturn(new NodeReachabilityResult(Set.of(), Set.of()));
         doNothing().when(clusterService).updateInstancesToRunning(any(), any());
         when(clusterApiConnectors.getConnector(any(Stack.class))).thenReturn(clusterApi);
         when(targetedUpscaleSupportService.targetedUpscaleOperationSupported(any())).thenReturn(Boolean.TRUE);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ClusterDBValidationServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ClusterDBValidationServiceTest.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.service.cluster;
 
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Set;
@@ -13,14 +14,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ResourceStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
-import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
-import com.sequenceiq.cloudbreak.service.rdsconfig.RdsConfigService;
+import com.sequenceiq.cloudbreak.domain.view.RdsConfigWithoutCluster;
+import com.sequenceiq.cloudbreak.service.rdsconfig.RdsConfigWithoutClusterService;
 
 @ExtendWith(MockitoExtension.class)
 public class ClusterDBValidationServiceTest {
     @Mock
-    private RdsConfigService rdsConfigService;
+    private RdsConfigWithoutClusterService rdsConfigWithoutClusterService;
 
     @InjectMocks
     private ClusterDBValidationService underTest;
@@ -54,9 +55,10 @@ public class ClusterDBValidationServiceTest {
         Cluster cluster = new Cluster();
         cluster.setId(0L);
         cluster.setEmbeddedDatabaseOnAttachedDisk(false);
-        Set<RDSConfig> rdsConfigs = Set.of(createRdsConfig(0L, ResourceStatus.USER_MANAGED, DatabaseType.CLOUDERA_MANAGER),
-                createRdsConfig(1L, ResourceStatus.USER_MANAGED, DatabaseType.CLOUDERA_MANAGER_MANAGEMENT_SERVICE_REPORTS_MANAGER));
-        when(rdsConfigService.findByClusterId(0L)).thenReturn(rdsConfigs);
+//        Set<RdsConfigWithoutCluster> rdsConfigs = Set.of(createRdsConfig(0L, ResourceStatus.USER_MANAGED, DatabaseType.CLOUDERA_MANAGER),
+//                createRdsConfig(1L, ResourceStatus.USER_MANAGED, DatabaseType.CLOUDERA_MANAGER_MANAGEMENT_SERVICE_REPORTS_MANAGER));
+        when(rdsConfigWithoutClusterService.countByClusterIdAndStatusInAndTypeIn(0L, Set.of(ResourceStatus.USER_MANAGED),
+                Set.of(DatabaseType.CLOUDERA_MANAGER, DatabaseType.CLOUDERA_MANAGER_MANAGEMENT_SERVICE_REPORTS_MANAGER))).thenReturn(2L);
         // WHEN
         Boolean actualResult = underTest.isGatewayRepairEnabled(cluster);
         // THEN
@@ -69,9 +71,8 @@ public class ClusterDBValidationServiceTest {
         Cluster cluster = new Cluster();
         cluster.setId(0L);
         cluster.setEmbeddedDatabaseOnAttachedDisk(false);
-        Set<RDSConfig> rdsConfigs = Set.of(createRdsConfig(0L, ResourceStatus.USER_MANAGED, DatabaseType.CLOUDERA_MANAGER),
-                createRdsConfig(1L, ResourceStatus.USER_MANAGED, DatabaseType.HIVE));
-        when(rdsConfigService.findByClusterId(0L)).thenReturn(rdsConfigs);
+        when(rdsConfigWithoutClusterService.countByClusterIdAndStatusInAndTypeIn(0L, Set.of(ResourceStatus.USER_MANAGED),
+                Set.of(DatabaseType.CLOUDERA_MANAGER, DatabaseType.CLOUDERA_MANAGER_MANAGEMENT_SERVICE_REPORTS_MANAGER))).thenReturn(1L);
         // WHEN
         Boolean actualResult = underTest.isGatewayRepairEnabled(cluster);
         // THEN
@@ -89,11 +90,11 @@ public class ClusterDBValidationServiceTest {
         Assertions.assertFalse(actualResult);
     }
 
-    private RDSConfig createRdsConfig(Long id, ResourceStatus resourceStatus, DatabaseType databaseType) {
-        RDSConfig rdsConfig = new RDSConfig();
-        rdsConfig.setId(id);
-        rdsConfig.setStatus(resourceStatus);
-        rdsConfig.setType(databaseType.name());
+    private RdsConfigWithoutCluster createRdsConfig(Long id, ResourceStatus resourceStatus, DatabaseType databaseType) {
+        RdsConfigWithoutCluster rdsConfig = mock(RdsConfigWithoutCluster.class);
+        when(rdsConfig.getId()).thenReturn(id);
+        when(rdsConfig.getStatus()).thenReturn(resourceStatus);
+        when(rdsConfig.getType()).thenReturn(databaseType.name());
         return rdsConfig;
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/rdsconfig/AbstractRdsConfigProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/rdsconfig/AbstractRdsConfigProviderTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import java.util.HashSet;
 import java.util.Map;
 
 import org.junit.Before;
@@ -70,6 +71,7 @@ public class AbstractRdsConfigProviderTest {
         metaData.setInstanceMetadataType(InstanceMetadataType.GATEWAY_PRIMARY);
         testStack.getNotTerminatedAndNotZombieGatewayInstanceMetadata().add(metaData);
         Cluster testCluster = TestUtil.cluster();
+        testCluster.setRdsConfigs(new HashSet<>());
 
         Map<String, Object> result = underTest.createServicePillarConfigMapIfNeeded(testStack, testCluster);
 

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/views/RdsView.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/views/RdsView.java
@@ -8,6 +8,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.domain.RdsSslMode;
+import com.sequenceiq.cloudbreak.domain.view.RdsConfigWithoutCluster;
 import com.sequenceiq.cloudbreak.template.views.dialect.DefaultRdsViewDialect;
 import com.sequenceiq.cloudbreak.template.views.dialect.OracleRdsViewDialect;
 import com.sequenceiq.cloudbreak.template.views.dialect.RdsViewDialect;
@@ -27,43 +28,71 @@ public class RdsView {
 
     private static final String SSL_OPTIONS_WITHOUT_CERTIFICATE_FILE_PATH = "sslmode=verify-full&sslrootcert=";
 
-    private final String connectionURL;
+    private String connectionURL;
 
-    private final boolean useSsl;
+    private boolean useSsl;
 
-    private final String sslCertificateFilePath;
+    private String sslCertificateFilePath;
 
-    private final String connectionDriver;
+    private String connectionDriver;
 
-    private final String connectionUserName;
+    private String connectionUserName;
 
-    private final String connectionPassword;
+    private String connectionPassword;
 
-    private final String databaseName;
+    private String databaseName;
 
-    private final String host;
+    private String host;
 
-    private final String hostWithPortWithJdbc;
+    private String hostWithPortWithJdbc;
 
-    private final String subprotocol;
+    private String subprotocol;
 
-    private final String connectionString;
+    private String connectionString;
 
-    private final String port;
+    private String port;
 
-    private final DatabaseVendor databaseVendor;
+    private DatabaseVendor databaseVendor;
 
-    private final String withoutJDBCPrefix;
+    private String withoutJDBCPrefix;
 
-    private final RdsViewDialect rdsViewDialect;
+    private RdsViewDialect rdsViewDialect;
 
     public RdsView(RDSConfig rdsConfig) {
         this(rdsConfig, "");
     }
 
     public RdsView(RDSConfig rdsConfig, String sslCertificateFilePath) {
-        // Note: any value is valid for sslCertificateFile for sake of backward compatibility.
         this.sslCertificateFilePath = Objects.requireNonNullElse(sslCertificateFilePath, "");
+        setup(rdsConfig);
+    }
+
+    public RdsView(RdsConfigWithoutCluster rdsConfig) {
+        this(rdsConfig, "");
+    }
+
+    public RdsView(RdsConfigWithoutCluster rdsConfigWithoutCluster, String sslCertificateFilePath) {
+        this.sslCertificateFilePath = Objects.requireNonNullElse(sslCertificateFilePath, "");
+        RDSConfig rdsConfig = new RDSConfig();
+        rdsConfig.setArchived(rdsConfigWithoutCluster.isArchived());
+        rdsConfig.setConnectionDriver(rdsConfigWithoutCluster.getConnectionDriver());
+        rdsConfig.setConnectionURL(rdsConfigWithoutCluster.getConnectionURL());
+        rdsConfig.setConnectionPassword(rdsConfigWithoutCluster.getConnectionPassword().getRaw());
+        rdsConfig.setConnectionUserName(rdsConfigWithoutCluster.getConnectionUserName().getRaw());
+        rdsConfig.setConnectorJarUrl(rdsConfigWithoutCluster.getConnectorJarUrl());
+        rdsConfig.setCreationDate(rdsConfigWithoutCluster.getCreationDate());
+        rdsConfig.setDatabaseEngine(rdsConfigWithoutCluster.getDatabaseEngine());
+        rdsConfig.setDeletionTimestamp(rdsConfigWithoutCluster.getDeletionTimestamp());
+        rdsConfig.setDescription(rdsConfigWithoutCluster.getDescription());
+        rdsConfig.setId(rdsConfigWithoutCluster.getId());
+        rdsConfig.setName(rdsConfigWithoutCluster.getName());
+        rdsConfig.setSslMode(rdsConfigWithoutCluster.getSslMode());
+        rdsConfig.setType(rdsConfigWithoutCluster.getType());
+        setup(rdsConfig);
+    }
+
+    private void setup(RDSConfig rdsConfig) {
+        // Note: any value is valid for sslCertificateFile for sake of backward compatibility.
         useSsl = RdsSslMode.isEnabled(rdsConfig.getSslMode());
         if (useSsl) {
             String configConnectionURL = rdsConfig.getConnectionURL();


### PR DESCRIPTION
The rds config fetch is too expensive because the hibernate fetch all of the attached clusters as references.

See detailed description in the commit message.