### PR TITLE
CB-16701 Improved StackStatusCheckerJob performance

### DIFF
--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/client/AmazonEc2Client.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/client/AmazonEc2Client.java
@@ -31,6 +31,8 @@ import com.amazonaws.services.ec2.model.DescribeAvailabilityZonesRequest;
 import com.amazonaws.services.ec2.model.DescribeAvailabilityZonesResult;
 import com.amazonaws.services.ec2.model.DescribeImagesRequest;
 import com.amazonaws.services.ec2.model.DescribeImagesResult;
+import com.amazonaws.services.ec2.model.DescribeInstanceStatusRequest;
+import com.amazonaws.services.ec2.model.DescribeInstanceStatusResult;
 import com.amazonaws.services.ec2.model.DescribeInstanceTypeOfferingsRequest;
 import com.amazonaws.services.ec2.model.DescribeInstanceTypeOfferingsResult;
 import com.amazonaws.services.ec2.model.DescribeInstanceTypesRequest;
@@ -63,10 +65,10 @@ import com.amazonaws.services.ec2.model.ImportKeyPairRequest;
 import com.amazonaws.services.ec2.model.ImportKeyPairResult;
 import com.amazonaws.services.ec2.model.ModifyInstanceAttributeRequest;
 import com.amazonaws.services.ec2.model.ModifyInstanceAttributeResult;
-import com.amazonaws.services.ec2.model.ReleaseAddressRequest;
-import com.amazonaws.services.ec2.model.ReleaseAddressResult;
 import com.amazonaws.services.ec2.model.ModifyLaunchTemplateRequest;
 import com.amazonaws.services.ec2.model.ModifyLaunchTemplateResult;
+import com.amazonaws.services.ec2.model.ReleaseAddressRequest;
+import com.amazonaws.services.ec2.model.ReleaseAddressResult;
 import com.amazonaws.services.ec2.model.RunInstancesRequest;
 import com.amazonaws.services.ec2.model.RunInstancesResult;
 import com.amazonaws.services.ec2.model.StartInstancesRequest;
@@ -171,7 +173,11 @@ public class AmazonEc2Client extends AmazonClient {
     }
 
     public DescribeInstancesResult describeInstances(DescribeInstancesRequest describeInstancesRequest) {
-        return client.describeInstances(describeInstancesRequest);
+        return client.describeInstances(describeInstancesRequest.withFilters());
+    }
+
+    public DescribeInstanceStatusResult describeInstanceStatuses(DescribeInstanceStatusRequest describeInstanceStatusRequest) {
+        return client.describeInstanceStatus(describeInstanceStatusRequest);
     }
 
     public CreateTagsResult createTags(CreateTagsRequest createTagsRequest) {

--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/util/AwsInstanceStatusMapper.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/util/AwsInstanceStatusMapper.java
@@ -6,6 +6,12 @@ import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
 
 public class AwsInstanceStatusMapper {
 
+    public static final String RUNNING = "running";
+
+    public static final String STOPPED = "stopped";
+
+    public static final String TERMINATED = "terminated";
+
     private AwsInstanceStatusMapper() {
     }
 
@@ -15,16 +21,20 @@ public class AwsInstanceStatusMapper {
 
     public static InstanceStatus getInstanceStatusByAwsStateAndReason(InstanceState state, StateReason stateReason) {
         switch (state.getName().toLowerCase()) {
-            case "stopped":
+            case STOPPED:
                 return InstanceStatus.STOPPED;
-            case "running":
+            case RUNNING:
                 return InstanceStatus.STARTED;
-            case "terminated":
+            case TERMINATED:
                 return stateReason != null && "Server.SpotInstanceTermination".equals(stateReason.getCode())
                         ? InstanceStatus.TERMINATED_BY_PROVIDER
                         : InstanceStatus.TERMINATED;
             default:
                 return InstanceStatus.IN_PROGRESS;
         }
+    }
+
+    public static boolean isTerminated(InstanceState instanceState) {
+        return TERMINATED.equalsIgnoreCase(instanceState.getName());
     }
 }

--- a/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/AwsInstanceConnectorRetryingTest.java
+++ b/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/AwsInstanceConnectorRetryingTest.java
@@ -1,0 +1,417 @@
+package com.sequenceiq.cloudbreak.cloud.aws.common;
+
+import static com.sequenceiq.cloudbreak.cloud.aws.common.AwsInstanceConnector.INSTANCE_NOT_FOUND_ERROR_CODE;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.InstanceProfileCredentialsProvider;
+import com.amazonaws.services.ec2.model.AmazonEC2Exception;
+import com.amazonaws.services.ec2.model.DescribeInstanceStatusRequest;
+import com.amazonaws.services.ec2.model.DescribeInstanceStatusResult;
+import com.amazonaws.services.ec2.model.InstanceState;
+import com.amazonaws.services.ec2.model.StartInstancesRequest;
+import com.amazonaws.services.ec2.model.StartInstancesResult;
+import com.amazonaws.services.ec2.model.StopInstancesRequest;
+import com.amazonaws.services.ec2.model.StopInstancesResult;
+import com.dyngr.exception.PollerStoppedException;
+import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonEc2Client;
+import com.sequenceiq.cloudbreak.cloud.aws.common.mapper.SdkClientExceptionMapper;
+import com.sequenceiq.cloudbreak.cloud.aws.common.poller.PollerUtil;
+import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsCredentialView;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
+import com.sequenceiq.cloudbreak.cloud.model.CloudVmInstanceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.Location;
+import com.sequenceiq.cloudbreak.cloud.model.Region;
+import com.sequenceiq.cloudbreak.service.RetryService;
+
+import io.opentracing.Tracer;
+
+@ExtendWith(SpringExtension.class)
+@TestPropertySource(properties = {
+        "cb.aws.hostkey.verify=true",
+        "cb.vm.status.polling.interval=1",
+        "cb.vm.status.polling.attempt=7",
+        "cb.vm.retry.backoff.delay=20",
+        "cb.vm.retry.backoff.multiplier=2",
+        "cb.vm.retry.backoff.maxdelay=10000",
+        "cb.vm.retry.attempt=5"
+})
+public class AwsInstanceConnectorRetryingTest {
+
+    private static final int POLLING_LIMIT = 7;
+
+    @Inject
+    private AwsInstanceConnector underTest;
+
+    @Inject
+    private AwsAuthenticator awsAuthenticator;
+
+    @MockBean
+    private AwsEnvironmentVariableChecker awsEnvironmentVariableChecker;
+
+    @Mock
+    private AmazonEc2Client amazonEC2Client;
+
+    @Mock
+    private InstanceProfileCredentialsProvider instanceProfileCredentialsProvider;
+
+    @MockBean
+    private Tracer tracer;
+
+    @SpyBean
+    private CommonAwsClient commonAwsClient;
+
+    @MockBean
+    private SdkClientExceptionMapper sdkClientExceptionMapper;
+
+    private AuthenticatedContext authenticatedContext;
+
+    private List<CloudInstance> inputList;
+
+    @BeforeEach
+    public void awsClientSetup() {
+        doReturn(amazonEC2Client).when(commonAwsClient).createEc2Client(any(AwsCredentialView.class));
+        doReturn(amazonEC2Client).when(commonAwsClient).createEc2Client(any(AwsCredentialView.class), anyString());
+
+        CloudContext context = CloudContext.Builder.builder()
+                .withId(1L)
+                .withName("context")
+                .withCrn("crn")
+                .withPlatform("AWS")
+                .withVariant("AWS")
+                .withLocation(Location.location(Region.region("region")))
+                .withAccountId("account")
+                .build();
+        CloudCredential credential = new CloudCredential("id", "alma",
+                Map.of("accessKey", "ac", "secretKey", "secret"), "acc", false);
+        authenticatedContext = awsAuthenticator.authenticate(context, credential);
+
+        StopInstancesResult stopInstancesResult = new StopInstancesResult();
+        StartInstancesResult startInstanceResult = new StartInstancesResult();
+        when(amazonEC2Client.stopInstances(any(StopInstancesRequest.class))).thenReturn(stopInstancesResult);
+        when(amazonEC2Client.startInstances(any(StartInstancesRequest.class))).thenReturn(startInstanceResult);
+
+        inputList = getCloudInstances();
+    }
+
+    @Test
+    public void testCheckException() {
+        mockDescribeInstanceStatusesException("silence of the lambs", "would you ...");
+        List<CloudInstance> list = getCloudInstances();
+        Assertions.assertThrows(AmazonEC2Exception.class, () -> underTest.check(authenticatedContext, list));
+        MatcherAssert.assertThat(list, hasSize(2));
+    }
+
+    @Test
+    public void testCheckRemovesUnknownInstancesBasedOnErrorMessage() {
+        mockDescribeInstanceStatusesException(INSTANCE_NOT_FOUND_ERROR_CODE, "i-1 is a sheep!");
+        List<CloudInstance> mutableList = new ArrayList<>(getCloudInstances());
+        Assertions.assertThrows(AmazonEC2Exception.class, () -> underTest.check(authenticatedContext, mutableList));
+        MatcherAssert.assertThat(mutableList, hasSize(1));
+    }
+
+    @Test
+    public void testCheckSdkExceptionRetry() {
+        when(amazonEC2Client.describeInstanceStatuses(any(DescribeInstanceStatusRequest.class)))
+                .thenThrow(new SdkClientException("lamb"),
+                        new SdkClientException("sheep"),
+                        new SdkClientException("shepherd"))
+                .thenReturn(getDescribeInstanceStatusesResult("running", 16));
+        List<CloudInstance> list = getCloudInstances();
+        List<CloudVmInstanceStatus> result = underTest.check(authenticatedContext, list);
+        verify(amazonEC2Client, times(4)).describeInstanceStatuses(any(DescribeInstanceStatusRequest.class));
+        MatcherAssert.assertThat(result, hasSize(2));
+    }
+
+    @Test
+    public void testStartPollingWithSuccess() {
+        String status = "Running";
+        int lastStatusCode = 16;
+        //given
+        mockDescribeInstances(POLLING_LIMIT - 2, status, lastStatusCode);
+        ArgumentCaptor<StartInstancesRequest> captorStart = ArgumentCaptor.forClass(StartInstancesRequest.class);
+
+        //then
+        List<CloudVmInstanceStatus> result = underTest.start(authenticatedContext, List.of(), inputList);
+
+        //then
+        verify(amazonEC2Client, times(1)).startInstances(captorStart.capture());
+        Assertions.assertEquals(captorStart.getValue().getInstanceIds().size(), inputList.size());
+        MatcherAssert.assertThat(result, hasItem(allOf(hasProperty("status", is(InstanceStatus.STARTED)))));
+    }
+
+    @Test
+    public void testStopPollingWithSuccess() {
+        String status = "Stopped";
+        int lastStatusCode = 16;
+        //given
+        mockDescribeInstances(POLLING_LIMIT - 2, status, lastStatusCode);
+        ArgumentCaptor<StopInstancesRequest> captorStop = ArgumentCaptor.forClass(StopInstancesRequest.class);
+
+        //then
+        List<CloudVmInstanceStatus> result = underTest.stop(authenticatedContext, List.of(), inputList);
+
+        //then
+        verify(amazonEC2Client, times(1)).stopInstances(captorStop.capture());
+        Assertions.assertEquals(captorStop.getValue().getInstanceIds().size(), inputList.size());
+        MatcherAssert.assertThat(result, hasItem(allOf(hasProperty("status", is(InstanceStatus.STOPPED)))));
+    }
+
+    @Test
+    public void testStartSomeInstancesStarted() {
+        mockDescribeInstancesOneIsRunningLastSuccess(POLLING_LIMIT - 2);
+        ArgumentCaptor<StartInstancesRequest> captor = ArgumentCaptor.forClass(StartInstancesRequest.class);
+
+        List<CloudVmInstanceStatus> result = underTest.start(authenticatedContext, List.of(), inputList);
+        verify(amazonEC2Client, times(1)).startInstances(captor.capture());
+        Assertions.assertTrue(captor.getValue().getInstanceIds().size() < inputList.size());
+        MatcherAssert.assertThat(result, hasItem(allOf(hasProperty("status", is(InstanceStatus.STARTED)))));
+    }
+
+    @Test
+    public void testStopSomeInstancesStopped() {
+        mockDescribeInstancesOneIsStoppedLastSuccess(POLLING_LIMIT - 2);
+        ArgumentCaptor<StopInstancesRequest> captor = ArgumentCaptor.forClass(StopInstancesRequest.class);
+
+        List<CloudVmInstanceStatus> result = underTest.stop(authenticatedContext, List.of(), inputList);
+        verify(amazonEC2Client, times(1)).stopInstances(captor.capture());
+        Assertions.assertTrue(captor.getValue().getInstanceIds().size() < inputList.size());
+        MatcherAssert.assertThat(result, hasItem(allOf(hasProperty("status", is(InstanceStatus.STOPPED)))));
+    }
+
+    @Test
+    public void testRebootEveryInstancesStarted() {
+        mockDescribeInstancesAllisRebooted(POLLING_LIMIT - 2);
+        ArgumentCaptor<StopInstancesRequest> stopCaptor = ArgumentCaptor.forClass(StopInstancesRequest.class);
+        ArgumentCaptor<StartInstancesRequest> startCaptor = ArgumentCaptor.forClass(StartInstancesRequest.class);
+        List<CloudVmInstanceStatus> result = underTest.reboot(authenticatedContext, new ArrayList<>(), inputList);
+
+        verify(amazonEC2Client, times(2)).stopInstances(stopCaptor.capture());
+        verify(amazonEC2Client, times(2)).startInstances(startCaptor.capture());
+        MatcherAssert.assertThat(result, hasItem(allOf(hasProperty("status", is(InstanceStatus.STARTED)))));
+    }
+
+    @Test
+    public void testStartEveryInstancesStartedAlready() {
+        mockDescribeInstancesAllIsRunning(POLLING_LIMIT - 2);
+        List<CloudVmInstanceStatus> result = underTest.start(authenticatedContext, List.of(), inputList);
+        verify(amazonEC2Client, never()).startInstances(any(StartInstancesRequest.class));
+        MatcherAssert.assertThat(result, hasItem(allOf(hasProperty("status", is(InstanceStatus.STARTED)))));
+    }
+
+    @Test
+    public void testStartPollingWithFail() {
+        mockDescribeInstances(POLLING_LIMIT + 2, "Running", 16);
+        ArgumentCaptor<StartInstancesRequest> captor = ArgumentCaptor.forClass(StartInstancesRequest.class);
+
+        Assertions.assertThrows(PollerStoppedException.class, () -> underTest.start(authenticatedContext, List.of(), inputList));
+        verify(amazonEC2Client, times(1)).startInstances(captor.capture());
+        Assertions.assertEquals(captor.getValue().getInstanceIds().size(), inputList.size());
+    }
+
+    @Test
+    public void testStopPollingWithFail() {
+        mockDescribeInstances(POLLING_LIMIT + 2, "Stopped", 41);
+        ArgumentCaptor<StopInstancesRequest> captor = ArgumentCaptor.forClass(StopInstancesRequest.class);
+
+        Assertions.assertThrows(PollerStoppedException.class, () -> underTest.stop(authenticatedContext, List.of(), inputList));
+        verify(amazonEC2Client, times(1)).stopInstances(captor.capture());
+        Assertions.assertEquals(captor.getValue().getInstanceIds().size(), inputList.size());
+    }
+
+    @Test
+    public void testStartException() {
+        mockDescribeInstanceStatusesException("silence of the lambs", "would you ...");
+        Assertions.assertThrows(AmazonEC2Exception.class, () -> underTest.start(authenticatedContext, List.of(), inputList));
+        MatcherAssert.assertThat(inputList, hasSize(2));
+    }
+
+    @Test
+    public void testStopException() {
+        mockDescribeInstanceStatusesException("silence of the lambs", "would you ...");
+        Assertions.assertThrows(AmazonEC2Exception.class, () -> underTest.stop(authenticatedContext, List.of(), inputList));
+        MatcherAssert.assertThat(inputList, hasSize(2));
+    }
+
+    @Test
+    public void testStartExceptionHandle() {
+        mockDescribeInstanceStatusesException(INSTANCE_NOT_FOUND_ERROR_CODE, "i-1 is a sheep!");
+        List<CloudInstance> mutableList = new ArrayList<>(getCloudInstances());
+        Assertions.assertThrows(AmazonEC2Exception.class, () -> underTest.start(authenticatedContext, List.of(), mutableList));
+        MatcherAssert.assertThat(mutableList, hasSize(1));
+    }
+
+    @Test
+    public void testStopExceptionHandle() {
+        mockDescribeInstanceStatusesException(INSTANCE_NOT_FOUND_ERROR_CODE, "i-1 is a sheep!");
+        List<CloudInstance> mutableList = new ArrayList<>(getCloudInstances());
+        Assertions.assertThrows(AmazonEC2Exception.class, () -> underTest.stop(authenticatedContext, List.of(), mutableList));
+        MatcherAssert.assertThat(mutableList, hasSize(1));
+    }
+
+    @Test
+    public void testStartSdkExceptionRetry() {
+        when(amazonEC2Client.describeInstanceStatuses(any(DescribeInstanceStatusRequest.class)))
+                .thenThrow(
+                        new SdkClientException("lamb"),
+                        new SdkClientException("sheep"),
+                        new SdkClientException("shepherd"))
+                .thenReturn(getDescribeInstanceStatusesResult("running", 16));
+        List<CloudVmInstanceStatus> result = underTest.start(authenticatedContext, List.of(), inputList);
+        verify(amazonEC2Client, times(5)).describeInstanceStatuses(any(DescribeInstanceStatusRequest.class));
+        MatcherAssert.assertThat(result, hasSize(2));
+    }
+
+    @Test
+    public void testStopSdkExceptionRetry() {
+        when(amazonEC2Client.describeInstanceStatuses(any(DescribeInstanceStatusRequest.class)))
+                .thenThrow(new SdkClientException("lamb"),
+                        new SdkClientException("sheep"),
+                        new SdkClientException("shepherd"))
+                .thenReturn(getDescribeInstanceStatusesResult("stopped", 55));
+        List<CloudVmInstanceStatus> result = underTest.stop(authenticatedContext, List.of(), inputList);
+        verify(amazonEC2Client, times(5)).describeInstanceStatuses(any(DescribeInstanceStatusRequest.class));
+        MatcherAssert.assertThat(result, hasSize(2));
+    }
+
+    private void mockDescribeInstances(int pollResponses, String lastStatus, int lastStatusCode) {
+        mockListOfDescribeInstances(getDescribeInstanceStatusesResult("notrunning", 16), pollResponses,
+                getDescribeInstanceStatusesResult(lastStatus, lastStatusCode));
+    }
+
+    private void mockDescribeInstancesOneIsRunningLastSuccess(int pollResponses) {
+        mockListOfDescribeInstances(getDescribeInstancesResultOneRunning("notrunning", 16), pollResponses,
+                getDescribeInstanceStatusesResult("running", 16));
+    }
+
+    private void mockDescribeInstancesOneIsStoppedLastSuccess(int pollResponses) {
+        mockListOfDescribeInstances(getDescribeInstancesResultOneStopped("notrunning", 16), pollResponses,
+                getDescribeInstanceStatusesResult("stopped", 16));
+    }
+
+    private void mockDescribeInstancesAllIsRunning(int pollResponses) {
+        mockListOfDescribeInstances(getDescribeInstanceStatusesResult("running", 16), pollResponses,
+                getDescribeInstanceStatusesResult("running", 16));
+    }
+
+    private void mockDescribeInstancesAllisRebooted(int pollResponses) {
+        mockListOfDescribeInstancesStopAndThenRunning(getDescribeInstancesResultOneRunning("running", 16), pollResponses,
+                getDescribeInstanceStatusesResult("stopped", 16));
+    }
+
+    private void mockListOfDescribeInstancesStopAndThenRunning(DescribeInstanceStatusResult cons, int repeatNo, DescribeInstanceStatusResult stopped) {
+        DescribeInstanceStatusResult[] describeInstancesResults = new DescribeInstanceStatusResult[repeatNo * 2];
+        Arrays.fill(describeInstancesResults, cons);
+        describeInstancesResults[2] = stopped;
+        describeInstancesResults[4] = stopped;
+        describeInstancesResults[5] = stopped;
+        describeInstancesResults[6] = stopped;
+        describeInstancesResults[8] = stopped;
+        when(amazonEC2Client.describeInstanceStatuses(any(DescribeInstanceStatusRequest.class))).thenReturn(cons,
+                describeInstancesResults);
+    }
+
+    private void mockListOfDescribeInstances(DescribeInstanceStatusResult cons, int repeatNo, DescribeInstanceStatusResult last) {
+        DescribeInstanceStatusResult[] describeInstancesResults = new DescribeInstanceStatusResult[repeatNo];
+        Arrays.fill(describeInstancesResults, cons);
+        describeInstancesResults[repeatNo - 1] = last;
+        when(amazonEC2Client.describeInstanceStatuses(any(DescribeInstanceStatusRequest.class))).thenReturn(cons,
+                describeInstancesResults);
+    }
+
+    private void mockDescribeInstanceStatusesException(String errorCode, String errorMessage) {
+        when(amazonEC2Client.describeInstanceStatuses(any(DescribeInstanceStatusRequest.class))).then(invocation -> {
+            AmazonEC2Exception exception = new AmazonEC2Exception("Sheep lost control");
+            exception.setErrorCode(errorCode);
+            exception.setErrorMessage(errorMessage);
+            throw exception;
+        });
+    }
+
+    private DescribeInstanceStatusResult getDescribeInstanceStatusesResult(String state, int code) {
+        return new DescribeInstanceStatusResult().withInstanceStatuses(
+                new com.amazonaws.services.ec2.model.InstanceStatus()
+                        .withInstanceId("i-1")
+                        .withInstanceState(new InstanceState().withName(state).withCode(code)),
+                new com.amazonaws.services.ec2.model.InstanceStatus()
+                        .withInstanceId("i-2")
+                        .withInstanceState(new InstanceState().withName(state).withCode(code)));
+    }
+
+    private DescribeInstanceStatusResult getDescribeInstancesResultOneRunning(String state, int code) {
+        return new DescribeInstanceStatusResult().withInstanceStatuses(
+                new com.amazonaws.services.ec2.model.InstanceStatus()
+                        .withInstanceId("i-1")
+                        .withInstanceState(new InstanceState().withName(state).withCode(code)),
+                new com.amazonaws.services.ec2.model.InstanceStatus()
+                        .withInstanceId("i-2")
+                        .withInstanceState(new InstanceState().withName("running").withCode(16)));
+    }
+
+    private DescribeInstanceStatusResult getDescribeInstancesResultOneStopped(String state, int code) {
+        return new DescribeInstanceStatusResult().withInstanceStatuses(
+                new com.amazonaws.services.ec2.model.InstanceStatus()
+                        .withInstanceId("i-1")
+                        .withInstanceState(new InstanceState().withName(state).withCode(code)),
+                new com.amazonaws.services.ec2.model.InstanceStatus()
+                        .withInstanceId("i-2")
+                        .withInstanceState(new InstanceState().withName("stopped").withCode(16)));
+    }
+
+    private List<CloudInstance> getCloudInstances() {
+        CloudInstance instance1 = new CloudInstance("i-1", null, null, "subnet-123", "az1");
+        CloudInstance instance2 = new CloudInstance("i-2", null, null, "subnet-123", "az1");
+        return List.of(instance1, instance2);
+    }
+
+    @Configuration
+    @EnableRetry(proxyTargetClass = true)
+    @Import({AwsInstanceConnector.class,
+            AwsAuthenticator.class,
+            CommonAwsClient.class,
+            PollerUtil.class,
+            AwsSessionCredentialClient.class,
+            AwsDefaultZoneProvider.class,
+            AwsEnvironmentVariableChecker.class,
+            RetryService.class
+    })
+    static class Config {
+    }
+}

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
@@ -9,19 +9,17 @@ import java.util.Set;
 import com.sequenceiq.cloudbreak.cluster.model.ParcelOperationStatus;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterClientInitException;
 import com.sequenceiq.cloudbreak.cluster.status.ClusterStatus;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterComponent;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.polling.ExtendedPollingResult;
 import com.sequenceiq.cloudbreak.service.CloudbreakException;
-import com.sequenceiq.common.api.telemetry.model.Telemetry;
 
 public interface ClusterApi {
 
     String CLOUDERA_MANAGER = "CLOUDERA_MANAGER";
 
-    default void waitForServer(Stack stack, boolean defaultClusterManagerAuth) throws CloudbreakException, ClusterClientInitException {
+    default void waitForServer(boolean defaultClusterManagerAuth) throws CloudbreakException, ClusterClientInitException {
         clusterSetupService().waitForServer(defaultClusterManagerAuth);
     }
 
@@ -35,22 +33,6 @@ public interface ClusterApi {
 
     default void waitForServices(int requestId) throws CloudbreakException {
         clusterSetupService().waitForServices(requestId);
-    }
-
-    default void replaceUserNamePassword(String newUserName, String newPassword) throws CloudbreakException {
-        clusterSecurityService().replaceUserNamePassword(newUserName, newPassword);
-    }
-
-    default void updateUserNamePassword(String newPassword) throws CloudbreakException {
-        clusterSecurityService().updateUserNamePassword(newPassword);
-    }
-
-    default void prepareSecurity() {
-        clusterSecurityService().prepareSecurity();
-    }
-
-    default void disableSecurity() {
-        clusterSecurityService().disableSecurity();
     }
 
     default void changeOriginalCredentialsAndCreateCloudbreakUser(boolean ldapConfigured) throws CloudbreakException {
@@ -116,10 +98,6 @@ public interface ClusterApi {
 
     default void startComponents(Map<String, String> components, String hostname) throws CloudbreakException {
         clusterModificationService().startComponents(components, hostname);
-    }
-
-    default void cleanupCluster(Telemetry telemetry) throws CloudbreakException {
-        clusterModificationService().cleanupCluster(telemetry);
     }
 
     default void restartAll(boolean withMgmtServices) throws CloudbreakException {

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterStatusService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterStatusService.java
@@ -26,8 +26,6 @@ public interface ClusterStatusService {
 
     boolean isClusterManagerRunning();
 
-    boolean isClusterManagerRunningQuickCheck();
-
     Optional<String> getClusterManagerVersion();
 
     List<String> getActiveCommandsList();

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerConnector.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerConnector.java
@@ -28,9 +28,12 @@ public class ClouderaManagerConnector implements ClusterApi {
 
     private final HttpClientConfig clientConfig;
 
-    public ClouderaManagerConnector(Stack stack, HttpClientConfig clientConfig) {
+    private final boolean useShortTimeouts;
+
+    public ClouderaManagerConnector(Stack stack, HttpClientConfig clientConfig, boolean useShortTimeouts) {
         this.stack = stack;
         this.clientConfig = clientConfig;
+        this.useShortTimeouts = useShortTimeouts;
     }
 
     @Override
@@ -50,7 +53,7 @@ public class ClouderaManagerConnector implements ClusterApi {
 
     @Override
     public ClusterStatusService clusterStatusService() {
-        return applicationContext.getBean(ClouderaManagerClusterStatusService.class, stack, clientConfig);
+        return applicationContext.getBean(ClouderaManagerClusterStatusService.class, stack, clientConfig, useShortTimeouts);
     }
 
     @Override

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusServiceTest.java
@@ -97,7 +97,7 @@ public class ClouderaManagerClusterStatusServiceTest {
         stack.setName(CLUSTER_NAME);
         stack.setCluster(cluster);
 
-        subject = new ClouderaManagerClusterStatusService(stack, clientConfig);
+        subject = new ClouderaManagerClusterStatusService(stack, clientConfig, false);
 
         MockitoAnnotations.initMocks(this);
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/conclusion/step/VmStatusCheckerConclusionStep.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/conclusion/step/VmStatusCheckerConclusionStep.java
@@ -56,7 +56,7 @@ public class VmStatusCheckerConclusionStep extends ConclusionStep {
     @Override
     public Conclusion check(Long resourceId) {
         Stack stack = stackService.getById(resourceId);
-        ClusterApi connector = clusterApiConnectors.getConnector(stack);
+        ClusterApi connector = clusterApiConnectors.getConnectorWithShortTimeouts(stack);
         Set<InstanceMetaData> runningInstances = instanceMetaDataService.findNotTerminatedAndNotZombieForStack(stack.getId());
         if (isClusterManagerRunning(stack, connector)) {
             return checkCMForInstanceStatuses(connector, runningInstances, stack.getCluster().getId());
@@ -119,6 +119,6 @@ public class VmStatusCheckerConclusionStep extends ConclusionStep {
     }
 
     private boolean isCMRunning(ClusterApi connector) {
-        return connector.clusterStatusService().isClusterManagerRunningQuickCheck();
+        return connector.clusterStatusService().isClusterManagerRunning();
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterBuilderService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterBuilderService.java
@@ -99,7 +99,7 @@ public class ClusterBuilderService {
     public void startCluster(Long stackId) throws CloudbreakException, ClusterClientInitException {
         Stack stack = stackService.getByIdWithTransaction(stackId);
         ClusterApi connector = clusterApiConnectors.getConnector(stack);
-        connector.waitForServer(stack, true);
+        connector.waitForServer(true);
         boolean ldapConfigured = ldapConfigService.isLdapConfigExistsForEnvironment(stack.getEnvironmentCrn(), stack.getName());
         connector.changeOriginalCredentialsAndCreateCloudbreakUser(ldapConfigured);
     }
@@ -110,7 +110,7 @@ public class ClusterBuilderService {
         clusterService.updateCreationDateOnCluster(stack.getCluster());
         clusterApiConnectors
                 .getConnector(stack)
-                .waitForServer(stack, true);
+                .waitForServer(true);
     }
 
     public void validateLicence(Long stackId) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJob.java
@@ -230,7 +230,7 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
     }
 
     private void doSync(Stack stack) {
-        ClusterApi connector = clusterApiConnectors.getConnector(stack);
+        ClusterApi connector = clusterApiConnectors.getConnectorWithShortTimeouts(stack);
         Set<InstanceMetaData> runningInstances = instanceMetaDataService.findNotTerminatedAndNotZombieForStack(stack.getId());
         try {
             if (isClusterManagerRunning(stack, connector)) {
@@ -239,8 +239,10 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
                 Map<HostName, Set<HealthCheck>> hostStatuses = extendedHostStatuses.getHostsHealth();
                 LOGGER.debug("Cluster '{}' state check, host certicates expiring: [{}], cm running, hoststates: {}",
                         stack.getId(), extendedHostStatuses.isAnyCertExpiring(), hostStatuses);
-                reportHealthAndSyncInstances(stack, runningInstances, getFailedInstancesInstanceMetadata(extendedHostStatuses, runningInstances),
-                        getNewHealthyHostNames(extendedHostStatuses, runningInstances), extendedHostStatuses.isAnyCertExpiring());
+                reportHealthAndSyncInstances(stack, runningInstances,
+                        getFailedInstancesInstanceMetadata(extendedHostStatuses, runningInstances),
+                        getNewHealthyHostNames(extendedHostStatuses, runningInstances),
+                        extendedHostStatuses.isAnyCertExpiring());
             } else {
                 syncInstances(stack, runningInstances, false);
             }
@@ -329,7 +331,7 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
     }
 
     private boolean isCMRunning(ClusterApi connector) {
-        return connector.clusterStatusService().isClusterManagerRunningQuickCheck();
+        return connector.clusterStatusService().isClusterManagerRunning();
     }
 
     private Set<String> getNewHealthyHostNames(ExtendedHostStatuses hostStatuses, Set<InstanceMetaData> runningInstances) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/RestartCmForLbHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/RestartCmForLbHandler.java
@@ -66,7 +66,7 @@ public class RestartCmForLbHandler extends ExceptionCatcherEventHandler<RestartC
         try {
             LOGGER.debug("Restarting CM server to pick up latest config changes");
             restartCMServer(stack);
-            clusterApiConnectors.getConnector(stack).waitForServer(stack, false);
+            clusterApiConnectors.getConnector(stack).waitForServer(false);
             LOGGER.debug("CM server restart was successful");
             return new RestartCmForLbSuccess(request.getResourceId());
         } catch (Exception e) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/RestartClusterManagerServerHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/RestartClusterManagerServerHandler.java
@@ -70,7 +70,7 @@ public class RestartClusterManagerServerHandler  extends ExceptionCatcherEventHa
         try {
             Stack stack = stackService.getByIdWithListsInTransaction(stackId);
             restartCMServer(stack);
-            clusterApiConnectors.getConnector(stack).waitForServer(stack, request.isDefaultClusterManagerAuth());
+            clusterApiConnectors.getConnector(stack).waitForServer(request.isDefaultClusterManagerAuth());
             response = new RestartClusterManagerServerSuccess(stackId);
         } catch (Exception e) {
             LOGGER.info("Cluster Manager restart failed", e);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/WaitingClusterServerHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/WaitingClusterServerHandler.java
@@ -39,7 +39,7 @@ public class WaitingClusterServerHandler implements EventHandler<WaitForClusterS
         Selectable response;
         try {
             Stack stack = stackService.getByIdWithTransaction(stackId);
-            clusterApiConnectors.getConnector(stack).waitForServer(stack, true);
+            clusterApiConnectors.getConnector(stack).waitForServer(true);
             response = new WaitForAmbariServerSuccess(stackId);
         } catch (Exception e) {
             response = new WaitForAmbariServerFailed(stackId, e);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterApiConnectors.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterApiConnectors.java
@@ -25,7 +25,13 @@ public class ClusterApiConnectors {
     public ClusterApi getConnector(Stack stack) {
         HttpClientConfig httpClientConfig = tlsSecurityService.buildTLSClientConfigForPrimaryGateway(stack.getId(),
                 stack.getClusterManagerIp(), stack.cloudPlatform());
-        return (ClusterApi) applicationContext.getBean(stack.getCluster().getVariant(), stack, httpClientConfig);
+        return (ClusterApi) applicationContext.getBean(stack.getCluster().getVariant(), stack, httpClientConfig, false);
+    }
+
+    public ClusterApi getConnectorWithShortTimeouts(Stack stack) {
+        HttpClientConfig httpClientConfig = tlsSecurityService.buildTLSClientConfigForPrimaryGateway(stack.getId(),
+                stack.getClusterManagerIp(), stack.cloudPlatform());
+        return (ClusterApi) applicationContext.getBean(stack.getCluster().getVariant(), stack, httpClientConfig, true);
     }
 
     public ClusterPreCreationApi getConnector(Cluster cluster) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/conclusion/step/VmStatusCheckerConclusionStepTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/conclusion/step/VmStatusCheckerConclusionStepTest.java
@@ -81,14 +81,14 @@ class VmStatusCheckerConclusionStepTest {
         cluster.setId(2L);
         stack.setCluster(cluster);
         when(stackService.getById(anyLong())).thenReturn(stack);
-        when(clusterApiConnectors.getConnector(any(Stack.class))).thenReturn(connector);
+        when(clusterApiConnectors.getConnectorWithShortTimeouts(any(Stack.class))).thenReturn(connector);
         when(connector.clusterStatusService()).thenReturn(clusterStatusService);
         lenient().when(runtimeVersionService.getRuntimeVersion(anyLong())).thenReturn(Optional.of("7.2.11"));
     }
 
     @Test
     public void checkShouldBeSuccessfulIfCMIsRunningAndAllInstanceIsHealthy() {
-        when(clusterStatusService.isClusterManagerRunningQuickCheck()).thenReturn(Boolean.TRUE);
+        when(clusterStatusService.isClusterManagerRunning()).thenReturn(Boolean.TRUE);
         when(instanceMetaDataService.findNotTerminatedAndNotZombieForStack(anyLong()))
                 .thenReturn(Set.of(createInstanceMetadata("host1"), createInstanceMetadata("host2")));
         when(clusterStatusService.getExtendedHostStatuses(any())).thenReturn(createExtendedHostStatuses(true));
@@ -102,7 +102,7 @@ class VmStatusCheckerConclusionStepTest {
 
     @Test
     public void checkShouldFailIfCMIsRunningAndUnhealthyOrUnknownInstanceExists() {
-        when(clusterStatusService.isClusterManagerRunningQuickCheck()).thenReturn(Boolean.TRUE);
+        when(clusterStatusService.isClusterManagerRunning()).thenReturn(Boolean.TRUE);
         when(instanceMetaDataService.findNotTerminatedAndNotZombieForStack(anyLong()))
                 .thenReturn(Set.of(createInstanceMetadata("host1"), createInstanceMetadata("host2"), createInstanceMetadata("host3")));
         when(clusterStatusService.getExtendedHostStatuses(any())).thenReturn(createExtendedHostStatuses(false));
@@ -118,7 +118,7 @@ class VmStatusCheckerConclusionStepTest {
 
     @Test
     public void checkShouldBeSuccessfulIfCMIsNotRunningAndAllInstanceIsHealthy() {
-        when(clusterStatusService.isClusterManagerRunningQuickCheck()).thenReturn(Boolean.FALSE);
+        when(clusterStatusService.isClusterManagerRunning()).thenReturn(Boolean.FALSE);
         when(instanceMetaDataService.findNotTerminatedAndNotZombieForStack(anyLong()))
                 .thenReturn(Set.of(createInstanceMetadata("host1"), createInstanceMetadata("host2")));
         when(stackInstanceStatusChecker.queryInstanceStatuses(any(), anyList()))
@@ -133,7 +133,7 @@ class VmStatusCheckerConclusionStepTest {
 
     @Test
     public void checkShouldFailIfCMIsNotRunningAndUnhealthyInstanceExists() {
-        when(clusterStatusService.isClusterManagerRunningQuickCheck()).thenReturn(Boolean.FALSE);
+        when(clusterStatusService.isClusterManagerRunning()).thenReturn(Boolean.FALSE);
         when(instanceMetaDataService.findNotTerminatedAndNotZombieForStack(anyLong()))
                 .thenReturn(Set.of(createInstanceMetadata("host1"), createInstanceMetadata("host2")));
         when(stackInstanceStatusChecker.queryInstanceStatuses(any(), anyList()))
@@ -150,7 +150,7 @@ class VmStatusCheckerConclusionStepTest {
 
     @Test
     public void checkShouldHandleMissingFqdns() {
-        when(clusterStatusService.isClusterManagerRunningQuickCheck()).thenReturn(Boolean.FALSE);
+        when(clusterStatusService.isClusterManagerRunning()).thenReturn(Boolean.FALSE);
         InstanceMetaData instanceMetaData = new InstanceMetaData();
         instanceMetaData.setInstanceId("1");
         when(instanceMetaDataService.findNotTerminatedAndNotZombieForStack(anyLong())).thenReturn(Set.of(instanceMetaData));

--- a/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJobTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJobTest.java
@@ -230,7 +230,7 @@ public class StackStatusCheckerJobTest {
     @Test
     public void testInstanceSyncCMRunning() throws JobExecutionException {
         setupForCM();
-        when(clusterApiConnectors.getConnector(stack)).thenReturn(clusterApi);
+        when(clusterApiConnectors.getConnectorWithShortTimeouts(stack)).thenReturn(clusterApi);
         when(clusterApi.clusterStatusService()).thenReturn(clusterStatusService);
         when(regionAwareInternalCrnGenerator.getInternalCrnForServiceAsString()).thenReturn("crn");
         when(regionAwareInternalCrnGeneratorFactory.datahub()).thenReturn(regionAwareInternalCrnGenerator);
@@ -250,7 +250,7 @@ public class StackStatusCheckerJobTest {
         when(clusterStatusService.getExtendedHostStatuses(any())).thenReturn(extendedHostStatuses);
         when(instanceMetaData.getInstanceStatus()).thenReturn(InstanceStatus.STOPPED);
         when(instanceMetaData.getDiscoveryFQDN()).thenReturn("host1");
-        when(clusterApiConnectors.getConnector(stack)).thenReturn(clusterApi);
+        when(clusterApiConnectors.getConnectorWithShortTimeouts(stack)).thenReturn(clusterApi);
         when(clusterApi.clusterStatusService()).thenReturn(clusterStatusService);
         when(regionAwareInternalCrnGenerator.getInternalCrnForServiceAsString()).thenReturn("crn");
         when(regionAwareInternalCrnGeneratorFactory.datahub()).thenReturn(regionAwareInternalCrnGenerator);
@@ -296,7 +296,7 @@ public class StackStatusCheckerJobTest {
         InstanceGroup instanceGroup = new InstanceGroup();
         instanceGroup.setGroupName(instanceHgName);
         when(instanceMetaData.getInstanceGroup()).thenReturn(instanceGroup);
-        when(clusterApiConnectors.getConnector(stack)).thenReturn(clusterApi);
+        when(clusterApiConnectors.getConnectorWithShortTimeouts(stack)).thenReturn(clusterApi);
         when(clusterApi.clusterStatusService()).thenReturn(clusterStatusService);
         when(stackUtil.stopStartScalingEntitlementEnabled(any())).thenReturn(true);
         Set<String> computeGroups = new HashSet<>();
@@ -330,7 +330,7 @@ public class StackStatusCheckerJobTest {
     private void setupForCM() {
         setStackStatus(DetailedStackStatus.AVAILABLE);
         when(clusterApi.clusterStatusService()).thenReturn(clusterStatusService);
-        when(clusterStatusService.isClusterManagerRunningQuickCheck()).thenReturn(true);
+        when(clusterStatusService.isClusterManagerRunning()).thenReturn(true);
         Set<HealthCheck> healthChecks = Sets.newHashSet(new HealthCheck(HealthCheckType.HOST, HealthCheckResult.HEALTHY, Optional.empty()),
                 new HealthCheck(HealthCheckType.CERT, HealthCheckResult.UNHEALTHY, Optional.empty()));
         ExtendedHostStatuses extendedHostStatuses = new ExtendedHostStatuses(Map.of(HostName.hostName("host1"), healthChecks));

--- a/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusIntegrationTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusIntegrationTest.java
@@ -218,7 +218,7 @@ class StackStatusIntegrationTest {
         ClusterApi clusterApi = Mockito.mock(ClusterApi.class);
         when(clusterApi.clusterStatusService()).thenReturn(clusterStatusService);
 
-        when(clusterApiConnectors.getConnector(stack)).thenReturn(clusterApi);
+        when(clusterApiConnectors.getConnectorWithShortTimeouts(stack)).thenReturn(clusterApi);
 
         hostStatuses = new HashMap<>();
 
@@ -374,7 +374,7 @@ class StackStatusIntegrationTest {
 
     private void setUpClusterStatus(ClusterStatus clusterStatus) {
         when(clusterStatusService.getStatus(anyBoolean())).thenReturn(new ClusterStatusResult(clusterStatus, ""));
-        when(clusterStatusService.isClusterManagerRunningQuickCheck()).thenReturn(true);
+        when(clusterStatusService.isClusterManagerRunning()).thenReturn(true);
     }
 
     private void setUpHealthForInstance(String fqdn, HealthCheckResult healthCheckResult) {


### PR DESCRIPTION
Improved StackStatusCheckerJob performance by:
- reducing CM connect/read timeouts,
- optimizing AWS instance status check by describing only the status and only describe the instance when the status is terminated (this is necessary because for terminated instances we gather additional information such as spot termination by the provider)