### PR TITLE
CB-16289 CB-16289 Bring your own DNS zone - EDH integration

### DIFF
--- a/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/EnvironmentDetailsToCDPNetworkDetailsConverter.java
+++ b/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/EnvironmentDetailsToCDPNetworkDetailsConverter.java
@@ -4,8 +4,10 @@ import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -13,11 +15,13 @@ import org.springframework.stereotype.Component;
 import com.cloudera.thunderhead.service.common.usage.UsageProto;
 import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
 import com.sequenceiq.cloudbreak.cloud.model.network.SubnetType;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.structuredevent.event.cdp.environment.EnvironmentDetails;
 import com.sequenceiq.cloudbreak.structuredevent.event.cdp.environment.proxy.ProxyDetails;
 import com.sequenceiq.common.api.type.CcmV2TlsType;
 import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
 import com.sequenceiq.common.api.type.Tunnel;
+import com.sequenceiq.environment.network.dto.AzureParams;
 import com.sequenceiq.environment.network.dto.NetworkDto;
 
 @Component
@@ -73,6 +77,7 @@ public class EnvironmentDetailsToCDPNetworkDetailsConverter {
         cdpNetworkDetails.setSecurityAccessType(defaultIfEmpty(environmentDetails.getSecurityAccessType(), ""));
         cdpNetworkDetails.setProxyDetails(convertProxy(environmentDetails.getProxyDetails()));
         cdpNetworkDetails.setDomain(defaultIfEmpty(environmentDetails.getDomain(), ""));
+        cdpNetworkDetails.setOwnDnsZones(convertOwnDnsZones(network, environmentDetails.getCloudPlatform()));
 
         UsageProto.CDPNetworkDetails ret = cdpNetworkDetails.build();
         LOGGER.debug("Converted CDPNetworkDetails: {}", ret);
@@ -87,5 +92,23 @@ public class EnvironmentDetailsToCDPNetworkDetailsConverter {
             cdpProxyDetailsBuilder.setAuthentication(proxyDetails.getAuthentication());
         }
         return cdpProxyDetailsBuilder.build();
+    }
+
+    private UsageProto.CDPOwnDnsZones convertOwnDnsZones(NetworkDto networkDto, String cloudPlatform) {
+        UsageProto.CDPOwnDnsZones.Builder builder = UsageProto.CDPOwnDnsZones.newBuilder();
+        if (networkDto == null || cloudPlatform == null) {
+            return builder.build();
+        }
+
+        if (CloudPlatform.AZURE.equalsIgnoreCase(cloudPlatform)) {
+            boolean postgresPrivateDnsZonePresent = Optional.ofNullable(networkDto.getAzure())
+                    .map(AzureParams::getPrivateDnsZoneId)
+                    .map(StringUtils::isNotEmpty)
+                    .orElse(false);
+            builder.setPostgres(postgresPrivateDnsZonePresent);
+        } else {
+            LOGGER.debug("CloudPlatform is not azure thus not reading info on DNS zones");
+        }
+        return builder.build();
     }
 }

--- a/usage-collection/src/main/proto/usage.proto
+++ b/usage-collection/src/main/proto/usage.proto
@@ -752,16 +752,32 @@ message CDPCMLWorkspaceStatus {
   }
 }
 
+// The status of the Cloudera Machine Learning workspace backups.
 message CDPCMLWorkspaceBackupStatus {
   enum Value {
-    // The status when workspace is trying to create a backup
-    BACKUP_STARTED = 0;
-    // The status when workpsace has finsihed creating a backup
-    BACKUP_FINSHED = 1;
-    // The status when backup for a workspace has been deleted
-    BACKUP_DELETED = 2;
-    // The status when backup creation for a workspace has failed
-    BACKUP_FAILED = 3;
+    // A value indicating the enum is unset.
+    UNSET = 0;
+
+    // The status when the backup of a workspace has started.
+    CREATION_STARTED = 1;
+    // The status when backup of a workspace has succeeded.
+    CREATION_SUCCEEDED = 2;
+    // The status when backup of a workspace has failed.
+    CREATION_FAILED = 3;
+
+    // The status when deletion of the backup snapshot has started.
+    DELETION_STARTED = 4;
+    // The status when backup of a workspace has been successfully deleted.
+    DELETION_SUCCEEDED = 5;
+    // The status when deletion of the backup snapshot has failed.
+    DELETION_FAILED = 6;
+
+    // The status when validation for creating backup request has started.
+    VALIDATION_STARTED = 7;
+    // The status when validation for creating backup request has succeeded.
+    VALIDATION_SUCCEEDED = 8;
+    // The status when validation for creating backup request has failed.
+    VALIDATION_FAILED = 9;
   }
 }
 
@@ -1226,6 +1242,13 @@ message CDPFreeIPAStatus {
     DOWNSCALE_FINISHED = 5;
     // The status when CDP FreeIPA downscale has failed.
     DOWNSCALE_FAILED = 6;
+
+    // The status when CDP FreeIPA upgrade is initiated.
+    UPGRADE_STARTED = 7;
+    // The status when CDP FreeIPA upgrade has successfully finished.
+    UPGRADE_FINISHED = 8;
+    // The status when CDP FreeIPA upgrade has failed.
+    UPGRADE_FAILED = 9;
   }
 }
 
@@ -1414,6 +1437,11 @@ message CDPProxyDetails {
   string authentication = 3;
 }
 
+message CDPOwnDnsZones {
+    // Whether DNS is provided for the postgres by the customer or not
+    bool postgres = 1;
+}
+
 message CDPNetworkDetails {
   // Whether the network is created by CDP CP or by the customer
   string networkType = 1;
@@ -1435,6 +1463,8 @@ message CDPNetworkDetails {
   string controlPlaneAndCCMAgentConnectionSecurity = 9;
   // Generated domain name
   string domain = 10;
+  // If the customer is using his own DNS zones for some services
+  CDPOwnDnsZones ownDnsZones= 11;
 }
 
 // Generated when Environment creation has been requested or finished
@@ -3026,10 +3056,10 @@ message CDPStackPatchEvent {
 // Type of stack patch event.
 message CDPStackPatchEventType {
   enum Value {
-    UNSET = 0;
-    AFFECTED = 1;
-    SUCCESS = 2;
-    FAILURE = 3;
+      UNSET = 0;
+      AFFECTED = 1;
+      SUCCESS = 2;
+      FAILURE = 3;
   }
 }
 


### PR DESCRIPTION
On Azure (and also on AWS) it is possible to create private endpoints to a select of cloud services. On Azure this requires the creation of a private DNS zone to resolve the service.
Up to now the DNS zone was created by CDP. A new feature, however, is to allow the customer to provide its own private DNS zone.
This commit enhances the EDH tracking of the private endpoint feature with specifying if the DNS zone was provided by the customer (aka Bring your own DNS zone) or is managed by CDP.

See detailed description in the commit message.