### PR TITLE
CB-16668 Reenabling consumption service build

### DIFF
--- a/cloudera/docker_images.yaml
+++ b/cloudera/docker_images.yaml
@@ -3,6 +3,7 @@ docker_images:
   cloudbreak-autoscale: hortonworks/cloudbreak-autoscale
   cloudbreak-datalake: hortonworks/cloudbreak-datalake
   cloudbreak-environment: hortonworks/cloudbreak-environment
+  cloudbreak-consumption: hortonworks/cloudbreak-consumption
   cloudbreak-freeipa: hortonworks/cloudbreak-freeipa
   cloudbreak-redbeams: hortonworks/cloudbreak-redbeams
   periscope-mock: hortonworks/periscope-mock


### PR DESCRIPTION
- turning back cinsumption-service build to why it fails
- local build works
- `./gradlew :cloud-consumption:publishToMavenLocal` works
- since we lost the logs this is the only way to find out why the build failed on releng portal