### PR TITLE
CB-15964: Validate the availability of the parcel before the upgrade

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/PaywallCredentialPopulator.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/PaywallCredentialPopulator.java
@@ -13,15 +13,15 @@ import org.springframework.stereotype.Component;
 @Component
 public class PaywallCredentialPopulator {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(PaywallCredentialPopulator.class);
+    public static final Pattern ARCHIVE_URL_PATTERN = Pattern.compile("http[s]?://archive\\.cloudera\\.com.+");
 
-    private static final Pattern URL_PATTERN = Pattern.compile("http[s]?://archive\\.cloudera\\.com.+");
+    private static final Logger LOGGER = LoggerFactory.getLogger(PaywallCredentialPopulator.class);
 
     @Inject
     private ClouderaManagerLicenseProvider clouderaManagerLicenseProvider;
 
     public void populateWebTarget(String baseUrl, WebTarget target) {
-        if (URL_PATTERN.matcher(baseUrl).find()) {
+        if (ARCHIVE_URL_PATTERN.matcher(baseUrl).find()) {
             LOGGER.debug("Adding Paywall credential to request to access {}.", baseUrl);
             String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
             JsonCMLicense license = clouderaManagerLicenseProvider.getLicense(userCrn);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/ClusterUpgradeImageValidationEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/ClusterUpgradeImageValidationEvent.java
@@ -5,6 +5,7 @@ import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.vali
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationEvent;
 
 public class ClusterUpgradeImageValidationEvent extends ClusterUpgradeValidationEvent {
@@ -15,12 +16,15 @@ public class ClusterUpgradeImageValidationEvent extends ClusterUpgradeValidation
 
     private final CloudContext cloudContext;
 
+    private final Image targetImage;
+
     public ClusterUpgradeImageValidationEvent(Long resourceId, String imageId, CloudStack cloudStack, CloudCredential cloudCredential,
-            CloudContext cloudContext) {
+            CloudContext cloudContext, Image targetImage) {
         super(VALIDATE_IMAGE_EVENT.selector(), resourceId, imageId);
         this.cloudStack = cloudStack;
         this.cloudCredential = cloudCredential;
         this.cloudContext = cloudContext;
+        this.targetImage = targetImage;
     }
 
     public CloudCredential getCloudCredential() {
@@ -33,6 +37,10 @@ public class ClusterUpgradeImageValidationEvent extends ClusterUpgradeValidation
 
     public CloudContext getCloudContext() {
         return cloudContext;
+    }
+
+    public Image getTargetImage() {
+        return targetImage;
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/config/ClusterUpgradeValidationEventToClusterUpgradeDiskSpaceValidationEventConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/config/ClusterUpgradeValidationEventToClusterUpgradeDiskSpaceValidationEventConverter.java
@@ -1,0 +1,19 @@
+package com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.config;
+
+import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeDiskSpaceValidationEvent;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationEvent;
+import com.sequenceiq.flow.core.PayloadConverter;
+
+public class ClusterUpgradeValidationEventToClusterUpgradeDiskSpaceValidationEventConverter
+        implements PayloadConverter<ClusterUpgradeDiskSpaceValidationEvent> {
+    @Override
+    public boolean canConvert(Class<?> sourceClass) {
+        return ClusterUpgradeValidationEvent.class.isAssignableFrom(sourceClass);
+    }
+
+    @Override
+    public ClusterUpgradeDiskSpaceValidationEvent convert(Object payload) {
+        ClusterUpgradeValidationEvent sourcePayload = (ClusterUpgradeValidationEvent) payload;
+        return new ClusterUpgradeDiskSpaceValidationEvent(sourcePayload.selector(), sourcePayload.getResourceId(), 1L);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/event/ClusterUpgradeDiskSpaceValidationEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/event/ClusterUpgradeDiskSpaceValidationEvent.java
@@ -1,0 +1,24 @@
+package com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event;
+
+import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+
+public class ClusterUpgradeDiskSpaceValidationEvent extends StackEvent {
+
+    private final long requiredFreeSpace;
+
+    public ClusterUpgradeDiskSpaceValidationEvent(String selector, Long resourceId, long requiredFreeSpace) {
+        super(selector, resourceId);
+        this.requiredFreeSpace = requiredFreeSpace;
+    }
+
+    public long getRequiredFreeSpace() {
+        return requiredFreeSpace;
+    }
+
+    @Override
+    public String toString() {
+        return "ClusterUpgradeDiskSpaceValidationEvent{" +
+                "requiredFreeSpace=" + requiredFreeSpace +
+                "} " + super.toString();
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/handler/ClusterUpgradeImageValidationHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/handler/ClusterUpgradeImageValidationHandler.java
@@ -1,8 +1,12 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.handler;
 
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationHandlerSelectors.VALIDATE_IMAGE_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationStateSelectors.START_CLUSTER_UPGRADE_DISK_SPACE_VALIDATION_EVENT;
+
+import java.util.Set;
 
 import javax.inject.Inject;
+import javax.ws.rs.core.Response;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,9 +20,10 @@ import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.ClusterUpgradeImageValidationEvent;
-import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationEvent;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeDiskSpaceValidationEvent;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationFailureEvent;
-import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationStateSelectors;
+import com.sequenceiq.cloudbreak.service.parcel.ParcelAvailabilityService;
+import com.sequenceiq.cloudbreak.service.upgrade.validation.ParcelSizeService;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
 import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
@@ -32,23 +37,35 @@ public class ClusterUpgradeImageValidationHandler extends ExceptionCatcherEventH
     @Inject
     private CloudPlatformConnectors cloudPlatformConnectors;
 
+    @Inject
+    private ParcelAvailabilityService parcelAvailabilityService;
+
+    @Inject
+    private ParcelSizeService parcelSizeService;
+
     @Override
     protected Selectable doAccept(HandlerEvent<ClusterUpgradeImageValidationEvent> event) {
         LOGGER.debug("Accepting cluster upgrade image validation event.");
         ClusterUpgradeImageValidationEvent request = event.getData();
         CloudContext cloudContext = request.getCloudContext();
         try {
-            CloudConnector<Object> connector = cloudPlatformConnectors.get(cloudContext.getPlatformVariant());
-            AuthenticatedContext ac = connector.authentication().authenticate(cloudContext, request.getCloudCredential());
-            for (Validator validator : connector.validators(ValidatorType.IMAGE)) {
-                validator.validate(ac, request.getCloudStack());
-            }
+            Set<Response> parcelsResponses = parcelAvailabilityService.validateAvailability(request.getTargetImage(), request.getResourceId());
+            long requiredDiskSpaceForUpgrade = parcelSizeService.getRequiredFreeSpace(parcelsResponses);
+            executePlatformSpecificValidations(request, cloudContext);
             LOGGER.debug("Cluster upgrade image validation succeeded.");
-            return new ClusterUpgradeValidationEvent(ClusterUpgradeValidationStateSelectors.START_CLUSTER_UPGRADE_DISK_SPACE_VALIDATION_EVENT.selector(),
-                        request.getResourceId(), request.getImageId());
+            return new ClusterUpgradeDiskSpaceValidationEvent(START_CLUSTER_UPGRADE_DISK_SPACE_VALIDATION_EVENT.selector(), request.getResourceId(),
+                    requiredDiskSpaceForUpgrade);
         } catch (RuntimeException e) {
             LOGGER.warn("Cluster upgrade image validation failed: ", e);
             return new ClusterUpgradeValidationFailureEvent(request.getResourceId(), e);
+        }
+    }
+
+    private void executePlatformSpecificValidations(ClusterUpgradeImageValidationEvent request, CloudContext cloudContext) {
+        CloudConnector<Object> connector = cloudPlatformConnectors.get(cloudContext.getPlatformVariant());
+        AuthenticatedContext ac = connector.authentication().authenticate(cloudContext, request.getCloudCredential());
+        for (Validator validator : connector.validators(ValidatorType.IMAGE)) {
+            validator.validate(ac, request.getCloudStack());
         }
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/parcel/ManifestRetrieverService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/parcel/ManifestRetrieverService.java
@@ -26,7 +26,7 @@ public class ManifestRetrieverService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ManifestRetrieverService.class);
 
-    private static final int MANIFEST_READ_TIMEOUT = 5000;
+    private static final int MANIFEST_READ_TIMEOUT_IN_MS = 5000;
 
     @Inject
     private PaywallCredentialPopulator paywallCredentialPopulator;
@@ -39,8 +39,8 @@ public class ManifestRetrieverService {
         String manifestUrl = StringUtils.stripEnd(baseUrl, "/") + "/manifest.json";
         try {
             Client client = restClientFactory.getOrCreateDefault();
-            client.property(ClientProperties.CONNECT_TIMEOUT, MANIFEST_READ_TIMEOUT);
-            client.property(ClientProperties.READ_TIMEOUT, MANIFEST_READ_TIMEOUT);
+            client.property(ClientProperties.CONNECT_TIMEOUT, MANIFEST_READ_TIMEOUT_IN_MS);
+            client.property(ClientProperties.READ_TIMEOUT, MANIFEST_READ_TIMEOUT_IN_MS);
             LOGGER.debug("Trying to retrieve manifest {}", manifestUrl);
             WebTarget target = client.target(manifestUrl);
             addPaywallCredentialsIfNecessary(baseUrl, target);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/parcel/ParcelAvailabilityService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/parcel/ParcelAvailabilityService.java
@@ -1,0 +1,108 @@
+package com.sequenceiq.cloudbreak.service.parcel;
+
+import static com.sequenceiq.cloudbreak.auth.PaywallCredentialPopulator.ARCHIVE_URL_PATTERN;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.auth.PaywallCredentialPopulator;
+import com.sequenceiq.cloudbreak.client.RestClientFactory;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+import com.sequenceiq.cloudbreak.common.exception.UpgradeValidationFailedException;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.service.upgrade.validation.ParcelUrlProvider;
+
+@Service
+public class ParcelAvailabilityService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ParcelAvailabilityService.class);
+
+    @Inject
+    private ParcelUrlProvider parcelUrlProvider;
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private RestClientFactory restClientFactory;
+
+    @Inject
+    private PaywallCredentialPopulator paywallCredentialPopulator;
+
+    public Set<Response> validateAvailability(Image image, Long resourceId) {
+        Set<String> requiredParcelsFromImage = new HashSet<>();
+        String cmRpmUrl = parcelUrlProvider.getCmRpmUrl(image);
+        requiredParcelsFromImage.addAll(parcelUrlProvider.getRequiredParcelsFromImage(image, stackService.getByIdWithListsInTransaction(resourceId)));
+        requiredParcelsFromImage.add(cmRpmUrl);
+
+        Map<String, Optional<Response>> parcelsByResponse = getParcelsByResponse(requiredParcelsFromImage);
+        Set<String> unavailableParcels = getUnavailableParcels(parcelsByResponse);
+
+        if (unavailableParcels.isEmpty()) {
+            LOGGER.debug("All required parcels are available on the image {}", image.getUuid());
+            return parcelsByResponse.entrySet().stream()
+                    .filter(filterCmRpmFile(cmRpmUrl).and(entry -> entry.getValue().isPresent()))
+                    .map(entry -> entry.getValue().get())
+                    .collect(Collectors.toSet());
+        } else {
+            String errorMessage = String.format("Failed to access the following parcels: %s imageId: %s", unavailableParcels, image.getUuid());
+            LOGGER.error(errorMessage);
+            throw new UpgradeValidationFailedException(errorMessage);
+        }
+    }
+
+    private Predicate<Map.Entry<String, Optional<Response>>> filterCmRpmFile(String cmRpmUrl) {
+        return entry -> !entry.getKey().equals(cmRpmUrl);
+    }
+
+    private Map<String, Optional<Response>> getParcelsByResponse(Set<String> requiredParcelsFromImage) {
+        Client client = restClientFactory.getOrCreateDefault();
+        return requiredParcelsFromImage.stream()
+                .collect(Collectors.toMap(
+                        url -> url,
+                        url -> getHeadResponse(client, url)));
+    }
+
+    private Set<String> getUnavailableParcels(Map<String, Optional<Response>> parcelsByResponse) {
+        return parcelsByResponse.entrySet().stream()
+                .filter(entry -> isArchiveUrl(entry) && isNotAvailable(entry))
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toSet());
+    }
+
+    private boolean isArchiveUrl(Map.Entry<String, Optional<Response>> entry) {
+        return ARCHIVE_URL_PATTERN.matcher(entry.getKey()).find();
+    }
+
+    private boolean isNotAvailable(Map.Entry<String, Optional<Response>> entry) {
+        return entry.getValue().isEmpty() || entry.getValue().get().getStatus() != HttpStatus.OK.value();
+    }
+
+    private Optional<Response> getHeadResponse(Client client, String url) {
+        try {
+            WebTarget target = client.target(url);
+            paywallCredentialPopulator.populateWebTarget(url, target);
+            Response response = target.request().head();
+            LOGGER.debug("Head request was successful for {} status: {}", url, response.getStatus());
+            return Optional.of(response);
+        } catch (Exception e) {
+            LOGGER.warn("Could not get the size of the parcel: {} Reason: {}", url, e.getMessage(), e);
+            return Optional.empty();
+        }
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/DiskSpaceValidationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/DiskSpaceValidationService.java
@@ -19,9 +19,7 @@ import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
-import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.cloudbreak.service.GatewayConfigService;
-import com.sequenceiq.cloudbreak.service.image.StatedImage;
 import com.sequenceiq.cloudbreak.service.resource.ResourceService;
 import com.sequenceiq.cloudbreak.util.StackUtil;
 
@@ -50,11 +48,7 @@ public class DiskSpaceValidationService {
     @Inject
     private ResourceService resourceService;
 
-    @Inject
-    private ParcelSizeService parcelSizeService;
-
-    public void validateFreeSpaceForUpgrade(Stack stack, StatedImage targetImage) throws CloudbreakException {
-        long requiredFreeSpace = parcelSizeService.getRequiredFreeSpace(targetImage, stack);
+    public void validateFreeSpaceForUpgrade(Stack stack, long requiredFreeSpace) {
         Map<String, String> freeDiskSpaceByNodes = getFreeDiskSpaceByNodes(stack);
         LOGGER.debug("Required free space for parcels {} KB. Free space by nodes in KB: {}", requiredFreeSpace, freeDiskSpaceByNodes);
         Map<String, String> notEligibleNodes = getNotEligibleNodes(freeDiskSpaceByNodes, requiredFreeSpace,

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/ParcelSizeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/ParcelSizeService.java
@@ -1,26 +1,17 @@
 package com.sequenceiq.cloudbreak.service.upgrade.validation;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
-import javax.inject.Inject;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 
-import com.sequenceiq.cloudbreak.auth.PaywallCredentialPopulator;
-import com.sequenceiq.cloudbreak.client.RestClientFactory;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
-import com.sequenceiq.cloudbreak.service.CloudbreakException;
-import com.sequenceiq.cloudbreak.service.image.StatedImage;
-
 @Service
-class ParcelSizeService {
+public class ParcelSizeService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ParcelSizeService.class);
 
@@ -28,69 +19,19 @@ class ParcelSizeService {
 
     private static final long CM_PACKAGE_SIZE_IN_KB = 3145728L;
 
-    @Inject
-    private RestClientFactory restClientFactory;
-
-    @Inject
-    private PaywallCredentialPopulator paywallCredentialPopulator;
-
-    @Inject
-    private ParcelUrlProvider parcelUrlProvider;
-
-    long getRequiredFreeSpace(StatedImage targetImage, Stack stack) throws CloudbreakException {
-        Map<String, Long> parcelsBySize = getParcelsBySize(targetImage, stack);
-        return getAllParcelSize(parcelsBySize) + CM_PACKAGE_SIZE_IN_KB;
+    public long getRequiredFreeSpace(Set<Response> parcelResponses) {
+        long allParcelSizeInKb = getAllParcelSize(parcelResponses) / DIVIDER_TO_KB;
+        LOGGER.debug("Size of the parcels {} Kb.", allParcelSizeInKb);
+        return allParcelSizeInKb + CM_PACKAGE_SIZE_IN_KB;
     }
 
-    private Map<String, Long> getParcelsBySize(StatedImage targetImage, Stack stack) throws CloudbreakException {
-        Map<String, Long> result = new HashMap<>();
-        Client client = restClientFactory.getOrCreateDefault();
-        for (String parcelUrl : getParcelUrls(targetImage, stack)) {
-            try {
-                WebTarget target = client.target(parcelUrl);
-                paywallCredentialPopulator.populateWebTarget(parcelUrl, target);
-                long parcelSize = Long.parseLong(target.request().head().getHeaderString("Content-Length"));
-                result.put(parcelUrl, parcelSize);
-            } catch (Exception e) {
-                LOGGER.warn("Could not get the size of the parcel: {} Reason: {}", parcelUrl, e.getMessage());
-                result.put(parcelUrl, 0L);
-            }
-        }
-        validateParcelSizes(result);
-        return result;
-    }
-
-    private Set<String> getParcelUrls(StatedImage targetImage, Stack stack) {
-        Set<String> requiredParcelsFromImage = parcelUrlProvider.getRequiredParcelsFromImage(targetImage, stack);
-        LOGGER.debug("The required parcel URLs {} from image {}", requiredParcelsFromImage, targetImage.getImage().getUuid());
-        return requiredParcelsFromImage;
-    }
-
-    private void validateParcelSizes(Map<String, Long> parcelsBySize) throws CloudbreakException {
-        Set<String> unknownParcels = getUnknownParcels(parcelsBySize);
-        if (!unknownParcels.isEmpty()) {
-            throw new CloudbreakException(
-                    String.format("Failed to validate the required free space for upgrade because we're unable to get the size of the following parcels: %s",
-                            unknownParcels));
-        }
-    }
-
-    private Set<String> getUnknownParcels(Map<String, Long> parcelsBySize) {
-        return parcelsBySize.entrySet()
-                .stream()
-                .filter(entry -> entry.getValue() == null || entry.getValue() == 0 || entry.getValue() == -1)
-                .map(Map.Entry::getKey)
-                .collect(Collectors.toSet());
-    }
-
-    private long getAllParcelSize(Map<String, Long> parcelsBySize) {
-        return addParcelSize(parcelsBySize) / DIVIDER_TO_KB;
-    }
-
-    private long addParcelSize(Map<String, Long> parcelsBySize) {
-        return parcelsBySize.values()
-                .stream()
-                .filter(size -> !size.equals(0L))
+    private Long getAllParcelSize(Set<Response> parcelsResponses) {
+        return parcelsResponses.stream()
+                .map(response -> Long.parseLong(getParcelSize(response)))
                 .reduce(1L, Math::addExact);
+    }
+
+    private String getParcelSize(Response response) {
+        return Optional.ofNullable(response.getHeaderString(HttpHeaders.CONTENT_LENGTH)).orElse("0");
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/config/ClusterUpgradeValidationEventToClusterUpgradeDiskSpaceValidationEventConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/config/ClusterUpgradeValidationEventToClusterUpgradeDiskSpaceValidationEventConverterTest.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationHandlerSelectors.VALIDATE_DISK_SPACE_EVENT;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeDiskSpaceValidationEvent;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationEvent;
+
+@ExtendWith(MockitoExtension.class)
+public class ClusterUpgradeValidationEventToClusterUpgradeDiskSpaceValidationEventConverterTest {
+
+    private static final long RESOURCE_ID = 25L;
+
+    @InjectMocks
+    private ClusterUpgradeValidationEventToClusterUpgradeDiskSpaceValidationEventConverter underTest;
+
+    @Test
+    public void testConvertShouldCreateAClusterUpgradeDiskSpaceValidationEvent() {
+        ClusterUpgradeValidationEvent sourceEvent = new ClusterUpgradeValidationEvent(VALIDATE_DISK_SPACE_EVENT.event(), RESOURCE_ID, "image-id");
+        ClusterUpgradeDiskSpaceValidationEvent actual = underTest.convert(sourceEvent);
+
+        assertEquals(RESOURCE_ID, actual.getResourceId());
+        assertEquals(1L, actual.getRequiredFreeSpace());
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/handler/ClusterUpgradeDiskSpaceValidationHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/handler/ClusterUpgradeDiskSpaceValidationHandlerTest.java
@@ -1,14 +1,13 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.handler;
 
-import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationHandlerSelectors.VALIDATE_DISK_SPACE_EVENT;
-import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationStateSelectors.FAILED_CLUSTER_UPGRADE_VALIDATION_EVENT;
-import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationStateSelectors.FINISH_CLUSTER_UPGRADE_DISK_SPACE_VALIDATION_EVENT;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationHandlerSelectors.VALIDATE_DISK_SPACE_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationStateSelectors.FAILED_CLUSTER_UPGRADE_VALIDATION_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationStateSelectors.FINISH_CLUSTER_UPGRADE_DISK_SPACE_VALIDATION_EVENT;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -18,14 +17,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.common.exception.UpgradeValidationFailedException;
-import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
-import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
-import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationEvent;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeDiskSpaceValidationEvent;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
-import com.sequenceiq.cloudbreak.service.CloudbreakException;
-import com.sequenceiq.cloudbreak.service.image.ImageService;
-import com.sequenceiq.cloudbreak.service.image.ImageTestUtil;
-import com.sequenceiq.cloudbreak.service.image.StatedImage;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.service.upgrade.validation.DiskSpaceValidationService;
 import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
@@ -35,13 +28,9 @@ import reactor.bus.Event;
 @RunWith(MockitoJUnitRunner.class)
 public class ClusterUpgradeDiskSpaceValidationHandlerTest {
 
-    private static final String IMAGE_ID = "fe2ad098-88e9-4ffd-b1fa-780a2d353dc5";
-
     private static final long STACK_ID = 1L;
 
-    private static final String IMAGE_CATALOG_NAME = "test-catalog";
-
-    private static final String IMAGE_CATALOG_URL = "catalog-url";
+    private static final long REQUIRED_FREE_SPACE = 1024L;
 
     @InjectMocks
     private ClusterUpgradeDiskSpaceValidationHandler underTest;
@@ -50,63 +39,36 @@ public class ClusterUpgradeDiskSpaceValidationHandlerTest {
     private DiskSpaceValidationService diskSpaceValidationService;
 
     @Mock
-    private ImageService imageService;
-
-    @Mock
     private StackService stackService;
 
     @Mock
     private Stack stack;
 
     @Test
-    public void testHandlerToRetrieveTheImageFromTheCurrentImageCatalog()
-            throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException, CloudbreakException {
-        StatedImage targetImage = createStatedImage();
-        when(imageService.getCurrentImage(STACK_ID)).thenReturn(targetImage);
+    public void testHandlerToRetrieveTheImageFromTheCurrentImageCatalog() {
         when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
 
         Selectable nextFlowStepSelector = underTest.doAccept(createEvent());
 
         assertEquals(FINISH_CLUSTER_UPGRADE_DISK_SPACE_VALIDATION_EVENT.name(), nextFlowStepSelector.selector());
-        verify(imageService).getCurrentImage(STACK_ID);
         verify(stackService).getByIdWithListsInTransaction(STACK_ID);
-        verify(diskSpaceValidationService).validateFreeSpaceForUpgrade(stack, targetImage);
+        verify(diskSpaceValidationService).validateFreeSpaceForUpgrade(stack, REQUIRED_FREE_SPACE);
     }
 
     @Test
-    public void testHandlerShouldReturnFinishEventWhenImageServiceThrowsAnException() throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
-        when(imageService.getCurrentImage(STACK_ID)).thenThrow(new CloudbreakImageNotFoundException("Image not found"));
-
-        Selectable nextFlowStepSelector = underTest.doAccept(createEvent());
-
-        assertEquals(FINISH_CLUSTER_UPGRADE_DISK_SPACE_VALIDATION_EVENT.name(), nextFlowStepSelector.selector());
-        verify(imageService).getCurrentImage(STACK_ID);
-        verifyNoInteractions(stackService);
-        verifyNoInteractions(diskSpaceValidationService);
-    }
-
-    @Test
-    public void testHandlerShouldReturnValidationFailedEventWhenTheDiskValidationFailed()
-            throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException, CloudbreakException {
-        StatedImage targetImage = createStatedImage();
-        when(imageService.getCurrentImage(STACK_ID)).thenReturn(targetImage);
+    public void testHandlerShouldReturnValidationFailedEventWhenTheDiskValidationFailed() {
         when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
-        doThrow(new UpgradeValidationFailedException("Validation failed")).when(diskSpaceValidationService).validateFreeSpaceForUpgrade(stack, targetImage);
+        doThrow(new UpgradeValidationFailedException("Validation failed")).when(diskSpaceValidationService)
+                .validateFreeSpaceForUpgrade(stack, REQUIRED_FREE_SPACE);
 
         Selectable nextFlowStepSelector = underTest.doAccept(createEvent());
 
         assertEquals(FAILED_CLUSTER_UPGRADE_VALIDATION_EVENT.name(), nextFlowStepSelector.selector());
-        verify(imageService).getCurrentImage(STACK_ID);
         verify(stackService).getByIdWithListsInTransaction(STACK_ID);
-        verify(diskSpaceValidationService).validateFreeSpaceForUpgrade(stack, targetImage);
+        verify(diskSpaceValidationService).validateFreeSpaceForUpgrade(stack, REQUIRED_FREE_SPACE);
     }
 
-    private HandlerEvent<ClusterUpgradeValidationEvent> createEvent() {
-        return new HandlerEvent<>(new Event<>(new ClusterUpgradeValidationEvent(VALIDATE_DISK_SPACE_EVENT.selector(), STACK_ID, IMAGE_ID)));
+    private HandlerEvent<ClusterUpgradeDiskSpaceValidationEvent> createEvent() {
+        return new HandlerEvent<>(new Event<>(new ClusterUpgradeDiskSpaceValidationEvent(VALIDATE_DISK_SPACE_EVENT.selector(), STACK_ID, REQUIRED_FREE_SPACE)));
     }
-
-    private StatedImage createStatedImage() {
-        return StatedImage.statedImage(ImageTestUtil.getImage(false, IMAGE_ID, null), IMAGE_CATALOG_URL, IMAGE_CATALOG_NAME);
-    }
-
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/parcel/ParcelAvailabilityServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/parcel/ParcelAvailabilityServiceTest.java
@@ -1,0 +1,203 @@
+package com.sequenceiq.cloudbreak.service.parcel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.auth.PaywallCredentialPopulator;
+import com.sequenceiq.cloudbreak.client.RestClientFactory;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+import com.sequenceiq.cloudbreak.common.exception.UpgradeValidationFailedException;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.service.upgrade.validation.ParcelUrlProvider;
+
+@ExtendWith(MockitoExtension.class)
+public class ParcelAvailabilityServiceTest {
+
+    private static final String PARCEL_1 = "parcel1";
+
+    private static final String PARCEL_2 = "parcel2";
+
+    private static final String ARCHIVE_PARCEL = "https://archive.cloudera.com/parcel";
+
+    private static final String CM_RPM = "cm-rpm";
+
+    private static final long STACK_ID = 1L;
+
+    @InjectMocks
+    private ParcelAvailabilityService underTest;
+
+    @Mock
+    private ParcelUrlProvider parcelUrlProvider;
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private RestClientFactory restClientFactory;
+
+    @Mock
+    private PaywallCredentialPopulator paywallCredentialPopulator;
+
+    @Mock
+    private Client client;
+
+    private final Image image = createImage();
+
+    private final Stack stack = new Stack();
+
+    @Test
+    public void testValidateParcelAvailabilityShouldReturnTheAvailableParcels() {
+        Set<String> requiredParcelsFromImage = createRequiredParcelsSet();
+        when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
+        when(parcelUrlProvider.getRequiredParcelsFromImage(image, stack)).thenReturn(requiredParcelsFromImage);
+        when(parcelUrlProvider.getCmRpmUrl(image)).thenReturn(CM_RPM);
+
+        when(restClientFactory.getOrCreateDefault()).thenReturn(client);
+
+        Response response1 = createMockResponse(200, PARCEL_1);
+        Response response2 = createMockResponse(200, PARCEL_2);
+        Response response3 = createMockResponse(200, ARCHIVE_PARCEL);
+        Response response4 = createMockResponse(200, CM_RPM);
+
+        Set<Response> actual = underTest.validateAvailability(image, STACK_ID);
+
+        assertTrue(actual.contains(response1));
+        assertTrue(actual.contains(response2));
+        assertTrue(actual.contains(response3));
+        assertFalse(actual.contains(response4));
+        assertEquals(3, actual.size());
+    }
+
+    @Test
+    public void testValidateParcelAvailabilityShouldNotThrowExceptionWhenANonArchiveParcelIsNotAvailable() {
+        Set<String> requiredParcelsFromImage = createRequiredParcelsSet();
+        when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
+        when(parcelUrlProvider.getRequiredParcelsFromImage(image, stack)).thenReturn(requiredParcelsFromImage);
+        when(parcelUrlProvider.getCmRpmUrl(image)).thenReturn(CM_RPM);
+
+        when(restClientFactory.getOrCreateDefault()).thenReturn(client);
+
+        Response response1 = createMockResponse(404, PARCEL_1);
+        Response response2 = createMockResponse(200, PARCEL_2);
+        Response response3 = createMockResponse(200, ARCHIVE_PARCEL);
+        Response response4 = createMockResponse(200, CM_RPM);
+
+        Set<Response> actual = underTest.validateAvailability(image, STACK_ID);
+
+        assertTrue(actual.contains(response1));
+        assertTrue(actual.contains(response2));
+        assertTrue(actual.contains(response3));
+        assertFalse(actual.contains(response4));
+        assertEquals(3, actual.size());
+    }
+
+    @Test
+    public void testValidateParcelAvailabilityShouldThrowExceptionWhenAParcelIsNotAvailable() {
+        Set<String> requiredParcelsFromImage = createRequiredParcelsSet();
+        when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
+        when(parcelUrlProvider.getRequiredParcelsFromImage(image, stack)).thenReturn(requiredParcelsFromImage);
+        when(parcelUrlProvider.getCmRpmUrl(image)).thenReturn(CM_RPM);
+
+        when(restClientFactory.getOrCreateDefault()).thenReturn(client);
+
+        createMockResponse(404, ARCHIVE_PARCEL);
+        createMockResponse(200, PARCEL_1);
+        createMockResponse(200, PARCEL_2);
+        createMockResponse(200, CM_RPM);
+
+        assertThrows(UpgradeValidationFailedException.class, () -> underTest.validateAvailability(image, STACK_ID));
+    }
+
+    @Test
+    public void testValidateParcelAvailabilityShouldThrowExceptionWhenTheWebTargetThrowsAnException() {
+        Set<String> requiredParcelsFromImage = createRequiredParcelsSet();
+        when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
+        when(parcelUrlProvider.getRequiredParcelsFromImage(image, stack)).thenReturn(requiredParcelsFromImage);
+        when(parcelUrlProvider.getCmRpmUrl(image)).thenReturn(CM_RPM);
+
+        when(restClientFactory.getOrCreateDefault()).thenReturn(client);
+
+        WebTarget webTarget = mock(WebTarget.class);
+        when(client.target(ARCHIVE_PARCEL)).thenReturn(webTarget);
+        Invocation.Builder request = mock(Invocation.Builder.class);
+        when(webTarget.request()).thenReturn(request);
+        when(request.head()).thenThrow(new BadRequestException());
+
+        createMockResponse(200, PARCEL_1);
+        createMockResponse(200, PARCEL_2);
+        createMockResponse(200, CM_RPM);
+
+        assertThrows(UpgradeValidationFailedException.class, () -> underTest.validateAvailability(image, STACK_ID));
+    }
+
+    @Test
+    public void testValidateParcelAvailabilityShouldNotThrowExceptionWhenTheWebTargetThrowsAnExceptionInCaseOfNonArchiveParcel() {
+        Set<String> requiredParcelsFromImage = createRequiredParcelsSet();
+        when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
+        when(parcelUrlProvider.getRequiredParcelsFromImage(image, stack)).thenReturn(requiredParcelsFromImage);
+        when(parcelUrlProvider.getCmRpmUrl(image)).thenReturn(CM_RPM);
+
+        when(restClientFactory.getOrCreateDefault()).thenReturn(client);
+
+        WebTarget webTarget = mock(WebTarget.class);
+        when(client.target(PARCEL_1)).thenReturn(webTarget);
+        Invocation.Builder request = mock(Invocation.Builder.class);
+        when(webTarget.request()).thenReturn(request);
+        when(request.head()).thenThrow(new BadRequestException());
+
+        Response response3 = createMockResponse(200, ARCHIVE_PARCEL);
+        Response response2 = createMockResponse(200, PARCEL_2);
+        Response response4 = createMockResponse(200, CM_RPM);
+
+        Set<Response> actual = underTest.validateAvailability(image, STACK_ID);
+
+        assertTrue(actual.contains(response2));
+        assertTrue(actual.contains(response3));
+        assertFalse(actual.contains(response4));
+        assertEquals(2, actual.size());
+    }
+
+    private Response createMockResponse(int status, String url) {
+        WebTarget webTarget = mock(WebTarget.class);
+        Invocation.Builder request = mock(Invocation.Builder.class);
+        Response response = mock(Response.class);
+        when(client.target(url)).thenReturn(webTarget);
+        when(webTarget.request()).thenReturn(request);
+        when(request.head()).thenReturn(response);
+        when(response.getStatus()).thenReturn(status);
+        return response;
+    }
+
+    private Image createImage() {
+        return new Image(null, null, null, null, null, "image-id", null, null, null, null, null, null, null, null, null, true, null, null);
+    }
+
+    private Set<String> createRequiredParcelsSet() {
+        Set<String> requiredParcelsFromImage = new HashSet<>();
+        requiredParcelsFromImage.add(PARCEL_1);
+        requiredParcelsFromImage.add(PARCEL_2);
+        requiredParcelsFromImage.add(ARCHIVE_PARCEL);
+        return requiredParcelsFromImage;
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/validation/DiskSpaceValidationServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/validation/DiskSpaceValidationServiceTest.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.service.upgrade.validation;
 
 import static java.util.Collections.emptySet;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
@@ -25,9 +26,7 @@ import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
-import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.cloudbreak.service.GatewayConfigService;
-import com.sequenceiq.cloudbreak.service.image.StatedImage;
 import com.sequenceiq.cloudbreak.service.resource.ResourceService;
 import com.sequenceiq.cloudbreak.util.StackUtil;
 import com.sequenceiq.common.api.type.InstanceGroupType;
@@ -48,12 +47,6 @@ public class DiskSpaceValidationServiceTest {
 
     @Mock
     private ResourceService resourceService;
-
-    @Mock
-    private ParcelSizeService parcelSizeService;
-
-    @Mock
-    private StatedImage targetImage;
 
     @InjectMocks
     private DiskSpaceValidationService underTest;
@@ -80,42 +73,32 @@ public class DiskSpaceValidationServiceTest {
     }
 
     @Test
-    public void testValidateFreeSpaceForUpgradeShouldNotThrowExceptionWhenThereAreEnoughFreeSpaceForUpgrade() throws CloudbreakException {
-        when(parcelSizeService.getRequiredFreeSpace(targetImage, stack)).thenReturn(9000L);
-
-        underTest.validateFreeSpaceForUpgrade(stack, targetImage);
-
+    public void testValidateFreeSpaceForUpgradeShouldNotThrowExceptionWhenThereAreEnoughFreeSpaceForUpgrade() {
+        underTest.validateFreeSpaceForUpgrade(stack, 9000L);
         verifyMocks();
     }
 
     @Test
-    public void testValidateFreeSpaceForUpgradeShouldThrowExceptionWhenThereAreNoEnoughFreeSpaceAndTheRequiredSpaceIsReturnedInMb() throws CloudbreakException {
-        when(parcelSizeService.getRequiredFreeSpace(targetImage, stack)).thenReturn(920000L);
-
+    public void testValidateFreeSpaceForUpgradeShouldThrowExceptionWhenThereAreNoEnoughFreeSpaceAndTheRequiredSpaceIsReturnedInMb() {
         Exception exception = assertThrows(UpgradeValidationFailedException.class, () -> {
-            underTest.validateFreeSpaceForUpgrade(stack, targetImage);
+            underTest.validateFreeSpaceForUpgrade(stack, 920000L);
         });
         assertEquals("There is not enough free space on the nodes to perform upgrade operation. The required free space by nodes: host1: 2.2 GB, host2: 3.1 GB",
                 exception.getMessage());
-
         verifyMocks();
     }
 
     @Test
-    public void testValidateFreeSpaceForUpgradeShouldThrowExceptionWhenThereAreNoEnoughFreeSpaceAndTheRequiredSpaceIsReturnedInGb() throws CloudbreakException {
-        when(parcelSizeService.getRequiredFreeSpace(targetImage, stack)).thenReturn(1750000L);
-
+    public void testValidateFreeSpaceForUpgradeShouldThrowExceptionWhenThereAreNoEnoughFreeSpaceAndTheRequiredSpaceIsReturnedInGb() {
         Exception exception = assertThrows(UpgradeValidationFailedException.class, () -> {
-            underTest.validateFreeSpaceForUpgrade(stack, targetImage);
+            underTest.validateFreeSpaceForUpgrade(stack, 1750000L);
         });
         assertEquals("There is not enough free space on the nodes to perform upgrade operation. The required free space by nodes: host1: 4.2 GB, host2: 5.8 GB",
                 exception.getMessage());
-
         verifyMocks();
     }
 
-    private void verifyMocks() throws CloudbreakException {
-        verify(parcelSizeService).getRequiredFreeSpace(targetImage, stack);
+    private void verifyMocks() {
         verify(resourceService).getAllByStackId(STACK_ID);
         verify(stackUtil).collectNodesWithDiskData(stack);
         verify(gatewayConfigService).getAllGatewayConfigs(stack);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/validation/ParcelSizeServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/validation/ParcelSizeServiceTest.java
@@ -1,125 +1,46 @@
 package com.sequenceiq.cloudbreak.service.upgrade.validation;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpHeaders.CONTENT_LENGTH;
 
 import java.util.Set;
 
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import com.sequenceiq.cloudbreak.auth.PaywallCredentialPopulator;
-import com.sequenceiq.cloudbreak.client.RestClientFactory;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
-import com.sequenceiq.cloudbreak.service.CloudbreakException;
-import com.sequenceiq.cloudbreak.service.image.ImageTestUtil;
-import com.sequenceiq.cloudbreak.service.image.StatedImage;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ParcelSizeServiceTest {
 
-    private static final long CM_PACKAGE_SIZE = 3145728L;
-
-    @Mock
-    private RestClientFactory restClientFactory;
-
-    @Mock
-    private PaywallCredentialPopulator paywallCredentialPopulator;
-
-    @Mock
-    private ParcelUrlProvider parcelUrlProvider;
-
-    @Mock
-    private Client client;
-
-    @Mock
-    private WebTarget webTarget;
-
-    @Mock
-    private Invocation.Builder request;
-
-    @Mock
-    private Response response;
-
-    private StatedImage targetImage;
-
     @InjectMocks
     private ParcelSizeService underTest;
 
-    @Before
-    public void before() {
-        targetImage = createTargetImage();
-        when(restClientFactory.getOrCreateDefault()).thenReturn(client);
-        when(client.target(any(String.class))).thenReturn(webTarget);
-        when(webTarget.request()).thenReturn(request);
+    @Test
+    public void testGetAllParcelSizeShouldReturnTheSizeOfTheParcels() {
+        Response response1 = Mockito.mock(Response.class);
+        when(response1.getHeaderString(CONTENT_LENGTH)).thenReturn("10000");
+        Response response2 = Mockito.mock(Response.class);
+        when(response2.getHeaderString(CONTENT_LENGTH)).thenReturn("10000");
+
+        long actual = underTest.getRequiredFreeSpace(Set.of(response1, response2));
+
+        assertEquals(3145747L, actual);
     }
 
     @Test
-    public void testGetAllParcelSizeShouldReturnTheSizeOfTheParcels() throws CloudbreakException {
-        Stack stack = new Stack();
-        Set<String> parcelUrls = createParcelUrls();
+    public void testGetAllParcelSizeShouldReturnTheSizeOfTheParcelsWhenAContentLengthIsNotAvailable() {
+        Response response1 = Mockito.mock(Response.class);
+        when(response1.getHeaderString(CONTENT_LENGTH)).thenReturn("10000");
+        Response response2 = Mockito.mock(Response.class);
 
-        when(parcelUrlProvider.getRequiredParcelsFromImage(targetImage, stack)).thenReturn(parcelUrls);
-        when(request.head()).thenReturn(response);
-        when(response.getHeaderString("Content-Length")).thenReturn("1000000000");
+        long actual = underTest.getRequiredFreeSpace(Set.of(response1, response2));
 
-        long actual = underTest.getRequiredFreeSpace(targetImage, stack);
-
-        assertEquals(2929687L + CM_PACKAGE_SIZE, actual);
-        verify(restClientFactory).getOrCreateDefault();
-        verify(parcelUrlProvider).getRequiredParcelsFromImage(targetImage, stack);
-        verify(paywallCredentialPopulator, times(3)).populateWebTarget(any(), eq(webTarget));
-    }
-
-    @Test(expected = CloudbreakException.class)
-    public void testGetAllParcelSizeShouldThrowExceptionWhenTheParcelsAreNotAvailable() throws CloudbreakException {
-        Stack stack = new Stack();
-        Set<String> parcelUrls = createParcelUrls();
-
-        when(parcelUrlProvider.getRequiredParcelsFromImage(targetImage, stack)).thenReturn(parcelUrls);
-        when(request.head()).thenThrow(new ProcessingException("Error"));
-
-        underTest.getRequiredFreeSpace(targetImage, stack);
-        verify(restClientFactory).getOrCreateDefault();
-        verify(parcelUrlProvider).getRequiredParcelsFromImage(targetImage, stack);
-        verify(paywallCredentialPopulator).populateWebTarget(any(), eq(webTarget));
-    }
-
-    @Test(expected = CloudbreakException.class)
-    public void testGetAllParcelSizeShouldThrowExceptionWhenTheParcelSizeIsZero() throws CloudbreakException {
-        Stack stack = new Stack();
-        Set<String> parcelUrls = createParcelUrls();
-
-        when(parcelUrlProvider.getRequiredParcelsFromImage(targetImage, stack)).thenReturn(parcelUrls);
-        when(request.head()).thenReturn(response);
-        when(response.getHeaderString("Content-Length")).thenReturn("0");
-
-        underTest.getRequiredFreeSpace(targetImage, stack);
-        verify(restClientFactory).getOrCreateDefault();
-        verify(parcelUrlProvider).getRequiredParcelsFromImage(targetImage, stack);
-        verify(paywallCredentialPopulator).populateWebTarget(any(), eq(webTarget));
-    }
-
-    private Set<String> createParcelUrls() {
-        return Set.of("http://parcel1", "http://parcel2", "http://parcel3");
-    }
-
-    private StatedImage createTargetImage() {
-        return StatedImage.statedImage(ImageTestUtil.getImage(false, "IMAGE_ID", null), "IMAGE_CATALOG_URL", "IMAGE_CATALOG_NAME");
+        assertEquals(3145737L, actual);
     }
 
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/ImageCatalogMockServerSetup.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/ImageCatalogMockServerSetup.java
@@ -3,8 +3,6 @@ package com.sequenceiq.it.cloudbreak.mock;
 import static com.sequenceiq.it.cloudbreak.CloudbreakTest.CLOUDBREAK_SERVER_ROOT;
 import static com.sequenceiq.it.cloudbreak.CloudbreakTest.IMAGE_CATALOG_MOCK_SERVER_ROOT;
 
-import java.time.format.DateTimeFormatter;
-
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.ws.rs.client.Client;
@@ -26,8 +24,6 @@ import com.sequenceiq.it.cloudbreak.cloud.v4.CommonClusterManagerProperties;
 @DependsOn("cloudbreakServer")
 public class ImageCatalogMockServerSetup {
 
-    public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
-
     private static final Logger LOGGER = LoggerFactory.getLogger(ImageCatalogMockServerSetup.class);
 
     private String cdhRuntime;
@@ -48,7 +44,7 @@ public class ImageCatalogMockServerSetup {
     @PostConstruct
     void initImageCatalogIfNecessary() {
         mockImageCatalogServer = testParameter.get(IMAGE_CATALOG_MOCK_SERVER_ROOT);
-        cbVersion =  getCloudbreakUnderTestVersion(testParameter.get(CLOUDBREAK_SERVER_ROOT));
+        cbVersion = getCloudbreakUnderTestVersion(testParameter.get(CLOUDBREAK_SERVER_ROOT));
         cdhRuntime = commonClusterManagerProperties.getRuntimeVersion();
     }
 
@@ -73,61 +69,68 @@ public class ImageCatalogMockServerSetup {
 
     // DYNAMIC address http://localhost:10080/thunderhead/mock-image-catalog?catalog-name=cb-catalog&cb-version=CB-2.29.0&runtime=7.2.2
     public String getFreeIpaImageCatalogUrl() {
-        return String.format("https://%s/mock-image-catalog?catalog-name=%s&cb-version=%s&runtime=%s",
+        return String.format("https://%s/mock-image-catalog?catalog-name=%s&cb-version=%s&runtime=%s&mock-server-address=%s",
                 mockImageCatalogServer,
                 "freeipa-catalog",
                 cbVersion,
-                cdhRuntime);
+                cdhRuntime,
+                mockImageCatalogServer);
     }
 
     public String getFreeIpaImageCatalogUrlWitdDefaultImageUuid(String defaultImageUuid) {
-        return String.format("https://%s/mock-image-catalog?catalog-name=%s&cb-version=%s&runtime=%s&default-image-uuid=%s",
+        return String.format("https://%s/mock-image-catalog?catalog-name=%s&cb-version=%s&runtime=%s&default-image-uuid=%s&mock-server-address=%s",
                 mockImageCatalogServer,
                 "freeipa-catalog",
                 cbVersion,
                 cdhRuntime,
-                defaultImageUuid);
+                defaultImageUuid,
+                mockImageCatalogServer);
     }
 
     public String getImageCatalogUrl() {
-        return String.format("https://%s/mock-image-catalog?catalog-name=%s&cb-version=%s&runtime=%s",
+        return String.format("https://%s/mock-image-catalog?catalog-name=%s&cb-version=%s&runtime=%s&mock-server-address=%s",
                 mockImageCatalogServer,
                 "cb-catalog",
                 cbVersion,
-                cdhRuntime);
+                cdhRuntime,
+                mockImageCatalogServer);
     }
 
     public String getPreWarmedImageCatalogUrl() {
-        return String.format("https://%s/mock-image-catalog?catalog-name=%s&cb-version=%s&runtime=%s",
-                mockImageCatalogServer,
-                "catalog-with-prewarmed",
-                cbVersion,
-                cdhRuntime);
-    }
-
-    public String getPreWarmedImageCatalogUrlWithDefaultImageUuid(String defaultImageUuid) {
-        return String.format("https://%s/mock-image-catalog?catalog-name=%s&cb-version=%s&runtime=%s&default-image-uuid=%s",
+        return String.format("https://%s/mock-image-catalog?catalog-name=%s&cb-version=%s&runtime=%s&mock-server-address=%s",
                 mockImageCatalogServer,
                 "catalog-with-prewarmed",
                 cbVersion,
                 cdhRuntime,
-                defaultImageUuid);
+                mockImageCatalogServer);
+    }
+
+    public String getPreWarmedImageCatalogUrlWithDefaultImageUuid(String defaultImageUuid) {
+        return String.format("https://%s/mock-image-catalog?catalog-name=%s&cb-version=%s&runtime=%s&default-image-uuid=%s&mock-server-address=%s",
+                mockImageCatalogServer,
+                "catalog-with-prewarmed",
+                cbVersion,
+                cdhRuntime,
+                defaultImageUuid,
+                mockImageCatalogServer);
     }
 
     public String getPreWarmedImageCatalogUrlWithCmAndCdhVersions(String cmVersion, String cdhVersion) {
-        return String.format("https://%s/mock-image-catalog?catalog-name=%s&cb-version=%s&runtime=%s&cm=%s",
+        return String.format("https://%s/mock-image-catalog?catalog-name=%s&cb-version=%s&runtime=%s&cm=%s&mock-server-address=%s",
                 mockImageCatalogServer,
                 "catalog-with-prewarmed",
                 cbVersion,
                 cdhVersion,
-                cmVersion);
+                cmVersion,
+                mockImageCatalogServer);
     }
 
     public String getUpgradeImageCatalogUrl() {
-        return String.format("https://%s/mock-image-catalog?catalog-name=%s&cb-version=%s&runtime=%s",
+        return String.format("https://%s/mock-image-catalog?catalog-name=%s&cb-version=%s&runtime=%s&mock-server-address=%s",
                 mockImageCatalogServer,
                 "catalog-with-for-upgrade",
                 cbVersion,
-                cdhRuntime);
+                cdhRuntime,
+                mockImageCatalogServer);
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXClusterCreationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXClusterCreationTest.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.it.cloudbreak.testcase.mock;
 
+import static com.sequenceiq.it.cloudbreak.CloudbreakTest.IMAGE_CATALOG_MOCK_SERVER_ROOT;
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.expectedMessage;
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.pollingInterval;
@@ -19,6 +20,7 @@ import com.sequenceiq.common.api.telemetry.request.TelemetryRequest;
 import com.sequenceiq.common.model.FileSystemType;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkMockParams;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
+import com.sequenceiq.it.TestParameter;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.assertion.audit.DatahubAuditGrpcServiceAssertion;
 import com.sequenceiq.it.cloudbreak.client.BlueprintTestClient;
@@ -85,6 +87,9 @@ public class DistroXClusterCreationTest extends AbstractClouderaManagerTest {
 
     @Inject
     private FreeIpaTestClient freeIpaTestClient;
+
+    @Inject
+    private TestParameter testParameter;
 
     @Override
     protected void setupTest(TestContext testContext) {
@@ -187,7 +192,7 @@ public class DistroXClusterCreationTest extends AbstractClouderaManagerTest {
                 .mockCm().cmImportClusterTemplate().post()
                 .bodyContains(String.format("\"clusterName\":\"%s\"", testContext.get(DistroXTestDto.class).getName()), 1).verify()
                 .mockCm().cmImportClusterTemplate().post().bodyContains("repositories", 1).verify()
-                .mockCm().cmImportClusterTemplate().post().bodyContains("http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/", 1).verify()
+                .mockCm().cmImportClusterTemplate().post().bodyContains(testParameter.get(IMAGE_CATALOG_MOCK_SERVER_ROOT), 4).verify()
                 .validate();
     }
 

--- a/mock-infrastructure/src/main/java/com/sequenceiq/mock/controller/MockImageCatalogController.java
+++ b/mock-infrastructure/src/main/java/com/sequenceiq/mock/controller/MockImageCatalogController.java
@@ -22,7 +22,8 @@ public class MockImageCatalogController {
             @RequestParam("runtime") String runtime,
             @RequestParam(name = "cm", required = false) String cm,
             @RequestParam(name = "default-image-uuid", required = false) String defaultImageUuid,
-            @RequestParam(name = "non-default-image-uuid", required = false) String nonDefaultImageUuid) {
-        return imageCatalogMockService.getImageCatalogByName(name, cbVersion, runtime, cm, defaultImageUuid, nonDefaultImageUuid);
+            @RequestParam(name = "non-default-image-uuid", required = false) String nonDefaultImageUuid,
+            @RequestParam("mock-server-address") String mockServerAddress) {
+        return imageCatalogMockService.getImageCatalogByName(name, cbVersion, runtime, cm, defaultImageUuid, nonDefaultImageUuid, mockServerAddress);
     }
 }

--- a/mock-infrastructure/src/main/java/com/sequenceiq/mock/controller/MockParcelController.java
+++ b/mock-infrastructure/src/main/java/com/sequenceiq/mock/controller/MockParcelController.java
@@ -1,0 +1,16 @@
+package com.sequenceiq.mock.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MockParcelController {
+
+    @GetMapping("/mock-parcel/**")
+    public ResponseEntity<String> getMockParcel() {
+        return new ResponseEntity<>("", HttpStatus.OK);
+    }
+
+}

--- a/mock-infrastructure/src/main/java/com/sequenceiq/mock/service/ImageCatalogMockService.java
+++ b/mock-infrastructure/src/main/java/com/sequenceiq/mock/service/ImageCatalogMockService.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.mock.service;
 
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -18,7 +17,7 @@ public class ImageCatalogMockService {
     private static final String NON_DEFAULT_IMAGE_UUID = "1a6eadd2-5B95-4EC9-B300-13dc43208b64";
 
     public String getImageCatalogByName(String name, String cbVersion, String runtimeVersion, String cmVersion, String defaultImageUuid,
-            String nonDefaultImageUuid) {
+            String nonDefaultImageUuid, String mockServerAddress) {
         String catalog = FileReaderUtils.readFileFromClasspathQuietly(String.format("mock-image-catalogs/%s.json", name));
         String nextRuntimeVersion = getNextRuntimeVersion(runtimeVersion);
         return catalog.replace("CB_VERSION", cbVersion)
@@ -27,7 +26,8 @@ public class ImageCatalogMockService {
                 .replace("CM_VERSION_NEXT", Objects.requireNonNullElse(cmVersion, nextRuntimeVersion))
                 .replace("CM_VERSION", Objects.requireNonNullElse(cmVersion, runtimeVersion))
                 .replace("NON_DEFAULT_IMAGE_UUID", Objects.requireNonNullElse(nonDefaultImageUuid, NON_DEFAULT_IMAGE_UUID))
-                .replace("DEFAULT_IMAGE_UUID", Objects.requireNonNullElse(defaultImageUuid, DEFAULT_IMAGE_UUID));
+                .replace("DEFAULT_IMAGE_UUID", Objects.requireNonNullElse(defaultImageUuid, DEFAULT_IMAGE_UUID))
+                .replace("MOCK_SERVER_ADDRESS", mockServerAddress);
     }
 
     private String getNextRuntimeVersion(String runtime) {

--- a/mock-infrastructure/src/main/resources/mock-image-catalogs/catalog-with-for-upgrade.json
+++ b/mock-infrastructure/src/main/resources/mock-image-catalogs/catalog-with-for-upgrade.json
@@ -14,6 +14,7 @@
         "os_type": "redhat7",
         "uuid": "aaa778fc-7f17-4535-9021-515351df3691",
         "package-versions": {
+          "cm-build-number": "5949264",
           "cm": "CM_VERSION",
           "salt": "2017.7.5",
           "salt-bootstrap": "0.13.0-2018-05-03T07:39:07",
@@ -22,7 +23,7 @@
         "stack-details": {
           "repo": {
             "stack": {
-              "redhat7": "http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/1922354/cdh/7.x/parcels/",
+              "redhat7": "https://MOCK_SERVER_ADDRESS/mock-parcel",
               "repoid": "CDH-CDH_RUNTIME",
               "repository-version": "CDH_RUNTIME-1.cdhCDH_RUNTIME.p0.1922354"
             },
@@ -32,40 +33,40 @@
           "build-number": "1922354"
         },
         "repo": {
-          "redhat7": "http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/1922616/cm7/CM_VERSION/redhat7/yum/"
+          "redhat7": "https://MOCK_SERVER_ADDRESS/mock-parcel"
         },
         "version": "CDH_RUNTIME",
         "build-number": "5949264",
         "pre_warm_parcels": [
           [
             "SCHEMAREGISTRY-0.8.1.3.0.0.0-118-el7.parcel",
-            "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-118/tars/parcel"
+            "https://MOCK_SERVER_ADDRESS/mock-parcel"
           ],
           [
             "STREAMS_MESSAGING_MANAGER-2.1.0.3.0.0.0-118-el7.parcel",
-            "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-118/tars/parcel"
+            "https://MOCK_SERVER_ADDRESS/mock-parcel"
           ],
           [
             "PROFILER_MANAGER-2.0.3.2.0.3.0-50-el7.parcel",
-            "http://s3.amazonaws.com/dev.hortonworks.com/DSS/centos7/2.x/BUILDS/2.0.3.0-50/tars/dataplane_profilers"
+            "https://MOCK_SERVER_ADDRESS/mock-parcel"
           ],
           [
             "PROFILER_SCHEDULER-2.0.3.2.0.3.0-50-el7.parcel",
-            "http://s3.amazonaws.com/dev.hortonworks.com/DSS/centos7/2.x/BUILDS/2.0.3.0-50/tars/dataplane_profilers"
+            "https://MOCK_SERVER_ADDRESS/mock-parcel"
           ],
           [
             "CFM-2.0.0.0-el7.parcel",
-            "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-176/tars/parcel"
+            "https://MOCK_SERVER_ADDRESS/mock-parcel"
           ]
         ],
         "pre_warm_csd": [
-          "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-118/tars/parcel/SCHEMAREGISTRY-0.8.1.jar",
-          "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-118/tars/parcel/STREAMS_MESSAGING_MANAGER-2.1.0.jar",
-          "http://s3.amazonaws.com/dev.hortonworks.com/DSS/centos7/2.x/BUILDS/2.0.3.0-50/tars/dataplane_profilers/PROFILER_MANAGER-2.0.3.2.0.3.0-50.jar",
-          "http://s3.amazonaws.com/dev.hortonworks.com/DSS/centos7/2.x/BUILDS/2.0.3.0-50/tars/dataplane_profilers/PROFILER_SCHEDULER-2.0.3.2.0.3.0-50.jar",
-          "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-176/tars/parcel/NIFI-1.11.1.2.0.0.0-176.jar",
-          "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-176/tars/parcel/NIFICA-1.11.1.2.0.0.0-176.jar",
-          "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-176/tars/parcel/NIFIREGISTRY-0.5.0.2.0.0.0-176.jar"
+          "https://MOCK_SERVER_ADDRESS/mock-parcel/SCHEMAREGISTRY-0.8.1.jar",
+          "https://MOCK_SERVER_ADDRESS/mock-parcel/STREAMS_MESSAGING_MANAGER-2.1.0.jar",
+          "https://MOCK_SERVER_ADDRESS/mock-parcel/PROFILER_MANAGER-2.0.3.2.0.3.0-50.jar",
+          "https://MOCK_SERVER_ADDRESS/mock-parcel/PROFILER_SCHEDULER-2.0.3.2.0.3.0-50.jar",
+          "https://MOCK_SERVER_ADDRESS/mock-parcel/NIFI-1.11.1.2.0.0.0-176.jar",
+          "https://MOCK_SERVER_ADDRESS/mock-parcel/NIFICA-1.11.1.2.0.0.0-176.jar",
+          "https://MOCK_SERVER_ADDRESS/mock-parcel/NIFIREGISTRY-0.5.0.2.0.0.0-176.jar"
         ]
       },
       {
@@ -81,6 +82,7 @@
         "os_type": "redhat7",
         "uuid": "bbbeadd2-5B95-4EC9-B300-13dc43208b64",
         "package-versions": {
+          "cm-build-number": "5949264",
           "cm": "CM_VERSION",
           "salt": "2017.7.5",
           "salt-bootstrap": "0.13.0-2018-05-03T07:39:07",
@@ -89,7 +91,7 @@
         "stack-details": {
           "repo": {
             "stack": {
-              "redhat7": "http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/1922354/cdh/7.x/parcels/",
+              "redhat7": "https://MOCK_SERVER_ADDRESS/mock-parcel/",
               "repoid": "CDH-CDH_RUNTIME",
               "repository-version": "CDH_RUNTIME-1.cdhCDH_RUNTIME.p0.1922354"
             },
@@ -99,40 +101,40 @@
           "build-number": "1922354"
         },
         "repo": {
-          "redhat7": "http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/1922616/cm7/CM_VERSION/redhat7/yum/"
+          "redhat7": "https://MOCK_SERVER_ADDRESS/mock-parcel/"
         },
         "build-number": "5949264",
         "version": "CDH_RUNTIME",
         "pre_warm_parcels": [
           [
             "SCHEMAREGISTRY-0.8.1.3.0.0.0-118-el7.parcel",
-            "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-118/tars/parcel"
+            "https://MOCK_SERVER_ADDRESS/mock-parcel"
           ],
           [
             "STREAMS_MESSAGING_MANAGER-2.1.0.3.0.0.0-118-el7.parcel",
-            "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-118/tars/parcel"
+            "https://MOCK_SERVER_ADDRESS/mock-parcel"
           ],
           [
             "PROFILER_MANAGER-2.0.3.2.0.3.0-50-el7.parcel",
-            "http://s3.amazonaws.com/dev.hortonworks.com/DSS/centos7/2.x/BUILDS/2.0.3.0-50/tars/dataplane_profilers"
+            "https://MOCK_SERVER_ADDRESS/mock-parcel"
           ],
           [
             "PROFILER_SCHEDULER-2.0.3.2.0.3.0-50-el7.parcel",
-            "http://s3.amazonaws.com/dev.hortonworks.com/DSS/centos7/2.x/BUILDS/2.0.3.0-50/tars/dataplane_profilers"
+            "https://MOCK_SERVER_ADDRESS/mock-parcel"
           ],
           [
             "CFM-2.0.0.0-el7.parcel",
-            "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-176/tars/parcel"
+            "https://MOCK_SERVER_ADDRESS/mock-parcel"
           ]
         ],
         "pre_warm_csd": [
-          "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-118/tars/parcel/SCHEMAREGISTRY-0.8.1.jar",
-          "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-118/tars/parcel/STREAMS_MESSAGING_MANAGER-2.1.0.jar",
-          "http://s3.amazonaws.com/dev.hortonworks.com/DSS/centos7/2.x/BUILDS/2.0.3.0-50/tars/dataplane_profilers/PROFILER_MANAGER-2.0.3.2.0.3.0-50.jar",
-          "http://s3.amazonaws.com/dev.hortonworks.com/DSS/centos7/2.x/BUILDS/2.0.3.0-50/tars/dataplane_profilers/PROFILER_SCHEDULER-2.0.3.2.0.3.0-50.jar",
-          "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-176/tars/parcel/NIFI-1.11.1.2.0.0.0-176.jar",
-          "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-176/tars/parcel/NIFICA-1.11.1.2.0.0.0-176.jar",
-          "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-176/tars/parcel/NIFIREGISTRY-0.5.0.2.0.0.0-176.jar"
+          "https://MOCK_SERVER_ADDRESS/mock-parcel/SCHEMAREGISTRY-0.8.1.jar",
+          "https://MOCK_SERVER_ADDRESS/mock-parcel/STREAMS_MESSAGING_MANAGER-2.1.0.jar",
+          "https://MOCK_SERVER_ADDRESS/mock-parcel/PROFILER_MANAGER-2.0.3.2.0.3.0-50.jar",
+          "https://MOCK_SERVER_ADDRESS/mock-parcel/PROFILER_SCHEDULER-2.0.3.2.0.3.0-50.jar",
+          "https://MOCK_SERVER_ADDRESS/mock-parcel/NIFI-1.11.1.2.0.0.0-176.jar",
+          "https://MOCK_SERVER_ADDRESS/mock-parcel/NIFICA-1.11.1.2.0.0.0-176.jar",
+          "https://MOCK_SERVER_ADDRESS/mock-parcel/NIFIREGISTRY-0.5.0.2.0.0.0-176.jar"
         ]
       }
     ]

--- a/mock-infrastructure/src/main/resources/mock-image-catalogs/catalog-with-prewarmed.json
+++ b/mock-infrastructure/src/main/resources/mock-image-catalogs/catalog-with-prewarmed.json
@@ -16,6 +16,7 @@
         "defaultImage": true,
         "package-versions": {
           "cm": "CM_VERSION",
+          "cm-build-number": "14450219",
           "salt": "2017.7.5",
           "salt-bootstrap": "0.13.0-2018-05-03T07:39:07",
           "stack": "CDH_RUNTIME"
@@ -23,7 +24,7 @@
         "stack-details": {
           "repo": {
             "stack": {
-              "redhat7": "http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/1454941/cdh/7.x/parcels/",
+              "redhat7": "https://MOCK_SERVER_ADDRESS/mock-parcel",
               "repoid": "CDH-CDH_RUNTIME",
               "repository-version": "CDH_RUNTIME-1.cdhCDH_RUNTIME.p0.1454941"
             },
@@ -32,29 +33,29 @@
           "version": "CDH_RUNTIME"
         },
         "repo": {
-          "redhat7": "http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/1455819/cm7/CM_VERSION/redhat7/yum/"
+          "redhat7": "https://MOCK_SERVER_ADDRESS/mock-parcel/"
         },
         "version": "CM_VERSION",
         "pre_warm_parcels": [
           [
             "SCHEMAREGISTRY-0.8.0.3.0.0.0-21-el7.parcel",
-            "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-21/tars/parcel"
+            "https://MOCK_SERVER_ADDRESS/mock-parcel"
           ],
           [
             "STREAMS_MESSAGING_MANAGER-2.1.0.3.0.0.0-21-el7.parcel",
-            "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-21/tars/parcel"
+            "https://MOCK_SERVER_ADDRESS/mock-parcel"
           ],
           [
             "CFM-2.0.0.0-el7.parcel",
-            "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-23/tars/parcel"
+            "https://MOCK_SERVER_ADDRESS/mock-parcel"
           ]
         ],
         "pre_warm_csd": [
-          "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-21/tars/parcel/SCHEMAREGISTRY-0.8.0.jar",
-          "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-21/tars/parcel/STREAMS_MESSAGING_MANAGER-2.1.0.jar",
-          "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-23/tars/parcel/NIFI-1.10.0.2.0.0.0-23.jar",
-          "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-23/tars/parcel/NIFICA-1.10.0.2.0.0.0-23.jar",
-          "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-23/tars/parcel/NIFIREGISTRY-0.5.0.2.0.0.0-23.jar"
+          "https://MOCK_SERVER_ADDRESS/mock-parcel/SCHEMAREGISTRY-0.8.0.jar",
+          "https://MOCK_SERVER_ADDRESS/mock-parcel/STREAMS_MESSAGING_MANAGER-2.1.0.jar",
+          "https://MOCK_SERVER_ADDRESS/mock-parcel/NIFI-1.10.0.2.0.0.0-23.jar",
+          "https://MOCK_SERVER_ADDRESS/mock-parcel/NIFICA-1.10.0.2.0.0.0-23.jar",
+          "https://MOCK_SERVER_ADDRESS/mock-parcel/NIFIREGISTRY-0.5.0.2.0.0.0-23.jar"
         ]
       },
       {
@@ -71,6 +72,7 @@
         "uuid": "NON_DEFAULT_IMAGE_UUID",
         "package-versions": {
           "cm": "CM_VERSION_NEXT",
+          "cm-build-number": "14450219",
           "salt": "2017.7.5",
           "salt-bootstrap": "0.13.0-2018-05-03T07:39:07",
           "stack": "CDH_RUNTIME_NEXT"
@@ -78,7 +80,7 @@
         "stack-details": {
           "repo": {
             "stack": {
-              "redhat7": "http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/1454941/cdh/7.x/parcels/",
+              "redhat7": "https://MOCK_SERVER_ADDRESS/mock-parcel/",
               "repoid": "CDH-CDH_RUNTIME_NEXT",
               "repository-version": "CDH_RUNTIME-1.cdhCDH_RUNTIME_NEXT.p0.1454941"
             },
@@ -87,29 +89,29 @@
           "version": "CDH_RUNTIME_NEXT"
         },
         "repo": {
-          "redhat7": "http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/1455819/cm7/CDH_RUNTIME_NEXT/redhat7/yum/"
+          "redhat7": "https://MOCK_SERVER_ADDRESS/mock-parcel/"
         },
         "version": "CM_VERSION_NEXT",
         "pre_warm_parcels": [
           [
             "SCHEMAREGISTRY-0.8.0.3.0.0.0-21-el7.parcel",
-            "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-21/tars/parcel"
+            "https://MOCK_SERVER_ADDRESS/mock-parcel"
           ],
           [
             "STREAMS_MESSAGING_MANAGER-2.1.0.3.0.0.0-21-el7.parcel",
-            "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-21/tars/parcel"
+            "https://MOCK_SERVER_ADDRESS/mock-parcel"
           ],
           [
             "CFM-2.0.0.0-el7.parcel",
-            "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-23/tars/parcel"
+            "https://MOCK_SERVER_ADDRESS/mock-parcel"
           ]
         ],
         "pre_warm_csd": [
-          "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-21/tars/parcel/SCHEMAREGISTRY-0.8.0.jar",
-          "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-21/tars/parcel/STREAMS_MESSAGING_MANAGER-2.1.0.jar",
-          "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-23/tars/parcel/NIFI-1.10.0.2.0.0.0-23.jar",
-          "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-23/tars/parcel/NIFICA-1.10.0.2.0.0.0-23.jar",
-          "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-23/tars/parcel/NIFIREGISTRY-0.5.0.2.0.0.0-23.jar"
+          "https://MOCK_SERVER_ADDRESS/mock-parcel/SCHEMAREGISTRY-0.8.0.jar",
+          "https://MOCK_SERVER_ADDRESS/mock-parcel/STREAMS_MESSAGING_MANAGER-2.1.0.jar",
+          "https://MOCK_SERVER_ADDRESS/mock-parcel/NIFI-1.10.0.2.0.0.0-23.jar",
+          "https://MOCK_SERVER_ADDRESS/mock-parcel/NIFICA-1.10.0.2.0.0.0-23.jar",
+          "https://MOCK_SERVER_ADDRESS/mock-parcel/NIFIREGISTRY-0.5.0.2.0.0.0-23.jar"
         ]
       }
     ]


### PR DESCRIPTION
Add a new validator for the upgrade validation step to test the availability of the parcels.

The validator should check the following items:
- CDH parcel
- required non CDH parcels
- CM repo files
- CSD files
If the validation fails then the upgrade flow should not be started.
