### PR TITLE
CB-16609 Expose OpDB Agent service - correct CM and Knox service names

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
@@ -320,9 +320,9 @@
                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
             </param>
             {%- endif %}
-            {% if 'OPDB_AGENT' in exposed and 'OPDB_AGENT' in salt['pillar.get']('gateway:location') -%}
+            {% if 'OPDB-AGENT' in exposed and 'OPDB_AGENT' in salt['pillar.get']('gateway:location') -%}
             <param>
-                <name>OPDB_AGENT</name>
+                <name>OPDB-AGENT</name>
                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
             </param>
             {%- endif %}
@@ -691,11 +691,11 @@
     {%- endif %}
 
     {% if 'OPDB_AGENT' in salt['pillar.get']('gateway:location') -%}
-    {% if 'OPDB_AGENT' in exposed -%}
+    {% if 'OPDB-AGENT' in exposed -%}
     <service>
-        <role>OPDB_AGENT</role>
+        <role>OPDB-AGENT</role>
         {% for hostloc in salt['pillar.get']('gateway:location')['OPDB_AGENT'] -%}
-        <url>{{ protocol }}://{{ hostloc }}:{{ ports['OPDB_AGENT'] }}/</url>
+        <url>{{ protocol }}://{{ hostloc }}:{{ ports['OPDB-AGENT'] }}/</url>
         {%- endfor %}
     </service>
     {%- endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_token.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_token.xml.j2
@@ -278,9 +278,9 @@
                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
             </param>
             {%- endif %}
-            {% if 'OPDB_AGENT' in exposed and 'OPDB_AGENT' in salt['pillar.get']('gateway:location') -%}
+            {% if 'OPDB-AGENT' in exposed and 'OPDB_AGENT' in salt['pillar.get']('gateway:location') -%}
             <param>
-                <name>OPDB_AGENT</name>
+                <name>OPDB-AGENT</name>
                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
             </param>
             {%- endif %}
@@ -604,11 +604,11 @@
     {%- endif %}
 
     {% if 'OPDB_AGENT' in salt['pillar.get']('gateway:location') -%}
-    {% if 'OPDB_AGENT' in exposed -%}
+    {% if 'OPDB-AGENT' in exposed -%}
     <service>
-        <role>OPDB_AGENT</role>
+        <role>OPDB-AGENT</role>
         {% for hostloc in salt['pillar.get']('gateway:location')['OPDB_AGENT'] -%}
-        <url>{{ protocol }}://{{ hostloc }}:{{ ports['OPDB_AGENT'] }}</url>
+        <url>{{ protocol }}://{{ hostloc }}:{{ ports['OPDB-AGENT'] }}</url>
         {%- endfor %}
     </service>
     {%- endif %}


### PR DESCRIPTION
Fixed the OpDB Agent topology files. The service name in Knox is OPDB-AGENT and in CM it is called OPDB_AGENT.