### PR TITLE
CB-17328. Node exporter should not collect its own metrics.

### DIFF
--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/systemd/cdp-node-exporter.service.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/systemd/cdp-node-exporter.service.j2
@@ -37,6 +37,7 @@ ExecStart=/opt/node_exporter/node_exporter --web.config=/opt/node_exporter/node_
      {%- endif %}
      {%- endfor %}
 {%- endif %}
+     --web.disable-exporter-metrics \
      --web.listen-address=:{{ monitoring.nodeExporterPort }}
 
 Restart=always


### PR DESCRIPTION
See detailed description in the commit message.