### PR TITLE
CB-16292 Bring your own DNS zone - e2e test

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/AbstractCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/AbstractCloudProvider.java
@@ -17,7 +17,6 @@ import com.sequenceiq.common.api.telemetry.request.LoggingRequest;
 import com.sequenceiq.common.api.type.ServiceEndpointCreation;
 import com.sequenceiq.distrox.api.v1.distrox.model.network.InstanceGroupNetworkV1Request;
 import com.sequenceiq.environment.api.v1.environment.model.request.AttachedFreeIpaRequest;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.NetworkRequest;
 import com.sequenceiq.it.TestParameter;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.cloud.HostGroupType;
@@ -168,11 +167,6 @@ public abstract class AbstractCloudProvider implements CloudProvider {
     }
 
     @Override
-    public NetworkRequest networkRequest(FreeIpaTestDto dto) {
-        return null;
-    }
-
-    @Override
     public InstanceGroupNetworkV4Request instanceGroupNetworkV4Request(SubnetId subnetId) {
         return null;
     }
@@ -310,4 +304,5 @@ public abstract class AbstractCloudProvider implements CloudProvider {
         LOGGER.warn("'freeIpaUpgradeImageCatalog' is not implemented");
         return null;
     }
+
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/AbstractCloudProviderAssertion.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/AbstractCloudProviderAssertion.java
@@ -1,0 +1,17 @@
+package com.sequenceiq.it.cloudbreak.cloud.v4;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+
+public abstract class AbstractCloudProviderAssertion implements CloudProviderAssertion {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractCloudProviderAssertion.class);
+
+    @Override
+    public void assertServiceEndpoint(EnvironmentTestDto environmentTestDto) {
+        LOGGER.debug("Service endpoint not applicable for cloud provider " + getCloudPlatform().name());
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProvider.java
@@ -10,7 +10,6 @@ import com.sequenceiq.common.api.type.ServiceEndpointCreation;
 import com.sequenceiq.common.model.FileSystemType;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.InstanceTemplateV1Request;
 import com.sequenceiq.distrox.api.v1.distrox.model.network.InstanceGroupNetworkV1Request;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.NetworkRequest;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.ClusterTestDto;
@@ -83,8 +82,6 @@ public interface CloudProvider {
     LoggingRequest loggingRequest(TelemetryTestDto dto);
 
     DistroXRootVolumeTestDto distroXRootVolume(DistroXRootVolumeTestDto distroXRootVolume);
-
-    NetworkRequest networkRequest(FreeIpaTestDto dto);
 
     NetworkV4TestDto network(NetworkV4TestDto network);
 
@@ -181,4 +178,5 @@ public interface CloudProvider {
     String getFreeIpaUpgradeImageCatalog();
 
     String getStorageOptimizedInstanceType();
+
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProviderAssertion.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProviderAssertion.java
@@ -1,0 +1,12 @@
+package com.sequenceiq.it.cloudbreak.cloud.v4;
+
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+
+public interface CloudProviderAssertion {
+
+    CloudPlatform getCloudPlatform();
+
+    void assertServiceEndpoint(EnvironmentTestDto environmentTestDto);
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProviderAssertionProxy.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProviderAssertionProxy.java
@@ -1,0 +1,45 @@
+package com.sequenceiq.it.cloudbreak.cloud.v4;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+
+@Component
+public class CloudProviderAssertionProxy implements CloudProviderAssertion {
+    private CloudProviderAssertion delegate;
+
+    @Inject
+    private CommonCloudProperties commonCloudProperties;
+
+    @Inject
+    private List<CloudProviderAssertion> cloudProviders;
+
+    private final Map<CloudPlatform, CloudProviderAssertion> cloudProviderMap = new HashMap<>();
+
+    @PostConstruct
+    private void init() {
+        cloudProviders.forEach(cloudProvider -> {
+            cloudProviderMap.put(cloudProvider.getCloudPlatform(), cloudProvider);
+        });
+        delegate = cloudProviderMap.get(CloudPlatform.valueOf(commonCloudProperties.getCloudProvider()));
+    }
+
+    @Override
+    public CloudPlatform getCloudPlatform() {
+        return delegate.getCloudPlatform();
+    }
+
+    @Override
+    public void assertServiceEndpoint(EnvironmentTestDto environmentTestDto) {
+        delegate.assertServiceEndpoint(environmentTestDto);
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProviderProxy.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProviderProxy.java
@@ -17,7 +17,6 @@ import com.sequenceiq.common.api.type.ServiceEndpointCreation;
 import com.sequenceiq.common.model.FileSystemType;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.InstanceTemplateV1Request;
 import com.sequenceiq.distrox.api.v1.distrox.model.network.InstanceGroupNetworkV1Request;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.NetworkRequest;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
@@ -386,11 +385,6 @@ public class CloudProviderProxy implements CloudProvider {
     @Override
     public LoggingRequest loggingRequest(TelemetryTestDto dto) {
         return getDelegate(dto).loggingRequest(dto);
-    }
-
-    @Override
-    public NetworkRequest networkRequest(FreeIpaTestDto dto) {
-        return getDelegate(dto).networkRequest(dto);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProvider.java
@@ -42,8 +42,6 @@ import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsEnviro
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsFreeIpaParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsFreeIpaSpotParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.S3GuardRequestParameters;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.AwsNetworkParameters;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.NetworkRequest;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.cloud.v4.AbstractCloudProvider;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
@@ -64,7 +62,6 @@ import com.sequenceiq.it.cloudbreak.dto.distrox.instancegroup.DistroXRootVolumeT
 import com.sequenceiq.it.cloudbreak.dto.distrox.instancegroup.DistroXVolumeTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentNetworkTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
-import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCloudStorageTestDto;
 import com.sequenceiq.it.cloudbreak.dto.stack.StackTestDtoBase;
@@ -187,16 +184,6 @@ public class AwsCloudProvider extends AbstractCloudProvider {
     public DistroXRootVolumeTestDto distroXRootVolume(DistroXRootVolumeTestDto distroXRootVolume) {
         int rootVolumeSize = awsProperties.getInstance().getRootVolumeSize();
         return distroXRootVolume.withSize(rootVolumeSize);
-    }
-
-    @Override
-    public NetworkRequest networkRequest(FreeIpaTestDto dto) {
-        NetworkRequest networkRequest = new NetworkRequest();
-        AwsNetworkParameters networkParameters = new AwsNetworkParameters();
-        networkParameters.setSubnetId(getSubnetId());
-        networkParameters.setVpcId(getVpcId());
-        networkRequest.setAws(networkParameters);
-        return networkRequest;
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProviderAssertion.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProviderAssertion.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.it.cloudbreak.cloud.v4.aws;
+
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.common.api.type.ServiceEndpointCreation;
+import com.sequenceiq.it.cloudbreak.cloud.v4.AbstractCloudProviderAssertion;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+
+@Component
+public class AwsCloudProviderAssertion extends AbstractCloudProviderAssertion {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsCloudProviderAssertion.class);
+
+    @Override
+    public CloudPlatform getCloudPlatform() {
+        return CloudPlatform.AWS;
+    }
+
+    @Override
+    public void assertServiceEndpoint(EnvironmentTestDto environmentTestDto) {
+        ServiceEndpointCreation serviceEndpointCreationRequest = Optional.ofNullable(environmentTestDto.getRequest().getNetwork().getServiceEndpointCreation())
+                .orElse(ServiceEndpointCreation.DISABLED);
+        ServiceEndpointCreation serviceEndpointCreationResponse = environmentTestDto.getResponse().getNetwork().getServiceEndpointCreation();
+        if (serviceEndpointCreationResponse != serviceEndpointCreationRequest) {
+            String message = String.format("Service endpoint creation is expected to be %s, but is %s", serviceEndpointCreationRequest,
+                    serviceEndpointCreationResponse);
+            LOGGER.error(message);
+            throw new TestFailException(message);
+        }
+
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
@@ -34,8 +34,6 @@ import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureEn
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureResourceEncryptionParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureResourceGroup;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.ResourceGroupUsage;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.AzureNetworkParameters;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.NetworkRequest;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.ResourceGroupTest;
 import com.sequenceiq.it.cloudbreak.cloud.v4.AbstractCloudProvider;
@@ -56,7 +54,6 @@ import com.sequenceiq.it.cloudbreak.dto.distrox.instancegroup.DistroXRootVolumeT
 import com.sequenceiq.it.cloudbreak.dto.distrox.instancegroup.DistroXVolumeTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentNetworkTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
-import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCloudStorageTestDto;
 import com.sequenceiq.it.cloudbreak.dto.stack.StackTestDtoBase;
@@ -212,25 +209,15 @@ public class AzureCloudProvider extends AbstractCloudProvider {
     }
 
     @Override
-    public NetworkRequest networkRequest(FreeIpaTestDto dto) {
-        NetworkRequest networkRequest = new NetworkRequest();
-        AzureNetworkParameters networkParameters = new AzureNetworkParameters();
-        networkParameters.setSubnetId(getSubnetId());
-        networkParameters.setNetworkId(getNetworkId());
-        networkParameters.setNoPublicIp(getNoPublicIp());
-        networkParameters.setResourceGroupName(getResourceGroupName());
-        networkRequest.setAzure(networkParameters);
-        return networkRequest;
-    }
-
-    @Override
-    public NetworkV4TestDto network(NetworkV4TestDto network) {
+    public NetworkV4TestDto network(NetworkV4TestDto networkTestDto) {
         AzureNetworkV4Parameters parameters = new AzureNetworkV4Parameters();
-        parameters.setNoPublicIp(false);
-        parameters.setSubnetId(azureProperties.getNetwork().getSubnetIds().stream().findFirst().get());
-        parameters.setNetworkId(azureProperties.getNetwork().getNetworkId());
-        parameters.setResourceGroupName(azureProperties.getNetwork().getResourceGroupName());
-        return network.withAzure(parameters)
+        AzureProperties.Network network = azureProperties.getNetwork();
+        parameters.setNoPublicIp(network.getNoPublicIp());
+        parameters.setSubnetId(network.getSubnetIds().stream().findFirst().get());
+        parameters.setNetworkId(network.getNetworkId());
+        parameters.setResourceGroupName(network.getResourceGroupName());
+        parameters.setDatabasePrivateDnsZoneId(network.getDatabasePrivateDnsZoneId());
+        return networkTestDto.withAzure(parameters)
                 .withSubnetCIDR(getSubnetCIDR());
     }
 
@@ -238,8 +225,8 @@ public class AzureCloudProvider extends AbstractCloudProvider {
     public ServiceEndpointCreation serviceEndpoint() {
         ServiceEndpointCreation serviceEndpointCreation =
                 ResourceGroupTest.isSingleResourceGroup(getTestParameter().get(ResourceGroupTest.AZURE_RESOURCE_GROUP_USAGE))
-                ? ServiceEndpointCreation.ENABLED_PRIVATE_ENDPOINT
-                : ServiceEndpointCreation.DISABLED;
+                        ? ServiceEndpointCreation.ENABLED_PRIVATE_ENDPOINT
+                        : ServiceEndpointCreation.DISABLED;
         LOGGER.debug("Azure service endpoint creation: {}", serviceEndpointCreation);
         return serviceEndpointCreation;
     }
@@ -258,9 +245,11 @@ public class AzureCloudProvider extends AbstractCloudProvider {
 
     private EnvironmentNetworkAzureParams environmentNetworkParameters() {
         EnvironmentNetworkAzureParams environmentNetworkAzureParams = new EnvironmentNetworkAzureParams();
-        environmentNetworkAzureParams.setNetworkId(getNetworkId());
-        environmentNetworkAzureParams.setNoPublicIp(getNoPublicIp());
-        environmentNetworkAzureParams.setResourceGroupName(getResourceGroupName());
+        AzureProperties.Network network = azureProperties.getNetwork();
+        environmentNetworkAzureParams.setNetworkId(network.getNetworkId());
+        environmentNetworkAzureParams.setNoPublicIp(network.getNoPublicIp());
+        environmentNetworkAzureParams.setResourceGroupName(network.getResourceGroupName());
+        environmentNetworkAzureParams.setDatabasePrivateDnsZoneId(network.getDatabasePrivateDnsZoneId());
         return environmentNetworkAzureParams;
     }
 
@@ -280,25 +269,8 @@ public class AzureCloudProvider extends AbstractCloudProvider {
         return stackAuthenticationEntity.withPublicKey(sshPublicKey);
     }
 
-    public String getNetworkId() {
-        return azureProperties.getNetwork().getNetworkId();
-    }
-
     public Set<String> getSubnetIds() {
         return azureProperties.getNetwork().getSubnetIds();
-    }
-
-    public String getSubnetId() {
-        Set<String> subnetIDs = getSubnetIds();
-        return subnetIDs.iterator().next();
-    }
-
-    public Boolean getNoPublicIp() {
-        return azureProperties.getNetwork().getNoPublicIp();
-    }
-
-    public String getResourceGroupName() {
-        return azureProperties.getNetwork().getResourceGroupName();
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProviderAssertion.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProviderAssertion.java
@@ -1,0 +1,47 @@
+package com.sequenceiq.it.cloudbreak.cloud.v4.azure;
+
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.common.api.type.ServiceEndpointCreation;
+import com.sequenceiq.it.cloudbreak.cloud.v4.AbstractCloudProviderAssertion;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+
+@Component
+public class AzureCloudProviderAssertion extends AbstractCloudProviderAssertion {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AzureCloudProviderAssertion.class);
+
+    @Override
+    public CloudPlatform getCloudPlatform() {
+        return CloudPlatform.AZURE;
+    }
+
+    @Override
+    public void assertServiceEndpoint(EnvironmentTestDto environmentTestDto) {
+        ServiceEndpointCreation serviceEndpointCreationRequest = Optional.ofNullable(environmentTestDto.getRequest().getNetwork().getServiceEndpointCreation())
+                .orElse(ServiceEndpointCreation.DISABLED);
+        ServiceEndpointCreation serviceEndpointCreationResponse = environmentTestDto.getResponse().getNetwork().getServiceEndpointCreation();
+        if (serviceEndpointCreationRequest != serviceEndpointCreationResponse) {
+            String message = String.format("Service endpoint creation in request (%s) does not match that in response (%s)", serviceEndpointCreationRequest,
+                    serviceEndpointCreationResponse);
+            LOGGER.error(message);
+            throw new TestFailException(message);
+        }
+
+        String databasePrivateDnsZoneIdRequest = environmentTestDto.getRequest().getNetwork().getAzure().getDatabasePrivateDnsZoneId();
+        String databasePrivateDnsZoneIdResponse = environmentTestDto.getResponse().getNetwork().getAzure().getDatabasePrivateDnsZoneId();
+        if (databasePrivateDnsZoneIdRequest != null && !databasePrivateDnsZoneIdRequest.equals(databasePrivateDnsZoneIdResponse)) {
+            String message = String.format("Private DNS zone id for database was requested to be %s, but is %s", databasePrivateDnsZoneIdRequest,
+                    databasePrivateDnsZoneIdResponse);
+            LOGGER.error(message);
+            throw new TestFailException(message);
+        }
+
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureProperties.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureProperties.java
@@ -300,6 +300,16 @@ public class AzureProperties {
 
         private Set<String> subnetIds;
 
+        private String databasePrivateDnsZoneId;
+
+        public String getDatabasePrivateDnsZoneId() {
+            return databasePrivateDnsZoneId;
+        }
+
+        public void setDatabasePrivateDnsZoneId(String databasePrivateDnsZoneId) {
+            this.databasePrivateDnsZoneId = databasePrivateDnsZoneId;
+        }
+
         public Set<String> getSubnetIds() {
             return subnetIds;
         }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpCloudProvider.java
@@ -32,8 +32,6 @@ import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkGcp
 import com.sequenceiq.environment.api.v1.environment.model.request.SecurityAccessRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.gcp.GcpEnvironmentParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.gcp.GcpResourceEncryptionParameters;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.GcpNetworkParameters;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.NetworkRequest;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.cloud.v4.AbstractCloudProvider;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
@@ -55,7 +53,6 @@ import com.sequenceiq.it.cloudbreak.dto.distrox.instancegroup.DistroXVolumeTestD
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentNetworkTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentSecurityAccessTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
-import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCloudStorageTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCustomTestDto;
@@ -180,19 +177,6 @@ public class GcpCloudProvider extends AbstractCloudProvider {
     public DistroXRootVolumeTestDto distroXRootVolume(DistroXRootVolumeTestDto distroXRootVolume) {
         int rootVolumeSize = gcpProperties.getInstance().getRootVolumeSize();
         return distroXRootVolume.withSize(rootVolumeSize);
-    }
-
-    @Override
-    public NetworkRequest networkRequest(FreeIpaTestDto dto) {
-        NetworkRequest networkRequest = new NetworkRequest();
-        GcpNetworkParameters networkParameters = new GcpNetworkParameters();
-        networkParameters.setSubnetId(getSubnetId());
-        networkParameters.setNetworkId(getNetworkId());
-        networkParameters.setNoPublicIp(getNoPublicIp());
-        networkParameters.setNoFirewallRules(getNoFirewallRules());
-        networkParameters.setSharedProjectId(getSharedProjectId());
-        networkRequest.setGcp(networkParameters);
-        return networkRequest;
     }
 
     public String getNetworkId() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpCloudProviderAssertion.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpCloudProviderAssertion.java
@@ -1,0 +1,16 @@
+package com.sequenceiq.it.cloudbreak.cloud.v4.gcp;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.it.cloudbreak.cloud.v4.AbstractCloudProviderAssertion;
+
+@Component
+public class GcpCloudProviderAssertion extends AbstractCloudProviderAssertion {
+
+    @Override
+    public CloudPlatform getCloudPlatform() {
+        return CloudPlatform.GCP;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/mock/MockCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/mock/MockCloudProvider.java
@@ -24,8 +24,6 @@ import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.Instan
 import com.sequenceiq.distrox.api.v1.distrox.model.network.mock.MockNetworkV1Parameters;
 import com.sequenceiq.environment.api.v1.credential.model.parameters.mock.MockParameters;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkMockParams;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.MockNetworkParameters;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.NetworkRequest;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.ResourcePropertyProvider;
 import com.sequenceiq.it.cloudbreak.cloud.v4.AbstractCloudProvider;
@@ -49,7 +47,6 @@ import com.sequenceiq.it.cloudbreak.dto.distrox.instancegroup.DistroXRootVolumeT
 import com.sequenceiq.it.cloudbreak.dto.distrox.instancegroup.DistroXVolumeTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentNetworkTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
-import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCloudStorageTestDto;
 import com.sequenceiq.it.cloudbreak.dto.stack.StackTestDtoBase;
@@ -319,17 +316,6 @@ public class MockCloudProvider extends AbstractCloudProvider {
     @Override
     public DistroXRootVolumeTestDto distroXRootVolume(DistroXRootVolumeTestDto distroXRootVolume) {
         return distroXRootVolume.withSize(100);
-    }
-
-    @Override
-    public NetworkRequest networkRequest(FreeIpaTestDto dto) {
-        NetworkRequest networkRequest = new NetworkRequest();
-        MockNetworkParameters networkParameters = new MockNetworkParameters();
-        networkParameters.setSubnetId(getSubnetId());
-        networkParameters.setVpcId(getVpcId());
-        networkParameters.setInternetGatewayId(getInternetGatewayId());
-        networkRequest.setMock(networkParameters);
-        return networkRequest;
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/mock/MockCloudProviderAssertion.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/mock/MockCloudProviderAssertion.java
@@ -1,0 +1,15 @@
+package com.sequenceiq.it.cloudbreak.cloud.v4.mock;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.it.cloudbreak.cloud.v4.AbstractCloudProviderAssertion;
+
+@Component
+public class MockCloudProviderAssertion extends AbstractCloudProviderAssertion {
+    @Override
+    public CloudPlatform getCloudPlatform() {
+        return CloudPlatform.MOCK;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/yarn/YarnCloudProviderAssertion.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/yarn/YarnCloudProviderAssertion.java
@@ -1,0 +1,16 @@
+package com.sequenceiq.it.cloudbreak.cloud.v4.yarn;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.it.cloudbreak.cloud.v4.AbstractCloudProviderAssertion;
+
+@Component
+public class YarnCloudProviderAssertion extends AbstractCloudProviderAssertion {
+
+    @Override
+    public CloudPlatform getCloudPlatform() {
+        return CloudPlatform.YARN;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
@@ -43,6 +43,7 @@ import com.sequenceiq.it.cloudbreak.action.Action;
 import com.sequenceiq.it.cloudbreak.actor.CloudbreakActor;
 import com.sequenceiq.it.cloudbreak.actor.CloudbreakUser;
 import com.sequenceiq.it.cloudbreak.assertion.Assertion;
+import com.sequenceiq.it.cloudbreak.cloud.v4.CloudProviderAssertionProxy;
 import com.sequenceiq.it.cloudbreak.cloud.v4.CloudProviderProxy;
 import com.sequenceiq.it.cloudbreak.cloud.v4.CommonCloudProperties;
 import com.sequenceiq.it.cloudbreak.cloud.v4.CommonClusterManagerProperties;
@@ -119,6 +120,9 @@ public abstract class TestContext implements ApplicationContextAware {
 
     @Inject
     private CloudProviderProxy cloudProvider;
+
+    @Inject
+    private CloudProviderAssertionProxy cloudProviderAssertion;
 
     @Inject
     private CommonCloudProperties commonCloudProperties;
@@ -1205,6 +1209,10 @@ public abstract class TestContext implements ApplicationContextAware {
 
     public CloudProviderProxy getCloudProvider() {
         return cloudProvider;
+    }
+
+    public CloudProviderAssertionProxy getCloudProviderAssertion() {
+        return cloudProviderAssertion;
     }
 
     public CloudPlatform getCloudPlatform() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentNetworkTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentNetworkTestDto.java
@@ -1,8 +1,5 @@
 package com.sequenceiq.it.cloudbreak.dto.environment;
 
-import static com.sequenceiq.it.cloudbreak.PrivateEndpointTest.PRIVATE_ENDPOINT_ENABLED;
-import static com.sequenceiq.it.cloudbreak.PrivateEndpointTest.PRIVATE_ENDPOINT_USAGE;
-
 import java.util.Set;
 
 import com.sequenceiq.common.api.type.OutboundInternetTraffic;
@@ -37,8 +34,7 @@ public class EnvironmentNetworkTestDto extends AbstractCloudbreakTestDto<Environ
 
     public EnvironmentNetworkTestDto valid() {
         return getCloudProvider()
-                .network(this)
-                .withTryUseServiceEndpoints();
+                .network(this);
     }
 
     public EnvironmentNetworkTestDto withAzure(EnvironmentNetworkAzureParams azure) {
@@ -74,14 +70,6 @@ public class EnvironmentNetworkTestDto extends AbstractCloudbreakTestDto<Environ
 
     public EnvironmentNetworkTestDto withPrivateSubnets() {
         getRequest().setPrivateSubnetCreation(PrivateSubnetCreation.ENABLED);
-        return this;
-    }
-
-    public EnvironmentNetworkTestDto withTryUseServiceEndpoints() {
-        if (PRIVATE_ENDPOINT_ENABLED.equals(getTestParameter().get(PRIVATE_ENDPOINT_USAGE))) {
-            LOGGER.debug("Private endpoints enabled via environment parameters");
-            withServiceEndpoints();
-        }
         return this;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaTestDto.java
@@ -239,11 +239,6 @@ public class FreeIpaTestDto extends AbstractFreeIpaTestDto<CreateFreeIpaRequest,
         return template;
     }
 
-    public FreeIpaTestDto withNetwork() {
-        getRequest().setNetwork(getCloudProvider().networkRequest(this));
-        return this;
-    }
-
     private FreeIpaTestDto withNetwork(NetworkV4TestDto network) {
         NetworkV4Request request = network.getRequest();
         NetworkRequest networkRequest = new NetworkRequest();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXEncryptedVolumeTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXEncryptedVolumeTest.java
@@ -200,6 +200,7 @@ public class DistroXEncryptedVolumeTest extends AbstractE2ETest {
 
         testContext
                 .given(EnvironmentNetworkTestDto.class)
+                    .withServiceEndpoints()
                 .given("telemetry", TelemetryTestDto.class)
                     .withLogging()
                     .withReportClusterLogs()
@@ -211,6 +212,10 @@ public class DistroXEncryptedVolumeTest extends AbstractE2ETest {
                     .withTunnel(Tunnel.CLUSTER_PROXY)
                     .withCreateFreeIpa(Boolean.FALSE)
                 .when(environmentTestClient.create())
+                .then((context, dto, client) -> {
+                    context.getCloudProviderAssertion().assertServiceEndpoint(dto);
+                    return dto;
+                })
                 .await(EnvironmentStatus.AVAILABLE)
                 .given(FreeIpaTestDto.class)
                     .withEnvironment()

--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -160,6 +160,7 @@ integrationtest:
       subnetIds:
         - cloud-daily.internal.1.westus2
         - cloud-daily.internal.0.westus2
+      databasePrivateDnsZoneId:
     credential:
       appId:
       appPassword:


### PR DESCRIPTION
Currently e2e tests with private endpoints for Azure are not possible because cloudbreak tests are running in the peered network, using cloudera on-prem DNS servers. It seems that adding DNS forwarders for Azure DNS might take much time.

In this commit
1) we introduced network parameters for a second, private endpoint enabled network on Azure. If the service endpoints flag is turned on, then the private endpoint enabled network is used in the e2e tests. Also, if the databaseprivateDnsZone is filled in, then that will also be sent in the EnvRequest, and CDP will use that instead of creating its own.
2) we modified an already existing test tailored for azure single RG to use private endpoints

See detailed description in the commit message.