### PR TITLE
CB-17116 remove restartable logic (it is not the same as retryable!)

### DIFF
--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/flow/ConsumptionFlowInformation.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/flow/ConsumptionFlowInformation.java
@@ -11,11 +11,6 @@ import com.sequenceiq.flow.core.config.FlowConfiguration;
 public class ConsumptionFlowInformation implements ApplicationFlowInformation {
 
     @Override
-    public List<Class<? extends FlowConfiguration<?>>> getRestartableFlows() {
-        return List.of();
-    }
-
-    @Override
     public List<String> getAllowedParallelFlows() {
         return List.of();
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/CloudbreakFlowInformation.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/CloudbreakFlowInformation.java
@@ -9,39 +9,12 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.core.flow2.cluster.certrenew.ClusterCertificateRenewFlowConfig;
-import com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.PillarConfigUpdateFlowConfig;
-import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.dr.backup.DatabaseBackupFlowConfig;
-import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.dr.restore.DatabaseRestoreFlowConfig;
-import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.ClusterUpgradeFlowConfig;
-import com.sequenceiq.cloudbreak.core.flow2.cluster.downscale.ClusterDownscaleFlowConfig;
-import com.sequenceiq.cloudbreak.core.flow2.cluster.provision.ClusterCreationFlowConfig;
-import com.sequenceiq.cloudbreak.core.flow2.cluster.repair.master.ha.ChangePrimaryGatewayFlowConfig;
-import com.sequenceiq.cloudbreak.core.flow2.cluster.reset.ClusterResetFlowConfig;
-import com.sequenceiq.cloudbreak.core.flow2.cluster.start.ClusterStartFlowConfig;
-import com.sequenceiq.cloudbreak.core.flow2.cluster.stop.ClusterStopFlowConfig;
-import com.sequenceiq.cloudbreak.core.flow2.cluster.stopstartds.StopStartDownscaleFlowConfig;
-import com.sequenceiq.cloudbreak.core.flow2.cluster.stopstartus.StopStartUpscaleFlowConfig;
-import com.sequenceiq.cloudbreak.core.flow2.cluster.sync.ClusterSyncFlowConfig;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.termination.ClusterTerminationEvent;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.termination.ClusterTerminationFlowConfig;
-import com.sequenceiq.cloudbreak.core.flow2.cluster.upscale.ClusterUpscaleFlowConfig;
-import com.sequenceiq.cloudbreak.core.flow2.cluster.userpasswd.ClusterCredentialChangeFlowConfig;
-import com.sequenceiq.cloudbreak.core.flow2.externaldatabase.start.config.ExternalDatabaseStartFlowConfig;
-import com.sequenceiq.cloudbreak.core.flow2.externaldatabase.stop.config.ExternalDatabaseStopFlowConfig;
 import com.sequenceiq.cloudbreak.core.flow2.externaldatabase.terminate.config.ExternalDatabaseTerminationEvent;
 import com.sequenceiq.cloudbreak.core.flow2.externaldatabase.terminate.config.ExternalDatabaseTerminationFlowConfig;
-import com.sequenceiq.cloudbreak.core.flow2.stack.downscale.StackDownscaleConfig;
-import com.sequenceiq.cloudbreak.core.flow2.stack.instance.termination.InstanceTerminationFlowConfig;
-import com.sequenceiq.cloudbreak.core.flow2.stack.migration.AwsVariantMigrationFlowConfig;
-import com.sequenceiq.cloudbreak.core.flow2.stack.provision.StackCreationFlowConfig;
-import com.sequenceiq.cloudbreak.core.flow2.stack.repair.ManualStackRepairTriggerFlowConfig;
-import com.sequenceiq.cloudbreak.core.flow2.stack.start.StackStartFlowConfig;
-import com.sequenceiq.cloudbreak.core.flow2.stack.stop.StackStopFlowConfig;
-import com.sequenceiq.cloudbreak.core.flow2.stack.sync.StackSyncFlowConfig;
 import com.sequenceiq.cloudbreak.core.flow2.stack.termination.StackTerminationEvent;
 import com.sequenceiq.cloudbreak.core.flow2.stack.termination.StackTerminationFlowConfig;
-import com.sequenceiq.cloudbreak.core.flow2.stack.upscale.StackUpscaleConfig;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.StackStatus;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
@@ -58,30 +31,8 @@ public class CloudbreakFlowInformation implements ApplicationFlowInformation {
             StackTerminationEvent.TERMINATION_EVENT.event(),
             ClusterTerminationEvent.PROPER_TERMINATION_EVENT.event());
 
-    private static final List<Class<? extends FlowConfiguration<?>>> RESTARTABLE_FLOWS = Arrays.asList(
-            StackCreationFlowConfig.class,
-            StackSyncFlowConfig.class, StackTerminationFlowConfig.class, StackStopFlowConfig.class, StackStartFlowConfig.class,
-            ExternalDatabaseStartFlowConfig.class, ExternalDatabaseStopFlowConfig.class,
-            StackUpscaleConfig.class, StackDownscaleConfig.class,
-            InstanceTerminationFlowConfig.class,
-            ManualStackRepairTriggerFlowConfig.class,
-            ClusterCreationFlowConfig.class,
-            ClusterSyncFlowConfig.class, ClusterTerminationFlowConfig.class, ClusterCredentialChangeFlowConfig.class,
-            ClusterStartFlowConfig.class, ClusterStopFlowConfig.class,
-            ClusterUpscaleFlowConfig.class, ClusterDownscaleFlowConfig.class,
-            StopStartUpscaleFlowConfig.class, StopStartDownscaleFlowConfig.class,
-            ClusterUpgradeFlowConfig.class, ClusterResetFlowConfig.class, ChangePrimaryGatewayFlowConfig.class,
-            ClusterCertificateRenewFlowConfig.class, DatabaseBackupFlowConfig.class, DatabaseRestoreFlowConfig.class, PillarConfigUpdateFlowConfig.class,
-            AwsVariantMigrationFlowConfig.class
-    );
-
     @Inject
     private StackService stackService;
-
-    @Override
-    public List<Class<? extends FlowConfiguration<?>>> getRestartableFlows() {
-        return RESTARTABLE_FLOWS;
-    }
 
     @Override
     public List<String> getAllowedParallelFlows() {

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxFlowInformation.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxFlowInformation.java
@@ -2,7 +2,6 @@ package com.sequenceiq.datalake.flow;
 
 import static com.sequenceiq.datalake.flow.delete.SdxDeleteEvent.SDX_DELETE_EVENT;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -16,16 +15,7 @@ import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.datalake.entity.DatalakeStatusEnum;
 import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.entity.SdxStatusEntity;
-import com.sequenceiq.datalake.flow.create.SdxCreateFlowConfig;
-import com.sequenceiq.datalake.flow.datalake.recovery.DatalakeUpgradeRecoveryFlowConfig;
-import com.sequenceiq.datalake.flow.datalake.upgrade.DatalakeUpgradeFlowConfig;
 import com.sequenceiq.datalake.flow.delete.SdxDeleteFlowConfig;
-import com.sequenceiq.datalake.flow.dr.backup.DatalakeBackupFlowConfig;
-import com.sequenceiq.datalake.flow.dr.restore.DatalakeRestoreFlowConfig;
-import com.sequenceiq.datalake.flow.repair.SdxRepairFlowConfig;
-import com.sequenceiq.datalake.flow.start.SdxStartFlowConfig;
-import com.sequenceiq.datalake.flow.stop.SdxStopFlowConfig;
-import com.sequenceiq.datalake.flow.upgrade.ccm.UpgradeCcmFlowConfig;
 import com.sequenceiq.datalake.service.sdx.SdxService;
 import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
 import com.sequenceiq.flow.core.ApplicationFlowInformation;
@@ -37,18 +27,6 @@ public class SdxFlowInformation implements ApplicationFlowInformation {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SdxFlowInformation.class);
 
-    private static final List<Class<? extends FlowConfiguration<?>>> RESTARTABLE_FLOWS = Arrays.asList(
-            SdxCreateFlowConfig.class,
-            SdxDeleteFlowConfig.class,
-            SdxStartFlowConfig.class,
-            SdxStopFlowConfig.class,
-            SdxRepairFlowConfig.class,
-            DatalakeUpgradeFlowConfig.class,
-            DatalakeBackupFlowConfig.class,
-            DatalakeRestoreFlowConfig.class,
-            DatalakeUpgradeRecoveryFlowConfig.class,
-            UpgradeCcmFlowConfig.class);
-
     private static final List<String> ALLOWED_PARALLEL_FLOWS = Collections.singletonList(SDX_DELETE_EVENT.event());
 
     @Inject
@@ -56,11 +34,6 @@ public class SdxFlowInformation implements ApplicationFlowInformation {
 
     @Inject
     private SdxStatusService sdxStatusService;
-
-    @Override
-    public List<Class<? extends FlowConfiguration<?>>> getRestartableFlows() {
-        return RESTARTABLE_FLOWS;
-    }
 
     @Override
     public List<String> getAllowedParallelFlows() {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/EnvironmentFlowInformation.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/EnvironmentFlowInformation.java
@@ -7,29 +7,13 @@ import java.util.List;
 
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.environment.environment.flow.creation.config.EnvCreationFlowConfig;
 import com.sequenceiq.environment.environment.flow.deletion.config.EnvClustersDeleteFlowConfig;
 import com.sequenceiq.environment.environment.flow.deletion.config.EnvDeleteFlowConfig;
-import com.sequenceiq.environment.environment.flow.loadbalancer.config.LoadBalancerUpdateFlowConfig;
-import com.sequenceiq.environment.environment.flow.start.config.EnvStartFlowConfig;
-import com.sequenceiq.environment.environment.flow.stop.config.EnvStopFlowConfig;
-import com.sequenceiq.environment.environment.flow.upgrade.ccm.config.UpgradeCcmFlowConfig;
 import com.sequenceiq.flow.core.ApplicationFlowInformation;
 import com.sequenceiq.flow.core.config.FlowConfiguration;
 
 @Component
 public class EnvironmentFlowInformation implements ApplicationFlowInformation {
-
-    @Override
-    public List<Class<? extends FlowConfiguration<?>>> getRestartableFlows() {
-        return List.of(EnvCreationFlowConfig.class,
-                EnvDeleteFlowConfig.class,
-                EnvClustersDeleteFlowConfig.class,
-                EnvStopFlowConfig.class,
-                EnvStartFlowConfig.class,
-                LoadBalancerUpdateFlowConfig.class,
-                UpgradeCcmFlowConfig.class);
-    }
 
     @Override
     public List<String> getAllowedParallelFlows() {

--- a/flow/src/main/java/com/sequenceiq/flow/core/ApplicationFlowInformation.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/ApplicationFlowInformation.java
@@ -7,8 +7,6 @@ import com.sequenceiq.flow.domain.FlowLog;
 
 public interface ApplicationFlowInformation  {
 
-    List<Class<? extends FlowConfiguration<?>>> getRestartableFlows();
-
     List<String> getAllowedParallelFlows();
 
     List<Class<? extends FlowConfiguration<?>>> getTerminationFlow();

--- a/flow/src/test/java/com/sequenceiq/flow/component/ComponentTestConfig.java
+++ b/flow/src/test/java/com/sequenceiq/flow/component/ComponentTestConfig.java
@@ -40,7 +40,6 @@ import com.sequenceiq.flow.core.FlowConstants;
 import com.sequenceiq.flow.core.PayloadContextProvider;
 import com.sequenceiq.flow.core.ResourceIdProvider;
 import com.sequenceiq.flow.core.config.FlowConfiguration;
-import com.sequenceiq.flow.component.sleep.SleepFlowConfig;
 
 @EnableAutoConfiguration
 @EnableJpaRepositories(basePackages = "com.sequenceiq")
@@ -59,11 +58,6 @@ public class ComponentTestConfig {
     @Bean
     public ApplicationFlowInformation applicationFlowInformation() {
         return new ApplicationFlowInformation() {
-            @Override
-            public List<Class<? extends FlowConfiguration<?>>> getRestartableFlows() {
-                return List.of(SleepFlowConfig.class);
-            }
-
             @Override
             public List<String> getAllowedParallelFlows() {
                 return List.of();

--- a/flow/src/test/java/com/sequenceiq/flow/core/Flow2HandlerTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/core/Flow2HandlerTest.java
@@ -507,7 +507,6 @@ public class Flow2HandlerTest {
         Payload payload = new TestPayload(STACK_ID);
         flowLog.setPayloadType(ClassValue.of(TestPayload.class));
         flowLog.setPayload(JsonWriter.objectToJson(payload));
-        when(applicationFlowInformation.getRestartableFlows()).thenReturn(List.of(HelloWorldFlowConfig.class));
         when(flowLogService.findFirstByFlowIdOrderByCreatedDesc(FLOW_ID)).thenReturn(Optional.of(flowLog));
 
         HelloWorldFlowConfig helloWorldFlowConfig = new HelloWorldFlowConfig();
@@ -541,7 +540,6 @@ public class Flow2HandlerTest {
         flowLog.setPayloadType(ClassValue.of(TestPayload.class));
         flowLog.setPayload(JsonWriter.objectToJson(payload));
         when(flowLogService.findFirstByFlowIdOrderByCreatedDesc(FLOW_ID)).thenReturn(Optional.of(flowLog));
-        when(applicationFlowInformation.getRestartableFlows()).thenReturn(List.of(HelloWorldFlowConfig.class));
 
         HelloWorldFlowConfig helloWorldFlowConfig = new HelloWorldFlowConfig();
 
@@ -564,7 +562,6 @@ public class Flow2HandlerTest {
         flowLog.setPayloadType(ClassValue.of(TestPayload.class));
         flowLog.setPayload(JsonWriter.objectToJson(payload));
         when(flowLogService.findFirstByFlowIdOrderByCreatedDesc(FLOW_ID)).thenReturn(Optional.of(flowLog));
-        when(applicationFlowInformation.getRestartableFlows()).thenReturn(List.of(HelloWorldFlowConfig.class));
         HelloWorldFlowConfig helloWorldFlowConfig = new HelloWorldFlowConfig();
 
         setUpFlowConfigCreateFlow(helloWorldFlowConfig);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/FreeIpaFlowInformation.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/FreeIpaFlowInformation.java
@@ -6,49 +6,18 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.flow.core.ApplicationFlowInformation;
 import com.sequenceiq.flow.core.config.FlowConfiguration;
-import com.sequenceiq.freeipa.flow.freeipa.binduser.create.CreateBindUserFlowConfig;
 import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserFlowEvent;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.FreeIpaCleanupEvent;
-import com.sequenceiq.freeipa.flow.freeipa.cleanup.FreeIpaCleanupFlowConfig;
-import com.sequenceiq.freeipa.flow.freeipa.diagnostics.config.DiagnosticsCollectionFlowConfig;
-import com.sequenceiq.freeipa.flow.freeipa.downscale.DownscaleFlowConfig;
 import com.sequenceiq.freeipa.flow.freeipa.downscale.DownscaleFlowEvent;
-import com.sequenceiq.freeipa.flow.freeipa.provision.FreeIpaProvisionFlowConfig;
-import com.sequenceiq.freeipa.flow.freeipa.repair.changeprimarygw.ChangePrimaryGatewayFlowConfig;
 import com.sequenceiq.freeipa.flow.freeipa.repair.changeprimarygw.ChangePrimaryGatewayFlowEvent;
 import com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateEvent;
-import com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateFlowConfig;
-import com.sequenceiq.freeipa.flow.freeipa.upscale.UpscaleFlowConfig;
 import com.sequenceiq.freeipa.flow.freeipa.upscale.UpscaleFlowEvent;
-import com.sequenceiq.freeipa.flow.instance.reboot.RebootFlowConfig;
-import com.sequenceiq.freeipa.flow.stack.image.change.ImageChangeFlowConfig;
 import com.sequenceiq.freeipa.flow.stack.image.change.event.ImageChangeEvents;
-import com.sequenceiq.freeipa.flow.stack.provision.StackProvisionFlowConfig;
-import com.sequenceiq.freeipa.flow.stack.start.StackStartFlowConfig;
-import com.sequenceiq.freeipa.flow.stack.stop.StackStopFlowConfig;
 import com.sequenceiq.freeipa.flow.stack.termination.StackTerminationEvent;
 import com.sequenceiq.freeipa.flow.stack.termination.StackTerminationFlowConfig;
-import com.sequenceiq.freeipa.flow.stack.update.UpdateUserDataFlowConfig;
 
 @Component
 public class FreeIpaFlowInformation implements ApplicationFlowInformation {
-
-    private static final List<Class<? extends FlowConfiguration<?>>> RESTARTABLE_FLOWS = List.of(
-            ImageChangeFlowConfig.class,
-            UpdateUserDataFlowConfig.class,
-            StackProvisionFlowConfig.class,
-            StackTerminationFlowConfig.class,
-            FreeIpaProvisionFlowConfig.class,
-            StackStartFlowConfig.class,
-            StackStopFlowConfig.class,
-            FreeIpaCleanupFlowConfig.class,
-            CreateBindUserFlowConfig.class,
-            DownscaleFlowConfig.class,
-            UpscaleFlowConfig.class,
-            ChangePrimaryGatewayFlowConfig.class,
-            DiagnosticsCollectionFlowConfig.class,
-            RebootFlowConfig.class,
-            SaltUpdateFlowConfig.class);
 
     private static final List<String> PARALLEL_FLOWS = List.of(
             FreeIpaCleanupEvent.CLEANUP_EVENT.event(),
@@ -63,11 +32,6 @@ public class FreeIpaFlowInformation implements ApplicationFlowInformation {
     private static final List<Class<? extends FlowConfiguration<?>>> TERMINATION_FLOWS = List.of(StackTerminationFlowConfig.class);
 
     @Override
-    public List<Class<? extends FlowConfiguration<?>>> getRestartableFlows() {
-        return RESTARTABLE_FLOWS;
-    }
-
-    @Override
     public List<String> getAllowedParallelFlows() {
         return PARALLEL_FLOWS;
     }
@@ -76,4 +40,5 @@ public class FreeIpaFlowInformation implements ApplicationFlowInformation {
     public List<Class<? extends FlowConfiguration<?>>> getTerminationFlow() {
         return TERMINATION_FLOWS;
     }
+
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/RedbeamsFlowInformation.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/RedbeamsFlowInformation.java
@@ -9,22 +9,10 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.flow.core.ApplicationFlowInformation;
 import com.sequenceiq.flow.core.config.FlowConfiguration;
-import com.sequenceiq.redbeams.flow.redbeams.provision.RedbeamsProvisionFlowConfig;
-import com.sequenceiq.redbeams.flow.redbeams.start.RedbeamsStartFlowConfing;
-import com.sequenceiq.redbeams.flow.redbeams.stop.RedbeamsStopFlowConfing;
 import com.sequenceiq.redbeams.flow.redbeams.termination.RedbeamsTerminationFlowConfig;
 
 @Component
 public class RedbeamsFlowInformation implements ApplicationFlowInformation {
-    @Override
-    public List<Class<? extends FlowConfiguration<?>>> getRestartableFlows() {
-        return List.of(
-                RedbeamsProvisionFlowConfig.class,
-                RedbeamsTerminationFlowConfig.class,
-                RedbeamsStartFlowConfing.class,
-                RedbeamsStopFlowConfing.class
-        );
-    }
 
     @Override
     public List<String> getAllowedParallelFlows() {


### PR DESCRIPTION
Restartable flows can be restarted after it was interrupted. So for example rolling upgrade on prod. There is no reason for a flow to be not restartable, so I remove the whole restartable concept. Retryable flows are not the same thing.