### PR TITLE
CB-14357 [EDH] Attempted host removal failing should leave the cluste…

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/service/NodeIsBusyException.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/service/NodeIsBusyException.java
@@ -1,0 +1,9 @@
+package com.sequenceiq.cloudbreak.cluster.service;
+
+public class NodeIsBusyException extends RuntimeException {
+
+    public NodeIsBusyException(String message) {
+        super(message);
+    }
+
+}

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/status/HostServiceStatus.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/status/HostServiceStatus.java
@@ -1,0 +1,5 @@
+package com.sequenceiq.cloudbreak.cluster.status;
+
+public enum HostServiceStatus {
+    OK, BUSY;
+}

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/status/HostServiceStatuses.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/status/HostServiceStatuses.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.cloudbreak.cluster.status;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.sequenceiq.cloudbreak.cloud.model.HostName;
+
+public class HostServiceStatuses {
+    private final Map<HostName, HostServiceStatus> hostServiceStates;
+
+    public HostServiceStatuses(Map<HostName, HostServiceStatus> hostServiceStates) {
+        this.hostServiceStates = hostServiceStates;
+    }
+
+    public boolean anyHostBusy() {
+        return hostServiceStates.values().stream().anyMatch(status -> status == HostServiceStatus.BUSY);
+    }
+
+    public Set<String> getBusyHosts() {
+        return hostServiceStates.entrySet().stream()
+                .filter(entry -> entry.getValue() == HostServiceStatus.BUSY)
+                .map(Map.Entry::getKey)
+                .map(HostName::value)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public String toString() {
+        return "HostServiceStatuses{" +
+                "hostServiceStates=" + hostServiceStates +
+                '}';
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/downscale/ClusterDownscaleService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/downscale/ClusterDownscaleService.java
@@ -26,6 +26,7 @@ import org.springframework.stereotype.Service;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
+import com.sequenceiq.cloudbreak.cluster.service.NodeIsBusyException;
 import com.sequenceiq.cloudbreak.cluster.service.NotEnoughNodeException;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterDownscaleDetails;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
@@ -117,7 +118,7 @@ public class ClusterDownscaleService {
         String errorDetails = error.getMessage();
         LOGGER.warn("Error during Cluster downscale flow: ", error);
         DetailedStackStatus detailedStackStatus = DetailedStackStatus.DOWNSCALE_FAILED;
-        if (error instanceof NotEnoughNodeException) {
+        if (error instanceof NotEnoughNodeException || error instanceof NodeIsBusyException) {
             detailedStackStatus = DetailedStackStatus.AVAILABLE;
         }
         stackUpdater.updateStackStatus(stackId, detailedStackStatus, "Node(s) could not be removed from the cluster: " + errorDetails);


### PR DESCRIPTION
…r available

In case of node decommission CM error could happen if the services are 'busy' on that node. 
his pull contains a validation for busy hosts before decommission (only applied if not forced) and the cluster will stay in available state.