### PR TITLE
CB-13609 Datahub Autoscaling should use machine user for polling yarn…

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/UmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/UmsClient.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.cloudera.thunderhead.service.NullableScalarTypeProto;
 import com.cloudera.thunderhead.service.common.paging.PagingProto;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementGrpc;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementGrpc.UserManagementBlockingStub;
@@ -531,6 +532,21 @@ public class UmsClient {
             }
         }
         return emptyResponse;
+    }
+
+    public MachineUser getOrCreateMachineUserWithoutAccessKey(String requestId, String accountId, String machineUserName) {
+        checkNotNull(requestId, "requestId should not be null.");
+        checkNotNull(machineUserName, "machineUserName should not be null.");
+        validateAccountIdWithWarning(accountId);
+        //Idempotent api creates only if not existing.
+        UserManagementProto.CreateWorkloadMachineUserResponse response = newStub(requestId).createWorkloadMachineUser(
+                UserManagementProto.CreateWorkloadMachineUserRequest.newBuilder()
+                        .setAccountId(accountId)
+                        .setMachineUserName(machineUserName)
+                        .setGenerateAccessKey(NullableScalarTypeProto.BoolValue.newBuilder().setValue(false))
+                        .build());
+        LOGGER.info("Machine user created: {}.", response.getMachineUser());
+        return response.getMachineUser();
     }
 
     /**

--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/service/RoleCrnGenerator.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/service/RoleCrnGenerator.java
@@ -26,6 +26,10 @@ public class RoleCrnGenerator {
         return getResourceRoleCrn("EnvironmentAdmin").toString();
     }
 
+    public String getBuiltInEnvironmentUserResourceRoleCrn() {
+        return getResourceRoleCrn("EnvironmentUser").toString();
+    }
+
     public Crn getResourceRoleCrn(String resourceRoleName) {
         // we need to find out the proper partition and region in case of every cdp deployment, we stick to altus partition and current region
         return regionAwareCrnGenerator.generateAltusCrn(CrnResourceDescriptor.RESOURCE_ROLE, resourceRoleName);

--- a/autoscale/build.gradle
+++ b/autoscale/build.gradle
@@ -202,6 +202,7 @@ dependencies {
 
     implementation project(':core-api')
     implementation project(':autoscale-api')
+    implementation project(':freeipa-api')
     implementation project(':common')
     implementation project(':workspace')
     implementation project(':secret-engine')

--- a/autoscale/src/main/java/com/sequenceiq/periscope/aspects/RequestLogging.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/aspects/RequestLogging.java
@@ -16,11 +16,10 @@ public class RequestLogging {
         T response;
         try {
             response = callback.get();
+            LOGGER.info("Request '{}' finished in '{}' ms.", requestName, System.currentTimeMillis() - start);
         } catch (Exception ex) {
             LOGGER.error("Request '{}', Exception: ", requestName, ex);
             throw ex;
-        } finally {
-            LOGGER.info("Request '{}' finished in '{}' ms.", requestName, System.currentTimeMillis() - start);
         }
         return response;
     }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/config/ServiceEndpointConfig.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/config/ServiceEndpointConfig.java
@@ -27,6 +27,15 @@ public class ServiceEndpointConfig {
     @Value("${periscope.cloudbreak.url:}")
     private String cloudbreakUrl;
 
+    @Value("${periscope.freeipa.url:}")
+    private String freeIpaServerUrl;
+
+    @Value("${periscope.freeipa.serviceid:}")
+    private String freeIpaServiceId;
+
+    @Value("${periscope.freeipa.contextPath:}")
+    private String freeIpaContextPath;
+
     @Value("${periscope.cloudbreak.serviceid:}")
     private String cloudbreakServiceId;
 
@@ -45,5 +54,11 @@ public class ServiceEndpointConfig {
     @DependsOn("serviceAddressResolver")
     public String cloudbreakUrl(ServiceAddressResolver serviceAddressResolver) throws ServiceAddressResolvingException {
         return serviceAddressResolver.resolveUrl(cloudbreakUrl, "http", cloudbreakServiceId);
+    }
+
+    @Bean
+    @DependsOn("serviceAddressResolver")
+    public String freeIpaServerUrl(ServiceAddressResolver serviceAddressResolver) throws ServiceAddressResolvingException {
+        return serviceAddressResolver.resolveUrl(freeIpaServerUrl + freeIpaContextPath, "http", freeIpaServiceId);
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/domain/Cluster.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/domain/Cluster.java
@@ -73,6 +73,12 @@ public class Cluster implements Monitored, Clustered {
     @Column(name = "cb_stack_name")
     private String stackName;
 
+    @Column(name = "environment_crn")
+    private String environmentCrn;
+
+    @Column(name = "machine_user_crn")
+    private String machineUserCrn;
+
     @Column(name = "cloud_platform")
     private String cloudPlatform;
 
@@ -325,6 +331,22 @@ public class Cluster implements Monitored, Clustered {
 
     public void setStopStartScalingEnabled(Boolean stopStartScalingEnabled) {
         this.stopStartScalingEnabled = stopStartScalingEnabled;
+    }
+
+    public String getEnvironmentCrn() {
+        return environmentCrn;
+    }
+
+    public void setEnvironmentCrn(String environmentCrn) {
+        this.environmentCrn = environmentCrn;
+    }
+
+    public String getMachineUserCrn() {
+        return machineUserCrn;
+    }
+
+    public void setMachineUserCrn(String machineUserCrn) {
+        this.machineUserCrn = machineUserCrn;
     }
 }
 

--- a/autoscale/src/main/java/com/sequenceiq/periscope/init/InitializeMachineUserService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/init/InitializeMachineUserService.java
@@ -1,0 +1,43 @@
+package com.sequenceiq.periscope.init;
+
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.google.common.base.Strings;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.monitor.handler.CloudbreakCommunicator;
+import com.sequenceiq.periscope.service.AltusMachineUserService;
+import com.sequenceiq.periscope.service.ClusterService;
+
+@Component
+public class InitializeMachineUserService {
+
+    @Inject
+    private ClusterService clusterService;
+
+    @Inject
+    private AltusMachineUserService altusMachineUserService;
+
+    @Inject
+    private CloudbreakCommunicator cloudbreakCommunicator;
+
+    @PostConstruct
+    public void init() {
+        List<Cluster> clusters = clusterService.findByEnvironmentCrnOrMachineUserCrn(null, null);
+        clusters.forEach(cluster ->  {
+            if (Strings.isNullOrEmpty(cluster.getEnvironmentCrn())) {
+                String envCrn = cloudbreakCommunicator.getAutoscaleClusterByCrn(cluster.getStackCrn()).getEnvironmentCrn();
+                clusterService.setEnvironmentCrn(cluster.getId(), envCrn);
+                cluster = clusterService.findById(cluster.getId());
+            }
+
+            if (Strings.isNullOrEmpty(cluster.getMachineUserCrn())) {
+                altusMachineUserService.initializeMachineUserForEnvironment(cluster);
+            }
+        });
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/client/YarnMetricsClient.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/client/YarnMetricsClient.java
@@ -71,7 +71,9 @@ public class YarnMetricsClient {
                 new HostGroupInstanceType(instanceConfig.getInstanceName(),
                         instanceConfig.getMemoryInMb().intValue(), instanceConfig.getCoreCPU())));
 
-        String clusterCreatorCrn = cluster.getClusterPertain().getUserCrn();
+        String pollingUserCrn = Optional.ofNullable(cluster.getMachineUserCrn()).orElse(cluster.getClusterPertain().getUserCrn());
+        LOGGER.info("Using actorCrn '{}' for Cluster '{}' yarn polling.", pollingUserCrn, cluster.getStackCrn());
+
         UriBuilder yarnMetricsURI = UriBuilder.fromPath(yarnApiUrl)
                 .queryParam(PARAM_UPSCALE_FACTOR_NODE_RESOURCE_TYPE, DEFAULT_UPSCALE_RESOURCE_TYPE);
 
@@ -81,7 +83,7 @@ public class YarnMetricsClient {
         YarnScalingServiceV1Response yarnResponse = requestLogging.logResponseTime(
                 () -> restClient.target(yarnMetricsURI).request()
                         .accept(MediaType.APPLICATION_JSON_VALUE)
-                        .header(HEADER_ACTOR_CRN, clusterCreatorCrn)
+                        .header(HEADER_ACTOR_CRN, pollingUserCrn)
                         .post(Entity.json(yarnScalingServiceV1Request), YarnScalingServiceV1Response.class),
                 String.format("YarnScalingAPI query for cluster crn '%s'", cluster.getStackCrn()));
 

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/load/YarnLoadEvaluator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/load/YarnLoadEvaluator.java
@@ -104,7 +104,7 @@ public class YarnLoadEvaluator extends EvaluatorExecutor {
             }
         } catch (Exception ex) {
             LOGGER.info("Failed to process load alert for Cluster '{}', exception '{}'", stackCrn, ex);
-            eventPublisher.publishEvent(new UpdateFailedEvent(clusterId));
+            eventPublisher.publishEvent(new UpdateFailedEvent(clusterId, ex));
         } finally {
             LOGGER.debug("Finished loadEvaluator for cluster '{}' in '{}' ms", stackCrn, System.currentTimeMillis() - start);
         }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/event/UpdateFailedEvent.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/event/UpdateFailedEvent.java
@@ -4,12 +4,22 @@ import org.springframework.context.ApplicationEvent;
 
 public class UpdateFailedEvent extends ApplicationEvent {
 
+    private Exception causedBy;
+
     public UpdateFailedEvent(long clusterId) {
         super(clusterId);
+    }
+
+    public UpdateFailedEvent(long clusterId, Exception causedBy) {
+        super(clusterId);
+        this.causedBy = causedBy;
     }
 
     public long getClusterId() {
         return (long) source;
     }
 
+    public Exception getCausedBy() {
+        return causedBy;
+    }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/CloudbreakCommunicator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/CloudbreakCommunicator.java
@@ -5,11 +5,14 @@ import java.util.Optional;
 
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.base.ScalingStrategy;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.response.CertificateV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.response.ClusterProxyConfiguration;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.response.LimitsConfigurationResponse;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses.AutoscaleRecommendationV4Response;
@@ -19,10 +22,13 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response
 import com.sequenceiq.cloudbreak.client.CloudbreakInternalCrnClient;
 import com.sequenceiq.periscope.aspects.RequestLogging;
 import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.SecurityConfig;
 import com.sequenceiq.periscope.service.AutoscaleRestRequestThreadLocalService;
 
 @Service
 public class CloudbreakCommunicator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CloudbreakCommunicator.class);
 
     @Inject
     private CloudbreakInternalCrnClient cloudbreakInternalCrnClient;
@@ -33,15 +39,18 @@ public class CloudbreakCommunicator {
     @Inject
     private RequestLogging requestLogging;
 
+    @Retryable(value = Exception.class, maxAttempts = 5, backoff = @Backoff(delay = 10000))
     public StackV4Response getByCrn(String stackCrn) {
         return cloudbreakInternalCrnClient.withInternalCrn().autoscaleEndpoint().get(stackCrn);
     }
 
+    @Retryable(value = Exception.class, maxAttempts = 5, backoff = @Backoff(delay = 10000))
     public AutoscaleStackV4Response getAutoscaleClusterByCrn(String stackCrn) {
         return cloudbreakInternalCrnClient.withInternalCrn()
                 .autoscaleEndpoint().getAutoscaleClusterByCrn(stackCrn);
     }
 
+    @Retryable(value = Exception.class, maxAttempts = 5, backoff = @Backoff(delay = 10000))
     public AutoscaleStackV4Response getAutoscaleClusterByName(String stackName, String accountId) {
         return cloudbreakInternalCrnClient.withInternalCrn()
                 .autoscaleEndpoint().getInternalAutoscaleClusterByName(stackName, accountId);
@@ -78,5 +87,13 @@ public class CloudbreakCommunicator {
     @Retryable(value = Exception.class, maxAttempts = 5, backoff = @Backoff(delay = 10000))
     public LimitsConfigurationResponse getLimitsConfiguration() {
         return cloudbreakInternalCrnClient.withInternalCrn().autoscaleEndpoint().getLimitsConfiguration();
+    }
+
+    @Retryable(value = Exception.class, maxAttempts = 5, backoff = @Backoff(delay = 10000))
+    public SecurityConfig getRemoteSecurityConfig(String stackCrn) {
+        LOGGER.info("Looks like that SecurityConfig is not in database, calling Cloudbreak: {}", stackCrn);
+        CertificateV4Response response = cloudbreakInternalCrnClient.withInternalCrn().autoscaleEndpoint().getCertificate(stackCrn);
+        LOGGER.info("We got a certificate back from Cloudbreak: {}", stackCrn);
+        return new SecurityConfig(response.getClientKeyPath(), response.getClientCertPath(), response.getServerCert());
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ClusterStatusSyncHandler.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ClusterStatusSyncHandler.java
@@ -17,6 +17,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackStatusV4Re
 import com.sequenceiq.periscope.api.model.ClusterState;
 import com.sequenceiq.periscope.domain.Cluster;
 import com.sequenceiq.periscope.monitor.event.ClusterStatusSyncEvent;
+import com.sequenceiq.periscope.service.AltusMachineUserService;
 import com.sequenceiq.periscope.service.ClusterService;
 import com.sequenceiq.periscope.utils.LoggingUtils;
 
@@ -30,6 +31,9 @@ public class ClusterStatusSyncHandler implements ApplicationListener<ClusterStat
 
     @Inject
     private CloudbreakCommunicator cloudbreakCommunicator;
+
+    @Inject
+    private AltusMachineUserService altusMachineUserService;
 
     @Override
     public void onApplicationEvent(ClusterStatusSyncEvent event) {
@@ -56,6 +60,7 @@ public class ClusterStatusSyncHandler implements ApplicationListener<ClusterStat
         LOGGER.info("Analysing CBCluster Status '{}' for Cluster '{}. Available(Determined)={}' ", statusResponse, cluster.getStackCrn(), clusterAvailable);
 
         if (DELETE_COMPLETED.equals(statusResponse.getStatus())) {
+            beforeDeleteCleanup(cluster);
             clusterService.removeById(autoscaleClusterId);
             LOGGER.info("Deleted cluster '{}', CB Stack Status '{}'.", cluster.getStackCrn(), statusResponse.getStatus());
         } else if (clusterAvailable && !RUNNING.equals(cluster.getState())) {
@@ -66,6 +71,18 @@ public class ClusterStatusSyncHandler implements ApplicationListener<ClusterStat
             clusterService.setState(cluster.getId(), ClusterState.SUSPENDED);
             LOGGER.info("Suspended cluster '{}', CB Stack Status '{}', CB Cluster Status '{}'",
                     cluster.getStackCrn(), statusResponse.getStatus(), statusResponse.getClusterStatus());
+        }
+    }
+
+    protected void beforeDeleteCleanup(Cluster cluster) {
+        try {
+            if ((cluster.getEnvironmentCrn() != null) && (clusterService.countByEnvironmentCrn(cluster.getEnvironmentCrn()) <= 1)) {
+                altusMachineUserService.deleteMachineUserForEnvironment(cluster.getClusterPertain().getTenant(),
+                        cluster.getMachineUserCrn(), cluster.getEnvironmentCrn());
+            }
+        } catch (Exception ex) {
+            LOGGER.warn("Error deleting machineUserCrn '{}' for environment '{}'",
+                    cluster.getMachineUserCrn(), cluster.getEnvironmentCrn(), ex);
         }
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/UpdateFailedHandler.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/UpdateFailedHandler.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.inject.Inject;
+import javax.ws.rs.ForbiddenException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,6 +18,7 @@ import com.sequenceiq.periscope.api.model.ScalingStatus;
 import com.sequenceiq.periscope.common.MessageCode;
 import com.sequenceiq.periscope.domain.Cluster;
 import com.sequenceiq.periscope.monitor.event.UpdateFailedEvent;
+import com.sequenceiq.periscope.service.AltusMachineUserService;
 import com.sequenceiq.periscope.service.ClusterService;
 import com.sequenceiq.periscope.service.HistoryService;
 import com.sequenceiq.periscope.utils.LoggingUtils;
@@ -37,7 +39,12 @@ public class UpdateFailedHandler implements ApplicationListener<UpdateFailedEven
     @Inject
     private CloudbreakMessagesService messagesService;
 
+    @Inject
+    private AltusMachineUserService altusMachineUserService;
+
     private final Map<Long, Integer> updateFailures = new ConcurrentHashMap<>();
+
+    private final Map<Long, Integer> forbiddenFailures = new ConcurrentHashMap<>();
 
     @Override
     public void onApplicationEvent(UpdateFailedEvent event) {
@@ -51,13 +58,28 @@ public class UpdateFailedHandler implements ApplicationListener<UpdateFailedEven
         if (failed < RETRY_THRESHOLD) {
             updateFailures.put(autoscaleClusterId, failed);
             LOGGER.debug("Increased failed count '{}' for cluster '{}'", failed, cluster.getStackCrn());
+
+            if (event.getCausedBy() != null && (event.getCausedBy() instanceof ForbiddenException)) {
+                Integer forbiddencount = getForbiddenFailureCount(autoscaleClusterId) + 1;
+                forbiddenFailures.put(autoscaleClusterId, forbiddencount);
+                LOGGER.debug("Increased forbidden count '{}' for cluster '{}'", forbiddencount, cluster.getStackCrn());
+            }
         } else {
+            if (getForbiddenFailureCount(autoscaleClusterId) >= (RETRY_THRESHOLD - 1)) {
+                LOGGER.info("Forbidden(403) failures exceeds max threshold '{}', reinitializaing polling machine user " +
+                        " for cluster '{}'.", RETRY_THRESHOLD, cluster.getStackCrn());
+                altusMachineUserService.initializeMachineUserForEnvironment(cluster);
+            }
             suspendCluster(cluster);
             updateFailures.remove(autoscaleClusterId);
-            historyService.createEntry(ScalingStatus.TRIGGER_FAILED,
-                        messagesService.getMessage(MessageCode.AUTOSCALING_TRIGGER_FAILURE), cluster);
+            forbiddenFailures.remove(autoscaleClusterId);
+            historyService.createEntry(ScalingStatus.TRIGGER_FAILED, messagesService.getMessage(MessageCode.AUTOSCALING_TRIGGER_FAILURE), cluster);
             LOGGER.debug("Suspended cluster monitoring for cluster '{}' due to failing update attempts", cluster.getStackCrn());
         }
+    }
+
+    private Integer getForbiddenFailureCount(long autoscaleClusterId) {
+        return Optional.ofNullable(forbiddenFailures.get(autoscaleClusterId)).orElse(0);
     }
 
     private void suspendCluster(Cluster cluster) {

--- a/autoscale/src/main/java/com/sequenceiq/periscope/repository/ClusterRepository.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/repository/ClusterRepository.java
@@ -41,6 +41,8 @@ public interface ClusterRepository extends CrudRepository<Cluster, Long> {
     @Query("SELECT c FROM Cluster c LEFT JOIN FETCH c.clusterPertain WHERE c.clusterPertain.tenant = :tenant and c.stackType = :stackType")
     List<Cluster> findByTenantAndStackType(@Param("tenant") String tenant, @Param("stackType") StackType stackType);
 
+    List<Cluster> findByEnvironmentCrnOrMachineUserCrn(String environmentCrn, String machineUserCrn);
+
     @Query("SELECT distinct c.id FROM Cluster c JOIN c.loadAlerts loadalert WHERE c.stackType = :stackType " +
             " and c.autoscalingEnabled = :autoScalingEnabled" +
             " and c.state = :clusterState  " +
@@ -76,6 +78,8 @@ public interface ClusterRepository extends CrudRepository<Cluster, Long> {
 
     int countByStateAndAutoscalingEnabledAndPeriscopeNodeId(ClusterState state, boolean autoscalingEnabled, String nodeId);
 
+    int countByEnvironmentCrn(String environmentCrn);
+
     List<Cluster> findAllByPeriscopeNodeIdNotInOrPeriscopeNodeIdIsNull(List<String> nodes);
 
     @Modifying
@@ -85,6 +89,14 @@ public interface ClusterRepository extends CrudRepository<Cluster, Long> {
     @Modifying
     @Query("UPDATE Cluster c SET c.lastEvaluated = :lastEvaluated WHERE c.id = :clusterId")
     void setClusterLastEvaluated(@Param("clusterId") Long clusterId, @Param("lastEvaluated") Long lastEvaluated);
+
+    @Modifying
+    @Query("UPDATE Cluster c SET c.environmentCrn = :environmentCrn WHERE c.id = :clusterId")
+    void setEnvironmentCrn(@Param("clusterId") Long clusterId, @Param("environmentCrn") String environmentCrn);
+
+    @Modifying
+    @Query("UPDATE Cluster c SET c.machineUserCrn = :machineUserCrn WHERE c.id = :clusterId")
+    void setMachineUserCrn(@Param("clusterId") Long clusterId, @Param("machineUserCrn") String machineUserCrn);
 
     @Modifying
     @Query("UPDATE Cluster c SET c.lastScalingActivity = :lastScalingActivity WHERE c.id = :clusterId")

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/AltusMachineUserService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/AltusMachineUserService.java
@@ -1,0 +1,98 @@
+package com.sequenceiq.periscope.service;
+
+import java.util.Optional;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.MachineUser;
+import com.google.common.collect.Multimap;
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
+import com.sequenceiq.cloudbreak.auth.altus.service.RoleCrnGenerator;
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
+import com.sequenceiq.cloudbreak.logger.MDCUtils;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.UserV1Endpoint;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeAllUsersRequest;
+import com.sequenceiq.periscope.domain.Cluster;
+
+@Service
+public class AltusMachineUserService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AltusMachineUserService.class);
+
+    private static final String AUTOSCALE_MACHINE_USER_NAME_PATTERN = "datahub-autoscale-metrics-%s";
+
+    @Inject
+    private GrpcUmsClient grpcUmsClient;
+
+    @Inject
+    private UserV1Endpoint userV1Endpoint;
+
+    @Inject
+    private ClusterService clusterService;
+
+    @Inject
+    private RoleCrnGenerator roleCrnGenerator;
+
+    @Retryable(value = Exception.class, maxAttempts = 5, backoff = @Backoff(delay = 10000))
+    public void initializeMachineUserForEnvironment(Cluster cluster) {
+        try {
+            String environmentCrn = cluster.getEnvironmentCrn();
+            if (environmentCrn != null) {
+                String machineUserCrn = getOrCreateAutoscaleMachineUser(environmentCrn, cluster.getClusterPertain().getTenant()).getCrn();
+                Multimap<String, String> assignedResourceRoles =
+                        grpcUmsClient.listAssignedResourceRoles(machineUserCrn, MDCUtils.getRequestId());
+                if (!assignedResourceRoles.get(environmentCrn).contains(roleCrnGenerator.getBuiltInEnvironmentUserResourceRoleCrn())) {
+                    grpcUmsClient.assignResourceRole(machineUserCrn, environmentCrn,
+                            roleCrnGenerator.getBuiltInEnvironmentUserResourceRoleCrn(), MDCUtils.getRequestId());
+                    LOGGER.info("Assigned resourcerole '{}' for  machineUserCrn '{}' for environment '{}'",
+                            roleCrnGenerator.getBuiltInEnvironmentUserResourceRoleCrn(), machineUserCrn, environmentCrn);
+                }
+                syncEnvironment(cluster.getClusterPertain().getTenant(), machineUserCrn, environmentCrn, Optional.empty());
+                clusterService.setMachineUserCrn(cluster.getId(), machineUserCrn);
+            }
+        } catch (Exception ex) {
+            LOGGER.warn("Error initializing machineUserCrn for cluster '{}' yarn polling", cluster.getStackCrn(), ex);
+        }
+    }
+
+    @Retryable(value = Exception.class, maxAttempts = 5, backoff = @Backoff(delay = 10000))
+    public void deleteMachineUserForEnvironment(String accountId, String machineUserCrn, String environmentCrn) {
+        if (environmentCrn != null && machineUserCrn != null) {
+            MachineUser machineUser = getOrCreateAutoscaleMachineUser(environmentCrn, accountId);
+            grpcUmsClient.deleteMachineUser(machineUser.getCrn(), ThreadBasedUserCrnProvider.INTERNAL_ACTOR_CRN, accountId, MDCUtils.getRequestId());
+            syncEnvironment(accountId, machineUserCrn, environmentCrn, Optional.of(machineUser.getWorkloadUsername()));
+            LOGGER.info("Deleted MachineUser for machineUserCrn '{}', environment '{}'", machineUserCrn, environmentCrn);
+        }
+    }
+
+    private MachineUser getOrCreateAutoscaleMachineUser(String environmentCrn, String accountId) {
+        //Idempotent api retrieves machine user or creates if missing.
+        String autoscaleMachineUserName = String.format(AUTOSCALE_MACHINE_USER_NAME_PATTERN, Crn.fromString(environmentCrn).getResource());
+        MachineUser machineUser = grpcUmsClient.getOrCreateMachineUserWithoutAccessKey(autoscaleMachineUserName, accountId, MDCUtils.getRequestId());
+        LOGGER.info("Retrieved machineUser '{}' for machineUserName '{}' ", machineUser, autoscaleMachineUserName);
+        return machineUser;
+    }
+
+    private void syncEnvironment(String accountId, String machineUserCrn, String environmentCrn, Optional<String> deletedWorkloadUserName) {
+        ThreadBasedUserCrnProvider.doAsInternalActor(() -> {
+            SynchronizeAllUsersRequest request = new SynchronizeAllUsersRequest();
+            request.setAccountId(accountId);
+            request.setEnvironments(Set.of(environmentCrn));
+            request.setMachineUsers(Set.of(machineUserCrn));
+            if (deletedWorkloadUserName.isPresent()) {
+                request.setDeletedWorkloadUsers(Set.of(deletedWorkloadUserName.get()));
+            }
+            userV1Endpoint.synchronizeAllUsers(request);
+            LOGGER.info("Triggered freeipa sync for resourcerole '{}', machineUserCrn '{}', for environment '{}'",
+                    roleCrnGenerator.getBuiltInEnvironmentUserResourceRoleCrn(), machineUserCrn, environmentCrn);
+        });
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/configuration/FreeIpaClientConfiguration.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/configuration/FreeIpaClientConfiguration.java
@@ -1,0 +1,43 @@
+package com.sequenceiq.periscope.service.configuration;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.ws.rs.client.WebTarget;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Bean;
+
+import com.sequenceiq.cloudbreak.client.WebTargetEndpointFactory;
+import com.sequenceiq.freeipa.api.client.internal.FreeIpaApiClientParams;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.UserV1Endpoint;
+
+@Configuration
+public class FreeIpaClientConfiguration {
+
+    @Value("${rest.debug:false}")
+    private boolean restDebug;
+
+    @Value("${cert.validation:true}")
+    private boolean certificateValidation;
+
+    @Value("${cert.ignorePreValidation:true}")
+    private boolean ignorePreValidation;
+
+    @Inject
+    @Named("freeIpaServerUrl")
+    private String freeIpaServerUrl;
+
+    @Bean
+    public FreeIpaApiClientParams freeIpaApiClientParams() {
+        return new FreeIpaApiClientParams(restDebug, certificateValidation, ignorePreValidation, freeIpaServerUrl);
+    }
+
+    @Bean
+    @ConditionalOnBean(name = "freeIpaApiClientWebTarget")
+    UserV1Endpoint userV1Endpoint(WebTarget freeIpaApiClientWebTarget) {
+        return new WebTargetEndpointFactory().createEndpoint(freeIpaApiClientWebTarget, UserV1Endpoint.class);
+    }
+}
+

--- a/autoscale/src/main/resources/application.yml
+++ b/autoscale/src/main/resources/application.yml
@@ -53,6 +53,9 @@ periscope:
       addr: localhost
       port: 5432
   cloudbreak.url: http://localhost:9091
+  freeipa:
+    url: http://localhost:8090
+    contextPath: /freeipa
   notification:
     endpoint: http://localhost:3000/notifications
   entitlementCheckEnabled: true

--- a/autoscale/src/main/resources/schema/app/20210920153927_CB-13609_Autoscaling_should_used_machineuser.sql
+++ b/autoscale/src/main/resources/schema/app/20210920153927_CB-13609_Autoscaling_should_used_machineuser.sql
@@ -1,0 +1,17 @@
+-- // CB-13609 Autoscaling should used machineuser
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE cluster ADD COLUMN IF NOT EXISTS environment_crn VARCHAR(255);
+
+ALTER TABLE cluster ADD COLUMN IF NOT EXISTS machine_user_crn VARCHAR(255);
+
+CREATE INDEX IF NOT EXISTS idx_cluster_environment_crn ON cluster (environment_crn);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+DROP INDEX IF EXISTS idx_cluster_environment_crn;
+
+ALTER TABLE cluster DROP COLUMN IF EXISTS environment_crn;
+
+ALTER TABLE cluster DROP COLUMN IF EXISTS machine_user_crn;

--- a/autoscale/src/test/java/com/sequenceiq/periscope/repository/ClusterRepositoryTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/repository/ClusterRepositoryTest.java
@@ -39,6 +39,8 @@ class ClusterRepositoryTest {
 
     private static final String CLOUDBREAK_STACK_CRN_2 = "crn:cdp:datahub:us-west-1:tenant:cluster:35ae1d9d-4c4b-4d11-a714-91eadcc5be8a";
 
+    private static final String TEST_ENV_CRN = "crn:cdp:environments:us-west-1:tenant:environment:c11d716f-8b87-432b-98ef-14a46399ea74";
+
     private static final int TEST_HOSTGROUP_MIN_SIZE = 3;
 
     private static final int TEST_HOSTGROUP_MAX_SIZE = 200;
@@ -101,6 +103,24 @@ class ClusterRepositoryTest {
         List<Cluster> result = underTest.findByTenantAndStackType(TEST_TENANT, StackType.WORKLOAD);
 
         assertThat(result).hasSize(2).hasSameElementsAs(Arrays.asList(loadCluster, timeCluster));
+    }
+
+    @Test
+    void testFindByEnvironmentCrnOrMachineUserCrnWithAllNull() {
+        List<Cluster> result = underTest.findByEnvironmentCrnOrMachineUserCrn(null, null);
+
+        assertThat(result).hasSize(2).hasSameElementsAs(Arrays.asList(loadCluster, timeCluster));
+    }
+
+    @Test
+    void testFindByEnvironmentCrnOrMachineUserCrnWithEnvironmentCrn() {
+        Cluster cluster = getAClusterWithLoadAlerts();
+        cluster.setEnvironmentCrn(TEST_ENV_CRN);
+        saveWithLoadAlerts(cluster);
+
+        List<Cluster> result = underTest.findByEnvironmentCrnOrMachineUserCrn(TEST_ENV_CRN, null);
+
+        assertThat(result).hasSize(3).hasSameElementsAs(Arrays.asList(loadCluster, timeCluster, cluster));
     }
 
     @Test

--- a/autoscale/src/test/java/com/sequenceiq/periscope/service/AltusMachineUserServiceTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/service/AltusMachineUserServiceTest.java
@@ -1,0 +1,158 @@
+package com.sequenceiq.periscope.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.MachineUser;
+import com.google.common.collect.LinkedHashMultimap;
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
+import com.sequenceiq.cloudbreak.auth.altus.service.RoleCrnGenerator;
+import com.sequenceiq.cloudbreak.logger.MDCUtils;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.UserV1Endpoint;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeAllUsersRequest;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.ClusterPertain;
+
+public class AltusMachineUserServiceTest {
+
+    @InjectMocks
+    AltusMachineUserService underTest;
+
+    @Mock
+    private GrpcUmsClient grpcUmsClient;
+
+    @Mock
+    private UserV1Endpoint userV1Endpoint;
+
+    @Mock
+    private ClusterService clusterService;
+
+    @Mock
+    private RoleCrnGenerator roleCrnGenerator;
+
+    private String testEnvironmentCrn;
+
+    private String testAccountId;
+
+    private String autoscaleMachineUserName;
+
+    private String autoscaleMachineUserCrn;
+
+    private String environmentRoleCrn;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        testEnvironmentCrn = "crn:cdp:environments:us-west-1:9d74eee4-1cad-45d7-b645-7ccf9edbb73d:environment:1584cdfa-ad2f-45ff-b3d9-414b5b013001";
+        testAccountId = "testTenant";
+        autoscaleMachineUserName = "datahub-autoscale-metrics-1584cdfa-ad2f-45ff-b3d9-414b5b013001";
+        autoscaleMachineUserCrn = "testMachineUserCrn";
+        environmentRoleCrn = "environmentuserRoleCrn";
+    }
+
+    @Test
+    public void testInitializeMachineUserForEnvironment() {
+        Cluster cluster = getACluster();
+        MachineUser machineUser = mock(MachineUser.class);
+
+        when(machineUser.getCrn()).thenReturn(autoscaleMachineUserCrn);
+        when(grpcUmsClient.getOrCreateMachineUserWithoutAccessKey(autoscaleMachineUserName, testAccountId, MDCUtils.getRequestId()))
+                .thenReturn(machineUser);
+        when(grpcUmsClient.listAssignedResourceRoles(anyString(), any(Optional.class)))
+                .thenReturn(LinkedHashMultimap.create());
+        when(roleCrnGenerator.getBuiltInEnvironmentUserResourceRoleCrn()).thenReturn(environmentRoleCrn);
+
+        underTest.initializeMachineUserForEnvironment(cluster);
+
+        verify(grpcUmsClient, times(1)).assignResourceRole(
+                eq(autoscaleMachineUserCrn), eq(testEnvironmentCrn), eq(environmentRoleCrn), any(Optional.class));
+        verify(clusterService, times(1)).setMachineUserCrn(cluster.getId(), autoscaleMachineUserCrn);
+
+        ArgumentCaptor<SynchronizeAllUsersRequest> synchronizeUserCaptor = ArgumentCaptor.forClass(SynchronizeAllUsersRequest.class);
+        verify(userV1Endpoint, times(1)).synchronizeAllUsers(synchronizeUserCaptor.capture());
+
+        SynchronizeAllUsersRequest synchronizeAllUsersRequest = synchronizeUserCaptor.getValue();
+        assertEquals("Environment Crn Should match", synchronizeAllUsersRequest.getEnvironments(), Set.of(testEnvironmentCrn));
+        assertEquals("Machine User Crn Should match", synchronizeAllUsersRequest.getMachineUsers(), Set.of(autoscaleMachineUserCrn));
+        assertEquals("Account Id Should match", synchronizeAllUsersRequest.getAccountId(), cluster.getClusterPertain().getTenant());
+    }
+
+    @Test
+    public void testinitializeMachineUserForEnvironmentWhenRoleAlreadyAssigned() {
+        Cluster cluster = getACluster();
+        MachineUser machineUser = mock(MachineUser.class);
+
+        LinkedHashMultimap rolesMap = LinkedHashMultimap.create();
+        rolesMap.put(cluster.getEnvironmentCrn(), environmentRoleCrn);
+
+        when(grpcUmsClient.getOrCreateMachineUserWithoutAccessKey(autoscaleMachineUserName, testAccountId, MDCUtils.getRequestId()))
+                .thenReturn(machineUser);
+        when(machineUser.getCrn()).thenReturn(autoscaleMachineUserCrn);
+        when(grpcUmsClient.listAssignedResourceRoles(anyString(), any(Optional.class))).thenReturn(rolesMap);
+        when(roleCrnGenerator.getBuiltInEnvironmentUserResourceRoleCrn()).thenReturn(environmentRoleCrn);
+
+        underTest.initializeMachineUserForEnvironment(cluster);
+
+        verify(grpcUmsClient, times(0)).assignResourceRole(
+                eq(autoscaleMachineUserCrn), eq(testEnvironmentCrn), eq(environmentRoleCrn), any(Optional.class));
+        verify(clusterService, times(1)).setMachineUserCrn(cluster.getId(), autoscaleMachineUserCrn);
+
+        ArgumentCaptor<SynchronizeAllUsersRequest> synchronizeUserCaptor = ArgumentCaptor.forClass(SynchronizeAllUsersRequest.class);
+        verify(userV1Endpoint, times(1)).synchronizeAllUsers(synchronizeUserCaptor.capture());
+
+        SynchronizeAllUsersRequest synchronizeAllUsersRequest = synchronizeUserCaptor.getValue();
+        assertEquals("Environment Crn Should match", synchronizeAllUsersRequest.getEnvironments(), Set.of(testEnvironmentCrn));
+        assertEquals("Machine User Crn Should match", synchronizeAllUsersRequest.getMachineUsers(), Set.of(autoscaleMachineUserCrn));
+        assertEquals("Account Id Should match", synchronizeAllUsersRequest.getAccountId(), cluster.getClusterPertain().getTenant());
+    }
+
+    @Test
+    public void testDeleteMachineUserForEnvironment() {
+        MachineUser machineUserMock = mock(MachineUser.class);
+        when(machineUserMock.getCrn()).thenReturn(autoscaleMachineUserCrn);
+        when(machineUserMock.getWorkloadUsername()).thenReturn("workloadUserName");
+        when(roleCrnGenerator.getBuiltInEnvironmentUserResourceRoleCrn()).thenReturn(environmentRoleCrn);
+        when(grpcUmsClient.getOrCreateMachineUserWithoutAccessKey(eq(autoscaleMachineUserName),
+                eq("testTenant"), any(Optional.class))).thenReturn(machineUserMock);
+
+        underTest.deleteMachineUserForEnvironment(testAccountId, autoscaleMachineUserCrn, testEnvironmentCrn);
+
+        verify(grpcUmsClient, times(1)).deleteMachineUser(
+                eq(autoscaleMachineUserCrn), eq(ThreadBasedUserCrnProvider.INTERNAL_ACTOR_CRN), eq(testAccountId), any(Optional.class));
+        ArgumentCaptor<SynchronizeAllUsersRequest> synchronizeUserCaptor = ArgumentCaptor.forClass(SynchronizeAllUsersRequest.class);
+        verify(userV1Endpoint, times(1)).synchronizeAllUsers(synchronizeUserCaptor.capture());
+        SynchronizeAllUsersRequest synchronizeAllUsersRequest = synchronizeUserCaptor.getValue();
+        assertEquals("WorkloadUserName Should match", synchronizeAllUsersRequest.getDeletedWorkloadUsers(), Set.of("workloadUserName"));
+        assertEquals("Environment Crn Should match", synchronizeAllUsersRequest.getEnvironments(), Set.of(testEnvironmentCrn));
+        assertEquals("Machine User Crn Should match", synchronizeAllUsersRequest.getMachineUsers(), Set.of(autoscaleMachineUserCrn));
+        assertEquals("Account Id Should match", synchronizeAllUsersRequest.getAccountId(), testAccountId);
+    }
+
+    protected Cluster getACluster() {
+        Cluster cluster = new Cluster();
+        cluster.setEnvironmentCrn(testEnvironmentCrn);
+        cluster.setId(10);
+
+        ClusterPertain clusterPertain = new ClusterPertain();
+        clusterPertain.setTenant(testAccountId);
+        cluster.setClusterPertain(clusterPertain);
+        return cluster;
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/AutoscaleStackV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/AutoscaleStackV4Response.java
@@ -72,6 +72,9 @@ public class AutoscaleStackV4Response {
     @ApiModelProperty(StackModelDescription.TYPE)
     private StackType stackType;
 
+    @ApiModelProperty(StackModelDescription.ENVIRONMENT_CRN)
+    private String environmentCrn;
+
     @ApiModelProperty(StackModelDescription.TUNNEL)
     private Tunnel tunnel;
 
@@ -217,5 +220,13 @@ public class AutoscaleStackV4Response {
 
     public void setCloudPlatform(String cloudPlatform) {
         this.cloudPlatform = cloudPlatform;
+    }
+
+    public String getEnvironmentCrn() {
+        return environmentCrn;
+    }
+
+    public void setEnvironmentCrn(String environmentCrn) {
+        this.environmentCrn = environmentCrn;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackToAutoscaleStackV4ResponseConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackToAutoscaleStackV4ResponseConverter.java
@@ -24,6 +24,7 @@ public class StackToAutoscaleStackV4ResponseConverter {
         result.setCloudPlatform(source.getCloudPlatform());
         result.setUserCrn(source.getCreator().getUserCrn());
         result.setStackType(source.getType());
+        result.setEnvironmentCrn(source.getEnvironmentCrn());
 
         if (source.getCluster() != null) {
             Cluster cluster = source.getCluster();


### PR DESCRIPTION
… recommendations

 - An internal machine user with EnvironmentUser role is used to query yarn
 - This machine user will be deleted once the cluster has been deleted.

See detailed description in the commit message.