### PR TITLE
CB-16711 Removed DBStack entity type from redbeams flow events

### DIFF
--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/action/RedbeamsProvisionActions.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/action/RedbeamsProvisionActions.java
@@ -69,7 +69,6 @@ public class RedbeamsProvisionActions {
                 return new AllocateDatabaseServerRequest(
                         context.getCloudContext(),
                         context.getCloudCredential(),
-                        context.getDBStack(),
                         context.getDatabaseStack()
                 );
             }
@@ -89,7 +88,6 @@ public class RedbeamsProvisionActions {
                         new UpdateDatabaseServerRegistrationRequest(
                                 context.getCloudContext(),
                                 context.getCloudCredential(),
-                                context.getDBStack(),
                                 context.getDatabaseStack(),
                                 ResourceLists.transform(dbResourcesList)
                         )

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/event/allocate/AllocateDatabaseServerRequest.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/event/allocate/AllocateDatabaseServerRequest.java
@@ -3,7 +3,6 @@ package com.sequenceiq.redbeams.flow.redbeams.provision.event.allocate;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
-import com.sequenceiq.redbeams.domain.stack.DBStack;
 import com.sequenceiq.redbeams.flow.redbeams.common.RedbeamsEvent;
 
 /**
@@ -15,15 +14,12 @@ public class AllocateDatabaseServerRequest extends RedbeamsEvent {
 
     private final CloudCredential cloudCredential;
 
-    private final DBStack dbStack;
-
     private final DatabaseStack databaseStack;
 
-    public AllocateDatabaseServerRequest(CloudContext cloudContext, CloudCredential cloudCredential, DBStack dbStack, DatabaseStack databaseStack) {
+    public AllocateDatabaseServerRequest(CloudContext cloudContext, CloudCredential cloudCredential, DatabaseStack databaseStack) {
         super(cloudContext != null ? cloudContext.getId() : null);
         this.cloudContext = cloudContext;
         this.cloudCredential = cloudCredential;
-        this.dbStack = dbStack;
         this.databaseStack = databaseStack;
     }
 
@@ -35,10 +31,6 @@ public class AllocateDatabaseServerRequest extends RedbeamsEvent {
         return cloudCredential;
     }
 
-    public DBStack getDbStack() {
-        return dbStack;
-    }
-
     public DatabaseStack getDatabaseStack() {
         return databaseStack;
     }
@@ -48,7 +40,6 @@ public class AllocateDatabaseServerRequest extends RedbeamsEvent {
         return "AllocateDatabaseServerRequest{" +
                 "cloudContext=" + cloudContext +
                 ", cloudCredential=" + cloudCredential +
-                ", dbStack=" + dbStack +
                 ", databaseStack=" + databaseStack +
                 '}';
     }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/event/register/UpdateDatabaseServerRegistrationRequest.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/event/register/UpdateDatabaseServerRegistrationRequest.java
@@ -7,7 +7,6 @@ import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
-import com.sequenceiq.redbeams.domain.stack.DBStack;
 import com.sequenceiq.redbeams.flow.redbeams.common.RedbeamsEvent;
 
 /**
@@ -19,18 +18,15 @@ public class UpdateDatabaseServerRegistrationRequest extends RedbeamsEvent {
 
     private final CloudCredential cloudCredential;
 
-    private final DBStack dbStack;
-
     private final DatabaseStack databaseStack;
 
     private final List<CloudResource> dbResources;
 
-    public UpdateDatabaseServerRegistrationRequest(CloudContext cloudContext, CloudCredential cloudCredential, DBStack dbStack,
+    public UpdateDatabaseServerRegistrationRequest(CloudContext cloudContext, CloudCredential cloudCredential,
             DatabaseStack databaseStack, List<CloudResource> dbResources) {
         super(cloudContext != null ? cloudContext.getId() : null);
         this.cloudContext = cloudContext;
         this.cloudCredential = cloudCredential;
-        this.dbStack = dbStack;
         this.databaseStack = databaseStack;
         this.dbResources = ImmutableList.copyOf(dbResources);
     }
@@ -41,10 +37,6 @@ public class UpdateDatabaseServerRegistrationRequest extends RedbeamsEvent {
 
     public CloudCredential getCloudCredential() {
         return cloudCredential;
-    }
-
-    public DBStack getDBStack() {
-        return dbStack;
     }
 
     public DatabaseStack getDatabaseStack() {
@@ -60,7 +52,6 @@ public class UpdateDatabaseServerRegistrationRequest extends RedbeamsEvent {
         return "UpdateDatabaseServerRegistrationRequest{" +
                 "cloudContext=" + cloudContext +
                 ", cloudCredential=" + cloudCredential +
-                ", dbStack=" + dbStack +
                 ", databaseStack=" + databaseStack +
                 ", dbResources=" + dbResources +
                 '}';

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/handler/UpdateDatabaseServerRegistrationHandler.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/handler/UpdateDatabaseServerRegistrationHandler.java
@@ -27,6 +27,7 @@ import com.sequenceiq.redbeams.flow.redbeams.provision.event.register.UpdateData
 import com.sequenceiq.redbeams.service.UserGeneratorService;
 import com.sequenceiq.redbeams.service.dbserverconfig.DatabaseServerConfigService;
 import com.sequenceiq.redbeams.service.sslcertificate.DatabaseServerSslCertificateSyncService;
+import com.sequenceiq.redbeams.service.stack.DBStackService;
 
 import reactor.bus.Event;
 
@@ -47,17 +48,20 @@ public class UpdateDatabaseServerRegistrationHandler extends ExceptionCatcherEve
     @Inject
     private DatabaseServerSslCertificateSyncService databaseServerSslCertificateSyncService;
 
+    @Inject
+    private DBStackService dbStackService;
+
     @Override
     public String selector() {
         return EventSelectorUtil.selector(UpdateDatabaseServerRegistrationRequest.class);
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent handlerEvent) {
+    protected Selectable doAccept(HandlerEvent<UpdateDatabaseServerRegistrationRequest> handlerEvent) {
         Event<UpdateDatabaseServerRegistrationRequest> event = handlerEvent.getEvent();
         LOGGER.debug("Received event: {}", event);
         UpdateDatabaseServerRegistrationRequest request = event.getData();
-        DBStack dbStack = request.getDBStack();
+        DBStack dbStack = dbStackService.getById(request.getResourceId());
         List<CloudResource> dbResources = request.getDbResources();
 
         Selectable response;

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/termination/action/RedbeamsTerminationActions.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/termination/action/RedbeamsTerminationActions.java
@@ -67,7 +67,7 @@ public class RedbeamsTerminationActions {
             @Override
             protected Selectable createRequest(RedbeamsContext context) {
                 dbStackJobService.unschedule(context.getDBStack().getId(), context.getDBStack().getName());
-                return new DeregisterDatabaseServerRequest(context.getCloudContext(), context.getDatabaseStack(), context.getDBStack());
+                return new DeregisterDatabaseServerRequest(context.getCloudContext(), context.getDatabaseStack());
             }
 
             @Override

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/termination/event/deregister/DeregisterDatabaseServerRequest.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/termination/event/deregister/DeregisterDatabaseServerRequest.java
@@ -2,7 +2,6 @@ package com.sequenceiq.redbeams.flow.redbeams.termination.event.deregister;
 
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
-import com.sequenceiq.redbeams.domain.stack.DBStack;
 import com.sequenceiq.redbeams.flow.redbeams.common.RedbeamsEvent;
 
 /**
@@ -14,13 +13,10 @@ public class DeregisterDatabaseServerRequest extends RedbeamsEvent {
 
     private final DatabaseStack databaseStack;
 
-    private final DBStack dbStack;
-
-    public DeregisterDatabaseServerRequest(CloudContext cloudContext, DatabaseStack databaseStack, DBStack dbStack) {
+    public DeregisterDatabaseServerRequest(CloudContext cloudContext, DatabaseStack databaseStack) {
         super(cloudContext != null ? cloudContext.getId() : null);
         this.cloudContext = cloudContext;
         this.databaseStack = databaseStack;
-        this.dbStack = dbStack;
     }
 
     public CloudContext getCloudContext() {
@@ -29,9 +25,5 @@ public class DeregisterDatabaseServerRequest extends RedbeamsEvent {
 
     public DatabaseStack getDatabaseStack() {
         return databaseStack;
-    }
-
-    public DBStack getDbStack() {
-        return dbStack;
     }
 }

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/EnforceEntityDenialInFlowPayloadTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/EnforceEntityDenialInFlowPayloadTest.java
@@ -2,11 +2,12 @@ package com.sequenceiq.redbeams.flow.redbeams;
 
 import org.junit.jupiter.api.Test;
 
+import com.sequenceiq.flow.EnforceEntityDenialUtil;
+
 public class EnforceEntityDenialInFlowPayloadTest {
 
     @Test
     public void enforceDenialOfEntitiesInFlowPayload() {
-        // TODO CB-16711
-        //EnforceEntityDenialUtil.denyEntity();
+        EnforceEntityDenialUtil.denyEntity();
     }
 }

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/provision/action/RedbeamsProvisionActionsTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/provision/action/RedbeamsProvisionActionsTest.java
@@ -126,7 +126,6 @@ class RedbeamsProvisionActionsTest {
         assertThat(allocateDatabaseServerRequest.getResourceId()).isEqualTo(RESOURCE_ID);
         assertThat(allocateDatabaseServerRequest.getCloudContext()).isSameAs(cloudContext);
         assertThat(allocateDatabaseServerRequest.getCloudCredential()).isSameAs(cloudCredential);
-        assertThat(allocateDatabaseServerRequest.getDbStack()).isSameAs(dbStack);
         assertThat(allocateDatabaseServerRequest.getDatabaseStack()).isSameAs(databaseStack);
     }
 
@@ -167,7 +166,6 @@ class RedbeamsProvisionActionsTest {
         assertThat(updateDatabaseServerRegistrationRequest.getResourceId()).isEqualTo(RESOURCE_ID);
         assertThat(updateDatabaseServerRegistrationRequest.getCloudContext()).isSameAs(cloudContext);
         assertThat(updateDatabaseServerRegistrationRequest.getCloudCredential()).isSameAs(cloudCredential);
-        assertThat(updateDatabaseServerRegistrationRequest.getDBStack()).isSameAs(dbStack);
         assertThat(updateDatabaseServerRegistrationRequest.getDatabaseStack()).isSameAs(databaseStack);
         assertThat(updateDatabaseServerRegistrationRequest.getDbResources()).isEqualTo(List.of(cloudResource));
     }

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/provision/handler/AllocateDatabaseServerHandlerTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/provision/handler/AllocateDatabaseServerHandlerTest.java
@@ -3,7 +3,9 @@ package com.sequenceiq.redbeams.flow.redbeams.provision.handler;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -45,6 +47,7 @@ import com.sequenceiq.redbeams.flow.redbeams.provision.event.allocate.AllocateDa
 import com.sequenceiq.redbeams.flow.redbeams.provision.event.allocate.AllocateDatabaseServerRequest;
 import com.sequenceiq.redbeams.flow.redbeams.provision.event.allocate.AllocateDatabaseServerSuccess;
 import com.sequenceiq.redbeams.service.sslcertificate.DatabaseServerSslCertificatePrescriptionService;
+import com.sequenceiq.redbeams.service.stack.DBStackService;
 
 import reactor.bus.Event;
 
@@ -75,6 +78,9 @@ class AllocateDatabaseServerHandlerTest {
 
     @Mock
     private DatabaseServerSslCertificatePrescriptionService databaseServerSslCertificatePrescriptionService;
+
+    @Mock
+    private DBStackService dbStackService;
 
     @InjectMocks
     private AllocateDatabaseServerHandler underTest;
@@ -117,6 +123,7 @@ class AllocateDatabaseServerHandlerTest {
     void setUp() {
         dbStack = new DBStack();
         dbStack.setCloudPlatform(CloudPlatform.AWS.name());
+        lenient().when(dbStackService.getById(anyLong())).thenReturn(dbStack);
         databaseStack = new DatabaseStack(null, null, Map.of(), "");
     }
 
@@ -303,7 +310,7 @@ class AllocateDatabaseServerHandlerTest {
         when(cloudContext.getId()).thenReturn(RESOURCE_ID);
         when(cloudContext.getPlatformVariant()).thenReturn(cloudPlatformVariant);
 
-        AllocateDatabaseServerRequest request = new AllocateDatabaseServerRequest(cloudContext, cloudCredential, dbStack, databaseStack);
+        AllocateDatabaseServerRequest request = new AllocateDatabaseServerRequest(cloudContext, cloudCredential, databaseStack);
         when(event.getData()).thenReturn(request);
 
         when(cloudPlatformConnectors.get(cloudPlatformVariant)).thenReturn(cloudConnector);

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/termination/handler/DeregisterDatabaseServerHandlerTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/termination/handler/DeregisterDatabaseServerHandlerTest.java
@@ -1,0 +1,86 @@
+package com.sequenceiq.redbeams.flow.redbeams.termination.handler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
+import com.sequenceiq.redbeams.domain.stack.DBStack;
+import com.sequenceiq.redbeams.flow.redbeams.termination.event.deregister.DeregisterDatabaseServerRequest;
+import com.sequenceiq.redbeams.service.dbserverconfig.DatabaseServerConfigService;
+import com.sequenceiq.redbeams.service.stack.DBStackService;
+
+import reactor.bus.Event;
+import reactor.bus.EventBus;
+
+@ExtendWith(MockitoExtension.class)
+class DeregisterDatabaseServerHandlerTest {
+
+    private static final Long RESOURCE_ID = 1L;
+
+    private static final String RESOURCE_CRN = "crn:cdp:redbeams:us-west-1:tenantId:databaseServer:dbId";
+
+    @Mock
+    private EventBus eventBus;
+
+    @Mock
+    private DatabaseServerConfigService databaseServerConfigService;
+
+    @Mock
+    private DBStackService dbStackService;
+
+    @InjectMocks
+    private DeregisterDatabaseServerHandler underTest;
+
+    @Mock
+    private Event<DeregisterDatabaseServerRequest> event;
+
+    @Test
+    public void testDeleteDatabaseServerConfigIfExists() {
+        mockDeregisterEvent();
+
+        DBStack dbStack = new DBStack();
+        dbStack.setResourceCrn(RESOURCE_CRN);
+        when(dbStackService.getById(RESOURCE_ID)).thenReturn(dbStack);
+
+        DatabaseServerConfig databaseServerConfig = new DatabaseServerConfig();
+        when(databaseServerConfigService.getByCrn(any(Crn.class))).thenReturn(Optional.of(databaseServerConfig));
+
+        underTest.accept(event);
+
+        verify(databaseServerConfigService).delete(databaseServerConfig);
+        verify(eventBus).notify(any(Object.class), any(Event.class));
+    }
+
+    @Test
+    public void testNotDeleteDatabaseServerConfigIfExists() {
+        mockDeregisterEvent();
+
+        DBStack dbStack = new DBStack();
+        dbStack.setResourceCrn(RESOURCE_CRN);
+        when(dbStackService.getById(RESOURCE_ID)).thenReturn(dbStack);
+
+        when(databaseServerConfigService.getByCrn(any(Crn.class))).thenReturn(Optional.empty());
+
+        underTest.accept(event);
+
+        verify(databaseServerConfigService, times(0)).delete(any());
+        verify(eventBus).notify(any(Object.class), any(Event.class));
+    }
+
+    private void mockDeregisterEvent() {
+        when(event.getData()).thenReturn(new DeregisterDatabaseServerRequest(new CloudContext.Builder().withId(RESOURCE_ID).build(), null));
+        when(event.getHeaders()).thenReturn(new Event.Headers());
+    }
+}


### PR DESCRIPTION
Removed DBStack entity type from redbeams flow events. Fixed one datalake unit test which took 1 minute, now it takes 1 sec.

See detailed description in the commit message.