### PR TITLE
CB-16440 Add gateway nodes to Spark3 DataHub template

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.11/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.11/cdp-data-engineering-spark3.bp
@@ -410,6 +410,19 @@
           "yarn-NODEMANAGER-COMPUTE",
           "yarn-GATEWAY-BASE"
         ]
+      },
+      {
+        "refName": "gateway",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "hdfs-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
+          "hive_on_tez-GATEWAY-BASE",
+          "spark3_on_yarn-GATEWAY-BASE",
+          "livy_for_spark3-GATEWAY-BASE",
+          "yarn-GATEWAY-BASE"
+        ]
       }
     ]
   }

--- a/core/src/main/resources/defaults/blueprints/7.2.12/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.12/cdp-data-engineering-spark3.bp
@@ -410,6 +410,19 @@
           "yarn-NODEMANAGER-COMPUTE",
           "yarn-GATEWAY-BASE"
         ]
+      },
+      {
+        "refName": "gateway",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "hdfs-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
+          "hive_on_tez-GATEWAY-BASE",
+          "spark3_on_yarn-GATEWAY-BASE",
+          "livy_for_spark3-GATEWAY-BASE",
+          "yarn-GATEWAY-BASE"
+        ]
       }
     ]
   }

--- a/core/src/main/resources/defaults/blueprints/7.2.14/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.14/cdp-data-engineering-spark3.bp
@@ -436,6 +436,19 @@
           "yarn-NODEMANAGER-COMPUTE",
           "yarn-GATEWAY-BASE"
         ]
+      },
+      {
+        "refName": "gateway",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "hdfs-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
+          "hive_on_tez-GATEWAY-BASE",
+          "spark3_on_yarn-GATEWAY-BASE",
+          "livy_for_spark3-GATEWAY-BASE",
+          "yarn-GATEWAY-BASE"
+        ]
       }
     ]
   }

--- a/core/src/main/resources/defaults/blueprints/7.2.15/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.15/cdp-data-engineering-spark3.bp
@@ -436,6 +436,19 @@
           "yarn-NODEMANAGER-COMPUTE",
           "yarn-GATEWAY-BASE"
         ]
+      },
+      {
+        "refName": "gateway",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "hdfs-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
+          "hive_on_tez-GATEWAY-BASE",
+          "spark3_on_yarn-GATEWAY-BASE",
+          "livy_for_spark3-GATEWAY-BASE",
+          "yarn-GATEWAY-BASE"
+        ]
       }
     ]
   }

--- a/core/src/main/resources/defaults/blueprints/7.2.16/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.16/cdp-data-engineering-spark3.bp
@@ -436,6 +436,19 @@
           "yarn-NODEMANAGER-COMPUTE",
           "yarn-GATEWAY-BASE"
         ]
+      },
+      {
+        "refName": "gateway",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "hdfs-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
+          "hive_on_tez-GATEWAY-BASE",
+          "spark3_on_yarn-GATEWAY-BASE",
+          "livy_for_spark3-GATEWAY-BASE",
+          "yarn-GATEWAY-BASE"
+        ]
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.11/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.11/aws/dataengineering-spark3.json
@@ -71,6 +71,27 @@
         "nodeCount": 3,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "gateway",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "gp2"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.11/azure/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.11/azure/dataengineering-spark3.json
@@ -77,6 +77,29 @@
         "nodeCount": 3,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "gateway",
+        "template": {
+          "attachedVolumes": [
+            {
+              "size": 100,
+              "count": 1,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D8_v3"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.11/gcp/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.11/gcp/dataengineering-spark3.json
@@ -56,6 +56,22 @@
         "nodeCount": 3,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "gateway",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "pd-ssd"
+            }
+          ],
+          "instanceType": "e2-standard-8"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.11/yarn/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.11/yarn/dataengineering-spark3.json
@@ -53,6 +53,21 @@
         "nodeCount": 3,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "gateway",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 8192
+          }
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.12/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.12/aws/dataengineering-spark3.json
@@ -71,6 +71,27 @@
         "nodeCount": 3,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "gateway",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "gp2"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.12/azure/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.12/azure/dataengineering-spark3.json
@@ -77,6 +77,29 @@
         "nodeCount": 3,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "gateway",
+        "template": {
+          "attachedVolumes": [
+            {
+              "size": 100,
+              "count": 1,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D8_v3"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.12/gcp/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.12/gcp/dataengineering-spark3.json
@@ -56,6 +56,22 @@
         "nodeCount": 3,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "gateway",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "pd-ssd"
+            }
+          ],
+          "instanceType": "e2-standard-8"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.12/yarn/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.12/yarn/dataengineering-spark3.json
@@ -53,6 +53,21 @@
         "nodeCount": 3,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "gateway",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 8192
+          }
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.14/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.14/aws/dataengineering-spark3.json
@@ -71,6 +71,27 @@
         "nodeCount": 3,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "gateway",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "gp2"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.14/azure/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.14/azure/dataengineering-spark3.json
@@ -77,6 +77,29 @@
         "nodeCount": 3,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "gateway",
+        "template": {
+          "attachedVolumes": [
+            {
+              "size": 100,
+              "count": 1,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D8_v3"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.14/gcp/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.14/gcp/dataengineering-spark3.json
@@ -56,6 +56,22 @@
         "nodeCount": 3,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "gateway",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "pd-ssd"
+            }
+          ],
+          "instanceType": "e2-standard-8"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.14/yarn/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.14/yarn/dataengineering-spark3.json
@@ -53,6 +53,21 @@
         "nodeCount": 3,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "gateway",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 8192
+          }
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.15/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.15/aws/dataengineering-spark3.json
@@ -71,6 +71,27 @@
         "nodeCount": 3,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "gateway",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "gp2"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.15/azure/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.15/azure/dataengineering-spark3.json
@@ -77,6 +77,29 @@
         "nodeCount": 3,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "gateway",
+        "template": {
+          "attachedVolumes": [
+            {
+              "size": 100,
+              "count": 1,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D8_v3"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.15/gcp/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.15/gcp/dataengineering-spark3.json
@@ -56,6 +56,22 @@
         "nodeCount": 3,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "gateway",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "pd-ssd"
+            }
+          ],
+          "instanceType": "e2-standard-8"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.15/yarn/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.15/yarn/dataengineering-spark3.json
@@ -53,6 +53,21 @@
         "nodeCount": 3,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "gateway",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 8192
+          }
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.16/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.16/aws/dataengineering-spark3.json
@@ -71,6 +71,27 @@
         "nodeCount": 3,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "gateway",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "gp2"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.16/azure/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.16/azure/dataengineering-spark3.json
@@ -77,6 +77,29 @@
         "nodeCount": 3,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "gateway",
+        "template": {
+          "attachedVolumes": [
+            {
+              "size": 100,
+              "count": 1,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D8_v3"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.16/gcp/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.16/gcp/dataengineering-spark3.json
@@ -56,6 +56,22 @@
         "nodeCount": 3,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "gateway",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "pd-ssd"
+            }
+          ],
+          "instanceType": "e2-standard-8"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.16/yarn/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.16/yarn/dataengineering-spark3.json
@@ -53,6 +53,21 @@
         "nodeCount": 3,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "gateway",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 8192
+          }
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }


### PR DESCRIPTION
The Spark 3 template is missing the option to add gateway nodes and this has been requested by one of the customers. They would like to have this added to 7.2.11 and later templates.