### PR TITLE
CB-16401 Temporarily revert UBI base image changes in CB Java services

### DIFF
--- a/docker-autoscale/Dockerfile
+++ b/docker-autoscale/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-ubi-minimal-java:jdk11-ubi8.5-218
+FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.13-cldr-jre-slim-buster-15122021
 # We can not use alpine based image because of https://github.com/grpc/grpc-java/issues/8751
 MAINTAINER info@cloudera.com
 
@@ -10,7 +10,7 @@ ENV VERSION ${VERSION}
 
 WORKDIR /
 
-RUN microdnf install unzip
+RUN apt-get install unzip
 
 # install the periscope app
 ADD ${REPO_URL}/com/sequenceiq/periscope/$VERSION/periscope-$VERSION.jar /periscope.jar

--- a/docker-autoscale/bootstrap/start_autoscale_app.sh
+++ b/docker-autoscale/bootstrap/start_autoscale_app.sh
@@ -12,7 +12,7 @@ echo "Importing certificates to the default Java certificate  trust store."
 if [ -d "$TRUSTED_CERT_DIR" ]; then
     for cert in $(ls -A "$TRUSTED_CERT_DIR"); do
         if [ -f "$TRUSTED_CERT_DIR/$cert" ]; then
-            if keytool -import -alias "$cert" -noprompt -file "$TRUSTED_CERT_DIR/$cert" -keystore /etc/pki/java/cacerts -storepass changeit; then
+            if keytool -import -alias "$cert" -noprompt -file "$TRUSTED_CERT_DIR/$cert" -keystore /usr/local/openjdk-11/lib/security/cacerts -storepass changeit; then
                 echo -e "Certificate added to default Java trust store with alias $cert."
             else
                 echo -e "WARNING: Failed to add $cert to trust store.\n"

--- a/docker-cloudbreak/Dockerfile
+++ b/docker-cloudbreak/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-ubi-minimal-java:jdk11-ubi8.5-218
+FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.13-cldr-jre-slim-buster-15122021
 # We can not use alpine based image because of https://github.com/grpc/grpc-java/issues/8751
 MAINTAINER info@cloudera.com
 
@@ -10,7 +10,7 @@ ENV VERSION ${VERSION}
 
 WORKDIR /
 
-RUN microdnf install unzip
+RUN apt-get install unzip
 
 # install the cloudbreak app
 ADD ${REPO_URL}/com/sequenceiq/cloudbreak/$VERSION/cloudbreak-$VERSION.jar /cloudbreak.jar

--- a/docker-cloudbreak/bootstrap/start_cloudbreak_app.sh
+++ b/docker-cloudbreak/bootstrap/start_cloudbreak_app.sh
@@ -12,7 +12,7 @@ echo "Importing certificates to the default Java certificate  trust store."
 if [ -d "$TRUSTED_CERT_DIR" ]; then
     for cert in $(ls -A "$TRUSTED_CERT_DIR"); do
         if [ -f "$TRUSTED_CERT_DIR/$cert" ]; then
-            if keytool -import -alias "$cert" -noprompt -file "$TRUSTED_CERT_DIR/$cert" -keystore /etc/pki/java/cacerts -storepass changeit; then
+            if keytool -import -alias "$cert" -noprompt -file "$TRUSTED_CERT_DIR/$cert" -keystore /usr/local/openjdk-11/lib/security/cacerts -storepass changeit; then
                 echo -e "Certificate added to default Java trust store with alias $cert."
             else
                 echo -e "WARNING: Failed to add $cert to trust store.\n"

--- a/docker-datalake/Dockerfile
+++ b/docker-datalake/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-ubi-minimal-java:jdk11-ubi8.5-218
+FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.13-cldr-jre-slim-buster-15122021
 # We can not use alpine based image because of https://github.com/grpc/grpc-java/issues/8751
 MAINTAINER info@cloudera.com
 
@@ -10,7 +10,7 @@ ENV VERSION ${VERSION}
 
 WORKDIR /
 
-RUN microdnf install unzip
+RUN apt-get install unzip
 
 # install the datalake app
 ADD ${REPO_URL}/com/sequenceiq/datalake/$VERSION/datalake-$VERSION.jar /datalake.jar

--- a/docker-datalake/bootstrap/start_datalake_app.sh
+++ b/docker-datalake/bootstrap/start_datalake_app.sh
@@ -12,7 +12,7 @@ echo "Importing certificates to the default Java certificate  trust store."
 if [ -d "$TRUSTED_CERT_DIR" ]; then
     for cert in $(ls -A "$TRUSTED_CERT_DIR"); do
         if [ -f "$TRUSTED_CERT_DIR/$cert" ]; then
-            if keytool -import -alias "$cert" -noprompt -file "$TRUSTED_CERT_DIR/$cert" -keystore /etc/pki/java/cacerts -storepass changeit; then
+            if keytool -import -alias "$cert" -noprompt -file "$TRUSTED_CERT_DIR/$cert" -keystore /usr/local/openjdk-11/lib/security/cacerts -storepass changeit; then
                 echo -e "Certificate added to default Java trust store with alias $cert."
             else
                 echo -e "WARNING: Failed to add $cert to trust store.\n"

--- a/docker-environment/Dockerfile
+++ b/docker-environment/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-ubi-minimal-java:jdk11-ubi8.5-218
+FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.13-cldr-jre-slim-buster-15122021
 # We can not use alpine based image because of https://github.com/grpc/grpc-java/issues/8751
 MAINTAINER info@cloudera.com
 
@@ -10,7 +10,7 @@ ENV VERSION ${VERSION}
 
 WORKDIR /
 
-RUN microdnf install unzip
+RUN apt-get install unzip
 
 # install the environment app
 ADD ${REPO_URL}/com/sequenceiq/environment/$VERSION/environment-$VERSION.jar /environment.jar

--- a/docker-environment/bootstrap/start_environment_app.sh
+++ b/docker-environment/bootstrap/start_environment_app.sh
@@ -12,7 +12,7 @@ echo "Importing certificates to the default Java certificate  trust store."
 if [ -d "$TRUSTED_CERT_DIR" ]; then
     for cert in $(ls -A "$TRUSTED_CERT_DIR"); do
         if [ -f "$TRUSTED_CERT_DIR/$cert" ]; then
-            if keytool -import -alias "$cert" -noprompt -file "$TRUSTED_CERT_DIR/$cert" -keystore /etc/pki/java/cacerts -storepass changeit; then
+            if keytool -import -alias "$cert" -noprompt -file "$TRUSTED_CERT_DIR/$cert" -keystore /usr/local/openjdk-11/lib/security/cacerts -storepass changeit; then
                 echo -e "Certificate added to default Java trust store with alias $cert."
             else
                 echo -e "WARNING: Failed to add $cert to trust store.\n"

--- a/docker-freeipa/Dockerfile
+++ b/docker-freeipa/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-ubi-minimal-java:jdk11-ubi8.5-218
+FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.13-cldr-jre-slim-buster-15122021
 # We can not use alpine based image because of https://github.com/grpc/grpc-java/issues/8751
 MAINTAINER info@cloudera.com
 
@@ -10,7 +10,7 @@ ENV VERSION ${VERSION}
 
 WORKDIR /
 
-RUN microdnf install unzip
+RUN apt-get install unzip
 
 # install the freeipa app
 ADD ${REPO_URL}/com/sequenceiq/freeipa/$VERSION/freeipa-$VERSION.jar /freeipa.jar

--- a/docker-freeipa/bootstrap/start_freeipa_app.sh
+++ b/docker-freeipa/bootstrap/start_freeipa_app.sh
@@ -12,7 +12,7 @@ echo "Importing certificates to the default Java certificate  trust store."
 if [ -d "$TRUSTED_CERT_DIR" ]; then
     for cert in $(ls -A "$TRUSTED_CERT_DIR"); do
         if [ -f "$TRUSTED_CERT_DIR/$cert" ]; then
-            if keytool -import -alias "$cert" -noprompt -file "$TRUSTED_CERT_DIR/$cert" -keystore /etc/pki/java/cacerts -storepass changeit; then
+            if keytool -import -alias "$cert" -noprompt -file "$TRUSTED_CERT_DIR/$cert" -keystore /usr/local/openjdk-11/lib/security/cacerts -storepass changeit; then
                 echo -e "Certificate added to default Java trust store with alias $cert."
             else
                 echo -e "WARNING: Failed to add $cert to trust store.\n"

--- a/docker-redbeams/Dockerfile
+++ b/docker-redbeams/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-ubi-minimal-java:jdk11-ubi8.5-218
+FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.13-cldr-jre-slim-buster-15122021
 # We can not use alpine based image because of https://github.com/grpc/grpc-java/issues/8751
 MAINTAINER info@cloudera.com
 
@@ -10,7 +10,7 @@ ENV VERSION ${VERSION}
 
 WORKDIR /
 
-RUN microdnf install unzip
+RUN apt-get install unzip
 
 # install the Redbeams app
 ADD ${REPO_URL}/com/sequenceiq/redbeams/$VERSION/redbeams-$VERSION.jar /redbeams.jar

--- a/docker-redbeams/bootstrap/start_redbeams_app.sh
+++ b/docker-redbeams/bootstrap/start_redbeams_app.sh
@@ -12,7 +12,7 @@ echo "Importing certificates to the default Java certificate trust store."
 if [ -d "$TRUSTED_CERT_DIR" ]; then
     for cert in $(ls -A "$TRUSTED_CERT_DIR"); do
         if [ -f "$TRUSTED_CERT_DIR/$cert" ]; then
-            if keytool -import -alias "$cert" -noprompt -file "$TRUSTED_CERT_DIR/$cert" -keystore /etc/pki/java/cacerts -storepass changeit; then
+            if keytool -import -alias "$cert" -noprompt -file "$TRUSTED_CERT_DIR/$cert" -keystore /usr/local/openjdk-11/lib/security/cacerts -storepass changeit; then
                 echo -e "Certificate added to default Java trust store with alias $cert."
             else
                 echo -e "WARNING: Failed to add $cert to trust store.\n"

--- a/integration-test/test-image/Dockerfile
+++ b/integration-test/test-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-ubi-minimal-java:jdk11-ubi8.5-218
+FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.13-cldr-jre-slim-buster-15122021
 MAINTAINER info@cloudera.com
 
 WORKDIR /

--- a/mock-infrastructure/Dockerfile
+++ b/mock-infrastructure/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-ubi-minimal-java:jdk11-ubi8.5-218
+FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.13-cldr-jre-slim-buster-15122021
 MAINTAINER info@cloudera.com
 
 # REPO URL to download jar

--- a/mock-thunderhead/Dockerfile
+++ b/mock-thunderhead/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-ubi-minimal-java:jdk11-ubi8.5-218
+FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.13-cldr-jre-slim-buster-15122021
 MAINTAINER info@cloudera.com
 
 # REPO URL to download jar


### PR DESCRIPTION
* Partially reverts cd86d83f2d069a76180e261975c6ca7c6bbabf70 / #12078.
* Changes to the following files have been untouched:
  * `build.gradle`
  * `integration-test/integcb/Profile_template`
  * `integration-test/scripts/docker-compose.sh`
