### PR TITLE
DISTX-681: AZURE: Switch DE templates to use temporaryStorage: EPHEMERAL or temporaryStorage: COMBINED/EPHEMERAL_OR_ATTACHED

### DIFF
--- a/core/src/main/resources/defaults/clustertemplates/7.2.14/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.14/azure/dataengineering-ha.json
@@ -56,7 +56,7 @@
           "attachedVolumes": [
             {
               "size": 500,
-              "count": 1,
+              "count": 0,
               "type": "StandardSSD_LRS"
             }
           ],

--- a/core/src/main/resources/defaults/clustertemplates/7.2.14/azure/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.14/azure/dataengineering-spark3.json
@@ -26,7 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3"
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,7 +38,7 @@
           "attachedVolumes": [
             {
               "size": 100,
-              "count": 1,
+              "count": 0,
               "type": "StandardSSD_LRS"
             }
           ],

--- a/core/src/main/resources/defaults/clustertemplates/7.2.14/azure/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.14/azure/dataengineering.json
@@ -37,7 +37,7 @@
           "attachedVolumes": [
             {
               "size": 100,
-              "count": 1,
+              "count": 0,
               "type": "StandardSSD_LRS"
             }
           ],

--- a/core/src/main/resources/defaults/clustertemplates/7.2.15/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.15/azure/dataengineering-ha.json
@@ -56,7 +56,7 @@
           "attachedVolumes": [
             {
               "size": 500,
-              "count": 1,
+              "count": 0,
               "type": "StandardSSD_LRS"
             }
           ],

--- a/core/src/main/resources/defaults/clustertemplates/7.2.15/azure/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.15/azure/dataengineering-spark3.json
@@ -26,7 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3"
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,7 +38,7 @@
           "attachedVolumes": [
             {
               "size": 100,
-              "count": 1,
+              "count": 0,
               "type": "StandardSSD_LRS"
             }
           ],

--- a/core/src/main/resources/defaults/clustertemplates/7.2.15/azure/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.15/azure/dataengineering.json
@@ -37,7 +37,7 @@
           "attachedVolumes": [
             {
               "size": 100,
-              "count": 1,
+              "count": 0,
               "type": "StandardSSD_LRS"
             }
           ],

--- a/core/src/main/resources/defaults/clustertemplates/7.2.16/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.16/azure/dataengineering-ha.json
@@ -56,7 +56,7 @@
           "attachedVolumes": [
             {
               "size": 500,
-              "count": 1,
+              "count": 0,
               "type": "StandardSSD_LRS"
             }
           ],

--- a/core/src/main/resources/defaults/clustertemplates/7.2.16/azure/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.16/azure/dataengineering-spark3.json
@@ -26,7 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3"
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,7 +38,7 @@
           "attachedVolumes": [
             {
               "size": 100,
-              "count": 1,
+              "count": 0,
               "type": "StandardSSD_LRS"
             }
           ],

--- a/core/src/main/resources/defaults/clustertemplates/7.2.16/azure/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.16/azure/dataengineering.json
@@ -37,7 +37,7 @@
           "attachedVolumes": [
             {
               "size": 100,
-              "count": 1,
+              "count": 0,
               "type": "StandardSSD_LRS"
             }
           ],


### PR DESCRIPTION
DISTX-681: AZURE: Switch DE templates to use temporaryStorage: EPHEMERAL or temporaryStorage: COMBINED/EPHEMERAL_OR_ATTACHED

This commit changes 7.2.14, 7.2.15, 7.2.16 runtime versions of DE, DE-HA and DE spark3 templates.
 - The master instance type for DE Spark3 template is changed from "Standard_D8_v3" to "Standard_D16_v3".
 - The attached volume count for compute host group is changed to 0. So that only ephemeral/local volumes are used by default.

Compute nodes run YARN and require storage only for temporary data - this requirement is fulfilled by instance storage, so making the attached volumes count to 0 by default is better for customer w.r.t cost.
