### PR TITLE
CB-15452 Tune `createuserhome.sh` for larger number of users

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/post-recipes/scripts/createuserhome.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/post-recipes/scripts/createuserhome.sh
@@ -59,11 +59,15 @@ webhdfs_command()   {
     fi
 }
 
+DELAY=$(( RANDOM % 180 ))
 ### BEGIN OF SCRIPT ###
-echo "Start time of script $0, PID $$: `date`"
+echo "Start time of script $0, PID $$: `date` Delay: $DELAY"
 
 # Simplest example is avoiding running multiple instances of script.
 exlock_now || exit 1
+
+# Random sleep to avoid all clusters trying to reach FreeIPA at the same time
+sleep $DELAY
 
 # the file where all known users yet would be stored. We don't want to unnecessarily invoke namenode ops
 # for users we already created dirs for
@@ -114,7 +118,7 @@ echo "Webhdfs url: $WEBHDFS_URL"
 
 WEBHDFS_COOKIE_JAR=/tmp/cloudbreak-webhdfs.cookies
 
-mapfile -t users < <((ipa user-find --sizelimit=0 --timelimit=0) | grep 'User login:' | awk '{ print $3}')
+mapfile -t users < <((ipa user-find --pkey-only --sizelimit=0 --timelimit=0) | grep 'User login:' | awk '{ print $3}')
 declare -a existingusers
 if test -f "$EXISTING_USERS_FILE"; then
   mapfile -t existingusers < <(cat $EXISTING_USERS_FILE)

--- a/orchestrator-salt/src/main/resources/salt/salt/recipes/post-cluster-install.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/recipes/post-cluster-install.sls
@@ -41,6 +41,7 @@ createusername-cron:
   cron.present:
     - name: /opt/scripts/post-cluster-install/createuserhome.sh >> /var/log/createusername.log 2>&1
     - user: root
+    - minute: '*/5'
     - require:
         - file: /opt/scripts/post-cluster-install/createuserhome.sh
 {% endif %}


### PR DESCRIPTION
As we are moving toward to have thousands of users some tweaks are necessary to handle it a bit better:
- instead of querying the whole user from now only the login is queried
- instead of running the script every minute it will run every 5 minute to ease the load on FreeIPA
- random delay is added to the script, between 0 and 179 sec, so the clusters won't start pulling data from FreeIPA at once

This is still a workaround, and the whole script should be removed.

See detailed description in the commit message.