### PR TITLE
CB-16960: Enabled Autorestart for OMID in Datahub.

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ProcessAutoRestartInjector.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ProcessAutoRestartInjector.java
@@ -35,7 +35,8 @@ public class ProcessAutoRestartInjector implements CmTemplateConfigInjector {
             "SPARK_ON_YARN",
             YarnRoles.YARN,
             "ZEPPELIN",
-            "QUEUEMANAGER"
+            "QUEUEMANAGER",
+            "OMID"
     );
 
     private static final Set<String> IGNORED_ROLES = Set.of(


### PR DESCRIPTION
Enabled autorestart for OMID as OMID server getting crashed when the HBase service is stopped or having any issues. As a workaround we are enabling the autorestart.

**Tested on Local CB.**
1. Created an Operational Datahub cluster with the change and verified the auto restart in OMID config is enabled. 