### PR TITLE
CB-16727 Remove stack from external database related flow payloads

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/provision/ExternalDatabaseCreationActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/provision/ExternalDatabaseCreationActions.java
@@ -43,7 +43,7 @@ public class ExternalDatabaseCreationActions {
             @Override
             protected Selectable createRequest(ExternalDatabaseContext context) {
                 Stack stack = context.getStack();
-                return new CreateExternalDatabaseRequest(stack.getId(), "CreateExternalDatabaseRequest", stack.getName(), stack.getResourceCrn(), stack);
+                return new CreateExternalDatabaseRequest(stack.getId(), "CreateExternalDatabaseRequest", stack.getName(), stack.getResourceCrn());
             }
         };
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/provision/handler/CreateExternalDatabaseHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/provision/handler/CreateExternalDatabaseHandler.java
@@ -24,6 +24,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase.CreateExtern
 import com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase.CreateExternalDatabaseRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase.CreateExternalDatabaseResult;
 import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.flow.reactor.api.handler.EventHandler;
 
@@ -50,6 +51,9 @@ public class CreateExternalDatabaseHandler implements EventHandler<CreateExterna
     @Inject
     private EnvironmentValidator environmentValidator;
 
+    @Inject
+    private StackService stackService;
+
     @Override
     public String selector() {
         return "CreateExternalDatabaseRequest";
@@ -59,7 +63,7 @@ public class CreateExternalDatabaseHandler implements EventHandler<CreateExterna
     public void accept(Event<CreateExternalDatabaseRequest> createExternalDatabaseRequest) {
         LOGGER.debug("In CreateExternalDatabaseHandler.accept");
         CreateExternalDatabaseRequest request = createExternalDatabaseRequest.getData();
-        Stack stack = request.getStack();
+        Stack stack = stackService.getById(request.getResourceId());
         DatabaseAvailabilityType externalDatabase = ObjectUtils.defaultIfNull(stack.getExternalDatabaseCreationType(), DatabaseAvailabilityType.NONE);
         LOGGER.debug("External database: {} for stack {}", externalDatabase.name(), stack.getName());
         Selectable result;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/start/ExternalDatabaseStartActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/start/ExternalDatabaseStartActions.java
@@ -43,7 +43,7 @@ public class ExternalDatabaseStartActions {
             @Override
             protected Selectable createRequest(ExternalDatabaseContext context) {
                 Stack stack = context.getStack();
-                return new StartExternalDatabaseRequest(stack.getId(), "StartExternalDatabaseRequest", stack.getName(), stack.getResourceCrn(), stack);
+                return new StartExternalDatabaseRequest(stack.getId(), "StartExternalDatabaseRequest", stack.getName(), stack.getResourceCrn());
             }
         };
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/start/handler/StartExternalDatabaseHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/start/handler/StartExternalDatabaseHandler.java
@@ -27,6 +27,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase.StartExterna
 import com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase.StartExternalDatabaseRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase.StartExternalDatabaseResult;
 import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
 import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
@@ -50,6 +51,9 @@ public class StartExternalDatabaseHandler extends ExceptionCatcherEventHandler<S
     @Inject
     private ExternalDatabaseConfig externalDatabaseConfig;
 
+    @Inject
+    private StackService stackService;
+
     @Override
     public String selector() {
         return "StartExternalDatabaseRequest";
@@ -57,7 +61,7 @@ public class StartExternalDatabaseHandler extends ExceptionCatcherEventHandler<S
 
     @Override
     protected Selectable defaultFailureEvent(Long resourceId, Exception e, Event<StartExternalDatabaseRequest> event) {
-        Stack stack = event.getData().getStack();
+        Stack stack = stackService.getById(event.getData().getResourceId());
         LOGGER.error(String.format("Exception during DB 'start' for stack/cluster: %s", stack.getName()), e);
         return startFailedEvent(stack, e);
     }
@@ -66,7 +70,7 @@ public class StartExternalDatabaseHandler extends ExceptionCatcherEventHandler<S
     protected Selectable doAccept(HandlerEvent<StartExternalDatabaseRequest> event) {
         LOGGER.debug("In StartExternalDatabaseHandler.doAccept");
         StartExternalDatabaseRequest request = event.getData();
-        Stack stack = request.getStack();
+        Stack stack = stackService.getById(request.getResourceId());
         DatabaseAvailabilityType externalDatabase = ObjectUtils.defaultIfNull(stack.getExternalDatabaseCreationType(), DatabaseAvailabilityType.NONE);
         LOGGER.debug("External database: {} for stack {}", externalDatabase.name(), stack.getName());
         LOGGER.debug("Getting environment CRN for stack {}", stack.getName());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/stop/ExternalDatabaseStopActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/stop/ExternalDatabaseStopActions.java
@@ -43,7 +43,7 @@ public class ExternalDatabaseStopActions {
             @Override
             protected Selectable createRequest(ExternalDatabaseContext context) {
                 Stack stack = context.getStack();
-                return new StopExternalDatabaseRequest(stack.getId(), "StopExternalDatabaseRequest", stack.getName(), stack.getResourceCrn(), stack);
+                return new StopExternalDatabaseRequest(stack.getId(), "StopExternalDatabaseRequest", stack.getName(), stack.getResourceCrn());
             }
         };
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/terminate/ExternalDatabaseTerminationActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/terminate/ExternalDatabaseTerminationActions.java
@@ -40,7 +40,7 @@ public class ExternalDatabaseTerminationActions {
             protected void doExecute(ExternalDatabaseContext context, TerminationEvent payload, Map<Object, Object> variables) {
                 Stack stack = context.getStack();
                 TerminateExternalDatabaseRequest request = new TerminateExternalDatabaseRequest(stack.getId(), "TerminateExternalDatabaseRequest",
-                        stack.getName(), stack.getResourceCrn(), stack, payload.getTerminationType().isForced());
+                        stack.getName(), stack.getResourceCrn(), payload.getTerminationType().isForced());
                 sendEvent(context, request);
             }
         };

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/terminate/handler/TerminateExternalDatabaseHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/terminate/handler/TerminateExternalDatabaseHandler.java
@@ -24,6 +24,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase.TerminateExt
 import com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase.TerminateExternalDatabaseRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase.TerminateExternalDatabaseResult;
 import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.flow.reactor.api.handler.EventHandler;
 
@@ -47,6 +48,9 @@ public class TerminateExternalDatabaseHandler implements EventHandler<TerminateE
     @Inject
     private EnvironmentClientService environmentClientService;
 
+    @Inject
+    private StackService stackService;
+
     @Override
     public String selector() {
         return "TerminateExternalDatabaseRequest";
@@ -56,7 +60,7 @@ public class TerminateExternalDatabaseHandler implements EventHandler<TerminateE
     public void accept(Event<TerminateExternalDatabaseRequest> terminateExternalDatabaseRequest) {
         LOGGER.debug("In TerminateExternalDatabaseHandler.accept");
         TerminateExternalDatabaseRequest request = terminateExternalDatabaseRequest.getData();
-        Stack stack = request.getStack();
+        Stack stack = stackService.getById(request.getResourceId());
         DatabaseAvailabilityType externalDatabase = ObjectUtils.defaultIfNull(stack.getExternalDatabaseCreationType(), DatabaseAvailabilityType.NONE);
         LOGGER.debug("External database: {} for stack {}", externalDatabase.name(), stack.getName());
         Selectable result;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/externaldatabase/CreateExternalDatabaseRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/externaldatabase/CreateExternalDatabaseRequest.java
@@ -1,19 +1,11 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase;
 
 import com.sequenceiq.cloudbreak.core.flow2.externaldatabase.ExternalDatabaseSelectableEvent;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
 
 public class CreateExternalDatabaseRequest extends ExternalDatabaseSelectableEvent {
 
-    private final Stack stack;
-
-    public CreateExternalDatabaseRequest(Long resourceId, String selector, String resourceName, String resourceCrn, Stack stack) {
+    public CreateExternalDatabaseRequest(Long resourceId, String selector, String resourceName, String resourceCrn) {
         super(resourceId, selector, resourceName, resourceCrn);
-        this.stack = stack;
-    }
-
-    public Stack getStack() {
-        return stack;
     }
 
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/externaldatabase/StartExternalDatabaseRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/externaldatabase/StartExternalDatabaseRequest.java
@@ -1,19 +1,11 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase;
 
 import com.sequenceiq.cloudbreak.core.flow2.externaldatabase.ExternalDatabaseSelectableEvent;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
 
 public class StartExternalDatabaseRequest extends ExternalDatabaseSelectableEvent {
 
-    private final Stack stack;
-
-    public StartExternalDatabaseRequest(Long resourceId, String selector, String resourceName, String resourceCrn, Stack stack) {
+    public StartExternalDatabaseRequest(Long resourceId, String selector, String resourceName, String resourceCrn) {
         super(resourceId, selector, resourceName, resourceCrn);
-        this.stack = stack;
-    }
-
-    public Stack getStack() {
-        return stack;
     }
 
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/externaldatabase/StopExternalDatabaseRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/externaldatabase/StopExternalDatabaseRequest.java
@@ -1,19 +1,11 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase;
 
 import com.sequenceiq.cloudbreak.core.flow2.externaldatabase.ExternalDatabaseSelectableEvent;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
 
 public class StopExternalDatabaseRequest extends ExternalDatabaseSelectableEvent {
 
-    private final Stack stack;
-
-    public StopExternalDatabaseRequest(Long resourceId, String selector, String resourceName, String resourceCrn, Stack stack) {
+    public StopExternalDatabaseRequest(Long resourceId, String selector, String resourceName, String resourceCrn) {
         super(resourceId, selector, resourceName, resourceCrn);
-        this.stack = stack;
-    }
-
-    public Stack getStack() {
-        return stack;
     }
 
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/externaldatabase/TerminateExternalDatabaseRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/externaldatabase/TerminateExternalDatabaseRequest.java
@@ -1,22 +1,14 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase;
 
 import com.sequenceiq.cloudbreak.core.flow2.externaldatabase.ExternalDatabaseSelectableEvent;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
 
 public class TerminateExternalDatabaseRequest extends ExternalDatabaseSelectableEvent {
 
-    private final Stack stack;
-
     private final boolean forced;
 
-    public TerminateExternalDatabaseRequest(Long resourceId, String selector, String resourceName, String resourceCrn, Stack stack, boolean forced) {
+    public TerminateExternalDatabaseRequest(Long resourceId, String selector, String resourceName, String resourceCrn, boolean forced) {
         super(resourceId, selector, resourceName, resourceCrn);
-        this.stack = stack;
         this.forced = forced;
-    }
-
-    public Stack getStack() {
-        return stack;
     }
 
     public boolean isForced() {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/EnforceEntityDenialInFlowPayloadTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/EnforceEntityDenialInFlowPayloadTest.java
@@ -8,7 +8,6 @@ public class EnforceEntityDenialInFlowPayloadTest {
     public void enforceDenialOfEntitiesInFlowPayload() {
         // TODO CB-16709
         // TODO CB-16714
-        // TODO CB-16727
         //EnforceEntityDenialUtil.denyEntity();
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/provision/handler/CreateExternalDatabaseHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/provision/handler/CreateExternalDatabaseHandlerTest.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.core.flow2.externaldatabase.provision.handler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -38,6 +39,7 @@ import com.sequenceiq.cloudbreak.event.ResourceEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase.CreateExternalDatabaseRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase.CreateExternalDatabaseResult;
 import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 
 import reactor.bus.Event;
@@ -69,6 +71,9 @@ class CreateExternalDatabaseHandlerTest {
     @Mock
     private EnvironmentValidator environmentValidator;
 
+    @Mock
+    private StackService stackService;
+
     @InjectMocks
     private CreateExternalDatabaseHandler underTest;
 
@@ -88,9 +93,9 @@ class CreateExternalDatabaseHandlerTest {
         environment.setCloudPlatform("cloudplatform");
         when(environmentClientService.getByCrn(anyString())).thenReturn(environment);
 
-        Stack stack = buildStack(DatabaseAvailabilityType.HA);
+        when(stackService.getById(anyLong())).thenReturn(buildStack(DatabaseAvailabilityType.HA));
         CreateExternalDatabaseRequest request =
-                new CreateExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn", stack);
+                new CreateExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn");
         Event<CreateExternalDatabaseRequest> event = new Event<>(EVENT_HEADERS, request);
 
         underTest.accept(event);
@@ -120,9 +125,9 @@ class CreateExternalDatabaseHandlerTest {
             return null;
         }).when(provisionService).provisionDatabase(any(), any(), any());
 
-        Stack stack = buildStack(DatabaseAvailabilityType.HA);
+        when(stackService.getById(anyLong())).thenReturn(buildStack(DatabaseAvailabilityType.HA));
         CreateExternalDatabaseRequest request =
-                new CreateExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn", stack);
+                new CreateExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn");
         Event<CreateExternalDatabaseRequest> event = new Event<>(EVENT_HEADERS, request);
 
         underTest.accept(event);
@@ -146,9 +151,9 @@ class CreateExternalDatabaseHandlerTest {
 
     @Test
     void acceptDbNone() {
-        Stack stack = buildStack(DatabaseAvailabilityType.NONE);
+        when(stackService.getById(anyLong())).thenReturn(buildStack(DatabaseAvailabilityType.NONE));
         CreateExternalDatabaseRequest request =
-                new CreateExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn", stack);
+                new CreateExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn");
         Event<CreateExternalDatabaseRequest> event = new Event<>(EVENT_HEADERS, request);
 
         underTest.accept(event);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/start/handler/StartExternalDatabaseHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/start/handler/StartExternalDatabaseHandlerTest.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.core.flow2.externaldatabase.start.handler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -40,6 +41,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase.StartExterna
 import com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase.StartExternalDatabaseRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase.StartExternalDatabaseResult;
 import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 
 import reactor.bus.Event;
@@ -71,6 +73,9 @@ class StartExternalDatabaseHandlerTest {
     @Mock
     private ExternalDatabaseConfig externalDatabaseConfig;
 
+    @Mock
+    private StackService stackService;
+
     @InjectMocks
     private StartExternalDatabaseHandler underTest;
 
@@ -94,8 +99,9 @@ class StartExternalDatabaseHandlerTest {
         Stack stack = buildStack(DatabaseAvailabilityType.HA);
         stack.setType(StackType.WORKLOAD);
         stack.getCluster().setDatabaseServerCrn(DATABASE_CRN);
+        when(stackService.getById(anyLong())).thenReturn(stack);
         StartExternalDatabaseRequest request =
-                new StartExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn", stack);
+                new StartExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn");
         Event<StartExternalDatabaseRequest> event = new Event<>(EVENT_HEADERS, request);
 
         underTest.accept(event);
@@ -124,8 +130,9 @@ class StartExternalDatabaseHandlerTest {
         Stack stack = buildStack(DatabaseAvailabilityType.HA);
         stack.setType(StackType.DATALAKE);
         stack.getCluster().setDatabaseServerCrn(DATABASE_CRN);
+        when(stackService.getById(anyLong())).thenReturn(stack);
         StartExternalDatabaseRequest request =
-                new StartExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn", stack);
+                new StartExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn");
         Event<StartExternalDatabaseRequest> event = new Event<>(EVENT_HEADERS, request);
 
         underTest.accept(event);
@@ -143,8 +150,9 @@ class StartExternalDatabaseHandlerTest {
 
         Stack stack = buildStack(DatabaseAvailabilityType.NONE);
         stack.setType(StackType.WORKLOAD);
+        when(stackService.getById(anyLong())).thenReturn(stack);
         StartExternalDatabaseRequest request =
-                new StartExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn", stack);
+                new StartExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn");
         Event<StartExternalDatabaseRequest> event = new Event<>(EVENT_HEADERS, request);
 
         underTest.accept(event);
@@ -164,8 +172,9 @@ class StartExternalDatabaseHandlerTest {
         Stack stack = buildStack(DatabaseAvailabilityType.HA);
         stack.setType(StackType.WORKLOAD);
         stack.getCluster().setDatabaseServerCrn(DATABASE_CRN);
+        when(stackService.getById(anyLong())).thenReturn(stack);
         StartExternalDatabaseRequest request =
-                new StartExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn", stack);
+                new StartExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn");
         Event<StartExternalDatabaseRequest> event = new Event<>(EVENT_HEADERS, request);
 
         underTest.accept(event);
@@ -185,8 +194,9 @@ class StartExternalDatabaseHandlerTest {
         Stack stack = buildStack(DatabaseAvailabilityType.HA);
         stack.setType(StackType.WORKLOAD);
         stack.getCluster().setDatabaseServerCrn(DATABASE_CRN);
+        when(stackService.getById(anyLong())).thenReturn(stack);
         StartExternalDatabaseRequest request =
-                new StartExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn", stack);
+                new StartExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn");
         Event<StartExternalDatabaseRequest> event = new Event<>(EVENT_HEADERS, request);
 
         underTest.accept(event);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/stop/handler/StopExternalDatabaseHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/stop/handler/StopExternalDatabaseHandlerTest.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.core.flow2.externaldatabase.stop.handler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -40,6 +41,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase.StopExternal
 import com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase.StopExternalDatabaseRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase.StopExternalDatabaseResult;
 import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 
 import reactor.bus.Event;
@@ -71,6 +73,9 @@ class StopExternalDatabaseHandlerTest {
     @Mock
     private ExternalDatabaseConfig externalDatabaseConfig;
 
+    @Mock
+    private StackService stackService;
+
     @InjectMocks
     private StopExternalDatabaseHandler underTest;
 
@@ -94,8 +99,9 @@ class StopExternalDatabaseHandlerTest {
         Stack stack = buildStack(DatabaseAvailabilityType.HA);
         stack.setType(StackType.WORKLOAD);
         stack.getCluster().setDatabaseServerCrn(DATABASE_CRN);
+        when(stackService.getById(anyLong())).thenReturn(stack);
         StopExternalDatabaseRequest request =
-                new StopExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn", stack);
+                new StopExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn");
         Event<StopExternalDatabaseRequest> event = new Event<>(EVENT_HEADERS, request);
 
         underTest.accept(event);
@@ -124,8 +130,9 @@ class StopExternalDatabaseHandlerTest {
         Stack stack = buildStack(DatabaseAvailabilityType.HA);
         stack.setType(StackType.DATALAKE);
         stack.getCluster().setDatabaseServerCrn(DATABASE_CRN);
+        when(stackService.getById(anyLong())).thenReturn(stack);
         StopExternalDatabaseRequest request =
-                new StopExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn", stack);
+                new StopExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn");
         Event<StopExternalDatabaseRequest> event = new Event<>(EVENT_HEADERS, request);
 
         underTest.accept(event);
@@ -143,8 +150,9 @@ class StopExternalDatabaseHandlerTest {
 
         Stack stack = buildStack(DatabaseAvailabilityType.NONE);
         stack.setType(StackType.WORKLOAD);
+        when(stackService.getById(anyLong())).thenReturn(stack);
         StopExternalDatabaseRequest request =
-                new StopExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn", stack);
+                new StopExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn");
         Event<StopExternalDatabaseRequest> event = new Event<>(EVENT_HEADERS, request);
 
         underTest.accept(event);
@@ -164,8 +172,9 @@ class StopExternalDatabaseHandlerTest {
         Stack stack = buildStack(DatabaseAvailabilityType.HA);
         stack.setType(StackType.WORKLOAD);
         stack.getCluster().setDatabaseServerCrn(DATABASE_CRN);
+        when(stackService.getById(anyLong())).thenReturn(stack);
         StopExternalDatabaseRequest request =
-                new StopExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn", stack);
+                new StopExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn");
         Event<StopExternalDatabaseRequest> event = new Event<>(EVENT_HEADERS, request);
 
         underTest.accept(event);
@@ -185,8 +194,9 @@ class StopExternalDatabaseHandlerTest {
         Stack stack = buildStack(DatabaseAvailabilityType.HA);
         stack.setType(StackType.WORKLOAD);
         stack.getCluster().setDatabaseServerCrn(DATABASE_CRN);
+        when(stackService.getById(anyLong())).thenReturn(stack);
         StopExternalDatabaseRequest request =
-                new StopExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn", stack);
+                new StopExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn");
         Event<StopExternalDatabaseRequest> event = new Event<>(EVENT_HEADERS, request);
 
         underTest.accept(event);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/terminate/handler/TerminateExternalDatabaseHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/terminate/handler/TerminateExternalDatabaseHandlerTest.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.core.flow2.externaldatabase.terminate.handler;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -39,6 +40,7 @@ import com.sequenceiq.cloudbreak.event.ResourceEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase.TerminateExternalDatabaseRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase.TerminateExternalDatabaseResult;
 import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 
 import reactor.bus.Event;
@@ -67,6 +69,9 @@ class TerminateExternalDatabaseHandlerTest {
     @Mock
     private EnvironmentClientService environmentClientService;
 
+    @Mock
+    private StackService stackService;
+
     @InjectMocks
     private TerminateExternalDatabaseHandler underTest;
 
@@ -86,9 +91,9 @@ class TerminateExternalDatabaseHandlerTest {
         environment.setCloudPlatform("cloudplatform");
         when(environmentClientService.getByCrn(anyString())).thenReturn(environment);
 
-        Stack stack = buildStack(DatabaseAvailabilityType.HA);
+        when(stackService.getById(anyLong())).thenReturn(buildStack(DatabaseAvailabilityType.HA));
         TerminateExternalDatabaseRequest request =
-                new TerminateExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn", stack, true);
+                new TerminateExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn", true);
         Event<TerminateExternalDatabaseRequest> event = new Event<>(EVENT_HEADERS, request);
 
         underTest.accept(event);
@@ -117,9 +122,9 @@ class TerminateExternalDatabaseHandlerTest {
             return null;
         }).when(terminationService).terminateDatabase(any(), any(), any(), anyBoolean());
 
-        Stack stack = buildStack(DatabaseAvailabilityType.HA);
+        when(stackService.getById(anyLong())).thenReturn(buildStack(DatabaseAvailabilityType.HA));
         TerminateExternalDatabaseRequest request =
-                new TerminateExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn", stack, needHA);
+                new TerminateExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn", needHA);
         Event<TerminateExternalDatabaseRequest> event = new Event<>(EVENT_HEADERS, request);
 
         underTest.accept(event);
@@ -142,9 +147,9 @@ class TerminateExternalDatabaseHandlerTest {
 
     @Test
     void acceptDbNone() {
-        Stack stack = buildStack(DatabaseAvailabilityType.NONE);
+        when(stackService.getById(anyLong())).thenReturn(buildStack(DatabaseAvailabilityType.NONE));
         TerminateExternalDatabaseRequest request =
-                new TerminateExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn", stack, false);
+                new TerminateExternalDatabaseRequest(STACK_ID, "selector", "resourceName", "crn", false);
         Event<TerminateExternalDatabaseRequest> event = new Event<>(EVENT_HEADERS, request);
 
         underTest.accept(event);


### PR DESCRIPTION
I checked that removing the stack from these events is backward compatible, flows will be able to restart.

See detailed description in the commit message.