### PR TITLE
ENGESC-14092 Increase CB hikari pool size to mitigate prod periodic o…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/conf/DatabaseConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/conf/DatabaseConfig.java
@@ -48,7 +48,7 @@ public class DatabaseConfig {
     @Value("${cb.db.env.db:}")
     private String dbName;
 
-    @Value("${cb.db.env.poolsize:30}")
+    @Value("${cb.db.env.poolsize:60}")
     private int poolSize;
 
     @Value("${cb.db.env.connectiontimeout:30}")


### PR DESCRIPTION
…utage

Until we don't have an RCA we would like to avoid further outage. Our main lead is the hikari pool exhaustion.
The current value is 30, we are doubling it for now ot 60.

See detailed description in the commit message.