### PR TITLE
CB-17042 e2e: azure test with service endpoint fails

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProviderAssertion.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProviderAssertion.java
@@ -2,6 +2,7 @@ package com.sequenceiq.it.cloudbreak.cloud.v4.azure;
 
 import java.util.Optional;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -36,7 +37,7 @@ public class AzureCloudProviderAssertion extends AbstractCloudProviderAssertion 
 
         String databasePrivateDnsZoneIdRequest = environmentTestDto.getRequest().getNetwork().getAzure().getDatabasePrivateDnsZoneId();
         String databasePrivateDnsZoneIdResponse = environmentTestDto.getResponse().getNetwork().getAzure().getDatabasePrivateDnsZoneId();
-        if (databasePrivateDnsZoneIdRequest != null && !databasePrivateDnsZoneIdRequest.equals(databasePrivateDnsZoneIdResponse)) {
+        if (StringUtils.isNotEmpty(databasePrivateDnsZoneIdRequest) && !databasePrivateDnsZoneIdRequest.equals(databasePrivateDnsZoneIdResponse)) {
             String message = String.format("Private DNS zone id for database was requested to be %s, but is %s", databasePrivateDnsZoneIdRequest,
                     databasePrivateDnsZoneIdResponse);
             LOGGER.error(message);


### PR DESCRIPTION
The test testCreateDistroXWithEncryptedVolumesInSingleRG was equipped with a check that the service endpoint in the request and response do match. It, however, did not account for testparameter databsePrivateDnsZoneId to be not null but still an empty string. The present commit fixes this bug.

See detailed description in the commit message.