### PR TITLE
CB-16794: Ignore exceptions during recovery validation to allow other recovery services to be used.

### DIFF
--- a/datalake/src/test/java/com/sequenceiq/datalake/service/recovery/SdxRecoverySelectorServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/recovery/SdxRecoverySelectorServiceTest.java
@@ -101,6 +101,26 @@ public class SdxRecoverySelectorServiceTest {
     }
 
     @Test
+    public void testRecoveryServiceCanSwitchDespiteValidationError() {
+        setUpgradeTest();
+        when(mockResizeRecoveryService.validateRecovery(cluster, request)).thenAnswer(invocation -> {
+            throw new Exception("Error!");
+        });
+
+        SdxRecoveryResponse response = new SdxRecoveryResponse();
+        when(mockSdxUpgradeRecoveryService.triggerRecovery(cluster, request)).thenReturn(response);
+
+        SdxRecoveryResponse result = sdxRecoverySelectorService.triggerRecovery(cluster, request);
+
+        // Basically, just check that we pass through to the Upgrade Recovery Service despite error during resize recovery validation.
+        Mockito.verify(mockResizeRecoveryService, never()).triggerRecovery(cluster, request);
+        Mockito.verify(mockSdxUpgradeRecoveryService).triggerRecovery(cluster, request);
+
+        assertNotNull(result);
+        assertEquals(response, result);
+    }
+
+    @Test
     public void testRecoveryServiceCanSwitchToResizeRecovery() {
         setResizeTest();
 


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-16794

Please look at the Jira for an explanation on what this issue is and how it occurs.

Basically there is no reason to throw an exception here, an exception is thrown anyway if recovery validation is unsuccessful for all services.
