### PR TITLE
CB-16361. Add extra tests against cdp-infra-tools repo.

### DIFF
--- a/orchestrator-salt/src/main/resources/salt-common/salt/telemetry/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/telemetry/settings.sls
@@ -93,6 +93,11 @@
 {% set repo_base_url = salt['pillar.get']('telemetry:repoBaseUrl') %}
 {% set repo_gpg_key = salt['pillar.get']('telemetry:repoGpgKey') %}
 {% set repo_gpg_check = salt['pillar.get']('telemetry:repoGpgCheck') %}
+{% if salt['pillar.get']('cloudera-manager:paywall_username') %}
+  {% set test_infra_repo_curl_cmd = 'curl -o /dev/null -s -w "%{http_code}" --max-time 30 -s -k -L -f -u $(grep username= /etc/yum.repos.d/cdp-infra-tools.repo | cut -d = -f2):$(grep password= /etc/yum.repos.d/cdp-infra-tools.repo | cut -d = -f2) ' + repo_gpg_key + ' | grep 200' %}
+{% else %}
+  {% set test_infra_repo_curl_cmd = 'curl -o /dev/null -s -w "%{http_code}" --max-time 30 -s -k -L -f ' + repo_gpg_key + ' | grep 200' %}
+{% endif %}
 
 {% do telemetry.update({
     "platform": platform,
@@ -120,5 +125,6 @@
     "noProxyHosts": no_proxy_hosts,
     "logs": logs,
     "skipValidation": skip_validation,
-    "testCloudStorageUploadParams": test_cloud_storage_upload_params
+    "testCloudStorageUploadParams": test_cloud_storage_upload_params,
+    "testInfraRepoCurlCmd": test_infra_repo_curl_cmd
 }) %}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/telemetry/template/proxy.env.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/telemetry/template/proxy.env.j2
@@ -1,0 +1,8 @@
+#!/bin/bash
+{%- from 'telemetry/settings.sls' import telemetry with context %}
+{%- if telemetry.proxyUrl %}
+export https_proxy={{ telemetry.proxyUrl }}
+  {%- if telemetry.noProxyHosts %}
+export no_proxy={{ telemetry.noProxyHosts }}
+  {%- endif %}
+{%- endif %}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/telemetry/upgrade.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/telemetry/upgrade.sls
@@ -1,6 +1,12 @@
 {%- from 'telemetry/settings.sls' import telemetry with context %}
 {% set test_cmd = 'test -f /etc/yum.repos.d/cdp-infra-tools.repo && (' + telemetry.testInfraRepoCurlCmd + ')' %}
 {% set test_delete_cmd = 'test -f /etc/yum.repos.d/cdp-infra-tools.repo && ! (' + telemetry.testInfraRepoCurlCmd + ')' %}
+/opt/cdp-telemetry/conf/proxy.env:
+  file.managed:
+    - source: salt://telemetry/template/proxy.env.j2
+    - template: jinja
+    - mode: 700
+
 {%- if telemetry.repoName and (telemetry.desiredCdpTelemetryVersion or telemetry.desiredCdpLoggingAgentVersion) %}
 /etc/yum.repos.d/cdp-infra-tools.repo:
   file.managed:
@@ -16,14 +22,7 @@
 delete_repo_file:
   file.absent:
     - name: /etc/yum.repos.d/cdp-infra-tools.repo
-    - onlyif: {{ test_delete_cmd }}
-    {%- if telemetry.proxyUrl %}
-    - env:
-       - https_proxy: {{ telemetry.proxyUrl }}
-       {%- if telemetry.noProxyHosts %}
-       - no_proxy: {{ telemetry.noProxyHosts }}
-       {%- endif %}
-    {%- endif %}
+    - onlyif: source /opt/cdp-telemetry/conf/proxy.env; {{ test_delete_cmd }}
 
 /opt/salt/scripts/cdp-telemetry-deployer.sh:
     file.managed:
@@ -35,17 +34,10 @@ upgrade_cdp_infra_tools_components:
     cmd.run:
         - names:
 {%- if telemetry.desiredCdpTelemetryVersion %}
-          - /bin/bash -c '/opt/salt/scripts/cdp-telemetry-deployer.sh upgrade -c cdp-telemetry -v {{ telemetry.desiredCdpTelemetryVersion }}';exit 0
+          - /bin/bash -c 'source /opt/cdp-telemetry/conf/proxy.env; /opt/salt/scripts/cdp-telemetry-deployer.sh upgrade -c cdp-telemetry -v {{ telemetry.desiredCdpTelemetryVersion }}';exit 0
 {%- endif %}
 {%- if telemetry.desiredCdpLoggingAgentVersion %}
-          - /bin/bash -c '/opt/salt/scripts/cdp-telemetry-deployer.sh upgrade -c cdp-logging-agent -v {{ telemetry.desiredCdpLoggingAgentVersion }}';exit 0
+          - /bin/bash -c 'source /opt/cdp-telemetry/conf/proxy.env; /opt/salt/scripts/cdp-telemetry-deployer.sh upgrade -c cdp-logging-agent -v {{ telemetry.desiredCdpLoggingAgentVersion }}';exit 0
 {%- endif %}
-        - onlyif: {{ test_cmd }}
-    {%- if telemetry.proxyUrl %}
-        - env:
-          - https_proxy: {{ telemetry.proxyUrl }}
-          {%- if telemetry.noProxyHosts %}
-          - no_proxy: {{ telemetry.noProxyHosts }}
-          {%- endif %}
-    {%- endif %}
+        - onlyif: source /opt/cdp-telemetry/conf/proxy.env; {{ test_cmd }}
 {%- endif %}


### PR DESCRIPTION
details:
- at the moment repo usage is skipped if it is available
- possibly, with wrong paywall credentials - it's still can be available but you can get 403 errors
- to avoid authz/r issues, use a curl against the Rpm key, to see we can successfully download it, if we cannot, delete the repo file if it was created before and do not execute any upgrade commands
- in case of no desiredXXXVersion is set, skip the repo file generation (for the deletion, that will be handled)

See detailed description in the commit message.