### PR TITLE
CRB-1916 disable consumption service related docker image from the build temporarily

### DIFF
--- a/cloudera/docker_images.yaml
+++ b/cloudera/docker_images.yaml
@@ -3,7 +3,6 @@ docker_images:
   cloudbreak-autoscale: hortonworks/cloudbreak-autoscale
   cloudbreak-datalake: hortonworks/cloudbreak-datalake
   cloudbreak-environment: hortonworks/cloudbreak-environment
-  cloudbreak-consumption: hortonworks/cloudbreak-consumption
   cloudbreak-freeipa: hortonworks/cloudbreak-freeipa
   cloudbreak-redbeams: hortonworks/cloudbreak-redbeams
   periscope-mock: hortonworks/periscope-mock


### PR DESCRIPTION
Backporting consumption service related build fix from master.