### PR TITLE
[oozie] OPSAPS-62127 Remove Oozie NameNode whitelist setting.

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.16/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.16/cdp-data-engineering-ha.bp
@@ -237,12 +237,7 @@
           {
             "refName": "oozie-OOZIE_SERVER-BASE",
             "roleType": "OOZIE_SERVER",
-            "configs": [
-              {
-                "name": "oozie_config_safety_valve",
-                "value": "<property><name>oozie.service.HadoopAccessorService.nameNode.whitelist</name><value></value></property>"
-              }
-            ],
+            "configs": [ ],
             "base": true
           }
         ]

--- a/core/src/main/resources/defaults/blueprints/7.2.16/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.16/cdp-data-engineering.bp
@@ -415,12 +415,7 @@
           {
             "refName": "oozie-OOZIE_SERVER-BASE",
             "roleType": "OOZIE_SERVER",
-            "configs": [
-              {
-                "name": "oozie_config_safety_valve",
-                "value": "<property><name>oozie.service.HadoopAccessorService.nameNode.whitelist</name><value></value></property>"
-              }
-            ],
+            "configs": [ ],
             "base": true
           }
         ]


### PR DESCRIPTION
The whitelist of Oozie NameNodes did not include the NameNodes
of the base cluster when the Oozie service was installed onto a
compute cluster, which lead to an error when an Oozie job was
submitted. This issue has been fixed in CM, so it is safe to remove
this safety valve setting.