### PR TITLE
CB-15451 Use 200k LDAP database locks in FreeIPA

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/init.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/init.sls
@@ -74,3 +74,11 @@ disable_old_tls_for_ldap_server:
     - group: root
     - mode: 700
     - source: salt://freeipa/scripts/initdnarange.py
+
+/opt/salt/initial-ldap-conf.ldif:
+  file.managed:
+    - makedirs: True
+    - user: root
+    - group: root
+    - mode: 600
+    - source: salt://freeipa/templates/initial-ldap-conf.ldif

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_install.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_install.sh
@@ -34,6 +34,7 @@ ipa-server-install \
           --no-dnssec-validation \
 {%- endif %}
           --unattended \
+          --dirsrv-config-file /opt/salt/initial-ldap-conf.ldif \
           --no-ntp
 
 set +e

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_replica_install.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_replica_install.sh
@@ -120,6 +120,7 @@ ipa-replica-install \
           --no-dnssec-validation \
 {%- endif %}
           --unattended \
+          --dirsrv-config-file /opt/salt/initial-ldap-conf.ldif \
           --no-ntp
 
 set +e

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/templates/initial-ldap-conf.ldif
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/templates/initial-ldap-conf.ldif
@@ -1,0 +1,4 @@
+dn: cn=config,cn=ldbm database,cn=plugins,cn=config
+changetype: modify
+replace: nsslapd-db-locks
+nsslapd-db-locks: 200000


### PR DESCRIPTION
we identified issues were were were close to running out of database locks. There were some math formulas which suggested that we increase the locks significantly (e.g. 2M). But we found increasing it from 50k to 200k was effective.

To avoid LDAP server restart the change is added to the installation phase

See detailed description in the commit message.