### PR TITLE
CDPCP-6883. Add CONTROL_PLANE_LOCKED_OUT to FmsUserConverter

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/conversion/FmsUserConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/conversion/FmsUserConverter.java
@@ -58,6 +58,7 @@ public class FmsUserConverter {
             case DEACTIVATED:
                 return FmsUser.State.DISABLED;
             case ACTIVE:
+            case CONTROL_PLANE_LOCKED_OUT:
             case DELETING:
             case UNRECOGNIZED:
             default:

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/conversion/FmsUserConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/conversion/FmsUserConverterTest.java
@@ -101,6 +101,22 @@ class FmsUserConverterTest {
     }
 
     @Test
+    public void testUserToFmsUserControlPlaneLockedOutState() {
+        String workloadUsername = "foobar";
+        UserManagementProto.User umsUser = UserManagementProto.User.newBuilder()
+                .setWorkloadUsername(workloadUsername)
+                .setState(UserManagementProto.ActorState.Value.CONTROL_PLANE_LOCKED_OUT)
+                .build();
+
+        FmsUser fmsUser = underTest.toFmsUser(umsUser);
+
+        assertEquals(workloadUsername, fmsUser.getName());
+        assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
+        assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
+        assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
+    }
+
+    @Test
     public void testUserToFmsUserUnrecognizedState() {
         String workloadUsername = "foobar";
         UserManagementProto.User umsUser = UserManagementProto.User.newBuilder()


### PR DESCRIPTION
The CONTROL_PLANE_LOCKED_OUT state was added to the ActorState model in
usermanagement.proto. This state is indicates that the user has been
locked out (or disabled) from accessing the control plane but that the
user should still be enabled for workloads. This commit explicitly handles
this state when converting UMS actors into the FmsUser model.

See detailed description in the commit message.