### PR TITLE
CDPCP-6171 update crn regex

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/auth/crn/Crn.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/auth/crn/Crn.java
@@ -35,7 +35,7 @@ import com.google.common.collect.ImmutableMap;
 public class Crn {
 
     private static final Pattern CRN_PATTERN =
-            Pattern.compile("^crn:(\\w+):(\\w+):(\\S+):(\\S+):(\\w+):(\\S+)$");
+            Pattern.compile("^crn:([\\w\\-]+):(\\w+):([\\w\\-]+):([\\w\\-]+):(\\w+):(\\S+)$");
 
     private static final boolean ADMIN_SERVICE = true;
 


### PR DESCRIPTION
The previous regex didn't allow for partitions with a 'hyphen' in it,
causing partition name 'cdp-us-gov' to fail. Also added Neil's
change to remove backtracking. This makes the regex used in cloudbreak
be the same as the one in thunderhead.

Reference:
- https://github.infra.cloudera.com/thunderhead/thunderhead/commit/e3c87608308d149c836f58d71ea8b49c2f65cbd7
- https://github.infra.cloudera.com/thunderhead/thunderhead/commit/6a771e0da29b7727bc6f10a5dc640583bef805c2

See detailed description in the commit message.