### PR TITLE
CB-16518 Run kinit test only if usersync is COMPLETED

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/freeipa/FreeIpaUpgradeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/freeipa/FreeIpaUpgradeTests.java
@@ -12,14 +12,13 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
-import com.sequenceiq.freeipa.api.v1.kerberosmgmt.model.ServiceKeytabRequest;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Assertions;
 import org.testng.annotations.Test;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.polling.AbsolutTimeBasedTimeoutChecker;
 import com.sequenceiq.freeipa.api.v1.dns.model.AddDnsARecordRequest;
@@ -33,6 +32,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizationStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeAllUsersRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.WorkloadCredentialsUpdateType;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.model.HostKeytabRequest;
+import com.sequenceiq.freeipa.api.v1.kerberosmgmt.model.ServiceKeytabRequest;
 import com.sequenceiq.freeipa.api.v1.operation.model.OperationStatus;
 import com.sequenceiq.it.cloudbreak.FreeIpaClient;
 import com.sequenceiq.it.cloudbreak.SdxClient;
@@ -170,7 +170,7 @@ public class FreeIpaUpgradeTests extends AbstractE2ETest {
                 generateServiceKeytab(ipaClient, environmentCrn);
                 dnsLookups(testContext.given(SdxTestDto.class), testContext.getSdxClient());
                 cleanUp(testContext, ipaClient, environmentCrn);
-                kinit(testContext.given(SdxTestDto.class), testContext.getSdxClient());
+                kinit(testContext.given(SdxTestDto.class), testContext.getSdxClient(), ipaClient, environmentCrn);
                 syncUsers(testContext, ipaClient, environmentCrn, accountId);
             }
         } catch (TestFailException e) {
@@ -312,10 +312,15 @@ public class FreeIpaUpgradeTests extends AbstractE2ETest {
                 .await(COMPLETED, waitForFlow().withWaitForFlow(Boolean.FALSE).withTimeoutChecker(new AbsolutTimeBasedTimeoutChecker(FIVE_MINUTES_IN_SEC)));
     }
 
-    private void kinit(SdxTestDto sdxTestDto, SdxClient sdxClient) {
+    private void kinit(SdxTestDto sdxTestDto, SdxClient sdxClient, com.sequenceiq.freeipa.api.client.FreeIpaClient ipaClient, String environmentCrn) {
         try {
-            sshJClientActions.checkKinitDuringFreeipaUpgrade(sdxTestDto, getInstanceGroups(sdxTestDto, sdxClient),
-                    List.of(HostGroupType.MASTER.getName()));
+            SyncOperationStatus lastSyncOperationStatus = ipaClient.getUserV1Endpoint().getLastSyncOperationStatus(environmentCrn);
+            if (lastSyncOperationStatus.getStatus() == SynchronizationStatus.COMPLETED) {
+                sshJClientActions.checkKinitDuringFreeipaUpgrade(sdxTestDto, getInstanceGroups(sdxTestDto, sdxClient),
+                        List.of(HostGroupType.MASTER.getName()));
+            } else {
+                logger.debug("Skipping kinit test because usersync state is not COMPLETED: " + lastSyncOperationStatus);
+            }
         } catch (TestFailException e) {
             throw e;
         } catch (Exception e) {


### PR DESCRIPTION
Sometimes usersync can fail and leave users not fully available.
To avoid test failures caused by failing initial usersync, kinit test is only runs if last usersync is `COMPLETED`.See detailed description in the commit message.