### PR TITLE
Revert "DISTX-681: AZURE: Switch DE templates to use temporaryStorage: EPHEMERAL or temporaryStorage: COMBINED/EPHEMERAL_OR_ATTACHED"

### DIFF
--- a/core/src/main/resources/defaults/clustertemplates/7.2.14/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.14/azure/dataengineering-ha.json
@@ -56,7 +56,7 @@
           "attachedVolumes": [
             {
               "size": 500,
-              "count": 0,
+              "count": 1,
               "type": "StandardSSD_LRS"
             }
           ],

--- a/core/src/main/resources/defaults/clustertemplates/7.2.14/azure/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.14/azure/dataengineering-spark3.json
@@ -26,7 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3"
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,7 +38,7 @@
           "attachedVolumes": [
             {
               "size": 100,
-              "count": 0,
+              "count": 1,
               "type": "StandardSSD_LRS"
             }
           ],

--- a/core/src/main/resources/defaults/clustertemplates/7.2.14/azure/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.14/azure/dataengineering.json
@@ -37,7 +37,7 @@
           "attachedVolumes": [
             {
               "size": 100,
-              "count": 0,
+              "count": 1,
               "type": "StandardSSD_LRS"
             }
           ],

--- a/core/src/main/resources/defaults/clustertemplates/7.2.15/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.15/azure/dataengineering-ha.json
@@ -56,7 +56,7 @@
           "attachedVolumes": [
             {
               "size": 500,
-              "count": 0,
+              "count": 1,
               "type": "StandardSSD_LRS"
             }
           ],

--- a/core/src/main/resources/defaults/clustertemplates/7.2.15/azure/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.15/azure/dataengineering-spark3.json
@@ -26,7 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3"
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,7 +38,7 @@
           "attachedVolumes": [
             {
               "size": 100,
-              "count": 0,
+              "count": 1,
               "type": "StandardSSD_LRS"
             }
           ],

--- a/core/src/main/resources/defaults/clustertemplates/7.2.15/azure/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.15/azure/dataengineering.json
@@ -37,7 +37,7 @@
           "attachedVolumes": [
             {
               "size": 100,
-              "count": 0,
+              "count": 1,
               "type": "StandardSSD_LRS"
             }
           ],

--- a/core/src/main/resources/defaults/clustertemplates/7.2.16/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.16/azure/dataengineering-ha.json
@@ -56,7 +56,7 @@
           "attachedVolumes": [
             {
               "size": 500,
-              "count": 0,
+              "count": 1,
               "type": "StandardSSD_LRS"
             }
           ],

--- a/core/src/main/resources/defaults/clustertemplates/7.2.16/azure/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.16/azure/dataengineering-spark3.json
@@ -26,7 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3"
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,7 +38,7 @@
           "attachedVolumes": [
             {
               "size": 100,
-              "count": 0,
+              "count": 1,
               "type": "StandardSSD_LRS"
             }
           ],

--- a/core/src/main/resources/defaults/clustertemplates/7.2.16/azure/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.16/azure/dataengineering.json
@@ -37,7 +37,7 @@
           "attachedVolumes": [
             {
               "size": 100,
-              "count": 0,
+              "count": 1,
               "type": "StandardSSD_LRS"
             }
           ],


### PR DESCRIPTION
Reverts hortonworks/cloudbreak#12672

Nightly test failed with validation:
http://ci-cloudbreak.eng.hortonworks.com/job/gui-e2e-azure/3101/allure/data/attachments/9953f2c0cc587312.png
