### PR TITLE
CB-16623:Add backend changes for removing "do not encrypt" and default options from Datahubs

### DIFF
--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateParameterConverter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateParameterConverter.java
@@ -55,10 +55,11 @@ public class InstanceTemplateParameterConverter {
 
     private AwsEncryptionV4Parameters convert(AwsEncryptionV1Parameters source, DetailedEnvironmentResponse environment) {
         AwsEncryptionV4Parameters response = new AwsEncryptionV4Parameters();
+        String dataHubEncryptionKey = source.getKey();
         EncryptionType dataHubEncryptionKeyType = source.getType();
         if (EncryptionType.CUSTOM.equals(dataHubEncryptionKeyType)) {
-            response.setKey(source.getKey());
-            response.setType(source.getType());
+            response.setKey(dataHubEncryptionKey);
+            response.setType(dataHubEncryptionKeyType);
         } else {
             String environmentEncryptionKeyArn = Optional.ofNullable(environment)
                     .map(DetailedEnvironmentResponse::getAws)
@@ -69,8 +70,7 @@ public class InstanceTemplateParameterConverter {
                 response.setKey(environmentEncryptionKeyArn);
                 response.setType(EncryptionType.CUSTOM);
             } else {
-                response.setKey(source.getKey());
-                response.setType(source.getType());
+                response.setType(EncryptionType.DEFAULT);
             }
         }
         return response;


### PR DESCRIPTION
The expected behaviour from this PR is to remove the "do not encrypt" and "default encryption" options for datahubs. For environment we encrypt the freeipa,External RDS and Datalake with AWS managed key until and unless user passes a CMK during Env creation. We would like to have the same behaviour for Dtaahubs too. So as part of https://jira.cloudera.com/browse/CB-16943 UI change will be made to remove the options and this PR handles the backend behaviour for the same.

The new behaviour would be:

1. Datahubs would be encrypted with default AWS managed keys all the time when NO CMK is passed during Environment creation.
2. If User selects a different CMK from the one passed during env creation then Datahubs are encrypted by CMK2 and env by CMK1.
3. If a CMK is passed at Env level but NO CMK at Datahub level then Datahubs are encrypted with the same CMK that was passed during env creation.