### PR TITLE
CB-17345 Fix the validation of CBD start with all the required containers as service sanity check

### DIFF
--- a/integration-test/scripts/check-results.sh
+++ b/integration-test/scripts/check-results.sh
@@ -6,7 +6,7 @@ status_code=0
 
 set -ex
 
-if [[ "$CIRCLECI" ]]; then
+if [[ "$CIRCLECI" && "$CIRCLECI" == "true" ]]; then
 
     # Check integration test results
     date

--- a/integration-test/scripts/download-cbd.sh
+++ b/integration-test/scripts/download-cbd.sh
@@ -9,7 +9,7 @@ cd $INTEGCB_LOCATION
 os=$(uname)
 echo -e "\n\033[1;96m--- build latest cbd: $CB_TARGET_BRANCH for $os\033[0m\n"
 rm_flag=""
-if ! [[ "$CIRCLECI" ]]; then
+if ! [[ "$CIRCLECI" && "$CIRCLECI" == "true" ]]; then
     rm_flag="--rm"
 fi
 


### PR DESCRIPTION
This fix is mandatory for Cloudbreak integration testing. The original commit for [CB-1543 check cbd start-wait result on service sanity check](https://jira.cloudera.com/browse/CB-1543) is https://github.com/hortonworks/cloudbreak/commit/fc56308f8d2c45ef4dbdaf682db628862c6d7c4f at 2.11.0. Unfortunately this is not working since October 2019, because of another commit where an additional command was introduced to the result check:
```
date
if [ $? -ne 0 ]; then
```
then another year later an additional command as well:
```
docker ps --format '{{.Image}}'

date
if [ $? -ne 0 ]; then
```
I think `docker ps -a -f status=exited -f status=dead -q` additional validation should be placed here to validate all the the CBD containers are running as expected before start integration testing.

Beyond these the `CIRCLECI` environment variable check was not complete, because of the existing conditions were only checked the variable presence and not the value.