### PR TITLE
[CB-17231][datahub] Remove console role from cloudbreak blueprints

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.16/cdp-flink-heavy.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.16/cdp-flink-heavy.bp
@@ -15,7 +15,6 @@
           "hdfs-JOURNALNODE-BASE",
           "kafka-GATEWAY-BASE",
           "sql_stream_builder-MATERIALIZED_VIEW_ENGINE-BASE",
-          "sql_stream_builder-STREAMING_SQL_CONSOLE-BASE",
           "sql_stream_builder-STREAMING_SQL_ENGINE-BASE",
           "yarn-GATEWAY-BASE",
           "yarn-JOBHISTORY-BASE",
@@ -255,11 +254,6 @@
           {
             "refName": "sql_stream_builder-STREAMING_SQL_ENGINE-BASE",
             "roleType": "STREAMING_SQL_ENGINE",
-            "base": true
-          },
-          {
-            "refName": "sql_stream_builder-STREAMING_SQL_CONSOLE-BASE",
-            "roleType": "STREAMING_SQL_CONSOLE",
             "base": true
           },
           {

--- a/core/src/main/resources/defaults/blueprints/7.2.16/cdp-flink-light.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.16/cdp-flink-light.bp
@@ -15,7 +15,6 @@
           "hdfs-JOURNALNODE-BASE",
           "kafka-GATEWAY-BASE",
           "sql_stream_builder-MATERIALIZED_VIEW_ENGINE-BASE",
-          "sql_stream_builder-STREAMING_SQL_CONSOLE-BASE",
           "sql_stream_builder-STREAMING_SQL_ENGINE-BASE",
           "yarn-GATEWAY-BASE",
           "yarn-JOBHISTORY-BASE",
@@ -247,11 +246,6 @@
           {
             "refName": "sql_stream_builder-STREAMING_SQL_ENGINE-BASE",
             "roleType": "STREAMING_SQL_ENGINE",
-            "base": true
-          },
-          {
-            "refName": "sql_stream_builder-STREAMING_SQL_CONSOLE-BASE",
-            "roleType": "STREAMING_SQL_CONSOLE",
             "base": true
           },
           {


### PR DESCRIPTION

The role `STREAMING_SQL_CONSOLE` got removed in CSA-DH-1.7.0.0. Removing it from the blueprints as well.