### PR TITLE
CB-11052 - Validate existing backup for recovery

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/service/recovery/RecoveryService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/recovery/RecoveryService.java
@@ -15,6 +15,7 @@ import com.sequenceiq.sdx.api.model.SdxRecoveryResponse;
  *
  */
 public interface RecoveryService {
+
     /**
      * Starts recovery of the CB infrastructure related to the recovery request.
      *
@@ -23,6 +24,7 @@ public interface RecoveryService {
      *
      * Validation should have already been performed before calling
      *
+     * @param sdxCluster affected cluster to be recovered
      * @param recoveryRequest detailed information about the recovery
      * @return a response containing the identifier of the triggered recovery Flow
      */
@@ -31,8 +33,17 @@ public interface RecoveryService {
     /**
      * Validates that triggering a recovery is allowed.
      *
+     * @param sdxCluster affected cluster to be validated for recovery
      * @return a message detailing if recovery is allowed and the reason why
      */
     SdxRecoverableResponse validateRecovery(SdxCluster sdxCluster);
 
+    /**
+     * Validates that triggering a recovery is allowed.
+     *
+     * @param sdxCluster affected cluster to be validated for recovery
+     * @param recoveryRequest detailed information about the recovery
+     * @return a message detailing if recovery is allowed and the reason why
+     */
+    SdxRecoverableResponse validateRecovery(SdxCluster sdxCluster, SdxRecoveryRequest recoveryRequest);
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/recovery/SdxRecoverySelectorService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/recovery/SdxRecoverySelectorService.java
@@ -38,7 +38,7 @@ public class SdxRecoverySelectorService {
         List<String> responseReasons = new ArrayList<>();
 
         for (RecoveryService recoveryService : services) {
-            SdxRecoverableResponse recoverableResponse = recoveryService.validateRecovery(sdxCluster);
+            SdxRecoverableResponse recoverableResponse = recoveryService.validateRecovery(sdxCluster, sdxRecoveryRequest);
             responseReasons.add(recoverableResponse.getReason());
             if (recoverableResponse.getStatus().recoverable()) {
                 return recoveryService.triggerRecovery(sdxCluster, sdxRecoveryRequest);

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/resize/recovery/ResizeRecoveryService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/resize/recovery/ResizeRecoveryService.java
@@ -53,7 +53,8 @@ public class ResizeRecoveryService implements RecoveryService {
     @Inject
     private FlowChainLogService flowChainLogService;
 
-    public SdxRecoverableResponse validateRecovery(SdxCluster sdxCluster) {
+    @Override
+    public SdxRecoverableResponse validateRecovery(SdxCluster sdxCluster, SdxRecoveryRequest request) {
         Optional<FlowLog> flowLogOptional = flow2Handler.getFirstStateLogfromLatestFlow(sdxCluster.getId());
         if (flowLogOptional.isEmpty()) {
             return new SdxRecoverableResponse("No recent actions on this cluster", RecoveryStatus.NON_RECOVERABLE);
@@ -84,6 +85,12 @@ public class ResizeRecoveryService implements RecoveryService {
         }
     }
 
+    @Override
+    public SdxRecoverableResponse validateRecovery(SdxCluster sdxCluster) {
+        return validateRecovery(sdxCluster, null);
+    }
+
+    @Override
     public SdxRecoveryResponse triggerRecovery(SdxCluster sdxCluster, SdxRecoveryRequest sdxRecoveryRequest) {
         SdxStatusEntity actualStatusForSdx = sdxStatusService.getActualStatusForSdx(sdxCluster);
         if (entitlementService.isDatalakeResizeRecoveryEnabled(ThreadBasedUserCrnProvider.getAccountId())) {

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/recovery/SdxUpgradeRecoveryService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/recovery/SdxUpgradeRecoveryService.java
@@ -1,5 +1,8 @@
 package com.sequenceiq.datalake.service.upgrade.recovery;
 
+import java.util.Objects;
+import java.util.Optional;
+
 import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
 
@@ -7,10 +10,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.cloudera.thunderhead.service.datalakedr.datalakeDRProto;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.StackV4Endpoint;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.recovery.RecoveryStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.recovery.RecoveryValidationV4Response;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.common.exception.WebApplicationExceptionMessageExtractor;
+import com.sequenceiq.cloudbreak.datalakedr.DatalakeDrClient;
 import com.sequenceiq.cloudbreak.exception.CloudbreakApiException;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.datalake.entity.SdxCluster;
@@ -20,6 +26,7 @@ import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.sdx.api.model.SdxRecoverableResponse;
 import com.sequenceiq.sdx.api.model.SdxRecoveryRequest;
 import com.sequenceiq.sdx.api.model.SdxRecoveryResponse;
+import com.sequenceiq.sdx.api.model.SdxRecoveryType;
 
 @Component
 public class SdxUpgradeRecoveryService implements RecoveryService {
@@ -35,6 +42,10 @@ public class SdxUpgradeRecoveryService implements RecoveryService {
     @Inject
     private WebApplicationExceptionMessageExtractor exceptionMessageExtractor;
 
+    @Inject
+    private DatalakeDrClient datalakeDrClient;
+
+    @Override
     public SdxRecoveryResponse triggerRecovery(SdxCluster sdxCluster, SdxRecoveryRequest recoverRequest) {
         MDCBuilder.buildMdcContext(sdxCluster);
 
@@ -42,10 +53,21 @@ public class SdxUpgradeRecoveryService implements RecoveryService {
         return new SdxRecoveryResponse(flowIdentifier);
     }
 
-    public SdxRecoverableResponse validateRecovery(SdxCluster sdxCluster) {
+    @Override
+    public SdxRecoverableResponse validateRecovery(SdxCluster sdxCluster, SdxRecoveryRequest request) {
         MDCBuilder.buildMdcContext(sdxCluster);
         try {
             String initiatorUserCrn = ThreadBasedUserCrnProvider.getUserCrn();
+            if (Objects.nonNull(request) && request.getType() == SdxRecoveryType.RECOVER_WITH_DATA) {
+                String clusterRuntime = sdxCluster.getRuntime();
+                datalakeDRProto.DatalakeBackupInfo lastSuccessfulBackup = datalakeDrClient.getLastSuccessfulBackup(sdxCluster.getClusterName(),
+                        initiatorUserCrn, Optional.of(clusterRuntime));
+                if (Objects.isNull(lastSuccessfulBackup)) {
+                    return new SdxRecoverableResponse("There is no successful backup taken yet for data lake cluster with runtime " + clusterRuntime + ".",
+                            RecoveryStatus.NON_RECOVERABLE);
+                }
+            }
+
             RecoveryValidationV4Response response = ThreadBasedUserCrnProvider.doAsInternalActor(() ->
                     stackV4Endpoint.getClusterRecoverableByNameInternal(0L, sdxCluster.getClusterName(), initiatorUserCrn));
             return new SdxRecoverableResponse(response.getReason(), response.getStatus());
@@ -57,4 +79,8 @@ public class SdxUpgradeRecoveryService implements RecoveryService {
         }
     }
 
+    @Override
+    public SdxRecoverableResponse validateRecovery(SdxCluster sdxCluster) {
+        return validateRecovery(sdxCluster, null);
+    }
 }


### PR DESCRIPTION
This commit validates for an existing successful backup taken with the original runtime present before upgrade.

The Thunderhead change that includes the Runtime information for a given backup is, it is on "Stage" now:
https://github.infra.cloudera.com/thunderhead/thunderhead/commit/66e8a169fcb11e5f27d28843bb594bea9b88d981

