### PR TITLE
CB-16451: Fix issue when getting SDX events for environment with deleted datalakes.

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/service/SdxEventsService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/SdxEventsService.java
@@ -3,6 +3,7 @@ package com.sequenceiq.datalake.service;
 import static java.util.stream.Collectors.toList;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
@@ -117,6 +118,10 @@ public class SdxEventsService {
     }
 
     private List<CDPStructuredEvent> retrievePagedCloudbreakServiceEvents(SdxCluster sdxCluster, Integer page, Integer size) {
+        if (sdxCluster.getDeleted() != null) {
+            return Collections.emptyList();
+        }
+
         try {
             // Get and translate the cloudbreak events
             List<CloudbreakEventV4Response> cloudbreakEventV4Responses = ThreadBasedUserCrnProvider.doAsInternalActor(() ->
@@ -130,6 +135,10 @@ public class SdxEventsService {
     }
 
     private List<CDPStructuredEvent> retrieveCloudbreakServiceEvents(SdxCluster sdxCluster) {
+        if (sdxCluster.getDeleted() != null) {
+            return Collections.emptyList();
+        }
+
         try {
             // Get and translate the cloudbreak events
             StructuredEventContainer structuredEventContainer = ThreadBasedUserCrnProvider.doAsInternalActor(() ->


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-16451

Please look at the Jira description for the reason behind this bug and how I resolved it. Essentially, SDX events will run into an error if any of the environment's DLs are deleted, this being a result of additional error handling we added into 2.54.0.

This simply does nothing for the cloudbreak events if the DL is deleted, allowing for its SDX events to still be present, but not breaking the overall event retrieval.

I have tested this both via local UI and through both endpoint methods via Postman.