### PR TITLE
CB-17253 Add ipahealthagent logs to diag bundle

### DIFF
--- a/freeipa/src/main/resources/defaults/vm-logs.json
+++ b/freeipa/src/main/resources/defaults/vm-logs.json
@@ -98,5 +98,9 @@
   {
     "path": "/var/log/upgrade-ccm.log",
     "label": "upgrade_ccm"
+  },
+  {
+    "path": "/cdp/ipahealthagent/ipahealthagent.log",
+    "label": "ipahealthagent"
   }
 ]


### PR DESCRIPTION
`/cdp/ipahealthagent/ipahealthagent.log` needs to be collected

See detailed description in the commit message.