### PR TITLE
CB-16926 Redbeams provisioning flow restart causes duplicate deployme…

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
@@ -109,6 +109,7 @@ import com.sequenceiq.cloudbreak.cloud.azure.AzureDiskType;
 import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneServiceEnum;
 import com.sequenceiq.cloudbreak.cloud.azure.image.marketplace.AzureMarketplaceImage;
 import com.sequenceiq.cloudbreak.cloud.azure.status.AzureStatusMapper;
+import com.sequenceiq.cloudbreak.cloud.azure.template.AzureTemplateDeploymentParameters;
 import com.sequenceiq.cloudbreak.cloud.azure.util.AzureAuthExceptionHandler;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
@@ -186,6 +187,15 @@ public class AzureClient {
                 .withRegion(region)
                 .withTags(tags)
                 .create());
+    }
+
+    public Deployment createTemplateDeployment(AzureTemplateDeploymentParameters azureTemplateDeploymentParameters) {
+        return createTemplateDeployment(
+                azureTemplateDeploymentParameters.getResourceGroupName(),
+                azureTemplateDeploymentParameters.getTemplateName(),
+                azureTemplateDeploymentParameters.getTemplateContent(),
+                azureTemplateDeploymentParameters.getTemplateParameters()
+        );
     }
 
     public Deployment createTemplateDeployment(String resourceGroupName, String deploymentName, String templateContent, String parameterContent) {

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/AzurePollTaskFactory.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/AzurePollTaskFactory.java
@@ -18,6 +18,8 @@ import com.sequenceiq.cloudbreak.cloud.azure.task.networkinterface.NetworkInterf
 import com.sequenceiq.cloudbreak.cloud.azure.task.networkinterface.NetworkInterfaceDetachCheckerContext;
 import com.sequenceiq.cloudbreak.cloud.azure.task.storageaccount.StorageAccountChecker;
 import com.sequenceiq.cloudbreak.cloud.azure.task.storageaccount.StorageAccountCheckerContext;
+import com.sequenceiq.cloudbreak.cloud.azure.task.database.AzureDatabaseTemplateDeploymentContext;
+import com.sequenceiq.cloudbreak.cloud.azure.task.database.AzureDatabaseTemplateDeploymentPollTask;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.task.PollTask;
@@ -55,6 +57,10 @@ public class AzurePollTaskFactory {
     public PollTask<DiskEncryptionSetInner> diskEncryptionSetCreationCheckerTask(AuthenticatedContext authenticatedContext,
             DiskEncryptionSetCreationCheckerContext checkerContext) {
         return createPollTask(DiskEncryptionSetCreationCheckerTask.NAME, authenticatedContext, checkerContext);
+    }
+
+    public PollTask<Boolean> databaseCreationPollTask(AuthenticatedContext authenticatedContext, AzureDatabaseTemplateDeploymentContext deploymentContext) {
+        return createPollTask(AzureDatabaseTemplateDeploymentPollTask.NAME, authenticatedContext, deploymentContext);
     }
 
     @SuppressWarnings("unchecked")

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/database/AzureDatabaseTemplateDeploymentContext.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/database/AzureDatabaseTemplateDeploymentContext.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.cloudbreak.cloud.azure.task.database;
+
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.azure.template.AzureTemplateDeploymentParameters;
+
+public class AzureDatabaseTemplateDeploymentContext {
+
+    private final AzureClient azureClient;
+
+    private final AzureTemplateDeploymentParameters azureTemplateDeploymentParameters;
+
+    public AzureDatabaseTemplateDeploymentContext(AzureClient azureClient, AzureTemplateDeploymentParameters azureTemplateDeploymentParameters) {
+        this.azureClient = azureClient;
+        this.azureTemplateDeploymentParameters = azureTemplateDeploymentParameters;
+    }
+
+    public AzureClient getAzureClient() {
+        return azureClient;
+    }
+
+    public AzureTemplateDeploymentParameters getAzureTemplateDeploymentParameters() {
+        return azureTemplateDeploymentParameters;
+    }
+
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/database/AzureDatabaseTemplateDeploymentPollTask.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/database/AzureDatabaseTemplateDeploymentPollTask.java
@@ -1,0 +1,66 @@
+package com.sequenceiq.cloudbreak.cloud.azure.task.database;
+
+import static com.sequenceiq.cloudbreak.cloud.model.ResourceStatus.DELETED;
+import static com.sequenceiq.cloudbreak.cloud.model.ResourceStatus.FAILED;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
+import com.sequenceiq.cloudbreak.cloud.task.PollBooleanStateTask;
+
+@Component(AzureDatabaseTemplateDeploymentPollTask.NAME)
+@Scope("prototype")
+public class AzureDatabaseTemplateDeploymentPollTask extends PollBooleanStateTask {
+
+    public static final String NAME = "AzureTemplateDeploymentPollTask";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AzureDatabaseTemplateDeploymentPollTask.class);
+
+    private final AzureDatabaseTemplateDeploymentContext deploymentContext;
+
+    public AzureDatabaseTemplateDeploymentPollTask(AuthenticatedContext authenticatedContext,
+            AzureDatabaseTemplateDeploymentContext azureDatabaseTemplateDeploymentContext) {
+        super(authenticatedContext, false);
+        deploymentContext = azureDatabaseTemplateDeploymentContext;
+    }
+
+    @Override
+    protected Boolean doCall() {
+        AzureClient azureClient = deploymentContext.getAzureClient();
+        String resourceGroupName = deploymentContext.getAzureTemplateDeploymentParameters().getResourceGroupName();
+        String deploymentName = deploymentContext.getAzureTemplateDeploymentParameters().getTemplateName();
+
+        ResourceStatus templateDeploymentStatus = azureClient.getTemplateDeploymentStatus(resourceGroupName, deploymentName);
+        if (templateDeploymentStatus.isPermanent()) {
+            LOGGER.info("Deployment {} has been finished with status {}", deploymentName, templateDeploymentStatus);
+            checkDeploymentStatus(resourceGroupName, deploymentName, templateDeploymentStatus);
+            return true;
+        } else {
+            LOGGER.debug("Azure template deployment has not finished yet: {}.", deploymentName);
+            return false;
+        }
+    }
+
+    private void checkDeploymentStatus(String resourceGroupName, String deploymentName, ResourceStatus templateDeploymentStatus) {
+        if (DELETED == templateDeploymentStatus) {
+            throwException("Deployment %s in resource group %s is either deleted or does not exist", deploymentName, resourceGroupName);
+        }
+
+        if (FAILED == templateDeploymentStatus) {
+            throwException("Deployment %s in resource group %s was either cancelled or failed.", deploymentName, resourceGroupName);
+        }
+    }
+
+    private void throwException(String format, String deploymentName, String resourceGroupName) {
+        String message = String.format(format, deploymentName, resourceGroupName);
+        LOGGER.warn(message);
+        throw new CloudConnectorException(message);
+    }
+
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/database/AzureDatabaseTemplateDeploymentPoller.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/database/AzureDatabaseTemplateDeploymentPoller.java
@@ -1,0 +1,41 @@
+package com.sequenceiq.cloudbreak.cloud.azure.task.database;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.azure.task.AzurePollTaskFactory;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.scheduler.SyncPollingScheduler;
+import com.sequenceiq.cloudbreak.cloud.task.PollTask;
+
+@Component
+public class AzureDatabaseTemplateDeploymentPoller {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AzureDatabaseTemplateDeploymentPoller.class);
+
+    @Value("${cb.azure.poller.template.deployment.checkinterval:10000}")
+    private int deploymentCheckInterval;
+
+    @Value("${cb.azure.poller.template.deployment.maxattempt:120}")
+    private int deploymentCheckMaxAttempt;
+
+    @Value("${cb.azure.poller.template.deployment.maxfailurenumber:5}")
+    private int maxTolerableFailureNumber;
+
+    @Inject
+    private AzurePollTaskFactory azurePollTaskFactory;
+
+    @Inject
+    private SyncPollingScheduler<Boolean> syncPollingScheduler;
+
+    public void startPolling(AuthenticatedContext ac, AzureDatabaseTemplateDeploymentContext deploymentContext) throws Exception {
+        PollTask<Boolean> templateDeploymentPollTask = azurePollTaskFactory.databaseCreationPollTask(ac, deploymentContext);
+        LOGGER.info("Start polling template deployment: {}", deploymentContext.getAzureTemplateDeploymentParameters().getTemplateName());
+        syncPollingScheduler.schedule(templateDeploymentPollTask, deploymentCheckInterval, deploymentCheckMaxAttempt, maxTolerableFailureNumber);
+    }
+
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/database/PollingStarter.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/database/PollingStarter.java
@@ -1,0 +1,6 @@
+package com.sequenceiq.cloudbreak.cloud.azure.task.database;
+
+public interface PollingStarter {
+
+    void startPolling() throws Exception;
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/template/AzureTemplateCreatorService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/template/AzureTemplateCreatorService.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.cloudbreak.cloud.azure.template;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.microsoft.azure.management.resources.Deployment;
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.azure.task.database.PollingStarter;
+import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
+
+@Service
+public class AzureTemplateCreatorService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AzureTemplateCreatorService.class);
+
+    public Deployment createOrPollTemplateDeployment(AzureClient azureClient,
+            AzureTemplateDeploymentParameters templateDeploymentParameters, PollingStarter deploymentPoller) throws Exception {
+        String resourceGroupName = templateDeploymentParameters.getResourceGroupName();
+        String deploymentName = templateDeploymentParameters.getTemplateName();
+        if (shouldCreateTemplateDeployment(azureClient, resourceGroupName, deploymentName)) {
+            LOGGER.debug("Creating deployment {} in RG {}", deploymentName, resourceGroupName);
+            return azureClient.createTemplateDeployment(templateDeploymentParameters);
+        } else {
+            LOGGER.debug("Deployment {} in RG {} is in progress, starting polling", deploymentName, resourceGroupName);
+            deploymentPoller.startPolling();
+            return azureClient.getTemplateDeployment(resourceGroupName, deploymentName);
+        }
+    }
+
+    private boolean shouldCreateTemplateDeployment(AzureClient client, String resourceGroupName, String stackName) {
+        boolean deploymentExists = client.templateDeploymentExists(resourceGroupName, stackName);
+        LOGGER.debug("Checking the existence of deployment {} in RG {}: {}", stackName, resourceGroupName, deploymentExists);
+        return !deploymentExists || client.getTemplateDeploymentStatus(resourceGroupName, stackName) != ResourceStatus.IN_PROGRESS;
+    }
+
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/template/AzureTemplateDeploymentParameters.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/template/AzureTemplateDeploymentParameters.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.cloudbreak.cloud.azure.template;
+
+public class AzureTemplateDeploymentParameters {
+
+    private final String resourceGroupName;
+
+    private final String templateName;
+
+    private final String templateContent;
+
+    private final String templateParameters;
+
+    public AzureTemplateDeploymentParameters(String resourceGroupName, String templateName, String templateContent, String templateParameters) {
+        this.resourceGroupName = resourceGroupName;
+        this.templateName = templateName;
+        this.templateContent = templateContent;
+        this.templateParameters = templateParameters;
+    }
+
+    public String getResourceGroupName() {
+        return resourceGroupName;
+    }
+
+    public String getTemplateName() {
+        return templateName;
+    }
+
+    public String getTemplateContent() {
+        return templateContent;
+    }
+
+    public String getTemplateParameters() {
+        return templateParameters;
+    }
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/task/database/AzureDatabaseTemplateDeploymentPollTaskTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/task/database/AzureDatabaseTemplateDeploymentPollTaskTest.java
@@ -1,0 +1,95 @@
+package com.sequenceiq.cloudbreak.cloud.azure.task.database;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.azure.template.AzureTemplateDeploymentParameters;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
+
+@ExtendWith(MockitoExtension.class)
+public class AzureDatabaseTemplateDeploymentPollTaskTest {
+
+    private static final String RESOURCE_GROUP_NAME = "resourceGroupName";
+
+    private static final String TEMPLATE_NAME = "templateName";
+
+    private static final String TEMPLATE_CONTENT = "templateContent";
+
+    private static final String TEMPLATE_PARAMETERS = "templateParameters";
+
+    @Mock
+    private AuthenticatedContext authenticatedContext;
+
+    @Mock
+    private AzureDatabaseTemplateDeploymentContext azureDatabaseTemplateDeploymentContext;
+
+    @InjectMocks
+    private AzureDatabaseTemplateDeploymentPollTask underTest;
+
+    @Mock
+    private AzureClient azureClient;
+
+    @BeforeEach
+    void setup() {
+        when(azureDatabaseTemplateDeploymentContext.getAzureClient()).thenReturn(azureClient);
+        AzureTemplateDeploymentParameters azureTemplateDeploymentParameters =
+                new AzureTemplateDeploymentParameters(RESOURCE_GROUP_NAME, TEMPLATE_NAME, TEMPLATE_CONTENT, TEMPLATE_PARAMETERS);
+        when(azureDatabaseTemplateDeploymentContext.getAzureTemplateDeploymentParameters()).thenReturn(azureTemplateDeploymentParameters);
+    }
+
+    @Test
+    void testDoCallWhenTemplateSucceeded() {
+        when(azureClient.getTemplateDeploymentStatus(RESOURCE_GROUP_NAME, TEMPLATE_NAME)).thenReturn(ResourceStatus.CREATED);
+
+        Boolean result = underTest.doCall();
+
+        assertTrue(result);
+    }
+
+    @Test
+    void testDoCallWhenTemplateDeleted() {
+        when(azureClient.getTemplateDeploymentStatus(RESOURCE_GROUP_NAME, TEMPLATE_NAME)).thenReturn(ResourceStatus.DELETED);
+
+        CloudConnectorException e = assertThrows(CloudConnectorException.class, () ->
+                underTest.doCall()
+        );
+
+        String exceptionTest = String.format("Deployment %s in resource group %s is either deleted or does not exist", TEMPLATE_NAME, RESOURCE_GROUP_NAME);
+        assertEquals(exceptionTest, e.getMessage());
+    }
+
+    @Test
+    void testDoCallWhenTemplateFailed() {
+        when(azureClient.getTemplateDeploymentStatus(RESOURCE_GROUP_NAME, TEMPLATE_NAME)).thenReturn(ResourceStatus.FAILED);
+
+        CloudConnectorException e = assertThrows(CloudConnectorException.class, () ->
+                underTest.doCall()
+        );
+
+        String exceptionTest = String.format("Deployment %s in resource group %s was either cancelled or failed.", TEMPLATE_NAME, RESOURCE_GROUP_NAME);
+        assertEquals(exceptionTest, e.getMessage());
+    }
+
+    @Test
+    void testDoCallWhenTemplateInProgress() {
+        when(azureClient.getTemplateDeploymentStatus(RESOURCE_GROUP_NAME, TEMPLATE_NAME)).thenReturn(ResourceStatus.IN_PROGRESS);
+
+        Boolean result = underTest.doCall();
+
+        assertFalse(result);
+    }
+
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/template/AzureTemplateCreatorServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/template/AzureTemplateCreatorServiceTest.java
@@ -1,0 +1,88 @@
+package com.sequenceiq.cloudbreak.cloud.azure.template;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.microsoft.azure.management.resources.Deployment;
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.azure.task.database.PollingStarter;
+import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
+
+@ExtendWith(MockitoExtension.class)
+public class AzureTemplateCreatorServiceTest {
+
+    private static final String RESOURCE_GROUP_NAME = "resourceGroupName";
+
+    private static final String TEMPLATE_NAME = "templateName";
+
+    private static final String TEMPLATE_CONTENT = "templateContent";
+
+    private static final String TEMPLATE_PARAMETERS = "templateParameters";
+
+    private final AzureTemplateCreatorService underTest = new AzureTemplateCreatorService();
+
+    private final AzureTemplateDeploymentParameters azureTemplateDeploymentParameters =
+            new AzureTemplateDeploymentParameters(RESOURCE_GROUP_NAME, TEMPLATE_NAME, TEMPLATE_CONTENT, TEMPLATE_PARAMETERS);
+
+    @Mock
+    private AzureClient azureClient;
+
+    @Mock
+    private PollingStarter deploymentPoller;
+
+    @Test
+    void testCreateOrPollTemplateDeploymentWhenDeploymentDoesNotExists() throws Exception {
+        Deployment deployment = mock(Deployment.class);
+        when(azureClient.templateDeploymentExists(RESOURCE_GROUP_NAME, TEMPLATE_NAME)).thenReturn(false);
+        when(azureClient.createTemplateDeployment(azureTemplateDeploymentParameters)).thenReturn(deployment);
+
+        Deployment returnedDeployment = underTest.createOrPollTemplateDeployment(azureClient, azureTemplateDeploymentParameters, deploymentPoller);
+
+        assertEquals(deployment, returnedDeployment);
+        verify(azureClient).createTemplateDeployment(azureTemplateDeploymentParameters);
+        verify(deploymentPoller, never()).startPolling();
+        verify(azureClient, never()).getTemplateDeployment(RESOURCE_GROUP_NAME, TEMPLATE_NAME);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ResourceStatus.class, names = {"IN_PROGRESS"}, mode = EnumSource.Mode.EXCLUDE)
+    void testCreateOrPollTemplateDeploymentWhenDeploymentNotInProgress(ResourceStatus resourceStatus) throws Exception {
+        Deployment deployment = mock(Deployment.class);
+        when(azureClient.templateDeploymentExists(RESOURCE_GROUP_NAME, TEMPLATE_NAME)).thenReturn(true);
+        when(azureClient.getTemplateDeploymentStatus(RESOURCE_GROUP_NAME, TEMPLATE_NAME)).thenReturn(resourceStatus);
+        when(azureClient.createTemplateDeployment(azureTemplateDeploymentParameters)).thenReturn(deployment);
+
+        Deployment returnedDeployment = underTest.createOrPollTemplateDeployment(azureClient, azureTemplateDeploymentParameters, deploymentPoller);
+
+        assertEquals(deployment, returnedDeployment);
+        verify(azureClient).createTemplateDeployment(azureTemplateDeploymentParameters);
+        verify(deploymentPoller, never()).startPolling();
+        verify(azureClient, never()).getTemplateDeployment(RESOURCE_GROUP_NAME, TEMPLATE_NAME);
+    }
+
+    @Test
+    void testCreateOrPollTemplateDeploymentWhenDeploymentIsInProgress() throws Exception {
+        Deployment deployment = mock(Deployment.class);
+        when(azureClient.templateDeploymentExists(RESOURCE_GROUP_NAME, TEMPLATE_NAME)).thenReturn(true);
+        when(azureClient.getTemplateDeploymentStatus(RESOURCE_GROUP_NAME, TEMPLATE_NAME)).thenReturn(ResourceStatus.IN_PROGRESS);
+        when(azureClient.getTemplateDeployment(RESOURCE_GROUP_NAME, TEMPLATE_NAME)).thenReturn(deployment);
+
+        Deployment returnedDeployment = underTest.createOrPollTemplateDeployment(azureClient, azureTemplateDeploymentParameters, deploymentPoller);
+
+        assertEquals(deployment, returnedDeployment);
+        verify(azureClient, never()).createTemplateDeployment(azureTemplateDeploymentParameters);
+        verify(deploymentPoller).startPolling();
+        verify(azureClient).getTemplateDeployment(RESOURCE_GROUP_NAME, TEMPLATE_NAME);
+    }
+
+}


### PR DESCRIPTION
…nt submission on Azure

In redbeams, when the provisioning flow restarts, the database template deployment is sometimes posted twice, causing an Azure error.

This commit has a generalized solution for the problem. If a template needs to be submitted, then the code
- checks if there is a template already in the given resource group (RG) with the given name. If no, then a new teplate is submitted
- if the template exists but is terminal (succeeded, failed, recently deleted etc), then a new template is submitted. If the previous and current templates had to provisioned the same resources, no change is done, if the resources still exist.
- if the template is in progress, then a poller is started.

The poller in this case is a new databasePoller.It does not check the existence of the database as after the database provisioning either service or private endpoints are also created.

The new solution was added only for database provisioning. If needed it can be added to other places in the code.

See detailed description in the commit message.