### PR TITLE
CB-16349 Bring your own DNS zone - Environment service: modify valida…

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/network/NetworkResourcesCreationRequest.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/network/NetworkResourcesCreationRequest.java
@@ -2,8 +2,7 @@ package com.sequenceiq.cloudbreak.cloud.model.network;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import org.apache.commons.lang3.StringUtils;
+import java.util.Set;
 
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
@@ -27,7 +26,7 @@ public class NetworkResourcesCreationRequest {
 
     private final boolean privateEndpointsEnabled;
 
-    private final String existingPrivateDnsZoneId;
+    private final Set<String> servicesWithExistingPrivateDnsZone;
 
     private final Map<String, String> tags;
 
@@ -40,7 +39,7 @@ public class NetworkResourcesCreationRequest {
         region = builder.region;
         resourceGroup = builder.resourceGroup;
         privateEndpointsEnabled = builder.privateEndpointsEnabled;
-        existingPrivateDnsZoneId = builder.existingPrivateDnsZoneId;
+        servicesWithExistingPrivateDnsZone = builder.servicesWithExistingPrivateDnsZones;
         tags = builder.tags;
     }
 
@@ -76,12 +75,8 @@ public class NetworkResourcesCreationRequest {
         return privateEndpointsEnabled;
     }
 
-    public String getExistingPrivateDnsZoneId() {
-        return existingPrivateDnsZoneId;
-    }
-
-    public boolean isExistingPrivateDnsZone() {
-        return StringUtils.isNotEmpty(existingPrivateDnsZoneId);
+    public Set<String> getServicesWithExistingPrivateDnsZone() {
+        return servicesWithExistingPrivateDnsZone;
     }
 
     public Map<String, String> getTags() {
@@ -106,7 +101,7 @@ public class NetworkResourcesCreationRequest {
 
         private boolean privateEndpointsEnabled;
 
-        private String existingPrivateDnsZoneId;
+        private Set<String> servicesWithExistingPrivateDnsZones;
 
         private Map<String, String> tags = new HashMap<>();
 
@@ -155,8 +150,8 @@ public class NetworkResourcesCreationRequest {
             return this;
         }
 
-        public Builder withExistingPrivateDnsZone(String existingPrivateDnsZoneId) {
-            this.existingPrivateDnsZoneId = existingPrivateDnsZoneId;
+        public Builder withServicesWithExistingPrivateDnsZones(Set<String> servicesWithExistingPrivateDnsZones) {
+            this.servicesWithExistingPrivateDnsZones = servicesWithExistingPrivateDnsZones;
             return this;
         }
 

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePrivateEndpointServicesProvider.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePrivateEndpointServicesProvider.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.cloud.azure;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -16,11 +17,20 @@ public class AzurePrivateEndpointServicesProvider {
     @Value("${cb.arm.privateendpoint.services:}")
     private List<String> privateEndpointServices;
 
-    public List<AzurePrivateDnsZoneServiceEnum> getEnabledPrivateEndpointServices() {
+    public List<AzurePrivateDnsZoneServiceEnum> getCdpManagedDnsZones(Set<AzurePrivateDnsZoneServiceEnum> servicesWithExistingPrivateDnsZone) {
+        List<AzurePrivateDnsZoneServiceEnum> enabledPrivateEndpointServices = getEnabledPrivateEndpointServices();
+        enabledPrivateEndpointServices.removeAll(servicesWithExistingPrivateDnsZone);
+        LOGGER.debug("Services with existing private dns zones: {}, services where new private DNS zone needs to be created: {}",
+                servicesWithExistingPrivateDnsZone, enabledPrivateEndpointServices);
+        return enabledPrivateEndpointServices;
+    }
+
+    private List<AzurePrivateDnsZoneServiceEnum> getEnabledPrivateEndpointServices() {
         List<AzurePrivateDnsZoneServiceEnum> serviceEnumList = privateEndpointServices.stream()
                 .map(AzurePrivateDnsZoneServiceEnum::getBySubResource)
                 .collect(Collectors.toList());
         LOGGER.debug("Enabled private endpoint services: {}", serviceEnumList);
         return serviceEnumList;
     }
+
 }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzureExistingPrivateDnsZoneValidatorService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzureExistingPrivateDnsZoneValidatorService.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.cloudbreak.cloud.azure.validator.privatedns;
+
+import java.security.InvalidParameterException;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.microsoft.azure.arm.resources.ResourceId;
+import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneServiceEnum;
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.validation.ValidationResult;
+
+@Service
+public class AzureExistingPrivateDnsZoneValidatorService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AzureExistingPrivateDnsZoneValidatorService.class);
+
+    @Inject
+    private AzurePrivateDnsZoneValidatorService azurePrivateDnsZoneValidatorService;
+
+    public ValidationResult.ValidationResultBuilder validate(AzureClient azureClient, String networkResourceGroupName,
+            String networkName, Map<AzurePrivateDnsZoneServiceEnum, String> serviceToPrivateDnsZoneId, ValidationResult.ValidationResultBuilder resultBuilder) {
+        serviceToPrivateDnsZoneId.forEach((service, privateDnsZoneId) -> {
+            try {
+                ResourceId privateDnsZoneResourceId = ResourceId.fromString(privateDnsZoneId);
+                azurePrivateDnsZoneValidatorService.existingPrivateDnsZoneNameIsSupported(service, privateDnsZoneResourceId, resultBuilder);
+                azurePrivateDnsZoneValidatorService.privateDnsZoneExists(azureClient, privateDnsZoneResourceId, resultBuilder);
+                azurePrivateDnsZoneValidatorService.privateDnsZoneConnectedToNetwork(azureClient, networkResourceGroupName, networkName,
+                        privateDnsZoneResourceId, resultBuilder);
+            } catch (InvalidParameterException e) {
+                String validationMessage = String.format("The provided private DNS zone id %s for service %s is not a valid azure resource id.",
+                        privateDnsZoneId, service.getResourceType());
+                LOGGER.warn(validationMessage);
+                resultBuilder.error(validationMessage);
+            }
+        });
+
+        return resultBuilder;
+    }
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzureNewPrivateDnsZoneValidatorService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzureNewPrivateDnsZoneValidatorService.java
@@ -1,0 +1,50 @@
+package com.sequenceiq.cloudbreak.cloud.azure.validator.privatedns;
+
+import java.util.List;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.microsoft.azure.PagedList;
+import com.microsoft.azure.management.privatedns.v2018_09_01.PrivateZone;
+import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneServiceEnum;
+import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateEndpointServicesProvider;
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.validation.ValidationResult;
+
+@Service
+public class AzureNewPrivateDnsZoneValidatorService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AzureNewPrivateDnsZoneValidatorService.class);
+
+    @Inject
+    private AzurePrivateDnsZoneValidatorService azurePrivateDnsZoneValidatorService;
+
+    @Inject
+    private AzurePrivateEndpointServicesProvider azurePrivateEndpointServicesProvider;
+
+    public ValidationResult.ValidationResultBuilder zonesNotConnectedToNetwork(AzureClient azureClient, String networkId, String singleResourceGroupName,
+            Set<AzurePrivateDnsZoneServiceEnum> servicesWithExistingDnsZones, ValidationResult.ValidationResultBuilder resultBuilder) {
+        List<AzurePrivateDnsZoneServiceEnum> cdpManagedPrivateEndpointServices = azurePrivateEndpointServicesProvider
+                .getCdpManagedDnsZones(servicesWithExistingDnsZones);
+        if (cdpManagedPrivateEndpointServices.isEmpty()) {
+            LOGGER.debug("There are no private DNS zone services that CDP would manage on its own, skipping checking if DNS zones are already connected " +
+                    "to the network");
+            return resultBuilder;
+        }
+
+        PagedList<PrivateZone> privateDnsZoneList = azureClient.getPrivateDnsZoneList();
+        for (AzurePrivateDnsZoneServiceEnum service : cdpManagedPrivateEndpointServices) {
+            LOGGER.debug("Validating network that no private DNS zone with name {} is connected to it.", service.getDnsZoneName());
+            azurePrivateDnsZoneValidatorService.privateDnsZonesNotConnectedToNetwork(azureClient, networkId, singleResourceGroupName,
+                    service.getDnsZoneName(), resultBuilder, privateDnsZoneList);
+        }
+
+        return resultBuilder;
+    }
+
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzurePrivateDnsZoneValidatorService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzurePrivateDnsZoneValidatorService.java
@@ -1,0 +1,89 @@
+package com.sequenceiq.cloudbreak.cloud.azure.validator.privatedns;
+
+import static com.microsoft.azure.management.privatedns.v2018_09_01.ProvisioningState.SUCCEEDED;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.microsoft.azure.PagedList;
+import com.microsoft.azure.arm.resources.ResourceId;
+import com.microsoft.azure.management.privatedns.v2018_09_01.PrivateZone;
+import com.microsoft.azure.management.privatedns.v2018_09_01.implementation.VirtualNetworkLinkInner;
+import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneServiceEnum;
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.validation.ValidationResult;
+
+@Service
+public class AzurePrivateDnsZoneValidatorService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AzurePrivateDnsZoneValidatorService.class);
+
+    public ValidationResult.ValidationResultBuilder existingPrivateDnsZoneNameIsSupported(AzurePrivateDnsZoneServiceEnum serviceEnum,
+            ResourceId existingPrivateDnsZoneResourceId, ValidationResult.ValidationResultBuilder resultBuilder) {
+        if (!serviceEnum.getDnsZoneName().equals(existingPrivateDnsZoneResourceId.name())) {
+            String validationMessage = String.format("The provided private DNS zone %s is not a valid DNS zone name for %s. Please use a DNS zone with " +
+                    "name %s and try again.", existingPrivateDnsZoneResourceId.id(), serviceEnum.getResourceType(), serviceEnum.getDnsZoneName());
+            addValidationError(validationMessage, resultBuilder);
+        }
+        return resultBuilder;
+    }
+
+    public ValidationResult.ValidationResultBuilder privateDnsZoneExists(AzureClient azureClient, ResourceId privateDnsZoneResourceId,
+            ValidationResult.ValidationResultBuilder resultBuilder) {
+        boolean privateDnsZoneExists = azureClient.getPrivateDnsZonesByResourceGroup(privateDnsZoneResourceId.subscriptionId(),
+                        privateDnsZoneResourceId.resourceGroupName())
+                .stream()
+                .anyMatch(pz -> pz.name().equals(privateDnsZoneResourceId.name()));
+        if (!privateDnsZoneExists) {
+            String validationMessage = String.format("The provided private DNS zone %s does not exist. Please make sure the specified " +
+                    "private DNS zone exists and try environment creation again.", privateDnsZoneResourceId.id());
+            addValidationError(validationMessage, resultBuilder);
+        }
+        return resultBuilder;
+    }
+
+    public ValidationResult.ValidationResultBuilder privateDnsZoneConnectedToNetwork(AzureClient azureClient, String networkResourceGroupName,
+            String networkName, ResourceId privateDnsZoneResourceId, ValidationResult.ValidationResultBuilder resultBuilder) {
+        String networkId = azureClient.getNetworkByResourceGroup(networkResourceGroupName, networkName).id();
+        PagedList<VirtualNetworkLinkInner> virtualNetworkLinks = azureClient.listNetworkLinksByPrivateDnsZoneName(privateDnsZoneResourceId.subscriptionId(),
+                privateDnsZoneResourceId.resourceGroupName(), privateDnsZoneResourceId.name());
+        List<String> connectedNetworks = virtualNetworkLinks.stream().map(vnl -> vnl.virtualNetwork().id()).collect(Collectors.toList());
+        if (!connectedNetworks.contains(networkId)) {
+            String validationMessage = String.format("The private DNS zone %s does not have a network link to network %s. Please make sure the private DNS " +
+                    "zone is connected to the network provided to the environment.", privateDnsZoneResourceId.id(), networkName);
+            addValidationError(validationMessage, resultBuilder);
+        }
+        return resultBuilder;
+    }
+
+    public ValidationResult privateDnsZonesNotConnectedToNetwork(AzureClient azureClient, String networkId, String resourceGroupName, String dnsZoneName,
+            ValidationResult.ValidationResultBuilder resultBuilder, PagedList<PrivateZone> privateDnsZoneList) {
+        Optional<PrivateZone> privateZoneWithNetworkLink = privateDnsZoneList.stream()
+                .filter(privateZone -> !privateZone.resourceGroupName().equalsIgnoreCase(resourceGroupName))
+                .filter(privateZone -> privateZone.name().equalsIgnoreCase(dnsZoneName))
+                .filter(privateZone -> privateZone.provisioningState().equals(SUCCEEDED))
+                .filter(privateZone -> Objects.nonNull(azureClient.getNetworkLinkByPrivateDnsZone(privateZone.resourceGroupName(), dnsZoneName, networkId)))
+                .findFirst();
+        if (privateZoneWithNetworkLink.isPresent()) {
+            PrivateZone privateZone = privateZoneWithNetworkLink.get();
+            String validationMessage = String.format("Network link for the network %s already exists for Private DNS Zone %s in resource group %s. "
+                            + "Please ensure that there is no existing network link and try again!",
+                    networkId, dnsZoneName, privateZone.resourceGroupName());
+            addValidationError(validationMessage, resultBuilder);
+        }
+
+        return resultBuilder.build();
+    }
+
+    private void addValidationError(String validationMessage, ValidationResult.ValidationResultBuilder resultBuilder) {
+        LOGGER.warn(validationMessage);
+        resultBuilder.error(validationMessage);
+    }
+
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureDnsZoneServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureDnsZoneServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -79,7 +80,7 @@ public class AzureDnsZoneServiceTest {
         when(azureResourceDeploymentHelperService.getAzureNetwork(any(), any(), any())).thenReturn(mock(Network.class));
         when(client.getCurrentSubscription()).thenReturn(mock(Subscription.class));
         when(client.getCurrentSubscription().subscriptionId()).thenReturn(SUBSCRIPTION_ID);
-        when(azurePrivateEndpointServicesProvider.getEnabledPrivateEndpointServices())
+        when(azurePrivateEndpointServicesProvider.getCdpManagedDnsZones(any()))
                 .thenReturn(List.of(AzurePrivateDnsZoneServiceEnum.STORAGE, AzurePrivateDnsZoneServiceEnum.POSTGRES));
     }
 
@@ -87,7 +88,7 @@ public class AzureDnsZoneServiceTest {
     public void testCheckOrCreateWhenAllResourceExists() {
 
         when(client.checkIfDnsZonesDeployed(any(), any())).thenReturn(true);
-        underTest.checkOrCreateDnsZones(ac, client, getNetworkView(), RESOURCE_GROUP, Collections.emptyMap());
+        underTest.checkOrCreateDnsZones(ac, client, getNetworkView(), RESOURCE_GROUP, Collections.emptyMap(), Set.of());
 
         verify(azureResourcePersistenceHelperService, times(0)).persistCloudResource(any(), any(), any(), any());
         verify(azureResourcePersistenceHelperService, times(0)).updateCloudResource(any(), any(), any(), any(), any());
@@ -103,7 +104,7 @@ public class AzureDnsZoneServiceTest {
         when(client.checkIfDnsZonesDeployed(any(), any())).thenReturn(false);
         when(azureResourcePersistenceHelperService.isRequested(DEPLOYMENT_ID, AZURE_PRIVATE_DNS_ZONE)).thenReturn(true);
 
-        underTest.checkOrCreateDnsZones(ac, client, getNetworkView(), RESOURCE_GROUP, Collections.emptyMap());
+        underTest.checkOrCreateDnsZones(ac, client, getNetworkView(), RESOURCE_GROUP, Collections.emptyMap(), Set.of());
 
         verify(azureResourcePersistenceHelperService, times(0)).persistCloudResource(any(), any(), any(), any());
         verify(azureResourcePersistenceHelperService, times(0)).updateCloudResource(any(), any(), any(), any(), any());
@@ -119,7 +120,7 @@ public class AzureDnsZoneServiceTest {
         when(azureResourcePersistenceHelperService.isRequested(DEPLOYMENT_ID, AZURE_PRIVATE_DNS_ZONE)).thenReturn(false);
         when(azureResourcePersistenceHelperService.isCreated(DEPLOYMENT_ID, AZURE_PRIVATE_DNS_ZONE)).thenReturn(true);
 
-        underTest.checkOrCreateDnsZones(ac, client, getNetworkView(), RESOURCE_GROUP, Collections.emptyMap());
+        underTest.checkOrCreateDnsZones(ac, client, getNetworkView(), RESOURCE_GROUP, Collections.emptyMap(), Set.of());
 
         verify(azureResourcePersistenceHelperService, times(0)).persistCloudResource(any(), any(), any(), any());
         verify(azureResourcePersistenceHelperService, times(2)).updateCloudResource(any(), any(), any(), any(), any());
@@ -135,7 +136,7 @@ public class AzureDnsZoneServiceTest {
         when(azureResourcePersistenceHelperService.isRequested(DEPLOYMENT_ID, AZURE_PRIVATE_DNS_ZONE)).thenReturn(false);
         when(azureResourcePersistenceHelperService.isCreated(DEPLOYMENT_ID, AZURE_PRIVATE_DNS_ZONE)).thenReturn(false);
 
-        underTest.checkOrCreateDnsZones(ac, client, getNetworkView(), RESOURCE_GROUP, Collections.emptyMap());
+        underTest.checkOrCreateDnsZones(ac, client, getNetworkView(), RESOURCE_GROUP, Collections.emptyMap(), Set.of());
 
         verify(azureResourcePersistenceHelperService, times(1)).persistCloudResource(any(), any(), any(), any());
         verify(azureResourcePersistenceHelperService, times(1)).updateCloudResource(any(), any(), any(), any(), any());
@@ -152,7 +153,7 @@ public class AzureDnsZoneServiceTest {
         when(azureResourcePersistenceHelperService.isCreated(DEPLOYMENT_ID, AZURE_PRIVATE_DNS_ZONE)).thenReturn(false);
         doThrow(new CloudConnectorException("", null)).when(azureResourceDeploymentHelperService).deployTemplate(any(), any());
 
-        underTest.checkOrCreateDnsZones(ac, client, getNetworkView(), RESOURCE_GROUP, Collections.emptyMap());
+        underTest.checkOrCreateDnsZones(ac, client, getNetworkView(), RESOURCE_GROUP, Collections.emptyMap(), Set.of());
 
         verify(azureResourcePersistenceHelperService, times(1)).persistCloudResource(any(), any(), any(), any());
         verify(azureResourcePersistenceHelperService, times(0)).updateCloudResource(any(), any(), any(), any(), any());

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureNetworkLinkServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureNetworkLinkServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -78,7 +79,7 @@ public class AzureNetworkLinkServiceTest {
         when(azureResourceDeploymentHelperService.getAzureNetwork(any(), any(), any())).thenReturn(mock(Network.class));
         when(client.getCurrentSubscription()).thenReturn(mock(Subscription.class));
         when(client.getCurrentSubscription().subscriptionId()).thenReturn(SUBSCRIPTION_ID);
-        when(azurePrivateEndpointServicesProvider.getEnabledPrivateEndpointServices())
+        when(azurePrivateEndpointServicesProvider.getCdpManagedDnsZones(any()))
                 .thenReturn(List.of(AzurePrivateDnsZoneServiceEnum.STORAGE, AzurePrivateDnsZoneServiceEnum.POSTGRES));
     }
 
@@ -87,7 +88,7 @@ public class AzureNetworkLinkServiceTest {
 
         when(client.checkIfNetworkLinksDeployed(any(), any(), any())).thenReturn(true);
 
-        underTest.checkOrCreateNetworkLinks(ac, client, getNetworkView(), RESOURCE_GROUP, Collections.emptyMap());
+        underTest.checkOrCreateNetworkLinks(ac, client, getNetworkView(), RESOURCE_GROUP, Collections.emptyMap(), Set.of());
 
         verify(azureResourcePersistenceHelperService, times(0)).persistCloudResource(any(), any(), any(), any());
         verify(azureResourcePersistenceHelperService, times(0)).updateCloudResource(any(), any(), any(), any(), any());
@@ -103,7 +104,7 @@ public class AzureNetworkLinkServiceTest {
         when(client.checkIfNetworkLinksDeployed(any(), any(), any())).thenReturn(false);
         when(azureResourcePersistenceHelperService.isRequested(DEPLOYMENT_ID, AZURE_VIRTUAL_NETWORK_LINK)).thenReturn(true);
 
-        underTest.checkOrCreateNetworkLinks(ac, client, getNetworkView(), RESOURCE_GROUP, Collections.emptyMap());
+        underTest.checkOrCreateNetworkLinks(ac, client, getNetworkView(), RESOURCE_GROUP, Collections.emptyMap(), Set.of());
 
         verify(azureResourcePersistenceHelperService, times(0)).persistCloudResource(any(), any(), any(), any());
         verify(azureResourcePersistenceHelperService, times(0)).updateCloudResource(any(), any(), any(), any(), any());
@@ -119,7 +120,7 @@ public class AzureNetworkLinkServiceTest {
         when(azureResourcePersistenceHelperService.isRequested(DEPLOYMENT_ID, AZURE_VIRTUAL_NETWORK_LINK)).thenReturn(false);
         when(azureResourcePersistenceHelperService.isCreated(DEPLOYMENT_ID, AZURE_VIRTUAL_NETWORK_LINK)).thenReturn(true);
 
-        underTest.checkOrCreateNetworkLinks(ac, client, getNetworkView(), RESOURCE_GROUP, Collections.emptyMap());
+        underTest.checkOrCreateNetworkLinks(ac, client, getNetworkView(), RESOURCE_GROUP, Collections.emptyMap(), Set.of());
 
         verify(azureResourcePersistenceHelperService, times(0)).persistCloudResource(any(), any(), any(), any());
         verify(azureResourcePersistenceHelperService, times(2)).updateCloudResource(any(), any(), any(), any(), any());
@@ -135,7 +136,7 @@ public class AzureNetworkLinkServiceTest {
         when(azureResourcePersistenceHelperService.isRequested(DEPLOYMENT_ID, AZURE_VIRTUAL_NETWORK_LINK)).thenReturn(false);
         when(azureResourcePersistenceHelperService.isCreated(DEPLOYMENT_ID, AZURE_VIRTUAL_NETWORK_LINK)).thenReturn(false);
 
-        underTest.checkOrCreateNetworkLinks(ac, client, getNetworkView(), RESOURCE_GROUP, Collections.emptyMap());
+        underTest.checkOrCreateNetworkLinks(ac, client, getNetworkView(), RESOURCE_GROUP, Collections.emptyMap(), Set.of());
 
         verify(azureResourcePersistenceHelperService, times(1)).persistCloudResource(any(), any(), any(), any());
         verify(azureResourcePersistenceHelperService, times(1)).updateCloudResource(any(), any(), any(), any(), any());
@@ -150,9 +151,10 @@ public class AzureNetworkLinkServiceTest {
         when(client.checkIfNetworkLinksDeployed(any(), any(), any())).thenReturn(false);
         when(azureResourcePersistenceHelperService.isRequested(DEPLOYMENT_ID, AZURE_VIRTUAL_NETWORK_LINK)).thenReturn(false);
         when(azureResourcePersistenceHelperService.isCreated(DEPLOYMENT_ID, AZURE_VIRTUAL_NETWORK_LINK)).thenReturn(false);
+        when(azurePrivateEndpointServicesProvider.getCdpManagedDnsZones(any())).thenReturn(List.of(AzurePrivateDnsZoneServiceEnum.POSTGRES));
         doThrow(new CloudConnectorException("", null)).when(azureResourceDeploymentHelperService).deployTemplate(any(), any());
 
-        underTest.checkOrCreateNetworkLinks(ac, client, getNetworkView(), RESOURCE_GROUP, Collections.emptyMap());
+        underTest.checkOrCreateNetworkLinks(ac, client, getNetworkView(), RESOURCE_GROUP, Collections.emptyMap(), Set.of());
 
         verify(azureResourcePersistenceHelperService, times(1)).persistCloudResource(any(), any(), any(), any());
         verify(azureResourcePersistenceHelperService, times(0)).updateCloudResource(any(), any(), any(), any(), any());

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePrivateEndpointServicesProviderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePrivateEndpointServicesProviderTest.java
@@ -1,0 +1,56 @@
+package com.sequenceiq.cloudbreak.cloud.azure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.util.ReflectionUtils;
+
+@ExtendWith(MockitoExtension.class)
+public class AzurePrivateEndpointServicesProviderTest {
+
+    private final AzurePrivateEndpointServicesProvider underTest = new AzurePrivateEndpointServicesProvider();
+
+    @Test
+    void testGetCdpManagedDnsZonesWhenExistingDnsZone() {
+        setEnabledPrivateEndpointServices(List.of("postgresqlServer"));
+        Set<AzurePrivateDnsZoneServiceEnum> servicesWithExistingPrivateDnsZone = Set.of(AzurePrivateDnsZoneServiceEnum.POSTGRES);
+
+        List<AzurePrivateDnsZoneServiceEnum> privateEndpointServices = underTest.getCdpManagedDnsZones(servicesWithExistingPrivateDnsZone);
+
+        assertThat(privateEndpointServices).isEmpty();
+    }
+
+    @Test
+    void testGetCdpManagedDnsZonesWhenCdpManagesZone() {
+        setEnabledPrivateEndpointServices(List.of("postgresqlServer"));
+        Set<AzurePrivateDnsZoneServiceEnum> servicesWithExistingPrivateDnsZone = Set.of();
+
+        List<AzurePrivateDnsZoneServiceEnum> privateEndpointServices = underTest.getCdpManagedDnsZones(servicesWithExistingPrivateDnsZone);
+
+        assertThat(privateEndpointServices).hasSize(1);
+        assertThat(privateEndpointServices).contains(AzurePrivateDnsZoneServiceEnum.POSTGRES);
+    }
+
+    @Test
+    void testGetCdpManagedDnsZonesWhenServiceNotEnabled() {
+        setEnabledPrivateEndpointServices(List.of());
+        Set<AzurePrivateDnsZoneServiceEnum> servicesWithExistingPrivateDnsZone = Set.of();
+
+        List<AzurePrivateDnsZoneServiceEnum> privateEndpointServices = underTest.getCdpManagedDnsZones(servicesWithExistingPrivateDnsZone);
+
+        assertThat(privateEndpointServices).isEmpty();
+    }
+
+    private void setEnabledPrivateEndpointServices(List<String> enabledPrivateEndpointServices) {
+        Field privateEndpointServicesField = ReflectionUtils.findField(AzurePrivateEndpointServicesProvider.class, "privateEndpointServices");
+        ReflectionUtils.makeAccessible(privateEndpointServicesField);
+        ReflectionUtils.setField(privateEndpointServicesField, underTest, enabledPrivateEndpointServices);
+    }
+
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/ValidationTestUtil.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/ValidationTestUtil.java
@@ -1,0 +1,22 @@
+package com.sequenceiq.cloudbreak.cloud.azure.validator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import com.sequenceiq.cloudbreak.validation.ValidationResult;
+
+public class ValidationTestUtil {
+
+    private ValidationTestUtil() {
+    }
+
+    public static void checkErrorsPresent(ValidationResult.ValidationResultBuilder resultBuilder, List<String> errorMessages) {
+        ValidationResult validationResult = resultBuilder.build();
+        assertEquals(errorMessages.size(), validationResult.getErrors().size(), validationResult.getFormattedErrors());
+        List<String> actual = validationResult.getErrors();
+        errorMessages.forEach(message -> assertTrue(actual.stream().anyMatch(item -> item.equals(message)), validationResult::getFormattedErrors));
+    }
+
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzureExistingPrivateDnsZoneValidatorServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzureExistingPrivateDnsZoneValidatorServiceTest.java
@@ -1,0 +1,104 @@
+package com.sequenceiq.cloudbreak.cloud.azure.validator.privatedns;
+
+import static com.sequenceiq.cloudbreak.cloud.azure.validator.privatedns.PrivateDnsZoneValidationTestConstants.NETWORK_NAME;
+import static com.sequenceiq.cloudbreak.cloud.azure.validator.privatedns.PrivateDnsZoneValidationTestConstants.NETWORK_RESOURCE_GROUP_NAME;
+import static com.sequenceiq.cloudbreak.cloud.azure.validator.privatedns.PrivateDnsZoneValidationTestConstants.getPrivateDnsZoneResourceId;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.security.InvalidParameterException;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.microsoft.azure.arm.resources.ResourceId;
+import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneServiceEnum;
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.azure.validator.ValidationTestUtil;
+import com.sequenceiq.cloudbreak.validation.ValidationResult;
+
+@ExtendWith(MockitoExtension.class)
+public class AzureExistingPrivateDnsZoneValidatorServiceTest {
+
+    @Mock
+    private AzurePrivateDnsZoneValidatorService azurePrivateDnsZoneValidatorService;
+
+    @InjectMocks
+    private AzureExistingPrivateDnsZoneValidatorService underTest;
+
+    @Mock
+    private AzureClient azureClient;
+
+    @Test
+    void testValidate() {
+        ValidationResult.ValidationResultBuilder resultBuilder = new ValidationResult.ValidationResultBuilder();
+        ResourceId privateDnsZoneId = getPrivateDnsZoneResourceId();
+        Map<AzurePrivateDnsZoneServiceEnum, String> serviceToPrivateDnsZoneId = Map.of(AzurePrivateDnsZoneServiceEnum.POSTGRES, privateDnsZoneId.id());
+
+        resultBuilder = underTest.validate(azureClient, NETWORK_RESOURCE_GROUP_NAME, NETWORK_NAME, serviceToPrivateDnsZoneId, resultBuilder);
+
+        assertFalse(resultBuilder.build().hasError());
+        verify(azurePrivateDnsZoneValidatorService).existingPrivateDnsZoneNameIsSupported(eq(AzurePrivateDnsZoneServiceEnum.POSTGRES), any(),
+                eq(resultBuilder));
+        verify(azurePrivateDnsZoneValidatorService).privateDnsZoneExists(eq(azureClient), any(), eq(resultBuilder));
+        verify(azurePrivateDnsZoneValidatorService).privateDnsZoneConnectedToNetwork(eq(azureClient), eq(NETWORK_RESOURCE_GROUP_NAME), eq(NETWORK_NAME), any(),
+                eq(resultBuilder));
+    }
+
+    @Test
+    void testValidateWhenInvalidPrivateDnsZoneResourceId() {
+        ValidationResult.ValidationResultBuilder resultBuilder = new ValidationResult.ValidationResultBuilder();
+        String privateDnsZoneId = "invalidPrivateDnsZoneId";
+        Map<AzurePrivateDnsZoneServiceEnum, String> serviceToPrivateDnsZoneId = Map.of(AzurePrivateDnsZoneServiceEnum.POSTGRES, privateDnsZoneId);
+
+        resultBuilder = underTest.validate(azureClient, NETWORK_RESOURCE_GROUP_NAME, NETWORK_NAME, serviceToPrivateDnsZoneId, resultBuilder);
+
+        ValidationTestUtil.checkErrorsPresent(resultBuilder, List.of("The provided private DNS zone id invalidPrivateDnsZoneId for service " +
+                "Microsoft.DBforPostgreSQL/servers is not a valid azure resource id."));
+        verify(azurePrivateDnsZoneValidatorService, never()).existingPrivateDnsZoneNameIsSupported(any(), any(), eq(resultBuilder));
+        verify(azurePrivateDnsZoneValidatorService, never()).privateDnsZoneExists(any(), any(), any());
+        verify(azurePrivateDnsZoneValidatorService, never()).privateDnsZoneConnectedToNetwork(any(), anyString(), anyString(), any(), any());
+    }
+
+    @Test
+    void testValidateWhenValidAndInvalidPrivateDnsZoneResourceId() {
+        ValidationResult.ValidationResultBuilder resultBuilder = new ValidationResult.ValidationResultBuilder();
+        ResourceId privateDnsZoneIdPostgres = getPrivateDnsZoneResourceId();
+        String privateDnsZoneIdStorage = "invalidPrivateDnsZoneId";
+        Map<AzurePrivateDnsZoneServiceEnum, String> serviceToPrivateDnsZoneId = Map.of(
+                AzurePrivateDnsZoneServiceEnum.POSTGRES, privateDnsZoneIdPostgres.id(),
+                AzurePrivateDnsZoneServiceEnum.STORAGE, privateDnsZoneIdStorage
+        );
+        when(azurePrivateDnsZoneValidatorService.existingPrivateDnsZoneNameIsSupported(any(), any(), any())).thenAnswer(invocation -> {
+            ValidationResult.ValidationResultBuilder validationResultBuilder = invocation.getArgument(2);
+            ResourceId privateDnsZoneId = invocation.getArgument(1);
+            if (privateDnsZoneId.id().equals(privateDnsZoneIdStorage)) {
+                throw new InvalidParameterException();
+            }
+            return validationResultBuilder;
+        });
+
+        resultBuilder = underTest.validate(azureClient, NETWORK_RESOURCE_GROUP_NAME, NETWORK_NAME, serviceToPrivateDnsZoneId, resultBuilder);
+
+        ValidationTestUtil.checkErrorsPresent(resultBuilder, List.of("The provided private DNS zone id invalidPrivateDnsZoneId for service " +
+                "Microsoft.Storage/storageAccounts is not a valid azure resource id."));
+        verify(azurePrivateDnsZoneValidatorService).existingPrivateDnsZoneNameIsSupported(eq(AzurePrivateDnsZoneServiceEnum.POSTGRES), any(),
+                eq(resultBuilder));
+        verify(azurePrivateDnsZoneValidatorService).privateDnsZoneExists(eq(azureClient), any(), eq(resultBuilder));
+        verify(azurePrivateDnsZoneValidatorService).privateDnsZoneConnectedToNetwork(eq(azureClient), eq(NETWORK_RESOURCE_GROUP_NAME), eq(NETWORK_NAME),
+                any(), eq(resultBuilder));
+
+        verify(azurePrivateDnsZoneValidatorService, never()).existingPrivateDnsZoneNameIsSupported(eq(AzurePrivateDnsZoneServiceEnum.STORAGE), any(), any());
+    }
+
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzureNewPrivateDnsZoneValidatorServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzureNewPrivateDnsZoneValidatorServiceTest.java
@@ -1,0 +1,89 @@
+package com.sequenceiq.cloudbreak.cloud.azure.validator.privatedns;
+
+import static com.sequenceiq.cloudbreak.cloud.azure.validator.privatedns.PrivateDnsZoneValidationTestConstants.NETWORK_NAME;
+import static com.sequenceiq.cloudbreak.cloud.azure.validator.privatedns.PrivateDnsZoneValidationTestConstants.SINGLE_RESOURCE_GROUP_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.microsoft.azure.PagedList;
+import com.microsoft.azure.management.privatedns.v2018_09_01.PrivateZone;
+import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneServiceEnum;
+import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateEndpointServicesProvider;
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.azure.validator.privatedns.PrivateDnsZoneValidationTestConstants.TestPagedList;
+import com.sequenceiq.cloudbreak.validation.ValidationResult;
+
+@ExtendWith(MockitoExtension.class)
+public class AzureNewPrivateDnsZoneValidatorServiceTest {
+
+    @Mock
+    private AzurePrivateDnsZoneValidatorService azurePrivateDnsZoneValidatorService;
+
+    @Mock
+    private AzurePrivateEndpointServicesProvider azurePrivateEndpointServicesProvider;
+
+    @InjectMocks
+    private AzureNewPrivateDnsZoneValidatorService underTest;
+
+    @Mock
+    private AzureClient azureClient;
+
+    private final List<AzurePrivateDnsZoneServiceEnum> availableServicesForPrivateEndpoint = Arrays.asList(AzurePrivateDnsZoneServiceEnum.values());
+
+    @Test
+    void testZonesNotConnectedToNetworkWhenNoExistingDnsZones() {
+        ValidationResult.ValidationResultBuilder resultBuilder = new ValidationResult.ValidationResultBuilder();
+        Set<AzurePrivateDnsZoneServiceEnum> servicesWithExistingPrivateDnsZone = Set.of();
+        when(azurePrivateEndpointServicesProvider.getCdpManagedDnsZones(servicesWithExistingPrivateDnsZone)).thenReturn(availableServicesForPrivateEndpoint);
+        PagedList<PrivateZone> privateDnsZoneList = setupPrivateDnsZones();
+
+        underTest.zonesNotConnectedToNetwork(azureClient, NETWORK_NAME, SINGLE_RESOURCE_GROUP_NAME, servicesWithExistingPrivateDnsZone, resultBuilder);
+
+        ArgumentCaptor<String> dnsZoneNameArgumentCaptor = ArgumentCaptor.forClass(String.class);
+        verify(azurePrivateDnsZoneValidatorService, times(availableServicesForPrivateEndpoint.size())).privateDnsZonesNotConnectedToNetwork(eq(azureClient),
+                eq(NETWORK_NAME), eq(SINGLE_RESOURCE_GROUP_NAME), dnsZoneNameArgumentCaptor.capture(), eq(resultBuilder), eq(privateDnsZoneList));
+        List<String> checkedDnsZoneNames = dnsZoneNameArgumentCaptor.getAllValues();
+        List<String> servicesNotChecked = availableServicesForPrivateEndpoint.stream()
+                .map(AzurePrivateDnsZoneServiceEnum::getDnsZoneName)
+                .filter(dzn -> !checkedDnsZoneNames.contains(dzn))
+                .collect(Collectors.toList());
+        assertThat(servicesNotChecked).isEmpty();
+    }
+
+    @Test
+    void testZonesNotConnectedToNetworkWhenNoCdpManagedZones() {
+        ValidationResult.ValidationResultBuilder resultBuilder = new ValidationResult.ValidationResultBuilder();
+        Set<AzurePrivateDnsZoneServiceEnum> servicesWithExistingPrivateDnsZone = new HashSet<>(availableServicesForPrivateEndpoint);
+        when(azurePrivateEndpointServicesProvider.getCdpManagedDnsZones(servicesWithExistingPrivateDnsZone)).thenReturn(List.of());
+
+        underTest.zonesNotConnectedToNetwork(azureClient, NETWORK_NAME, SINGLE_RESOURCE_GROUP_NAME, servicesWithExistingPrivateDnsZone, resultBuilder);
+
+        verify(azurePrivateDnsZoneValidatorService, never()).privateDnsZonesNotConnectedToNetwork(any(), any(), anyString(), anyString(), any(), any());
+    }
+
+    private PagedList<PrivateZone> setupPrivateDnsZones() {
+        PagedList<PrivateZone> privateDnsZoneList = new TestPagedList<>();
+        when(azureClient.getPrivateDnsZoneList()).thenReturn(privateDnsZoneList);
+        return privateDnsZoneList;
+    }
+
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzurePrivateDnsZoneValidatorServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzurePrivateDnsZoneValidatorServiceTest.java
@@ -1,0 +1,251 @@
+package com.sequenceiq.cloudbreak.cloud.azure.validator.privatedns;
+
+import static com.sequenceiq.cloudbreak.cloud.azure.validator.privatedns.PrivateDnsZoneValidationTestConstants.A_RESOURCE_GROUP_NAME;
+import static com.sequenceiq.cloudbreak.cloud.azure.validator.privatedns.PrivateDnsZoneValidationTestConstants.NETWORK_NAME;
+import static com.sequenceiq.cloudbreak.cloud.azure.validator.privatedns.PrivateDnsZoneValidationTestConstants.NETWORK_RESOURCE_GROUP_NAME;
+import static com.sequenceiq.cloudbreak.cloud.azure.validator.privatedns.PrivateDnsZoneValidationTestConstants.NETWORK_RESOURCE_ID;
+import static com.sequenceiq.cloudbreak.cloud.azure.validator.privatedns.PrivateDnsZoneValidationTestConstants.SINGLE_RESOURCE_GROUP_NAME;
+import static com.sequenceiq.cloudbreak.cloud.azure.validator.privatedns.PrivateDnsZoneValidationTestConstants.ZONE_NAME_POSTGRES;
+import static com.sequenceiq.cloudbreak.cloud.azure.validator.privatedns.PrivateDnsZoneValidationTestConstants.getPrivateDnsZoneResourceId;
+import static com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudAdlsView.SUBSCRIPTION_ID;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.microsoft.azure.PagedList;
+import com.microsoft.azure.SubResource;
+import com.microsoft.azure.management.network.Network;
+import com.microsoft.azure.management.privatedns.v2018_09_01.PrivateZone;
+import com.microsoft.azure.management.privatedns.v2018_09_01.ProvisioningState;
+import com.microsoft.azure.management.privatedns.v2018_09_01.implementation.VirtualNetworkLinkInner;
+import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneServiceEnum;
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.azure.validator.ValidationTestUtil;
+import com.sequenceiq.cloudbreak.cloud.azure.validator.privatedns.PrivateDnsZoneValidationTestConstants.TestPagedList;
+import com.sequenceiq.cloudbreak.validation.ValidationResult;
+
+@ExtendWith(MockitoExtension.class)
+public class AzurePrivateDnsZoneValidatorServiceTest {
+
+    @InjectMocks
+    private AzurePrivateDnsZoneValidatorService underTest;
+
+    @Mock
+    private AzureClient azureClient;
+
+    @Test
+    void testExistingPrivateDnsZoneNamesAreSupportedWhenSupportedDnsZoneName() {
+        ValidationResult.ValidationResultBuilder resultBuilder = new ValidationResult.ValidationResultBuilder();
+
+        resultBuilder = underTest.existingPrivateDnsZoneNameIsSupported(AzurePrivateDnsZoneServiceEnum.POSTGRES, getPrivateDnsZoneResourceId(), resultBuilder);
+
+        assertFalse(resultBuilder.build().hasError());
+    }
+
+    @Test
+    void testExistingPrivateDnsZoneNamesAreSupportedWhenUnsupportedDnsZoneName() {
+        ValidationResult.ValidationResultBuilder resultBuilder = new ValidationResult.ValidationResultBuilder();
+
+        resultBuilder = underTest.existingPrivateDnsZoneNameIsSupported(AzurePrivateDnsZoneServiceEnum.POSTGRES,
+                getPrivateDnsZoneResourceId(A_RESOURCE_GROUP_NAME, "another.zone.name"), resultBuilder);
+
+        ValidationTestUtil.checkErrorsPresent(resultBuilder, List.of(
+                "The provided private DNS zone /subscriptions/subscriptionId/resourceGroups/a-resource-group-name/providers/Microsoft.Network/privateDnsZones" +
+                        "/another.zone.name is not a valid DNS zone name for Microsoft.DBforPostgreSQL/servers. Please use a DNS zone with name " +
+                        "privatelink.postgres.database.azure.com and try again."));
+    }
+
+    @Test
+    void testPrivateDnsZoneExistsWhenZoneExists() {
+        ValidationResult.ValidationResultBuilder resultBuilder = ValidationResult.builder();
+        PagedList<PrivateZone> privateZones = new TestPagedList<>();
+        privateZones.add(getPrivateDnsZone(null, ZONE_NAME_POSTGRES, null));
+        when(azureClient.getPrivateDnsZonesByResourceGroup(SUBSCRIPTION_ID, SINGLE_RESOURCE_GROUP_NAME)).thenReturn(privateZones);
+
+        resultBuilder = underTest.privateDnsZoneExists(azureClient, getPrivateDnsZoneResourceId(), resultBuilder);
+
+        ValidationResult result = resultBuilder.build();
+        assertFalse(result.hasError());
+    }
+
+    @Test
+    void testPrivateDnsZoneExistsWhenZoneDoesNotExist() {
+        ValidationResult.ValidationResultBuilder resultBuilder = ValidationResult.builder();
+        PagedList<PrivateZone> privateZones = new TestPagedList<>();
+        when(azureClient.getPrivateDnsZonesByResourceGroup(SUBSCRIPTION_ID, A_RESOURCE_GROUP_NAME)).thenReturn(privateZones);
+
+        resultBuilder = underTest.privateDnsZoneExists(azureClient, getPrivateDnsZoneResourceId(A_RESOURCE_GROUP_NAME), resultBuilder);
+
+        ValidationTestUtil.checkErrorsPresent(resultBuilder, List.of(
+                "The provided private DNS zone /subscriptions/subscriptionId/resourceGroups/a-resource-group-name/providers/Microsoft.Network/privateDnsZones" +
+                        "/privatelink.postgres.database.azure.com does not exist. Please make sure the specified private DNS zone exists and try environment " +
+                        "creation again."));
+    }
+
+    @Test
+    void testPrivateDnsZoneConnectedToNetworkWhenConnectedToEnvironmentNetwork() {
+        ValidationResult.ValidationResultBuilder resultBuilder = ValidationResult.builder();
+        Network network = getNetwork();
+        when(azureClient.getNetworkByResourceGroup(NETWORK_RESOURCE_GROUP_NAME, NETWORK_NAME)).thenReturn(network);
+        PagedList<VirtualNetworkLinkInner> virtualNetworkLinks = getNetworkLinks(List.of(NETWORK_RESOURCE_ID));
+        when(azureClient.listNetworkLinksByPrivateDnsZoneName(SUBSCRIPTION_ID, A_RESOURCE_GROUP_NAME, ZONE_NAME_POSTGRES)).thenReturn(virtualNetworkLinks);
+
+        resultBuilder = underTest.privateDnsZoneConnectedToNetwork(azureClient, NETWORK_RESOURCE_GROUP_NAME, NETWORK_NAME,
+                getPrivateDnsZoneResourceId(A_RESOURCE_GROUP_NAME), resultBuilder);
+
+        assertFalse(resultBuilder.build().hasError());
+    }
+
+    @Test
+    void testPrivateDnsZoneConnectedToNetworkWhenNotConnectedToEnvironmentNetwork() {
+        ValidationResult.ValidationResultBuilder resultBuilder = ValidationResult.builder();
+        Network network = getNetwork();
+        when(azureClient.getNetworkByResourceGroup(NETWORK_RESOURCE_GROUP_NAME, NETWORK_NAME)).thenReturn(network);
+        PagedList<VirtualNetworkLinkInner> virtualNetworkLinks = getNetworkLinks(List.of("anotherNetwork"));
+        when(azureClient.listNetworkLinksByPrivateDnsZoneName(SUBSCRIPTION_ID, A_RESOURCE_GROUP_NAME, ZONE_NAME_POSTGRES)).thenReturn(virtualNetworkLinks);
+
+        resultBuilder = underTest.privateDnsZoneConnectedToNetwork(azureClient, NETWORK_RESOURCE_GROUP_NAME, NETWORK_NAME,
+                getPrivateDnsZoneResourceId(A_RESOURCE_GROUP_NAME), resultBuilder);
+
+        assertTrue(resultBuilder.build().hasError());
+        ValidationTestUtil.checkErrorsPresent(resultBuilder, List.of(
+                "The private DNS zone /subscriptions/subscriptionId/resourceGroups/a-resource-group-name/providers/Microsoft.Network/privateDnsZones" +
+                        "/privatelink.postgres.database.azure.com does not have a network link to network networkName. Please make sure the private DNS zone " +
+                        "is connected to the network provided to the environment."));
+    }
+
+    @Test
+    void testPrivateDnsZonesNotConnectedToNetworkWhenNoZonesFound() {
+        ValidationResult.ValidationResultBuilder resultBuilder = ValidationResult.builder();
+        PagedList<PrivateZone> privateDnsZoneList = new TestPagedList<>();
+
+        ValidationResult result = underTest.privateDnsZonesNotConnectedToNetwork(azureClient, NETWORK_NAME, A_RESOURCE_GROUP_NAME, ZONE_NAME_POSTGRES,
+                resultBuilder, privateDnsZoneList);
+
+        assertFalse(result.hasError());
+        verify(azureClient, never()).getNetworkLinkByPrivateDnsZone(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void testPrivateDnsZonesNotConnectedToNetworkWhenZoneInSingleRG() {
+        ValidationResult.ValidationResultBuilder resultBuilder = ValidationResult.builder();
+        PagedList<PrivateZone> privateDnsZoneList = getPrivateDnsZones(SINGLE_RESOURCE_GROUP_NAME, List.of(""), null);
+
+        ValidationResult result = underTest.privateDnsZonesNotConnectedToNetwork(azureClient, NETWORK_NAME, SINGLE_RESOURCE_GROUP_NAME, ZONE_NAME_POSTGRES,
+                resultBuilder, privateDnsZoneList);
+
+        assertFalse(result.hasError());
+        verify(azureClient, never()).getNetworkLinkByPrivateDnsZone(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void testPrivateDnsZonesNotConnectedToNetworkWhenZoneNameIsNotSupported() {
+        ValidationResult.ValidationResultBuilder resultBuilder = ValidationResult.builder();
+        PagedList<PrivateZone> privateDnsZoneList = getPrivateDnsZones(A_RESOURCE_GROUP_NAME, List.of("unrelated.zone"), null);
+
+        ValidationResult result = underTest.privateDnsZonesNotConnectedToNetwork(azureClient, NETWORK_NAME, SINGLE_RESOURCE_GROUP_NAME, ZONE_NAME_POSTGRES,
+                resultBuilder, privateDnsZoneList);
+
+        assertFalse(result.hasError());
+        verify(azureClient, never()).getNetworkLinkByPrivateDnsZone(anyString(), anyString(), anyString());
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "getAllProvisioningStates")
+    void testPrivateDnsZonesNotConnectedToNetworkWhenZoneProvisioningStateNotSucceeded(ProvisioningState provisioningState) {
+        ValidationResult.ValidationResultBuilder resultBuilder = ValidationResult.builder();
+        PagedList<PrivateZone> privateDnsZoneList = getPrivateDnsZones(A_RESOURCE_GROUP_NAME, List.of(ZONE_NAME_POSTGRES), provisioningState);
+
+        ValidationResult result = underTest.privateDnsZonesNotConnectedToNetwork(azureClient, NETWORK_NAME, SINGLE_RESOURCE_GROUP_NAME, ZONE_NAME_POSTGRES,
+                resultBuilder, privateDnsZoneList);
+
+        assertFalse(result.hasError());
+        verify(azureClient, never()).getNetworkLinkByPrivateDnsZone(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void testPrivateDnsZonesNotConnectedToNetworkWhenZoneNotConnected() {
+        ValidationResult.ValidationResultBuilder resultBuilder = ValidationResult.builder();
+        PagedList<PrivateZone> privateDnsZoneList = getPrivateDnsZones(A_RESOURCE_GROUP_NAME, List.of(ZONE_NAME_POSTGRES), ProvisioningState.SUCCEEDED);
+        when(azureClient.getNetworkLinkByPrivateDnsZone(A_RESOURCE_GROUP_NAME, ZONE_NAME_POSTGRES, NETWORK_NAME)).thenReturn(null);
+
+        ValidationResult result = underTest.privateDnsZonesNotConnectedToNetwork(azureClient, NETWORK_NAME, SINGLE_RESOURCE_GROUP_NAME, ZONE_NAME_POSTGRES,
+                resultBuilder, privateDnsZoneList);
+
+        assertFalse(result.hasError());
+    }
+
+    @Test
+    void testPrivateDnsZonesNotConnectedToNetworkWhenZoneConnected() {
+        ValidationResult.ValidationResultBuilder resultBuilder = ValidationResult.builder();
+        PagedList<PrivateZone> privateDnsZoneList = getPrivateDnsZones(A_RESOURCE_GROUP_NAME, List.of(ZONE_NAME_POSTGRES), ProvisioningState.SUCCEEDED);
+        when(azureClient.getNetworkLinkByPrivateDnsZone(A_RESOURCE_GROUP_NAME, ZONE_NAME_POSTGRES, NETWORK_NAME)).thenReturn(new VirtualNetworkLinkInner());
+
+        ValidationResult result = underTest.privateDnsZonesNotConnectedToNetwork(azureClient, NETWORK_NAME, SINGLE_RESOURCE_GROUP_NAME, ZONE_NAME_POSTGRES,
+                resultBuilder, privateDnsZoneList);
+
+        assertTrue(result.hasError());
+        ValidationTestUtil.checkErrorsPresent(resultBuilder, List.of("Network link for the network networkName already exists for Private DNS Zone " +
+                "privatelink.postgres.database.azure.com in resource group a-resource-group-name. Please ensure that there is no existing network link and " +
+                "try again!"));
+    }
+
+    private static List<ProvisioningState> getAllProvisioningStates() {
+        return ProvisioningState.values().stream()
+                .filter(ps -> !ps.equals(ProvisioningState.SUCCEEDED))
+                .collect(Collectors.toList());
+    }
+
+    private PagedList<VirtualNetworkLinkInner> getNetworkLinks(List<String> foundNetworkIds) {
+        PagedList<VirtualNetworkLinkInner> virtualNetworkLinks = new TestPagedList<>();
+        foundNetworkIds.stream()
+                .map(id -> new VirtualNetworkLinkInner().withVirtualNetwork(new SubResource().withId(id)))
+                .forEach(virtualNetworkLinks::add);
+        return virtualNetworkLinks;
+    }
+
+    private Network getNetwork() {
+        Network network = mock(Network.class);
+        when(network.id()).thenReturn(NETWORK_RESOURCE_ID);
+        return network;
+    }
+
+    private PagedList<PrivateZone> getPrivateDnsZones(String resourceGroupName, List<String> privateZoneNames, ProvisioningState provisioningState) {
+        PagedList<PrivateZone> privateZones = new TestPagedList<>();
+        privateZoneNames.stream()
+                .map(pzn -> getPrivateDnsZone(resourceGroupName, pzn, provisioningState))
+                .forEach(privateZones::add);
+        return privateZones;
+    }
+
+    private PrivateZone getPrivateDnsZone(String resourceGroupName, String dnsZoneName, ProvisioningState provisioningState) {
+        PrivateZone privateZone = mock(PrivateZone.class);
+        if (StringUtils.isNotEmpty(dnsZoneName)) {
+            when(privateZone.name()).thenReturn(dnsZoneName);
+        }
+        if (StringUtils.isNotEmpty(resourceGroupName)) {
+            when(privateZone.resourceGroupName()).thenReturn(resourceGroupName);
+        }
+        if (provisioningState != null) {
+            when(privateZone.provisioningState()).thenReturn(provisioningState);
+        }
+        return privateZone;
+    }
+
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/PrivateDnsZoneValidationTestConstants.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/PrivateDnsZoneValidationTestConstants.java
@@ -1,0 +1,57 @@
+package com.sequenceiq.cloudbreak.cloud.azure.validator.privatedns;
+
+import com.microsoft.azure.Page;
+import com.microsoft.azure.PagedList;
+import com.microsoft.azure.arm.resources.ResourceId;
+import com.microsoft.rest.RestException;
+
+public class PrivateDnsZoneValidationTestConstants {
+
+    static final String SUBSCRIPTION_ID = "subscriptionId";
+
+    static final String SINGLE_RESOURCE_GROUP_NAME = "single-resource-group-name";
+
+    static final String A_RESOURCE_GROUP_NAME = "a-resource-group-name";
+
+    static final String ZONE_NAME_POSTGRES = "privatelink.postgres.database.azure.com";
+
+    static final String PRIVATE_DNS_ZONE_ID = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s";
+
+    static final String NETWORK_SUBSCRIPTION_ID = "networkSubscriptionId";
+
+    static final String NETWORK_RESOURCE_GROUP_NAME = "networkResourceGroupName";
+
+    static final String NETWORK_NAME = "networkName";
+
+    static final String NETWORK_RESOURCE_ID = "/subscriptions/" + NETWORK_SUBSCRIPTION_ID + "/resourceGroups/" + NETWORK_RESOURCE_GROUP_NAME +
+            "/providers/Microsoft.Network/virtualNetworks/" + NETWORK_NAME;
+
+    private PrivateDnsZoneValidationTestConstants() {
+    }
+
+    static ResourceId getPrivateDnsZoneResourceId() {
+        String privateDnsZoneId = getPrivateDnsZoneId(SINGLE_RESOURCE_GROUP_NAME, ZONE_NAME_POSTGRES);
+        return ResourceId.fromString(privateDnsZoneId);
+    }
+
+    static ResourceId getPrivateDnsZoneResourceId(String resourceGroupName) {
+        String privateDnsZoneId = String.format(PRIVATE_DNS_ZONE_ID, SUBSCRIPTION_ID, resourceGroupName, ZONE_NAME_POSTGRES);
+        return ResourceId.fromString(privateDnsZoneId);
+    }
+
+    static ResourceId getPrivateDnsZoneResourceId(String resourceGroupName, String zoneName) {
+        return ResourceId.fromString(getPrivateDnsZoneId(resourceGroupName, zoneName));
+    }
+
+    private static String getPrivateDnsZoneId(String resourceGroupName, String zoneName) {
+        return String.format(PRIVATE_DNS_ZONE_ID, SUBSCRIPTION_ID, resourceGroupName, zoneName);
+    }
+
+    static class TestPagedList<E> extends PagedList<E> {
+        @Override
+        public Page<E> nextPage(String nextPageLink) throws RestException {
+            return null;
+        }
+    }
+
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/network/azure/AzureEnvironmentNetworkValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/network/azure/AzureEnvironmentNetworkValidator.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.validation.ValidationResult.ValidationResultBuilder;
-import com.sequenceiq.common.api.type.ServiceEndpointCreation;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
 import com.sequenceiq.environment.environment.dto.EnvironmentValidationDto;
 import com.sequenceiq.environment.environment.validation.ValidationType;
@@ -50,10 +49,10 @@ public class AzureEnvironmentNetworkValidator implements EnvironmentNetworkValid
         Map<String, CloudSubnet> cloudNetworks = cloudNetworkService.retrieveSubnetMetadata(environmentDto, networkDto);
         checkSubnetsProvidedWhenExistingNetwork(resultBuilder, networkDto, networkDto.getAzure(), cloudNetworks);
         if (environmentValidationDto.getValidationType() == ValidationType.ENVIRONMENT_CREATION) {
-            checkPrivateEndpointNetworkPoliciesWhenExistingNetwork(networkDto, cloudNetworks, resultBuilder);
-            checkPrivateEndpointsWhenMultipleResourceGroup(resultBuilder, environmentDto, networkDto.getServiceEndpointCreation());
-            checkExistingPrivateDnsZoneWhenNotPrivateEndpoint(resultBuilder, networkDto);
-            checkPrivateEndpointForExistingNetworkLink(resultBuilder, environmentDto, networkDto);
+            azurePrivateEndpointValidator.checkNetworkPoliciesWhenExistingNetwork(networkDto, cloudNetworks, resultBuilder);
+            azurePrivateEndpointValidator.checkMultipleResourceGroup(resultBuilder, environmentDto, networkDto);
+            azurePrivateEndpointValidator.checkExistingPrivateDnsZone(resultBuilder, environmentDto, networkDto);
+            azurePrivateEndpointValidator.checkNewPrivateDnsZone(resultBuilder, environmentDto, networkDto);
         } else {
             LOGGER.debug("Skipping Private Endpoint related validations as they have been validated before during env creation");
         }
@@ -106,15 +105,6 @@ public class AzureEnvironmentNetworkValidator implements EnvironmentNetworkValid
         }
     }
 
-    private void checkPrivateEndpointNetworkPoliciesWhenExistingNetwork(
-            NetworkDto networkDto, Map<String, CloudSubnet> cloudNetworks, ValidationResultBuilder resultBuilder) {
-        azurePrivateEndpointValidator.checkPrivateEndpointNetworkPoliciesWhenExistingNetwork(networkDto, cloudNetworks, resultBuilder);
-    }
-
-    private void checkPrivateEndpointForExistingNetworkLink(ValidationResultBuilder resultBuilder, EnvironmentDto environmentDto, NetworkDto networkDto) {
-        azurePrivateEndpointValidator.checkPrivateEndpointForExistingNetworkLink(resultBuilder, environmentDto, networkDto);
-    }
-
     private void checkResourceGroupNameWhenExistingNetwork(ValidationResultBuilder resultBuilder, AzureParams azureParams) {
         if (StringUtils.isNotEmpty(azureParams.getNetworkId()) && StringUtils.isEmpty(azureParams.getResourceGroupName())) {
             resultBuilder.error("If networkId is specified, then resourceGroupName must be specified too.");
@@ -154,15 +144,6 @@ public class AzureEnvironmentNetworkValidator implements EnvironmentNetworkValid
             LOGGER.info(message);
             resultBuilder.error(message);
         }
-    }
-
-    private void checkPrivateEndpointsWhenMultipleResourceGroup(ValidationResultBuilder resultBuilder, EnvironmentDto environmentDto,
-            ServiceEndpointCreation serviceEndpointCreation) {
-        azurePrivateEndpointValidator.checkPrivateEndpointsWhenMultipleResourceGroup(resultBuilder, environmentDto, serviceEndpointCreation);
-    }
-
-    private void checkExistingPrivateDnsZoneWhenNotPrivateEndpoint(ValidationResultBuilder resultBuilder, NetworkDto networkDto) {
-        azurePrivateEndpointValidator.checkExistingPrivateDnsZoneWhenNotPrivateEndpoint(resultBuilder, networkDto);
     }
 
     @Override

--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/network/azure/AzureExistingPrivateDnsZonesService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/network/azure/AzureExistingPrivateDnsZonesService.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.environment.environment.validation.network.azure;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneServiceEnum;
+import com.sequenceiq.environment.network.dto.NetworkDto;
+
+@Service
+public class AzureExistingPrivateDnsZonesService {
+
+    public Map<AzurePrivateDnsZoneServiceEnum, String> getExistingZones(NetworkDto networkDto) {
+        Map<AzurePrivateDnsZoneServiceEnum, String> result = new HashMap<>();
+        Optional.ofNullable(networkDto.getAzure().getPrivateDnsZoneId())
+                .ifPresent(privateDnsZone -> result.put(AzurePrivateDnsZoneServiceEnum.POSTGRES, privateDnsZone));
+        return result;
+    }
+
+    public Set<AzurePrivateDnsZoneServiceEnum> getServicesWithExistingZones(NetworkDto networkDto) {
+        return getExistingZones(networkDto).keySet();
+    }
+
+    public boolean hasNoExistingZones(NetworkDto networkDto) {
+        return getExistingZones(networkDto).isEmpty();
+    }
+
+    public Set<String> getServiceNamesWithExistingZones(NetworkDto networkDto) {
+        return getServicesWithExistingZones(networkDto).stream()
+                .map(Enum::name)
+                .collect(Collectors.toSet());
+    }
+
+}

--- a/environment/src/test/java/com/sequenceiq/environment/environment/validation/network/azure/AzureEnvironmentNetworkValidatorTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/validation/network/azure/AzureEnvironmentNetworkValidatorTest.java
@@ -96,11 +96,11 @@ class AzureEnvironmentNetworkValidatorTest {
         underTest.validateDuringFlow(environmentValidationDto, networkDto, validationResultBuilder);
 
         EnvironmentDto environmentDto = environmentValidationDto.getEnvironmentDto();
-        verify(azurePrivateEndpointValidator).checkPrivateEndpointForExistingNetworkLink(validationResultBuilder, environmentDto, networkDto);
-        verify(azurePrivateEndpointValidator).checkPrivateEndpointsWhenMultipleResourceGroup(validationResultBuilder, environmentDto,
-                networkDto.getServiceEndpointCreation());
-        verify(azurePrivateEndpointValidator).checkPrivateEndpointForExistingNetworkLink(validationResultBuilder, environmentDto, networkDto);
-        verify(azurePrivateEndpointValidator).checkExistingPrivateDnsZoneWhenNotPrivateEndpoint(validationResultBuilder, networkDto);
+        verify(azurePrivateEndpointValidator).checkNewPrivateDnsZone(validationResultBuilder, environmentDto, networkDto);
+        verify(azurePrivateEndpointValidator).checkMultipleResourceGroup(validationResultBuilder, environmentDto,
+                networkDto);
+        verify(azurePrivateEndpointValidator).checkNewPrivateDnsZone(validationResultBuilder, environmentDto, networkDto);
+        verify(azurePrivateEndpointValidator).checkExistingPrivateDnsZone(validationResultBuilder, environmentDto, networkDto);
     }
 
     @Test
@@ -115,10 +115,10 @@ class AzureEnvironmentNetworkValidatorTest {
 
         underTest.validateDuringFlow(environmentDto, networkDto, validationResultBuilder);
 
-        verify(azurePrivateEndpointValidator, never()).checkPrivateEndpointForExistingNetworkLink(any(), any(), any());
-        verify(azurePrivateEndpointValidator, never()).checkPrivateEndpointsWhenMultipleResourceGroup(any(), any(), any());
-        verify(azurePrivateEndpointValidator, never()).checkPrivateEndpointForExistingNetworkLink(any(), any(), any());
-        verify(azurePrivateEndpointValidator, never()).checkExistingPrivateDnsZoneWhenNotPrivateEndpoint(any(), any());
+        verify(azurePrivateEndpointValidator, never()).checkNewPrivateDnsZone(any(), any(), any());
+        verify(azurePrivateEndpointValidator, never()).checkMultipleResourceGroup(any(), any(), any());
+        verify(azurePrivateEndpointValidator, never()).checkNewPrivateDnsZone(any(), any(), any());
+        verify(azurePrivateEndpointValidator, never()).checkExistingPrivateDnsZone(any(), any(), any());
         assertFalse(validationResultBuilder.build().hasError());
     }
 

--- a/environment/src/test/java/com/sequenceiq/environment/environment/validation/network/azure/AzureExistingPrivateDnsZonesServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/validation/network/azure/AzureExistingPrivateDnsZonesServiceTest.java
@@ -1,0 +1,88 @@
+package com.sequenceiq.environment.environment.validation.network.azure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneServiceEnum;
+import com.sequenceiq.environment.network.dto.AzureParams;
+import com.sequenceiq.environment.network.dto.NetworkDto;
+
+@ExtendWith(MockitoExtension.class)
+public class AzureExistingPrivateDnsZonesServiceTest {
+
+    private final AzureExistingPrivateDnsZonesService underTest = new AzureExistingPrivateDnsZonesService();
+
+    @Test
+    void testGetExistingZonesWhenPostgresPresent() {
+        NetworkDto networkDto = getNetworkDto("postgresPrivateDnsZoneId");
+
+        Map<AzurePrivateDnsZoneServiceEnum, String> existingZones = underTest.getExistingZones(networkDto);
+
+        assertEquals("postgresPrivateDnsZoneId", existingZones.get(AzurePrivateDnsZoneServiceEnum.POSTGRES));
+    }
+
+    @Test
+    void testGetExistingZonesWhenPostgresNotPresent() {
+        NetworkDto networkDto = getNetworkDto(null);
+
+        Map<AzurePrivateDnsZoneServiceEnum, String> existingZones = underTest.getExistingZones(networkDto);
+
+        assertThat(existingZones).isEmpty();
+    }
+
+    @Test
+    void testGetServicesWithExistingZonesWhenPostgresWithExistingPrivateDnsZone() {
+        NetworkDto networkDto = getNetworkDto("postgresPrivateDnsZoneId");
+
+        Set<AzurePrivateDnsZoneServiceEnum> servicesWithPrivateDnsZones = underTest.getServicesWithExistingZones(networkDto);
+
+        assertThat(servicesWithPrivateDnsZones).hasSize(1);
+        assertThat(servicesWithPrivateDnsZones).contains(AzurePrivateDnsZoneServiceEnum.POSTGRES);
+    }
+
+    @Test
+    void testGetServicesWithExistingZonesWhenNoServicesWithExistingPrivateDnsZone() {
+        NetworkDto networkDto = getNetworkDto(null);
+
+        Set<AzurePrivateDnsZoneServiceEnum> servicesWithPrivateDnsZones = underTest.getServicesWithExistingZones(networkDto);
+
+        assertThat(servicesWithPrivateDnsZones).isEmpty();
+    }
+
+    @Test
+    void testGetServiceNamesWithExistingZonesWhenPostgresWithExistingPrivateDnsZone() {
+        NetworkDto networkDto = getNetworkDto("postgresPrivateDnsZoneId");
+
+        Set<String> servicesWithPrivateDnsZones = underTest.getServiceNamesWithExistingZones(networkDto);
+
+        assertThat(servicesWithPrivateDnsZones).hasSize(1);
+        assertThat(servicesWithPrivateDnsZones).contains(AzurePrivateDnsZoneServiceEnum.POSTGRES.name());
+    }
+
+    @Test
+    void testGetServiceNamesWithExistingZonesWhenNoServicesWithExistingPrivateDnsZone() {
+        NetworkDto networkDto = getNetworkDto(null);
+
+        Set<String> servicesWithPrivateDnsZones = underTest.getServiceNamesWithExistingZones(networkDto);
+
+        assertThat(servicesWithPrivateDnsZones).isEmpty();
+    }
+
+    private NetworkDto getNetworkDto(String postgresPrivateDnsZoneId) {
+        return NetworkDto.builder()
+                .withAzure(
+                        AzureParams.builder()
+                                .withPrivateDnsZoneId(postgresPrivateDnsZoneId)
+                                .build()
+                )
+                .build();
+    }
+
+}

--- a/environment/src/test/java/com/sequenceiq/environment/network/service/NetworkCreationRequestFactoryTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/network/service/NetworkCreationRequestFactoryTest.java
@@ -24,16 +24,17 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.network.NetworkCreationRequest;
-import com.sequenceiq.cloudbreak.cloud.model.network.NetworkSubnetRequest;
 import com.sequenceiq.cloudbreak.cloud.model.network.NetworkResourcesCreationRequest;
+import com.sequenceiq.cloudbreak.cloud.model.network.NetworkSubnetRequest;
+import com.sequenceiq.cloudbreak.converter.ServiceEndpointCreationToEndpointTypeConverter;
 import com.sequenceiq.common.api.type.ServiceEndpointCreation;
 import com.sequenceiq.environment.credential.domain.Credential;
 import com.sequenceiq.environment.credential.v1.converter.CredentialToCloudCredentialConverter;
 import com.sequenceiq.environment.environment.domain.EnvironmentTags;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
 import com.sequenceiq.environment.environment.dto.LocationDto;
-import com.sequenceiq.cloudbreak.converter.ServiceEndpointCreationToEndpointTypeConverter;
 import com.sequenceiq.environment.environment.service.EnvironmentTagProvider;
+import com.sequenceiq.environment.environment.validation.network.azure.AzureExistingPrivateDnsZonesService;
 import com.sequenceiq.environment.network.dao.domain.AzureNetwork;
 import com.sequenceiq.environment.network.dao.domain.BaseNetwork;
 import com.sequenceiq.environment.network.dto.AzureParams;
@@ -67,13 +68,16 @@ class NetworkCreationRequestFactoryTest {
 
     private final CredentialToCloudCredentialConverter credentialToCloudCredentialConverter = Mockito.mock(CredentialToCloudCredentialConverter.class);
 
+    private final AzureExistingPrivateDnsZonesService azureExistingPrivateDnsZonesService = Mockito.mock(AzureExistingPrivateDnsZonesService.class);
+
     private final EnvironmentTagProvider environmentTagProvider = mock(EnvironmentTagProvider.class);
 
     private final ServiceEndpointCreationToEndpointTypeConverter serviceEndpointCreationToEndpointTypeConverter
             = mock(ServiceEndpointCreationToEndpointTypeConverter.class);
 
     private final NetworkCreationRequestFactory underTest = new NetworkCreationRequestFactory(Collections.emptyList(),
-            credentialToCloudCredentialConverter, defaultSubnetCidrProvider, environmentTagProvider, serviceEndpointCreationToEndpointTypeConverter);
+            credentialToCloudCredentialConverter, defaultSubnetCidrProvider, environmentTagProvider, serviceEndpointCreationToEndpointTypeConverter,
+            azureExistingPrivateDnsZonesService);
 
     @Test
     void testCreateShouldCreateANetworkCreationRequestWhenAzureParamsAreNotPresent() {

--- a/structuredevent-model/src/main/java/com/sequenceiq/environment/network/dto/NetworkDto.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/environment/network/dto/NetworkDto.java
@@ -14,8 +14,8 @@ import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.common.api.type.LoadBalancerCreation;
 import com.sequenceiq.common.api.type.OutboundInternetTraffic;
 import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
-import com.sequenceiq.environment.api.v1.environment.model.base.PrivateSubnetCreation;
 import com.sequenceiq.common.api.type.ServiceEndpointCreation;
+import com.sequenceiq.environment.api.v1.environment.model.base.PrivateSubnetCreation;
 import com.sequenceiq.environment.network.dao.domain.RegistrationType;
 
 public class NetworkDto {
@@ -214,6 +214,16 @@ public class NetworkDto {
 
     public ServiceEndpointCreation getServiceEndpointCreation() {
         return serviceEndpointCreation;
+    }
+
+    public boolean isPrivateEndpointEnabled(CloudPlatform cloudPlatform) {
+        if (CloudPlatform.AWS == cloudPlatform) {
+            return serviceEndpointCreation == ServiceEndpointCreation.ENABLED;
+        } else if (CloudPlatform.AZURE == cloudPlatform) {
+            return serviceEndpointCreation == ServiceEndpointCreation.ENABLED_PRIVATE_ENDPOINT;
+        } else {
+            return false;
+        }
     }
 
     public OutboundInternetTraffic getOutboundInternetTraffic() {


### PR DESCRIPTION
…tion and network creation to suite also existing private DNS zones

The commit contains 1) validation, 2) provider specific network creation changes and 3) refactors.

1) Validation was reorganized to check:
- existing private DNS zone: if the name is valid, supported, if the zone exists and is connected to the network
- new (when CDP creates) private DNS zone: checks if any DNS zone with a given name is connected to the network

2) Provider specific network resources: if a private DNS zone exists then no new zone is created.

3) Refactoring targeted to put private DNS zone validations into a single package.

An important extra requirement was to keep in mind that in the future there could be more than one private DNS zones, and so the code should work even if a next zone is introduced.

See detailed description in the commit message.