### PR TITLE
CB-17150 do not enable all the cloud providers and gov cloud providers whith empty list as config value

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/account/PreferencesService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/account/PreferencesService.java
@@ -71,7 +71,7 @@ public class PreferencesService {
         Map<String, Boolean> result = new HashMap<>();
         if (StringUtils.isEmpty(enabledPlatforms)) {
             for (CloudConstant cloudConstant : cloudConstants) {
-                result.put(cloudConstant.platform().value(), true);
+                result.put(cloudConstant.platform().value(), false);
             }
         } else {
             for (String platform : enabledPlatforms()) {
@@ -90,7 +90,7 @@ public class PreferencesService {
         Map<String, Boolean> result = new HashMap<>();
         if (StringUtils.isEmpty(enabledGovPlatforms)) {
             for (CloudConstant cloudConstant : cloudConstants) {
-                result.put(cloudConstant.platform().value(), true);
+                result.put(cloudConstant.platform().value(), false);
             }
         } else {
             for (String platform : enabledGovPlatforms()) {

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -108,7 +108,7 @@ altus:
     caller: cloudbreak
 
 cb:
-  enabledplatforms: AZURE,AWS,GCP
+  enabledplatforms: AWS,AZURE,YARN,GCP,MOCK
   enabledgovplatforms: AWS
   platform.default.rootVolumeSize:
     AWS: 100

--- a/core/src/test/java/com/sequenceiq/cloudbreak/PropertiesTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/PropertiesTest.java
@@ -26,7 +26,7 @@ public class PropertiesTest {
     public void testEnabledPlatforms() {
         String[] platforms = enabledPlatforms.split(",");
 
-        assertThat(platforms, Matchers.arrayContainingInAnyOrder("AWS", "GCP", "AZURE"));
+        assertThat(platforms, Matchers.arrayContainingInAnyOrder("AWS", "GCP", "AZURE", "MOCK", "YARN"));
     }
 
     @Configuration


### PR DESCRIPTION
It doesn't enable all the cloud providers and GOV cloud providers when an empty list is set up for the `cb.enabledplatforms` and `cb.enabledgovplatforms` config keys as value.
Also the default set of supported cloud providers has been upgraded to have all providers in our `core/src/main/resources/application.yml`.
This change has been built on top of [the necessary dps-k8s config changes](https://github.infra.cloudera.com/thunderhead/dps-k8s/pull/305) not to have empty list as config value explicitly for our testing environments. The CSI repo has also been checked and verified that we are using explicit set of providers on every supported manowar environment.