### PR TITLE
CB-16616 Created API format validator.

### DIFF
--- a/common/src/test/java/com/sequenceiq/cloudbreak/apiformat/ApiFormatRule.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/apiformat/ApiFormatRule.java
@@ -1,0 +1,7 @@
+package com.sequenceiq.cloudbreak.apiformat;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+public interface ApiFormatRule extends Function<Class<?>, Optional<String>> {
+}

--- a/common/src/test/java/com/sequenceiq/cloudbreak/apiformat/ApiFormatRules.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/apiformat/ApiFormatRules.java
@@ -1,0 +1,79 @@
+package com.sequenceiq.cloudbreak.apiformat;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.google.common.base.Strings;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+public enum ApiFormatRules implements ApiFormatRule {
+
+    HAS_JSON_IGNORE_UNKNOWN_ANNOTATION {
+        @Override
+        public Optional<String> apply(Class<?> modelClass) {
+            if (hasAnnotation(modelClass, JsonIgnoreProperties.class, JsonIgnoreProperties::ignoreUnknown)) {
+                return Optional.empty();
+            }
+            return validationError("missing @JsonIgnoreProperties(ignoreUnknown = true) annotation", this);
+        }
+    },
+    HAS_API_MODEL_ANNOTATION {
+        @Override
+        public Optional<String> apply(Class<?> modelClass) {
+            if (hasAnnotation(modelClass, ApiModel.class)) {
+                return Optional.empty();
+            }
+            return validationError("missing @ApiModel annotation", this);
+        }
+    },
+    HAS_JSON_INCLUDE_NON_NULL {
+        @Override
+        public Optional<String> apply(Class<?> modelClass) {
+            if (hasAnnotation(modelClass, JsonInclude.class,
+                    annotation -> JsonInclude.Include.NON_NULL.equals(annotation.value()))) {
+                return Optional.empty();
+            }
+            return validationError("missing @JsonInclude(Include.NON_NULL) annotation", this);
+        }
+    },
+    HAS_API_MODEL_PROPERTY_ON_FIELDS {
+        @Override
+        public Optional<String> apply(Class<?> modelClass) {
+            List<String> fieldsWithoutAnnotation = new ArrayList<>();
+            for (Field field : modelClass.getDeclaredFields()) {
+
+                if (!Modifier.isStatic(field.getModifiers())
+                        && (!field.isAnnotationPresent(ApiModelProperty.class)
+                        || Strings.isNullOrEmpty(field.getAnnotation(ApiModelProperty.class).value()))) {
+                    fieldsWithoutAnnotation.add(field.getName());
+                }
+            }
+            if (fieldsWithoutAnnotation.isEmpty()) {
+                return Optional.empty();
+            } else {
+                return validationError("missing @ApiModelProperty(<description>) annotation on properties: " + fieldsWithoutAnnotation, this);
+            }
+        }
+    };
+
+    private static <T extends Annotation> boolean hasAnnotation(Class<?> clazz, Class<T> annotation) {
+        return clazz.isAnnotationPresent(annotation);
+    }
+
+    private static <T extends Annotation> boolean hasAnnotation(Class<?> clazz, Class<T> annotation, Predicate<T> annotationCondition) {
+        return clazz.isAnnotationPresent(annotation) && annotationCondition.test(clazz.getAnnotation(annotation));
+    }
+
+    private static Optional<String> validationError(String message, ApiFormatRules rule) {
+        return Optional.of(message + ", rule: " + rule.name());
+    }
+}

--- a/common/src/test/java/com/sequenceiq/cloudbreak/apiformat/ApiFormatValidationResult.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/apiformat/ApiFormatValidationResult.java
@@ -1,0 +1,40 @@
+package com.sequenceiq.cloudbreak.apiformat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+class ApiFormatValidationResult {
+
+    private Class<?> validatedClass;
+
+    private List<String> errors;
+
+    ApiFormatValidationResult(Class<?> validatedClass) {
+        this.validatedClass = validatedClass;
+        errors = new ArrayList<>();
+    }
+
+    public Class<?> getValidatedClass() {
+        return validatedClass;
+    }
+
+    public void addError(String error) {
+        errors.add(error);
+    }
+
+    public boolean hasError() {
+        return !errors.isEmpty();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder result = new StringBuilder();
+        result.append(validatedClass.getName());
+        if (hasError()) {
+            result.append(System.lineSeparator());
+            result.append(errors.stream().map(e -> "- " + e).collect(Collectors.joining(System.lineSeparator())));
+        }
+        return result.toString();
+    }
+}

--- a/common/src/test/java/com/sequenceiq/cloudbreak/apiformat/ApiFormatValidator.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/apiformat/ApiFormatValidator.java
@@ -1,0 +1,92 @@
+package com.sequenceiq.cloudbreak.apiformat;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.opentest4j.AssertionFailedError;
+import org.reflections.Reflections;
+import org.reflections.scanners.SubTypesScanner;
+
+public class ApiFormatValidator {
+
+    private final String modelPackage;
+
+    private final Set<Class<?>> excludedClasses;
+
+    private final Map<Class<?>, Set<ApiFormatRule>> excludedRulesByClasses;
+
+    public ApiFormatValidator(String packageName, Set<Class<?>> excludedClasses, Map<Class<?>, Set<ApiFormatRule>> excludedRulesByClasses) {
+        this.modelPackage = packageName;
+        this.excludedClasses = excludedClasses;
+        this.excludedRulesByClasses = excludedRulesByClasses;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public void validate() {
+        List<ApiFormatValidationResult> apiFormatErrors = getModelClasses(modelPackage)
+                .stream()
+                .filter(c -> !excludedClasses.contains(c))
+                .map(this::validateFormattingRules)
+                .filter(ApiFormatValidationResult::hasError)
+                .collect(Collectors.toList());
+
+        if (!apiFormatErrors.isEmpty()) {
+            throw new AssertionFailedError("The following API model classes(" + apiFormatErrors.size() + ") have formatting issues:\n\n" +
+                    apiFormatErrors
+                            .stream()
+                            .map(ApiFormatValidationResult::toString)
+                            .collect(Collectors.joining("\n\n")));
+        }
+    }
+
+    private ApiFormatValidationResult validateFormattingRules(Class<?> modelClass) {
+        ApiFormatValidationResult formatValidation = new ApiFormatValidationResult(modelClass);
+        for (ApiFormatRule apiFormatRule : ApiFormatRules.values()) {
+            if (!excludedRulesByClasses.containsKey(modelClass) || !excludedRulesByClasses.get(modelClass).contains(apiFormatRule)) {
+                Optional<String> error = apiFormatRule.apply(formatValidation.getValidatedClass());
+                error.ifPresent(formatValidation::addError);
+            }
+        }
+        return formatValidation;
+    }
+
+    private Set<Class<?>> getModelClasses(String packageName) {
+        return new Reflections(packageName, new SubTypesScanner(false)).getSubTypesOf(Object.class);
+    }
+
+    public static class Builder {
+
+        private String modelPackage;
+
+        private Set<Class<?>> excludedClasses = new HashSet<>();
+
+        private Map<Class<?>, Set<ApiFormatRule>> excludedRulesByClasses = new HashMap<>();
+
+        public Builder modelPackage(String modelPackage) {
+            this.modelPackage = modelPackage;
+            return this;
+        }
+
+        public Builder excludedClasses(Class<?>... excludedClasses) {
+            this.excludedClasses.addAll(Set.of(excludedClasses));
+            return this;
+        }
+
+        public Builder excludeRules(Class<?> clazz, ApiFormatRule... rules) {
+            excludedRulesByClasses.computeIfAbsent(clazz, i -> new HashSet<>()).addAll(Set.of(rules));
+            return this;
+        }
+
+        public ApiFormatValidator build() {
+            return new ApiFormatValidator(modelPackage, excludedClasses, excludedRulesByClasses);
+        }
+    }
+}

--- a/datalake-api/build.gradle
+++ b/datalake-api/build.gradle
@@ -13,4 +13,6 @@ dependencies {
   implementation project(':structuredevent-model')
 
   implementation     group: 'io.opentracing.contrib',        name: 'opentracing-jaxrs2',             version: opentracingJaxrs2Version
+
+  testImplementation project(path: ':common', configuration: 'tests')
 }

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/AdvertisedRuntime.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/AdvertisedRuntime.java
@@ -2,10 +2,21 @@ package com.sequenceiq.sdx.api.model;
 
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class AdvertisedRuntime {
 
+    @ApiModelProperty(ModelDescriptions.RUNTIME_VERSION)
     private String runtimeVersion;
 
+    @ApiModelProperty(ModelDescriptions.DEFAULT_RUNTIME_VERSION)
     private boolean defaultRuntimeVersion;
 
     public String getRuntimeVersion() {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/ModelDescriptions.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/ModelDescriptions.java
@@ -10,6 +10,144 @@ public class ModelDescriptions {
 
     public static final String CLOSE_CONNECTIONS = "The conditional parameter for whether connections to the database will be closed during backup or not.";
 
+    public static final String ENVIRONMENT_CRN = "Environment crn.";
+
+    public static final String ENVIRONMENT_NAME = "The name of the environment.";
+
+    public static final String CLUSTER_SHAPE = "The shape of the cluster such as Micro Duty, Light Duty, Medium Duty...";
+
+    public static final String DATA_ACCESS_ROLE = "The role used for cloud storage access.";
+
+    public static final String RANGER_AUDIT_ROLE = "The role used by Ranger for cloud storage access.";
+
+    public static final String CREDENTIAL_CRN = "The crn of the credential used for the cloud provider.";
+
+    public static final String CLOUD_STORAGE_DETAILS = "Details about the cloud storage type and location.";
+
+    public static final String CLOUD_STORAGE_BASE_LOCATION = "Cloud storage base location.";
+
+    public static final String CLOUD_STORAGE_FILE_SYSTEM_TYPE = "Cloud storage file system type.";
+
+    public static final String CLUSTER_TEMPLATE_NAME = "The name of the cluster template used for Data Lake creation.";
+
+    public static final String FLOW_IDENTIFIER = "The id of the flow or flow chain that was triggered as part of the process.";
+
+    public static final String CCM_UPGRADE_RESPONSE_TYPE = "Information about the CCM upgrade process.";
+
+    public static final String CCM_UPGRADE_ERROR_REASON = "Reason of the error if CCM upgrade could not be started.";
+
+    public static final String TEMPLATE_DETAILS = "Template details.";
+
+    public static final String OPERATION_STATUS = "Operation status.";
+
+    public static final String OPERATION_STATUS_REASON = "Operation status reason.";
+
+    public static final String STACK_REQUEST = "Stack request.";
+
+    public static final String STACK_RESPONSE = "Stack response.";
+
+    public static final String OPERATION_ID = "Operation id.";
+
+    public static final String COMMAND_ID = "Command id.";
+
+    public static final String RECOVERABLE_STATUS_REASON = "Description about why the cluster is recoverable or not recoverable.";
+
+    public static final String RECOVERABLE_STATUS = "Status that indicates whether the cluster is recoverable or not recoverable.";
+
+    public static final String INSTANCE_GROUP_NAME = "Instance group name.";
+
+    public static final String INSTANCE_TYPE = "Instance type.";
+
+    public static final String IMAGE_CATALOG = "Image catalog.";
+
+    public static final String IMAGE_ID = "Image id.";
+
+    public static final String HOST_GROUP_NAME = "Host group name.";
+
+    public static final String HOST_GROUP_NAMES = "Host group names.";
+
+    public static final String NODE_IDS = "Node ids.";
+
+    public static final String DATA_LAKE_CRN = "Data Lake crn.";
+
+    public static final String DATA_LAKE_NAME = "Data Lake name.";
+
+    public static final String DATA_LAKE_STATUS = "Data Lake status.";
+
+    public static final String DATA_LAKE_STATUS_REASON = "Data Lake status reason.";
+
+    public static final String DATABASE_SERVER_CRN = "Database server crn.";
+
+    public static final String STACK_CRN = "Stack crn.";
+
+    public static final String CREATED = "Timestamp when the resource was created.";
+
+    public static final String RUNTIME_VERSION = "Runtime version.";
+
+    public static final String DEFAULT_RUNTIME_VERSION = "Default runtime version.";
+
+    public static final String LOCK_COMPONENTS = "Option to lock components during the upgrade.";
+
+    public static final String DRY_RUN = "Doesn't perform the actual operation just validates if all preconditions are met.";
+
+    public static final String SKIP_BACKUP = "Option to skip the backup before the upgrade.";
+
+    public static final String SHOW_AVAILABLE_IMAGES = "Option to show available images.";
+
+    public static final String REPLACE_VMS = "Option to replace virtual machines  during the upgrade.";
+
+    public static final String LOAD_BALANCER_SKU = "Load balancer SKU type.";
+
+    public static final String CURRENT_IMAGE = "Information about the image that the Data Lake cluster is using currently.";
+
+    public static final String UPGRADE_CANDIDATE_IMAGES = "Images that the Data Lake cluster can be upgraded to.";
+
+    public static final String UPGRADE_ERROR_REASON = "Error reason why the Data Lake cluster can't be upgraded.";
+
+    public static final String RANGER_RAZ_ENABLED = "Option to enable ranger raz.";
+
+    public static final String MULTI_AZ_ENABLED = "Option to enable multi AZ.";
+
+    public static final String TAGS = "Tags.";
+
+    public static final String DATA_LAKE_CLUSTER_SERVICE_VERSION = "Data Lake cluster service version.";
+
+    public static final String DETACHED = "Shows whether the cluster is in detached state.";
+
+    public static final String DATABASE_ENGINE_VERSION = "Database engine version.";
+
+    public static final String EXTERNAL_DATABASE_OPTIONS = "External database options.";
+
+    public static final String AWS_OPTIONS = "AWS options.";
+
+    public static final String AZURE_OPTIONS = "Azure options.";
+
+    public static final String CUSTOM_INSTANCE_GROUP_OPTIONS = "Custom instance group options.";
+
+    public static final String RECIPES = "Recipes.";
+
+    public static final String RECIPE_NAME = "Recipe name.";
+
+    public static final String SPOT_PARAMETERS = "Spot parameters.";
+
+    public static final String IMAGE_SETTINGS = "Image settings.";
+
+    public static final String RECENT_FLOW_OPERATIONS = "Recent flow operations.";
+
+    public static final String RECENT_INTERNAL_FLOW_OPERATIONS = "Recent internal flow operations.";
+
+    public static final String LAST_FLOW_OPERATION = "Last flow operations.";
+
+    public static final String LAST_INTERNAL_FLOW_OPERATION = "Last internal flow operations.";
+
+    public static final String CREATE_DATABASE_OPTION = "Option to create external database.";
+
+    public static final String DATABASE_AVAILABILITY_TYPE = "Database availability type.";
+
+    public static final String AZURE_USER_MAPPING = "Azure user mapping.";
+
+    public static final String AZURE_GROUP_MAPPING = "Deprecated. Azure group mapping.";
+
     private ModelDescriptions() {
     }
 }

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/RangerCloudIdentitySyncStatus.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/RangerCloudIdentitySyncStatus.java
@@ -1,19 +1,26 @@
 package com.sequenceiq.sdx.api.model;
 
-import io.swagger.annotations.ApiModelProperty;
-
 import javax.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class RangerCloudIdentitySyncStatus {
 
-    @ApiModelProperty
+    @ApiModelProperty(ModelDescriptions.COMMAND_ID)
     private Long commandId;
 
-    @ApiModelProperty
+    @ApiModelProperty(ModelDescriptions.OPERATION_STATUS)
     @NotNull
     private RangerCloudIdentitySyncState state;
 
-    @ApiModelProperty
+    @ApiModelProperty(ModelDescriptions.OPERATION_STATUS_REASON)
     private String statusReason;
 
     public Long getCommandId() {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/RedeploySdxClusterRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/RedeploySdxClusterRequest.java
@@ -1,4 +1,12 @@
 package com.sequenceiq.sdx.api.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.swagger.annotations.ApiModel;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class RedeploySdxClusterRequest {
 }

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxAwsBase.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxAwsBase.java
@@ -2,8 +2,18 @@ package com.sequenceiq.sdx.api.model;
 
 import javax.validation.Valid;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxAwsBase {
 
+    @ApiModelProperty(ModelDescriptions.SPOT_PARAMETERS)
     @Valid
     private SdxAwsSpotParameters spot;
 

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxAwsRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxAwsRequest.java
@@ -1,4 +1,12 @@
 package com.sequenceiq.sdx.api.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.swagger.annotations.ApiModel;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxAwsRequest extends SdxAwsBase {
 }

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxAwsSpotParameters.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxAwsSpotParameters.java
@@ -5,13 +5,20 @@ import javax.validation.constraints.Digits;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.cloudbreak.doc.ModelDescriptions;
 import com.sequenceiq.cloudbreak.validation.Choice;
 
+import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxAwsSpotParameters {
 
+    @ApiModelProperty(ModelDescriptions.TemplateModelDescription.SPOT_PERCENTAGE)
     @Min(value = 0, message = "Spot percentage must be between 0 and 100 percent")
     @Max(value = 100, message = "Spot percentage must be between 0 and 100 percent")
     @Digits(fraction = 0, integer = 3, message = "Spot percentage has to be a number")

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxAzureBase.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxAzureBase.java
@@ -1,9 +1,18 @@
 package com.sequenceiq.sdx.api.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.common.api.type.LoadBalancerSku;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxAzureBase {
 
+    @ApiModelProperty(ModelDescriptions.LOAD_BALANCER_SKU)
     private LoadBalancerSku loadBalancerSku;
 
     public LoadBalancerSku getLoadBalancerSku() {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxAzureRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxAzureRequest.java
@@ -1,4 +1,12 @@
 package com.sequenceiq.sdx.api.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.swagger.annotations.ApiModel;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxAzureRequest extends SdxAzureBase {
 }

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxBackupResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxBackupResponse.java
@@ -1,11 +1,21 @@
 package com.sequenceiq.sdx.api.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxBackupResponse {
 
+    @ApiModelProperty(ModelDescriptions.OPERATION_ID)
     private String operationId;
 
+    @ApiModelProperty(ModelDescriptions.FLOW_IDENTIFIER)
     private FlowIdentifier flowIdentifier;
 
     public SdxBackupResponse() {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxBackupStatusResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxBackupStatusResponse.java
@@ -1,11 +1,23 @@
 package com.sequenceiq.sdx.api.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxBackupStatusResponse {
 
+    @ApiModelProperty(ModelDescriptions.OPERATION_ID)
     private String operationId;
 
+    @ApiModelProperty(ModelDescriptions.OPERATION_STATUS)
     private String status;
 
+    @ApiModelProperty(ModelDescriptions.OPERATION_STATUS_REASON)
     private String reason;
 
     public SdxBackupStatusResponse() {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxCcmUpgradeResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxCcmUpgradeResponse.java
@@ -2,14 +2,25 @@ package com.sequenceiq.sdx.api.model;
 
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxCcmUpgradeResponse {
 
+    @ApiModelProperty(ModelDescriptions.FLOW_IDENTIFIER)
     private FlowIdentifier flowIdentifier;
 
+    @ApiModelProperty(ModelDescriptions.CCM_UPGRADE_RESPONSE_TYPE)
     private CcmUpgradeResponseType responseType;
 
+    @ApiModelProperty(ModelDescriptions.CCM_UPGRADE_ERROR_REASON)
     private String reason;
 
     public SdxCcmUpgradeResponse() {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxChangeImageCatalogRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxChangeImageCatalogRequest.java
@@ -4,12 +4,16 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.cloudbreak.doc.ModelDescriptions;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
 @ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxChangeImageCatalogRequest {
 
     @Size(max = 100, min = 5, message = "The length of the image catalog has to be in range of 5 to 100")

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterDetailResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterDetailResponse.java
@@ -4,14 +4,23 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 import com.sequenceiq.common.api.tag.response.TaggedResponse;
 import com.sequenceiq.common.api.type.CertExpirationState;
 import com.sequenceiq.common.model.FileSystemType;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxClusterDetailResponse extends SdxClusterResponse implements TaggedResponse {
 
+    @ApiModelProperty(ModelDescriptions.STACK_RESPONSE)
     private StackV4Response stackV4Response;
 
     public static SdxClusterDetailResponse create(SdxClusterResponse sdxClusterResponse, StackV4Response stackV4Response) {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterRequest.java
@@ -2,10 +2,21 @@ package com.sequenceiq.sdx.api.model;
 
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxClusterRequest extends SdxClusterRequestBase {
 
+    @ApiModelProperty(ModelDescriptions.RUNTIME_VERSION)
     private String runtime;
 
+    @ApiModelProperty(ModelDescriptions.RECIPES)
     private Set<SdxRecipe> recipes;
 
     public String getRuntime() {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterRequestBase.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterRequestBase.java
@@ -7,31 +7,49 @@ import java.util.Map;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.common.api.tag.request.TaggableRequest;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxClusterRequestBase implements TaggableRequest {
 
+    @ApiModelProperty(ModelDescriptions.ENVIRONMENT_NAME)
     @NotNull
     private String environment;
 
+    @ApiModelProperty(ModelDescriptions.CLUSTER_SHAPE)
     @NotNull
     private SdxClusterShape clusterShape;
 
+    @ApiModelProperty(ModelDescriptions.CLOUD_STORAGE_DETAILS)
     private SdxCloudStorageRequest cloudStorage;
 
+    @ApiModelProperty(ModelDescriptions.EXTERNAL_DATABASE_OPTIONS)
     private SdxDatabaseRequest externalDatabase;
 
+    @ApiModelProperty(ModelDescriptions.AWS_OPTIONS)
     @Valid
     private SdxAwsRequest aws;
 
+    @ApiModelProperty(ModelDescriptions.AZURE_OPTIONS)
     private SdxAzureRequest azure;
 
+    @ApiModelProperty(ModelDescriptions.TAGS)
     private Map<String, String> tags;
 
+    @ApiModelProperty(ModelDescriptions.RANGER_RAZ_ENABLED)
     private boolean enableRangerRaz;
 
+    @ApiModelProperty(ModelDescriptions.MULTI_AZ_ENABLED)
     private boolean enableMultiAz;
 
+    @ApiModelProperty(ModelDescriptions.CUSTOM_INSTANCE_GROUP_OPTIONS)
     @Valid
     private List<SdxInstanceGroupRequest> customInstanceGroups;
 

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterResizeRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterResizeRequest.java
@@ -2,11 +2,22 @@ package com.sequenceiq.sdx.api.model;
 
 import javax.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxClusterResizeRequest {
 
+    @ApiModelProperty(ModelDescriptions.ENVIRONMENT_NAME)
     @NotNull
     private String environment;
 
+    @ApiModelProperty(ModelDescriptions.CLUSTER_SHAPE)
     @NotNull
     private SdxClusterShape clusterShape;
 

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterResponse.java
@@ -3,57 +3,81 @@ package com.sequenceiq.sdx.api.model;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.cloudbreak.doc.ModelDescriptions.ClusterModelDescription;
 import com.sequenceiq.common.api.type.CertExpirationState;
 import com.sequenceiq.common.model.FileSystemType;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 
+import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
+@ApiModel
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxClusterResponse {
 
+    @ApiModelProperty(ModelDescriptions.DATA_LAKE_CRN)
     private String crn;
 
+    @ApiModelProperty(ModelDescriptions.DATA_LAKE_NAME)
     private String name;
 
+    @ApiModelProperty(ModelDescriptions.CLUSTER_SHAPE)
     private SdxClusterShape clusterShape;
 
+    @ApiModelProperty(ModelDescriptions.DATA_LAKE_STATUS)
     private SdxClusterStatusResponse status;
 
+    @ApiModelProperty(ModelDescriptions.DATA_LAKE_STATUS_REASON)
     private String statusReason;
 
+    @ApiModelProperty(ModelDescriptions.ENVIRONMENT_NAME)
     private String environmentName;
 
+    @ApiModelProperty(ModelDescriptions.ENVIRONMENT_CRN)
     private String environmentCrn;
 
+    @ApiModelProperty(ModelDescriptions.DATABASE_SERVER_CRN)
     private String databaseServerCrn;
 
+    @ApiModelProperty(ModelDescriptions.STACK_CRN)
     private String stackCrn;
 
+    @ApiModelProperty(ModelDescriptions.CREATED)
     private Long created;
 
+    @ApiModelProperty(ModelDescriptions.CLOUD_STORAGE_BASE_LOCATION)
     private String cloudStorageBaseLocation;
 
+    @ApiModelProperty(ModelDescriptions.CLOUD_STORAGE_FILE_SYSTEM_TYPE)
     private FileSystemType cloudStorageFileSystemType;
 
+    @ApiModelProperty(ModelDescriptions.RUNTIME_VERSION)
     private String runtime;
 
+    @ApiModelProperty(ModelDescriptions.FLOW_IDENTIFIER)
     private FlowIdentifier flowIdentifier;
 
+    @ApiModelProperty(ModelDescriptions.RANGER_RAZ_ENABLED)
     private boolean rangerRazEnabled;
 
+    @ApiModelProperty(ModelDescriptions.MULTI_AZ_ENABLED)
     private boolean enableMultiAz;
 
+    @ApiModelProperty(ModelDescriptions.TAGS)
     private Map<String, String> tags;
 
     @ApiModelProperty(ClusterModelDescription.CERT_EXPIRATION)
     private CertExpirationState certExpirationState;
 
+    @ApiModelProperty(ModelDescriptions.DATA_LAKE_CLUSTER_SERVICE_VERSION)
     private String sdxClusterServiceVersion;
 
+    @ApiModelProperty(ModelDescriptions.DETACHED)
     private boolean detached;
 
+    @ApiModelProperty(ModelDescriptions.DATABASE_ENGINE_VERSION)
     private String databaseEngineVersion;
 
     public String getCrn() {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxCustomClusterRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxCustomClusterRequest.java
@@ -2,9 +2,19 @@ package com.sequenceiq.sdx.api.model;
 
 import org.apache.commons.lang3.tuple.Pair;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.image.ImageSettingsV4Request;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxCustomClusterRequest extends SdxClusterRequestBase {
+
+    @ApiModelProperty(ModelDescriptions.IMAGE_SETTINGS)
     private ImageSettingsV4Request imageSettingsV4Request;
 
     public ImageSettingsV4Request getImageSettingsV4Request() {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxDatabaseBackupResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxDatabaseBackupResponse.java
@@ -1,11 +1,21 @@
 package com.sequenceiq.sdx.api.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxDatabaseBackupResponse {
 
+    @ApiModelProperty(ModelDescriptions.OPERATION_ID)
     private String operationId;
 
+    @ApiModelProperty(ModelDescriptions.FLOW_IDENTIFIER)
     private FlowIdentifier flowIdentifier;
 
     public SdxDatabaseBackupResponse() {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxDatabaseBackupStatusResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxDatabaseBackupStatusResponse.java
@@ -1,8 +1,20 @@
 package com.sequenceiq.sdx.api.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxDatabaseBackupStatusResponse {
+
+    @ApiModelProperty(ModelDescriptions.OPERATION_STATUS)
     private DatalakeDatabaseDrStatus status;
 
+    @ApiModelProperty(ModelDescriptions.OPERATION_STATUS_REASON)
     private String statusReason;
 
     public SdxDatabaseBackupStatusResponse(DatalakeDatabaseDrStatus status) {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxDatabaseRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxDatabaseRequest.java
@@ -4,12 +4,24 @@ import static com.sequenceiq.cloudbreak.common.database.DatabaseCommon.POSTGRES_
 
 import javax.validation.constraints.Pattern;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxDatabaseRequest {
 
+    @ApiModelProperty(ModelDescriptions.CREATE_DATABASE_OPTION)
     private Boolean create;
 
+    @ApiModelProperty(ModelDescriptions.DATABASE_AVAILABILITY_TYPE)
     private SdxDatabaseAvailabilityType availabilityType;
 
+    @ApiModelProperty(ModelDescriptions.DATABASE_ENGINE_VERSION)
     @Pattern(regexp = POSTGRES_VERSION_REGEX, message = "Not a valid database major version")
     private String databaseEngineVersion;
 

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxDatabaseRestoreResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxDatabaseRestoreResponse.java
@@ -1,10 +1,21 @@
 package com.sequenceiq.sdx.api.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxDatabaseRestoreResponse {
+
+    @ApiModelProperty(ModelDescriptions.OPERATION_ID)
     private String operationId;
 
+    @ApiModelProperty(ModelDescriptions.FLOW_IDENTIFIER)
     private FlowIdentifier flowIdentifier;
 
     public SdxDatabaseRestoreResponse() {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxDatabaseRestoreStatusResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxDatabaseRestoreStatusResponse.java
@@ -1,8 +1,20 @@
 package com.sequenceiq.sdx.api.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxDatabaseRestoreStatusResponse {
+
+    @ApiModelProperty(ModelDescriptions.OPERATION_STATUS)
     private DatalakeDatabaseDrStatus status;
 
+    @ApiModelProperty(ModelDescriptions.OPERATION_STATUS_REASON)
     private String statusReason;
 
     public SdxDatabaseRestoreStatusResponse(DatalakeDatabaseDrStatus status) {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxDefaultTemplateResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxDefaultTemplateResponse.java
@@ -4,10 +4,15 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackV4Request;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxDefaultTemplateResponse {
 
+    @ApiModelProperty(ModelDescriptions.TEMPLATE_DETAILS)
     private StackV4Request template;
 
     public SdxDefaultTemplateResponse() {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxGenerateImageCatalogResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxGenerateImageCatalogResponse.java
@@ -7,12 +7,14 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakImageCatalogV3;
 
 import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 
 @ApiModel
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxGenerateImageCatalogResponse {
 
+    @ApiModelProperty(ModelDescriptions.IMAGE_CATALOG)
     @NotNull
     private CloudbreakImageCatalogV3 imageCatalog;
 

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxInstanceGroupRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxInstanceGroupRequest.java
@@ -2,11 +2,22 @@ package com.sequenceiq.sdx.api.model;
 
 import javax.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxInstanceGroupRequest {
 
+    @ApiModelProperty(ModelDescriptions.INSTANCE_GROUP_NAME)
     @NotNull
     private String name;
 
+    @ApiModelProperty(ModelDescriptions.INSTANCE_TYPE)
     private String instanceType;
 
     public String getName() {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxInternalClusterRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxInternalClusterRequest.java
@@ -1,9 +1,18 @@
 package com.sequenceiq.sdx.api.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackV4Request;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxInternalClusterRequest extends SdxClusterRequest {
 
+    @ApiModelProperty(ModelDescriptions.STACK_REQUEST)
     private StackV4Request stackV4Request;
 
     public StackV4Request getStackV4Request() {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxProgressListResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxProgressListResponse.java
@@ -4,13 +4,21 @@ import java.io.Serializable;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.flow.api.model.FlowProgressResponse;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxProgressListResponse implements Serializable {
 
+    @ApiModelProperty(ModelDescriptions.RECENT_FLOW_OPERATIONS)
     private List<FlowProgressResponse> recentFlowOperations;
 
+    @ApiModelProperty(ModelDescriptions.RECENT_INTERNAL_FLOW_OPERATIONS)
     private List<FlowProgressResponse> recentInternalFlowOperations;
 
     public List<FlowProgressResponse> getRecentFlowOperations() {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxProgressResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxProgressResponse.java
@@ -3,13 +3,21 @@ package com.sequenceiq.sdx.api.model;
 import java.io.Serializable;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.flow.api.model.FlowProgressResponse;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxProgressResponse implements Serializable {
 
+    @ApiModelProperty(ModelDescriptions.LAST_FLOW_OPERATION)
     private FlowProgressResponse lastFlowOperation;
 
+    @ApiModelProperty(ModelDescriptions.LAST_INTERNAL_FLOW_OPERATION)
     private FlowProgressResponse lastInternalFlowOperation;
 
     public FlowProgressResponse getLastFlowOperation() {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxRecipe.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxRecipe.java
@@ -5,13 +5,21 @@ import java.io.Serializable;
 import javax.validation.constraints.NotBlank;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxRecipe implements Serializable {
 
+    @ApiModelProperty(ModelDescriptions.RECIPE_NAME)
     @NotBlank
     private String name;
 
+    @ApiModelProperty(ModelDescriptions.HOST_GROUP_NAME)
     @NotBlank
     private String hostGroup;
 

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxRecoverableResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxRecoverableResponse.java
@@ -1,11 +1,21 @@
 package com.sequenceiq.sdx.api.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.recovery.RecoveryStatus;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxRecoverableResponse {
 
+    @ApiModelProperty(ModelDescriptions.RECOVERABLE_STATUS_REASON)
     private String reason;
 
+    @ApiModelProperty(ModelDescriptions.RECOVERABLE_STATUS)
     private RecoveryStatus status;
 
     public SdxRecoverableResponse(String reason, RecoveryStatus status) {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxRecoveryRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxRecoveryRequest.java
@@ -2,10 +2,15 @@ package com.sequenceiq.sdx.api.model;
 
 import java.util.StringJoiner;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
 @ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxRecoveryRequest {
 
     @ApiModelProperty(ModelDescriptions.RECOVERY_TYPE)

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxRecoveryResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxRecoveryResponse.java
@@ -1,9 +1,18 @@
 package com.sequenceiq.sdx.api.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxRecoveryResponse {
 
+    @ApiModelProperty(ModelDescriptions.FLOW_IDENTIFIER)
     private FlowIdentifier flowIdentifier;
 
     public SdxRecoveryResponse() {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxRepairRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxRepairRequest.java
@@ -2,12 +2,24 @@ package com.sequenceiq.sdx.api.model;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxRepairRequest {
 
+    @ApiModelProperty(ModelDescriptions.HOST_GROUP_NAME)
     private String hostGroupName;
 
+    @ApiModelProperty(ModelDescriptions.HOST_GROUP_NAMES)
     private List<String> hostGroupNames;
 
+    @ApiModelProperty(ModelDescriptions.NODE_IDS)
     private List<String> nodesIds;
 
     public String getHostGroupName() {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxRestoreResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxRestoreResponse.java
@@ -1,11 +1,21 @@
 package com.sequenceiq.sdx.api.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxRestoreResponse {
 
+    @ApiModelProperty(ModelDescriptions.OPERATION_ID)
     private String operationId;
 
+    @ApiModelProperty(ModelDescriptions.FLOW_IDENTIFIER)
     private FlowIdentifier flowIdentifier;
 
     public SdxRestoreResponse() {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxRestoreStatusResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxRestoreStatusResponse.java
@@ -1,11 +1,23 @@
 package com.sequenceiq.sdx.api.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxRestoreStatusResponse {
 
+    @ApiModelProperty(ModelDescriptions.OPERATION_ID)
     private String operationId;
 
+    @ApiModelProperty(ModelDescriptions.OPERATION_STATUS)
     private String status;
 
+    @ApiModelProperty(ModelDescriptions.OPERATION_STATUS_REASON)
     private String reason;
 
     public SdxRestoreStatusResponse() {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxSyncComponentVersionsFromCmResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxSyncComponentVersionsFromCmResponse.java
@@ -1,9 +1,18 @@
 package com.sequenceiq.sdx.api.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxSyncComponentVersionsFromCmResponse {
 
+    @ApiModelProperty(ModelDescriptions.FLOW_IDENTIFIER)
     private FlowIdentifier flowIdentifier;
 
     public SdxSyncComponentVersionsFromCmResponse() {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxUpgradeRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxUpgradeRequest.java
@@ -2,25 +2,38 @@ package com.sequenceiq.sdx.api.model;
 
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.sdx.validation.ValidUpgradeRequest;
 
+import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @ValidUpgradeRequest
 public class SdxUpgradeRequest {
 
+    @ApiModelProperty(ModelDescriptions.IMAGE_ID)
     private String imageId;
 
+    @ApiModelProperty(ModelDescriptions.RUNTIME_VERSION)
     private String runtime;
 
+    @ApiModelProperty(ModelDescriptions.LOCK_COMPONENTS)
     private Boolean lockComponents;
 
+    @ApiModelProperty(ModelDescriptions.DRY_RUN)
     private Boolean dryRun;
 
+    @ApiModelProperty(ModelDescriptions.SKIP_BACKUP)
     private Boolean skipBackup;
 
+    @ApiModelProperty(ModelDescriptions.SHOW_AVAILABLE_IMAGES)
     private SdxUpgradeShowAvailableImages showAvailableImages;
 
+    @ApiModelProperty(ModelDescriptions.REPLACE_VMS)
     private SdxUpgradeReplaceVms replaceVms;
 
     public String getImageId() {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxUpgradeResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxUpgradeResponse.java
@@ -4,18 +4,30 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.image.ImageInfoV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.upgrade.UpgradeOptionV4Response;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxUpgradeResponse {
 
+    @ApiModelProperty(ModelDescriptions.CURRENT_IMAGE)
     private ImageInfoV4Response current;
 
+    @ApiModelProperty(ModelDescriptions.UPGRADE_CANDIDATE_IMAGES)
     private List<ImageInfoV4Response> upgradeCandidates;
 
+    @ApiModelProperty(ModelDescriptions.UPGRADE_ERROR_REASON)
     private String reason;
 
+    @ApiModelProperty(ModelDescriptions.FLOW_IDENTIFIER)
     private FlowIdentifier flowIdentifier;
 
     public SdxUpgradeResponse() {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxValidateCloudStorageRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxValidateCloudStorageRequest.java
@@ -2,20 +2,34 @@ package com.sequenceiq.sdx.api.model;
 
 import javax.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SdxValidateCloudStorageRequest {
 
+    @ApiModelProperty(ModelDescriptions.DATA_ACCESS_ROLE)
     @NotNull
     private String dataAccessRole;
 
+    @ApiModelProperty(ModelDescriptions.RANGER_AUDIT_ROLE)
     @NotNull
     private String rangerAuditRole;
 
+    @ApiModelProperty(ModelDescriptions.CREDENTIAL_CRN)
     @NotNull
     private String credentialCrn;
 
+    @ApiModelProperty(ModelDescriptions.CLOUD_STORAGE_DETAILS)
     @NotNull
     private SdxCloudStorageRequest sdxCloudStorageRequest;
 
+    @ApiModelProperty(ModelDescriptions.CLUSTER_TEMPLATE_NAME)
     @NotNull
     private String blueprintName;
 

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SetRangerCloudIdentityMappingRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SetRangerCloudIdentityMappingRequest.java
@@ -1,26 +1,30 @@
 package com.sequenceiq.sdx.api.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
-
-import javax.validation.constraints.NotNull;
 import java.util.Map;
 import java.util.Objects;
 
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
 @ApiModel
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SetRangerCloudIdentityMappingRequest {
 
-    @ApiModelProperty
+    @ApiModelProperty(ModelDescriptions.AZURE_USER_MAPPING)
     @NotNull
     private Map<String, String> azureUserMapping;
 
     /**
-     * @deprecated azureGroupMapping is not unsupported
+     * @deprecated azureGroupMapping is not supported
      */
     @Deprecated
-    @ApiModelProperty
+    @ApiModelProperty(ModelDescriptions.AZURE_GROUP_MAPPING)
     private Map<String, String> azureGroupMapping;
 
     public Map<String, String> getAzureUserMapping() {

--- a/datalake-api/src/test/java/com/sequenceiq/sdx/api/ApiFormatTest.java
+++ b/datalake-api/src/test/java/com/sequenceiq/sdx/api/ApiFormatTest.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.sdx.api;
+
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.sdx.api.model.ModelDescriptions;
+import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
+import com.sequenceiq.sdx.api.model.SdxClusterDetailResponseTest;
+import com.sequenceiq.sdx.api.model.diagnostics.docs.DiagnosticsOperationDescriptions;
+import com.sequenceiq.cloudbreak.apiformat.ApiFormatValidator;
+
+public class ApiFormatTest {
+
+    @Test
+    public void testApiFormat() {
+        ApiFormatValidator.builder()
+                .modelPackage("com.sequenceiq.sdx.api.model")
+                .excludedClasses(
+                        SdxClusterDetailResponseTest.class,
+                        SdxClusterDetailResponse.Builder.class,
+                        ModelDescriptions.class,
+                        DiagnosticsOperationDescriptions.class
+                )
+                .build()
+                .validate();
+    }
+}

--- a/datalake-api/src/test/java/com/sequenceiq/sdx/api/model/SdxClusterDetailResponseTest.java
+++ b/datalake-api/src/test/java/com/sequenceiq/sdx/api/model/SdxClusterDetailResponseTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 
-class SdxClusterDetailResponseTest {
+public class SdxClusterDetailResponseTest {
 
     private static final String TAG_KEY = "sometthing";
 


### PR DESCRIPTION
Created API format validator. Currently it checks API model classes and looks for mandatory annotations like @apimodel, @JsonIgnoreProperties(ignoreUnknown = true), @JsonInclude(JsonInclude.Include.NON_NULL), @ApiModelProperty(description).

This can be used to validate the format of other REST APIs as well.