### PR TITLE
CB-16424 Change Azure LB default sku to Standard

### DIFF
--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilderTest.java
@@ -727,7 +727,7 @@ public class AzureTemplateBuilderTest {
         assertTrue(templateString.contains("\"name\": \"port-443-rule\","));
         assertTrue(templateString.contains("\"name\": \"port-8443-probe\","));
         assertTrue(templateString.contains("\"type\": \"Microsoft.Network/publicIPAddresses\","));
-        assertTrue(templateString.contains("\"name\": \"Basic\""));
+        assertTrue(templateString.contains("\"name\": \"" + LoadBalancerSku.getDefault().getTemplateName() + "\""));
         assertEquals(2, StringUtils.countMatches(templateString,
             "\"[resourceId('Microsoft.Network/loadBalancers'"));
         assertEquals(2, StringUtils.countMatches(templateString,

--- a/common-model/src/main/java/com/sequenceiq/common/api/type/LoadBalancerSku.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/type/LoadBalancerSku.java
@@ -19,7 +19,7 @@ public enum LoadBalancerSku {
     }
 
     public static LoadBalancerSku getDefault() {
-        return BASIC;
+        return STANDARD;
     }
 
     public static LoadBalancerSku getValueOrDefault(LoadBalancerSku sku) {


### PR DESCRIPTION
Changes the default SKU from BASIC to STANDARD. Note that the changes for adding the standard LB
were done as part of a previous change, so no additional logic needed to be added.

See detailed description in the commit message.