### PR TITLE
CB-17142 Modify java.arg.7 property in Flow cluster templates. Update…

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.16/cdp-flow-management-small.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.16/cdp-flow-management-small.bp
@@ -163,7 +163,7 @@
               },
               {
                 "name": "java.arg.7",
-                "value": "-Djava.io.tmpdir=${nifi.working.directory}/tmp"
+                "value": "${nifi.working.directory}/tmp"
               },
               {
                 "name": "nifi.registry.client.name",

--- a/core/src/main/resources/defaults/blueprints/7.2.16/cdp-flow-management.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.16/cdp-flow-management.bp
@@ -139,7 +139,7 @@
               },
               {
                 "name": "java.arg.7",
-                "value": "-Djava.io.tmpdir=${nifi.working.directory}/tmp"
+                "value": "${nifi.working.directory}/tmp"
               },
               {
                 "name": "nifi.registry.client.name",


### PR DESCRIPTION
…d this java arg value according to related changes in CFM. Now value for this property is more user friendly and requires only path to tmp dir, no need to add arg key name.

See detailed description in the commit message.