### PR TITLE
CB-15848 - Cloudera Manager upgrade flow step is not restartable

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerStatusListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerStatusListenerTask.java
@@ -1,0 +1,22 @@
+package com.sequenceiq.cloudbreak.cm.polling.task;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.cluster.service.ClusterEventService;
+import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
+
+public class ClouderaManagerStatusListenerTask extends ClouderaManagerStartupListenerTask {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerStatusListenerTask.class);
+
+    public ClouderaManagerStatusListenerTask(ClouderaManagerApiPojoFactory clouderaManagerApiPojoFactory, ClusterEventService clusterEventService) {
+        super(clouderaManagerApiPojoFactory, clusterEventService);
+    }
+
+    @Override
+    public void handleTimeout(ClouderaManagerPollerObject clouderaManagerPollerObject) {
+        LOGGER.info("Timeout ignored for polling of CM status of stack id {}, command={}.", clouderaManagerPollerObject.getStack().getId(), getPollingName());
+    }
+}


### PR DESCRIPTION
This commit contains the following:
 - stopCluster check if CM is up and running
 - if it is stopped then we do not attempt to stop it once again as it would result in an ApiException
 - if not then the logic is as it used to be

See detailed description in the commit message.