### PR TITLE
CDPCP-6883. Update usermanagement.proto

### DIFF
--- a/auth-connector/src/generated/main/grpc/com/cloudera/thunderhead/service/usermanagement/UserManagementGrpc.java
+++ b/auth-connector/src/generated/main/grpc/com/cloudera/thunderhead/service/usermanagement/UserManagementGrpc.java
@@ -3026,6 +3026,37 @@ public final class UserManagementGrpc {
     return getGetActorWorkloadCredentialsMethod;
   }
 
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordMinLifetimeRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordMinLifetimeResponse> getUnsetWorkloadPasswordMinLifetimeMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UnsetWorkloadPasswordMinLifetime",
+      requestType = com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordMinLifetimeRequest.class,
+      responseType = com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordMinLifetimeResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordMinLifetimeRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordMinLifetimeResponse> getUnsetWorkloadPasswordMinLifetimeMethod() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordMinLifetimeRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordMinLifetimeResponse> getUnsetWorkloadPasswordMinLifetimeMethod;
+    if ((getUnsetWorkloadPasswordMinLifetimeMethod = UserManagementGrpc.getUnsetWorkloadPasswordMinLifetimeMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getUnsetWorkloadPasswordMinLifetimeMethod = UserManagementGrpc.getUnsetWorkloadPasswordMinLifetimeMethod) == null) {
+          UserManagementGrpc.getUnsetWorkloadPasswordMinLifetimeMethod = getUnsetWorkloadPasswordMinLifetimeMethod =
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordMinLifetimeRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordMinLifetimeResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UnsetWorkloadPasswordMinLifetime"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordMinLifetimeRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordMinLifetimeResponse.getDefaultInstance()))
+              .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("UnsetWorkloadPasswordMinLifetime"))
+              .build();
+        }
+      }
+    }
+    return getUnsetWorkloadPasswordMinLifetimeMethod;
+  }
+
   private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsRequest,
       com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsResponse> getGetEventGenerationIdsMethod;
 
@@ -3646,6 +3677,192 @@ public final class UserManagementGrpc {
     return getUpdateUserMethod;
   }
 
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetCssoStrictModeRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetCssoStrictModeResponse> getSetCssoStrictModeMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "SetCssoStrictMode",
+      requestType = com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetCssoStrictModeRequest.class,
+      responseType = com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetCssoStrictModeResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetCssoStrictModeRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetCssoStrictModeResponse> getSetCssoStrictModeMethod() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetCssoStrictModeRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetCssoStrictModeResponse> getSetCssoStrictModeMethod;
+    if ((getSetCssoStrictModeMethod = UserManagementGrpc.getSetCssoStrictModeMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getSetCssoStrictModeMethod = UserManagementGrpc.getSetCssoStrictModeMethod) == null) {
+          UserManagementGrpc.getSetCssoStrictModeMethod = getSetCssoStrictModeMethod =
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetCssoStrictModeRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetCssoStrictModeResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "SetCssoStrictMode"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetCssoStrictModeRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetCssoStrictModeResponse.getDefaultInstance()))
+              .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("SetCssoStrictMode"))
+              .build();
+        }
+      }
+    }
+    return getSetCssoStrictModeMethod;
+  }
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.InteractiveLogoutRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.InteractiveLogoutResponse> getInteractiveLogoutMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "InteractiveLogout",
+      requestType = com.cloudera.thunderhead.service.usermanagement.UserManagementProto.InteractiveLogoutRequest.class,
+      responseType = com.cloudera.thunderhead.service.usermanagement.UserManagementProto.InteractiveLogoutResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.InteractiveLogoutRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.InteractiveLogoutResponse> getInteractiveLogoutMethod() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.InteractiveLogoutRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.InteractiveLogoutResponse> getInteractiveLogoutMethod;
+    if ((getInteractiveLogoutMethod = UserManagementGrpc.getInteractiveLogoutMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getInteractiveLogoutMethod = UserManagementGrpc.getInteractiveLogoutMethod) == null) {
+          UserManagementGrpc.getInteractiveLogoutMethod = getInteractiveLogoutMethod =
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.InteractiveLogoutRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.InteractiveLogoutResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "InteractiveLogout"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.InteractiveLogoutRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.InteractiveLogoutResponse.getDefaultInstance()))
+              .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("InteractiveLogout"))
+              .build();
+        }
+      }
+    }
+    return getInteractiveLogoutMethod;
+  }
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListUsersRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListUsersResponse> getScimListUsersMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ScimListUsers",
+      requestType = com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListUsersRequest.class,
+      responseType = com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListUsersResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListUsersRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListUsersResponse> getScimListUsersMethod() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListUsersRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListUsersResponse> getScimListUsersMethod;
+    if ((getScimListUsersMethod = UserManagementGrpc.getScimListUsersMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getScimListUsersMethod = UserManagementGrpc.getScimListUsersMethod) == null) {
+          UserManagementGrpc.getScimListUsersMethod = getScimListUsersMethod =
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListUsersRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListUsersResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ScimListUsers"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListUsersRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListUsersResponse.getDefaultInstance()))
+              .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("ScimListUsers"))
+              .build();
+        }
+      }
+    }
+    return getScimListUsersMethod;
+  }
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimRemoveAllMembersFromGroupRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimRemoveAllMembersFromGroupResponse> getScimRemoveAllMembersFromGroupMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ScimRemoveAllMembersFromGroup",
+      requestType = com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimRemoveAllMembersFromGroupRequest.class,
+      responseType = com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimRemoveAllMembersFromGroupResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimRemoveAllMembersFromGroupRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimRemoveAllMembersFromGroupResponse> getScimRemoveAllMembersFromGroupMethod() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimRemoveAllMembersFromGroupRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimRemoveAllMembersFromGroupResponse> getScimRemoveAllMembersFromGroupMethod;
+    if ((getScimRemoveAllMembersFromGroupMethod = UserManagementGrpc.getScimRemoveAllMembersFromGroupMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getScimRemoveAllMembersFromGroupMethod = UserManagementGrpc.getScimRemoveAllMembersFromGroupMethod) == null) {
+          UserManagementGrpc.getScimRemoveAllMembersFromGroupMethod = getScimRemoveAllMembersFromGroupMethod =
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimRemoveAllMembersFromGroupRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimRemoveAllMembersFromGroupResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ScimRemoveAllMembersFromGroup"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimRemoveAllMembersFromGroupRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimRemoveAllMembersFromGroupResponse.getDefaultInstance()))
+              .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("ScimRemoveAllMembersFromGroup"))
+              .build();
+        }
+      }
+    }
+    return getScimRemoveAllMembersFromGroupMethod;
+  }
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimReplaceAllMembersOfGroupRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimReplaceAllMembersOfGroupResponse> getScimReplaceAllMembersOfGroupMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ScimReplaceAllMembersOfGroup",
+      requestType = com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimReplaceAllMembersOfGroupRequest.class,
+      responseType = com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimReplaceAllMembersOfGroupResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimReplaceAllMembersOfGroupRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimReplaceAllMembersOfGroupResponse> getScimReplaceAllMembersOfGroupMethod() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimReplaceAllMembersOfGroupRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimReplaceAllMembersOfGroupResponse> getScimReplaceAllMembersOfGroupMethod;
+    if ((getScimReplaceAllMembersOfGroupMethod = UserManagementGrpc.getScimReplaceAllMembersOfGroupMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getScimReplaceAllMembersOfGroupMethod = UserManagementGrpc.getScimReplaceAllMembersOfGroupMethod) == null) {
+          UserManagementGrpc.getScimReplaceAllMembersOfGroupMethod = getScimReplaceAllMembersOfGroupMethod =
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimReplaceAllMembersOfGroupRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimReplaceAllMembersOfGroupResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ScimReplaceAllMembersOfGroup"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimReplaceAllMembersOfGroupRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimReplaceAllMembersOfGroupResponse.getDefaultInstance()))
+              .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("ScimReplaceAllMembersOfGroup"))
+              .build();
+        }
+      }
+    }
+    return getScimReplaceAllMembersOfGroupMethod;
+  }
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListGroupsRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListGroupsResponse> getScimListGroupsMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ScimListGroups",
+      requestType = com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListGroupsRequest.class,
+      responseType = com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListGroupsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListGroupsRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListGroupsResponse> getScimListGroupsMethod() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListGroupsRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListGroupsResponse> getScimListGroupsMethod;
+    if ((getScimListGroupsMethod = UserManagementGrpc.getScimListGroupsMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getScimListGroupsMethod = UserManagementGrpc.getScimListGroupsMethod) == null) {
+          UserManagementGrpc.getScimListGroupsMethod = getScimListGroupsMethod =
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListGroupsRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListGroupsResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ScimListGroups"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListGroupsRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListGroupsResponse.getDefaultInstance()))
+              .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("ScimListGroups"))
+              .build();
+        }
+      }
+    }
+    return getScimListGroupsMethod;
+  }
+
   /**
    * Creates a new async stub that supports all call types for the service
    */
@@ -4024,6 +4241,8 @@ public final class UserManagementGrpc {
     /**
      * <pre>
      * Get the rights for an actor.
+     * These rights handle authorization and not authentication
+     * i.e., the rights of the actor are returned regardless of whether the actor is disabled.
      * </pre>
      */
     public void getRights(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetRightsRequest request,
@@ -4034,6 +4253,8 @@ public final class UserManagementGrpc {
     /**
      * <pre>
      * Checks if an actor has the input rights on the input resources.
+     * These rights handle authorization and not authentication
+     * i.e., the rights of the actor are checked regardless of whether the actor is disabled.
      * </pre>
      */
     public void checkRights(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CheckRightsRequest request,
@@ -4702,6 +4923,16 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
+     * Removes workload password minimum lifetime date for an actor.
+     * </pre>
+     */
+    public void unsetWorkloadPasswordMinLifetime(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordMinLifetimeRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordMinLifetimeResponse> responseObserver) {
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getUnsetWorkloadPasswordMinLifetimeMethod(), responseObserver);
+    }
+
+    /**
+     * <pre>
      * Returns a unique ID for the following events:
      * * Role assignment events.
      * * Resource role assignment events.
@@ -4906,6 +5137,68 @@ public final class UserManagementGrpc {
     public void updateUser(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UpdateUserRequest request,
         io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UpdateUserResponse> responseObserver) {
       io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getUpdateUserMethod(), responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Set Cloudera SSO strict mode for the account.
+     * </pre>
+     */
+    public void setCssoStrictMode(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetCssoStrictModeRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetCssoStrictModeResponse> responseObserver) {
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getSetCssoStrictModeMethod(), responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Handles interactive logout requests from console.
+     * </pre>
+     */
+    public void interactiveLogout(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.InteractiveLogoutRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.InteractiveLogoutResponse> responseObserver) {
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getInteractiveLogoutMethod(), responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Lists users for SCIM client. It's not a shared backend method for other services to call.
+     * </pre>
+     */
+    public void scimListUsers(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListUsersRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListUsersResponse> responseObserver) {
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getScimListUsersMethod(), responseObserver);
+    }
+
+    /**
+     * <pre>
+     * SCIM call. Remove all SCIM members from a group. It is not a shared backend method for other
+     * services to call.
+     * </pre>
+     */
+    public void scimRemoveAllMembersFromGroup(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimRemoveAllMembersFromGroupRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimRemoveAllMembersFromGroupResponse> responseObserver) {
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getScimRemoveAllMembersFromGroupMethod(), responseObserver);
+    }
+
+    /**
+     * <pre>
+     * SCIM call. Replace all SCIM members of a group. It is not a shared backend method for other
+     * services to call.
+     * </pre>
+     */
+    public void scimReplaceAllMembersOfGroup(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimReplaceAllMembersOfGroupRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimReplaceAllMembersOfGroupResponse> responseObserver) {
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getScimReplaceAllMembersOfGroupMethod(), responseObserver);
+    }
+
+    /**
+     * <pre>
+     * SCIM call. Lists all groups. It's not a shared backend method for other services to call.
+     * </pre>
+     */
+    public void scimListGroups(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListGroupsRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListGroupsResponse> responseObserver) {
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getScimListGroupsMethod(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
@@ -5590,6 +5883,13 @@ public final class UserManagementGrpc {
                 com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetActorWorkloadCredentialsResponse>(
                   this, METHODID_GET_ACTOR_WORKLOAD_CREDENTIALS)))
           .addMethod(
+            getUnsetWorkloadPasswordMinLifetimeMethod(),
+            io.grpc.stub.ServerCalls.asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordMinLifetimeRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordMinLifetimeResponse>(
+                  this, METHODID_UNSET_WORKLOAD_PASSWORD_MIN_LIFETIME)))
+          .addMethod(
             getGetEventGenerationIdsMethod(),
             io.grpc.stub.ServerCalls.asyncUnaryCall(
               new MethodHandlers<
@@ -5729,6 +6029,48 @@ public final class UserManagementGrpc {
                 com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UpdateUserRequest,
                 com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UpdateUserResponse>(
                   this, METHODID_UPDATE_USER)))
+          .addMethod(
+            getSetCssoStrictModeMethod(),
+            io.grpc.stub.ServerCalls.asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetCssoStrictModeRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetCssoStrictModeResponse>(
+                  this, METHODID_SET_CSSO_STRICT_MODE)))
+          .addMethod(
+            getInteractiveLogoutMethod(),
+            io.grpc.stub.ServerCalls.asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.InteractiveLogoutRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.InteractiveLogoutResponse>(
+                  this, METHODID_INTERACTIVE_LOGOUT)))
+          .addMethod(
+            getScimListUsersMethod(),
+            io.grpc.stub.ServerCalls.asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListUsersRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListUsersResponse>(
+                  this, METHODID_SCIM_LIST_USERS)))
+          .addMethod(
+            getScimRemoveAllMembersFromGroupMethod(),
+            io.grpc.stub.ServerCalls.asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimRemoveAllMembersFromGroupRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimRemoveAllMembersFromGroupResponse>(
+                  this, METHODID_SCIM_REMOVE_ALL_MEMBERS_FROM_GROUP)))
+          .addMethod(
+            getScimReplaceAllMembersOfGroupMethod(),
+            io.grpc.stub.ServerCalls.asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimReplaceAllMembersOfGroupRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimReplaceAllMembersOfGroupResponse>(
+                  this, METHODID_SCIM_REPLACE_ALL_MEMBERS_OF_GROUP)))
+          .addMethod(
+            getScimListGroupsMethod(),
+            io.grpc.stub.ServerCalls.asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListGroupsRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListGroupsResponse>(
+                  this, METHODID_SCIM_LIST_GROUPS)))
           .build();
     }
   }
@@ -6108,6 +6450,8 @@ public final class UserManagementGrpc {
     /**
      * <pre>
      * Get the rights for an actor.
+     * These rights handle authorization and not authentication
+     * i.e., the rights of the actor are returned regardless of whether the actor is disabled.
      * </pre>
      */
     public void getRights(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetRightsRequest request,
@@ -6119,6 +6463,8 @@ public final class UserManagementGrpc {
     /**
      * <pre>
      * Checks if an actor has the input rights on the input resources.
+     * These rights handle authorization and not authentication
+     * i.e., the rights of the actor are checked regardless of whether the actor is disabled.
      * </pre>
      */
     public void checkRights(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CheckRightsRequest request,
@@ -6852,6 +7198,17 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
+     * Removes workload password minimum lifetime date for an actor.
+     * </pre>
+     */
+    public void unsetWorkloadPasswordMinLifetime(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordMinLifetimeRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordMinLifetimeResponse> responseObserver) {
+      io.grpc.stub.ClientCalls.asyncUnaryCall(
+          getChannel().newCall(getUnsetWorkloadPasswordMinLifetimeMethod(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
      * Returns a unique ID for the following events:
      * * Role assignment events.
      * * Resource role assignment events.
@@ -7076,6 +7433,74 @@ public final class UserManagementGrpc {
         io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UpdateUserResponse> responseObserver) {
       io.grpc.stub.ClientCalls.asyncUnaryCall(
           getChannel().newCall(getUpdateUserMethod(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Set Cloudera SSO strict mode for the account.
+     * </pre>
+     */
+    public void setCssoStrictMode(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetCssoStrictModeRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetCssoStrictModeResponse> responseObserver) {
+      io.grpc.stub.ClientCalls.asyncUnaryCall(
+          getChannel().newCall(getSetCssoStrictModeMethod(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Handles interactive logout requests from console.
+     * </pre>
+     */
+    public void interactiveLogout(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.InteractiveLogoutRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.InteractiveLogoutResponse> responseObserver) {
+      io.grpc.stub.ClientCalls.asyncUnaryCall(
+          getChannel().newCall(getInteractiveLogoutMethod(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Lists users for SCIM client. It's not a shared backend method for other services to call.
+     * </pre>
+     */
+    public void scimListUsers(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListUsersRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListUsersResponse> responseObserver) {
+      io.grpc.stub.ClientCalls.asyncUnaryCall(
+          getChannel().newCall(getScimListUsersMethod(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * SCIM call. Remove all SCIM members from a group. It is not a shared backend method for other
+     * services to call.
+     * </pre>
+     */
+    public void scimRemoveAllMembersFromGroup(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimRemoveAllMembersFromGroupRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimRemoveAllMembersFromGroupResponse> responseObserver) {
+      io.grpc.stub.ClientCalls.asyncUnaryCall(
+          getChannel().newCall(getScimRemoveAllMembersFromGroupMethod(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * SCIM call. Replace all SCIM members of a group. It is not a shared backend method for other
+     * services to call.
+     * </pre>
+     */
+    public void scimReplaceAllMembersOfGroup(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimReplaceAllMembersOfGroupRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimReplaceAllMembersOfGroupResponse> responseObserver) {
+      io.grpc.stub.ClientCalls.asyncUnaryCall(
+          getChannel().newCall(getScimReplaceAllMembersOfGroupMethod(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * SCIM call. Lists all groups. It's not a shared backend method for other services to call.
+     * </pre>
+     */
+    public void scimListGroups(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListGroupsRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListGroupsResponse> responseObserver) {
+      io.grpc.stub.ClientCalls.asyncUnaryCall(
+          getChannel().newCall(getScimListGroupsMethod(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -7423,6 +7848,8 @@ public final class UserManagementGrpc {
     /**
      * <pre>
      * Get the rights for an actor.
+     * These rights handle authorization and not authentication
+     * i.e., the rights of the actor are returned regardless of whether the actor is disabled.
      * </pre>
      */
     public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetRightsResponse getRights(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetRightsRequest request) {
@@ -7433,6 +7860,8 @@ public final class UserManagementGrpc {
     /**
      * <pre>
      * Checks if an actor has the input rights on the input resources.
+     * These rights handle authorization and not authentication
+     * i.e., the rights of the actor are checked regardless of whether the actor is disabled.
      * </pre>
      */
     public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CheckRightsResponse checkRights(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CheckRightsRequest request) {
@@ -8101,6 +8530,16 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
+     * Removes workload password minimum lifetime date for an actor.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordMinLifetimeResponse unsetWorkloadPasswordMinLifetime(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordMinLifetimeRequest request) {
+      return io.grpc.stub.ClientCalls.blockingUnaryCall(
+          getChannel(), getUnsetWorkloadPasswordMinLifetimeMethod(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
      * Returns a unique ID for the following events:
      * * Role assignment events.
      * * Resource role assignment events.
@@ -8305,6 +8744,68 @@ public final class UserManagementGrpc {
     public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UpdateUserResponse updateUser(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UpdateUserRequest request) {
       return io.grpc.stub.ClientCalls.blockingUnaryCall(
           getChannel(), getUpdateUserMethod(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * Set Cloudera SSO strict mode for the account.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetCssoStrictModeResponse setCssoStrictMode(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetCssoStrictModeRequest request) {
+      return io.grpc.stub.ClientCalls.blockingUnaryCall(
+          getChannel(), getSetCssoStrictModeMethod(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * Handles interactive logout requests from console.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.InteractiveLogoutResponse interactiveLogout(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.InteractiveLogoutRequest request) {
+      return io.grpc.stub.ClientCalls.blockingUnaryCall(
+          getChannel(), getInteractiveLogoutMethod(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * Lists users for SCIM client. It's not a shared backend method for other services to call.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListUsersResponse scimListUsers(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListUsersRequest request) {
+      return io.grpc.stub.ClientCalls.blockingUnaryCall(
+          getChannel(), getScimListUsersMethod(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * SCIM call. Remove all SCIM members from a group. It is not a shared backend method for other
+     * services to call.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimRemoveAllMembersFromGroupResponse scimRemoveAllMembersFromGroup(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimRemoveAllMembersFromGroupRequest request) {
+      return io.grpc.stub.ClientCalls.blockingUnaryCall(
+          getChannel(), getScimRemoveAllMembersFromGroupMethod(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * SCIM call. Replace all SCIM members of a group. It is not a shared backend method for other
+     * services to call.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimReplaceAllMembersOfGroupResponse scimReplaceAllMembersOfGroup(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimReplaceAllMembersOfGroupRequest request) {
+      return io.grpc.stub.ClientCalls.blockingUnaryCall(
+          getChannel(), getScimReplaceAllMembersOfGroupMethod(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * SCIM call. Lists all groups. It's not a shared backend method for other services to call.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListGroupsResponse scimListGroups(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListGroupsRequest request) {
+      return io.grpc.stub.ClientCalls.blockingUnaryCall(
+          getChannel(), getScimListGroupsMethod(), getCallOptions(), request);
     }
   }
 
@@ -8683,6 +9184,8 @@ public final class UserManagementGrpc {
     /**
      * <pre>
      * Get the rights for an actor.
+     * These rights handle authorization and not authentication
+     * i.e., the rights of the actor are returned regardless of whether the actor is disabled.
      * </pre>
      */
     public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetRightsResponse> getRights(
@@ -8694,6 +9197,8 @@ public final class UserManagementGrpc {
     /**
      * <pre>
      * Checks if an actor has the input rights on the input resources.
+     * These rights handle authorization and not authentication
+     * i.e., the rights of the actor are checked regardless of whether the actor is disabled.
      * </pre>
      */
     public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CheckRightsResponse> checkRights(
@@ -9427,6 +9932,17 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
+     * Removes workload password minimum lifetime date for an actor.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordMinLifetimeResponse> unsetWorkloadPasswordMinLifetime(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordMinLifetimeRequest request) {
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
+          getChannel().newCall(getUnsetWorkloadPasswordMinLifetimeMethod(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
      * Returns a unique ID for the following events:
      * * Role assignment events.
      * * Resource role assignment events.
@@ -9652,6 +10168,74 @@ public final class UserManagementGrpc {
       return io.grpc.stub.ClientCalls.futureUnaryCall(
           getChannel().newCall(getUpdateUserMethod(), getCallOptions()), request);
     }
+
+    /**
+     * <pre>
+     * Set Cloudera SSO strict mode for the account.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetCssoStrictModeResponse> setCssoStrictMode(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetCssoStrictModeRequest request) {
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
+          getChannel().newCall(getSetCssoStrictModeMethod(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
+     * Handles interactive logout requests from console.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.InteractiveLogoutResponse> interactiveLogout(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.InteractiveLogoutRequest request) {
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
+          getChannel().newCall(getInteractiveLogoutMethod(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
+     * Lists users for SCIM client. It's not a shared backend method for other services to call.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListUsersResponse> scimListUsers(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListUsersRequest request) {
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
+          getChannel().newCall(getScimListUsersMethod(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
+     * SCIM call. Remove all SCIM members from a group. It is not a shared backend method for other
+     * services to call.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimRemoveAllMembersFromGroupResponse> scimRemoveAllMembersFromGroup(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimRemoveAllMembersFromGroupRequest request) {
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
+          getChannel().newCall(getScimRemoveAllMembersFromGroupMethod(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
+     * SCIM call. Replace all SCIM members of a group. It is not a shared backend method for other
+     * services to call.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimReplaceAllMembersOfGroupResponse> scimReplaceAllMembersOfGroup(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimReplaceAllMembersOfGroupRequest request) {
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
+          getChannel().newCall(getScimReplaceAllMembersOfGroupMethod(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
+     * SCIM call. Lists all groups. It's not a shared backend method for other services to call.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListGroupsResponse> scimListGroups(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListGroupsRequest request) {
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
+          getChannel().newCall(getScimListGroupsMethod(), getCallOptions()), request);
+    }
   }
 
   private static final int METHODID_INTERACTIVE_LOGIN = 0;
@@ -9751,26 +10335,33 @@ public final class UserManagementGrpc {
   private static final int METHODID_SET_ACTOR_WORKLOAD_CREDENTIALS = 94;
   private static final int METHODID_VALIDATE_ACTOR_WORKLOAD_CREDENTIALS = 95;
   private static final int METHODID_GET_ACTOR_WORKLOAD_CREDENTIALS = 96;
-  private static final int METHODID_GET_EVENT_GENERATION_IDS = 97;
-  private static final int METHODID_ADD_ACTOR_SSH_PUBLIC_KEY = 98;
-  private static final int METHODID_LIST_ACTOR_SSH_PUBLIC_KEYS = 99;
-  private static final int METHODID_DESCRIBE_ACTOR_SSH_PUBLIC_KEY = 100;
-  private static final int METHODID_DELETE_ACTOR_SSH_PUBLIC_KEY = 101;
-  private static final int METHODID_SET_WORKLOAD_PASSWORD_POLICY = 102;
-  private static final int METHODID_UNSET_WORKLOAD_PASSWORD_POLICY = 103;
-  private static final int METHODID_SET_AUTHENTICATION_POLICY = 104;
-  private static final int METHODID_ASSIGN_CLOUD_IDENTITY = 105;
-  private static final int METHODID_UNASSIGN_CLOUD_IDENTITY = 106;
-  private static final int METHODID_ASSIGN_SERVICE_PRINCIPAL_CLOUD_IDENTITY = 107;
-  private static final int METHODID_UNASSIGN_SERVICE_PRINCIPAL_CLOUD_IDENTITY = 108;
-  private static final int METHODID_LIST_SERVICE_PRINCIPAL_CLOUD_IDENTITIES = 109;
-  private static final int METHODID_GET_DEFAULT_IDENTITY_PROVIDER_CONNECTOR = 110;
-  private static final int METHODID_SET_DEFAULT_IDENTITY_PROVIDER_CONNECTOR = 111;
-  private static final int METHODID_GET_USER_SYNC_STATE_MODEL = 112;
-  private static final int METHODID_LIST_ROLE_ASSIGNMENTS = 113;
-  private static final int METHODID_GENERATE_WORKLOAD_AUTH_TOKEN = 114;
-  private static final int METHODID_GET_WORKLOAD_AUTH_CONFIGURATION = 115;
-  private static final int METHODID_UPDATE_USER = 116;
+  private static final int METHODID_UNSET_WORKLOAD_PASSWORD_MIN_LIFETIME = 97;
+  private static final int METHODID_GET_EVENT_GENERATION_IDS = 98;
+  private static final int METHODID_ADD_ACTOR_SSH_PUBLIC_KEY = 99;
+  private static final int METHODID_LIST_ACTOR_SSH_PUBLIC_KEYS = 100;
+  private static final int METHODID_DESCRIBE_ACTOR_SSH_PUBLIC_KEY = 101;
+  private static final int METHODID_DELETE_ACTOR_SSH_PUBLIC_KEY = 102;
+  private static final int METHODID_SET_WORKLOAD_PASSWORD_POLICY = 103;
+  private static final int METHODID_UNSET_WORKLOAD_PASSWORD_POLICY = 104;
+  private static final int METHODID_SET_AUTHENTICATION_POLICY = 105;
+  private static final int METHODID_ASSIGN_CLOUD_IDENTITY = 106;
+  private static final int METHODID_UNASSIGN_CLOUD_IDENTITY = 107;
+  private static final int METHODID_ASSIGN_SERVICE_PRINCIPAL_CLOUD_IDENTITY = 108;
+  private static final int METHODID_UNASSIGN_SERVICE_PRINCIPAL_CLOUD_IDENTITY = 109;
+  private static final int METHODID_LIST_SERVICE_PRINCIPAL_CLOUD_IDENTITIES = 110;
+  private static final int METHODID_GET_DEFAULT_IDENTITY_PROVIDER_CONNECTOR = 111;
+  private static final int METHODID_SET_DEFAULT_IDENTITY_PROVIDER_CONNECTOR = 112;
+  private static final int METHODID_GET_USER_SYNC_STATE_MODEL = 113;
+  private static final int METHODID_LIST_ROLE_ASSIGNMENTS = 114;
+  private static final int METHODID_GENERATE_WORKLOAD_AUTH_TOKEN = 115;
+  private static final int METHODID_GET_WORKLOAD_AUTH_CONFIGURATION = 116;
+  private static final int METHODID_UPDATE_USER = 117;
+  private static final int METHODID_SET_CSSO_STRICT_MODE = 118;
+  private static final int METHODID_INTERACTIVE_LOGOUT = 119;
+  private static final int METHODID_SCIM_LIST_USERS = 120;
+  private static final int METHODID_SCIM_REMOVE_ALL_MEMBERS_FROM_GROUP = 121;
+  private static final int METHODID_SCIM_REPLACE_ALL_MEMBERS_OF_GROUP = 122;
+  private static final int METHODID_SCIM_LIST_GROUPS = 123;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -10177,6 +10768,10 @@ public final class UserManagementGrpc {
           serviceImpl.getActorWorkloadCredentials((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetActorWorkloadCredentialsRequest) request,
               (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetActorWorkloadCredentialsResponse>) responseObserver);
           break;
+        case METHODID_UNSET_WORKLOAD_PASSWORD_MIN_LIFETIME:
+          serviceImpl.unsetWorkloadPasswordMinLifetime((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordMinLifetimeRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordMinLifetimeResponse>) responseObserver);
+          break;
         case METHODID_GET_EVENT_GENERATION_IDS:
           serviceImpl.getEventGenerationIds((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsRequest) request,
               (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsResponse>) responseObserver);
@@ -10256,6 +10851,30 @@ public final class UserManagementGrpc {
         case METHODID_UPDATE_USER:
           serviceImpl.updateUser((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UpdateUserRequest) request,
               (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UpdateUserResponse>) responseObserver);
+          break;
+        case METHODID_SET_CSSO_STRICT_MODE:
+          serviceImpl.setCssoStrictMode((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetCssoStrictModeRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetCssoStrictModeResponse>) responseObserver);
+          break;
+        case METHODID_INTERACTIVE_LOGOUT:
+          serviceImpl.interactiveLogout((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.InteractiveLogoutRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.InteractiveLogoutResponse>) responseObserver);
+          break;
+        case METHODID_SCIM_LIST_USERS:
+          serviceImpl.scimListUsers((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListUsersRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListUsersResponse>) responseObserver);
+          break;
+        case METHODID_SCIM_REMOVE_ALL_MEMBERS_FROM_GROUP:
+          serviceImpl.scimRemoveAllMembersFromGroup((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimRemoveAllMembersFromGroupRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimRemoveAllMembersFromGroupResponse>) responseObserver);
+          break;
+        case METHODID_SCIM_REPLACE_ALL_MEMBERS_OF_GROUP:
+          serviceImpl.scimReplaceAllMembersOfGroup((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimReplaceAllMembersOfGroupRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimReplaceAllMembersOfGroupResponse>) responseObserver);
+          break;
+        case METHODID_SCIM_LIST_GROUPS:
+          serviceImpl.scimListGroups((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListGroupsRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ScimListGroupsResponse>) responseObserver);
           break;
         default:
           throw new AssertionError();
@@ -10415,6 +11034,7 @@ public final class UserManagementGrpc {
               .addMethod(getSetActorWorkloadCredentialsMethod())
               .addMethod(getValidateActorWorkloadCredentialsMethod())
               .addMethod(getGetActorWorkloadCredentialsMethod())
+              .addMethod(getUnsetWorkloadPasswordMinLifetimeMethod())
               .addMethod(getGetEventGenerationIdsMethod())
               .addMethod(getAddActorSshPublicKeyMethod())
               .addMethod(getListActorSshPublicKeysMethod())
@@ -10435,6 +11055,12 @@ public final class UserManagementGrpc {
               .addMethod(getGenerateWorkloadAuthTokenMethod())
               .addMethod(getGetWorkloadAuthConfigurationMethod())
               .addMethod(getUpdateUserMethod())
+              .addMethod(getSetCssoStrictModeMethod())
+              .addMethod(getInteractiveLogoutMethod())
+              .addMethod(getScimListUsersMethod())
+              .addMethod(getScimRemoveAllMembersFromGroupMethod())
+              .addMethod(getScimReplaceAllMembersOfGroupMethod())
+              .addMethod(getScimListGroupsMethod())
               .build();
         }
       }

--- a/auth-connector/src/generated/main/java/com/cloudera/thunderhead/service/common/options/Options.java
+++ b/auth-connector/src/generated/main/java/com/cloudera/thunderhead/service/common/options/Options.java
@@ -7,6 +7,15 @@ public final class Options {
   private Options() {}
   public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistryLite registry) {
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.rateLimitGroupDefinition);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.apiServiceName);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.release);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.admin);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.formFactor);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.version);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.tagGroup);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.FileExtension.audit);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.FileExtension.auditEntitlement);
     registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.sensitive);
     registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.skipLogging);
     registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.pagingPageSize);
@@ -17,6 +26,15 @@ public final class Options {
     registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.hidden);
     registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.hiddenReason);
     registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.hiddenRetention);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.required);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.minimum);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.maximum);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.minimumLength);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.maximumLength);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.deprecated);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.noParamfile);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.default_);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.formFactor);
     registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.right);
     registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.entitlement);
     registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.paginates);
@@ -24,9 +42,21 @@ public final class Options {
     registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.hidden);
     registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.hiddenReason);
     registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.hiddenRetention);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.deprecated);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.rateLimitGroup);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.mutating);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.skipAuditing);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.formFactor);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.extension);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.tag);
     registry.add(com.cloudera.thunderhead.service.common.options.Options.MessageExtension.hidden);
     registry.add(com.cloudera.thunderhead.service.common.options.Options.MessageExtension.hiddenReason);
     registry.add(com.cloudera.thunderhead.service.common.options.Options.MessageExtension.hiddenRetention);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.MessageExtension.deprecated);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.MessageExtension.formFactor);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension.hidden);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension.hiddenReason);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension.hiddenRetention);
   }
 
   public static void registerAllExtensions(
@@ -34,6 +64,3686 @@ public final class Options {
     registerAllExtensions(
         (com.google.protobuf.ExtensionRegistryLite) registry);
   }
+  public interface ServiceExtensionOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:options.ServiceExtension)
+      com.google.protobuf.MessageOrBuilder {
+  }
+  /**
+   * Protobuf type {@code options.ServiceExtension}
+   */
+  public static final class ServiceExtension extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:options.ServiceExtension)
+      ServiceExtensionOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use ServiceExtension.newBuilder() to construct.
+    private ServiceExtension(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private ServiceExtension() {
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new ServiceExtension();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private ServiceExtension(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_ServiceExtension_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_ServiceExtension_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.class, com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.Builder.class);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.cloudera.thunderhead.service.common.options.Options.ServiceExtension)) {
+        return super.equals(obj);
+      }
+      com.cloudera.thunderhead.service.common.options.Options.ServiceExtension other = (com.cloudera.thunderhead.service.common.options.Options.ServiceExtension) obj;
+
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.cloudera.thunderhead.service.common.options.Options.ServiceExtension parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ServiceExtension parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ServiceExtension parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ServiceExtension parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ServiceExtension parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ServiceExtension parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ServiceExtension parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ServiceExtension parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ServiceExtension parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ServiceExtension parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ServiceExtension parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ServiceExtension parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.cloudera.thunderhead.service.common.options.Options.ServiceExtension prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code options.ServiceExtension}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:options.ServiceExtension)
+        com.cloudera.thunderhead.service.common.options.Options.ServiceExtensionOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_ServiceExtension_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_ServiceExtension_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.class, com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.Builder.class);
+      }
+
+      // Construct using com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_ServiceExtension_descriptor;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.ServiceExtension getDefaultInstanceForType() {
+        return com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.ServiceExtension build() {
+        com.cloudera.thunderhead.service.common.options.Options.ServiceExtension result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.ServiceExtension buildPartial() {
+        com.cloudera.thunderhead.service.common.options.Options.ServiceExtension result = new com.cloudera.thunderhead.service.common.options.Options.ServiceExtension(this);
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.cloudera.thunderhead.service.common.options.Options.ServiceExtension) {
+          return mergeFrom((com.cloudera.thunderhead.service.common.options.Options.ServiceExtension)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.cloudera.thunderhead.service.common.options.Options.ServiceExtension other) {
+        if (other == com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.getDefaultInstance()) return this;
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.cloudera.thunderhead.service.common.options.Options.ServiceExtension parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.cloudera.thunderhead.service.common.options.Options.ServiceExtension) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:options.ServiceExtension)
+    }
+
+    // @@protoc_insertion_point(class_scope:options.ServiceExtension)
+    private static final com.cloudera.thunderhead.service.common.options.Options.ServiceExtension DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.cloudera.thunderhead.service.common.options.Options.ServiceExtension();
+    }
+
+    public static com.cloudera.thunderhead.service.common.options.Options.ServiceExtension getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<ServiceExtension>
+        PARSER = new com.google.protobuf.AbstractParser<ServiceExtension>() {
+      @java.lang.Override
+      public ServiceExtension parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new ServiceExtension(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<ServiceExtension> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<ServiceExtension> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.cloudera.thunderhead.service.common.options.Options.ServiceExtension getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+    public static final int RATELIMITGROUPDEFINITION_FIELD_NUMBER = 40000;
+    /**
+     * <pre>
+     * At least one method in this service is rate limited by the specified
+     * rate limit group. Use of this option causes the generated API controller
+     * to include rate limiting for methods that have the rateLimitGroup option.
+     * (Currently, only one group may be defined.) Most services do not require
+     * rate limiting; contact the CDPCP core infra team for guidance.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.ServiceOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.ServiceOptions,
+        com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition> rateLimitGroupDefinition = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.getDefaultInstance(),
+          0,
+          com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition.class,
+          com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition.getDefaultInstance());
+    public static final int APISERVICENAME_FIELD_NUMBER = 40001;
+    /**
+     * <pre>
+     * The API service name, in various casings.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.ServiceOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.ServiceOptions,
+        com.cloudera.thunderhead.service.common.options.Options.ApiServiceName> apiServiceName = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.getDefaultInstance(),
+          1,
+          com.cloudera.thunderhead.service.common.options.Options.ApiServiceName.class,
+          com.cloudera.thunderhead.service.common.options.Options.ApiServiceName.getDefaultInstance());
+    public static final int RELEASE_FIELD_NUMBER = 40002;
+    /**
+     * <pre>
+     * The releases that the service belongs in, i.e., PUBLIC.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.ServiceOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.ServiceOptions,
+        java.util.List<java.lang.String>> release = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.getDefaultInstance(),
+          2,
+          java.lang.String.class,
+          null);
+    public static final int ADMIN_FIELD_NUMBER = 40003;
+    /**
+     * <pre>
+     * Whether this service is an administrative service. These services are put
+     * on a special, internal only ingress and may only be called by members of
+     * the CDP administration account.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.ServiceOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.ServiceOptions,
+        java.lang.Boolean> admin = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.getDefaultInstance(),
+          3,
+          java.lang.Boolean.class,
+          null);
+    public static final int FORMFACTOR_FIELD_NUMBER = 40004;
+    /**
+     * <pre>
+     * The form factor(s) that the service is part of, e.g., public, private.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.ServiceOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.ServiceOptions,
+        java.util.List<java.lang.String>> formFactor = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.getDefaultInstance(),
+          4,
+          java.lang.String.class,
+          null);
+    public static final int VERSION_FIELD_NUMBER = 40005;
+    /**
+     * <pre>
+     * The version of the service definition.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.ServiceOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.ServiceOptions,
+        java.lang.String> version = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.getDefaultInstance(),
+          5,
+          java.lang.String.class,
+          null);
+    public static final int TAGGROUP_FIELD_NUMBER = 40006;
+    /**
+     * <pre>
+     * The Tag Groups for the Service
+     * </pre>
+     *
+     * <code>extend .google.protobuf.ServiceOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.ServiceOptions,
+        java.util.List<com.cloudera.thunderhead.service.common.options.Options.TagGroup>> tagGroup = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.getDefaultInstance(),
+          6,
+          com.cloudera.thunderhead.service.common.options.Options.TagGroup.class,
+          com.cloudera.thunderhead.service.common.options.Options.TagGroup.getDefaultInstance());
+  }
+
+  public interface TagGroupOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:options.TagGroup)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     * The name of the tag group to use in the MethodExtention.
+     * </pre>
+     *
+     * <code>string name = 1;</code>
+     * @return The name.
+     */
+    java.lang.String getName();
+    /**
+     * <pre>
+     * The name of the tag group to use in the MethodExtention.
+     * </pre>
+     *
+     * <code>string name = 1;</code>
+     * @return The bytes for name.
+     */
+    com.google.protobuf.ByteString
+        getNameBytes();
+
+    /**
+     * <pre>
+     * The description pf the tag group.
+     * </pre>
+     *
+     * <code>string description = 2;</code>
+     * @return The description.
+     */
+    java.lang.String getDescription();
+    /**
+     * <pre>
+     * The description pf the tag group.
+     * </pre>
+     *
+     * <code>string description = 2;</code>
+     * @return The bytes for description.
+     */
+    com.google.protobuf.ByteString
+        getDescriptionBytes();
+
+    /**
+     * <pre>
+     * The external docs url link for the tag group.
+     * </pre>
+     *
+     * <code>string externalDocs = 3;</code>
+     * @return The externalDocs.
+     */
+    java.lang.String getExternalDocs();
+    /**
+     * <pre>
+     * The external docs url link for the tag group.
+     * </pre>
+     *
+     * <code>string externalDocs = 3;</code>
+     * @return The bytes for externalDocs.
+     */
+    com.google.protobuf.ByteString
+        getExternalDocsBytes();
+  }
+  /**
+   * <pre>
+   * The Swagger Tag Group
+   * </pre>
+   *
+   * Protobuf type {@code options.TagGroup}
+   */
+  public static final class TagGroup extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:options.TagGroup)
+      TagGroupOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use TagGroup.newBuilder() to construct.
+    private TagGroup(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private TagGroup() {
+      name_ = "";
+      description_ = "";
+      externalDocs_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new TagGroup();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private TagGroup(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              name_ = s;
+              break;
+            }
+            case 18: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              description_ = s;
+              break;
+            }
+            case 26: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              externalDocs_ = s;
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_TagGroup_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_TagGroup_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.cloudera.thunderhead.service.common.options.Options.TagGroup.class, com.cloudera.thunderhead.service.common.options.Options.TagGroup.Builder.class);
+    }
+
+    public static final int NAME_FIELD_NUMBER = 1;
+    private volatile java.lang.Object name_;
+    /**
+     * <pre>
+     * The name of the tag group to use in the MethodExtention.
+     * </pre>
+     *
+     * <code>string name = 1;</code>
+     * @return The name.
+     */
+    @java.lang.Override
+    public java.lang.String getName() {
+      java.lang.Object ref = name_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        name_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * The name of the tag group to use in the MethodExtention.
+     * </pre>
+     *
+     * <code>string name = 1;</code>
+     * @return The bytes for name.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getNameBytes() {
+      java.lang.Object ref = name_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        name_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int DESCRIPTION_FIELD_NUMBER = 2;
+    private volatile java.lang.Object description_;
+    /**
+     * <pre>
+     * The description pf the tag group.
+     * </pre>
+     *
+     * <code>string description = 2;</code>
+     * @return The description.
+     */
+    @java.lang.Override
+    public java.lang.String getDescription() {
+      java.lang.Object ref = description_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        description_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * The description pf the tag group.
+     * </pre>
+     *
+     * <code>string description = 2;</code>
+     * @return The bytes for description.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getDescriptionBytes() {
+      java.lang.Object ref = description_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        description_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int EXTERNALDOCS_FIELD_NUMBER = 3;
+    private volatile java.lang.Object externalDocs_;
+    /**
+     * <pre>
+     * The external docs url link for the tag group.
+     * </pre>
+     *
+     * <code>string externalDocs = 3;</code>
+     * @return The externalDocs.
+     */
+    @java.lang.Override
+    public java.lang.String getExternalDocs() {
+      java.lang.Object ref = externalDocs_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        externalDocs_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * The external docs url link for the tag group.
+     * </pre>
+     *
+     * <code>string externalDocs = 3;</code>
+     * @return The bytes for externalDocs.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getExternalDocsBytes() {
+      java.lang.Object ref = externalDocs_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        externalDocs_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(name_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(description_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, description_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(externalDocs_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 3, externalDocs_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(name_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(description_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, description_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(externalDocs_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, externalDocs_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.cloudera.thunderhead.service.common.options.Options.TagGroup)) {
+        return super.equals(obj);
+      }
+      com.cloudera.thunderhead.service.common.options.Options.TagGroup other = (com.cloudera.thunderhead.service.common.options.Options.TagGroup) obj;
+
+      if (!getName()
+          .equals(other.getName())) return false;
+      if (!getDescription()
+          .equals(other.getDescription())) return false;
+      if (!getExternalDocs()
+          .equals(other.getExternalDocs())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (37 * hash) + NAME_FIELD_NUMBER;
+      hash = (53 * hash) + getName().hashCode();
+      hash = (37 * hash) + DESCRIPTION_FIELD_NUMBER;
+      hash = (53 * hash) + getDescription().hashCode();
+      hash = (37 * hash) + EXTERNALDOCS_FIELD_NUMBER;
+      hash = (53 * hash) + getExternalDocs().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.cloudera.thunderhead.service.common.options.Options.TagGroup parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.TagGroup parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.TagGroup parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.TagGroup parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.TagGroup parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.TagGroup parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.TagGroup parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.TagGroup parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.TagGroup parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.TagGroup parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.TagGroup parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.TagGroup parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.cloudera.thunderhead.service.common.options.Options.TagGroup prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     * The Swagger Tag Group
+     * </pre>
+     *
+     * Protobuf type {@code options.TagGroup}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:options.TagGroup)
+        com.cloudera.thunderhead.service.common.options.Options.TagGroupOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_TagGroup_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_TagGroup_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.cloudera.thunderhead.service.common.options.Options.TagGroup.class, com.cloudera.thunderhead.service.common.options.Options.TagGroup.Builder.class);
+      }
+
+      // Construct using com.cloudera.thunderhead.service.common.options.Options.TagGroup.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        name_ = "";
+
+        description_ = "";
+
+        externalDocs_ = "";
+
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_TagGroup_descriptor;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.TagGroup getDefaultInstanceForType() {
+        return com.cloudera.thunderhead.service.common.options.Options.TagGroup.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.TagGroup build() {
+        com.cloudera.thunderhead.service.common.options.Options.TagGroup result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.TagGroup buildPartial() {
+        com.cloudera.thunderhead.service.common.options.Options.TagGroup result = new com.cloudera.thunderhead.service.common.options.Options.TagGroup(this);
+        result.name_ = name_;
+        result.description_ = description_;
+        result.externalDocs_ = externalDocs_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.cloudera.thunderhead.service.common.options.Options.TagGroup) {
+          return mergeFrom((com.cloudera.thunderhead.service.common.options.Options.TagGroup)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.cloudera.thunderhead.service.common.options.Options.TagGroup other) {
+        if (other == com.cloudera.thunderhead.service.common.options.Options.TagGroup.getDefaultInstance()) return this;
+        if (!other.getName().isEmpty()) {
+          name_ = other.name_;
+          onChanged();
+        }
+        if (!other.getDescription().isEmpty()) {
+          description_ = other.description_;
+          onChanged();
+        }
+        if (!other.getExternalDocs().isEmpty()) {
+          externalDocs_ = other.externalDocs_;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.cloudera.thunderhead.service.common.options.Options.TagGroup parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.cloudera.thunderhead.service.common.options.Options.TagGroup) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+
+      private java.lang.Object name_ = "";
+      /**
+       * <pre>
+       * The name of the tag group to use in the MethodExtention.
+       * </pre>
+       *
+       * <code>string name = 1;</code>
+       * @return The name.
+       */
+      public java.lang.String getName() {
+        java.lang.Object ref = name_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          name_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The name of the tag group to use in the MethodExtention.
+       * </pre>
+       *
+       * <code>string name = 1;</code>
+       * @return The bytes for name.
+       */
+      public com.google.protobuf.ByteString
+          getNameBytes() {
+        java.lang.Object ref = name_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          name_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The name of the tag group to use in the MethodExtention.
+       * </pre>
+       *
+       * <code>string name = 1;</code>
+       * @param value The name to set.
+       * @return This builder for chaining.
+       */
+      public Builder setName(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        name_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The name of the tag group to use in the MethodExtention.
+       * </pre>
+       *
+       * <code>string name = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearName() {
+        
+        name_ = getDefaultInstance().getName();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The name of the tag group to use in the MethodExtention.
+       * </pre>
+       *
+       * <code>string name = 1;</code>
+       * @param value The bytes for name to set.
+       * @return This builder for chaining.
+       */
+      public Builder setNameBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        name_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object description_ = "";
+      /**
+       * <pre>
+       * The description pf the tag group.
+       * </pre>
+       *
+       * <code>string description = 2;</code>
+       * @return The description.
+       */
+      public java.lang.String getDescription() {
+        java.lang.Object ref = description_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          description_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The description pf the tag group.
+       * </pre>
+       *
+       * <code>string description = 2;</code>
+       * @return The bytes for description.
+       */
+      public com.google.protobuf.ByteString
+          getDescriptionBytes() {
+        java.lang.Object ref = description_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          description_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The description pf the tag group.
+       * </pre>
+       *
+       * <code>string description = 2;</code>
+       * @param value The description to set.
+       * @return This builder for chaining.
+       */
+      public Builder setDescription(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        description_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The description pf the tag group.
+       * </pre>
+       *
+       * <code>string description = 2;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearDescription() {
+        
+        description_ = getDefaultInstance().getDescription();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The description pf the tag group.
+       * </pre>
+       *
+       * <code>string description = 2;</code>
+       * @param value The bytes for description to set.
+       * @return This builder for chaining.
+       */
+      public Builder setDescriptionBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        description_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object externalDocs_ = "";
+      /**
+       * <pre>
+       * The external docs url link for the tag group.
+       * </pre>
+       *
+       * <code>string externalDocs = 3;</code>
+       * @return The externalDocs.
+       */
+      public java.lang.String getExternalDocs() {
+        java.lang.Object ref = externalDocs_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          externalDocs_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The external docs url link for the tag group.
+       * </pre>
+       *
+       * <code>string externalDocs = 3;</code>
+       * @return The bytes for externalDocs.
+       */
+      public com.google.protobuf.ByteString
+          getExternalDocsBytes() {
+        java.lang.Object ref = externalDocs_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          externalDocs_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The external docs url link for the tag group.
+       * </pre>
+       *
+       * <code>string externalDocs = 3;</code>
+       * @param value The externalDocs to set.
+       * @return This builder for chaining.
+       */
+      public Builder setExternalDocs(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        externalDocs_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The external docs url link for the tag group.
+       * </pre>
+       *
+       * <code>string externalDocs = 3;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearExternalDocs() {
+        
+        externalDocs_ = getDefaultInstance().getExternalDocs();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The external docs url link for the tag group.
+       * </pre>
+       *
+       * <code>string externalDocs = 3;</code>
+       * @param value The bytes for externalDocs to set.
+       * @return This builder for chaining.
+       */
+      public Builder setExternalDocsBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        externalDocs_ = value;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:options.TagGroup)
+    }
+
+    // @@protoc_insertion_point(class_scope:options.TagGroup)
+    private static final com.cloudera.thunderhead.service.common.options.Options.TagGroup DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.cloudera.thunderhead.service.common.options.Options.TagGroup();
+    }
+
+    public static com.cloudera.thunderhead.service.common.options.Options.TagGroup getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<TagGroup>
+        PARSER = new com.google.protobuf.AbstractParser<TagGroup>() {
+      @java.lang.Override
+      public TagGroup parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new TagGroup(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<TagGroup> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<TagGroup> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.cloudera.thunderhead.service.common.options.Options.TagGroup getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface RateLimitGroupDefinitionOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:options.RateLimitGroupDefinition)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     * The name of the group. This must be one of the values of the
+     * ApiRateLimitGroup enum.
+     * </pre>
+     *
+     * <code>string name = 1;</code>
+     * @return The name.
+     */
+    java.lang.String getName();
+    /**
+     * <pre>
+     * The name of the group. This must be one of the values of the
+     * ApiRateLimitGroup enum.
+     * </pre>
+     *
+     * <code>string name = 1;</code>
+     * @return The bytes for name.
+     */
+    com.google.protobuf.ByteString
+        getNameBytes();
+
+    /**
+     * <pre>
+     * The limit (calls per second) by remote address for calls controlled by
+     * this group.
+     * </pre>
+     *
+     * <code>int32 byRemoteAddress = 2;</code>
+     * @return The byRemoteAddress.
+     */
+    int getByRemoteAddress();
+
+    /**
+     * <pre>
+     * The limit (calls per second) by access key ID for calls controlled by this
+     * group. (Not yet supported.)
+     * </pre>
+     *
+     * <code>int32 byAccessKeyId = 3;</code>
+     * @return The byAccessKeyId.
+     */
+    int getByAccessKeyId();
+
+    /**
+     * <pre>
+     * The limit (calls per second) by account for calls controlled by this group.
+     * </pre>
+     *
+     * <code>int32 byAccount = 4;</code>
+     * @return The byAccount.
+     */
+    int getByAccount();
+  }
+  /**
+   * <pre>
+   * The definition of an API rate limit group. See the Java classes
+   * ApiRateLimiter and ApiRateLimiterProvider for context.
+   * </pre>
+   *
+   * Protobuf type {@code options.RateLimitGroupDefinition}
+   */
+  public static final class RateLimitGroupDefinition extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:options.RateLimitGroupDefinition)
+      RateLimitGroupDefinitionOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use RateLimitGroupDefinition.newBuilder() to construct.
+    private RateLimitGroupDefinition(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private RateLimitGroupDefinition() {
+      name_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new RateLimitGroupDefinition();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private RateLimitGroupDefinition(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              name_ = s;
+              break;
+            }
+            case 16: {
+
+              byRemoteAddress_ = input.readInt32();
+              break;
+            }
+            case 24: {
+
+              byAccessKeyId_ = input.readInt32();
+              break;
+            }
+            case 32: {
+
+              byAccount_ = input.readInt32();
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_RateLimitGroupDefinition_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_RateLimitGroupDefinition_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition.class, com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition.Builder.class);
+    }
+
+    public static final int NAME_FIELD_NUMBER = 1;
+    private volatile java.lang.Object name_;
+    /**
+     * <pre>
+     * The name of the group. This must be one of the values of the
+     * ApiRateLimitGroup enum.
+     * </pre>
+     *
+     * <code>string name = 1;</code>
+     * @return The name.
+     */
+    @java.lang.Override
+    public java.lang.String getName() {
+      java.lang.Object ref = name_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        name_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * The name of the group. This must be one of the values of the
+     * ApiRateLimitGroup enum.
+     * </pre>
+     *
+     * <code>string name = 1;</code>
+     * @return The bytes for name.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getNameBytes() {
+      java.lang.Object ref = name_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        name_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int BYREMOTEADDRESS_FIELD_NUMBER = 2;
+    private int byRemoteAddress_;
+    /**
+     * <pre>
+     * The limit (calls per second) by remote address for calls controlled by
+     * this group.
+     * </pre>
+     *
+     * <code>int32 byRemoteAddress = 2;</code>
+     * @return The byRemoteAddress.
+     */
+    @java.lang.Override
+    public int getByRemoteAddress() {
+      return byRemoteAddress_;
+    }
+
+    public static final int BYACCESSKEYID_FIELD_NUMBER = 3;
+    private int byAccessKeyId_;
+    /**
+     * <pre>
+     * The limit (calls per second) by access key ID for calls controlled by this
+     * group. (Not yet supported.)
+     * </pre>
+     *
+     * <code>int32 byAccessKeyId = 3;</code>
+     * @return The byAccessKeyId.
+     */
+    @java.lang.Override
+    public int getByAccessKeyId() {
+      return byAccessKeyId_;
+    }
+
+    public static final int BYACCOUNT_FIELD_NUMBER = 4;
+    private int byAccount_;
+    /**
+     * <pre>
+     * The limit (calls per second) by account for calls controlled by this group.
+     * </pre>
+     *
+     * <code>int32 byAccount = 4;</code>
+     * @return The byAccount.
+     */
+    @java.lang.Override
+    public int getByAccount() {
+      return byAccount_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(name_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
+      }
+      if (byRemoteAddress_ != 0) {
+        output.writeInt32(2, byRemoteAddress_);
+      }
+      if (byAccessKeyId_ != 0) {
+        output.writeInt32(3, byAccessKeyId_);
+      }
+      if (byAccount_ != 0) {
+        output.writeInt32(4, byAccount_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(name_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
+      }
+      if (byRemoteAddress_ != 0) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(2, byRemoteAddress_);
+      }
+      if (byAccessKeyId_ != 0) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(3, byAccessKeyId_);
+      }
+      if (byAccount_ != 0) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(4, byAccount_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition)) {
+        return super.equals(obj);
+      }
+      com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition other = (com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition) obj;
+
+      if (!getName()
+          .equals(other.getName())) return false;
+      if (getByRemoteAddress()
+          != other.getByRemoteAddress()) return false;
+      if (getByAccessKeyId()
+          != other.getByAccessKeyId()) return false;
+      if (getByAccount()
+          != other.getByAccount()) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (37 * hash) + NAME_FIELD_NUMBER;
+      hash = (53 * hash) + getName().hashCode();
+      hash = (37 * hash) + BYREMOTEADDRESS_FIELD_NUMBER;
+      hash = (53 * hash) + getByRemoteAddress();
+      hash = (37 * hash) + BYACCESSKEYID_FIELD_NUMBER;
+      hash = (53 * hash) + getByAccessKeyId();
+      hash = (37 * hash) + BYACCOUNT_FIELD_NUMBER;
+      hash = (53 * hash) + getByAccount();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     * The definition of an API rate limit group. See the Java classes
+     * ApiRateLimiter and ApiRateLimiterProvider for context.
+     * </pre>
+     *
+     * Protobuf type {@code options.RateLimitGroupDefinition}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:options.RateLimitGroupDefinition)
+        com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinitionOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_RateLimitGroupDefinition_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_RateLimitGroupDefinition_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition.class, com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition.Builder.class);
+      }
+
+      // Construct using com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        name_ = "";
+
+        byRemoteAddress_ = 0;
+
+        byAccessKeyId_ = 0;
+
+        byAccount_ = 0;
+
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_RateLimitGroupDefinition_descriptor;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition getDefaultInstanceForType() {
+        return com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition build() {
+        com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition buildPartial() {
+        com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition result = new com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition(this);
+        result.name_ = name_;
+        result.byRemoteAddress_ = byRemoteAddress_;
+        result.byAccessKeyId_ = byAccessKeyId_;
+        result.byAccount_ = byAccount_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition) {
+          return mergeFrom((com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition other) {
+        if (other == com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition.getDefaultInstance()) return this;
+        if (!other.getName().isEmpty()) {
+          name_ = other.name_;
+          onChanged();
+        }
+        if (other.getByRemoteAddress() != 0) {
+          setByRemoteAddress(other.getByRemoteAddress());
+        }
+        if (other.getByAccessKeyId() != 0) {
+          setByAccessKeyId(other.getByAccessKeyId());
+        }
+        if (other.getByAccount() != 0) {
+          setByAccount(other.getByAccount());
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+
+      private java.lang.Object name_ = "";
+      /**
+       * <pre>
+       * The name of the group. This must be one of the values of the
+       * ApiRateLimitGroup enum.
+       * </pre>
+       *
+       * <code>string name = 1;</code>
+       * @return The name.
+       */
+      public java.lang.String getName() {
+        java.lang.Object ref = name_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          name_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The name of the group. This must be one of the values of the
+       * ApiRateLimitGroup enum.
+       * </pre>
+       *
+       * <code>string name = 1;</code>
+       * @return The bytes for name.
+       */
+      public com.google.protobuf.ByteString
+          getNameBytes() {
+        java.lang.Object ref = name_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          name_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The name of the group. This must be one of the values of the
+       * ApiRateLimitGroup enum.
+       * </pre>
+       *
+       * <code>string name = 1;</code>
+       * @param value The name to set.
+       * @return This builder for chaining.
+       */
+      public Builder setName(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        name_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The name of the group. This must be one of the values of the
+       * ApiRateLimitGroup enum.
+       * </pre>
+       *
+       * <code>string name = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearName() {
+        
+        name_ = getDefaultInstance().getName();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The name of the group. This must be one of the values of the
+       * ApiRateLimitGroup enum.
+       * </pre>
+       *
+       * <code>string name = 1;</code>
+       * @param value The bytes for name to set.
+       * @return This builder for chaining.
+       */
+      public Builder setNameBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        name_ = value;
+        onChanged();
+        return this;
+      }
+
+      private int byRemoteAddress_ ;
+      /**
+       * <pre>
+       * The limit (calls per second) by remote address for calls controlled by
+       * this group.
+       * </pre>
+       *
+       * <code>int32 byRemoteAddress = 2;</code>
+       * @return The byRemoteAddress.
+       */
+      @java.lang.Override
+      public int getByRemoteAddress() {
+        return byRemoteAddress_;
+      }
+      /**
+       * <pre>
+       * The limit (calls per second) by remote address for calls controlled by
+       * this group.
+       * </pre>
+       *
+       * <code>int32 byRemoteAddress = 2;</code>
+       * @param value The byRemoteAddress to set.
+       * @return This builder for chaining.
+       */
+      public Builder setByRemoteAddress(int value) {
+        
+        byRemoteAddress_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The limit (calls per second) by remote address for calls controlled by
+       * this group.
+       * </pre>
+       *
+       * <code>int32 byRemoteAddress = 2;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearByRemoteAddress() {
+        
+        byRemoteAddress_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private int byAccessKeyId_ ;
+      /**
+       * <pre>
+       * The limit (calls per second) by access key ID for calls controlled by this
+       * group. (Not yet supported.)
+       * </pre>
+       *
+       * <code>int32 byAccessKeyId = 3;</code>
+       * @return The byAccessKeyId.
+       */
+      @java.lang.Override
+      public int getByAccessKeyId() {
+        return byAccessKeyId_;
+      }
+      /**
+       * <pre>
+       * The limit (calls per second) by access key ID for calls controlled by this
+       * group. (Not yet supported.)
+       * </pre>
+       *
+       * <code>int32 byAccessKeyId = 3;</code>
+       * @param value The byAccessKeyId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setByAccessKeyId(int value) {
+        
+        byAccessKeyId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The limit (calls per second) by access key ID for calls controlled by this
+       * group. (Not yet supported.)
+       * </pre>
+       *
+       * <code>int32 byAccessKeyId = 3;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearByAccessKeyId() {
+        
+        byAccessKeyId_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private int byAccount_ ;
+      /**
+       * <pre>
+       * The limit (calls per second) by account for calls controlled by this group.
+       * </pre>
+       *
+       * <code>int32 byAccount = 4;</code>
+       * @return The byAccount.
+       */
+      @java.lang.Override
+      public int getByAccount() {
+        return byAccount_;
+      }
+      /**
+       * <pre>
+       * The limit (calls per second) by account for calls controlled by this group.
+       * </pre>
+       *
+       * <code>int32 byAccount = 4;</code>
+       * @param value The byAccount to set.
+       * @return This builder for chaining.
+       */
+      public Builder setByAccount(int value) {
+        
+        byAccount_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The limit (calls per second) by account for calls controlled by this group.
+       * </pre>
+       *
+       * <code>int32 byAccount = 4;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearByAccount() {
+        
+        byAccount_ = 0;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:options.RateLimitGroupDefinition)
+    }
+
+    // @@protoc_insertion_point(class_scope:options.RateLimitGroupDefinition)
+    private static final com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition();
+    }
+
+    public static com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<RateLimitGroupDefinition>
+        PARSER = new com.google.protobuf.AbstractParser<RateLimitGroupDefinition>() {
+      @java.lang.Override
+      public RateLimitGroupDefinition parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new RateLimitGroupDefinition(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<RateLimitGroupDefinition> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<RateLimitGroupDefinition> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface ApiServiceNameOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:options.ApiServiceName)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     * The lowercased service name.
+     * </pre>
+     *
+     * <code>string lowercase = 1;</code>
+     * @return The lowercase.
+     */
+    java.lang.String getLowercase();
+    /**
+     * <pre>
+     * The lowercased service name.
+     * </pre>
+     *
+     * <code>string lowercase = 1;</code>
+     * @return The bytes for lowercase.
+     */
+    com.google.protobuf.ByteString
+        getLowercaseBytes();
+
+    /**
+     * <pre>
+     * The camel-cased service name.
+     * </pre>
+     *
+     * <code>string camelcase = 2;</code>
+     * @return The camelcase.
+     */
+    java.lang.String getCamelcase();
+    /**
+     * <pre>
+     * The camel-cased service name.
+     * </pre>
+     *
+     * <code>string camelcase = 2;</code>
+     * @return The bytes for camelcase.
+     */
+    com.google.protobuf.ByteString
+        getCamelcaseBytes();
+  }
+  /**
+   * <pre>
+   * The API service name, in various casings.
+   * </pre>
+   *
+   * Protobuf type {@code options.ApiServiceName}
+   */
+  public static final class ApiServiceName extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:options.ApiServiceName)
+      ApiServiceNameOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use ApiServiceName.newBuilder() to construct.
+    private ApiServiceName(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private ApiServiceName() {
+      lowercase_ = "";
+      camelcase_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new ApiServiceName();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private ApiServiceName(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              lowercase_ = s;
+              break;
+            }
+            case 18: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              camelcase_ = s;
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_ApiServiceName_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_ApiServiceName_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.cloudera.thunderhead.service.common.options.Options.ApiServiceName.class, com.cloudera.thunderhead.service.common.options.Options.ApiServiceName.Builder.class);
+    }
+
+    public static final int LOWERCASE_FIELD_NUMBER = 1;
+    private volatile java.lang.Object lowercase_;
+    /**
+     * <pre>
+     * The lowercased service name.
+     * </pre>
+     *
+     * <code>string lowercase = 1;</code>
+     * @return The lowercase.
+     */
+    @java.lang.Override
+    public java.lang.String getLowercase() {
+      java.lang.Object ref = lowercase_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        lowercase_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * The lowercased service name.
+     * </pre>
+     *
+     * <code>string lowercase = 1;</code>
+     * @return The bytes for lowercase.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getLowercaseBytes() {
+      java.lang.Object ref = lowercase_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        lowercase_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int CAMELCASE_FIELD_NUMBER = 2;
+    private volatile java.lang.Object camelcase_;
+    /**
+     * <pre>
+     * The camel-cased service name.
+     * </pre>
+     *
+     * <code>string camelcase = 2;</code>
+     * @return The camelcase.
+     */
+    @java.lang.Override
+    public java.lang.String getCamelcase() {
+      java.lang.Object ref = camelcase_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        camelcase_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * The camel-cased service name.
+     * </pre>
+     *
+     * <code>string camelcase = 2;</code>
+     * @return The bytes for camelcase.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getCamelcaseBytes() {
+      java.lang.Object ref = camelcase_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        camelcase_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(lowercase_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, lowercase_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(camelcase_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, camelcase_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(lowercase_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, lowercase_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(camelcase_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, camelcase_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.cloudera.thunderhead.service.common.options.Options.ApiServiceName)) {
+        return super.equals(obj);
+      }
+      com.cloudera.thunderhead.service.common.options.Options.ApiServiceName other = (com.cloudera.thunderhead.service.common.options.Options.ApiServiceName) obj;
+
+      if (!getLowercase()
+          .equals(other.getLowercase())) return false;
+      if (!getCamelcase()
+          .equals(other.getCamelcase())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (37 * hash) + LOWERCASE_FIELD_NUMBER;
+      hash = (53 * hash) + getLowercase().hashCode();
+      hash = (37 * hash) + CAMELCASE_FIELD_NUMBER;
+      hash = (53 * hash) + getCamelcase().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.cloudera.thunderhead.service.common.options.Options.ApiServiceName parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ApiServiceName parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ApiServiceName parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ApiServiceName parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ApiServiceName parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ApiServiceName parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ApiServiceName parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ApiServiceName parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ApiServiceName parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ApiServiceName parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ApiServiceName parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ApiServiceName parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.cloudera.thunderhead.service.common.options.Options.ApiServiceName prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     * The API service name, in various casings.
+     * </pre>
+     *
+     * Protobuf type {@code options.ApiServiceName}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:options.ApiServiceName)
+        com.cloudera.thunderhead.service.common.options.Options.ApiServiceNameOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_ApiServiceName_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_ApiServiceName_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.cloudera.thunderhead.service.common.options.Options.ApiServiceName.class, com.cloudera.thunderhead.service.common.options.Options.ApiServiceName.Builder.class);
+      }
+
+      // Construct using com.cloudera.thunderhead.service.common.options.Options.ApiServiceName.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        lowercase_ = "";
+
+        camelcase_ = "";
+
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_ApiServiceName_descriptor;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.ApiServiceName getDefaultInstanceForType() {
+        return com.cloudera.thunderhead.service.common.options.Options.ApiServiceName.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.ApiServiceName build() {
+        com.cloudera.thunderhead.service.common.options.Options.ApiServiceName result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.ApiServiceName buildPartial() {
+        com.cloudera.thunderhead.service.common.options.Options.ApiServiceName result = new com.cloudera.thunderhead.service.common.options.Options.ApiServiceName(this);
+        result.lowercase_ = lowercase_;
+        result.camelcase_ = camelcase_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.cloudera.thunderhead.service.common.options.Options.ApiServiceName) {
+          return mergeFrom((com.cloudera.thunderhead.service.common.options.Options.ApiServiceName)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.cloudera.thunderhead.service.common.options.Options.ApiServiceName other) {
+        if (other == com.cloudera.thunderhead.service.common.options.Options.ApiServiceName.getDefaultInstance()) return this;
+        if (!other.getLowercase().isEmpty()) {
+          lowercase_ = other.lowercase_;
+          onChanged();
+        }
+        if (!other.getCamelcase().isEmpty()) {
+          camelcase_ = other.camelcase_;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.cloudera.thunderhead.service.common.options.Options.ApiServiceName parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.cloudera.thunderhead.service.common.options.Options.ApiServiceName) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+
+      private java.lang.Object lowercase_ = "";
+      /**
+       * <pre>
+       * The lowercased service name.
+       * </pre>
+       *
+       * <code>string lowercase = 1;</code>
+       * @return The lowercase.
+       */
+      public java.lang.String getLowercase() {
+        java.lang.Object ref = lowercase_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          lowercase_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The lowercased service name.
+       * </pre>
+       *
+       * <code>string lowercase = 1;</code>
+       * @return The bytes for lowercase.
+       */
+      public com.google.protobuf.ByteString
+          getLowercaseBytes() {
+        java.lang.Object ref = lowercase_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          lowercase_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The lowercased service name.
+       * </pre>
+       *
+       * <code>string lowercase = 1;</code>
+       * @param value The lowercase to set.
+       * @return This builder for chaining.
+       */
+      public Builder setLowercase(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        lowercase_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The lowercased service name.
+       * </pre>
+       *
+       * <code>string lowercase = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearLowercase() {
+        
+        lowercase_ = getDefaultInstance().getLowercase();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The lowercased service name.
+       * </pre>
+       *
+       * <code>string lowercase = 1;</code>
+       * @param value The bytes for lowercase to set.
+       * @return This builder for chaining.
+       */
+      public Builder setLowercaseBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        lowercase_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object camelcase_ = "";
+      /**
+       * <pre>
+       * The camel-cased service name.
+       * </pre>
+       *
+       * <code>string camelcase = 2;</code>
+       * @return The camelcase.
+       */
+      public java.lang.String getCamelcase() {
+        java.lang.Object ref = camelcase_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          camelcase_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The camel-cased service name.
+       * </pre>
+       *
+       * <code>string camelcase = 2;</code>
+       * @return The bytes for camelcase.
+       */
+      public com.google.protobuf.ByteString
+          getCamelcaseBytes() {
+        java.lang.Object ref = camelcase_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          camelcase_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The camel-cased service name.
+       * </pre>
+       *
+       * <code>string camelcase = 2;</code>
+       * @param value The camelcase to set.
+       * @return This builder for chaining.
+       */
+      public Builder setCamelcase(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        camelcase_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The camel-cased service name.
+       * </pre>
+       *
+       * <code>string camelcase = 2;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearCamelcase() {
+        
+        camelcase_ = getDefaultInstance().getCamelcase();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The camel-cased service name.
+       * </pre>
+       *
+       * <code>string camelcase = 2;</code>
+       * @param value The bytes for camelcase to set.
+       * @return This builder for chaining.
+       */
+      public Builder setCamelcaseBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        camelcase_ = value;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:options.ApiServiceName)
+    }
+
+    // @@protoc_insertion_point(class_scope:options.ApiServiceName)
+    private static final com.cloudera.thunderhead.service.common.options.Options.ApiServiceName DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.cloudera.thunderhead.service.common.options.Options.ApiServiceName();
+    }
+
+    public static com.cloudera.thunderhead.service.common.options.Options.ApiServiceName getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<ApiServiceName>
+        PARSER = new com.google.protobuf.AbstractParser<ApiServiceName>() {
+      @java.lang.Override
+      public ApiServiceName parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new ApiServiceName(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<ApiServiceName> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<ApiServiceName> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.cloudera.thunderhead.service.common.options.Options.ApiServiceName getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface FileExtensionOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:options.FileExtension)
+      com.google.protobuf.MessageOrBuilder {
+  }
+  /**
+   * Protobuf type {@code options.FileExtension}
+   */
+  public static final class FileExtension extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:options.FileExtension)
+      FileExtensionOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use FileExtension.newBuilder() to construct.
+    private FileExtension(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private FileExtension() {
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new FileExtension();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private FileExtension(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_FileExtension_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_FileExtension_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.cloudera.thunderhead.service.common.options.Options.FileExtension.class, com.cloudera.thunderhead.service.common.options.Options.FileExtension.Builder.class);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.cloudera.thunderhead.service.common.options.Options.FileExtension)) {
+        return super.equals(obj);
+      }
+      com.cloudera.thunderhead.service.common.options.Options.FileExtension other = (com.cloudera.thunderhead.service.common.options.Options.FileExtension) obj;
+
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.cloudera.thunderhead.service.common.options.Options.FileExtension parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FileExtension parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FileExtension parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FileExtension parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FileExtension parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FileExtension parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FileExtension parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FileExtension parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FileExtension parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FileExtension parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FileExtension parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FileExtension parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.cloudera.thunderhead.service.common.options.Options.FileExtension prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code options.FileExtension}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:options.FileExtension)
+        com.cloudera.thunderhead.service.common.options.Options.FileExtensionOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_FileExtension_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_FileExtension_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.cloudera.thunderhead.service.common.options.Options.FileExtension.class, com.cloudera.thunderhead.service.common.options.Options.FileExtension.Builder.class);
+      }
+
+      // Construct using com.cloudera.thunderhead.service.common.options.Options.FileExtension.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_FileExtension_descriptor;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.FileExtension getDefaultInstanceForType() {
+        return com.cloudera.thunderhead.service.common.options.Options.FileExtension.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.FileExtension build() {
+        com.cloudera.thunderhead.service.common.options.Options.FileExtension result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.FileExtension buildPartial() {
+        com.cloudera.thunderhead.service.common.options.Options.FileExtension result = new com.cloudera.thunderhead.service.common.options.Options.FileExtension(this);
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.cloudera.thunderhead.service.common.options.Options.FileExtension) {
+          return mergeFrom((com.cloudera.thunderhead.service.common.options.Options.FileExtension)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.cloudera.thunderhead.service.common.options.Options.FileExtension other) {
+        if (other == com.cloudera.thunderhead.service.common.options.Options.FileExtension.getDefaultInstance()) return this;
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.cloudera.thunderhead.service.common.options.Options.FileExtension parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.cloudera.thunderhead.service.common.options.Options.FileExtension) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:options.FileExtension)
+    }
+
+    // @@protoc_insertion_point(class_scope:options.FileExtension)
+    private static final com.cloudera.thunderhead.service.common.options.Options.FileExtension DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.cloudera.thunderhead.service.common.options.Options.FileExtension();
+    }
+
+    public static com.cloudera.thunderhead.service.common.options.Options.FileExtension getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<FileExtension>
+        PARSER = new com.google.protobuf.AbstractParser<FileExtension>() {
+      @java.lang.Override
+      public FileExtension parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new FileExtension(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<FileExtension> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<FileExtension> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.cloudera.thunderhead.service.common.options.Options.FileExtension getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+    public static final int AUDIT_FIELD_NUMBER = 80000;
+    /**
+     * <pre>
+     * This field is used to enable auditing for the service.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.FileOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.FileOptions,
+        java.lang.Boolean> audit = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.FileExtension.getDefaultInstance(),
+          0,
+          java.lang.Boolean.class,
+          null);
+    public static final int AUDITENTITLEMENT_FIELD_NUMBER = 80001;
+    /**
+     * <pre>
+     * The name of the entitlement to use to enable submitting auditing records.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.FileOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.FileOptions,
+        java.lang.String> auditEntitlement = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.FileExtension.getDefaultInstance(),
+          1,
+          java.lang.String.class,
+          null);
+  }
+
   public interface FieldExtensionOrBuilder extends
       // @@protoc_insertion_point(interface_extends:options.FieldExtension)
       com.google.protobuf.MessageOrBuilder {
@@ -41,7 +3751,7 @@ public final class Options {
   /**
    * Protobuf type {@code options.FieldExtension}
    */
-  public  static final class FieldExtension extends
+  public static final class FieldExtension extends
       com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:options.FieldExtension)
       FieldExtensionOrBuilder {
@@ -51,6 +3761,13 @@ public final class Options {
       super(builder);
     }
     private FieldExtension() {
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new FieldExtension();
     }
 
     @java.lang.Override
@@ -77,7 +3794,7 @@ public final class Options {
               done = true;
               break;
             default: {
-              if (!parseUnknownFieldProto3(
+              if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
@@ -146,9 +3863,8 @@ public final class Options {
       }
       com.cloudera.thunderhead.service.common.options.Options.FieldExtension other = (com.cloudera.thunderhead.service.common.options.Options.FieldExtension) obj;
 
-      boolean result = true;
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -323,35 +4039,35 @@ public final class Options {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -396,7 +4112,7 @@ public final class Options {
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFieldsProto3(unknownFields);
+        return super.setUnknownFields(unknownFields);
       }
 
       @java.lang.Override
@@ -616,6 +4332,160 @@ public final class Options {
           9,
           java.lang.String.class,
           null);
+    public static final int REQUIRED_FIELD_NUMBER = 50010;
+    /**
+     * <pre>
+     * This field is required.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.FieldOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.FieldOptions,
+        java.lang.Boolean> required = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.FieldExtension.getDefaultInstance(),
+          10,
+          java.lang.Boolean.class,
+          null);
+    public static final int MINIMUM_FIELD_NUMBER = 50011;
+    /**
+     * <pre>
+     * The minimum value for this field.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.FieldOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.FieldOptions,
+        java.lang.Integer> minimum = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.FieldExtension.getDefaultInstance(),
+          11,
+          java.lang.Integer.class,
+          null);
+    public static final int MAXIMUM_FIELD_NUMBER = 50012;
+    /**
+     * <pre>
+     * The minimum value for this field.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.FieldOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.FieldOptions,
+        java.lang.Integer> maximum = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.FieldExtension.getDefaultInstance(),
+          12,
+          java.lang.Integer.class,
+          null);
+    public static final int MINIMUMLENGTH_FIELD_NUMBER = 50013;
+    /**
+     * <pre>
+     * The minimum length for this field.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.FieldOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.FieldOptions,
+        java.lang.Integer> minimumLength = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.FieldExtension.getDefaultInstance(),
+          13,
+          java.lang.Integer.class,
+          null);
+    public static final int MAXIMUMLENGTH_FIELD_NUMBER = 50014;
+    /**
+     * <pre>
+     * The minimum length for this field.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.FieldOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.FieldOptions,
+        java.lang.Integer> maximumLength = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.FieldExtension.getDefaultInstance(),
+          14,
+          java.lang.Integer.class,
+          null);
+    public static final int DEPRECATED_FIELD_NUMBER = 50015;
+    /**
+     * <pre>
+     * This field has been deprecated.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.FieldOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.FieldOptions,
+        java.lang.Boolean> deprecated = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.FieldExtension.getDefaultInstance(),
+          15,
+          java.lang.Boolean.class,
+          null);
+    public static final int NOPARAMFILE_FIELD_NUMBER = 50016;
+    /**
+     * <pre>
+     * This field doesn't reference a parameter file.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.FieldOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.FieldOptions,
+        java.lang.Boolean> noParamfile = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.FieldExtension.getDefaultInstance(),
+          16,
+          java.lang.Boolean.class,
+          null);
+    public static final int DEFAULT_FIELD_NUMBER = 50017;
+    /**
+     * <pre>
+     * Default value for this field.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.FieldOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.FieldOptions,
+        java.lang.String> default_ = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.FieldExtension.getDefaultInstance(),
+          17,
+          java.lang.String.class,
+          null);
+    public static final int FORMFACTOR_FIELD_NUMBER = 50018;
+    /**
+     * <pre>
+     * The form factor(s) that the field is part of, e.g., public, private.
+     * By default, a parameter is part of every form factor of its operation or service.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.FieldOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.FieldOptions,
+        java.util.List<java.lang.String>> formFactor = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.FieldExtension.getDefaultInstance(),
+          18,
+          java.lang.String.class,
+          null);
   }
 
   public interface MethodExtensionOrBuilder extends
@@ -625,7 +4495,7 @@ public final class Options {
   /**
    * Protobuf type {@code options.MethodExtension}
    */
-  public  static final class MethodExtension extends
+  public static final class MethodExtension extends
       com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:options.MethodExtension)
       MethodExtensionOrBuilder {
@@ -635,6 +4505,13 @@ public final class Options {
       super(builder);
     }
     private MethodExtension() {
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new MethodExtension();
     }
 
     @java.lang.Override
@@ -661,7 +4538,7 @@ public final class Options {
               done = true;
               break;
             default: {
-              if (!parseUnknownFieldProto3(
+              if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
@@ -730,9 +4607,8 @@ public final class Options {
       }
       com.cloudera.thunderhead.service.common.options.Options.MethodExtension other = (com.cloudera.thunderhead.service.common.options.Options.MethodExtension) obj;
 
-      boolean result = true;
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -907,35 +4783,35 @@ public final class Options {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -980,7 +4856,7 @@ public final class Options {
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFieldsProto3(unknownFields);
+        return super.setUnknownFields(unknownFields);
       }
 
       @java.lang.Override
@@ -1065,7 +4941,7 @@ public final class Options {
     public static final int PAGINATES_FIELD_NUMBER = 60002;
     /**
      * <pre>
-     * This method returnes paginated results.
+     * This method returns paginated results.
      * </pre>
      *
      * <code>extend .google.protobuf.MethodOptions { ... }</code>
@@ -1147,6 +5023,127 @@ public final class Options {
           6,
           java.lang.String.class,
           null);
+    public static final int DEPRECATED_FIELD_NUMBER = 60007;
+    /**
+     * <pre>
+     * This method has been deprecated.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.MethodOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.MethodOptions,
+        java.lang.Boolean> deprecated = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.MethodExtension.getDefaultInstance(),
+          7,
+          java.lang.Boolean.class,
+          null);
+    public static final int RATELIMITGROUP_FIELD_NUMBER = 60008;
+    /**
+     * <pre>
+     * This method is rate limited with the specified group. This name must
+     * match the name of a rate limit group declared for the service itself.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.MethodOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.MethodOptions,
+        java.lang.String> rateLimitGroup = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.MethodExtension.getDefaultInstance(),
+          8,
+          java.lang.String.class,
+          null);
+    public static final int MUTATING_FIELD_NUMBER = 60009;
+    /**
+     * <pre>
+     * This method is a mutating call.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.MethodOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.MethodOptions,
+        java.lang.Boolean> mutating = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.MethodExtension.getDefaultInstance(),
+          9,
+          java.lang.Boolean.class,
+          null);
+    public static final int SKIPAUDITING_FIELD_NUMBER = 60010;
+    /**
+     * <pre>
+     * This method should not be audited.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.MethodOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.MethodOptions,
+        java.lang.Boolean> skipAuditing = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.MethodExtension.getDefaultInstance(),
+          10,
+          java.lang.Boolean.class,
+          null);
+    public static final int FORMFACTOR_FIELD_NUMBER = 60011;
+    /**
+     * <pre>
+     * The form factor(s) that the operation is part of, e.g., public, private.
+     * By default, an operation is part of every form factor of its service.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.MethodOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.MethodOptions,
+        java.util.List<java.lang.String>> formFactor = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.MethodExtension.getDefaultInstance(),
+          11,
+          java.lang.String.class,
+          null);
+    public static final int EXTENSION_FIELD_NUMBER = 60012;
+    /**
+     * <pre>
+     * This method has extensions
+     * </pre>
+     *
+     * <code>extend .google.protobuf.MethodOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.MethodOptions,
+        java.util.List<java.lang.String>> extension = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.MethodExtension.getDefaultInstance(),
+          12,
+          java.lang.String.class,
+          null);
+    public static final int TAG_FIELD_NUMBER = 60013;
+    /**
+     * <pre>
+     * The grouping tag for this method
+     * </pre>
+     *
+     * <code>extend .google.protobuf.MethodOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.MethodOptions,
+        java.lang.String> tag = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.MethodExtension.getDefaultInstance(),
+          13,
+          java.lang.String.class,
+          null);
   }
 
   public interface MessageExtensionOrBuilder extends
@@ -1156,7 +5153,7 @@ public final class Options {
   /**
    * Protobuf type {@code options.MessageExtension}
    */
-  public  static final class MessageExtension extends
+  public static final class MessageExtension extends
       com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:options.MessageExtension)
       MessageExtensionOrBuilder {
@@ -1166,6 +5163,13 @@ public final class Options {
       super(builder);
     }
     private MessageExtension() {
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new MessageExtension();
     }
 
     @java.lang.Override
@@ -1192,7 +5196,7 @@ public final class Options {
               done = true;
               break;
             default: {
-              if (!parseUnknownFieldProto3(
+              if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
@@ -1261,9 +5265,8 @@ public final class Options {
       }
       com.cloudera.thunderhead.service.common.options.Options.MessageExtension other = (com.cloudera.thunderhead.service.common.options.Options.MessageExtension) obj;
 
-      boolean result = true;
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -1438,35 +5441,35 @@ public final class Options {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -1511,7 +5514,7 @@ public final class Options {
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFieldsProto3(unknownFields);
+        return super.setUnknownFields(unknownFields);
       }
 
       @java.lang.Override
@@ -1610,8 +5613,536 @@ public final class Options {
           2,
           java.lang.String.class,
           null);
+    public static final int DEPRECATED_FIELD_NUMBER = 70003;
+    /**
+     * <pre>
+     * This message has been deprecated.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.MessageOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.MessageOptions,
+        java.lang.Boolean> deprecated = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.MessageExtension.getDefaultInstance(),
+          3,
+          java.lang.Boolean.class,
+          null);
+    public static final int FORMFACTOR_FIELD_NUMBER = 70004;
+    /**
+     * <pre>
+     * The form factor(s) for the message.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.MessageOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.MessageOptions,
+        java.util.List<java.lang.String>> formFactor = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.MessageExtension.getDefaultInstance(),
+          4,
+          java.lang.String.class,
+          null);
   }
 
+  public interface EnumValueExtensionOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:options.EnumValueExtension)
+      com.google.protobuf.MessageOrBuilder {
+  }
+  /**
+   * Protobuf type {@code options.EnumValueExtension}
+   */
+  public static final class EnumValueExtension extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:options.EnumValueExtension)
+      EnumValueExtensionOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use EnumValueExtension.newBuilder() to construct.
+    private EnumValueExtension(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private EnumValueExtension() {
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new EnumValueExtension();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private EnumValueExtension(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_EnumValueExtension_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_EnumValueExtension_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension.class, com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension.Builder.class);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension)) {
+        return super.equals(obj);
+      }
+      com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension other = (com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension) obj;
+
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code options.EnumValueExtension}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:options.EnumValueExtension)
+        com.cloudera.thunderhead.service.common.options.Options.EnumValueExtensionOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_EnumValueExtension_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_EnumValueExtension_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension.class, com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension.Builder.class);
+      }
+
+      // Construct using com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_EnumValueExtension_descriptor;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension getDefaultInstanceForType() {
+        return com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension build() {
+        com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension buildPartial() {
+        com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension result = new com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension(this);
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension) {
+          return mergeFrom((com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension other) {
+        if (other == com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension.getDefaultInstance()) return this;
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:options.EnumValueExtension)
+    }
+
+    // @@protoc_insertion_point(class_scope:options.EnumValueExtension)
+    private static final com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension();
+    }
+
+    public static com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<EnumValueExtension>
+        PARSER = new com.google.protobuf.AbstractParser<EnumValueExtension>() {
+      @java.lang.Override
+      public EnumValueExtension parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new EnumValueExtension(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<EnumValueExtension> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<EnumValueExtension> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+    public static final int HIDDEN_FIELD_NUMBER = 90000;
+    /**
+     * <pre>
+     * This value is hidden.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.EnumValueOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.EnumValueOptions,
+        java.lang.Boolean> hidden = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension.getDefaultInstance(),
+          0,
+          java.lang.Boolean.class,
+          null);
+    public static final int HIDDENREASON_FIELD_NUMBER = 90001;
+    /**
+     * <pre>
+     * The reason this value is hidden.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.EnumValueOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.EnumValueOptions,
+        java.lang.String> hiddenReason = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension.getDefaultInstance(),
+          1,
+          java.lang.String.class,
+          null);
+    public static final int HIDDENRETENTION_FIELD_NUMBER = 90002;
+    /**
+     * <pre>
+     * This conditions under this hidden value is made visible.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.EnumValueOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.EnumValueOptions,
+        java.lang.String> hiddenRetention = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension.getDefaultInstance(),
+          2,
+          java.lang.String.class,
+          null);
+  }
+
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_options_ServiceExtension_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_options_ServiceExtension_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_options_TagGroup_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_options_TagGroup_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_options_RateLimitGroupDefinition_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_options_RateLimitGroupDefinition_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_options_ApiServiceName_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_options_ApiServiceName_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_options_FileExtension_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_options_FileExtension_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_options_FieldExtension_descriptor;
   private static final 
@@ -1627,6 +6158,11 @@ public final class Options {
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_options_MessageExtension_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_options_EnumValueExtension_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_options_EnumValueExtension_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -1637,69 +6173,148 @@ public final class Options {
   static {
     java.lang.String[] descriptorData = {
       "\n\roptions.proto\022\007options\032 google/protobu" +
-      "f/descriptor.proto\"\266\004\n\016FieldExtension22\n" +
-      "\tsensitive\022\035.google.protobuf.FieldOption" +
-      "s\030\320\206\003 \001(\01024\n\013skipLogging\022\035.google.protob" +
-      "uf.FieldOptions\030\321\206\003 \001(\01027\n\016pagingPageSiz" +
-      "e\022\035.google.protobuf.FieldOptions\030\322\206\003 \001(\010" +
-      "29\n\020pagingInputToken\022\035.google.protobuf.F" +
-      "ieldOptions\030\323\206\003 \001(\01025\n\014pagingResult\022\035.go" +
-      "ogle.protobuf.FieldOptions\030\324\206\003 \001(\0102:\n\021pa" +
-      "gingOutputToken\022\035.google.protobuf.FieldO" +
-      "ptions\030\325\206\003 \001(\01021\n\010datetime\022\035.google.prot" +
-      "obuf.FieldOptions\030\326\206\003 \001(\0102/\n\006hidden\022\035.go" +
-      "ogle.protobuf.FieldOptions\030\327\206\003 \001(\01025\n\014hi" +
-      "ddenReason\022\035.google.protobuf.FieldOption" +
-      "s\030\330\206\003 \001(\t28\n\017hiddenRetention\022\035.google.pr" +
-      "otobuf.FieldOptions\030\331\206\003 \001(\t\"\224\003\n\017MethodEx" +
-      "tension2/\n\005right\022\036.google.protobuf.Metho" +
-      "dOptions\030\340\324\003 \001(\t25\n\013entitlement\022\036.google" +
-      ".protobuf.MethodOptions\030\341\324\003 \001(\t23\n\tpagin" +
-      "ates\022\036.google.protobuf.MethodOptions\030\342\324\003" +
-      " \001(\0102?\n\025pagingDefaultMaxItems\022\036.google.p" +
-      "rotobuf.MethodOptions\030\343\324\003 \001(\00520\n\006hidden\022" +
-      "\036.google.protobuf.MethodOptions\030\344\324\003 \001(\0102" +
-      "6\n\014hiddenReason\022\036.google.protobuf.Method" +
-      "Options\030\345\324\003 \001(\t29\n\017hiddenRetention\022\036.goo" +
-      "gle.protobuf.MethodOptions\030\346\324\003 \001(\t\"\272\001\n\020M" +
-      "essageExtension21\n\006hidden\022\037.google.proto" +
-      "buf.MessageOptions\030\360\242\004 \001(\01027\n\014hiddenReas" +
-      "on\022\037.google.protobuf.MessageOptions\030\361\242\004 " +
-      "\001(\t2:\n\017hiddenRetention\022\037.google.protobuf" +
-      ".MessageOptions\030\362\242\004 \001(\tBU\n/com.cloudera." +
-      "thunderhead.service.common.optionsB\007Opti" +
-      "onsZ\031com/cloudera/cdp/protobufb\006proto3"
+      "f/descriptor.proto\"\347\003\n\020ServiceExtension2" +
+      "f\n\030rateLimitGroupDefinition\022\037.google.pro" +
+      "tobuf.ServiceOptions\030\300\270\002 \001(\0132!.options.R" +
+      "ateLimitGroupDefinition2R\n\016apiServiceNam" +
+      "e\022\037.google.protobuf.ServiceOptions\030\301\270\002 \001" +
+      "(\0132\027.options.ApiServiceName22\n\007release\022\037" +
+      ".google.protobuf.ServiceOptions\030\302\270\002 \003(\t2" +
+      "0\n\005admin\022\037.google.protobuf.ServiceOption" +
+      "s\030\303\270\002 \001(\01025\n\nformFactor\022\037.google.protobu" +
+      "f.ServiceOptions\030\304\270\002 \003(\t22\n\007version\022\037.go" +
+      "ogle.protobuf.ServiceOptions\030\305\270\002 \001(\t2F\n\010" +
+      "tagGroup\022\037.google.protobuf.ServiceOption" +
+      "s\030\306\270\002 \003(\0132\021.options.TagGroup\"C\n\010TagGroup" +
+      "\022\014\n\004name\030\001 \001(\t\022\023\n\013description\030\002 \001(\t\022\024\n\014e" +
+      "xternalDocs\030\003 \001(\t\"k\n\030RateLimitGroupDefin" +
+      "ition\022\014\n\004name\030\001 \001(\t\022\027\n\017byRemoteAddress\030\002" +
+      " \001(\005\022\025\n\rbyAccessKeyId\030\003 \001(\005\022\021\n\tbyAccount" +
+      "\030\004 \001(\005\"6\n\016ApiServiceName\022\021\n\tlowercase\030\001 " +
+      "\001(\t\022\021\n\tcamelcase\030\002 \001(\t\"\202\001\n\rFileExtension" +
+      "2-\n\005audit\022\034.google.protobuf.FileOptions\030" +
+      "\200\361\004 \001(\01028\n\020auditEntitlement\022\034.google.pro" +
+      "tobuf.FileOptions\030\201\361\004 \001(\tJ\010\010\202\361\004\020\203\361\004\"\217\010\n\016" +
+      "FieldExtension22\n\tsensitive\022\035.google.pro" +
+      "tobuf.FieldOptions\030\320\206\003 \001(\01024\n\013skipLoggin" +
+      "g\022\035.google.protobuf.FieldOptions\030\321\206\003 \001(\010" +
+      "27\n\016pagingPageSize\022\035.google.protobuf.Fie" +
+      "ldOptions\030\322\206\003 \001(\01029\n\020pagingInputToken\022\035." +
+      "google.protobuf.FieldOptions\030\323\206\003 \001(\01025\n\014" +
+      "pagingResult\022\035.google.protobuf.FieldOpti" +
+      "ons\030\324\206\003 \001(\0102:\n\021pagingOutputToken\022\035.googl" +
+      "e.protobuf.FieldOptions\030\325\206\003 \001(\01021\n\010datet" +
+      "ime\022\035.google.protobuf.FieldOptions\030\326\206\003 \001" +
+      "(\0102/\n\006hidden\022\035.google.protobuf.FieldOpti" +
+      "ons\030\327\206\003 \001(\01025\n\014hiddenReason\022\035.google.pro" +
+      "tobuf.FieldOptions\030\330\206\003 \001(\t28\n\017hiddenRete" +
+      "ntion\022\035.google.protobuf.FieldOptions\030\331\206\003" +
+      " \001(\t21\n\010required\022\035.google.protobuf.Field" +
+      "Options\030\332\206\003 \001(\01020\n\007minimum\022\035.google.prot" +
+      "obuf.FieldOptions\030\333\206\003 \001(\00520\n\007maximum\022\035.g" +
+      "oogle.protobuf.FieldOptions\030\334\206\003 \001(\00526\n\rm" +
+      "inimumLength\022\035.google.protobuf.FieldOpti" +
+      "ons\030\335\206\003 \001(\00526\n\rmaximumLength\022\035.google.pr" +
+      "otobuf.FieldOptions\030\336\206\003 \001(\00523\n\ndeprecate" +
+      "d\022\035.google.protobuf.FieldOptions\030\337\206\003 \001(\010" +
+      "24\n\013noParamfile\022\035.google.protobuf.FieldO" +
+      "ptions\030\340\206\003 \001(\01020\n\007default\022\035.google.proto" +
+      "buf.FieldOptions\030\341\206\003 \001(\t23\n\nformFactor\022\035" +
+      ".google.protobuf.FieldOptions\030\342\206\003 \003(\t\"\212\006" +
+      "\n\017MethodExtension2/\n\005right\022\036.google.prot" +
+      "obuf.MethodOptions\030\340\324\003 \001(\t25\n\013entitlemen" +
+      "t\022\036.google.protobuf.MethodOptions\030\341\324\003 \001(" +
+      "\t23\n\tpaginates\022\036.google.protobuf.MethodO" +
+      "ptions\030\342\324\003 \001(\0102?\n\025pagingDefaultMaxItems\022" +
+      "\036.google.protobuf.MethodOptions\030\343\324\003 \001(\0052" +
+      "0\n\006hidden\022\036.google.protobuf.MethodOption" +
+      "s\030\344\324\003 \001(\01026\n\014hiddenReason\022\036.google.proto" +
+      "buf.MethodOptions\030\345\324\003 \001(\t29\n\017hiddenReten" +
+      "tion\022\036.google.protobuf.MethodOptions\030\346\324\003" +
+      " \001(\t24\n\ndeprecated\022\036.google.protobuf.Met" +
+      "hodOptions\030\347\324\003 \001(\01028\n\016rateLimitGroup\022\036.g" +
+      "oogle.protobuf.MethodOptions\030\350\324\003 \001(\t22\n\010" +
+      "mutating\022\036.google.protobuf.MethodOptions" +
+      "\030\351\324\003 \001(\01026\n\014skipAuditing\022\036.google.protob" +
+      "uf.MethodOptions\030\352\324\003 \001(\01024\n\nformFactor\022\036" +
+      ".google.protobuf.MethodOptions\030\353\324\003 \003(\t23" +
+      "\n\textension\022\036.google.protobuf.MethodOpti" +
+      "ons\030\354\324\003 \003(\t2-\n\003tag\022\036.google.protobuf.Met" +
+      "hodOptions\030\355\324\003 \001(\t\"\250\002\n\020MessageExtension2" +
+      "1\n\006hidden\022\037.google.protobuf.MessageOptio" +
+      "ns\030\360\242\004 \001(\01027\n\014hiddenReason\022\037.google.prot" +
+      "obuf.MessageOptions\030\361\242\004 \001(\t2:\n\017hiddenRet" +
+      "ention\022\037.google.protobuf.MessageOptions\030" +
+      "\362\242\004 \001(\t25\n\ndeprecated\022\037.google.protobuf." +
+      "MessageOptions\030\363\242\004 \001(\01025\n\nformFactor\022\037.g" +
+      "oogle.protobuf.MessageOptions\030\364\242\004 \003(\t\"\302\001" +
+      "\n\022EnumValueExtension23\n\006hidden\022!.google." +
+      "protobuf.EnumValueOptions\030\220\277\005 \001(\01029\n\014hid" +
+      "denReason\022!.google.protobuf.EnumValueOpt" +
+      "ions\030\221\277\005 \001(\t2<\n\017hiddenRetention\022!.google" +
+      ".protobuf.EnumValueOptions\030\222\277\005 \001(\tBU\n/co" +
+      "m.cloudera.thunderhead.service.common.op" +
+      "tionsB\007OptionsZ\031com/cloudera/cdp/protobu" +
+      "fb\006proto3"
     };
-    com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-        new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
-          public com.google.protobuf.ExtensionRegistry assignDescriptors(
-              com.google.protobuf.Descriptors.FileDescriptor root) {
-            descriptor = root;
-            return null;
-          }
-        };
-    com.google.protobuf.Descriptors.FileDescriptor
+    descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
           com.google.protobuf.DescriptorProtos.getDescriptor(),
-        }, assigner);
-    internal_static_options_FieldExtension_descriptor =
+        });
+    internal_static_options_ServiceExtension_descriptor =
       getDescriptor().getMessageTypes().get(0);
+    internal_static_options_ServiceExtension_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_options_ServiceExtension_descriptor,
+        new java.lang.String[] { });
+    internal_static_options_TagGroup_descriptor =
+      getDescriptor().getMessageTypes().get(1);
+    internal_static_options_TagGroup_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_options_TagGroup_descriptor,
+        new java.lang.String[] { "Name", "Description", "ExternalDocs", });
+    internal_static_options_RateLimitGroupDefinition_descriptor =
+      getDescriptor().getMessageTypes().get(2);
+    internal_static_options_RateLimitGroupDefinition_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_options_RateLimitGroupDefinition_descriptor,
+        new java.lang.String[] { "Name", "ByRemoteAddress", "ByAccessKeyId", "ByAccount", });
+    internal_static_options_ApiServiceName_descriptor =
+      getDescriptor().getMessageTypes().get(3);
+    internal_static_options_ApiServiceName_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_options_ApiServiceName_descriptor,
+        new java.lang.String[] { "Lowercase", "Camelcase", });
+    internal_static_options_FileExtension_descriptor =
+      getDescriptor().getMessageTypes().get(4);
+    internal_static_options_FileExtension_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_options_FileExtension_descriptor,
+        new java.lang.String[] { });
+    internal_static_options_FieldExtension_descriptor =
+      getDescriptor().getMessageTypes().get(5);
     internal_static_options_FieldExtension_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_options_FieldExtension_descriptor,
         new java.lang.String[] { });
     internal_static_options_MethodExtension_descriptor =
-      getDescriptor().getMessageTypes().get(1);
+      getDescriptor().getMessageTypes().get(6);
     internal_static_options_MethodExtension_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_options_MethodExtension_descriptor,
         new java.lang.String[] { });
     internal_static_options_MessageExtension_descriptor =
-      getDescriptor().getMessageTypes().get(2);
+      getDescriptor().getMessageTypes().get(7);
     internal_static_options_MessageExtension_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_options_MessageExtension_descriptor,
+        new java.lang.String[] { });
+    internal_static_options_EnumValueExtension_descriptor =
+      getDescriptor().getMessageTypes().get(8);
+    internal_static_options_EnumValueExtension_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_options_EnumValueExtension_descriptor,
         new java.lang.String[] { });
     com.google.protobuf.DescriptorProtos.getDescriptor();
   }

--- a/auth-connector/src/main/proto/options.proto
+++ b/auth-connector/src/main/proto/options.proto
@@ -1,0 +1,187 @@
+syntax = "proto3";
+
+import "google/protobuf/descriptor.proto";
+
+package options;
+
+option java_package = "com.cloudera.thunderhead.service.common.options";
+option java_outer_classname = "Options";
+option go_package = "com/cloudera/cdp/protobuf";
+
+message ServiceExtension {
+  extend google.protobuf.ServiceOptions {
+    // At least one method in this service is rate limited by the specified
+    // rate limit group. Use of this option causes the generated API controller
+    // to include rate limiting for methods that have the rateLimitGroup option.
+    // (Currently, only one group may be defined.) Most services do not require
+    // rate limiting; contact the CDPCP core infra team for guidance.
+    RateLimitGroupDefinition rateLimitGroupDefinition = 40000;
+    // The API service name, in various casings.
+    ApiServiceName apiServiceName = 40001;
+    // The releases that the service belongs in, i.e., PUBLIC.
+    repeated string release = 40002;
+    // Whether this service is an administrative service. These services are put
+    // on a special, internal only ingress and may only be called by members of
+    // the CDP administration account.
+    bool admin = 40003;
+    // The form factor(s) that the service is part of, e.g., public, private.
+    repeated string formFactor = 40004;
+    // The version of the service definition.
+    string version = 40005;
+    // The Tag Groups for the Service
+    repeated TagGroup tagGroup = 40006;
+  }
+}
+
+// The Swagger Tag Group
+message TagGroup {
+  // The name of the tag group to use in the MethodExtention.
+  string name = 1;
+  // The description pf the tag group.
+  string description = 2;
+  // The external docs url link for the tag group.
+  string externalDocs = 3;
+}
+
+// The definition of an API rate limit group. See the Java classes
+// ApiRateLimiter and ApiRateLimiterProvider for context.
+message RateLimitGroupDefinition {
+  // The name of the group. This must be one of the values of the
+  // ApiRateLimitGroup enum.
+  string name = 1;
+  // The limit (calls per second) by remote address for calls controlled by
+  // this group.
+  int32 byRemoteAddress = 2;
+  // The limit (calls per second) by access key ID for calls controlled by this
+  // group. (Not yet supported.)
+  int32 byAccessKeyId = 3;
+  // The limit (calls per second) by account for calls controlled by this group.
+  int32 byAccount = 4;
+}
+
+// The API service name, in various casings.
+message ApiServiceName {
+  // The lowercased service name.
+  string lowercase = 1;
+  // The camel-cased service name.
+  string camelcase = 2;
+}
+
+message FileExtension {
+  reserved 80002;
+  extend google.protobuf.FileOptions {
+    // This field is used to enable auditing for the service.
+    bool audit = 80000;
+    // The name of the entitlement to use to enable submitting auditing records.
+    string auditEntitlement = 80001;
+  }
+}
+
+message FieldExtension {
+  extend google.protobuf.FieldOptions {
+    // The field is sensitive. It will not be logged and may receive other special
+    // handling in the future.
+    bool sensitive = 50000;
+    // The field should not be logged. This may be useful on fields that have very
+    // large values.
+    bool skipLogging = 50001;
+    // This field controls the page size.
+    bool pagingPageSize = 50002;
+    // This field is the input paging token.
+    bool pagingInputToken = 50003;
+    // This field contains a page of results.
+    bool pagingResult = 50004;
+    // This field is the output paging token.
+    bool pagingOutputToken = 50005;
+    // This field is a date time.
+    bool datetime = 50006;
+    // This field is hidden.
+    bool hidden = 50007;
+    // The reason this field is hidden.
+    string hiddenReason = 50008;
+    // This conditions under which this hidden field is made visible.
+    string hiddenRetention = 50009;
+    // This field is required.
+    bool required = 50010;
+    // The minimum value for this field.
+    int32 minimum = 50011;
+    // The minimum value for this field.
+    int32 maximum = 50012;
+    // The minimum length for this field.
+    int32 minimumLength = 50013;
+    // The minimum length for this field.
+    int32 maximumLength = 50014;
+    // This field has been deprecated.
+    bool deprecated = 50015;
+    // This field doesn't reference a parameter file.
+    bool noParamfile = 50016;
+    // Default value for this field.
+    string default = 50017;
+    // The form factor(s) that the field is part of, e.g., public, private.
+    // By default, a parameter is part of every form factor of its operation or service.
+    repeated string formFactor = 50018;
+  }
+}
+
+message MethodExtension {
+  extend google.protobuf.MethodOptions {
+    // This method requires the specified right.
+    string right = 60000;
+    // This method requires the specified entitlement.
+    string entitlement = 60001;
+    // This method returns paginated results.
+    bool paginates = 60002;
+    // This default number of max items for auto-pagination to fetch.
+    int32 pagingDefaultMaxItems = 60003;
+    // This method is hidden.
+    bool hidden = 60004;
+    // The reason this method is hidden.
+    string hiddenReason = 60005;
+    // This conditions under which this hidden method is made visible.
+    string hiddenRetention = 60006;
+    // This method has been deprecated.
+    bool deprecated = 60007;
+    // This method is rate limited with the specified group. This name must
+    // match the name of a rate limit group declared for the service itself.
+    string rateLimitGroup = 60008;
+    // This method is a mutating call.
+    bool mutating = 60009;
+    // This method should not be audited.
+    bool skipAuditing = 60010;
+    // The form factor(s) that the operation is part of, e.g., public, private.
+    // By default, an operation is part of every form factor of its service.
+    repeated string formFactor = 60011;
+    // This method has extensions
+    repeated string extension = 60012;
+    // The grouping tag for this method
+    string tag = 60013;
+  }
+}
+
+message MessageExtension {
+  extend google.protobuf.MessageOptions {
+    // This message is hidden.
+    bool hidden = 70000;
+    // The reason this message is hidden.
+    string hiddenReason = 70001;
+    // This conditions under this hidden message is made visible.
+    string hiddenRetention = 70002;
+    // This message has been deprecated.
+    bool deprecated = 70003;
+    // The form factor(s) for the message.
+    repeated string formFactor = 70004;
+  }
+}
+
+// reserving 8xxxx for EnumExtension
+
+message EnumValueExtension {
+  extend google.protobuf.EnumValueOptions {
+    // This value is hidden.
+    bool hidden = 90000;
+    // The reason this value is hidden.
+    string hiddenReason = 90001;
+    // This conditions under this hidden value is made visible.
+    string hiddenRetention = 90002;
+  }
+}

--- a/auth-connector/src/main/proto/usermanagement.proto
+++ b/auth-connector/src/main/proto/usermanagement.proto
@@ -154,10 +154,14 @@ service UserManagement {
     returns (ListAccountsResponse) {}
 
   // Get the rights for an actor.
+  // These rights handle authorization and not authentication
+  // i.e., the rights of the actor are returned regardless of whether the actor is disabled.
   rpc GetRights(GetRightsRequest)
     returns (GetRightsResponse) {}
 
   // Checks if an actor has the input rights on the input resources.
+  // These rights handle authorization and not authentication
+  // i.e., the rights of the actor are checked regardless of whether the actor is disabled.
   rpc CheckRights(CheckRightsRequest)
     returns (CheckRightsResponse) {}
 
@@ -438,6 +442,10 @@ service UserManagement {
   rpc GetActorWorkloadCredentials(GetActorWorkloadCredentialsRequest)
     returns (GetActorWorkloadCredentialsResponse) {}
 
+  // Removes workload password minimum lifetime date for an actor.
+  rpc UnsetWorkloadPasswordMinLifetime (UnsetWorkloadPasswordMinLifetimeRequest)
+      returns (UnsetWorkloadPasswordMinLifetimeResponse) {}
+
   // Returns a unique ID for the following events:
   // * Role assignment events.
   // * Resource role assignment events.
@@ -525,6 +533,44 @@ service UserManagement {
   // Update user.
   rpc UpdateUser(UpdateUserRequest)
     returns (UpdateUserResponse) {}
+
+  // Set Cloudera SSO strict mode for the account.
+  rpc SetCssoStrictMode(SetCssoStrictModeRequest)
+      returns (SetCssoStrictModeResponse) {}
+
+  // Handles interactive logout requests from console.
+  rpc InteractiveLogout(InteractiveLogoutRequest)
+      returns (InteractiveLogoutResponse) {}
+
+  // Lists users for SCIM client. It's not a shared backend method for other services to call.
+  rpc ScimListUsers (ScimListUsersRequest)
+      returns (ScimListUsersResponse) {
+    option (options.MethodExtension.hidden) = true;
+    option (options.MethodExtension.hiddenReason) = "FOR_CLOUDERA_USE_ONLY: For SCIM use only. It is NOT a shared backend method for other services to call.";
+  }
+
+  // SCIM call. Remove all SCIM members from a group. It is not a shared backend method for other
+  // services to call.
+  rpc ScimRemoveAllMembersFromGroup (ScimRemoveAllMembersFromGroupRequest)
+      returns (ScimRemoveAllMembersFromGroupResponse) {
+    option (options.MethodExtension.hidden) = true;
+    option (options.MethodExtension.hiddenReason) = "FOR_CLOUDERA_USE_ONLY: For SCIM use only. It is NOT a shared backend method for other services to call.";
+  }
+
+  // SCIM call. Replace all SCIM members of a group. It is not a shared backend method for other
+  // services to call.
+  rpc ScimReplaceAllMembersOfGroup (ScimReplaceAllMembersOfGroupRequest)
+      returns (ScimReplaceAllMembersOfGroupResponse) {
+    option (options.MethodExtension.hidden) = true;
+    option (options.MethodExtension.hiddenReason) = "FOR_CLOUDERA_USE_ONLY: For SCIM use only. It is NOT a shared backend method for other services to call.";
+  }
+
+  // SCIM call. Lists all groups. It's not a shared backend method for other services to call.
+  rpc ScimListGroups (ScimListGroupsRequest)
+      returns (ScimListGroupsResponse) {
+    option (options.MethodExtension.hidden) = true;
+    option (options.MethodExtension.hiddenReason) = "FOR_CLOUDERA_USE_ONLY: For SCIM use only. It is NOT a shared backend method for other services to call.";
+  }
 }
 
 // The state of the actor.
@@ -538,6 +584,10 @@ message ActorState {
     DELETING = 1;
     // Deactivated actor can no longer authenticate in to CDP.
     DEACTIVATED = 2;
+    // Control plane locked out indicates that the actor can no longer
+    // authenticate to the control plane, but can authenticate to workload
+    // clusters. The state is used for inactivity timeout for FedRAMP AC-2 (3).
+    CONTROL_PLANE_LOCKED_OUT = 3;
   }
 }
 
@@ -589,6 +639,8 @@ message User {
   // identify user. It also maps to the "userName" attribute of the SCIM User schema and passed as
   // "userName" while creating users through SCIM.
   string idpUserId = 18;
+  // Information about the workload password details for the user.
+  WorkloadPasswordDetails workloadPasswordDetails = 19;
 }
 
 // A MachineUser is an internal Altus identity, used by applications to call
@@ -625,6 +677,21 @@ message MachineUser {
   uint64 safeDeleteDateMs = 8;
   // A list of cloud identities for the machine user.
   repeated CloudIdentity cloudIdentities = 9;
+  // Information about the workload password details for the machine user.
+  WorkloadPasswordDetails workloadPasswordDetails = 10;
+}
+
+message WorkloadPasswordDetails {
+  // Whether a workload password has been set.
+  bool isPasswordSet = 1;
+  // The workload password expiration date, in ms from the Java epoch of
+  // 1970-01-01T00:00:00Z. The value of 0 means that the password does
+  // not expire.
+  uint64 passwordExpirationDate = 2;
+  // The workload password min lifetime date, in ms from the Java epoch of
+  // 1970-01-01T00:00:00Z. A new password can not be set until the min lifetime
+  // date. The value of 0 means there is no min lifetime date.
+  uint64 passwordMinLifetimeDate = 3;
 }
 
 // A Group is a Altus resource that contains a collection of Actors. Groups
@@ -1045,6 +1112,11 @@ message GetUserRequest {
   reserved 1;
   string accountId = 2;
   string userIdOrCrn = 3;
+  // The CRN of the identity provider connector the user belongs to.
+  // This field is deprecated and optional.
+  nullable.StringValue identityProviderCrn = 4 [(options.FieldExtension.hidden) = true,
+    (options.FieldExtension.hiddenReason) = "FOR_CLOUDERA_USE_ONLY",
+    (options.FieldExtension.deprecated) = true];
 }
 
 message GetUserResponse {
@@ -1053,6 +1125,13 @@ message GetUserResponse {
 
 message ListUsersRequest {
   reserved 1;
+  // The fields 7 (identityProviderCrn), 8 (identityProviderUserId) were SCIM specific, which got removed as a part
+  // of CDPCP-5490. These numbers should be un-reserved but at the moment of this writing we are unsure of its usage
+  // by any internal client.
+  // CDPCP-5606 Tracks adding callingServiceName header to SCIM API. Once we have callingServiceName in SCIM API, we
+  // can check the logs and confirm that whether these fields are only used from SCIM or from other internal clients
+  // as well. If they were only used by SCIM then we can un-reserve 7 and 8.
+  reserved 7, 8;
   // The account in which to list users.
   string accountId = 4;
   // The list is optional. The default is to return all users.
@@ -1077,6 +1156,11 @@ message DeleteActorRequest {
   Actor actor = 2;
   // If set the 'true' the actor will be deleted from storage.
   bool forceDelete = 3;
+  // The CRN of the identity provider connector the user belongs to.
+  // This field is deprecated and optional.
+  nullable.StringValue identityProviderCrn = 4 [(options.FieldExtension.hidden) = true,
+    (options.FieldExtension.hiddenReason) = "FOR_CLOUDERA_USE_ONLY",
+    (options.FieldExtension.deprecated) = true];
 }
 
 message DeleteActorResponse {
@@ -1434,6 +1518,11 @@ message Account {
   WorkloadPasswordPolicy machineUserPasswordPolicy = 16;
   // The authentication policy.
   AuthenticationPolicy authenticationPolicy = 17;
+  // Whether strict mode is enabled on the account. The default value is 'false'.
+  // When it is true, it means that strict mode is enabled on the account and interactive login
+  // through Cloudera SSO is disabled for all users including account administrators of the
+  // account. The 'true' value overrides the setting for `clouderaSSOLoginEnabled`.
+  bool clouderaSSOStrictModeEnabled = 18;
 }
 
 message AuthenticationPolicy {
@@ -1959,6 +2048,23 @@ message RedisSessionTokenCacheEntry {
   int32 inactivityDurationSec = 6;
 }
 
+// This structure is used to serialize the redis SCIM pagination entry and is not used in
+// our rpc system. It provides mapping between the integer-based `startIndex` and
+// ItemPage (nextPageToken).
+message RedisScimPaginationCacheEntry {
+  // The DynamoDB next page token.
+  string nextPageToken = 1;
+  // The query ID of the first pagination call. It will be same for subsequent pagination requests
+  // initiated by the same SCIM client. Generally used for logging purpose to correlate page(s)
+  // between subsequent pagination requests.
+  string queryId = 2;
+  // The total number of resources (users or groups) found before the current pagination request.
+  // It will be updated after each pagination query to DynamoDB.
+  int32 runningTotalResults = 3;
+  // The estimated total number of resources (users or groups) in storage.
+  int32 estimatedTotalResults = 4;
+}
+
 // This is used to serialize all the Role dynamoDB related information that is
 // not indexed.
 message RoleDetails {
@@ -2066,6 +2172,14 @@ message WorkloadPasswordPolicyStorage {
   // Whether passwords must include symbols. The symbols are '#', '&', '*', '$', '%',
   // '@', '^', '.', '_', and '!'. The default is 'false'.
   bool mustIncludeSymbols = 6;
+  // The number of previous passwords that should be remembered, the actor is prevented
+  // from reusing these passwords. Can be any number between 0 and 20. The default is 0,
+  // this value means all previous passwords may be reused.
+  uint32 passwordHistorySize = 7;
+  // Account-wide min lifetime, in ms, of actors workload passwords. Password for an actor can't
+  // be set again until this duration is complete. A value of 0 indicates that passwords can be
+  // changed any time.
+  uint64 workloadPasswordMinLifetime = 8;
 }
 
 // Object used to serialize account metadata that does not require its own
@@ -2085,6 +2199,11 @@ message AccountDetails {
   WorkloadPasswordPolicyStorage machineUsersPasswordPolicy = 5;
   // The console authentication policy.
   AuthenticationPolicy authenticationPolicy = 6;
+  // Whether strict mode is enabled on the account. The default value is 'false'.
+  // When it is 'true', it means that strict mode is enabled on the account and interactive login
+  // through Cloudera SSO is disabled for all users including account administrators of the
+  // account. The 'true' value also overrides the setting for `clouderaSSOLoginDisabled`.
+  bool clouderaSSOStrictModeEnabled = 7;
 }
 
 // Set Account Messages request object.
@@ -3239,6 +3358,10 @@ message ActorDetails {
   // 1970-01-01T00:00:00Z. The value of 0 means that the password hash does
   // not expire.
   uint64 encryptedPasswordHashExpirationDate = 4;
+  // The password hash min lifetime date, in ms from the Java epoch of
+  // 1970-01-01T00:00:00Z. A new password can not be set until the min lifetime
+  // date. The value of 0 means there is no min lifetime date.
+  uint64 encryptedPasswordHashMinLifetimeDate = 9;
   // A list of kerberos keys for the actor.
   repeated StoredKerberosKey kerberosKeys = 2;
   // A list of ssh public keys for the actor.
@@ -3249,6 +3372,16 @@ message ActorDetails {
   int64 workloadCredentialsVersion = 7;
   // Cloud identities assigned to the actor.
   CloudIdentitiesStorage cloudIdentities = 5;
+  // A list of previously used passwords for the actor. The newest passwords
+  // are at the front of the list.
+  repeated PasswordDetails passwordHistory = 8;
+}
+
+message PasswordDetails {
+  // The cdp workload password hash, encrypted.
+  string encryptedPasswordHash = 1 [(options.FieldExtension.sensitive) = true];
+  // The salt used to generate the password hash.
+  string passwordHashSalt = 2;
 }
 
 // This is used to serialize all the Group dynamoDB related information that is
@@ -3286,6 +3419,13 @@ message ValidateActorWorkloadCredentialsRequest {
 message ValidateActorWorkloadCredentialsResponse {
 }
 
+message UnsetWorkloadPasswordMinLifetimeRequest {
+  string actorCrn = 1;
+}
+
+message UnsetWorkloadPasswordMinLifetimeResponse {
+}
+
 // Definition of a Kerberos Key used in rpc calls (vs storage)
 message ActorKerberosKey {
   // The key type
@@ -3311,6 +3451,10 @@ message GetActorWorkloadCredentialsResponse {
   // password hash expires. A value of 0 indicates that the password hash
   // never expires.
   uint64 passwordHashExpirationDate = 3;
+  // The password hash min lifetime date, in ms from the Java epoch of
+  // 1970-01-01T00:00:00Z. A new password can not be set until the min lifetime
+  // date. The value of 0 means there is no min lifetime date.
+  uint64 passwordHashMinLifetimeDate  = 7;
   // A list of kerberos keys for the actor.
   repeated ActorKerberosKey kerberosKeys = 2;
   // The workload username for the actor.
@@ -3462,6 +3606,14 @@ message WorkloadPasswordPolicy {
   // Whether passwords must include symbols. The symbols are '#', '&', '*', '$', '%',
   // '@', '^', '.', '_', and '!'. The default is 'false'.
   bool mustIncludeSymbols = 6;
+  // The number of previous passwords that should be remembered. The actor is prevented
+  // from reusing these passwords. Can be any number between 0 and 20. The default is 0,
+  // this value means all previous passwords may be reused.
+  uint32 passwordHistorySize = 7;
+  // Account-wide min lifetime, in ms, of actor's workload passwords. Password for an actor can't
+  // be set again until this duration is complete. A value of 0 indicates that passwords can be
+  // changed any time.
+  uint64 workloadPasswordMinLifetime = 8;
 }
 
 message SetWorkloadPasswordPolicyRequest {
@@ -3662,6 +3814,9 @@ message GetUserSyncStateModelRequest {
   // actors that pass at least one of these rights checks. The results of the rights
   // checks are included in the response for each included actor.
   repeated RightsCheck rightsCheck = 2;
+  // Whether to skip the workload credentials in the response.
+  // If skipped, only the workload credentials version will be included.
+  bool skipCredentials = 3;
 }
 
 message GetUserSyncStateModelResponse {
@@ -3682,7 +3837,7 @@ message GetUserSyncStateModelResponse {
 // workload credentials through user sync.
 // TODO CDPCP-3033 - migrate GetActorWorkloadCredentialsResponse to use this object
 message ActorWorkloadCredentials {
-  reserved 4;
+  reserved 4, 7;
   // The password hash.
   string passwordHash = 1 [(options.FieldExtension.sensitive) = true];
   // The date, in ms from the Java epoch of 1970-01-01T00:00:00Z, when the
@@ -3695,6 +3850,11 @@ message ActorWorkloadCredentials {
   repeated SshPublicKey sshPublicKey = 5;
   // The version number of the workload credentials. Version numbering begins at zero.
   int64 workloadCredentialsVersion = 6;
+}
+
+message ActorWorkloadCredentialsVersion {
+  // The version number of the workload credentials. Version numbering begins at zero.
+  int64 workloadCredentialsVersion = 1;
 }
 
 message RightsCheckResult {
@@ -3715,8 +3875,12 @@ message UserSyncActor {
   // Wags this actor is a member of, represented as indices into the
   // list of workload administration groups in the response.
   repeated int32 workloadAdministrationGroupIndex = 4;
-  // Credentials.
-  ActorWorkloadCredentials credentials = 5;
+  oneof usersyncactor_oneof {
+    // Credentials.
+    ActorWorkloadCredentials credentials = 5;
+    // Credentials version only
+    ActorWorkloadCredentialsVersion credentialsVersion = 6;
+  }
 }
 
 message UserSyncActorDetails {
@@ -3893,9 +4057,181 @@ message UpdateUserRequest {
   // User.state will be set to ActorState.Value.ACTIVE if the value is false.
   // If it is not set then the user's state will not be changed.
   nullable.BoolValue isDeactivated = 7;
+  // The CRN of the identity provider connector the user belongs to.
+  // This field is deprecated and optional.
+  nullable.StringValue identityProviderCrn = 8 [(options.FieldExtension.hidden) = true,
+    (options.FieldExtension.hiddenReason) = "FOR_CLOUDERA_USE_ONLY",
+    (options.FieldExtension.deprecated) = true];
 }
 
 message UpdateUserResponse {
   // The updated user.
   User user = 1;
+}
+
+message SetCssoStrictModeRequest {
+  // The account ID for which strict mode is being enabled or disabled.
+  string accountId = 1;
+  // Whether to enable or disable strict mode on the account. The default value is 'false'.
+  // Set it 'true' to enable strict mode. Enabling strict mode will restrict Cloudera SSO login
+  // for all the users including account administrators of the account. Disabling strict mode
+  // will allow account administrator login through Cloudera SSO. The 'true' value also overrides
+  // the setting for `clouderaSSOLoginEnabled`.
+  bool enableStrictMode = 2;
+}
+
+message SetCssoStrictModeResponse {
+}
+
+message InteractiveLogoutRequest {
+  // The session token to be removed from server as a part of interactive logout process.
+  string sessionToken = 1 [(options.FieldExtension.sensitive) = true];
+  // The IP address that the request was made from.
+  string sourceIpAddress = 2;
+}
+
+message InteractiveLogoutResponse {
+}
+
+// ========================================================================
+// SECTION: SCIM
+//
+// These messages pertain to SCIM.
+// ========================================================================
+
+message ScimListUsersRequest {
+  option (options.MessageExtension.hidden) = true;
+  option (options.MessageExtension.hiddenReason) = "FOR_CLOUDERA_USE_ONLY";
+
+  // The account in which to list users.
+  string accountId = 1;
+  // The ID of the identity provider connector the user belongs to.
+  string identityProviderId = 2;
+  // The list of identity provider user IDs. Current implementation only supports filtering based
+  // on single identityProviderUserId and throws exception if more than 1 values are provided for
+  // identityProviderUserId.
+  repeated string identityProviderUserId = 3;
+  // The start index from where pagination request should start or continue.
+  // It is a 1-based index. It can be negative. A value less than 1 SHALL be interpreted as 1.
+  sint32 startIndex = 4;
+  // The number of users to list for this request. It corresponds to a page size.
+  // It can be negative. A negative value SHALL be interpreted as "0". A value of "0"
+  // indicates that no resource results are to be returned  except for "totalResults".
+  // Ref: https://datatracker.ietf.org/doc/html/rfc7644#section-3.4.2.4
+  sint32 count = 5;
+  // The query string used for filtering. It can be empty if no filtering is requested by the
+  // SCIM client.
+  string filter = 6;
+}
+
+message ScimListUsersResponse {
+  option (options.MessageExtension.hidden) = true;
+  option (options.MessageExtension.hiddenReason) = "FOR_CLOUDERA_USE_ONLY";
+
+  // The list of users.
+  repeated User user = 1;
+  // The estimated total number of users in the account for the queried identity provider.
+  int32 totalResults = 2;
+  // The 1-based index of the first result in the current set of query results.
+  int32 startIndex = 3;
+}
+
+message ScimRemoveAllMembersFromGroupRequest {
+  option (options.MessageExtension.hidden) = true;
+  option (options.MessageExtension.hiddenReason) = "FOR_CLOUDERA_USE_ONLY";
+
+  // Account ID for which the request is being made.
+  string accountId = 1;
+  // The group ID.
+  string groupId = 2;
+  // The identity provider ID. This limits the members-to-be-removed to users in this identity
+  // provider.
+  string identityProviderId = 3;
+}
+
+message ScimRemoveAllMembersFromGroupResponse {
+  option (options.MessageExtension.hidden) = true;
+  option (options.MessageExtension.hiddenReason) = "FOR_CLOUDERA_USE_ONLY";
+
+  // A list of all the user CRNs that were removed from the group.
+  repeated string membersRemoved = 1;
+}
+
+message ScimReplaceAllMembersOfGroupRequest {
+  option (options.MessageExtension.hidden) = true;
+  option (options.MessageExtension.hiddenReason) = "FOR_CLOUDERA_USE_ONLY";
+
+  // Account ID for which the request is being made.
+  string accountId = 1;
+  // The group ID.
+  string groupId = 2;
+  // The identity provider ID. This limits the members-to-be-removed to users in this identity
+  // provider.
+  string identityProviderId = 3;
+  // The list of user IDs to add to the group.
+  repeated string userId = 4;
+}
+
+message ScimReplaceAllMembersOfGroupResponse {
+  option (options.MessageExtension.hidden) = true;
+  option (options.MessageExtension.hiddenReason) = "FOR_CLOUDERA_USE_ONLY";
+  // A list of all the user CRNs that were removed from the group.
+  repeated string membersRemoved = 1;
+  // A list of all the user CRNs that were added to the group.
+  repeated string membersAdded = 2;
+}
+
+message ScimListGroupsRequest {
+  option (options.MessageExtension.hidden) = true;
+  option (options.MessageExtension.hiddenReason) = "FOR_CLOUDERA_USE_ONLY";
+
+  // The account ID for which the request is being made.
+  string accountId = 1;
+  // The ID of the identity provider connector initiating this request.
+  string identityProviderId = 2;
+  // The list of group names. It is optional. The default is to return all groups in the account.
+  // The current implementation only supports filtering based on a single groupName and throws an
+  // exception if more than one value is provided for groupName.
+  repeated string groupName = 3;
+  // The start index from where pagination request should start or continue.
+  // It is a 1-based index. It can be negative. A value less than 1 SHALL be interpreted as 1.
+  sint32 startIndex = 4;
+  // The number of groups to list for this request. It corresponds to a page size.
+  // It can be negative. A negative value SHALL be interpreted as "0". A value of "0"
+  // indicates that no resource results are to be returned except for "totalResults".
+  // Ref: https://datatracker.ietf.org/doc/html/rfc7644#section-3.4.2.4
+  sint32 count = 5;
+  // The query string used for filtering. It can be empty if no filtering is requested by the
+  // SCIM client.
+  string filter = 6;
+  // Whether to exclude group members from the response.
+  bool excludeMembers = 7;
+}
+
+message ScimListGroupsResponse {
+  option (options.MessageExtension.hidden) = true;
+  option (options.MessageExtension.hiddenReason) = "FOR_CLOUDERA_USE_ONLY";
+  // The list of SCIM groups in the queried account. Note that the groups are not IdP specific
+  // like users.
+  repeated ScimGroup scimGroup = 1;
+  // The estimated total number of groups in the account.
+  // If request provided non-empty `groupName`, then it is total number of matching groups
+  // in the account.
+  int32 totalResults = 2;
+  // The 1-based index of the first result in the current set of query results.
+  int32 startIndex = 3;
+}
+
+// An object encapsulating SCIM Group schema attributes.
+message ScimGroup {
+  option (options.MessageExtension.hidden) = true;
+  option (options.MessageExtension.hiddenReason) = "FOR_CLOUDERA_USE_ONLY";
+  // The group ID.
+  string groupId = 1;
+  // The group name. Must be unique within the account. Cannot be empty string.
+  string groupName = 2;
+  // The creation date in ms from the Java epoch of 1970-01-01T00:00:00Z.
+  uint64 creationDate = 3;
+  // The list of group member (user) CRNs. The group members are optional.
+  repeated string memberCrn = 4;
 }


### PR DESCRIPTION
Update usermanagement.proto, rebuild and check in build artifacts.
We also need to include options.proto to define the "deprecated"
flag that's used in the usermanagement.proto.
