### PR TITLE
CB-15401 Prevent unneccesary cluster upscale and downscale operations…

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/utils/StackResponseUtils.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/utils/StackResponseUtils.java
@@ -33,9 +33,18 @@ public class StackResponseUtils {
                 .filter(instanceGroupV4Response -> instanceGroupV4Response.getName().equalsIgnoreCase(hostGroup))
                 .flatMap(instanceGroupV4Response -> instanceGroupV4Response.getMetadata().stream())
                 .filter(instanceMetaData -> instanceMetaData.getDiscoveryFQDN() != null)
-                .filter(instanceMetaData -> InstanceStatus.SERVICES_HEALTHY.equals(instanceMetaData.getInstanceStatus()))
                 .collect(Collectors.toMap(InstanceMetaDataV4Response::getDiscoveryFQDN,
                         InstanceMetaDataV4Response::getInstanceId));
+    }
+
+    public Integer getCloudInstanceIdsWithServicesHealthyForHostGroup(StackV4Response stackResponse, String hostGroup) {
+        return stackResponse.getInstanceGroups().stream()
+                .filter(instanceGroupV4Response -> instanceGroupV4Response.getName().equalsIgnoreCase(hostGroup))
+                .flatMap(instanceGroupV4Response -> instanceGroupV4Response.getMetadata().stream())
+                .filter(instanceMetaData -> instanceMetaData.getDiscoveryFQDN() != null)
+                .filter(instanceMetaData -> InstanceStatus.SERVICES_HEALTHY.equals(instanceMetaData.getInstanceStatus()))
+                .collect(Collectors.counting())
+                .intValue();
     }
 
     public Integer getStoppedInstanceCountInHostGroup(StackV4Response stackV4Response, String policyHostGroup) {

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/CronTimeEvaluatorTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/CronTimeEvaluatorTest.java
@@ -166,7 +166,7 @@ public class CronTimeEvaluatorTest {
 
         TimeAlert alert = getAAlert(desiredNodeCount);
         StackV4Response stackV4Response = MockStackResponseGenerator
-                .getMockStackV4Response(clusterCrn, testHostGroup, "testFqdn" + testHostGroup, currentHostGroupCount, false);
+                .getMockStackV4Response(clusterCrn, testHostGroup, "testFqdn" + testHostGroup, currentHostGroupCount, 0);
 
         when(cloudbreakCommunicator.getByCrn(anyString())).thenReturn(stackV4Response);
         when(stackResponseUtils.getNodeCountForHostGroup(stackV4Response, testHostGroup)).thenCallRealMethod();

--- a/autoscale/src/test/java/com/sequenceiq/periscope/utils/StackResponseUtilsTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/utils/StackResponseUtilsTest.java
@@ -25,7 +25,7 @@ public class StackResponseUtilsTest {
         String hostGroup = "compute";
 
         Map<String, String> instanceIdsForHostGroups = underTest
-                .getCloudInstanceIdsForHostGroup(getMockStackV4Response(hostGroup, false), hostGroup);
+                .getCloudInstanceIdsForHostGroup(getMockStackV4Response(hostGroup, 0), hostGroup);
 
         assertEquals("Retrieved Instance Ids size should match", instanceIdsForHostGroups.size(), 3);
         assertEquals("Retrieved Instance Id should match",
@@ -40,11 +40,10 @@ public class StackResponseUtilsTest {
     public void testGetCloudInstanceIdsForHostGroupWithUnhealthyInstances() {
         String hostGroup = "compute";
 
-        Map<String, String> instanceIdsToHostGroup = underTest.
-                getCloudInstanceIdsForHostGroup(getMockStackV4Response(hostGroup, true), hostGroup);
+        int servicesHealthyHostGroupSize = underTest.
+                getCloudInstanceIdsWithServicesHealthyForHostGroup(getMockStackV4Response(hostGroup, 2), hostGroup);
 
-        assertEquals("Retrieved Instance Ids size should match", 1, instanceIdsToHostGroup.size());
-        assertEquals("Retrieved Instance Id should match", "test_instanceid_compute2", instanceIdsToHostGroup.get("test_fqdn2"));
+        assertEquals("Retrieved healthy host group size should match", 1, servicesHealthyHostGroupSize);
     }
 
     @Test
@@ -63,7 +62,7 @@ public class StackResponseUtilsTest {
         String hostGroup = "compute";
 
         Integer nodeCountForHostGroup = underTest
-                .getNodeCountForHostGroup(getMockStackV4Response(hostGroup, false), hostGroup);
+                .getNodeCountForHostGroup(getMockStackV4Response(hostGroup, 0), hostGroup);
         assertEquals("Retrieved HostGroup Instance Count should match.", Integer.valueOf(3), nodeCountForHostGroup);
     }
 
@@ -110,14 +109,14 @@ public class StackResponseUtilsTest {
         assertEquals("RoleConfigName in template should match for HostGroup", expectedRoleConfigName, hostGroupRolename);
     }
 
-    private StackV4Response getMockStackV4Response(String hostGroup, boolean withUnhealthyInstances) {
+    private StackV4Response getMockStackV4Response(String hostGroup, int withUnhealthyInstances) {
         return MockStackResponseGenerator
                 .getMockStackV4Response("test-crn", hostGroup, "test_fqdn", 3, withUnhealthyInstances);
     }
 
     private StackV4Response getMockStackV4ResponseForStopStart(String hostGroup, int runningHostGroupCount, int stoppedHostGroupCount) {
         return MockStackResponseGenerator
-                .getMockStackV4Response("test-crn", hostGroup, "test-fqdn", runningHostGroupCount, stoppedHostGroupCount);
+                .getMockStackV4ResponseWithStoppedAndRunningNodes("test-crn", hostGroup, "test-fqdn", runningHostGroupCount, stoppedHostGroupCount);
     }
 
     private String getTestBP() throws IOException {


### PR DESCRIPTION
… in periscope.

### Overview
 - Changes to recognise the appropriate number of instances based on the upscale or downscale operations.
 - Tested by triggering upscale and downscale operations via regular autoscaling, stop / start scaling for a Data Hub with unhealthy instances

### Testing
 - UTs for the corresponding evaluators.

See detailed description in the commit message.