### PR TITLE
CB-16699 Bring your own DNS zone - Rename endpoint body field to prep…

### DIFF
--- a/environment/src/main/resources/schema/app/20220419144557_CB-16699_Bring_your_own_DNS_zone_-_Rename_endpoint_body_field,_step_2.sql
+++ b/environment/src/main/resources/schema/app/20220419144557_CB-16699_Bring_your_own_DNS_zone_-_Rename_endpoint_body_field,_step_2.sql
@@ -1,0 +1,9 @@
+-- // CB-16699 Bring your own DNS zone - Rename endpoint body field, step 2
+-- Migration SQL that makes the change goes here.
+ALTER TABLE environment_network DROP COLUMN IF EXISTS privatednszoneid;
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE environment_network ADD COLUMN IF NOT EXISTS privatednszoneid VARCHAR(255);


### PR DESCRIPTION
…are endpoint for multiple private DNS zones part 2

In part 1 privateDnsZoneId was renamed to databasePrivateDnsZoneId. For the DB schema, however, rename is a two step process. In part 1 the new column databaseprivatednszoneid was introcuded.
In this commit the old field privatednszoneid will be deleted.

See detailed description in the commit message.