### PR TITLE
CB-17150 remove unnecessary cb.enabledplatforms config from the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,6 @@ To launch the Cloudbreak application execute the `com.sequenceiq.cloudbreak.Clou
 -Daltus.ums.host=localhost
 -Dvault.addr=localhost
 -Dvault.root.token=<VAULT_ROOT_TOKEN>
--Dcb.enabledplatforms=""
 -Dinstance.node.id=<NODE_ID>
 ```
 


### PR DESCRIPTION
Removing `cb.enabledplatforms` config from the Cloudbreak/Core related section of the README.md as it has changed and unnecessary as the default values enabled all the supported cloud platorms.
https://github.com/hortonworks/cloudbreak/blob/CB-2.57.0/core/src/main/resources/application.yml#L111

Thanks @lturcsanyi for catching it!