### PR TITLE
CB-16698 ZDU OS upgrade for DL

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
@@ -6,8 +6,8 @@ import static com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.PillarC
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.dr.restore.DatabaseRestoreEvent.DATABASE_RESTORE_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.provision.ClusterCreationEvent.CLUSTER_CREATION_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.salt.update.SaltUpdateEvent.SALT_UPDATE_EVENT;
-import static com.sequenceiq.cloudbreak.core.flow2.cluster.start.ClusterStartEvent.CLUSTER_START_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.services.restart.ClusterServicesRestartEvent.CLUSTER_SERVICES_RESTART_TRIGGER_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.start.ClusterStartEvent.CLUSTER_START_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.sync.ClusterSyncEvent.CLUSTER_SYNC_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.upscale.ClusterUpscaleEvent.CLUSTER_UPSCALE_TRIGGER_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.userpasswd.ClusterCredentialChangeEvent.CLUSTER_CREDENTIALCHANGE_EVENT;
@@ -308,7 +308,14 @@ public class ReactorFlowManager {
         reactorNotifier.notify(stackId, selector, new StackRepairTriggerEvent(stackId, unhealthyInstances));
     }
 
-    public FlowIdentifier triggerClusterRepairFlow(Long stackId, Map<String, List<String>> failedNodesMap, boolean restartServices) {
+    public FlowIdentifier triggerClusterRepairFlow(Long stackId, Map<String, List<String>> failedNodesMap, boolean oneNodeFromEachHostGroupAtOnce,
+            boolean restartServices) {
+        return reactorNotifier.notify(stackId, FlowChainTriggers.CLUSTER_REPAIR_TRIGGER_EVENT,
+                new ClusterRepairTriggerEvent(stackId, failedNodesMap, oneNodeFromEachHostGroupAtOnce, restartServices));
+    }
+
+    public FlowIdentifier triggerClusterRepairFlow(Long stackId, Map<String, List<String>> failedNodesMap,
+            boolean restartServices) {
         return reactorNotifier.notify(stackId, FlowChainTriggers.CLUSTER_REPAIR_TRIGGER_EVENT,
                 new ClusterRepairTriggerEvent(stackId, failedNodesMap, restartServices));
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/ClusterRepairTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/ClusterRepairTriggerEvent.java
@@ -12,6 +12,8 @@ public class ClusterRepairTriggerEvent extends StackEvent {
 
     private final Map<String, List<String>> failedNodesMap;
 
+    private final boolean oneNodeFromEachHostGroupAtOnce;
+
     private final boolean restartServices;
 
     private final boolean upgrade;
@@ -24,6 +26,17 @@ public class ClusterRepairTriggerEvent extends StackEvent {
         super(stackId);
         this.failedNodesMap = copyToSerializableMap(failedNodesMap);
         this.stackId = stackId;
+        this.oneNodeFromEachHostGroupAtOnce = false;
+        this.restartServices = restartServices;
+        this.upgrade = false;
+        this.triggeredStackVariant = null;
+    }
+
+    public ClusterRepairTriggerEvent(Long stackId, Map<String, List<String>> failedNodesMap, boolean oneNodeFromEachHostGroupAtOnce, boolean restartServices) {
+        super(stackId);
+        this.failedNodesMap = copyToSerializableMap(failedNodesMap);
+        this.stackId = stackId;
+        this.oneNodeFromEachHostGroupAtOnce = oneNodeFromEachHostGroupAtOnce;
         this.restartServices = restartServices;
         this.upgrade = false;
         this.triggeredStackVariant = null;
@@ -34,6 +47,7 @@ public class ClusterRepairTriggerEvent extends StackEvent {
         super(event, stackId);
         this.failedNodesMap = copyToSerializableMap(failedNodesMap);
         this.stackId = stackId;
+        this.oneNodeFromEachHostGroupAtOnce = false;
         this.restartServices = restartServices;
         this.upgrade = true;
         this.triggeredStackVariant = triggeredStackVariant;
@@ -57,6 +71,10 @@ public class ClusterRepairTriggerEvent extends StackEvent {
 
     public String getTriggeredStackVariant() {
         return triggeredStackVariant;
+    }
+
+    public boolean isOneNodeFromEachHostGroupAtOnce() {
+        return oneNodeFromEachHostGroupAtOnce;
     }
 
     private Map<String, List<String>> copyToSerializableMap(Map<String, List<String>> map) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
@@ -268,6 +268,9 @@ public interface StackRepository extends WorkspaceResourceRepository<Stack, Long
     @Query("SELECT s.id FROM Stack s WHERE s.resourceCrn= :crn AND s.workspace.id= :workspaceId AND s.terminated = null")
     Optional<Long> findIdByCrnAndWorkspaceId(@Param("crn") String crn, @Param("workspaceId") Long workspaceId);
 
+    @Query("SELECT s.resourceCrn FROM Stack s WHERE s.id= :id AND s.terminated = null")
+    Optional<String> findCrnById(@Param("id") Long id);
+
     @Query("SELECT s.name as name, s.resourceCrn as crn FROM Stack s WHERE s.workspace.id = :workspaceId AND s.resourceCrn IN (:resourceCrns)")
     List<ResourceCrnAndNameView> findResourceNamesByCrnAndWorkspaceId(@Param("resourceCrns") Collection<String> resourceCrns,
             @Param("workspaceId") Long workspaceId);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
@@ -956,6 +956,10 @@ public class StackService implements ResourceIdProvider, AuthorizationResourceNa
         return stackRepository.findIdByCrnAndWorkspaceId(crn, workspaceId).orElseThrow(notFound("Stack", crn));
     }
 
+    public Crn getCrnById(Long id) {
+        return Crn.fromString(stackRepository.findCrnById(id).orElseThrow(notFound("Stack", id)));
+    }
+
     public Set<StackListItem> getByWorkspaceId(Long workspaceId, String environmentCrn, List<StackType> stackTypes) {
         return stackRepository.findByWorkspaceId(workspaceId, environmentCrn, stackTypes);
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
@@ -138,6 +138,7 @@ public class ReactorFlowManagerTest {
         underTest.triggerManualRepairFlow(STACK_ID);
         underTest.triggerStackRepairFlow(STACK_ID, new UnhealthyInstances());
         underTest.triggerClusterRepairFlow(STACK_ID, new HashMap<>(), false);
+        underTest.triggerClusterRepairFlow(STACK_ID, new HashMap<>(), true, false);
         underTest.triggerStackImageUpdate(new ImageChangeDto(STACK_ID, "asdf"));
         underTest.triggerMaintenanceModeValidationFlow(STACK_ID);
         underTest.triggerClusterCertificationRenewal(STACK_ID);
@@ -154,7 +155,6 @@ public class ReactorFlowManagerTest {
         underTest.triggerStopStartStackUpscale(STACK_ID, instanceGroupAdjustment, true);
         underTest.triggerStopStartStackDownscale(STACK_ID, instanceIdsByHostgroup, false);
         underTest.triggerClusterServicesRestart(STACK_ID);
-
 
         int count = 0;
         for (Method method : underTest.getClass().getDeclaredMethods()) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ClusterRepairServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ClusterRepairServiceTest.java
@@ -199,7 +199,7 @@ public class ClusterRepairServiceTest {
 
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.repairHostGroups(1L, Set.of("hostGroup1"), false));
 
-        verify(flowManager).triggerClusterRepairFlow(eq(1L), eq(Map.of("hostGroup1", List.of("host1"))), eq(false));
+        verify(flowManager).triggerClusterRepairFlow(eq(1L), eq(Map.of("hostGroup1", List.of("host1"))), eq(false), eq(false));
     }
 
     @Test
@@ -370,7 +370,7 @@ public class ClusterRepairServiceTest {
         ArgumentCaptor<List<Resource>> saveCaptor = ArgumentCaptor.forClass(List.class);
         verify(resourceService).saveAll(saveCaptor.capture());
         assertFalse(resourceAttributeUtil.getTypedAttributes(saveCaptor.getValue().get(0), VolumeSetAttributes.class).get().getDeleteOnTermination());
-        verify(flowManager).triggerClusterRepairFlow(eq(1L), eq(Map.of("hostGroup1", List.of("host1Name.healthy"))), eq(false));
+        verify(flowManager).triggerClusterRepairFlow(eq(1L), eq(Map.of("hostGroup1", List.of("host1Name.healthy"))), eq(false), eq(false));
     }
 
     @Test

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxInternalUpgradeAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxInternalUpgradeAction.java
@@ -1,0 +1,36 @@
+package com.sequenceiq.it.cloudbreak.action.sdx;
+
+import java.util.Collections;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.SdxClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
+import com.sequenceiq.sdx.api.model.SdxUpgradeRequest;
+import com.sequenceiq.sdx.api.model.SdxUpgradeResponse;
+
+public class SdxInternalUpgradeAction implements Action<SdxInternalTestDto, SdxClient> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxInternalUpgradeAction.class);
+
+    @Override
+    public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
+        SdxUpgradeRequest upgradeRequest = testDto.getSdxUpgradeRequest();
+        Log.when(LOGGER, " SDX endpoint: %s" + client.getDefaultClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
+        Log.whenJson(LOGGER, " SDX upgrade request: ", upgradeRequest);
+        SdxUpgradeResponse upgradeResponse = client.getDefaultClient()
+                .sdxUpgradeEndpoint()
+                .upgradeClusterByName(testDto.getName(), upgradeRequest);
+        testDto.setFlow("SDX upgrade", upgradeResponse.getFlowIdentifier());
+        SdxClusterDetailResponse detailedResponse = client.getDefaultClient()
+                .sdxEndpoint()
+                .getDetail(testDto.getName(), Collections.emptySet());
+        testDto.setResponse(detailedResponse);
+        Log.whenJson(LOGGER, " SDX upgrade response: ", detailedResponse);
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/SdxTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/SdxTestClient.java
@@ -26,6 +26,7 @@ import com.sequenceiq.it.cloudbreak.action.sdx.SdxForceDeleteCustomAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxForceDeleteInternalAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxGetAuditsAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxGetDatalakeEventsZipAction;
+import com.sequenceiq.it.cloudbreak.action.sdx.SdxInternalUpgradeAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxListAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxRecoveryAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxRefreshAction;
@@ -138,6 +139,10 @@ public class SdxTestClient {
 
     public Action<SdxTestDto, SdxClient> upgrade() {
         return new SdxUpgradeAction();
+    }
+
+    public Action<SdxInternalTestDto, SdxClient> upgradeInternal() {
+        return new SdxInternalUpgradeAction();
     }
 
     public Action<SdxTestDto, SdxClient> recover() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxInternalTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxInternalTestDto.java
@@ -62,6 +62,7 @@ import com.sequenceiq.sdx.api.model.SdxDatabaseAvailabilityType;
 import com.sequenceiq.sdx.api.model.SdxDatabaseRequest;
 import com.sequenceiq.sdx.api.model.SdxInternalClusterRequest;
 import com.sequenceiq.sdx.api.model.SdxRepairRequest;
+import com.sequenceiq.sdx.api.model.SdxUpgradeRequest;
 
 @Prototype
 public class SdxInternalTestDto extends AbstractSdxTestDto<SdxInternalClusterRequest, SdxClusterDetailResponse, SdxInternalTestDto>
@@ -448,6 +449,14 @@ public class SdxInternalTestDto extends AbstractSdxTestDto<SdxInternalClusterReq
             throw new IllegalArgumentException("SDX Repair does not exist!");
         }
         return repair.getRequest();
+    }
+
+    public SdxUpgradeRequest getSdxUpgradeRequest() {
+        SdxUpgradeTestDto upgrade = given(SdxUpgradeTestDto.class);
+        if (upgrade == null) {
+            throw new IllegalArgumentException("SDX Upgrade does not exist!");
+        }
+        return upgrade.getRequest();
     }
 
     public SdxClusterResizeRequest getSdxResizeRequest() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxUpgradeTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxUpgradeTestDto.java
@@ -49,4 +49,9 @@ public class SdxUpgradeTestDto extends AbstractSdxTestDto<SdxUpgradeRequest, Sdx
         getRequest().setSkipBackup(skipBackup);
         return this;
     }
+
+    public SdxUpgradeTestDto withLockComponents(Boolean lockComponents) {
+        getRequest().setLockComponents(lockComponents);
+        return this;
+    }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxUpgradeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxUpgradeTests.java
@@ -2,6 +2,7 @@ package com.sequenceiq.it.cloudbreak.testcase.mock;
 
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
 
+import java.time.Duration;
 import java.util.UUID;
 
 import javax.inject.Inject;
@@ -32,10 +33,12 @@ import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxUpgradeTestDto;
 import com.sequenceiq.it.cloudbreak.dto.stack.StackTestDto;
 import com.sequenceiq.redbeams.api.model.common.Status;
 import com.sequenceiq.sdx.api.model.SdxClusterShape;
 import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
+import com.sequenceiq.sdx.api.model.SdxUpgradeReplaceVms;
 
 public class MockSdxUpgradeTests extends AbstractMockTest {
 
@@ -153,6 +156,15 @@ public class MockSdxUpgradeTests extends AbstractMockTest {
                 .when(sdxTestClient.createInternal(), key(sdxInternal))
                 .await(SdxClusterStatusResponse.RUNNING)
                 .then(SdxUpgradeTestAssertion.validateSuccessfulUpgrade())
+                .given(SdxUpgradeTestDto.class)
+                .withRuntime(null)
+                .withLockComponents(true)
+                .withReplaceVms(SdxUpgradeReplaceVms.ENABLED)
+                .given(sdxInternal, SdxInternalTestDto.class)
+                .when(sdxTestClient.upgradeInternal(), key(sdxInternal))
+                .await(SdxClusterStatusResponse.DATALAKE_UPGRADE_IN_PROGRESS, key(sdxInternal).withWaitForFlow(Boolean.FALSE))
+                .await(SdxClusterStatusResponse.RUNNING, key(sdxInternal).withPollingInterval(Duration.ofSeconds(5L)))
+                .awaitForHealthyInstances()
                 .validate();
     }
 


### PR DESCRIPTION
We would like to do DL OS upgrade in a rolling style:
Select one node from every hostgroup at once and do this until all
nodes are updated.
It is very important to select primary gateway in the first round.

It will result the HA Medium Duty being available in the upgrading process
because replication is > 2 for every service and we don't kill more
than 1 node from a host group. So the service on the other node(s) should
handle requests and it should work properly.
