### PR TITLE
CDPSDX-3539: Resize datalake fails on Azure due to backup datalake failure.

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/BackupRestoreStatusService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/BackupRestoreStatusService.java
@@ -43,7 +43,8 @@ public class BackupRestoreStatusService {
     }
 
     public void backupDatabaseFinished(long stackId) {
-        stackUpdater.updateStackStatus(stackId, DetailedStackStatus.DATABASE_BACKUP_IN_PROGRESS, "Database was successfully backed up.");
+        stackUpdater.updateStackStatus(stackId, DetailedStackStatus.DATABASE_BACKUP_FINISHED, "Database was successfully backed up." +
+                " Continuing with the rest.");
         flowMessageService.fireEventAndLog(stackId, Status.AVAILABLE.name(), DATALAKE_DATABASE_BACKUP_FINISHED);
     }
 
@@ -58,7 +59,8 @@ public class BackupRestoreStatusService {
     }
 
     public void restoreDatabaseFinished(long stackId) {
-        stackUpdater.updateStackStatus(stackId, DetailedStackStatus.DATABASE_RESTORE_FINISHED, "Database was successfully restored.");
+        stackUpdater.updateStackStatus(stackId, DetailedStackStatus.DATABASE_RESTORE_FINISHED, "Database was successfully restored. " +
+                "Continuing with the rest.");
         flowMessageService.fireEventAndLog(stackId, Status.AVAILABLE.name(), DATALAKE_DATABASE_RESTORE_FINISHED);
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/BackupRestoreStatusServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/BackupRestoreStatusServiceTest.java
@@ -77,8 +77,8 @@ public class BackupRestoreStatusServiceTest {
     public void testBackupFinished() {
         ArgumentCaptor<ResourceEvent> captor = ArgumentCaptor.forClass(ResourceEvent.class);
         service.backupDatabaseFinished(STACK_ID);
-        verify(stackUpdater, times(1)).updateStackStatus(STACK_ID, DetailedStackStatus.DATABASE_BACKUP_IN_PROGRESS,
-                "Database was successfully backed up.");
+        verify(stackUpdater, times(1)).updateStackStatus(STACK_ID, DetailedStackStatus.DATABASE_BACKUP_FINISHED,
+                "Database was successfully backed up. Continuing with the rest.");
         verify(flowMessageService).fireEventAndLog(eq(STACK_ID), eq(Status.AVAILABLE.name()), captor.capture());
         assertEquals(DATALAKE_DATABASE_BACKUP_FINISHED, captor.getValue());
     }
@@ -107,7 +107,7 @@ public class BackupRestoreStatusServiceTest {
         ArgumentCaptor<ResourceEvent> captor = ArgumentCaptor.forClass(ResourceEvent.class);
         service.restoreDatabaseFinished(STACK_ID);
         verify(stackUpdater, times(1)).updateStackStatus(STACK_ID, DetailedStackStatus.DATABASE_RESTORE_FINISHED,
-                "Database was successfully restored.");
+                "Database was successfully restored. Continuing with the rest.");
         verify(flowMessageService).fireEventAndLog(eq(STACK_ID), eq(Status.AVAILABLE.name()), captor.capture());
         assertEquals(DATALAKE_DATABASE_RESTORE_FINISHED, captor.getValue());
     }


### PR DESCRIPTION
This is introduced with the changes done for CB-16642. Status was wrongly updated.