### PR TITLE
CB-14578 Make CCMv2 Jumpgate parameters serializable

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/CcmConnectivityParameters.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/CcmConnectivityParameters.java
@@ -1,9 +1,15 @@
 package com.sequenceiq.cloudbreak.ccm.cloudinit;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class CcmConnectivityParameters {
 
+    @JsonIgnore
     private CcmParameters ccmParameters;
 
+    @JsonIgnore
     private CcmV2Parameters ccmV2Parameters;
 
     private CcmV2JumpgateParameters ccmV2JumpgateParameters;
@@ -47,6 +53,7 @@ public class CcmConnectivityParameters {
         this.ccmV2JumpgateParameters = ccmV2JumpgateParameters;
     }
 
+    @JsonIgnore
     public CcmConnectivityMode getConnectivityMode() {
         if (ccmParameters != null) {
             return CcmConnectivityMode.CCMV1;

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/CcmV2JumpgateParameters.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/CcmV2JumpgateParameters.java
@@ -7,8 +7,10 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public interface CcmV2JumpgateParameters extends CcmV2Parameters {
     static void addToTemplateModel(InstanceGroupType type, @Nullable CcmV2JumpgateParameters ccmV2JumpgateParameters, @Nonnull Map<String, Object> model) {
         if (ccmV2JumpgateParameters == null || !isGateway(type)) {

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/CcmV2Parameters.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/CcmV2Parameters.java
@@ -3,10 +3,21 @@ package com.sequenceiq.cloudbreak.ccm.cloudinit;
 import static com.sequenceiq.common.api.type.InstanceGroupType.isGateway;
 
 import java.util.Map;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "@type")
+@JsonSubTypes({ @Type(value = DefaultCcmV2JumpgateParameters.class, name = "ccmV2JumpgateParameters"),
+        @Type(value = DefaultCcmV2Parameters.class, name = "ccmV2Parameters") })
 public interface CcmV2Parameters {
 
     static void addToTemplateModel(InstanceGroupType type, @Nullable CcmV2Parameters ccmV2Parameters, @Nonnull Map<String, Object> model) {
@@ -30,6 +41,7 @@ public interface CcmV2Parameters {
 
     String getAgentCrn();
 
+    @JsonIgnore
     String getAgentBackendIdPrefix();
 
     void addToTemplateModel(@Nonnull Map<String, Object> model);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/Stack.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/Stack.java
@@ -30,6 +30,8 @@ import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 import javax.persistence.Version;
 
+import com.sequenceiq.cloudbreak.ccm.cloudinit.CcmConnectivityParameters;
+import com.sequenceiq.cloudbreak.common.dal.model.AccountAwareResource;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.json.JsonToString;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
@@ -38,7 +40,6 @@ import com.sequenceiq.cloudbreak.converter.TunnelConverter;
 import com.sequenceiq.cloudbreak.service.secret.SecretValue;
 import com.sequenceiq.cloudbreak.service.secret.domain.Secret;
 import com.sequenceiq.cloudbreak.service.secret.domain.SecretToString;
-import com.sequenceiq.cloudbreak.common.dal.model.AccountAwareResource;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
 import com.sequenceiq.common.api.type.Tunnel;
 import com.sequenceiq.freeipa.api.model.Backup;
@@ -141,6 +142,10 @@ public class Stack implements AccountAwareResource, OrchestratorAware {
 
     @Version
     private Long version;
+
+    @Convert(converter = SecretToString.class)
+    @SecretValue
+    private Secret ccmParameters = Secret.EMPTY;
 
     public Long getId() {
         return id;
@@ -467,6 +472,17 @@ public class Stack implements AccountAwareResource, OrchestratorAware {
         this.ccmV2AgentCrn = ccmV2AgentCrn;
     }
 
+    public CcmConnectivityParameters getCcmParameters() {
+        if (ccmParameters != null && ccmParameters.getRaw() != null) {
+            return JsonUtil.readValueOpt(ccmParameters.getRaw(), CcmConnectivityParameters.class).orElse(null);
+        }
+        return null;
+    }
+
+    public void setCcmParameters(CcmConnectivityParameters ccmParameters) {
+        this.ccmParameters = new Secret(JsonUtil.writeValueAsStringSilent(ccmParameters));
+    }
+
     @Override
     public String toString() {
         return "Stack{" +
@@ -530,7 +546,8 @@ public class Stack implements AccountAwareResource, OrchestratorAware {
                     && Objects.equals(appVersion, stack.appVersion)
                     && Objects.equals(minaSshdServiceId, stack.minaSshdServiceId)
                     && Objects.equals(ccmV2AgentCrn, stack.ccmV2AgentCrn)
-                    && Objects.equals(version, stack.version);
+                    && Objects.equals(version, stack.version)
+                    && Objects.equals(ccmParameters, stack.ccmParameters);
         }
     }
 
@@ -538,7 +555,7 @@ public class Stack implements AccountAwareResource, OrchestratorAware {
     public int hashCode() {
         return Objects.hash(id, resourceCrn, name, environmentCrn, accountId, region, created, platformvariant, availabilityZone, cloudPlatform, gatewayport,
                 useCcm, tunnel, clusterProxyRegistered, terminated, tags, telemetry, backup, template, owner, appVersion, minaSshdServiceId, ccmV2AgentCrn,
-                version);
+                version, ccmParameters);
     }
 
     @Override

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaOrchestrationConfigService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaOrchestrationConfigService.java
@@ -1,34 +1,22 @@
 package com.sequenceiq.freeipa.service.freeipa.flow;
 
-import static java.util.Collections.singletonMap;
-
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import javax.inject.Inject;
 
 import org.springframework.stereotype.Service;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.common.orchestration.Node;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
-import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.orchestrator.model.SaltConfig;
-import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
 import com.sequenceiq.freeipa.entity.InstanceMetaData;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.orchestrator.StackBasedExitCriteriaModel;
 import com.sequenceiq.freeipa.service.GatewayConfigService;
-import com.sequenceiq.freeipa.service.freeipa.config.FreeIpaConfigService;
-import com.sequenceiq.freeipa.service.freeipa.config.FreeIpaConfigView;
-import com.sequenceiq.freeipa.service.proxy.ProxyConfigService;
 import com.sequenceiq.freeipa.service.stack.StackService;
-import com.sequenceiq.freeipa.service.tag.TagConfigService;
-import com.sequenceiq.freeipa.service.telemetry.TelemetryConfigService;
 
 @Service
 public class FreeIpaOrchestrationConfigService {
@@ -43,45 +31,17 @@ public class FreeIpaOrchestrationConfigService {
     private StackService stackService;
 
     @Inject
-    private FreeIpaConfigService freeIpaConfigService;
-
-    @Inject
-    private ProxyConfigService proxyConfigService;
-
-    @Inject
-    private TagConfigService tagConfigService;
-
-    @Inject
-    private TelemetryConfigService telemetryConfigService;
-
-    @Inject
     private FreeIpaNodeUtilService freeIpaNodeUtilService;
+
+    @Inject
+    private SaltConfigProvider saltConfigProvider;
 
     public void configureOrchestrator(Long stackId) throws CloudbreakOrchestratorException {
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
         Set<InstanceMetaData> instanceMetaDatas = stack.getNotDeletedInstanceMetaDataSet();
         List<GatewayConfig> gatewayConfigs = gatewayConfigService.getGatewayConfigs(stack, instanceMetaDatas);
         Set<Node> allNodes = freeIpaNodeUtilService.mapInstancesToNodes(instanceMetaDatas);
-
-        createAndPushPillarsToNodes(stackId, stack, gatewayConfigs, allNodes);
-    }
-
-    @VisibleForTesting
-    SaltConfig getSaltConfig(Stack stack, Set<Node> hosts) throws CloudbreakOrchestratorFailedException {
-        SaltConfig saltConfig = new SaltConfig();
-        Map<String, SaltPillarProperties> servicePillarConfig = saltConfig.getServicePillarConfig();
-        FreeIpaConfigView freeIpaConfigView = freeIpaConfigService.createFreeIpaConfigs(stack, hosts);
-        servicePillarConfig.put("freeipa", new SaltPillarProperties("/freeipa/init.sls", Collections.singletonMap("freeipa", freeIpaConfigView.toMap())));
-        servicePillarConfig.put("discovery", new SaltPillarProperties("/discovery/init.sls", singletonMap("platform", stack.getCloudPlatform())));
-        servicePillarConfig.putAll(telemetryConfigService.createTelemetryPillarConfig(stack));
-        servicePillarConfig.putAll(proxyConfigService.createProxyPillarConfig(stack.getEnvironmentCrn()));
-        servicePillarConfig.putAll(tagConfigService.createTagsPillarConfig(stack));
-        return saltConfig;
-    }
-
-    private void createAndPushPillarsToNodes(Long stackId, Stack stack, List<GatewayConfig> gatewayConfigs, Set<Node> allNodes)
-            throws CloudbreakOrchestratorFailedException {
-        SaltConfig saltConfig = getSaltConfig(stack, allNodes);
+        SaltConfig saltConfig = saltConfigProvider.getSaltConfig(stack, allNodes);
         hostOrchestrator.initSaltConfig(stack, gatewayConfigs, allNodes, saltConfig, new StackBasedExitCriteriaModel(stackId));
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/SaltConfigProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/SaltConfigProvider.java
@@ -1,0 +1,63 @@
+package com.sequenceiq.freeipa.service.freeipa.flow;
+
+import static java.util.Collections.singletonMap;
+
+import java.util.Map;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.ccm.cloudinit.CcmConnectivityParameters;
+import com.sequenceiq.cloudbreak.common.orchestration.Node;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.orchestrator.model.SaltConfig;
+import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.freeipa.config.FreeIpaConfigService;
+import com.sequenceiq.freeipa.service.freeipa.config.FreeIpaConfigView;
+import com.sequenceiq.freeipa.service.proxy.ProxyConfigService;
+import com.sequenceiq.freeipa.service.tag.TagConfigService;
+import com.sequenceiq.freeipa.service.telemetry.TelemetryConfigService;
+import com.sequenceiq.freeipa.service.upgrade.ccm.CcmParametersConfigService;
+
+@Service
+public class SaltConfigProvider {
+
+    @Inject
+    private FreeIpaConfigService freeIpaConfigService;
+
+    @Inject
+    private ProxyConfigService proxyConfigService;
+
+    @Inject
+    private TagConfigService tagConfigService;
+
+    @Inject
+    private TelemetryConfigService telemetryConfigService;
+
+    @Inject
+    private CcmParametersConfigService ccmParametersConfigService;
+
+    public SaltConfig getSaltConfig(Stack stack, Set<Node> hosts) throws CloudbreakOrchestratorFailedException {
+        SaltConfig saltConfig = new SaltConfig();
+        Map<String, SaltPillarProperties> servicePillarConfig = saltConfig.getServicePillarConfig();
+        FreeIpaConfigView freeIpaConfigView = freeIpaConfigService.createFreeIpaConfigs(stack, hosts);
+        servicePillarConfig.put("freeipa", new SaltPillarProperties("/freeipa/init.sls", singletonMap("freeipa", freeIpaConfigView.toMap())));
+        servicePillarConfig.put("discovery", new SaltPillarProperties("/discovery/init.sls", singletonMap("platform", stack.getCloudPlatform())));
+        servicePillarConfig.putAll(telemetryConfigService.createTelemetryPillarConfig(stack));
+        servicePillarConfig.putAll(proxyConfigService.createProxyPillarConfig(stack.getEnvironmentCrn()));
+        servicePillarConfig.putAll(tagConfigService.createTagsPillarConfig(stack));
+        servicePillarConfig.putAll(getCcmPillarProperties(stack));
+        return saltConfig;
+    }
+
+    private Map<String, SaltPillarProperties> getCcmPillarProperties(Stack stack) {
+        CcmConnectivityParameters ccmParameters = stack.getCcmParameters();
+        if (ccmParameters != null && ccmParameters.getCcmV2JumpgateParameters() != null) {
+            return ccmParametersConfigService.createCcmParametersPillarConfig(stack.getAccountId(), ccmParameters.getCcmV2JumpgateParameters());
+        }
+        return Map.of();
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/upgrade/ccm/CcmParametersConfigService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/upgrade/ccm/CcmParametersConfigService.java
@@ -1,0 +1,53 @@
+package com.sequenceiq.freeipa.service.upgrade.ccm;
+
+import static java.util.Collections.singletonMap;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.ccm.cloudinit.CcmV2JumpgateParameters;
+import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
+
+@Service
+public class CcmParametersConfigService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CcmParametersConfigService.class);
+
+    private static final String UPGRADE_CCM_KEY = "ccm_jumpgate";
+
+    private static final String UPGRADE_CCM_SLS_PATH = "/upgradeccm/init.sls";
+
+    @Inject
+    private EntitlementService entitlementService;
+
+    public Map<String, SaltPillarProperties> createCcmParametersPillarConfig(String accountId, CcmV2JumpgateParameters ccmParameters) {
+        if (ccmParameters != null) {
+            LOGGER.debug("Filling CCM properties to Salt Pillar");
+            Map<String, Object> ccmConfig = new HashMap<>();
+            ccmConfig.put("inverting_proxy_host", ccmParameters.getInvertingProxyHost());
+            ccmConfig.put("inverting_proxy_certificate", ccmParameters.getInvertingProxyCertificate());
+            ccmConfig.put("agent_certificate", ccmParameters.getAgentCertificate());
+            ccmConfig.put("agent_enciphered_key", ccmParameters.getAgentEncipheredPrivateKey());
+            ccmConfig.put("agent_key_id", ccmParameters.getAgentKeyId());
+            ccmConfig.put("agent_backend_id_prefix", ccmParameters.getAgentBackendIdPrefix());
+            ccmConfig.put("environment_crn", ccmParameters.getEnvironmentCrn());
+            boolean useOneWayTls = entitlementService.ccmV2UseOneWayTls(accountId);
+            ccmConfig.put("agent_access_key_id", useOneWayTls ? ccmParameters.getAgentMachineUserAccessKey() : EMPTY);
+            ccmConfig.put("agent_enciphered_access_key", useOneWayTls ? ccmParameters.getAgentMachineUserEncipheredAccessKey() : EMPTY);
+            return Map.of(UPGRADE_CCM_KEY, new SaltPillarProperties(UPGRADE_CCM_SLS_PATH, singletonMap(UPGRADE_CCM_KEY, ccmConfig)));
+        } else {
+            LOGGER.debug("CCM properties are empty in the Salt Pillar");
+            return Map.of();
+        }
+    }
+
+}
+

--- a/freeipa/src/main/resources/schema/app/20220321174423_CB-14578_add_ccmparameters.sql
+++ b/freeipa/src/main/resources/schema/app/20220321174423_CB-14578_add_ccmparameters.sql
@@ -1,0 +1,9 @@
+-- // CB-14578 create CCM Parameters column
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE stack ADD COLUMN IF NOT EXISTS ccmparameters text;
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+ALTER TABLE stack DROP COLUMN IF EXISTS ccmparameters;

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/userdata/CcmUserDataServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/userdata/CcmUserDataServiceTest.java
@@ -12,11 +12,11 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.ccm.cloudinit.CcmConnectivityMode;
@@ -36,8 +36,8 @@ import com.sequenceiq.freeipa.service.freeipa.FreeIpaService;
 import com.sequenceiq.freeipa.service.stack.StackService;
 import com.sequenceiq.freeipa.util.CrnService;
 
-@RunWith(MockitoJUnitRunner.class)
-public class CcmUserDataServiceTest {
+@ExtendWith(MockitoExtension.class)
+class CcmUserDataServiceTest {
 
     private static final String TEST_ACCOUNT_ID = "accid";
 
@@ -76,14 +76,14 @@ public class CcmUserDataServiceTest {
     private StackService stackService;
 
     @Test
-    public void testFetchAndSaveCcmParametersWhenCcmTunnelNotEnabled() {
+    void testFetchAndSaveCcmParametersWhenCcmTunnelNotEnabled() {
         Stack stack = getAStack();
         CcmConnectivityParameters ccmNotEnabled = underTest.fetchAndSaveCcmParameters(stack);
         assertEquals(CcmConnectivityMode.NONE, ccmNotEnabled.getConnectivityMode(), "CCM should not be enabled.");
     }
 
     @Test
-    public void testFetchAndSaveCcmParametersWhenCcmV1IsEnabled() {
+    void testFetchAndSaveCcmParametersWhenCcmV1IsEnabled() {
         Stack stack = getAStack();
         stack.setTunnel(Tunnel.CCM);
         DefaultCcmParameters defaultCcmParameters = mock(DefaultCcmParameters.class);
@@ -105,7 +105,7 @@ public class CcmUserDataServiceTest {
     }
 
     @Test
-    public void testFetchAndSaveCcmParametersWhenCcmV2IsEnabled() {
+    void testFetchAndSaveCcmParametersWhenCcmV2IsEnabled() {
         Stack stack = getAStack();
         stack.setTunnel(Tunnel.CCMV2);
         DefaultCcmV2Parameters defaultCcmV2Parameters = mock(DefaultCcmV2Parameters.class);
@@ -129,7 +129,7 @@ public class CcmUserDataServiceTest {
     }
 
     @Test
-    public void testFetchAndSaveCcmParametersWhenCcmV2JumpgateIsEnabled() {
+    void testFetchAndSaveCcmParametersWhenCcmV2JumpgateIsEnabled() {
         Stack stack = getAStack();
         stack.setTunnel(Tunnel.CCMV2_JUMPGATE);
         DefaultCcmV2JumpgateParameters defaultCcmV2JumpgateParameters = mock(DefaultCcmV2JumpgateParameters.class);

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/upgrade/ccm/CcmParametersConfigServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/upgrade/ccm/CcmParametersConfigServiceTest.java
@@ -1,0 +1,115 @@
+package com.sequenceiq.freeipa.service.upgrade.ccm;
+
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.ccm.cloudinit.CcmV2JumpgateParameters;
+import com.sequenceiq.cloudbreak.ccm.cloudinit.DefaultCcmV2JumpgateParameters;
+import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
+
+@ExtendWith(MockitoExtension.class)
+class CcmParametersConfigServiceTest {
+
+    private static final String ACCOUNT = "account";
+
+    private static final String INVERTING_PROXY_HOST = "hostname";
+
+    private static final String INVERTING_PROXY_CERTIFICATE = "proxycert";
+
+    private static final String AGENT_CRN = "agent1";
+
+    private static final String AGENT_KEY_ID = "key1";
+
+    private static final String PRIVATE_KEY = "privatekey1";
+
+    private static final String AGENT_CERT = "agent certificate";
+
+    private static final String ENV_CRN = "environment1";
+
+    private static final String MACHINE_USER_ACCESS_KEY = "accessKey1";
+
+    private static final String MACHINE_USER_PRIVATE_KEY = "privateKey1";
+
+    @Mock
+    private EntitlementService entitlementService;
+
+    @InjectMocks
+    private CcmParametersConfigService underTest;
+
+    @Test
+    void testEmptyParams() {
+        Map<String, SaltPillarProperties> result = underTest.createCcmParametersPillarConfig(ACCOUNT, null);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void testParamsWithOneWayTls() {
+        when(entitlementService.ccmV2UseOneWayTls(ACCOUNT)).thenReturn(true);
+        CcmV2JumpgateParameters params = createParams();
+        Map<String, SaltPillarProperties> result = underTest.createCcmParametersPillarConfig(ACCOUNT, params);
+        assertThat(result).containsKey("ccm_jumpgate");
+        Map<String, Object> properties = result.get("ccm_jumpgate").getProperties();
+        assertThat(properties).containsKey("ccm_jumpgate");
+        Map<String, Object> ccmParameterMap = (Map<String, Object>) properties.get("ccm_jumpgate");
+
+        assertThat(ccmParameterMap).containsOnly(
+                Map.entry("inverting_proxy_certificate", INVERTING_PROXY_CERTIFICATE),
+                Map.entry("inverting_proxy_host", INVERTING_PROXY_HOST),
+                Map.entry("agent_certificate", AGENT_CERT),
+                Map.entry("agent_enciphered_key", PRIVATE_KEY),
+                Map.entry("agent_key_id", AGENT_KEY_ID),
+                Map.entry("agent_backend_id_prefix", params.getAgentBackendIdPrefix()),
+                Map.entry("environment_crn", ENV_CRN),
+                Map.entry("agent_access_key_id", MACHINE_USER_ACCESS_KEY),
+                Map.entry("agent_enciphered_access_key", MACHINE_USER_PRIVATE_KEY)
+        );
+    }
+
+    @Test
+    void testParamsWithTwoWayTls() {
+        when(entitlementService.ccmV2UseOneWayTls(ACCOUNT)).thenReturn(false);
+        CcmV2JumpgateParameters params = createParams();
+        Map<String, SaltPillarProperties> result = underTest.createCcmParametersPillarConfig(ACCOUNT, params);
+        assertThat(result).containsKey("ccm_jumpgate");
+        Map<String, Object> properties = result.get("ccm_jumpgate").getProperties();
+        assertThat(properties).containsKey("ccm_jumpgate");
+        Map<String, Object> ccmParameterMap = (Map<String, Object>) properties.get("ccm_jumpgate");
+
+        assertThat(ccmParameterMap).containsOnly(
+                Map.entry("inverting_proxy_certificate", INVERTING_PROXY_CERTIFICATE),
+                Map.entry("inverting_proxy_host", INVERTING_PROXY_HOST),
+                Map.entry("agent_certificate", AGENT_CERT),
+                Map.entry("agent_enciphered_key", PRIVATE_KEY),
+                Map.entry("agent_key_id", AGENT_KEY_ID),
+                Map.entry("agent_backend_id_prefix", params.getAgentBackendIdPrefix()),
+                Map.entry("environment_crn", ENV_CRN),
+                Map.entry("agent_access_key_id", EMPTY),
+                Map.entry("agent_enciphered_access_key", EMPTY)
+        );
+    }
+
+    private CcmV2JumpgateParameters createParams() {
+        CcmV2JumpgateParameters params = new DefaultCcmV2JumpgateParameters(
+                INVERTING_PROXY_HOST,
+                INVERTING_PROXY_CERTIFICATE,
+                AGENT_CRN,
+                AGENT_KEY_ID,
+                PRIVATE_KEY,
+                AGENT_CERT,
+                ENV_CRN,
+                MACHINE_USER_ACCESS_KEY,
+                MACHINE_USER_PRIVATE_KEY
+        );
+        return params;
+    }
+}

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
@@ -781,6 +781,7 @@ public class SaltOrchestrator implements HostOrchestrator {
         }
     }
 
+    @Override
     public Map<String, String> runCommandOnAllHosts(GatewayConfig gateway, String command) throws CloudbreakOrchestratorFailedException {
         try (SaltConnector saltConnector = saltService.createSaltConnector(gateway)) {
             return SaltStates.runCommand(retry, saltConnector, command);


### PR DESCRIPTION
For the migration from earlier versions.
Store the parameters on FreeIPA Stack to persist them for the flow chain.
Prepare UserDataService and FreeIpaOrchestrationConfigService to accept CCM parameters
from Stack.