### PR TITLE
CB-16575 User data did not contain the proxy's protocol

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/userdata/UserDataBuilder.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/userdata/UserDataBuilder.java
@@ -94,6 +94,7 @@ public class UserDataBuilder {
             model.put("proxyEnabled", Boolean.TRUE);
             model.put("proxyHost", proxyConfig.getServerHost());
             model.put("proxyPort", proxyConfig.getServerPort().toString());
+            model.put("proxyProtocol", proxyConfig.getProtocol());
             proxyConfig.getProxyAuthentication().ifPresent(auth -> {
                 model.put("proxyUser", auth.getUserName());
                 model.put("proxyPassword", auth.getPassword());

--- a/core/src/main/resources/init/init.ftl
+++ b/core/src/main/resources/init/init.ftl
@@ -19,6 +19,7 @@ export CB_CERT=${cbCert}
 export IS_PROXY_ENABLED=true
 export PROXY_HOST=${proxyHost}
 export PROXY_PORT=${proxyPort}
+export PROXY_PROTOCOL=${proxyProtocol}
 <#if proxyUser??>
 export PROXY_USER="${proxyUser}"
 <#if proxyPassword??>

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/userdata/UserDataBuilderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/userdata/UserDataBuilderTest.java
@@ -144,6 +144,7 @@ public class UserDataBuilderTest {
                 .withServerHost("proxy.host")
                 .withServerPort(1234)
                 .withNoProxyHosts("noproxy.com")
+                .withProtocol("http")
                 .build();
         Map<InstanceGroupType, String> userdata = underTest.buildUserData(Platform.platform("AZURE"), "priv-key".getBytes(),
                 "cloudbreak", getPlatformParameters(), "pass", "cert", new CcmConnectivityParameters(), proxyConfig);
@@ -164,6 +165,7 @@ public class UserDataBuilderTest {
                 .withServerPort(1234)
                 .withProxyAuthentication(proxyAuthentication)
                 .withNoProxyHosts("noproxy.com")
+                .withProtocol("https")
                 .build();
         Map<InstanceGroupType, String> userdata = underTest.buildUserData(Platform.platform("AZURE"), "priv-key".getBytes(),
                 "cloudbreak", getPlatformParameters(), "pass", "cert", new CcmConnectivityParameters(), proxyConfig);

--- a/core/src/test/resources/azure-gateway-init-authproxy.sh
+++ b/core/src/test/resources/azure-gateway-init-authproxy.sh
@@ -18,6 +18,7 @@ export CB_CERT=cert
 export IS_PROXY_ENABLED=true
 export PROXY_HOST=proxy.host
 export PROXY_PORT=1234
+export PROXY_PROTOCOL=https
 export PROXY_USER="user"
 export PROXY_PASSWORD="pwd"
 export PROXY_NO_PROXY_HOSTS="noproxy.com"

--- a/core/src/test/resources/azure-gateway-init-noauthproxy.sh
+++ b/core/src/test/resources/azure-gateway-init-noauthproxy.sh
@@ -18,6 +18,7 @@ export CB_CERT=cert
 export IS_PROXY_ENABLED=true
 export PROXY_HOST=proxy.host
 export PROXY_PORT=1234
+export PROXY_PROTOCOL=http
 export PROXY_NO_PROXY_HOSTS="noproxy.com"
 export IS_CCM_ENABLED=false
 export IS_CCM_V2_ENABLED=false

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/userdata/UserDataBuilder.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/userdata/UserDataBuilder.java
@@ -113,6 +113,7 @@ public class UserDataBuilder {
             model.put("proxyEnabled", Boolean.TRUE);
             model.put("proxyHost", proxyConfig.getServerHost());
             model.put("proxyPort", proxyConfig.getServerPort().toString());
+            model.put("proxyProtocol", proxyConfig.getProtocol());
             proxyConfig.getProxyAuthentication().ifPresent(auth -> {
                 model.put("proxyUser", auth.getUserName());
                 model.put("proxyPassword", auth.getPassword());

--- a/freeipa/src/main/resources/init/init.ftl
+++ b/freeipa/src/main/resources/init/init.ftl
@@ -20,6 +20,7 @@ export CB_CERT=${cbCert}
 export IS_PROXY_ENABLED=true
 export PROXY_HOST=${proxyHost}
 export PROXY_PORT=${proxyPort}
+export PROXY_PROTOCOL=${proxyProtocol}
 <#if proxyUser??>
 export PROXY_USER="${proxyUser}"
 <#if proxyPassword??>

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/userdata/UserDataBuilderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/userdata/UserDataBuilderTest.java
@@ -40,6 +40,8 @@ import com.sequenceiq.cloudbreak.ccm.endpoint.KnownServiceIdentifier;
 import com.sequenceiq.cloudbreak.cloud.PlatformParameters;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
 import com.sequenceiq.cloudbreak.cloud.model.ScriptParams;
+import com.sequenceiq.cloudbreak.dto.ProxyAuthentication;
+import com.sequenceiq.cloudbreak.dto.ProxyConfig;
 import com.sequenceiq.cloudbreak.util.FileReaderUtils;
 import com.sequenceiq.cloudbreak.util.FreeMarkerTemplateUtils;
 import com.sequenceiq.common.api.type.CcmV2TlsType;
@@ -90,7 +92,17 @@ class UserDataBuilderTest {
         DefaultTunnelParameters nginxTunnel = new DefaultTunnelParameters(KnownServiceIdentifier.GATEWAY, 9443);
         CcmParameters ccmParameters = new DefaultCcmParameters(serverParameters, instanceParameters, List.of(nginxTunnel));
         CcmConnectivityParameters ccmConnectivityParameters = new CcmConnectivityParameters(ccmParameters);
-
+        ProxyAuthentication proxyAuthentication = ProxyAuthentication.builder()
+                .withUserName("user")
+                .withPassword("pwd")
+                .build();
+        ProxyConfig proxyConfig = ProxyConfig.builder()
+                .withServerHost("proxy.host")
+                .withServerPort(1234)
+                .withProxyAuthentication(proxyAuthentication)
+                .withNoProxyHosts("noproxy.com")
+                .withProtocol("https")
+                .build();
         PlatformParameters platformParameters = mock(PlatformParameters.class);
         ScriptParams scriptParams = mock(ScriptParams.class);
         when(scriptParams.getDiskPrefix()).thenReturn("sd");
@@ -98,7 +110,7 @@ class UserDataBuilderTest {
         when(platformParameters.scriptParams()).thenReturn(scriptParams);
 
         String userData = underTest.buildUserData(ACCOUNT_ID, environment, Platform.platform("AZURE"), "priv-key".getBytes(),
-                "cloudbreak", platformParameters, "pass", "cert", ccmConnectivityParameters, null);
+                "cloudbreak", platformParameters, "pass", "cert", ccmConnectivityParameters, proxyConfig);
 
         String expectedUserData = FileReaderUtils.readFileFromClasspath("azure-ccm-init.sh");
         assertEquals(expectedUserData, userData);
@@ -174,4 +186,5 @@ class UserDataBuilderTest {
         String expectedUserData = FileReaderUtils.readFileFromClasspath("azure-init.sh");
         assertEquals(expectedUserData, userData);
     }
+
 }

--- a/freeipa/src/test/resources/azure-ccm-init.sh
+++ b/freeipa/src/test/resources/azure-ccm-init.sh
@@ -16,7 +16,13 @@ export SSH_USER=cloudbreak
 export SALT_BOOT_PASSWORD=pass
 export SALT_BOOT_SIGN_KEY=cHJpdi1rZXk=
 export CB_CERT=cert
-export IS_PROXY_ENABLED=false
+export IS_PROXY_ENABLED=true
+export PROXY_HOST=proxy.host
+export PROXY_PORT=1234
+export PROXY_PROTOCOL=https
+export PROXY_USER="user"
+export PROXY_PASSWORD="pwd"
+export PROXY_NO_PROXY_HOSTS="noproxy.com"
 export IS_CCM_ENABLED=true
 export CCM_HOST=ccm.cloudera.com
 export CCM_SSH_PORT=8990


### PR DESCRIPTION
It caused an issue when the user created a https proxy but the proxy URL was
assembled with fixed "http" protocol
Needs a fix in the cloudbreak-images repo too.

See detailed description in the commit message.