### PR TITLE
CB-16724 Reduce the unit test output in builds

### DIFF
--- a/autoscale/build.gradle
+++ b/autoscale/build.gradle
@@ -215,7 +215,7 @@ dependencies {
 
 test {
     include 'com/sequenceiq/**'
-    testLogging.showStandardStreams = true
+    testLogging.showStandardStreams = false
     ignoreFailures = false
     beforeTest { descriptor ->
         logger.lifecycle("Running test: " + descriptor)

--- a/build.gradle
+++ b/build.gradle
@@ -161,8 +161,8 @@ subprojects {
     maxHeapSize = "1g"
     useJUnitPlatform()
     testlogger {
-      showSummary true
-      showStandardStreams true
+      showSummary false
+      showStandardStreams false
     }
     jacoco {
       destinationFile = file("$buildDir/jacoco/jacocoTest.exec")
@@ -192,7 +192,12 @@ subprojects {
     configFile = rootProject.file('config/checkstyle/checkstyle.xml')
   }
 
-  test.testLogging.showStandardStreams = project.hasProperty('showStandardStreams')
+  test {
+    testLogging {
+      showStandardStreams false
+      events "failed", "standardError"
+    }
+  }
 
   task allDeps(type: DependencyReportTask) {}
 

--- a/cloudera/docker_images.yaml
+++ b/cloudera/docker_images.yaml
@@ -3,6 +3,7 @@ docker_images:
   cloudbreak-autoscale: hortonworks/cloudbreak-autoscale
   cloudbreak-datalake: hortonworks/cloudbreak-datalake
   cloudbreak-environment: hortonworks/cloudbreak-environment
+  cloudbreak-consumption: hortonworks/cloudbreak-consumption
   cloudbreak-freeipa: hortonworks/cloudbreak-freeipa
   cloudbreak-redbeams: hortonworks/cloudbreak-redbeams
   periscope-mock: hortonworks/periscope-mock


### PR DESCRIPTION
RE mentioned that we logging the success tests as well which is not required