### PR TITLE
CB-16444 Fix stack log of ExistingStackPatcherJob

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJob.java
@@ -86,7 +86,7 @@ public class ExistingStackPatcherJob extends StatusCheckerJob {
     }
 
     private void unscheduleJob(JobExecutionContext context, Stack stack, StackPatchType stackPatchType) {
-        LOGGER.info("Unscheduling stack patcher {} job for stack {}", stackPatchType, stack);
+        LOGGER.info("Unscheduling stack patcher {} job for stack {}", stackPatchType, stack.getResourceCrn());
         jobService.unschedule(context.getJobDetail().getKey());
     }
 


### PR DESCRIPTION
Stack.toString() throws an org.hibernate.LazyInitializationException if the stack resources are not queried, so the log was modified to only include the CRN.

See detailed description in the commit message.