### PR TITLE
CB-16555 instance status checker should never fail when status reason is not present

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/freeipa/FreeIpaInstanceWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/freeipa/FreeIpaInstanceWaitObject.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,8 +65,17 @@ public class FreeIpaInstanceWaitObject implements InstanceWaitObject {
 
     @Override
     public Map<String, String> actualStatusReason() {
-        return getInstanceMetaDatas().stream().collect(Collectors.toMap(InstanceMetaDataResponse::getInstanceId,
-                InstanceMetaDataResponse::getState));
+        return getInstanceMetaDatas().stream()
+                .collect(Collectors.toMap(InstanceMetaDataResponse::getInstanceId,
+                        instanceMetaData -> {
+                            String statusReason = instanceMetaData.getState();
+                            if (StringUtils.isBlank(statusReason)) {
+                                return "Status reason is NOT available for FreeIPA instance!";
+                            } else {
+                                return statusReason;
+                            }
+                        }
+                ));
     }
 
     @Override


### PR DESCRIPTION
Some of the E2E tests are failing, because of `java.lang.NullPointerException` from:
```
...
at com.sequenceiq.it.cloudbreak.util.wait.service.instance.cloudbreak.CloudbreakInstanceWaitObject.actualStatusReason(CloudbreakInstanceWaitObject.java:75)
at com.sequenceiq.it.cloudbreak.util.wait.service.instance.InstanceOperationChecker.handleTimeout(InstanceOperationChecker.java:55)
at com.sequenceiq.it.cloudbreak.util.wait.service.instance.InstanceOperationChecker.handleTimeout(InstanceOperationChecker.java:12)
at com.sequenceiq.it.cloudbreak.util.wait.service.WaitService.waitObject(WaitService.java:60)
...
```
and 
```
...
com.sequenceiq.it.cloudbreak.util.wait.service.instance.freeipa.FreeIpaInstanceWaitObject.actualStatusReason(FreeIpaInstanceWaitObject.java:68)
at com.sequenceiq.it.cloudbreak.util.wait.service.instance.InstanceOperationChecker.checkStatus(InstanceOperationChecker.java:33)
at com.sequenceiq.it.cloudbreak.util.wait.service.instance.InstanceOperationChecker.checkStatus(InstanceOperationChecker.java:12)
at com.sequenceiq.it.cloudbreak.util.wait.service.WaitService.waitObject(WaitService.java:33)
...
```
So we should eliminate the risk to fail an entire test, because of a missing `StatusReason`.