### PR TITLE
DISTX-681: Switch DE templates to use temporaryStorage as ephemeral volumes

### DIFF
--- a/core/src/main/resources/defaults/clustertemplates/7.2.14/aws/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.14/aws/dataengineering-ha.json
@@ -43,14 +43,14 @@
         "recoveryMode": "MANUAL",
         "template": {
           "aws": {},
-          "instanceType": "m5.4xlarge",
+          "instanceType": "r5d.4xlarge",
           "rootVolume": {
             "size": 150
           },
           "attachedVolumes": [{
-            "size": 500,
-            "count": 1,
-            "type": "gp2"
+            "size": 300,
+            "count": 2,
+            "type": "ephemeral"
           }],
           "cloudPlatform": "AWS"
         },
@@ -87,7 +87,7 @@
               "strategy" : "PARTITION"
             }
           },
-          "instanceType": "m5.4xlarge",
+          "instanceType": "r5d.4xlarge",
           "rootVolume": {
             "size": 150
           },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.14/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.14/aws/dataengineering-spark3.json
@@ -36,8 +36,8 @@
           "attachedVolumes": [
             {
               "count": 1,
-              "size": 100,
-              "type": "gp2"
+              "size": 300,
+              "type": "ephemeral"
             }
           ],
           "aws": {
@@ -45,7 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge"
+          "instanceType": "r5d.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -66,7 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge"
+          "instanceType": "r5d.2xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.14/aws/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.14/aws/dataengineering.json
@@ -36,8 +36,8 @@
           "attachedVolumes": [
             {
               "count": 1,
-              "size": 100,
-              "type": "gp2"
+              "size": 300,
+              "type": "ephemeral"
             }
           ],
           "aws": {
@@ -45,7 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge"
+          "instanceType": "r5d.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -66,7 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge"
+          "instanceType": "r5d.2xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.15/aws/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.15/aws/dataengineering-ha.json
@@ -43,14 +43,14 @@
         "recoveryMode": "MANUAL",
         "template": {
           "aws": {},
-          "instanceType": "m5.4xlarge",
+          "instanceType": "r5d.4xlarge",
           "rootVolume": {
             "size": 150
           },
           "attachedVolumes": [{
-            "size": 500,
-            "count": 1,
-            "type": "gp2"
+            "size": 300,
+            "count": 2,
+            "type": "ephemeral"
           }],
           "cloudPlatform": "AWS"
         },
@@ -87,7 +87,7 @@
               "strategy" : "PARTITION"
             }
           },
-          "instanceType": "m5.4xlarge",
+          "instanceType": "r5d.4xlarge",
           "rootVolume": {
             "size": 150
           },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.15/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.15/aws/dataengineering-spark3.json
@@ -36,8 +36,8 @@
           "attachedVolumes": [
             {
               "count": 1,
-              "size": 100,
-              "type": "gp2"
+              "size": 300,
+              "type": "ephemeral"
             }
           ],
           "aws": {
@@ -45,7 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge"
+          "instanceType": "r5d.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -66,7 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge"
+          "instanceType": "r5d.2xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.15/aws/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.15/aws/dataengineering.json
@@ -36,8 +36,8 @@
           "attachedVolumes": [
             {
               "count": 1,
-              "size": 100,
-              "type": "gp2"
+              "size": 300,
+              "type": "ephemeral"
             }
           ],
           "aws": {
@@ -45,7 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge"
+          "instanceType": "r5d.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -66,7 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge"
+          "instanceType": "r5d.2xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",


### PR DESCRIPTION
DISTX-681: Switch DE templates to use temporaryStorage as ephemeral volumes

This commit changes the instance type for compute and worker nodes of Data engineering cluster templates for AWS of 7.2.14 and 7.2.15.
Compute nodes are updated to use "r5d.2xlarge" and "r5d.4xlarge" for non-ha and ha templates respectively with ephemeral volume.
Worker nodes are updated to use "r5d.2xlarge" and "r5d.4xlarge" for non-ha and ha templates respectively with gp2/ebs volume.
