### PR TITLE
CB-17338 - getParcelsInStatus() should indicate parcel status

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerParcelDecommissionService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerParcelDecommissionService.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.cm;
 
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.Map;
@@ -40,14 +41,16 @@ class ClouderaManagerParcelDecommissionService {
     private ClouderaManagerParcelManagementService parcelManagementService;
 
     public Map<String, String> getParcelsInStatus(ParcelsResourceApi parcelsResourceApi, String stackName, ParcelStatus parcelStatus) {
+        requireNonNull(parcelStatus, "Parcel status cannot be null");
         try {
             Map<String, String> parcelResponse = parcelManagementService.getClouderaManagerParcelsByStatus(parcelsResourceApi, stackName, parcelStatus).stream()
                     .collect(toMap(ApiParcel::getProduct, ApiParcel::getVersion));
             LOGGER.debug("The following parcels are found in {} status: {}", parcelStatus, parcelResponse);
             return parcelResponse;
         } catch (ApiException e) {
-            LOGGER.info("Unable to fetch the list of activated parcels", e);
-            throw new ClouderaManagerOperationFailedException("Unable to fetch the list of activated parcels", e);
+            String errorMessage = String.format("Unable to fetch the list of %s parcels due to: %s", parcelStatus.name().toLowerCase(), e.getMessage());
+            LOGGER.info(errorMessage, e);
+            throw new ClouderaManagerOperationFailedException(errorMessage, e);
         }
     }
 

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerParcelDecommissionServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerParcelDecommissionServiceTest.java
@@ -1,10 +1,12 @@
 package com.sequenceiq.cloudbreak.cm;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -16,6 +18,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -247,6 +250,18 @@ public class ClouderaManagerParcelDecommissionServiceTest {
         assertTrue(parcelVersionsCaptorForDelete.getValue().containsEntry("CDH", "old"));
         assertTrue(parcelVersionsCaptorForDelete.getValue().containsEntry("CDH", "old2"));
         verifyNoMoreInteractions(parcelResourceApi);
+    }
+
+    @Test
+    public void testGetParcelsInStatusThrowsException() throws ApiException {
+
+        doThrow(new ApiException("Operation failed")).
+                when(parcelManagementService).getClouderaManagerParcelsByStatus(parcelsResourceApi, STACK_NAME, ParcelStatus.ACTIVATED);
+
+        ClouderaManagerOperationFailedException actual = assertThrows(ClouderaManagerOperationFailedException.class, () ->
+        underTest.getParcelsInStatus(parcelsResourceApi, STACK_NAME, ParcelStatus.ACTIVATED));
+
+        Assertions.assertEquals(actual.getMessage(), "Unable to fetch the list of activated parcels due to: Operation failed");
     }
 
     private ApiParcelList createApiParcelList(Map<String, String> products, ParcelStatus parcelStatus) {


### PR DESCRIPTION
Small change to indicate the actual parcel operation in the error message and the logline, too
for method getParcelsInStatus().

