### PR TITLE
CB-17211 Add toString() to VolumeSetAttributes.Volume for better logging

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/VolumeSetAttributes.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/VolumeSetAttributes.java
@@ -185,6 +185,18 @@ public class VolumeSetAttributes {
         public void setCloudVolumeUsageType(CloudVolumeUsageType cloudVolumeUsageType) {
             this.cloudVolumeUsageType = cloudVolumeUsageType;
         }
+
+        @Override
+        public String toString() {
+            return "Volume{" +
+                    "id='" + id + '\'' +
+                    ", device='" + device + '\'' +
+                    ", size=" + size +
+                    ", type='" + type + '\'' +
+                    ", cloudVolumeUsageType=" + cloudVolumeUsageType +
+                    '}';
+        }
+
     }
 
     public static class Builder {


### PR DESCRIPTION
Override `VolumeSetAttributes.Volume.toString()` for sake of improved logging and troubleshooting. All the fields are included since neither of them is sensitive.
