### PR TITLE
CB-16079 Do not schedule finalized stack patches

### DIFF
--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/converter/StackPatchStatusConverter.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/converter/StackPatchStatusConverter.java
@@ -1,0 +1,15 @@
+package com.sequenceiq.cloudbreak.domain.converter;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.converter.DefaultEnumConverter;
+import com.sequenceiq.cloudbreak.domain.stack.StackPatchStatus;
+
+@Component
+public class StackPatchStatusConverter extends DefaultEnumConverter<StackPatchStatus>  {
+
+    @Override
+    public StackPatchStatus getDefault() {
+        return StackPatchStatus.UNKNOWN;
+    }
+}

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/StackPatch.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/StackPatch.java
@@ -1,17 +1,18 @@
 package com.sequenceiq.cloudbreak.domain.stack;
 
+import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
+import javax.persistence.Transient;
 import javax.persistence.UniqueConstraint;
 
 import com.sequenceiq.cloudbreak.domain.ProvisionEntity;
+import com.sequenceiq.cloudbreak.domain.converter.StackPatchStatusConverter;
 import com.sequenceiq.cloudbreak.domain.converter.StackPatchTypeConverter;
 
 @Entity
@@ -23,11 +24,23 @@ public class StackPatch implements ProvisionEntity  {
     @SequenceGenerator(name = "stackpatch_generator", sequenceName = "stackpatch_id_seq", allocationSize = 1)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    /**
+     * Stack is not mapped from DB, only stored in the object
+     */
+    @Transient
     private Stack stack;
+
+    @Column(name = "stack_id")
+    private Long stackId;
 
     @Convert(converter = StackPatchTypeConverter.class)
     private StackPatchType type;
+
+    @Convert(converter = StackPatchStatusConverter.class)
+    private StackPatchStatus status;
+
+    @Column(name = "status_reason")
+    private String statusReason;
 
     private Long created = System.currentTimeMillis();
 
@@ -36,7 +49,9 @@ public class StackPatch implements ProvisionEntity  {
 
     public StackPatch(Stack stack, StackPatchType type) {
         this.stack = stack;
+        this.stackId = stack.getId();
         this.type = type;
+        this.status = StackPatchStatus.SCHEDULED;
     }
 
     public Long getId() {
@@ -55,12 +70,36 @@ public class StackPatch implements ProvisionEntity  {
         this.stack = stack;
     }
 
+    public Long getStackId() {
+        return stackId;
+    }
+
+    public void setStackId(Long stackId) {
+        this.stackId = stackId;
+    }
+
     public StackPatchType getType() {
         return type;
     }
 
     public void setType(StackPatchType type) {
         this.type = type;
+    }
+
+    public StackPatchStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(StackPatchStatus status) {
+        this.status = status;
+    }
+
+    public String getStatusReason() {
+        return statusReason;
+    }
+
+    public void setStatusReason(String statusReason) {
+        this.statusReason = statusReason;
     }
 
     public Long getCreated() {
@@ -75,9 +114,11 @@ public class StackPatch implements ProvisionEntity  {
     public String toString() {
         return "StackPatch{" +
                 "id=" + id +
+                ", stackId=" + stackId +
                 ", type=" + type +
+                ", status=" + status +
+                ", statusReason='" + statusReason + '\'' +
                 ", created=" + created +
                 '}';
     }
-
 }

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/StackPatchStatus.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/StackPatchStatus.java
@@ -1,0 +1,20 @@
+package com.sequenceiq.cloudbreak.domain.stack;
+
+import java.util.Set;
+
+public enum StackPatchStatus {
+    SCHEDULED,
+    UNSCHEDULED,
+    NOT_AFFECTED,
+    AFFECTED,
+    FIXED,
+    FAILED,
+    SKIPPED,
+    UNKNOWN;
+
+    private static final Set<StackPatchStatus> FINAL_STATUSES = Set.of(UNSCHEDULED, NOT_AFFECTED, FIXED);
+
+    public boolean isFinal() {
+        return FINAL_STATUSES.contains(this);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJob.java
@@ -13,15 +13,16 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.StackPatch;
+import com.sequenceiq.cloudbreak.domain.stack.StackPatchStatus;
 import com.sequenceiq.cloudbreak.domain.stack.StackPatchType;
 import com.sequenceiq.cloudbreak.domain.view.StackView;
 import com.sequenceiq.cloudbreak.quartz.statuschecker.job.StatusCheckerJob;
-import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.service.stack.StackViewService;
 import com.sequenceiq.cloudbreak.service.stackpatch.ExistingStackPatchApplyException;
 import com.sequenceiq.cloudbreak.service.stackpatch.ExistingStackPatchService;
-import com.sequenceiq.cloudbreak.service.stackpatch.StackPatchUsageReporterService;
+import com.sequenceiq.cloudbreak.service.stackpatch.StackPatchService;
 
 import io.opentracing.Tracer;
 
@@ -44,7 +45,7 @@ public class ExistingStackPatcherJob extends StatusCheckerJob {
     private ExistingStackPatcherServiceProvider existingStackPatcherServiceProvider;
 
     @Inject
-    private StackPatchUsageReporterService stackPatchUsageReporterService;
+    private StackPatchService stackPatchService;
 
     public ExistingStackPatcherJob(Tracer tracer) {
         super(tracer, "Existing Stack Patcher Job");
@@ -62,54 +63,65 @@ public class ExistingStackPatcherJob extends StatusCheckerJob {
         String stackPatchTypeName = context.getJobDetail().getJobDataMap().getString(STACK_PATCH_TYPE_NAME);
         try {
             ExistingStackPatchService existingStackPatchService = existingStackPatcherServiceProvider.provide(stackPatchTypeName);
+            StackPatchType stackPatchType = existingStackPatchService.getStackPatchType();
+            StackPatch stackPatch = stackPatchService.getOrCreate(stack, stackPatchType);
             if (!Status.getUnschedulableStatuses().contains(stackStatus)) {
-                boolean success = applyStackPatch(existingStackPatchService, stack);
+                boolean success = applyStackPatch(existingStackPatchService, stackPatch);
                 if (success) {
-                    unscheduleJob(context, stack, existingStackPatchService.getStackPatchType());
+                    unscheduleJob(context, stackPatch);
                 }
             } else {
                 LOGGER.debug("Existing stack patching will be unscheduled, because stack {} status is {}", stack.getResourceCrn(), stackStatus);
-                unscheduleJob(context, stack, existingStackPatchService.getStackPatchType());
+                stackPatchService.updateStatus(stackPatch, StackPatchStatus.UNSCHEDULED);
+                unscheduleJob(context, stackPatch);
             }
-        } catch (CloudbreakException e) {
+        } catch (UnknownStackPatchTypeException e) {
             String message = "Unknown stack patch type: " + stackPatchTypeName;
-            unscheduleAndFailJob(message, context, stack, StackPatchType.UNKNOWN);
+            unscheduleAndFailJob(message, context, new StackPatch(stack, StackPatchType.UNKNOWN));
+        } catch (Exception e) {
+            LOGGER.error("Failed", e);
+            throw e;
         }
     }
 
-    private void unscheduleAndFailJob(String message, JobExecutionContext context, Stack stack, StackPatchType stackPatchType)
+    private void unscheduleAndFailJob(String message, JobExecutionContext context, StackPatch stackPatch)
             throws JobExecutionException {
-        LOGGER.info("Unscheduling and failing stack patcher {} for stack {} with message: {}", stackPatchType, stack.getResourceCrn(), message);
-        unscheduleJob(context, stack, stackPatchType);
-        stackPatchUsageReporterService.reportFailure(stack, stackPatchType, message);
+        LOGGER.info("Unscheduling and failing stack patcher {} for stack {} with message: {}",
+                stackPatch.getType(), stackPatch.getStack().getResourceCrn(), message);
+        unscheduleJob(context, stackPatch);
+        stackPatchService.updateStatusAndReportUsage(stackPatch, StackPatchStatus.FAILED, message);
         throw new JobExecutionException(message);
     }
 
-    private void unscheduleJob(JobExecutionContext context, Stack stack, StackPatchType stackPatchType) {
-        LOGGER.info("Unscheduling stack patcher {} job for stack {}", stackPatchType, stack.getResourceCrn());
+    private void unscheduleJob(JobExecutionContext context, StackPatch stackPatch) {
+        LOGGER.info("Unscheduling stack patcher {} job for stack {}", stackPatch.getType(), stackPatch.getStack().getResourceCrn());
         jobService.unschedule(context.getJobDetail().getKey());
     }
 
-    private boolean applyStackPatch(ExistingStackPatchService existingStackPatchService, Stack stack) throws JobExecutionException {
+    private boolean applyStackPatch(ExistingStackPatchService existingStackPatchService, StackPatch stackPatch) throws JobExecutionException {
+        Stack stack = stackPatch.getStack();
         StackPatchType stackPatchType = existingStackPatchService.getStackPatchType();
-        if (!existingStackPatchService.isStackAlreadyFixed(stack)) {
+        if (!StackPatchStatus.FIXED.equals(stackPatch.getStatus())) {
             try {
                 if (existingStackPatchService.isAffected(stack)) {
                     LOGGER.debug("Stack {} needs patch for {}", stack.getResourceCrn(), stackPatchType);
-                    stackPatchUsageReporterService.reportAffected(stack, stackPatchType);
+                    stackPatchService.updateStatusAndReportUsage(stackPatch, StackPatchStatus.AFFECTED);
                     boolean success = existingStackPatchService.apply(stack);
                     if (success) {
-                        stackPatchUsageReporterService.reportSuccess(stack, stackPatchType);
+                        stackPatchService.updateStatusAndReportUsage(stackPatch, StackPatchStatus.FIXED);
+                    } else {
+                        stackPatchService.updateStatus(stackPatch, StackPatchStatus.SKIPPED);
                     }
                     return success;
                 } else {
                     LOGGER.debug("Stack {} is not affected by {}", stack.getResourceCrn(), stackPatchType);
+                    stackPatchService.updateStatus(stackPatch, StackPatchStatus.NOT_AFFECTED);
                     return true;
                 }
             } catch (ExistingStackPatchApplyException e) {
                 String message = String.format("Failed to patch stack %s for %s", stack.getResourceCrn(), stackPatchType);
                 LOGGER.error(message, e);
-                stackPatchUsageReporterService.reportFailure(stack, stackPatchType, e.getMessage());
+                stackPatchService.updateStatusAndReportUsage(stackPatch, StackPatchStatus.FAILED, e.getMessage());
                 throw new JobExecutionException(message, e);
             }
         } else {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJobInitializer.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJobInitializer.java
@@ -11,10 +11,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.domain.stack.StackPatch;
 import com.sequenceiq.cloudbreak.domain.stack.StackPatchType;
 import com.sequenceiq.cloudbreak.job.AbstractStackJobInitializer;
 import com.sequenceiq.cloudbreak.job.stackpatcher.config.ExistingStackPatcherConfig;
 import com.sequenceiq.cloudbreak.quartz.model.JobResource;
+import com.sequenceiq.cloudbreak.service.stackpatch.StackPatchService;
 
 @Component
 public class ExistingStackPatcherJobInitializer extends AbstractStackJobInitializer {
@@ -27,15 +29,34 @@ public class ExistingStackPatcherJobInitializer extends AbstractStackJobInitiali
     @Inject
     private ExistingStackPatcherJobService jobService;
 
+    @Inject
+    private StackPatchService stackPatchService;
+
     @Override
     public void initJobs() {
         Set<StackPatchType> enabledStackPatchTypes = getEnabledStackPatchTypes();
         LOGGER.info("Existing stack patch types enabled: {}", enabledStackPatchTypes);
 
         List<JobResource> stacks = getAliveJobResources();
+        Set<Long> stackIds = stacks.stream()
+                .map(JobResource::getLocalId)
+                .map(Long::valueOf)
+                .collect(Collectors.toSet());
         enabledStackPatchTypes.forEach(stackPatchType -> {
             LOGGER.info("Scheduling stack patcher jobs for {}", stackPatchType);
-            stacks.forEach(stack -> jobService.schedule(new ExistingStackPatcherJobAdapter(stack, stackPatchType)));
+            Map<Long, List<StackPatch>> stackPatchesByStack = stackPatchService.findAllByTypeForStackIds(stackPatchType, stackIds).stream()
+                    .collect(Collectors.groupingBy(StackPatch::getStackId));
+
+            for (JobResource stack : stacks) {
+                Long stackId = Long.valueOf(stack.getLocalId());
+                List<StackPatch> stackPatches = stackPatchesByStack.get(stackId);
+                boolean stackPatchIsFinalized = stackPatches != null && stackPatches.stream().anyMatch(stackPatch -> stackPatch.getStatus().isFinal());
+                if (!stackPatchIsFinalized) {
+                    ExistingStackPatcherJobAdapter jobAdapter = new ExistingStackPatcherJobAdapter(stack, stackPatchType);
+                    stackPatchService.getOrCreate(stackId, stackPatchType);
+                    jobService.schedule(jobAdapter);
+                }
+            }
         });
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJobService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJobService.java
@@ -17,7 +17,6 @@ import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.domain.stack.StackPatchType;
 import com.sequenceiq.cloudbreak.quartz.model.JobResource;
-import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.service.stackpatch.ExistingStackPatchService;
 
@@ -58,7 +57,7 @@ public class ExistingStackPatcherJobService {
             LOGGER.info("Scheduling stack patcher {} job for stack with key: '{}' and group: '{}'",
                     stackPatchType, jobKey.getName(), jobKey.getGroup());
             scheduler.scheduleJob(jobDetail, trigger);
-        } catch (CloudbreakException e) {
+        } catch (UnknownStackPatchTypeException e) {
             LOGGER.error("Failed to get stack patcher for type {}", stackPatchType, e);
         } catch (SchedulerException e) {
             LOGGER.error("Error during scheduling stack patcher job: {}", jobDetail, e);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackPatchRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackPatchRepository.java
@@ -1,12 +1,13 @@
 package com.sequenceiq.cloudbreak.repository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 import javax.transaction.Transactional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.StackPatch;
 import com.sequenceiq.cloudbreak.domain.stack.StackPatchType;
 import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
@@ -15,5 +16,7 @@ import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
 @Transactional(Transactional.TxType.REQUIRED)
 public interface StackPatchRepository extends JpaRepository<StackPatch, Long> {
 
-    Optional<StackPatch> findByStackAndType(Stack stack, StackPatchType stackPatchType);
+    Optional<StackPatch> findByStackIdAndType(Long stackId, StackPatchType stackPatchType);
+
+    List<StackPatch> findByTypeAndStackIdIn(StackPatchType stackPatchType, Collection<Long> stackIds);
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/MockPatchService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/MockPatchService.java
@@ -79,7 +79,7 @@ public class MockPatchService extends ExistingStackPatchService {
         try {
             StackTags stackTags = stack.getTags().get(StackTags.class);
             String stackPatchResultTag = stackTags.getUserDefinedTags().get(STACK_PATCH_RESULT_TAG_KEY);
-            stackUpdater.updateStackStatus(stack.getId(), STACK_STATUS, STATUS_REASON);
+            stack = stackUpdater.updateStackStatus(stack.getId(), STACK_STATUS, STATUS_REASON);
             switch (stackPatchResultTag) {
                 case STACK_PATCH_RESULT_TAG_VALUE_SUCCESS:
                     return true;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/StackPatchService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/StackPatchService.java
@@ -1,0 +1,71 @@
+package com.sequenceiq.cloudbreak.service.stackpatch;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.StackPatch;
+import com.sequenceiq.cloudbreak.domain.stack.StackPatchStatus;
+import com.sequenceiq.cloudbreak.domain.stack.StackPatchType;
+import com.sequenceiq.cloudbreak.repository.StackPatchRepository;
+
+@Service
+public class StackPatchService {
+
+    @Inject
+    private StackPatchRepository stackPatchRepository;
+
+    @Inject
+    private StackPatchUsageReporterService stackPatchUsageReporterService;
+
+    public StackPatch getOrCreate(Stack stack, StackPatchType stackPatchType) {
+        StackPatch stackPatch = getOrCreate(stack.getId(), stackPatchType);
+        stackPatch.setStack(stack);
+        return stackPatch;
+    }
+
+    public StackPatch getOrCreate(Long stackId, StackPatchType stackPatchType) {
+        return find(stackId, stackPatchType)
+                .orElseGet(() -> create(stackId, stackPatchType));
+    }
+
+    private Optional<StackPatch> find(Long stackId, StackPatchType stackPatchType) {
+        return stackPatchRepository.findByStackIdAndType(stackId, stackPatchType);
+    }
+
+    private StackPatch create(Long stackId, StackPatchType stackPatchType) {
+        Stack stack = new Stack();
+        stack.setId(stackId);
+        return stackPatchRepository.save(new StackPatch(stack, stackPatchType));
+    }
+
+    public StackPatch updateStatus(StackPatch stackPatch, StackPatchStatus status) {
+        return updateStatus(stackPatch, status, "", false);
+    }
+
+    public StackPatch updateStatusAndReportUsage(StackPatch stackPatch, StackPatchStatus status) {
+        return updateStatus(stackPatch, status, "", true);
+    }
+
+    public StackPatch updateStatusAndReportUsage(StackPatch stackPatch, StackPatchStatus status, String statusReason) {
+        return updateStatus(stackPatch, status, statusReason, true);
+    }
+
+    private StackPatch updateStatus(StackPatch stackPatch, StackPatchStatus status, String statusReason, boolean reportUsage) {
+        stackPatch.setStatus(status);
+        stackPatch.setStatusReason(statusReason);
+        if (reportUsage) {
+            stackPatchUsageReporterService.reportUsage(stackPatch);
+        }
+        return stackPatchRepository.save(stackPatch);
+    }
+
+    public List<StackPatch> findAllByTypeForStackIds(StackPatchType stackPatchType, Collection<Long> stackIds) {
+        return stackPatchRepository.findByTypeAndStackIdIn(stackPatchType, stackIds);
+    }
+}

--- a/core/src/main/resources/schema/app/20220303125000_CB-16079_alter_stackpatch_table_add_status_columns.sql
+++ b/core/src/main/resources/schema/app/20220303125000_CB-16079_alter_stackpatch_table_add_status_columns.sql
@@ -1,0 +1,12 @@
+-- // CB-16079
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE stackpatch ADD COLUMN IF NOT EXISTS status CHARACTER VARYING(255);
+UPDATE stackpatch SET status = 'FIXED' WHERE status IS NULL;
+ALTER TABLE stackpatch ALTER COLUMN status SET NOT NULL;
+ALTER TABLE stackpatch ALTER COLUMN status SET DEFAULT 'FIXED';
+
+ALTER TABLE stackpatch ADD COLUMN IF NOT EXISTS status_reason TEXT;
+
+-- //@UNDO
+-- SQL to undo the change goes here.

--- a/core/src/test/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJobInitializerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJobInitializerTest.java
@@ -8,7 +8,11 @@ import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.DELETE_IN_
 import static com.sequenceiq.cloudbreak.domain.stack.StackPatchType.LOGGING_AGENT_AUTO_RESTART;
 import static com.sequenceiq.cloudbreak.domain.stack.StackPatchType.METERING_AZURE_METADATA;
 import static com.sequenceiq.cloudbreak.domain.stack.StackPatchType.UNBOUND_RESTART;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -28,17 +32,22 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.StackPatch;
+import com.sequenceiq.cloudbreak.domain.stack.StackPatchStatus;
+import com.sequenceiq.cloudbreak.domain.stack.StackPatchType;
 import com.sequenceiq.cloudbreak.job.stackpatcher.config.ExistingStackPatcherConfig;
 import com.sequenceiq.cloudbreak.job.stackpatcher.config.StackPatchTypeConfig;
 import com.sequenceiq.cloudbreak.quartz.model.JobResource;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.service.stackpatch.StackPatchService;
 
 @ExtendWith(MockitoExtension.class)
 class ExistingStackPatcherJobInitializerTest {
 
-    private static final String CRN_1 = "crn1";
+    private static final String ID_1 = "1";
 
-    private static final String CRN_2 = "crn2";
+    private static final String ID_2 = "2";
 
     @InjectMocks
     private ExistingStackPatcherJobInitializer underTest;
@@ -53,6 +62,9 @@ class ExistingStackPatcherJobInitializerTest {
     private StackService stackService;
 
     @Mock
+    private StackPatchService stackPatchService;
+
+    @Mock
     private JobResource stack1;
 
     @Mock
@@ -63,10 +75,12 @@ class ExistingStackPatcherJobInitializerTest {
 
     @BeforeEach
     void setUp() {
-        lenient().when(stack1.getRemoteResourceId()).thenReturn(CRN_1);
-        lenient().when(stack2.getRemoteResourceId()).thenReturn(CRN_2);
+        lenient().when(stack1.getLocalId()).thenReturn(ID_1);
+        lenient().when(stack2.getLocalId()).thenReturn(ID_2);
         lenient().when(stackService.getAllAliveForAutoSync(Set.of(DELETE_COMPLETED, DELETE_IN_PROGRESS, DELETE_FAILED, CREATE_FAILED, CREATE_IN_PROGRESS)))
                 .thenReturn(List.of(stack1, stack2));
+
+        lenient().when(stackPatchService.findAllByTypeForStackIds(any(), any())).thenReturn(List.of());
     }
 
     @Test
@@ -90,16 +104,55 @@ class ExistingStackPatcherJobInitializerTest {
 
         verify(jobService, times(4)).schedule(captor.capture());
         Assertions.assertThat(captor.getAllValues())
-                .anyMatch(a -> a.getJobResource().getRemoteResourceId().equals(CRN_1) && a.getStackPatchType().equals(UNBOUND_RESTART))
-                .anyMatch(a -> a.getJobResource().getRemoteResourceId().equals(CRN_1) && a.getStackPatchType().equals(LOGGING_AGENT_AUTO_RESTART))
-                .anyMatch(a -> a.getJobResource().getRemoteResourceId().equals(CRN_2) && a.getStackPatchType().equals(UNBOUND_RESTART))
-                .anyMatch(a -> a.getJobResource().getRemoteResourceId().equals(CRN_2) && a.getStackPatchType().equals(LOGGING_AGENT_AUTO_RESTART));
+                .anyMatch(a -> a.getJobResource().getLocalId().equals(ID_1) && a.getStackPatchType().equals(UNBOUND_RESTART))
+                .anyMatch(a -> a.getJobResource().getLocalId().equals(ID_1) && a.getStackPatchType().equals(LOGGING_AGENT_AUTO_RESTART))
+                .anyMatch(a -> a.getJobResource().getLocalId().equals(ID_2) && a.getStackPatchType().equals(UNBOUND_RESTART))
+                .anyMatch(a -> a.getJobResource().getLocalId().equals(ID_2) && a.getStackPatchType().equals(LOGGING_AGENT_AUTO_RESTART));
+    }
+
+    @Test
+    void alreadyScheduledShouldBeRescheduled() {
+        when(config.getPatchConfigs()).thenReturn(Map.of(UNBOUND_RESTART, getConfig(true)));
+        doReturn(List.of(createStackPatch(stack1, UNBOUND_RESTART))).when(stackPatchService).findAllByTypeForStackIds(eq(UNBOUND_RESTART), any());
+
+        underTest.initJobs();
+
+        verify(stackPatchService).findAllByTypeForStackIds(UNBOUND_RESTART, Set.of(Long.valueOf(ID_1), Long.valueOf(ID_2)));
+        verify(jobService, times(2)).schedule(captor.capture());
+        Assertions.assertThat(captor.getAllValues())
+                .anyMatch(a -> a.getJobResource().getLocalId().equals(ID_1) && a.getStackPatchType().equals(UNBOUND_RESTART))
+                .anyMatch(a -> a.getJobResource().getLocalId().equals(ID_2) && a.getStackPatchType().equals(UNBOUND_RESTART));
+        verify(stackPatchService).getOrCreate(Long.valueOf(ID_1), UNBOUND_RESTART);
+        verify(stackPatchService).getOrCreate(Long.valueOf(ID_2), UNBOUND_RESTART);
+    }
+
+    @Test
+    void alreadyFixedShouldNotBeRescheduled() {
+        when(config.getPatchConfigs()).thenReturn(Map.of(UNBOUND_RESTART, getConfig(true)));
+        StackPatch stackPatch = createStackPatch(stack1, UNBOUND_RESTART);
+        stackPatch.setStatus(StackPatchStatus.FIXED);
+        doReturn(List.of(stackPatch)).when(stackPatchService).findAllByTypeForStackIds(eq(UNBOUND_RESTART), any());
+
+        underTest.initJobs();
+
+        verify(jobService, times(1)).schedule(captor.capture());
+        Assertions.assertThat(captor.getAllValues())
+                .noneMatch(a -> a.getJobResource().getLocalId().equals(ID_1) && a.getStackPatchType().equals(UNBOUND_RESTART))
+                .anyMatch(a -> a.getJobResource().getLocalId().equals(ID_2) && a.getStackPatchType().equals(UNBOUND_RESTART));
+        verify(stackPatchService, never()).getOrCreate(Long.valueOf(ID_1), UNBOUND_RESTART);
+        verify(stackPatchService).getOrCreate(Long.valueOf(ID_2), UNBOUND_RESTART);
     }
 
     private StackPatchTypeConfig getConfig(boolean enabled) {
         StackPatchTypeConfig disabledConfig = new StackPatchTypeConfig();
         disabledConfig.setEnabled(enabled);
         return disabledConfig;
+    }
+
+    private StackPatch createStackPatch(JobResource jobResource, StackPatchType stackPatchType) {
+        Stack stack = new Stack();
+        stack.setId(Long.valueOf(jobResource.getLocalId()));
+        return new StackPatch(stack, stackPatchType);
     }
 
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stackpatch/ExistingStackPatchServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stackpatch/ExistingStackPatchServiceTest.java
@@ -2,7 +2,6 @@ package com.sequenceiq.cloudbreak.service.stackpatch;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -56,24 +55,6 @@ class ExistingStackPatchServiceTest {
     }
 
     @Test
-    void isStackAlreadyFixedFalse() {
-        when(stackPatchRepository.findByStackAndType(stack, StackPatchType.UNKNOWN)).thenReturn(Optional.empty());
-
-        boolean result = underTest.isStackAlreadyFixed(stack);
-
-        assertThat(result).isFalse();
-    }
-
-    @Test
-    void isStackAlreadyFixedTrue() {
-        when(stackPatchRepository.findByStackAndType(stack, StackPatchType.UNKNOWN)).thenReturn(Optional.of(new StackPatch()));
-
-        boolean result = underTest.isStackAlreadyFixed(stack);
-
-        assertThat(result).isTrue();
-    }
-
-    @Test
     void applyShouldNotSucceedWhenFlowIsRunning() throws ExistingStackPatchApplyException {
         when(flowLogService.isOtherFlowRunning(stack.getId())).thenReturn(true);
 
@@ -103,21 +84,10 @@ class ExistingStackPatchServiceTest {
     }
 
     @Test
-    void shouldSaveStackPatchWhenApplyIsSuccessful() throws ExistingStackPatchApplyException {
-        underTest.apply(stack);
-
-        verify(stackPatchRepository).save(stackPatchArgumentCaptor.capture());
-        StackPatch stackPatch = stackPatchArgumentCaptor.getValue();
-        assertThat(stackPatch)
-                .returns(stack, StackPatch::getStack)
-                .returns(StackPatchType.UNKNOWN, StackPatch::getType);
-    }
-
-    @Test
     void shouldTranslateUnexpectedExceptionType() throws ExistingStackPatchApplyException {
         assertThatThrownBy(() -> alsoUnderTest.apply(stack))
                 .isInstanceOf(ExistingStackPatchApplyException.class)
-                .hasMessage("Something unexpected went wrong with stack %s while applying patch %s",
+                .hasMessage("Something unexpected went wrong with stack %s while applying patch %s: Unexpected exception",
                         stack.getResourceCrn(), StackPatchType.UNKNOWN);
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stackpatch/MockPatchServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stackpatch/MockPatchServiceTest.java
@@ -9,6 +9,9 @@ import static com.sequenceiq.cloudbreak.service.stackpatch.MockPatchService.STAC
 import static com.sequenceiq.cloudbreak.service.stackpatch.MockPatchService.STATUS_REASON;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -59,6 +62,8 @@ class MockPatchServiceTest {
         stack.setId(STACK_ID);
         stack.setResourceCrn("crn:cdp:datalake:us-west-1:tenant:datalake:935ad382-fe9c-400b-bf38-2156c1f09b6d");
         stack.setCloudPlatform(CloudPlatform.MOCK.name());
+
+        lenient().when(stackUpdater.updateStackStatus(any(), any(), anyString())).thenReturn(stack);
     }
 
     @Test

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stackpatch/StackPatchServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stackpatch/StackPatchServiceTest.java
@@ -1,0 +1,107 @@
+package com.sequenceiq.cloudbreak.service.stackpatch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.domain.stack.StackPatch;
+import com.sequenceiq.cloudbreak.domain.stack.StackPatchStatus;
+import com.sequenceiq.cloudbreak.domain.stack.StackPatchType;
+import com.sequenceiq.cloudbreak.repository.StackPatchRepository;
+
+@ExtendWith(MockitoExtension.class)
+class StackPatchServiceTest {
+
+    private static final Long STACK_ID = 123L;
+
+    private static final StackPatchType STACK_PATCH_TYPE = StackPatchType.MOCK;
+
+    @InjectMocks
+    private StackPatchService underTest;
+
+    @Mock
+    private StackPatchRepository stackPatchRepository;
+
+    @Mock
+    private StackPatchUsageReporterService stackPatchUsageReporterService;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(stackPatchRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @Test
+    void getOrCreateShouldNotCreateWhenExists() {
+        StackPatch stackPatch = new StackPatch();
+        when(stackPatchRepository.findByStackIdAndType(STACK_ID, STACK_PATCH_TYPE)).thenReturn(Optional.of(stackPatch));
+
+        StackPatch result = underTest.getOrCreate(STACK_ID, STACK_PATCH_TYPE);
+
+        assertThat(result).isEqualTo(stackPatch);
+        verify(stackPatchRepository, never()).save(any());
+    }
+
+    @Test
+    void getOrCreateShouldCreateWhenDoesNotExist() {
+        when(stackPatchRepository.findByStackIdAndType(STACK_ID, STACK_PATCH_TYPE)).thenReturn(Optional.empty());
+
+        StackPatch result = underTest.getOrCreate(STACK_ID, STACK_PATCH_TYPE);
+
+        assertThat(result)
+                .returns(STACK_ID, StackPatch::getStackId)
+                .returns(STACK_PATCH_TYPE, StackPatch::getType);
+        verify(stackPatchRepository).save(result);
+    }
+
+    @Test
+    void updateStatusWithoutReason() {
+        StackPatch stackPatch = new StackPatch();
+        StackPatchStatus status = StackPatchStatus.SCHEDULED;
+        StackPatch result = underTest.updateStatus(stackPatch, status);
+
+        assertThat(result)
+                .returns(status, StackPatch::getStatus)
+                .returns("", StackPatch::getStatusReason);
+        verify(stackPatchRepository).save(stackPatch);
+    }
+
+    @Test
+    void updateStatusWithReason() {
+        StackPatch stackPatch = new StackPatch();
+        String reason = "reason";
+        StackPatchStatus status = StackPatchStatus.SCHEDULED;
+        StackPatch result = underTest.updateStatusAndReportUsage(stackPatch, status, reason);
+
+        assertThat(result)
+                .returns(status, StackPatch::getStatus)
+                .returns(reason, StackPatch::getStatusReason);
+        verify(stackPatchRepository).save(stackPatch);
+        verify(stackPatchUsageReporterService).reportUsage(stackPatch);
+    }
+
+    @Test
+    void findByTypeAndStackIdIn() {
+        List<StackPatch> stackPatches = List.of(new StackPatch());
+        List<Long> stackIds = List.of(1L, 2L);
+        when(stackPatchRepository.findByTypeAndStackIdIn(STACK_PATCH_TYPE, stackIds)).thenReturn(stackPatches);
+
+        List<StackPatch> result = underTest.findAllByTypeForStackIds(STACK_PATCH_TYPE, stackIds);
+
+        assertThat(result).isEqualTo(stackPatches);
+        verify(stackPatchRepository).findByTypeAndStackIdIn(STACK_PATCH_TYPE, stackIds);
+    }
+
+}


### PR DESCRIPTION
Stack patcher should not schedule jobs for stacks that are either already finalized: either unsheduled, not affected or already fixed.

See detailed description in the commit message.