### PR TITLE
CB-16687 StopStartDownscaleDecommissionViaCMRequest sould not contain…

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterDecomissionService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterDecomissionService.java
@@ -25,7 +25,7 @@ public interface ClusterDecomissionService {
 
     Set<String> decommissionClusterNodesStopStart(Map<String, InstanceMetaData> hostsToRemove, long pollingTimeout);
 
-    void enterMaintenanceMode(Stack stack, Set<String> hostFqdnList);
+    void enterMaintenanceMode(Set<String> hostFqdnList);
 
     void removeManagementServices();
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterDecommissionService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterDecommissionService.java
@@ -104,8 +104,8 @@ public class ClouderaManagerClusterDecommissionService implements ClusterDecomis
     }
 
     @Override
-    public void enterMaintenanceMode(Stack stack, Set<String> hostFqdnList) {
-        clouderaManagerDecomissioner.enterMaintenanceMode(stack, hostFqdnList, v31Client);
+    public void enterMaintenanceMode(Set<String> hostFqdnList) {
+        clouderaManagerDecomissioner.enterMaintenanceMode(hostFqdnList, v31Client);
     }
 
     @Override

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerDecomissioner.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerDecomissioner.java
@@ -229,7 +229,7 @@ public class ClouderaManagerDecomissioner {
         }
     }
 
-    public void enterMaintenanceMode(Stack stack, Set<String> hostList, ApiClient client) {
+    public void enterMaintenanceMode(Set<String> hostList, ApiClient client) {
         HostsResourceApi hostsResourceApi = clouderaManagerApiFactory.getHostsResourceApi(client);
         String currentHostId = null;
         int successCount = 0;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartds/StopStartDownscaleActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartds/StopStartDownscaleActions.java
@@ -94,7 +94,7 @@ public class StopStartDownscaleActions {
 
             @Override
             protected Selectable createRequest(StopStartDownscaleContext context) {
-                return new StopStartDownscaleDecommissionViaCMRequest(context.getStack(), context.getHostGroupName(), context.getHostIdsToRemove());
+                return new StopStartDownscaleDecommissionViaCMRequest(context.getStack().getId(), context.getHostGroupName(), context.getHostIdsToRemove());
             }
         };
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/StopStartDownscaleDecommissionViaCMRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/StopStartDownscaleDecommissionViaCMRequest.java
@@ -2,7 +2,6 @@ package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
 import java.util.Set;
 
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.HostGroupPayload;
 
@@ -10,23 +9,16 @@ public class StopStartDownscaleDecommissionViaCMRequest extends ClusterPlatformR
 
     private final String hostGroupName;
 
-    private final Stack stack;
-
     private final Set<Long> instanceIdsToDecommission;
 
-    public StopStartDownscaleDecommissionViaCMRequest(Stack stack, String hostGroupName, Set<Long> instanceIdsToDecommission) {
-        super(stack.getId());
+    public StopStartDownscaleDecommissionViaCMRequest(Long resourceId, String hostGroupName, Set<Long> instanceIdsToDecommission) {
+        super(resourceId);
         this.hostGroupName = hostGroupName;
-        this.stack = stack;
         this.instanceIdsToDecommission = instanceIdsToDecommission;
     }
 
     public Set<Long> getInstanceIdsToDecommission() {
         return instanceIdsToDecommission;
-    }
-
-    public Stack getStack() {
-        return stack;
     }
 
     @Override
@@ -37,7 +29,6 @@ public class StopStartDownscaleDecommissionViaCMRequest extends ClusterPlatformR
     @Override
     public String toString() {
         return "StopStartDownscaleDecommissionViaCMRequest{" +
-                "stack=" + stack +
                 ", instanceIdsToDecommission=" + instanceIdsToDecommission +
                 '}';
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/StopStartDownscaleDecommissionViaCMHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/StopStartDownscaleDecommissionViaCMHandler.java
@@ -81,7 +81,7 @@ public class StopStartDownscaleDecommissionViaCMHandler extends ExceptionCatcher
         LOGGER.info("StopStartDownscaleDecommissionViaCMHandler for: {}, {}", event.getData().getResourceId(), event.getData());
 
         try {
-            Stack stack = request.getStack();
+            Stack stack = stackService.getByIdWithLists(request.getResourceId());
             Cluster cluster = stack.getCluster();
             ClusterDecomissionService clusterDecomissionService = clusterApiConnectors.getConnector(stack).clusterDecomissionService();
 
@@ -137,7 +137,7 @@ public class StopStartDownscaleDecommissionViaCMHandler extends ExceptionCatcher
                 flowMessageService.fireEventAndLog(stack.getId(), UPDATE_IN_PROGRESS.name(), CLUSTER_SCALING_STOPSTART_DOWNSCALE_ENTERINGCMMAINTMODE,
                         String.valueOf(decommissionedHostNames.size()));
 
-                clusterDecomissionService.enterMaintenanceMode(stack, decommissionedHostNames);
+                clusterDecomissionService.enterMaintenanceMode(decommissionedHostNames);
 
                 flowMessageService.fireEventAndLog(stack.getId(), UPDATE_IN_PROGRESS.name(), CLUSTER_SCALING_STOPSTART_DOWNSCALE_ENTEREDCMMAINTMODE,
                         String.valueOf(decommissionedHostNames.size()));

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartds/StopStartDownscaleActionsTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartds/StopStartDownscaleActionsTest.java
@@ -183,7 +183,7 @@ public class StopStartDownscaleActionsTest {
 
         StopStartDownscaleContext stopStartDownscaleContext = createContext(instanceIdsToRemove);
         StopStartDownscaleDecommissionViaCMRequest r =
-                new StopStartDownscaleDecommissionViaCMRequest(stack, INSTANCE_GROUP_NAME_ACTIONABLE, instanceIdsToRemove);
+                new StopStartDownscaleDecommissionViaCMRequest(1L, INSTANCE_GROUP_NAME_ACTIONABLE, instanceIdsToRemove);
         StopStartDownscaleDecommissionViaCMResult payload = new StopStartDownscaleDecommissionViaCMResult(r, decommissionedHostsFqdns, Collections.emptyList());
 
         mockStackEtc(instancesActionableStarted, instancesActionableNotStarted, instancesRandomStarted, instancesRandomNotStarted);
@@ -226,7 +226,7 @@ public class StopStartDownscaleActionsTest {
 
         StopStartDownscaleContext stopStartDownscaleContext = createContext(instanceIdsToRemove);
         StopStartDownscaleDecommissionViaCMRequest r =
-                new StopStartDownscaleDecommissionViaCMRequest(stack, INSTANCE_GROUP_NAME_ACTIONABLE, instanceIdsToRemove);
+                new StopStartDownscaleDecommissionViaCMRequest(1L, INSTANCE_GROUP_NAME_ACTIONABLE, instanceIdsToRemove);
         StopStartDownscaleDecommissionViaCMResult payload = new StopStartDownscaleDecommissionViaCMResult(r, decommissionedHostsFqdns, notDecommissionedFqdns);
 
         mockStackEtc(instancesActionableStarted, instancesActionableNotStarted, instancesRandomStarted, instancesRandomNotStarted);
@@ -270,7 +270,7 @@ public class StopStartDownscaleActionsTest {
 
         StopStartDownscaleContext stopStartDownscaleContext = createContext(instanceIdsToRemove);
         StopStartDownscaleDecommissionViaCMRequest r =
-                new StopStartDownscaleDecommissionViaCMRequest(stack, INSTANCE_GROUP_NAME_ACTIONABLE, instanceIdsToRemove);
+                new StopStartDownscaleDecommissionViaCMRequest(1L, INSTANCE_GROUP_NAME_ACTIONABLE, instanceIdsToRemove);
         StopStartDownscaleDecommissionViaCMResult payload = new StopStartDownscaleDecommissionViaCMResult(r, decommissionedHostsFqdns, notDecommissionedFqdns);
 
         mockStackEtc(instancesActionableStarted, instancesActionableNotStarted, instancesRandomStarted, instancesRandomNotStarted);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/StopStartDownscaleDecommissionViaCMHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/StopStartDownscaleDecommissionViaCMHandlerTest.java
@@ -93,6 +93,7 @@ public class StopStartDownscaleDecommissionViaCMHandlerTest {
     @BeforeEach
     void setUp() {
         setupBasicMocks();
+        when(stackService.getByIdWithLists(any())).thenReturn(stack);
     }
 
     @Test
@@ -134,7 +135,7 @@ public class StopStartDownscaleDecommissionViaCMHandlerTest {
         Set<String> hostnamesToDecommission = instancesToDecommission.stream().map(InstanceMetaData::getDiscoveryFQDN).collect(Collectors.toUnmodifiableSet());
 
         StopStartDownscaleDecommissionViaCMRequest request =
-                new StopStartDownscaleDecommissionViaCMRequest(stack, INSTANCE_GROUP_NAME, instanceIdsToDecommission);
+                new StopStartDownscaleDecommissionViaCMRequest(1L, INSTANCE_GROUP_NAME, instanceIdsToDecommission);
         HandlerEvent handlerEvent = new HandlerEvent(Event.wrap(request));
         Selectable selectable = underTest.doAccept(handlerEvent);
 
@@ -170,7 +171,7 @@ public class StopStartDownscaleDecommissionViaCMHandlerTest {
         Set<String> hostnamesToDecommission = instancesToDecommission.stream().map(InstanceMetaData::getDiscoveryFQDN).collect(Collectors.toUnmodifiableSet());
 
         StopStartDownscaleDecommissionViaCMRequest request =
-                new StopStartDownscaleDecommissionViaCMRequest(stack, INSTANCE_GROUP_NAME, instanceIdsToDecommission);
+                new StopStartDownscaleDecommissionViaCMRequest(1L, INSTANCE_GROUP_NAME, instanceIdsToDecommission);
         HandlerEvent handlerEvent = new HandlerEvent(Event.wrap(request));
         Selectable selectable = underTest.doAccept(handlerEvent);
 
@@ -207,7 +208,7 @@ public class StopStartDownscaleDecommissionViaCMHandlerTest {
         Set<String> hostnamesToDecommission = instancesToDecommission.stream().map(InstanceMetaData::getDiscoveryFQDN).collect(Collectors.toUnmodifiableSet());
 
         StopStartDownscaleDecommissionViaCMRequest request =
-                new StopStartDownscaleDecommissionViaCMRequest(stack, INSTANCE_GROUP_NAME, instanceIdsToDecommission);
+                new StopStartDownscaleDecommissionViaCMRequest(1L, INSTANCE_GROUP_NAME, instanceIdsToDecommission);
         HandlerEvent handlerEvent = new HandlerEvent(Event.wrap(request));
         Selectable selectable = underTest.doAccept(handlerEvent);
 
@@ -244,7 +245,7 @@ public class StopStartDownscaleDecommissionViaCMHandlerTest {
                 .thenThrow(new RuntimeException("collectHostsToDecommissionError"));
 
         StopStartDownscaleDecommissionViaCMRequest request =
-                new StopStartDownscaleDecommissionViaCMRequest(stack, INSTANCE_GROUP_NAME, instanceIdsToDecommission);
+                new StopStartDownscaleDecommissionViaCMRequest(1L, INSTANCE_GROUP_NAME, instanceIdsToDecommission);
         HandlerEvent handlerEvent = new HandlerEvent(Event.wrap(request));
         Selectable selectable = underTest.doAccept(handlerEvent);
         verify(clusterDecomissionService).collectHostsToRemove(eq(hostGroup), eq(hostnamesToDecommission));
@@ -284,7 +285,7 @@ public class StopStartDownscaleDecommissionViaCMHandlerTest {
                 .thenThrow(new RuntimeException("decommissionHostsError"));
 
         StopStartDownscaleDecommissionViaCMRequest request =
-                new StopStartDownscaleDecommissionViaCMRequest(stack, INSTANCE_GROUP_NAME, instanceIdsToDecommission);
+                new StopStartDownscaleDecommissionViaCMRequest(1L, INSTANCE_GROUP_NAME, instanceIdsToDecommission);
         HandlerEvent handlerEvent = new HandlerEvent(Event.wrap(request));
         Selectable selectable = underTest.doAccept(handlerEvent);
         verify(clusterDecomissionService).collectHostsToRemove(eq(hostGroup), eq(hostnamesToDecommission));
@@ -320,7 +321,7 @@ public class StopStartDownscaleDecommissionViaCMHandlerTest {
         Set<String> hostnamesToDecommission = instancesToDecommission.stream().map(InstanceMetaData::getDiscoveryFQDN).collect(Collectors.toUnmodifiableSet());
 
         StopStartDownscaleDecommissionViaCMRequest request =
-                new StopStartDownscaleDecommissionViaCMRequest(stack, INSTANCE_GROUP_NAME, instanceIdsToDecommission);
+                new StopStartDownscaleDecommissionViaCMRequest(1L, INSTANCE_GROUP_NAME, instanceIdsToDecommission);
         HandlerEvent handlerEvent = new HandlerEvent(Event.wrap(request));
         Selectable selectable = underTest.doAccept(handlerEvent);
 
@@ -340,7 +341,7 @@ public class StopStartDownscaleDecommissionViaCMHandlerTest {
 
         verify(flowMessageService).fireEventAndLog(eq(STACK_ID), eq(UPDATE_IN_PROGRESS.name()),
                 eq(CLUSTER_SCALING_STOPSTART_DOWNSCALE_ENTERINGCMMAINTMODE), eq(String.valueOf(fqdnsDecommissioned.size())));
-        verify(clusterDecomissionService).enterMaintenanceMode(eq(stack), eq(fqdnsDecommissioned));
+        verify(clusterDecomissionService).enterMaintenanceMode(eq(fqdnsDecommissioned));
         verify(flowMessageService).fireEventAndLog(eq(STACK_ID), eq(UPDATE_IN_PROGRESS.name()),
                 eq(CLUSTER_SCALING_STOPSTART_DOWNSCALE_ENTEREDCMMAINTMODE), eq(String.valueOf(fqdnsDecommissioned.size())));
         verifyNoMoreInteractions(flowMessageService);


### PR DESCRIPTION
… entity

- calling FlowLogDBService getSerializedString ends up with infinite recursion and StackOverFlowError because we are calling toString on Stack entity

See detailed description in the commit message.