### PR TITLE
DISTX-681: AZURE: Switch DE templates to use temporaryStorage: EPHEMERAL or temporaryStorage: COMBINED/EPHEMERAL_OR_ATTACHED

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/validation/template/TemplateValidator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/validation/template/TemplateValidator.java
@@ -46,6 +46,8 @@ public class TemplateValidator {
 
     public static final String GROUP_NAME_ID_BROKER = "idbroker";
 
+    public static final String GROUP_NAME_COMPUTE = "compute";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(TemplateValidator.class);
 
     @Inject
@@ -181,6 +183,10 @@ public class TemplateValidator {
         return GROUP_NAME_ID_BROKER.equalsIgnoreCase(instanceGroup.getGroupName());
     }
 
+    private boolean isComputeInstanceGroup(InstanceGroup instanceGroup) {
+        return GROUP_NAME_COMPUTE.equalsIgnoreCase(instanceGroup.getGroupName());
+    }
+
     private void validateVolumeCount(VolumeTemplate value, VmType vmType, VolumeParameterType volumeParameterType,
         ValidationResult.ValidationResultBuilder validationBuilder, InstanceGroup instanceGroup) {
         if (vmType != null && needToCheckVolume(volumeParameterType, value.getVolumeCount())) {
@@ -190,7 +196,8 @@ public class TemplateValidator {
                 // To be backward-compatible, we only check max limit and allow the min limit to be zero for IDBroker
                 if (value.getVolumeCount() > config.maximumNumber()) {
                     validationBuilder.error(String.format("Max allowed volume count for '%s': %s", vmType.value(), config.maximumNumber()));
-                } else if (!isIDBrokerInstanceGroup(instanceGroup) && value.getVolumeCount() < config.minimumNumber()) {
+                } else if (!(isIDBrokerInstanceGroup(instanceGroup) || isComputeInstanceGroup(instanceGroup)) &&
+                        value.getVolumeCount() < config.minimumNumber()) {
                     validationBuilder.error(String.format("Min allowed volume count for '%s': %s", vmType.value(), config.minimumNumber()));
                 }
             } else {
@@ -208,7 +215,8 @@ public class TemplateValidator {
                 // To be backward-compatible, we only check max limit and allow the min limit to be zero for IDBroker
                 if (value.getVolumeSize() > config.maximumSize()) {
                     validationBuilder.error(String.format("Max allowed volume size for '%s': %s", vmType.value(), config.maximumSize()));
-                } else if (!isIDBrokerInstanceGroup(instanceGroup) && value.getVolumeSize() < config.minimumSize()) {
+                } else if (!(isIDBrokerInstanceGroup(instanceGroup) || isComputeInstanceGroup(instanceGroup)) &&
+                        value.getVolumeSize() < config.minimumSize()) {
                     validationBuilder.error(String.format("Min allowed volume size for '%s': %s", vmType.value(), config.minimumSize()));
                 }
             } else {

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -321,6 +321,7 @@ cb:
         georedundantbackup: false
     distrox:
       enabled.instance.types: >
+        Standard_D5_v2,
         Standard_D8_v3,
         Standard_D8s_v3,
         Standard_D16_v3,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.14/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.14/azure/dataengineering-ha.json
@@ -49,14 +49,14 @@
         "recoveryMode": "MANUAL",
         "template": {
           "azure": {},
-          "instanceType": "Standard_D16_v3",
+          "instanceType": "Standard_D5_v2",
           "rootVolume": {
             "size": 150
           },
           "attachedVolumes": [
             {
               "size": 500,
-              "count": 1,
+              "count": 0,
               "type": "StandardSSD_LRS"
             }
           ],
@@ -78,7 +78,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
+          "instanceType": "Standard_D5_v2",
           "rootVolume": {
             "size": 150
           },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.14/azure/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.14/azure/dataengineering-spark3.json
@@ -26,7 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3"
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,7 +38,7 @@
           "attachedVolumes": [
             {
               "size": 100,
-              "count": 1,
+              "count": 0,
               "type": "StandardSSD_LRS"
             }
           ],
@@ -49,7 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3"
+          "instanceType": "Standard_D5_v2"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,7 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3"
+          "instanceType": "Standard_D5_v2"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.14/azure/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.14/azure/dataengineering.json
@@ -37,7 +37,7 @@
           "attachedVolumes": [
             {
               "size": 100,
-              "count": 1,
+              "count": 0,
               "type": "StandardSSD_LRS"
             }
           ],
@@ -48,7 +48,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3"
+          "instanceType": "Standard_D5_v2"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -71,7 +71,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3"
+          "instanceType": "Standard_D5_v2"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.15/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.15/azure/dataengineering-ha.json
@@ -49,14 +49,14 @@
         "recoveryMode": "MANUAL",
         "template": {
           "azure": {},
-          "instanceType": "Standard_D16_v3",
+          "instanceType": "Standard_D5_v2",
           "rootVolume": {
             "size": 150
           },
           "attachedVolumes": [
             {
               "size": 500,
-              "count": 1,
+              "count": 0,
               "type": "StandardSSD_LRS"
             }
           ],
@@ -78,7 +78,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
+          "instanceType": "Standard_D5_v2",
           "rootVolume": {
             "size": 150
           },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.15/azure/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.15/azure/dataengineering-spark3.json
@@ -26,7 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3"
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,7 +38,7 @@
           "attachedVolumes": [
             {
               "size": 100,
-              "count": 1,
+              "count": 0,
               "type": "StandardSSD_LRS"
             }
           ],
@@ -49,7 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3"
+          "instanceType": "Standard_D5_v2"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,7 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3"
+          "instanceType": "Standard_D5_v2"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.15/azure/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.15/azure/dataengineering.json
@@ -37,7 +37,7 @@
           "attachedVolumes": [
             {
               "size": 100,
-              "count": 1,
+              "count": 0,
               "type": "StandardSSD_LRS"
             }
           ],
@@ -48,7 +48,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3"
+          "instanceType": "Standard_D5_v2"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -71,7 +71,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3"
+          "instanceType": "Standard_D5_v2"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.16/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.16/azure/dataengineering-ha.json
@@ -49,14 +49,14 @@
         "recoveryMode": "MANUAL",
         "template": {
           "azure": {},
-          "instanceType": "Standard_D16_v3",
+          "instanceType": "Standard_D5_v2",
           "rootVolume": {
             "size": 150
           },
           "attachedVolumes": [
             {
               "size": 500,
-              "count": 1,
+              "count": 0,
               "type": "StandardSSD_LRS"
             }
           ],
@@ -78,7 +78,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
+          "instanceType": "Standard_D5_v2",
           "rootVolume": {
             "size": 150
           },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.16/azure/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.16/azure/dataengineering-spark3.json
@@ -26,7 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3"
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,7 +38,7 @@
           "attachedVolumes": [
             {
               "size": 100,
-              "count": 1,
+              "count": 0,
               "type": "StandardSSD_LRS"
             }
           ],
@@ -49,7 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3"
+          "instanceType": "Standard_D5_v2"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,7 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3"
+          "instanceType": "Standard_D5_v2"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.16/azure/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.16/azure/dataengineering.json
@@ -37,7 +37,7 @@
           "attachedVolumes": [
             {
               "size": 100,
-              "count": 1,
+              "count": 0,
               "type": "StandardSSD_LRS"
             }
           ],
@@ -48,7 +48,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3"
+          "instanceType": "Standard_D5_v2"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -71,7 +71,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3"
+          "instanceType": "Standard_D5_v2"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/test/java/com/sequenceiq/cloudbreak/controller/validation/template/TemplateValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/controller/validation/template/TemplateValidatorTest.java
@@ -117,7 +117,7 @@ public class TemplateValidatorTest {
 
     @Test
     public void validateIDBrokerDataVolumeZeroCountZeroSize() {
-        instanceGroup = createInstanceGroup(0, 0, true, false, "c3.2xlarge");
+        instanceGroup = createInstanceGroup(0, 0, true, false, false, "c3.2xlarge");
         underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
         Mockito.verify(builder, Mockito.times(0)).error(anyString());
         verifyIDBrokerVolume(instanceGroup);
@@ -125,7 +125,22 @@ public class TemplateValidatorTest {
 
     @Test
     public void validateIDBrokerDataVolumeCountOne() {
-        instanceGroup = createInstanceGroup(1, 0, true, false, "c3.2xlarge");
+        instanceGroup = createInstanceGroup(1, 0, true, false, false, "c3.2xlarge");
+        underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
+        Mockito.verify(builder, Mockito.times(0)).error(anyString());
+    }
+
+    @Test
+    public void validateComputeDataVolumeZeroCountZeroSize() {
+        instanceGroup = createInstanceGroup(0, 0, false, true, false, "c3.2xlarge");
+        underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
+        Mockito.verify(builder, Mockito.times(0)).error(anyString());
+        verifyIDBrokerVolume(instanceGroup);
+    }
+
+    @Test
+    public void validateComputeDataVolumeCountOne() {
+        instanceGroup = createInstanceGroup(1, 0, false, true, false, "c3.2xlarge");
         underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
         Mockito.verify(builder, Mockito.times(0)).error(anyString());
     }
@@ -133,28 +148,28 @@ public class TemplateValidatorTest {
     @Test
     public void validateIDBrokerDataVolumeInvalidCount() {
         // volume count is larger than the max value of 24
-        instanceGroup = createInstanceGroup(25, 1, true, false, "c3.2xlarge");
+        instanceGroup = createInstanceGroup(25, 1, true, false, false, "c3.2xlarge");
         underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
         Mockito.verify(builder, Mockito.times(1)).error(anyString());
     }
 
     @Test
     public void validateIDBrokerDataVolumeDefaultSize() {
-        instanceGroup = createInstanceGroup(1, 100, true, false, "c3.2xlarge");
+        instanceGroup = createInstanceGroup(1, 100, true, false, false, "c3.2xlarge");
         underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
         Mockito.verify(builder, Mockito.times(0)).error(anyString());
     }
 
     @Test
     public void validateIDBrokerDataVolumeInvalidSize() {
-        instanceGroup = createInstanceGroup(1, 18000, true, false, "c3.2xlarge");
+        instanceGroup = createInstanceGroup(1, 18000, true, false, false, "c3.2xlarge");
         underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
         Mockito.verify(builder, Mockito.times(1)).error(anyString());
     }
 
     @Test
     public void validateIDBrokerMixedVolumeCountOne() {
-        instanceGroup = createInstanceGroup(1, 0, true, true, "i3.2xlarge");
+        instanceGroup = createInstanceGroup(1, 0, true, false, true, "i3.2xlarge");
         underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
         Mockito.verify(builder, Mockito.times(0)).error(anyString());
     }
@@ -162,35 +177,35 @@ public class TemplateValidatorTest {
     @Test
     public void validateIDBrokerMixedVolumeInvalidCount() {
         // volume count is larger than the max value of 24
-        instanceGroup = createInstanceGroup(25, 1, true, true, "i3.2xlarge");
+        instanceGroup = createInstanceGroup(25, 1, true, false, true, "i3.2xlarge");
         underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
         Mockito.verify(builder, Mockito.times(2)).error(anyString());
     }
 
     @Test
     public void validateIDBrokerMixedVolumeDefaultSize() {
-        instanceGroup = createInstanceGroup(1, 100, true, true, "i3.2xlarge");
+        instanceGroup = createInstanceGroup(1, 100, true, false, true, "i3.2xlarge");
         underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
         Mockito.verify(builder, Mockito.times(0)).error(anyString());
     }
 
     @Test
     public void validateIDBrokerMixedVolumeInvalidSize() {
-        instanceGroup = createInstanceGroup(1, 18000, true, true, "i3.2xlarge");
+        instanceGroup = createInstanceGroup(1, 18000, true, false, true, "i3.2xlarge");
         underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
         Mockito.verify(builder, Mockito.times(2)).error(anyString());
     }
 
     @Test
     public void validateMasterDataVolumeZeroCountZeroSize() {
-        instanceGroup = createInstanceGroup(0, 0, false, false, "c3.2xlarge");
+        instanceGroup = createInstanceGroup(0, 0, false, false, false, "c3.2xlarge");
         underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
         Mockito.verify(builder, Mockito.times(2)).error(anyString());
     }
 
     @Test
     public void validateMasterDataVolumeCountOne() {
-        instanceGroup = createInstanceGroup(1, 1, false, false, "c3.2xlarge");
+        instanceGroup = createInstanceGroup(1, 1, false, false, false, "c3.2xlarge");
         underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
         Mockito.verify(builder, Mockito.times(0)).error(anyString());
     }
@@ -198,26 +213,27 @@ public class TemplateValidatorTest {
     @Test
     public void validateMasterDataVolumeInvalidCount() {
         // volume count is larger than the max value of 24
-        instanceGroup = createInstanceGroup(25, 1, false, false, "c3.2xlarge");
+        instanceGroup = createInstanceGroup(25, 1, false, false, false, "c3.2xlarge");
         underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
         Mockito.verify(builder, Mockito.times(1)).error(anyString());
     }
 
     @Test
     public void validateMasterDataVolumeDefaultSize() {
-        instanceGroup = createInstanceGroup(1, 100, false, false, "c3.2xlarge");
+        instanceGroup = createInstanceGroup(1, 100, false, false, false, "c3.2xlarge");
         underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
         Mockito.verify(builder, Mockito.times(0)).error(anyString());
     }
 
     @Test
     public void validateMasterDataVolumeInvalidSize() {
-        instanceGroup = createInstanceGroup(1, 18000, false, false, "c3.2xlarge");
+        instanceGroup = createInstanceGroup(1, 18000, false, false, false, "c3.2xlarge");
         underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
         Mockito.verify(builder, Mockito.times(1)).error(anyString());
     }
 
-    private InstanceGroup createInstanceGroup(int dataVolumeCount, int dataVolumeSize, boolean createIDBroker, boolean addEphemeralVolume, String instanceType) {
+    private InstanceGroup createInstanceGroup(int dataVolumeCount, int dataVolumeSize, boolean createIDBroker, boolean createCompute,
+            boolean addEphemeralVolume, String instanceType) {
         Template awsTemplate = TestUtil.awsTemplate(1L, instanceType);
         int volumeCount = dataVolumeCount;
         int volumeSize = dataVolumeSize;
@@ -232,6 +248,9 @@ public class TemplateValidatorTest {
         if (createIDBroker) {
             instanceGroup = TestUtil.instanceGroup(1L, InstanceGroupType.CORE, awsTemplate);
             instanceGroup.setGroupName(TemplateValidator.GROUP_NAME_ID_BROKER);
+        } else if (createCompute) {
+            instanceGroup = TestUtil.instanceGroup(1L, InstanceGroupType.CORE, awsTemplate);
+            instanceGroup.setGroupName("compute");
         } else {
             instanceGroup = TestUtil.instanceGroup(1L, InstanceGroupType.GATEWAY, awsTemplate);
             instanceGroup.setGroupName("master");


### PR DESCRIPTION
DISTX-681: AZURE: Switch DE templates to use temporaryStorage: EPHEMERAL or temporaryStorage: COMBINED/EPHEMERAL_OR_ATTACHED

This commit changes **7.2.14, 7.2.15, 7.2.16 runtime versions of DE, DE-HA and DE spark3 templates.**

-  **The master instance type for DE Spark3 template is changed from "Standard_D8_v3" to "Standard_D16_v3".**
-  **The compute and worker instance types for DE, DE-HA and spark3 templates are changed to "Standard_D5_v2".**
-  **The attached volume count for compute host group is changed to 0. So that only ephemeral/local volumes are used by default.**

Compute nodes run YARN and require storage only for temporary data - this requirement is fulfilled by instance storage, so making the attached volumes count to 0 by default is better for customer w.r.t cost.

Template Validator is updated to allow compute instance group to have zero volume count. Earlier as part of CB-7552 , this check was removed for IDbroker instance group type. I am removing the check for compute instance group in similar way it was removed for IDbroker.

Attaching screenshots for DH with "Standard_D5_v2" as compute and worker instance type.
 - **for DE compute node.**
 
<img width="1430" alt="Screenshot 2022-05-16 at 5 04 29 PM" src="https://user-images.githubusercontent.com/32215750/168601731-5f6e2e63-eb93-470b-8f52-b225c81f31d1.png">


 - **for DE worker node.**
 
<img width="1433" alt="Screenshot 2022-05-16 at 5 04 56 PM" src="https://user-images.githubusercontent.com/32215750/168601819-40b625b8-88ca-4f7e-bcca-d4c21e96be65.png">


- **for SPARK3 compute node.**

<img width="1477" alt="Screenshot 2022-05-16 at 6 30 37 PM" src="https://user-images.githubusercontent.com/32215750/168602215-2f28f776-d851-4a94-b6f4-83f73bddf888.png">

- **for SPARK3 worker node.**

<img width="1506" alt="Screenshot 2022-05-16 at 6 30 57 PM" src="https://user-images.githubusercontent.com/32215750/168601982-d435c31e-36c7-416d-8f2e-fdeded6086f8.png">


See detailed description in the commit message.