### PR TITLE
CB-16896: Allowed for not found exceptions to not cause failure during DL event retrieval if stack not present.

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/service/SdxEventsService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/SdxEventsService.java
@@ -131,8 +131,17 @@ public class SdxEventsService {
             List<CloudbreakEventV4Response> cloudbreakEventV4Responses = ThreadBasedUserCrnProvider.doAsInternalActor(
                     regionAwareInternalCrnGeneratorFactory.iam().getInternalCrnForServiceAsString(),
                     () ->
-                    eventV4Endpoint.getPagedCloudbreakEventListByCrn(sdxCluster.getCrn(), page, size, false));
+                            eventV4Endpoint.getPagedCloudbreakEventListByCrn(sdxCluster.getCrn(), page, size, false));
             return cloudbreakEventV4Responses.stream().map(entry -> convert(entry, sdxCluster.getCrn())).collect(toList());
+        } catch (NotFoundException notFoundException) {
+            LOGGER.error("Failed to retrieve paged cloudbreak service events due to not found exception!", notFoundException);
+            // We allow not found exceptions when stack not present as they may be caused due to transiency during DL creation.
+            if (sdxCluster.getStackId() == null) {
+                return Collections.emptyList();
+            } else {
+                throw new CloudbreakServiceException("Failed to retrieve paged cloudbreak service events due to not found exception!",
+                        notFoundException);
+            }
         } catch (Exception exception) {
             LOGGER.error("Failed to retrieve paged cloudbreak service events!", exception);
             throw new CloudbreakServiceException("Failed to retrieve paged cloudbreak service events!", exception);


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-16896

Basically we believe that there may be `NotFoundException`s that pop up due to DL creation when the DL does not have a stack yet. 

I decided to check for this and ignore exceptions when this is the case.

I am open to any feedback or comments on this as I believe this change to not be necessarily correct for the original issue.