### PR TITLE
[fms] CDPCP-6883 Add CONTROL_PLANE_LOCKOUT_STATE to FreeIPA user conv…

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/conversion/FmsUserConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/conversion/FmsUserConverter.java
@@ -59,6 +59,7 @@ public class FmsUserConverter {
                 return FmsUser.State.DISABLED;
             case ACTIVE:
             case DELETING:
+            case CONTROL_PLANE_LOCKED_OUT:
             case UNRECOGNIZED:
             default:
                 return FmsUser.State.ENABLED;


### PR DESCRIPTION
…erter

We are adding a new state `CONTROL_PLANE_LOCKOUT_STATE` to UMS which
represents actor (user and machine user) lockout in the control plane.
The user will still be able to authenticate to workload clusters.
Therefore, the user should be still converted as an "ENABLED" user in
FreeIPA.