### PR TITLE
CB-16479 Move Tag Validation from TestContext Cleanup

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/E2ETestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/E2ETestContext.java
@@ -27,7 +27,6 @@ public class E2ETestContext extends TestContext {
 
     @Override
     public void cleanupTestContext() {
-        getResourceNames().values().forEach(value -> tagsUtil.verifyTags(value, this));
         super.cleanupTestContext();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/AbstractE2ETest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/AbstractE2ETest.java
@@ -17,6 +17,7 @@ import com.sequenceiq.it.cloudbreak.testcase.AbstractIntegrationTest;
 import com.sequenceiq.it.cloudbreak.util.spot.SpotRetryOnceTestListener;
 import com.sequenceiq.it.cloudbreak.util.spot.SpotRetryUtil;
 import com.sequenceiq.it.cloudbreak.util.spot.SpotUtil;
+import com.sequenceiq.it.util.TagsUtil;
 
 @Listeners(SpotRetryOnceTestListener.class)
 public abstract class AbstractE2ETest extends AbstractIntegrationTest {
@@ -26,6 +27,9 @@ public abstract class AbstractE2ETest extends AbstractIntegrationTest {
 
     @Inject
     private SpotRetryUtil spotRetryUtil;
+
+    @Inject
+    private TagsUtil tagsUtil;
 
     @Override
     protected void setupTest(ITestResult testResult) {
@@ -43,7 +47,8 @@ public abstract class AbstractE2ETest extends AbstractIntegrationTest {
     }
 
     @AfterMethod
-    public void tearDownSpot() {
+    public void tearDownSpotValidateTags(Object[] data) {
+        ((TestContext) data[0]).getResourceNames().values().forEach(value -> tagsUtil.verifyTags(value, (TestContext) data[0]));
         spotUtil.setUseSpotInstances(Boolean.FALSE);
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXEncryptedVolumeTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXEncryptedVolumeTest.java
@@ -112,7 +112,7 @@ public class DistroXEncryptedVolumeTest extends AbstractE2ETest {
         createDefaultCredential(testContext);
     }
 
-    @AfterMethod(onlyForGroups = { "azure_singlerg" }, dependsOnMethods = { "tearDown", "tearDownSpot" })
+    @AfterMethod(onlyForGroups = { "azure_singlerg" }, dependsOnMethods = { "tearDown", "tearDownSpotValidateTags" })
     public void singleResourceGroupTearDown(Object[] data) {
         LOGGER.info("Delete the '{}' resource group after test has been done!", resourceGroupForTest);
         deleteResourceGroupCreatedForEnvironment(resourceGroupForTest);


### PR DESCRIPTION
We experienced malfunction at our API E2E project `Tear down context` in case of the Tag Validation is failing at [E2ETestContext](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/E2ETestContext.java#L28-L32):
```
    @Override
    public void cleanupTestContext() {
        getResourceNames().values().forEach(value -> tagsUtil.verifyTags(value, this));
        super.cleanupTestContext();
    }
```
If the `tagsUtil.verifyTags` is failing, then the `super.cleanupTestContext()` wont be executed.

We should fix this part and force the cleanupTestContext even if the verifyTags is failing.