### PR TITLE
CB-16497. Usersync retrieve credentials separately from bulk ums model

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
@@ -909,17 +909,19 @@ public class GrpcUmsClient {
     /**
      * Retrieves user sync state model from UMS.
      *
-     * @param accountId    the account Id
-     * @param requestId    an optional request Id
-     * @param rightsChecks list of rights checks for resources. a List is used to preserve order.
+     * @param accountId         the account Id
+     * @param requestId         an optional request Id
+     * @param rightsChecks      list of rights checks for resources. a List is used to preserve order.
+     * @param skipCredentials   whether to skip including credentials in the response
      * @return the user sync state for this account and rights checks
      */
-    public GetUserSyncStateModelResponse getUserSyncStateModel(String accountId, List<RightsCheck> rightsChecks, Optional<String> requestId,
+    public GetUserSyncStateModelResponse getUserSyncStateModel(String accountId, List<RightsCheck> rightsChecks,
+        boolean skipCredentials, Optional<String> requestId,
         RegionAwareInternalCrnGeneratorFactory regionAwareInternalCrnGeneratorFactory) {
         UmsClient client = makeClient(channelWrapper.getChannel(), regionAwareInternalCrnGeneratorFactory);
         String generatedRequestId = RequestIdUtil.getOrGenerate(requestId);
         LOGGER.debug("Retrieving user sync state model for account {} using request ID {}", accountId, generatedRequestId);
-        return client.getUserSyncStateModel(generatedRequestId, accountId, rightsChecks);
+        return client.getUserSyncStateModel(generatedRequestId, accountId, rightsChecks, skipCredentials);
     }
 
     protected boolean isReadRight(String action) {

--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/UmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/UmsClient.java
@@ -1144,14 +1144,16 @@ public class UmsClient {
      * @param requestId          the request ID for the request
      * @param accountId          the account ID
      * @param rightsChecks       list of rights checks for resources. A List is used to preserve order.
+     * @param skipCredentials    whether to skip including credentials in the response
      * @return the user sync state model
      */
     public GetUserSyncStateModelResponse getUserSyncStateModel(
-            String requestId, String accountId, List<RightsCheck> rightsChecks) {
+            String requestId, String accountId, List<RightsCheck> rightsChecks, boolean skipCredentials) {
         validateAccountIdWithWarning(accountId);
         GetUserSyncStateModelRequest request = GetUserSyncStateModelRequest.newBuilder()
                 .setAccountId(accountId)
                 .addAllRightsCheck(rightsChecks)
+                .setSkipCredentials(skipCredentials)
                 .build();
         return newStub(requestId).getUserSyncStateModel(request);
     }


### PR DESCRIPTION
GRPC requests have a 1 minute timeout. The UMS bulk user sync state rpc
spends a long time decrypting credentials and may exceed the 1 minute timeout
when retrieving 2500+ actors.

A flag was added to the request to skip credentials retrieval in the bulk rpc.
This commit adds the flag to the GrpcUmsClient and modifies the
BulkUmsUsersStateProvider to retrieve the credentials separately.

See detailed description in the commit message.