### PR TITLE
CB-16846 DistroX resilient scaling test failed with wrong number of new instances

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/distrox/DistroxScaleThresholdAssertions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/distrox/DistroxScaleThresholdAssertions.java
@@ -3,23 +3,16 @@ package com.sequenceiq.it.cloudbreak.assertion.distrox;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.assertion.Assertion;
-import com.sequenceiq.it.cloudbreak.cloud.HostGroupType;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
-import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.it.cloudbreak.util.DistroxUtil;
 
 public class DistroxScaleThresholdAssertions implements Assertion<DistroXTestDto, CloudbreakClient> {
 
@@ -37,30 +30,6 @@ public class DistroxScaleThresholdAssertions implements Assertion<DistroXTestDto
         this.threshold = threshold;
     }
 
-    private String getHostGroup() {
-        return Arrays.stream(HostGroupType.values())
-                .filter(hostGroup -> hostGroup.name().equalsIgnoreCase(hostGroupName))
-                .findFirst()
-                .orElseThrow(() -> new TestFailException(String.format("There is no HostGroupType for '%s' name!", hostGroupName)))
-                .name();
-    }
-
-    private List<String> getInstanceIds(DistroXTestDto testDto) {
-        Optional<InstanceGroupV4Response> instanceGroup = testDto.getResponse().getInstanceGroups().stream()
-                .filter(instanceGroups -> getHostGroup().equalsIgnoreCase(instanceGroups.getName()))
-                .filter(instanceGroups -> instanceGroups.getMetadata().stream()
-                        .anyMatch(instanceMetaData -> Objects.nonNull(instanceMetaData.getInstanceId())))
-                .findAny();
-        if (instanceGroup.isPresent()) {
-            return instanceGroup.get().getMetadata().stream()
-                    .map(InstanceMetaDataV4Response::getInstanceId)
-                    .filter(Objects::nonNull)
-                    .collect(Collectors.toList());
-        } else {
-            throw new TestFailException(String.format("Can't find valid instance group with this '%s' name!", hostGroupName));
-        }
-    }
-
     private float getScalingThreshold() {
         float scalingPercentage = (float) threshold / 100;
         return scaleUpTarget * scalingPercentage;
@@ -68,11 +37,14 @@ public class DistroxScaleThresholdAssertions implements Assertion<DistroXTestDto
 
     @Override
     public DistroXTestDto doAssertion(TestContext testContext, DistroXTestDto testDto, CloudbreakClient client) throws Exception {
-        int instanceCount = getInstanceIds(testDto).size();
+        DistroxUtil distroxUtil = new DistroxUtil();
+        List<String> instanceIds = distroxUtil.getInstanceIds(testDto, client, hostGroupName);
+        LOGGER.info(String.format("Found instanceIds after DistroX scaling: [%s]", instanceIds));
+        int instanceCount = instanceIds.size();
 
         assertThat(
-                String.format("Available Compute node count '%d' is NOT match with the required (at least) scale percentage '%d'.",
-                        instanceCount, threshold),
+                String.format("Available '%s' node count '%d' is NOT match with the required (at least) scale percentage '%d'.",
+                        hostGroupName, instanceCount, threshold),
                 (float) instanceCount,
                 greaterThanOrEqualTo(getScalingThreshold()));
 


### PR DESCRIPTION
Our [API AZURE E2E Build #3104--2.56.0-b28-AZURE (13-Apr-2022 11:51:44)](http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-azure/3104/) is failing, because of:
```
com.sequenceiq.it.cloudbreak.exception.TestFailException: Available Compute node count '1' is NOT match with the required (at least) scale percentage '90'.
Expected: a value equal to or greater than <9.0F>
     but: <1.0F> was less than <9.0F> 
Resource Crn: crn:cdp:datahub:eu-1:qe-azure:cluster:9fbbb7dc-1a43-4521-be06-bdc9782b2bf2
```
Actually the referenced assertion did not get the right number of the scaled instances. So I fixed the related InstanceId getter for the assertion.