### PR TITLE
CB-16551: add event publish to the trigger method

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
@@ -476,6 +476,8 @@ public enum ResourceEvent {
     DATALAKE_RECOVERY_FAILED("datalake.recovery.failed"),
     DATALAKE_RECOVERY_FINISHED("datalake.recovery.finished"),
 
+    DATALAKE_RESIZE_TRIGGERED("datalake.resize.triggered"),
+
     DATAHUB_REFRESH_IN_PROGRESS("datalake.datahub.refresh.in.progress"),
     DATAHUB_REFRESH_FAILED("datalake.datahub.refresh.failed"),
 

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -526,6 +526,7 @@ datalake.recovery.failed=Datalake recovery failed.
 datalake.recovery.bringup.failed=Datalake stack recovery failed.
 datalake.recovery.bringup.finished=Datalake stack successfully recovered, creating datalake cluster.
 datalake.recovery.teardown.finished=Datalake stack tear-down for recovery completed successfully.
+datalake.resize.triggered=Datalake resize initiated.
 
 datalake.datahub.refresh.in.progress=Datahub refresh in progress
 datalake.datahub.refresh.failed=Datahub refresh failed. Reason: {0}


### PR DESCRIPTION
Jira: [CB-16551](https://jira.cloudera.com/browse/CB-16551) Add Event History when the data lake is resized.

Add eventPublis to the Datalake resize trigger method. Add resource value to the message.properties. 

Tested by running locally and verifying:
- datalake resize trigger works and do what is expected.
- EventLog is created and published and contains the proper value from the properties.
