### PR TITLE
Revert "CB-14321: Call the CM syncer before upscale"

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpscaleFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpscaleFlowEventChainFactory.java
@@ -1,11 +1,9 @@
 package com.sequenceiq.cloudbreak.core.flow2.chain;
 
-import static com.sequenceiq.cloudbreak.core.flow2.cluster.cmsync.CmSyncEvent.CM_SYNC_TRIGGER_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.upscale.ClusterUpscaleEvent.CLUSTER_UPSCALE_TRIGGER_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.sync.StackSyncEvent.STACK_SYNC_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.upscale.StackUpscaleEvent.ADD_INSTANCES_EVENT;
 
-import java.util.Collections;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
@@ -21,7 +19,6 @@ import com.sequenceiq.cloudbreak.core.flow2.event.StackScaleTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.StackSyncTriggerEvent;
 import com.sequenceiq.cloudbreak.domain.view.ClusterView;
 import com.sequenceiq.cloudbreak.domain.view.StackView;
-import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.CmSyncTriggerEvent;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
 import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
@@ -42,7 +39,6 @@ public class UpscaleFlowEventChainFactory implements FlowEventChainFactory<Stack
         ClusterView clusterView = stackView.getClusterView();
         Queue<Selectable> flowEventChain = new ConcurrentLinkedQueue<>();
         addStackSyncTriggerEvent(event, flowEventChain);
-        addCmSyncTriggerEvent(event, flowEventChain);
         addStackScaleTriggerEvent(event, flowEventChain);
         addClusterScaleTriggerEventIfNeeded(event, stackView, clusterView, flowEventChain);
         return new FlowTriggerEventQueue(getName(), event, flowEventChain);
@@ -54,14 +50,6 @@ public class UpscaleFlowEventChainFactory implements FlowEventChainFactory<Stack
                 event.getResourceId(),
                 false,
                 event.accepted())
-        );
-    }
-
-    private void addCmSyncTriggerEvent(StackAndClusterUpscaleTriggerEvent event, Queue<Selectable> flowEventChain) {
-        flowEventChain.add(new CmSyncTriggerEvent(
-                CM_SYNC_TRIGGER_EVENT.event(),
-                event.getResourceId(),
-                Collections.emptySet())
         );
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/CmSyncTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/CmSyncTriggerEvent.java
@@ -13,11 +13,6 @@ public class CmSyncTriggerEvent extends StackEvent {
         this.candidateImageUuids = candidateImageUuids;
     }
 
-    public CmSyncTriggerEvent(String selector, Long stackId, Set<String> candidateImageUuids) {
-        super(selector, stackId);
-        this.candidateImageUuids = candidateImageUuids;
-    }
-
     public Set<String> getCandidateImageUuids() {
         return candidateImageUuids;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/util/cleanup/ParcelGeneratorUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/util/cleanup/ParcelGeneratorUtil.java
@@ -2,19 +2,13 @@ package com.sequenceiq.it.util.cleanup;
 
 import java.math.BigDecimal;
 
-import javax.inject.Inject;
-
 import org.springframework.stereotype.Component;
 
 import com.cloudera.api.swagger.model.ApiParcel;
 import com.cloudera.api.swagger.model.ApiParcelState;
-import com.sequenceiq.it.cloudbreak.cloud.v4.CommonClusterManagerProperties;
 
 @Component
 public class ParcelGeneratorUtil {
-
-    @Inject
-    private CommonClusterManagerProperties commonClusterManagerProperties;
 
     /**
      * Provides a CDH <code>ApiParcel</code> instance with some predefined values with the status if <code>ACTIVATED</code>.
@@ -22,8 +16,7 @@ public class ParcelGeneratorUtil {
      * @return a minimal configuration of a CDH ApiParcel instance
      */
     public ApiParcel getActivatedCDHParcel() {
-        String runtimeVersion = commonClusterManagerProperties.getRuntimeVersion();
-        return getActivatedCDHParcelWithVersion(runtimeVersion.concat("-1.cdh").concat(runtimeVersion).concat(".p0.1454941"));
+        return getActivatedCDHParcelWithVersion("someParcelVersion");
     }
 
     public ApiParcel getActivatedCDHParcelWithVersion(String version) {


### PR DESCRIPTION
Reverts hortonworks/cloudbreak#12734
It turned out this new sync fails during repair/upgrade operations more info in [this slack conversation](https://cloudera.slack.com/archives/CQ1R8L37D/p1653465770218649) 