### PR TITLE
JIRA: CB-16642 remove duplicated event logs

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/BackupRestoreStatusService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/BackupRestoreStatusService.java
@@ -43,7 +43,7 @@ public class BackupRestoreStatusService {
     }
 
     public void backupDatabaseFinished(long stackId) {
-        stackUpdater.updateStackStatus(stackId, DetailedStackStatus.DATABASE_BACKUP_FINISHED, "Database was successfully backed up.");
+        stackUpdater.updateStackStatus(stackId, DetailedStackStatus.DATABASE_BACKUP_IN_PROGRESS, "Database was successfully backed up.");
         flowMessageService.fireEventAndLog(stackId, Status.AVAILABLE.name(), DATALAKE_DATABASE_BACKUP_FINISHED);
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/BackupRestoreStatusServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/BackupRestoreStatusServiceTest.java
@@ -77,7 +77,7 @@ public class BackupRestoreStatusServiceTest {
     public void testBackupFinished() {
         ArgumentCaptor<ResourceEvent> captor = ArgumentCaptor.forClass(ResourceEvent.class);
         service.backupDatabaseFinished(STACK_ID);
-        verify(stackUpdater, times(1)).updateStackStatus(STACK_ID, DetailedStackStatus.DATABASE_BACKUP_FINISHED,
+        verify(stackUpdater, times(1)).updateStackStatus(STACK_ID, DetailedStackStatus.DATABASE_BACKUP_IN_PROGRESS,
                 "Database was successfully backed up.");
         verify(flowMessageService).fireEventAndLog(eq(STACK_ID), eq(Status.AVAILABLE.name()), captor.capture());
         assertEquals(DATALAKE_DATABASE_BACKUP_FINISHED, captor.getValue());

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/DatalakeBackupActions.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/DatalakeBackupActions.java
@@ -143,9 +143,6 @@ public class DatalakeBackupActions {
             protected void doExecute(SdxContext context, DatalakeDatabaseBackupStartEvent payload, Map<Object, Object> variables) {
                 LOGGER.info("Datalake database backup has been started for {}", payload.getResourceId());
 
-                SdxCluster sdxCluster = sdxService.getById(payload.getResourceId());
-                eventSenderService.sendEventAndNotification(sdxCluster, context.getFlowTriggerUserCrn(), ResourceEvent.DATALAKE_DATABASE_BACKUP);
-
                 sdxBackupRestoreService.databaseBackup(payload.getDrStatus(),
                         payload.getResourceId(),
                         payload.getBackupRequest());


### PR DESCRIPTION
JIRA: CB-16642 remove, event log duplication, and the stack status update on the database backup finished status

See detailed description in the commit message.

tested locally:
- resize datalake
- datalake API triggered. 

All test result is passed.