### PR TITLE
CB-17073 Set workload password and UMS validation fixes

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
@@ -319,6 +319,24 @@ public class GrpcUmsClient {
     }
 
     /**
+     * Set machine user Workload password.
+     *
+     * @param userCrn   the CRN of the machine user
+     * @param requestId an optional request Id
+     * @return the workload credentials associated with this machine user CRN
+     */
+    public UserManagementProto.SetActorWorkloadCredentialsResponse setMachineUserWorkloadPassword(String userCrn, String accountId, String password,
+            Optional<String> requestId, RegionAwareInternalCrnGeneratorFactory regionAwareInternalCrnGeneratorFactory) {
+        UmsClient client = makeClient(channelWrapper.getChannel(), regionAwareInternalCrnGeneratorFactory);
+        String workloadUserName = getMachineUserDetails(userCrn, accountId, requestId, regionAwareInternalCrnGeneratorFactory).getWorkloadUsername();
+        LOGGER.debug("Setting workload password for machine user {} with workload name {}", userCrn, workloadUserName);
+        UserManagementProto.SetActorWorkloadCredentialsResponse response = client.setActorWorkloadPassword(RequestIdUtil.getOrGenerate(requestId), userCrn,
+                password);
+        LOGGER.debug("Workload password has been set for machine user {} with workload name {}", userCrn, workloadUserName);
+        return response;
+    }
+
+    /**
      * Retrieves list of all machine users from UMS.
      *
      * @param accountId                   the account Id

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/UmsClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/UmsClient.java
@@ -54,7 +54,7 @@ public class UmsClient<E extends Enum<E>, W extends WaitObject> extends Microser
         ReflectionUtils.setField(callingServiceName, clientConfig, "cloudbreak");
         Field grpcTimeoutSec = ReflectionUtils.findField(UmsClientConfig.class, "grpcTimeoutSec");
         ReflectionUtils.makeAccessible(grpcTimeoutSec);
-        ReflectionUtils.setField(grpcTimeoutSec, clientConfig, 5L);
+        ReflectionUtils.setField(grpcTimeoutSec, clientConfig, 60L);
         clientEntity.umsClient = GrpcUmsClient.createClient(
                 UmsChannelConfig.newManagedChannelWrapper(umsHost, 8982), clientConfig, tracer);
         return clientEntity;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/ums/SetWorkloadPasswordAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/ums/SetWorkloadPasswordAction.java
@@ -37,14 +37,22 @@ public class SetWorkloadPasswordAction implements Action<UmsTestDto, UmsClient> 
         if (resourceType.equals(Crn.ResourceType.MACHINE_USER)) {
             workloadUsername = client.getDefaultClient().getMachineUserDetails(userCrn, accountId, Optional.of(""),
                     regionAwareInternalCrnGeneratorFactory).getWorkloadUsername();
+            LOGGER.info("Setting new workload password '{}' for machine user '{}' with workload username '{}'...",
+                    newPassword, userCrn, workloadUsername);
+            Log.when(LOGGER, format(" Setting new workload password '%s' for machine user '%s' workload username '%s'... ",
+                    newPassword, userCrn, workloadUsername));
+            client.getDefaultClient().setMachineUserWorkloadPassword(userCrn, accountId, newPassword, Optional.of(""),
+                    regionAwareInternalCrnGeneratorFactory);
         } else {
             workloadUsername = client.getDefaultClient().getUserDetails(userCrn, Optional.of(""),
                     regionAwareInternalCrnGeneratorFactory).getWorkloadUsername();
+            LOGGER.info("Setting new workload password '{}' for user '{}' with workload username '{}'...",
+                    newPassword, userCrn, workloadUsername);
+            Log.when(LOGGER, format(" Setting new workload password '%s' for user '%s' workload username '%s'... ",
+                    newPassword, userCrn, workloadUsername));
+            client.getDefaultClient().setActorWorkloadPassword(userCrn, newPassword, Optional.of(""),
+                    regionAwareInternalCrnGeneratorFactory);
         }
-        LOGGER.info("Setting new workload password '{}' for user '{}' with workload username '{}'", newPassword, userCrn, workloadUsername);
-        Log.when(LOGGER, format(" Setting new workload password '%s' for user '%s' workload username '%s' ", newPassword, userCrn, workloadUsername));
-        client.getDefaultClient().setActorWorkloadPassword(userCrn, newPassword, Optional.of(""),
-                regionAwareInternalCrnGeneratorFactory);
         // wait for UmsRightsCache to expire
         Thread.sleep(7000);
         LOGGER.info("New workload password has been set for '{}' with workload username '{}'!", userCrn, workloadUsername);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/ums/ResourceRoleTestAssertion.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/ums/ResourceRoleTestAssertion.java
@@ -1,0 +1,60 @@
+package com.sequenceiq.it.cloudbreak.assertion.ums;
+
+import static java.lang.String.format;
+
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Multimap;
+import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
+import com.sequenceiq.it.cloudbreak.UmsClient;
+import com.sequenceiq.it.cloudbreak.actor.CloudbreakUser;
+import com.sequenceiq.it.cloudbreak.assertion.Assertion;
+import com.sequenceiq.it.cloudbreak.dto.ums.UmsTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.it.cloudbreak.log.Log;
+
+public class ResourceRoleTestAssertion {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResourceRoleTestAssertion.class);
+
+    private ResourceRoleTestAssertion() {
+    }
+
+    public static Assertion<UmsTestDto, UmsClient> validateAssignedResourceRole(CloudbreakUser assignee, String roleCrn, boolean expectedPresence,
+            RegionAwareInternalCrnGeneratorFactory crnGeneratorFactory) {
+        return (testContext, umsTestDto, umsClient) -> {
+            String resourceCrn = umsTestDto.getRequest().getResourceCrn();
+            String userCrn = assignee.getCrn();
+
+            LOGGER.info(format(" Validate resource role '%s' has been successfully assigned to user '%s' at resource '%s'... ", roleCrn, userCrn, resourceCrn));
+            Multimap<String, String> assignedResourceRoles = umsClient.getDefaultClient()
+                    .listAssignedResourceRoles(userCrn, Optional.of(""), crnGeneratorFactory);
+            boolean resourceRoleAssigned = assignedResourceRoles.get(resourceCrn).contains(roleCrn);
+            if (expectedPresence) {
+                if (resourceRoleAssigned) {
+                    LOGGER.info(format(" Resource role '%s' has successfully been assigned to user '%s' at resource '%s' ", roleCrn, userCrn,
+                            resourceCrn));
+                    Log.then(LOGGER, format(" Resource role '%s' has successfully been assigned to user '%s' at resource '%s' ", roleCrn, userCrn,
+                            resourceCrn));
+                } else {
+                    throw new TestFailException(format(" Resource role '%s' has not been assigned to user '%s' at resource '%s'! ", roleCrn,
+                            userCrn, resourceCrn));
+                }
+            } else {
+                if (!resourceRoleAssigned) {
+                    LOGGER.info(format(" Resource role '%s' has successfully been revoked from user '%s' at resource '%s' ", roleCrn, userCrn,
+                            resourceCrn));
+                    Log.then(LOGGER, format(" Resource role '%s' has successfully been revoked from user '%s' at resource '%s' ", roleCrn,
+                            userCrn, resourceCrn));
+                } else {
+                    throw new TestFailException(format(" Resource role '%s' has not been revoked from user '%s' at resource '%s'! ", roleCrn,
+                            userCrn, resourceCrn));
+                }
+            }
+            return umsTestDto;
+        };
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/ums/UserGroupTestAssertion.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/ums/UserGroupTestAssertion.java
@@ -1,0 +1,53 @@
+package com.sequenceiq.it.cloudbreak.assertion.ums;
+
+import static java.lang.String.format;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
+import com.sequenceiq.it.cloudbreak.UmsClient;
+import com.sequenceiq.it.cloudbreak.actor.CloudbreakUser;
+import com.sequenceiq.it.cloudbreak.assertion.Assertion;
+import com.sequenceiq.it.cloudbreak.dto.ums.UmsGroupTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.it.cloudbreak.log.Log;
+
+public class UserGroupTestAssertion {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserGroupTestAssertion.class);
+
+    private UserGroupTestAssertion() {
+    }
+
+    public static Assertion<UmsGroupTestDto, UmsClient> validateUserGroupMembership(CloudbreakUser groupMember, String groupName, boolean expectedPresence,
+            RegionAwareInternalCrnGeneratorFactory crnGeneratorFactory) {
+        return (testContext, umsGroupTestDto, umsClient) -> {
+            String accountId = testContext.getActingUserCrn().getAccountId();
+
+            List<String> groupMembers = umsClient.getDefaultClient().listMembersFromGroup(accountId, groupName,
+                    Optional.of(""), crnGeneratorFactory);
+            boolean memberPresent = groupMembers.stream().anyMatch(memberCrn -> groupMember.getCrn().equals(memberCrn));
+            LOGGER.info("Member is present '{}' at group '{}', group members: [{}]", memberPresent, groupName, groupMembers);
+            if (expectedPresence) {
+                if (memberPresent) {
+                    LOGGER.info("User '{}' have been assigned successfully to group {}.", groupMember.getDisplayName(), groupName);
+                    Log.then(LOGGER, format(" User '%s' have been assigned successfully to group '%s'. ", groupMember.getDisplayName(), groupName));
+                } else {
+                    throw new TestFailException(format(" User '%s' is missing from group '%s' members! ", groupMember.getDisplayName(), groupName));
+                }
+            } else {
+                if (!memberPresent) {
+                    LOGGER.info("User '{}' have been removed successfully from group {}.", groupMember.getDisplayName(), groupName);
+                    Log.then(LOGGER, format(" User '%s' have been removed successfully from group '%s'. ", groupMember.getDisplayName(), groupName));
+                } else {
+                    throw new TestFailException(format(" User '%s' is still member of group '%s'! ", groupMember.getDisplayName(), groupName));
+                }
+            }
+            return umsGroupTestDto;
+        };
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/ums/VirtualGroupTestAssertion.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/ums/VirtualGroupTestAssertion.java
@@ -1,0 +1,53 @@
+package com.sequenceiq.it.cloudbreak.assertion.ums;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.auth.altus.UmsVirtualGroupRight;
+import com.sequenceiq.it.cloudbreak.FreeIpaClient;
+import com.sequenceiq.it.cloudbreak.assertion.Assertion;
+import com.sequenceiq.it.cloudbreak.client.FreeIpaTestClient;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
+
+public class VirtualGroupTestAssertion {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(VirtualGroupTestAssertion.class);
+
+    private VirtualGroupTestAssertion() {
+    }
+
+    public static Assertion<FreeIpaTestDto, FreeIpaClient> validateAdminVirtualGroupMembership(FreeIpaTestClient freeIpaTestClient, Map<UmsVirtualGroupRight,
+            String> environmentVirtualGroups, Set<String> adminUsers, boolean expectedPresence) {
+        return (testContext, freeIpaTestDto, freeIpaClient) -> {
+            List<String> adminGroups = environmentVirtualGroups
+                    .entrySet().stream()
+                    .filter(group -> group.getKey().name().contains("ADMIN"))
+                    .map(Map.Entry::getValue)
+                    .collect(Collectors.toList());
+            LOGGER.info(String.format(" Admin groups are present [%s] at environment '%s' ", adminGroups, freeIpaTestDto.getResponse().getEnvironmentCrn()));
+            adminGroups.forEach(adminGroup -> freeIpaTestClient.findUsersInGroup(adminUsers, adminGroup, expectedPresence));
+
+            return freeIpaTestDto;
+        };
+    }
+
+    public static Assertion<FreeIpaTestDto, FreeIpaClient> validateUserVirtualGroupMembership(FreeIpaTestClient freeIpaTestClient, Map<UmsVirtualGroupRight,
+            String> environmentVirtualGroups, Set<String> environmentUsers, boolean expectedPresence) {
+        return (testContext, freeIpaTestDto, freeIpaClient) -> {
+            List<String> userGroups = environmentVirtualGroups
+                .entrySet().stream()
+                .filter(group -> group.getKey().name().contains("ACCESS"))
+                .map(Map.Entry::getValue)
+                .collect(Collectors.toList());
+            LOGGER.info(String.format(" User groups are present [%s] at environment '%s' ", userGroups, freeIpaTestDto.getResponse().getEnvironmentCrn()));
+            userGroups.forEach(userGroup -> freeIpaTestClient.findUsersInGroup(environmentUsers, userGroup, expectedPresence));
+
+            return freeIpaTestDto;
+        };
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
@@ -405,7 +405,8 @@ public abstract class TestContext implements ApplicationContextAware {
 
         CloudbreakUser who = setActingUser(runningParameter);
 
-        Log.then(LOGGER, assertion.getClass().getSimpleName() + " exception assertion on " + entity + " by " + who);
+        LOGGER.info("then exception {} action on {} by {}, name: {}", key, entity, who, entity.getName());
+        Log.thenException(LOGGER, assertion.getClass().getSimpleName() + " exception assertion on " + entity + " by " + who);
         try {
             String message = String.format("Expected exception with message (%s) has not been thrown!", runningParameter.getExpectedMessage());
             CloudbreakTestDto cloudbreakTestDto = resourceNames.get(key);
@@ -1102,6 +1103,8 @@ public abstract class TestContext implements ApplicationContextAware {
     private void htmlLoggerForExceptionValidation(String message, String stepKey) {
         if ("expect".equalsIgnoreCase(stepKey)) {
             Log.expect(LOGGER, message);
+        } else if ("thenException".equalsIgnoreCase(stepKey)) {
+            Log.thenException(LOGGER, message);
         } else {
             Log.whenException(LOGGER, message);
         }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/log/Log.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/log/Log.java
@@ -85,6 +85,10 @@ public class Log<T extends CloudbreakTestDto> {
         log(logger, "WhenException", message);
     }
 
+    public static void thenException(Logger logger, String message) {
+        log(logger, "ThenException", message);
+    }
+
     public static void then(Logger logger, String message) {
         log(logger, "Then", message);
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/EnvironmentUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/EnvironmentUtil.java
@@ -1,0 +1,65 @@
+package com.sequenceiq.it.cloudbreak.util;
+
+import static java.lang.String.format;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.apache.commons.collections4.MapUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import com.sequenceiq.cloudbreak.auth.altus.UmsVirtualGroupRight;
+import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
+import com.sequenceiq.cloudbreak.logger.MDCUtils;
+import com.sequenceiq.it.cloudbreak.UmsClient;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.it.cloudbreak.log.Log;
+
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+
+@Component
+public class EnvironmentUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EnvironmentUtil.class);
+
+    @Inject
+    private RegionAwareInternalCrnGeneratorFactory regionAwareInternalCrnGeneratorFactory;
+
+    public Map<UmsVirtualGroupRight, String> getEnvironmentVirtualGroups(TestContext testContext, UmsClient client) {
+        String accountId = testContext.getActingUserCrn().getAccountId();
+        String environmentCrn = testContext.given(EnvironmentTestDto.class).getCrn();
+        Map<UmsVirtualGroupRight, String> virtualGroups = new HashMap<>();
+        String virtualGroup = null;
+
+        for (UmsVirtualGroupRight right : UmsVirtualGroupRight.values()) {
+            try {
+                virtualGroup = client.getDefaultClient().getWorkloadAdministrationGroupName(accountId, MDCUtils.getRequestId(),
+                        right, environmentCrn, regionAwareInternalCrnGeneratorFactory);
+            } catch (StatusRuntimeException ex) {
+                if (Status.Code.NOT_FOUND != ex.getStatus().getCode()) {
+                    LOGGER.info(format(" Virtual groups are missing for right: '%s' ", right.getRight()));
+                }
+            }
+            if (StringUtils.hasText(virtualGroup)) {
+                virtualGroups.put(right, virtualGroup);
+            }
+        }
+
+        if (MapUtils.isNotEmpty(virtualGroups)) {
+            Log.then(LOGGER, format(" Virtual groups are present [%s] for environment '%s' ", virtualGroups, environmentCrn));
+            LOGGER.info(String.format(" Virtual groups are present [%s] for environment '%s' ", virtualGroups, environmentCrn));
+        } else {
+            throw new TestFailException(String.format(" Cannot find virtual groups for environment '%s' ", environmentCrn));
+        }
+
+        return virtualGroups;
+    }
+}


### PR DESCRIPTION
Recently introduced [l0promotion.EnvironmentPrivilegedUserTest](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/EnvironmentPrivilegedUserTest.java) related `tearDownSpotValidateTags` is failing, because of:
```
Exception com.sequenceiq.it.cloudbreak.exception.TestFailException
Message: 
Default tag: [owner] value: [cb-qe-machine-envcreator-a] NOT equals [cloudbreak-qe@cloudera.com] acting user name!
Stacktrace:
at com.sequenceiq.it.util.TagsUtil.validateOwnerTag(TagsUtil.java:141)
at com.sequenceiq.it.util.TagsUtil.lambda$verifyTags$1(TagsUtil.java:90)
```
Furthermore [l0promotion.DistroXRepairTests](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/DistroXRepairTests.java) is affected as well. 

While fixing the issue I had to realise setting of new Workload Password for user is flaky and machine user related parts are missing and some commonly used validations were not implemented as [Test Assertion](https://github.com/hortonworks/cloudbreak/tree/master/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion).