### PR TITLE
CB-16547 Upscale failed during Post installing FreeIPA

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/handler/RemoveReplicationAgreementsHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/handler/RemoveReplicationAgreementsHandler.java
@@ -53,19 +53,16 @@ public class RemoveReplicationAgreementsHandler extends ExceptionCatcherEventHan
     @Override
     protected Selectable doAccept(HandlerEvent<RemoveReplicationAgreementsRequest> event) {
         RemoveReplicationAgreementsRequest request = event.getData();
-        Selectable result;
         try {
             Long stackId = request.getResourceId();
             Stack stack = stackService.getStackById(stackId);
             FreeIpaClient freeIpaClient = freeIpaClientFactory.getFreeIpaClientForStack(stack);
             freeIpaTopologyService.updateReplicationTopology(stackId, request.getHosts(), freeIpaClient);
-
-            result = new RemoveReplicationAgreementsResponse(request.getResourceId());
+            return new RemoveReplicationAgreementsResponse(request.getResourceId());
         } catch (Exception e) {
             LOGGER.error("Downscale removing replication agreements failed", e);
-            result = new DownscaleFailureEvent(REMOVE_REPLICATION_AGREEMENTS_FAILED_EVENT.event(),
+            return new DownscaleFailureEvent(REMOVE_REPLICATION_AGREEMENTS_FAILED_EVENT.event(),
                     request.getResourceId(), "Downscale Remove Replication Agreements", Set.of(), Map.of(), e);
         }
-        return result;
     }
 }


### PR DESCRIPTION
Sometimes adding a replica topology fails when upscaling FreeIPA.
After the investigation it seems this is caused by the way FreeIPA/389ds replication works, as it's eventual consistency.
If the new FreeIPA instance is in connection with an instance and the new topology command runs against another replica it might have not the information yet.
To avoid this issue until CB-15454 is implemented, a retry is added to give time for the replication to happen.

The chance for the issue to happen without this retry according to my test runs is about 5%, after the change I wasn't able to reproduce the issue.