### PR TITLE
CB-16504 Outbound only load balancer option

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/loadbalancer/AzureLoadBalancer.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/loadbalancer/AzureLoadBalancer.java
@@ -14,6 +14,8 @@ public class AzureLoadBalancer {
 
     private final List<AzureLoadBalancingRule> rules;
 
+    private final List<AzureOutboundRule> outboundRules;
+
     private final Set<AzureLoadBalancerProbe> probes;
 
     private final String name;
@@ -26,6 +28,7 @@ public class AzureLoadBalancer {
 
     private AzureLoadBalancer(Builder builder) {
         this.rules = List.copyOf(builder.rules);
+        this.outboundRules = List.copyOf(builder.outboundRules);
         this.probes = Set.copyOf(builder.probes);
         this.name = getLoadBalancerName(builder.type, builder.stackName);
         this.type = builder.type;
@@ -61,6 +64,10 @@ public class AzureLoadBalancer {
         return sku;
     }
 
+    public List<AzureOutboundRule> getOutboundRules() {
+        return outboundRules;
+    }
+
     @Override
     public String toString() {
         return "AzureLoadBalancer{" +
@@ -76,6 +83,8 @@ public class AzureLoadBalancer {
     public static final class Builder {
         private List<AzureLoadBalancingRule> rules;
 
+        private List<AzureOutboundRule> outboundRules;
+
         private Set<AzureLoadBalancerProbe> probes;
 
         private String stackName;
@@ -88,6 +97,11 @@ public class AzureLoadBalancer {
 
         public Builder setRules(List<AzureLoadBalancingRule> rules) {
             this.rules = rules;
+            return this;
+        }
+
+        public Builder setOutboundRules(List<AzureOutboundRule> outboundRules) {
+            this.outboundRules = outboundRules;
             return this;
         }
 

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/loadbalancer/AzureOutboundRule.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/loadbalancer/AzureOutboundRule.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.cloudbreak.cloud.azure.loadbalancer;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.sequenceiq.cloudbreak.cloud.model.Group;
+
+public final class AzureOutboundRule {
+    private final String name;
+
+    private final String groupName;
+
+    public AzureOutboundRule(Group group) {
+        this.groupName = checkNotNull(group, "Group must be provided.").getName();
+        this.name = defaultNameFromGroup(group.getName());
+    }
+
+    private String defaultNameFromGroup(String groupName) {
+        return "group-" + groupName + "-outbound-rule";
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getGroupName() {
+        return groupName;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class AzureOutboundRule {\n");
+        sb.append("    name: ").append(name).append("\n");
+        sb.append("    groupName: ").append(name).append("\n");
+        return sb.toString();
+    }
+}

--- a/common-model/src/main/java/com/sequenceiq/common/api/type/LoadBalancerSku.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/type/LoadBalancerSku.java
@@ -19,7 +19,7 @@ public enum LoadBalancerSku {
     }
 
     public static LoadBalancerSku getDefault() {
-        return BASIC;
+        return STANDARD;
     }
 
     public static LoadBalancerSku getValueOrDefault(LoadBalancerSku sku) {

--- a/common-model/src/main/java/com/sequenceiq/common/api/type/LoadBalancerType.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/type/LoadBalancerType.java
@@ -2,5 +2,6 @@ package com.sequenceiq.common.api.type;
 
 public enum LoadBalancerType {
     PUBLIC,
-    PRIVATE
+    PRIVATE,
+    OUTBOUND
 }


### PR DESCRIPTION
Adds a new load balancer type, OUTBOUND. An OUTBOUND load balancer is a public load balancer that
only does egress, and does not have any rules for routing ingress traffic. This is used in Azure
clusters when public IPs are disabled. With the Standard load balancer, any VMs behind a private LB
will not have a path for public egress. So in that scenario, an outbound only load balancer will
also be created solely to handle public egress.

This also changes the default Azure load balancer SKU from BASIC to STANDARD.

Tested by setting up a cluster with only the private LB and verifying the VMs behind it had no path
to the internet, and then setting up a cluster with a private LB and a second outbound only LB and
verifying the VMs could now do public egress over the internet.

This change is an implementation of the recommended approach in the [Azure Load Balancer Updates in Cloudbreak](https://docs.google.com/document/d/1SIcko6n8SFhTj5kdvu1JKKMYsfmYHjwGJnIwJUWYsxw/edit) doc.