### PR TITLE
CB-17079 Added Virtual Group related parameter into Knox's HadoopGroupProvider config

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -30,6 +30,10 @@
             <name>CENTRAL_GROUP_CONFIG_PREFIX</name>
             <value>gateway.group.config.</value>
         </param>
+        <param>
+            <name>group.mapping.{{ salt['pillar.get']('gateway:envAccessGroup') }}</name>
+            <value>(!= 0 (size groups))</value>
+        </param>
     </provider>
     <provider>
     {%- if salt['pillar.get']('gateway:enable_knox_ranger_authorizer') == True %}

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
@@ -44,6 +44,10 @@
                 <name>CENTRAL_GROUP_CONFIG_PREFIX</name>
                 <value>gateway.group.config.</value>
             </param>
+            <param>
+                <name>group.mapping.{{ salt['pillar.get']('gateway:envAccessGroup') }}</name>
+                <value>(!= 0 (size groups))</value>
+            </param>
         </provider>
         <provider>
         {%- if salt['pillar.get']('gateway:enable_knox_ranger_authorizer') == True %}

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_token.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_token.xml.j2
@@ -36,6 +36,10 @@
                 <name>CENTRAL_GROUP_CONFIG_PREFIX</name>
                 <value>gateway.group.config.</value>
             </param>
+            <param>
+                <name>group.mapping.{{ salt['pillar.get']('gateway:envAccessGroup') }}</name>
+                <value>(!= 0 (size groups))</value>
+            </param>
         </provider>
         <provider>
         {%- if salt['pillar.get']('gateway:enable_knox_ranger_authorizer') == True %}


### PR DESCRIPTION
Knox introduced a more flexible way to map principals to groups than the existing `group.principal.mapping` mechanism in `CommonIdentityAssertionFilter`. You may check out [KNOX-2707](KNOX-2707) for further details.
This PR takes care of setting the `ENV_ASSIGNEES_####` group as virtual group mapping for anyone with at least one group.
This is required for some of our significant customers, such as Itau.
Please note this new config is not harmful to Knox in previous CDH versions; it's ignored.