### PR TITLE
CDPSDX-3491: Modified use of stack name for stack termination and status checking when the stack is detached to avoid multiple issues.

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/context/CloudContext.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/context/CloudContext.java
@@ -36,6 +36,11 @@ public class CloudContext {
 
     private final String crn;
 
+    /**
+     * Specifically used for cases in which the original stack has been detached during a resize operation.
+     */
+    private String originalName;
+
     private CloudContext(Builder builder) {
         this.id = builder.id;
         this.name = builder.name;
@@ -47,6 +52,7 @@ public class CloudContext {
         this.tenantId = builder.tenantId;
         this.userName = builder.userName;
         this.govCloud = builder.govCloud;
+        this.originalName = builder.originalName;
     }
 
     public Long getId() {
@@ -93,6 +99,10 @@ public class CloudContext {
         return govCloud;
     }
 
+    public String getOriginalName() {
+        return originalName;
+    }
+
     @Override
     public String toString() {
         return "CloudContext{" +
@@ -129,6 +139,8 @@ public class CloudContext {
         private String crn;
 
         private boolean govCloud;
+
+        private String originalName;
 
         public Builder withId(Long id) {
             this.id = id;
@@ -182,6 +194,11 @@ public class CloudContext {
 
         public Builder withGovCloud(boolean govCloud) {
             this.govCloud = govCloud;
+            return this;
+        }
+
+        public Builder withOriginalName(String originalName) {
+            this.originalName = originalName;
             return this;
         }
 

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceGroupMetadataProvider.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceGroupMetadataProvider.java
@@ -27,7 +27,8 @@ public class AzureResourceGroupMetadataProvider {
 
     public String getStackName(CloudContext cloudContext) {
         return Splitter.fixedLength(maxResourceNameLength - cloudContext.getId().toString().length())
-                .splitToList(cloudContext.getName()).get(0) + cloudContext.getId();
+                .splitToList(cloudContext.getOriginalName() == null ? cloudContext.getName() : cloudContext.getOriginalName())
+                .get(0) + cloudContext.getId();
     }
 
     public String getResourceGroupName(CloudContext cloudContext, CloudStack cloudStack) {

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
@@ -179,7 +179,8 @@ public interface StackV4Endpoint {
     @ApiOperation(value = UPDATE_BY_NAME_IN_WORKSPACE, produces = MediaType.APPLICATION_JSON, notes = Notes.STACK_NOTES,
             nickname = "updateNameCrnAndType")
     void updateNameAndCrn(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name,
-            @QueryParam("initiatorUserCrn") String initiatorUserCrn, @QueryParam("newName") String newName, @QueryParam("newCrn") String newCrn);
+            @QueryParam("initiatorUserCrn") String initiatorUserCrn, @QueryParam("newName") String newName, @QueryParam("newCrn") String newCrn,
+            @QueryParam("retainOriginalName") @DefaultValue("false") boolean retainOriginalName);
 
     @POST
     @Path("{name}/sync")

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Stack.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Stack.java
@@ -224,6 +224,13 @@ public class Stack implements ProvisionEntity, WorkspaceAwareResource, Orchestra
     @Convert(converter = DnsResolverTypeConverter.class)
     private DnsResolverType domainDnsResolver;
 
+    /**
+     * Specifically used for cases in which the stack has been detached during a resize operation.
+     * This allows us to retain the original stack name which can be necessary when resources are defined around
+     * the original name.
+     */
+    private String originalName;
+
     public String getResourceCrn() {
         return resourceCrn;
     }
@@ -936,6 +943,14 @@ public class Stack implements ProvisionEntity, WorkspaceAwareResource, Orchestra
         this.domainDnsResolver = domainDnsResolver;
     }
 
+    public String getOriginalName() {
+        return originalName;
+    }
+
+    public void setOriginalName(String originalName) {
+        this.originalName = originalName;
+    }
+
     @Override
     public String toString() {
         return "Stack{" +
@@ -983,6 +998,7 @@ public class Stack implements ProvisionEntity, WorkspaceAwareResource, Orchestra
                 ", ccmV2AgentCrn='" + ccmV2AgentCrn + '\'' +
                 ", externalDatabaseCreationType=" + externalDatabaseCreationType +
                 ", externalDatabaseEngineVersion=" + externalDatabaseEngineVersion +
+                ", originalName=" + originalName +
                 '}';
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
@@ -141,8 +141,12 @@ public class StackV4Controller extends NotificationController implements StackV4
 
     @Override
     @InternalOnly
-    public void updateNameAndCrn(Long workspaceId, String name, @InitiatorUserCrn String initiatorUserCrn, String newName, String newCrn) {
-        stackOperations.updateNameAndCrn(NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId(), newName, newCrn);
+    public void updateNameAndCrn(Long workspaceId, String name, @InitiatorUserCrn String initiatorUserCrn, String newName, String newCrn,
+            boolean retainOriginalName) {
+        stackOperations.updateNameAndCrn(
+                NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId(), newName, newCrn,
+                retainOriginalName
+        );
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/detach/StackUpdateService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/detach/StackUpdateService.java
@@ -39,10 +39,15 @@ public class StackUpdateService {
     @Inject
     private TransactionService transactionService;
 
-    public void updateNameAndCrn(Stack stack, String newName, String newCrn) {
+    public void updateNameAndCrn(Stack stack, String newName, String newCrn, boolean retainOriginalName) {
         MDCBuilder.buildMdcContext(stack);
         try {
             transactionService.required(() -> {
+                if (retainOriginalName) {
+                    stack.setOriginalName(stack.getName());
+                } else {
+                    stack.setOriginalName(null);
+                }
                 stack.setName(newName);
                 stack.setResourceCrn(newCrn);
                 Stack savedStack = measure(() -> stackService.save(stack),

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/termination/AbstractStackTerminationAction.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/termination/AbstractStackTerminationAction.java
@@ -68,6 +68,7 @@ abstract class AbstractStackTerminationAction<P extends Payload>
         CloudContext cloudContext = CloudContext.Builder.builder()
                 .withId(stack.getId())
                 .withName(stack.getName())
+                .withOriginalName(stack.getOriginalName())
                 .withCrn(stack.getResourceCrn())
                 .withPlatform(stack.getCloudPlatform())
                 .withVariant(stack.getPlatformVariant())

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackInstanceStatusChecker.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackInstanceStatusChecker.java
@@ -48,6 +48,7 @@ public class StackInstanceStatusChecker {
             CloudContext cloudContext = CloudContext.Builder.builder()
                     .withId(stack.getId())
                     .withName(stack.getName())
+                    .withOriginalName(stack.getOriginalName())
                     .withCrn(stack.getResourceCrn())
                     .withPlatform(stack.getCloudPlatform())
                     .withVariant(stack.getPlatformVariant())

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
@@ -290,9 +290,9 @@ public class StackOperations implements HierarchyAuthResourcePropertyProvider {
         stackCommonService.deleteWithKerberosInWorkspace(nameOrCrn, workspaceId, forced);
     }
 
-    public void updateNameAndCrn(@NotNull NameOrCrn nameOrCrn, Long workspaceId, String newName, String newCrn) {
+    public void updateNameAndCrn(@NotNull NameOrCrn nameOrCrn, Long workspaceId, String newName, String newCrn, boolean retainOriginalName) {
         Stack stack = stackService.getByNameOrCrnInWorkspace(nameOrCrn, workspaceId);
-        stackUpdateService.updateNameAndCrn(stack, newName, newCrn);
+        stackUpdateService.updateNameAndCrn(stack, newName, newCrn, retainOriginalName);
     }
 
     public StackV4Request getRequest(@NotNull NameOrCrn nameOrCrn, Long workspaceId) {

--- a/core/src/main/resources/schema/app/20220408210524_CDPSDX-3491:_Adding_original_name_field_to_stack.sql
+++ b/core/src/main/resources/schema/app/20220408210524_CDPSDX-3491:_Adding_original_name_field_to_stack.sql
@@ -1,0 +1,9 @@
+-- // CDPSDX-3491: Adding original name field to stack.
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE stack ADD COLUMN IF NOT EXISTS originalname VARCHAR(255);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE stack DROP COLUMN IF EXISTS originalname;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverterTest.java
@@ -225,7 +225,7 @@ class StackV4RequestToStackConverterTest extends AbstractJsonConverterTest<Stack
                         "version", "created", "platformVariant", "cloudPlatform",
                         "customHostname", "customDomain", "clusterNameAsSubdomain", "hostgroupNameAsHostname", "parameters", "creator",
                         "environmentCrn", "terminated", "datalakeCrn", "type", "inputs", "failurePolicy", "resourceCrn", "minaSshdServiceId",
-                        "ccmV2AgentCrn", "externalDatabaseCreationType", "stackVersion", "externalDatabaseEngineVersion"));
+                        "ccmV2AgentCrn", "externalDatabaseCreationType", "stackVersion", "externalDatabaseEngineVersion", "originalName"));
         assertEquals("eu-west-1", stack.getRegion());
         assertEquals("AWS", stack.getCloudPlatform());
         assertEquals("mystack", stack.getName());
@@ -254,7 +254,7 @@ class StackV4RequestToStackConverterTest extends AbstractJsonConverterTest<Stack
                         "version", "created", "platformVariant", "cloudPlatform", "resourceCrn",
                         "customHostname", "customDomain", "clusterNameAsSubdomain", "hostgroupNameAsHostname", "parameters", "creator",
                         "environmentCrn", "terminated", "datalakeCrn", "type", "inputs", "failurePolicy", "minaSshdServiceId",
-                        "ccmV2AgentCrn", "externalDatabaseCreationType", "stackVersion", "externalDatabaseEngineVersion"));
+                        "ccmV2AgentCrn", "externalDatabaseCreationType", "stackVersion", "externalDatabaseEngineVersion", "originalName"));
         assertEquals("eu-west-1", stack.getRegion());
         assertEquals("AWS", stack.getCloudPlatform());
         assertEquals("mystack", stack.getName());

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/attach/SdxAttachDetachUtils.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/attach/SdxAttachDetachUtils.java
@@ -33,14 +33,14 @@ public class SdxAttachDetachUtils {
         sdxCluster.setStackCrn(newCrn);
     }
 
-    public void updateStack(String originalName, String newName, String newCrn) {
+    public void updateStack(String originalName, String newName, String newCrn, boolean retainOriginalName) {
         String initiatorUserCrn = ThreadBasedUserCrnProvider.getUserCrn();
         ThreadBasedUserCrnProvider.doAsInternalActor(
             regionAwareInternalCrnGeneratorFactory.iam().getInternalCrnForServiceAsString(),
             () -> {
                 try {
                     stackV4Endpoint.updateNameAndCrn(
-                            0L, originalName, initiatorUserCrn, newName, newCrn
+                            0L, originalName, initiatorUserCrn, newName, newCrn, retainOriginalName
                     );
                 } catch (NotFoundException e) {
                     LOGGER.warn("Stack not found for original name: '" + originalName +

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/attach/SdxAttachService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/attach/SdxAttachService.java
@@ -97,7 +97,7 @@ public class SdxAttachService {
      */
     public void reattachStack(SdxCluster cluster, String originalName) {
         LOGGER.info("Started reattaching stack of SDX cluster with ID: {}", cluster.getId());
-        sdxAttachDetachUtils.updateStack(originalName, cluster.getClusterName(), cluster.getCrn());
+        sdxAttachDetachUtils.updateStack(originalName, cluster.getClusterName(), cluster.getCrn(), false);
         jobService.schedule(cluster.getId(), SdxClusterJobAdapter.class);
         LOGGER.info("Finished reattaching stack of SDX cluster with ID: {}. Now has name {} and crn {}.",
                 cluster.getId(), cluster.getClusterName(), cluster.getCrn());
@@ -115,7 +115,7 @@ public class SdxAttachService {
                     cluster.getId(), cluster.getCrn());
         } catch (RuntimeException e) {
             // Undo the stack update to put everything back in its original state.
-            sdxAttachDetachUtils.updateStack(cluster.getClusterName(), detachedName, detachedCrn);
+            sdxAttachDetachUtils.updateStack(cluster.getClusterName(), detachedName, detachedCrn, true);
             jobService.schedule(cluster.getId(), SdxClusterJobAdapter.class);
             throw e;
         }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/attach/SdxDetachService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/attach/SdxDetachService.java
@@ -76,7 +76,7 @@ public class SdxDetachService {
      */
     public void detachStack(SdxCluster cluster, String originalName) {
         LOGGER.info("Started detaching stack of SDX cluster with ID: {}.", cluster.getId());
-        sdxAttachDetachUtils.updateStack(originalName, cluster.getClusterName(), cluster.getCrn());
+        sdxAttachDetachUtils.updateStack(originalName, cluster.getClusterName(), cluster.getCrn(), true);
         jobService.schedule(cluster.getId(), SdxClusterJobAdapter.class);
         LOGGER.info("Finished detaching stack of SDX cluster with ID: {}.", cluster.getId());
     }

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/attach/SdxAttachServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/attach/SdxAttachServiceTest.java
@@ -129,7 +129,8 @@ public class SdxAttachServiceTest {
         testCluster.setCrn(ORIGINAL_TEST_CLUSTER_CRN);
         sdxAttachService.reattachStack(testCluster, TEST_CLUSTER_NAME);
         verify(mockStackV4Endpoint).updateNameAndCrn(
-                eq(0L), eq(TEST_CLUSTER_NAME), any(), eq(ORIGINAL_TEST_CLUSTER_NAME), eq(ORIGINAL_TEST_CLUSTER_CRN)
+                eq(0L), eq(TEST_CLUSTER_NAME), any(), eq(ORIGINAL_TEST_CLUSTER_NAME), eq(ORIGINAL_TEST_CLUSTER_CRN),
+                eq(false)
         );
     }
 
@@ -139,7 +140,7 @@ public class SdxAttachServiceTest {
         when(regionAwareInternalCrnGeneratorFactory.iam()).thenReturn(regionAwareInternalCrnGenerator);
         testCluster.setClusterName(ORIGINAL_TEST_CLUSTER_NAME);
         testCluster.setCrn(ORIGINAL_TEST_CLUSTER_CRN);
-        doThrow(new NotFoundException("Stack not found.")).when(mockStackV4Endpoint).updateNameAndCrn(any(), any(), any(), any(), any());
+        doThrow(new NotFoundException("Stack not found.")).when(mockStackV4Endpoint).updateNameAndCrn(any(), any(), any(), any(), any(), eq(false));
         sdxAttachService.reattachStack(testCluster, TEST_CLUSTER_NAME);
     }
 

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/attach/SdxDetachServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/attach/SdxDetachServiceTest.java
@@ -134,7 +134,7 @@ public class SdxDetachServiceTest {
         when(regionAwareInternalCrnGeneratorFactory.iam()).thenReturn(regionAwareInternalCrnGenerator);
         sdxDetachService.detachStack(testCluster, TEST_CLUSTER_NAME);
         verify(mockStackV4Endpoint).updateNameAndCrn(
-                eq(0L), eq(TEST_CLUSTER_NAME), any(), eq(NEW_TEST_CLUSTER_NAME), eq(NEW_TEST_CLUSTER_CRN)
+                eq(0L), eq(TEST_CLUSTER_NAME), any(), eq(NEW_TEST_CLUSTER_NAME), eq(NEW_TEST_CLUSTER_CRN), eq(true)
         );
     }
 
@@ -144,7 +144,7 @@ public class SdxDetachServiceTest {
         testCluster.setCrn(NEW_TEST_CLUSTER_CRN);
         when(regionAwareInternalCrnGenerator.getInternalCrnForServiceAsString()).thenReturn("crn");
         when(regionAwareInternalCrnGeneratorFactory.iam()).thenReturn(regionAwareInternalCrnGenerator);
-        doThrow(new NotFoundException("Stack not found.")).when(mockStackV4Endpoint).updateNameAndCrn(any(), any(), any(), any(), any());
+        doThrow(new NotFoundException("Stack not found.")).when(mockStackV4Endpoint).updateNameAndCrn(any(), any(), any(), any(), any(), eq(true));
         sdxDetachService.detachStack(testCluster, TEST_CLUSTER_NAME);
     }
 


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CDPSDX-3491

Main issue here is that for certain cloud providers (specifically Azure and the Mock Cloud Provider), in some cases the stack name is used to define important resources.
For Azure this includes the name of the resource group created where the stack instances are located (this is only for cases where the environment is created without a pre-specified resource group).

It's very clear that after a detach, when the stack name is modified, these resources will no longer be able to be located resulting in errors.

Specifically, we see errors in two places:

- The `StackStatusCheckerJob` as it attempts to verify the health of the stack instances using an incorrect resource name
- The termination of the stack, where it attempts to terminate the stack and its instances using an incorrect resource name

My main goal with this work was to provide a way for the 2 cases above to use the _original_ stack name, instead of the detached one. I hope it is clear how this fixes the issue.

As such, my changes consist of the following:

- Adding a new `originalName` field to the stack object
- During updating of the stack name/crn, I now update the `originalName` field and ensure the field is what we expect if the stack is being detached
- Use a new `retainOriginalName` field in the `updateNameAndCrn` method to track if we want to store the original name or set it to `null`

That's literally all I changed. I unfortunately have not been able to test this yet, but am doing so now. However, as this is a pretty important issue, I would appreciate as many eyes on it as possible.