### PR TITLE
CB-16794: Ignore exceptions during recovery validation to allow other recovery services to be used.

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/recovery/SdxUpgradeRecoveryService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/recovery/SdxUpgradeRecoveryService.java
@@ -76,11 +76,11 @@ public class SdxUpgradeRecoveryService implements RecoveryService {
                     () ->
                     stackV4Endpoint.getClusterRecoverableByNameInternal(0L, sdxCluster.getClusterName(), initiatorUserCrn));
             return new SdxRecoverableResponse(response.getReason(), response.getStatus());
-        } catch (WebApplicationException e) {
+        } catch (Exception e) {
+            LOGGER.error("Stack recovery validation failed on cluster: " + sdxCluster.getClusterName(), e);
             String exceptionMessage = exceptionMessageExtractor.getErrorMessage(e);
-            String message = String.format("Stack recovery validation failed on cluster: [%s]. Message: [%s]",
-                    sdxCluster.getClusterName(), exceptionMessage);
-            throw new CloudbreakApiException(message, e);
+            return new SdxRecoverableResponse(String.format("Stack recovery validation failed on cluster: [%s]. Message: [%s]",
+                    sdxCluster.getClusterName(), exceptionMessage), RecoveryStatus.NON_RECOVERABLE);
         }
     }
 


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-16794

Please look at the Jira for an explanation on what this issue is and how it occurs.

Basically there is no reason to throw an exception here, an exception is thrown anyway if recovery validation is unsuccessful for all services.