### PR TITLE
Usersync. Improve logs

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncForStackService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncForStackService.java
@@ -8,13 +8,16 @@ import static com.sequenceiq.freeipa.service.freeipa.user.UserSyncLogEvent.RETRI
 import static com.sequenceiq.freeipa.service.freeipa.user.UserSyncLogEvent.SYNC_CLOUD_IDENTITIES;
 import static com.sequenceiq.freeipa.service.freeipa.user.UserSyncLogEvent.USER_SYNC_DELETE;
 
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import com.google.common.collect.ArrayListMultimap;
@@ -36,6 +39,9 @@ import com.sequenceiq.freeipa.service.freeipa.user.model.UsersStateDifference;
 public class UserSyncForStackService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UserSyncForStackService.class);
+
+    @Value("${freeipa.usersync.scale.large-group-size}")
+    private int largeGroupLogThreshold;
 
     @Inject
     private FreeIpaClientFactory freeIpaClientFactory;
@@ -62,6 +68,7 @@ public class UserSyncForStackService {
         MDCBuilder.buildMdcContext(stack);
         String environmentCrn = stack.getEnvironmentCrn();
         Multimap<String, String> warnings = ArrayListMultimap.create();
+        logLargeGroupMembershipSizes(environmentCrn, umsUsersState);
         try {
             FreeIpaClient freeIpaClient = freeIpaClientFactory.getFreeIpaClientForStack(stack);
             UsersStateDifference usersStateDifferenceBeforeSync = compareUmsAndFreeIpa(umsUsersState, options, freeIpaClient);
@@ -96,6 +103,24 @@ public class UserSyncForStackService {
         } catch (Exception e) {
             LOGGER.warn("Failed to synchronize environment {}", environmentCrn, e);
             return SyncStatusDetail.fail(environmentCrn, e.getLocalizedMessage(), warnings);
+        }
+    }
+
+    private void logLargeGroupMembershipSizes(String envCrn, UmsUsersState umsUsersState) {
+        if (LOGGER.isDebugEnabled()) {
+            List<Integer> largeGroupSizes = umsUsersState.getUsersState().getGroupMembership()
+                    .asMap().values().stream()
+                    .map(collection -> collection.size())
+                    .filter(size -> size >= largeGroupLogThreshold)
+                    .sorted()
+                    .collect(Collectors.toList());
+            if (!largeGroupSizes.isEmpty()) {
+                LOGGER.debug("Environment {} has {} groups with size >= {}. {}",
+                        envCrn,
+                        largeGroupSizes.size(),
+                        largeGroupLogThreshold,
+                        largeGroupSizes);
+            }
         }
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/ums/UmsUsersStateProviderDispatcher.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/ums/UmsUsersStateProviderDispatcher.java
@@ -52,7 +52,7 @@ public class UmsUsersStateProviderDispatcher {
         try {
             return bulkUmsUsersStateProvider.get(accountId, environmentCrns, requestIdOptional);
         } catch (RuntimeException e) {
-            LOGGER.debug("Failed to retrieve UMS user sync state through bulk request. Falling back on default approach");
+            LOGGER.debug("Failed to retrieve UMS user sync state through bulk request. Falling back on default approach.", e);
             return dispatchDefault(accountId, environmentCrns, userCrns, machineUserCrns,
                     requestIdOptional, fullSync);
         }

--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -117,6 +117,7 @@ freeipa:
     threadpool:
       core.size: 100
       capacity.size: 4000
+    scale.large-group-size: 500
   cloudidsync:
     poller:
       timeoutMs: 4000


### PR DESCRIPTION
Bulk ums usersync state retrieval falls back to the default ums
state retrieval on failure. The exception is now added to the logs
since it is otherwise swallowed.

Additionally, add a log message to indicate when how many large
groups are being synced to the environment.

See detailed description in the commit message.