### PR TITLE
CB-16759: Made it so recovery can be performed on an SDX cluster that is detached, allowing for more flexibility with resize recovery.

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxRecoveryController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxRecoveryController.java
@@ -32,7 +32,7 @@ public class SdxRecoveryController implements SdxRecoveryEndpoint {
     @Override
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.RECOVER_DATALAKE)
     public SdxRecoveryResponse recoverClusterByName(@ResourceName String name, @Valid SdxRecoveryRequest recoverSdxClusterRequest) {
-        SdxCluster cluster = sdxService.getByNameInAccount(ThreadBasedUserCrnProvider.getUserCrn(), name);
+        SdxCluster cluster = sdxService.getByNameInAccountAllowDetached(ThreadBasedUserCrnProvider.getUserCrn(), name);
         return sdxRecoverySelectorService.triggerRecovery(cluster, recoverSdxClusterRequest);
     }
 
@@ -47,7 +47,7 @@ public class SdxRecoveryController implements SdxRecoveryEndpoint {
     @Override
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.RECOVER_DATALAKE)
     public SdxRecoverableResponse getClusterRecoverableByName(@ResourceName String name) {
-        SdxCluster cluster = sdxService.getByNameInAccount(ThreadBasedUserCrnProvider.getUserCrn(), name);
+        SdxCluster cluster = sdxService.getByNameInAccountAllowDetached(ThreadBasedUserCrnProvider.getUserCrn(), name);
         return sdxRecoverySelectorService.validateRecovery(cluster);
     }
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -328,11 +328,16 @@ public class SdxService implements ResourceIdProvider, PayloadContextProvider, H
         Optional<SdxCluster> sdxCluster = measure(() ->
                         sdxClusterRepository.findByAccountIdAndClusterNameAndDeletedIsNullAndDetachedIsFalse(accountIdFromCrn, name), LOGGER,
                 "Fetching SDX cluster took {}ms from DB. Name: [{}]", name);
-        if (sdxCluster.isPresent()) {
-            return sdxCluster.get();
-        } else {
-            throw notFound("SDX cluster", name).get();
-        }
+        return sdxCluster.orElseThrow(notFound("SDX cluster", name));
+    }
+
+    public SdxCluster getByNameInAccountAllowDetached(String userCrn, String name) {
+        LOGGER.info("Searching for SDX cluster by name {} allowing detached", name);
+        String accountIdFromCrn = getAccountIdFromCrn(userCrn);
+        Optional<SdxCluster> sdxCluster = measure(() ->
+                        sdxClusterRepository.findByAccountIdAndClusterNameAndDeletedIsNull(accountIdFromCrn, name), LOGGER,
+                "Fetching SDX cluster allowing detached took {}ms from DB. Name: [{}]", name);
+        return sdxCluster.orElseThrow(notFound("SDX cluster", name));
     }
 
     public void delete(SdxCluster sdxCluster) {


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-16759

Essentially recovery used to only be doable on SDX clusters that were not detached due to the way in which it got the cluster via its name.

This change simply uses a new function on top of an already existing repository query.

Please note that I tested this by modifying the original `getByNameInAccount` method. I could not test these changes exactly as they are since I could not get the changes to the `SdxRecoveryController` to build locally for some reason. Not sure if it's always been the case that controller modifications require some extra work to rebuild locally.