### PR TITLE
CB-16477: [In-Place Migration][7.2.12][AWS][mow-int] Restart of services with stale configurations is not issued for when starting OpsDB DH

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
@@ -6,6 +6,7 @@ import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUD
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_CM_CLUSTER_SERVICES_STARTED;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_CM_CLUSTER_SERVICES_STARTING;
+import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_CM_CLUSTER_SERVICES_RESTARTING;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_CM_UPDATED_REMOTE_DATA_CONTEXT;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_CM_UPDATING_REMOTE_DATA_CONTEXT;
 
@@ -557,11 +558,16 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
         LOGGER.debug("Deployed client configs and refreshed services in Cloudera Manager.");
     }
 
-    private void restartServices(ClustersResourceApi clustersResourceApi) throws ApiException, CloudbreakException {
-        doRestartServicesIfNeeded(clustersResourceApi, false);
+    private int restartServices() throws ApiException, CloudbreakException {
+        ClustersResourceApi apiInstance = clouderaManagerApiFactory.getClustersResourceApi(apiClient);
+        return restartServices(apiInstance);
     }
 
-    private void doRestartServicesIfNeeded(ClustersResourceApi clustersResourceApi, boolean waitForCommandExecutionOnly)
+    private int restartServices(ClustersResourceApi clustersResourceApi) throws ApiException, CloudbreakException {
+        return doRestartServicesIfNeeded(clustersResourceApi, false);
+    }
+
+    private int doRestartServicesIfNeeded(ClustersResourceApi clustersResourceApi, boolean waitForCommandExecutionOnly)
             throws ApiException, CloudbreakException {
         ApiCommandList apiCommandList = clustersResourceApi.listActiveCommands(stack.getName(), SUMMARY);
         Optional<ApiCommand> optionalRestartCommand = apiCommandList.getItems().stream()
@@ -575,12 +581,14 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
             ApiRestartClusterArgs restartClusterArgs = new ApiRestartClusterArgs();
             restartClusterArgs.setRedeployClientConfiguration(true);
             restartCommand = clustersResourceApi.restartCommand(stack.getName(), restartClusterArgs);
+            eventService.fireCloudbreakEvent(stack.getId(), UPDATE_IN_PROGRESS.name(), CLUSTER_CM_CLUSTER_SERVICES_RESTARTING);
         }
         if (restartCommand != null) {
             ExtendedPollingResult pollingResult = clouderaManagerPollingServiceProvider.startPollingCmServicesRestart(stack, apiClient, restartCommand.getId());
             handlePollingResult(pollingResult, "Cluster was terminated while restarting services.",
                     "Timeout happened while restarting services.");
         }
+        return getCommandId(restartCommand);
     }
 
     private void restartClouderaManagementServices(MgmtServiceResourceApi mgmtServiceResourceApi) throws ApiException, CloudbreakException {
@@ -771,9 +779,9 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
     @Override
     public int deployConfigAndStartClusterServices() throws CloudbreakException {
         try {
-            LOGGER.info("Deploying configuration and starting services");
+            LOGGER.info("Deploying configuration and restarting services");
             deployConfig();
-            return startServices();
+            return restartServices();
         } catch (ApiException e) {
             LOGGER.info("Couldn't start Cloudera Manager services", e);
             throw new ClouderaManagerOperationFailedException(e.getMessage(), e);
@@ -846,9 +854,8 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
             handlePollingResult(pollingResult, "Cluster was terminated while waiting for Cloudera Runtime services to start",
                     "Timeout while stopping Cloudera Manager services.");
         }
-        eventService
-                .fireCloudbreakEvent(stack.getId(), UPDATE_IN_PROGRESS.name(), CLUSTER_CM_CLUSTER_SERVICES_STARTED);
-        return apiCommand == null ? 0 : apiCommand.getId().intValue();
+        eventService.fireCloudbreakEvent(stack.getId(), UPDATE_IN_PROGRESS.name(), CLUSTER_CM_CLUSTER_SERVICES_STARTED);
+        return getCommandId(apiCommand);
     }
 
     private void startAgents() {
@@ -915,5 +922,9 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
             LOGGER.debug("Failed to determine if {} service is present in cluster {}.", serviceType, stack.getCluster().getId());
         }
         return servicePresent;
+    }
+
+    private int getCommandId(ApiCommand command) {
+        return command == null ? 0 : command.getId().intValue();
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
@@ -382,6 +382,7 @@ public enum ResourceEvent {
     CLUSTER_CM_CLUSTER_SERVICES_STOPPED("cm.cluster.services.stopped"),
     CLUSTER_CM_CLUSTER_SERVICES_STARTED("cm.cluster.services.started"),
     CLUSTER_CM_CLUSTER_SERVICES_STARTING("cm.cluster.services.starting"),
+    CLUSTER_CM_CLUSTER_SERVICES_RESTARTING("cm.cluster.services.restarting"),
     CLUSTER_CM_UPDATING_REMOTE_DATA_CONTEXT("cm.cluster.updating.remote.data.context"),
     CLUSTER_CM_UPDATED_REMOTE_DATA_CONTEXT("cm.cluster.updated.remote.data.context"),
     CLUSTER_CM_SECURITY_GROUP_TOO_STRICT("cm.cluster.securitygroup.too.strict"),

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -218,6 +218,7 @@ cm.cluster.command.failed=Cloudera Manager command [{0}] failed, you can check t
 cm.cluster.command.timeout=Cloudera Manager command [{0}] timed out, you can check the command here: {1}
 cm.cluster.services.started=Cloudera Manager services have been started.
 cm.cluster.services.starting=Starting Cloudera Manager services.
+cm.cluster.services.restarting=Restarting Cloudera Manager services.
 cm.cluster.services.stopping=Stopping Cloudera Manager services.
 cm.cluster.services.stopped=Cloudera Manager services have been stopped.
 cm.cluster.updating.remote.data.context=Cloudera Manager updating remote data context, started.


### PR DESCRIPTION
As the root cause was the auto-start configuration setup for Knox. Just starting the services would not work as the knox service is up even before the RDC refresh is performed.

Changing the logic from just starting the services to restarting the services.

Made sure that the issue is not observed in the local dev environment.