### PR TITLE
CB-17090. Optimize freeipa node status check.

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/nodestatus/NodeStatusCheckerJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/nodestatus/NodeStatusCheckerJob.java
@@ -96,7 +96,7 @@ public class NodeStatusCheckerJob extends StatusCheckerJob {
             if (StackType.WORKLOAD.equals(stack.getType())) {
                 requestBuilder.withMetering(true);
             }
-            CdpNodeStatusRequest request = requestBuilder.withCmMonitoring(true).build();
+            CdpNodeStatusRequest request = requestBuilder.withCmMonitoring(true).withSkipObjectMapping(true).build();
             CdpNodeStatuses statuses = nodeStatusService.getNodeStatuses(stack, request);
             processNodeStatusReport(statuses.getNetworkReport(), NodeStatusProto.NodeStatus::getNetworkDetails, stack, "Network");
             processNodeStatusReport(statuses.getServicesReport(), NodeStatusProto.NodeStatus::getServicesDetails, stack, "Services");

--- a/core/src/main/java/com/sequenceiq/cloudbreak/node/status/NodeStatusService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/node/status/NodeStatusService.java
@@ -113,7 +113,7 @@ public class NodeStatusService {
         MDCBuilder.buildMdcContext(stack);
         LOGGER.debug("Retrieving salt ping report from the hosts of stack: {}", stack.getResourceCrn());
         try (CdpNodeStatusMonitorClient client = factory.getClient(stack, stack.getPrimaryGatewayInstance())) {
-            return client.saltPing(false);
+            return client.saltPing(false, false);
         } catch (CdpNodeStatusMonitorClientException e) {
             throw new CloudbreakServiceException("Could not get salt ping report from stack.");
         }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/AbstractCommonChainAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/AbstractCommonChainAction.java
@@ -15,6 +15,7 @@ import com.sequenceiq.flow.core.FlowState;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.flow.OperationAwareAction;
 import com.sequenceiq.freeipa.flow.stack.AbstractStackAction;
+import com.sequenceiq.freeipa.nodestatus.NodeStatusJobService;
 import com.sequenceiq.freeipa.sync.FreeipaJobService;
 
 public abstract class AbstractCommonChainAction<S extends FlowState, E extends FlowEvent, C extends CommonContext, P extends Payload>
@@ -33,6 +34,9 @@ public abstract class AbstractCommonChainAction<S extends FlowState, E extends F
 
     @Inject
     private FreeipaJobService jobService;
+
+    @Inject
+    private NodeStatusJobService nodeStatusJobService;
 
     protected AbstractCommonChainAction(Class<P> payloadClass) {
         super(payloadClass);
@@ -81,6 +85,11 @@ public abstract class AbstractCommonChainAction<S extends FlowState, E extends F
     protected void enableStatusChecker(Stack stack, String reason) {
         LOGGER.info("Enabling the status checker for stack ID {}. {}", stack.getId(), reason);
         jobService.schedule(stack.getId());
+    }
+
+    protected void enableNodeStatusChecker(Stack stack, String reason) {
+        LOGGER.info("Enabling the status checker for stack ID {}, {}", stack.getId(), reason);
+        nodeStatusJobService.schedule(stack.getId());
     }
 
     protected boolean shouldCompleteOperation(Map<Object, Object> variables) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/action/FreeIpaDownscaleActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/action/FreeIpaDownscaleActions.java
@@ -454,6 +454,7 @@ public class FreeIpaDownscaleActions {
                 stackUpdater.updateStackStatus(context.getStack().getId(), getFailedStatus(variables), errorReason);
                 operationService.failOperation(stack.getAccountId(), getOperationId(variables), message, List.of(successDetails), List.of(failureDetails));
                 enableStatusChecker(stack, "Failed downscaling FreeIPA");
+                enableNodeStatusChecker(stack, "Failed downscaling FreeIPA");
                 sendEvent(context, FAIL_HANDLED_EVENT.event(), payload);
             }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/provision/action/FreeIpaProvisionActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/provision/action/FreeIpaProvisionActions.java
@@ -35,6 +35,7 @@ import com.sequenceiq.freeipa.flow.stack.StackFailureEvent;
 import com.sequenceiq.freeipa.flow.stack.provision.action.AbstractStackProvisionAction;
 import com.sequenceiq.freeipa.metrics.FreeIpaMetricService;
 import com.sequenceiq.freeipa.metrics.MetricType;
+import com.sequenceiq.freeipa.nodestatus.NodeStatusJobService;
 import com.sequenceiq.freeipa.service.config.AbstractConfigRegister;
 import com.sequenceiq.freeipa.service.stack.StackUpdater;
 import com.sequenceiq.freeipa.sync.FreeipaJobService;
@@ -176,11 +177,15 @@ public class FreeIpaProvisionActions {
             @Inject
             private FreeipaJobService freeipaJobService;
 
+            @Inject
+            private NodeStatusJobService nodeStatusJobService;
+
             @Override
             protected void doExecute(StackContext context, PostInstallFreeIpaSuccess payload, Map<Object, Object> variables) {
                 configRegisters.forEach(configProvider -> configProvider.register(context.getStack().getId()));
                 metricService.incrementMetricCounter(MetricType.FREEIPA_CREATION_FINISHED, context.getStack());
                 freeipaJobService.schedule(context.getStack().getId());
+                nodeStatusJobService.schedule(context.getStack().getId());
                 stackUpdater.updateStackStatus(context.getStack().getId(), DetailedStackStatus.PROVISIONED, "FreeIPA installation finished");
                 sendEvent(context);
             }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/repair/changeprimarygw/action/ChangePrimaryGatewayActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/repair/changeprimarygw/action/ChangePrimaryGatewayActions.java
@@ -219,6 +219,7 @@ public class ChangePrimaryGatewayActions {
                 operationService.failOperation(stack.getAccountId(), getOperationId(variables), message, List.of(successDetails), List.of(failureDetails));
                 LOGGER.info("Enabling the status checker for stack ID {} after failing repairing", stack.getId());
                 enableStatusChecker(stack, "Failed to repair FreeIPA");
+                enableNodeStatusChecker(stack, "Failed to repair FreeIPA");
                 sendEvent(context, FAIL_HANDLED_EVENT.event(), payload);
             }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/action/FreeIpaUpscaleActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/action/FreeIpaUpscaleActions.java
@@ -638,6 +638,7 @@ public class FreeIpaUpscaleActions {
                 stackUpdater.updateStackStatus(context.getStack().getId(), getFailedStatus(variables), errorReason);
                 operationService.failOperation(stack.getAccountId(), getOperationId(variables), message, List.of(successDetails), List.of(failureDetails));
                 enableStatusChecker(stack, "Failed upscaling FreeIPA");
+                enableNodeStatusChecker(stack, "Failed upscaling FreeIPA");
                 sendEvent(context, FAIL_HANDLED_EVENT.event(), payload);
             }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/nodestatus/NodeStatusJob.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/nodestatus/NodeStatusJob.java
@@ -1,0 +1,154 @@
+package com.sequenceiq.freeipa.nodestatus;
+
+import static com.sequenceiq.cloudbreak.util.Benchmark.checkedMeasure;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.Response;
+
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.cloudera.thunderhead.telemetry.nodestatus.NodeStatusProto;
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
+import com.sequenceiq.cloudbreak.client.RPCMessage;
+import com.sequenceiq.cloudbreak.client.RPCResponse;
+import com.sequenceiq.cloudbreak.quartz.statuschecker.job.StatusCheckerJob;
+import com.sequenceiq.flow.core.FlowLogService;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.stack.FreeIpaNodeStatusService;
+import com.sequenceiq.freeipa.service.stack.StackService;
+import com.sequenceiq.freeipa.sync.InterruptSyncingException;
+import com.sequenceiq.node.health.client.model.CdpNodeStatuses;
+
+import io.opentracing.Tracer;
+
+@DisallowConcurrentExecution
+@Component
+public class NodeStatusJob extends StatusCheckerJob {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NodeStatusJob.class);
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private FreeIpaNodeStatusService freeIpaNodeStatusService;
+
+    @Inject
+    private FlowLogService flowLogService;
+
+    @Inject
+    private NodeStatusJobService nodeStatusJobService;
+
+    @Inject
+    private RegionAwareInternalCrnGeneratorFactory regionAwareInternalCrnGeneratorFactory;
+
+    public NodeStatusJob(Tracer tracer) {
+        super(tracer, "Node status checker job");
+    }
+
+    @Override
+    protected Object getMdcContextObject() {
+        return stackService.getStackById(getStackId());
+    }
+
+    @Override
+    protected void executeTracedJob(JobExecutionContext context) throws JobExecutionException {
+        Long stackId = getStackId();
+        Stack stack = stackService.getByIdWithListsInTransaction(stackId);
+        try {
+            if (flowLogService.isOtherFlowRunning(stackId)) {
+                LOGGER.debug("NodeStatusJob cannot run, because flow is running for freeipa stack: {}", stackId);
+            } else {
+                LOGGER.debug("No flows running, trying to check node status for freeipa");
+                checkNodeHealthReports(stack);
+            }
+        } catch (InterruptSyncingException e) {
+            LOGGER.info("Node status check was interrupted", e);
+        }
+    }
+
+    private void checkNodeHealthReports(Stack stack) {
+        checkedMeasure(() -> {
+            ThreadBasedUserCrnProvider.doAsInternalActor(
+                    regionAwareInternalCrnGeneratorFactory.iam().getInternalCrnForServiceAsString(),
+                    () -> {
+                        if (unshedulableStates().contains(stack.getStackStatus().getStatus())) {
+                            LOGGER.debug("NodeStatus check will be unscheduled, stack state is {}", stack.getStackStatus().getStatus());
+                            nodeStatusJobService.unschedule(stack);
+                        } else {
+                            Set<InstanceMetaData> checkableInstances = stack.getAllInstanceMetaDataList().stream()
+                                    .filter(InstanceMetaData::isAvailable)
+                                    .collect(Collectors.toSet());
+                            if (checkableInstances.isEmpty()) {
+                                LOGGER.debug("No available instance for freeipa stack with id {}, skipping node status check.", stack.getId());
+                            } else {
+                                checkNodeHealthReports(stack, checkableInstances);
+                            }
+                        }
+                    });
+        }, LOGGER, "Node status check job execution took {}ms");
+    }
+
+    private void checkNodeHealthReports(Stack stack, Set<InstanceMetaData> checkableInstances) {
+        for (InstanceMetaData instanceMetaData : checkableInstances) {
+            try {
+                CdpNodeStatuses nodeStatuses =  checkedMeasure(() -> freeIpaNodeStatusService.nodeStatusReport(stack, instanceMetaData), LOGGER,
+                        "FreeIPA node status job checks ran in {}ms");
+                LOGGER.debug("Fetching node health reports for instance: {}", instanceMetaData.getInstanceId());
+                if (nodeStatuses.getNetworkReport().isPresent()) {
+                    logReportResult(instanceMetaData, nodeStatuses.getNetworkReport().get(), "network");
+                }
+                if (nodeStatuses.getServicesReport().isPresent()) {
+                    logReportResult(instanceMetaData, nodeStatuses.getServicesReport().get(), "services");
+                }
+                if (nodeStatuses.getSystemMetricsReport().isPresent()) {
+                    logReportResult(instanceMetaData, nodeStatuses.getServicesReport().get(), "system metrics");
+                }
+            } catch (Exception e) {
+                LOGGER.info("FreeIpaClientException occurred during node status check: " + e.getMessage(), e);
+            }
+        }
+    }
+
+    private Set<Status> unshedulableStates() {
+        return Set.of(Status.CREATE_FAILED,
+                Status.DELETED_ON_PROVIDER_SIDE,
+                Status.DELETE_IN_PROGRESS);
+    }
+
+    private void logReportResult(InstanceMetaData instanceMetaData, RPCResponse<NodeStatusProto.NodeStatusReport> nodeStatusRpcResponse, String reportType) {
+        if (isSuccessfulRequest(nodeStatusRpcResponse)) {
+            LOGGER.info("FreeIPA " + reportType + " reports for instance: [{}], report: [{}]",
+                    instanceMetaData.getInstanceId(), nodeStatusRpcResponse.getFirstTextMessage());
+        } else {
+            LOGGER.info("Failed to get " + reportType + " reports for instance: [{}], reason: [{}]", instanceMetaData.getInstanceId(),
+                    nodeStatusRpcResponse.getSummary());
+        }
+    }
+
+    private Boolean isSuccessfulRequest(RPCResponse<NodeStatusProto.NodeStatusReport> response) {
+        return response.getMessages().stream()
+                .map(RPCMessage::getCode)
+                .filter(Objects::nonNull)
+                .map(Response.Status.Family::familyOf)
+                .map(f -> f.equals(Response.Status.Family.SUCCESSFUL))
+                .reduce(Boolean::logicalAnd)
+                .orElse(Boolean.FALSE);
+    }
+
+    private Long getStackId() {
+        return Long.valueOf(getLocalId());
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/nodestatus/NodeStatusJobAdapter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/nodestatus/NodeStatusJobAdapter.java
@@ -1,0 +1,30 @@
+package com.sequenceiq.freeipa.nodestatus;
+
+import org.quartz.Job;
+import org.springframework.context.ApplicationContext;
+
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
+import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.repository.StackRepository;
+
+public class NodeStatusJobAdapter extends JobResourceAdapter<Stack> {
+
+    public NodeStatusJobAdapter(Long id, ApplicationContext context) {
+        super(id, context);
+    }
+
+    public NodeStatusJobAdapter(JobResource jobResource) {
+        super(jobResource);
+    }
+
+    @Override
+    public Class<? extends Job> getJobClassForResource() {
+        return NodeStatusJob.class;
+    }
+
+    @Override
+    public Class<StackRepository> getRepositoryClassForResource() {
+        return StackRepository.class;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/nodestatus/NodeStatusJobConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/nodestatus/NodeStatusJobConfig.java
@@ -1,0 +1,41 @@
+package com.sequenceiq.freeipa.nodestatus;
+
+import javax.annotation.PostConstruct;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NodeStatusJobConfig {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NodeStatusJobConfig.class);
+
+    @Value("${freeipa.nodestatus.intervalsec:1800}")
+    private int intervalInSeconds;
+
+    @Value("${freeipa.nodestatus.enabled:true}")
+    private boolean enabled;
+
+    @PostConstruct
+    void logEnablement() {
+        LOGGER.info("Periodical node status check is {}", enabled ? "enabled" : "disabled");
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public int getIntervalInSeconds() {
+        return intervalInSeconds;
+    }
+
+    public void setIntervalInSeconds(int intervalInSeconds) {
+        this.intervalInSeconds = intervalInSeconds;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/nodestatus/NodeStatusJobInitializer.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/nodestatus/NodeStatusJobInitializer.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.freeipa.nodestatus;
+
+import static com.sequenceiq.cloudbreak.util.Benchmark.checkedMeasure;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.quartz.model.JobInitializer;
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+@Component
+public class NodeStatusJobInitializer implements JobInitializer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NodeStatusJobInitializer.class);
+
+    @Inject
+    private NodeStatusJobConfig nodeStatusJobConfig;
+
+    @Inject
+    private NodeStatusJobService nodeStatusJobService;
+
+    @Inject
+    private StackService stackService;
+
+    @Override
+    public void initJobs() {
+        if (nodeStatusJobConfig.isEnabled()) {
+            List<JobResource> jobResources = checkedMeasure(() -> stackService.findAllForAutoSync(), LOGGER,
+                    ":::Node status check::: Stacks are fetched from db in {}ms");
+            for (JobResource jobResource : jobResources) {
+                nodeStatusJobService.schedule(new NodeStatusJobAdapter(jobResource));
+            }
+            LOGGER.info("Node status checks are inited with {} stacks on start", jobResources.size());
+        } else {
+            LOGGER.info("Skipping scheduling node status checker jobs, as they are disabled");
+        }
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/nodestatus/NodeStatusJobService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/nodestatus/NodeStatusJobService.java
@@ -1,0 +1,125 @@
+package com.sequenceiq.freeipa.nodestatus;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.Random;
+
+import javax.inject.Inject;
+
+import org.quartz.Job;
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.SimpleScheduleBuilder;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
+import com.sequenceiq.freeipa.entity.Stack;
+
+@Component
+public class NodeStatusJobService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NodeStatusJobService.class);
+
+    private static final Random RANDOM = new SecureRandom();
+
+    private static final String JOB_NAME = "node-status-checker-job";
+
+    private static final String JOB_GROUP = "node-status-checker-group";
+
+    private static final String TRIGGER_GROUP = "node-status-check-triggers";
+
+    @Inject
+    private Scheduler scheduler;
+
+    @Inject
+    private NodeStatusJobConfig nodeStatusJobConfig;
+
+    @Inject
+    private ApplicationContext applicationContext;
+
+    public void schedule(Long id) {
+        if (nodeStatusJobConfig.isEnabled()) {
+            schedule(id, NodeStatusJobAdapter.class);
+        }
+    }
+
+    public <T> void schedule(JobResourceAdapter<T> resource) {
+        JobDetail jobDetail = buildJobDetail(resource);
+        Trigger trigger = buildJobTrigger(jobDetail, RANDOM.nextInt(nodeStatusJobConfig.getIntervalInSeconds()));
+        try {
+            LOGGER.info("Unscheduling Node status job with name: '{}' and group: '{}'", JOB_NAME, JOB_GROUP);
+            unschedule(resource.getJobResource().getLocalId());
+            LOGGER.info("Scheduling Node status job with name: '{}' and group: '{}'", JOB_NAME, JOB_GROUP);
+            scheduler.scheduleJob(jobDetail, trigger);
+        } catch (SchedulerException e) {
+            LOGGER.error(String.format("Error during scheduling quartz job: %s", jobDetail), e);
+        }
+    }
+
+    public void schedule(Long id, Class<? extends JobResourceAdapter<?>> resourceAdapterClass) {
+        try {
+            Constructor<? extends JobResourceAdapter> c = resourceAdapterClass.getConstructor(Long.class, ApplicationContext.class);
+            JobResourceAdapter resourceAdapter = c.newInstance(id, applicationContext);
+            schedule(resourceAdapter);
+        } catch (NoSuchMethodException | IllegalAccessException | InstantiationException | InvocationTargetException e) {
+            LOGGER.error("Error during scheduling quartz job: {}", id, e);
+        }
+    }
+
+    public void unschedule(String id) {
+        JobKey jobKey = JobKey.jobKey(id, JOB_GROUP);
+        try {
+            if (scheduler.getJobDetail(jobKey) != null) {
+                scheduler.deleteJob(jobKey);
+            }
+        } catch (SchedulerException e) {
+            LOGGER.error(String.format("Error during unscheduling quartz job: %s", jobKey), e);
+        }
+    }
+
+    public void unschedule(Stack stack) {
+        unschedule(String.valueOf(stack.getId()));
+    }
+
+    private <T> JobDetail buildJobDetail(JobResourceAdapter<T> resource) {
+        return JobBuilder.newJob(getJobClass())
+                .withIdentity(resource.getJobResource().getLocalId(), JOB_GROUP)
+                .withDescription("Checking stack nodestatus Job")
+                .usingJobData(resource.toJobDataMap())
+                .storeDurably()
+                .build();
+    }
+
+    private Trigger buildJobTrigger(JobDetail jobDetail, int delayedInSeconds) {
+        return TriggerBuilder.newTrigger()
+                .forJob(jobDetail)
+                .withIdentity(jobDetail.getKey().getName(), TRIGGER_GROUP)
+                .withDescription("Checking nodestatus Trigger")
+                .startAt(delayedStart(delayedInSeconds))
+                .withSchedule(SimpleScheduleBuilder.simpleSchedule()
+                        .withIntervalInSeconds(nodeStatusJobConfig.getIntervalInSeconds())
+                        .repeatForever()
+                        .withMisfireHandlingInstructionNextWithRemainingCount())
+                .build();
+    }
+
+    private Date delayedStart(int delayInSeconds) {
+        return Date.from(ZonedDateTime.now().toInstant().plus(Duration.ofSeconds(delayInSeconds)));
+    }
+
+    private Class<? extends Job> getJobClass() {
+        return NodeStatusJob.class;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaDeletionService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaDeletionService.java
@@ -23,6 +23,7 @@ import com.sequenceiq.freeipa.entity.ChildEnvironment;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.flow.stack.termination.StackTerminationState;
 import com.sequenceiq.freeipa.flow.stack.termination.event.TerminationEvent;
+import com.sequenceiq.freeipa.nodestatus.NodeStatusJobService;
 import com.sequenceiq.freeipa.service.freeipa.flow.FreeIpaFlowManager;
 import com.sequenceiq.freeipa.sync.FreeipaJobService;
 
@@ -47,6 +48,9 @@ public class FreeIpaDeletionService {
     private FreeipaJobService freeipaJobService;
 
     @Inject
+    private NodeStatusJobService nodeStatusJobService;
+
+    @Inject
     private FlowLogService flowLogService;
 
     @Inject
@@ -65,6 +69,7 @@ public class FreeIpaDeletionService {
         MDCBuilder.buildMdcContext(stack);
         flowCancelService.cancelTooOldTerminationFlowForResource(stack.getId(), stack.getName());
         freeipaJobService.unschedule(stack);
+        nodeStatusJobService.unschedule(stack);
         if (!stack.isDeleteCompleted()) {
             handleIfStackIsNotTerminated(stack, forced);
         } else {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/FreeipaChecker.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/FreeipaChecker.java
@@ -7,27 +7,22 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
-import javax.ws.rs.core.Response;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Component;
 
-import com.cloudera.thunderhead.telemetry.nodestatus.NodeStatusProto;
-import com.sequenceiq.cloudbreak.client.RPCMessage;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.client.RPCResponse;
 import com.sequenceiq.freeipa.entity.InstanceMetaData;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.service.stack.FreeIpaInstanceHealthDetailsService;
-import com.sequenceiq.freeipa.service.stack.FreeIpaNodeStatusService;
 
 @Component
 public class FreeipaChecker {
@@ -36,9 +31,6 @@ public class FreeipaChecker {
 
     @Inject
     private FreeIpaInstanceHealthDetailsService freeIpaInstanceHealthDetailsService;
-
-    @Inject
-    private FreeIpaNodeStatusService freeIpaNodeStatusService;
 
     private Pair<Map<InstanceMetaData, DetailedStackStatus>, String> checkStatus(Stack stack, Set<InstanceMetaData> checkableInstances) throws Exception {
         return checkedMeasure(() -> {
@@ -79,7 +71,6 @@ public class FreeipaChecker {
             Set<InstanceMetaData> notTermiatedStackInstances = stack.getAllInstanceMetaDataList().stream()
                     .filter(Predicate.not(InstanceMetaData::isTerminated))
                     .collect(Collectors.toSet());
-            checkNodeHealthReports(stack, checkableInstances);
             Pair<Map<InstanceMetaData, DetailedStackStatus>, String> statusCheckPair = checkStatus(stack, checkableInstances);
             List<DetailedStackStatus> responses = new ArrayList<>(statusCheckPair.getFirst().values());
             DetailedStackStatus status;
@@ -94,48 +85,6 @@ public class FreeipaChecker {
             LOGGER.info("Error occurred during status fetch: " + e.getMessage(), e);
             return new SyncResult("FreeIpa is unreachable, because error occurred: " + e.getMessage(), DetailedStackStatus.UNREACHABLE, null);
         }
-    }
-
-    private void checkNodeHealthReports(Stack stack, Set<InstanceMetaData> checkableInstances) {
-        for (InstanceMetaData instanceMetaData : checkableInstances) {
-            try {
-                LOGGER.debug("Fetching node health reports for instance: {}", instanceMetaData.getInstanceId());
-                RPCResponse<NodeStatusProto.NodeStatusReport> networkReportRPCResponse = checkedMeasure(
-                        () -> freeIpaNodeStatusService.nodeNetworkReport(stack, instanceMetaData), LOGGER,
-                        ":::Auto sync::: FreeIPA network report ran in {}ms");
-                logReportResult(instanceMetaData, networkReportRPCResponse, "network");
-                RPCResponse<NodeStatusProto.NodeStatusReport> servicesReportRPCResponse = checkedMeasure(
-                        () -> freeIpaNodeStatusService.nodeServicesReport(stack, instanceMetaData), LOGGER,
-                        ":::Auto sync::: FreeIPA services report ran in {}ms");
-                logReportResult(instanceMetaData, servicesReportRPCResponse, "services");
-                RPCResponse<NodeStatusProto.NodeStatusReport> systemMetricsReportRPCResponse = checkedMeasure(
-                        () -> freeIpaNodeStatusService.nodeSystemMetricsReport(stack, instanceMetaData), LOGGER,
-                        ":::Auto sync::: FreeIPA system metrics report ran in {}ms");
-                logReportResult(instanceMetaData, systemMetricsReportRPCResponse, "system metrics");
-            } catch (Exception e) {
-                LOGGER.info("FreeIpaClientException occurred during status fetch: " + e.getMessage(), e);
-            }
-        }
-    }
-
-    private void logReportResult(InstanceMetaData instanceMetaData, RPCResponse<NodeStatusProto.NodeStatusReport> nodeStatusRpcResponse, String reportType) {
-        if (isSuccessfulRequest(nodeStatusRpcResponse)) {
-            LOGGER.info("FreeIPA " + reportType + " reports for instance: [{}], report: [{}]",
-                    instanceMetaData.getInstanceId(), nodeStatusRpcResponse.getFirstTextMessage());
-        } else {
-            LOGGER.info("Failed to get " + reportType + " reports for instance: [{}], reason: [{}]", instanceMetaData.getInstanceId(),
-                    nodeStatusRpcResponse.getSummary());
-        }
-    }
-
-    private Boolean isSuccessfulRequest(RPCResponse<NodeStatusProto.NodeStatusReport> response) {
-        return response.getMessages().stream()
-                .map(RPCMessage::getCode)
-                .filter(Objects::nonNull)
-                .map(Response.Status.Family::familyOf)
-                .map(f -> f.equals(Response.Status.Family.SUCCESSFUL))
-                .reduce(Boolean::logicalAnd)
-                .orElse(Boolean.FALSE);
     }
 
     private boolean areAllStatusTheSame(List<DetailedStackStatus> response) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/FreeipaJobService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/FreeipaJobService.java
@@ -2,8 +2,6 @@ package com.sequenceiq.freeipa.sync;
 
 import javax.inject.Inject;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.quartz.model.JobResource;
@@ -12,8 +10,6 @@ import com.sequenceiq.cloudbreak.quartz.statuschecker.service.StatusCheckerJobSe
 
 @Component
 public class FreeipaJobService {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(FreeipaJobService.class);
 
     @Inject
     private AutoSyncConfig autoSyncConfig;

--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -126,6 +126,8 @@ freeipa:
     connectionTimeoutMs: 5000
     readTimeoutMs: 5000
   nodestatus:
+    enabled: true
+    intervalsec: 1800
     connectionTimeoutMs: 5000
     readTimeoutMs: 5000
   batch:

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaDeletionServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaDeletionServiceTest.java
@@ -39,6 +39,7 @@ import com.sequenceiq.freeipa.entity.StackStatus;
 import com.sequenceiq.freeipa.flow.stack.termination.StackTerminationFlowConfig;
 import com.sequenceiq.freeipa.flow.stack.termination.StackTerminationState;
 import com.sequenceiq.freeipa.flow.stack.termination.event.TerminationEvent;
+import com.sequenceiq.freeipa.nodestatus.NodeStatusJobService;
 import com.sequenceiq.freeipa.service.freeipa.flow.FreeIpaFlowManager;
 import com.sequenceiq.freeipa.sync.FreeipaJobService;
 
@@ -67,6 +68,9 @@ class FreeIpaDeletionServiceTest {
 
     @Mock
     private FreeipaJobService freeipaJobService;
+
+    @Mock
+    private NodeStatusJobService nodeStatusJobService;
 
     @Mock
     private FlowCancelService flowCancelService;
@@ -101,6 +105,7 @@ class FreeIpaDeletionServiceTest {
         verify(flowManager, times(1)).notify(eq(TERMINATION_EVENT.event()), terminationEventArgumentCaptor.capture());
         verify(flowCancelService).cancelTooOldTerminationFlowForResource(stack.getId(), stack.getName());
         verify(freeipaJobService).unschedule(stack);
+        verify(nodeStatusJobService).unschedule(stack);
 
         assertAll(
                 () -> assertEquals(TERMINATION_EVENT.event(), terminationEventArgumentCaptor.getValue().selector()),

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeipaCheckerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeipaCheckerTest.java
@@ -17,7 +17,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.cloudera.thunderhead.telemetry.nodestatus.NodeStatusProto;
 import com.sequenceiq.cloudbreak.client.RPCMessage;
 import com.sequenceiq.cloudbreak.client.RPCResponse;
 import com.sequenceiq.freeipa.client.FreeIpaClientException;
@@ -32,9 +31,6 @@ public class FreeipaCheckerTest {
 
     @InjectMocks
     private FreeipaChecker underTest;
-
-    @Mock
-    private FreeIpaNodeStatusService freeIpaNodeStatusService;
 
     @Mock
     private FreeIpaInstanceHealthDetailsService freeIpaInstanceHealthDetailsService;
@@ -52,24 +48,10 @@ public class FreeipaCheckerTest {
         Set<InstanceMetaData> instanceMetaDataSet = createInstanceMetaDataSet();
         given(freeIpaInstanceHealthDetailsService.checkFreeIpaHealth(any(), any()))
                 .willReturn(createHealthResponse());
-        given(freeIpaNodeStatusService.nodeNetworkReport(any(), any()))
-                .willReturn(createNodeStatusResponse());
-        given(freeIpaNodeStatusService.nodeServicesReport(any(), any()))
-                .willReturn(createNodeStatusResponse());
         // WHEN
         underTest.getStatus(stack, instanceMetaDataSet);
         // THEN
         verify(freeIpaInstanceHealthDetailsService, times(2)).checkFreeIpaHealth(any(), any());
-        verify(freeIpaNodeStatusService, times(2)).nodeNetworkReport(any(), any());
-        verify(freeIpaNodeStatusService, times(2)).nodeServicesReport(any(), any());
-    }
-
-    private RPCResponse<NodeStatusProto.NodeStatusReport> createNodeStatusResponse() {
-        RPCResponse<NodeStatusProto.NodeStatusReport> rpcResponse = new RPCResponse<>();
-        NodeStatusProto.NodeStatusReport report = NodeStatusProto.NodeStatusReport.newBuilder().build();
-        rpcResponse.setResult(report);
-        rpcResponse.setMessages(createRpcMessage());
-        return rpcResponse;
     }
 
     private RPCResponse<Boolean> createHealthResponse() {

--- a/node-status-monitor-client/src/main/java/com/sequenceiq/node/health/client/model/CdpNodeStatusRequest.java
+++ b/node-status-monitor-client/src/main/java/com/sequenceiq/node/health/client/model/CdpNodeStatusRequest.java
@@ -2,6 +2,8 @@ package com.sequenceiq.node.health.client.model;
 
 public class CdpNodeStatusRequest {
 
+    private final boolean skipObjectMapping;
+
     private final boolean metering;
 
     private final boolean cmMonitoring;
@@ -9,6 +11,7 @@ public class CdpNodeStatusRequest {
     public CdpNodeStatusRequest(Builder builder) {
         this.metering = builder.metering;
         this.cmMonitoring = builder.cmMonitoring;
+        this.skipObjectMapping = builder.skipObjectMapping;
     }
 
     public boolean isMetering() {
@@ -19,11 +22,17 @@ public class CdpNodeStatusRequest {
         return cmMonitoring;
     }
 
+    public boolean isSkipObjectMapping() {
+        return skipObjectMapping;
+    }
+
     public static class Builder {
 
         private boolean metering;
 
         private boolean cmMonitoring;
+
+        private boolean skipObjectMapping;
 
         private Builder() {
         }
@@ -43,6 +52,11 @@ public class CdpNodeStatusRequest {
 
         public Builder withCmMonitoring(boolean cmMonitoring) {
             this.cmMonitoring = cmMonitoring;
+            return this;
+        }
+
+        public Builder withSkipObjectMapping(boolean skipObjectMapping) {
+            this.skipObjectMapping = skipObjectMapping;
             return this;
         }
 


### PR DESCRIPTION
details:
- remove node status check from health check
- create new node status check job
- increase frequency from 2 min to 30 min
- do not map parsed string (json) to grpc object (no need for that anymore as metrics-consumer won't be used, we will have a different monitoring design)
- use (open/close) only 1 socket for multiple node status related http calls instead of n sockets for n calls

See detailed description in the commit message.