### PR TITLE
CB-17308 Adapt SSB DB setup to the new architecture

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/SqlStreamBuilderAdminRdsConfigProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/SqlStreamBuilderAdminRdsConfigProvider.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessorFactory;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.ssb.SqlStreamBuilderRoles;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
 
 @Component
@@ -18,10 +19,10 @@ public class SqlStreamBuilderAdminRdsConfigProvider extends AbstractRdsConfigPro
     @Value("${cb.ssb.database.admin.port:5432}")
     private String port;
 
-    @Value("${cb.ssb.database.admin.user:eventador_admin}")
+    @Value("${cb.ssb.database.admin.user:" + PILLAR_KEY + "}")
     private String userName;
 
-    @Value("${cb.ssb.database.admin.db:eventador_admin}")
+    @Value("${cb.ssb.database.admin.db:" + PILLAR_KEY + "}")
     private String db;
 
     @Inject
@@ -55,6 +56,6 @@ public class SqlStreamBuilderAdminRdsConfigProvider extends AbstractRdsConfigPro
     @Override
     protected boolean isRdsConfigNeeded(Blueprint blueprint, boolean hasGateway) {
         CmTemplateProcessor blueprintProcessor = cmTemplateProcessorFactory.get(blueprint.getBlueprintText());
-        return blueprintProcessor.isCMComponentExistsInBlueprint("STREAMING_SQL_CONSOLE");
+        return blueprintProcessor.isCMComponentExistsInBlueprint(SqlStreamBuilderRoles.STREAMING_SQL_ENGINE);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/SqlStreamBuilderSnapperRdsConfigProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/SqlStreamBuilderSnapperRdsConfigProvider.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessorFactory;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.ssb.SqlStreamBuilderRoles;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
 
 @Component
@@ -18,10 +19,10 @@ public class SqlStreamBuilderSnapperRdsConfigProvider extends AbstractRdsConfigP
     @Value("${cb.ssb.database.snapper.port:5432}")
     private String port;
 
-    @Value("${cb.ssb.database.snapper.user:eventador_snapper}")
+    @Value("${cb.ssb.database.snapper.user:ssb_mve}")
     private String userName;
 
-    @Value("${cb.ssb.database.snapper.db:eventador_snapper}")
+    @Value("${cb.ssb.database.snapper.db:ssb_mve}")
     private String db;
 
     @Inject
@@ -55,6 +56,6 @@ public class SqlStreamBuilderSnapperRdsConfigProvider extends AbstractRdsConfigP
     @Override
     protected boolean isRdsConfigNeeded(Blueprint blueprint, boolean hasGateway) {
         CmTemplateProcessor blueprintProcessor = cmTemplateProcessorFactory.get(blueprint.getBlueprintText());
-        return blueprintProcessor.isCMComponentExistsInBlueprint("MATERIALIZED_VIEW_ENGINE");
+        return blueprintProcessor.isCMComponentExistsInBlueprint(SqlStreamBuilderRoles.MATERIALIZED_VIEW_ENGINE);
     }
 }

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ssb/SqlStreamBuilderAdminDatabaseConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ssb/SqlStreamBuilderAdminDatabaseConfigProvider.java
@@ -36,7 +36,7 @@ public class SqlStreamBuilderAdminDatabaseConfigProvider extends SqlStreamBuilde
 
     @Override
     public List<String> getRoleTypes() {
-        return List.of(SqlStreamBuilderRoles.STREAMING_SQL_ENGINE, SqlStreamBuilderRoles.STREAMING_SQL_CONSOLE, SqlStreamBuilderRoles.MATERIALIZED_VIEW_ENGINE);
+        return List.of(SqlStreamBuilderRoles.STREAMING_SQL_ENGINE, SqlStreamBuilderRoles.MATERIALIZED_VIEW_ENGINE);
     }
 
     @Override

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ssb/SqlStreamBuilderMveDatabaseConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ssb/SqlStreamBuilderMveDatabaseConfigProvider.java
@@ -13,7 +13,7 @@ import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.views.RdsView;
 
 @Component
-public class SqlStreamBuilderSnapperDatabaseConfigProvider extends SqlStreamBuilderConfigProvider {
+public class SqlStreamBuilderMveDatabaseConfigProvider extends SqlStreamBuilderConfigProvider {
 
     static final String DATABASE_URL = "ssb.mve.datasource.url";
 

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ssb/SqlStreamBuilderRoles.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ssb/SqlStreamBuilderRoles.java
@@ -6,8 +6,6 @@ public class SqlStreamBuilderRoles {
 
     public static final String STREAMING_SQL_ENGINE = "STREAMING_SQL_ENGINE";
 
-    public static final String STREAMING_SQL_CONSOLE = "STREAMING_SQL_CONSOLE";
-
     public static final String MATERIALIZED_VIEW_ENGINE = "MATERIALIZED_VIEW_ENGINE";
 
     private SqlStreamBuilderRoles() { }

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ssb/SqlStreamBuilderAdminDatabaseConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ssb/SqlStreamBuilderAdminDatabaseConfigProviderTest.java
@@ -55,12 +55,12 @@ public class SqlStreamBuilderAdminDatabaseConfigProviderTest {
 
         assertThat(roleConfigs).hasSameElementsAs(
                 List.of(
-                        config("database_type", "postgresql"),
-                        config("database_host", "testhost"),
-                        config("database_port", "5432"),
-                        config("database_schema", "eventador_admin"),
-                        config("database_user", "ssb_test_user"),
-                        config("database_password", "ssb_test_pw")
+                        config(SqlStreamBuilderAdminDatabaseConfigProvider.DATABASE_TYPE, "postgresql"),
+                        config(SqlStreamBuilderAdminDatabaseConfigProvider.DATABASE_HOST, "testhost"),
+                        config(SqlStreamBuilderAdminDatabaseConfigProvider.DATABASE_PORT, "5432"),
+                        config(SqlStreamBuilderAdminDatabaseConfigProvider.DATABASE_SCHEMA, "ssb_admin"),
+                        config(SqlStreamBuilderAdminDatabaseConfigProvider.DATABASE_USER, "ssb_test_user"),
+                        config(SqlStreamBuilderAdminDatabaseConfigProvider.DATABASE_PASSWORD, "ssb_test_pw")
                 ));
     }
 
@@ -81,7 +81,7 @@ public class SqlStreamBuilderAdminDatabaseConfigProviderTest {
         when(rdsConfig.getType()).thenReturn(DatabaseType.SQL_STREAM_BUILDER_ADMIN.toString());
         when(rdsConfig.getDatabaseEngine()).thenReturn(DatabaseVendor.POSTGRES);
         when(rdsConfig.getConnectionDriver()).thenReturn(DatabaseVendor.POSTGRES.connectionDriver());
-        when(rdsConfig.getConnectionURL()).thenReturn("jdbc:postgresql://testhost:5432/eventador_admin");
+        when(rdsConfig.getConnectionURL()).thenReturn("jdbc:postgresql://testhost:5432/ssb_admin");
         when(rdsConfig.getConnectionUserName()).thenReturn("ssb_test_user");
         when(rdsConfig.getConnectionPassword()).thenReturn("ssb_test_pw");
 

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ssb/SqlStreamBuilderMveDatabaseConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ssb/SqlStreamBuilderMveDatabaseConfigProviderTest.java
@@ -26,9 +26,9 @@ import com.sequenceiq.cloudbreak.util.FileReaderUtils;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 
 @RunWith(MockitoJUnitRunner.class)
-public class SqlStreamBuilderSnapperDatabaseConfigProviderTest {
+public class SqlStreamBuilderMveDatabaseConfigProviderTest {
 
-    private final SqlStreamBuilderSnapperDatabaseConfigProvider underTest = new SqlStreamBuilderSnapperDatabaseConfigProvider();
+    private final SqlStreamBuilderMveDatabaseConfigProvider underTest = new SqlStreamBuilderMveDatabaseConfigProvider();
 
     @Test
     public void testNoConfigNeeded() {
@@ -55,9 +55,9 @@ public class SqlStreamBuilderSnapperDatabaseConfigProviderTest {
 
         assertThat(roleConfigs).hasSameElementsAs(
                 List.of(
-                        config("ssb.mve.datasource.url", "jdbc:postgresql://testhost:5432/eventador_snapper"),
-                        config("ssb.mve.datasource.username", "ssb_test_user"),
-                        config("ssb.mve.datasource.password", "ssb_test_pw")
+                        config(SqlStreamBuilderMveDatabaseConfigProvider.DATABASE_URL, "jdbc:postgresql://testhost:5432/ssb_mve"),
+                        config(SqlStreamBuilderMveDatabaseConfigProvider.DATABASE_USER, "ssb_test_user"),
+                        config(SqlStreamBuilderMveDatabaseConfigProvider.DATABASE_PASSWORD, "ssb_test_pw")
                 ));
     }
 
@@ -78,7 +78,7 @@ public class SqlStreamBuilderSnapperDatabaseConfigProviderTest {
         when(rdsConfig.getType()).thenReturn(DatabaseType.SQL_STREAM_BUILDER_SNAPPER.toString());
         when(rdsConfig.getDatabaseEngine()).thenReturn(DatabaseVendor.POSTGRES);
         when(rdsConfig.getConnectionDriver()).thenReturn(DatabaseVendor.POSTGRES.connectionDriver());
-        when(rdsConfig.getConnectionURL()).thenReturn("jdbc:postgresql://testhost:5432/eventador_snapper");
+        when(rdsConfig.getConnectionURL()).thenReturn("jdbc:postgresql://testhost:5432/ssb_mve");
         when(rdsConfig.getConnectionUserName()).thenReturn("ssb_test_user");
         when(rdsConfig.getConnectionPassword()).thenReturn("ssb_test_pw");
 


### PR DESCRIPTION
Recently the architecture of `SQL_STREAM_BUILDER` changed and we are bringing this change to Public Cloud with the 7.2.16 release.

The relevant change is the `STREAMING_SQL_CONSOLE` role got removed from the product. Although the rest of the roles are intact. I pointed the Admin DB config condition to `STREAMING_SQL_ENGINE` instead, which will be backward compatible.

Open question is: I renamed the default users and databases for both SSB DB. Could that cause problems for existing environments? My guess was it would not bother already existing workloads and only applied to new cluster provisions, which should work. On our end, definitely but I am not a CB expert.