### PR TITLE
CB-16673 Implement quartz jobs for cloud storage calculation

### DIFF
--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/job/storage/StorageConsumptionConfig.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/job/storage/StorageConsumptionConfig.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.consumption.job.storage;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class StorageConsumptionConfig {
+
+    @Value("${storageconsumption.intervalminutes:30}")
+    private int intervalInMinutes;
+
+    @Value("${storageconsumption.enabled:true}")
+    private boolean storageConsumptionEnabled;
+
+    public int getIntervalInMinutes() {
+        return intervalInMinutes;
+    }
+
+    public boolean isStorageConsumptionEnabled() {
+        return storageConsumptionEnabled;
+    }
+
+}

--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/job/storage/StorageConsumptionJob.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/job/storage/StorageConsumptionJob.java
@@ -1,0 +1,30 @@
+package com.sequenceiq.consumption.job.storage;
+
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.quartz.TracedQuartzJob;
+
+import io.opentracing.Tracer;
+
+@Component
+public class StorageConsumptionJob extends TracedQuartzJob {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StorageConsumptionJob.class);
+
+    public StorageConsumptionJob(Tracer tracer) {
+        super(tracer, "Storage Consumption Job");
+    }
+
+    @Override
+    protected void executeTracedJob(JobExecutionContext context) throws JobExecutionException {
+    }
+
+    @Override
+    protected Object getMdcContextObject() {
+        return null;
+    }
+}

--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/job/storage/StorageConsumptionJobAdapter.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/job/storage/StorageConsumptionJobAdapter.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.consumption.job.storage;
+
+import org.quartz.Job;
+import org.springframework.context.ApplicationContext;
+
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
+import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
+import com.sequenceiq.cloudbreak.quartz.model.JobResourceRepository;
+import com.sequenceiq.consumption.configuration.repository.ConsumptionRepository;
+import com.sequenceiq.consumption.domain.Consumption;
+
+public class StorageConsumptionJobAdapter extends JobResourceAdapter<Consumption> {
+
+    public StorageConsumptionJobAdapter(Long id, ApplicationContext context) {
+        super(id, context);
+    }
+
+    public StorageConsumptionJobAdapter(JobResource jobResource) {
+        super(jobResource);
+    }
+
+    @Override
+    public Class<? extends Job> getJobClassForResource() {
+        return StorageConsumptionJob.class;
+    }
+
+    @Override
+    public Class<? extends JobResourceRepository<Consumption, Long>> getRepositoryClassForResource() {
+        return ConsumptionRepository.class;
+    }
+}

--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/job/storage/StorageConsumptionJobService.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/job/storage/StorageConsumptionJobService.java
@@ -1,0 +1,110 @@
+package com.sequenceiq.consumption.job.storage;
+
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import org.quartz.JobBuilder;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.SimpleScheduleBuilder;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Service;
+
+@Service
+public class StorageConsumptionJobService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StorageConsumptionJobService.class);
+
+    private static final String JOB_GROUP = "storage-consumption-job-group";
+
+    private static final String TRIGGER_GROUP = "storage-consumption-job-triggers";
+
+    private static final Random RANDOM = new SecureRandom();
+
+    @Inject
+    private  ApplicationContext applicationContext;
+
+    @Inject
+    private Scheduler scheduler;
+
+    @Inject
+    private StorageConsumptionConfig storageConsumptionConfig;
+
+    public void schedule(StorageConsumptionJobAdapter resource) {
+        if (storageConsumptionConfig.isStorageConsumptionEnabled()) {
+            JobDetail jobDetail = buildJobDetail(resource);
+            Trigger trigger = buildJobTrigger(jobDetail);
+            try {
+                JobKey jobKey = JobKey.jobKey(resource.getJobResource().getLocalId(), JOB_GROUP);
+                if (scheduler.getJobDetail(jobKey) != null) {
+                    LOGGER.info("Unscheduling storage consumption job key: '{}' and group: '{}'", jobKey.getName(), jobKey.getGroup());
+                    unschedule(jobKey.getName());
+                }
+                LOGGER.info("Scheduling storage consumption job for key: '{}' and group: '{}'", jobKey.getName(), jobKey.getGroup());
+                scheduler.scheduleJob(jobDetail, trigger);
+            } catch (SchedulerException e) {
+                LOGGER.error(String.format("Error during scheduling quartz job: %s", jobDetail), e);
+            }
+        }
+
+    }
+
+    public void schedule(Long id) {
+        StorageConsumptionJobAdapter resourceAdapter = new StorageConsumptionJobAdapter(id, applicationContext);
+        schedule(resourceAdapter);
+    }
+
+    private JobDetail buildJobDetail(StorageConsumptionJobAdapter resource) {
+        JobDataMap jobDataMap = resource.toJobDataMap();
+        return JobBuilder.newJob(StorageConsumptionJob.class)
+                .withIdentity(resource.getJobResource().getLocalId(), JOB_GROUP)
+                .withDescription("Getting storage usage")
+                .usingJobData(jobDataMap)
+                .storeDurably()
+                .build();
+
+    }
+
+    private Trigger buildJobTrigger(JobDetail jobDetail) {
+        return TriggerBuilder.newTrigger()
+                .forJob(jobDetail)
+                .withIdentity(jobDetail.getKey().getName(), TRIGGER_GROUP)
+                .withDescription("Trigger for getting storage usage")
+                .startAt(delayedFirstStart())
+                .withSchedule(SimpleScheduleBuilder.simpleSchedule()
+                        .withIntervalInMinutes(storageConsumptionConfig.getIntervalInMinutes())
+                        .repeatForever()
+                        .withMisfireHandlingInstructionIgnoreMisfires())
+                .build();
+
+    }
+
+    public void unschedule(String id) {
+        JobKey jobKey = JobKey.jobKey(id, JOB_GROUP);
+        try {
+            LOGGER.info("Unscheduling storage consumption job key: '{}' and group: '{}'", jobKey.getName(), jobKey.getGroup());
+            scheduler.deleteJob(jobKey);
+        } catch (SchedulerException e) {
+            LOGGER.error(String.format("Error during unscheduling quartz job: %s", jobKey), e);
+        }
+
+    }
+
+    private Date delayedFirstStart() {
+        int delayInSeconds = RANDOM.nextInt((int) TimeUnit.MINUTES.toSeconds(storageConsumptionConfig.getIntervalInMinutes()));
+        return Date.from(ZonedDateTime.now().toInstant().plus(Duration.ofSeconds(delayInSeconds)));
+    }
+}


### PR DESCRIPTION
Implemented skeleton for quartz jobs. Jobs are running in 30 minutes interval. The scheduler will be called from Consumption service either with ID or JobResource. For now execution function just logs success message, however ,it will get credentials from environment service in later implementation.