### PR TITLE
CB-16744. Cdp telemetry binary can be removed without reinstalling it…

### DIFF
--- a/orchestrator-salt/src/main/resources/salt-common/salt/telemetry/scripts/cdp-telemetry-deployer.sh
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/telemetry/scripts/cdp-telemetry-deployer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-LOGFILE_FOLDER:="/var/log/cdp-telemetry-deployer"
+LOGFILE_FOLDER="/var/log/cdp-telemetry-deployer"
 
 function print_help() {
   cat << EOF
@@ -108,7 +108,7 @@ function upgrade_package() {
   if [[ "$local_version" == "-1" ]]; then
     cleanup_td_agent "$component"
     yum clean all --disablerepo="*" --enablerepo=cdp-infra-tools
-    yum install -y "${component}"
+    yum install -y "${component}" --disablerepo="*" --enablerepo=cdp-infra-tools
   else
     local version_cmp_result=$(version_lt $expected_version $local_version)
     if [[ "$version_cmp_result" == "0" ]]; then
@@ -116,7 +116,7 @@ function upgrade_package() {
     else
       yum clean all --disablerepo="*" --enablerepo=cdp-infra-tools
       yum remove -y "${component}"
-      yum install -y "${component}"
+      yum install -y "${component}" --disablerepo="*" --enablerepo=cdp-infra-tools
     fi
   fi
 }


### PR DESCRIPTION
… in case of yum related issues.

here the issue could be that: during upgrade yum could try to access centos mirror, if it's not available , yum command can time out, but as clean command has the disable/enable repo already, remove will run anyway, but install won't work so we can loose the cdp-telemetry package