### PR TITLE
CB-16795: Allow encryption at host for FreeIPA and DataLake VM disks in Azure

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/instance/AzureInstanceTemplate.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/instance/AzureInstanceTemplate.java
@@ -48,6 +48,23 @@ public class AzureInstanceTemplate extends InstanceTemplate {
      */
     public static final String DISK_ENCRYPTION_SET_ID = "diskEncryptionSetId";
 
+    /**
+     * Key of the optional Boolean dynamic parameter denoting whether Azure virtual machines will be encrypted at host or not.
+     *
+     * <p>
+     *     Permitted values:
+     *     <ul>
+     *         <li>{@code Boolean.TRUE} instance, {@code "true"} (ignoring case): Encryption at host is enabled.</li>
+     *         <li>{@code Boolean.FALSE} instance, {@code "false"} (or any other {@code String} not equal to {@code "true"} ignoring case), {@code null}:
+     *         Encryption at host is disabled. This implies that the virtual machines will not be encrypted at host.</li>
+     *     </ul>
+     * </p>
+     *
+     * @see #putParameter(String, Object)
+     * @see Boolean#parseBoolean(String)
+     */
+    public static final String ENCRYPTION_AT_HOST_ENABLED = "encryptionAtHost";
+
     public AzureInstanceTemplate(String flavor, String groupName, Long privateId, Collection<Volume> volumes, InstanceStatus status,
             Map<String, Object> parameters, Long templateId, String imageId) {
         super(flavor, groupName, privateId, volumes, status, parameters, templateId, imageId, TemporaryStorage.ATTACHED_VOLUMES, 0L);

--- a/cloud-azure/src/main/resources/templates/arm-v2-freeipa.ftl
+++ b/cloud-azure/src/main/resources/templates/arm-v2-freeipa.ftl
@@ -260,6 +260,11 @@
                        "hardwareProfile": {
                            "vmSize": "${instance.flavor}"
                        },
+                       <#if instance.encryptionAtHostEnabled?? && instance.encryptionAtHostEnabled == true>
+                       "securityProfile": {
+                           "encryptionAtHost": true
+                       },
+                       </#if>
                        "osProfile": {
                            "computername": "${instance.instanceName}",
                            "adminUsername": "[parameters('adminUsername')]",

--- a/cloud-azure/src/main/resources/templates/arm-v2.ftl
+++ b/cloud-azure/src/main/resources/templates/arm-v2.ftl
@@ -363,6 +363,11 @@
                        "hardwareProfile": {
                            "vmSize": "${instance.flavor}"
                        },
+                       <#if instance.encryptionAtHostEnabled?? && instance.encryptionAtHostEnabled == true>
+                       "securityProfile": {
+                           "encryptionAtHost": true
+                       },
+                       </#if>
                        "osProfile": {
                            "computername": "${instance.instanceName}",
                            "adminUsername": "[parameters('adminUsername')]",

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/template/AzureEncryptionV4Parameters.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/template/AzureEncryptionV4Parameters.java
@@ -14,12 +14,23 @@ public class AzureEncryptionV4Parameters extends EncryptionParametersV4Base {
     @ApiModelProperty(value = ModelDescriptions.TemplateModelDescription.DISK_ENCRYPTION_SET_ID)
     private String diskEncryptionSetId;
 
+    @ApiModelProperty(value = ModelDescriptions.TemplateModelDescription.ENCRYPTION_AT_HOST_ENABLED)
+    private Boolean encryptionAtHostEnabled;
+
     public String getDiskEncryptionSetId() {
         return diskEncryptionSetId;
     }
 
     public void setDiskEncryptionSetId(String diskEncryptionSetId) {
         this.diskEncryptionSetId = diskEncryptionSetId;
+    }
+
+    public Boolean isEncryptionAtHostEnabled() {
+        return encryptionAtHostEnabled;
+    }
+
+    public void setEncryptionAtHostEnabled(Boolean encryptionAtHostEnabled) {
+        this.encryptionAtHostEnabled = encryptionAtHostEnabled;
     }
 
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
@@ -82,6 +82,7 @@ public class ModelDescriptions {
         public static final String ENCRYPTED = "should encrypt the vm";
         public static final String ENCRYPTION_METHOD = "encryption method for the key (RAW|RSA)";
         public static final String DISK_ENCRYPTION_SET_ID = "disk encryption set Resource ID";
+        public static final String ENCRYPTION_AT_HOST_ENABLED = "boolean determining if VM should be encrypted at host";
         public static final String SECRET_PARAMETERS = "cloud specific secret parameters for template";
     }
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
@@ -418,19 +418,22 @@ public class StackRequestManifester {
                 .map(DetailedEnvironmentResponse::getAzure)
                 .map(AzureEnvironmentParameters::getResourceEncryptionParameters)
                 .map(AzureResourceEncryptionParameters::getDiskEncryptionSetId);
-        if (encryptionKeyUrl.isPresent() && diskEncryptionSetId.isPresent()) {
-            stackRequest.getInstanceGroups().forEach(ig -> {
-                AzureInstanceTemplateV4Parameters azure = ig.getTemplate().createAzure();
-                AzureEncryptionV4Parameters encryption = azure.getEncryption();
-                if (encryption == null) {
-                    encryption = new AzureEncryptionV4Parameters();
-                    azure.setEncryption(encryption);
-                }
+        stackRequest.getInstanceGroups().forEach(ig -> {
+            AzureInstanceTemplateV4Parameters azure = ig.getTemplate().createAzure();
+            AzureEncryptionV4Parameters encryption = azure.getEncryption();
+            if (encryption == null) {
+                encryption = new AzureEncryptionV4Parameters();
+                azure.setEncryption(encryption);
+            }
+            if (encryptionKeyUrl.isPresent() && diskEncryptionSetId.isPresent()) {
                 azure.getEncryption().setKey(encryptionKeyUrl.get());
                 azure.getEncryption().setType(EncryptionType.CUSTOM);
                 azure.getEncryption().setDiskEncryptionSetId(diskEncryptionSetId.get());
-            });
-        }
+            }
+            if (entitlementService.isAzureEncryptionAtHostEnabled(environmentResponse.getAccountId())) {
+                azure.getEncryption().setEncryptionAtHostEnabled(Boolean.TRUE);
+            }
+        });
     }
 
     @VisibleForTesting

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/instance/template/InstanceTemplateRequestToTemplateConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/instance/template/InstanceTemplateRequestToTemplateConverterTest.java
@@ -172,6 +172,32 @@ class InstanceTemplateRequestToTemplateConverterTest {
     }
 
     @Test
+    void shouldSetEncryptionAtHostPropertyWhenAzureAndEncryptionAtHostEnabled() {
+        InstanceTemplateRequest source = new InstanceTemplateRequest();
+        source.setInstanceType(INSTANCE_TYPE);
+        when(entitlementService.isAzureEncryptionAtHostEnabled(ACCOUNT_ID)).thenReturn(Boolean.TRUE);
+
+        Template result = underTest.convert(source, CloudPlatform.AZURE, ACCOUNT_ID, "dummyDiskEncryptionSet", "", "");
+
+        Json attributes = result.getAttributes();
+        assertThat(attributes).isNotNull();
+        assertThat(attributes.<Object>getValue(AzureInstanceTemplate.ENCRYPTION_AT_HOST_ENABLED)).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void shouldNotSetEncryptionAtHostPropertyWhenAzureAndEncryptionAtHostIsNotEnabled() {
+        InstanceTemplateRequest source = new InstanceTemplateRequest();
+        source.setInstanceType(INSTANCE_TYPE);
+        when(entitlementService.isAzureEncryptionAtHostEnabled(ACCOUNT_ID)).thenReturn(Boolean.FALSE);
+
+        Template result = underTest.convert(source, CloudPlatform.AZURE, ACCOUNT_ID, null, null, null);
+
+        Json attributes = result.getAttributes();
+        assertThat(attributes).isNotNull();
+        assertThat(attributes.<Object>getValue(AzureInstanceTemplate.ENCRYPTION_AT_HOST_ENABLED)).isNull();
+    }
+
+    @Test
     void shouldSetEncryptionKeyAndEncryptionMethodPropertyWhenGcpEncryptionKeyPresent() {
         InstanceTemplateRequest source = new InstanceTemplateRequest();
         source.setInstanceType(INSTANCE_TYPE);


### PR DESCRIPTION
CB-16795: Allow encryption at host for FreeIPA and DataLake VM disks in Azure

If Encryption at Host is enabled for a VM, data stored on the VM host is encrypted at rest and flows encrypted to the Storage service.
This commit would ensure encryption at VM.
Customer needs to enable "encryptionAtHost" feature for all of their subscriptions to use this feature.

See detailed description in the commit message.