### PR TITLE
CB-17162: Show warning message when we are unable to read details of the Azure Marketplace image.

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/exception/CloudPlatformValidationWarningException.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/exception/CloudPlatformValidationWarningException.java
@@ -1,0 +1,8 @@
+package com.sequenceiq.cloudbreak.cloud.exception;
+
+public class CloudPlatformValidationWarningException extends RuntimeException {
+
+    public CloudPlatformValidationWarningException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/setup/ValidationResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/setup/ValidationResult.java
@@ -1,11 +1,20 @@
 package com.sequenceiq.cloudbreak.cloud.event.setup;
 
+import java.util.Set;
+
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
 
 public class ValidationResult extends CloudPlatformResult {
 
+    private Set<String> warningMessages;
+
     public ValidationResult(Long resourceId) {
         super(resourceId);
+    }
+
+    public ValidationResult(Long resourceId, Set<String> warningMessages) {
+        super(resourceId);
+        this.warningMessages = warningMessages;
     }
 
     public ValidationResult(Exception errorDetails, Long resourceId) {
@@ -16,4 +25,7 @@ public class ValidationResult extends CloudPlatformResult {
         super(statusReason, errorDetails, resourceId);
     }
 
+    public Set<String> getWarningMessages() {
+        return warningMessages;
+    }
 }

--- a/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/ProvisionValidationHandlerTest.java
+++ b/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/ProvisionValidationHandlerTest.java
@@ -1,0 +1,136 @@
+package com.sequenceiq.cloudbreak.cloud.handler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cloud.Authenticator;
+import com.sequenceiq.cloudbreak.cloud.CloudConnector;
+import com.sequenceiq.cloudbreak.cloud.Validator;
+import com.sequenceiq.cloudbreak.cloud.ValidatorType;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.event.setup.ValidationRequest;
+import com.sequenceiq.cloudbreak.cloud.event.setup.ValidationResult;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudPlatformValidationWarningException;
+import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+
+import reactor.bus.Event;
+import reactor.bus.EventBus;
+
+@ExtendWith(MockitoExtension.class)
+public class ProvisionValidationHandlerTest {
+
+    private static final long STACK_ID = 1L;
+
+    private static final String WARNING_MESSAGE = "warning";
+
+    @InjectMocks
+    private ProvisionValidationHandler underTest;
+
+    @Mock
+    private CloudPlatformConnectors cloudPlatformConnectors;
+
+    @Mock
+    private EventBus eventBus;
+
+    @Mock
+    private CloudConnector<Object> cloudConnector;
+
+    @Mock
+    private Authenticator authenticator;
+
+    @Mock
+    private AuthenticatedContext ac;
+
+    @Mock
+    private Validator validator;
+
+    @Test
+    void testAcceptShouldSendEventWhenAllValidationWereSuccessful() {
+        ValidationRequest request = createValidationRequest();
+        CloudContext cloudContext = request.getCloudContext();
+        mockCloudConnector(request, cloudContext);
+
+        underTest.accept(new Event<>(request));
+
+        verifyCloudConnectorCalls(request, cloudContext);
+        ArgumentCaptor<Event> argumentCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(eventBus).notify(eq("VALIDATIONRESULT"), argumentCaptor.capture());
+        Event<ValidationResult> resultEvent = argumentCaptor.getValue();
+        assertTrue(resultEvent.getData().getWarningMessages().isEmpty());
+    }
+
+    @Test
+    void testAcceptShouldSendEventWhenTheValidatorThrowsWarningMessage() {
+        ValidationRequest request = createValidationRequest();
+        CloudContext cloudContext = request.getCloudContext();
+        mockCloudConnector(request, cloudContext);
+        doThrow(new CloudPlatformValidationWarningException(WARNING_MESSAGE, new Exception()))
+                .when(validator).validate(ac, request.getCloudStack());
+
+        underTest.accept(new Event<>(request));
+
+        verifyCloudConnectorCalls(request, cloudContext);
+        ArgumentCaptor<Event> argumentCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(eventBus).notify(eq("VALIDATIONRESULT"), argumentCaptor.capture());
+        Event<ValidationResult> resultEvent = argumentCaptor.getValue();
+        ValidationResult validationResult = resultEvent.getData();
+        assertTrue(validationResult.getWarningMessages().contains(WARNING_MESSAGE));
+        assertEquals(1, validationResult.getWarningMessages().size());
+    }
+
+    @Test
+    void testAcceptShouldSendFailureEventWhenTheValidationFailed() {
+        ValidationRequest request = createValidationRequest();
+        CloudContext cloudContext = request.getCloudContext();
+        mockCloudConnector(request, cloudContext);
+        CloudConnectorException exception = new CloudConnectorException("Error");
+        doThrow(exception).when(validator).validate(ac, request.getCloudStack());
+
+        underTest.accept(new Event<>(request));
+
+        verifyCloudConnectorCalls(request, cloudContext);
+        ArgumentCaptor<Event> argumentCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(eventBus).notify(eq("VALIDATIONRESULT_ERROR"), argumentCaptor.capture());
+        Event<ValidationResult> resultEvent = argumentCaptor.getValue();
+        assertEquals(exception, resultEvent.getData().getErrorDetails());
+    }
+
+    private void verifyCloudConnectorCalls(ValidationRequest request, CloudContext cloudContext) {
+        verify(cloudPlatformConnectors).get(cloudContext.getPlatformVariant());
+        verify(cloudConnector).authentication();
+        verify(authenticator).authenticate(cloudContext, request.getCloudCredential());
+        verify(cloudConnector).validators(ValidatorType.ALL);
+        verify(validator).validate(ac, request.getCloudStack());
+    }
+
+    private void mockCloudConnector(ValidationRequest request, CloudContext cloudContext) {
+        when(cloudPlatformConnectors.get(cloudContext.getPlatformVariant())).thenReturn(cloudConnector);
+        when(cloudConnector.authentication()).thenReturn(authenticator);
+        when(authenticator.authenticate(cloudContext, request.getCloudCredential())).thenReturn(ac);
+        when(cloudConnector.validators(ValidatorType.ALL)).thenReturn(List.of(validator));
+    }
+
+    private ValidationRequest createValidationRequest() {
+        CloudContext cloudContext = new CloudContext.Builder().withPlatform("AWS").withVariant("AWS").withId(STACK_ID).build();
+        return new ValidationRequest(cloudContext, mock(CloudCredential.class), mock(CloudStack.class));
+    }
+
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
@@ -440,6 +440,7 @@ public enum ResourceEvent {
     KERBEROS_CONFIG_VALIDATION_FAILED("cluster.kerberosconfig.validation.failed"),
 
     CLOUD_CONFIG_VALIDATION_FAILED("cluster.cloudconfig.validation.failed"),
+    CLOUD_PROVIDER_VALIDATION_WARNING("cluster.provider.validation.warning"),
 
     STACK_RETRY_FLOW_START("retry.flow.start"),
 

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -214,6 +214,7 @@ cluster.ccm.upgrade.finished=Cluster Connectivity Manager upgrade finished.
 cluster.kerberosconfig.validation.failed=Kerberos config validation failed with: {0}
 
 cluster.cloudconfig.validation.failed=Cloud config validation failed with the following errors: {0}
+cluster.provider.validation.warning=Cloud platform validation succeeded with the following warnings: {0}
 
 cm.cluster.command.failed=Cloudera Manager command [{0}] failed, you can check the command here: {1}
 cm.cluster.command.timeout=Cloudera Manager command [{0}] timed out, you can check the command here: {1}


### PR DESCRIPTION
At the beginning of the cluster provision, we're validating that the Terms and Conditions are accepted for the Azure Marketplace image.
To perform this validation we need the Microsoft.MarketplaceOrdering/offertypes/publishers/offers/plans/agreements/read permission.
Sometimes the customers are not providing this permission. After this change, we're sending an error message to the customer to make sure that the Terms and Conditions are accepted.