### PR TITLE
CB-16458 E2E tests for Resilient Scaling with percentage option

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXScaleAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXScaleAction.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.common.api.type.AdjustmentType;
 import com.sequenceiq.distrox.api.v1.distrox.model.DistroXScaleV1Request;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
@@ -19,22 +20,30 @@ public class DistroXScaleAction implements Action<DistroXTestDto, CloudbreakClie
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DistroXScaleAction.class);
 
-    private final Integer count;
+    private final Integer desiredCount;
 
     private final String hostGroup;
 
-    public DistroXScaleAction(String hostGroup, Integer count) {
-        this.count = count;
+    private final AdjustmentType adjustmentType;
+
+    private final Long threshold;
+
+    public DistroXScaleAction(String hostGroup, Integer desiredCount, AdjustmentType adjustmentType, Long threshold) {
+        this.desiredCount = desiredCount;
         this.hostGroup = hostGroup;
+        this.adjustmentType = adjustmentType;
+        this.threshold = threshold;
     }
 
     @Override
     public DistroXTestDto action(TestContext testContext, DistroXTestDto testDto, CloudbreakClient client) throws Exception {
-        Log.when(LOGGER, String.format("Distrox scale request on: %s. Hostgroup: %s, desiredCount: %d", testDto.getName(), hostGroup, count));
+        Log.when(LOGGER, String.format("Distrox scale request on: %s. Hostgroup: %s, desiredCount: %d", testDto.getName(), hostGroup, desiredCount));
         Log.whenJson(LOGGER, " Distrox scale request: ", testDto.getRequest());
         DistroXScaleV1Request scaleRequest = new DistroXScaleV1Request();
         scaleRequest.setGroup(hostGroup);
-        scaleRequest.setDesiredCount(count);
+        scaleRequest.setDesiredCount(desiredCount);
+        scaleRequest.setAdjustmentType(adjustmentType);
+        scaleRequest.setThreshold(threshold);
         FlowIdentifier flowIdentifier = client.getDefaultClient()
                 .distroXV1Endpoint()
                 .putScalingByName(testDto.getName(), scaleRequest);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/distrox/DistroxScaleThresholdAssertions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/distrox/DistroxScaleThresholdAssertions.java
@@ -1,0 +1,81 @@
+package com.sequenceiq.it.cloudbreak.assertion.distrox;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
+import com.sequenceiq.it.cloudbreak.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.assertion.Assertion;
+import com.sequenceiq.it.cloudbreak.cloud.HostGroupType;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+
+public class DistroxScaleThresholdAssertions implements Assertion<DistroXTestDto, CloudbreakClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DistroxScaleThresholdAssertions.class);
+
+    private final String hostGroupName;
+
+    private final int scaleUpTarget;
+
+    private final long threshold;
+
+    public DistroxScaleThresholdAssertions(String hostGroupName, int scaleUpTarget, long threshold) {
+        this.hostGroupName = hostGroupName;
+        this.scaleUpTarget = scaleUpTarget;
+        this.threshold = threshold;
+    }
+
+    private String getHostGroup() {
+        return Arrays.stream(HostGroupType.values())
+                .filter(hostGroup -> hostGroup.name().equalsIgnoreCase(hostGroupName))
+                .findFirst()
+                .orElseThrow(() -> new TestFailException(String.format("There is no HostGroupType for '%s' name!", hostGroupName)))
+                .name();
+    }
+
+    private List<String> getInstanceIds(DistroXTestDto testDto) {
+        Optional<InstanceGroupV4Response> instanceGroup = testDto.getResponse().getInstanceGroups().stream()
+                .filter(instanceGroups -> getHostGroup().equalsIgnoreCase(instanceGroups.getName()))
+                .filter(instanceGroups -> instanceGroups.getMetadata().stream()
+                        .anyMatch(instanceMetaData -> Objects.nonNull(instanceMetaData.getInstanceId())))
+                .findAny();
+        if (instanceGroup.isPresent()) {
+            return instanceGroup.get().getMetadata().stream()
+                    .map(InstanceMetaDataV4Response::getInstanceId)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+        } else {
+            throw new TestFailException(String.format("Can't find valid instance group with this '%s' name!", hostGroupName));
+        }
+    }
+
+    private float getScalingThreshold() {
+        float scalingPercentage = (float) threshold / 100;
+        return scaleUpTarget * scalingPercentage;
+    }
+
+    @Override
+    public DistroXTestDto doAssertion(TestContext testContext, DistroXTestDto testDto, CloudbreakClient client) throws Exception {
+        int instanceCount = getInstanceIds(testDto).size();
+
+        assertThat(
+                String.format("Available Compute node count '%d' is NOT match with the required (at least) scale percentage '%d'.",
+                        instanceCount, threshold),
+                (float) instanceCount,
+                greaterThanOrEqualTo(getScalingThreshold()));
+
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/DistroXTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/DistroXTestClient.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.common.api.type.AdjustmentType;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.action.Action;
 import com.sequenceiq.it.cloudbreak.action.v1.distrox.CheckVariant;
@@ -76,7 +77,11 @@ public class DistroXTestClient {
     }
 
     public Action<DistroXTestDto, CloudbreakClient> scale(String hostGroup, Integer count) {
-        return new DistroXScaleAction(hostGroup, count);
+        return new DistroXScaleAction(hostGroup, count, AdjustmentType.EXACT, null);
+    }
+
+    public Action<DistroXTestDto, CloudbreakClient> scale(String hostGroup, Integer count, AdjustmentType adjustmentType, Long threshold) {
+        return new DistroXScaleAction(hostGroup, count, adjustmentType, threshold);
     }
 
     public Action<DistroXTestDto, CloudbreakClient> scaleStopInstances() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/AbstractIntegrationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/AbstractIntegrationTest.java
@@ -175,6 +175,7 @@ public abstract class AbstractIntegrationTest extends AbstractMinimalTest {
     }
 
     protected void createDefaultDatahub(TestContext testContext) {
+        createEnvironmentWithFreeIpaAndDatalake(testContext);
         initiateDefaultDatahubCreation(testContext);
         waitForDefaultDatahubCreation(testContext);
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXResilientScaleTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXResilientScaleTests.java
@@ -1,0 +1,99 @@
+package com.sequenceiq.it.cloudbreak.testcase.e2e.distrox;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.ITestContext;
+import org.testng.annotations.Test;
+
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.it.cloudbreak.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.assertion.distrox.DistroxScaleThresholdAssertions;
+import com.sequenceiq.it.cloudbreak.client.DistroXTestClient;
+import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
+import com.sequenceiq.it.cloudbreak.util.CloudFunctionality;
+import com.sequenceiq.it.cloudbreak.util.DistroxUtil;
+
+public class DistroXResilientScaleTests extends AbstractE2ETest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DistroXResilientScaleTests.class);
+
+    @Inject
+    private DistroXTestClient distroXTestClient;
+
+    @Inject
+    private DistroxUtil distroxUtil;
+
+    @Override
+    protected void setupTest(TestContext testContext) {
+        // Along with "CB-12902 Add AwsNativeSetup" was introduced an extra AWS autoscailing validation:
+        // "Not all the existing instances are in [Started] state, upscale is not possible!"
+        // by /cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsCloudFormationSetup.java#L65-L69
+        // So this test is not supported at AWS right now.
+        assertNotSupportedCloudPlatform(CloudPlatform.AWS);
+        testContext.getCloudProvider().getCloudFunctionality().cloudStorageInitialize();
+        createDefaultUser(testContext);
+        createDefaultCredential(testContext);
+        initializeDefaultBlueprints(testContext);
+        createDefaultDatahub(testContext);
+    }
+
+    @Test(dataProvider = TEST_CONTEXT, description = "Resilient Scaling: " +
+            "UseCase4: " +
+            "- Start upscale on running cluster with percentage option with at least option " +
+            "- Provider only gives back above threshold " +
+            "- Upscale should complete ")
+    @Description(
+            given = "there is a running default Distrox cluster",
+            when = "cluster has been scaled up at least 90% of the required node count",
+                and = "cluster has been scaled up again while removing 10% of the instance from the scaled host group",
+            then = "cluster can be resiliently scaled up at least the required node count threshold")
+    public void testPercentageResilientScaleDistrox(TestContext testContext, ITestContext iTestContext) {
+        DistroXScaleTestParameters params = new DistroXScaleTestParameters(iTestContext.getCurrentXmlTest().getAllParameters());
+
+        testContext
+                .given(DistroXTestDto.class)
+                .when(distroXTestClient.scale(params.getHostGroup(), params.getScaleUpTarget(), params.getAdjustmentType(), params.getThreshold()))
+                .awaitForFlow()
+                .await(STACK_AVAILABLE)
+                .awaitForHealthyInstances()
+                .then(new DistroxScaleThresholdAssertions(params.getHostGroup(), params.getScaleUpTarget(), params.getThreshold()))
+                .when(distroXTestClient.scale(params.getHostGroup(), params.getScaleDownTarget()))
+                .awaitForFlow()
+                .when(distroXTestClient.scale(params.getHostGroup(), params.getScaleUpTarget(), params.getAdjustmentType(), params.getThreshold()))
+                .then((tc, testDto, client) -> removeInstanceWhileScalingGroup(tc, testDto, client, params))
+                .awaitForFlow()
+                .await(STACK_AVAILABLE)
+                .awaitForHealthyInstances()
+                .when(distroXTestClient.get())
+                .then(new DistroxScaleThresholdAssertions(params.getHostGroup(), params.getScaleUpTarget(), params.getThreshold()))
+                .validate();
+    }
+
+    private long getDeletionLimit(DistroXScaleTestParameters params) {
+        float scalingPercentage = (float) params.getThreshold() / 100;
+        float scalingThreshold = params.getScaleUpTarget() * scalingPercentage;
+
+        return params.getScaleUpTarget() - (long) scalingThreshold;
+    }
+
+    private DistroXTestDto removeInstanceWhileScalingGroup(TestContext testContext, DistroXTestDto testDto, CloudbreakClient client,
+            DistroXScaleTestParameters params) {
+        CloudFunctionality cloudFunctionality = testContext.getCloudProvider().getCloudFunctionality();
+        List<String> instancesToDelete = distroxUtil.getInstanceIds(testDto, client, params.getHostGroup()).stream()
+                .limit(getDeletionLimit(params)).collect(Collectors.toList());
+        if (instancesToDelete.isEmpty()) {
+            throw new TestFailException(String.format("At least 1 instance needed from '%s' group to delete!", params.getHostGroup()));
+        }
+        cloudFunctionality.deleteInstances(testDto.getName(), instancesToDelete);
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXScaleTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXScaleTest.java
@@ -34,23 +34,25 @@ public class DistroXScaleTest extends AbstractE2ETest {
         createDefaultUser(testContext);
         createDefaultCredential(testContext);
         initializeDefaultBlueprints(testContext);
-        createEnvironmentWithFreeIpaAndDatalake(testContext);
+        createDefaultDatahub(testContext);
     }
 
-    @Test(dataProvider = TEST_CONTEXT)
+    @Test(dataProvider = TEST_CONTEXT, description = "Resilient Scaling: " +
+            "UseCase1: " +
+            "- Start upscale on running cluster " +
+            "- Delete a non CM server host from provider other hostgroup during upscale " +
+            "- Upscale should complete ")
     @Description(
-            given = "there is a running cloudbreak",
-            when = "a valid DistroX create request is sent",
-            then = "DistroX cluster can be resiliently scaled up and down with higher node count")
+            given = "there is a running default Distrox cluster",
+            when = "deleted a Compute instance while cluster was upscaling (by Worker nodes)",
+            then = "cluster can be resiliently scaled up then down with higher node count")
     public void testCreateAndScaleDistroX(TestContext testContext, ITestContext iTestContext) {
         DistroXScaleTestParameters params = new DistroXScaleTestParameters(iTestContext.getCurrentXmlTest().getAllParameters());
-        testContext.given(DistroXTestDto.class)
-                .when(distroXTestClient.create())
-                .await(STACK_AVAILABLE)
-                .validate();
+
         if (params.getTimes() < 1) {
             throw new TestFailException("Test should execute at least 1 round of scaling");
         }
+
         testContext.given(DistroXTestDto.class)
                 .when(distroXTestClient.scale(params.getHostGroup(), params.getScaleUpTarget()))
                 .then((tc, testDto, client) -> {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXScaleTestParameters.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXScaleTestParameters.java
@@ -2,6 +2,11 @@ package com.sequenceiq.it.cloudbreak.testcase.e2e.distrox;
 
 import java.util.Map;
 
+import org.apache.commons.lang3.EnumUtils;
+
+import com.sequenceiq.common.api.type.AdjustmentType;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+
 public class DistroXScaleTestParameters {
 
     private static final String TIMES = "times";
@@ -14,6 +19,10 @@ public class DistroXScaleTestParameters {
 
     private static final String IRRELEVANT_HOST_GROUP = "irrelevant_host_group";
 
+    private static final String ADJUSTMENT_TYPE = "adjustment_type";
+
+    private static final String THRESHOLD = "threshold";
+
     private static final String DEFAULT_TIMES = "2";
 
     private static final String DEFAULT_SCALE_UP_TARGET = "6";
@@ -23,6 +32,10 @@ public class DistroXScaleTestParameters {
     private static final String DEFAULT_HOST_GROUP = "worker";
 
     private static final String DEFAULT_IRRELEVANT_HOST_GROUP = "compute";
+
+    private static final String DEFAULT_ADJUSTMENT_TYPE = "EXACT";
+
+    private static final String DEFAULT_THRESHOLD = "0";
 
     private int times;
 
@@ -34,12 +47,18 @@ public class DistroXScaleTestParameters {
 
     private String irrelevantHostGroup;
 
+    private AdjustmentType adjustmentType;
+
+    private long threshold;
+
     DistroXScaleTestParameters(Map<String, String> allParameters) {
         setHostGroup(allParameters.getOrDefault(HOST_GROUP, DEFAULT_HOST_GROUP));
         setScaleUpTarget(Integer.parseInt(allParameters.getOrDefault(SCALE_UP_TARGET, DEFAULT_SCALE_UP_TARGET)));
         setScaleDownTarget(Integer.parseInt(allParameters.getOrDefault(SCALE_DOWN_TARGET, DEFAULT_SCALE_DOWN_TARGET)));
         setTimes(Integer.parseInt(allParameters.getOrDefault(TIMES, DEFAULT_TIMES)));
         setIrrelevantHostGroup(allParameters.getOrDefault(IRRELEVANT_HOST_GROUP, DEFAULT_IRRELEVANT_HOST_GROUP));
+        setAdjustmentType(allParameters.getOrDefault(ADJUSTMENT_TYPE, DEFAULT_ADJUSTMENT_TYPE));
+        setThreshold(Long.parseLong(allParameters.getOrDefault(THRESHOLD, DEFAULT_THRESHOLD)));
     }
 
     public int getScaleUpTarget() {
@@ -80,5 +99,25 @@ public class DistroXScaleTestParameters {
 
     public void setIrrelevantHostGroup(String irrelevantHostGroup) {
         this.irrelevantHostGroup = irrelevantHostGroup;
+    }
+
+    public AdjustmentType getAdjustmentType() {
+        return adjustmentType;
+    }
+
+    public void setAdjustmentType(String adjustmentTypeName) {
+        if (EnumUtils.isValidEnum(AdjustmentType.class, adjustmentTypeName)) {
+            adjustmentType = EnumUtils.getEnum(AdjustmentType.class, adjustmentTypeName);
+        } else {
+            throw new TestFailException(String.format("There is no scaling AdjustmentType for '%s'", adjustmentTypeName));
+        }
+    }
+
+    public long getThreshold() {
+        return threshold;
+    }
+
+    public void setThreshold(long threshold) {
+        this.threshold = threshold;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXStopStartScaleTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXStopStartScaleTest.java
@@ -11,6 +11,7 @@ import org.testng.ITestContext;
 import org.testng.annotations.Test;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.it.cloudbreak.assertion.distrox.DistroxStopStartScaleDurationAssertions;
 import com.sequenceiq.it.cloudbreak.client.DistroXTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
@@ -30,11 +31,14 @@ public class DistroXStopStartScaleTest extends AbstractE2ETest {
 
     @Override
     protected void setupTest(TestContext testContext) {
+        // Azure and GCP are not supported right now.
+        // - GCP does not support stopping instances with ephemeral storage.
+        // - Azure starting/stopping nodes consume almost same time as adding/deleting nodes.
+        assertSupportedCloudPlatform(CloudPlatform.AWS);
         testContext.getCloudProvider().getCloudFunctionality().cloudStorageInitialize();
         createDefaultUser(testContext);
         createDefaultCredential(testContext);
         initializeDefaultBlueprints(testContext);
-        createEnvironmentWithFreeIpaAndDatalake(testContext);
         createDefaultDatahub(testContext);
     }
 

--- a/integration-test/src/main/resources/testsuites/e2e/distrox-resilientscale-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/distrox-resilientscale-tests.yaml
@@ -1,0 +1,13 @@
+name: "distrox-resilient-scale-tests"
+tests:
+  - name: "distrox_resilient_scale_tests"
+    parameters: {
+      host_group: compute,
+      scale_up_target: 10,
+      scale_down_target: 5,
+      adjustment_type: PERCENTAGE,
+      threshold: 90,
+      times: 1
+    }
+    classes:
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXResilientScaleTests


### PR DESCRIPTION
Based on the [CB-15971](https://jira.cloudera.com/browse/CB-15971) E2E test proposals to cover `usecase4` improvements regarding resilient scaling:
1. Start upscale on running cluster with percentage option with at least option
2. Provider only gives back above threshold
3. Upscale should complete