### PR TITLE
CB-17116. Recipes not uploaded during upscale if non-gateway node is …

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterUpscaleService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterUpscaleService.java
@@ -56,14 +56,6 @@ public class ClusterUpscaleService {
     @Inject
     private ParcelService parcelService;
 
-    public void uploadRecipesOnNewHosts(Long stackId, Set<String> hostGroupNames) throws CloudbreakException {
-        Stack stack = stackService.getByIdWithListsInTransaction(stackId);
-        LOGGER.debug("Start executing pre recipes");
-        Set<HostGroup> hostGroups = hostGroupService.getByClusterWithRecipes(stack.getCluster().getId());
-        Set<HostGroup> targetHostGroups = hostGroups.stream().filter(hostGroup -> hostGroupNames.contains(hostGroup.getName())).collect(Collectors.toSet());
-        recipeEngine.uploadUpscaleRecipes(stack, targetHostGroups, hostGroups);
-    }
-
     public void installServicesOnNewHosts(Long stackId, Set<String> hostGroupNames, Boolean repair, Boolean restartServices,
             Map<String, Set<String>> hostGroupsWithHostNames) throws CloudbreakException {
         Stack stack = stackService.getByIdWithClusterInTransaction(stackId);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/recipe/UploadRepairSingleMasterRecipesHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/recipe/UploadRepairSingleMasterRecipesHandler.java
@@ -5,7 +5,6 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.core.cluster.ClusterUpscaleService;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.cloudbreak.reactor.api.event.recipe.UploadRepairSingleMasterRecipesRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.recipe.UploadRepairSingleMasterRecipesResult;
@@ -20,9 +19,6 @@ public class UploadRepairSingleMasterRecipesHandler implements EventHandler<Uplo
     @Inject
     private EventBus eventBus;
 
-    @Inject
-    private ClusterUpscaleService clusterUpscaleService;
-
     @Override
     public String selector() {
         return EventSelectorUtil.selector(UploadRepairSingleMasterRecipesRequest.class);
@@ -33,7 +29,7 @@ public class UploadRepairSingleMasterRecipesHandler implements EventHandler<Uplo
         UploadRepairSingleMasterRecipesRequest request = event.getData();
         UploadRepairSingleMasterRecipesResult result;
         try {
-            clusterUpscaleService.uploadRecipesOnNewHosts(request.getResourceId(), request.getHostGroupNames());
+            // TODO: because of CB-17116 - step removed - cleanup the code
             result = new UploadRepairSingleMasterRecipesResult(request);
         } catch (Exception e) {
             result = new UploadRepairSingleMasterRecipesResult(e.getMessage(), e, request);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/recipe/UploadUpscaleRecipesHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/recipe/UploadUpscaleRecipesHandler.java
@@ -4,7 +4,6 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.core.cluster.ClusterUpscaleService;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.cloudbreak.reactor.api.event.recipe.UploadUpscaleRecipesRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.recipe.UploadUpscaleRecipesResult;
@@ -19,9 +18,6 @@ public class UploadUpscaleRecipesHandler implements EventHandler<UploadUpscaleRe
     @Inject
     private EventBus eventBus;
 
-    @Inject
-    private ClusterUpscaleService clusterUpscaleService;
-
     @Override
     public String selector() {
         return EventSelectorUtil.selector(UploadUpscaleRecipesRequest.class);
@@ -32,7 +28,7 @@ public class UploadUpscaleRecipesHandler implements EventHandler<UploadUpscaleRe
         UploadUpscaleRecipesRequest request = event.getData();
         UploadUpscaleRecipesResult result;
         try {
-            clusterUpscaleService.uploadRecipesOnNewHosts(request.getResourceId(), request.getHostGroupNames());
+            // TODO: because of CB-17116 - step removed - cleanup the code
             result = new UploadUpscaleRecipesResult(request);
         } catch (Exception e) {
             result = new UploadUpscaleRecipesResult(e.getMessage(), e, request);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/recipe/UpdateRecipeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/recipe/UpdateRecipeService.java
@@ -192,13 +192,15 @@ public class UpdateRecipeService {
                             .filter(r -> !r.getName().equals(recipeName))
                             .collect(Collectors.toSet())
             );
-            Optional<GeneratedRecipe> generatedRecipeToDelete =
+            Optional<GeneratedRecipe> generatedRecipeToDetach =
                     hostGroup.getGeneratedRecipes().stream()
                             .filter(gr -> recipeNamesMatchForGeneratedRecipe(gr, Set.of(recipeName)))
                             .findFirst();
-            generatedRecipeToDelete.ifPresent(generatedRecipe -> hostGroup.getGeneratedRecipes().remove(generatedRecipe));
             hostGroupService.save(hostGroup);
-            generatedRecipeToDelete.ifPresent(generatedRecipe -> generatedRecipeService.deleteAll(Set.of(generatedRecipe)));
+            generatedRecipeToDetach.ifPresent(generatedRecipe -> {
+                generatedRecipe.setRecipe(null);
+                generatedRecipeService.save(generatedRecipe);
+            });
         } else {
             LOGGER.debug("Recipe {} already detached from host group {}. ", recipeName, hostGroupName);
         }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/flow/recipe/RecipeEngineTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/flow/recipe/RecipeEngineTest.java
@@ -78,28 +78,6 @@ public class RecipeEngineTest {
     }
 
     @Test
-    public void testUploadUpscaleRecipes() throws CloudbreakException {
-        // GIVEN
-        // WHEN
-        recipeEngine.uploadUpscaleRecipes(stack(), Set.of(masterHostGroup()), hostGroups());
-        // THEN
-        verify(orchestratorRecipeExecutor, times(1)).uploadRecipes(any(Stack.class), anyMap());
-        verify(recipeTemplateService, times(1)).updateAllGeneratedRecipes(anySet(), anyMap());
-    }
-
-    @Test
-    public void testUploadUpscaleRecipesWithoutRecipe() throws CloudbreakException {
-        // GIVEN
-        HostGroup hostGroup = new HostGroup();
-        hostGroup.setName("worker");
-        // WHEN
-        recipeEngine.uploadUpscaleRecipes(stack(), Set.of(hostGroup), hostGroups());
-        // THEN
-        verify(orchestratorRecipeExecutor, times(0)).uploadRecipes(any(Stack.class), anyMap());
-        verify(recipeTemplateService, times(0)).updateAllGeneratedRecipes(anySet(), anyMap());
-    }
-
-    @Test
     public void testExecutePreTerminationRecipes() throws CloudbreakException {
         // GIVEN
         given(hostGroupService.getRecipesByHostGroups(anySet())).willReturn(Set.of(recipe()));

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/recipe/UpdateRecipeServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/recipe/UpdateRecipeServiceTest.java
@@ -171,13 +171,13 @@ public class UpdateRecipeServiceTest {
         given(recipeService.getByNameForWorkspaceId(anyString(), anyLong()))
                 .willReturn(sampleRecipe);
         given(hostGroupService.save(any())).willReturn(sampleHostGroup);
-        doNothing().when(generatedRecipeService).deleteAll(anySet());
+        given(generatedRecipeService.save(any())).willReturn(new GeneratedRecipe());
         // WHEN
         underTest.detachRecipeFromCluster(DUMMY_ID, createStack(), POST_CLDR_START_RECIPE, MASTER_HOST_GROUP_NAME);
         // THEN
         verify(hostGroupService, times(1)).save(any());
         verify(hostGroupService, times(1)).getByClusterIdAndNameWithRecipes(anyLong(), anyString());
-        verify(generatedRecipeService, times(1)).deleteAll(anySet());
+        verify(generatedRecipeService, times(1)).save(any());
     }
 
     private List<UpdateHostGroupRecipes> createUpdateHostGroupRecipes(Map<String, Set<String>> hostGroupRecipesMap) {


### PR DESCRIPTION
…scaled and recipes has been updated.

details:
- remove update recipes call that is used during upscale (no need for that as we are doing that on every recipe operation)
- during detach -> as generated recipes are deleted, it can cause that recipes won't be updated on the hosts.

See detailed description in the commit message.