### PR TITLE
CB-16945. Support https_proxy and no_proxy settings by cdp-vmagent

### DIFF
--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/exporters.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/exporters.sls
@@ -27,6 +27,14 @@
     - group: "root"
     - mode: 640
 
+/opt/blackbox_exporter/blackbox.env:
+  file.managed:
+    - source: salt://monitoring/template/blackbox.env.j2
+    - template: jinja
+    - user: "root"
+    - group: "root"
+    - mode: 600
+
 start_node_exporter:
   service.running:
     - enable: True
@@ -40,6 +48,7 @@ start_blackbox_exporter:
     - name: "cdp-blackbox-exporter"
     - watch:
       - file: /opt/blackbox_exporter/blackbox.yml
+      - file: /opt/blackbox_exporter/blackbox.env
       - file: /etc/systemd/system/cdp-blackbox-exporter.service
 
 {%- endif %}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/scripts/noproxy_check.py
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/scripts/noproxy_check.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import sys
+import os
+from urllib.request import proxy_bypass
+from urllib.parse import urlparse
+
+def skip_proxy(netloc, no_proxy):
+  if no_proxy:
+    os.environ["NO_PROXY"]=no_proxy
+    no_proxy = no_proxy.replace(' ', '').split(',')
+    for host in no_proxy:
+        if netloc.endswith(host) or netloc.split(':')[0].endswith(host):
+            return True
+    if proxy_bypass(netloc):
+        return True
+  return False
+
+def main(args):
+    if (len(args) < 2):
+        sys.stdout.write("false")
+    url=args[0]
+    no_proxy=args[1]
+    skipProxy=skip_proxy(urlparse(url).netloc, no_proxy)
+    if skipProxy:
+        sys.stdout.write("true")
+    else:
+        sys.stdout.write("false")
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/systemd/cdp-blackbox-exporter.service
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/systemd/cdp-blackbox-exporter.service
@@ -7,6 +7,7 @@ After=network-online.target
 Type=simple
 User=root
 Group=root
+EnvironmentFile=/opt/blackbox_exporter/blackbox.env
 ExecStart=/opt/blackbox_exporter/blackbox_exporter \
     --config.file=/opt/blackbox_exporter/blackbox.yml
 

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/systemd/cdp-vmagent.service.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/systemd/cdp-vmagent.service.j2
@@ -1,4 +1,19 @@
+{%- from 'telemetry/settings.sls' import telemetry with context %}
 {%- from 'monitoring/settings.sls' import monitoring with context %}
+{%- if telemetry.proxyUrl %}
+  {%- if telemetry.noProxyHosts %}
+    {%- set proxy_bypass = salt.cmd.run('python3 /opt/cdp-vmagent/noproxy_check.py ' + monitoring.remoteWriteUrl + ' ' + telemetry.noProxyHosts) %}
+    {%- if proxy_bypass == "true" %}
+      {%- set use_proxy = False %}
+    {%- else %}
+      {%- set use_proxy = True %}
+    {%- endif %}
+  {%- else %}
+    {%- set use_proxy = True %}
+  {%- endif %}
+{%- else %}
+  {%- set use_proxy = False %}
+{%- endif %}
 [Unit]
 Description=CDP VM agent for collecting metrics
 Wants=network-online.target
@@ -16,6 +31,9 @@ ExecStart=/opt/cdp-vmagent/bin/vmagent-prod -remoteWrite.url={{ monitoring.remot
 {%- endif %}
 {%- elif monitoring.token %}
      -remoteWrite.bearerTokenFile=/opt/cdp-vmagent/remote_token_file \
+{%- endif %}
+{%- if use_proxy %}
+     -remoteWrite.proxyURL={{ telemetry.proxyUrl }} \
 {%- endif %}
      -promscrape.config=/opt/cdp-vmagent/prometheus.yml
 Restart=always

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/template/blackbox.env.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/template/blackbox.env.j2
@@ -1,0 +1,7 @@
+{%- from 'telemetry/settings.sls' import telemetry with context %}
+{%- if telemetry.proxyUrl %}
+HTTPS_PROXY={{ telemetry.proxyUrl }}
+  {%- if telemetry.noProxyHosts %}
+NO_PROXY={{ telemetry.noProxyHosts }}
+  {%- endif %}
+{%- endif %}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/template/prometheus.yml.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/template/prometheus.yml.j2
@@ -23,6 +23,7 @@ scrape_configs:
         labels:
           resource_crn: {{ telemetry.clusterCrn }}
           platform: {{ telemetry.platform }}
+          proxy: {%- if telemetry.proxyUrl %}yes{%- else %}no{%- endif %}
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/vmagent.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/vmagent.sls
@@ -10,6 +10,13 @@ install_vmagent:
     - onlyif: "test -f /etc/yum.repos.d/cdp-infra-tools.repo && ! rpm -q cdp-vmagent"
 {%- endif %}
 
+/opt/cdp-vmagent/noproxy_check.py:
+  file.managed:
+    - source: salt://monitoring/scripts/noproxy_check.py
+    - user: "root"
+    - group: "root"
+    - mode: 750
+
 /etc/systemd/system/cdp-vmagent.service:
   file.managed:
     - source: salt://monitoring/systemd/cdp-vmagent.service.j2


### PR DESCRIPTION
details:
- support vmagent to use proxy during remote write
- vmagent does not care with HTTPS_PROXY or NO_PROXY env variables, proxy can be set by a flag but no_proxy needs to be calculated, to workaround this problem, there will be a python script that will check the proxy can be bypassed or not.