### PR TITLE
CB-16869 Veto job execution if it was scheduled with newer app version

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/quartz/JobDataMapProvider.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/quartz/JobDataMapProvider.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.cloudbreak.quartz;
+
+import org.quartz.JobDataMap;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
+
+@Component
+public class JobDataMapProvider {
+
+    public static final String APP_VERSION_KEY = "appVersion";
+
+    private final String appVersion;
+
+    public JobDataMapProvider(@Value("${info.app.version:}") String appVersion) {
+        this.appVersion = appVersion;
+    }
+
+    public JobDataMap provide(JobResourceAdapter<?> jobResourceAdapter) {
+        return addAppVersionToJobDataMap(jobResourceAdapter.toJobDataMap());
+    }
+
+    /**
+     * Add app version to jobDataMap. It will ensure that jobs will not be executed by older app versions.
+     *
+     * @param jobDataMap input
+     * @return jobDataMap extended with app version
+     */
+    public JobDataMap addAppVersionToJobDataMap(JobDataMap jobDataMap) {
+        jobDataMap.put(APP_VERSION_KEY, appVersion);
+        return jobDataMap;
+    }
+
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/quartz/configuration/JobAppVersionVerifier.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/quartz/configuration/JobAppVersionVerifier.java
@@ -1,0 +1,49 @@
+package com.sequenceiq.cloudbreak.quartz.configuration;
+
+import org.quartz.JobExecutionContext;
+import org.quartz.Trigger;
+import org.quartz.listeners.TriggerListenerSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.quartz.JobDataMapProvider;
+import com.sequenceiq.cloudbreak.util.VersionComparator;
+
+@Component
+public class JobAppVersionVerifier extends TriggerListenerSupport {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JobAppVersionVerifier.class);
+
+    private static final VersionComparator VERSION_COMPARATOR = new VersionComparator();
+
+    private final String appVersion;
+
+    public JobAppVersionVerifier(@Value("${info.app.version:}") String appVersion) {
+        this.appVersion = appVersion;
+    }
+
+    /**
+     * Veto job execution if the job was scheduled with a newer version app than the current app version.
+     *
+     * @param trigger The <code>Trigger</code> that has fired.
+     * @param context The <code>JobExecutionContext</code> that will be passed to the <code>Job</code>'s<code>execute(xx)</code> method.
+     * @return whether veto the job execution
+     */
+    @Override
+    public boolean vetoJobExecution(Trigger trigger, JobExecutionContext context) {
+        String jobAppVersion = context.getMergedJobDataMap().getString(JobDataMapProvider.APP_VERSION_KEY);
+        boolean jobIsNewerThanApp = jobAppVersion != null && VERSION_COMPARATOR.compare(() -> appVersion, () -> jobAppVersion) < 0;
+        if (jobIsNewerThanApp) {
+            LOGGER.info("Vetoing job {} execution, because its version ({}) is newer than app version ({})",
+                    context.getJobDetail().getKey(), jobAppVersion, appVersion);
+        }
+        return jobIsNewerThanApp;
+    }
+
+    @Override
+    public String getName() {
+        return JobAppVersionVerifier.class.getName();
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/quartz/configuration/QuartzConfig.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/quartz/configuration/QuartzConfig.java
@@ -1,9 +1,25 @@
 package com.sequenceiq.cloudbreak.quartz.configuration;
 
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 
 @Configuration
 @PropertySource("classpath:quartz.properties")
 public class QuartzConfig {
+
+    @Inject
+    private Scheduler scheduler;
+
+    @Inject
+    private JobAppVersionVerifier jobAppVersionVerifier;
+
+    @PostConstruct
+    public void configure() throws SchedulerException {
+        scheduler.getListenerManager().addTriggerListener(jobAppVersionVerifier);
+    }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/util/VersionComparator.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/util/VersionComparator.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.cloudbreak.cloud;
+package com.sequenceiq.cloudbreak.util;
 
 import java.io.Serializable;
 import java.util.Comparator;

--- a/common/src/test/java/com/sequenceiq/cloudbreak/quartz/JobDataMapProviderTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/quartz/JobDataMapProviderTest.java
@@ -1,0 +1,48 @@
+package com.sequenceiq.cloudbreak.quartz;
+
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.quartz.JobDataMap;
+
+import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
+
+@ExtendWith(MockitoExtension.class)
+class JobDataMapProviderTest {
+
+    private static final String APP_VERSION = "2.56.0-b28-2-gd167eb0";
+
+    private static final Map<String, String> EXISTING_JOB_PARAMS = Map.of("existing-key", "existing-value");
+
+    private static final JobDataMap JOB_DATA_MAP = new JobDataMap(EXISTING_JOB_PARAMS);
+
+    private final JobDataMapProvider underTest = new JobDataMapProvider(APP_VERSION);
+
+    @Test
+    void addAppVersionToExistingJobDataMap() {
+        JobDataMap result = underTest.addAppVersionToJobDataMap(JOB_DATA_MAP);
+
+        verifyResult(result);
+    }
+
+    @Test
+    void provideForJoBResourceAdapter() {
+        JobResourceAdapter<?> jobResourceAdapter = Mockito.mock(JobResourceAdapter.class);
+        Mockito.when(jobResourceAdapter.toJobDataMap()).thenReturn(JOB_DATA_MAP);
+
+        JobDataMap result = underTest.provide(jobResourceAdapter);
+
+        verifyResult(result);
+    }
+
+    private void verifyResult(JobDataMap result) {
+        Assertions.assertThat(result)
+                .containsAllEntriesOf(EXISTING_JOB_PARAMS)
+                .containsEntry(JobDataMapProvider.APP_VERSION_KEY, APP_VERSION);
+    }
+
+}

--- a/common/src/test/java/com/sequenceiq/cloudbreak/quartz/configuration/JobAppVersionVerifierTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/quartz/configuration/JobAppVersionVerifierTest.java
@@ -1,0 +1,78 @@
+package com.sequenceiq.cloudbreak.quartz.configuration;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.Trigger;
+
+import com.sequenceiq.cloudbreak.quartz.JobDataMapProvider;
+
+@ExtendWith(MockitoExtension.class)
+class JobAppVersionVerifierTest {
+
+    private static final String APP_VERSION = "2.56.0-b28-2-gd167eb0";
+
+    private final JobAppVersionVerifier underTest = new JobAppVersionVerifier(APP_VERSION);
+
+    @Mock
+    private JobExecutionContext context;
+
+    @Mock
+    private Trigger trigger;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(context.getJobDetail()).thenReturn(mock(JobDetail.class));
+        when(context.getMergedJobDataMap()).thenReturn(new JobDataMap());
+    }
+
+    @Test
+    void testMissingJobVersion() {
+        boolean veto = underTest.vetoJobExecution(trigger, context);
+
+        assertFalse(veto);
+    }
+
+    @Test
+    void testOlderJobVersion() {
+        setJobAppVersion("2.54.0-b42-2-gd167eb0");
+
+        boolean veto = underTest.vetoJobExecution(trigger, context);
+
+        assertFalse(veto);
+    }
+
+    @Test
+    void testSameJobVersion() {
+        setJobAppVersion(APP_VERSION);
+
+        boolean veto = underTest.vetoJobExecution(trigger, context);
+
+        assertFalse(veto);
+    }
+
+    @Test
+    void testNewerJobVersion() {
+        setJobAppVersion("2.57.0-b2-1-gd167eb0");
+
+        boolean veto = underTest.vetoJobExecution(trigger, context);
+
+        assertTrue(veto);
+    }
+
+    private void setJobAppVersion(String jobAppVersion) {
+        context.getMergedJobDataMap().put(JobDataMapProvider.APP_VERSION_KEY, jobAppVersion);
+    }
+
+}

--- a/common/src/test/java/com/sequenceiq/cloudbreak/util/VersionComparatorTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/util/VersionComparatorTest.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.cloudbreak.cloud;
+package com.sequenceiq.cloudbreak.util;
 
 import static org.junit.Assert.assertEquals;
 
@@ -17,34 +17,34 @@ public class VersionComparatorTest {
 
     @Test
     public void testEquals() {
-        Assert.assertEquals(0L, underTest.compare(new VersionString("2.4.0.0-770"), new VersionString("2.4.0.0-770")));
+        Assert.assertEquals(0L, underTest.compare(() -> "2.4.0.0-770", () -> "2.4.0.0-770"));
     }
 
     @Test
     public void testGreater() {
-        Assert.assertEquals(1L, underTest.compare(new VersionString("2.4.0.0-880"), new VersionString("2.4.0.0-770")));
-        Assert.assertEquals(1L, underTest.compare(new VersionString("2.4.0.0-1000"), new VersionString("2.4.0.0-770")));
-        Assert.assertEquals(1L, underTest.compare(new VersionString("2.5.0.0-1000"), new VersionString("2.4.0.0-1000")));
-        Assert.assertEquals(1L, underTest.compare(new VersionString("2.15.0.0-1000"), new VersionString("2.5.0.0-1000")));
+        Assert.assertEquals(1L, underTest.compare(() -> "2.4.0.0-880", () -> "2.4.0.0-770"));
+        Assert.assertEquals(1L, underTest.compare(() -> "2.4.0.0-1000", () -> "2.4.0.0-770"));
+        Assert.assertEquals(1L, underTest.compare(() -> "2.5.0.0-1000", () -> "2.4.0.0-1000"));
+        Assert.assertEquals(1L, underTest.compare(() -> "2.15.0.0-1000", () -> "2.5.0.0-1000"));
     }
 
     @Test
     public void testGreaterNonEqualLength() {
-        Assert.assertEquals(1L, underTest.compare(new VersionString("2.4.0.0"), new VersionString("2.4.0.0-770")));
-        Assert.assertEquals(1L, underTest.compare(new VersionString("2.5.0.0"), new VersionString("2.5.0.0-770")));
-        Assert.assertEquals(1L, underTest.compare(new VersionString("7.2.9.1"), new VersionString("7.2.9-1000")));
+        Assert.assertEquals(1L, underTest.compare(() -> "2.4.0.0", () -> "2.4.0.0-770"));
+        Assert.assertEquals(1L, underTest.compare(() -> "2.5.0.0", () -> "2.5.0.0-770"));
+        Assert.assertEquals(1L, underTest.compare(() -> "7.2.9.1", () -> "7.2.9-1000"));
     }
 
     @Test
     public void testSmaller() {
-        Assert.assertEquals(-1L, underTest.compare(new VersionString("2.4.0.0-770"), new VersionString("2.4.0.0-880")));
-        Assert.assertEquals(-1L, underTest.compare(new VersionString("2.4.0.0-770"), new VersionString("2.4.0.0-1000")));
-        Assert.assertEquals(-1L, underTest.compare(new VersionString("2.4.0.0-1000"), new VersionString("2.5.0.0-1000")));
-        Assert.assertEquals(-1L, underTest.compare(new VersionString("2.5.0.0-1000"), new VersionString("2.15.0.0-1000")));
-        Assert.assertEquals(-1L, underTest.compare(new VersionString("7.2.9"), new VersionString("7.2.9.1")));
-        Assert.assertEquals(-1L, underTest.compare(new VersionString("7.2.9-1000"), new VersionString("7.2.9.1")));
-        Assert.assertEquals(-1L, underTest.compare(new VersionString("7.2.9-1"), new VersionString("7.2.9.1-200")));
-        Assert.assertEquals(-1L, underTest.compare(new VersionString("7.2.9"), new VersionString("7.2.9.1-1000")));
+        Assert.assertEquals(-1L, underTest.compare(() -> "2.4.0.0-770", () -> "2.4.0.0-880"));
+        Assert.assertEquals(-1L, underTest.compare(() -> "2.4.0.0-770", () -> "2.4.0.0-1000"));
+        Assert.assertEquals(-1L, underTest.compare(() -> "2.4.0.0-1000", () -> "2.5.0.0-1000"));
+        Assert.assertEquals(-1L, underTest.compare(() -> "2.5.0.0-1000", () -> "2.15.0.0-1000"));
+        Assert.assertEquals(-1L, underTest.compare(() -> "7.2.9", () -> "7.2.9.1"));
+        Assert.assertEquals(-1L, underTest.compare(() -> "7.2.9-1000", () -> "7.2.9.1"));
+        Assert.assertEquals(-1L, underTest.compare(() -> "7.2.9-1", () -> "7.2.9.1-200"));
+        Assert.assertEquals(-1L, underTest.compare(() -> "7.2.9", () -> "7.2.9.1-1000"));
     }
 
     @Test
@@ -73,7 +73,7 @@ public class VersionComparatorTest {
 
     @Test
     public void testSmallerNonEqualLength() {
-        Assert.assertEquals(-1, underTest.compare(new VersionString("2.4.0.0"), new VersionString("2.5.0.0-770")));
+        Assert.assertEquals(-1, underTest.compare(() -> "2.4.0.0", () -> "2.5.0.0-770"));
     }
 
     @Test

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/service/ExposedServiceVersionSupport.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/service/ExposedServiceVersionSupport.java
@@ -6,7 +6,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
 import com.google.common.base.Strings;
-import com.sequenceiq.cloudbreak.cloud.VersionComparator;
+import com.sequenceiq.cloudbreak.util.VersionComparator;
 import com.sequenceiq.cloudbreak.common.type.Versioned;
 
 @Service

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/SaltBootstrapVersionChecker.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/SaltBootstrapVersionChecker.java
@@ -8,7 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.cloud.VersionComparator;
+import com.sequenceiq.cloudbreak.util.VersionComparator;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.type.Versioned;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/image/update/StackImageUpdateService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/image/update/StackImageUpdateService.java
@@ -10,7 +10,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.google.common.collect.Lists;
-import com.sequenceiq.cloudbreak.cloud.VersionComparator;
+import com.sequenceiq.cloudbreak.util.VersionComparator;
 import com.sequenceiq.cloudbreak.cloud.event.model.EventStatus;
 import com.sequenceiq.cloudbreak.cloud.model.CloudbreakDetails;
 import com.sequenceiq.cloudbreak.cloud.model.Image;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJobService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJobService.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.domain.stack.StackPatchType;
+import com.sequenceiq.cloudbreak.quartz.JobDataMapProvider;
 import com.sequenceiq.cloudbreak.quartz.model.JobResource;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.service.stackpatch.ExistingStackPatchService;
@@ -37,6 +38,9 @@ public class ExistingStackPatcherJobService {
 
     @Inject
     private ExistingStackPatcherServiceProvider existingStackPatcherServiceProvider;
+
+    @Inject
+    private JobDataMapProvider jobDataMapProvider;
 
     public void schedule(Long stackId, StackPatchType stackPatchType) {
         JobResource jobResource = stackService.getJobResource(stackId);
@@ -81,7 +85,7 @@ public class ExistingStackPatcherJobService {
         return JobBuilder.newJob(ExistingStackPatcherJob.class)
                 .withIdentity(resource.getJobResource().getLocalId(), JOB_GROUP)
                 .withDescription("Patching existing stack: " + resource.getJobResource().getRemoteResourceId())
-                .usingJobData(resource.toJobDataMap())
+                .usingJobData(jobDataMapProvider.provide(resource))
                 .storeDurably()
                 .build();
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/filesystem/FileSystemSupportMatrixService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/filesystem/FileSystemSupportMatrixService.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.CloudStorageSupportedV4Response;
-import com.sequenceiq.cloudbreak.cloud.VersionComparator;
+import com.sequenceiq.cloudbreak.util.VersionComparator;
 import com.sequenceiq.cloudbreak.common.type.Versioned;
 import com.sequenceiq.cloudbreak.service.CloudbreakResourceReaderService;
 import com.sequenceiq.cloudbreak.service.filesystem.resource.definition.CloudFileSystemSupportConfigEntry;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogVersionFilter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogVersionFilter.java
@@ -17,7 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.cloud.VersionComparator;
+import com.sequenceiq.cloudbreak.util.VersionComparator;
 import com.sequenceiq.cloudbreak.common.type.Versioned;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakVersion;
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/PrefixMatcherService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/PrefixMatcherService.java
@@ -15,7 +15,7 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.cloud.VersionComparator;
+import com.sequenceiq.cloudbreak.util.VersionComparator;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakVersion;
 
 @Component

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/catalog/ImageCatalogService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/catalog/ImageCatalogService.java
@@ -4,7 +4,7 @@ import static java.util.stream.Collectors.toList;
 
 import java.util.List;
 
-import com.sequenceiq.cloudbreak.cloud.VersionComparator;
+import com.sequenceiq.cloudbreak.util.VersionComparator;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakImageCatalogV3;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.common.type.Versioned;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/runtimes/SupportedRuntimes.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/runtimes/SupportedRuntimes.java
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.google.common.base.Strings;
-import com.sequenceiq.cloudbreak.cloud.VersionComparator;
+import com.sequenceiq.cloudbreak.util.VersionComparator;
 import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
 import com.sequenceiq.cloudbreak.service.image.ImageCatalogService;
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackStopRestrictionService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackStopRestrictionService.java
@@ -10,7 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-import com.sequenceiq.cloudbreak.cloud.VersionComparator;
+import com.sequenceiq.cloudbreak.util.VersionComparator;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessorFactory;
 import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/MountDisks.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/MountDisks.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
-import com.sequenceiq.cloudbreak.cloud.VersionComparator;
+import com.sequenceiq.cloudbreak.util.VersionComparator;
 import com.sequenceiq.cloudbreak.cloud.model.CloudbreakDetails;
 import com.sequenceiq.cloudbreak.cloud.model.VolumeSetAttributes;
 import com.sequenceiq.cloudbreak.cluster.util.ResourceAttributeUtil;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ComponentVersionComparator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ComponentVersionComparator.java
@@ -4,7 +4,7 @@ import static com.sequenceiq.cloudbreak.cloud.PrefixMatchLength.MAJOR;
 
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.cloud.VersionComparator;
+import com.sequenceiq.cloudbreak.util.VersionComparator;
 import com.sequenceiq.cloudbreak.cloud.VersionPrefix;
 
 @Component

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/PermittedServicesForUpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/PermittedServicesForUpgradeService.java
@@ -12,7 +12,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.cloud.VersionComparator;
+import com.sequenceiq.cloudbreak.util.VersionComparator;
 
 @Component
 class PermittedServicesForUpgradeService {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/MixedPackageVersionComparator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/MixedPackageVersionComparator.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
-import com.sequenceiq.cloudbreak.cloud.VersionComparator;
+import com.sequenceiq.cloudbreak.util.VersionComparator;
 import com.sequenceiq.cloudbreak.service.upgrade.sync.common.ParcelInfo;
 
 @Service

--- a/datalake/src/main/java/com/sequenceiq/datalake/configuration/CDPConfigService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/configuration/CDPConfigService.java
@@ -34,7 +34,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackV4Request;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.auth.altus.model.Entitlement;
-import com.sequenceiq.cloudbreak.cloud.VersionComparator;
+import com.sequenceiq.cloudbreak.util.VersionComparator;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxReactorFlowManager.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxReactorFlowManager.java
@@ -1,7 +1,7 @@
 package com.sequenceiq.datalake.flow;
 
-import static com.sequenceiq.datalake.flow.create.SdxCreateEvent.SDX_VALIDATION_EVENT;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.DATALAKE_RESIZE_TRIGGERED;
+import static com.sequenceiq.datalake.flow.create.SdxCreateEvent.SDX_VALIDATION_EVENT;
 import static com.sequenceiq.datalake.flow.datalake.recovery.DatalakeUpgradeRecoveryEvent.DATALAKE_RECOVERY_EVENT;
 import static com.sequenceiq.datalake.flow.datalake.upgrade.DatalakeUpgradeEvent.DATALAKE_UPGRADE_EVENT;
 import static com.sequenceiq.datalake.flow.delete.SdxDeleteEvent.SDX_DELETE_EVENT;

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxExternalDatabaseConfigurer.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxExternalDatabaseConfigurer.java
@@ -11,7 +11,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.cloud.VersionComparator;
+import com.sequenceiq.cloudbreak.util.VersionComparator;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.common.type.Versioned;

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -81,7 +81,7 @@ import com.sequenceiq.cloudbreak.auth.crn.CrnResourceDescriptor;
 import com.sequenceiq.cloudbreak.auth.crn.RegionAwareCrnGenerator;
 import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
 import com.sequenceiq.cloudbreak.client.CloudbreakInternalCrnClient;
-import com.sequenceiq.cloudbreak.cloud.VersionComparator;
+import com.sequenceiq.cloudbreak.util.VersionComparator;
 import com.sequenceiq.cloudbreak.common.event.PayloadContext;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/database/DatabaseService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/database/DatabaseService.java
@@ -24,7 +24,7 @@ import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
-import com.sequenceiq.cloudbreak.cloud.VersionComparator;
+import com.sequenceiq.cloudbreak.util.VersionComparator;
 import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/dr/SdxBackupRestoreService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/dr/SdxBackupRestoreService.java
@@ -33,7 +33,6 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.dr.BackupV4Resp
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.dr.RestoreV4Response;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
-import com.sequenceiq.cloudbreak.cloud.VersionComparator;
 import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.common.exception.WebApplicationExceptionMessageExtractor;
@@ -46,6 +45,7 @@ import com.sequenceiq.cloudbreak.datalakedr.model.DatalakeBackupStatusResponse;
 import com.sequenceiq.cloudbreak.datalakedr.model.DatalakeRestoreStatusResponse;
 import com.sequenceiq.cloudbreak.exception.CloudbreakApiException;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.cloudbreak.util.VersionComparator;
 import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.entity.operation.SdxOperation;
 import com.sequenceiq.datalake.entity.operation.SdxOperationStatus;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/util/AvailabilityChecker.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/util/AvailabilityChecker.java
@@ -3,7 +3,7 @@ package com.sequenceiq.freeipa.util;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.cloud.VersionComparator;
+import com.sequenceiq.cloudbreak.util.VersionComparator;
 import com.sequenceiq.cloudbreak.common.type.Versioned;
 import com.sequenceiq.freeipa.entity.Stack;
 

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sequenceiq.cloudbreak.cloud.VersionComparator;
+import com.sequenceiq.cloudbreak.util.VersionComparator;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;


### PR DESCRIPTION
With rolling deployments it can be an issue that a quartz job is scheduled with the newer app version, but an older app tries to execute it and fails.
This is fixed by adding the app version to the job data map, and comparing it to the executing app's version.
Additionally, VersionComparator had to be moved to common module.

See detailed description in the commit message.