### PR TITLE
CB-16893. Prevent EntityNotFoundException when handling recipes.

### DIFF
--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/recipe/UpdateRecipeServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/recipe/UpdateRecipeServiceTest.java
@@ -5,6 +5,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -27,6 +33,7 @@ import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.domain.Recipe;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.host.GeneratedRecipe;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
 import com.sequenceiq.cloudbreak.service.hostgroup.HostGroupService;
 
@@ -52,9 +59,12 @@ public class UpdateRecipeServiceTest {
     @Mock
     private HostGroupService hostGroupService;
 
+    @Mock
+    private GeneratedRecipeService generatedRecipeService;
+
     @BeforeEach
     public void setUp() {
-        underTest = new UpdateRecipeService(recipeService, hostGroupService);
+        underTest = new UpdateRecipeService(recipeService, hostGroupService, generatedRecipeService);
     }
 
     @Test
@@ -64,14 +74,16 @@ public class UpdateRecipeServiceTest {
         sampleMap.put(MASTER_HOST_GROUP_NAME, Set.of(PRE_CLDR_START_RECIPE));
         Map<String, Set<String>> hostGroupsSample = new HashMap<>();
         hostGroupsSample.put(MASTER_HOST_GROUP_NAME, Set.of(POST_CLDR_START_RECIPE));
-        when(recipeService.getByNamesForWorkspaceId(any(Set.class), anyLong()))
+        when(recipeService.getByNamesForWorkspaceId(anySet(), anyLong()))
                 .thenReturn(createRecipes(Set.of(PRE_CLDR_START_RECIPE, POST_CLDR_START_RECIPE)));
         when(hostGroupService.getByClusterWithRecipes(anyLong()))
                 .thenReturn(createHostGroupWithRecipes(hostGroupsSample));
+        doNothing().when(generatedRecipeService).deleteAll(anySet());
         // WHEN
         UpdateRecipesV4Response response = underTest.refreshRecipesForCluster(DUMMY_ID, createStack(), createUpdateHostGroupRecipes(sampleMap));
         // THEN
         assertTrue(response.getRecipesAttached().get(0).getRecipeNames().contains(PRE_CLDR_START_RECIPE));
+        verify(generatedRecipeService, times(1)).deleteAll(anySet());
     }
 
     @Test
@@ -81,7 +93,7 @@ public class UpdateRecipeServiceTest {
         sampleMap.put(MASTER_HOST_GROUP_NAME, Set.of(PRE_CLDR_START_RECIPE));
         Map<String, Set<String>> hostGroupsSample = new HashMap<>();
         hostGroupsSample.put(MASTER_HOST_GROUP_NAME, Set.of(PRE_CLDR_START_RECIPE));
-        when(recipeService.getByNamesForWorkspaceId(any(Set.class), anyLong()))
+        when(recipeService.getByNamesForWorkspaceId(anySet(), anyLong()))
                 .thenReturn(createRecipes(Set.of(PRE_CLDR_START_RECIPE)));
         when(hostGroupService.getByClusterWithRecipes(anyLong()))
                 .thenReturn(createHostGroupWithRecipes(hostGroupsSample));
@@ -97,9 +109,7 @@ public class UpdateRecipeServiceTest {
         // GIVEN
         Map<String, Set<String>> sampleMap = new HashMap<>();
         sampleMap.put(MASTER_HOST_GROUP_NAME, Set.of(PRE_CLDR_START_RECIPE));
-        Map<String, Set<String>> hostGroupsSample = new HashMap<>();
-        hostGroupsSample.put(MASTER_HOST_GROUP_NAME, Set.of(POST_CLDR_START_RECIPE));
-        when(recipeService.getByNamesForWorkspaceId(any(Set.class), anyLong()))
+        when(recipeService.getByNamesForWorkspaceId(anySet(), anyLong()))
                 .thenReturn(createRecipes(Set.of(POST_CLDR_START_RECIPE)));
         // WHEN
         BadRequestException exception = assertThrows(BadRequestException.class, () -> underTest.refreshRecipesForCluster(DUMMY_ID, createStack(),
@@ -117,7 +127,7 @@ public class UpdateRecipeServiceTest {
         Map<String, Set<String>> hostGroupsSample = new HashMap<>();
         hostGroupsSample.put(MASTER_HOST_GROUP_NAME, Set.of(POST_CLDR_START_RECIPE));
         hostGroupsSample.put(GATEWAY_HOST_GROUP_NAME, new HashSet<>());
-        when(recipeService.getByNamesForWorkspaceId(any(Set.class), anyLong()))
+        when(recipeService.getByNamesForWorkspaceId(anySet(), anyLong()))
                 .thenReturn(createRecipes(Set.of(PRE_CLDR_START_RECIPE, POST_CLDR_START_RECIPE)));
         when(hostGroupService.getByClusterWithRecipes(anyLong()))
                 .thenReturn(createHostGroupWithRecipes(hostGroupsSample));
@@ -136,7 +146,7 @@ public class UpdateRecipeServiceTest {
         sampleMap.put(MASTER_HOST_GROUP_NAME, Set.of(PRE_CLDR_START_RECIPE));
         Map<String, Set<String>> hostGroupsSample = new HashMap<>();
         hostGroupsSample.put(MASTER_HOST_GROUP_NAME, Set.of(POST_CLDR_START_RECIPE));
-        when(recipeService.getByNamesForWorkspaceId(any(Set.class), anyLong()))
+        when(recipeService.getByNamesForWorkspaceId(anySet(), anyLong()))
                 .thenReturn(createRecipes(Set.of(PRE_CLDR_START_RECIPE, POST_CLDR_START_RECIPE)));
         when(hostGroupService.getByClusterWithRecipes(anyLong()))
                 .thenReturn(createHostGroupWithRecipes(hostGroupsSample));
@@ -145,6 +155,29 @@ public class UpdateRecipeServiceTest {
                 createUpdateHostGroupRecipes(sampleMap));
         // THEN
         assertTrue(response.getRecipesAttached().get(0).getRecipeNames().contains(PRE_CLDR_START_RECIPE));
+    }
+
+    @Test
+    public void testDetachRecipeFromCluster() {
+        // GIVEN
+        Set<Recipe> recipes = createRecipes(Set.of(POST_CLDR_START_RECIPE));
+        Map<String, Set<String>> hostGroupsSample = new HashMap<>();
+        hostGroupsSample.put(MASTER_HOST_GROUP_NAME, Set.of(POST_CLDR_START_RECIPE));
+        Set<HostGroup> hostGroups = createHostGroupWithRecipes(hostGroupsSample);
+        Recipe sampleRecipe = recipes.stream().findFirst().orElse(null);
+        HostGroup sampleHostGroup = hostGroups.stream().findFirst().orElse(null);
+        given(hostGroupService.getByClusterIdAndNameWithRecipes(anyLong(), anyString()))
+                .willReturn(sampleHostGroup);
+        given(recipeService.getByNameForWorkspaceId(anyString(), anyLong()))
+                .willReturn(sampleRecipe);
+        given(hostGroupService.save(any())).willReturn(sampleHostGroup);
+        doNothing().when(generatedRecipeService).deleteAll(anySet());
+        // WHEN
+        underTest.detachRecipeFromCluster(DUMMY_ID, createStack(), POST_CLDR_START_RECIPE, MASTER_HOST_GROUP_NAME);
+        // THEN
+        verify(hostGroupService, times(1)).save(any());
+        verify(hostGroupService, times(1)).getByClusterIdAndNameWithRecipes(anyLong(), anyString());
+        verify(generatedRecipeService, times(1)).deleteAll(anySet());
     }
 
     private List<UpdateHostGroupRecipes> createUpdateHostGroupRecipes(Map<String, Set<String>> hostGroupRecipesMap) {
@@ -164,12 +197,18 @@ public class UpdateRecipeServiceTest {
             HostGroup hostGroup = new HostGroup();
             hostGroup.setName(entry.getKey());
             Set<Recipe> recipeSet = new HashSet<>();
+            Set<GeneratedRecipe> generatedRecipeSet = new HashSet<>();
             for (String recipeName : entry.getValue()) {
                 Recipe recipe = new Recipe();
+                GeneratedRecipe generatedRecipe = new GeneratedRecipe();
+                generatedRecipe.setRecipe(recipe);
                 recipe.setName(recipeName);
+                recipe.setGeneratedRecipes(Set.of(generatedRecipe));
                 recipeSet.add(recipe);
+                generatedRecipeSet.add(generatedRecipe);
             }
             hostGroup.setRecipes(recipeSet);
+            hostGroup.setGeneratedRecipes(generatedRecipeSet);
             result.add(hostGroup);
         }
         return result;


### PR DESCRIPTION
details:
- generated recipes entities are generated during cluster operations like deploy, upscale etc.
- in case of a recipe is detached and right after that is deleted, the next cluster operation that includes recipe operation will fail
- reason is, after recipe deletion, recipe is only set to archived, therefore cascading deletion is not used for the generated recipe, but for the quires, archived = true is skipped, so it can result an EntityNotFoundException, which can block upscales.

See detailed description in the commit message.