### PR TITLE
CB-16838 Add SMM user to mock ID Broker mappings

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/service/identitymapping/AccountMappingSubject.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/service/identitymapping/AccountMappingSubject.java
@@ -20,7 +20,7 @@ public class AccountMappingSubject {
      *
      * Adapted from {@code com.cloudera.thunderhead.service.idbrokermappingmanagement.server.IdBrokerMappingManagementService.BASELINE_SERVICES}.
      */
-    public static final Set<String> RANGER_AUDIT_USERS = Set.of("kafka", "solr", "knox", "atlas", "nifi", "nifiregistry");
+    public static final Set<String> RANGER_AUDIT_USERS = Set.of("kafka", "solr", "knox", "atlas", "nifi", "nifiregistry", "streamsmsgmgr");
 
     /**
      * Service user for Ranger RAZ. Never present in {@link #DATA_ACCESS_USERS} or {@link #RANGER_AUDIT_USERS}.


### PR DESCRIPTION
Added the streamsmsgmgr user to the mock id broker mappings. It is mapped to the Ranger identity. This is to follow up with CDPCP-6939 (add the SMM user is added to the default id broker mappings).

Testing: tested environment creation manually