### PR TITLE
CB-17045. Configure collector types for node-exporter.

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfigService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfigService.java
@@ -58,7 +58,8 @@ public class MonitoringConfigService {
         builder.withExporterPassword(exporterPassword);
         if (monitoringConfiguration.getNodeExporter() != null) {
             builder.withNodeExporterUser(monitoringConfiguration.getNodeExporter().getUser())
-                    .withNodeExporterPort(monitoringConfiguration.getNodeExporter().getPort());
+                    .withNodeExporterPort(monitoringConfiguration.getNodeExporter().getPort())
+                    .withNodeExporterCollectors(monitoringConfiguration.getNodeExporter().getCollectors());
         }
         if (monitoringConfiguration.getBlackboxExporter() != null) {
                 builder.withBlackboxExporterUser(monitoringConfiguration.getBlackboxExporter().getUser())

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfigView.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfigView.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.cloudbreak.telemetry.monitoring;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.ObjectUtils;
@@ -29,6 +31,8 @@ public class MonitoringConfigView implements TelemetryConfigView {
     private final String nodeExporterUser;
 
     private final Integer nodeExporterPort;
+
+    private final List<String> nodeExporterCollectors;
 
     private final String blackboxExporterUser;
 
@@ -61,6 +65,7 @@ public class MonitoringConfigView implements TelemetryConfigView {
         this.exporterPassword = builder.exporterPassword;
         this.nodeExporterUser = builder.nodeExporterUser;
         this.nodeExporterPort = builder.nodeExporterPort;
+        this.nodeExporterCollectors = builder.nodeExporterCollectors;
         this.blackboxExporterUser = builder.blackboxExporterUser;
         this.blackboxExporterPort = builder.blackboxExporterPort;
         this.agentUser = builder.agentUser;
@@ -118,6 +123,10 @@ public class MonitoringConfigView implements TelemetryConfigView {
         return nodeExporterPort;
     }
 
+    public List<String> getNodeExporterCollectors() {
+        return nodeExporterCollectors;
+    }
+
     public String getBlackboxExporterUser() {
         return blackboxExporterUser;
     }
@@ -164,6 +173,7 @@ public class MonitoringConfigView implements TelemetryConfigView {
         map.put("exporterPassword", this.exporterPassword != null ? new String(this.exporterPassword) : EMPTY_CONFIG_DEFAULT);
         map.put("nodeExporterUser", ObjectUtils.defaultIfNull(this.nodeExporterUser, EMPTY_CONFIG_DEFAULT));
         map.put("nodeExporterPort", this.nodeExporterPort);
+        map.put("nodeExporterCollectors", ObjectUtils.defaultIfNull(this.nodeExporterCollectors, new ArrayList<>()));
         map.put("blackboxExporterUser", ObjectUtils.defaultIfNull(this.blackboxExporterUser, EMPTY_CONFIG_DEFAULT));
         map.put("blackboxExporterPort", this.blackboxExporterPort);
         map.put("agentUser", ObjectUtils.defaultIfNull(this.agentUser, EMPTY_CONFIG_DEFAULT));
@@ -206,6 +216,8 @@ public class MonitoringConfigView implements TelemetryConfigView {
         private String nodeExporterUser;
 
         private Integer nodeExporterPort;
+
+        private List<String> nodeExporterCollectors;
 
         private String blackboxExporterUser;
 
@@ -293,6 +305,11 @@ public class MonitoringConfigView implements TelemetryConfigView {
 
         public Builder withNodeExporterPort(Integer nodeExporterPort) {
             this.nodeExporterPort = nodeExporterPort;
+            return this;
+        }
+
+        public Builder withNodeExporterCollectors(List<String> nodeExporterCollectors) {
+            this.nodeExporterCollectors = nodeExporterCollectors;
             return this;
         }
 

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfiguration.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfiguration.java
@@ -21,7 +21,7 @@ public class MonitoringConfiguration {
 
     private ExporterConfiguration clouderaManagerExporter;
 
-    private ExporterConfiguration nodeExporter;
+    private NodeExporterConfiguration nodeExporter;
 
     private ExporterConfiguration blackboxExporter;
 
@@ -73,11 +73,11 @@ public class MonitoringConfiguration {
         this.clouderaManagerExporter = clouderaManagerExporter;
     }
 
-    public ExporterConfiguration getNodeExporter() {
+    public NodeExporterConfiguration getNodeExporter() {
         return nodeExporter;
     }
 
-    public void setNodeExporter(ExporterConfiguration nodeExporter) {
+    public void setNodeExporter(NodeExporterConfiguration nodeExporter) {
         this.nodeExporter = nodeExporter;
     }
 

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/NodeExporterConfiguration.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/NodeExporterConfiguration.java
@@ -1,0 +1,16 @@
+package com.sequenceiq.cloudbreak.telemetry.monitoring;
+
+import java.util.List;
+
+public class NodeExporterConfiguration extends ExporterConfiguration {
+
+    private List<String> collectors;
+
+    public List<String> getCollectors() {
+        return collectors;
+    }
+
+    public void setCollectors(List<String> collectors) {
+        this.collectors = collectors;
+    }
+}

--- a/common/src/main/resources/common-config.yml
+++ b/common/src/main/resources/common-config.yml
@@ -41,6 +41,22 @@ telemetry:
     node-exporter:
       user: nodeuser
       port: 9100
+      # see: https://github.com/prometheus/node_exporter/blob/master/README.md#collectors
+      collectors:
+        - cpu
+        - cpufreq
+        - diskstats
+        - filefd
+        - filesystem
+        - loadavg
+        - meminfo
+        - netstat
+        - pressure
+        - processes
+        - stat
+        - systemd
+        - vmstat
+        - xfs
     blackbox-exporter:
       user: blackboxuser
       port: 9115

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/exporters.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/exporters.sls
@@ -1,7 +1,7 @@
 {%- from 'telemetry/settings.sls' import telemetry with context %}
 {%- from 'monitoring/settings.sls' import monitoring with context %}
 
-{%- if monitoring.enabled %}
+{%- if monitoring.enabled and monitoring.nodeExporterExists and monitoring.blackboxExporterExists %}
 
 /etc/systemd/system/cdp-node-exporter.service:
   file.managed:

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/settings.sls
@@ -1,5 +1,7 @@
 {% set monitoring = {} %}
 
+{% set node_exporter_exists = salt['file.directory_exists' ]('/opt/node_exporter') %}
+{% set blackbox_exporter_exists = salt['file.directory_exists' ]('/opt/blackbox_exporter') %}
 {% if salt['pillar.get']('monitoring:enabled') %}
     {% set monitoring_enabled = True %}
 {% else %}
@@ -23,6 +25,7 @@
 {% set agent_port = salt['pillar.get']('monitoring:agentPort', 8429) %}
 {% set node_exporter_user = salt['pillar.get']('monitoring:nodeExporterUser', 'nodeuser') %}
 {% set node_exporter_port = salt['pillar.get']('monitoring:nodeExporterPort', 9100) %}
+{% set node_exporter_collectors = salt['pillar.get']('monitoring:nodeExporterCollectors', []) %}
 {% set blackbox_exporter_user = salt['pillar.get']('monitoring:blackboxExporterUser', 'blackboxuser') %}
 {% set blackbox_exporter_port = salt['pillar.get']('monitoring:blackboxExporterPort', 9115) %}
 {% set exporter_password = salt['pillar.get']('monitoring:exporterPassword') %}
@@ -62,8 +65,11 @@
     "agentPort": agent_port,
     "nodeExporterUser": node_exporter_user,
     "nodeExporterPort": node_exporter_port,
+    "nodeExporterCollectors": node_exporter_collectors,
+    "nodeExporterExists": node_exporter_exists,
     "blackboxExporterUser": blackbox_exporter_user,
     "blackboxExporterPort": blackbox_exporter_port,
+    "blackboxExporterExists" : blackbox_exporter_exists,
     "exporterPassword": exporter_password,
     "useDevStack": use_dev_stack
 }) %}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/systemd/cdp-node-exporter.service.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/systemd/cdp-node-exporter.service.j2
@@ -1,4 +1,23 @@
 {%- from 'monitoring/settings.sls' import monitoring with context %}
+{%- set is_salt_master = salt['file.directory_exists' ]('/srv/salt') %}
+{%- set common_services = 'nginx|sshd|sssd|salt-bootstrap|salt-minion|cdp-logging-agent' %}
+{%- if is_salt_master %}
+  {%- set salt_services = '|salt-master|salt-api' %}
+{%- else %}
+  {%- set salt_services = '' %}
+{%- endif %}
+{%- set common_cm_services = '|cloudera-scm-agent|cloudera-scm-supervisord' %}
+{%- if monitoring.type == "cloudera_manager" and "manager_server" in grains.get('roles', []) %}
+  {%- set cm_services = common_cm_services + '|cloudera-scm-server' %}
+{%- else %}
+  {%- set cm_services = common_cm_services %}
+{%- endif %}
+{%- set freeipa_services = '|cdp-freeipa-healthagent|kadmin|krb5kdc|named-pkcs11|ipa|ipa-dnskeysyncd|ipa-custodia|sshd|sssd' %}
+{%- if monitoring.type == "freeipa" %}
+  {%- set systemd_units_include = common_services + salt_services + freeipa_services %}
+{%- else %}
+  {%- set systemd_units_include = common_services + salt_services + cm_services %}
+{%- endif %}
 [Unit]
 Description=CDP Node Exporter
 Wants=network-online.target
@@ -8,7 +27,17 @@ After=network-online.target
 Type=simple
 User=root
 Group=root
-ExecStart=/opt/node_exporter/node_exporter --web.config=/opt/node_exporter/node_exporter-web-config.yml --web.listen-address=:{{ monitoring.nodeExporterPort }}
+ExecStart=/opt/node_exporter/node_exporter --web.config=/opt/node_exporter/node_exporter-web-config.yml \
+{%- if monitoring.nodeExporterCollectors %}
+     --collector.disable-defaults \
+     {%- for collectorName in monitoring.nodeExporterCollectors %}
+     --collector.{{ collectorName }} \
+     {%- if collectorName == "systemd" %}
+     --collector.systemd.unit-include=({{ systemd_units_include }}).service \
+     {%- endif %}
+     {%- endfor %}
+{%- endif %}
+     --web.listen-address=:{{ monitoring.nodeExporterPort }}
 
 Restart=always
 

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/template/prometheus.yml.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/template/prometheus.yml.j2
@@ -1,6 +1,7 @@
 {%- from 'telemetry/settings.sls' import telemetry with context %}
 {%- from 'monitoring/settings.sls' import monitoring with context %}
 {%- set hostname = salt['grains.get']('fqdn') %}
+{%- set hostgroup = salt['grains.get']('hostgroup') %}
 global:
   scrape_interval: {{ monitoring.scrapeIntervalSeconds }}s
 scrape_configs:
@@ -11,6 +12,9 @@ scrape_configs:
        labels:
          resource_crn: {{ telemetry.clusterCrn }}
          platform: {{ telemetry.platform }}
+{%- if hostgroup %}
+         hostgroup: {{ hostgroup }}
+{%- endif %}
     relabel_configs:
       - target_label: instance
         replacement: {{ hostname }}:{{ monitoring.nodeExporterPort }}
@@ -32,6 +36,9 @@ scrape_configs:
         labels:
           resource_crn: {{ telemetry.clusterCrn }}
           platform: {{ telemetry.platform }}
+{%- if hostgroup %}
+          hostgroup: {{ hostgroup }}
+{%- endif %}
           proxy: {% if telemetry.proxyUrl %}yes{%- else %}no{% endif %}
     relabel_configs:
       - source_labels: [__address__]


### PR DESCRIPTION
collectors:
- cpu
- cpufreq
- diskstats
- filefd
- filesystem
- loadavg
- meminfo
- netstat
- pressure
- processes
- stat
- systemd
- vmstat
- xfs
see more: https://github.com/prometheus/node_exporter/blob/master/README.md#collectors