### PR TITLE
CB-16678: Create refresh DataHub endpoint 

### DIFF
--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxEndpoint.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxEndpoint.java
@@ -122,6 +122,12 @@ public interface SdxEndpoint {
     @ApiOperation(value = "Re-size SDX cluster", produces = "application/json", nickname = "resizeSdx")
     SdxClusterResponse resize(@PathParam("name") String name, @Valid SdxClusterResizeRequest resizeSdxClusterRequest);
 
+    @POST
+    @Path("{datalakeName}/refresh")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Restart and reload all configurations of the data hub by name", produces = "applicaton/json", nickname = "refreshDatahubs")
+    SdxClusterResponse refreshDataHubs(@PathParam("datalakeName") String name, @QueryParam("datahubName") String datahubName);
+
     @DELETE
     @Path("/crn/{clusterCrn}")
     @Produces(MediaType.APPLICATION_JSON)

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
@@ -165,6 +165,13 @@ public class SdxController implements SdxEndpoint {
     }
 
     @Override
+    @CheckPermissionByResourceName(action = AuthorizationResourceAction.RESIZE_DATALAKE)
+    public SdxClusterResponse refreshDataHubs(@ResourceName String name, String datahubName) {
+        SdxCluster sdxCluster = sdxService.refreshDataHub(name, datahubName);
+        return sdxClusterConverter.sdxClusterToResponse(sdxCluster);
+    }
+
+    @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.CREATE_ENVIRONMENT)
     @CheckPermissionByRequestProperty(path = "credentialCrn", type = CRN, action = DESCRIBE_CREDENTIAL)
     public ObjectStorageValidateResponse validateCloudStorage(@ValidStackNameFormat @ValidStackNameLength String clusterName,

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/refresh/event/DatahubRefreshStartEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/refresh/event/DatahubRefreshStartEvent.java
@@ -4,6 +4,7 @@ import com.sequenceiq.datalake.flow.SdxEvent;
 import com.sequenceiq.datalake.flow.refresh.DatahubRefreshFlowEvent;
 
 public class DatahubRefreshStartEvent extends SdxEvent {
+
     public DatahubRefreshStartEvent(Long sdxId, String sdxName, String userId) {
         super(DatahubRefreshFlowEvent.DATAHUB_REFRESH_START_EVENT.event(), sdxId, sdxName, userId);
     }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/DistroxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/DistroxService.java
@@ -34,11 +34,6 @@ public class DistroxService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DistroxService.class);
 
-    private enum Type {
-        STOP,
-        START
-    }
-
     @Value("${dl.dh.polling.attempt:360}")
     private Integer attempt;
 
@@ -82,6 +77,10 @@ public class DistroxService {
                     .waitPeriodly(sleeptime, TimeUnit.SECONDS)
                     .run(checkDistroxStatus(pollingCrnList, Type.START, this::stackAndClusterStarted));
         }
+    }
+
+    public void restartDistroxByCrns(List<String> crns) {
+        distroXV1Endpoint.restartClusterServicesByCrns(crns);
     }
 
     public void stopAttachedDistrox(String envCrn) {
@@ -170,5 +169,10 @@ public class DistroxService {
                 && cluster != null
                 && cluster.getStatus() != null
                 && cluster.getStatus().isAvailable();
+    }
+
+    private enum Type {
+        STOP,
+        START
     }
 }


### PR DESCRIPTION
JIRA: https://jira.cloudera.com/browse/CB-16678

Refresh DataHub endpoint created. The endpoint can handle specific dataHub by name. If the data hub name is not provided, the API will refresh all datahubs. 

Tested:
DataHub refresh endpoint
DataLake resize flow.

All local tests passed.