### PR TITLE
CB-16624: Do not transform the parcels from the image to ClouderaManagerProduct in case of base images.

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/parcel/ClouderaManagerProductTransformer.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/parcel/ClouderaManagerProductTransformer.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.service.parcel;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
@@ -8,6 +9,8 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
@@ -18,18 +21,25 @@ import com.sequenceiq.cloudbreak.service.image.PreWarmParcelParser;
 @Component
 public class ClouderaManagerProductTransformer {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerProductTransformer.class);
+
     @Inject
     private PreWarmParcelParser preWarmParcelParser;
 
     public Set<ClouderaManagerProduct> transform(Image image, boolean getCdhParcel, boolean getPreWarmParcels) {
-        Set<ClouderaManagerProduct> products = new HashSet<>();
-        if (getCdhParcel) {
-            products.add(getCdhParcel(image));
+        if (image.isPrewarmed()) {
+            Set<ClouderaManagerProduct> products = new HashSet<>();
+            if (getCdhParcel) {
+                products.add(getCdhParcel(image));
+            }
+            if (getPreWarmParcels) {
+                products.addAll(getPreWarmParcels(image));
+            }
+            return products;
+        } else {
+            LOGGER.debug("Not possible to get the products from the image because this is not a pre warmed image. ImageId: {}", image.getUuid());
+            return Collections.emptySet();
         }
-        if (getPreWarmParcels) {
-            products.addAll(getPreWarmParcels(image));
-        }
-        return products;
     }
 
     public Map<String, String> transformToMap(Image image, boolean getCdhParcel, boolean getPreWarmParcels) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/parcel/ClouderaManagerProductTransformerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/parcel/ClouderaManagerProductTransformerTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
@@ -58,6 +59,14 @@ public class ClouderaManagerProductTransformerTest {
         assertThat(foundProducts, hasSize(2));
         assertTrue(assertCdhProduct(foundProducts));
         verify(preWarmParcelParser).parseProductFromParcel(preWarmParcels, preWarmCsdList);
+    }
+
+    @Test
+    public void testTransformShouldReturnEmptySetWhenTheImageIsNotPreWarmed() {
+        Set<ClouderaManagerProduct> foundProducts = underTest.transform(createBaseImage(), true, true);
+
+        assertTrue(foundProducts.isEmpty());
+        verifyNoInteractions(preWarmParcelParser);
     }
 
     @Test
@@ -123,6 +132,10 @@ public class ClouderaManagerProductTransformerTest {
     private Image createImage(List<String> preWarmParcels, List<String> preWarmCsdList) {
         return new Image(null, null, null, null, null, null, null, null, null, new ImageStackDetails(null, createStackRepoDetails(), null), OS_TYPE,
                 null, List.of(preWarmParcels), preWarmCsdList, null, false, null, null);
+    }
+
+    private Image createBaseImage() {
+        return new Image(null, null, null, null, null, null, null, null, null, null, OS_TYPE, null, null, null, null, false, null, null);
     }
 
     private StackRepoDetails createStackRepoDetails() {


### PR DESCRIPTION
When we try to get the parcels from the image we can get a NPE when the image is a base image.
The reason for this exception is that there are no parcels on the image.
After this change, we're checking the image type and return an empty list if the image is not pre-warmed.