### PR TITLE
CB-16587 We should perform virtual group creation only for available stacks to avoid orphan workload administration groups in the UMS.

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UmsVirtualGroupCreateService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UmsVirtualGroupCreateService.java
@@ -2,8 +2,10 @@ package com.sequenceiq.freeipa.service.freeipa.user;
 
 import static com.sequenceiq.cloudbreak.util.Benchmark.measure;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -13,6 +15,7 @@ import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.auth.altus.UmsVirtualGroupRight;
 import com.sequenceiq.cloudbreak.auth.altus.VirtualGroupService;
+import com.sequenceiq.freeipa.entity.Stack;
 
 @Service
 public class UmsVirtualGroupCreateService {
@@ -22,8 +25,14 @@ public class UmsVirtualGroupCreateService {
     @Inject
     private VirtualGroupService virtualGroupService;
 
-    public void createVirtualGroups(String accountId, Set<String> environmentCrns) {
-        LOGGER.info("Sync virtual groups for environments: {}", environmentCrns);
+    public void createVirtualGroups(String accountId, List<Stack> stacks) {
+        Set<String> environmentCrns = stacks
+                .stream()
+                .filter(Stack::isAvailable)
+                .map(Stack::getEnvironmentCrn)
+                .collect(Collectors.toSet());
+
+        LOGGER.info("Sync virtual groups for environments with available stack: {}", environmentCrns);
         environmentCrns.forEach(envCrn -> {
             try {
                 Map<UmsVirtualGroupRight, String> virtualGroups = measure(() -> virtualGroupService.createVirtualGroups(accountId, envCrn), LOGGER,

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncService.java
@@ -289,7 +289,7 @@ public class UserSyncService {
             LOGGER.info("Starting {} for environments {} with operationId {} ...", logUserSyncEvent, environmentCrns, operationId);
 
             if (options.isFullSync()) {
-                umsVirtualGroupCreateService.createVirtualGroups(accountId, environmentCrns);
+                umsVirtualGroupCreateService.createVirtualGroups(accountId, stacks);
             }
 
             Map<String, Future<SyncStatusDetail>> statusFutures;

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UmsVirtualGroupCreateServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UmsVirtualGroupCreateServiceTest.java
@@ -3,8 +3,9 @@ package com.sequenceiq.freeipa.service.freeipa.user;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Set;
+import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -12,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.auth.altus.VirtualGroupService;
+import com.sequenceiq.freeipa.entity.Stack;
 
 @ExtendWith(MockitoExtension.class)
 public class UmsVirtualGroupCreateServiceTest {
@@ -20,20 +22,40 @@ public class UmsVirtualGroupCreateServiceTest {
 
     private static final String ENV_CRN2 = "env crn 2";
 
-    private static final Set<String> ENV_CRNS = Set.of(ENV_CRN1, ENV_CRN2);
-
     private static final String ACCOUNT_ID = "account id";
 
     @Mock
     private VirtualGroupService virtualGroupService;
 
+    @Mock
+    private Stack stack1;
+
+    @Mock
+    private Stack stack2;
+
+    @Mock
+    private Stack unavailableStack;
+
+    private List<Stack> stacks;
+
     @InjectMocks
     private UmsVirtualGroupCreateService victim;
 
-    @Test
-    public void testCreateVirtualGroupsForEachEnvironments() {
+    @BeforeEach
+    public void initTests() {
+        when(stack1.getEnvironmentCrn()).thenReturn(ENV_CRN1);
+        when(stack1.isAvailable()).thenReturn(true);
+        when(stack2.getEnvironmentCrn()).thenReturn(ENV_CRN2);
+        when(stack2.isAvailable()).thenReturn(true);
+        when(unavailableStack.isAvailable()).thenReturn(false);
 
-        victim.createVirtualGroups(ACCOUNT_ID, ENV_CRNS);
+        //Stacks are added multiple times to verify createVirtualGroups method is called 1 time per environment crn.
+        stacks = List.of(stack1, stack2, stack1, stack2, unavailableStack);
+    }
+
+    @Test
+    public void testCreateVirtualGroupsForEachStacks() {
+        victim.createVirtualGroups(ACCOUNT_ID, stacks);
 
         verify(virtualGroupService).createVirtualGroups(ACCOUNT_ID, ENV_CRN1);
         verify(virtualGroupService).createVirtualGroups(ACCOUNT_ID, ENV_CRN2);
@@ -43,7 +65,7 @@ public class UmsVirtualGroupCreateServiceTest {
     public void testFailSafeVirtualGroupCreation() {
         when(virtualGroupService.createVirtualGroups(ACCOUNT_ID, ENV_CRN1)).thenThrow(RuntimeException.class);
 
-        victim.createVirtualGroups(ACCOUNT_ID, ENV_CRNS);
+        victim.createVirtualGroups(ACCOUNT_ID, stacks);
 
         verify(virtualGroupService).createVirtualGroups(ACCOUNT_ID, ENV_CRN2);
     }


### PR DESCRIPTION
See detailed description in the commit message.