### PR TITLE
CB-16699 Bring your own DNS zone - Rename endpoint body field to prep…

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureDatabaseTemplateBuilder.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureDatabaseTemplateBuilder.java
@@ -67,7 +67,7 @@ public class AzureDatabaseTemplateBuilder {
             Map<String, Object> model = new HashMap<>();
             model.put("usePrivateEndpoints", USE_PRIVATE_ENDPOINT.equals(azureNetworkView.getEndpointType()));
             model.put("subnetIdForPrivateEndpoint", azureNetworkView.getSubnetIdForPrivateEndpoint());
-            model.put("existingPrivateDnsZoneId", azureNetworkView.getExistingPrivateDnsZoneId());
+            model.put("existingDatabasePrivateDnsZoneId", azureNetworkView.getExistingDatabasePrivateDnsZoneId());
             model.put("adminLoginName", azureDatabaseServerView.getAdminLoginName());
             model.put("adminPassword", azureDatabaseServerView.getAdminPassword());
             model.put("backupRetentionDays", azureDatabaseServerView.getBackupRetentionDays());

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtils.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtils.java
@@ -73,7 +73,7 @@ public class AzureUtils {
 
     public static final String NETWORK_ID = "networkId";
 
-    public static final String PRIVATE_DNS_ZONE_ID = "privateDnsZoneId";
+    public static final String DATABASE_PRIVATE_DS_ZONE_ID = "databasePrivateDsZoneId";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AzureUtils.class);
 
@@ -208,7 +208,7 @@ public class AzureUtils {
     }
 
     public String getPrivateDnsZoneId(Network network) {
-        return network.getStringParameter(PRIVATE_DNS_ZONE_ID);
+        return network.getStringParameter(DATABASE_PRIVATE_DS_ZONE_ID);
     }
 
     public String getCustomResourceGroupName(Network network) {

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureNetworkView.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureNetworkView.java
@@ -16,7 +16,7 @@ public class AzureNetworkView {
 
     private static final String ENDPOINT_TYPE = "endpointType";
 
-    private static final String EXISTING_PRIVATE_DNS_ZONE_ID = "existingPrivateDnsZoneId";
+    private static final String EXISTING_DATABASE_PRIVATE_DNS_ZONE_ID = "existingDatabasePrivateDnsZoneId";
 
     private String networkId;
 
@@ -103,7 +103,7 @@ public class AzureNetworkView {
         return network.getStringParameter(SUBNET_FOR_PRIVATE_ENDPOINT);
     }
 
-    public String getExistingPrivateDnsZoneId() {
-        return network.getStringParameter(EXISTING_PRIVATE_DNS_ZONE_ID);
+    public String getExistingDatabasePrivateDnsZoneId() {
+        return network.getStringParameter(EXISTING_DATABASE_PRIVATE_DNS_ZONE_ID);
     }
 }

--- a/cloud-azure/src/main/resources/templates/arm-dbstack.ftl
+++ b/cloud-azure/src/main/resources/templates/arm-dbstack.ftl
@@ -281,8 +281,8 @@
                     {
                         "name": "dns-${privateEndpointName}",
                         "properties": {
-                            <#if existingPrivateDnsZoneId??>
-                            "privateDnsZoneId": "${existingPrivateDnsZoneId}"
+                            <#if existingDatabasePrivateDnsZoneId??>
+                            "privateDnsZoneId": "${existingDatabasePrivateDnsZoneId}"
                             <#else>
                             "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', 'privatelink.postgres.database.azure.com')]"
                             </#if>

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureNetworkViewTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureNetworkViewTest.java
@@ -19,7 +19,7 @@ public class AzureNetworkViewTest {
 
     private static final String ENDPOINT_TYPE = "endpointType";
 
-    private static final String EXISTING_PRIVATE_DNS_ZONE_ID = "existingPrivateDnsZoneId";
+    private static final String EXISTING_PRIVATE_DNS_ZONE_ID = "existingDatabasePrivateDnsZoneId";
 
     @Mock
     private Network network;
@@ -54,6 +54,6 @@ public class AzureNetworkViewTest {
     @Test
     public void testGetPrivateDnsZoneId() {
         when(network.getStringParameter(EXISTING_PRIVATE_DNS_ZONE_ID)).thenReturn("privateDnsZoneId-a");
-        assertThat(underTest.getExistingPrivateDnsZoneId()).isEqualTo("privateDnsZoneId-a");
+        assertThat(underTest.getExistingDatabasePrivateDnsZoneId()).isEqualTo("privateDnsZoneId-a");
     }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/network/AzureNetworkV4Parameters.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/network/AzureNetworkV4Parameters.java
@@ -31,7 +31,7 @@ public class AzureNetworkV4Parameters extends MappableBase implements JsonEntity
     private String subnetId;
 
     @ApiModelProperty
-    private String privateDnsZoneId;
+    private String databasePrivateDnsZoneId;
 
     public Boolean getNoPublicIp() {
         return noPublicIp;
@@ -65,12 +65,12 @@ public class AzureNetworkV4Parameters extends MappableBase implements JsonEntity
         this.subnetId = subnetId;
     }
 
-    public String getPrivateDnsZoneId() {
-        return privateDnsZoneId;
+    public String getDatabasePrivateDnsZoneId() {
+        return databasePrivateDnsZoneId;
     }
 
-    public void setPrivateDnsZoneId(String privateDnsZoneId) {
-        this.privateDnsZoneId = privateDnsZoneId;
+    public void setDatabasePrivateDnsZoneId(String databasePrivateDnsZoneId) {
+        this.databasePrivateDnsZoneId = databasePrivateDnsZoneId;
     }
 
     @Override
@@ -80,7 +80,7 @@ public class AzureNetworkV4Parameters extends MappableBase implements JsonEntity
         putIfValueNotNull(map, "resourceGroupName", resourceGroupName);
         putIfValueNotNull(map, "networkId", networkId);
         putIfValueNotNull(map, "subnetId", subnetId);
-        putIfValueNotNull(map, "privateDnsZoneId", privateDnsZoneId);
+        putIfValueNotNull(map, "databasePrivateDsZoneId", databasePrivateDnsZoneId);
         return map;
     }
 
@@ -97,6 +97,6 @@ public class AzureNetworkV4Parameters extends MappableBase implements JsonEntity
         resourceGroupName = getParameterOrNull(parameters, "resourceGroupName");
         networkId = getParameterOrNull(parameters, "networkId");
         subnetId = getParameterOrNull(parameters, "subnetId");
-        privateDnsZoneId = getParameterOrNull(parameters, "privateDnsZoneId");
+        databasePrivateDnsZoneId = getParameterOrNull(parameters, "databasePrivateDsZoneId");
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/AzureEnvironmentNetworkConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/AzureEnvironmentNetworkConverter.java
@@ -25,12 +25,12 @@ public class AzureEnvironmentNetworkConverter extends EnvironmentBaseNetworkConv
                 "networkId", azure.getNetworkId(),
                 "resourceGroupName", azure.getResourceGroupName(),
                 "noPublicIp", azure.getNoPublicIp(),
-                "privateDnsZoneId", getPrivateDnsZoneId(azure)
+                "databasePrivateDsZoneId", getDatabasePrivateDnsZoneId(azure)
         );
     }
 
-    private String getPrivateDnsZoneId(EnvironmentNetworkAzureParams azure) {
-        return StringUtils.isNotEmpty(azure.getPrivateDnsZoneId()) ? azure.getPrivateDnsZoneId() : "";
+    private String getDatabasePrivateDnsZoneId(EnvironmentNetworkAzureParams azure) {
+        return StringUtils.isNotEmpty(azure.getDatabasePrivateDnsZoneId()) ? azure.getDatabasePrivateDnsZoneId() : "";
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/NetworkV1ToNetworkV4Converter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/NetworkV1ToNetworkV4Converter.java
@@ -128,7 +128,7 @@ public class NetworkV1ToNetworkV4Converter {
             response.setNetworkId(value.getAzure().getNetworkId());
             response.setNoPublicIp(value.getAzure().getNoPublicIp());
             response.setResourceGroupName(value.getAzure().getResourceGroupName());
-
+            response.setDatabasePrivateDnsZoneId(value.getAzure().getDatabasePrivateDnsZoneId());
             String subnetId = key.getSubnetId();
             if (!Strings.isNullOrEmpty(subnetId)) {
                 response.setSubnetId(subnetId);

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/EnvironmentNetworkAzureParams.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/EnvironmentNetworkAzureParams.java
@@ -26,7 +26,7 @@ public class EnvironmentNetworkAzureParams {
 
     @Size(max = 255)
     @ApiModelProperty(value = EnvironmentModelDescription.AZURE_PRIVATE_DNS_ZONE_ID)
-    private String privateDnsZoneId;
+    private String databasePrivateDnsZoneId;
 
     @NotNull
     @ApiModelProperty(EnvironmentModelDescription.AZURE_NO_PUBLIC_IP)
@@ -56,12 +56,12 @@ public class EnvironmentNetworkAzureParams {
         this.noPublicIp = noPublicIp;
     }
 
-    public String getPrivateDnsZoneId() {
-        return privateDnsZoneId;
+    public String getDatabasePrivateDnsZoneId() {
+        return databasePrivateDnsZoneId;
     }
 
-    public void setPrivateDnsZoneId(String privateDnsZoneId) {
-        this.privateDnsZoneId = privateDnsZoneId;
+    public void setDatabasePrivateDnsZoneId(String databasePrivateDnsZoneId) {
+        this.databasePrivateDnsZoneId = databasePrivateDnsZoneId;
     }
 
     @Override
@@ -69,7 +69,7 @@ public class EnvironmentNetworkAzureParams {
         return "EnvironmentNetworkAzureParams{" +
                 "networkId='" + networkId + '\'' +
                 ", resourceGroupName='" + resourceGroupName + '\'' +
-                ", privateDnsZoneId='" + privateDnsZoneId + '\'' +
+                ", databasePrivateDnsZoneId='" + databasePrivateDnsZoneId + '\'' +
                 ", noPublicIp=" + noPublicIp +
                 '}';
     }
@@ -81,7 +81,7 @@ public class EnvironmentNetworkAzureParams {
 
         private Boolean noPublicIp;
 
-        private String privateDnsZoneId;
+        private String databasePrivateDnsZoneId;
 
         private EnvironmentNetworkAzureParamsBuilder() {
         }
@@ -105,8 +105,8 @@ public class EnvironmentNetworkAzureParams {
             return this;
         }
 
-        public EnvironmentNetworkAzureParamsBuilder withPrivateDnsZoneId(String privateDnsZoneId) {
-            this.privateDnsZoneId = privateDnsZoneId;
+        public EnvironmentNetworkAzureParamsBuilder withDatabasePrivateDnsZoneId(String databasePrivateDnsZoneId) {
+            this.databasePrivateDnsZoneId = databasePrivateDnsZoneId;
             return this;
         }
 
@@ -115,7 +115,7 @@ public class EnvironmentNetworkAzureParams {
             environmentNetworkAzureParams.setNetworkId(networkId);
             environmentNetworkAzureParams.setResourceGroupName(resourceGroupName);
             environmentNetworkAzureParams.setNoPublicIp(noPublicIp);
-            environmentNetworkAzureParams.setPrivateDnsZoneId(privateDnsZoneId);
+            environmentNetworkAzureParams.setDatabasePrivateDnsZoneId(databasePrivateDnsZoneId);
             return environmentNetworkAzureParams;
         }
     }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/NetworkDtoToResponseConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/NetworkDtoToResponseConverter.java
@@ -60,7 +60,7 @@ public class NetworkDtoToResponseConverter {
                         .withNetworkId(p.getNetworkId())
                         .withResourceGroupName(p.getResourceGroupName())
                         .withNoPublicIp(p.isNoPublicIp())
-                        .withPrivateDnsZoneId(p.getPrivateDnsZoneId())
+                        .withDatabasePrivateDnsZoneId(p.getDatabasePrivateDnsZoneId())
                         .build()))
                 .withGcp(getIfNotNull(network.getGcp(), p -> EnvironmentNetworkGcpParams.EnvironmentNetworkGcpParamsBuilder
                         .anEnvironmentNetworkGcpParamsBuilder()

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/NetworkRequestToDtoConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/NetworkRequestToDtoConverter.java
@@ -45,7 +45,7 @@ public class NetworkRequestToDtoConverter {
                     .withNetworkId(network.getAzure().getNetworkId())
                     .withNoPublicIp(Boolean.TRUE.equals(network.getAzure().getNoPublicIp()))
                     .withResourceGroupName(network.getAzure().getResourceGroupName())
-                    .withPrivateDnsZoneId(network.getAzure().getPrivateDnsZoneId())
+                    .withDatabasePrivateDnsZoneId(network.getAzure().getDatabasePrivateDnsZoneId())
                     .build();
             builder.withAzure(azureParams);
             builder.withNetworkId(network.getAzure().getNetworkId());

--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/network/azure/AzureExistingPrivateDnsZonesService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/network/azure/AzureExistingPrivateDnsZonesService.java
@@ -16,7 +16,7 @@ public class AzureExistingPrivateDnsZonesService {
 
     public Map<AzurePrivateDnsZoneServiceEnum, String> getExistingZones(NetworkDto networkDto) {
         Map<AzurePrivateDnsZoneServiceEnum, String> result = new HashMap<>();
-        Optional.ofNullable(networkDto.getAzure().getPrivateDnsZoneId())
+        Optional.ofNullable(networkDto.getAzure().getDatabasePrivateDnsZoneId())
                 .ifPresent(privateDnsZone -> result.put(AzurePrivateDnsZoneServiceEnum.POSTGRES, privateDnsZone));
         return result;
     }

--- a/environment/src/main/java/com/sequenceiq/environment/network/dao/domain/AzureNetwork.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/dao/domain/AzureNetwork.java
@@ -12,7 +12,7 @@ public class AzureNetwork extends BaseNetwork {
 
     private Boolean noPublicIp;
 
-    private String privateDnsZoneId;
+    private String databasePrivateDnsZoneId;
 
     public String getNetworkId() {
         return networkId;
@@ -38,12 +38,12 @@ public class AzureNetwork extends BaseNetwork {
         this.noPublicIp = noPublicIp;
     }
 
-    public String getPrivateDnsZoneId() {
-        return privateDnsZoneId;
+    public String getDatabasePrivateDnsZoneId() {
+        return databasePrivateDnsZoneId;
     }
 
-    public void setPrivateDnsZoneId(String privateDnsZoneId) {
-        this.privateDnsZoneId = privateDnsZoneId;
+    public void setDatabasePrivateDnsZoneId(String databasePrivateDnsZoneId) {
+        this.databasePrivateDnsZoneId = databasePrivateDnsZoneId;
     }
 
     @Override
@@ -52,7 +52,7 @@ public class AzureNetwork extends BaseNetwork {
                 "networkId='" + networkId + '\'' +
                 ", resourceGroupName='" + resourceGroupName + '\'' +
                 ", noPublicIp=" + noPublicIp +
-                ", privateDnsZoneId='" + privateDnsZoneId + '\'' +
+                ", databasePrivateDnsZoneId='" + databasePrivateDnsZoneId + '\'' +
                 "} " + super.toString();
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/network/v1/converter/AzureEnvironmentNetworkConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/v1/converter/AzureEnvironmentNetworkConverter.java
@@ -1,7 +1,7 @@
 package com.sequenceiq.environment.network.v1.converter;
 
 import static com.sequenceiq.cloudbreak.cloud.azure.AzureUtils.NETWORK_ID;
-import static com.sequenceiq.cloudbreak.cloud.azure.AzureUtils.PRIVATE_DNS_ZONE_ID;
+import static com.sequenceiq.cloudbreak.cloud.azure.AzureUtils.DATABASE_PRIVATE_DS_ZONE_ID;
 import static com.sequenceiq.cloudbreak.cloud.azure.AzureUtils.RG_NAME;
 
 import java.util.HashMap;
@@ -44,7 +44,7 @@ public class AzureEnvironmentNetworkConverter extends EnvironmentBaseNetworkConv
             azureNetwork.setResourceGroupName(azureParams.getResourceGroupName());
             azureNetwork.setNoPublicIp(azureParams.isNoPublicIp());
             if (ServiceEndpointCreation.ENABLED_PRIVATE_ENDPOINT.equals(network.getServiceEndpointCreation())) {
-                azureNetwork.setPrivateDnsZoneId(azureParams.getPrivateDnsZoneId());
+                azureNetwork.setDatabasePrivateDnsZoneId(azureParams.getDatabasePrivateDnsZoneId());
             }
         }
         return azureNetwork;
@@ -81,7 +81,7 @@ public class AzureEnvironmentNetworkConverter extends EnvironmentBaseNetworkConv
                                 .withNetworkId(azureNetwork.getNetworkId())
                                 .withResourceGroupName(azureNetwork.getResourceGroupName())
                                 .withNoPublicIp(azureNetwork.getNoPublicIp())
-                                .withPrivateDnsZoneId(azureNetwork.getPrivateDnsZoneId())
+                                .withDatabasePrivateDnsZoneId(azureNetwork.getDatabasePrivateDnsZoneId())
                                 .build())
                 .build();
     }
@@ -112,7 +112,7 @@ public class AzureEnvironmentNetworkConverter extends EnvironmentBaseNetworkConv
         Map<String, Object> param = new HashMap<>();
         param.put(RG_NAME, azureNetwork.getResourceGroupName());
         param.put(NETWORK_ID, azureNetwork.getNetworkId());
-        param.put(PRIVATE_DNS_ZONE_ID, azureNetwork.getPrivateDnsZoneId());
+        param.put(DATABASE_PRIVATE_DS_ZONE_ID, azureNetwork.getDatabasePrivateDnsZoneId());
         return new Network(null, param);
     }
 }

--- a/environment/src/main/resources/schema/app/20220404143700_CB-16699_Bring_your_own_DNS_zone_-_prepare_private_DNS_zone_endpoint_name_multiple_private_DNS_zones.sql
+++ b/environment/src/main/resources/schema/app/20220404143700_CB-16699_Bring_your_own_DNS_zone_-_prepare_private_DNS_zone_endpoint_name_multiple_private_DNS_zones.sql
@@ -1,0 +1,8 @@
+-- // CB-16699 Bring your own DNS zone - prepare private DNS zone endpoint name multiple private DNS zones
+-- Migration SQL that makes the change goes here.
+ALTER TABLE environment_network ADD COLUMN IF NOT EXISTS databaseprivatednszoneid VARCHAR(255);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE environment_network DROP COLUMN IF EXISTS databaseprivatednszoneid;

--- a/environment/src/test/java/com/sequenceiq/environment/environment/validation/network/azure/AzureExistingPrivateDnsZonesServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/validation/network/azure/AzureExistingPrivateDnsZonesServiceTest.java
@@ -79,7 +79,7 @@ public class AzureExistingPrivateDnsZonesServiceTest {
         return NetworkDto.builder()
                 .withAzure(
                         AzureParams.builder()
-                                .withPrivateDnsZoneId(postgresPrivateDnsZoneId)
+                                .withDatabasePrivateDnsZoneId(postgresPrivateDnsZoneId)
                                 .build()
                 )
                 .build();

--- a/environment/src/test/java/com/sequenceiq/environment/environment/validation/network/azure/AzurePrivateEndpointValidatorTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/validation/network/azure/AzurePrivateEndpointValidatorTest.java
@@ -44,7 +44,7 @@ public class AzurePrivateEndpointValidatorTest {
 
     private static final String NETWORK_ID = "networkId";
 
-    private static final String EXISTING_PRIVATE_DNS_ZONE_ID = "existingPrivateDnsZoneId";
+    private static final String EXISTING_DATABASE_PRIVATE_DNS_ZONE_ID = "existingDatabasePrivateDnsZoneId";
 
     @Mock
     private AzureCloudSubnetParametersService azureCloudSubnetParametersService;
@@ -175,7 +175,7 @@ public class AzurePrivateEndpointValidatorTest {
     void testCheckNewPrivateDnsZoneWhenExistingDnsZone() {
         ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
         EnvironmentDto environmentDto = getEnvironmentDto(MY_SINGLE_RG, ResourceGroupUsagePattern.USE_SINGLE);
-        AzureParams azureParams = getAzureParams(EXISTING_PRIVATE_DNS_ZONE_ID);
+        AzureParams azureParams = getAzureParams(EXISTING_DATABASE_PRIVATE_DNS_ZONE_ID);
 
         underTest.checkNewPrivateDnsZone(validationResultBuilder, environmentDto, getNetworkDto(azureParams));
 
@@ -216,7 +216,7 @@ public class AzurePrivateEndpointValidatorTest {
     @Test
     void testCheckExistingPrivateDnsZoneWhenNotPrivateEndpoint() {
         ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
-        AzureParams azureParams = getAzureParams(EXISTING_PRIVATE_DNS_ZONE_ID);
+        AzureParams azureParams = getAzureParams(EXISTING_DATABASE_PRIVATE_DNS_ZONE_ID);
         NetworkDto networkDto = getNetworkDto(azureParams, ServiceEndpointCreation.DISABLED);
         when(azureExistingPrivateDnsZonesService.hasNoExistingZones(networkDto)).thenReturn(false);
 
@@ -231,7 +231,7 @@ public class AzurePrivateEndpointValidatorTest {
     @Test
     void testCheckExistingPrivateDnsZoneWhenPrivateEndpoint() {
         ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
-        AzureParams azureParams = getAzureParams(EXISTING_PRIVATE_DNS_ZONE_ID);
+        AzureParams azureParams = getAzureParams(EXISTING_DATABASE_PRIVATE_DNS_ZONE_ID);
         NetworkDto networkDto = getNetworkDto(azureParams);
         when(azureExistingPrivateDnsZonesService.hasNoExistingZones(networkDto)).thenReturn(false);
 
@@ -247,11 +247,11 @@ public class AzurePrivateEndpointValidatorTest {
         return getAzureParams(null);
     }
 
-    private AzureParams getAzureParams(String privateDnsZoneId) {
+    private AzureParams getAzureParams(String databasePrivateDnsZoneId) {
         return AzureParams.builder()
                 .withNetworkId(NETWORK_ID)
                 .withResourceGroupName("networkResourceGroupName")
-                .withPrivateDnsZoneId(privateDnsZoneId)
+                .withDatabasePrivateDnsZoneId(databasePrivateDnsZoneId)
                 .build();
     }
 

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/network/NetworkParameterAdder.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/network/NetworkParameterAdder.java
@@ -35,7 +35,7 @@ public class NetworkParameterAdder {
 
     private static final String SUBNET_FOR_PRIVATE_ENDPOINT = "subnetForPrivateEndpoint";
 
-    private static final String EXISTING_PRIVATE_DNS_ZONE_ID = "existingPrivateDnsZoneId";
+    private static final String EXISTING_PRIVATE_DNS_ZONE_ID = "existingDatabasePrivateDnsZoneId";
 
     private static final String SUBNETS = "subnets";
 
@@ -80,7 +80,7 @@ public class NetworkParameterAdder {
                 parameters.put(ENDPOINT_TYPE, privateEndpointType);
                 if (PrivateEndpointType.USE_PRIVATE_ENDPOINT == privateEndpointType) {
                     parameters.put(SUBNET_FOR_PRIVATE_ENDPOINT, getAzureSubnetToUseWithPrivateEndpoint(environmentResponse, dbStack));
-                    parameters.put(EXISTING_PRIVATE_DNS_ZONE_ID, environmentResponse.getNetwork().getAzure().getPrivateDnsZoneId());
+                    parameters.put(EXISTING_PRIVATE_DNS_ZONE_ID, environmentResponse.getNetwork().getAzure().getDatabasePrivateDnsZoneId());
                 }
                 break;
             case GCP:

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/service/network/NetworkParameterAdderTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/service/network/NetworkParameterAdderTest.java
@@ -51,7 +51,7 @@ public class NetworkParameterAdderTest {
 
     private static final String SUBNET_FOR_PRIVATE_ENDPOINT = "subnetForPrivateEndpoint";
 
-    private static final String EXISTING_PRIVATE_DNS_ZONE_ID = "existingPrivateDnsZoneId";
+    private static final String EXISTING_DATABASE_PRIVATE_DNS_ZONE_ID = "existingDatabasePrivateDnsZoneId";
 
     private static final String SUBNETS = "subnets";
 
@@ -130,7 +130,7 @@ public class NetworkParameterAdderTest {
         assertThat(parameters, IsMapContaining.hasEntry(ENDPOINT_TYPE, PrivateEndpointType.USE_PRIVATE_ENDPOINT));
         assertThat(parameters, IsMapContaining.hasEntry(SUBNET_FOR_PRIVATE_ENDPOINT,
                 "/subscriptions/mySubscription/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/networkId/subnets/mySubnet"));
-        assertThat(parameters, IsMapContaining.hasEntry(EXISTING_PRIVATE_DNS_ZONE_ID, "privateDnsZoneId"));
+        assertThat(parameters, IsMapContaining.hasEntry(EXISTING_DATABASE_PRIVATE_DNS_ZONE_ID, "databasePrivateDsZoneId"));
     }
 
     @Test
@@ -164,7 +164,7 @@ public class NetworkParameterAdderTest {
                                 EnvironmentNetworkAzureParams.EnvironmentNetworkAzureParamsBuilder.anEnvironmentNetworkAzureParams()
                                         .withResourceGroupName("myResourceGroup")
                                         .withNetworkId("networkId")
-                                        .withPrivateDnsZoneId("privateDnsZoneId")
+                                        .withDatabasePrivateDnsZoneId("databasePrivateDsZoneId")
                                         .build()
                         )
                         .build())

--- a/structuredevent-model/src/main/java/com/sequenceiq/environment/network/dto/AzureParams.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/environment/network/dto/AzureParams.java
@@ -8,13 +8,13 @@ public class AzureParams {
 
     private boolean noPublicIp;
 
-    private String privateDnsZoneId;
+    private String databasePrivateDnsZoneId;
 
     private AzureParams(Builder builder) {
         networkId = builder.networkId;
         resourceGroupName = builder.resourceGroupName;
         noPublicIp = builder.noPublicIp;
-        privateDnsZoneId = builder.privateDnsZoneId;
+        databasePrivateDnsZoneId = builder.databasePrivateDnsZoneId;
     }
 
     public String getNetworkId() {
@@ -41,12 +41,12 @@ public class AzureParams {
         this.noPublicIp = noPublicIp;
     }
 
-    public String getPrivateDnsZoneId() {
-        return privateDnsZoneId;
+    public String getDatabasePrivateDnsZoneId() {
+        return databasePrivateDnsZoneId;
     }
 
-    public void setPrivateDnsZoneId(String privateDnsZoneId) {
-        this.privateDnsZoneId = privateDnsZoneId;
+    public void setDatabasePrivateDnsZoneId(String databasePrivateDnsZoneId) {
+        this.databasePrivateDnsZoneId = databasePrivateDnsZoneId;
     }
 
     @Override
@@ -55,7 +55,7 @@ public class AzureParams {
                 "networkId='" + networkId + '\'' +
                 ", resourceGroupName='" + resourceGroupName + '\'' +
                 ", noPublicIp=" + noPublicIp +
-                ", privateDnsZoneId='" + privateDnsZoneId + '\'' +
+                ", databasePrivateDnsZoneId='" + databasePrivateDnsZoneId + '\'' +
                 '}';
     }
 
@@ -70,7 +70,7 @@ public class AzureParams {
 
         private boolean noPublicIp;
 
-        private String privateDnsZoneId;
+        private String databasePrivateDnsZoneId;
 
         private Builder() {
         }
@@ -90,8 +90,8 @@ public class AzureParams {
             return this;
         }
 
-        public Builder withPrivateDnsZoneId(String privateDnsZoneId) {
-            this.privateDnsZoneId = privateDnsZoneId;
+        public Builder withDatabasePrivateDnsZoneId(String databasePrivateDnsZoneId) {
+            this.databasePrivateDnsZoneId = databasePrivateDnsZoneId;
             return this;
         }
 

--- a/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/EnvironmentDetailsToCDPNetworkDetailsConverter.java
+++ b/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/EnvironmentDetailsToCDPNetworkDetailsConverter.java
@@ -102,7 +102,7 @@ public class EnvironmentDetailsToCDPNetworkDetailsConverter {
 
         if (CloudPlatform.AZURE.equalsIgnoreCase(cloudPlatform)) {
             boolean postgresPrivateDnsZonePresent = Optional.ofNullable(networkDto.getAzure())
-                    .map(AzureParams::getPrivateDnsZoneId)
+                    .map(AzureParams::getDatabasePrivateDnsZoneId)
                     .map(StringUtils::isNotEmpty)
                     .orElse(false);
             builder.setPostgres(postgresPrivateDnsZonePresent);

--- a/structuredevent-service-cdp/src/test/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/EnvironmentDetailsToCDPNetworkDetailsConverterTest.java
+++ b/structuredevent-service-cdp/src/test/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/EnvironmentDetailsToCDPNetworkDetailsConverterTest.java
@@ -263,7 +263,7 @@ class EnvironmentDetailsToCDPNetworkDetailsConverterTest {
     public void testSetOwnDnsZoneWhenAzurePrivateDnsZonePresent() {
         NetworkDto networkDto = NetworkDto.builder()
                 .withAzure(AzureParams.builder()
-                        .withPrivateDnsZoneId("privateDnsZoneId")
+                        .withDatabasePrivateDnsZoneId("privateDnsZoneId")
                         .build()
                 )
                 .withRegistrationType(RegistrationType.EXISTING)
@@ -282,7 +282,7 @@ class EnvironmentDetailsToCDPNetworkDetailsConverterTest {
     public void testSetOwnDnsZoneWhenAzurePrivateDnsZoneNull() {
         NetworkDto networkDto = NetworkDto.builder()
                 .withAzure(AzureParams.builder()
-                        .withPrivateDnsZoneId(null)
+                        .withDatabasePrivateDnsZoneId(null)
                         .build()
                 )
                 .withRegistrationType(RegistrationType.EXISTING)


### PR DESCRIPTION
…are endpoint for multiple private DNS zones

On azure the only service accepting private endpoints is the postgres server. In the future, however, it might be possible that there will be more, and the customer will be able to specify his own private DNS zone for them.
The request body has currently one field: privateDnsZoneId. This name does not reflect the service for which the customer specifies the private DNS zone.
This commit renames privateDnsZoneId to databasePrivateDnsZoneId, and with that all related fields within the Bring your own DNS zone feature, including DB persistence.

See detailed description in the commit message.