### PR TITLE
CB-16407 Bring your own DNS zone: enable specifying external private …

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureDatabaseTemplateBuilder.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureDatabaseTemplateBuilder.java
@@ -67,6 +67,7 @@ public class AzureDatabaseTemplateBuilder {
             Map<String, Object> model = new HashMap<>();
             model.put("usePrivateEndpoints", USE_PRIVATE_ENDPOINT.equals(azureNetworkView.getEndpointType()));
             model.put("subnetIdForPrivateEndpoint", azureNetworkView.getSubnetIdForPrivateEndpoint());
+            model.put("existingPrivateDnsZoneId", azureNetworkView.getExistingPrivateDnsZoneId());
             model.put("adminLoginName", azureDatabaseServerView.getAdminLoginName());
             model.put("adminPassword", azureDatabaseServerView.getAdminPassword());
             model.put("backupRetentionDays", azureDatabaseServerView.getBackupRetentionDays());

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureNetworkView.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureNetworkView.java
@@ -5,20 +5,18 @@ import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.cloud.model.Network;
 import com.sequenceiq.common.model.PrivateEndpointType;
 
 public class AzureNetworkView {
 
-    @VisibleForTesting
-    static final String SUBNETS = "subnets";
+    private static final String SUBNETS = "subnets";
 
-    @VisibleForTesting
-    static final String SUBNET_FOR_PRIVATE_ENDPOINT = "subnetForPrivateEndpoint";
+    private static final String SUBNET_FOR_PRIVATE_ENDPOINT = "subnetForPrivateEndpoint";
 
-    @VisibleForTesting
-    static final String ENDPOINT_TYPE = "endpointType";
+    private static final String ENDPOINT_TYPE = "endpointType";
+
+    private static final String EXISTING_PRIVATE_DNS_ZONE_ID = "existingPrivateDnsZoneId";
 
     private String networkId;
 
@@ -103,5 +101,9 @@ public class AzureNetworkView {
 
     public String getSubnetIdForPrivateEndpoint() {
         return network.getStringParameter(SUBNET_FOR_PRIVATE_ENDPOINT);
+    }
+
+    public String getExistingPrivateDnsZoneId() {
+        return network.getStringParameter(EXISTING_PRIVATE_DNS_ZONE_ID);
     }
 }

--- a/cloud-azure/src/main/resources/templates/arm-dbstack.ftl
+++ b/cloud-azure/src/main/resources/templates/arm-dbstack.ftl
@@ -281,7 +281,11 @@
                     {
                         "name": "dns-${privateEndpointName}",
                         "properties": {
+                            <#if existingPrivateDnsZoneId??>
+                            "privateDnsZoneId": "${existingPrivateDnsZoneId}"
+                            <#else>
                             "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', 'privatelink.postgres.database.azure.com')]"
+                            </#if>
                         }
                     }
                 ]

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureNetworkViewTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureNetworkViewTest.java
@@ -1,8 +1,5 @@
 package com.sequenceiq.cloudbreak.cloud.azure.view;
 
-import static com.sequenceiq.cloudbreak.cloud.azure.view.AzureNetworkView.ENDPOINT_TYPE;
-import static com.sequenceiq.cloudbreak.cloud.azure.view.AzureNetworkView.SUBNETS;
-import static com.sequenceiq.cloudbreak.cloud.azure.view.AzureNetworkView.SUBNET_FOR_PRIVATE_ENDPOINT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -15,6 +12,14 @@ import com.sequenceiq.cloudbreak.cloud.model.Network;
 import com.sequenceiq.common.model.PrivateEndpointType;
 
 public class AzureNetworkViewTest {
+
+    private static final String SUBNETS = "subnets";
+
+    private static final String SUBNET_FOR_PRIVATE_ENDPOINT = "subnetForPrivateEndpoint";
+
+    private static final String ENDPOINT_TYPE = "endpointType";
+
+    private static final String EXISTING_PRIVATE_DNS_ZONE_ID = "existingPrivateDnsZoneId";
 
     @Mock
     private Network network;
@@ -44,5 +49,11 @@ public class AzureNetworkViewTest {
     public void testGetEndpointType() {
         when(network.getStringParameter(ENDPOINT_TYPE)).thenReturn("USE_PRIVATE_ENDPOINT");
         assertThat(underTest.getEndpointType()).isEqualTo(PrivateEndpointType.USE_PRIVATE_ENDPOINT);
+    }
+
+    @Test
+    public void testGetPrivateDnsZoneId() {
+        when(network.getStringParameter(EXISTING_PRIVATE_DNS_ZONE_ID)).thenReturn("privateDnsZoneId-a");
+        assertThat(underTest.getExistingPrivateDnsZoneId()).isEqualTo("privateDnsZoneId-a");
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/network/NetworkParameterAdder.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/network/NetworkParameterAdder.java
@@ -7,7 +7,6 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Service;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.converter.ServiceEndpointCreationToEndpointTypeConverter;
@@ -19,35 +18,26 @@ import com.sequenceiq.redbeams.exception.RedbeamsException;
 @Service
 public class NetworkParameterAdder {
 
-    // These constants must match those in AwsNetworkView
+    // These constants must match those in AwsNetworkView, AzureNetworkView and/or GcpDatabaseNetworkView
+    private static final String VPC_ID = "vpcId";
 
-    @VisibleForTesting
-    static final String VPC_ID = "vpcId";
+    private static final String VPC_CIDR = "vpcCidr";
 
-    @VisibleForTesting
-    static final String VPC_CIDR = "vpcCidr";
+    private static final String SHARED_PROJECT_ID = "sharedProjectId";
 
-    @VisibleForTesting
-    static final String SHARED_PROJECT_ID = "sharedProjectId";
+    private static final String VPC_CIDRS = "vpcCidrs";
 
-    @VisibleForTesting
-    static final String VPC_CIDRS = "vpcCidrs";
+    private static final String SUBNET_ID = "subnetId";
 
-    @VisibleForTesting
-    static final String SUBNET_ID = "subnetId";
+    private static final String AVAILABILITY_ZONE = "availabilityZone";
 
-    @VisibleForTesting
-    static final String ENDPOINT_TYPE = "endpointType";
+    private static final String ENDPOINT_TYPE = "endpointType";
 
-    @VisibleForTesting
-    static final String SUBNET_FOR_PRIVATE_ENDPOINT = "subnetForPrivateEndpoint";
+    private static final String SUBNET_FOR_PRIVATE_ENDPOINT = "subnetForPrivateEndpoint";
 
-    @VisibleForTesting
-    static final String AVAILABILITY_ZONE = "availabilityZone";
+    private static final String EXISTING_PRIVATE_DNS_ZONE_ID = "existingPrivateDnsZoneId";
 
-    // These constants must match those in AzureNetworkView
-    @VisibleForTesting
-    static final String SUBNETS = "subnets";
+    private static final String SUBNETS = "subnets";
 
     @Inject
     private ServiceEndpointCreationToEndpointTypeConverter serviceEndpointCreationToEndpointTypeConverter;
@@ -90,6 +80,7 @@ public class NetworkParameterAdder {
                 parameters.put(ENDPOINT_TYPE, privateEndpointType);
                 if (PrivateEndpointType.USE_PRIVATE_ENDPOINT == privateEndpointType) {
                     parameters.put(SUBNET_FOR_PRIVATE_ENDPOINT, getAzureSubnetToUseWithPrivateEndpoint(environmentResponse, dbStack));
+                    parameters.put(EXISTING_PRIVATE_DNS_ZONE_ID, environmentResponse.getNetwork().getAzure().getPrivateDnsZoneId());
                 }
                 break;
             case GCP:

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/service/network/NetworkParameterAdderTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/service/network/NetworkParameterAdderTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.hamcrest.collection.IsMapContaining;
 import org.junit.Before;
@@ -23,6 +24,7 @@ import com.sequenceiq.cloudbreak.converter.ServiceEndpointCreationToEndpointType
 import com.sequenceiq.common.model.PrivateEndpointType;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkAwsParams.EnvironmentNetworkAwsParamsBuilder;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkAzureParams;
+import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkGcpParams;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
@@ -32,6 +34,26 @@ public class NetworkParameterAdderTest {
     private static final String TEST_VPC_CIDR = "1.2.3.4/16";
 
     private static final String TEST_VPC_ID = "vpcId";
+
+    private static final String VPC_ID = "vpcId";
+
+    private static final String VPC_CIDR = "vpcCidr";
+
+    private static final String SHARED_PROJECT_ID = "sharedProjectId";
+
+    private static final String VPC_CIDRS = "vpcCidrs";
+
+    private static final String SUBNET_ID = "subnetId";
+
+    private static final String AVAILABILITY_ZONE = "availabilityZone";
+
+    private static final String ENDPOINT_TYPE = "endpointType";
+
+    private static final String SUBNET_FOR_PRIVATE_ENDPOINT = "subnetForPrivateEndpoint";
+
+    private static final String EXISTING_PRIVATE_DNS_ZONE_ID = "existingPrivateDnsZoneId";
+
+    private static final String SUBNETS = "subnets";
 
     @Mock
     private ServiceEndpointCreationToEndpointTypeConverter serviceEndpointCreationToEndpointTypeConverter;
@@ -51,49 +73,52 @@ public class NetworkParameterAdderTest {
     }
 
     @Test
-    public void testAddNetworkParametersWhenAws() {
+    public void testAddSubnetIdsWhenAws() {
         Map<String, Object> parameters = new HashMap<>();
-        List<String> subnetIds = List.of("subnet1", "subnet2");
 
-        parameters = underTest.addSubnetIds(parameters, subnetIds, List.of(), CloudPlatform.AWS);
+        parameters = underTest.addSubnetIds(parameters, List.of("subnet1", "subnet2"), List.of("az1", "az2"), CloudPlatform.AWS);
 
-        assertThat(parameters, IsMapContaining.hasEntry(NetworkParameterAdder.SUBNET_ID, String.join(",", subnetIds)));
+        assertThat(parameters, IsMapContaining.hasEntry(SUBNET_ID, "subnet1,subnet2"));
+        assertThat(parameters, IsMapContaining.hasEntry(AVAILABILITY_ZONE, "az1,az2"));
+    }
+
+    @Test
+    public void testAddSubnetIdsWhenAzure() {
+        Map<String, Object> parameters = new HashMap<>();
+
+        parameters = underTest.addSubnetIds(parameters, List.of("subnet1", "subnet2"), List.of(), CloudPlatform.AZURE);
+
+        assertThat(parameters, IsMapContaining.hasEntry(SUBNETS, "subnet1,subnet2"));
+    }
+
+    @Test
+    public void testAddSubnetIdsWhenGcp() {
+        Map<String, Object> parameters = new HashMap<>();
+
+        parameters = underTest.addSubnetIds(parameters, List.of("subnet1", "subnet2"), List.of("az1", "az2"), CloudPlatform.GCP);
+
+        assertThat(parameters, IsMapContaining.hasEntry(SUBNET_ID, "subnet1,subnet2"));
+        assertThat(parameters, IsMapContaining.hasEntry(AVAILABILITY_ZONE, "az1,az2"));
     }
 
     @Test
     public void testAddParametersWhenAws() {
         Map<String, Object> parameters = new HashMap<>();
         DBStack dbStack = new DBStack();
-        DetailedEnvironmentResponse environment = DetailedEnvironmentResponse.builder()
-                .withCloudPlatform(CloudPlatform.AWS.name())
-                .withNetwork(EnvironmentNetworkResponse.builder()
-                        .withAws(EnvironmentNetworkAwsParamsBuilder.anEnvironmentNetworkAwsParams().withVpcId(TEST_VPC_ID).build())
-                        .withNetworkCidr(TEST_VPC_CIDR)
-                        .build())
-                .build();
+        DetailedEnvironmentResponse environment = getAwsDetailedEnvironmentResponse();
 
         parameters = underTest.addParameters(parameters, environment, CloudPlatform.AWS, dbStack);
 
-        assertThat(parameters, IsMapContaining.hasEntry(NetworkParameterAdder.VPC_ID, TEST_VPC_ID));
-        assertThat(parameters, IsMapContaining.hasEntry(NetworkParameterAdder.VPC_CIDR, TEST_VPC_CIDR));
+        assertThat(parameters, IsMapContaining.hasEntry(VPC_ID, TEST_VPC_ID));
+        assertThat(parameters, IsMapContaining.hasEntry(VPC_CIDR, TEST_VPC_CIDR));
+        assertThat(parameters, IsMapContaining.hasEntry(VPC_CIDRS, Set.of(TEST_VPC_CIDR)));
     }
 
     @Test
     public void testAddParametersWhenAzure() {
         Map<String, Object> parameters = new HashMap<>();
         DBStack dbStack = new DBStack();
-        DetailedEnvironmentResponse environment = DetailedEnvironmentResponse.builder()
-                .withCloudPlatform(CloudPlatform.AZURE.name())
-                .withNetwork(EnvironmentNetworkResponse.builder()
-                        .withSubnetMetas(Map.of())
-                        .withAzure(
-                                EnvironmentNetworkAzureParams.EnvironmentNetworkAzureParamsBuilder.anEnvironmentNetworkAzureParams()
-                                        .withResourceGroupName("myResourceGroup")
-                                        .withNetworkId("networkId")
-                                .build()
-                        )
-                        .build())
-                .build();
+        DetailedEnvironmentResponse environment = getAzureDetailedEnvironmentResponse();
         CloudSubnet subnetForPrivateEndpoint = new CloudSubnet("mySubnet", "");
         when(subnetListerService.getAzureSubscriptionId(any())).thenReturn("mySubscription");
         when(subnetChooserService.chooseSubnetForPrivateEndpoint(any(), any(), anyBoolean())).thenReturn(List.of(subnetForPrivateEndpoint));
@@ -102,8 +127,60 @@ public class NetworkParameterAdderTest {
 
         parameters = underTest.addParameters(parameters, environment, CloudPlatform.AZURE, dbStack);
 
-        assertThat(parameters, IsMapContaining.hasEntry(NetworkParameterAdder.ENDPOINT_TYPE, PrivateEndpointType.USE_PRIVATE_ENDPOINT));
-        assertThat(parameters, IsMapContaining.hasEntry(NetworkParameterAdder.SUBNET_FOR_PRIVATE_ENDPOINT,
+        assertThat(parameters, IsMapContaining.hasEntry(ENDPOINT_TYPE, PrivateEndpointType.USE_PRIVATE_ENDPOINT));
+        assertThat(parameters, IsMapContaining.hasEntry(SUBNET_FOR_PRIVATE_ENDPOINT,
                 "/subscriptions/mySubscription/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/networkId/subnets/mySubnet"));
+        assertThat(parameters, IsMapContaining.hasEntry(EXISTING_PRIVATE_DNS_ZONE_ID, "privateDnsZoneId"));
     }
+
+    @Test
+    public void testAddParametersWhenGcp() {
+        Map<String, Object> parameters = new HashMap<>();
+        DBStack dbStack = new DBStack();
+        DetailedEnvironmentResponse environment = getGcpDetailedEnvironmentResponse();
+
+        parameters = underTest.addParameters(parameters, environment, CloudPlatform.GCP, dbStack);
+
+        assertThat(parameters, IsMapContaining.hasEntry(SHARED_PROJECT_ID, "sharedProjectId"));
+    }
+
+    private DetailedEnvironmentResponse getAwsDetailedEnvironmentResponse() {
+        return DetailedEnvironmentResponse.builder()
+                .withCloudPlatform(CloudPlatform.AWS.name())
+                .withNetwork(EnvironmentNetworkResponse.builder()
+                        .withAws(EnvironmentNetworkAwsParamsBuilder.anEnvironmentNetworkAwsParams().withVpcId(TEST_VPC_ID).build())
+                        .withNetworkCidr(TEST_VPC_CIDR)
+                        .withNetworkCidrs(Set.of(TEST_VPC_CIDR))
+                        .build())
+                .build();
+    }
+
+    private DetailedEnvironmentResponse getAzureDetailedEnvironmentResponse() {
+        return DetailedEnvironmentResponse.builder()
+                .withCloudPlatform(CloudPlatform.AZURE.name())
+                .withNetwork(EnvironmentNetworkResponse.builder()
+                        .withSubnetMetas(Map.of())
+                        .withAzure(
+                                EnvironmentNetworkAzureParams.EnvironmentNetworkAzureParamsBuilder.anEnvironmentNetworkAzureParams()
+                                        .withResourceGroupName("myResourceGroup")
+                                        .withNetworkId("networkId")
+                                        .withPrivateDnsZoneId("privateDnsZoneId")
+                                        .build()
+                        )
+                        .build())
+                .build();
+    }
+
+    private DetailedEnvironmentResponse getGcpDetailedEnvironmentResponse() {
+        return DetailedEnvironmentResponse.builder()
+                .withCloudPlatform(CloudPlatform.GCP.name())
+                .withNetwork(EnvironmentNetworkResponse.builder()
+                        .withGcp(EnvironmentNetworkGcpParams.EnvironmentNetworkGcpParamsBuilder.anEnvironmentNetworkGcpParamsBuilder()
+                                .withSharedProjectId("sharedProjectId")
+                                .build())
+                        .withNetworkCidr(TEST_VPC_CIDR)
+                        .build())
+                .build();
+    }
+
 }


### PR DESCRIPTION
…DNS zones in Redbeams

When using private endpoints, environment service created so far a private DNS zone into the single RG. Redbeams in turn calculated the resource id of the DNS zone based on the single RG.
This commit makes it possible to specify the resource ID of a private DNS zone that exist outside of the single RG.

See detailed description in the commit message.