### PR TITLE
CB-16559 : Change FreeIPA default instance type to make it compatible for encryptionAtHost

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/instance/DefaultInstanceTypeProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/instance/DefaultInstanceTypeProvider.java
@@ -17,10 +17,10 @@ import com.sequenceiq.cloudbreak.cloud.model.generic.StringType;
 /**
  * This class reads the environment properties of default instance type configurations for each cloud provider platform.
  * In order to configure a instance type for a platform, eg. AWS, one must specify a property like this:
- * -Dfreeipa.platform.default.instanceType.AWS=m5.xlarge
+ * -Dfreeipa.platform.default.instanceType.AWS=m5.large
  *
  * For Azure:
- * -Dfreeipa.platform.default.instanceType.AZURE=Standard_D3_v2
+ * -Dfreeipa.platform.default.instanceType.AZURE=Standard_DS3_v2
  *
  * etc.
  *

--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -65,7 +65,7 @@ freeipa:
     cache.ttl: 15
   platform.default.instanceType:
     AWS: m5.large
-    AZURE: Standard_D3_v2
+    AZURE: Standard_DS3_v2
     GCP: n1-standard-2
   platform.dnssec.validation:
     AWS: true


### PR DESCRIPTION
CB-16559 : Change FreeIPA default instance type to make it compatible for encryptionAtHost
This commit updates the default instance type for FreeIPA from "Standard_D3_v2" to "Standard_DS3_v2". Also, fixes a comment for AWS default instance type.
