### PR TITLE
CB-16837 Use set -e in docker application start scripts to fail fast

### DIFF
--- a/docker-autoscale/bootstrap/start_autoscale_app.sh
+++ b/docker-autoscale/bootstrap/start_autoscale_app.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 : ${SECURE_RANDOM:=true}
 : ${EXPOSE_JMX_METRICS:=false}
 : ${EXPOSE_JMX_METRICS_PORT:=20105}

--- a/docker-cloudbreak/bootstrap/start_cloudbreak_app.sh
+++ b/docker-cloudbreak/bootstrap/start_cloudbreak_app.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 : ${SECURE_RANDOM:=true}
 : ${EXPOSE_JMX_METRICS:=false}
 : ${EXPOSE_JMX_METRICS_PORT:=20105}

--- a/docker-consumption/bootstrap/start_consumption_app.sh
+++ b/docker-consumption/bootstrap/start_consumption_app.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 : ${SECURE_RANDOM:=true}
 : ${EXPOSE_JMX_METRICS:=false}
 : ${EXPOSE_JMX_METRICS_PORT:=20105}

--- a/docker-datalake/bootstrap/start_datalake_app.sh
+++ b/docker-datalake/bootstrap/start_datalake_app.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 : ${SECURE_RANDOM:=true}
 : ${EXPOSE_JMX_METRICS:=false}
 : ${EXPOSE_JMX_METRICS_PORT:=20105}

--- a/docker-environment/bootstrap/start_environment_app.sh
+++ b/docker-environment/bootstrap/start_environment_app.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 : ${SECURE_RANDOM:=true}
 : ${EXPOSE_JMX_METRICS:=false}
 : ${EXPOSE_JMX_METRICS_PORT:=20105}

--- a/docker-freeipa/bootstrap/start_freeipa_app.sh
+++ b/docker-freeipa/bootstrap/start_freeipa_app.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 : ${SECURE_RANDOM:=true}
 : ${EXPOSE_JMX_METRICS:=false}
 : ${EXPOSE_JMX_METRICS_PORT:=20105}

--- a/docker-redbeams/bootstrap/start_redbeams_app.sh
+++ b/docker-redbeams/bootstrap/start_redbeams_app.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 : ${SECURE_RANDOM:=true}
 : ${EXPOSE_JMX_METRICS:=false}
 : ${EXPOSE_JMX_METRICS_PORT:=20105}


### PR DESCRIPTION
Use set -e in docker application start scripts to fail fast if cert import fails.