### PR TITLE
CB-15454 Disable DNSZone list assert in FreeIPA upgrade test

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/freeipa/FreeIpaUpgradeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/freeipa/FreeIpaUpgradeTests.java
@@ -245,15 +245,16 @@ public class FreeIpaUpgradeTests extends AbstractE2ETest {
             request.setSubnets(List.of("10.0.1.0/24", "192.168.1.0/24"));
             request.setEnvironmentCrn(environmentCrn);
             ipaClient.getDnsV1Endpoint().addDnsZoneForSubnets(request);
+/*          Until CB-15454 is fixed
             Set<String> dnsZones = ipaClient.getDnsV1Endpoint().listDnsZones(environmentCrn);
             Assertions.assertTrue(dnsZones.stream().anyMatch(dnsZone -> dnsZone.startsWith("1.0.10")));
-            Assertions.assertTrue(dnsZones.stream().anyMatch(dnsZone -> dnsZone.startsWith("1.168.192")));
+            Assertions.assertTrue(dnsZones.stream().anyMatch(dnsZone -> dnsZone.startsWith("1.168.192")));*/
 
             ipaClient.getDnsV1Endpoint().deleteDnsZoneBySubnet(environmentCrn, "192.168.1.0/24");
             ipaClient.getDnsV1Endpoint().deleteDnsZoneBySubnet(environmentCrn, "10.0.1.0/24");
-            dnsZones = ipaClient.getDnsV1Endpoint().listDnsZones(environmentCrn);
+/*            dnsZones = ipaClient.getDnsV1Endpoint().listDnsZones(environmentCrn);
             Assertions.assertFalse(dnsZones.stream().anyMatch(dnsZone -> dnsZone.startsWith("1.0.10")));
-            Assertions.assertFalse(dnsZones.stream().anyMatch(dnsZone -> dnsZone.startsWith("1.168.192")));
+            Assertions.assertFalse(dnsZones.stream().anyMatch(dnsZone -> dnsZone.startsWith("1.168.192")));*/
         } catch (Exception e) {
             logger.error("DNS ZONE test failed during upgrade", e);
             throw new TestFailException("DNS ZONE test failed during upgrade with: " + e.getMessage(), e);


### PR DESCRIPTION
Until CB-15454 is fixed we can't ensure the same instance receives the list and add/del requests. With the replication delay we can't ensure the assert returns valid result.

See detailed description in the commit message.