### PR TITLE
CB-17040 Add SSM permissions to CF cross-account policy

### DIFF
--- a/cloud-aws-cloudformation/src/main/resources/definitions/aws-cb-policy.json
+++ b/cloud-aws-cloudformation/src/main/resources/definitions/aws-cb-policy.json
@@ -271,6 +271,20 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Sid": "AllowSsmParams",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:DescribeParameters",
+        "ssm:GetParameter",
+        "ssm:GetParameters",
+        "ssm:GetParameterHistory",
+        "ssm:GetParametersByPath"
+      ],
+      "Resource": [
+        "arn:aws:ssm:*:*:parameter/aws/service/eks/optimized-ami/*"
+      ]
     }
   ],
   "Version": "2012-10-17"


### PR DESCRIPTION
Follow-up to #12759 / a18ec3661b5d85f172589d2f17c6f04e1465a8bd. Adds the same SSM permissions to the legacy CF-based policy as well for consistency.
