### PR TITLE
CB-14593 Core Upgrade CCM Flow

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterServiceRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterServiceRunner.java
@@ -92,6 +92,20 @@ public class ClusterServiceRunner {
         hostRunner.redeployGatewayCertificate(stack, cluster);
     }
 
+    public void redeployGatewayPillar(Long stackId) {
+        Stack stack = stackService.getByIdWithListsInTransaction(stackId);
+        Long clusterId = stack.getCluster().getId();
+        Cluster cluster = clusterService.findOneWithLists(clusterId).orElseThrow(NotFoundException.notFound("Cluster", clusterId));
+        hostRunner.redeployGatewayPillarOnly(stack, cluster);
+    }
+
+    public void redeployStates(Long stackId) {
+        Stack stack = stackService.getByIdWithListsInTransaction(stackId);
+        Long clusterId = stack.getCluster().getId();
+        Cluster cluster = clusterService.findOneWithLists(clusterId).orElseThrow(NotFoundException.notFound("Cluster", clusterId));
+        hostRunner.redeployStates(stack, cluster);
+    }
+
     public String changePrimaryGateway(Long stackId) throws CloudbreakException {
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
         return hostRunner.changePrimaryGateway(stack);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/ccm/upgrade/AbstractUpgradeCcmAction.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/ccm/upgrade/AbstractUpgradeCcmAction.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.cloudbreak.core.flow2.cluster.ccm.upgrade;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.springframework.statemachine.StateContext;
+
+import com.sequenceiq.cloudbreak.core.flow2.AbstractStackAction;
+import com.sequenceiq.cloudbreak.domain.view.StackView;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.cloudbreak.reactor.api.event.StackFailureEvent;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.AbstractUpgradeCcmEvent;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.flow.core.FlowEvent;
+import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.flow.core.FlowState;
+
+public abstract class AbstractUpgradeCcmAction<P extends AbstractUpgradeCcmEvent> extends AbstractStackAction<FlowState, FlowEvent, UpgradeCcmContext, P> {
+
+    @Inject
+    private StackService stackService;
+
+    protected AbstractUpgradeCcmAction(Class<P> payloadClass) {
+        super(payloadClass);
+    }
+
+    @Override
+    protected UpgradeCcmContext createFlowContext(FlowParameters flowParameters, StateContext<FlowState, FlowEvent> clusterContext, P payload) {
+        StackView stack = stackService.getViewByIdWithoutAuth(payload.getResourceId());
+        MDCBuilder.buildMdcContext(stack);
+        MDCBuilder.buildMdcContext(stack.getClusterView());
+        return new UpgradeCcmContext(flowParameters, stack, payload.getOldTunnel());
+    }
+
+    @Override
+    protected Object getFailurePayload(P payload, Optional<UpgradeCcmContext> flowContext, Exception ex) {
+        return new StackFailureEvent(payload.getResourceId(), ex);
+    }
+
+    public StackService getStackService() {
+        return stackService;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/ccm/upgrade/UpgradeCcmActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/ccm/upgrade/UpgradeCcmActions.java
@@ -1,167 +1,166 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.ccm.upgrade;
 
 import java.util.Map;
+import java.util.Optional;
 
 import javax.inject.Inject;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.statemachine.action.Action;
 
 import com.sequenceiq.cloudbreak.common.event.Selectable;
-import com.sequenceiq.cloudbreak.core.flow2.cluster.AbstractClusterAction;
-import com.sequenceiq.cloudbreak.core.flow2.cluster.ClusterViewContext;
 import com.sequenceiq.cloudbreak.core.flow2.stack.AbstractStackFailureAction;
 import com.sequenceiq.cloudbreak.core.flow2.stack.StackFailureContext;
+import com.sequenceiq.cloudbreak.domain.view.ClusterView;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackFailureEvent;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmDeregisterAgentRequest;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmDeregisterAgentResult;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmFailedEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmHealthCheckRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmHealthCheckResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmPushSaltStatesRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmPushSaltStatesResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmReconfigureNginxRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmReconfigureNginxResult;
-import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmRemoveAgentRequest;
-import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmRemoveAgentResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmRegisterClusterProxyRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmRegisterClusterProxyResult;
-import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmDeregisterAgentRequest;
-import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmDeregisterAgentResult;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmRemoveAgentRequest;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmRemoveAgentResult;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmTriggerRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmTunnelUpdateRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmTunnelUpdateResult;
 
 @Configuration
 public class UpgradeCcmActions {
-    private static final Logger LOGGER = LoggerFactory.getLogger(UpgradeCcmActions.class);
 
     @Inject
     private UpgradeCcmService upgradeCcmService;
 
     @Bean(name = "UPGRADE_CCM_TUNNEL_UPDATE_STATE")
     public Action<?, ?> tunnelUpdate() {
-        return new AbstractClusterAction<>(StackEvent.class) {
+        return new AbstractUpgradeCcmAction<>(UpgradeCcmTriggerRequest.class) {
             @Override
-            protected void doExecute(ClusterViewContext context, StackEvent payload, Map<Object, Object> variables) {
+            protected void doExecute(UpgradeCcmContext context, UpgradeCcmTriggerRequest payload, Map<Object, Object> variables) {
                 upgradeCcmService.tunnelUpdateState(payload.getResourceId());
                 sendEvent(context);
             }
 
             @Override
-            protected Selectable createRequest(ClusterViewContext context) {
-                return new UpgradeCcmTunnelUpdateRequest(context.getStackId());
+            protected Selectable createRequest(UpgradeCcmContext context) {
+                return new UpgradeCcmTunnelUpdateRequest(context.getStackId(), context.getClusterId(), context.getOldTunnel());
             }
         };
     }
 
     @Bean(name = "UPGRADE_CCM_PUSH_SALT_STATES_STATE")
     public Action<?, ?> pushSaltStates() {
-        return new AbstractClusterAction<>(UpgradeCcmTunnelUpdateResult.class) {
+        return new AbstractUpgradeCcmAction<>(UpgradeCcmTunnelUpdateResult.class) {
             @Override
-            protected void doExecute(ClusterViewContext context, UpgradeCcmTunnelUpdateResult payload, Map<Object, Object> variables) {
+            protected void doExecute(UpgradeCcmContext context, UpgradeCcmTunnelUpdateResult payload, Map<Object, Object> variables) {
                 upgradeCcmService.pushSaltStatesState(payload.getResourceId());
                 sendEvent(context);
             }
 
             @Override
-            protected Selectable createRequest(ClusterViewContext context) {
-                return new UpgradeCcmPushSaltStatesRequest(context.getStackId());
+            protected Selectable createRequest(UpgradeCcmContext context) {
+                return new UpgradeCcmPushSaltStatesRequest(context.getStackId(), context.getClusterId(), context.getOldTunnel());
             }
         };
     }
 
     @Bean(name = "UPGRADE_CCM_RECONFIGURE_NGINX_STATE")
     public Action<?, ?> reconfigureNginx() {
-        return new AbstractClusterAction<>(UpgradeCcmPushSaltStatesResult.class) {
+        return new AbstractUpgradeCcmAction<>(UpgradeCcmPushSaltStatesResult.class) {
             @Override
-            protected void doExecute(ClusterViewContext context, UpgradeCcmPushSaltStatesResult payload, Map<Object, Object> variables) {
+            protected void doExecute(UpgradeCcmContext context, UpgradeCcmPushSaltStatesResult payload, Map<Object, Object> variables) {
                 upgradeCcmService.reconfigureNginxState(payload.getResourceId());
                 sendEvent(context);
             }
 
             @Override
-            protected Selectable createRequest(ClusterViewContext context) {
-                return new UpgradeCcmReconfigureNginxRequest(context.getStackId());
+            protected Selectable createRequest(UpgradeCcmContext context) {
+                return new UpgradeCcmReconfigureNginxRequest(context.getStackId(), context.getClusterId(), context.getOldTunnel());
             }
         };
     }
 
     @Bean(name = "UPGRADE_CCM_REGISTER_CLUSTER_PROXY_STATE")
     public Action<?, ?> registerClusterToClusterProxy() {
-        return new AbstractClusterAction<>(UpgradeCcmReconfigureNginxResult.class) {
+        return new AbstractUpgradeCcmAction<>(UpgradeCcmReconfigureNginxResult.class) {
             @Override
-            protected void doExecute(ClusterViewContext context, UpgradeCcmReconfigureNginxResult payload, Map<Object, Object> variables) {
+            protected void doExecute(UpgradeCcmContext context, UpgradeCcmReconfigureNginxResult payload, Map<Object, Object> variables) {
                 upgradeCcmService.registerClusterProxyState(payload.getResourceId());
                 sendEvent(context);
             }
 
             @Override
-            protected Selectable createRequest(ClusterViewContext context) {
-                return new UpgradeCcmRegisterClusterProxyRequest(context.getStackId());
+            protected Selectable createRequest(UpgradeCcmContext context) {
+                return new UpgradeCcmRegisterClusterProxyRequest(context.getStackId(), context.getClusterId(), context.getOldTunnel());
             }
         };
     }
 
     @Bean(name = "UPGRADE_CCM_HEALTH_CHECK_STATE")
     public Action<?, ?> healthCheck() {
-        return new AbstractClusterAction<>(UpgradeCcmRegisterClusterProxyResult.class) {
+        return new AbstractUpgradeCcmAction<>(UpgradeCcmRegisterClusterProxyResult.class) {
             @Override
-            protected void doExecute(ClusterViewContext context, UpgradeCcmRegisterClusterProxyResult payload, Map<Object, Object> variables) {
+            protected void doExecute(UpgradeCcmContext context, UpgradeCcmRegisterClusterProxyResult payload, Map<Object, Object> variables) {
                 upgradeCcmService.healthCheckState(payload.getResourceId());
                 sendEvent(context);
             }
 
             @Override
-            protected Selectable createRequest(ClusterViewContext context) {
-                return new UpgradeCcmHealthCheckRequest(context.getStackId());
+            protected Selectable createRequest(UpgradeCcmContext context) {
+                return new UpgradeCcmHealthCheckRequest(context.getStackId(), context.getClusterId(), context.getOldTunnel());
             }
         };
     }
 
     @Bean(name = "UPGRADE_CCM_REMOVE_AGENT_STATE")
     public Action<?, ?> removeAgent() {
-        return new AbstractClusterAction<>(UpgradeCcmHealthCheckResult.class) {
+        return new AbstractUpgradeCcmAction<>(UpgradeCcmHealthCheckResult.class) {
             @Override
-            protected void doExecute(ClusterViewContext context, UpgradeCcmHealthCheckResult payload, Map<Object, Object> variables) {
+            protected void doExecute(UpgradeCcmContext context, UpgradeCcmHealthCheckResult payload, Map<Object, Object> variables) {
                 upgradeCcmService.removeAgentState(payload.getResourceId());
                 sendEvent(context);
             }
 
             @Override
-            protected Selectable createRequest(ClusterViewContext context) {
-                return new UpgradeCcmRemoveAgentRequest(context.getStackId());
+            protected Selectable createRequest(UpgradeCcmContext context) {
+                return new UpgradeCcmRemoveAgentRequest(context.getStackId(), context.getClusterId(), context.getOldTunnel());
             }
         };
     }
 
     @Bean(name = "UPGRADE_CCM_DEREGISTER_AGENT_STATE")
     public Action<?, ?> deregisterAgent() {
-        return new AbstractClusterAction<>(UpgradeCcmRemoveAgentResult.class) {
+        return new AbstractUpgradeCcmAction<>(UpgradeCcmRemoveAgentResult.class) {
             @Override
-            protected void doExecute(ClusterViewContext context, UpgradeCcmRemoveAgentResult payload, Map<Object, Object> variables) {
+            protected void doExecute(UpgradeCcmContext context, UpgradeCcmRemoveAgentResult payload, Map<Object, Object> variables) {
                 upgradeCcmService.deregisterAgentState(payload.getResourceId());
                 sendEvent(context);
             }
 
             @Override
-            protected Selectable createRequest(ClusterViewContext context) {
-                return new UpgradeCcmDeregisterAgentRequest(context.getStackId());
+            protected Selectable createRequest(UpgradeCcmContext context) {
+                return new UpgradeCcmDeregisterAgentRequest(context.getStackId(), context.getClusterId(), context.getOldTunnel());
             }
         };
     }
 
     @Bean(name = "UPGRADE_CCM_FINISHED_STATE")
     public Action<?, ?> upgradeCcmFinished() {
-        return new AbstractClusterAction<>(UpgradeCcmDeregisterAgentResult.class) {
+        return new AbstractUpgradeCcmAction<>(UpgradeCcmDeregisterAgentResult.class) {
             @Override
-            protected void doExecute(ClusterViewContext context, UpgradeCcmDeregisterAgentResult payload, Map<Object, Object> variables) {
-                upgradeCcmService.ccmUpgradeFinished(payload.getResourceId());
+            protected void doExecute(UpgradeCcmContext context, UpgradeCcmDeregisterAgentResult payload, Map<Object, Object> variables) {
+                upgradeCcmService.ccmUpgradeFinished(payload.getResourceId(), context.getClusterId());
                 sendEvent(context);
             }
 
             @Override
-            protected Selectable createRequest(ClusterViewContext context) {
+            protected Selectable createRequest(UpgradeCcmContext context) {
                 return new StackEvent(UpgradeCcmEvent.FINALIZED_EVENT.event(), context.getStackId());
             }
         };
@@ -172,7 +171,10 @@ public class UpgradeCcmActions {
         return new AbstractStackFailureAction<UpgradeCcmState, UpgradeCcmEvent>() {
             @Override
             protected void doExecute(StackFailureContext context, StackFailureEvent payload, Map<Object, Object> variables) {
-                upgradeCcmService.ccmUpgradeFailed(payload.getResourceId());
+                UpgradeCcmFailedEvent concretePayload = (UpgradeCcmFailedEvent) payload;
+                upgradeCcmService.ccmUpgradeFailed(concretePayload.getResourceId(),
+                        Optional.ofNullable(context.getStackView().getClusterView()).map(ClusterView::getId).orElse(null),
+                        concretePayload.getOldTunnel());
                 sendEvent(context);
             }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/ccm/upgrade/UpgradeCcmContext.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/ccm/upgrade/UpgradeCcmContext.java
@@ -1,0 +1,20 @@
+package com.sequenceiq.cloudbreak.core.flow2.cluster.ccm.upgrade;
+
+import com.sequenceiq.cloudbreak.core.flow2.cluster.ClusterViewContext;
+import com.sequenceiq.cloudbreak.domain.view.StackView;
+import com.sequenceiq.common.api.type.Tunnel;
+import com.sequenceiq.flow.core.FlowParameters;
+
+public class UpgradeCcmContext extends ClusterViewContext {
+
+    private final Tunnel oldTunnel;
+
+    public UpgradeCcmContext(FlowParameters flowParameters, StackView stack, Tunnel oldTunnel) {
+        super(flowParameters, stack);
+        this.oldTunnel = oldTunnel;
+    }
+
+    public Tunnel getOldTunnel() {
+        return oldTunnel;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/ccm/upgrade/UpgradeCcmService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/ccm/upgrade/UpgradeCcmService.java
@@ -4,6 +4,9 @@ import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.AVAILABLE;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.UPDATE_FAILED;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.UPDATE_IN_PROGRESS;
 
+import java.util.Optional;
+import java.util.Set;
+
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
@@ -11,10 +14,25 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
+import com.sequenceiq.cloudbreak.ccm.key.CcmResourceUtil;
+import com.sequenceiq.cloudbreak.ccm.termination.CcmResourceTerminationListener;
+import com.sequenceiq.cloudbreak.ccm.termination.CcmV2AgentTerminationListener;
+import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
+import com.sequenceiq.cloudbreak.cloud.store.InMemoryStateStore;
+import com.sequenceiq.cloudbreak.clusterproxy.ConfigRegistrationResponse;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterServiceRunner;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.provision.service.ClusterProxyService;
 import com.sequenceiq.cloudbreak.core.flow2.stack.CloudbreakFlowMessageService;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.event.ResourceEvent;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
 import com.sequenceiq.cloudbreak.service.StackUpdater;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.service.upgrade.ccm.HealthCheckService;
+import com.sequenceiq.cloudbreak.service.upgrade.ccm.UpgradeCcmOrchestratorService;
 import com.sequenceiq.common.api.type.Tunnel;
 
 @Service
@@ -30,6 +48,24 @@ public class UpgradeCcmService {
 
     @Inject
     private StackService stackService;
+
+    @Inject
+    private ClusterServiceRunner clusterServiceRunner;
+
+    @Inject
+    private UpgradeCcmOrchestratorService upgradeCcmOrchestratorService;
+
+    @Inject
+    private CcmResourceTerminationListener ccmResourceTerminationListener;
+
+    @Inject
+    private CcmV2AgentTerminationListener ccmV2AgentTerminationListener;
+
+    @Inject
+    private ClusterProxyService clusterProxyService;
+
+    @Inject
+    private HealthCheckService healthCheckService;
 
     void tunnelUpdateState(Long stackId) {
         String statusReason = "Updating tunnel type of the cluster";
@@ -80,16 +116,20 @@ public class UpgradeCcmService {
         flowMessageService.fireEventAndLog(stackId, UPDATE_IN_PROGRESS.name(), ResourceEvent.CLUSTER_CCM_UPGRADE_DEREGISTER_AGENT);
     }
 
-    void ccmUpgradeFinished(Long stackId) {
+    void ccmUpgradeFinished(Long stackId, Long clusterId) {
         String statusReason = "CCM upgrade finished";
         LOGGER.debug(statusReason);
+        InMemoryStateStore.deleteStack(stackId);
+        InMemoryStateStore.deleteCluster(clusterId);
         stackUpdater.updateStackStatus(stackId, DetailedStackStatus.AVAILABLE, statusReason);
         flowMessageService.fireEventAndLog(stackId, AVAILABLE.name(), ResourceEvent.CLUSTER_CCM_UPGRADE_FINISHED);
     }
 
-    void ccmUpgradeFailed(Long stackId) {
+    void ccmUpgradeFailed(Long stackId, Long clusterId, Tunnel oldTunnel) {
         String statusReason = "CCM upgrade failed";
         LOGGER.debug(statusReason);
+        InMemoryStateStore.deleteStack(stackId);
+        InMemoryStateStore.deleteCluster(clusterId);
         stackUpdater.updateStackStatus(stackId, DetailedStackStatus.CCM_UPGRADE_FAILED, statusReason);
         flowMessageService.fireEventAndLog(stackId, UPDATE_FAILED.name(), ResourceEvent.CLUSTER_CCM_UPGRADE_FAILED);
     }
@@ -98,21 +138,58 @@ public class UpgradeCcmService {
         stackService.setTunnelByStackId(stackId, Tunnel.latestUpgradeTarget());
     }
 
-    public void pushSaltState(Long stackId) {
+    public void pushSaltState(Long stackId, Long clusterId) {
+        InMemoryStateStore.putStack(stackId, PollGroup.POLLABLE);
+        if (clusterId != null) {
+            InMemoryStateStore.putCluster(clusterId, PollGroup.POLLABLE);
+        }
+        clusterServiceRunner.redeployStates(stackId);
+        clusterServiceRunner.redeployGatewayPillar(stackId);
     }
 
-    public void reconfigureNginx(Long stackId) {
+    public void reconfigureNginx(Long stackId) throws CloudbreakOrchestratorException {
+        upgradeCcmOrchestratorService.reconfigureNginx(stackId);
     }
 
     public void registerClusterProxy(Long stackId) {
+        Optional<ConfigRegistrationResponse> configRegistrationResponse = clusterProxyService.reRegisterCluster(stackId);
+        configRegistrationResponse.ifPresentOrElse(c -> LOGGER.debug(c.toString()), () -> LOGGER.debug("No clusterproxy register response for {}", stackId));
     }
 
     public void healthCheck(Long stackId) {
+        Set<String> unhealthyHosts;
+        try {
+            unhealthyHosts = healthCheckService.getUnhealthyHosts(stackId);
+        } catch (RuntimeException ex) {
+            throw new CloudbreakServiceException("Cannot get host statuses, CM is likely not accessible. Need to roll back CCM upgrade to previous version.");
+        }
+        if (!unhealthyHosts.isEmpty()) {
+            LOGGER.info("There are unhealthy hosts after registering to Cluster Proxy: {}", unhealthyHosts);
+            throw new CloudbreakServiceException("One or more Gateway instance is not available. Need to roll back CCM upgrade to previous version.");
+        } else {
+            LOGGER.info("All hosts are healthy after registering to Cluster Proxy.");
+        }
     }
 
-    public void removeAgent(Long stackId) {
+    public void removeAgent(Long stackId, Tunnel oldTunnel) throws CloudbreakOrchestratorException {
+        if (oldTunnel == Tunnel.CCM) {
+            upgradeCcmOrchestratorService.disableMina(stackId);
+        } else if (oldTunnel == Tunnel.CCMV2) {
+            upgradeCcmOrchestratorService.disableInvertingProxyAgent(stackId);
+        }
     }
 
-    public void deregisterAgent(Long stackId) {
+    public void deregisterAgent(Long stackId, Tunnel oldTunnel) {
+        Stack stack = stackService.getById(stackId);
+        if (oldTunnel == Tunnel.CCM) {
+            String keyId = CcmResourceUtil.getKeyId(stack.getResourceCrn());
+            String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
+            LOGGER.debug("Deregistering agent from {} with key ID {} and user CRN {}", oldTunnel, keyId, userCrn);
+            ccmResourceTerminationListener.deregisterCcmSshTunnelingKey(
+                    userCrn, Crn.safeFromString(stack.getResourceCrn()).getAccountId(), keyId, stack.getMinaSshdServiceId());
+        } else if (oldTunnel == Tunnel.CCMV2) {
+            LOGGER.debug("Deregistering agent from {} with agent CRN {}", oldTunnel, stack.getCcmV2AgentCrn());
+            ccmV2AgentTerminationListener.deregisterInvertingProxyAgent(stack.getCcmV2AgentCrn());
+        }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/service/ClusterProxyService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/service/ClusterProxyService.java
@@ -299,14 +299,16 @@ public class ClusterProxyService {
                 : com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.response.ClusterProxyConfiguration.disabled();
     }
 
-    public void reRegisterCluster(Long stackId) {
+    public Optional<ConfigRegistrationResponse> reRegisterCluster(Long stackId) {
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
         if (clusterProxyEnablementService.isClusterProxyApplicable(stack.getCloudPlatform())) {
             LOGGER.info("Cluster Proxy integration is ENABLED, starting re-registering with Cluster Proxy service");
-            reRegisterCluster(stack);
+            ConfigRegistrationResponse registrationResult = reRegisterCluster(stack);
             LOGGER.info("Cluster has been re-registered with Cluster Proxy service successfully.");
+            return Optional.of(registrationResult);
         } else {
             LOGGER.debug("Cluster Proxy integration is DISABLED, skipping re-registering with Cluster Proxy service");
+            return Optional.empty();
         }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/AbstractUpgradeCcmEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/AbstractUpgradeCcmEvent.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm;
+
+import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+import com.sequenceiq.common.api.type.Tunnel;
+
+public abstract class AbstractUpgradeCcmEvent extends StackEvent {
+
+    private final Long clusterId;
+
+    private final Tunnel oldTunnel;
+
+    public AbstractUpgradeCcmEvent(Long stackId, Long clusterId, Tunnel oldTunnel) {
+        super(stackId);
+        this.clusterId = clusterId;
+        this.oldTunnel = oldTunnel;
+    }
+
+    public Long getClusterId() {
+        return clusterId;
+    }
+
+    public Tunnel getOldTunnel() {
+        return oldTunnel;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmDeregisterAgentRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmDeregisterAgentRequest.java
@@ -1,10 +1,10 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm;
 
-import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+import com.sequenceiq.common.api.type.Tunnel;
 
-public class UpgradeCcmDeregisterAgentRequest extends StackEvent {
+public class UpgradeCcmDeregisterAgentRequest extends AbstractUpgradeCcmEvent {
 
-    public UpgradeCcmDeregisterAgentRequest(Long stackId) {
-        super(stackId);
+    public UpgradeCcmDeregisterAgentRequest(Long stackId, Long clusterId, Tunnel oldTunnel) {
+        super(stackId, clusterId, oldTunnel);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmDeregisterAgentResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmDeregisterAgentResult.java
@@ -1,14 +1,11 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm;
 
-import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+import com.sequenceiq.common.api.type.Tunnel;
 
-public class UpgradeCcmDeregisterAgentResult extends StackEvent {
+public class UpgradeCcmDeregisterAgentResult extends AbstractUpgradeCcmEvent {
 
-    public UpgradeCcmDeregisterAgentResult(Long stackId) {
-        super(stackId);
+    public UpgradeCcmDeregisterAgentResult(Long stackId, Long clusterId, Tunnel oldTunnel) {
+        super(stackId, clusterId, oldTunnel);
     }
 
-    public UpgradeCcmDeregisterAgentResult(String selector, Long stackId) {
-        super(selector, stackId);
-    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmFailedEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmFailedEvent.java
@@ -1,9 +1,18 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm;
 
 import com.sequenceiq.cloudbreak.reactor.api.event.StackFailureEvent;
+import com.sequenceiq.common.api.type.Tunnel;
 
 public class UpgradeCcmFailedEvent extends StackFailureEvent {
-    public UpgradeCcmFailedEvent(Long stackId, Exception ex) {
+
+    private final Tunnel oldTunnel;
+
+    public UpgradeCcmFailedEvent(Long stackId, Tunnel oldTunnel, Exception ex) {
         super(stackId, ex);
+        this.oldTunnel = oldTunnel;
+    }
+
+    public Tunnel getOldTunnel() {
+        return oldTunnel;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmHealthCheckRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmHealthCheckRequest.java
@@ -1,10 +1,10 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm;
 
-import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+import com.sequenceiq.common.api.type.Tunnel;
 
-public class UpgradeCcmHealthCheckRequest extends StackEvent {
+public class UpgradeCcmHealthCheckRequest extends AbstractUpgradeCcmEvent {
 
-    public UpgradeCcmHealthCheckRequest(Long stackId) {
-        super(stackId);
+    public UpgradeCcmHealthCheckRequest(Long stackId, Long clusterId, Tunnel oldTunnel) {
+        super(stackId, clusterId, oldTunnel);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmHealthCheckResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmHealthCheckResult.java
@@ -1,13 +1,11 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm;
 
-import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+import com.sequenceiq.common.api.type.Tunnel;
 
-public class UpgradeCcmHealthCheckResult extends StackEvent {
-    public UpgradeCcmHealthCheckResult(Long stackId) {
-        super(stackId);
+public class UpgradeCcmHealthCheckResult extends AbstractUpgradeCcmEvent {
+
+    public UpgradeCcmHealthCheckResult(Long stackId, Long clusterId, Tunnel oldTunnel) {
+        super(stackId, clusterId, oldTunnel);
     }
 
-    public UpgradeCcmHealthCheckResult(String request, Long stackId) {
-        super(request, stackId);
-    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmPushSaltStatesRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmPushSaltStatesRequest.java
@@ -1,10 +1,11 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm;
 
-import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+import com.sequenceiq.common.api.type.Tunnel;
 
-public class UpgradeCcmPushSaltStatesRequest extends StackEvent {
+public class UpgradeCcmPushSaltStatesRequest extends AbstractUpgradeCcmEvent {
 
-    public UpgradeCcmPushSaltStatesRequest(Long stackId) {
-        super(stackId);
+    public UpgradeCcmPushSaltStatesRequest(Long stackId, Long clusterId, Tunnel oldTunnel) {
+        super(stackId, clusterId, oldTunnel);
     }
+
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmPushSaltStatesResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmPushSaltStatesResult.java
@@ -1,13 +1,11 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm;
 
-import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+import com.sequenceiq.common.api.type.Tunnel;
 
-public class UpgradeCcmPushSaltStatesResult extends StackEvent {
-    public UpgradeCcmPushSaltStatesResult(Long stackId) {
-        super(stackId);
+public class UpgradeCcmPushSaltStatesResult extends AbstractUpgradeCcmEvent {
+
+    public UpgradeCcmPushSaltStatesResult(Long stackId, Long clusterId, Tunnel oldTunnel) {
+        super(stackId, clusterId, oldTunnel);
     }
 
-    public UpgradeCcmPushSaltStatesResult(String selector, Long stackId) {
-        super(selector, stackId);
-    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmReconfigureNginxResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmReconfigureNginxResult.java
@@ -1,14 +1,11 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm;
 
-import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+import com.sequenceiq.common.api.type.Tunnel;
 
-public class UpgradeCcmReconfigureNginxResult extends StackEvent {
+public class UpgradeCcmReconfigureNginxResult extends AbstractUpgradeCcmEvent {
 
-    public UpgradeCcmReconfigureNginxResult(Long stackId) {
-        super(stackId);
+    public UpgradeCcmReconfigureNginxResult(Long stackId, Long clusterId, Tunnel oldTunnel) {
+        super(stackId, clusterId, oldTunnel);
     }
 
-    public UpgradeCcmReconfigureNginxResult(String selector, Long stackId) {
-        super(selector, stackId);
-    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmRegisterClusterProxyRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmRegisterClusterProxyRequest.java
@@ -1,10 +1,10 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm;
 
-import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+import com.sequenceiq.common.api.type.Tunnel;
 
-public class UpgradeCcmRegisterClusterProxyRequest extends StackEvent {
+public class UpgradeCcmRegisterClusterProxyRequest extends AbstractUpgradeCcmEvent {
 
-    public UpgradeCcmRegisterClusterProxyRequest(Long stackId) {
-        super(stackId);
+    public UpgradeCcmRegisterClusterProxyRequest(Long stackId, Long clusterId, Tunnel oldTunnel) {
+        super(stackId, clusterId, oldTunnel);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmRegisterClusterProxyResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmRegisterClusterProxyResult.java
@@ -1,14 +1,11 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm;
 
-import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+import com.sequenceiq.common.api.type.Tunnel;
 
-public class UpgradeCcmRegisterClusterProxyResult extends StackEvent {
+public class UpgradeCcmRegisterClusterProxyResult extends AbstractUpgradeCcmEvent {
 
-    public UpgradeCcmRegisterClusterProxyResult(Long stackId) {
-        super(stackId);
+    public UpgradeCcmRegisterClusterProxyResult(Long stackId, Long clusterId, Tunnel oldTunnel) {
+        super(stackId, clusterId, oldTunnel);
     }
 
-    public UpgradeCcmRegisterClusterProxyResult(String selector, Long stackId) {
-        super(selector, stackId);
-    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmRemoveAgentRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmRemoveAgentRequest.java
@@ -1,10 +1,10 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm;
 
-import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+import com.sequenceiq.common.api.type.Tunnel;
 
-public class UpgradeCcmRemoveAgentRequest extends StackEvent {
+public class UpgradeCcmRemoveAgentRequest extends AbstractUpgradeCcmEvent {
 
-    public UpgradeCcmRemoveAgentRequest(Long stackId) {
-        super(stackId);
+    public UpgradeCcmRemoveAgentRequest(Long stackId, Long clusterId, Tunnel oldTunnel) {
+        super(stackId, clusterId, oldTunnel);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmRemoveAgentResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmRemoveAgentResult.java
@@ -1,13 +1,10 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm;
 
-import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+import com.sequenceiq.common.api.type.Tunnel;
 
-public class UpgradeCcmRemoveAgentResult extends StackEvent {
-    public UpgradeCcmRemoveAgentResult(Long stackId) {
-        super(stackId);
-    }
+public class UpgradeCcmRemoveAgentResult extends AbstractUpgradeCcmEvent {
 
-    public UpgradeCcmRemoveAgentResult(String request, Long stackId) {
-        super(request, stackId);
+    public UpgradeCcmRemoveAgentResult(Long stackId, Long clusterId, Tunnel oldTunnel) {
+        super(stackId, clusterId, oldTunnel);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmTriggerRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmTriggerRequest.java
@@ -2,9 +2,10 @@ package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm;
 
 import com.sequenceiq.common.api.type.Tunnel;
 
-public class UpgradeCcmReconfigureNginxRequest extends AbstractUpgradeCcmEvent {
+public class UpgradeCcmTriggerRequest extends AbstractUpgradeCcmEvent {
 
-    public UpgradeCcmReconfigureNginxRequest(Long stackId, Long clusterId, Tunnel oldTunnel) {
+    public UpgradeCcmTriggerRequest(Long stackId, Long clusterId, Tunnel oldTunnel) {
         super(stackId, clusterId, oldTunnel);
     }
+
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmTunnelUpdateRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmTunnelUpdateRequest.java
@@ -1,9 +1,10 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm;
 
-import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+import com.sequenceiq.common.api.type.Tunnel;
 
-public class UpgradeCcmTunnelUpdateRequest extends StackEvent {
-    public UpgradeCcmTunnelUpdateRequest(Long stackId) {
-        super(stackId);
+public class UpgradeCcmTunnelUpdateRequest extends AbstractUpgradeCcmEvent {
+
+    public UpgradeCcmTunnelUpdateRequest(Long stackId, Long clusterId, Tunnel oldTunnel) {
+        super(stackId, clusterId, oldTunnel);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmTunnelUpdateResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmTunnelUpdateResult.java
@@ -1,14 +1,11 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm;
 
-import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+import com.sequenceiq.common.api.type.Tunnel;
 
-public class UpgradeCcmTunnelUpdateResult extends StackEvent {
+public class UpgradeCcmTunnelUpdateResult extends AbstractUpgradeCcmEvent {
 
-    public UpgradeCcmTunnelUpdateResult(Long stackId) {
-        super(stackId);
+    public UpgradeCcmTunnelUpdateResult(Long stackId, Long clusterId, Tunnel oldTunnel) {
+        super(stackId, clusterId, oldTunnel);
     }
 
-    public UpgradeCcmTunnelUpdateResult(String selector, Long stackId) {
-        super(selector, stackId);
-    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/HealthCheckHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/HealthCheckHandler.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.reactor.handler.cluster.upgrade.ccm;
 
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.common.event.Selectable;
@@ -18,6 +20,8 @@ import reactor.bus.Event;
 @Component
 public class HealthCheckHandler extends ExceptionCatcherEventHandler<UpgradeCcmHealthCheckRequest> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(HealthCheckHandler.class);
+
     @Inject
     private UpgradeCcmService upgradeCcmService;
 
@@ -28,14 +32,16 @@ public class HealthCheckHandler extends ExceptionCatcherEventHandler<UpgradeCcmH
 
     @Override
     protected Selectable defaultFailureEvent(Long resourceId, Exception e, Event<UpgradeCcmHealthCheckRequest> event) {
-        return new UpgradeCcmFailedEvent(resourceId, e);
+        LOGGER.error("Health check for CCM upgrade has failed", e);
+        return new UpgradeCcmFailedEvent(resourceId, event.getData().getOldTunnel(), e);
     }
 
     @Override
     public Selectable doAccept(HandlerEvent<UpgradeCcmHealthCheckRequest> event) {
         UpgradeCcmHealthCheckRequest request = event.getData();
         Long stackId = request.getResourceId();
+        LOGGER.info("Health check for CCM upgrade...");
         upgradeCcmService.healthCheck(stackId);
-        return new UpgradeCcmHealthCheckResult(stackId);
+        return new UpgradeCcmHealthCheckResult(stackId, request.getClusterId(), request.getOldTunnel());
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/ReconfigureNginxHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/ReconfigureNginxHandler.java
@@ -2,10 +2,13 @@ package com.sequenceiq.cloudbreak.reactor.handler.cluster.upgrade.ccm;
 
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.ccm.upgrade.UpgradeCcmService;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmFailedEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmReconfigureNginxRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmReconfigureNginxResult;
@@ -18,6 +21,8 @@ import reactor.bus.Event;
 @Component
 public class ReconfigureNginxHandler extends ExceptionCatcherEventHandler<UpgradeCcmReconfigureNginxRequest> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReconfigureNginxHandler.class);
+
     @Inject
     private UpgradeCcmService upgradeCcmService;
 
@@ -28,14 +33,21 @@ public class ReconfigureNginxHandler extends ExceptionCatcherEventHandler<Upgrad
 
     @Override
     protected Selectable defaultFailureEvent(Long resourceId, Exception e, Event<UpgradeCcmReconfigureNginxRequest> event) {
-        return new UpgradeCcmFailedEvent(resourceId, e);
+        LOGGER.error("Reconfiguring NGINX for CCM upgrade has failed", e);
+        return new UpgradeCcmFailedEvent(resourceId, event.getData().getOldTunnel(), e);
     }
 
     @Override
     public Selectable doAccept(HandlerEvent<UpgradeCcmReconfigureNginxRequest> event) {
         UpgradeCcmReconfigureNginxRequest request = event.getData();
         Long stackId = request.getResourceId();
-        upgradeCcmService.reconfigureNginx(stackId);
-        return new UpgradeCcmReconfigureNginxResult(stackId);
+        LOGGER.info("NGINX reconfiguration is needed for previous CCM tunnel type");
+        try {
+            upgradeCcmService.reconfigureNginx(stackId);
+        } catch (CloudbreakOrchestratorException e) {
+            LOGGER.debug("Failed reconfiguring NGINX with salt state");
+            return new UpgradeCcmFailedEvent(stackId, request.getOldTunnel(), e);
+        }
+        return new UpgradeCcmReconfigureNginxResult(stackId, request.getClusterId(), request.getOldTunnel());
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/RegisterClusterProxyHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/RegisterClusterProxyHandler.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.reactor.handler.cluster.upgrade.ccm;
 
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.common.event.Selectable;
@@ -18,6 +20,8 @@ import reactor.bus.Event;
 @Component
 public class RegisterClusterProxyHandler extends ExceptionCatcherEventHandler<UpgradeCcmRegisterClusterProxyRequest> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(RegisterClusterProxyHandler.class);
+
     @Inject
     private UpgradeCcmService upgradeCcmService;
 
@@ -28,14 +32,16 @@ public class RegisterClusterProxyHandler extends ExceptionCatcherEventHandler<Up
 
     @Override
     protected Selectable defaultFailureEvent(Long resourceId, Exception e, Event<UpgradeCcmRegisterClusterProxyRequest> event) {
-        return new UpgradeCcmFailedEvent(resourceId, e);
+        LOGGER.error("Registering cluster proxy for CCM upgrade has failed", e);
+        return new UpgradeCcmFailedEvent(resourceId, event.getData().getOldTunnel(), e);
     }
 
     @Override
     protected Selectable doAccept(HandlerEvent<UpgradeCcmRegisterClusterProxyRequest> event) {
         UpgradeCcmRegisterClusterProxyRequest request = event.getData();
         Long stackId = request.getResourceId();
+        LOGGER.info("Registering to cluster proxy for CCM upgrade...");
         upgradeCcmService.registerClusterProxy(stackId);
-        return new UpgradeCcmRegisterClusterProxyResult(stackId);
+        return new UpgradeCcmRegisterClusterProxyResult(stackId, request.getClusterId(), request.getOldTunnel());
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/RemoveAgentHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/RemoveAgentHandler.java
@@ -2,13 +2,16 @@ package com.sequenceiq.cloudbreak.reactor.handler.cluster.upgrade.ccm;
 
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.ccm.upgrade.UpgradeCcmService;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmFailedEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmRemoveAgentRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmRemoveAgentResult;
-import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmFailedEvent;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
 import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
@@ -17,6 +20,8 @@ import reactor.bus.Event;
 
 @Component
 public class RemoveAgentHandler extends ExceptionCatcherEventHandler<UpgradeCcmRemoveAgentRequest> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RemoveAgentHandler.class);
 
     @Inject
     private UpgradeCcmService upgradeCcmService;
@@ -28,14 +33,21 @@ public class RemoveAgentHandler extends ExceptionCatcherEventHandler<UpgradeCcmR
 
     @Override
     protected Selectable defaultFailureEvent(Long resourceId, Exception e, Event<UpgradeCcmRemoveAgentRequest> event) {
-        return new UpgradeCcmFailedEvent(resourceId, e);
+        LOGGER.error("Removing agent for CCM upgrade has failed", e);
+        return new UpgradeCcmFailedEvent(resourceId, event.getData().getOldTunnel(), e);
     }
 
     @Override
     protected Selectable doAccept(HandlerEvent<UpgradeCcmRemoveAgentRequest> event) {
         UpgradeCcmRemoveAgentRequest request = event.getData();
         Long stackId = request.getResourceId();
-        upgradeCcmService.removeAgent(stackId);
-        return new UpgradeCcmRemoveAgentResult(stackId);
+        LOGGER.info("Remove agent for CCM upgrade...");
+        try {
+            upgradeCcmService.removeAgent(stackId, request.getOldTunnel());
+        } catch (CloudbreakOrchestratorException e) {
+            LOGGER.debug("Failed removing agent with a salt state");
+            return new UpgradeCcmFailedEvent(stackId, request.getOldTunnel(), e);
+        }
+        return new UpgradeCcmRemoveAgentResult(stackId, request.getClusterId(), request.getOldTunnel());
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/TunnelUpdateHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/TunnelUpdateHandler.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.reactor.handler.cluster.upgrade.ccm;
 
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.common.event.Selectable;
@@ -18,6 +20,8 @@ import reactor.bus.Event;
 @Component
 public class TunnelUpdateHandler extends ExceptionCatcherEventHandler<UpgradeCcmTunnelUpdateRequest> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(TunnelUpdateHandler.class);
+
     @Inject
     private UpgradeCcmService upgradeCcmService;
 
@@ -28,14 +32,16 @@ public class TunnelUpdateHandler extends ExceptionCatcherEventHandler<UpgradeCcm
 
     @Override
     protected Selectable defaultFailureEvent(Long resourceId, Exception e, Event<UpgradeCcmTunnelUpdateRequest> event) {
-        return new UpgradeCcmFailedEvent(resourceId, e);
+        LOGGER.error("Changing tunnel for CCM upgrade has failed", e);
+        return new UpgradeCcmFailedEvent(resourceId, event.getData().getOldTunnel(), e);
     }
 
     @Override
     public Selectable doAccept(HandlerEvent<UpgradeCcmTunnelUpdateRequest> event) {
         UpgradeCcmTunnelUpdateRequest request = event.getData();
         Long stackId = request.getResourceId();
+        LOGGER.info("Changing tunnel for CCM upgrade...");
         upgradeCcmService.updateTunnel(stackId);
-        return new UpgradeCcmTunnelUpdateResult(stackId);
+        return new UpgradeCcmTunnelUpdateResult(stackId, request.getClusterId(), request.getOldTunnel());
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ccm/HealthCheckService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ccm/HealthCheckService.java
@@ -1,0 +1,51 @@
+package com.sequenceiq.cloudbreak.service.upgrade.ccm;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
+import com.sequenceiq.cloudbreak.cluster.status.ExtendedHostStatuses;
+import com.sequenceiq.cloudbreak.common.type.HealthCheckResult;
+import com.sequenceiq.cloudbreak.common.type.HealthCheckType;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
+import com.sequenceiq.cloudbreak.service.stack.RuntimeVersionService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+
+@Service
+public class HealthCheckService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HealthCheckService.class);
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private ClusterApiConnectors clusterApiConnectors;
+
+    @Inject
+    private RuntimeVersionService runtimeVersionService;
+
+    @Retryable(value = RuntimeException.class, maxAttempts = 5, backoff = @Backoff(delay = 5000L))
+    public Set<String> getUnhealthyHosts(Long stackId) {
+        Stack stack = stackService.getById(stackId);
+        ClusterApi connector = clusterApiConnectors.getConnector(stack);
+        LOGGER.debug("Fetching extended host statuses for stack {} with retries", stack.getName());
+        ExtendedHostStatuses extendedHostStatuses = connector.clusterStatusService().getExtendedHostStatuses(
+                runtimeVersionService.getRuntimeVersion(stack.getCluster().getId()));
+        LOGGER.debug("Returned statuses: {}", extendedHostStatuses);
+        return extendedHostStatuses.getHostsHealth().entrySet().stream()
+                .filter(e -> e.getValue().stream().anyMatch(hc -> hc.getType() == HealthCheckType.HOST && hc.getResult() == HealthCheckResult.UNHEALTHY))
+                .map(e -> e.getKey().value())
+                .collect(Collectors.toSet());
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ccm/StackCcmUpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ccm/StackCcmUpgradeService.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.service.upgrade.ccm;
 
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.ccm.upgrade.UpgradeCcmEvent.UPGRADE_CCM_EVENT;
 
+import java.util.Optional;
+
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
@@ -11,8 +13,9 @@ import org.springframework.stereotype.Service;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
 import com.sequenceiq.cloudbreak.core.flow2.service.ReactorNotifier;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
-import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmTriggerRequest;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.structuredevent.CloudbreakRestRequestThreadLocalService;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
@@ -34,9 +37,11 @@ public class StackCcmUpgradeService {
     public FlowIdentifier upgradeCcm(NameOrCrn nameOrCrn) {
         Long workspaceId = restRequestThreadLocalService.getRequestedWorkspaceId();
         Stack stack = stackService.getByNameOrCrnInWorkspace(nameOrCrn, workspaceId);
+        Cluster cluster = stack.getCluster();
         MDCBuilder.buildMdcContext(stack);
         LOGGER.debug("CCM upgrade has been initiated for stack {}", nameOrCrn.getNameOrCrn());
         String selector = UPGRADE_CCM_EVENT.event();
-        return reactorNotifier.notify(stack.getId(), selector, new StackEvent(selector, stack.getId()));
+        return reactorNotifier.notify(stack.getId(), selector, new UpgradeCcmTriggerRequest(stack.getId(),
+                Optional.ofNullable(cluster).map(Cluster::getId).orElse(null), stack.getTunnel()));
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ccm/UpgradeCcmOrchestratorService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ccm/UpgradeCcmOrchestratorService.java
@@ -1,0 +1,75 @@
+package com.sequenceiq.cloudbreak.service.upgrade.ccm;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.common.orchestration.Node;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterDeletionBasedExitCriteriaModel;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
+import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.orchestrator.host.OrchestratorStateParams;
+import com.sequenceiq.cloudbreak.service.GatewayConfigService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.util.StackUtil;
+
+@Service
+public class UpgradeCcmOrchestratorService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UpgradeCcmOrchestratorService.class);
+
+    private static final String NGINX_STATE = "nginx";
+
+    private static final String DISABLE_MINA_STATE = "upgradeccm/disable-ccmv1";
+
+    private static final String DISABLE_INVERTING_PROXY_AGENT_STATE = "upgradeccm/disable-ccmv2";
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private GatewayConfigService gatewayConfigService;
+
+    @Inject
+    private StackUtil stackUtil;
+
+    @Inject
+    private HostOrchestrator hostOrchestrator;
+
+    public void reconfigureNginx(Long stackId) throws CloudbreakOrchestratorException {
+        OrchestratorStateParams stateParams = createStateParams(stackId, NGINX_STATE);
+        LOGGER.debug("Calling reconfigureNginx with state params '{}'", stateParams);
+        hostOrchestrator.runOrchestratorState(stateParams);
+    }
+
+    public void disableMina(Long stackId) throws CloudbreakOrchestratorException {
+        OrchestratorStateParams stateParams = createStateParams(stackId, DISABLE_MINA_STATE);
+        LOGGER.debug("Calling disableMina with state params '{}'", stateParams);
+        hostOrchestrator.runOrchestratorState(stateParams);
+    }
+
+    public void disableInvertingProxyAgent(Long stackId) throws CloudbreakOrchestratorException {
+        OrchestratorStateParams stateParams = createStateParams(stackId, DISABLE_INVERTING_PROXY_AGENT_STATE);
+        LOGGER.debug("Calling disableInvertingProxyAgent with state params '{}'", stateParams);
+        hostOrchestrator.runOrchestratorState(stateParams);
+    }
+
+    private OrchestratorStateParams createStateParams(Long stackId, String saltState) {
+        Stack stack = stackService.getByIdWithListsInTransaction(stackId);
+        Set<Node> gatewayNodes = stackUtil.collectGatewayNodes(stack);
+
+        OrchestratorStateParams stateParams = new OrchestratorStateParams();
+        stateParams.setState(saltState);
+        stateParams.setPrimaryGatewayConfig(gatewayConfigService.getPrimaryGatewayConfig(stack));
+        stateParams.setTargetHostNames(gatewayNodes.stream().map(Node::getHostname).collect(Collectors.toSet()));
+        stateParams.setAllNodes(gatewayNodes);
+        stateParams.setExitCriteriaModel(new ClusterDeletionBasedExitCriteriaModel(stack.getId(), stack.getCluster().getId()));
+        return stateParams;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/util/StackUtil.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/util/StackUtil.java
@@ -97,6 +97,17 @@ public class StackUtil {
         return agents;
     }
 
+    public Set<Node> collectGatewayNodes(Stack stack) {
+        Set<Node> agents = stack.getInstanceGroups().stream()
+                .filter(ig -> ig.getNodeCount() != 0)
+                .flatMap(ig -> ig.getNotDeletedInstanceMetaDataSet().stream())
+                .filter(imd -> imd.getDiscoveryFQDN() != null && imd.isGateway())
+                .map(imd -> new Node(imd.getPrivateIp(), imd.getPublicIp(), imd.getInstanceId(), imd.getInstanceGroup().getTemplate().getInstanceType(),
+                        imd.getDiscoveryFQDN(), imd.getInstanceGroupName()))
+                .collect(Collectors.toSet());
+        return agents;
+    }
+
     public Set<Node> collectReachableNodesByInstanceStates(Stack stack) {
         return stack.getInstanceGroups()
                 .stream()

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterServiceRunnerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterServiceRunnerTest.java
@@ -45,7 +45,7 @@ class ClusterServiceRunnerTest {
     private ClusterServiceRunner underTest;
 
     @Test
-    public void testRedeployGatewayCertificateWhenClusterCouldNotBeFoundByStackId() {
+    void testRedeployGatewayCertificateWhenClusterCouldNotBeFoundByStackId() {
         when(stackService.getByIdWithListsInTransaction(anyLong())).thenReturn(stack);
         when(stack.getCluster()).thenReturn(cluster);
         when(clusterService.findOneWithLists(anyLong())).thenThrow(new NotFoundException("Cluster could not be found"));
@@ -54,7 +54,7 @@ class ClusterServiceRunnerTest {
     }
 
     @Test
-    public void testRedeployGatewayCertificateWhenRedeployOnHostRunnerThrowRuntimeException() {
+    void testRedeployGatewayCertificateWhenRedeployOnHostRunnerThrowRuntimeException() {
         when(stackService.getByIdWithListsInTransaction(anyLong())).thenReturn(stack);
         when(stack.getCluster()).thenReturn(cluster);
         when(clusterService.findOneWithLists(anyLong())).thenReturn(Optional.of(cluster));
@@ -64,7 +64,7 @@ class ClusterServiceRunnerTest {
     }
 
     @Test
-    public void testRedeployGatewayCertificateHappyFlow() {
+    void testRedeployGatewayCertificateHappyFlow() {
         when(stackService.getByIdWithListsInTransaction(anyLong())).thenReturn(stack);
         when(stack.getCluster()).thenReturn(cluster);
         when(clusterService.findOneWithLists(anyLong())).thenReturn(Optional.of(cluster));
@@ -74,4 +74,21 @@ class ClusterServiceRunnerTest {
         verify(hostRunner, times(1)).redeployGatewayCertificate(any(), any());
     }
 
+    @Test
+    void testRedeployGatewayPillar() {
+        when(stackService.getByIdWithListsInTransaction(anyLong())).thenReturn(stack);
+        when(stack.getCluster()).thenReturn(cluster);
+        when(clusterService.findOneWithLists(any())).thenReturn(Optional.of(cluster));
+        underTest.redeployGatewayPillar(1L);
+        verify(hostRunner).redeployGatewayPillarOnly(stack, cluster);
+    }
+
+    @Test
+    void testRedeployStates() {
+        when(stackService.getByIdWithListsInTransaction(anyLong())).thenReturn(stack);
+        when(stack.getCluster()).thenReturn(cluster);
+        when(clusterService.findOneWithLists(any())).thenReturn(Optional.of(cluster));
+        underTest.redeployStates(1L);
+        verify(hostRunner).redeployStates(stack, cluster);
+    }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/DeregisterAgentHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/DeregisterAgentHandlerTest.java
@@ -1,0 +1,54 @@
+package com.sequenceiq.cloudbreak.reactor.handler.cluster.upgrade.ccm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.ccm.upgrade.UpgradeCcmService;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmDeregisterAgentRequest;
+import com.sequenceiq.common.api.type.Tunnel;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
+
+@ExtendWith(MockitoExtension.class)
+class DeregisterAgentHandlerTest {
+
+    private static final Long STACK_ID = 12L;
+
+    private static final Long CLUSTER_ID = 34L;
+
+    @Mock
+    private UpgradeCcmService upgradeCcmService;
+
+    @Mock
+    private HandlerEvent<UpgradeCcmDeregisterAgentRequest> event;
+
+    @InjectMocks
+    private DeregisterAgentHandler underTest;
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @Test
+    void selector() {
+        assertThat(underTest.selector()).isEqualTo("UPGRADECCMDEREGISTERAGENTREQUEST");
+    }
+
+    @Test
+    void doAccept() {
+        UpgradeCcmDeregisterAgentRequest request = new UpgradeCcmDeregisterAgentRequest(STACK_ID, CLUSTER_ID, Tunnel.CCM);
+        when(event.getData()).thenReturn(request);
+
+        Selectable result = underTest.doAccept(event);
+        verify(upgradeCcmService).deregisterAgent(STACK_ID, Tunnel.CCM);
+        assertThat(result.selector()).isEqualTo("UPGRADECCMDEREGISTERAGENTRESULT");
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/HealthCheckHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/HealthCheckHandlerTest.java
@@ -1,0 +1,55 @@
+package com.sequenceiq.cloudbreak.reactor.handler.cluster.upgrade.ccm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.ccm.upgrade.UpgradeCcmService;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmHealthCheckRequest;
+import com.sequenceiq.common.api.type.Tunnel;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
+
+@ExtendWith(MockitoExtension.class)
+class HealthCheckHandlerTest {
+
+    private static final Long STACK_ID = 12L;
+
+    private static final Long CLUSTER_ID = 34L;
+
+    @Mock
+    private UpgradeCcmService upgradeCcmService;
+
+    @Mock
+    private HandlerEvent<UpgradeCcmHealthCheckRequest> event;
+
+    @InjectMocks
+    private HealthCheckHandler underTest;
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @Test
+    void selector() {
+        assertThat(underTest.selector()).isEqualTo("UPGRADECCMHEALTHCHECKREQUEST");
+    }
+
+    @Test
+    void doAccept() {
+        UpgradeCcmHealthCheckRequest request = new UpgradeCcmHealthCheckRequest(STACK_ID, CLUSTER_ID, Tunnel.CCM);
+        when(event.getData()).thenReturn(request);
+
+        Selectable result = underTest.doAccept(event);
+        verify(upgradeCcmService).healthCheck(STACK_ID);
+        assertThat(result.selector()).isEqualTo("UPGRADECCMHEALTHCHECKRESULT");
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/PushSaltStateHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/PushSaltStateHandlerTest.java
@@ -1,0 +1,55 @@
+package com.sequenceiq.cloudbreak.reactor.handler.cluster.upgrade.ccm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.ccm.upgrade.UpgradeCcmService;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmPushSaltStatesRequest;
+import com.sequenceiq.common.api.type.Tunnel;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
+
+@ExtendWith(MockitoExtension.class)
+class PushSaltStateHandlerTest {
+
+    private static final Long STACK_ID = 12L;
+
+    private static final Long CLUSTER_ID = 34L;
+
+    @Mock
+    private UpgradeCcmService upgradeCcmService;
+
+    @Mock
+    private HandlerEvent<UpgradeCcmPushSaltStatesRequest> event;
+
+    @InjectMocks
+    private PushSaltStateHandler underTest;
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @Test
+    void selector() {
+        assertThat(underTest.selector()).isEqualTo("UPGRADECCMPUSHSALTSTATESREQUEST");
+    }
+
+    @Test
+    void doAccept() {
+        UpgradeCcmPushSaltStatesRequest request = new UpgradeCcmPushSaltStatesRequest(STACK_ID, CLUSTER_ID, Tunnel.CCM);
+        when(event.getData()).thenReturn(request);
+
+        Selectable result = underTest.doAccept(event);
+        verify(upgradeCcmService).pushSaltState(STACK_ID, CLUSTER_ID);
+        assertThat(result.selector()).isEqualTo("UPGRADECCMPUSHSALTSTATESRESULT");
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/ReconfigureNginxHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/ReconfigureNginxHandlerTest.java
@@ -1,0 +1,69 @@
+package com.sequenceiq.cloudbreak.reactor.handler.cluster.upgrade.ccm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.ccm.upgrade.UpgradeCcmService;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmReconfigureNginxRequest;
+import com.sequenceiq.common.api.type.Tunnel;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
+
+@ExtendWith(MockitoExtension.class)
+class ReconfigureNginxHandlerTest {
+
+    private static final Long STACK_ID = 12L;
+
+    private static final Long CLUSTER_ID = 34L;
+
+    @Mock
+    private UpgradeCcmService upgradeCcmService;
+
+    @Mock
+    private HandlerEvent<UpgradeCcmReconfigureNginxRequest> event;
+
+    @InjectMocks
+    private ReconfigureNginxHandler underTest;
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @Test
+    void selector() {
+        assertThat(underTest.selector()).isEqualTo("UPGRADECCMRECONFIGURENGINXREQUEST");
+    }
+
+    @Test
+    void doAccept() throws CloudbreakOrchestratorException {
+        UpgradeCcmReconfigureNginxRequest request = new UpgradeCcmReconfigureNginxRequest(STACK_ID, CLUSTER_ID, Tunnel.CCM);
+        when(event.getData()).thenReturn(request);
+
+        Selectable result = underTest.doAccept(event);
+        verify(upgradeCcmService).reconfigureNginx(STACK_ID);
+        assertThat(result.selector()).isEqualTo("UPGRADECCMRECONFIGURENGINXRESULT");
+    }
+
+    @Test
+    void orchestrationException() throws CloudbreakOrchestratorException {
+        UpgradeCcmReconfigureNginxRequest request = new UpgradeCcmReconfigureNginxRequest(STACK_ID, CLUSTER_ID, Tunnel.CCM);
+        when(event.getData()).thenReturn(request);
+        doThrow(new CloudbreakOrchestratorFailedException("salt error")).when(upgradeCcmService).reconfigureNginx(any());
+
+        Selectable result = underTest.doAccept(event);
+        verify(upgradeCcmService).reconfigureNginx(STACK_ID);
+        assertThat(result.selector()).isEqualTo("UPGRADECCMFAILEDEVENT");
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/RegisterClusterProxyHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/RegisterClusterProxyHandlerTest.java
@@ -1,0 +1,55 @@
+package com.sequenceiq.cloudbreak.reactor.handler.cluster.upgrade.ccm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.ccm.upgrade.UpgradeCcmService;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmRegisterClusterProxyRequest;
+import com.sequenceiq.common.api.type.Tunnel;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
+
+@ExtendWith(MockitoExtension.class)
+class RegisterClusterProxyHandlerTest {
+
+    private static final Long STACK_ID = 12L;
+
+    private static final Long CLUSTER_ID = 34L;
+
+    @Mock
+    private UpgradeCcmService upgradeCcmService;
+
+    @Mock
+    private HandlerEvent<UpgradeCcmRegisterClusterProxyRequest> event;
+
+    @InjectMocks
+    private RegisterClusterProxyHandler underTest;
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @Test
+    void selector() {
+        assertThat(underTest.selector()).isEqualTo("UPGRADECCMREGISTERCLUSTERPROXYREQUEST");
+    }
+
+    @Test
+    void doAccept() {
+        UpgradeCcmRegisterClusterProxyRequest request = new UpgradeCcmRegisterClusterProxyRequest(STACK_ID, CLUSTER_ID, Tunnel.CCM);
+        when(event.getData()).thenReturn(request);
+
+        Selectable result = underTest.doAccept(event);
+        verify(upgradeCcmService).registerClusterProxy(STACK_ID);
+        assertThat(result.selector()).isEqualTo("UPGRADECCMREGISTERCLUSTERPROXYRESULT");
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/RemoveAgentHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/RemoveAgentHandlerTest.java
@@ -1,0 +1,70 @@
+package com.sequenceiq.cloudbreak.reactor.handler.cluster.upgrade.ccm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.ccm.upgrade.UpgradeCcmService;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmRemoveAgentRequest;
+import com.sequenceiq.common.api.type.Tunnel;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
+
+@ExtendWith(MockitoExtension.class)
+class RemoveAgentHandlerTest {
+
+    private static final Long STACK_ID = 12L;
+
+    private static final Long CLUSTER_ID = 34L;
+
+    @Mock
+    private UpgradeCcmService upgradeCcmService;
+
+    @Mock
+    private HandlerEvent<UpgradeCcmRemoveAgentRequest> event;
+
+    @InjectMocks
+    private RemoveAgentHandler underTest;
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @Test
+    void selector() {
+        assertThat(underTest.selector()).isEqualTo("UPGRADECCMREMOVEAGENTREQUEST");
+    }
+
+    @Test
+    void doAccept() throws CloudbreakOrchestratorException {
+        UpgradeCcmRemoveAgentRequest request = new UpgradeCcmRemoveAgentRequest(STACK_ID, CLUSTER_ID, Tunnel.CCM);
+        when(event.getData()).thenReturn(request);
+
+        Selectable result = underTest.doAccept(event);
+        verify(upgradeCcmService).removeAgent(STACK_ID, Tunnel.CCM);
+        assertThat(result.selector()).isEqualTo("UPGRADECCMREMOVEAGENTRESULT");
+    }
+
+    @Test
+    void orchestrationException() throws CloudbreakOrchestratorException {
+        UpgradeCcmRemoveAgentRequest request = new UpgradeCcmRemoveAgentRequest(STACK_ID, CLUSTER_ID, Tunnel.CCM);
+        when(event.getData()).thenReturn(request);
+        doThrow(new CloudbreakOrchestratorFailedException("salt error")).when(upgradeCcmService).removeAgent(any(), any());
+
+        Selectable result = underTest.doAccept(event);
+        verify(upgradeCcmService).removeAgent(STACK_ID, Tunnel.CCM);
+        assertThat(result.selector()).isEqualTo("UPGRADECCMFAILEDEVENT");
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/TunnelUpdateHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/TunnelUpdateHandlerTest.java
@@ -1,0 +1,55 @@
+package com.sequenceiq.cloudbreak.reactor.handler.cluster.upgrade.ccm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.ccm.upgrade.UpgradeCcmService;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmTunnelUpdateRequest;
+import com.sequenceiq.common.api.type.Tunnel;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
+
+@ExtendWith(MockitoExtension.class)
+class TunnelUpdateHandlerTest {
+
+    private static final Long STACK_ID = 12L;
+
+    private static final Long CLUSTER_ID = 34L;
+
+    @Mock
+    private UpgradeCcmService upgradeCcmService;
+
+    @Mock
+    private HandlerEvent<UpgradeCcmTunnelUpdateRequest> event;
+
+    @InjectMocks
+    private TunnelUpdateHandler underTest;
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @Test
+    void selector() {
+        assertThat(underTest.selector()).isEqualTo("UPGRADECCMTUNNELUPDATEREQUEST");
+    }
+
+    @Test
+    void doAccept() {
+        UpgradeCcmTunnelUpdateRequest request = new UpgradeCcmTunnelUpdateRequest(STACK_ID, CLUSTER_ID, Tunnel.CCM);
+        when(event.getData()).thenReturn(request);
+
+        Selectable result = underTest.doAccept(event);
+        verify(upgradeCcmService).updateTunnel(STACK_ID);
+        assertThat(result.selector()).isEqualTo("UPGRADECCMTUNNELUPDATERESULT");
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ccm/HealthCheckServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ccm/HealthCheckServiceTest.java
@@ -1,0 +1,89 @@
+package com.sequenceiq.cloudbreak.service.upgrade.ccm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cloud.model.HostName;
+import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
+import com.sequenceiq.cloudbreak.cluster.api.ClusterStatusService;
+import com.sequenceiq.cloudbreak.cluster.status.ExtendedHostStatuses;
+import com.sequenceiq.cloudbreak.common.type.HealthCheck;
+import com.sequenceiq.cloudbreak.common.type.HealthCheckResult;
+import com.sequenceiq.cloudbreak.common.type.HealthCheckType;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
+import com.sequenceiq.cloudbreak.service.stack.RuntimeVersionService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+
+@ExtendWith(MockitoExtension.class)
+class HealthCheckServiceTest {
+
+    private static final Long STACK_ID = 2L;
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private ClusterApiConnectors clusterApiConnectors;
+
+    @Mock
+    private RuntimeVersionService runtimeVersionService;
+
+    @Mock
+    private ClusterApi clusterApi;
+
+    @Mock
+    private ClusterStatusService clusterStatusService;
+
+    @Mock
+    private Stack stack;
+
+    @InjectMocks
+    private HealthCheckService underTest;
+
+    // @formatter:off
+    // CHECKSTYLE:OFF
+    static Object[][] scenarios() {
+        return new Object[][] {
+                // Testcase name, Health Map, Expected result
+                { "No host", Map.of(HostName.hostName("host1"), Set.of(new HealthCheck(HealthCheckType.SERVICES, HealthCheckResult.UNHEALTHY, Optional.of("some insignificant error")))), Set.of() },
+                { "One host unhealthy", Map.of(HostName.hostName("host1"), Set.of(new HealthCheck(HealthCheckType.HOST, HealthCheckResult.UNHEALTHY, Optional.of("some significant error")))), Set.of("host1") },
+                { "One host healthy", Map.of(HostName.hostName("host1"), Set.of(new HealthCheck(HealthCheckType.HOST, HealthCheckResult.HEALTHY, Optional.empty()))), Set.of() },
+                { "One host healthy, one unhealthy", Map.of(HostName.hostName("host1"), Set.of(new HealthCheck(HealthCheckType.HOST, HealthCheckResult.UNHEALTHY, Optional.of("some significant error"))),
+                                                            HostName.hostName("host2"), Set.of(new HealthCheck(HealthCheckType.HOST, HealthCheckResult.HEALTHY, Optional.empty()))), Set.of("host1") },
+                { "Two hosts healthy", Map.of(HostName.hostName("host1"), Set.of(new HealthCheck(HealthCheckType.HOST, HealthCheckResult.HEALTHY, Optional.empty())),
+                                              HostName.hostName("host2"), Set.of(new HealthCheck(HealthCheckType.HOST, HealthCheckResult.HEALTHY, Optional.empty()))), Set.of() },
+                { "Two hosts unhealthy", Map.of(HostName.hostName("host1"), Set.of(new HealthCheck(HealthCheckType.HOST, HealthCheckResult.UNHEALTHY, Optional.of("some significant error"))),
+                                                HostName.hostName("host2"), Set.of(new HealthCheck(HealthCheckType.HOST, HealthCheckResult.UNHEALTHY, Optional.empty()))), Set.of("host1", "host2") },
+        };
+    }
+    // CHECKSTYLE:ON
+    // @formatter:on
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("scenarios")
+    void healthCheck(String testCaseName, Map<HostName, Set<HealthCheck>> hostsHealth, Set<String> expected) {
+        when(stackService.getById(STACK_ID)).thenReturn(stack);
+        when(stack.getCluster()).thenReturn(new Cluster());
+        when(clusterApiConnectors.getConnector(nullable(Stack.class))).thenReturn(clusterApi);
+        when(clusterApi.clusterStatusService()).thenReturn(clusterStatusService);
+        ExtendedHostStatuses statuses = new ExtendedHostStatuses(hostsHealth);
+        when(clusterStatusService.getExtendedHostStatuses(any())).thenReturn(statuses);
+        Set<String> result = underTest.getUnhealthyHosts(STACK_ID);
+        assertThat(result).hasSameElementsAs(expected);
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ccm/StackCcmUpgradeServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ccm/StackCcmUpgradeServiceTest.java
@@ -1,0 +1,61 @@
+package com.sequenceiq.cloudbreak.service.upgrade.ccm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
+import com.sequenceiq.cloudbreak.core.flow2.service.ReactorNotifier;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmTriggerRequest;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.structuredevent.CloudbreakRestRequestThreadLocalService;
+import com.sequenceiq.common.api.type.Tunnel;
+
+@ExtendWith(MockitoExtension.class)
+class StackCcmUpgradeServiceTest {
+
+    private static final Long CLUSTER_ID = 123L;
+
+    private static final Long STACK_ID = 234L;
+
+    @Mock
+    private CloudbreakRestRequestThreadLocalService restRequestThreadLocalService;
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private ReactorNotifier reactorNotifier;
+
+    @InjectMocks
+    private StackCcmUpgradeService underTest;
+
+    @Test
+    void testUpgradeCcm() {
+        Stack stack = new Stack();
+        stack.setId(STACK_ID);
+        stack.setTunnel(Tunnel.CCMV2);
+        Cluster cluster = new Cluster();
+        cluster.setId(CLUSTER_ID);
+        stack.setCluster(cluster);
+        when(stackService.getByNameOrCrnInWorkspace(any(), any())).thenReturn(stack);
+        underTest.upgradeCcm(NameOrCrn.ofName("name"));
+        ArgumentCaptor<UpgradeCcmTriggerRequest> requestCaptor = ArgumentCaptor.forClass(UpgradeCcmTriggerRequest.class);
+        verify(reactorNotifier).notify(eq(STACK_ID), eq("UPGRADE_CCM_TRIGGER_EVENT"), requestCaptor.capture());
+        UpgradeCcmTriggerRequest request = requestCaptor.getValue();
+        assertThat(request.getResourceId()).isEqualTo(STACK_ID);
+        assertThat(request.getClusterId()).isEqualTo(CLUSTER_ID);
+        assertThat(request.getOldTunnel()).isEqualTo(Tunnel.CCMV2);
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ccm/UpgradeCcmOrchestratorServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ccm/UpgradeCcmOrchestratorServiceTest.java
@@ -1,0 +1,113 @@
+package com.sequenceiq.cloudbreak.service.upgrade.ccm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.orchestration.Node;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterDeletionBasedExitCriteriaModel;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
+import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.orchestrator.host.OrchestratorStateParams;
+import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.cloudbreak.service.GatewayConfigService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.util.StackUtil;
+
+@ExtendWith(MockitoExtension.class)
+class UpgradeCcmOrchestratorServiceTest {
+
+    private static final long STACK_ID = 123L;
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private GatewayConfigService gatewayConfigService;
+
+    @Mock
+    private StackUtil stackUtil;
+
+    @Mock
+    private HostOrchestrator hostOrchestrator;
+
+    @Mock
+    private Stack stack;
+
+    @Mock
+    private Cluster cluster;
+
+    @Captor
+    private ArgumentCaptor<OrchestratorStateParams> paramCaptor;
+
+    @InjectMocks
+    private UpgradeCcmOrchestratorService underTest;
+
+    @Mock
+    private GatewayConfig gatewayConfig;
+
+    private Node node1;
+
+    private Node node2;
+
+    @BeforeEach
+    void setUp() {
+        node1 = new Node("privateIP1", "publicIP1", "instance1", "instanceType1", "fqdn1", "hostgroup");
+        node2 = new Node("privateIP2", "publicIP2", "instance2", "instanceType2", "fqdn2", "hostgroup");
+        when(stack.getId()).thenReturn(STACK_ID);
+        when(stack.getCluster()).thenReturn(cluster);
+        when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
+        when(gatewayConfigService.getPrimaryGatewayConfig(any())).thenReturn(gatewayConfig);
+        when(stackUtil.collectGatewayNodes(any())).thenReturn(Set.of(node1, node2));
+    }
+
+    @Test
+    void testReconfigureNginx() throws CloudbreakOrchestratorException {
+        underTest.reconfigureNginx(STACK_ID);
+        verify(hostOrchestrator).runOrchestratorState(paramCaptor.capture());
+        OrchestratorStateParams params = paramCaptor.getValue();
+        assertThat(params.getState()).isEqualTo("nginx");
+        assertOtherStateParams(params);
+    }
+
+    @Test
+    void testDisableMina() throws CloudbreakOrchestratorException {
+        underTest.disableMina(STACK_ID);
+        verify(hostOrchestrator).runOrchestratorState(paramCaptor.capture());
+        OrchestratorStateParams params = paramCaptor.getValue();
+        assertThat(params.getState()).isEqualTo("upgradeccm/disable-ccmv1");
+        assertOtherStateParams(params);
+    }
+
+    @Test
+    void testDisableInvertingProxyAgent() throws CloudbreakOrchestratorException {
+        underTest.disableInvertingProxyAgent(STACK_ID);
+        verify(hostOrchestrator).runOrchestratorState(paramCaptor.capture());
+        OrchestratorStateParams params = paramCaptor.getValue();
+        assertThat(params.getState()).isEqualTo("upgradeccm/disable-ccmv2");
+        assertOtherStateParams(params);
+    }
+
+    private void assertOtherStateParams(OrchestratorStateParams params) {
+        assertThat(params.getPrimaryGatewayConfig()).isEqualTo(gatewayConfig);
+        assertThat(params.getTargetHostNames()).hasSameElementsAs(Set.of("fqdn1", "fqdn2"));
+        assertThat(params.getAllNodes()).hasSameElementsAs(Set.of(node1, node2));
+        assertThat(params.getExitCriteriaModel()).isInstanceOf(ClusterDeletionBasedExitCriteriaModel.class);
+        assertThat(((ClusterDeletionBasedExitCriteriaModel) params.getExitCriteriaModel()).getStackId().get()).isEqualTo(STACK_ID);
+    }
+
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/handler/UpgradeCcmRegisterClusterProxyHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/handler/UpgradeCcmRegisterClusterProxyHandler.java
@@ -33,7 +33,7 @@ public class UpgradeCcmRegisterClusterProxyHandler extends AbstractUpgradeCcmEve
 
     @Override
     protected Selectable defaultFailureEvent(Long resourceId, Exception e, Event<UpgradeCcmEvent> event) {
-        LOGGER.error("Registering CCM for CCM upgrade has failed", e);
+        LOGGER.error("Registering cluster proxy for CCM upgrade has failed", e);
         return new UpgradeCcmFailureEvent(UPGRADE_CCM_FAILED_EVENT.event(), resourceId, e);
     }
 

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
@@ -127,4 +127,6 @@ public interface HostOrchestrator extends HostRecipeExecutor {
     void removeDeadSaltMinions(GatewayConfig gatewayConfig) throws CloudbreakOrchestratorFailedException;
 
     boolean unboundClusterConfigPresentOnAnyNodes(GatewayConfig primaryGateway, Set<String> nodes);
+
+    void uploadStates(List<GatewayConfig> allGatewayConfigs, ExitCriteriaModel exitModel) throws CloudbreakOrchestratorException;
 }

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
@@ -1027,7 +1027,7 @@ public class SaltOrchestrator implements HostOrchestrator {
             Callable<Boolean> saltPillarRunner = saltRunner.runnerWithUsingErrorCount(gatewayPillarSave, exitCriteria, exitModel);
             saltPillarRunner.call();
         } catch (Exception e) {
-            LOGGER.info("Error occurred during gateway pillar upload for certificate renewal", e);
+            LOGGER.info("Error occurred during gateway pillar upload", e);
             throw new CloudbreakOrchestratorFailedException(e.getMessage(), e);
         }
     }
@@ -1350,4 +1350,19 @@ public class SaltOrchestrator implements HostOrchestrator {
         });
         return new NodeReachabilityResult(responsiveNodes, unresponsiveNodes);
     }
+
+    @Override
+    public void uploadStates(List<GatewayConfig> allGatewayConfigs, ExitCriteriaModel exitModel) throws CloudbreakOrchestratorException {
+        LOGGER.debug("Start upload to gateways: {}", allGatewayConfigs);
+        GatewayConfig primaryGateway = saltService.getPrimaryGatewayConfig(allGatewayConfigs);
+        Set<String> gatewayTargets = getGatewayPrivateIps(allGatewayConfigs);
+        try (SaltConnector sc = saltService.createSaltConnector(primaryGateway)) {
+            uploadSaltConfig(sc, gatewayTargets, exitModel);
+        } catch (Exception e) {
+            LOGGER.info("Error occurred during the salt state upload", e);
+            throw new CloudbreakOrchestratorFailedException(e.getMessage(), e);
+        }
+        LOGGER.debug("Upload state finished");
+    }
+
 }

--- a/orchestrator-salt/src/main/resources/salt/salt/ccm/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/ccm/init.sls
@@ -4,4 +4,4 @@
     - group: root
     - mode: 750
     - source: salt://ccm/scripts/socket-wait-cleanup.sh
-    - unless: test ! -f /cdp/bin/reverse-tunnel-values-GATEWAY.sh
+    - unless: test ! -f /cdp/bin/reverse-tunnel-values-GATEWAY.sh || test -f /cdp/bin/reverse-tunnel-values-GATEWAY.sh.bak

--- a/orchestrator-salt/src/main/resources/salt/salt/upgradeccm/disable-ccmv1.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/upgradeccm/disable-ccmv1.sls
@@ -1,0 +1,29 @@
+rename_reverse_tunnel_values_gateway_script:
+  file.rename:
+    - name: /cdp/bin/reverse-tunnel-values-GATEWAY.sh.bak
+    - source: /cdp/bin/reverse-tunnel-values-GATEWAY.sh
+    - force: True
+    - makedirs: True
+
+rename_reverse_tunnel_values_knox_script:
+  file.rename:
+    - name: /cdp/bin/reverse-tunnel-values-KNOX.sh.bak
+    - source: /cdp/bin/reverse-tunnel-values-KNOX.sh
+    - force: True
+    - makedirs: True
+
+/etc/cron.hourly/socket-wait-cleanup.sh:
+  file.managed:
+    - user: root
+    - group: root
+    - mode: 640
+
+stop_ccm_v1_service_gateway:
+  service.dead:
+    - enable: False
+    - name: ccm-tunnel@GATEWAY
+
+stop_ccm_v1_service_knox:
+  service.dead:
+    - enable: False
+    - name: ccm-tunnel@KNOX

--- a/orchestrator-salt/src/main/resources/salt/salt/upgradeccm/disable-ccmv2.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/upgradeccm/disable-ccmv2.sls
@@ -1,0 +1,4 @@
+stop_ccm_v2_agent:
+  service.dead:
+    - enable: False
+    - name: jumpgate-agent


### PR DESCRIPTION
Refactor Reactor events to have a common base class, similarly refactor UpgradeCcmActions
to have common base class for the state actions.

A new UpgradeCcmContext subtype is also introduced that is used as CommonContext.

Introduced clusterId and oldTunnel to upgrade ccm-related reactor events like
UpgradeCcm*Request and UpgradeCcm*Result objects as these two parameters are needed
during flow steps execution.

New Salt orchestrator methods are added for creating and saving Gateway pillar only.

See detailed description in the commit message.