### PR TITLE
CB-16155 Fixed NPE when having POST request to v1/distrox/blueprint e…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cli/TemplateToInstanceTemplateV4RequestConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cli/TemplateToInstanceTemplateV4RequestConverter.java
@@ -44,7 +44,7 @@ public class TemplateToInstanceTemplateV4RequestConverter {
 
     private VolumeV4Request getAttachedVolume(VolumeTemplate source) {
         VolumeV4Request ret = new VolumeV4Request();
-        ret.setCount(source.getVolumeCount());
+        ret.setCount(source.getVolumeCount() == null ? Integer.valueOf(0) : source.getVolumeCount());
         ret.setSize(source.getVolumeSize());
         ret.setType(source.getVolumeType());
         return ret;

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/VolumeConverter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/VolumeConverter.java
@@ -23,7 +23,7 @@ public class VolumeConverter {
     public VolumeV4Request convert(VolumeV1Request source) {
         VolumeV4Request response = new VolumeV4Request();
         response.setSize(source.getSize());
-        response.setCount(source.getCount());
+        response.setCount(source.getCount() == null ? Integer.valueOf(0) : source.getCount());
         response.setType(source.getType());
         return response;
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cli/TemplateToInstanceTemplateV4RequestConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cli/TemplateToInstanceTemplateV4RequestConverterTest.java
@@ -1,0 +1,69 @@
+package com.sequenceiq.cloudbreak.converter.v4.stacks.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.template.InstanceTemplateV4Request;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.common.mappable.ProviderParameterCalculator;
+import com.sequenceiq.cloudbreak.domain.VolumeTemplate;
+import com.sequenceiq.cloudbreak.domain.Template;
+
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class TemplateToInstanceTemplateV4RequestConverterTest {
+
+    @InjectMocks
+    private TemplateToInstanceTemplateV4RequestConverter underTest;
+
+    @Mock
+    private ProviderParameterCalculator providerParameterCalculator;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void testAttachedVolumesWithoutCount() {
+        InstanceTemplateV4Request request = createInstanceTemplateV4Request(false);
+        request.getAttachedVolumes().stream().findFirst().ifPresent(actual -> assertEquals(0, actual.getCount()));
+    }
+
+    @Test
+    public void testAttachedVolumesWithCount() {
+        InstanceTemplateV4Request request = createInstanceTemplateV4Request(true);
+        request.getAttachedVolumes().stream().findFirst().ifPresent(actual -> assertEquals(1, actual.getCount()));
+    }
+
+    private InstanceTemplateV4Request createInstanceTemplateV4Request(boolean haveCount) {
+        Template template = createTemplate(haveCount);
+        return underTest.convert(template);
+    }
+
+    private Template createTemplate(boolean haveCount) {
+        Template template = new Template();
+        template.setAttributes(new Json(Map.of("someAttr", "value")));
+        template.setSecretAttributes(new Json(Map.of("otherAttr", "value")).getValue());
+
+        VolumeTemplate volume = new VolumeTemplate();
+        volume.setVolumeSize(100);
+        volume.setVolumeType("HDD");
+        if (haveCount) {
+            volume.setVolumeCount(1);
+        }
+        Set<VolumeTemplate> volumes = new HashSet<>();
+        volumes.add(volume);
+        template.setVolumeTemplates(volumes);
+        return template;
+    }
+}

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/VolumeConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/VolumeConverterTest.java
@@ -1,0 +1,39 @@
+package com.sequenceiq.distrox.v1.distrox.converter;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+
+import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.volume.VolumeV1Request;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class VolumeConverterTest {
+
+    private VolumeConverter underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new VolumeConverter();
+    }
+
+    @Test
+    public void testV4toV1converterWithoutCount() {
+        VolumeV1Request source = createVolumeV1request();
+        assertEquals(0, underTest.convert(source).getCount());
+    }
+
+    @Test
+    public void testV4toV1converterWithCount() {
+        VolumeV1Request source = createVolumeV1request();
+        source.setCount(1);
+        assertEquals(1, underTest.convert(source).getCount());
+    }
+
+    private VolumeV1Request createVolumeV1request() {
+        VolumeV1Request source = new VolumeV1Request();
+        source.setSize(100);
+        source.setType("HDD");
+        return source;
+    }
+
+}


### PR DESCRIPTION
…ndpoint

Added null checks where the possible VolumeV4Request.count property can be set. I have replicated the error by calling the endpoint explicitly via CURL and eliminating the count.


See detailed description in the commit message.