### PR TITLE
CDPD-30884: Make datamart datahub template GA on GCP

### DIFF
--- a/core/src/main/resources/defaults/clustertemplates/7.2.15/gcp/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.15/gcp/datamart.json
@@ -2,7 +2,7 @@
   "name": "7.2.15 - Data Mart for Google Cloud",
   "description": "",
   "type": "DATAMART",
-  "featureState": "PREVIEW",
+  "featureState": "RELEASED",
   "cloudPlatform": "GCP",
   "distroXTemplate": {
     "cluster": {

--- a/core/src/main/resources/defaults/clustertemplates/7.2.16/gcp/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.16/gcp/datamart.json
@@ -2,7 +2,7 @@
   "name": "7.2.16 - Data Mart for Google Cloud",
   "description": "",
   "type": "DATAMART",
-  "featureState": "PREVIEW",
+  "featureState": "RELEASED",
   "cloudPlatform": "GCP",
   "distroXTemplate": {
     "cluster": {


### PR DESCRIPTION
Mark featureState of GCP datamart templates as RELEASED since they're now considered GA.

See detailed description in the commit message.