### PR TITLE
CB-16723 Capture telemetry metrics for newly introduced flows in Stop…

### DIFF
--- a/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/mapper/ClusterUseCaseMapper.java
+++ b/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/mapper/ClusterUseCaseMapper.java
@@ -39,6 +39,10 @@ public class ClusterUseCaseMapper {
         firstStepUseCaseMap.put(Pair.of("UpscaleFlowEventChainFactory", "StackUpscaleConfig"), UsageProto.CDPClusterStatus.Value.UPSCALE_STARTED);
         firstStepUseCaseMap.put(Pair.of("MultiHostgroupDownscaleFlowEventChainFactory", "FlowChainInitFlowConfig"),
                 UsageProto.CDPClusterStatus.Value.DOWNSCALE_STARTED);
+        firstStepUseCaseMap.put(Pair.of("StopStartUpscaleFlowEventChainFactory", "StopStartUpscaleFlowConfig"),
+                UsageProto.CDPClusterStatus.Value.STOP_START_UPSCALE_STARTED);
+        firstStepUseCaseMap.put(Pair.of("StopStartDownscaleFlowEventChainFactory", "StopStartDownscaleFlowConfig"),
+                UsageProto.CDPClusterStatus.Value.STOP_START_DOWNSCALE_STARTED);
         firstStepUseCaseMap.put(Pair.of("DownscaleFlowEventChainFactory", "ClusterDownscaleFlowConfig"), UsageProto.CDPClusterStatus.Value.DOWNSCALE_STARTED);
         firstStepUseCaseMap.put(Pair.of("StartFlowEventChainFactory", "StackStartFlowConfig"), UsageProto.CDPClusterStatus.Value.RESUME_STARTED);
         firstStepUseCaseMap.put(Pair.of("StopFlowEventChainFactory", "ClusterStopFlowConfig"), UsageProto.CDPClusterStatus.Value.SUSPEND_STARTED);
@@ -97,6 +101,14 @@ public class ClusterUseCaseMapper {
                 case "MultiHostgroupDownscaleFlowEventChainFactory":
                     useCase = getClusterStatus(nextFlowState, "FLOWCHAIN_FINALIZE_FINISHED_STATE",
                             UsageProto.CDPClusterStatus.Value.DOWNSCALE_FINISHED, UsageProto.CDPClusterStatus.Value.DOWNSCALE_FAILED);
+                    break;
+                case "StopStartUpscaleFlowEventChainFactory":
+                    useCase = getClusterStatus(nextFlowState, "STOPSTART_UPSCALE_FINALIZE_STATE",
+                            UsageProto.CDPClusterStatus.Value.STOP_START_UPSCALE_FINISHED, UsageProto.CDPClusterStatus.Value.STOP_START_UPSCALE_FAILED);
+                    break;
+                case "StopStartDownscaleFlowEventChainFactory":
+                    useCase = getClusterStatus(nextFlowState, "STOPSTART_DOWNSCALE_FINALIZE_STATE",
+                            UsageProto.CDPClusterStatus.Value.STOP_START_DOWNSCALE_FINISHED, UsageProto.CDPClusterStatus.Value.STOP_START_DOWNSCALE_FAILED);
                     break;
                 case "DownscaleFlowEventChainFactory":
                     useCase = getClusterStatus(nextFlowState, "DOWNSCALE_FINISHED_STATE",

--- a/usage-collection/src/main/proto/usage.proto
+++ b/usage-collection/src/main/proto/usage.proto
@@ -1340,6 +1340,20 @@ message CDPClusterStatus {
     DIAGNOSTIC_COLLECTION_FINISHED = 35;
     // The status when CB could not create the diagnostic bundle for the the cluster
     DIAGNOSTIC_COLLECTION_FAILED = 36;
+
+    // The status when a cluster is trying to upscale via stop-start
+    STOP_START_UPSCALE_STARTED = 37;
+    // The status when a cluster has completed upscale via stop-start
+    STOP_START_UPSCALE_FINISHED = 38;
+    // The status when a cluster failed to upscale via stop-start
+    STOP_START_UPSCALE_FAILED = 39;
+
+    // The status when a cluster is trying to downscale via stop-start
+    STOP_START_DOWNSCALE_STARTED = 40;
+    // The status when a cluster has completed downscale via stop-start
+    STOP_START_DOWNSCALE_FINISHED = 41;
+    // The status when a cluster failed to downscale via stop-start
+    STOP_START_DOWNSCALE_FAILED = 42;
   }
 }
 


### PR DESCRIPTION
…Start scaling

- Added the new flows to ClusterUseCaseMapper to propagate metrics for faster autoscaling. 

See detailed description in the commit message.