### PR TITLE
CB-15784: Streaming template for Zookeeper Multi AZ

### DIFF
--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -552,6 +552,7 @@ cb:
           7.2.15 - Data Engineering: Apache Spark3=cdp-data-engineering-spark3;
           7.2.15 - Data Mart: Apache Impala, Hue=cdp-data-mart;
           7.2.15 - Real-time Data Mart: Apache Impala, Hue, Apache Kudu, Apache Spark=cdp-rt-data-mart;
+          7.2.15 - Streams Messaging High Availability: Apache Kafka, Schema Registry, Streams Messaging Manager, Streams Replication Manager, Cruise Control=cdp-streaming-ha;
           7.2.15 - Streams Messaging Heavy Duty: Apache Kafka, Schema Registry, Streams Messaging Manager, Streams Replication Manager, Cruise Control=cdp-streaming;
           7.2.15 - Streams Messaging Light Duty: Apache Kafka, Schema Registry, Streams Messaging Manager, Streams Replication Manager, Cruise Control=cdp-streaming-small;
           7.2.15 - Flow Management Light Duty with Apache NiFi, Apache NiFi Registry=cdp-flow-management-small;

--- a/core/src/main/resources/defaults/blueprints/7.2.15/cdp-streaming-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.15/cdp-streaming-ha.bp
@@ -1,0 +1,167 @@
+{
+  "description": "7.2.15 - Streams Messaging High Availability with Apache Kafka, Schema Registry, Streams Messaging Manager, Streams Replication Manager, Cruise Control",
+  "blueprint": {
+    "cdhVersion": "7.2.15",
+    "displayName": "streams-messaging",
+    "blueprintUpgradeOption": "GA",
+    "services": [
+      {
+        "refName": "streams_messaging_manager",
+        "serviceType": "STREAMS_MESSAGING_MANAGER",
+        "roleConfigGroups": [
+          {
+            "refName": "streams_messaging_manager-STREAMS_MESSAGING_MANAGER_SERVER-BASE",
+            "roleType": "STREAMS_MESSAGING_MANAGER_SERVER",
+            "base": true
+          },
+          {
+            "refName": "streams_messaging_manager-STREAMS_MESSAGING_MANAGER_UI-BASE",
+            "roleType": "STREAMS_MESSAGING_MANAGER_UI",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "core_settings",
+        "serviceType": "CORE_SETTINGS",
+        "roleConfigGroups": [
+          {
+            "refName": "core_settings-STORAGEOPERATIONS-BASE",
+            "roleType": "STORAGEOPERATIONS",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "kafka",
+        "serviceType": "KAFKA",
+        "roleConfigGroups": [
+          {
+            "refName": "kafka-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          },
+          {
+            "refName": "kafka-KAFKA_BROKER-BASE",
+            "roleType": "KAFKA_BROKER",
+            "base": true
+          },
+          {
+            "refName": "kafka-KAFKA_CONNECT-BASE",
+            "roleType": "KAFKA_CONNECT",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "zookeeper",
+        "serviceType": "ZOOKEEPER",
+        "roleConfigGroups": [
+          {
+            "refName": "zookeeper-SERVER-BASE",
+            "roleType": "SERVER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "schemaregistry",
+        "serviceType": "SCHEMAREGISTRY",
+        "roleConfigGroups": [
+          {
+            "refName": "schemaregistry-SCHEMA_REGISTRY_SERVER-BASE",
+            "roleType": "SCHEMA_REGISTRY_SERVER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName" : "streams_replication_manager",
+        "serviceType" : "STREAMS_REPLICATION_MANAGER",
+        "roleConfigGroups" : [
+          {
+            "refName" : "streams_replication_manager-STREAMS_REPLICATION_MANAGER_SERVICE-BASE",
+            "roleType" : "STREAMS_REPLICATION_MANAGER_SERVICE",
+            "base" : true
+          },
+          {
+            "refName" : "streams_replication_manager-STREAMS_REPLICATION_MANAGER_DRIVER-BASE",
+            "roleType" : "STREAMS_REPLICATION_MANAGER_DRIVER",
+            "base" : true
+          },
+          {
+            "refName" : "streams_replication_manager-GATEWAY-BASE",
+            "roleType" : "GATEWAY",
+            "base" : true
+          }
+        ]
+      },
+      {
+        "refName": "cruise_control",
+        "serviceType": "CRUISE_CONTROL",
+        "roleConfigGroups": [
+          {
+            "refName": "cruise_control-CRUISE_CONTROL_SERVER-BASE",
+            "roleType": "CRUISE_CONTROL_SERVER",
+            "base": true
+          }
+        ]
+      }
+    ],
+    "hostTemplates": [
+      {
+        "refName": "master",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "core_settings-STORAGEOPERATIONS-BASE",
+          "cruise_control-CRUISE_CONTROL_SERVER-BASE",
+          "streams_messaging_manager-STREAMS_MESSAGING_MANAGER_SERVER-BASE",
+          "streams_messaging_manager-STREAMS_MESSAGING_MANAGER_UI-BASE",
+          "streams_replication_manager-GATEWAY-BASE"
+        ]
+      },
+      {
+        "refName": "core_zookeeper",
+        "cardinality": 3,
+        "roleConfigGroupsRefNames": [
+          "zookeeper-SERVER-BASE",
+          "schemaregistry-SCHEMA_REGISTRY_SERVER-BASE",
+          "core_settings-STORAGEOPERATIONS-BASE"
+        ]
+      },
+      {
+        "refName": "core_broker",
+        "cardinality": 3,
+        "roleConfigGroupsRefNames": [
+          "kafka-GATEWAY-BASE",
+          "kafka-KAFKA_BROKER-BASE"
+        ]
+      },
+      {
+        "refName": "broker",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "kafka-GATEWAY-BASE",
+          "kafka-KAFKA_BROKER-BASE"
+        ]
+      },
+      {
+        "refName": "srm",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "streams_replication_manager-STREAMS_REPLICATION_MANAGER_SERVICE-BASE",
+          "streams_replication_manager-STREAMS_REPLICATION_MANAGER_DRIVER-BASE",
+          "streams_replication_manager-GATEWAY-BASE"
+        ]
+      },
+      {
+        "refName": "connect",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "kafka-GATEWAY-BASE",
+          "kafka-KAFKA_CONNECT-BASE"
+        ]
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.15/aws/streaming-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.15/aws/streaming-ha.json
@@ -1,0 +1,130 @@
+{
+  "name": "7.2.15 - Streams Messaging High Availability for AWS",
+  "description": "",
+  "type": "STREAMING",
+  "cloudPlatform": "AWS",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.15 - Streams Messaging High Availability: Apache Kafka, Schema Registry, Streams Messaging Manager, Streams Replication Manager, Cruise Control"
+    },
+    "externalDatabase": {
+      "availabilityType": "HA"
+    },
+    "instanceGroups": [
+      {
+        "name": "master",
+        "scalabilityOption": "FORBIDDEN",
+        "template": {
+          "instanceType": "r5.4xlarge",
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "standard"
+            }
+          ]
+        },
+        "nodeCount": 1,
+        "type": "GATEWAY",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "core_zookeeper",
+        "scalabilityOption": "FORBIDDEN",
+        "template": {
+          "instanceType": "m5.2xlarge",
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "standard"
+            }
+          ]
+        },
+        "nodeCount": 3,
+        "minimumNodeCount": 3,
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "recipeNames": []
+      },
+      {
+        "name": "core_broker",
+        "scalabilityOption": "FORBIDDEN",
+        "template": {
+          "instanceType": "m5.2xlarge",
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 1000,
+              "type": "gp2"
+            }
+          ]
+        },
+        "nodeCount": 3,
+        "minimumNodeCount": 3,
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "recipeNames": []
+      },
+      {
+        "name": "broker",
+        "template": {
+          "instanceType": "m5.2xlarge",
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 1000,
+              "type": "gp2"
+            }
+          ]
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "recipeNames": []
+      },
+      {
+        "name": "srm",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "standard"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "connect",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "standard"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.15/azure/streaming-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.15/azure/streaming-ha.json
@@ -1,0 +1,124 @@
+{
+  "name": "7.2.15 - Streams Messaging High Availability for Azure",
+  "description": "",
+  "type": "STREAMING",
+  "cloudPlatform": "AZURE",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.15 - Streams Messaging High Availability: Apache Kafka, Schema Registry, Streams Messaging Manager, Streams Replication Manager, Cruise Control"
+    },
+    "externalDatabase": {
+      "availabilityType": "HA"
+    },
+    "instanceGroups": [
+      {
+        "name": "master",
+        "scalabilityOption": "FORBIDDEN",
+        "template": {
+          "instanceType": "Standard_E16s_v3",
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "StandardSSD_LRS"
+            }
+          ]
+        },
+        "nodeCount": 1,
+        "type": "GATEWAY",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "core_zookeeper",
+        "scalabilityOption": "FORBIDDEN",
+        "template": {
+          "instanceType": "Standard_D8s_v3",
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "Standard_LRS"
+            }
+          ]
+        },
+        "nodeCount": 3,
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "recipeNames": []
+      },
+      {
+        "name": "core_broker",
+        "scalabilityOption": "FORBIDDEN",
+        "template": {
+          "instanceType": "Standard_D8s_v3",
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 1000,
+              "type": "Premium_LRS"
+            }
+          ]
+        },
+        "nodeCount": 3,
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "recipeNames": []
+      },
+      {
+        "name": "broker",
+        "template": {
+          "instanceType": "Standard_D8s_v3",
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 1000,
+              "type": "Premium_LRS"
+            }
+          ]
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "recipeNames": []
+      },
+      {
+        "name": "srm",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "Standard_LRS"
+            }
+          ],
+          "azure": {
+            "manageDisk": true
+          },
+          "instanceType": "Standard_D8_v3"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "connect",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "Standard_LRS"
+            }
+          ],
+          "azure": {
+            "manageDisk": true
+          },
+          "instanceType": "Standard_D8_v3"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.15/gcp/streaming-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.15/gcp/streaming-ha.json
@@ -1,0 +1,116 @@
+{
+  "name": "7.2.15 - Streams Messaging High Availability for Google Cloud",
+  "description": "",
+  "type": "STREAMING",
+  "cloudPlatform": "GCP",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.15 - Streams Messaging High Availability: Apache Kafka, Schema Registry, Streams Messaging Manager, Streams Replication Manager, Cruise Control"
+    },
+    "externalDatabase": {
+      "availabilityType": "HA"
+    },
+    "instanceGroups": [
+      {
+        "name": "master",
+        "scalabilityOption": "FORBIDDEN",
+        "template": {
+          "instanceType": "e2-highmem-16",
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "pd-standard"
+            }
+          ]
+        },
+        "nodeCount": 1,
+        "type": "GATEWAY",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "core_zookeeper",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "pd-standard"
+            }
+          ],
+          "instanceType": "e2-standard-8"
+        },
+        "nodeCount": 3,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "core_broker",
+        "scalabilityOption": "FORBIDDEN",
+        "template": {
+          "instanceType": "e2-standard-8",
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 1000,
+              "type": "pd-ssd"
+            }
+          ]
+        },
+        "nodeCount": 3,
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "recipeNames": []
+      },
+      {
+        "name": "broker",
+        "template": {
+          "instanceType": "e2-standard-8",
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 1000,
+              "type": "pd-ssd"
+            }
+          ]
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "recipeNames": []
+      },
+      {
+        "name": "srm",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "pd-standard"
+            }
+          ],
+          "instanceType": "e2-standard-8"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "connect",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "pd-standard"
+            }
+          ],
+          "instanceType": "e2-standard-8"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.15/yarn/streaming-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.15/yarn/streaming-ha.json
@@ -1,0 +1,107 @@
+{
+  "name": "7.2.15 - Streams Messaging High Availability for YCloud",
+  "description": "",
+  "type": "STREAMING",
+  "cloudPlatform": "YARN",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.15 - Streams Messaging High Availability: Apache Kafka, Schema Registry, Streams Messaging Manager, Streams Replication Manager, Cruise Control"
+    },
+    "instanceGroups": [
+      {
+        "name": "master",
+        "scalabilityOption": "FORBIDDEN",
+        "template": {
+          "yarn": {
+            "cpus": 8,
+            "memory": 65536
+          },
+          "rootVolume": {
+            "size": 100
+          }
+        },
+        "nodeCount": 1,
+        "type": "GATEWAY",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "core_zookeeper",
+        "template": {
+          "yarn": {
+            "cpus": 4,
+            "memory": 16384
+          },
+          "rootVolume": {
+            "size": 50
+          }
+        },
+        "nodeCount": 3,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "core_broker",
+        "scalabilityOption": "FORBIDDEN",
+        "template": {
+          "yarn": {
+            "cpus": 4,
+            "memory": 16384
+          },
+          "rootVolume": {
+            "size": 50
+          }
+        },
+        "nodeCount": 3,
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "recipeNames": []
+      },
+      {
+        "name": "broker",
+        "template": {
+          "yarn": {
+            "cpus": 4,
+            "memory": 16384
+          },
+          "rootVolume": {
+            "size": 50
+          }
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "recipeNames": []
+      },
+      {
+        "name": "srm",
+        "template": {
+          "yarn": {
+            "cpus": 4,
+            "memory": 16384
+          },
+          "rootVolume": {
+            "size": 50
+          }
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "connect",
+        "template": {
+          "yarn": {
+            "cpus": 4,
+            "memory": 16384
+          },
+          "rootVolume": {
+            "size": 50
+          }
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      }
+    ]
+  }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
@@ -365,7 +365,7 @@ public class ClusterTemplateTest extends AbstractMockTest {
             assertNotNull(entity);
             assertNotNull(entity.getResponses());
             long defaultCount = entity.getResponses().stream().filter(template -> ResourceStatus.DEFAULT.equals(template.getStatus())).count();
-            long expectedCount = 538;
+            long expectedCount = 542;
             assertEquals("Should have " + expectedCount + " of default cluster templates.", expectedCount, defaultCount);
         } catch (Exception e) {
             throw new TestFailException(String.format("Failed to validate default count of cluster templates: %s", e.getMessage()), e);


### PR DESCRIPTION
This commit adds a new streaming template to enable high availability for Zookeeper and Schema Registry as well.
It is basically derived from the Heavy Duty template. The node layout is the following:
- master: 1 node that runs Cruise Control, Streams Messaging Manager and Cloudera Manager.
- core_zookeeper: 3 nodes running Zookeeper and Schema Registry
- core_broker: 3 nodes running the core Kafka brokers
- broker: nodes running scalable Kafka brokers
- srm: nodes running Streams Replication Manager
- connect: nodes running Kafka Connect