### PR TITLE
CB-16814 Outbound load balancer being selected for DNS registration

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/san/LoadBalancerSANProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/san/LoadBalancerSANProvider.java
@@ -38,7 +38,7 @@ public class LoadBalancerSANProvider {
         if (isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERA_STACK_VERSION_7_2_11)) {
             Set<LoadBalancer> loadBalancers = loadBalancerPersistenceService.findByStackId(stack.getId());
             if (!loadBalancers.isEmpty()) {
-                Optional<LoadBalancer> loadBalancer = loadBalancerConfigService.selectLoadBalancer(loadBalancers, LoadBalancerType.PUBLIC);
+                Optional<LoadBalancer> loadBalancer = loadBalancerConfigService.selectLoadBalancerForFrontend(loadBalancers, LoadBalancerType.PUBLIC);
                 return loadBalancer.flatMap(this::getBestSANForLB);
             }
         }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigService.java
@@ -181,7 +181,7 @@ public class LoadBalancerConfigService {
         return lb.getIp();
     }
 
-    public Optional<LoadBalancer> selectLoadBalancer(Set<LoadBalancer> loadBalancers, LoadBalancerType preferredType) {
+    public Optional<LoadBalancer> selectLoadBalancerForFrontend(Set<LoadBalancer> loadBalancers, LoadBalancerType preferredType) {
         Preconditions.checkNotNull(preferredType);
         Optional<LoadBalancer> loadBalancerOptional = loadBalancers.stream()
             .filter(lb -> preferredType.equals(lb.getType()))
@@ -190,7 +190,7 @@ public class LoadBalancerConfigService {
             LOGGER.debug("Found load balancer of type {}", preferredType);
         } else {
             loadBalancerOptional = loadBalancers.stream()
-                .filter(lb -> lb.getType() != null && !preferredType.equals(lb.getType()))
+                .filter(lb -> lb.getType() != null && !LoadBalancerType.OUTBOUND.equals(lb.getType()))
                 .findFirst();
             loadBalancerOptional.ifPresent(loadBalancer ->
                     LOGGER.debug("Could not find load balancer of preferred type {}. Using type {}", preferredType, loadBalancer.getType()));

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/publicendpoint/FreeIPAEndpointManagementService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/publicendpoint/FreeIPAEndpointManagementService.java
@@ -130,7 +130,7 @@ public class FreeIPAEndpointManagementService extends BasePublicEndpointManageme
     private Optional<LoadBalancer> getLoadBalancer(Long stackId) {
         Set<LoadBalancer> loadBalancers = loadBalancerPersistenceService.findByStackId(stackId);
         if (!loadBalancers.isEmpty()) {
-            return loadBalancerConfigService.selectLoadBalancer(loadBalancers, LoadBalancerType.PRIVATE);
+            return loadBalancerConfigService.selectLoadBalancerForFrontend(loadBalancers, LoadBalancerType.PRIVATE);
         }
         return Optional.empty();
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/publicendpoint/GatewayPublicEndpointManagementService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/publicendpoint/GatewayPublicEndpointManagementService.java
@@ -311,7 +311,7 @@ public class GatewayPublicEndpointManagementService extends BasePublicEndpointMa
             LOGGER.info("No load balancers in stack {}", stack.getId());
             loadBalancerOptional = Optional.empty();
         } else {
-            loadBalancerOptional = loadBalancerConfigService.selectLoadBalancer(loadBalancers, LoadBalancerType.PUBLIC);
+            loadBalancerOptional = loadBalancerConfigService.selectLoadBalancerForFrontend(loadBalancers, LoadBalancerType.PUBLIC);
 
             if (loadBalancerOptional.isEmpty()) {
                 LOGGER.error("Unable to determine load balancer type. Load balancer public domain name will not be registered.");

--- a/core/src/test/java/com/sequenceiq/cloudbreak/san/LoadBalancerSANProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/san/LoadBalancerSANProviderTest.java
@@ -104,7 +104,7 @@ class LoadBalancerSANProviderTest {
         Set<LoadBalancer> loadBalancers = new HashSet<>();
         loadBalancers.add(loadBalancer);
         when(loadBalancerPersistenceService.findByStackId(ID)).thenReturn(loadBalancers);
-        when(loadBalancerConfigService.selectLoadBalancer(loadBalancers, LoadBalancerType.PUBLIC)).thenReturn(Optional.of(loadBalancer));
+        when(loadBalancerConfigService.selectLoadBalancerForFrontend(loadBalancers, LoadBalancerType.PUBLIC)).thenReturn(Optional.of(loadBalancer));
     }
 
     private String getBlueprintText(String path) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/publicendpoint/FreeIPAEndpointManagementServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/publicendpoint/FreeIPAEndpointManagementServiceTest.java
@@ -108,7 +108,7 @@ public class FreeIPAEndpointManagementServiceTest {
         loadBalancer.setDns(LB_DNS);
         loadBalancer.setEndpoint(LB_ENDPOINT);
         when(loadBalancerPersistenceService.findByStackId(any())).thenReturn(Set.of(loadBalancer));
-        when(loadBalancerConfigService.selectLoadBalancer(any(), any())).thenReturn(Optional.of(loadBalancer));
+        when(loadBalancerConfigService.selectLoadBalancerForFrontend(any(), any())).thenReturn(Optional.of(loadBalancer));
         when(regionAwareInternalCrnGenerator.getInternalCrnForServiceAsString()).thenReturn("crn:cdp:freeipa:us-west-1:altus:user:__internal__actor__");
         when(regionAwareInternalCrnGeneratorFactory.iam()).thenReturn(regionAwareInternalCrnGenerator);
         ThreadBasedUserCrnProvider.doAs(TEST_USER_CRN, () -> underTest.registerLoadBalancerDomainWithFreeIPA(stack));
@@ -126,7 +126,7 @@ public class FreeIPAEndpointManagementServiceTest {
         loadBalancer.setIp(LB_IP);
         loadBalancer.setEndpoint(LB_ENDPOINT);
         when(loadBalancerPersistenceService.findByStackId(any())).thenReturn(Set.of(loadBalancer));
-        when(loadBalancerConfigService.selectLoadBalancer(any(), any())).thenReturn(Optional.of(loadBalancer));
+        when(loadBalancerConfigService.selectLoadBalancerForFrontend(any(), any())).thenReturn(Optional.of(loadBalancer));
         when(regionAwareInternalCrnGenerator.getInternalCrnForServiceAsString()).thenReturn("crn:cdp:freeipa:us-west-1:altus:user:__internal__actor__");
         when(regionAwareInternalCrnGeneratorFactory.iam()).thenReturn(regionAwareInternalCrnGenerator);
         ThreadBasedUserCrnProvider.doAs(TEST_USER_CRN, () -> underTest.registerLoadBalancerDomainWithFreeIPA(stack));
@@ -144,7 +144,7 @@ public class FreeIPAEndpointManagementServiceTest {
         loadBalancer.setDns(LB_DNS);
         loadBalancer.setEndpoint(LB_ENDPOINT);
         when(loadBalancerPersistenceService.findByStackId(any())).thenReturn(Set.of(loadBalancer));
-        when(loadBalancerConfigService.selectLoadBalancer(any(), any())).thenReturn(Optional.of(loadBalancer));
+        when(loadBalancerConfigService.selectLoadBalancerForFrontend(any(), any())).thenReturn(Optional.of(loadBalancer));
         when(regionAwareInternalCrnGenerator.getInternalCrnForServiceAsString()).thenReturn("crn:cdp:freeipa:us-west-1:altus:user:__internal__actor__");
         when(regionAwareInternalCrnGeneratorFactory.iam()).thenReturn(regionAwareInternalCrnGenerator);
         ThreadBasedUserCrnProvider.doAs(TEST_USER_CRN, () -> underTest.deleteLoadBalancerDomainFromFreeIPA(stack));
@@ -159,7 +159,7 @@ public class FreeIPAEndpointManagementServiceTest {
         loadBalancer.setIp(LB_IP);
         loadBalancer.setEndpoint(LB_ENDPOINT);
         when(loadBalancerPersistenceService.findByStackId(any())).thenReturn(Set.of(loadBalancer));
-        when(loadBalancerConfigService.selectLoadBalancer(any(), any())).thenReturn(Optional.of(loadBalancer));
+        when(loadBalancerConfigService.selectLoadBalancerForFrontend(any(), any())).thenReturn(Optional.of(loadBalancer));
         when(regionAwareInternalCrnGenerator.getInternalCrnForServiceAsString()).thenReturn("crn:cdp:freeipa:us-west-1:altus:user:__internal__actor__");
         when(regionAwareInternalCrnGeneratorFactory.iam()).thenReturn(regionAwareInternalCrnGenerator);
         ThreadBasedUserCrnProvider.doAs(TEST_USER_CRN, () -> underTest.deleteLoadBalancerDomainFromFreeIPA(stack));

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/publicendpoint/GatewayPublicEndpointManagementServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/publicendpoint/GatewayPublicEndpointManagementServiceTest.java
@@ -620,7 +620,7 @@ class GatewayPublicEndpointManagementServiceTest {
         when(dnsManagementService.createOrUpdateDnsEntryWithCloudDns(eq("123"), eq(lbEndpointName), eq(envName), eq(cloudDns),
                 eq(hostedZoneId))).thenReturn(Boolean.TRUE);
         when(loadBalancerPersistenceService.findByStackId(anyLong())).thenReturn(Set.of(loadBalancer));
-        when(loadBalancerConfigService.selectLoadBalancer(any(), any())).thenReturn(Optional.of(loadBalancer));
+        when(loadBalancerConfigService.selectLoadBalancerForFrontend(any(), any())).thenReturn(Optional.of(loadBalancer));
 
         boolean result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.generateCertAndSaveForStackAndUpdateDnsEntry(stack));
 
@@ -677,7 +677,7 @@ class GatewayPublicEndpointManagementServiceTest {
         when(dnsManagementService.createOrUpdateDnsEntryWithIp(eq("123"), eq(lbEndpointName), eq(envName), eq(Boolean.FALSE),
                 eq(List.of(lbIp)))).thenReturn(Boolean.TRUE);
         when(loadBalancerPersistenceService.findByStackId(anyLong())).thenReturn(Set.of(loadBalancer));
-        when(loadBalancerConfigService.selectLoadBalancer(any(), any())).thenReturn(Optional.of(loadBalancer));
+        when(loadBalancerConfigService.selectLoadBalancerForFrontend(any(), any())).thenReturn(Optional.of(loadBalancer));
 
         boolean result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.generateCertAndSaveForStackAndUpdateDnsEntry(stack));
 
@@ -716,7 +716,7 @@ class GatewayPublicEndpointManagementServiceTest {
         when(dnsManagementService.deleteDnsEntryWithCloudDns(eq("123"), eq(lbEndpointName), eq(envName), eq(cloudDns),
                 eq(hostedZoneId))).thenReturn(Boolean.TRUE);
         when(loadBalancerPersistenceService.findByStackId(anyLong())).thenReturn(Set.of(loadBalancer));
-        when(loadBalancerConfigService.selectLoadBalancer(any(), any())).thenReturn(Optional.of(loadBalancer));
+        when(loadBalancerConfigService.selectLoadBalancerForFrontend(any(), any())).thenReturn(Optional.of(loadBalancer));
 
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.deleteLoadBalancerDnsEntry(stack, envName));
 
@@ -743,7 +743,7 @@ class GatewayPublicEndpointManagementServiceTest {
         when(dnsManagementService.deleteDnsEntryWithIp(eq("123"), eq(lbEndpointName), eq(envName), eq(Boolean.FALSE),
                 eq(List.of(ip)))).thenReturn(Boolean.TRUE);
         when(loadBalancerPersistenceService.findByStackId(anyLong())).thenReturn(Set.of(loadBalancer));
-        when(loadBalancerConfigService.selectLoadBalancer(any(), any())).thenReturn(Optional.of(loadBalancer));
+        when(loadBalancerConfigService.selectLoadBalancerForFrontend(any(), any())).thenReturn(Optional.of(loadBalancer));
 
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.deleteLoadBalancerDnsEntry(stack, envName));
 
@@ -789,7 +789,7 @@ class GatewayPublicEndpointManagementServiceTest {
                 .build();
 
         when(loadBalancerPersistenceService.findByStackId(anyLong())).thenReturn(Set.of(loadBalancer));
-        when(loadBalancerConfigService.selectLoadBalancer(any(), any())).thenReturn(Optional.of(loadBalancer));
+        when(loadBalancerConfigService.selectLoadBalancerForFrontend(any(), any())).thenReturn(Optional.of(loadBalancer));
         when(environmentClientService.getByCrn(anyString())).thenReturn(environment);
         when(dnsManagementService.createOrUpdateDnsEntryWithCloudDns(any(), any(), any(), any(), any())).thenReturn(Boolean.TRUE);
 


### PR DESCRIPTION
Adds a condition to the logic to select a load balancer for DNS registration to never select an
OUTBOUND load balancer. Also renames the method to clarify what the selection is for.

Tested with unit tests.

This is the CB-2.55.0 branch version of the PR originally posted at https://github.com/hortonworks/cloudbreak/pull/12613