### PR TITLE
Revert "[oozie] OPSAPS-62127 Remove Oozie NameNode whitelist setting."

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.16/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.16/cdp-data-engineering-ha.bp
@@ -237,7 +237,12 @@
           {
             "refName": "oozie-OOZIE_SERVER-BASE",
             "roleType": "OOZIE_SERVER",
-            "configs": [ ],
+            "configs": [
+              {
+                "name": "oozie_config_safety_valve",
+                "value": "<property><name>oozie.service.HadoopAccessorService.nameNode.whitelist</name><value></value></property>"
+              }
+            ],
             "base": true
           }
         ]

--- a/core/src/main/resources/defaults/blueprints/7.2.16/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.16/cdp-data-engineering.bp
@@ -415,7 +415,12 @@
           {
             "refName": "oozie-OOZIE_SERVER-BASE",
             "roleType": "OOZIE_SERVER",
-            "configs": [ ],
+            "configs": [
+              {
+                "name": "oozie_config_safety_valve",
+                "value": "<property><name>oozie.service.HadoopAccessorService.nameNode.whitelist</name><value></value></property>"
+              }
+            ],
             "base": true
           }
         ]


### PR DESCRIPTION
As it turned out with a multi comp test run our previous cloudbreak commit needs to be reverted.

The commit was added due to a CM change which should handle namenode whitelist for Oozie but as testing pointed out it does not work for cloud buckets.

Reverts https://github.com/hortonworks/cloudbreak/pull/12708