### PR TITLE
CB-17292 MachineUser not being initialized for Datahub clusters in pe…

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/service/RoleCrnGenerator.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/service/RoleCrnGenerator.java
@@ -11,7 +11,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.google.common.base.Joiner;
-import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.logger.MDCUtils;
@@ -28,28 +27,20 @@ public class RoleCrnGenerator {
         return getRoleCrn("DbusUploader", accountId).toString();
     }
 
-    public String getBuiltInOwnerResourceRoleCrn() {
-        return getResourceRoleCrn("Owner").toString();
+    public String getBuiltInOwnerResourceRoleCrn(String accountId) {
+        return getResourceRoleCrn("Owner", accountId).toString();
     }
 
-    public String getBuiltInEnvironmentAdminResourceRoleCrn() {
-        return getResourceRoleCrn("EnvironmentAdmin").toString();
+    public String getBuiltInEnvironmentAdminResourceRoleCrn(String accountId) {
+        return getResourceRoleCrn("EnvironmentAdmin", accountId).toString();
     }
 
-    public String getBuiltInEnvironmentUserResourceRoleCrn() {
-        return getResourceRoleCrn("EnvironmentUser").toString();
+    public String getBuiltInEnvironmentUserResourceRoleCrn(String accountId) {
+        return getResourceRoleCrn("EnvironmentUser", accountId).toString();
     }
 
     public String getBuiltInWXMClusterAdminResourceRoleCrn(String accountId) {
         return getResourceRoleCrn("WXMClusterAdmin", accountId).toString();
-    }
-
-    public Crn getResourceRoleCrn(String resourceRoleName) {
-        return getResourceRoleCrn(resourceRoleName, ThreadBasedUserCrnProvider.getAccountId());
-    }
-
-    public Crn getRoleCrn(String roleName) {
-        return getRoleCrn(roleName, ThreadBasedUserCrnProvider.getAccountId());
     }
 
     public Crn getResourceRoleCrn(String resourceRoleName, String accountId) {

--- a/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/altus/service/RoleCrnGeneratorTest.java
+++ b/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/altus/service/RoleCrnGeneratorTest.java
@@ -49,20 +49,21 @@ public class RoleCrnGeneratorTest {
 
     @Test
     public void testGetExistingRoles() {
-        Crn testRole1 = ThreadBasedUserCrnProvider.doAs(ACTOR, () -> underTest.getRoleCrn(TEST_ROLE_1));
-        Crn testRole2 = ThreadBasedUserCrnProvider.doAs(ACTOR, () -> underTest.getRoleCrn(TEST_ROLE_2));
+        Crn testRole1 = ThreadBasedUserCrnProvider.doAs(ACTOR, () -> underTest.getRoleCrn(TEST_ROLE_1, "altus"));
+        Crn testRole2 = ThreadBasedUserCrnProvider.doAs(ACTOR, () -> underTest.getRoleCrn(TEST_ROLE_2, "altus"));
         existingRoleAssertions(testRole1, testRole2, Crn.ResourceType.ROLE);
 
-        testRole1 = ThreadBasedUserCrnProvider.doAs(ACTOR, () -> underTest.getResourceRoleCrn(TEST_ROLE_1));
-        testRole2 = ThreadBasedUserCrnProvider.doAs(ACTOR, () -> underTest.getResourceRoleCrn(TEST_ROLE_2));
+        testRole1 = ThreadBasedUserCrnProvider.doAs(ACTOR, () -> underTest.getResourceRoleCrn(TEST_ROLE_1, "altus"));
+        testRole2 = ThreadBasedUserCrnProvider.doAs(ACTOR, () -> underTest.getResourceRoleCrn(TEST_ROLE_2, "altus"));
         existingRoleAssertions(testRole1, testRole2, Crn.ResourceType.RESOURCE_ROLE);
     }
 
     @Test
     public void testGetNonExistingRoles() {
-        assertThrows(InternalServerErrorException.class, () -> ThreadBasedUserCrnProvider.doAs(ACTOR, () -> underTest.getRoleCrn("whatever")));
-        assertThrows(InternalServerErrorException.class, () ->
-                ThreadBasedUserCrnProvider.doAs(ACTOR, () -> underTest.getResourceRoleCrn("whatever")));
+        assertThrows(InternalServerErrorException.class, () -> ThreadBasedUserCrnProvider.doAs(ACTOR, () ->
+                underTest.getRoleCrn("whatever", "altus")));
+        assertThrows(InternalServerErrorException.class, () -> ThreadBasedUserCrnProvider.doAs(ACTOR, () ->
+                underTest.getResourceRoleCrn("whatever", "altus")));
     }
 
     private void existingRoleAssertions(Crn testRole1, Crn testRole2, Crn.ResourceType roleType) {

--- a/authorization-common/src/main/java/com/sequenceiq/authorization/service/OwnerAssignmentService.java
+++ b/authorization-common/src/main/java/com/sequenceiq/authorization/service/OwnerAssignmentService.java
@@ -32,7 +32,7 @@ public class OwnerAssignmentService {
 
     public void assignResourceOwnerRoleIfEntitled(String userCrn, String resourceCrn, String accountId) {
         try {
-            umsClient.assignResourceRole(userCrn, resourceCrn, roleCrnGenerator.getBuiltInOwnerResourceRoleCrn(),
+            umsClient.assignResourceRole(userCrn, resourceCrn, roleCrnGenerator.getBuiltInOwnerResourceRoleCrn(accountId),
                     MDCUtils.getRequestId(), regionAwareInternalCrnGeneratorFactory);
             LOGGER.debug("Owner role of {} is successfully assigned to the {} user", resourceCrn, userCrn);
         } catch (StatusRuntimeException ex) {

--- a/autoscale/src/test/java/com/sequenceiq/periscope/service/AltusMachineUserServiceTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/service/AltusMachineUserServiceTest.java
@@ -91,7 +91,7 @@ class AltusMachineUserServiceTest {
                 .thenReturn(machineUser);
         when(grpcUmsClient.listAssignedResourceRoles(anyString(), any(Optional.class), any(RegionAwareInternalCrnGeneratorFactory.class)))
                 .thenReturn(LinkedHashMultimap.create());
-        when(roleCrnGenerator.getBuiltInEnvironmentUserResourceRoleCrn()).thenReturn(environmentRoleCrn);
+        when(roleCrnGenerator.getBuiltInEnvironmentUserResourceRoleCrn(anyString())).thenReturn(environmentRoleCrn);
         when(freeIpaCommunicator.synchronizeAllUsers(any(SynchronizeAllUsersRequest.class))).thenReturn(getSyncOpStatus(SynchronizationStatus.COMPLETED));
 
         underTest.initializeMachineUserForEnvironment(cluster);
@@ -122,7 +122,7 @@ class AltusMachineUserServiceTest {
                 .thenReturn(machineUser);
         when(machineUser.getCrn()).thenReturn(autoscaleMachineUserCrn);
         when(grpcUmsClient.listAssignedResourceRoles(anyString(), any(Optional.class), any(RegionAwareInternalCrnGeneratorFactory.class))).thenReturn(rolesMap);
-        when(roleCrnGenerator.getBuiltInEnvironmentUserResourceRoleCrn()).thenReturn(environmentRoleCrn);
+        when(roleCrnGenerator.getBuiltInEnvironmentUserResourceRoleCrn(anyString())).thenReturn(environmentRoleCrn);
         when(freeIpaCommunicator.synchronizeAllUsers(any(SynchronizeAllUsersRequest.class))).thenReturn(getSyncOpStatus(SynchronizationStatus.COMPLETED));
 
         underTest.initializeMachineUserForEnvironment(cluster);
@@ -147,7 +147,7 @@ class AltusMachineUserServiceTest {
         RegionAwareInternalCrnGenerator regionAwareInternalCrnGenerator = mock(RegionAwareInternalCrnGenerator.class);
         when(machineUserMock.getCrn()).thenReturn(autoscaleMachineUserCrn);
         when(machineUserMock.getWorkloadUsername()).thenReturn("workloadUserName");
-        when(roleCrnGenerator.getBuiltInEnvironmentUserResourceRoleCrn()).thenReturn(environmentRoleCrn);
+        when(roleCrnGenerator.getBuiltInEnvironmentUserResourceRoleCrn(anyString())).thenReturn(environmentRoleCrn);
         when(regionAwareInternalCrnGeneratorFactory.iam()).thenReturn(regionAwareInternalCrnGenerator);
         when(regionAwareInternalCrnGenerator.getInternalCrnForServiceAsString()).thenReturn(internalActorCrn);
         when(grpcUmsClient.getOrCreateMachineUserWithoutAccessKey(eq(autoscaleMachineUserName),

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentService.java
@@ -372,7 +372,7 @@ public class EnvironmentService extends AbstractAccountAwareResourceService<Envi
         try {
             grpcUmsClient.assignResourceRole(userCrn,
                     environmentCrn,
-                    roleCrnGenerator.getBuiltInEnvironmentAdminResourceRoleCrn(),
+                    roleCrnGenerator.getBuiltInEnvironmentAdminResourceRoleCrn(Crn.safeFromString(environmentCrn).getAccountId()),
                     MDCUtils.getRequestId(),
                     regionAwareInternalCrnGeneratorFactory);
             LOGGER.debug("EnvironmentAdmin role of {} environemnt is successfully assigned to the {} user", environmentCrn, userCrn);

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentServiceTest.java
@@ -53,6 +53,8 @@ import com.sequenceiq.environment.environment.validation.EnvironmentValidatorSer
 @ExtendWith(MockitoExtension.class)
 class EnvironmentServiceTest {
 
+    private static final String ENV_CRN = "crn:cdp:environments:us-west-1:accountId:environment:4c5ba74b-c35e-45e9-9f47-123456789876";
+
     @InjectMocks
     private EnvironmentService environmentServiceUnderTest;
 
@@ -80,7 +82,7 @@ class EnvironmentServiceTest {
 
     @BeforeEach
     void setup() {
-        lenient().when(roleCrnGenerator.getBuiltInEnvironmentAdminResourceRoleCrn())
+        lenient().when(roleCrnGenerator.getBuiltInEnvironmentAdminResourceRoleCrn(anyString()))
                 .thenReturn("crn:altus:iam:us-west-1:altus:resourceRole:EnvironmentAdmin");
         environment = new Environment();
         environmentDto = new EnvironmentDto();
@@ -235,11 +237,11 @@ class EnvironmentServiceTest {
     @Test
     void testRoleAssignment() {
         ThreadBasedUserCrnProvider.doAs(TestConstants.CRN, () -> {
-            environmentServiceUnderTest.assignEnvironmentAdminRole(TestConstants.CRN, "envCrn");
+            environmentServiceUnderTest.assignEnvironmentAdminRole(TestConstants.CRN, ENV_CRN);
         });
 
         verify(grpcUmsClient)
-                .assignResourceRole(eq(TestConstants.CRN), eq("envCrn"), eq("crn:altus:iam:us-west-1:altus:resourceRole:EnvironmentAdmin"), any(), any());
+                .assignResourceRole(eq(TestConstants.CRN), eq(ENV_CRN), eq("crn:altus:iam:us-west-1:altus:resourceRole:EnvironmentAdmin"), any(), any());
     }
 
     @Test
@@ -248,11 +250,11 @@ class EnvironmentServiceTest {
                 .when(grpcUmsClient).assignResourceRole(anyString(), anyString(), anyString(), any(), any());
 
         ThreadBasedUserCrnProvider.doAs(TestConstants.CRN, () -> {
-            environmentServiceUnderTest.assignEnvironmentAdminRole(TestConstants.CRN, "envCrn");
+            environmentServiceUnderTest.assignEnvironmentAdminRole(TestConstants.CRN, ENV_CRN);
         });
 
         verify(grpcUmsClient)
-                .assignResourceRole(eq(TestConstants.CRN), eq("envCrn"), eq("crn:altus:iam:us-west-1:altus:resourceRole:EnvironmentAdmin"), any(), any());
+                .assignResourceRole(eq(TestConstants.CRN), eq(ENV_CRN), eq("crn:altus:iam:us-west-1:altus:resourceRole:EnvironmentAdmin"), any(), any());
         verifyNoMoreInteractions(grpcUmsClient);
     }
 


### PR DESCRIPTION
…riscope - resource role crn query should use accountid from resource

See detailed description in the commit message.