### PR TITLE
CB-16257: Remove phantom parcels from CM and DB which can cause stuck upgrades and upscales.

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/service/ClouderaManagerProductsProvider.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/service/ClouderaManagerProductsProvider.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
 import com.sequenceiq.cloudbreak.cloud.model.component.StackType;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.common.type.ComponentType;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterComponent;
 
@@ -32,6 +33,13 @@ public class ClouderaManagerProductsProvider {
                 .filter(clusterComponent -> clusterComponent.getName().equals(StackType.CDH.name()))
                 .map(this::getClouderaManagerProduct)
                 .findFirst();
+    }
+
+    public ClouderaManagerProduct getCdhProducts(Set<ClouderaManagerProduct> products) {
+        return products.stream()
+                .filter(service -> service.getName().equals(StackType.CDH.name()))
+                .findFirst()
+                .orElseThrow(() -> new NotFoundException("Runtime component not found!"));
     }
 
     private ClouderaManagerProduct getClouderaManagerProduct(ClusterComponent clusterComponent) {

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
@@ -78,7 +78,6 @@ import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
 import com.sequenceiq.cloudbreak.cm.model.ParcelStatus;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollingServiceProvider;
 import com.sequenceiq.cloudbreak.cm.polling.PollingResultErrorHandler;
-import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.common.type.Versioned;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
@@ -286,7 +285,7 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
                 callPostClouderaRuntimeUpgradeCommandIfCMIsNewerThan751(clustersResourceApi);
                 restartServices(clustersResourceApi);
             } else {
-                ClouderaManagerProduct cdhProduct = getCdhProducts(products);
+                ClouderaManagerProduct cdhProduct = clouderaManagerProductsProvider.getCdhProducts(products);
                 upgradeNonCdhProducts(products, cdhProduct.getName(), parcelResourceApi, true);
                 upgradeCdh(clustersResourceApi, parcelResourceApi, cdhProduct);
                 startServices();
@@ -392,7 +391,7 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
                 LOGGER.info("Downloading parcels for {} products...", products);
                 downloadAndActivateParcels(products, parcelResourceApi, false);
             } else {
-                ClouderaManagerProduct cdhProduct = getCdhProducts(products);
+                ClouderaManagerProduct cdhProduct = clouderaManagerProductsProvider.getCdhProducts(products);
                 upgradeNonCdhProducts(products, cdhProduct.getName(), parcelResourceApi, false);
                 downloadAndActivateParcels(Collections.singleton(cdhProduct), parcelResourceApi, false);
             }
@@ -434,13 +433,6 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
         } else {
             LOGGER.info("No parcel activation is necessary yet.");
         }
-    }
-
-    private ClouderaManagerProduct getCdhProducts(Set<ClouderaManagerProduct> products) {
-        return products.stream()
-                .filter(service -> service.getName().equals(com.sequenceiq.cloudbreak.cloud.model.component.StackType.CDH.name()))
-                .findFirst()
-                .orElseThrow(() -> new NotFoundException("Runtime component not found!"));
     }
 
     private Set<ClouderaManagerProduct> getNonCdhProducts(Set<ClouderaManagerProduct> products, String cdhProductName) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterBuilderService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterBuilderService.java
@@ -226,10 +226,8 @@ public class ClusterBuilderService {
         clusterService.save(cluster);
     }
 
-    public void finalizeClusterInstall(Long stackId) throws CloudbreakException {
-        Stack stack = stackService.getByIdWithListsInTransaction(stackId);
+    public void finalizeClusterInstall(Stack stack) throws CloudbreakException {
         Set<HostGroup> hostGroups = hostGroupService.getByClusterWithRecipes(stack.getCluster().getId());
-
         try {
             transactionService.required(() -> {
                 Set<InstanceMetaData> instanceMetaDatas = loadInstanceMetadataForHostGroups(hostGroups).values()

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/parcel/ParcelFilterService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/parcel/ParcelFilterService.java
@@ -90,7 +90,7 @@ public class ParcelFilterService {
     }
 
     private boolean isCustomParcel(Long stackId, ClouderaManagerProduct parcel) {
-        Set<String> parcelNamesFromImage = imageReaderService.getParcelNames(stackId, false);
+        Set<String> parcelNamesFromImage = imageReaderService.getParcelNames(stackId);
         if (parcelNamesFromImage.stream().noneMatch(preWarmParcel -> preWarmParcel.equals(parcel.getName()))) {
             LOGGER.debug("Add custom parcel {}", parcel);
             return true;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/parcel/ParcelService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/parcel/ParcelService.java
@@ -91,7 +91,7 @@ public class ParcelService {
 
     public ParcelOperationStatus removeUnusedParcelComponents(Stack stack, Set<ClusterComponent> clusterComponentsByBlueprint) throws CloudbreakException {
         LOGGER.debug("Starting to remove unused parcels from the cluster.");
-        Set<String> parcelsFromImage = imageReaderService.getParcelNames(stack.getId(), stack.isDatalake());
+        Set<String> parcelsFromImage = imageReaderService.getParcelNames(stack.getId());
         ParcelOperationStatus removalStatus = clusterApiConnectors.getConnector(stack).removeUnusedParcels(clusterComponentsByBlueprint, parcelsFromImage);
         clusterComponentUpdater.removeUnusedCdhProductsFromClusterComponents(stack.getCluster().getId(), clusterComponentsByBlueprint, removalStatus);
         return removalStatus;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/ImageReaderService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/ImageReaderService.java
@@ -50,10 +50,10 @@ public class ImageReaderService {
         return foundParcelProducts;
     }
 
-    public Set<String> getParcelNames(Long stackId, boolean datalake) {
+    public Set<String> getParcelNames(Long stackId) {
         try {
             StatedImage currentImage = imageService.getCurrentImage(stackId);
-            return getParcels(Set.of(currentImage.getImage()), datalake)
+            return getParcels(Set.of(currentImage.getImage()), false)
                     .stream()
                     .map(ClouderaManagerProduct::getName)
                     .collect(Collectors.toSet());

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/parcel/ParcelFilterServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/parcel/ParcelFilterServiceTest.java
@@ -90,7 +90,7 @@ public class ParcelFilterServiceTest {
         String parcelName = "NIFI";
         ClouderaManagerProduct parcel = new ClouderaManagerProduct().withParcel(parcelUrl).withName(parcelName);
         when(clusterTemplateGeneratorService.getServicesByBlueprint(BLUEPRINT_TEXT)).thenReturn(getSupportedServices(Set.of(parcelName)));
-        when(imageReaderService.getParcelNames(STACK_ID, false)).thenReturn(Set.of(parcelName));
+        when(imageReaderService.getParcelNames(STACK_ID)).thenReturn(Set.of(parcelName));
         when(manifestRetrieverService.readRepoManifest(parcelUrl)).thenReturn(ImmutablePair.of(ManifestStatus.SUCCESS, getManifest("otherService1")));
 
         assertEquals(0, underTest.filterParcelsByBlueprint(STACK_ID, Set.of(parcel), getBlueprint()).size());
@@ -102,7 +102,7 @@ public class ParcelFilterServiceTest {
         String parcelName = "CUSTOM";
         ClouderaManagerProduct parcel = new ClouderaManagerProduct().withParcel(parcelUrl).withName(parcelName);
         when(clusterTemplateGeneratorService.getServicesByBlueprint(BLUEPRINT_TEXT)).thenReturn(getSupportedServices(Set.of("NIFI")));
-        when(imageReaderService.getParcelNames(STACK_ID, false)).thenReturn(Set.of("NIFI"));
+        when(imageReaderService.getParcelNames(STACK_ID)).thenReturn(Set.of("NIFI"));
         when(manifestRetrieverService.readRepoManifest(parcelUrl)).thenReturn(ImmutablePair.of(ManifestStatus.SUCCESS, getManifest(parcelName)));
 
         assertEquals(1, underTest.filterParcelsByBlueprint(STACK_ID, Set.of(parcel), getBlueprint()).size());

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/parcel/ParcelServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/parcel/ParcelServiceTest.java
@@ -12,7 +12,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
 import com.sequenceiq.cloudbreak.cluster.model.ParcelOperationStatus;
 import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
@@ -60,12 +59,12 @@ public class ParcelServiceTest {
         ParcelOperationStatus removalStatus = new ParcelOperationStatus();
 
         when(clusterApiConnectors.getConnector(stack)).thenReturn(clusterApi);
-        when(imageReaderService.getParcelNames(STACK_ID, stack.isDatalake())).thenReturn(parcelNames);
+        when(imageReaderService.getParcelNames(STACK_ID)).thenReturn(parcelNames);
         when(clusterApi.removeUnusedParcels(clusterComponentsByBlueprint, parcelNames)).thenReturn(removalStatus);
 
         underTest.removeUnusedParcelComponents(stack, clusterComponentsByBlueprint);
 
-        verify(imageReaderService).getParcelNames(STACK_ID, stack.isDatalake());
+        verify(imageReaderService).getParcelNames(STACK_ID);
         verify(clusterApiConnectors).getConnector(stack);
         verify(clusterApi).removeUnusedParcels(clusterComponentsByBlueprint, parcelNames);
         verify(clusterComponentUpdater).removeUnusedCdhProductsFromClusterComponents(stack.getCluster().getId(), clusterComponentsByBlueprint, removalStatus);
@@ -77,7 +76,6 @@ public class ParcelServiceTest {
         cluster.setId(CLUSTER_ID);
         stack.setId(STACK_ID);
         stack.setCluster(cluster);
-        stack.setType(StackType.WORKLOAD);
         return stack;
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/ImageReaderServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/ImageReaderServiceTest.java
@@ -106,7 +106,7 @@ public class ImageReaderServiceTest {
         when(imageService.getCurrentImage(STACK_ID)).thenReturn(StatedImage.statedImage(currentImage, null, null));
         when(clouderaManagerProductTransformer.transform(currentImage, true, true)).thenReturn(products);
 
-        Set<String> actual = underTest.getParcelNames(STACK_ID, false);
+        Set<String> actual = underTest.getParcelNames(STACK_ID);
 
         assertTrue(actual.contains(PARCEL_NAME));
         verify(imageService).getCurrentImage(STACK_ID);
@@ -117,7 +117,7 @@ public class ImageReaderServiceTest {
     public void testGetPreWarmParcelNamesFromImageShouldThrowException() throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
         when(imageService.getCurrentImage(STACK_ID)).thenThrow(new CloudbreakImageCatalogException("error"));
 
-        assertThrows(CloudbreakRuntimeException.class, () -> underTest.getParcelNames(STACK_ID, false));
+        assertThrows(CloudbreakRuntimeException.class, () -> underTest.getParcelNames(STACK_ID));
         verify(imageService).getCurrentImage(STACK_ID);
         verifyNoInteractions(clouderaManagerProductTransformer);
     }


### PR DESCRIPTION
This commit contains the following improvements:
- Removing unused parcels after cluster creation. This causes that only the activated parcels will be present on the CM and all prewarmed parcel (in downloaded) states will be removed.
- In the case of DataLake stack, we're not getting the required parcels by the ParcelFilterSercice instead only the CDH parcel will be used directly.