### PR TITLE
CB-8676 Datalake database backup stderr output has non-error messages

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/handler/DatalakeDatabaseBackupWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/handler/DatalakeDatabaseBackupWaitHandler.java
@@ -8,7 +8,6 @@ import com.dyngr.exception.UserBreakException;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.datalake.flow.dr.backup.event.DatalakeDatabaseBackupFailedEvent;
 import com.sequenceiq.datalake.flow.dr.backup.event.DatalakeDatabaseBackupWaitRequest;
-import com.sequenceiq.datalake.repository.SdxOperationRepository;
 import com.sequenceiq.datalake.service.sdx.PollingConfig;
 import com.sequenceiq.datalake.service.sdx.dr.SdxBackupRestoreService;
 import com.sequenceiq.flow.event.EventSelectorUtil;
@@ -39,9 +38,6 @@ public class DatalakeDatabaseBackupWaitHandler extends ExceptionCatcherEventHand
 
     @Inject
     private SdxBackupRestoreService sdxBackupRestoreService;
-
-    @Inject
-    private SdxOperationRepository sdxOperationRepository;
 
     @Override
     public String selector() {

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/handler/DatalakeDatabaseRestoreWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/handler/DatalakeDatabaseRestoreWaitHandler.java
@@ -8,7 +8,6 @@ import com.sequenceiq.datalake.entity.operation.SdxOperationStatus;
 import com.sequenceiq.datalake.flow.dr.restore.event.DatalakeDatabaseRestoreFailedEvent;
 import com.sequenceiq.datalake.flow.dr.restore.event.DatalakeDatabaseRestoreWaitRequest;
 import com.sequenceiq.datalake.flow.dr.restore.event.DatalakeFullRestoreInProgressEvent;
-import com.sequenceiq.datalake.repository.SdxOperationRepository;
 import com.sequenceiq.datalake.service.sdx.PollingConfig;
 import com.sequenceiq.datalake.service.sdx.dr.SdxBackupRestoreService;
 import com.sequenceiq.flow.event.EventSelectorUtil;
@@ -39,9 +38,6 @@ public class DatalakeDatabaseRestoreWaitHandler extends ExceptionCatcherEventHan
 
     @Inject
     private SdxBackupRestoreService sdxBackupRestoreService;
-
-    @Inject
-    private SdxOperationRepository sdxOperationRepository;
 
     @Override
     public String selector() {

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/dr/SdxBackupRestoreService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/dr/SdxBackupRestoreService.java
@@ -74,7 +74,7 @@ import com.sequenceiq.sdx.api.model.SdxRestoreStatusResponse;
 @Service
 public class SdxBackupRestoreService {
 
-    private static final int MAX_SIZE_OF_FAILURE_REASON = 254;
+    private static final int MAX_SIZE_OF_FAILURE_REASON = 1999;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SdxBackupRestoreService.class);
 

--- a/datalake/src/main/resources/schema/app/20220304194213_CB-8676_Datalake_database_backup_stderr_output_has_non-error_messages.sql
+++ b/datalake/src/main/resources/schema/app/20220304194213_CB-8676_Datalake_database_backup_stderr_output_has_non-error_messages.sql
@@ -1,0 +1,9 @@
+-- // CB-8676 Datalake database backup stderr output has non-error messages
+-- Migration SQL that makes the change goes here.
+
+alter table sdxoperation alter column statusreason type character varying(2000);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+alter table sdxoperation alter column statusreason type character varying(255);


### PR DESCRIPTION
Modifies the database backup and restore scripts to reduce the amount of non-error logging going to
stderr. The script changes are:

 - Removes xtrace logging from backup_db.sh and restore_db.sh so less noise is in the stderr otuput.
 - Adds a trap to both scripts so that output that was previously only going to the terminal is
   being captured in the log file.
 - Reduces the hdfs commands to log level ERROR, so lower level logs don't show up in stderr. This
   has the result of hdfs generating less logging overall, but we should still see logging about any
   error cases.

There is also new logic in BackupRestoreStatusService to strip any lines that are not related to
errors from the stderr output. The newly stripped down output is used as the failure reason in the
case of a database failure. The size of the statusreason field in the sdxoperation database has
also been expanded to retain more information about the errors.

For an example of how the error translation works, here's some raw stderr output from a failed backup:
```
Mar 04, 2022 6:02:29 PM org.apache.knox.gateway.shell.KnoxSession createClient
INFO: Using default JAAS configuration
mkdir: hreeve-dev3/denied/backup1_database_backup: PUT 0-byte object  on hreeve-dev3/denied/backup1_database_backup: com.amazonaws.services.s3.model.AmazonS3Exception: Access Denied (Service: Amazon S3; Status Code: 403; Error Code: AccessDenied; Request ID: 3881Q69KB3AJWVG3; S3 Extended Request ID: 8nUCIiyTnrTj7ZVYAdr29AZ0WCxRnnpveWEtBiBXr+bfo+VQzczIuQm0Hvb6HdNLZfBujpyTD48=; Proxy: null), S3 Extended Request ID: 8nUCIiyTnrTj7ZVYAdr29AZ0WCxRnnpveWEtBiBXr+bfo+VQzczIuQm0Hvb6HdNLZfBujpyTD48=:AccessDenied
Mar 04, 2022 6:02:32 PM org.apache.knox.gateway.shell.KnoxSession createClient
INFO: Using default JAAS configuration
moveFromLocal: `s3a://eng-sdx-daily-v2-datalake/hreeve-dev3/denied/backup1_database_backup/hive_backup': No such file or directory
```
And here's the stripped down error done as a single string:
```
mkdir: hreeve-dev3/denied/backup1_database_backup: PUT 0-byte object  on hreeve-dev3/denied/backup1_database_backup: com.amazonaws.services.s3.model.AmazonS3Exception: Access Denied (Service: Amazon S3; Status Code: 403; Error Code: AccessDenied; Request ID: AZWVXNAMVZGRMH6N; S3 Extended Request ID: +kQvwLsrvKvWJ8qXD6ffatnrAl6ktRwt7kNmv3CeF4rGLPVMLO5iKHShXR9SeA99apTunuMFHPk=; Proxy: null), S3 Extended Request ID: +kQvwLsrvKvWJ8qXD6ffatnrAl6ktRwt7kNmv3CeF4rGLPVMLO5iKHShXR9SeA99apTunuMFHPk=:AccessDenied; moveFromLocal: `s3a://eng-sdx-daily-v2-datalake/hreeve-dev3/denied/backup1_database_backup/hive_backup': No such file or directory; 
```