### PR TITLE
CB-17040 Add ssm Permissions to Default Cross-Account Policy

### DIFF
--- a/cloud-aws-common/src/main/resources/definitions/aws-cb-policy.json
+++ b/cloud-aws-common/src/main/resources/definitions/aws-cb-policy.json
@@ -271,6 +271,20 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Sid": "AllowSsmParams",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:DescribeParameters",
+        "ssm:GetParameter",
+        "ssm:GetParameters",
+        "ssm:GetParameterHistory",
+        "ssm:GetParametersByPath"
+      ],
+      "Resource": [
+        "arn:aws:ssm:*:*:parameter/aws/service/eks/optimized-ami/*"
+      ]
     }
   ],
   "Version": "2012-10-17"


### PR DESCRIPTION
https://jira.cloudera.com/browse/CB-17040

Adding ssm Permissions required when creating Kubernetes clusters that utilize SSM Parameters instead of explicit AMI.