### PR TITLE
CB-17085: The image in InstanceMetadata is overwritten after the runtime upgrade

### DIFF
--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/MetadataSetupServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/MetadataSetupServiceTest.java
@@ -15,6 +15,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -52,6 +53,7 @@ import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.service.Clock;
 import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
@@ -215,6 +217,38 @@ public class MetadataSetupServiceTest {
     }
 
     @Test
+    public void saveInstanceMetaDataTestExistingAvailableInstance() {
+        Stack stack = new Stack();
+        stack.setId(STACK_ID);
+        InstanceGroup instanceGroup = new InstanceGroup();
+        instanceGroup.setId(INSTANCE_GROUP_ID);
+        instanceGroup.setGroupName(GROUP_NAME);
+        Set<InstanceGroup> instanceGroupSet = new TreeSet<>();
+        instanceGroupSet.add(instanceGroup);
+        when(instanceGroupService.findByStackId(STACK_ID)).thenReturn(instanceGroupSet);
+        when(clock.getCurrentTimeMillis()).thenReturn(CURRENT_TIME);
+        Iterable<CloudVmMetaDataStatus> cloudVmMetaDataStatuses = getCloudVmMetaDataStatuses(InstanceStatus.CREATED);
+
+        Json image = new Json(getEmptyImage());
+        InstanceMetaData pgwInstanceMetadata = new InstanceMetaData();
+        pgwInstanceMetadata.setInstanceMetadataType(GATEWAY_PRIMARY);
+        pgwInstanceMetadata.setImage(image);
+        pgwInstanceMetadata.setPrivateId(PRIVATE_ID);
+        when(instanceMetaDataService.findNotTerminatedForStack(1L)).thenReturn(Set.of(pgwInstanceMetadata));
+
+        int newInstances = underTest.saveInstanceMetaData(stack, cloudVmMetaDataStatuses, CREATED);
+
+        assertEquals(1, newInstances);
+        verifyNoInteractions(imageService);
+        verify(instanceMetaDataService).save(instanceMetaDataCaptor.capture());
+        InstanceMetaData instanceMetaData = instanceMetaDataCaptor.getValue();
+        assertThat(instanceMetaData.getInstanceGroup()).isSameAs(instanceGroup);
+        assertEquals(CREATED, instanceMetaData.getInstanceStatus());
+        assertNotNull(instanceMetaData.getImage());
+        assertEquals(image, instanceMetaData.getImage());
+    }
+
+    @Test
     public void saveLoadBalancerMetadata() {
         Stack stack = new Stack();
         stack.setId(STACK_ID);
@@ -324,12 +358,9 @@ public class MetadataSetupServiceTest {
     }
 
     @Test
-    public void saveInstanceMetaDataTestOneTerminatedInstance()
-            throws CloudbreakImageNotFoundException {
+    public void saveInstanceMetaDataTestOneTerminatedInstance() {
         Stack stack = new Stack();
         stack.setId(STACK_ID);
-        Image image = getEmptyImage();
-        when(imageService.getImage(STACK_ID)).thenReturn(image);
         InstanceGroup instanceGroup = new InstanceGroup();
         instanceGroup.setId(INSTANCE_GROUP_ID);
         instanceGroup.setGroupName(GROUP_NAME);
@@ -346,7 +377,7 @@ public class MetadataSetupServiceTest {
         int newInstances = underTest.saveInstanceMetaData(stack, cloudVmMetaDataStatuses, SERVICES_RUNNING);
 
         assertEquals(0, newInstances);
-        verify(imageService).getImage(STACK_ID);
+        verifyNoInteractions(imageService);
         verify(instanceMetaDataService).save(instanceMetaDataCaptor.capture());
         InstanceMetaData instanceMetaData = instanceMetaDataCaptor.getValue();
         assertThat(instanceMetaData.getInstanceGroup()).isSameAs(instanceGroup);
@@ -357,12 +388,9 @@ public class MetadataSetupServiceTest {
     }
 
     @Test
-    public void saveInstanceMetaDataTestOneZombieInstance()
-            throws CloudbreakImageNotFoundException {
+    public void saveInstanceMetaDataTestOneZombieInstance() {
         Stack stack = new Stack();
         stack.setId(STACK_ID);
-        Image image = getEmptyImage();
-        when(imageService.getImage(STACK_ID)).thenReturn(image);
         InstanceGroup instanceGroup = new InstanceGroup();
         instanceGroup.setId(INSTANCE_GROUP_ID);
         instanceGroup.setGroupName(GROUP_NAME);
@@ -382,7 +410,7 @@ public class MetadataSetupServiceTest {
         int newInstances = underTest.saveInstanceMetaData(stack, cloudVmMetaDataStatuses, SERVICES_RUNNING);
 
         assertEquals(1, newInstances);
-        verify(imageService).getImage(STACK_ID);
+        verifyNoInteractions(imageService);
         verify(instanceMetaDataService).save(instanceMetaDataCaptor.capture());
         InstanceMetaData instanceMetaData = instanceMetaDataCaptor.getValue();
         assertThat(instanceMetaData.getInstanceGroup()).isSameAs(instanceGroup);


### PR DESCRIPTION
After the runtime upgrade the instances are running with the old image.
While we're not performing a repair or an OS upgrade the image can be overwritten to the new image by a stop-start or an upscale flow.
This can cause that the cluster is still running with the old instances and we're not offering the OS upgrade.