### PR TITLE
CB-16956 Add assertion for metering Heartbeat generation in CB tests

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CommonCloudProperties.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CommonCloudProperties.java
@@ -207,6 +207,8 @@ public class CommonCloudProperties {
 
         private String name;
 
+        private String workloadPassword;
+
         public String getAccessKey() {
             return accesskey;
         }
@@ -237,6 +239,14 @@ public class CommonCloudProperties {
 
         public void setName(String name) {
             this.name = name;
+        }
+
+        public String getWorkloadPassword() {
+            return workloadPassword;
+        }
+
+        public void setWorkloadPassword(String workloadPassword) {
+            this.workloadPassword = workloadPassword;
         }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/AbstractIntegrationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/AbstractIntegrationTest.java
@@ -30,6 +30,7 @@ import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.blueprint.BlueprintTestDto;
 import com.sequenceiq.it.cloudbreak.dto.credential.CredentialTestDto;
 import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
+import com.sequenceiq.it.cloudbreak.dto.distrox.instancegroup.DistroXInstanceGroupsBuilder;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaUserSyncTestDto;
 import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
@@ -175,8 +176,14 @@ public abstract class AbstractIntegrationTest extends AbstractMinimalTest {
     }
 
     protected void createDefaultDatahub(TestContext testContext) {
-        createEnvironmentWithFreeIpaAndDatalake(testContext);
+        createDefaultDatalake(testContext);
         initiateDefaultDatahubCreation(testContext);
+        waitForDefaultDatahubCreation(testContext);
+    }
+
+    protected void createStorageOptimizedDatahub(TestContext testContext) {
+        createDefaultDatalake(testContext);
+        initiateStorageOptimizedDatahubCreation(testContext);
         waitForDefaultDatahubCreation(testContext);
     }
 
@@ -192,6 +199,17 @@ public abstract class AbstractIntegrationTest extends AbstractMinimalTest {
                 .await(STACK_AVAILABLE)
                 .awaitForHealthyInstances()
                 .when(distroXTestClient.get())
+                .validate();
+    }
+
+    protected void initiateStorageOptimizedDatahubCreation(TestContext testContext) {
+        testContext
+                .given(DistroXTestDto.class)
+                .withInstanceGroupsEntity(new DistroXInstanceGroupsBuilder(testContext)
+                        .defaultHostGroup()
+                        .withStorageOptimizedInstancetype()
+                        .build())
+                .when(distroXTestClient.create())
                 .validate();
     }
 
@@ -280,7 +298,7 @@ public abstract class AbstractIntegrationTest extends AbstractMinimalTest {
                 .validate();
     }
 
-    protected void createEnvironmentWithFreeIpaAndDatalake(TestContext testContext) {
+    protected void createDefaultDatalake(TestContext testContext) {
         initiateEnvironmentCreation(testContext);
         initiateDatalakeCreation(testContext);
         waitForEnvironmentCreation(testContext);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/diagnostics/DiagnosticsTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/diagnostics/DiagnosticsTests.java
@@ -29,7 +29,7 @@ public class DiagnosticsTests extends AbstractE2ETest {
         createDefaultUser(testContext);
         createDefaultCredential(testContext);
         initializeDefaultBlueprints(testContext);
-        createEnvironmentWithFreeIpaAndDatalake(testContext);
+        createDefaultDatalake(testContext);
     }
 
     @Test(dataProvider = TEST_CONTEXT)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXAwsMigrationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXAwsMigrationTest.java
@@ -33,7 +33,7 @@ public class DistroXAwsMigrationTest extends AbstractE2ETest {
         createDefaultUser(testContext);
         initializeDefaultBlueprints(testContext);
         createDefaultCredential(testContext);
-        createEnvironmentWithFreeIpaAndDatalake(testContext);
+        createDefaultDatalake(testContext);
     }
 
     @Test(dataProvider = TEST_CONTEXT)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXImagesTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXImagesTests.java
@@ -45,7 +45,7 @@ public class DistroXImagesTests extends AbstractE2ETest {
         createDefaultUser(testContext);
         createDefaultCredential(testContext);
         initializeDefaultBlueprints(testContext);
-        createEnvironmentWithFreeIpaAndDatalake(testContext);
+        createDefaultDatalake(testContext);
     }
 
     @Ignore("This test case should be re-enabled in case of InternalSDXDistroXTest has been removed")

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXRepairTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXRepairTests.java
@@ -38,7 +38,7 @@ public class DistroXRepairTests extends AbstractE2ETest {
         createDefaultUser(testContext);
         createDefaultCredential(testContext);
         initializeDefaultBlueprints(testContext);
-        createEnvironmentWithFreeIpaAndDatalake(testContext);
+        createDefaultDatalake(testContext);
     }
 
     @Test(dataProvider = TEST_CONTEXT)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXScaleEdgeCasesTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXScaleEdgeCasesTest.java
@@ -32,7 +32,7 @@ public class DistroXScaleEdgeCasesTest extends AbstractE2ETest {
         createDefaultUser(testContext);
         createDefaultCredential(testContext);
         initializeDefaultBlueprints(testContext);
-        createEnvironmentWithFreeIpaAndDatalake(testContext);
+        createDefaultDatalake(testContext);
     }
 
     @Test(dataProvider = TEST_CONTEXT)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/ephemeral/DistroXStopStartTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/ephemeral/DistroXStopStartTest.java
@@ -10,9 +10,9 @@ import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
-import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.util.SanitizerUtil;
 import com.sequenceiq.it.TestParameter;
+import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.client.DistroXTestClient;
 import com.sequenceiq.it.cloudbreak.cloud.HostGroupType;
 import com.sequenceiq.it.cloudbreak.context.Description;
@@ -21,9 +21,9 @@ import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
 import com.sequenceiq.it.cloudbreak.dto.distrox.instancegroup.DistroXInstanceGroupsBuilder;
 import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
+import com.sequenceiq.it.cloudbreak.util.CloudFunctionality;
 import com.sequenceiq.it.cloudbreak.util.clouderamanager.ClouderaManagerUtil;
 import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
-import com.sequenceiq.it.cloudbreak.util.ssh.action.SshJClientActions;
 
 public class DistroXStopStartTest extends AbstractE2ETest {
 
@@ -40,16 +40,13 @@ public class DistroXStopStartTest extends AbstractE2ETest {
     @Inject
     private ClouderaManagerUtil clouderaManagerUtil;
 
-    @Inject
-    private SshJClientActions sshJClientActions;
-
     @Override
     protected void setupTest(TestContext testContext) {
         testContext.getCloudProvider().getCloudFunctionality().cloudStorageInitialize();
         createDefaultUser(testContext);
         initializeDefaultBlueprints(testContext);
         createDefaultCredential(testContext);
-        createEnvironmentWithFreeIpaAndDatalake(testContext);
+        createDefaultDatalake(testContext);
     }
 
     @Test(dataProvider = TEST_CONTEXT)
@@ -77,64 +74,42 @@ public class DistroXStopStartTest extends AbstractE2ETest {
                 .when(distroXTestClient.create(), RunningParameter.key("eph_dx"))
                 .given("non_eph_dx", DistroXTestDto.class)
                 .await(STACK_AVAILABLE, RunningParameter.key("non_eph_dx"))
-                .then((tc, testDto, client) -> {
-                    verifyEphemeralVolumesShouldNotBeConfiguredInHdfs(sanitizedUserName, testDto);
-                    return testDto;
-                })
+                .then((tc, testDto, client) -> verifyEphemeralVolumesShouldNotBeConfiguredInHdfs(tc, sanitizedUserName, testDto))
                 .when(distroXTestClient.stop(), RunningParameter.key("non_eph_dx"))
                 .await(STACK_STOPPED, RunningParameter.key("non_eph_dx"))
                 .when(distroXTestClient.start(), RunningParameter.key("non_eph_dx"))
                 .await(STACK_AVAILABLE, RunningParameter.key("non_eph_dx"))
-                .then((tc, testDto, client) -> {
-                    verifyEphemeralVolumesShouldNotBeConfiguredInHdfs(sanitizedUserName, testDto);
-                    return testDto;
-                })
+                .then((tc, testDto, client) -> verifyEphemeralVolumesShouldNotBeConfiguredInHdfs(tc, sanitizedUserName, testDto))
                 .given("eph_dx", DistroXTestDto.class)
                 .await(STACK_AVAILABLE, RunningParameter.key("eph_dx"))
-                .then((tc, testDto, client) -> {
-                    verifyMountPointsUsedForTemporalDisks(testDto, "ephfs", "ephfs1");
-                    return testDto;
-                })
-                .then((tc, testDto, client) -> {
-                    verifyEphemeralVolumesShouldNotBeConfiguredInHdfs(sanitizedUserName, testDto);
-                    return testDto;
-                })
+                .then(this::verifyMountedDisks)
+                .then((tc, testDto, client) -> verifyEphemeralVolumesShouldNotBeConfiguredInHdfs(tc, sanitizedUserName, testDto))
                 .then((tc, testDto, client) -> clouderaManagerUtil.checkClouderaManagerYarnNodemanagerRoleConfigGroups(testDto, sanitizedUserName,
                         MOCK_UMS_PASSWORD))
                 .when(distroXTestClient.stop(), RunningParameter.key("eph_dx"))
                 .await(STACK_STOPPED, RunningParameter.key("eph_dx"))
                 .when(distroXTestClient.start(), RunningParameter.key("eph_dx"))
                 .await(STACK_AVAILABLE, RunningParameter.key("eph_dx"))
-                .then((tc, testDto, client) -> {
-                    verifyMountPointsUsedForTemporalDisks(testDto, "ephfs", "ephfs1");
-                    return testDto;
-                })
+                .then(this::verifyMountedDisks)
                 .then((tc, testDto, client) -> clouderaManagerUtil.checkClouderaManagerYarnNodemanagerRoleConfigGroups(testDto, sanitizedUserName,
                         MOCK_UMS_PASSWORD))
                 .validate();
     }
 
-    private void verifyEphemeralVolumesShouldNotBeConfiguredInHdfs(String sanitizedUserName, DistroXTestDto testDto) {
-        Set<String> mountPoints = Set.of();
-        if (activeCloudPlatform(CloudPlatform.AWS)) {
-            mountPoints = sshJClientActions.getAwsEphemeralVolumeMountPoints(testDto.getResponse().getInstanceGroups(), List.of(HostGroupType.MASTER.getName()));
-        } else if (activeCloudPlatform(CloudPlatform.AZURE)) {
-            mountPoints = Set.of("/mnt/resource", "/hadoopfs/ephfs1");
-        }
+    private DistroXTestDto verifyEphemeralVolumesShouldNotBeConfiguredInHdfs(TestContext testContext, String sanitizedUserName, DistroXTestDto testDto) {
+        CloudFunctionality cloudFunctionality = testContext.getCloudProvider().getCloudFunctionality();
+        List<InstanceGroupV4Response> instanceGroups = testDto.getResponse().getInstanceGroups();
+        Set<String> mountPoints = cloudFunctionality.getVolumeMountPoints(instanceGroups, List.of(HostGroupType.WORKER.getName()));
+
         clouderaManagerUtil.checkClouderaManagerHdfsDatanodeRoleConfigGroups(testDto, sanitizedUserName, MOCK_UMS_PASSWORD, mountPoints);
         clouderaManagerUtil.checkClouderaManagerHdfsNamenodeRoleConfigGroups(testDto, sanitizedUserName, MOCK_UMS_PASSWORD, mountPoints);
+        return testDto;
     }
 
-    private void verifyMountPointsUsedForTemporalDisks(DistroXTestDto testDto, String awsMountPrefix, String azureMountDir) {
+    private DistroXTestDto verifyMountedDisks(TestContext testContext, DistroXTestDto testDto, CloudbreakClient cloudbreakClient) {
+        CloudFunctionality cloudFunctionality = testContext.getCloudProvider().getCloudFunctionality();
         List<InstanceGroupV4Response> instanceGroups = testDto.getResponse().getInstanceGroups();
-        if (activeCloudPlatform(CloudPlatform.AWS)) {
-            sshJClientActions.checkAwsEphemeralDisksMounted(instanceGroups, List.of(HostGroupType.WORKER.getName()), awsMountPrefix);
-        } else if (activeCloudPlatform(CloudPlatform.AZURE)) {
-            sshJClientActions.checkAzureTemporalDisksMounted(instanceGroups, List.of(HostGroupType.WORKER.getName()), azureMountDir);
-        }
-    }
-
-    private boolean activeCloudPlatform(CloudPlatform cloudPlatform) {
-        return cloudPlatform.name().equalsIgnoreCase(commonCloudProperties().getCloudProvider());
+        cloudFunctionality.checkMountedDisks(instanceGroups, List.of(HostGroupType.WORKER.getName()));
+        return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/ephemeral/DistroXUpgradeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/ephemeral/DistroXUpgradeTests.java
@@ -9,7 +9,6 @@ import javax.inject.Inject;
 import org.testng.annotations.Test;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
-import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.util.SanitizerUtil;
 import com.sequenceiq.it.cloudbreak.client.DistroXTestClient;
 import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
@@ -22,9 +21,9 @@ import com.sequenceiq.it.cloudbreak.dto.distrox.cluster.DistroXUpgradeTestDto;
 import com.sequenceiq.it.cloudbreak.dto.distrox.instancegroup.DistroXInstanceGroupsBuilder;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
 import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
+import com.sequenceiq.it.cloudbreak.util.CloudFunctionality;
 import com.sequenceiq.it.cloudbreak.util.clouderamanager.ClouderaManagerUtil;
 import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
-import com.sequenceiq.it.cloudbreak.util.ssh.action.SshJClientActions;
 import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 
 public class DistroXUpgradeTests extends AbstractE2ETest {
@@ -42,9 +41,6 @@ public class DistroXUpgradeTests extends AbstractE2ETest {
 
     @Inject
     private ClouderaManagerUtil clouderaManagerUtil;
-
-    @Inject
-    private SshJClientActions sshJClientActions;
 
     @Override
     protected void setupTest(TestContext testContext) {
@@ -95,24 +91,13 @@ public class DistroXUpgradeTests extends AbstractE2ETest {
                 .await(STACK_AVAILABLE, key(distroXName))
                 .awaitForHealthyInstances()
                 .then((tc, testDto, client) -> {
-                    verifyMountPointsUsedForTemporalDisks(testDto, "ephfs", "ephfs1");
+                    CloudFunctionality cloudFunctionality = tc.getCloudProvider().getCloudFunctionality();
+                    List<InstanceGroupV4Response> instanceGroups = testDto.getResponse().getInstanceGroups();
+                    cloudFunctionality.checkMountedDisks(instanceGroups, List.of(HostGroupType.WORKER.getName()));
                     return testDto;
                 })
                 .then((tc, testDto, client) -> clouderaManagerUtil.checkClouderaManagerYarnNodemanagerRoleConfigGroupsDirect(testDto, sanitizedUserName,
                         MOCK_UMS_PASSWORD))
                 .validate();
-    }
-
-    private void verifyMountPointsUsedForTemporalDisks(DistroXTestDto testDto, String awsMountPrefix, String azureMountDir) {
-        List<InstanceGroupV4Response> instanceGroups = testDto.getResponse().getInstanceGroups();
-        if (activeCloudPlatform(CloudPlatform.AWS)) {
-            sshJClientActions.checkAwsEphemeralDisksMounted(instanceGroups, List.of(HostGroupType.WORKER.getName()), awsMountPrefix);
-        } else if (activeCloudPlatform(CloudPlatform.AZURE)) {
-            sshJClientActions.checkAzureTemporalDisksMounted(instanceGroups, List.of(HostGroupType.WORKER.getName()), azureMountDir);
-        }
-    }
-
-    private boolean activeCloudPlatform(CloudPlatform cloudPlatform) {
-        return cloudPlatform.name().equalsIgnoreCase(commonCloudProperties().getCloudProvider());
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/freeipa/FreeIpaUpgradeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/freeipa/FreeIpaUpgradeTests.java
@@ -358,7 +358,7 @@ public class FreeIpaUpgradeTests extends AbstractE2ETest {
                 .findFirst().orElseThrow(() -> new TestFailException("FreeIPA upgrade DNS lookups test failed, idbroker instance group was not found."));
         try {
             String cmd = String.format(CHECK_DNS_LOOKUPS_CMD, instanceGroupMetadata.getDiscoveryFQDN(), instanceGroupMetadata.getPrivateIp());
-            Map<String, Pair<Integer, String>> results = sshJClientActions.executeSshCommand(getInstanceGroups(sdxTestDto, sdxClient),
+            Map<String, Pair<Integer, String>> results = sshJClientActions.executeSshCommandOnHost(getInstanceGroups(sdxTestDto, sdxClient),
                     List.of(HostGroupType.MASTER.getName()), cmd, false);
             results.values().forEach(result -> Assertions.assertEquals(0, result.getLeft()));
         } catch (Exception e) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/SdxBackupRestoreTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/SdxBackupRestoreTest.java
@@ -42,7 +42,7 @@ public class SdxBackupRestoreTest extends PreconditionSdxE2ETest {
         createDefaultUser(testContext);
         initializeDefaultBlueprints(testContext);
         createDefaultCredential(testContext);
-        createEnvironmentWithFreeIpaAndDatalake(testContext);
+        createDefaultDatalake(testContext);
     }
 
     @Test(dataProvider = TEST_CONTEXT)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxRecoveryTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxRecoveryTests.java
@@ -95,7 +95,7 @@ public class SdxRecoveryTests extends PreconditionSdxE2ETest {
     }
 
     private SdxTestDto executeCommandToCauseUpgradeFailure(SdxTestDto testDto, SdxClient client) {
-        Map<String, Pair<Integer, String>> hostsAppenderCmdResultByIpsMap = sshJClientActions.executeSshCommand(getInstanceGroups(testDto, client),
+        Map<String, Pair<Integer, String>> hostsAppenderCmdResultByIpsMap = sshJClientActions.executeSshCommandOnHost(getInstanceGroups(testDto, client),
                 List.of(HostGroupType.MASTER.getName(), HostGroupType.IDBROKER.getName()), INJECT_UPGRADE_FAILURE_CMD, false);
         LOGGER.debug("SSH hosts file edit result: " + hostsAppenderCmdResultByIpsMap);
         return testDto;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxSecurityTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxSecurityTests.java
@@ -59,8 +59,9 @@ public class SdxSecurityTests extends PreconditionSdxE2ETest {
                 .await(SdxClusterStatusResponse.RUNNING, key(sdx))
                 .awaitForHealthyInstances()
                 .then((tc, testDto, client) -> {
-                    Map<String, Pair<Integer, String>> certValidityCmdResultByIpsMap = sshJClientActions.executeSshCommand(getInstanceGroups(testDto, client),
-                            List.of(HostGroupType.MASTER.getName(), HostGroupType.IDBROKER.getName()), HOST_CERT_VALIDITY_CMD, false);
+                    Map<String, Pair<Integer, String>> certValidityCmdResultByIpsMap =
+                            sshJClientActions.executeSshCommandOnHost(getInstanceGroups(testDto, client), List.of(HostGroupType.MASTER.getName(),
+                                    HostGroupType.IDBROKER.getName()), HOST_CERT_VALIDITY_CMD, false);
                     originalCertValidityOutput.addAll(certValidityCmdResultByIpsMap.values().stream()
                             .map(Pair::getValue).collect(Collectors.toList()));
                     return testDto;
@@ -70,8 +71,9 @@ public class SdxSecurityTests extends PreconditionSdxE2ETest {
                 .await(SdxClusterStatusResponse.RUNNING, key(sdx))
                 .awaitForHealthyInstances()
                 .then((tc, testDto, client) -> {
-                    Map<String, Pair<Integer, String>> certValidityCmdResultByIpsMap = sshJClientActions.executeSshCommand(getInstanceGroups(testDto, client),
-                            List.of(HostGroupType.MASTER.getName(), HostGroupType.IDBROKER.getName()), HOST_CERT_VALIDITY_CMD, false);
+                    Map<String, Pair<Integer, String>> certValidityCmdResultByIpsMap =
+                            sshJClientActions.executeSshCommandOnHost(getInstanceGroups(testDto, client), List.of(HostGroupType.MASTER.getName(),
+                                    HostGroupType.IDBROKER.getName()), HOST_CERT_VALIDITY_CMD, false);
                     renewedCertValidityOutput.addAll(certValidityCmdResultByIpsMap.entrySet().stream()
                             .map(e -> e.getValue().getValue()).collect(Collectors.toList()));
                     return testDto;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/AbstractMockTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/AbstractMockTest.java
@@ -73,7 +73,7 @@ public abstract class AbstractMockTest extends AbstractIntegrationTest {
     }
 
     @Override
-    protected void createEnvironmentWithFreeIpaAndDatalake(TestContext testContext) {
+    protected void createDefaultDatalake(TestContext testContext) {
         createDefaultEnvironment(testContext);
         createDefaultFreeIpa(testContext);
         createDatalake(testContext);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXClusterCreationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXClusterCreationTest.java
@@ -90,11 +90,10 @@ public class DistroXClusterCreationTest extends AbstractClouderaManagerTest {
     protected void setupTest(TestContext testContext) {
         createDefaultUser(testContext);
         createDefaultCredential(testContext);
-        createDefaultEnvironment(testContext);
         createDefaultImageCatalog(testContext);
         initializeDefaultBlueprints(testContext);
         createCmBlueprint(testContext);
-        createDatalake(testContext);
+        createDefaultDatalake(testContext);
     }
 
     @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
@@ -103,7 +102,6 @@ public class DistroXClusterCreationTest extends AbstractClouderaManagerTest {
             when = "a DistroX with Cloudera Manager is created",
             then = "the cluster should be available")
     public void testCreateNewRegularDistroXCluster(MockedTestContext testContext) {
-        createDefaultFreeIpa(testContext);
         testContext
                 .given(DIX_NET_KEY, DistroXNetworkTestDto.class)
                 .given(DIX_IMG_KEY, DistroXImageTestDto.class)
@@ -139,7 +137,6 @@ public class DistroXClusterCreationTest extends AbstractClouderaManagerTest {
             then = "its creation should not be started due to the unavailability of the environment")
     public void testWhenEnvIsStoppedUnableToCreateDistroX(MockedTestContext testContext) {
         EnvironmentTestDto environment = testContext.get(EnvironmentTestDto.class);
-        createDefaultFreeIpa(testContext);
         givenAnEnvironmentInStoppedState(testContext)
                 .given(DIX_NET_KEY, DistroXNetworkTestDto.class)
                 .given(DIX_IMG_KEY, DistroXImageTestDto.class)
@@ -166,7 +163,6 @@ public class DistroXClusterCreationTest extends AbstractClouderaManagerTest {
             when = "a DistroX cluster has created",
             then = "the cluster should be available AND the generated cm template should contain the expected values")
     public void testCreateNewRegularDistroXClusterWhileValidatingCMTemplate(MockedTestContext testContext) {
-        createDefaultFreeIpa(testContext);
         testContext
                 .given(DIX_NET_KEY, DistroXNetworkTestDto.class)
                 .given(DIX_IMG_KEY, DistroXImageTestDto.class)
@@ -310,7 +306,6 @@ public class DistroXClusterCreationTest extends AbstractClouderaManagerTest {
             when = "a DistroX with Cloudera Manager is created",
             then = "the cluster should be available AND internal distrox crn should be equal with non-internal distrox response crn")
     public void testInternalDistroXResponse(MockedTestContext testContext) {
-        createDefaultFreeIpa(testContext);
         testContext
                 .given(DIX_NET_KEY, DistroXNetworkTestDto.class)
                 .given(DIX_IMG_KEY, DistroXImageTestDto.class)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXRepairTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXRepairTests.java
@@ -33,9 +33,7 @@ public class DistroXRepairTests extends AbstractMockTest {
         createDefaultCredential(testContext);
         createDefaultImageCatalog(testContext);
         initializeDefaultBlueprints(testContext);
-        createDefaultEnvironment(testContext);
-        createDatalake(testContext);
-        createDefaultFreeIpa(testContext);
+        createDefaultDatalake(testContext);
     }
 
     @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXUpgradeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXUpgradeTests.java
@@ -31,9 +31,7 @@ public class DistroXUpgradeTests extends AbstractMockTest {
         createDefaultCredential(testContext);
         createDefaultImageCatalog(testContext);
         initializeDefaultBlueprints(testContext);
-        createDefaultEnvironment(testContext);
-        createDatalake(testContext);
-        createDefaultFreeIpa(testContext);
+        createDefaultDatalake(testContext);
     }
 
     @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/clouderamanager/CMDownscaleWithHttp500ResponsesTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/clouderamanager/CMDownscaleWithHttp500ResponsesTest.java
@@ -50,7 +50,7 @@ public class CMDownscaleWithHttp500ResponsesTest extends AbstractClouderaManager
         createDefaultCredential(testContext);
         createDefaultImageCatalog(testContext);
         initializeDefaultBlueprints(testContext);
-        createEnvironmentWithFreeIpaAndDatalake(testContext);
+        createDefaultDatalake(testContext);
         createCmBlueprint(testContext);
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/clouderamanager/CMStartStopWithHttp500ResponsesTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/clouderamanager/CMStartStopWithHttp500ResponsesTest.java
@@ -33,7 +33,7 @@ public class CMStartStopWithHttp500ResponsesTest extends AbstractClouderaManager
         createDefaultCredential(testContext);
         createDefaultImageCatalog(testContext);
         initializeDefaultBlueprints(testContext);
-        createEnvironmentWithFreeIpaAndDatalake(testContext);
+        createDefaultDatalake(testContext);
         createCmBlueprint(testContext);
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/clouderamanager/CMUpscaleWithHttp500ResponsesTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/clouderamanager/CMUpscaleWithHttp500ResponsesTest.java
@@ -47,7 +47,7 @@ public class CMUpscaleWithHttp500ResponsesTest extends AbstractClouderaManagerTe
         createDefaultCredential(testContext);
         createDefaultImageCatalog(testContext);
         initializeDefaultBlueprints(testContext);
-        createEnvironmentWithFreeIpaAndDatalake(testContext);
+        createDefaultDatalake(testContext);
         createCmBlueprint(testContext);
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/CloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/CloudFunctionality.java
@@ -2,10 +2,12 @@ package com.sequenceiq.it.cloudbreak.util;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
 
 public interface CloudFunctionality {
@@ -117,4 +119,16 @@ public interface CloudFunctionality {
     default String getDataHubLogsUrl(String clusterName, String crn, String baseLocation) {
         return "/cluster-logs/datahub/" + clusterName + "_" + Crn.fromString(crn).getResource();
     }
+
+    @Retryable(
+            maxAttempts = ATTEMPTS,
+            backoff = @Backoff(delay = DELAY, multiplier = MULTIPLIER, maxDelay = MAX_DELAY)
+    )
+    void checkMountedDisks(List<InstanceGroupV4Response> instanceGroups, List<String> hostGroupNames);
+
+    @Retryable(
+            maxAttempts = ATTEMPTS,
+            backoff = @Backoff(delay = DELAY, multiplier = MULTIPLIER, maxDelay = MAX_DELAY)
+    )
+    Set<String> getVolumeMountPoints(List<InstanceGroupV4Response> instanceGroups, List<String> hostGroupNames);
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/AwsCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/AwsCloudFunctionality.java
@@ -2,6 +2,7 @@ package com.sequenceiq.it.cloudbreak.util.aws;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -9,9 +10,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
 import com.sequenceiq.it.cloudbreak.util.CloudFunctionality;
 import com.sequenceiq.it.cloudbreak.util.aws.amazonec2.AmazonEC2Util;
 import com.sequenceiq.it.cloudbreak.util.aws.amazons3.AmazonS3Util;
+import com.sequenceiq.it.cloudbreak.util.ssh.SshJUtil;
 
 @Component
 public class AwsCloudFunctionality implements CloudFunctionality {
@@ -23,6 +26,9 @@ public class AwsCloudFunctionality implements CloudFunctionality {
 
     @Inject
     private AmazonS3Util amazonS3Util;
+
+    @Inject
+    private SshJUtil sshJUtil;
 
     @Override
     public List<String> listInstanceVolumeIds(String clusterName, List<String> instanceIds) {
@@ -97,5 +103,15 @@ public class AwsCloudFunctionality implements CloudFunctionality {
     @Override
     public String getDataHubLogsUrl(String clusterName, String crn, String baseLocation) {
         return amazonS3Util.getDataHubLogsUrl(clusterName, crn, baseLocation);
+    }
+
+    @Override
+    public void checkMountedDisks(List<InstanceGroupV4Response> instanceGroups, List<String> hostGroupNames) {
+        sshJUtil.checkAwsMountedDisks(instanceGroups, hostGroupNames);
+    }
+
+    @Override
+    public Set<String> getVolumeMountPoints(List<InstanceGroupV4Response> instanceGroups, List<String> hostGroupNames) {
+        return sshJUtil.getAwsVolumeMountPoints(instanceGroups, hostGroupNames);
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/AzureCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/AzureCloudFunctionality.java
@@ -3,15 +3,18 @@ package com.sequenceiq.it.cloudbreak.util.azure;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
 import com.microsoft.azure.management.resources.ResourceGroup;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
 import com.sequenceiq.it.cloudbreak.util.CloudFunctionality;
 import com.sequenceiq.it.cloudbreak.util.azure.azurecloudblob.AzureCloudBlobUtil;
 import com.sequenceiq.it.cloudbreak.util.azure.azurevm.action.AzureClientActions;
+import com.sequenceiq.it.cloudbreak.util.ssh.SshJUtil;
 
 @Component
 public class AzureCloudFunctionality implements CloudFunctionality {
@@ -21,6 +24,9 @@ public class AzureCloudFunctionality implements CloudFunctionality {
 
     @Inject
     private AzureCloudBlobUtil azureCloudBlobUtil;
+
+    @Inject
+    private SshJUtil sshJUtil;
 
     @Override
     public List<String> listInstanceVolumeIds(String clusterName, List<String> instanceIds) {
@@ -104,5 +110,15 @@ public class AzureCloudFunctionality implements CloudFunctionality {
 
     public void deleteResourceGroup(String resourceGroupName) {
         azureClientActions.deleteResourceGroup(resourceGroupName);
+    }
+
+    @Override
+    public void checkMountedDisks(List<InstanceGroupV4Response> instanceGroups, List<String> hostGroupNames) {
+        sshJUtil.checkAzureMountedDisks(instanceGroups, hostGroupNames);
+    }
+
+    @Override
+    public Set<String> getVolumeMountPoints(List<InstanceGroupV4Response> instanceGroups, List<String> hostGroupNames) {
+        return Set.of("/mnt/resource", "/hadoopfs/ephfs1");
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpCloudFunctionality.java
@@ -3,6 +3,7 @@ package com.sequenceiq.it.cloudbreak.util.gcp;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -11,6 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
 import com.sequenceiq.cloudbreak.cloud.gcp.util.GcpLabelUtil;
 import com.sequenceiq.it.cloudbreak.util.CloudFunctionality;
 
@@ -106,5 +108,16 @@ public class GcpCloudFunctionality implements CloudFunctionality {
     @Override
     public String getDataHubLogsUrl(String clusterName, String crn, String baseLocation) {
         return gcpUtil.getDataHubLogsUrl(clusterName, crn, baseLocation);
+    }
+
+    @Override
+    public void checkMountedDisks(List<InstanceGroupV4Response> instanceGroups, List<String> hostGroupNames) {
+        LOGGER.debug("Currently not implemented for GCP!");
+    }
+
+    @Override
+    public Set<String> getVolumeMountPoints(List<InstanceGroupV4Response> instanceGroups, List<String> hostGroupNames) {
+        LOGGER.debug("Currently not implemented for GCP!");
+        return Collections.emptySet();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/SshJUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/SshJUtil.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.it.cloudbreak.util.ssh;
 
 import java.util.List;
+import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -8,6 +9,7 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
 import com.sequenceiq.it.cloudbreak.dto.AbstractSdxTestDto;
+import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
 import com.sequenceiq.it.cloudbreak.util.ssh.action.SshJClientActions;
 
 @Component
@@ -22,5 +24,21 @@ public class SshJUtil {
             List<String> hostGroupNames, String filePath, String fileName, long requiredNumberOfFiles, String user, String password) {
         return sshJClientActions.checkFilesByNameAndPath(testDto, instanceGroups, hostGroupNames, filePath, fileName, requiredNumberOfFiles, user,
                 password);
+    }
+
+    public void checkAwsMountedDisks(List<InstanceGroupV4Response> instanceGroups, List<String> hostGroupNames) {
+        sshJClientActions.checkAwsEphemeralDisksMounted(instanceGroups, hostGroupNames, "ephfs");
+    }
+
+    public void checkAzureMountedDisks(List<InstanceGroupV4Response> instanceGroups, List<String> hostGroupNames) {
+        sshJClientActions.checkAzureTemporalDisksMounted(instanceGroups, hostGroupNames, "ephfs1");
+    }
+
+    public Set<String> getAwsVolumeMountPoints(List<InstanceGroupV4Response> instanceGroups, List<String> hostGroupNames) {
+        return sshJClientActions.getAwsEphemeralVolumeMountPoints(instanceGroups, hostGroupNames);
+    }
+
+    public DistroXTestDto checkMeteringStatus(DistroXTestDto testDto, List<InstanceGroupV4Response> instanceGroups, List<String> hostGroupNames) {
+        return sshJClientActions.checkMeteringStatus(testDto, instanceGroups, hostGroupNames);
     }
 }

--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -52,6 +52,7 @@ integrationtest:
     secretkey: nHkdxgZR0BaNHaSYM3ooS6rIlpV5E+k1CIkr+jFId2g=
     crn:
     name:
+    workloadPassword: "Admin@123"
   userGroup:
     adminGroupName: testgroupa
     adminGroupCrn: "crn:altus:iam:us-west-1:f8e2f110-fc7e-4e46-ae55-381aacc6718c:group:testgroupa/ebc27aff-7d91-4f76-bf98-e81dbbd615e9"


### PR DESCRIPTION
Heartbeat files are generated for Datahub clusters. So our E2E tests should have at least one assertion that validates that Heartbeats are generated correctly:
- We have `cdp-doctor metering status --format json` command to check the heartbeats on the master instances. So at first version we can get the output of this command and based on that we can assert.
- Metering details are present in [nodestatus.proto](https://github.com/hortonworks/cloudbreak/blob/master/node-status-monitor-client/src/main/proto/nodestatus.proto)