### PR TITLE
CB-16759: Have resource authorization doable on detached DLs in order to enable recovery on detached DLs.

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -1238,7 +1238,7 @@ public class SdxService implements ResourceIdProvider, PayloadContextProvider, H
 
     @Override
     public String getResourceCrnByResourceName(String resourceName) {
-        return getByNameInAccount(ThreadBasedUserCrnProvider.getUserCrn(), resourceName).getCrn();
+        return getByNameInAccountAllowDetached(ThreadBasedUserCrnProvider.getUserCrn(), resourceName).getCrn();
     }
 
     @Override


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-16759

I recently made an initial change for this in: https://github.com/hortonworks/cloudbreak/pull/12585 thinking it was working as expected, but what I initially thought worked didn't.

Essentially, the resource authorization done by the Recovery API method calls an internal method which obtains the DL in a way that does not allow detached DLs. This makes recovery of detached DLs impossible.

This change makes it so the resource authorization is able to be done on detached DLs as well. I have tested this fully and in the correct manner this time.