### PR TITLE
CB-16565. Monitoring: Add VM dev stack (prometheus + grafana) for tes…

### DIFF
--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/dev-stack.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/dev-stack.sls
@@ -1,0 +1,61 @@
+/opt/dev-prometheus:
+  file.directory:
+    - name: /opt/dev-prometheus
+    - mode: 740
+
+/opt/dev-prometheus/data:
+  file.directory:
+    - name: /opt/dev-prometheus/data
+    - mode: 740
+
+install_prometheus:
+  archive.extracted:
+    - name: /opt/dev-prometheus/
+    - source: https://github.com/prometheus/prometheus/releases/download/v1.4.1/prometheus-1.4.1.linux-amd64.tar.gz
+    - archive_format: tar
+    - enforce_toplevel: False
+    - source_hash: md5=6cfb712ef7f33f42611bf7ebb02bc740
+    - options: --strip-components=1
+    - if_missing: /opt/dev-prometheus/prometheus
+
+/opt/dev-prometheus/prometheus.yml:
+  file.managed:
+    - user: root
+    - group: root
+    - mode: 600
+    - source: salt://monitoring/dev/prometheus.yml
+
+/etc/systemd/system/dev-prometheus.service:
+  file.managed:
+    - source: salt://monitoring/systemd/dev-prometheus.service
+    - template: jinja
+    - user: "root"
+    - group: "root"
+    - mode: 640
+
+start_dev_prometheus:
+  service.running:
+    - enable: True
+    - name: dev-prometheus
+    - watch:
+      - file: /etc/systemd/system/dev-prometheus.service
+
+/etc/yum.repos.d/dev-grafana.repo:
+  file.managed:
+    - source: salt://monitoring/dev/dev-grafana.repo
+    - template: jinja
+    - mode: 640
+
+clean_grafana_repo:
+  cmd.run:
+    - name: yum clean all --disablerepo="*" --enablerepo=grafana
+
+install_grafana:
+  pkg.installed:
+    - pkgs:
+        - grafana
+
+start_dev_grafana:
+  service.running:
+    - enable: True
+    - name: grafana-server

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/dev/dev-grafana.repo
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/dev/dev-grafana.repo
@@ -1,0 +1,9 @@
+[grafana]
+name=grafana
+baseurl=https://packages.grafana.com/oss/rpm
+repo_gpgcheck=1
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.grafana.com/gpg.key
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/dev/prometheus.yml
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/dev/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval:     15s
+  evaluation_interval: 15s
+rule_files:
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/init.sls
@@ -36,3 +36,8 @@ start_monitoring:
     - mode: 600
     - source: salt://monitoring/cron/cdp_resources_check
 
+{% if monitoring.useDevStack %}
+include:
+  - monitoring.dev-stack
+{% endif %}
+

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/settings.sls
@@ -12,6 +12,7 @@
     {% set is_systemd = True %}
 {% endif %}
 
+{% set use_dev_stack = salt['pillar.get']('monitoring:useDevStack') %}
 {% set type = salt['pillar.get']('monitoring:type') %}
 {% set cm_username = salt['pillar.get']('monitoring:cmUsername') %}
 {% set cm_password = salt['pillar.get']('monitoring:cmPassword') %}
@@ -28,5 +29,6 @@
     "type": type,
     "cmUsername": cm_username,
     "cmPassword": cm_password,
-    "cmClusterType": cm_cluster_type
+    "cmClusterType": cm_cluster_type,
+    "useDevStack": use_dev_stack
 }) %}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/systemd/dev-prometheus.service
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/systemd/dev-prometheus.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Dev Prometheus
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+User=root
+Group=root
+ExecStart=/opt/dev-prometheus/prometheus \
+  --config.file=/opt/dev-prometheus/prometheus.yml \
+  --storage.local.path="/opt/dev-prometheus/data/dev-prometheus" \
+  --web.console.templates=/opt/dev-prometheus/consoles \
+  --web.console.libraries=/opt/dev-prometheus/console_libraries \
+  --web.listen-address=0.0.0.0:9090
+
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
…ting purposes.

details:
- add grafana rpm repo and install if useDevStack is enabled
- download prometheus and install it into /opt/dev-prometheus if useDevStack is enabled
- start dev-prometheus and grafana as daemon systemd services

See detailed description in the commit message.