### PR TITLE
CB-17352 - Salt upgrade should wait for correct CM startup

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/AbstractClouderaManagerApiCheckerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/AbstractClouderaManagerApiCheckerTask.java
@@ -64,7 +64,7 @@ public abstract class AbstractClouderaManagerApiCheckerTask<T extends ClouderaMa
     }
 
     private boolean handleConnectException(T pollerObject, ApiException e) {
-        LOGGER.warn("{}. Notification is sent to the UI.", getErrorMessage(pollerObject, e), e.getMessage());
+        LOGGER.warn("{}.({}) Notification is sent to the UI.", getErrorMessage(pollerObject, e), e.getMessage());
         if (!connectExceptionOccurred) {
             connectExceptionOccurred = true;
             Stack stack = pollerObject.getStack();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/ClusterCreationActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/ClusterCreationActions.java
@@ -309,7 +309,7 @@ public class ClusterCreationActions {
 
             @Override
             protected Selectable createRequest(ClusterCreationViewContext context) {
-                return new StartAmbariServicesRequest(context.getStackId());
+                return new StartAmbariServicesRequest(context.getStackId(), true);
             }
         };
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/salt/update/SaltUpdateActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/salt/update/SaltUpdateActions.java
@@ -84,14 +84,14 @@ public class SaltUpdateActions {
     public Action<?, ?> runHighstateAction() {
         return new AbstractClusterAction<>(KeytabConfigurationSuccess.class) {
             @Override
-            protected void doExecute(ClusterViewContext context, KeytabConfigurationSuccess payload, Map<Object, Object> variables) throws Exception {
+            protected void doExecute(ClusterViewContext context, KeytabConfigurationSuccess payload, Map<Object, Object> variables) {
                 saltUpdateService.startingClusterServices(context.getStack());
                 sendEvent(context);
             }
 
             @Override
             protected Selectable createRequest(ClusterViewContext context) {
-                return new StartAmbariServicesRequest(context.getStackId());
+                return new StartAmbariServicesRequest(context.getStackId(), false);
             }
         };
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/StartAmbariServicesRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/StartAmbariServicesRequest.java
@@ -3,7 +3,15 @@ package com.sequenceiq.cloudbreak.reactor.api.event.orchestration;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 
 public class StartAmbariServicesRequest extends StackEvent {
-    public StartAmbariServicesRequest(Long stackId) {
+
+    private final boolean defaultClusterManagerAuth;
+
+    public StartAmbariServicesRequest(Long stackId, boolean defaultClusterManagerAuth) {
         super(stackId);
+        this.defaultClusterManagerAuth = defaultClusterManagerAuth;
+    }
+
+    public boolean isDefaultClusterManagerAuth() {
+        return defaultClusterManagerAuth;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/orchestration/StartAmbariServicesHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/orchestration/StartAmbariServicesHandler.java
@@ -8,10 +8,13 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterServiceRunner;
-import com.sequenceiq.flow.event.EventSelectorUtil;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.StartAmbariServicesFailed;
 import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.StartAmbariServicesRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.StartClusterManagerServicesSuccess;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.EventHandler;
 
 import reactor.bus.Event;
@@ -27,6 +30,12 @@ public class StartAmbariServicesHandler implements EventHandler<StartAmbariServi
     @Inject
     private ClusterServiceRunner clusterServiceRunner;
 
+    @Inject
+    private ClusterApiConnectors clusterApiConnectors;
+
+    @Inject
+    private StackService stackService;
+
     @Override
     public String selector() {
         return EventSelectorUtil.selector(StartAmbariServicesRequest.class);
@@ -34,10 +43,13 @@ public class StartAmbariServicesHandler implements EventHandler<StartAmbariServi
 
     @Override
     public void accept(Event<StartAmbariServicesRequest> event) {
-        Long stackId = event.getData().getResourceId();
+        StartAmbariServicesRequest request = event.getData();
+        Long stackId = request.getResourceId();
         Selectable response;
         try {
             clusterServiceRunner.runAmbariServices(stackId);
+            Stack stack = stackService.getByIdWithListsInTransaction(stackId);
+            clusterApiConnectors.getConnector(stack).waitForServer(stack, request.isDefaultClusterManagerAuth());
             response = new StartClusterManagerServicesSuccess(stackId);
         } catch (Exception e) {
             LOGGER.info("Start cluster manager services failed!", e);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/orchestration/StartAmbariServicesHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/orchestration/StartAmbariServicesHandlerTest.java
@@ -1,0 +1,107 @@
+package com.sequenceiq.cloudbreak.reactor.handler.orchestration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
+import com.sequenceiq.cloudbreak.cluster.service.ClusterClientInitException;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterServiceRunner;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.StartAmbariServicesFailed;
+import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.StartAmbariServicesRequest;
+import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.StartClusterManagerServicesSuccess;
+import com.sequenceiq.cloudbreak.service.CloudbreakException;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+
+import reactor.bus.Event;
+import reactor.bus.EventBus;
+
+@ExtendWith(MockitoExtension.class)
+class StartAmbariServicesHandlerTest {
+
+    private static final String EXCEPTION_MESSAGE = "Salt error";
+
+    private static final long STACK_ID = 1L;
+
+    @InjectMocks
+    private StartAmbariServicesHandler underTest;
+
+    @Mock
+    private EventBus eventBus;
+
+    @Mock
+    private ClusterServiceRunner clusterServiceRunner;
+
+    @Mock
+    private ClusterApiConnectors clusterApiConnectors;
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private Stack stack;
+
+    @Mock
+    private ClusterApi clusterApi;
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    void testAcceptWhenStartAmbariHandlerSucceeds(boolean defaultClusterManagerAuth) throws ClusterClientInitException, CloudbreakException {
+
+        when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
+        when(clusterApiConnectors.getConnector(stack)).thenReturn(clusterApi);
+
+        underTest.accept(getEvent(defaultClusterManagerAuth));
+
+        verify(clusterApi).waitForServer(eq(stack), eq(defaultClusterManagerAuth));
+        ArgumentCaptor<Event> resultCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(eventBus).notify(any(Object.class), resultCaptor.capture());
+
+        assertEquals(1, resultCaptor.getAllValues().size());
+        Event resultEvent = resultCaptor.getValue();
+        assertEquals(StartClusterManagerServicesSuccess.class, resultEvent.getData().getClass());
+        StartClusterManagerServicesSuccess result = (StartClusterManagerServicesSuccess) resultEvent.getData();
+        assertEquals(STACK_ID, result.getResourceId());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    void testAcceptWhenExceptionThenFailure(boolean defaultClusterManagerAuth) {
+
+        doThrow(new CloudbreakServiceException(EXCEPTION_MESSAGE)).when(clusterServiceRunner).runAmbariServices(STACK_ID);
+        underTest.accept(getEvent(defaultClusterManagerAuth));
+
+        ArgumentCaptor<Event> resultCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(eventBus).notify(any(Object.class), resultCaptor.capture());
+
+        assertEquals(1, resultCaptor.getAllValues().size());
+        Event resultEvent = resultCaptor.getValue();
+        assertEquals(StartAmbariServicesFailed.class, resultEvent.getData().getClass());
+        StartAmbariServicesFailed result = (StartAmbariServicesFailed) resultEvent.getData();
+        assertEquals(STACK_ID, result.getResourceId());
+        assertEquals(EXCEPTION_MESSAGE, result.getException().getMessage());
+    }
+
+    private Event<StartAmbariServicesRequest> getEvent(boolean defaultClusterManagerAuth) {
+        StartAmbariServicesRequest startAmbariServicesRequest =
+                new StartAmbariServicesRequest(STACK_ID, defaultClusterManagerAuth);
+        Event<StartAmbariServicesRequest> handlerEvent = mock(Event.class);
+        when(handlerEvent.getData()).thenReturn(startAmbariServicesRequest);
+        return handlerEvent;
+    }
+}


### PR DESCRIPTION
There are some customers for which salt update involves a CM restart for which we do not wait but progress to the actual upgrade that fails due to CM being inaccessible.
This commit introduces a waiter task to wait for the CM to be started up.

See detailed description in the commit message.