### PR TITLE
CB-15455 ipa client should prefer the primary gateway

### DIFF
--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/freeipa/FreeIpaConfigProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/freeipa/FreeIpaConfigProviderTest.java
@@ -20,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceMetaDataResponse;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceMetadataType;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.describe.DescribeFreeIpaResponse;
 
@@ -94,6 +95,40 @@ class FreeIpaConfigProviderTest {
         Map<String, Object> result = underTest.createFreeIpaConfig(ENVIRONMENT_CRN);
 
         assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testPgwChosen() {
+        DescribeFreeIpaResponse freeIpaResponse = new DescribeFreeIpaResponse();
+        InstanceGroupResponse instanceGroupResponse = new InstanceGroupResponse();
+        InstanceMetaDataResponse pgw = createInstanceMetadata("d", CREATED);
+        pgw.setInstanceType(InstanceMetadataType.GATEWAY_PRIMARY);
+        instanceGroupResponse.setMetaData(Set.of(createInstanceMetadata("b", TERMINATED), createInstanceMetadata("a", REQUESTED),
+                createInstanceMetadata("f", CREATED), pgw, createInstanceMetadata("c", CREATED)));
+        freeIpaResponse.setInstanceGroups(List.of(instanceGroupResponse));
+        when(freeipaClient.findByEnvironmentCrn(ENVIRONMENT_CRN)).thenReturn(Optional.of(freeIpaResponse));
+
+        Map<String, Object> result = underTest.createFreeIpaConfig(ENVIRONMENT_CRN);
+
+        assertEquals(1, result.size());
+        assertEquals("d", result.get("host"));
+    }
+
+    @Test
+    public void testPgwNotChosenIfNotCreated() {
+        DescribeFreeIpaResponse freeIpaResponse = new DescribeFreeIpaResponse();
+        InstanceGroupResponse instanceGroupResponse = new InstanceGroupResponse();
+        InstanceMetaDataResponse pgw = createInstanceMetadata("d", TERMINATED);
+        pgw.setInstanceType(InstanceMetadataType.GATEWAY_PRIMARY);
+        instanceGroupResponse.setMetaData(Set.of(createInstanceMetadata("b", TERMINATED), createInstanceMetadata("a", REQUESTED),
+                createInstanceMetadata("f", CREATED), pgw, createInstanceMetadata("c", CREATED)));
+        freeIpaResponse.setInstanceGroups(List.of(instanceGroupResponse));
+        when(freeipaClient.findByEnvironmentCrn(ENVIRONMENT_CRN)).thenReturn(Optional.of(freeIpaResponse));
+
+        Map<String, Object> result = underTest.createFreeIpaConfig(ENVIRONMENT_CRN);
+
+        assertEquals(1, result.size());
+        assertEquals("c", result.get("host"));
     }
 
     private InstanceMetaDataResponse createInstanceMetadata(String fqdn, InstanceStatus status) {

--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/template/join_ipa.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/template/join_ipa.j2
@@ -22,6 +22,9 @@ ipa-client-install \
   --unattended \
   --force-join \
   --ssh-trust-dns \
+  {%- if salt['pillar.get']('freeipa:host', None) != None %}
+  --server={{ pillar['freeipa']['host'] }} \
+  {%- endif %}
   --no-ntp
 
 echo "$PW" | kinit {{ pillar['sssd-ipa']['principal'] }}


### PR DESCRIPTION
- modified FreeIPA instance selection logic to prefer primary gateway
- `ipa-client-install` command now is using `--server` option to connect to the pgw if possible

Tested by creating a cluster and checking the rendered script on the host.

See detailed description in the commit message.