### PR TITLE
CB-16012: Set encryption key for an existing env that does not yet have encryption enabled

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentModificationService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentModificationService.java
@@ -40,6 +40,8 @@ import com.sequenceiq.environment.environment.validation.ValidationType;
 import com.sequenceiq.environment.network.NetworkService;
 import com.sequenceiq.environment.network.dao.domain.BaseNetwork;
 import com.sequenceiq.environment.parameter.dto.AzureResourceEncryptionParametersDto;
+import com.sequenceiq.environment.parameter.dto.GcpParametersDto;
+import com.sequenceiq.environment.parameter.dto.GcpResourceEncryptionParametersDto;
 import com.sequenceiq.environment.parameter.dto.ParametersDto;
 import com.sequenceiq.environment.parameters.dao.domain.AwsParameters;
 import com.sequenceiq.environment.parameters.dao.domain.AzureParameters;
@@ -366,6 +368,16 @@ public class EnvironmentModificationService {
                     AwsParameters awsOriginalParameters = (AwsParameters) originalParameters;
                     parametersDto.getAwsParametersDto().setFreeIpaSpotPercentage(awsOriginalParameters.getFreeIpaSpotPercentage());
                     validateAwsParameters(environment, parametersDto);
+                }
+            }
+            if (parametersDto.getGcpParametersDto() != null) {
+                String encryptionKey = Optional.of(parametersDto.getGcpParametersDto())
+                        .map(GcpParametersDto::getGcpResourceEncryptionParametersDto)
+                        .map(GcpResourceEncryptionParametersDto::getEncryptionKey)
+                        .orElse(null);
+                ValidationResult validationResult = environmentService.getValidatorService().validateEncryptionKey(encryptionKey, editDto.getAccountId());
+                if (validationResult.hasError()) {
+                    throw new BadRequestException(validationResult.getFormattedErrors());
                 }
             }
             BaseParameters parameters = parametersService.saveParameters(environment, parametersDto);

--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/EnvironmentValidatorService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/EnvironmentValidatorService.java
@@ -2,7 +2,6 @@ package com.sequenceiq.environment.environment.validation;
 
 import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AWS;
 import static com.sequenceiq.cloudbreak.util.SecurityGroupSeparator.getSecurityGroupIds;
-import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.GCP;
 import static com.sequenceiq.common.model.CredentialType.ENVIRONMENT;
 
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
@@ -304,22 +303,16 @@ public class EnvironmentValidatorService {
         return resultBuilder.build();
     }
 
-    public ValidationResult validateEncryptionKey(EnvironmentCreationDto creationDto) {
+    public ValidationResult validateEncryptionKey(String encryptionKey, String accountId) {
         ValidationResultBuilder resultBuilder = ValidationResult.builder();
-        if (GCP.name().equalsIgnoreCase(creationDto.getCloudPlatform())) {
-            String encryptionKey = Optional.ofNullable(creationDto.getParameters())
-                    .map(parametersDto -> parametersDto.getGcpParametersDto())
-                    .map(gcpParametersDto -> gcpParametersDto.getGcpResourceEncryptionParametersDto())
-                    .map(gcpREParamsDto -> gcpREParamsDto.getEncryptionKey()).orElse(null);
-            if (StringUtils.isNotEmpty(encryptionKey)) {
-                if (!entitlementService.isGcpDiskEncryptionWithCMEKEnabled(creationDto.getAccountId())) {
-                    resultBuilder.error(String.format("You have specified encryption-key to enable encryption for GCP resources with CMEK "
-                            + "but that feature is currently not enabled for this account."
-                            + " Please get 'CDP_CB_GCP_DISK_ENCRYPTION_WITH_CMEK' enabled for this account."));
-                } else {
-                    ValidationResult validationResult = encryptionKeyValidator.validateEncryptionKey(encryptionKey);
-                    resultBuilder.merge(validationResult);
-                }
+        if (StringUtils.isNotEmpty(encryptionKey)) {
+            if (!entitlementService.isGcpDiskEncryptionWithCMEKEnabled(accountId)) {
+                resultBuilder.error(String.format("You have specified encryption-key to enable encryption for GCP resources with CMEK "
+                        + "but that feature is currently not enabled for this account."
+                        + " Please get 'CDP_CB_GCP_DISK_ENCRYPTION_WITH_CMEK' enabled for this account."));
+            } else {
+                ValidationResult validationResult = encryptionKeyValidator.validateEncryptionKey(encryptionKey);
+                resultBuilder.merge(validationResult);
             }
         }
         return resultBuilder.build();

--- a/environment/src/test/java/com/sequenceiq/environment/environment/validation/EnvironmentValidatorServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/validation/EnvironmentValidatorServiceTest.java
@@ -34,7 +34,6 @@ import com.sequenceiq.environment.credential.service.CredentialService;
 import com.sequenceiq.environment.environment.EnvironmentStatus;
 import com.sequenceiq.environment.environment.domain.Environment;
 import com.sequenceiq.environment.environment.dto.AuthenticationDto;
-import com.sequenceiq.environment.environment.dto.EnvironmentCreationDto;
 import com.sequenceiq.environment.environment.dto.EnvironmentEditDto;
 import com.sequenceiq.environment.environment.dto.FreeIpaCreationAwsParametersDto;
 import com.sequenceiq.environment.environment.dto.FreeIpaCreationAwsSpotParametersDto;
@@ -47,9 +46,6 @@ import com.sequenceiq.environment.environment.validation.validators.EncryptionKe
 import com.sequenceiq.environment.environment.validation.validators.NetworkCreationValidator;
 import com.sequenceiq.environment.environment.validation.validators.PublicKeyValidator;
 import com.sequenceiq.environment.environment.validation.validators.TagValidator;
-import com.sequenceiq.environment.parameter.dto.GcpParametersDto;
-import com.sequenceiq.environment.parameter.dto.GcpResourceEncryptionParametersDto;
-import com.sequenceiq.environment.parameter.dto.ParametersDto;
 import com.sequenceiq.environment.platformresource.PlatformParameterService;
 
 @ExtendWith(MockitoExtension.class)
@@ -418,76 +414,33 @@ class EnvironmentValidatorServiceTest {
 
     @Test
     void shouldFailIfGcpEncryptionKeySpecifiedAndEntitlementAndWrongFormat() {
-        EnvironmentCreationDto creationDto = EnvironmentCreationDto.builder()
-                .withAccountId(ACCOUNT_ID)
-                .withCloudPlatform("GCP")
-                .withParameters(ParametersDto.builder()
-                        .withGcpParameters(GcpParametersDto.builder()
-                                .withEncryptionParameters(GcpResourceEncryptionParametersDto.builder()
-                                        .withEncryptionKey("project/Wrong-dummy-key-format")
-                                        .build())
-                                .build())
-                        .build())
-                .build();
-
+        String encryptionKey = "project/Wrong-dummy-key-format";
         ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
         validationResultBuilder.error("error");
         when(encryptionKeyValidator.validateEncryptionKey(any())).thenReturn(validationResultBuilder.build());
         when(entitlementService.isGcpDiskEncryptionWithCMEKEnabled(any())).thenReturn(true);
-        ValidationResult validationResult = underTest.validateEncryptionKey(creationDto);
+        ValidationResult validationResult = underTest.validateEncryptionKey(encryptionKey, ACCOUNT_ID);
         assertTrue(validationResult.hasError());
     }
 
     @Test
     void shouldFailIfGcpEncryptionKeySpecifiedAndNotEntitlement() {
-        EnvironmentCreationDto creationDto = EnvironmentCreationDto.builder()
-                .withAccountId(ACCOUNT_ID)
-                .withCloudPlatform("GCP")
-                .withParameters(ParametersDto.builder()
-                        .withGcpParameters(GcpParametersDto.builder()
-                                .withEncryptionParameters(GcpResourceEncryptionParametersDto.builder()
-                                        .withEncryptionKey("project/Wrong-dummy-key-format")
-                                        .build())
-                                .build())
-                        .build())
-                .build();
-
+        String encryptionKey = "projects/dummy-project/locations/us-west2/keyRings/dummy-ring/cryptoKeys/dummy-key";
         when(entitlementService.isGcpDiskEncryptionWithCMEKEnabled(any())).thenReturn(false);
-        ValidationResult validationResult = underTest.validateEncryptionKey(creationDto);
+        ValidationResult validationResult = underTest.validateEncryptionKey(encryptionKey, ACCOUNT_ID);
 
         assertTrue(validationResult.hasError());
     }
 
     @Test
-    void testValidateGcpEncryptionKeyNotSpecified() {
-        EnvironmentCreationDto creationDto = EnvironmentCreationDto.builder()
-                .withAccountId(ACCOUNT_ID)
-                .withCloudPlatform("GCP")
-                .build();
-        ValidationResult validationResult = underTest.validateEncryptionKey(creationDto);
-        assertFalse(validationResult.hasError());
-    }
-
-    @Test
     void testValidateGcpEncryptionKeySpecifiedAndEntitlement() {
-        EnvironmentCreationDto creationDto = EnvironmentCreationDto.builder()
-                .withAccountId(ACCOUNT_ID)
-                .withCloudPlatform("GCP")
-                .withParameters(ParametersDto.builder()
-                        .withGcpParameters(GcpParametersDto.builder()
-                                .withEncryptionParameters(GcpResourceEncryptionParametersDto.builder()
-                                        .withEncryptionKey("projects/dummy-project/locations/us-west2/keyRings/dummy-ring/cryptoKeys/dummy-key")
-                                        .build())
-                                .build())
-                        .build())
-                .build();
-
+        String encryptionKey = "projects/dummy-project/locations/us-west2/keyRings/dummy-ring/cryptoKeys/dummy-key";
         ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
 
         when(encryptionKeyValidator.validateEncryptionKey(any())).thenReturn(validationResultBuilder.build());
         when(entitlementService.isGcpDiskEncryptionWithCMEKEnabled(any())).thenReturn(true);
 
-        ValidationResult validationResult = underTest.validateEncryptionKey(creationDto);
+        ValidationResult validationResult = underTest.validateEncryptionKey(encryptionKey, ACCOUNT_ID);
         assertFalse(validationResult.hasError());
     }
 


### PR DESCRIPTION
CB-16012: Set encryption key for an existing env that does not yet have encryption enabled

This commit add the checks for GCP encryption key before updating the encryption resources for GCP.
Also, refactors the code and unit tests as per requirement.


Thunderhead PR - https://github.infra.cloudera.com/thunderhead/thunderhead/pull/7744