### PR TITLE
CB-17193. Recipes should run only on targeted hosts (during upscale).

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterBuilderService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterBuilderService.java
@@ -178,7 +178,7 @@ public class ClusterBuilderService {
     }
 
     public void executePostClusterManagerStartRecipes(Long stackId) throws CloudbreakException {
-        recipeEngine.executePostAmbariStartRecipes(
+        recipeEngine.executePostClouderaManagerStartRecipes(
                 stackService.getByIdWithListsInTransaction(stackId),
                 hostGroupService.getByClusterWithRecipes(
                         stackService.getByIdWithListsInTransaction(stackId).getCluster().getId()));

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/upscale/ClusterUpscaleActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/upscale/ClusterUpscaleActions.java
@@ -171,7 +171,7 @@ public class ClusterUpscaleActions {
                     Map<String, Set<String>> hostGroupsWithHostNames =
                             (Map<String, Set<String>>) variables.getOrDefault(HOST_NAMES_BY_HOST_GROUP, new HashMap<>());
                     UpscaleClusterRequest request = new UpscaleClusterRequest(context.getStackId(), context.getHostGroups(),
-                            context.isRepair(), context.isRestartServices(), hostGroupsWithHostNames);
+                            context.isRepair(), context.isRestartServices(), hostGroupsWithHostNames, context.getHostGroupWithAdjustment());
                     sendEvent(context, request.selector(), request);
                 }
             }
@@ -361,7 +361,7 @@ public class ClusterUpscaleActions {
             @Override
             protected Selectable createRequest(ClusterUpscaleContext context) {
                 UpscaleClusterRequest request = new UpscaleClusterRequest(context.getStackId(), context.getHostGroups(),
-                        context.isRepair(), context.isRestartServices());
+                        context.isRepair(), context.isRestartServices(), context.getHostGroupWithAdjustment());
                 return new UpscaleClusterResult(request);
             }
         };
@@ -378,7 +378,7 @@ public class ClusterUpscaleActions {
 
             @Override
             protected Selectable createRequest(ClusterUpscaleContext context) {
-                return new UpscalePostRecipesRequest(context.getStackId(), context.getHostGroups());
+                return new UpscalePostRecipesRequest(context.getStackId(), context.getHostGroups(), context.getHostGroupWithAdjustment());
             }
         };
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/UpscaleClusterRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/UpscaleClusterRequest.java
@@ -14,18 +14,22 @@ public class UpscaleClusterRequest extends AbstractClusterScaleRequest {
 
     private Map<String, Set<String>> hostGroupsWithHostNames;
 
-    public UpscaleClusterRequest(Long stackId, Set<String> hostGroups, boolean repair, boolean restartServices) {
+    private Map<String, Integer> hostGroupWithAdjustment;
+
+    public UpscaleClusterRequest(Long stackId, Set<String> hostGroups, boolean repair, boolean restartServices, Map<String, Integer> hostGroupWithAdjustment) {
         super(stackId, hostGroups);
         this.repair = repair;
         this.restartServices = restartServices;
+        this.hostGroupWithAdjustment = hostGroupWithAdjustment;
         this.hostGroupsWithHostNames = new HashMap<>();
     }
 
     public UpscaleClusterRequest(Long stackId, Set<String> hostGroups, boolean repair, boolean restartServices,
-            Map<String, Set<String>> hostGroupsWithHostNames) {
+            Map<String, Set<String>> hostGroupsWithHostNames, Map<String, Integer> hostGroupWithAdjustment) {
         super(stackId, hostGroups);
         this.repair = repair;
         this.restartServices = restartServices;
+        this.hostGroupWithAdjustment = hostGroupWithAdjustment;
         this.hostGroupsWithHostNames = hostGroupsWithHostNames;
     }
 
@@ -39,5 +43,9 @@ public class UpscaleClusterRequest extends AbstractClusterScaleRequest {
 
     public Map<String, Set<String>> getHostGroupsWithHostNames() {
         return hostGroupsWithHostNames;
+    }
+
+    public Map<String, Integer> getHostGroupWithAdjustment() {
+        return hostGroupWithAdjustment;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/recipe/UpscalePostRecipesRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/recipe/UpscalePostRecipesRequest.java
@@ -1,12 +1,20 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.recipe;
 
+import java.util.Map;
 import java.util.Set;
 
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleRequest;
 
 public class UpscalePostRecipesRequest extends AbstractClusterScaleRequest {
 
-    public UpscalePostRecipesRequest(Long stackId, Set<String> hostGroups) {
+    private final Map<String, Integer> hostGroupWithAdjustment;
+
+    public UpscalePostRecipesRequest(Long stackId, Set<String> hostGroups, Map<String, Integer> hostGroupWithAdjustment) {
         super(stackId, hostGroups);
+        this.hostGroupWithAdjustment = hostGroupWithAdjustment;
+    }
+
+    public Map<String, Integer> getHostGroupWithAdjustment() {
+        return hostGroupWithAdjustment;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/UpscaleClusterHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/UpscaleClusterHandler.java
@@ -32,7 +32,8 @@ public class UpscaleClusterHandler implements EventHandler<UpscaleClusterRequest
         UpscaleClusterResult result;
         try {
             clusterUpscaleService.installServicesOnNewHosts(request.getResourceId(), request.getHostGroupNames(),
-                    request.isRepair(), request.isRestartServices(), request.getHostGroupsWithHostNames());
+                    request.isRepair(), request.isRestartServices(), request.getHostGroupsWithHostNames(),
+                    request.getHostGroupWithAdjustment());
             result = new UpscaleClusterResult(request);
         } catch (Exception e) {
             result = new UpscaleClusterResult(e.getMessage(), e, request);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/recipe/UpscalePostRecipesHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/recipe/UpscalePostRecipesHandler.java
@@ -32,7 +32,7 @@ public class UpscalePostRecipesHandler implements EventHandler<UpscalePostRecipe
         UpscalePostRecipesRequest request = event.getData();
         UpscalePostRecipesResult result;
         try {
-            clusterUpscaleService.executePostRecipesOnNewHosts(request.getResourceId());
+            clusterUpscaleService.executePostRecipesOnNewHosts(request.getResourceId(), request.getHostGroupWithAdjustment());
             result = new UpscalePostRecipesResult(request);
         } catch (Exception e) {
             result = new UpscalePostRecipesResult(e.getMessage(), e, request);


### PR DESCRIPTION
details:
- as we can attach/detach recipes now, it's a possible use case that we have a new recipe that was originally not attached to a host group, but it has been attached later
- in that case a recipe has been attached after deployment, and a scale happens on that host group, the recipe will run on every node on that host group, not only against the scaled one
- without attach/detach recipe feature that did not happened, as recipes have been there already on the nodes, and could not be removed, so on an upscale, recipes only run against the new nodes (as they have been run already on the other nodes during deployment)

See detailed description in the commit message.