### PR TITLE
CB-16512 Include Azure policy name in failure reason

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureSetup.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureSetup.java
@@ -89,7 +89,7 @@ public class AzureSetup implements Setup {
                             "container of the storage account '%s' in resource group '%s'. Reason of failure: %s",
                     image.getImageName(), imageCopyDetails.getImageSource(), imageCopyDetails.getImageStorageName(),
                     imageCopyDetails.getImageResourceGroupName(), ExceptionUtils.getRootCause(ex).getMessage());
-            LOGGER.debug(message);
+            LOGGER.debug("Added details to exception: {}", message, ex);
             throw new CloudConnectorException(message, ex);
         } else {
             throw new CloudConnectorException(image.getImageName() + " image copy failed: " + ExceptionUtils.getRootCause(ex).getMessage(), ex);

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/AzureStorageAccountBuilderService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/AzureStorageAccountBuilderService.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.cloudbreak.cloud.azure.connector.resource;
 
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.inject.Inject;
 
@@ -8,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.microsoft.azure.CloudException;
 import com.microsoft.azure.management.resources.Deployment;
 import com.microsoft.azure.management.storage.StorageAccount;
@@ -22,6 +25,8 @@ import com.sequenceiq.cloudbreak.common.json.Json;
 public class AzureStorageAccountBuilderService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AzureStorageAccountBuilderService.class);
+
+    private static final Pattern POLICY_DEFINITION_NAME_PATTERN = Pattern.compile("\"policyDefinitionDisplayName\":\"(.*?)\"");
 
     @Inject
     private AzureStorageAccountTemplateBuilder azureStorageAccountTemplateBuilder;
@@ -46,9 +51,26 @@ public class AzureStorageAccountBuilderService {
         } catch (CloudException e) {
             throw azureUtils.convertToCloudConnectorException(e, "Storage account creation");
         } catch (Exception e) {
-            String message = String.format("Could not create storage account %s in resource group %s", storageAccountName, resourceGroupName);
+            String message = String.format("Could not create storage account %s in resource group %s%s",
+                    storageAccountName, resourceGroupName, getDeniedPolicyReasonIfApplicable(e));
             LOGGER.warn(message, e);
             throw new CloudConnectorException(message);
         }
+    }
+
+    /**
+     * Workaround for
+     * <a href="https://github.com/Azure/autorest-clientruntime-for-java/commit/fcd2f69ac7c04ac50337b0c37fab7ac24d4cce09">azure-sdk bug</a>
+     */
+    private String getDeniedPolicyReasonIfApplicable(Exception e) {
+        if (e.getMessage().equals("Unknown error with status code 400") && e.getCause() instanceof MismatchedInputException) {
+            MismatchedInputException cause = (MismatchedInputException) e.getCause();
+            Matcher matcher = POLICY_DEFINITION_NAME_PATTERN.matcher(cause.getLocation().sourceDescription());
+            if (matcher.find()) {
+                String policyDefinitionDisplayName = matcher.group(1);
+                return String.format(", because it was denied by policy '%s'", policyDefinitionDisplayName);
+            }
+        }
+        return "";
     }
 }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtilsTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtilsTest.java
@@ -13,6 +13,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,9 +34,12 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.util.ReflectionUtils;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.azure.CloudError;
 import com.microsoft.azure.CloudException;
+import com.microsoft.azure.PolicyViolation;
 import com.microsoft.azure.management.compute.VirtualMachine;
 import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
 import com.sequenceiq.cloudbreak.cloud.azure.validator.AzurePremiumValidatorService;
@@ -454,20 +459,55 @@ public class AzureUtilsTest {
         CloudError cloudError = new CloudError()
                 .withCode("123")
                 .withMessage("foobar");
-        cloudError.details().add(new CloudError().withMessage("detail1"));
-        cloudError.details().add(new CloudError().withMessage("detail2"));
+        cloudError.details().add(new CloudError().withCode("123").withMessage("detail1"));
+        cloudError.details().add(new CloudError().withCode("123").withMessage("detail2"));
         CloudException e = new CloudException("Serious problem", null, cloudError);
 
         CloudConnectorException result = underTest.convertToCloudConnectorException(e, "Checking resources");
 
-        verifyCloudConnectorException(result, e,
+        verifyCloudConnectorException(result,
                 "Checking resources failed, status code 123, error message: foobar, details: detail1, detail2");
     }
 
-    private void verifyCloudConnectorException(CloudConnectorException cloudConnectorException, Throwable causeExpected, String messageExpected) {
+    @Test
+    void convertToCloudConnectorExceptionTestWhenDetailCloudErrorsHaveRequestDisallowedByPolicyCode() throws IOException, NoSuchFieldException {
+        CloudError cloudError = new CloudError()
+                .withCode("InvalidTemplateDeployment")
+                .withMessage("The template deployment failed with multiple errors. Please see details for more information.");
+
+        PolicyViolation policyViolation = new PolicyViolation("PolicyViolation",
+                new ObjectMapper().createObjectNode().put("policyDefinitionDisplayName", "dbajzath-azure-restricted-policy"));
+        CloudError detail1 = new CloudError()
+                .withCode("RequestDisallowedByPolicy")
+                .withMessage("Resource 'cbimgwu29d62091481040a03' was disallowed by policy. Reasons: 'West US 2 location is disabled'. " +
+                        "See error details for policy resource IDs.");
+        Field field = CloudError.class.getDeclaredField("additionalInfo");
+        field.setAccessible(true);
+        ReflectionUtils.setField(field, detail1, List.of(policyViolation));
+        cloudError.details().add(detail1);
+        CloudError detail2 = new CloudError()
+                .withCode("RequestDisallowedByPolicy")
+                .withMessage("Resource 'cbimgwu29d62091481040a03/default' was disallowed by policy. Reasons: 'West US 2 location is disabled'. " +
+                        "See error details for policy resource IDs.");
+        ReflectionUtils.setField(field, detail2, List.of(policyViolation));
+        cloudError.details().add(detail2);
+
+        CloudException e = new CloudException("The template deployment failed with multiple errors. Please see details for more information.", null, cloudError);
+
+        CloudConnectorException result = underTest.convertToCloudConnectorException(e, "Storage account creation");
+
+        verifyCloudConnectorException(result,
+                "Storage account creation failed, status code InvalidTemplateDeployment, error message: The template deployment failed with multiple errors. " +
+                        "Please see details for more information., details: Resource 'cbimgwu29d62091481040a03' was disallowed by policy. " +
+                        "Reasons: 'West US 2 location is disabled'. Policy definition name: dbajzath-azure-restricted-policy, " +
+                        "Resource 'cbimgwu29d62091481040a03/default' was disallowed by policy. Reasons: 'West US 2 location is disabled'. " +
+                        "Policy definition name: dbajzath-azure-restricted-policy");
+    }
+
+    private void verifyCloudConnectorException(CloudConnectorException cloudConnectorException, String messageExpected) {
         assertThat(cloudConnectorException).isNotNull();
         assertThat(cloudConnectorException).hasMessage(messageExpected);
-        assertThat(cloudConnectorException).hasCauseReference(causeExpected);
+        assertThat(cloudConnectorException).hasNoCause();
     }
 
     private static CloudException createCloudExceptionWithNoDetails(boolean withBody) {
@@ -495,7 +535,7 @@ public class AzureUtilsTest {
     void convertToCloudConnectorExceptionTestWhenCloudExceptionAndNoDetails(String testCaseName, CloudException e) {
         CloudConnectorException result = underTest.convertToCloudConnectorException(e, "Checking resources");
 
-        verifyCloudConnectorException(result, e,
+        verifyCloudConnectorException(result,
                 "Checking resources failed: 'com.microsoft.azure.CloudException: Serious problem', please go to Azure Portal for detailed message");
     }
 
@@ -505,7 +545,7 @@ public class AzureUtilsTest {
 
         CloudConnectorException result = underTest.convertToCloudConnectorException(e, "Checking resources");
 
-        verifyCloudConnectorException(result, e,
+        verifyCloudConnectorException(result,
                 "Checking resources failed: 'com.microsoft.azure.CloudException: Serious problem', please go to Azure Portal for detailed message");
     }
 

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/AzureStorageAccountBuilderServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/AzureStorageAccountBuilderServiceTest.java
@@ -1,0 +1,78 @@
+package com.sequenceiq.cloudbreak.cloud.azure.connector.resource;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import com.microsoft.azure.management.storage.StorageAccountSkuType;
+import com.sequenceiq.cloudbreak.cloud.azure.AzureStorageAccountTemplateBuilder;
+import com.sequenceiq.cloudbreak.cloud.azure.AzureUtils;
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
+
+@ExtendWith(MockitoExtension.class)
+class AzureStorageAccountBuilderServiceTest {
+
+    private static final String POLICY_NAME = "dbajzath-azure-restricted-repro";
+
+    private static final String SOURCE_DESCRIPTION = "(String)\"{\"policyDefinitionDisplayName\":\"" + POLICY_NAME + "\"," +
+            "\"evaluationDetails\":{\"evaluatedExpressions\":[{\"result\":\"True\",\"expressionKind\":\"Field\",\"expression\":\"type\",\"path\":\"type\"," +
+            "\"expressionValue\":\"Microsoft.Storage/storageAccounts\",\"targetValue\":\"Microsoft.Storage/storageAccounts\",\"operator\":\"Equals\"}," +
+            "{\"result\":\"False\",\"expressionKind\":\"Field\",\"expression\":\"Microsoft.Storage/storageAccounts/minimumTlsVersion\",\"path\":" +
+            "\"properties.minimumTlsVersion\",\"targetValue\":\"TLS1_2\",\"operator\":\"Equals\"[truncated 1005 chars]";
+
+    private static final StorageAccountParameters STORAGE_ACCOUNT_PARAMETERS = new StorageAccountParameters("resourceGroupName", "storageAccountName", "",
+            StorageAccountSkuType.STANDARD_LRS, false, Map.of());
+
+    @InjectMocks
+    private AzureStorageAccountBuilderService underTest;
+
+    @Mock
+    private AzureStorageAccountTemplateBuilder azureStorageAccountTemplateBuilder;
+
+    @Mock
+    private AzureUtils azureUtils;
+
+    @Mock
+    private AzureClient client;
+
+    @BeforeEach
+    void setUp() {
+        when(azureStorageAccountTemplateBuilder.build(any())).thenReturn("");
+        when(client.getTemplateDeploymentStatus(anyString(), anyString())).thenReturn(ResourceStatus.CREATED);
+    }
+
+    @Test
+    void shouldAddPolicyNameToException() {
+        RuntimeException mismatchedInputException = createMismatchedInputException();
+        when(client.createTemplateDeployment(anyString(), anyString(), anyString(), anyString())).thenThrow(mismatchedInputException);
+
+        assertThatThrownBy(() -> underTest.buildStorageAccount(client, STORAGE_ACCOUNT_PARAMETERS))
+                .isInstanceOf(CloudConnectorException.class)
+                .hasMessage("Could not create storage account %s in resource group %s, because it was denied by policy '%s'",
+                        "storageAccountName", "resourceGroupName", POLICY_NAME);
+    }
+
+    private RuntimeException createMismatchedInputException() {
+        JsonLocation jsonLocation = mock(JsonLocation.class);
+        when(jsonLocation.sourceDescription()).thenReturn(SOURCE_DESCRIPTION);
+        MismatchedInputException mismatchedInputException = mock(MismatchedInputException.class);
+        when(mismatchedInputException.getLocation()).thenReturn(jsonLocation);
+        return new RuntimeException("Unknown error with status code 400", mismatchedInputException);
+    }
+
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/upscale/AzureUpscaleServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/upscale/AzureUpscaleServiceTest.java
@@ -231,8 +231,8 @@ public class AzureUpscaleServiceTest {
         List<Group> scaledGroups = createScaledGroups();
 
         when(cloudResourceHelper.getScaledGroups(stack)).thenReturn(scaledGroups);
-        CloudError cloudError = new CloudError().withMessage("Error happened");
-        cloudError.details().add(new CloudError().withMessage("Please check the power state later"));
+        CloudError cloudError = new CloudError().withCode("code").withMessage("Error happened");
+        cloudError.details().add(new CloudError().withCode("code").withMessage("Please check the power state later"));
         when(azureTemplateDeploymentService.getTemplateDeployment(client, stack, ac, azureStackView, AzureInstanceTemplateOperation.UPSCALE))
                 .thenThrow(new Retry.ActionFailedException("VMs not started in time.", new CloudException("Error", null, cloudError)));
         when(azureUtils.convertToCloudConnectorException(any(CloudException.class), anyString())).thenCallRealMethod();
@@ -242,7 +242,7 @@ public class AzureUpscaleServiceTest {
         );
 
         assertThat(cloudConnectorException.getMessage())
-                .contains("Stack upscale failed, status code null, error message: Error happened, details: Please check the power state later");
+                .contains("Stack upscale failed, status code code, error message: Error happened, details: Please check the power state later");
     }
 
     private List<Group> createScaledGroups() {


### PR DESCRIPTION
Azure policies blocking resource creation is a recurring issue for customers, so we should ease the identification of the policy, and include it in the error message.

See detailed description in the commit message.