### PR TITLE
CB-17037 Integrate storage consumption endpoint, quartz job and flow …

### DIFF
--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/configuration/repository/ConsumptionRepository.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/configuration/repository/ConsumptionRepository.java
@@ -61,4 +61,8 @@ public interface ConsumptionRepository extends AccountAwareResourceRepository<Co
     boolean doesStorageConsumptionExistWithLocationForMonitoredCrn(@Param("monitoredResourceCrn") String monitoredResourceCrn,
             @Param("storageLocation") String storageLocation);
 
+    @Query("SELECT c.resourceCrn as remoteResourceId, c.id as localId, c.name as name " +
+            "FROM Consumption c " +
+            "WHERE c.consumptionType = 'STORAGE' ")
+    List<JobResource> findAllStorageConsumptionJobResource();
 }

--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/endpoint/ConsumptionInternalV1Controller.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/endpoint/ConsumptionInternalV1Controller.java
@@ -2,6 +2,7 @@ package com.sequenceiq.consumption.endpoint;
 
 import javax.transaction.Transactional;
 import javax.validation.Valid;
+import javax.validation.ValidationException;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
@@ -12,14 +13,18 @@ import org.springframework.stereotype.Controller;
 import com.sequenceiq.authorization.annotation.InternalOnly;
 import com.sequenceiq.cloudbreak.auth.crn.CrnResourceDescriptor;
 import com.sequenceiq.cloudbreak.auth.security.internal.AccountId;
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.structuredevent.rest.annotation.AccountEntityType;
 import com.sequenceiq.cloudbreak.validation.ValidCrn;
+import com.sequenceiq.common.model.FileSystemType;
 import com.sequenceiq.consumption.api.v1.consumption.endpoint.ConsumptionInternalEndpoint;
 import com.sequenceiq.consumption.api.v1.consumption.model.request.StorageConsumptionRequest;
 import com.sequenceiq.consumption.domain.Consumption;
 import com.sequenceiq.consumption.dto.ConsumptionCreationDto;
 import com.sequenceiq.consumption.endpoint.converter.ConsumptionApiConverter;
+import com.sequenceiq.consumption.job.storage.StorageConsumptionJobService;
 import com.sequenceiq.consumption.service.ConsumptionService;
+import com.sequenceiq.consumption.util.CloudStorageLocationUtil;
 
 @Controller
 @Transactional(Transactional.TxType.NEVER)
@@ -32,16 +37,28 @@ public class ConsumptionInternalV1Controller implements ConsumptionInternalEndpo
 
     private final ConsumptionApiConverter consumptionApiConverter;
 
-    public ConsumptionInternalV1Controller(ConsumptionService consumptionService, ConsumptionApiConverter consumptionApiConverter) {
+    private final StorageConsumptionJobService jobService;
+
+    public ConsumptionInternalV1Controller(ConsumptionService consumptionService, ConsumptionApiConverter consumptionApiConverter,
+            StorageConsumptionJobService jobService) {
         this.consumptionService = consumptionService;
         this.consumptionApiConverter = consumptionApiConverter;
+        this.jobService = jobService;
     }
 
     @Override
     @InternalOnly
     public void scheduleStorageConsumptionCollection(@AccountId String accountId, @Valid @NotNull StorageConsumptionRequest request) {
         ConsumptionCreationDto consumptionCreationDto = consumptionApiConverter.initCreationDtoForStorage(request);
-        consumptionService.create(consumptionCreationDto);
+        try {
+            CloudStorageLocationUtil.validateCloudStorageType(FileSystemType.S3, consumptionCreationDto.getStorageLocation());
+            LOGGER.info("Registering storage consumption collection for resource with CRN [{}] and location [{}]",
+                    consumptionCreationDto.getMonitoredResourceCrn(), consumptionCreationDto.getStorageLocation());
+            Consumption consumption = consumptionService.create(consumptionCreationDto);
+            jobService.schedule(consumption.getId());
+        } catch (ValidationException e) {
+            throw new BadRequestException(String.format("Storage location validation failed, error: %s", e.getMessage()));
+        }
     }
 
     @Override
@@ -49,7 +66,9 @@ public class ConsumptionInternalV1Controller implements ConsumptionInternalEndpo
     public void unscheduleStorageConsumptionCollection(@AccountId String accountId,
             @NotNull @ValidCrn(resource = {CrnResourceDescriptor.ENVIRONMENT, CrnResourceDescriptor.DATALAKE}) String monitoredResourceCrn,
             @NotEmpty String storageLocation) {
+        LOGGER.info("Deregistering storage consumption collection for resource with CRN [{}] and location [{}]", monitoredResourceCrn, storageLocation);
         Consumption consumption = consumptionService.findStorageConsumptionByMonitoredResourceCrnAndLocation(monitoredResourceCrn, storageLocation);
+        jobService.unschedule(consumption.getId().toString());
         consumptionService.delete(consumption);
     }
 }

--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/flow/ConsumptionFillInMemoryStateStoreRestartAction.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/flow/ConsumptionFillInMemoryStateStoreRestartAction.java
@@ -1,9 +1,16 @@
 package com.sequenceiq.consumption.flow;
 
+import javax.inject.Inject;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.common.event.Payload;
+import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.consumption.domain.Consumption;
+import com.sequenceiq.consumption.service.ConsumptionService;
 import com.sequenceiq.flow.core.FlowParameters;
 import com.sequenceiq.flow.core.restart.DefaultRestartAction;
 
@@ -11,9 +18,23 @@ import com.sequenceiq.flow.core.restart.DefaultRestartAction;
 public class ConsumptionFillInMemoryStateStoreRestartAction extends DefaultRestartAction {
     private static final Logger LOGGER = LoggerFactory.getLogger(ConsumptionFillInMemoryStateStoreRestartAction.class);
 
+    @Inject
+    private ConsumptionService consumptionService;
+
     @Override
     public void restart(FlowParameters flowParameters, String flowChainId, String event, Object payload) {
         LOGGER.debug("Restoring MDC context and InMemoryStateStore entry for flow: '{}', flow chain: '{}', event: '{}'", flowParameters.getFlowId(),
                 flowChainId, event);
+        Payload consumptionPayload = (Payload) payload;
+        try {
+            Consumption consumption = consumptionService.findConsumptionById(consumptionPayload.getResourceId());
+            MDCBuilder.buildMdcContext(consumption);
+            MDCBuilder.addFlowId(flowParameters.getFlowId());
+            LOGGER.debug("MDC context and InMemoryStateStore entry have been restored for flow: '{}', flow chain: '{}', event: '{}'", flowParameters.getFlowId(),
+                    flowChainId, event);
+            super.restart(flowParameters, flowChainId, event, payload);
+        } catch (NotFoundException e) {
+            LOGGER.error("Consumption not found with id [{}], error: {}", consumptionPayload.getResourceId(), e.getMessage());
+        }
     }
 }

--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/job/storage/StorageConsumptionJob.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/job/storage/StorageConsumptionJob.java
@@ -1,19 +1,37 @@
 package com.sequenceiq.consumption.job.storage;
 
+import javax.inject.Inject;
+
+import org.quartz.DisallowConcurrentExecution;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.quartz.TracedQuartzJob;
+import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGenerator;
+import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
+import com.sequenceiq.cloudbreak.quartz.statuschecker.job.StatusCheckerJob;
+import com.sequenceiq.consumption.domain.Consumption;
+import com.sequenceiq.consumption.flow.ConsumptionReactorFlowManager;
+import com.sequenceiq.consumption.service.ConsumptionService;
 
 import io.opentracing.Tracer;
 
+@DisallowConcurrentExecution
 @Component
-public class StorageConsumptionJob extends TracedQuartzJob {
+public class StorageConsumptionJob extends StatusCheckerJob {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StorageConsumptionJob.class);
+
+    @Inject
+    private ConsumptionService consumptionService;
+
+    @Inject
+    private ConsumptionReactorFlowManager flowManager;
+
+    @Inject
+    private RegionAwareInternalCrnGeneratorFactory regionAwareInternalCrnGeneratorFactory;
 
     public StorageConsumptionJob(Tracer tracer) {
         super(tracer, "Storage Consumption Job");
@@ -21,10 +39,20 @@ public class StorageConsumptionJob extends TracedQuartzJob {
 
     @Override
     protected void executeTracedJob(JobExecutionContext context) throws JobExecutionException {
+        try {
+            Consumption consumption = consumptionService.findConsumptionById(getLocalIdAsLong());
+            LOGGER.info("Triggering storage consumption collection flow for consumption with ID [{}].", consumption.getId());
+            RegionAwareInternalCrnGenerator crnGenerator = regionAwareInternalCrnGeneratorFactory.consumption();
+            flowManager.triggerStorageConsumptionCollectionFlow(consumption, crnGenerator.getInternalCrnForServiceAsString());
+        } catch (Exception e) {
+            LOGGER.error("Failed triggering storage consumption collection flow for consumption with ID [{}].", getLocalIdAsLong(), e);
+            throw new JobExecutionException(String.format("Failed triggering storage consumption collection flow for consumption with ID [%s], exception: %s",
+                    getLocalId(), e));
+        }
     }
 
     @Override
     protected Object getMdcContextObject() {
-        return null;
+        return consumptionService.findConsumptionById(getLocalIdAsLong());
     }
 }

--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/job/storage/StorageConsumptionJobInitializer.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/job/storage/StorageConsumptionJobInitializer.java
@@ -1,0 +1,36 @@
+package com.sequenceiq.consumption.job.storage;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.quartz.model.JobInitializer;
+import com.sequenceiq.consumption.service.ConsumptionService;
+
+@Component
+public class StorageConsumptionJobInitializer implements JobInitializer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StorageConsumptionJobInitializer.class);
+
+    @Inject
+    private StorageConsumptionJobService jobService;
+
+    @Inject
+    private ConsumptionService consumptionService;
+
+    @Inject
+    private StorageConsumptionConfig storageConsumptionConfig;
+
+    @Override
+    public void initJobs() {
+        if (storageConsumptionConfig.isStorageConsumptionEnabled()) {
+            LOGGER.info("Scheduling Storage consumption collection jobs");
+            consumptionService.findAllStorageConsumptionJobResource()
+                    .forEach(storageConsumption -> jobService.schedule(new StorageConsumptionJobAdapter(storageConsumption)));
+        } else {
+            LOGGER.info("Skipping scheduling storage consumption collection jobs as they are disabled");
+        }
+    }
+}

--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/service/ConsumptionService.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/service/ConsumptionService.java
@@ -2,6 +2,8 @@ package com.sequenceiq.consumption.service;
 
 import static com.sequenceiq.cloudbreak.common.exception.NotFoundException.notFound;
 
+import java.util.List;
+
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
@@ -14,6 +16,7 @@ import com.sequenceiq.cloudbreak.common.event.PayloadContext;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.common.service.account.AbstractAccountAwareResourceService;
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
 import com.sequenceiq.consumption.api.v1.consumption.model.common.ConsumptionType;
 import com.sequenceiq.consumption.domain.Consumption;
 import com.sequenceiq.consumption.configuration.repository.ConsumptionRepository;
@@ -92,5 +95,9 @@ public class ConsumptionService extends AbstractAccountAwareResourceService<Cons
 
     private boolean isStorageLocationOccupied(String monitoredResourceCrn, String storageLocation) {
         return consumptionRepository.doesStorageConsumptionExistWithLocationForMonitoredCrn(monitoredResourceCrn, storageLocation);
+    }
+
+    public List<JobResource> findAllStorageConsumptionJobResource() {
+        return consumptionRepository.findAllStorageConsumptionJobResource();
     }
 }

--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/util/CloudStorageLocationUtil.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/util/CloudStorageLocationUtil.java
@@ -1,0 +1,24 @@
+package com.sequenceiq.consumption.util;
+
+import javax.validation.ValidationException;
+
+import com.sequenceiq.common.model.FileSystemType;
+
+public class CloudStorageLocationUtil {
+
+    private CloudStorageLocationUtil() {
+    }
+
+    public static void validateCloudStorageType(FileSystemType requiredType, String storageLocation) {
+        if (storageLocation == null || !storageLocation.startsWith(requiredType.getProtocol())) {
+            throw new ValidationException(String.format("Storage location must start with '%s' if required file system type is '%s'!",
+                    requiredType.getProtocol(), requiredType.name()));
+        }
+    }
+
+    public static String getS3BucketName(String storageLocation) {
+        validateCloudStorageType(FileSystemType.S3, storageLocation);
+        storageLocation = storageLocation.replace(FileSystemType.S3.getProtocol() + "://", "");
+        return storageLocation.split("/")[0];
+    }
+}

--- a/cloud-consumption/src/test/java/com/sequenceiq/consumption/job/storage/StorageConsumptionJobInitializerTest.java
+++ b/cloud-consumption/src/test/java/com/sequenceiq/consumption/job/storage/StorageConsumptionJobInitializerTest.java
@@ -1,0 +1,82 @@
+package com.sequenceiq.consumption.job.storage;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
+import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
+import com.sequenceiq.consumption.service.ConsumptionService;
+
+@ExtendWith(MockitoExtension.class)
+public class StorageConsumptionJobInitializerTest {
+
+    @Mock
+    private StorageConsumptionJobService jobService;
+
+    @Mock
+    private ConsumptionService consumptionService;
+
+    @Mock
+    private StorageConsumptionConfig storageConsumptionConfig;
+
+    @Mock
+    private JobResource consumption1;
+
+    @Mock
+    private JobResource consumption2;
+
+    @InjectMocks
+    private StorageConsumptionJobInitializer underTest;
+
+    @Captor
+    private ArgumentCaptor<StorageConsumptionJobAdapter> jobAdapterCaptor;
+
+    @Test
+    public void testJobDisabled() {
+        when(storageConsumptionConfig.isStorageConsumptionEnabled()).thenReturn(false);
+
+        underTest.initJobs();
+
+        verifyNoInteractions(consumptionService);
+        verifyNoInteractions(jobService);
+    }
+
+    @Test
+    public void testNoJobsPresent() {
+        when(storageConsumptionConfig.isStorageConsumptionEnabled()).thenReturn(true);
+        when(consumptionService.findAllStorageConsumptionJobResource()).thenReturn(List.of());
+
+        underTest.initJobs();
+
+        verify(consumptionService, times(1)).findAllStorageConsumptionJobResource();
+        verifyNoInteractions(jobService);
+    }
+
+    @Test
+    public void testJobsScheduled() {
+        when(storageConsumptionConfig.isStorageConsumptionEnabled()).thenReturn(true);
+        when(consumptionService.findAllStorageConsumptionJobResource()).thenReturn(List.of(consumption1, consumption2));
+
+        underTest.initJobs();
+
+        verify(consumptionService, times(1)).findAllStorageConsumptionJobResource();
+        verify(jobService, times(2)).schedule(jobAdapterCaptor.capture());
+        Assertions.assertEquals(List.of(consumption1, consumption2),
+                jobAdapterCaptor.getAllValues().stream().map(JobResourceAdapter::getJobResource).collect(Collectors.toList()));
+    }
+
+}

--- a/cloud-consumption/src/test/java/com/sequenceiq/consumption/job/storage/StorageConsumptionJobTest.java
+++ b/cloud-consumption/src/test/java/com/sequenceiq/consumption/job/storage/StorageConsumptionJobTest.java
@@ -1,0 +1,99 @@
+package com.sequenceiq.consumption.job.storage;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
+import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGenerator;
+import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
+import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
+import com.sequenceiq.consumption.domain.Consumption;
+import com.sequenceiq.consumption.flow.ConsumptionReactorFlowManager;
+import com.sequenceiq.consumption.service.ConsumptionService;
+
+@ExtendWith(MockitoExtension.class)
+public class StorageConsumptionJobTest {
+
+    private static final Long LOCAL_ID = 42L;
+
+    private static final String REMOTE_CRN = "remote-crn";
+
+    private static final Long CONSUMPTION_ID = 1L;
+
+    @Mock
+    private ConsumptionService consumptionService;
+
+    @Mock
+    private ConsumptionReactorFlowManager flowManager;
+
+    @Mock
+    private RegionAwareInternalCrnGeneratorFactory regionAwareInternalCrnGeneratorFactory;
+
+    @Mock
+    private Consumption consumption;
+
+    @Mock
+    private RegionAwareInternalCrnGenerator crnGenerator;
+
+    @Mock
+    private JobExecutionContext jobExecutionContext;
+
+    @InjectMocks
+    private StorageConsumptionJob underTest;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        underTest.setLocalId(LOCAL_ID.toString());
+        underTest.setRemoteResourceCrn(REMOTE_CRN);
+        consumption.setId(CONSUMPTION_ID);
+    }
+
+    @Test
+    public void testGetMdcContextObjectThrowsError() {
+        when(consumptionService.findConsumptionById(LOCAL_ID)).thenThrow(new NotFoundException("error"));
+
+        Assertions.assertThrows(NotFoundException.class, () -> underTest.getMdcContextObject());
+    }
+
+    @Test
+    public void testGetMdcContextObject() {
+        when(consumptionService.findConsumptionById(LOCAL_ID)).thenReturn(consumption);
+
+        Assertions.assertEquals(consumption, underTest.getMdcContextObject());
+    }
+
+    @Test
+    public void testExecuteTracedJob() {
+        when(consumptionService.findConsumptionById(LOCAL_ID)).thenReturn(consumption);
+        when(regionAwareInternalCrnGeneratorFactory.consumption()).thenReturn(crnGenerator);
+        String crn = "internal-crn";
+        when(crnGenerator.getInternalCrnForServiceAsString()).thenReturn(crn);
+        doNothing().when(flowManager).triggerStorageConsumptionCollectionFlow(consumption, crn);
+
+        Assertions.assertDoesNotThrow(() -> underTest.executeTracedJob(jobExecutionContext));
+        verify(consumptionService).findConsumptionById(LOCAL_ID);
+        verify(regionAwareInternalCrnGeneratorFactory).consumption();
+        verify(crnGenerator).getInternalCrnForServiceAsString();
+        verify(flowManager).triggerStorageConsumptionCollectionFlow(consumption, crn);
+    }
+
+    @Test
+    public void testExecuteTracedJobThrowsError() {
+        when(consumptionService.findConsumptionById(LOCAL_ID)).thenThrow(new NotFoundException("error"));
+
+        Assertions.assertThrows(JobExecutionException.class, () -> underTest.executeTracedJob(jobExecutionContext));
+        verify(consumptionService).findConsumptionById(LOCAL_ID);
+    }
+}

--- a/cloud-consumption/src/test/java/com/sequenceiq/consumption/util/CloudStorageLocationUtilTest.java
+++ b/cloud-consumption/src/test/java/com/sequenceiq/consumption/util/CloudStorageLocationUtilTest.java
@@ -1,0 +1,50 @@
+package com.sequenceiq.consumption.util;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import javax.validation.ValidationException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.sequenceiq.common.model.FileSystemType;
+
+public class CloudStorageLocationUtilTest {
+
+    private static final String S3_OBJECT_PATH = "s3a://bucket-name/folder/file";
+
+    private static final String ABFS_OBJECT_PATH = "abfs://FILESYSTEM@STORAGEACCOUNT.dfs.core.windows.net/PATH";
+
+    @Test
+    public void testGetBucketName() {
+        assertEquals("bucket-name", CloudStorageLocationUtil.getS3BucketName(S3_OBJECT_PATH));
+    }
+
+    @Test
+    public void testGetBucketNameWithInvalidStorageType() {
+        assertThrows(ValidationException.class, () -> CloudStorageLocationUtil.getS3BucketName(ABFS_OBJECT_PATH));
+    }
+
+    @ParameterizedTest(name = "With requiredType={0} and storageLocation={1}, validation should succeed: {2}")
+    @MethodSource("scenarios")
+    public void testValidateCloudStorageType(FileSystemType requiredType, String storageLocation, boolean valid) {
+        if (valid) {
+            assertDoesNotThrow(() -> CloudStorageLocationUtil.validateCloudStorageType(requiredType, storageLocation));
+        } else {
+            assertThrows(ValidationException.class, () -> CloudStorageLocationUtil.validateCloudStorageType(requiredType, storageLocation));
+        }
+    }
+
+    static Object[][] scenarios() {
+        return new Object[][]{
+                {FileSystemType.S3,     S3_OBJECT_PATH,     true},
+                {FileSystemType.S3,     ABFS_OBJECT_PATH,   false},
+                {FileSystemType.S3,     "",                 false},
+                {FileSystemType.S3,     null,               false},
+                {FileSystemType.WASB,   S3_OBJECT_PATH,     false}
+        };
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/auth/crn/RegionAwareInternalCrnGeneratorFactory.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/auth/crn/RegionAwareInternalCrnGeneratorFactory.java
@@ -33,6 +33,10 @@ public class RegionAwareInternalCrnGeneratorFactory {
         return init(Crn.Service.AUTOSCALE);
     }
 
+    public RegionAwareInternalCrnGenerator consumption() {
+        return init(Crn.Service.CONSUMPTION);
+    }
+
     private RegionAwareInternalCrnGenerator init(Crn.Service serviceType) {
         return regionalAwareInternalCrnGenerator(serviceType, partition, region);
     }


### PR DESCRIPTION
…together

This commit contains the following changes:
* The storage consumption schedule and uschedule endpoint now respectively schedule and unschedule the storage consumption quartz job for the requested resource and storage location
* Implement JobInitializer for the storage consumption quartz job
* Add a until class that helps validationg storage location strings by checking if the location starts with the correct protocol for the given storage location. This validation is added to the storage collection schedule endpoint to validate if the given location is a valid S3 storage location. Additionally a function is created that gathers the bucket name from the storage location string.

Unit tests were written where applicable, also manual testing was done by scheduling and unsceduling manually storage locations and checking if the flow run correctly. The initializer was also tested by stopping and restarting the service and observing if the registered jobs were rescheduled.

See detailed description in the commit message.