### PR TITLE
CB-16713 CB-16714 Flow events/payloads should not use entities (stop …

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartus/StopStartUpscaleActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartus/StopStartUpscaleActions.java
@@ -157,7 +157,7 @@ public class StopStartUpscaleActions {
                 clusterUpscaleFlowService.upscaleCommissioningNodes(context.getStack().getId(), context.getHostGroupName(),
                         startedInstancesMetaData, metaDataWithServicesNotRunning);
 
-                StopStartUpscaleCommissionViaCMRequest commissionRequest = new StopStartUpscaleCommissionViaCMRequest(context.getStack(),
+                StopStartUpscaleCommissionViaCMRequest commissionRequest = new StopStartUpscaleCommissionViaCMRequest(context.getStack().getId(),
                         context.getHostGroupName(), startedInstancesMetaData, metaDataWithServicesNotRunning);
                 sendEvent(context, commissionRequest);
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/StopStartUpscaleCommissionViaCMRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/StopStartUpscaleCommissionViaCMRequest.java
@@ -3,7 +3,6 @@ package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 import java.util.Collections;
 import java.util.List;
 
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.HostGroupPayload;
@@ -16,13 +15,10 @@ public class StopStartUpscaleCommissionViaCMRequest extends ClusterPlatformReque
 
     private final List<InstanceMetaData> servicesNotRunningInstancesToCommission;
 
-    private final Stack stack;
-
-    public StopStartUpscaleCommissionViaCMRequest(Stack stack, String hostGroupName, List<InstanceMetaData> startedInstancesToCommission,
+    public StopStartUpscaleCommissionViaCMRequest(Long stackId, String hostGroupName, List<InstanceMetaData> startedInstancesToCommission,
             List<InstanceMetaData> servicesNotRunningInstancesToCommission) {
-        super(stack.getId());
+        super(stackId);
         this.hostGroupName = hostGroupName;
-        this.stack = stack;
         this.startedInstancesToCommission = startedInstancesToCommission == null ? Collections.emptyList() : startedInstancesToCommission;
         this.servicesNotRunningInstancesToCommission =
                 servicesNotRunningInstancesToCommission == null ? Collections.emptyList() : servicesNotRunningInstancesToCommission;
@@ -36,10 +32,6 @@ public class StopStartUpscaleCommissionViaCMRequest extends ClusterPlatformReque
         return servicesNotRunningInstancesToCommission;
     }
 
-    public Stack getStack() {
-        return stack;
-    }
-
     @Override
     public String getHostGroupName() {
         return hostGroupName;
@@ -50,7 +42,6 @@ public class StopStartUpscaleCommissionViaCMRequest extends ClusterPlatformReque
         return "StopStartUpscaleCommissionViaCMRequest{" +
                 "startedInstancesToCommissionCount=" + startedInstancesToCommission.size() +
                 ", servicesNotRunningInstancesToCommissionCount=" + servicesNotRunningInstancesToCommission.size() +
-                ", stack=" + stack +
                 '}';
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/StopStartUpscaleCommissionViaCMHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/StopStartUpscaleCommissionViaCMHandler.java
@@ -31,6 +31,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.StopStartUpscaleCommi
 import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.StopStartUpscaleCommissionViaCMResult;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
 import com.sequenceiq.cloudbreak.service.hostgroup.HostGroupService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
 import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
@@ -50,6 +51,9 @@ public class StopStartUpscaleCommissionViaCMHandler extends ExceptionCatcherEven
 
     @Inject
     private CloudbreakFlowMessageService flowMessageService;
+
+    @Inject
+    private StackService stackService;
 
     @Override
     public String selector() {
@@ -76,7 +80,7 @@ public class StopStartUpscaleCommissionViaCMHandler extends ExceptionCatcherEven
         allInstancesToCommission.addAll(request.getServicesNotRunningInstancesToCommission());
 
         try {
-            Stack stack = request.getStack();
+            Stack stack = stackService.getByIdWithLists(request.getResourceId());
             Cluster cluster = stack.getCluster();
 
             flowMessageService.fireEventAndLog(stack.getId(), UPDATE_IN_PROGRESS.name(), CLUSTER_SCALING_STOPSTART_UPSCALE_WAITING_HOSTSTART,

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartus/StopStartUpscaleActionsTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartus/StopStartUpscaleActionsTest.java
@@ -342,7 +342,7 @@ public class StopStartUpscaleActionsTest {
         List<InstanceMetaData> startedInstances = instancesActionableStopped.subList(0, adjustment);
 
         StopStartUpscaleCommissionViaCMRequest request =
-                new StopStartUpscaleCommissionViaCMRequest(stack, INSTANCE_GROUP_NAME_ACTIONABLE, startedInstances, Collections.emptyList());
+                new StopStartUpscaleCommissionViaCMRequest(1L, INSTANCE_GROUP_NAME_ACTIONABLE, startedInstances, Collections.emptyList());
         Set<String> successfullyCommissionedFqdns = startedInstances.stream().map(i -> i.getDiscoveryFQDN()).collect(Collectors.toUnmodifiableSet());
         StopStartUpscaleCommissionViaCMResult payload =
                 new StopStartUpscaleCommissionViaCMResult(request, successfullyCommissionedFqdns, Collections.emptyList());
@@ -386,7 +386,7 @@ public class StopStartUpscaleActionsTest {
         List<String> notCommissionedFqdns = notCommissioned.stream().map(x -> x.getDiscoveryFQDN()).collect(Collectors.toList());
 
         StopStartUpscaleCommissionViaCMRequest request =
-                new StopStartUpscaleCommissionViaCMRequest(stack, INSTANCE_GROUP_NAME_ACTIONABLE, startedInstances, notCommissioned);
+                new StopStartUpscaleCommissionViaCMRequest(1L, INSTANCE_GROUP_NAME_ACTIONABLE, startedInstances, notCommissioned);
         Set<String> successfullyCommissionedFqdns = startedInstances.stream().map(i -> i.getDiscoveryFQDN()).collect(Collectors.toUnmodifiableSet());
         StopStartUpscaleCommissionViaCMResult payload = new StopStartUpscaleCommissionViaCMResult(request, successfullyCommissionedFqdns, notCommissionedFqdns);
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/StopStartUpscaleCommissionViaCMHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/StopStartUpscaleCommissionViaCMHandlerTest.java
@@ -41,6 +41,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.StopStartUpscaleCommi
 import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.StopStartUpscaleCommissionViaCMResult;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
 import com.sequenceiq.cloudbreak.service.hostgroup.HostGroupService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
@@ -83,9 +84,13 @@ public class StopStartUpscaleCommissionViaCMHandlerTest {
     @Mock
     private ClusterCommissionService clusterCommissionService;
 
+    @Mock
+    private StackService stackService;
+
     @BeforeEach
     void setUp() {
         setupBasicMocks();
+        when(stackService.getByIdWithLists(any())).thenReturn(stack);
     }
 
     @Test
@@ -101,7 +106,7 @@ public class StopStartUpscaleCommissionViaCMHandlerTest {
         setupPerTestMocks(hostGroup, hostNames, cmAvailableHosts,  recommissionedFqdns);
 
         StopStartUpscaleCommissionViaCMRequest request =
-                new StopStartUpscaleCommissionViaCMRequest(stack, INSTANCE_GROUP_NAME, instancesToCommission, Collections.emptyList());
+                new StopStartUpscaleCommissionViaCMRequest(1L,  INSTANCE_GROUP_NAME, instancesToCommission, Collections.emptyList());
 
         HandlerEvent handlerEvent = new HandlerEvent(Event.wrap(request));
         Selectable selectable = underTest.doAccept(handlerEvent);
@@ -126,7 +131,7 @@ public class StopStartUpscaleCommissionViaCMHandlerTest {
         setupPerTestMocks(hostGroup, hostNames, cmAvailableHosts,  recommissionedFqdns);
 
         StopStartUpscaleCommissionViaCMRequest request =
-                new StopStartUpscaleCommissionViaCMRequest(stack, INSTANCE_GROUP_NAME, instancesToCommission, Collections.emptyList());
+                new StopStartUpscaleCommissionViaCMRequest(1L,  INSTANCE_GROUP_NAME, instancesToCommission, Collections.emptyList());
 
         HandlerEvent handlerEvent = new HandlerEvent(Event.wrap(request));
         Selectable selectable = underTest.doAccept(handlerEvent);
@@ -150,7 +155,7 @@ public class StopStartUpscaleCommissionViaCMHandlerTest {
         setupPerTestMocks(hostGroup, hostNames, cmAvailableHosts,  recommissionedFqdns);
 
         StopStartUpscaleCommissionViaCMRequest request =
-                new StopStartUpscaleCommissionViaCMRequest(stack, INSTANCE_GROUP_NAME, instancesToCommission, Collections.emptyList());
+                new StopStartUpscaleCommissionViaCMRequest(1L,  INSTANCE_GROUP_NAME, instancesToCommission, Collections.emptyList());
 
         HandlerEvent handlerEvent = new HandlerEvent(Event.wrap(request));
         Selectable selectable = underTest.doAccept(handlerEvent);
@@ -175,7 +180,7 @@ public class StopStartUpscaleCommissionViaCMHandlerTest {
         setupPerTestMocks(hostGroup, hostNames, cmAvailableHosts,  recommissionedFqdns);
 
         StopStartUpscaleCommissionViaCMRequest request =
-                new StopStartUpscaleCommissionViaCMRequest(stack, INSTANCE_GROUP_NAME, instancesToCommission, Collections.emptyList());
+                new StopStartUpscaleCommissionViaCMRequest(1L,  INSTANCE_GROUP_NAME, instancesToCommission, Collections.emptyList());
 
         HandlerEvent handlerEvent = new HandlerEvent(Event.wrap(request));
         Selectable selectable = underTest.doAccept(handlerEvent);
@@ -200,7 +205,7 @@ public class StopStartUpscaleCommissionViaCMHandlerTest {
         doThrow(new RuntimeException("waitForHostsHealthyException")).when(clusterSetupService).waitForHostsHealthy(anySet());
 
         StopStartUpscaleCommissionViaCMRequest request =
-                new StopStartUpscaleCommissionViaCMRequest(stack, INSTANCE_GROUP_NAME, instancesToCommission, Collections.emptyList());
+                new StopStartUpscaleCommissionViaCMRequest(1L,  INSTANCE_GROUP_NAME, instancesToCommission, Collections.emptyList());
 
         HandlerEvent handlerEvent = new HandlerEvent(Event.wrap(request));
         Selectable selectable = underTest.doAccept(handlerEvent);
@@ -229,7 +234,7 @@ public class StopStartUpscaleCommissionViaCMHandlerTest {
                 .thenThrow(new RuntimeException("collectHostsToCommissionError"));
 
         StopStartUpscaleCommissionViaCMRequest request =
-                new StopStartUpscaleCommissionViaCMRequest(stack, INSTANCE_GROUP_NAME, instancesToCommission, Collections.emptyList());
+                new StopStartUpscaleCommissionViaCMRequest(1L,  INSTANCE_GROUP_NAME, instancesToCommission, Collections.emptyList());
 
         HandlerEvent handlerEvent = new HandlerEvent(Event.wrap(request));
         Selectable selectable = underTest.doAccept(handlerEvent);
@@ -257,7 +262,7 @@ public class StopStartUpscaleCommissionViaCMHandlerTest {
         when(clusterCommissionService.recommissionClusterNodes(cmAvailableHosts)).thenThrow(new RuntimeException("commissionHostsError"));
 
         StopStartUpscaleCommissionViaCMRequest request =
-                new StopStartUpscaleCommissionViaCMRequest(stack, INSTANCE_GROUP_NAME, instancesToCommission, Collections.emptyList());
+                new StopStartUpscaleCommissionViaCMRequest(1L,  INSTANCE_GROUP_NAME, instancesToCommission, Collections.emptyList());
 
         HandlerEvent handlerEvent = new HandlerEvent(Event.wrap(request));
         Selectable selectable = underTest.doAccept(handlerEvent);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxReactorFlowManager.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxReactorFlowManager.java
@@ -272,7 +272,7 @@ public class SdxReactorFlowManager {
     public FlowIdentifier triggerCcmUpgradeFlow(SdxCluster cluster) {
         LOGGER.info("Trigger CCM Upgrade on Datalake for: {}", cluster);
         String initiatorUserCrn = ThreadBasedUserCrnProvider.getUserCrn();
-        UpgradeCcmStackEvent event = new UpgradeCcmStackEvent(UPGRADE_CCM_UPGRADE_STACK_EVENT.event(), cluster, initiatorUserCrn);
+        UpgradeCcmStackEvent event = new UpgradeCcmStackEvent(UPGRADE_CCM_UPGRADE_STACK_EVENT.event(), cluster.getId(), initiatorUserCrn);
         return notify(event.selector(), event, cluster.getClusterName());
     }
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/upgrade/ccm/UpgradeCcmActions.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/upgrade/ccm/UpgradeCcmActions.java
@@ -43,7 +43,7 @@ public class UpgradeCcmActions {
             @Override
             protected void doExecute(SdxContext context, UpgradeCcmStackEvent payload, Map<Object, Object> variables) {
                 LOGGER.info("Execute CCM upgrade stack flow for SDX: {}", payload.getResourceId());
-                UpgradeCcmStackRequest request = UpgradeCcmStackRequest.from(context, payload.getSdxCluster());
+                UpgradeCcmStackRequest request = UpgradeCcmStackRequest.from(context);
                 sendEvent(context, request);
             }
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/upgrade/ccm/event/UpgradeCcmStackEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/upgrade/ccm/event/UpgradeCcmStackEvent.java
@@ -1,19 +1,11 @@
 package com.sequenceiq.datalake.flow.upgrade.ccm.event;
 
-import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.flow.SdxEvent;
 
 public class UpgradeCcmStackEvent extends SdxEvent {
 
-    private final SdxCluster sdxCluster;
-
-    public UpgradeCcmStackEvent(String selector, SdxCluster sdxCluster, String userId) {
-        super(selector, sdxCluster.getId(), userId);
-        this.sdxCluster = sdxCluster;
-    }
-
-    public SdxCluster getSdxCluster() {
-        return sdxCluster;
+    public UpgradeCcmStackEvent(String selector, Long sdxId, String userId) {
+        super(selector, sdxId, userId);
     }
 
     @Override

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/upgrade/ccm/event/UpgradeCcmStackRequest.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/upgrade/ccm/event/UpgradeCcmStackRequest.java
@@ -1,29 +1,21 @@
 package com.sequenceiq.datalake.flow.upgrade.ccm.event;
 
-import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.flow.SdxContext;
 import com.sequenceiq.datalake.flow.SdxEvent;
 
 public class UpgradeCcmStackRequest extends SdxEvent {
 
-    private final SdxCluster sdxCluster;
-
-    public UpgradeCcmStackRequest(Long sdxId, String userId, SdxCluster sdxCluster) {
+    public UpgradeCcmStackRequest(Long sdxId, String userId) {
         super(sdxId, userId);
-        this.sdxCluster = sdxCluster;
     }
 
-    public static UpgradeCcmStackRequest from(SdxContext context, SdxCluster sdxCluster) {
-        return new UpgradeCcmStackRequest(context.getSdxId(), context.getUserId(), sdxCluster);
+    public static UpgradeCcmStackRequest from(SdxContext context) {
+        return new UpgradeCcmStackRequest(context.getSdxId(), context.getUserId());
     }
 
     @Override
     public String selector() {
         return UpgradeCcmStackRequest.class.getSimpleName();
-    }
-
-    public SdxCluster getSdxCluster() {
-        return sdxCluster;
     }
 }
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/upgrade/ccm/handler/UpgradeCcmStackHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/upgrade/ccm/handler/UpgradeCcmStackHandler.java
@@ -18,6 +18,7 @@ import com.sequenceiq.datalake.flow.upgrade.ccm.event.UpgradeCcmFailedEvent;
 import com.sequenceiq.datalake.flow.upgrade.ccm.event.UpgradeCcmStackRequest;
 import com.sequenceiq.datalake.flow.upgrade.ccm.event.UpgradeCcmSuccessEvent;
 import com.sequenceiq.datalake.service.sdx.PollingConfig;
+import com.sequenceiq.datalake.service.sdx.SdxService;
 import com.sequenceiq.datalake.service.upgrade.ccm.SdxCcmUpgradeService;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
 import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
@@ -38,6 +39,9 @@ public class UpgradeCcmStackHandler extends ExceptionCatcherEventHandler<Upgrade
     @Inject
     private SdxCcmUpgradeService ccmUpgradeService;
 
+    @Inject
+    private SdxService sdxService;
+
     @Override
     public String selector() {
         return UpgradeCcmStackRequest.class.getSimpleName();
@@ -51,7 +55,7 @@ public class UpgradeCcmStackHandler extends ExceptionCatcherEventHandler<Upgrade
     @Override
     protected Selectable doAccept(HandlerEvent<UpgradeCcmStackRequest> event) {
         UpgradeCcmStackRequest request = event.getData();
-        SdxCluster sdxCluster = request.getSdxCluster();
+        SdxCluster sdxCluster = sdxService.getById(request.getResourceId());
         Long sdxId = request.getResourceId();
         String userId = request.getUserId();
         Selectable response;

--- a/datalake/src/test/java/com/sequenceiq/datalake/flow/upgrade/ccm/UpgradeCcmActionsTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/flow/upgrade/ccm/UpgradeCcmActionsTest.java
@@ -177,7 +177,7 @@ class UpgradeCcmActionsTest {
 
     @Test
     void stackUpgradeHappyPath() {
-        actionPayload = new UpgradeCcmStackEvent(ACTION_PAYLOAD_SELECTOR, sdxCluster, USER_ID);
+        actionPayload = new UpgradeCcmStackEvent(ACTION_PAYLOAD_SELECTOR, SDX_ID, USER_ID);
         setupContextWithPayload();
         testUpgradeActionHappyPath(underTest::upgradeCcmStack);
         UpgradeCcmStackRequest payload = (UpgradeCcmStackRequest) payloadArgumentCaptor.getValue();


### PR DESCRIPTION
…start scaling, datalake service)

See detailed description in the commit message.