### PR TITLE
CB-17065 Send the full usersync result to AuthDistributor

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
@@ -18,6 +18,7 @@ import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
@@ -74,6 +75,7 @@ public class GrpcUmsClient {
 
     private static final int CHECK_RIGHT_HAS_RIGHTS_TRESHOLD = 3;
 
+    @Qualifier("umsManagedChannelWrapper")
     @Inject
     private ManagedChannelWrapper channelWrapper;
 

--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/config/UmsChannelConfig.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/config/UmsChannelConfig.java
@@ -21,7 +21,7 @@ public class UmsChannelConfig {
     private int port;
 
     @Bean
-    public ManagedChannelWrapper managedChannelWrapper() {
+    public ManagedChannelWrapper umsManagedChannelWrapper() {
         return newManagedChannelWrapper(endpoint, port);
     }
 

--- a/auth-distributor-connector/src/generated/main/grpc/com/cloudera/thunderhead/service/authdistributor/AuthDistributorGrpc.java
+++ b/auth-distributor-connector/src/generated/main/grpc/com/cloudera/thunderhead/service/authdistributor/AuthDistributorGrpc.java
@@ -3,10 +3,6 @@ package com.cloudera.thunderhead.service.authdistributor;
 import static io.grpc.MethodDescriptor.generateFullMethodName;
 
 /**
- * <pre>
- * For future compatibility, all rpcs must take a request and return a response
- * even if there is initially no content for these messages.
- * </pre>
  */
 @javax.annotation.Generated(
     value = "by gRPC proto compiler (version 1.42.1)",
@@ -188,10 +184,6 @@ public final class AuthDistributorGrpc {
   }
 
   /**
-   * <pre>
-   * For future compatibility, all rpcs must take a request and return a response
-   * even if there is initially no content for these messages.
-   * </pre>
    */
   public static abstract class AuthDistributorImplBase implements io.grpc.BindableService {
 
@@ -261,10 +253,6 @@ public final class AuthDistributorGrpc {
   }
 
   /**
-   * <pre>
-   * For future compatibility, all rpcs must take a request and return a response
-   * even if there is initially no content for these messages.
-   * </pre>
    */
   public static final class AuthDistributorStub extends io.grpc.stub.AbstractAsyncStub<AuthDistributorStub> {
     private AuthDistributorStub(
@@ -315,10 +303,6 @@ public final class AuthDistributorGrpc {
   }
 
   /**
-   * <pre>
-   * For future compatibility, all rpcs must take a request and return a response
-   * even if there is initially no content for these messages.
-   * </pre>
    */
   public static final class AuthDistributorBlockingStub extends io.grpc.stub.AbstractBlockingStub<AuthDistributorBlockingStub> {
     private AuthDistributorBlockingStub(
@@ -365,10 +349,6 @@ public final class AuthDistributorGrpc {
   }
 
   /**
-   * <pre>
-   * For future compatibility, all rpcs must take a request and return a response
-   * even if there is initially no content for these messages.
-   * </pre>
    */
   public static final class AuthDistributorFutureStub extends io.grpc.stub.AbstractFutureStub<AuthDistributorFutureStub> {
     private AuthDistributorFutureStub(

--- a/auth-distributor-connector/src/generated/main/java/com/cloudera/thunderhead/service/authdistributor/AuthDistributorProto.java
+++ b/auth-distributor-connector/src/generated/main/java/com/cloudera/thunderhead/service/authdistributor/AuthDistributorProto.java
@@ -5904,6 +5904,644 @@ public final class AuthDistributorProto {
 
   }
 
+  public interface GroupMembershipOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:authdistributor.GroupMembership)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>repeated string user = 1;</code>
+     * @return A list containing the user.
+     */
+    java.util.List<java.lang.String>
+        getUserList();
+    /**
+     * <code>repeated string user = 1;</code>
+     * @return The count of user.
+     */
+    int getUserCount();
+    /**
+     * <code>repeated string user = 1;</code>
+     * @param index The index of the element to return.
+     * @return The user at the given index.
+     */
+    java.lang.String getUser(int index);
+    /**
+     * <code>repeated string user = 1;</code>
+     * @param index The index of the value to return.
+     * @return The bytes of the user at the given index.
+     */
+    com.google.protobuf.ByteString
+        getUserBytes(int index);
+  }
+  /**
+   * Protobuf type {@code authdistributor.GroupMembership}
+   */
+  public static final class GroupMembership extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:authdistributor.GroupMembership)
+      GroupMembershipOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use GroupMembership.newBuilder() to construct.
+    private GroupMembership(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private GroupMembership() {
+      user_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new GroupMembership();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private GroupMembership(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              java.lang.String s = input.readStringRequireUtf8();
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
+                user_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              user_.add(s);
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
+          user_ = user_.getUnmodifiableView();
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.internal_static_authdistributor_GroupMembership_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.internal_static_authdistributor_GroupMembership_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership.class, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership.Builder.class);
+    }
+
+    public static final int USER_FIELD_NUMBER = 1;
+    private com.google.protobuf.LazyStringList user_;
+    /**
+     * <code>repeated string user = 1;</code>
+     * @return A list containing the user.
+     */
+    public com.google.protobuf.ProtocolStringList
+        getUserList() {
+      return user_;
+    }
+    /**
+     * <code>repeated string user = 1;</code>
+     * @return The count of user.
+     */
+    public int getUserCount() {
+      return user_.size();
+    }
+    /**
+     * <code>repeated string user = 1;</code>
+     * @param index The index of the element to return.
+     * @return The user at the given index.
+     */
+    public java.lang.String getUser(int index) {
+      return user_.get(index);
+    }
+    /**
+     * <code>repeated string user = 1;</code>
+     * @param index The index of the value to return.
+     * @return The bytes of the user at the given index.
+     */
+    public com.google.protobuf.ByteString
+        getUserBytes(int index) {
+      return user_.getByteString(index);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      for (int i = 0; i < user_.size(); i++) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, user_.getRaw(i));
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      {
+        int dataSize = 0;
+        for (int i = 0; i < user_.size(); i++) {
+          dataSize += computeStringSizeNoTag(user_.getRaw(i));
+        }
+        size += dataSize;
+        size += 1 * getUserList().size();
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership)) {
+        return super.equals(obj);
+      }
+      com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership other = (com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership) obj;
+
+      if (!getUserList()
+          .equals(other.getUserList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (getUserCount() > 0) {
+        hash = (37 * hash) + USER_FIELD_NUMBER;
+        hash = (53 * hash) + getUserList().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code authdistributor.GroupMembership}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:authdistributor.GroupMembership)
+        com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembershipOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.internal_static_authdistributor_GroupMembership_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.internal_static_authdistributor_GroupMembership_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership.class, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership.Builder.class);
+      }
+
+      // Construct using com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        user_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.internal_static_authdistributor_GroupMembership_descriptor;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership getDefaultInstanceForType() {
+        return com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership build() {
+        com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership buildPartial() {
+        com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership result = new com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership(this);
+        int from_bitField0_ = bitField0_;
+        if (((bitField0_ & 0x00000001) != 0)) {
+          user_ = user_.getUnmodifiableView();
+          bitField0_ = (bitField0_ & ~0x00000001);
+        }
+        result.user_ = user_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership) {
+          return mergeFrom((com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership other) {
+        if (other == com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership.getDefaultInstance()) return this;
+        if (!other.user_.isEmpty()) {
+          if (user_.isEmpty()) {
+            user_ = other.user_;
+            bitField0_ = (bitField0_ & ~0x00000001);
+          } else {
+            ensureUserIsMutable();
+            user_.addAll(other.user_);
+          }
+          onChanged();
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private com.google.protobuf.LazyStringList user_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      private void ensureUserIsMutable() {
+        if (!((bitField0_ & 0x00000001) != 0)) {
+          user_ = new com.google.protobuf.LazyStringArrayList(user_);
+          bitField0_ |= 0x00000001;
+         }
+      }
+      /**
+       * <code>repeated string user = 1;</code>
+       * @return A list containing the user.
+       */
+      public com.google.protobuf.ProtocolStringList
+          getUserList() {
+        return user_.getUnmodifiableView();
+      }
+      /**
+       * <code>repeated string user = 1;</code>
+       * @return The count of user.
+       */
+      public int getUserCount() {
+        return user_.size();
+      }
+      /**
+       * <code>repeated string user = 1;</code>
+       * @param index The index of the element to return.
+       * @return The user at the given index.
+       */
+      public java.lang.String getUser(int index) {
+        return user_.get(index);
+      }
+      /**
+       * <code>repeated string user = 1;</code>
+       * @param index The index of the value to return.
+       * @return The bytes of the user at the given index.
+       */
+      public com.google.protobuf.ByteString
+          getUserBytes(int index) {
+        return user_.getByteString(index);
+      }
+      /**
+       * <code>repeated string user = 1;</code>
+       * @param index The index to set the value at.
+       * @param value The user to set.
+       * @return This builder for chaining.
+       */
+      public Builder setUser(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureUserIsMutable();
+        user_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string user = 1;</code>
+       * @param value The user to add.
+       * @return This builder for chaining.
+       */
+      public Builder addUser(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureUserIsMutable();
+        user_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string user = 1;</code>
+       * @param values The user to add.
+       * @return This builder for chaining.
+       */
+      public Builder addAllUser(
+          java.lang.Iterable<java.lang.String> values) {
+        ensureUserIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, user_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string user = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearUser() {
+        user_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string user = 1;</code>
+       * @param value The bytes of the user to add.
+       * @return This builder for chaining.
+       */
+      public Builder addUserBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        ensureUserIsMutable();
+        user_.add(value);
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:authdistributor.GroupMembership)
+    }
+
+    // @@protoc_insertion_point(class_scope:authdistributor.GroupMembership)
+    private static final com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership();
+    }
+
+    public static com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<GroupMembership>
+        PARSER = new com.google.protobuf.AbstractParser<GroupMembership>() {
+      @java.lang.Override
+      public GroupMembership parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new GroupMembership(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<GroupMembership> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<GroupMembership> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   public interface UserStateOrBuilder extends
       // @@protoc_insertion_point(interface_extends:authdistributor.UserState)
       com.google.protobuf.MessageOrBuilder {
@@ -5913,43 +6551,43 @@ public final class AuthDistributorProto {
      * The users assigned to the environment.
      * </pre>
      *
-     * <code>repeated .authdistributor.User user = 1;</code>
+     * <code>repeated .authdistributor.User users = 1;</code>
      */
     java.util.List<com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User> 
-        getUserList();
+        getUsersList();
     /**
      * <pre>
      * The users assigned to the environment.
      * </pre>
      *
-     * <code>repeated .authdistributor.User user = 1;</code>
+     * <code>repeated .authdistributor.User users = 1;</code>
      */
-    com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User getUser(int index);
+    com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User getUsers(int index);
     /**
      * <pre>
      * The users assigned to the environment.
      * </pre>
      *
-     * <code>repeated .authdistributor.User user = 1;</code>
+     * <code>repeated .authdistributor.User users = 1;</code>
      */
-    int getUserCount();
+    int getUsersCount();
     /**
      * <pre>
      * The users assigned to the environment.
      * </pre>
      *
-     * <code>repeated .authdistributor.User user = 1;</code>
+     * <code>repeated .authdistributor.User users = 1;</code>
      */
     java.util.List<? extends com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserOrBuilder> 
-        getUserOrBuilderList();
+        getUsersOrBuilderList();
     /**
      * <pre>
      * The users assigned to the environment.
      * </pre>
      *
-     * <code>repeated .authdistributor.User user = 1;</code>
+     * <code>repeated .authdistributor.User users = 1;</code>
      */
-    com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserOrBuilder getUserOrBuilder(
+    com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserOrBuilder getUsersOrBuilder(
         int index);
 
     /**
@@ -6001,53 +6639,53 @@ public final class AuthDistributorProto {
      * The mapping of group name to list of group members.
      * </pre>
      *
-     * <code>map&lt;string, string&gt; groupMembership = 3;</code>
+     * <code>map&lt;string, .authdistributor.GroupMembership&gt; groupMemberships = 3;</code>
      */
-    int getGroupMembershipCount();
+    int getGroupMembershipsCount();
     /**
      * <pre>
      * The mapping of group name to list of group members.
      * </pre>
      *
-     * <code>map&lt;string, string&gt; groupMembership = 3;</code>
+     * <code>map&lt;string, .authdistributor.GroupMembership&gt; groupMemberships = 3;</code>
      */
-    boolean containsGroupMembership(
+    boolean containsGroupMemberships(
         java.lang.String key);
     /**
-     * Use {@link #getGroupMembershipMap()} instead.
+     * Use {@link #getGroupMembershipsMap()} instead.
      */
     @java.lang.Deprecated
-    java.util.Map<java.lang.String, java.lang.String>
-    getGroupMembership();
+    java.util.Map<java.lang.String, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership>
+    getGroupMemberships();
     /**
      * <pre>
      * The mapping of group name to list of group members.
      * </pre>
      *
-     * <code>map&lt;string, string&gt; groupMembership = 3;</code>
+     * <code>map&lt;string, .authdistributor.GroupMembership&gt; groupMemberships = 3;</code>
      */
-    java.util.Map<java.lang.String, java.lang.String>
-    getGroupMembershipMap();
+    java.util.Map<java.lang.String, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership>
+    getGroupMembershipsMap();
     /**
      * <pre>
      * The mapping of group name to list of group members.
      * </pre>
      *
-     * <code>map&lt;string, string&gt; groupMembership = 3;</code>
+     * <code>map&lt;string, .authdistributor.GroupMembership&gt; groupMemberships = 3;</code>
      */
 
-    java.lang.String getGroupMembershipOrDefault(
+    com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership getGroupMembershipsOrDefault(
         java.lang.String key,
-        java.lang.String defaultValue);
+        com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership defaultValue);
     /**
      * <pre>
      * The mapping of group name to list of group members.
      * </pre>
      *
-     * <code>map&lt;string, string&gt; groupMembership = 3;</code>
+     * <code>map&lt;string, .authdistributor.GroupMembership&gt; groupMemberships = 3;</code>
      */
 
-    java.lang.String getGroupMembershipOrThrow(
+    com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership getGroupMembershipsOrThrow(
         java.lang.String key);
 
     /**
@@ -6117,7 +6755,7 @@ public final class AuthDistributorProto {
       super(builder);
     }
     private UserState() {
-      user_ = java.util.Collections.emptyList();
+      users_ = java.util.Collections.emptyList();
       groups_ = java.util.Collections.emptyList();
     }
 
@@ -6154,10 +6792,10 @@ public final class AuthDistributorProto {
               break;
             case 10: {
               if (!((mutable_bitField0_ & 0x00000001) != 0)) {
-                user_ = new java.util.ArrayList<com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User>();
+                users_ = new java.util.ArrayList<com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User>();
                 mutable_bitField0_ |= 0x00000001;
               }
-              user_.add(
+              users_.add(
                   input.readMessage(com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User.parser(), extensionRegistry));
               break;
             }
@@ -6172,15 +6810,15 @@ public final class AuthDistributorProto {
             }
             case 26: {
               if (!((mutable_bitField0_ & 0x00000004) != 0)) {
-                groupMembership_ = com.google.protobuf.MapField.newMapField(
-                    GroupMembershipDefaultEntryHolder.defaultEntry);
+                groupMemberships_ = com.google.protobuf.MapField.newMapField(
+                    GroupMembershipsDefaultEntryHolder.defaultEntry);
                 mutable_bitField0_ |= 0x00000004;
               }
-              com.google.protobuf.MapEntry<java.lang.String, java.lang.String>
-              groupMembership__ = input.readMessage(
-                  GroupMembershipDefaultEntryHolder.defaultEntry.getParserForType(), extensionRegistry);
-              groupMembership_.getMutableMap().put(
-                  groupMembership__.getKey(), groupMembership__.getValue());
+              com.google.protobuf.MapEntry<java.lang.String, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership>
+              groupMemberships__ = input.readMessage(
+                  GroupMembershipsDefaultEntryHolder.defaultEntry.getParserForType(), extensionRegistry);
+              groupMemberships_.getMutableMap().put(
+                  groupMemberships__.getKey(), groupMemberships__.getValue());
               break;
             }
             case 34: {
@@ -6212,7 +6850,7 @@ public final class AuthDistributorProto {
             e).setUnfinishedMessage(this);
       } finally {
         if (((mutable_bitField0_ & 0x00000001) != 0)) {
-          user_ = java.util.Collections.unmodifiableList(user_);
+          users_ = java.util.Collections.unmodifiableList(users_);
         }
         if (((mutable_bitField0_ & 0x00000002) != 0)) {
           groups_ = java.util.Collections.unmodifiableList(groups_);
@@ -6232,7 +6870,7 @@ public final class AuthDistributorProto {
         int number) {
       switch (number) {
         case 3:
-          return internalGetGroupMembership();
+          return internalGetGroupMemberships();
         case 4:
           return internalGetUserMetadataMap();
         default:
@@ -6248,64 +6886,64 @@ public final class AuthDistributorProto {
               com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserState.class, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserState.Builder.class);
     }
 
-    public static final int USER_FIELD_NUMBER = 1;
-    private java.util.List<com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User> user_;
+    public static final int USERS_FIELD_NUMBER = 1;
+    private java.util.List<com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User> users_;
     /**
      * <pre>
      * The users assigned to the environment.
      * </pre>
      *
-     * <code>repeated .authdistributor.User user = 1;</code>
+     * <code>repeated .authdistributor.User users = 1;</code>
      */
     @java.lang.Override
-    public java.util.List<com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User> getUserList() {
-      return user_;
+    public java.util.List<com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User> getUsersList() {
+      return users_;
     }
     /**
      * <pre>
      * The users assigned to the environment.
      * </pre>
      *
-     * <code>repeated .authdistributor.User user = 1;</code>
+     * <code>repeated .authdistributor.User users = 1;</code>
      */
     @java.lang.Override
     public java.util.List<? extends com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserOrBuilder> 
-        getUserOrBuilderList() {
-      return user_;
+        getUsersOrBuilderList() {
+      return users_;
     }
     /**
      * <pre>
      * The users assigned to the environment.
      * </pre>
      *
-     * <code>repeated .authdistributor.User user = 1;</code>
+     * <code>repeated .authdistributor.User users = 1;</code>
      */
     @java.lang.Override
-    public int getUserCount() {
-      return user_.size();
+    public int getUsersCount() {
+      return users_.size();
     }
     /**
      * <pre>
      * The users assigned to the environment.
      * </pre>
      *
-     * <code>repeated .authdistributor.User user = 1;</code>
+     * <code>repeated .authdistributor.User users = 1;</code>
      */
     @java.lang.Override
-    public com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User getUser(int index) {
-      return user_.get(index);
+    public com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User getUsers(int index) {
+      return users_.get(index);
     }
     /**
      * <pre>
      * The users assigned to the environment.
      * </pre>
      *
-     * <code>repeated .authdistributor.User user = 1;</code>
+     * <code>repeated .authdistributor.User users = 1;</code>
      */
     @java.lang.Override
-    public com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserOrBuilder getUserOrBuilder(
+    public com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserOrBuilder getUsersOrBuilder(
         int index) {
-      return user_.get(index);
+      return users_.get(index);
     }
 
     public static final int GROUPS_FIELD_NUMBER = 2;
@@ -6368,81 +7006,81 @@ public final class AuthDistributorProto {
       return groups_.get(index);
     }
 
-    public static final int GROUPMEMBERSHIP_FIELD_NUMBER = 3;
-    private static final class GroupMembershipDefaultEntryHolder {
+    public static final int GROUPMEMBERSHIPS_FIELD_NUMBER = 3;
+    private static final class GroupMembershipsDefaultEntryHolder {
       static final com.google.protobuf.MapEntry<
-          java.lang.String, java.lang.String> defaultEntry =
+          java.lang.String, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership> defaultEntry =
               com.google.protobuf.MapEntry
-              .<java.lang.String, java.lang.String>newDefaultInstance(
-                  com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.internal_static_authdistributor_UserState_GroupMembershipEntry_descriptor, 
+              .<java.lang.String, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership>newDefaultInstance(
+                  com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.internal_static_authdistributor_UserState_GroupMembershipsEntry_descriptor, 
                   com.google.protobuf.WireFormat.FieldType.STRING,
                   "",
-                  com.google.protobuf.WireFormat.FieldType.STRING,
-                  "");
+                  com.google.protobuf.WireFormat.FieldType.MESSAGE,
+                  com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership.getDefaultInstance());
     }
     private com.google.protobuf.MapField<
-        java.lang.String, java.lang.String> groupMembership_;
-    private com.google.protobuf.MapField<java.lang.String, java.lang.String>
-    internalGetGroupMembership() {
-      if (groupMembership_ == null) {
+        java.lang.String, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership> groupMemberships_;
+    private com.google.protobuf.MapField<java.lang.String, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership>
+    internalGetGroupMemberships() {
+      if (groupMemberships_ == null) {
         return com.google.protobuf.MapField.emptyMapField(
-            GroupMembershipDefaultEntryHolder.defaultEntry);
+            GroupMembershipsDefaultEntryHolder.defaultEntry);
       }
-      return groupMembership_;
+      return groupMemberships_;
     }
 
-    public int getGroupMembershipCount() {
-      return internalGetGroupMembership().getMap().size();
+    public int getGroupMembershipsCount() {
+      return internalGetGroupMemberships().getMap().size();
     }
     /**
      * <pre>
      * The mapping of group name to list of group members.
      * </pre>
      *
-     * <code>map&lt;string, string&gt; groupMembership = 3;</code>
+     * <code>map&lt;string, .authdistributor.GroupMembership&gt; groupMemberships = 3;</code>
      */
 
     @java.lang.Override
-    public boolean containsGroupMembership(
+    public boolean containsGroupMemberships(
         java.lang.String key) {
       if (key == null) { throw new NullPointerException("map key"); }
-      return internalGetGroupMembership().getMap().containsKey(key);
+      return internalGetGroupMemberships().getMap().containsKey(key);
     }
     /**
-     * Use {@link #getGroupMembershipMap()} instead.
+     * Use {@link #getGroupMembershipsMap()} instead.
      */
     @java.lang.Override
     @java.lang.Deprecated
-    public java.util.Map<java.lang.String, java.lang.String> getGroupMembership() {
-      return getGroupMembershipMap();
+    public java.util.Map<java.lang.String, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership> getGroupMemberships() {
+      return getGroupMembershipsMap();
     }
     /**
      * <pre>
      * The mapping of group name to list of group members.
      * </pre>
      *
-     * <code>map&lt;string, string&gt; groupMembership = 3;</code>
+     * <code>map&lt;string, .authdistributor.GroupMembership&gt; groupMemberships = 3;</code>
      */
     @java.lang.Override
 
-    public java.util.Map<java.lang.String, java.lang.String> getGroupMembershipMap() {
-      return internalGetGroupMembership().getMap();
+    public java.util.Map<java.lang.String, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership> getGroupMembershipsMap() {
+      return internalGetGroupMemberships().getMap();
     }
     /**
      * <pre>
      * The mapping of group name to list of group members.
      * </pre>
      *
-     * <code>map&lt;string, string&gt; groupMembership = 3;</code>
+     * <code>map&lt;string, .authdistributor.GroupMembership&gt; groupMemberships = 3;</code>
      */
     @java.lang.Override
 
-    public java.lang.String getGroupMembershipOrDefault(
+    public com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership getGroupMembershipsOrDefault(
         java.lang.String key,
-        java.lang.String defaultValue) {
+        com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership defaultValue) {
       if (key == null) { throw new NullPointerException("map key"); }
-      java.util.Map<java.lang.String, java.lang.String> map =
-          internalGetGroupMembership().getMap();
+      java.util.Map<java.lang.String, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership> map =
+          internalGetGroupMemberships().getMap();
       return map.containsKey(key) ? map.get(key) : defaultValue;
     }
     /**
@@ -6450,15 +7088,15 @@ public final class AuthDistributorProto {
      * The mapping of group name to list of group members.
      * </pre>
      *
-     * <code>map&lt;string, string&gt; groupMembership = 3;</code>
+     * <code>map&lt;string, .authdistributor.GroupMembership&gt; groupMemberships = 3;</code>
      */
     @java.lang.Override
 
-    public java.lang.String getGroupMembershipOrThrow(
+    public com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership getGroupMembershipsOrThrow(
         java.lang.String key) {
       if (key == null) { throw new NullPointerException("map key"); }
-      java.util.Map<java.lang.String, java.lang.String> map =
-          internalGetGroupMembership().getMap();
+      java.util.Map<java.lang.String, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership> map =
+          internalGetGroupMemberships().getMap();
       if (!map.containsKey(key)) {
         throw new java.lang.IllegalArgumentException();
       }
@@ -6576,8 +7214,8 @@ public final class AuthDistributorProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      for (int i = 0; i < user_.size(); i++) {
-        output.writeMessage(1, user_.get(i));
+      for (int i = 0; i < users_.size(); i++) {
+        output.writeMessage(1, users_.get(i));
       }
       for (int i = 0; i < groups_.size(); i++) {
         output.writeMessage(2, groups_.get(i));
@@ -6585,8 +7223,8 @@ public final class AuthDistributorProto {
       com.google.protobuf.GeneratedMessageV3
         .serializeStringMapTo(
           output,
-          internalGetGroupMembership(),
-          GroupMembershipDefaultEntryHolder.defaultEntry,
+          internalGetGroupMemberships(),
+          GroupMembershipsDefaultEntryHolder.defaultEntry,
           3);
       com.google.protobuf.GeneratedMessageV3
         .serializeStringMapTo(
@@ -6603,23 +7241,23 @@ public final class AuthDistributorProto {
       if (size != -1) return size;
 
       size = 0;
-      for (int i = 0; i < user_.size(); i++) {
+      for (int i = 0; i < users_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(1, user_.get(i));
+          .computeMessageSize(1, users_.get(i));
       }
       for (int i = 0; i < groups_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, groups_.get(i));
       }
-      for (java.util.Map.Entry<java.lang.String, java.lang.String> entry
-           : internalGetGroupMembership().getMap().entrySet()) {
-        com.google.protobuf.MapEntry<java.lang.String, java.lang.String>
-        groupMembership__ = GroupMembershipDefaultEntryHolder.defaultEntry.newBuilderForType()
+      for (java.util.Map.Entry<java.lang.String, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership> entry
+           : internalGetGroupMemberships().getMap().entrySet()) {
+        com.google.protobuf.MapEntry<java.lang.String, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership>
+        groupMemberships__ = GroupMembershipsDefaultEntryHolder.defaultEntry.newBuilderForType()
             .setKey(entry.getKey())
             .setValue(entry.getValue())
             .build();
         size += com.google.protobuf.CodedOutputStream
-            .computeMessageSize(3, groupMembership__);
+            .computeMessageSize(3, groupMemberships__);
       }
       for (java.util.Map.Entry<java.lang.String, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserMetadata> entry
            : internalGetUserMetadataMap().getMap().entrySet()) {
@@ -6646,12 +7284,12 @@ public final class AuthDistributorProto {
       }
       com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserState other = (com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserState) obj;
 
-      if (!getUserList()
-          .equals(other.getUserList())) return false;
+      if (!getUsersList()
+          .equals(other.getUsersList())) return false;
       if (!getGroupsList()
           .equals(other.getGroupsList())) return false;
-      if (!internalGetGroupMembership().equals(
-          other.internalGetGroupMembership())) return false;
+      if (!internalGetGroupMemberships().equals(
+          other.internalGetGroupMemberships())) return false;
       if (!internalGetUserMetadataMap().equals(
           other.internalGetUserMetadataMap())) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
@@ -6665,17 +7303,17 @@ public final class AuthDistributorProto {
       }
       int hash = 41;
       hash = (19 * hash) + getDescriptor().hashCode();
-      if (getUserCount() > 0) {
-        hash = (37 * hash) + USER_FIELD_NUMBER;
-        hash = (53 * hash) + getUserList().hashCode();
+      if (getUsersCount() > 0) {
+        hash = (37 * hash) + USERS_FIELD_NUMBER;
+        hash = (53 * hash) + getUsersList().hashCode();
       }
       if (getGroupsCount() > 0) {
         hash = (37 * hash) + GROUPS_FIELD_NUMBER;
         hash = (53 * hash) + getGroupsList().hashCode();
       }
-      if (!internalGetGroupMembership().getMap().isEmpty()) {
-        hash = (37 * hash) + GROUPMEMBERSHIP_FIELD_NUMBER;
-        hash = (53 * hash) + internalGetGroupMembership().hashCode();
+      if (!internalGetGroupMemberships().getMap().isEmpty()) {
+        hash = (37 * hash) + GROUPMEMBERSHIPS_FIELD_NUMBER;
+        hash = (53 * hash) + internalGetGroupMemberships().hashCode();
       }
       if (!internalGetUserMetadataMap().getMap().isEmpty()) {
         hash = (37 * hash) + USERMETADATAMAP_FIELD_NUMBER;
@@ -6793,7 +7431,7 @@ public final class AuthDistributorProto {
           int number) {
         switch (number) {
           case 3:
-            return internalGetGroupMembership();
+            return internalGetGroupMemberships();
           case 4:
             return internalGetUserMetadataMap();
           default:
@@ -6806,7 +7444,7 @@ public final class AuthDistributorProto {
           int number) {
         switch (number) {
           case 3:
-            return internalGetMutableGroupMembership();
+            return internalGetMutableGroupMemberships();
           case 4:
             return internalGetMutableUserMetadataMap();
           default:
@@ -6835,18 +7473,18 @@ public final class AuthDistributorProto {
       private void maybeForceBuilderInitialization() {
         if (com.google.protobuf.GeneratedMessageV3
                 .alwaysUseFieldBuilders) {
-          getUserFieldBuilder();
+          getUsersFieldBuilder();
           getGroupsFieldBuilder();
         }
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
-        if (userBuilder_ == null) {
-          user_ = java.util.Collections.emptyList();
+        if (usersBuilder_ == null) {
+          users_ = java.util.Collections.emptyList();
           bitField0_ = (bitField0_ & ~0x00000001);
         } else {
-          userBuilder_.clear();
+          usersBuilder_.clear();
         }
         if (groupsBuilder_ == null) {
           groups_ = java.util.Collections.emptyList();
@@ -6854,7 +7492,7 @@ public final class AuthDistributorProto {
         } else {
           groupsBuilder_.clear();
         }
-        internalGetMutableGroupMembership().clear();
+        internalGetMutableGroupMemberships().clear();
         internalGetMutableUserMetadataMap().clear();
         return this;
       }
@@ -6883,14 +7521,14 @@ public final class AuthDistributorProto {
       public com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserState buildPartial() {
         com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserState result = new com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserState(this);
         int from_bitField0_ = bitField0_;
-        if (userBuilder_ == null) {
+        if (usersBuilder_ == null) {
           if (((bitField0_ & 0x00000001) != 0)) {
-            user_ = java.util.Collections.unmodifiableList(user_);
+            users_ = java.util.Collections.unmodifiableList(users_);
             bitField0_ = (bitField0_ & ~0x00000001);
           }
-          result.user_ = user_;
+          result.users_ = users_;
         } else {
-          result.user_ = userBuilder_.build();
+          result.users_ = usersBuilder_.build();
         }
         if (groupsBuilder_ == null) {
           if (((bitField0_ & 0x00000002) != 0)) {
@@ -6901,8 +7539,8 @@ public final class AuthDistributorProto {
         } else {
           result.groups_ = groupsBuilder_.build();
         }
-        result.groupMembership_ = internalGetGroupMembership();
-        result.groupMembership_.makeImmutable();
+        result.groupMemberships_ = internalGetGroupMemberships();
+        result.groupMemberships_.makeImmutable();
         result.userMetadataMap_ = internalGetUserMetadataMap();
         result.userMetadataMap_.makeImmutable();
         onBuilt();
@@ -6953,29 +7591,29 @@ public final class AuthDistributorProto {
 
       public Builder mergeFrom(com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserState other) {
         if (other == com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserState.getDefaultInstance()) return this;
-        if (userBuilder_ == null) {
-          if (!other.user_.isEmpty()) {
-            if (user_.isEmpty()) {
-              user_ = other.user_;
+        if (usersBuilder_ == null) {
+          if (!other.users_.isEmpty()) {
+            if (users_.isEmpty()) {
+              users_ = other.users_;
               bitField0_ = (bitField0_ & ~0x00000001);
             } else {
-              ensureUserIsMutable();
-              user_.addAll(other.user_);
+              ensureUsersIsMutable();
+              users_.addAll(other.users_);
             }
             onChanged();
           }
         } else {
-          if (!other.user_.isEmpty()) {
-            if (userBuilder_.isEmpty()) {
-              userBuilder_.dispose();
-              userBuilder_ = null;
-              user_ = other.user_;
+          if (!other.users_.isEmpty()) {
+            if (usersBuilder_.isEmpty()) {
+              usersBuilder_.dispose();
+              usersBuilder_ = null;
+              users_ = other.users_;
               bitField0_ = (bitField0_ & ~0x00000001);
-              userBuilder_ = 
+              usersBuilder_ = 
                 com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
-                   getUserFieldBuilder() : null;
+                   getUsersFieldBuilder() : null;
             } else {
-              userBuilder_.addAllMessages(other.user_);
+              usersBuilder_.addAllMessages(other.users_);
             }
           }
         }
@@ -7005,8 +7643,8 @@ public final class AuthDistributorProto {
             }
           }
         }
-        internalGetMutableGroupMembership().mergeFrom(
-            other.internalGetGroupMembership());
+        internalGetMutableGroupMemberships().mergeFrom(
+            other.internalGetGroupMemberships());
         internalGetMutableUserMetadataMap().mergeFrom(
             other.internalGetUserMetadataMap());
         this.mergeUnknownFields(other.unknownFields);
@@ -7039,30 +7677,30 @@ public final class AuthDistributorProto {
       }
       private int bitField0_;
 
-      private java.util.List<com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User> user_ =
+      private java.util.List<com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User> users_ =
         java.util.Collections.emptyList();
-      private void ensureUserIsMutable() {
+      private void ensureUsersIsMutable() {
         if (!((bitField0_ & 0x00000001) != 0)) {
-          user_ = new java.util.ArrayList<com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User>(user_);
+          users_ = new java.util.ArrayList<com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User>(users_);
           bitField0_ |= 0x00000001;
          }
       }
 
       private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User.Builder, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserOrBuilder> userBuilder_;
+          com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User.Builder, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserOrBuilder> usersBuilder_;
 
       /**
        * <pre>
        * The users assigned to the environment.
        * </pre>
        *
-       * <code>repeated .authdistributor.User user = 1;</code>
+       * <code>repeated .authdistributor.User users = 1;</code>
        */
-      public java.util.List<com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User> getUserList() {
-        if (userBuilder_ == null) {
-          return java.util.Collections.unmodifiableList(user_);
+      public java.util.List<com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User> getUsersList() {
+        if (usersBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(users_);
         } else {
-          return userBuilder_.getMessageList();
+          return usersBuilder_.getMessageList();
         }
       }
       /**
@@ -7070,13 +7708,13 @@ public final class AuthDistributorProto {
        * The users assigned to the environment.
        * </pre>
        *
-       * <code>repeated .authdistributor.User user = 1;</code>
+       * <code>repeated .authdistributor.User users = 1;</code>
        */
-      public int getUserCount() {
-        if (userBuilder_ == null) {
-          return user_.size();
+      public int getUsersCount() {
+        if (usersBuilder_ == null) {
+          return users_.size();
         } else {
-          return userBuilder_.getCount();
+          return usersBuilder_.getCount();
         }
       }
       /**
@@ -7084,13 +7722,13 @@ public final class AuthDistributorProto {
        * The users assigned to the environment.
        * </pre>
        *
-       * <code>repeated .authdistributor.User user = 1;</code>
+       * <code>repeated .authdistributor.User users = 1;</code>
        */
-      public com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User getUser(int index) {
-        if (userBuilder_ == null) {
-          return user_.get(index);
+      public com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User getUsers(int index) {
+        if (usersBuilder_ == null) {
+          return users_.get(index);
         } else {
-          return userBuilder_.getMessage(index);
+          return usersBuilder_.getMessage(index);
         }
       }
       /**
@@ -7098,19 +7736,19 @@ public final class AuthDistributorProto {
        * The users assigned to the environment.
        * </pre>
        *
-       * <code>repeated .authdistributor.User user = 1;</code>
+       * <code>repeated .authdistributor.User users = 1;</code>
        */
-      public Builder setUser(
+      public Builder setUsers(
           int index, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User value) {
-        if (userBuilder_ == null) {
+        if (usersBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
-          ensureUserIsMutable();
-          user_.set(index, value);
+          ensureUsersIsMutable();
+          users_.set(index, value);
           onChanged();
         } else {
-          userBuilder_.setMessage(index, value);
+          usersBuilder_.setMessage(index, value);
         }
         return this;
       }
@@ -7119,16 +7757,16 @@ public final class AuthDistributorProto {
        * The users assigned to the environment.
        * </pre>
        *
-       * <code>repeated .authdistributor.User user = 1;</code>
+       * <code>repeated .authdistributor.User users = 1;</code>
        */
-      public Builder setUser(
+      public Builder setUsers(
           int index, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User.Builder builderForValue) {
-        if (userBuilder_ == null) {
-          ensureUserIsMutable();
-          user_.set(index, builderForValue.build());
+        if (usersBuilder_ == null) {
+          ensureUsersIsMutable();
+          users_.set(index, builderForValue.build());
           onChanged();
         } else {
-          userBuilder_.setMessage(index, builderForValue.build());
+          usersBuilder_.setMessage(index, builderForValue.build());
         }
         return this;
       }
@@ -7137,18 +7775,18 @@ public final class AuthDistributorProto {
        * The users assigned to the environment.
        * </pre>
        *
-       * <code>repeated .authdistributor.User user = 1;</code>
+       * <code>repeated .authdistributor.User users = 1;</code>
        */
-      public Builder addUser(com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User value) {
-        if (userBuilder_ == null) {
+      public Builder addUsers(com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User value) {
+        if (usersBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
-          ensureUserIsMutable();
-          user_.add(value);
+          ensureUsersIsMutable();
+          users_.add(value);
           onChanged();
         } else {
-          userBuilder_.addMessage(value);
+          usersBuilder_.addMessage(value);
         }
         return this;
       }
@@ -7157,19 +7795,19 @@ public final class AuthDistributorProto {
        * The users assigned to the environment.
        * </pre>
        *
-       * <code>repeated .authdistributor.User user = 1;</code>
+       * <code>repeated .authdistributor.User users = 1;</code>
        */
-      public Builder addUser(
+      public Builder addUsers(
           int index, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User value) {
-        if (userBuilder_ == null) {
+        if (usersBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
-          ensureUserIsMutable();
-          user_.add(index, value);
+          ensureUsersIsMutable();
+          users_.add(index, value);
           onChanged();
         } else {
-          userBuilder_.addMessage(index, value);
+          usersBuilder_.addMessage(index, value);
         }
         return this;
       }
@@ -7178,16 +7816,16 @@ public final class AuthDistributorProto {
        * The users assigned to the environment.
        * </pre>
        *
-       * <code>repeated .authdistributor.User user = 1;</code>
+       * <code>repeated .authdistributor.User users = 1;</code>
        */
-      public Builder addUser(
+      public Builder addUsers(
           com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User.Builder builderForValue) {
-        if (userBuilder_ == null) {
-          ensureUserIsMutable();
-          user_.add(builderForValue.build());
+        if (usersBuilder_ == null) {
+          ensureUsersIsMutable();
+          users_.add(builderForValue.build());
           onChanged();
         } else {
-          userBuilder_.addMessage(builderForValue.build());
+          usersBuilder_.addMessage(builderForValue.build());
         }
         return this;
       }
@@ -7196,16 +7834,16 @@ public final class AuthDistributorProto {
        * The users assigned to the environment.
        * </pre>
        *
-       * <code>repeated .authdistributor.User user = 1;</code>
+       * <code>repeated .authdistributor.User users = 1;</code>
        */
-      public Builder addUser(
+      public Builder addUsers(
           int index, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User.Builder builderForValue) {
-        if (userBuilder_ == null) {
-          ensureUserIsMutable();
-          user_.add(index, builderForValue.build());
+        if (usersBuilder_ == null) {
+          ensureUsersIsMutable();
+          users_.add(index, builderForValue.build());
           onChanged();
         } else {
-          userBuilder_.addMessage(index, builderForValue.build());
+          usersBuilder_.addMessage(index, builderForValue.build());
         }
         return this;
       }
@@ -7214,17 +7852,17 @@ public final class AuthDistributorProto {
        * The users assigned to the environment.
        * </pre>
        *
-       * <code>repeated .authdistributor.User user = 1;</code>
+       * <code>repeated .authdistributor.User users = 1;</code>
        */
-      public Builder addAllUser(
+      public Builder addAllUsers(
           java.lang.Iterable<? extends com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User> values) {
-        if (userBuilder_ == null) {
-          ensureUserIsMutable();
+        if (usersBuilder_ == null) {
+          ensureUsersIsMutable();
           com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, user_);
+              values, users_);
           onChanged();
         } else {
-          userBuilder_.addAllMessages(values);
+          usersBuilder_.addAllMessages(values);
         }
         return this;
       }
@@ -7233,15 +7871,15 @@ public final class AuthDistributorProto {
        * The users assigned to the environment.
        * </pre>
        *
-       * <code>repeated .authdistributor.User user = 1;</code>
+       * <code>repeated .authdistributor.User users = 1;</code>
        */
-      public Builder clearUser() {
-        if (userBuilder_ == null) {
-          user_ = java.util.Collections.emptyList();
+      public Builder clearUsers() {
+        if (usersBuilder_ == null) {
+          users_ = java.util.Collections.emptyList();
           bitField0_ = (bitField0_ & ~0x00000001);
           onChanged();
         } else {
-          userBuilder_.clear();
+          usersBuilder_.clear();
         }
         return this;
       }
@@ -7250,15 +7888,15 @@ public final class AuthDistributorProto {
        * The users assigned to the environment.
        * </pre>
        *
-       * <code>repeated .authdistributor.User user = 1;</code>
+       * <code>repeated .authdistributor.User users = 1;</code>
        */
-      public Builder removeUser(int index) {
-        if (userBuilder_ == null) {
-          ensureUserIsMutable();
-          user_.remove(index);
+      public Builder removeUsers(int index) {
+        if (usersBuilder_ == null) {
+          ensureUsersIsMutable();
+          users_.remove(index);
           onChanged();
         } else {
-          userBuilder_.remove(index);
+          usersBuilder_.remove(index);
         }
         return this;
       }
@@ -7267,24 +7905,24 @@ public final class AuthDistributorProto {
        * The users assigned to the environment.
        * </pre>
        *
-       * <code>repeated .authdistributor.User user = 1;</code>
+       * <code>repeated .authdistributor.User users = 1;</code>
        */
-      public com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User.Builder getUserBuilder(
+      public com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User.Builder getUsersBuilder(
           int index) {
-        return getUserFieldBuilder().getBuilder(index);
+        return getUsersFieldBuilder().getBuilder(index);
       }
       /**
        * <pre>
        * The users assigned to the environment.
        * </pre>
        *
-       * <code>repeated .authdistributor.User user = 1;</code>
+       * <code>repeated .authdistributor.User users = 1;</code>
        */
-      public com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserOrBuilder getUserOrBuilder(
+      public com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserOrBuilder getUsersOrBuilder(
           int index) {
-        if (userBuilder_ == null) {
-          return user_.get(index);  } else {
-          return userBuilder_.getMessageOrBuilder(index);
+        if (usersBuilder_ == null) {
+          return users_.get(index);  } else {
+          return usersBuilder_.getMessageOrBuilder(index);
         }
       }
       /**
@@ -7292,14 +7930,14 @@ public final class AuthDistributorProto {
        * The users assigned to the environment.
        * </pre>
        *
-       * <code>repeated .authdistributor.User user = 1;</code>
+       * <code>repeated .authdistributor.User users = 1;</code>
        */
       public java.util.List<? extends com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserOrBuilder> 
-           getUserOrBuilderList() {
-        if (userBuilder_ != null) {
-          return userBuilder_.getMessageOrBuilderList();
+           getUsersOrBuilderList() {
+        if (usersBuilder_ != null) {
+          return usersBuilder_.getMessageOrBuilderList();
         } else {
-          return java.util.Collections.unmodifiableList(user_);
+          return java.util.Collections.unmodifiableList(users_);
         }
       }
       /**
@@ -7307,10 +7945,10 @@ public final class AuthDistributorProto {
        * The users assigned to the environment.
        * </pre>
        *
-       * <code>repeated .authdistributor.User user = 1;</code>
+       * <code>repeated .authdistributor.User users = 1;</code>
        */
-      public com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User.Builder addUserBuilder() {
-        return getUserFieldBuilder().addBuilder(
+      public com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User.Builder addUsersBuilder() {
+        return getUsersFieldBuilder().addBuilder(
             com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User.getDefaultInstance());
       }
       /**
@@ -7318,11 +7956,11 @@ public final class AuthDistributorProto {
        * The users assigned to the environment.
        * </pre>
        *
-       * <code>repeated .authdistributor.User user = 1;</code>
+       * <code>repeated .authdistributor.User users = 1;</code>
        */
-      public com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User.Builder addUserBuilder(
+      public com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User.Builder addUsersBuilder(
           int index) {
-        return getUserFieldBuilder().addBuilder(
+        return getUsersFieldBuilder().addBuilder(
             index, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User.getDefaultInstance());
       }
       /**
@@ -7330,25 +7968,25 @@ public final class AuthDistributorProto {
        * The users assigned to the environment.
        * </pre>
        *
-       * <code>repeated .authdistributor.User user = 1;</code>
+       * <code>repeated .authdistributor.User users = 1;</code>
        */
       public java.util.List<com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User.Builder> 
-           getUserBuilderList() {
-        return getUserFieldBuilder().getBuilderList();
+           getUsersBuilderList() {
+        return getUsersFieldBuilder().getBuilderList();
       }
       private com.google.protobuf.RepeatedFieldBuilderV3<
           com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User.Builder, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserOrBuilder> 
-          getUserFieldBuilder() {
-        if (userBuilder_ == null) {
-          userBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
+          getUsersFieldBuilder() {
+        if (usersBuilder_ == null) {
+          usersBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User.Builder, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserOrBuilder>(
-                  user_,
+                  users_,
                   ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
                   isClean());
-          user_ = null;
+          users_ = null;
         }
-        return userBuilder_;
+        return usersBuilder_;
       }
 
       private java.util.List<com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.Group> groups_ =
@@ -7664,80 +8302,80 @@ public final class AuthDistributorProto {
       }
 
       private com.google.protobuf.MapField<
-          java.lang.String, java.lang.String> groupMembership_;
-      private com.google.protobuf.MapField<java.lang.String, java.lang.String>
-      internalGetGroupMembership() {
-        if (groupMembership_ == null) {
+          java.lang.String, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership> groupMemberships_;
+      private com.google.protobuf.MapField<java.lang.String, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership>
+      internalGetGroupMemberships() {
+        if (groupMemberships_ == null) {
           return com.google.protobuf.MapField.emptyMapField(
-              GroupMembershipDefaultEntryHolder.defaultEntry);
+              GroupMembershipsDefaultEntryHolder.defaultEntry);
         }
-        return groupMembership_;
+        return groupMemberships_;
       }
-      private com.google.protobuf.MapField<java.lang.String, java.lang.String>
-      internalGetMutableGroupMembership() {
+      private com.google.protobuf.MapField<java.lang.String, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership>
+      internalGetMutableGroupMemberships() {
         onChanged();;
-        if (groupMembership_ == null) {
-          groupMembership_ = com.google.protobuf.MapField.newMapField(
-              GroupMembershipDefaultEntryHolder.defaultEntry);
+        if (groupMemberships_ == null) {
+          groupMemberships_ = com.google.protobuf.MapField.newMapField(
+              GroupMembershipsDefaultEntryHolder.defaultEntry);
         }
-        if (!groupMembership_.isMutable()) {
-          groupMembership_ = groupMembership_.copy();
+        if (!groupMemberships_.isMutable()) {
+          groupMemberships_ = groupMemberships_.copy();
         }
-        return groupMembership_;
+        return groupMemberships_;
       }
 
-      public int getGroupMembershipCount() {
-        return internalGetGroupMembership().getMap().size();
+      public int getGroupMembershipsCount() {
+        return internalGetGroupMemberships().getMap().size();
       }
       /**
        * <pre>
        * The mapping of group name to list of group members.
        * </pre>
        *
-       * <code>map&lt;string, string&gt; groupMembership = 3;</code>
+       * <code>map&lt;string, .authdistributor.GroupMembership&gt; groupMemberships = 3;</code>
        */
 
       @java.lang.Override
-      public boolean containsGroupMembership(
+      public boolean containsGroupMemberships(
           java.lang.String key) {
         if (key == null) { throw new NullPointerException("map key"); }
-        return internalGetGroupMembership().getMap().containsKey(key);
+        return internalGetGroupMemberships().getMap().containsKey(key);
       }
       /**
-       * Use {@link #getGroupMembershipMap()} instead.
+       * Use {@link #getGroupMembershipsMap()} instead.
        */
       @java.lang.Override
       @java.lang.Deprecated
-      public java.util.Map<java.lang.String, java.lang.String> getGroupMembership() {
-        return getGroupMembershipMap();
+      public java.util.Map<java.lang.String, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership> getGroupMemberships() {
+        return getGroupMembershipsMap();
       }
       /**
        * <pre>
        * The mapping of group name to list of group members.
        * </pre>
        *
-       * <code>map&lt;string, string&gt; groupMembership = 3;</code>
+       * <code>map&lt;string, .authdistributor.GroupMembership&gt; groupMemberships = 3;</code>
        */
       @java.lang.Override
 
-      public java.util.Map<java.lang.String, java.lang.String> getGroupMembershipMap() {
-        return internalGetGroupMembership().getMap();
+      public java.util.Map<java.lang.String, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership> getGroupMembershipsMap() {
+        return internalGetGroupMemberships().getMap();
       }
       /**
        * <pre>
        * The mapping of group name to list of group members.
        * </pre>
        *
-       * <code>map&lt;string, string&gt; groupMembership = 3;</code>
+       * <code>map&lt;string, .authdistributor.GroupMembership&gt; groupMemberships = 3;</code>
        */
       @java.lang.Override
 
-      public java.lang.String getGroupMembershipOrDefault(
+      public com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership getGroupMembershipsOrDefault(
           java.lang.String key,
-          java.lang.String defaultValue) {
+          com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership defaultValue) {
         if (key == null) { throw new NullPointerException("map key"); }
-        java.util.Map<java.lang.String, java.lang.String> map =
-            internalGetGroupMembership().getMap();
+        java.util.Map<java.lang.String, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership> map =
+            internalGetGroupMemberships().getMap();
         return map.containsKey(key) ? map.get(key) : defaultValue;
       }
       /**
@@ -7745,23 +8383,23 @@ public final class AuthDistributorProto {
        * The mapping of group name to list of group members.
        * </pre>
        *
-       * <code>map&lt;string, string&gt; groupMembership = 3;</code>
+       * <code>map&lt;string, .authdistributor.GroupMembership&gt; groupMemberships = 3;</code>
        */
       @java.lang.Override
 
-      public java.lang.String getGroupMembershipOrThrow(
+      public com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership getGroupMembershipsOrThrow(
           java.lang.String key) {
         if (key == null) { throw new NullPointerException("map key"); }
-        java.util.Map<java.lang.String, java.lang.String> map =
-            internalGetGroupMembership().getMap();
+        java.util.Map<java.lang.String, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership> map =
+            internalGetGroupMemberships().getMap();
         if (!map.containsKey(key)) {
           throw new java.lang.IllegalArgumentException();
         }
         return map.get(key);
       }
 
-      public Builder clearGroupMembership() {
-        internalGetMutableGroupMembership().getMutableMap()
+      public Builder clearGroupMemberships() {
+        internalGetMutableGroupMemberships().getMutableMap()
             .clear();
         return this;
       }
@@ -7770,13 +8408,13 @@ public final class AuthDistributorProto {
        * The mapping of group name to list of group members.
        * </pre>
        *
-       * <code>map&lt;string, string&gt; groupMembership = 3;</code>
+       * <code>map&lt;string, .authdistributor.GroupMembership&gt; groupMemberships = 3;</code>
        */
 
-      public Builder removeGroupMembership(
+      public Builder removeGroupMemberships(
           java.lang.String key) {
         if (key == null) { throw new NullPointerException("map key"); }
-        internalGetMutableGroupMembership().getMutableMap()
+        internalGetMutableGroupMemberships().getMutableMap()
             .remove(key);
         return this;
       }
@@ -7784,26 +8422,26 @@ public final class AuthDistributorProto {
        * Use alternate mutation accessors instead.
        */
       @java.lang.Deprecated
-      public java.util.Map<java.lang.String, java.lang.String>
-      getMutableGroupMembership() {
-        return internalGetMutableGroupMembership().getMutableMap();
+      public java.util.Map<java.lang.String, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership>
+      getMutableGroupMemberships() {
+        return internalGetMutableGroupMemberships().getMutableMap();
       }
       /**
        * <pre>
        * The mapping of group name to list of group members.
        * </pre>
        *
-       * <code>map&lt;string, string&gt; groupMembership = 3;</code>
+       * <code>map&lt;string, .authdistributor.GroupMembership&gt; groupMemberships = 3;</code>
        */
-      public Builder putGroupMembership(
+      public Builder putGroupMemberships(
           java.lang.String key,
-          java.lang.String value) {
+          com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership value) {
         if (key == null) { throw new NullPointerException("map key"); }
         if (value == null) {
   throw new NullPointerException("map value");
 }
 
-        internalGetMutableGroupMembership().getMutableMap()
+        internalGetMutableGroupMemberships().getMutableMap()
             .put(key, value);
         return this;
       }
@@ -7812,12 +8450,12 @@ public final class AuthDistributorProto {
        * The mapping of group name to list of group members.
        * </pre>
        *
-       * <code>map&lt;string, string&gt; groupMembership = 3;</code>
+       * <code>map&lt;string, .authdistributor.GroupMembership&gt; groupMemberships = 3;</code>
        */
 
-      public Builder putAllGroupMembership(
-          java.util.Map<java.lang.String, java.lang.String> values) {
-        internalGetMutableGroupMembership().getMutableMap()
+      public Builder putAllGroupMemberships(
+          java.util.Map<java.lang.String, com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership> values) {
+        internalGetMutableGroupMemberships().getMutableMap()
             .putAll(values);
         return this;
       }
@@ -8079,15 +8717,20 @@ public final class AuthDistributorProto {
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_authdistributor_UserMetadata_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_authdistributor_GroupMembership_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_authdistributor_GroupMembership_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_authdistributor_UserState_descriptor;
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_authdistributor_UserState_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_authdistributor_UserState_GroupMembershipEntry_descriptor;
+    internal_static_authdistributor_UserState_GroupMembershipsEntry_descriptor;
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_authdistributor_UserState_GroupMembershipEntry_fieldAccessorTable;
+      internal_static_authdistributor_UserState_GroupMembershipsEntry_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_authdistributor_UserState_UserMetadataMapEntry_descriptor;
   private static final 
@@ -8119,31 +8762,33 @@ public final class AuthDistributorProto {
       "hdistributor.User.State\"\"\n\005State\022\013\n\007ENAB" +
       "LED\020\000\022\014\n\010DISABLED\020\001\"?\n\014UserMetadata\022\013\n\003c" +
       "rn\030\001 \001(\t\022\"\n\032workloadCredentialsVersion\030\002" +
-      " \001(\003\"\373\002\n\tUserState\022#\n\004user\030\001 \003(\0132\025.authd" +
-      "istributor.User\022&\n\006groups\030\002 \003(\0132\026.authdi" +
-      "stributor.Group\022H\n\017groupMembership\030\003 \003(\013" +
-      "2/.authdistributor.UserState.GroupMember" +
-      "shipEntry\022H\n\017userMetadataMap\030\004 \003(\0132/.aut" +
-      "hdistributor.UserState.UserMetadataMapEn" +
-      "try\0326\n\024GroupMembershipEntry\022\013\n\003key\030\001 \001(\t" +
-      "\022\r\n\005value\030\002 \001(\t:\0028\001\032U\n\024UserMetadataMapEn" +
-      "try\022\013\n\003key\030\001 \001(\t\022,\n\005value\030\002 \001(\0132\035.authdi" +
-      "stributor.UserMetadata:\0028\0012\201\004\n\017AuthDistr" +
-      "ibutor\022A\n\nGetVersion\022\027.version.VersionRe" +
-      "quest\032\030.version.VersionResponse\"\000\022\212\001\n\033Fe" +
-      "tchAuthViewForEnvironment\0223.authdistribu" +
-      "tor.FetchAuthViewForEnvironmentRequest\0324" +
-      ".authdistributor.FetchAuthViewForEnviron" +
-      "mentResponse\"\000\022\215\001\n\034RemoveAuthViewForEnvi" +
-      "ronment\0224.authdistributor.RemoveAuthView" +
-      "ForEnvironmentRequest\0325.authdistributor." +
-      "RemoveAuthViewForEnvironmentResponse\"\000\022\215" +
-      "\001\n\034UpdateAuthViewForEnvironment\0224.authdi" +
-      "stributor.UpdateAuthViewForEnvironmentRe" +
-      "quest\0325.authdistributor.UpdateAuthViewFo" +
-      "rEnvironmentResponse\"\000BH\n0com.cloudera.t" +
-      "hunderhead.service.authdistributorB\024Auth" +
-      "DistributorProtob\006proto3"
+      " \001(\003\"\037\n\017GroupMembership\022\014\n\004user\030\001 \003(\t\"\241\003" +
+      "\n\tUserState\022$\n\005users\030\001 \003(\0132\025.authdistrib" +
+      "utor.User\022&\n\006groups\030\002 \003(\0132\026.authdistribu" +
+      "tor.Group\022J\n\020groupMemberships\030\003 \003(\01320.au" +
+      "thdistributor.UserState.GroupMemberships" +
+      "Entry\022H\n\017userMetadataMap\030\004 \003(\0132/.authdis" +
+      "tributor.UserState.UserMetadataMapEntry\032" +
+      "Y\n\025GroupMembershipsEntry\022\013\n\003key\030\001 \001(\t\022/\n" +
+      "\005value\030\002 \001(\0132 .authdistributor.GroupMemb" +
+      "ership:\0028\001\032U\n\024UserMetadataMapEntry\022\013\n\003ke" +
+      "y\030\001 \001(\t\022,\n\005value\030\002 \001(\0132\035.authdistributor" +
+      ".UserMetadata:\0028\0012\201\004\n\017AuthDistributor\022A\n" +
+      "\nGetVersion\022\027.version.VersionRequest\032\030.v" +
+      "ersion.VersionResponse\"\000\022\212\001\n\033FetchAuthVi" +
+      "ewForEnvironment\0223.authdistributor.Fetch" +
+      "AuthViewForEnvironmentRequest\0324.authdist" +
+      "ributor.FetchAuthViewForEnvironmentRespo" +
+      "nse\"\000\022\215\001\n\034RemoveAuthViewForEnvironment\0224" +
+      ".authdistributor.RemoveAuthViewForEnviro" +
+      "nmentRequest\0325.authdistributor.RemoveAut" +
+      "hViewForEnvironmentResponse\"\000\022\215\001\n\034Update" +
+      "AuthViewForEnvironment\0224.authdistributor" +
+      ".UpdateAuthViewForEnvironmentRequest\0325.a" +
+      "uthdistributor.UpdateAuthViewForEnvironm" +
+      "entResponse\"\000BH\n0com.cloudera.thunderhea" +
+      "d.service.authdistributorB\024AuthDistribut" +
+      "orProtob\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -8204,17 +8849,23 @@ public final class AuthDistributorProto {
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_authdistributor_UserMetadata_descriptor,
         new java.lang.String[] { "Crn", "WorkloadCredentialsVersion", });
-    internal_static_authdistributor_UserState_descriptor =
+    internal_static_authdistributor_GroupMembership_descriptor =
       getDescriptor().getMessageTypes().get(9);
+    internal_static_authdistributor_GroupMembership_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_authdistributor_GroupMembership_descriptor,
+        new java.lang.String[] { "User", });
+    internal_static_authdistributor_UserState_descriptor =
+      getDescriptor().getMessageTypes().get(10);
     internal_static_authdistributor_UserState_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_authdistributor_UserState_descriptor,
-        new java.lang.String[] { "User", "Groups", "GroupMembership", "UserMetadataMap", });
-    internal_static_authdistributor_UserState_GroupMembershipEntry_descriptor =
+        new java.lang.String[] { "Users", "Groups", "GroupMemberships", "UserMetadataMap", });
+    internal_static_authdistributor_UserState_GroupMembershipsEntry_descriptor =
       internal_static_authdistributor_UserState_descriptor.getNestedTypes().get(0);
-    internal_static_authdistributor_UserState_GroupMembershipEntry_fieldAccessorTable = new
+    internal_static_authdistributor_UserState_GroupMembershipsEntry_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_authdistributor_UserState_GroupMembershipEntry_descriptor,
+        internal_static_authdistributor_UserState_GroupMembershipsEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
     internal_static_authdistributor_UserState_UserMetadataMapEntry_descriptor =
       internal_static_authdistributor_UserState_descriptor.getNestedTypes().get(1);

--- a/auth-distributor-connector/src/main/java/com/sequenceiq/cloudbreak/authdistributor/GrpcAuthDistributorClient.java
+++ b/auth-distributor-connector/src/main/java/com/sequenceiq/cloudbreak/authdistributor/GrpcAuthDistributorClient.java
@@ -1,18 +1,22 @@
 package com.sequenceiq.cloudbreak.authdistributor;
 
+import java.util.Optional;
+
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 
 import com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserState;
+import com.google.common.base.Preconditions;
 import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
-import com.sequenceiq.cloudbreak.authdistributor.config.AuthDistributorConfig;
 import com.sequenceiq.cloudbreak.grpc.ManagedChannelWrapper;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 
-import io.grpc.ManagedChannel;
 import io.opentracing.Tracer;
 
 @Component
@@ -20,11 +24,9 @@ public class GrpcAuthDistributorClient {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GrpcAuthDistributorClient.class);
 
+    @Qualifier("authDistributorManagedChannelWrapper")
     @Inject
     private ManagedChannelWrapper channelWrapper;
-
-    @Inject
-    private AuthDistributorConfig authDistributorConfig;
 
     @Inject
     private RegionAwareInternalCrnGeneratorFactory regionAwareInternalCrnGeneratorFactory;
@@ -32,21 +34,39 @@ public class GrpcAuthDistributorClient {
     @Inject
     private Tracer tracer;
 
-    private AuthDistributorClient makeClient(ManagedChannel channel, RegionAwareInternalCrnGeneratorFactory regionAwareInternalCrnGeneratorFactory) {
-        return new AuthDistributorClient(channel, authDistributorConfig, tracer, regionAwareInternalCrnGeneratorFactory);
+    public static GrpcAuthDistributorClient createClient(ManagedChannelWrapper channelWrapper, Tracer tracer,
+            RegionAwareInternalCrnGeneratorFactory regionAwareInternalCrnGeneratorFactory) {
+        GrpcAuthDistributorClient client = new GrpcAuthDistributorClient();
+        client.channelWrapper = Preconditions.checkNotNull(channelWrapper, "channelWrapper should not be null.");
+        client.tracer = Preconditions.checkNotNull(tracer, "tracer should not be null.");
+        client.regionAwareInternalCrnGeneratorFactory = Preconditions.checkNotNull(regionAwareInternalCrnGeneratorFactory,
+                "regionAwareInternalCrnGeneratorFactory should not be null.");
+        return client;
     }
 
+    @Retryable(value = Exception.class, maxAttempts = 5, backoff = @Backoff(delay = 1000, multiplier = 2, maxDelay = 20000))
     public void updateAuthViewForEnvironment(String environmentCrn, UserState userState) {
         LOGGER.debug("Updating auth view for environment: {}", environmentCrn);
-        AuthDistributorClient authDistributorClient = makeClient(channelWrapper.getChannel(), regionAwareInternalCrnGeneratorFactory);
+        AuthDistributorClient authDistributorClient = makeClient(channelWrapper, tracer, regionAwareInternalCrnGeneratorFactory);
         authDistributorClient.updateAuthViewForEnvironment(MDCBuilder.getOrGenerateRequestId(), environmentCrn, userState);
-        LOGGER.debug("Auth view for environment: {} has been updated.", environmentCrn);
     }
 
+    @Retryable(value = Exception.class, maxAttempts = 5, backoff = @Backoff(delay = 1000, multiplier = 2, maxDelay = 20000))
     public void removeAuthViewForEnvironment(String environmentCrn) {
         LOGGER.debug("Remove auth view for environment: {}", environmentCrn);
-        AuthDistributorClient authDistributorClient = makeClient(channelWrapper.getChannel(), regionAwareInternalCrnGeneratorFactory);
+        AuthDistributorClient authDistributorClient = makeClient(channelWrapper, tracer, regionAwareInternalCrnGeneratorFactory);
         authDistributorClient.removeAuthViewForEnvironment(MDCBuilder.getOrGenerateRequestId(), environmentCrn);
-        LOGGER.debug("Auth view for environment: {} has been removed.", environmentCrn);
+    }
+
+    @Retryable(value = Exception.class, maxAttempts = 5, backoff = @Backoff(delay = 1000, multiplier = 2, maxDelay = 20000))
+    public Optional<UserState> fetchAuthViewForEnvironment(String environmentCrn) {
+        LOGGER.debug("Fetch auth view for environment: {}", environmentCrn);
+        AuthDistributorClient authDistributorClient = makeClient(channelWrapper, tracer, regionAwareInternalCrnGeneratorFactory);
+        return authDistributorClient.fetchAuthViewForEnvironment(MDCBuilder.getOrGenerateRequestId(), environmentCrn);
+    }
+
+    private AuthDistributorClient makeClient(ManagedChannelWrapper channelWrapper, Tracer tracer,
+            RegionAwareInternalCrnGeneratorFactory regionAwareInternalCrnGeneratorFactory) {
+        return new AuthDistributorClient(channelWrapper.getChannel(), tracer, regionAwareInternalCrnGeneratorFactory);
     }
 }

--- a/auth-distributor-connector/src/main/java/com/sequenceiq/cloudbreak/authdistributor/config/AuthDistributorConfig.java
+++ b/auth-distributor-connector/src/main/java/com/sequenceiq/cloudbreak/authdistributor/config/AuthDistributorConfig.java
@@ -1,23 +1,35 @@
 package com.sequenceiq.cloudbreak.authdistributor.config;
 
+import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
+
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import com.sequenceiq.cloudbreak.grpc.ManagedChannelWrapper;
+
+import io.grpc.ManagedChannelBuilder;
 
 @Configuration
 public class AuthDistributorConfig {
 
-    @Value("${authdistributor.host:}")
+    @Value("${authdistributor.host:localhost}")
     private String endpoint;
 
     @Value("${authdistributor.port:8982}")
     private int port;
 
-    public String getEndpoint() {
-        return endpoint;
+    @Bean
+    public ManagedChannelWrapper authDistributorManagedChannelWrapper() {
+        return newManagedChannelWrapper(endpoint, port);
     }
 
-    public int getPort() {
-        return port;
+    public static ManagedChannelWrapper newManagedChannelWrapper(String endpoint, int port) {
+        return new ManagedChannelWrapper(
+                ManagedChannelBuilder.forAddress(endpoint, port)
+                        .usePlaintext()
+                        .maxInboundMessageSize(DEFAULT_MAX_MESSAGE_SIZE)
+                        .build());
     }
 
 }

--- a/auth-distributor-connector/src/main/proto/authdistributor.proto
+++ b/auth-distributor-connector/src/main/proto/authdistributor.proto
@@ -7,8 +7,6 @@ option java_outer_classname = "AuthDistributorProto";
 
 import "version.proto";
 
-// For future compatibility, all rpcs must take a request and return a response
-// even if there is initially no content for these messages.
 service AuthDistributor {
   // Get the service version.
   rpc GetVersion (version.VersionRequest)
@@ -74,13 +72,17 @@ message UserMetadata {
   int64 workloadCredentialsVersion = 2;
 }
 
+message GroupMembership {
+  repeated string user = 1;
+}
+
 message UserState {
   // The users assigned to the environment.
-  repeated User user = 1;
+  repeated User users = 1;
   // The groups assigned to the environment.
   repeated Group groups = 2;
   // The mapping of group name to list of group members.
-  map<string, string> groupMembership = 3;
+  map<string, GroupMembership> groupMemberships = 3;
   // The mapping of user to its metadata.
   map<string, UserMetadata> userMetadataMap = 4;
 }

--- a/freeipa/build.gradle
+++ b/freeipa/build.gradle
@@ -120,6 +120,7 @@ dependencies {
   implementation project(':structuredevent-model')
   implementation project(':audit-connector')
   implementation project(':authorization-common')
+  implementation project(':auth-distributor-connector')
   implementation project(':cloud-reactor-api')
   implementation project(':cloud-reactor')
   implementation project(':cloud-aws-common')

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/freeipa/user/UmsUsersStateToAuthDistributorUserStateConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/freeipa/user/UmsUsersStateToAuthDistributorUserStateConverter.java
@@ -1,0 +1,96 @@
+package com.sequenceiq.freeipa.converter.freeipa.user;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.ObjectUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto;
+import com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.Group;
+import com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.GroupMembership;
+import com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User;
+import com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User.State;
+import com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserState;
+import com.sequenceiq.freeipa.service.freeipa.user.model.FmsGroup;
+import com.sequenceiq.freeipa.service.freeipa.user.model.FmsUser;
+import com.sequenceiq.freeipa.service.freeipa.user.model.UmsUsersState;
+import com.sequenceiq.freeipa.service.freeipa.user.model.UserMetadata;
+
+@Component
+public class UmsUsersStateToAuthDistributorUserStateConverter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UmsUsersStateToAuthDistributorUserStateConverter.class);
+
+    public UserState convert(UmsUsersState umsUsersState) {
+        Set<User> users = umsUsersState.getUsersState().getUsers().stream()
+                .filter(Objects::nonNull)
+                .map(this::convert)
+                .collect(Collectors.toSet());
+        Set<Group> groups = umsUsersState.getUsersState().getGroups().stream()
+                .filter(Objects::nonNull)
+                .map(this::convert)
+                .collect(Collectors.toSet());
+        Map<String, GroupMembership> groupMemberships = umsUsersState.getUsersState().getGroupMembership().asMap().entrySet().stream()
+                .filter(e -> ObjectUtils.allNotNull(e, e.getKey(), e.getValue()))
+                .collect(Collectors.toMap(e -> e.getKey(), e -> convert(e.getValue())));
+        Map<String, AuthDistributorProto.UserMetadata> userMetadataMap = umsUsersState.getUsersState().getUserMetadataMap().entrySet().stream()
+                .filter(e -> ObjectUtils.allNotNull(e, e.getKey(), e.getValue()))
+                .collect(Collectors.toMap(e -> e.getKey(), e -> convert(e.getValue())));
+        return UserState.newBuilder()
+                .addAllUsers(users)
+                .addAllGroups(groups)
+                .putAllGroupMemberships(groupMemberships)
+                .putAllUserMetadataMap(userMetadataMap)
+                .build();
+    }
+
+    private User convert(FmsUser fmsUser) {
+        User.Builder builder = User.newBuilder();
+        if (fmsUser.getName() != null) {
+            builder.setName(fmsUser.getName());
+        }
+        if (fmsUser.getFirstName() != null) {
+            builder.setFirstName(fmsUser.getFirstName());
+        }
+        if (fmsUser.getLastName() != null) {
+            builder.setLastName(fmsUser.getLastName());
+        }
+        if (fmsUser.getState() != null) {
+            try {
+                builder.setState(State.valueOf(fmsUser.getState().name()));
+            } catch (IllegalArgumentException e) {
+                LOGGER.error("Invalid state value: {} for fms user: {}", fmsUser.getState(), fmsUser.getName());
+            }
+        }
+        return builder.build();
+    }
+
+    private Group convert(FmsGroup fmsGroup) {
+        Group.Builder builder = Group.newBuilder();
+        if (fmsGroup.getName() != null) {
+            builder.setName(fmsGroup.getName());
+        }
+        return builder.build();
+    }
+
+    private GroupMembership convert(Collection<String> members) {
+        return GroupMembership.newBuilder()
+                .addAllUser(members)
+                .build();
+    }
+
+    private AuthDistributorProto.UserMetadata convert(UserMetadata umsUserMetadata) {
+        AuthDistributorProto.UserMetadata.Builder builder = AuthDistributorProto.UserMetadata.newBuilder();
+        if (umsUserMetadata.getCrn() != null) {
+            builder.setCrn(umsUserMetadata.getCrn());
+        }
+        builder.setWorkloadCredentialsVersion(umsUserMetadata.getWorkloadCredentialsVersion());
+        return builder.build();
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/action/StackTerminationFinishedAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/action/StackTerminationFinishedAction.java
@@ -5,17 +5,23 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.cloud.event.resource.TerminateStackResult;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.flow.stack.StackEvent;
 import com.sequenceiq.freeipa.flow.stack.termination.StackTerminationContext;
 import com.sequenceiq.freeipa.flow.stack.termination.StackTerminationEvent;
 import com.sequenceiq.freeipa.service.config.AbstractConfigRegister;
+import com.sequenceiq.freeipa.service.freeipa.user.AuthDistributorService;
 
 @Component("StackTerminationFinishedAction")
 public class StackTerminationFinishedAction extends AbstractStackTerminationAction<TerminateStackResult> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StackTerminationFinishedAction.class);
 
     @Inject
     private StackTerminationService stackTerminationService;
@@ -23,13 +29,19 @@ public class StackTerminationFinishedAction extends AbstractStackTerminationActi
     @Inject
     private Set<AbstractConfigRegister> configRegisters;
 
+    @Inject
+    private AuthDistributorService authDistributorService;
+
     public StackTerminationFinishedAction() {
         super(TerminateStackResult.class);
     }
 
     @Override
     protected void doExecute(StackTerminationContext context, TerminateStackResult payload, Map<Object, Object> variables) {
-        configRegisters.forEach(configProvider -> configProvider.delete(context.getStack()));
+        Stack stack = context.getStack();
+        LOGGER.info("Stack termination finished for stack: {}", stack.getId());
+        configRegisters.forEach(configProvider -> configProvider.delete(stack));
+        authDistributorService.removeAuthViewForEnvironment(stack.getEnvironmentCrn(), stack.getAccountId());
         stackTerminationService.finishStackTermination(context, payload);
         sendEvent(context);
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/AuthDistributorService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/AuthDistributorService.java
@@ -1,0 +1,53 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserState;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.authdistributor.GrpcAuthDistributorClient;
+import com.sequenceiq.freeipa.converter.freeipa.user.UmsUsersStateToAuthDistributorUserStateConverter;
+import com.sequenceiq.freeipa.service.freeipa.user.model.UmsUsersState;
+
+@Service
+public class AuthDistributorService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AuthDistributorService.class);
+
+    @Inject
+    private GrpcAuthDistributorClient grpcAuthDistributorClient;
+
+    @Inject
+    private UmsUsersStateToAuthDistributorUserStateConverter umsUsersStateToAuthDistributorUserStateConverter;
+
+    @Inject
+    private EntitlementService entitlementService;
+
+    public void updateAuthViewForEnvironment(String environmentCrn, UmsUsersState umsUsersState, String accountId, String operationId) {
+        if (entitlementService.isCdpSaasEnabled(accountId)) {
+            try {
+                LOGGER.debug("Update auth view in auth distributor for env: {}, operationId: {}", environmentCrn, operationId);
+                UserState userState = umsUsersStateToAuthDistributorUserStateConverter.convert(umsUsersState);
+                grpcAuthDistributorClient.updateAuthViewForEnvironment(environmentCrn, userState);
+                LOGGER.debug("Update auth view in auth distributor finished for env: {}, operationId: {}", environmentCrn, operationId);
+            } catch (Exception e) {
+                LOGGER.error("Update auth view in auth distributor failed for env: {}, operationId: {}", environmentCrn, operationId, e);
+            }
+        }
+    }
+
+    public void removeAuthViewForEnvironment(String environmentCrn, String accountId) {
+        if (entitlementService.isCdpSaasEnabled(accountId)) {
+            try {
+                LOGGER.debug("Remove auth view from auth distributor for env: {}", environmentCrn);
+                grpcAuthDistributorClient.removeAuthViewForEnvironment(environmentCrn);
+                LOGGER.debug("Remove auth view from auth distributor finished for env: {}", environmentCrn);
+            } catch (Exception e) {
+                LOGGER.error("Remove auth view from auth distributor failed for env: {}", environmentCrn, e);
+            }
+        }
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncForEnvService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncForEnvService.java
@@ -165,7 +165,7 @@ public class UserSyncForEnvService {
     private Future<SyncStatusDetail> asyncSynchronizeStack(Stack stack, UmsUsersState umsUsersState, UmsEventGenerationIds umsEventGenerationIds,
             UserSyncOptions options, String operationId, String accountId) {
         return asyncTaskExecutor.submit(() -> {
-            SyncStatusDetail statusDetail = userSyncForStackService.synchronizeStack(stack, umsUsersState, options);
+            SyncStatusDetail statusDetail = userSyncForStackService.synchronizeStack(stack, umsUsersState, options, operationId);
             if (options.isFullSync() && statusDetail.getStatus() == SynchronizationStatus.COMPLETED) {
                 UserSyncStatus userSyncStatus = userSyncStatusService.getOrCreateForStack(stack);
                 userSyncStatus.setUmsEventGenerationIds(new Json(umsEventGenerationIds));

--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -332,3 +332,7 @@ clusterProxy:
 crn:
   partition: cdp
   region: us-west-1
+
+authdistributor:
+  host: localhost
+  port: 8982

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/freeipa/user/UmsUsersStateToAuthDistributorUserStateConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/freeipa/user/UmsUsersStateToAuthDistributorUserStateConverterTest.java
@@ -1,0 +1,95 @@
+package com.sequenceiq.freeipa.converter.freeipa.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.Group;
+import com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.User;
+import com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserState;
+import com.sequenceiq.freeipa.service.freeipa.user.model.FmsGroup;
+import com.sequenceiq.freeipa.service.freeipa.user.model.FmsUser;
+import com.sequenceiq.freeipa.service.freeipa.user.model.FmsUser.State;
+import com.sequenceiq.freeipa.service.freeipa.user.model.UmsUsersState;
+import com.sequenceiq.freeipa.service.freeipa.user.model.UserMetadata;
+import com.sequenceiq.freeipa.service.freeipa.user.model.UsersState;
+
+class UmsUsersStateToAuthDistributorUserStateConverterTest {
+
+    private UmsUsersStateToAuthDistributorUserStateConverter underTest = new UmsUsersStateToAuthDistributorUserStateConverter();
+
+    @Test
+    public void testConvert() {
+        UmsUsersState umsUsersState = UmsUsersState.newBuilder()
+                .setUsersState(UsersState.newBuilder()
+                        .addUser(new FmsUser().withName("name1").withFirstName("firstName1").withLastName("lastName1").withState(State.ENABLED))
+                        .addUser(new FmsUser().withName("name2").withFirstName("firstName2").withLastName("lastName2").withState(State.DISABLED))
+                        .addGroup(new FmsGroup().withName("group1"))
+                        .addGroup(new FmsGroup().withName("group2"))
+                        .addUserMetadata("name1", new UserMetadata("crn1", 1L))
+                        .addUserMetadata("name2", new UserMetadata("crn2", 2L))
+                        .addMemberToGroup("group1", "name1")
+                        .addMemberToGroup("group1", "name2")
+                        .build())
+                .build();
+        UserState result = underTest.convert(umsUsersState);
+
+        assertThat(result.getUsersList())
+                .hasSize(2)
+                .extracting(User::getName, User::getFirstName, User::getLastName, User::getState)
+                .containsOnly(
+                        tuple("name1", "firstName1", "lastName1", User.State.ENABLED),
+                        tuple("name2", "firstName2", "lastName2", User.State.DISABLED));
+
+        assertThat(result.getGroupsList())
+                .hasSize(2)
+                .extracting(Group::getName)
+                .containsOnly("group1", "group2");
+
+        assertThat(result.getUserMetadataMapMap().entrySet())
+                .hasSize(2)
+                .extracting(Map.Entry::getKey, e -> e.getValue().getCrn(), e -> e.getValue().getWorkloadCredentialsVersion())
+                .containsOnly(
+                        tuple("name1", "crn1", 1L),
+                        tuple("name2", "crn2", 2L));
+
+        assertThat(result.getGroupMembershipsMap())
+                .hasSize(1)
+                .containsOnlyKeys("group1");
+        assertThat(result.getGroupMembershipsMap().get("group1").getUserList()).containsOnly("name1", "name2");
+    }
+
+    @Test
+    public void testConvertWithNullValues() {
+        UmsUsersState umsUsersState = UmsUsersState.newBuilder()
+                .setUsersState(UsersState.newBuilder()
+                        .addUser(new FmsUser().withName(null).withFirstName(null).withLastName(null).withState(null))
+                        .addGroup(new FmsGroup().withName(null))
+                        .addUserMetadata("name1", new UserMetadata(null, 1L))
+                        .build())
+                .build();
+        UserState result = underTest.convert(umsUsersState);
+
+        assertThat(result.getUsersList())
+                .hasSize(1)
+                .extracting(User::getName, User::getFirstName, User::getLastName, User::getState)
+                .containsOnly(
+                        tuple("", "", "", User.State.ENABLED));
+
+        assertThat(result.getGroupsList())
+                .hasSize(1)
+                .extracting(Group::getName)
+                .containsOnly("");
+
+        assertThat(result.getUserMetadataMapMap().entrySet())
+                .hasSize(1)
+                .extracting(Map.Entry::getKey, e -> e.getValue().getCrn(), e -> e.getValue().getWorkloadCredentialsVersion())
+                .containsOnly(
+                        tuple("name1", "", 1L));
+
+        assertThat(result.getGroupMembershipsMap()).isEmpty();
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/AuthDistributorServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/AuthDistributorServiceTest.java
@@ -1,0 +1,100 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.authdistributor.GrpcAuthDistributorClient;
+import com.sequenceiq.freeipa.converter.freeipa.user.UmsUsersStateToAuthDistributorUserStateConverter;
+import com.sequenceiq.freeipa.service.freeipa.user.model.UmsUsersState;
+import com.sequenceiq.freeipa.service.freeipa.user.model.UsersState;
+
+@ExtendWith(MockitoExtension.class)
+class AuthDistributorServiceTest {
+
+    @Spy
+    private UmsUsersStateToAuthDistributorUserStateConverter umsUsersStateToAuthDistributorUserStateConverter;
+
+    @Mock
+    private GrpcAuthDistributorClient grpcAuthDistributorClient;
+
+    @Mock
+    private EntitlementService entitlementService;
+
+    @InjectMocks
+    private AuthDistributorService underTest;
+
+    @Test
+    public void testUpdateAuthViewForEnvironment() {
+        when(entitlementService.isCdpSaasEnabled("accountId")).thenReturn(Boolean.TRUE);
+        UmsUsersState umsUsersState = UmsUsersState.newBuilder().setUsersState(UsersState.newBuilder().build()).build();
+        underTest.updateAuthViewForEnvironment("envCrn", umsUsersState, "accountId", "operationId");
+
+        verify(umsUsersStateToAuthDistributorUserStateConverter).convert(eq(umsUsersState));
+        verify(grpcAuthDistributorClient).updateAuthViewForEnvironment(eq("envCrn"), any());
+    }
+
+    @Test
+    public void testUpdateAuthViewForEnvironmentWhenConverterFails() {
+        when(entitlementService.isCdpSaasEnabled("accountId")).thenReturn(Boolean.TRUE);
+        doThrow(new RuntimeException("error")).when(umsUsersStateToAuthDistributorUserStateConverter).convert(any());
+        UmsUsersState umsUsersState = UmsUsersState.newBuilder().setUsersState(UsersState.newBuilder().build()).build();
+        Assertions.assertDoesNotThrow(() -> underTest.updateAuthViewForEnvironment("envCrn", umsUsersState, "accountId", "operationId"));
+
+        verify(grpcAuthDistributorClient, never()).updateAuthViewForEnvironment(eq("envCrn"), any());
+    }
+
+    @Test
+    public void testUpdateAuthViewForEnvironmentWhenGrpcFails() {
+        when(entitlementService.isCdpSaasEnabled("accountId")).thenReturn(Boolean.TRUE);
+        doThrow(new RuntimeException("error")).when(grpcAuthDistributorClient).updateAuthViewForEnvironment(eq("envCrn"), any());
+        UmsUsersState umsUsersState = UmsUsersState.newBuilder().setUsersState(UsersState.newBuilder().build()).build();
+        Assertions.assertDoesNotThrow(() -> underTest.updateAuthViewForEnvironment("envCrn", umsUsersState, "accountId", "operationId"));
+
+        verify(umsUsersStateToAuthDistributorUserStateConverter).convert(eq(umsUsersState));
+    }
+
+    @Test
+    public void testUpdateAuthViewForEnvironmentWhenCdpSaasEntitlementDisabled() {
+        when(entitlementService.isCdpSaasEnabled("accountId")).thenReturn(Boolean.FALSE);
+        UmsUsersState umsUsersState = UmsUsersState.newBuilder().setUsersState(UsersState.newBuilder().build()).build();
+        underTest.updateAuthViewForEnvironment("envCrn", umsUsersState, "accountId", "operationId");
+
+        verify(umsUsersStateToAuthDistributorUserStateConverter, never()).convert(eq(umsUsersState));
+        verify(grpcAuthDistributorClient, never()).updateAuthViewForEnvironment(eq("envCrn"), any());
+    }
+
+    @Test
+    public void testRemoveAuthViewForEnvironment() {
+        when(entitlementService.isCdpSaasEnabled("accountId")).thenReturn(Boolean.TRUE);
+        underTest.removeAuthViewForEnvironment("envCrn", "accountId");
+        verify(grpcAuthDistributorClient).removeAuthViewForEnvironment(eq("envCrn"));
+    }
+
+    @Test
+    public void testRemoveAuthViewForEnvironmentWhenGrpcFails() {
+        when(entitlementService.isCdpSaasEnabled("accountId")).thenReturn(Boolean.TRUE);
+        doThrow(new RuntimeException("error")).when(grpcAuthDistributorClient).removeAuthViewForEnvironment(eq("envCrn"));
+        Assertions.assertDoesNotThrow(() -> underTest.removeAuthViewForEnvironment("envCrn", "accountId"));
+    }
+
+    @Test
+    public void testRemoveAuthViewForEnvironmentWhenCdpSaasEntitlementDisabled() {
+        when(entitlementService.isCdpSaasEnabled("accountId")).thenReturn(Boolean.FALSE);
+        underTest.removeAuthViewForEnvironment("envCrn", "accountId");
+        verify(grpcAuthDistributorClient, never()).removeAuthViewForEnvironment(eq("envCrn"));
+    }
+
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncForEnvServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncForEnvServiceTest.java
@@ -121,9 +121,9 @@ class UserSyncForEnvServiceTest {
             return future;
         });
         when(umsEventGenerationIdsProvider.getEventGenerationIds(eq(ACCOUNT_ID), any(Optional.class))).thenReturn(new UmsEventGenerationIds());
-        when(userSyncForStackService.synchronizeStack(stack1, umsUsersState1, options))
+        when(userSyncForStackService.synchronizeStack(stack1, umsUsersState1, options, OPERATION_ID))
                 .thenReturn(new SyncStatusDetail(ENV_CRN, SynchronizationStatus.COMPLETED, "", ImmutableMultimap.of()));
-        when(userSyncForStackService.synchronizeStack(stack2, umsUsersState2, options))
+        when(userSyncForStackService.synchronizeStack(stack2, umsUsersState2, options, OPERATION_ID))
                 .thenReturn(new SyncStatusDetail(ENV_CRN_2, SynchronizationStatus.COMPLETED, "", ImmutableMultimap.of()));
         when(userSyncStatusService.getOrCreateForStack(stack1)).thenReturn(new UserSyncStatus());
         when(userSyncStatusService.getOrCreateForStack(stack2)).thenReturn(new UserSyncStatus());
@@ -163,9 +163,9 @@ class UserSyncForEnvServiceTest {
             return future;
         });
         when(umsEventGenerationIdsProvider.getEventGenerationIds(eq(ACCOUNT_ID), any(Optional.class))).thenReturn(new UmsEventGenerationIds());
-        when(userSyncForStackService.synchronizeStack(stack1, umsUsersState1, options))
+        when(userSyncForStackService.synchronizeStack(stack1, umsUsersState1, options, OPERATION_ID))
                 .thenReturn(new SyncStatusDetail(ENV_CRN, SynchronizationStatus.FAILED, "fial1", ImmutableMultimap.of(ENV_CRN, "failed1")));
-        when(userSyncForStackService.synchronizeStack(stack2, umsUsersState2, options))
+        when(userSyncForStackService.synchronizeStack(stack2, umsUsersState2, options, OPERATION_ID))
                 .thenReturn(new SyncStatusDetail(ENV_CRN_2, SynchronizationStatus.REJECTED, "fial2", ImmutableMultimap.of(ENV_CRN_2, "failed2")));
 
         underTest.synchronizeUsers(OPERATION_ID, ACCOUNT_ID, List.of(stack1, stack2), userSyncFilter, options, System.currentTimeMillis());
@@ -281,7 +281,7 @@ class UserSyncForEnvServiceTest {
         UmsUsersState umsUsersState1 = mock(UmsUsersState.class);
         when(umsUsersStateProviderDispatcher.getEnvToUmsUsersStateMap(eq(ACCOUNT_ID), eq(Set.of(ENV_CRN)), eq(Set.of()), eq(Set.of()), any()))
                 .thenReturn(Map.of(ENV_CRN, umsUsersState1));
-        when(userSyncForStackService.synchronizeStack(stack1, umsUsersState1, options))
+        when(userSyncForStackService.synchronizeStack(stack1, umsUsersState1, options, OPERATION_ID))
                 .thenReturn(new SyncStatusDetail(ENV_CRN, SynchronizationStatus.COMPLETED, "", ImmutableMultimap.of()));
         Future<SyncStatusDetail> future = mock(Future.class);
         when(asyncTaskExecutor.submit(any(Callable.class))).thenAnswer(inv -> {

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -110,6 +110,9 @@ dependencies {
   implementation (project(':sdx-connector')) {
     transitive = false;
   }
+  implementation (project(':auth-distributor-connector')) {
+    transitive = false;
+  }
 
   implementation project(':common')
   implementation project(':cloud-gcp')

--- a/integration-test/integcb/Profile_template
+++ b/integration-test/integcb/Profile_template
@@ -22,6 +22,8 @@ export ENVIRONMENT_EXPERIENCE_SCAN_ENABLED=true
 export CB_LOCAL_DEV_LIST=jaeger,environments2-api,audit-api,distrox-api,thunderhead-api,datalake-api
 
 export ALTUS_AUDIT_ENDPOINT=thunderhead-mock
+export INTEGRATIONTEST_AUTHDISTRIBUTOR_HOST=thunderhead-mock
+export AUTHDISTRIBUTOR_HOST=thunderhead-mock
 export CLUSTERDNS_HOST=thunderhead-mock
 export MOCK_INFRASTRUCTURE_HOST=mock-infrastructure
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/AuthDistributorClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/AuthDistributorClient.java
@@ -1,0 +1,57 @@
+package com.sequenceiq.it.cloudbreak;
+
+import java.util.Set;
+
+import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
+import com.sequenceiq.cloudbreak.authdistributor.GrpcAuthDistributorClient;
+import com.sequenceiq.cloudbreak.authdistributor.config.AuthDistributorConfig;
+import com.sequenceiq.flow.api.FlowPublicEndpoint;
+import com.sequenceiq.it.cloudbreak.dto.authdistributor.FetchAuthViewTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.it.cloudbreak.util.wait.service.WaitObject;
+import com.sequenceiq.it.cloudbreak.util.wait.service.WaitService;
+
+import io.opentracing.Tracer;
+
+public class AuthDistributorClient<E extends Enum<E>, W extends WaitObject> extends MicroserviceClient<GrpcAuthDistributorClient, Void, E, W> {
+
+    public static final String AUTH_DISTRIBUTOR_CLIENT = "AUTH_DISTRIBUTOR_CLIENT";
+
+    private GrpcAuthDistributorClient grpcAuthDistributorClient;
+
+    AuthDistributorClient(String newId) {
+        super(newId);
+    }
+
+    AuthDistributorClient() {
+        this(AUTH_DISTRIBUTOR_CLIENT);
+    }
+
+    @Override
+    public FlowPublicEndpoint flowPublicEndpoint() {
+        throw new TestFailException("Flow does not support by auth distributor client");
+    }
+
+    @Override
+    public <T extends WaitObject> WaitService<T> waiterService() {
+        throw new TestFailException("Wait service does not support by auth distributor client");
+    }
+
+    @Override
+    public GrpcAuthDistributorClient getDefaultClient() {
+        return grpcAuthDistributorClient;
+    }
+
+    public static synchronized AuthDistributorClient createProxyAuthDistributorClient(Tracer tracer,
+            RegionAwareInternalCrnGeneratorFactory regionAwareInternalCrnGeneratorFactory, String host) {
+        AuthDistributorClient clientEntity = new AuthDistributorClient();
+        clientEntity.grpcAuthDistributorClient = GrpcAuthDistributorClient.createClient(
+                AuthDistributorConfig.newManagedChannelWrapper(host, 8982), tracer, regionAwareInternalCrnGeneratorFactory);
+        return clientEntity;
+    }
+
+    @Override
+    public Set<String> supportedTestDtos() {
+        return Set.of(FetchAuthViewTestDto.class.getSimpleName());
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaSynchronizeAllUsersInternalAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaSynchronizeAllUsersInternalAction.java
@@ -2,6 +2,8 @@ package com.sequenceiq.it.cloudbreak.action.freeipa;
 
 import static java.lang.String.format;
 
+import javax.ws.rs.BadRequestException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,13 +17,27 @@ public class FreeIpaSynchronizeAllUsersInternalAction extends AbstractFreeIpaAct
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FreeIpaSynchronizeAllUsersInternalAction.class);
 
+    private static final String PARTIAL_SYNC_NOT_ENABLED_ERROR = "Partial sync is not available for CDP SAAS.";
+
     @Override
     protected FreeIpaUserSyncTestDto freeIpaAction(TestContext testContext, FreeIpaUserSyncTestDto testDto, FreeIpaClient client) throws Exception {
         Log.when(LOGGER, format(" Environment Crn: [%s], freeIpa Crn: %s", testDto.getEnvironmentCrn(), testDto.getRequest().getEnvironments()));
         Log.whenJson(LOGGER, format(" FreeIPA sync internal request: %n"), testDto.getRequest());
-        SyncOperationStatus syncOperationStatus = client.getInternalClient(testContext)
-                .getUserV1Endpoint()
-                .synchronizeAllUsers(testDto.getRequest());
+        SyncOperationStatus syncOperationStatus;
+        try {
+            syncOperationStatus = client.getInternalClient(testContext)
+                    .getUserV1Endpoint()
+                    .synchronizeAllUsers(testDto.getRequest());
+        } catch (BadRequestException e) {
+            String message = e.getResponse().readEntity(String.class);
+            if (message != null && message.contains(PARTIAL_SYNC_NOT_ENABLED_ERROR)) {
+                LOGGER.info(PARTIAL_SYNC_NOT_ENABLED_ERROR);
+                testDto.setErrorMessage(PARTIAL_SYNC_NOT_ENABLED_ERROR);
+                return testDto;
+            } else {
+                throw e;
+            }
+        }
         testDto.setOperationId(syncOperationStatus.getOperationId());
         LOGGER.info("Sync is in state: [{}], sync internal operation: [{}] with type: [{}]", syncOperationStatus.getStatus(),
                 syncOperationStatus.getOperationId(), syncOperationStatus.getSyncOperationType());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
@@ -31,6 +31,7 @@ import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.it.TestParameter;
+import com.sequenceiq.it.cloudbreak.AuthDistributorClient;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.CloudbreakTest;
 import com.sequenceiq.it.cloudbreak.EnvironmentClient;
@@ -118,6 +119,9 @@ public abstract class TestContext implements ApplicationContextAware {
 
     @Value("${integrationtest.ums.host:localhost}")
     private String umsHost;
+
+    @Value("${integrationtest.authdistributor.host:localhost}")
+    private String authDistributorHost;
 
     @Inject
     private CloudProviderProxy cloudProvider;
@@ -449,6 +453,8 @@ public abstract class TestContext implements ApplicationContextAware {
             SdxClient sdxClient = SdxClient.createProxySdxClient(testParameter, cloudbreakUser);
             UmsClient umsClient = UmsClient.createProxyUmsClient(tracer, umsHost);
             SdxSaasItClient sdxSaasItClient = SdxSaasItClient.createProxySdxSaasClient(tracer, umsHost, regionAwareInternalCrnGeneratorFactory);
+            AuthDistributorClient authDistributorClient = AuthDistributorClient.createProxyAuthDistributorClient(tracer,
+                    regionAwareInternalCrnGeneratorFactory, authDistributorHost);
             RedbeamsClient redbeamsClient = RedbeamsClient.createProxyRedbeamsClient(testParameter, cloudbreakUser);
             Map<Class<? extends MicroserviceClient>, MicroserviceClient> clientMap = Map.of(
                     CloudbreakClient.class, cloudbreakClient,
@@ -457,7 +463,8 @@ public abstract class TestContext implements ApplicationContextAware {
                     SdxClient.class, sdxClient,
                     RedbeamsClient.class, redbeamsClient,
                     UmsClient.class, umsClient,
-                    SdxSaasItClient.class, sdxSaasItClient);
+                    SdxSaasItClient.class, sdxSaasItClient,
+                    AuthDistributorClient.class, authDistributorClient);
             clients.put(cloudbreakUser.getAccessKey(), clientMap);
             cloudbreakClient.setWorkspaceId(0L);
         }
@@ -475,6 +482,8 @@ public abstract class TestContext implements ApplicationContextAware {
             SdxClient sdxClient = SdxClient.createProxySdxClient(testParameter, accountAdmin);
             UmsClient umsClient = UmsClient.createProxyUmsClient(tracer, umsHost);
             SdxSaasItClient sdxSaasItClient = SdxSaasItClient.createProxySdxSaasClient(tracer, umsHost, regionAwareInternalCrnGeneratorFactory);
+            AuthDistributorClient authDistributorClient = AuthDistributorClient.createProxyAuthDistributorClient(tracer,
+                    regionAwareInternalCrnGeneratorFactory, authDistributorHost);
             RedbeamsClient redbeamsClient = RedbeamsClient.createProxyRedbeamsClient(testParameter, accountAdmin);
             Map<Class<? extends MicroserviceClient>, MicroserviceClient> clientMap = Map.of(
                     CloudbreakClient.class, cloudbreakClient,
@@ -483,7 +492,8 @@ public abstract class TestContext implements ApplicationContextAware {
                     SdxClient.class, sdxClient,
                     RedbeamsClient.class, redbeamsClient,
                     UmsClient.class, umsClient,
-                    SdxSaasItClient.class, sdxSaasItClient);
+                    SdxSaasItClient.class, sdxSaasItClient,
+                    AuthDistributorClient.class, authDistributorClient);
             clients.put(accountAdmin.getAccessKey(), clientMap);
         }
         LOGGER.info(" Microservice clients have been initialized successfully for UMS account admin:: \nDisplay name: {} \nAccess key: {} \nSecret key: {} " +

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/authdistributor/FetchAuthViewTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/authdistributor/FetchAuthViewTestDto.java
@@ -1,0 +1,45 @@
+package com.sequenceiq.it.cloudbreak.dto.authdistributor;
+
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.emptyRunningParameter;
+
+import com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserState;
+import com.sequenceiq.it.cloudbreak.AuthDistributorClient;
+import com.sequenceiq.it.cloudbreak.Prototype;
+import com.sequenceiq.it.cloudbreak.assertion.Assertion;
+import com.sequenceiq.it.cloudbreak.context.RunningParameter;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractTestDto;
+import com.sequenceiq.it.cloudbreak.request.authdistributor.FetchAuthViewRequest;
+
+@Prototype
+public class FetchAuthViewTestDto extends AbstractTestDto<FetchAuthViewRequest, UserState, FetchAuthViewTestDto, AuthDistributorClient> {
+
+    public FetchAuthViewTestDto(TestContext testContext) {
+        super(new FetchAuthViewRequest(), testContext);
+    }
+
+    public FetchAuthViewTestDto() {
+        super(FetchAuthViewTestDto.class.getSimpleName().toUpperCase());
+        setRequest(new FetchAuthViewRequest());
+    }
+
+    public FetchAuthViewTestDto withEnvironmentCrn(String environmentCrn) {
+        getRequest().setEnvironmentCrn(environmentCrn);
+        return this;
+    }
+
+    @Override
+    public FetchAuthViewTestDto then(Assertion<FetchAuthViewTestDto, AuthDistributorClient> assertion) {
+        return then(assertion, emptyRunningParameter());
+    }
+
+    @Override
+    public FetchAuthViewTestDto then(Assertion<FetchAuthViewTestDto, AuthDistributorClient> assertion, RunningParameter runningParameter) {
+        return getTestContext().then(this, AuthDistributorClient.class, assertion, runningParameter);
+    }
+
+    public FetchAuthViewTestDto valid() {
+        return new FetchAuthViewTestDto();
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaUserSyncTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaUserSyncTestDto.java
@@ -20,6 +20,8 @@ import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 @Prototype
 public class FreeIpaUserSyncTestDto extends AbstractFreeIpaTestDto<SynchronizeAllUsersRequest, SyncOperationStatus, FreeIpaUserSyncTestDto> {
 
+    private String errorMessage;
+
     public FreeIpaUserSyncTestDto(TestContext testContext) {
         super(new SynchronizeAllUsersRequest(), testContext);
     }
@@ -33,6 +35,11 @@ public class FreeIpaUserSyncTestDto extends AbstractFreeIpaTestDto<SynchronizeAl
 
     public FreeIpaUserSyncTestDto forAllEnvironments() {
         getRequest().setEnvironments(Set.of());
+        return this;
+    }
+
+    public FreeIpaUserSyncTestDto withUsers(Set<String> users) {
+        getRequest().setUsers(users);
         return this;
     }
 
@@ -62,4 +69,11 @@ public class FreeIpaUserSyncTestDto extends AbstractFreeIpaTestDto<SynchronizeAl
         return getEnvironmentCrn();
     }
 
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/request/authdistributor/FetchAuthViewRequest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/request/authdistributor/FetchAuthViewRequest.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.it.cloudbreak.request.authdistributor;
+
+public class FetchAuthViewRequest {
+
+    private String environmentCrn;
+
+    public FetchAuthViewRequest() {
+    }
+
+    public FetchAuthViewRequest(String environmentCrn) {
+        this.environmentCrn = environmentCrn;
+    }
+
+    public String getEnvironmentCrn() {
+        return environmentCrn;
+    }
+
+    public void setEnvironmentCrn(String environmentCrn) {
+        this.environmentCrn = environmentCrn;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/FreeIpaCdpSaasSyncTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/FreeIpaCdpSaasSyncTest.java
@@ -1,0 +1,103 @@
+package com.sequenceiq.it.cloudbreak.testcase.mock;
+
+import static java.lang.String.format;
+
+import java.util.Optional;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.StringUtils;
+import org.testng.annotations.Test;
+
+import com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserState;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationState;
+import com.sequenceiq.it.cloudbreak.AuthDistributorClient;
+import com.sequenceiq.it.cloudbreak.FreeIpaClient;
+import com.sequenceiq.it.cloudbreak.actor.CloudbreakActor;
+import com.sequenceiq.it.cloudbreak.assertion.Assertion;
+import com.sequenceiq.it.cloudbreak.client.FreeIpaTestClient;
+import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.authdistributor.FetchAuthViewTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaUserSyncTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+
+public class FreeIpaCdpSaasSyncTest extends AbstractMockTest {
+
+    @Inject
+    private FreeIpaTestClient freeIpaTestClient;
+
+    @Inject
+    private CloudbreakActor cloudbreakActor;
+
+    @Override
+    protected void setupTest(TestContext testContext) {
+        testContext.as(cloudbreakActor.create("CDP_SAAS_TENANT", "cdpsaasuser@cloudera.com"));
+        createDefaultCredential(testContext);
+        createDefaultEnvironment(testContext);
+        createDefaultImageCatalog(testContext);
+        initializeDefaultBlueprints(testContext);
+    }
+
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
+    @Description(
+            given = "environment is present",
+            when = "calling a freeipe start",
+            then = "freeipa sould be available")
+    public void testSyncFreeIpaCdpSaasWithInternalActor(MockedTestContext testContext) {
+        FreeIpaUserSyncTestDto freeIpaUserSyncTestDto = testContext
+                .given(FreeIpaTestDto.class)
+                .when(freeIpaTestClient.create())
+                .await(Status.AVAILABLE)
+                .given(FreeIpaUserSyncTestDto.class)
+                .when(freeIpaTestClient.getLastSyncOperationStatus())
+                .await(OperationState.COMPLETED);
+        String environmentCrn = freeIpaUserSyncTestDto.getEnvironmentCrn();
+        testContext.given(FetchAuthViewTestDto.class)
+                .withEnvironmentCrn(environmentCrn)
+                .then(validateUpdatedAuthView(true))
+                .given(FreeIpaUserSyncTestDto.class)
+                .when(freeIpaTestClient.syncAllInternal())
+                .await(OperationState.COMPLETED)
+                .given(FreeIpaTestDto.class)
+                .when(freeIpaTestClient.delete())
+                .await(Status.DELETE_COMPLETED)
+                .given(FetchAuthViewTestDto.class)
+                .withEnvironmentCrn(environmentCrn)
+                .then(validateUpdatedAuthView(false))
+                .given(FreeIpaUserSyncTestDto.class)
+                .withUsers(Set.of("user1"))
+                .when(freeIpaTestClient.syncAllInternal())
+                .then(validatePartialUserSyncFailed())
+                .validate();
+    }
+
+    public static Assertion<FreeIpaUserSyncTestDto, FreeIpaClient> validatePartialUserSyncFailed() {
+        return (testContext, freeIpaUserSyncTestDto, freeIpaClient) -> {
+            String errorMessage = freeIpaUserSyncTestDto.getErrorMessage();
+            if (StringUtils.isBlank(errorMessage)) {
+                throw new TestFailException("Partial user sync should fail if CDP_SAAS entitlement is enabled!");
+            }
+            return freeIpaUserSyncTestDto;
+        };
+    }
+
+    public static Assertion<FetchAuthViewTestDto, AuthDistributorClient> validateUpdatedAuthView(boolean exists) {
+        return (testContext, fetchAuthViewTestDto, authDistributorClient) -> {
+            String environmentCrn = fetchAuthViewTestDto.getRequest().getEnvironmentCrn();
+            Optional<UserState> userState = authDistributorClient.getDefaultClient().fetchAuthViewForEnvironment(environmentCrn);
+
+            if (exists && userState.isEmpty()) {
+                throw new TestFailException(format("User state is not exists for environment '%s' ", environmentCrn));
+            }
+            if (!exists && userState.isPresent()) {
+                throw new TestFailException(format("User state exists for environment '%s' ", environmentCrn));
+            }
+            return fetchAuthViewTestDto;
+        };
+    }
+}

--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -319,6 +319,9 @@ integrationtest:
     cluster:
     app:
 
+  authdistributor:
+    host: thunderhead-mock
+
 altus:
   audit:
     endpoint: localhost:8982

--- a/mock-thunderhead/build.gradle
+++ b/mock-thunderhead/build.gradle
@@ -83,4 +83,5 @@ dependencies {
   implementation project (':cloud-api')
   implementation project(':cluster-dns-connector')
   implementation project(':sdx-connector')
+  implementation project(':auth-distributor-connector')
 }

--- a/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/config/GrpcServerConfig.java
+++ b/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/config/GrpcServerConfig.java
@@ -11,6 +11,7 @@ import com.sequenceiq.thunderhead.grpc.service.audit.MockAuditLogService;
 import com.sequenceiq.thunderhead.grpc.service.auth.MockAuthorizationService;
 import com.sequenceiq.thunderhead.grpc.service.auth.MockPersonalResourceViewService;
 import com.sequenceiq.thunderhead.grpc.service.auth.MockUserManagementService;
+import com.sequenceiq.thunderhead.grpc.service.authdistributor.MockAuthDistributorService;
 import com.sequenceiq.thunderhead.grpc.service.datalakedr.MockDatalakeDrService;
 import com.sequenceiq.thunderhead.grpc.service.pem.MockPublicEndpointManagementService;
 import com.sequenceiq.thunderhead.grpc.service.saas.sdx.MockSdxSaasService;
@@ -43,6 +44,9 @@ public class GrpcServerConfig {
     @Inject
     private MockServiceDiscoveryService mockServiceDiscoveryService;
 
+    @Inject
+    private MockAuthDistributorService mockAuthDistributorService;
+
     @Value("${grpc.server.port:8982}")
     private int grpcServerPort;
 
@@ -59,7 +63,8 @@ public class GrpcServerConfig {
                 mockAuditLogService.bindService(),
                 mockPublicEndpointManagementService.bindService(),
                 mockSdxSaasService.bindService(),
-                mockServiceDiscoveryService.bindService());
+                mockServiceDiscoveryService.bindService(),
+                mockAuthDistributorService.bindService());
     }
 
     @Bean

--- a/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
+++ b/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
@@ -753,8 +753,9 @@ public class MockUserManagementService extends UserManagementImplBase {
 
     @Override
     public void getAccount(GetAccountRequest request, StreamObserver<GetAccountResponse> responseObserver) {
-        mockCrnService.ensureProperAccountIdUsage(request.getAccountId());
-        LOGGER.info("Get account: {}", request.getAccountId());
+        String accountId = request.getAccountId();
+        mockCrnService.ensureProperAccountIdUsage(accountId);
+        LOGGER.info("Get account: {}", accountId);
         Account.Builder builder = Account.newBuilder();
         if (enableBaseImages) {
             builder.addEntitlements(createEntitlement(CDP_BASE_IMAGE));
@@ -906,7 +907,7 @@ public class MockUserManagementService extends UserManagementImplBase {
         if (diagnosticsEnabled) {
             builder.addEntitlements(createEntitlement(CDP_VM_DIAGNOSTICS));
         }
-        if (enableSaas) {
+        if (enableSaas || accountId.contains("CDP_SAAS")) {
             builder.addEntitlements(createEntitlement(CDP_SAAS));
         }
         if (enableFmsFreeipaBatchCall) {
@@ -989,8 +990,8 @@ public class MockUserManagementService extends UserManagementImplBase {
                                 .addEntitlements(createEntitlement(CDP_RAW_S3))
                                 .addEntitlements(createEntitlement(CDP_CM_BULK_HOSTS_REMOVAL))
                                 .setGlobalPasswordPolicy(workloadPasswordPolicy)
-                                .setAccountId(request.getAccountId())
-                                .setExternalAccountId("external-" + request.getAccountId())
+                                .setAccountId(accountId)
+                                .setExternalAccountId("external-" + accountId)
                                 .build())
                         .build());
         responseObserver.onCompleted();

--- a/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/authdistributor/MockAuthDistributorService.java
+++ b/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/authdistributor/MockAuthDistributorService.java
@@ -1,0 +1,63 @@
+package com.sequenceiq.thunderhead.grpc.service.authdistributor;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.cloudera.thunderhead.service.authdistributor.AuthDistributorGrpc.AuthDistributorImplBase;
+import com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.FetchAuthViewForEnvironmentRequest;
+import com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.FetchAuthViewForEnvironmentResponse;
+import com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.RemoveAuthViewForEnvironmentRequest;
+import com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.RemoveAuthViewForEnvironmentResponse;
+import com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UpdateAuthViewForEnvironmentRequest;
+import com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UpdateAuthViewForEnvironmentResponse;
+import com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserState;
+import com.sequenceiq.thunderhead.service.UserStateStoreService;
+
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+
+@Component
+public class MockAuthDistributorService extends AuthDistributorImplBase {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MockAuthDistributorService.class);
+
+    @Inject
+    private UserStateStoreService userStateStoreService;
+
+    @Override
+    public void updateAuthViewForEnvironment(UpdateAuthViewForEnvironmentRequest request,
+            StreamObserver<UpdateAuthViewForEnvironmentResponse> responseObserver) {
+        LOGGER.info("Update auth view for environment: {}", request.getEnvironmentCrn());
+        userStateStoreService.store(request.getEnvironmentCrn(), request.getUserState());
+        responseObserver.onNext(UpdateAuthViewForEnvironmentResponse.newBuilder().build());
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void removeAuthViewForEnvironment(RemoveAuthViewForEnvironmentRequest request,
+            StreamObserver<RemoveAuthViewForEnvironmentResponse> responseObserver) {
+        LOGGER.info("Remove auth view for environment: {}", request.getEnvironmentCrn());
+        userStateStoreService.remove(request.getEnvironmentCrn());
+        responseObserver.onNext(RemoveAuthViewForEnvironmentResponse.newBuilder().build());
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void fetchAuthViewForEnvironment(FetchAuthViewForEnvironmentRequest request,
+            StreamObserver<FetchAuthViewForEnvironmentResponse> responseObserver) {
+        UserState userState = userStateStoreService.fetch(request.getEnvironmentCrn());
+        if (userState == null) {
+            responseObserver.onError(Status.NOT_FOUND.withDescription("User state not found for environment: " + request.getEnvironmentCrn())
+                    .asRuntimeException());
+        } else {
+            FetchAuthViewForEnvironmentResponse response = FetchAuthViewForEnvironmentResponse.newBuilder()
+                    .setUserState(userState)
+                    .build();
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+        }
+    }
+}

--- a/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/service/UserStateStoreService.java
+++ b/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/service/UserStateStoreService.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.thunderhead.service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.cloudera.thunderhead.service.authdistributor.AuthDistributorProto.UserState;
+
+@Component
+public class UserStateStoreService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserStateStoreService.class);
+
+    private final Map<String, UserState> userStates = new HashMap<>();
+
+    public void store(String environmentCrn, UserState userState) {
+        LOGGER.info("Store user state for environment: {}", environmentCrn);
+        userStates.put(environmentCrn, userState);
+    }
+
+    public void remove(String environmentCrn) {
+        LOGGER.info("Remove user state from store for environment: {}", environmentCrn);
+        userStates.remove(environmentCrn);
+    }
+
+    public UserState fetch(String environmentCrn) {
+        LOGGER.info("Fetch user state from store for environment: {}", environmentCrn);
+        return userStates.get(environmentCrn);
+    }
+}


### PR DESCRIPTION
- Call auth distributor updateAuthViewForEnvironment endpoint after usersync and send full user data.
- Call auth distributor removeAuthViewForEnvironment endpoint during FreeIpa delete.
- Create endpoints in thunderhead mock for local development and mock tests.
- If auth distributor is not available or fails, first retry and then fail silently and log the error.

See detailed description in the commit message.