### PR TITLE
CB-17220 - Azure regional endpoint

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
@@ -1061,7 +1061,7 @@ public class AzureClient {
     }
 
     public Optional<String> getAccessToken() {
-        return azureClientCredentials.getAccesToken();
+        return azureClientCredentials.getAccessToken();
     }
 
 }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClientService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClientService.java
@@ -33,14 +33,18 @@ public class AzureClientService {
 
     public AuthenticatedContext createAuthenticatedContext(CloudContext cloudContext, CloudCredential cloudCredential) {
         AuthenticatedContext authenticatedContext = new AuthenticatedContext(cloudContext, cloudCredential);
-        AzureClient azureClient = getClient(cloudCredential);
+        AzureClient azureClient = getClient(cloudContext, cloudCredential);
         authenticatedContext.putParameter(AzureClient.class, azureClient);
         return authenticatedContext;
     }
 
     public AzureClient getClient(CloudCredential cloudCredential) {
+        return getClient(null, cloudCredential);
+    }
+
+    public AzureClient getClient(CloudContext cloudContext, CloudCredential cloudCredential) {
         AzureCredentialView azureCredentialView = new AzureCredentialView(cloudCredential);
-        AzureClientCredentials azureClientCredentials = new AzureClientCredentials(azureCredentialView, logLevel, cbRefreshTokenClientProvider,
+        AzureClientCredentials azureClientCredentials = new AzureClientCredentials(cloudContext, azureCredentialView, logLevel, cbRefreshTokenClientProvider,
                 authenticationContextProvider, tracingInterceptor);
         return new AzureClient(azureClientCredentials, azureAuthExceptionHandler);
     }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClientServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClientServiceTest.java
@@ -60,7 +60,12 @@ class AzureClientServiceTest {
     @Test
     void getClientTest() {
         AzureClient azureClient = underTest.getClient(cloudCredential);
+        verifyAzureClient(azureClient);
+    }
 
+    @Test
+    void getClientWithContextTest() {
+        AzureClient azureClient = underTest.getClient(cloudContext, cloudCredential);
         verifyAzureClient(azureClient);
     }
 


### PR DESCRIPTION
This commit introduces the following change:
 - Azure regional endpoint for resource manager calls is used any time if CloudContext.Location.Region is not null
   e.g. for West US region it is https://westus.management.azure.com/ instead of https://management.azure.com/
 - global endpoint remains in use for all the other cases

See detailed description in the commit message.