### PR TITLE
CB-16897: Removed flow log use from resize recovery validation.

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/detach/SdxDetachActions.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/detach/SdxDetachActions.java
@@ -301,8 +301,11 @@ public class SdxDetachActions {
                 Exception exception = payload.getException();
                 LOGGER.error("Detaching SDX cluster with ID {} and name {} failed with error {}.",
                         payload.getResourceId(), payload.getSdxName(), exception.getMessage(), exception);
-                String statusReason = Optional.ofNullable(exception.getMessage()).orElse("SDX detach failed");
-                sdxStatusService.setStatusForDatalakeAndNotify(DatalakeStatusEnum.STOPPED, statusReason, payload.getResourceId());
+                String statusReason = Optional.ofNullable(exception.getMessage()).orElse("unknown error");
+                sdxStatusService.setStatusForDatalakeAndNotify(
+                        DatalakeStatusEnum.STOPPED,
+                        "SDX detach failed due to: " + statusReason, payload.getResourceId()
+                );
                 getFlow(context.getFlowParameters().getFlowId()).setFlowFailed(payload.getException());
                 sendEvent(context, SDX_DETACH_FAILED_HANDLED_EVENT.event(), payload);
             }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/resize/recovery/ResizeRecoveryService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/resize/recovery/ResizeRecoveryService.java
@@ -1,6 +1,11 @@
 package com.sequenceiq.datalake.service.resize.recovery;
 
 import static com.sequenceiq.cloudbreak.common.exception.NotFoundException.notFound;
+import static com.sequenceiq.datalake.entity.DatalakeStatusEnum.DELETE_FAILED;
+import static com.sequenceiq.datalake.entity.DatalakeStatusEnum.PROVISIONING_FAILED;
+import static com.sequenceiq.datalake.entity.DatalakeStatusEnum.RUNNING;
+import static com.sequenceiq.datalake.entity.DatalakeStatusEnum.STOPPED;
+import static com.sequenceiq.datalake.entity.DatalakeStatusEnum.STOP_FAILED;
 
 import java.util.Optional;
 
@@ -15,16 +20,13 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.recovery.Recove
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.datalake.entity.DatalakeStatusEnum;
 import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.entity.SdxStatusEntity;
 import com.sequenceiq.datalake.flow.SdxReactorFlowManager;
-import com.sequenceiq.datalake.flow.chain.DatalakeResizeFlowEventChainFactory;
 import com.sequenceiq.datalake.repository.SdxClusterRepository;
 import com.sequenceiq.datalake.service.recovery.RecoveryService;
 import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
-import com.sequenceiq.flow.core.Flow2Handler;
-import com.sequenceiq.flow.domain.FlowLog;
-import com.sequenceiq.flow.service.flowlog.FlowChainLogService;
 import com.sequenceiq.sdx.api.model.SdxRecoverableResponse;
 import com.sequenceiq.sdx.api.model.SdxRecoveryRequest;
 import com.sequenceiq.sdx.api.model.SdxRecoveryResponse;
@@ -51,51 +53,21 @@ public class ResizeRecoveryService implements RecoveryService {
     private SdxReactorFlowManager sdxReactorFlowManager;
 
     @Inject
-    private Flow2Handler flow2Handler;
-
-    @Inject
-    private FlowChainLogService flowChainLogService;
-
-    @Inject
     private SdxClusterRepository sdxClusterRepository;
 
     @Override
     public SdxRecoverableResponse validateRecovery(SdxCluster sdxCluster, SdxRecoveryRequest request) {
-        Optional<FlowLog> flowLogOptional = flow2Handler.getFirstStateLogfromLatestFlow(sdxCluster.getId());
-        if (flowLogOptional.isEmpty()) {
-            return new SdxRecoverableResponse("No recent actions on this cluster", RecoveryStatus.NON_RECOVERABLE);
-        }
-        if (entitlementService.isDatalakeResizeRecoveryEnabled(ThreadBasedUserCrnProvider.getAccountId())) {
-            if (!DatalakeResizeFlowEventChainFactory.class.getSimpleName()
-                    .equals(flowChainLogService.getFlowChainType(flowLogOptional.get().getFlowChainId()))) {
-                return new SdxRecoverableResponse("No recent resize operation", RecoveryStatus.NON_RECOVERABLE);
-            }
-        } else {
+        if (!entitlementService.isDatalakeResizeRecoveryEnabled(ThreadBasedUserCrnProvider.getAccountId())) {
             return new SdxRecoverableResponse("Resize Recovery entitlement not enabled", RecoveryStatus.NON_RECOVERABLE);
         }
         SdxStatusEntity actualStatusForSdx = sdxStatusService.getActualStatusForSdx(sdxCluster);
-        switch (actualStatusForSdx.getStatus()) {
-            case STOP_FAILED:
-                return new SdxRecoverableResponse("Resize can be recovered from a failed stop", RecoveryStatus.RECOVERABLE);
-            case STOPPED:
-                return new SdxRecoverableResponse("Resize can recover cluster", RecoveryStatus.RECOVERABLE);
-            case PROVISIONING_FAILED:
-                return new SdxRecoverableResponse("Failed to provision, recovery will restart original data lake, and delete the new one",
-                        RecoveryStatus.RECOVERABLE);
-            case DELETE_FAILED:
-                return new SdxRecoverableResponse("Failed to delete original data lake, not a recoverable error", RecoveryStatus.NON_RECOVERABLE);
-            case RUNNING:
-                if (actualStatusForSdx.getStatusReason().contains("Datalake restore failed")) {
-                    return new SdxRecoverableResponse(
-                            "Failed to restore backup to new data lake, recovery will restart original data lake, and delete the new one",
-                            RecoveryStatus.RECOVERABLE
-                    );
-                } else {
-                    return new SdxRecoverableResponse("Datalake is running, resize can not be recovered from this point", RecoveryStatus.NON_RECOVERABLE);
-                }
-            default:
-                return new SdxRecoverableResponse("Resize can not be recovered from this point", RecoveryStatus.NON_RECOVERABLE);
+        DatalakeStatusEnum status = actualStatusForSdx.getStatus();
+        String statusReason = actualStatusForSdx.getStatusReason();
+
+        if (getOldCluster(sdxCluster).isPresent()) {
+            return validateRecoveryResizedClusterPresent(sdxCluster, status, statusReason);
         }
+        return validateRecoveryOnlyOriginalCluster(sdxCluster, status, statusReason);
     }
 
     @Override
@@ -117,10 +89,10 @@ public class ResizeRecoveryService implements RecoveryService {
                         return new SdxRecoveryResponse(sdxReactorFlowManager.triggerSdxStartFlow(sdxCluster));
                     }
                 case PROVISIONING_FAILED:
-                    return new SdxRecoveryResponse(sdxReactorFlowManager.triggerSdxResizeRecovery(getOldCluster(sdxCluster), sdxCluster));
+                    return new SdxRecoveryResponse(sdxReactorFlowManager.triggerSdxResizeRecovery(getOldClusterErrorIfNotFound(sdxCluster), sdxCluster));
                 case RUNNING:
                     if (actualStatusForSdx.getStatusReason().contains("Datalake restore failed")) {
-                        return new SdxRecoveryResponse(sdxReactorFlowManager.triggerSdxResizeRecovery(getOldCluster(sdxCluster), sdxCluster));
+                        return new SdxRecoveryResponse(sdxReactorFlowManager.triggerSdxResizeRecovery(getOldClusterErrorIfNotFound(sdxCluster), sdxCluster));
                     } else {
                         throw new NotImplementedException("Cluster is currently running and cannot be recovered");
                     }
@@ -132,12 +104,60 @@ public class ResizeRecoveryService implements RecoveryService {
         }
     }
 
-    private SdxCluster getOldCluster(SdxCluster newCluster) {
-        return sdxClusterRepository.findByAccountIdAndEnvCrnAndDeletedIsNullAndDetachedIsTrue(
-                newCluster.getAccountId(), newCluster.getEnvCrn()
-        ).orElseThrow(notFound(
+    private SdxCluster getOldClusterErrorIfNotFound(SdxCluster newCluster) {
+        return getOldCluster(newCluster).orElseThrow(notFound(
                 "detached SDX cluster",
                 "Env CRN: " + newCluster.getEnvCrn() + ", Account ID: " + newCluster.getAccountId()
         ));
+    }
+
+    private Optional<SdxCluster> getOldCluster(SdxCluster newCluster) {
+        Optional<SdxCluster> oldCluster = sdxClusterRepository.findByAccountIdAndEnvCrnAndDeletedIsNullAndDetachedIsTrue(
+                newCluster.getAccountId(), newCluster.getEnvCrn()
+        );
+        return (oldCluster.isPresent() && !oldCluster.get().getClusterName().equals(newCluster.getClusterName())) ?
+                oldCluster : Optional.empty();
+    }
+
+    private String getReasonNonRecoverable(DatalakeStatusEnum status) {
+        String reason = "";
+        if (RUNNING.equals(status)) {
+            reason = "Datalake is running, resize can not be recovered from this point";
+        } else if (DELETE_FAILED.equals(status)) {
+            reason = "Failed to delete original data lake, not a recoverable error";
+        }
+        return reason.isEmpty() ? reason : (": " + reason);
+    }
+
+    private SdxRecoverableResponse validateRecoveryResizedClusterPresent(SdxCluster sdxCluster, DatalakeStatusEnum status, String statusReason) {
+        if (PROVISIONING_FAILED.equals(status)) {
+            return new SdxRecoverableResponse("Failed to provision, recovery will restart original data lake, and delete the new one",
+                    RecoveryStatus.RECOVERABLE);
+        } else if (RUNNING.equals(status) && statusReason.contains("Datalake restore failed")) {
+            return new SdxRecoverableResponse(
+                    "Failed to restore backup to new data lake, recovery will restart original data lake, and delete the new one",
+                    RecoveryStatus.RECOVERABLE
+            );
+        }
+        return new SdxRecoverableResponse(
+                "Resize can not be recovered from this point" + getReasonNonRecoverable(status),
+                RecoveryStatus.NON_RECOVERABLE
+        );
+    }
+
+    private SdxRecoverableResponse validateRecoveryOnlyOriginalCluster(SdxCluster sdxCluster, DatalakeStatusEnum status, String statusReason) {
+        if (STOPPED.equals(status)) {
+            if (sdxCluster.isDetached()) {
+                return new SdxRecoverableResponse("Resize can recover detached cluster", RecoveryStatus.RECOVERABLE);
+            } else if (statusReason.contains("SDX detach failed")) {
+                return new SdxRecoverableResponse("Resize can recover stopped cluster", RecoveryStatus.RECOVERABLE);
+            }
+        } else if (STOP_FAILED.equals(status) && statusReason.contains("Datalake resize failure")) {
+            return new SdxRecoverableResponse("Resize can be recovered from a failed stop", RecoveryStatus.RECOVERABLE);
+        }
+        return new SdxRecoverableResponse(
+                "Resize can not be recovered from this point" + getReasonNonRecoverable(status),
+                RecoveryStatus.NON_RECOVERABLE
+        );
     }
 }


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-16897

Objective of this change was to remove the use of flow logs for resize recovery validation since flow logs are not permanent.

This consisted of the following changes:

- Remove flow log usage from resize recovery validation
- Add validation for each status using existing knowledge:
     - `PROVISIONING_FAILED` just checks if a _detached_ DL exists for the environment
     - Restore failure also checks for a _detached_ DL
     - DL stuck in detached state just checks if currently in `STOPPED` state and if current DL is detached
     - DL in `STOPPED` state due to detach failure checks if **new** detach-related status reason is present
     - DL in `STOP_FAILED` state checks if **new** resize-related status reason is present

I still need to test everything and deal with the cyclomatic complexity issue but wanted some members of my team to go ahead and take a look.