### PR TITLE
CB-16426 Recommission decommissioned nodes during repair

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusService.java
@@ -288,7 +288,11 @@ public class ClouderaManagerClusterStatusService implements ClusterStatusService
         try {
             ApiHostList apiHostList = api.readHosts(null, null, SUMMARY);
             LOGGER.trace("Response from CM for readHosts call: {}", apiHostList);
-            return apiHostList.getItems().stream().filter(ApiHost::getMaintenanceMode).map(ApiHost::getHostname).collect(toList());
+            return apiHostList.getItems()
+                    .stream()
+                    .filter(host -> Boolean.TRUE.equals(host.getMaintenanceMode()))
+                    .map(ApiHost::getHostname)
+                    .collect(toList());
         } catch (ApiException e) {
             LOGGER.info("Failed to get hosts from CM", e);
             throw new RuntimeException("Failed to get hosts from CM due to: " + e.getMessage(), e);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/UpscaleClusterRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/UpscaleClusterRequest.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleRequest;
@@ -10,10 +12,21 @@ public class UpscaleClusterRequest extends AbstractClusterScaleRequest {
 
     private boolean restartServices;
 
+    private Map<String, Set<String>> hostGroupsWithHostNames;
+
     public UpscaleClusterRequest(Long stackId, Set<String> hostGroups, boolean repair, boolean restartServices) {
         super(stackId, hostGroups);
         this.repair = repair;
         this.restartServices = restartServices;
+        this.hostGroupsWithHostNames = new HashMap<>();
+    }
+
+    public UpscaleClusterRequest(Long stackId, Set<String> hostGroups, boolean repair, boolean restartServices,
+            Map<String, Set<String>> hostGroupsWithHostNames) {
+        super(stackId, hostGroups);
+        this.repair = repair;
+        this.restartServices = restartServices;
+        this.hostGroupsWithHostNames = hostGroupsWithHostNames;
     }
 
     public boolean isRepair() {
@@ -24,4 +37,7 @@ public class UpscaleClusterRequest extends AbstractClusterScaleRequest {
         return restartServices;
     }
 
+    public Map<String, Set<String>> getHostGroupsWithHostNames() {
+        return hostGroupsWithHostNames;
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/UpscaleClusterHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/UpscaleClusterHandler.java
@@ -32,7 +32,7 @@ public class UpscaleClusterHandler implements EventHandler<UpscaleClusterRequest
         UpscaleClusterResult result;
         try {
             clusterUpscaleService.installServicesOnNewHosts(request.getResourceId(), request.getHostGroupNames(),
-                    request.isRepair(), request.isRestartServices());
+                    request.isRepair(), request.isRestartServices(), request.getHostGroupsWithHostNames());
             result = new UpscaleClusterResult(request);
         } catch (Exception e) {
             result = new UpscaleClusterResult(e.getMessage(), e, request);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/TlsSecurityService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/TlsSecurityService.java
@@ -167,7 +167,7 @@ public class TlsSecurityService {
     public HttpClientConfig buildTLSClientConfig(Long stackId, String cloudPlatform, String apiAddress, InstanceMetaData gateway) {
         Optional<SecurityConfig> securityConfig = securityConfigService.findOneByStackId(stackId);
         if (securityConfig.isEmpty()) {
-            return decorateWithCLusterProxyConfig(stackId, cloudPlatform, new HttpClientConfig(apiAddress));
+            return decorateWithClusterProxyConfig(stackId, cloudPlatform, new HttpClientConfig(apiAddress));
         } else {
             LOGGER.info("Security config is not empty");
             String serverCert = gateway == null ? null : gateway.getServerCert() == null ? null : new String(decodeBase64(gateway.getServerCert()));
@@ -175,11 +175,11 @@ public class TlsSecurityService {
             String clientKeyB64 = securityConfig.get().getClientKey();
             HttpClientConfig httpClientConfig = new HttpClientConfig(apiAddress, serverCert,
                     new String(decodeBase64(clientCertB64)), new String(decodeBase64(clientKeyB64)));
-            return decorateWithCLusterProxyConfig(stackId, cloudPlatform, httpClientConfig);
+            return decorateWithClusterProxyConfig(stackId, cloudPlatform, httpClientConfig);
         }
     }
 
-    private HttpClientConfig decorateWithCLusterProxyConfig(Long stackId, String cloudPlatform, HttpClientConfig httpClientConfig) {
+    private HttpClientConfig decorateWithClusterProxyConfig(Long stackId, String cloudPlatform, HttpClientConfig httpClientConfig) {
         LOGGER.info("Decorate with cluster proxy config");
         if (clusterProxyEnablementService.isClusterProxyApplicable(cloudPlatform)) {
             LOGGER.info("Cluster proxy is applicable");


### PR DESCRIPTION
Recommission decommissioned nodes during repair. This change fixes repair during stop/start scaling where we need to recommission nodes. It also fixes the cluster when the user decommissioned a node.