### PR TITLE
CB-16656 Fixes for code issues in WaitService for Instances

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/ResourceAwait.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/ResourceAwait.java
@@ -21,10 +21,10 @@ public class ResourceAwait {
 
     public <E extends Enum<E>> CloudbreakTestDto await(CloudbreakTestDto entity, Map<String, E> desiredStatuses,
             TestContext testContext, RunningParameter runningParameter, Duration pollingInterval, int maxRetry, int maxRetryCount, MicroserviceClient client) {
+        if (entity == null) {
+            throw new RuntimeException("Cloudbreak key has been provided but no result in resource map!");
+        }
         try {
-            if (entity == null) {
-                throw new RuntimeException("Cloudbreak key has been provided but no result in resource map!");
-            }
             Log.await(LOGGER, String.format("%s for %s", entity.getName(), desiredStatuses));
             String name = entity.getName();
             WaitObject waitObject = client.waitObject(entity, name, desiredStatuses, testContext, runningParameter.getIgnoredStatuses());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceAwait.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceAwait.java
@@ -23,10 +23,10 @@ public class InstanceAwait {
 
     public <E extends Enum<E>> CloudbreakTestDto await(CloudbreakTestDto entity, Map<List<String>, E> desiredStatuses, TestContext testContext,
             RunningParameter runningParameter, Duration pollingInterval, int maxRetry) {
+        if (entity == null) {
+            throw new RuntimeException("Sdx key has been provided but no result in resource map!");
+        }
         try {
-            if (entity == null) {
-                throw new RuntimeException("Sdx key has been provided but no result in resource map!");
-            }
             Log.await(LOGGER, String.format("%s for %s", entity.getName(), desiredStatuses));
             MicroserviceClient client = testContext.getMicroserviceClient(entity.getClass(), testContext.setActingUser(runningParameter).getAccessKey());
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceOperationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceOperationChecker.java
@@ -17,7 +17,7 @@ public class InstanceOperationChecker<T extends InstanceWaitObject> extends Exce
     public boolean checkStatus(T waitObject) {
         List<String> instanceIds = waitObject.getInstanceIds();
         Map<String, String> actualStatuses = waitObject.actualStatuses();
-        if (waitObject.getInstanceIds().size() > 0) {
+        if (!waitObject.getInstanceIds().isEmpty()) {
             if (actualStatuses.isEmpty()) {
                 throw new TestFailException(String.format("'%s' instance was not found.", instanceIds));
             }
@@ -26,7 +26,7 @@ public class InstanceOperationChecker<T extends InstanceWaitObject> extends Exce
             if (waitObject.isDeletionInProgress() || waitObject.isDeleted()) {
                 LOGGER.error("Instance '{}' has been getting terminated (status:'{}'), waiting is cancelled.", instanceIds,
                         actualStatuses);
-                throw new TestFailException(String.format("Instance '%s' has been getting terminated, waiting is cancelled." +
+                throw new TestFailException(String.format("Instance has been getting terminated, waiting is cancelled." +
                         " Status: '%s' statusReason: '%s'", instanceIds, actualStatuses));
             }
             if (waitObject.isFailed()) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/cloudbreak/CloudbreakInstanceWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/cloudbreak/CloudbreakInstanceWaitObject.java
@@ -59,7 +59,7 @@ public class CloudbreakInstanceWaitObject implements InstanceWaitObject {
                     .getDefaultClient().distroXV1Endpoint().getByName(name, Set.of()).getInstanceGroups();
             instanceResourceType = "Data Hub";
         } catch (NotFoundException e) {
-            LOGGER.info("SDX '{}' instance groups are present for validation.", getName());
+            LOGGER.info("SDX '{}' instance groups are present for validation.", name);
             instanceGroups = testContext.getSdxClient().getDefaultClient().sdxEndpoint().getDetail(name, Set.of()).getStackV4Response().getInstanceGroups();
         } catch (Exception e) {
             LOGGER.error("Instance groups cannot be determined, because of: {}", e.getMessage(), e);
@@ -71,7 +71,7 @@ public class CloudbreakInstanceWaitObject implements InstanceWaitObject {
     public Map<String, String> actualStatuses() {
         return getInstanceMetaDatas().stream()
                 .collect(Collectors.toMap(InstanceMetaDataV4Response::getInstanceId,
-                        instanceMetaDataV4Response -> instanceMetaDataV4Response.getInstanceStatus().name()));
+                        instanceMetaData -> instanceMetaData.getInstanceStatus().name()));
     }
 
     @Override
@@ -150,7 +150,7 @@ public class CloudbreakInstanceWaitObject implements InstanceWaitObject {
     @Override
     public Map<String, String> getFetchedInstanceStatuses() {
         return getInstanceMetaDatas().stream().collect(Collectors.toMap(InstanceMetaDataV4Response::getInstanceId,
-                instanceMetaDataV4Response -> instanceMetaDataV4Response.getInstanceStatus().name()));
+                instanceMetaData -> instanceMetaData.getInstanceStatus().name()));
     }
 
     public Map<String, InstanceStatus> getInstanceStatuses() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/freeipa/FreeIpaInstanceWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/freeipa/FreeIpaInstanceWaitObject.java
@@ -60,7 +60,7 @@ public class FreeIpaInstanceWaitObject implements InstanceWaitObject {
     public Map<String, String> actualStatuses() {
         return getInstanceMetaDatas().stream()
                 .collect(Collectors.toMap(InstanceMetaDataResponse::getInstanceId,
-                        instanceMetaDataV4Response -> instanceMetaDataV4Response.getInstanceStatus().name()));
+                        instanceMetaData -> instanceMetaData.getInstanceStatus().name()));
     }
 
     @Override
@@ -139,7 +139,7 @@ public class FreeIpaInstanceWaitObject implements InstanceWaitObject {
     @Override
     public Map<String, String> getFetchedInstanceStatuses() {
         return getInstanceMetaDatas().stream().collect(Collectors.toMap(InstanceMetaDataResponse::getInstanceId,
-                instanceMetaDataResponse -> instanceMetaDataResponse.getInstanceStatus().name()));
+                instanceMetaData -> instanceMetaData.getInstanceStatus().name()));
     }
 
     public Map<String, InstanceStatus> getInstanceStatuses() {


### PR DESCRIPTION
Fixing the issue for the failing [testStopStartScaleDistroX](http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-aws/4209/testngreports/com.sequenceiq.it.cloudbreak.testcase.e2e.distrox/DistroXStopStartScaleTest/testStopStartScaleDistroX/):
```
await DistroXTestDto[name: aws-test-51b2c1] for desired statuses {[i-070579159b9263220, i-01ccbd554b722f5fe, i-06fbc8dc5825451fb]=STOPPED}: Format specifier '%s'
com.sequenceiq.it.cloudbreak.exception.TestFailException: Format specifier '%s'
```
Furthermore it is fixing some additional code issues in the [Instance WaitService](https://github.com/hortonworks/cloudbreak/tree/master/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance).