### PR TITLE
CB-16009: Nightly e2e GCP tests should use encryption

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/AbstractCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/AbstractCloudProvider.java
@@ -17,6 +17,7 @@ import com.sequenceiq.common.api.telemetry.request.LoggingRequest;
 import com.sequenceiq.common.api.type.ServiceEndpointCreation;
 import com.sequenceiq.distrox.api.v1.distrox.model.network.InstanceGroupNetworkV1Request;
 import com.sequenceiq.environment.api.v1.environment.model.request.AttachedFreeIpaRequest;
+import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.it.TestParameter;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.cloud.HostGroupType;
@@ -305,4 +306,13 @@ public abstract class AbstractCloudProvider implements CloudProvider {
         return null;
     }
 
+    @Override
+    public void verifyDiskEncryptionKey(DetailedEnvironmentResponse environment, String environmentName) {
+        LOGGER.warn("Disk encryption feature is not available currently");
+    }
+
+    @Override
+    public void verifyVolumeEncryptionKey(List<String> volumeEncryptionKeyIds, String environmentName) {
+        LOGGER.warn("Disk encryption feature is not available currently");
+    }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProvider.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.it.cloudbreak.cloud.v4;
 
+import java.util.List;
 import java.util.Map;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.stack.StackV4ParameterBase;
@@ -10,6 +11,7 @@ import com.sequenceiq.common.api.type.ServiceEndpointCreation;
 import com.sequenceiq.common.model.FileSystemType;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.InstanceTemplateV1Request;
 import com.sequenceiq.distrox.api.v1.distrox.model.network.InstanceGroupNetworkV1Request;
+import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.ClusterTestDto;
@@ -179,4 +181,7 @@ public interface CloudProvider {
 
     String getStorageOptimizedInstanceType();
 
+    void verifyDiskEncryptionKey(DetailedEnvironmentResponse environment, String environmentName);
+
+    void verifyVolumeEncryptionKey(List<String> volumeEncryptionKeyIds, String environmentName);
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProviderProxy.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProviderProxy.java
@@ -7,6 +7,8 @@ import java.util.Map;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.stack.StackV4ParameterBase;
@@ -17,6 +19,7 @@ import com.sequenceiq.common.api.type.ServiceEndpointCreation;
 import com.sequenceiq.common.model.FileSystemType;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.InstanceTemplateV1Request;
 import com.sequenceiq.distrox.api.v1.distrox.model.network.InstanceGroupNetworkV1Request;
+import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
@@ -55,6 +58,8 @@ import com.sequenceiq.sdx.api.model.SdxClusterShape;
 
 @Component
 public class CloudProviderProxy implements CloudProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CloudProviderProxy.class);
 
     private CloudProvider delegate;
 
@@ -413,5 +418,15 @@ public class CloudProviderProxy implements CloudProvider {
     @Override
     public String getFreeIpaUpgradeImageCatalog() {
         return delegate.getFreeIpaUpgradeImageCatalog();
+    }
+
+    @Override
+    public void verifyDiskEncryptionKey(DetailedEnvironmentResponse environment, String environmentName) {
+        delegate.verifyDiskEncryptionKey(environment, environmentName);
+    }
+
+    @Override
+    public void verifyVolumeEncryptionKey(List<String> volumeEncryptionKeyIds, String environmentName) {
+        delegate.verifyVolumeEncryptionKey(volumeEncryptionKeyIds, environmentName);
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/CloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/CloudFunctionality.java
@@ -7,8 +7,10 @@ import java.util.Set;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
+import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 
 public interface CloudFunctionality {
 
@@ -131,4 +133,10 @@ public interface CloudFunctionality {
             backoff = @Backoff(delay = DELAY, multiplier = MULTIPLIER, maxDelay = MAX_DELAY)
     )
     Set<String> getVolumeMountPoints(List<InstanceGroupV4Response> instanceGroups, List<String> hostGroupNames);
+
+    @Retryable(
+            maxAttempts = ATTEMPTS,
+            backoff = @Backoff(delay = DELAY, multiplier = MULTIPLIER, maxDelay = MAX_DELAY)
+    )
+    void verifyEnaDriver(StackV4Response stackV4Response, CloudbreakClient cloudbreakClient);
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/AwsCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/AwsCloudFunctionality.java
@@ -10,10 +10,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
 import com.sequenceiq.it.cloudbreak.util.CloudFunctionality;
 import com.sequenceiq.it.cloudbreak.util.aws.amazonec2.AmazonEC2Util;
 import com.sequenceiq.it.cloudbreak.util.aws.amazons3.AmazonS3Util;
+import com.sequenceiq.it.cloudbreak.util.ssh.action.SshEnaDriverCheckActions;
 import com.sequenceiq.it.cloudbreak.util.ssh.SshJUtil;
 
 @Component
@@ -26,6 +29,9 @@ public class AwsCloudFunctionality implements CloudFunctionality {
 
     @Inject
     private AmazonS3Util amazonS3Util;
+
+    @Inject
+    private SshEnaDriverCheckActions sshEnaDriverCheckActions;
 
     @Inject
     private SshJUtil sshJUtil;
@@ -103,6 +109,11 @@ public class AwsCloudFunctionality implements CloudFunctionality {
     @Override
     public String getDataHubLogsUrl(String clusterName, String crn, String baseLocation) {
         return amazonS3Util.getDataHubLogsUrl(clusterName, crn, baseLocation);
+    }
+
+    @Override
+    public void verifyEnaDriver(StackV4Response stackV4Response, CloudbreakClient cloudbreakClient) {
+        sshEnaDriverCheckActions.checkEnaDriverOnAws(stackV4Response, cloudbreakClient);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/AzureCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/AzureCloudFunctionality.java
@@ -7,9 +7,14 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.microsoft.azure.management.resources.ResourceGroup;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.it.cloudbreak.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.log.Log;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
 import com.sequenceiq.it.cloudbreak.util.CloudFunctionality;
 import com.sequenceiq.it.cloudbreak.util.azure.azurecloudblob.AzureCloudBlobUtil;
@@ -18,6 +23,8 @@ import com.sequenceiq.it.cloudbreak.util.ssh.SshJUtil;
 
 @Component
 public class AzureCloudFunctionality implements CloudFunctionality {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AzureCloudFunctionality.class);
 
     @Inject
     private AzureClientActions azureClientActions;
@@ -80,13 +87,16 @@ public class AzureCloudFunctionality implements CloudFunctionality {
 
     @Override
     public Map<String, Boolean> enaSupport(List<String> instanceIds) {
+        LOGGER.warn("enaSupport ::: ENA driver is only available for AWS!");
+        Log.log(LOGGER, " enaSupport ::: ENA driver is only available at AWS! ");
         return Collections.emptyMap();
     }
 
     @Override
     public Map<String, String> getInstanceSubnetMap(List<String> instanceIds) {
-        //TODO
-        return null;
+        LOGGER.warn("getInstanceSubnetMap ::: Not implemented for AZURE!");
+        Log.log(LOGGER, " getInstanceSubnetMap ::: Not implemented for AZURE! ");
+        return Collections.emptyMap();
     }
 
     @Override
@@ -102,6 +112,12 @@ public class AzureCloudFunctionality implements CloudFunctionality {
     @Override
     public String getDataHubLogsUrl(String clusterName, String crn, String baseLocation) {
         return azureCloudBlobUtil.getDataHubLogsUrl(clusterName, crn, baseLocation);
+    }
+
+    @Override
+    public void verifyEnaDriver(StackV4Response stackV4Response, CloudbreakClient cloudbreakClient) {
+        LOGGER.warn("ENA driver is only available at AWS. So validation on AZURE is not possible!");
+        Log.then(LOGGER, " ENA driver is only available at AWS. So validation on AZURE is not possible! ");
     }
 
     public ResourceGroup createResourceGroup(String resourceGroupName, Map<String, String> tags) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpCloudFunctionality.java
@@ -7,13 +7,15 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import org.apache.commons.lang3.NotImplementedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 import com.sequenceiq.cloudbreak.cloud.gcp.util.GcpLabelUtil;
+import com.sequenceiq.it.cloudbreak.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.log.Log;
 import com.sequenceiq.it.cloudbreak.util.CloudFunctionality;
 
 @Component
@@ -36,7 +38,7 @@ public class GcpCloudFunctionality implements CloudFunctionality {
 
     @Override
     public List<String> listVolumeEncryptionKeyIds(String clusterName, String resourceGroupName, List<String> instanceIds) {
-        throw new NotImplementedException("Not yet implemented on GCP");
+        return gcpUtil.listVolumeEncryptionKey(instanceIds);
     }
 
     @Override
@@ -46,8 +48,9 @@ public class GcpCloudFunctionality implements CloudFunctionality {
 
     @Override
     public Map<String, String> getInstanceSubnetMap(List<String> instanceIds) {
-        return null;
-        //TODO
+        LOGGER.warn("getInstanceSubnetMap ::: Not implemented for GCP!");
+        Log.log(LOGGER, " getInstanceSubnetMap ::: Not implemented for GCP! ");
+        return Collections.emptyMap();
     }
 
     @Override
@@ -87,6 +90,8 @@ public class GcpCloudFunctionality implements CloudFunctionality {
 
     @Override
     public Map<String, Boolean> enaSupport(List<String> instanceIds) {
+        LOGGER.warn("enaSupport ::: ENA driver is only available for AWS!");
+        Log.log(LOGGER, " enaSupport ::: ENA driver is only available at AWS! ");
         return Collections.emptyMap();
     }
 
@@ -108,6 +113,12 @@ public class GcpCloudFunctionality implements CloudFunctionality {
     @Override
     public String getDataHubLogsUrl(String clusterName, String crn, String baseLocation) {
         return gcpUtil.getDataHubLogsUrl(clusterName, crn, baseLocation);
+    }
+
+    @Override
+    public void verifyEnaDriver(StackV4Response stackV4Response, CloudbreakClient cloudbreakClient) {
+        LOGGER.warn("ENA driver is only available at AWS. So validation on GCP is not possible!");
+        Log.then(LOGGER, " ENA driver is only available at AWS. So validation on GCP is not possible! ");
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpUtil.java
@@ -32,6 +32,10 @@ public class GcpUtil {
         return gcpClientActions.listInstanceDiskNames(instanceIds);
     }
 
+    public List<String> listVolumeEncryptionKey(List<String> instanceIds) {
+        return gcpClientActions.listVolumeEncryptionKey(instanceIds);
+    }
+
     public Map<String, Map<String, String>> listTagsByInstanceId(List<String> instanceIds) {
         return gcpClientActions.listTagsByInstanceId(instanceIds);
     }

--- a/integration-test/src/main/resources/testsuites/e2e/gcp-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/gcp-e2e-tests.yaml
@@ -1,10 +1,12 @@
 name: "gcp-e2e-tests"
 tests:
   - name: "gcp_e2e_tests"
+    excludedGroups: [ azure_singlerg ]
     classes:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.NewNetworkEnvironmentTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.imagevalidation.PrewarmImageValidatorE2ETest
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.freeipa.FreeIpaScalingTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXEncryptedVolumeTest
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXRepairTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXScaleTest
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxImagesTests


### PR DESCRIPTION
CB-16009: Nightly e2e GCP tests should use encryption
This commit adds the e2e gcp tests for encryption key.

