### PR TITLE
CB-16567 Remove clusters from periscope after they are deleted from c…

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/DeleteMonitor.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/DeleteMonitor.java
@@ -1,0 +1,39 @@
+package com.sequenceiq.periscope.monitor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.monitor.evaluator.ClusterDeleteEvaluator;
+
+@Component
+@ConditionalOnProperty(prefix = "periscope.enabledAutoscaleMonitors.delete-monitor", name = "enabled", havingValue = "true")
+public class DeleteMonitor extends ClusterMonitor {
+
+    @Override
+    public String getIdentifier() {
+        return "delete-monitor";
+    }
+
+    @Override
+    public String getTriggerExpression() {
+        return MonitorUpdateRate.EVERY_TEN_MIN_RATE_CRON;
+    }
+
+    @Override
+    public Class<?> getEvaluatorType(Cluster monitored) {
+        return ClusterDeleteEvaluator.class;
+    }
+
+    @Override
+    protected List<Cluster> getMonitored() {
+        return getClusterService()
+                .findClusterIdsByStackTypeAndPeriscopeNodeId(StackType.WORKLOAD, getPeriscopeNodeConfig().getId())
+                .stream().map(Cluster::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/MonitorUpdateRate.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/MonitorUpdateRate.java
@@ -48,6 +48,11 @@ public final class MonitorUpdateRate {
     public static final String EVERY_FIVE_MIN_RATE_CRON = "0 0/5 * * * ?";
 
     /**
+     * Every 10 minutes.
+     */
+    public static final String EVERY_TEN_MIN_RATE_CRON = "0 0/10 * * * ?";
+
+    /**
      * Every minutes.
      */
     public static final String EVERY_QUARTER_PAST_SEC_RATE_CRON = "15 * * * * ?";

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ClusterDeleteEvaluator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ClusterDeleteEvaluator.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.periscope.monitor.evaluator;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.periscope.monitor.context.ClusterIdEvaluatorContext;
+import com.sequenceiq.periscope.monitor.context.EvaluatorContext;
+import com.sequenceiq.periscope.monitor.event.ClusterDeleteEvent;
+
+@Component("ClusterDeleteEvaluator")
+@Scope("prototype")
+public class ClusterDeleteEvaluator extends EvaluatorExecutor {
+
+    private static final String EVALUATOR_NAME = ClusterDeleteEvaluator.class.getName();
+
+    private long clusterId;
+
+    @Inject
+    private EventPublisher eventPublisher;
+
+    @Nonnull
+    @Override
+    public EvaluatorContext getContext() {
+        return new ClusterIdEvaluatorContext(clusterId);
+    }
+
+    @Override
+    public String getName() {
+        return EVALUATOR_NAME;
+    }
+
+    @Override
+    public void setContext(EvaluatorContext context) {
+        this.clusterId = (long) context.getData();
+    }
+
+    @Override
+    protected void execute() {
+        eventPublisher.publishEvent(new ClusterDeleteEvent(clusterId));
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/event/ClusterDeleteEvent.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/event/ClusterDeleteEvent.java
@@ -1,0 +1,14 @@
+package com.sequenceiq.periscope.monitor.event;
+
+import org.springframework.context.ApplicationEvent;
+
+public class ClusterDeleteEvent extends ApplicationEvent {
+
+    public ClusterDeleteEvent(long clusterId) {
+        super(clusterId);
+    }
+
+    public long getClusterId() {
+        return (long) source;
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ClusterDeleteHandler.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ClusterDeleteHandler.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.periscope.monitor.handler;
+
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.DELETE_COMPLETED;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackStatusV4Response;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.monitor.event.ClusterDeleteEvent;
+import com.sequenceiq.periscope.service.ClusterService;
+import com.sequenceiq.periscope.utils.LoggingUtils;
+
+@Component
+public class ClusterDeleteHandler implements ApplicationListener<ClusterDeleteEvent> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterDeleteHandler.class);
+
+    @Inject
+    private ClusterService clusterService;
+
+    @Inject
+    private CloudbreakCommunicator cloudbreakCommunicator;
+
+    @Override
+    public void onApplicationEvent(ClusterDeleteEvent event) {
+        Cluster cluster = clusterService.findById(event.getClusterId());
+        if (cluster == null) {
+            return;
+        }
+        LoggingUtils.buildMdcContext(cluster);
+
+        StackStatusV4Response statusResponse = cloudbreakCommunicator.getStackStatusByCrn(cluster.getStackCrn());
+
+        if (DELETE_COMPLETED.equals(statusResponse.getStatus())) {
+            clusterService.removeById(event.getClusterId());
+            LOGGER.info("Deleted cluster: {}, CB Stack status: {}", cluster.getStackCrn(), statusResponse.getStatus());
+        }
+    }
+}

--- a/autoscale/src/main/resources/application-test.yml
+++ b/autoscale/src/main/resources/application-test.yml
@@ -56,6 +56,8 @@ periscope:
       enabled: false
     cluster-status-monitor:
       enabled: false
+    delete-monitor:
+      enabled: false
 
 cb:
   server:

--- a/autoscale/src/main/resources/application.yml
+++ b/autoscale/src/main/resources/application.yml
@@ -63,6 +63,8 @@ periscope:
       enabled: true
     cluster-status-monitor:
       enabled: true
+    delete-monitor:
+      enabled: true
 
 cb:
   server:

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/handler/ClusterDeleteHandlerTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/handler/ClusterDeleteHandlerTest.java
@@ -1,0 +1,91 @@
+package com.sequenceiq.periscope.monitor.handler;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackStatusV4Response;
+import com.sequenceiq.periscope.api.model.ClusterState;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.ClusterPertain;
+import com.sequenceiq.periscope.monitor.event.ClusterDeleteEvent;
+import com.sequenceiq.periscope.service.ClusterService;
+
+@ExtendWith(MockitoExtension.class)
+class ClusterDeleteHandlerTest {
+
+    private static final Long AUTOSCALE_CLUSTER_ID = 1L;
+
+    private static final String CLOUDBREAK_STACK_CRN = "crn:cdp:datahub:us-west-1:tenant:datahub:012e39ab-e972-4345-87ee-0e12b47aa5b8";
+
+    @Mock
+    private ClusterService clusterService;
+
+    @Mock
+    private CloudbreakCommunicator cloudbreakCommunicator;
+
+    @InjectMocks
+    private ClusterDeleteHandler underTest;
+
+    @Test
+    void testOnApplicationEventReturnsIfClusterIsNull() {
+        when(clusterService.findById(anyLong())).thenReturn(null);
+
+        underTest.onApplicationEvent(new ClusterDeleteEvent(AUTOSCALE_CLUSTER_ID));
+
+        verify(clusterService).findById(AUTOSCALE_CLUSTER_ID);
+        verify(cloudbreakCommunicator, never()).getStackStatusByCrn(anyString());
+    }
+
+    @Test
+    void testOnApplicationEventWhenCBClusterDeleted() {
+        Cluster cluster = getCluster(ClusterState.RUNNING);
+        when(clusterService.findById(anyLong())).thenReturn(cluster);
+        when(cloudbreakCommunicator.getStackStatusByCrn(anyString())).thenReturn(getStackResponse(Status.DELETE_COMPLETED));
+
+        underTest.onApplicationEvent(new ClusterDeleteEvent(AUTOSCALE_CLUSTER_ID));
+
+        verify(clusterService).removeById(AUTOSCALE_CLUSTER_ID);
+        verify(cloudbreakCommunicator).getStackStatusByCrn(CLOUDBREAK_STACK_CRN);
+    }
+
+    @Test
+    void testOnApplicationEventWhenCBClusterRunning() {
+        Cluster cluster = getCluster(ClusterState.RUNNING);
+        when(clusterService.findById(anyLong())).thenReturn(cluster);
+        when(cloudbreakCommunicator.getStackStatusByCrn(anyString())).thenReturn(getStackResponse(Status.AVAILABLE));
+
+        underTest.onApplicationEvent(new ClusterDeleteEvent(AUTOSCALE_CLUSTER_ID));
+
+        verify(clusterService, never()).removeById(AUTOSCALE_CLUSTER_ID);
+        verify(cloudbreakCommunicator).getStackStatusByCrn(CLOUDBREAK_STACK_CRN);
+    }
+
+    private StackStatusV4Response getStackResponse(Status clusterStatus) {
+        StackStatusV4Response stackResponse = new StackStatusV4Response();
+        stackResponse.setStatus(clusterStatus);
+        stackResponse.setClusterStatus(clusterStatus);
+        return stackResponse;
+    }
+
+    private Cluster getCluster(ClusterState clusterState) {
+        Cluster cluster = new Cluster();
+        cluster.setId(AUTOSCALE_CLUSTER_ID);
+        cluster.setStackCrn(CLOUDBREAK_STACK_CRN);
+        cluster.setState(clusterState);
+        cluster.setStopStartScalingEnabled(Boolean.FALSE);
+
+        ClusterPertain clusterPertain = new ClusterPertain();
+        cluster.setClusterPertain(clusterPertain);
+        return cluster;
+    }
+}


### PR DESCRIPTION
…loudbreak

 - Added a new monitor that runs every 10 minutes to poll CB and check if a Datahub has been deleted.
 - Covered the new monitor with UTs

See detailed description in the commit message.