### PR TITLE
CB-16954 Add eventLog creation to the recovery process started, and the recovery process finished state.

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
@@ -503,6 +503,7 @@ public enum ResourceEvent {
     DATALAKE_RECOVERY_TEARDOWN_FINISHED("datalake.recovery.teardown.finished"),
     DATALAKE_RECOVERY_FAILED("datalake.recovery.failed"),
     DATALAKE_RECOVERY_FINISHED("datalake.recovery.finished"),
+    DATALAKE_RECOVERY_STARTED("datalake.recovery.started"),
 
     DATALAKE_RESIZE_TRIGGERED("datalake.resize.triggered"),
     DATALAKE_RESIZE_COMPLETE("datalake.resize.complete"),

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -555,6 +555,7 @@ datalake.recovery.failed=Datalake recovery failed.
 datalake.recovery.bringup.failed=Datalake stack recovery failed.
 datalake.recovery.bringup.finished=Datalake stack successfully recovered, creating datalake cluster.
 datalake.recovery.teardown.finished=Datalake stack tear-down for recovery completed successfully.
+datalake.recovery.started=Datalake recovery started.
 datalake.resize.triggered=Datalake resize initiated.
 datalake.resize.complete=Datalake resize complete.
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxReactorFlowManager.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxReactorFlowManager.java
@@ -31,6 +31,7 @@ import org.springframework.stereotype.Service;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.common.event.Acceptable;
+import com.sequenceiq.cloudbreak.event.ResourceEvent;
 import com.sequenceiq.cloudbreak.exception.CloudbreakApiException;
 import com.sequenceiq.cloudbreak.exception.FlowNotAcceptedException;
 import com.sequenceiq.cloudbreak.exception.FlowsAlreadyRunningException;
@@ -126,6 +127,7 @@ public class SdxReactorFlowManager {
         LOGGER.info("Triggering recovery for failed SDX resize with original cluster: {} and resized cluster: {}",
                 oldSdxCluster, newSdxCluster);
         String userId = ThreadBasedUserCrnProvider.getUserCrn();
+        eventSenderService.sendEventAndNotification(newSdxCluster, userId, ResourceEvent.DATALAKE_RECOVERY_STARTED);
         return notify(
                 SDX_RESIZE_RECOVERY_FLOW_CHAIN_START_EVENT,
                 new DatalakeResizeRecoveryFlowChainStartEvent(oldSdxCluster, newSdxCluster, userId),

--- a/datalake/src/test/java/com/sequenceiq/datalake/flow/datalake/recovery/DatalakeUpgradeRecoveryActionsTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/flow/datalake/recovery/DatalakeUpgradeRecoveryActionsTest.java
@@ -1,0 +1,145 @@
+package com.sequenceiq.datalake.flow.datalake.recovery;
+
+import static com.sequenceiq.cloudbreak.event.ResourceEvent.DATALAKE_RECOVERY_STARTED;
+import static com.sequenceiq.datalake.flow.datalake.recovery.DatalakeUpgradeRecoveryEvent.DATALAKE_RECOVERY_EVENT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.statemachine.action.Action;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.sequenceiq.cloudbreak.event.ResourceEvent;
+import com.sequenceiq.datalake.entity.DatalakeStatusEnum;
+import com.sequenceiq.datalake.entity.SdxCluster;
+import com.sequenceiq.datalake.events.EventSenderService;
+import com.sequenceiq.datalake.flow.SdxContext;
+import com.sequenceiq.datalake.flow.datalake.recovery.event.DatalakeRecoveryStartEvent;
+import com.sequenceiq.datalake.flow.datalake.recovery.event.DatalakeRecoverySuccessEvent;
+import com.sequenceiq.datalake.service.sdx.SdxRecoveryService;
+import com.sequenceiq.datalake.service.sdx.SdxService;
+import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
+import com.sequenceiq.flow.core.AbstractAction;
+import com.sequenceiq.flow.core.AbstractActionTestSupport;
+import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.flow.core.FlowRegister;
+import com.sequenceiq.flow.reactor.ErrorHandlerAwareReactorEventFactory;
+import com.sequenceiq.sdx.api.model.SdxClusterShape;
+import com.sequenceiq.sdx.api.model.SdxRecoveryType;
+
+import reactor.bus.EventBus;
+
+@ExtendWith(MockitoExtension.class)
+public class DatalakeUpgradeRecoveryActionsTest {
+
+    private static final Long SDX_ID = 1L;
+
+    private static final String DATALAKE_NAME = "test_dl";
+
+    private static final String FLOW_ID = "flow_id_1";
+
+    private static final String USER_CRN = "crn:cdp:iam:us-west-1:1234:user:1";
+
+    @Mock
+    private SdxRecoveryService sdxRecoveryService;
+
+    @Mock
+    private SdxStatusService sdxStatusService;
+
+    @Mock
+    private EventSenderService eventSenderService;
+
+    @Mock
+    private SdxService sdxService;
+
+    @Mock
+    private FlowRegister runningFlows;
+
+    @Mock
+    private EventBus eventBus;
+
+    @Mock
+    private ErrorHandlerAwareReactorEventFactory reactorEventFactory;
+
+    @InjectMocks
+    private DatalakeUpgradeRecoveryActions datalakeUpgradeRecoveryActions;
+
+    @Test
+    public void datalakeRecoveryStart() throws Exception {
+        SdxCluster sdxCluster = generateCluster();
+        when(sdxService.getById(anyLong())).thenReturn(sdxCluster);
+        AbstractAction action = (AbstractAction) datalakeUpgradeRecoveryActions.datalakeRecoveryStart();
+        initActionPrivateFields(action);
+        AbstractActionTestSupport testSupport = new AbstractActionTestSupport(action);
+        DatalakeRecoveryStartEvent datalakeRecoveryStartEvent = new DatalakeRecoveryStartEvent(DATALAKE_RECOVERY_EVENT.event(),
+                SDX_ID, USER_CRN, SdxRecoveryType.RECOVER_WITHOUT_DATA);
+        SdxContext sdxContext = SdxContext.from(new FlowParameters(FLOW_ID, FLOW_ID, null), datalakeRecoveryStartEvent);
+        when(runningFlows.getFlowChainId(anyString())).thenReturn(FLOW_ID);
+        testSupport.doExecute(sdxContext, datalakeRecoveryStartEvent, new HashMap<>());
+        verify(sdxRecoveryService).recoverCluster(anyLong());
+        verify(eventSenderService, times(1))
+                .sendEventAndNotification(any(SdxCluster.class), anyString(), eq(DATALAKE_RECOVERY_STARTED));
+        ArgumentCaptor<DatalakeRecoveryStartEvent> captor = ArgumentCaptor.forClass(DatalakeRecoveryStartEvent.class);
+        verify(reactorEventFactory, times(1)).createEvent(any(), captor.capture());
+        DatalakeRecoveryStartEvent captorValue = captor.getValue();
+        assertEquals(SDX_ID, captorValue.getResourceId());
+        assertEquals(USER_CRN, captorValue.getUserId());
+    }
+
+    @Test
+    public void datalakeRecoveryFinished() throws Exception {
+        SdxCluster sdxCluster = generateCluster();
+        when(sdxService.getById(anyLong())).thenReturn(sdxCluster);
+        AbstractAction action = (AbstractAction) datalakeUpgradeRecoveryActions.finishedAction();
+        initActionPrivateFields(action);
+        AbstractActionTestSupport testSupport = new AbstractActionTestSupport(action);
+        DatalakeRecoverySuccessEvent successEvent = new DatalakeRecoverySuccessEvent(SDX_ID, USER_CRN);
+        SdxContext sdxContext = SdxContext.from(new FlowParameters(FLOW_ID, FLOW_ID, null), successEvent);
+        when(runningFlows.getFlowChainId(anyString())).thenReturn(FLOW_ID);
+
+        testSupport.doExecute(sdxContext, successEvent, new HashMap<>());
+        ArgumentCaptor<DatalakeRecoverySuccessEvent> captor = ArgumentCaptor.forClass(DatalakeRecoverySuccessEvent.class);
+        verify(reactorEventFactory, times(1)).createEvent(any(), captor.capture());
+
+        assertEquals(SDX_ID, captor.getValue().getResourceId());
+        assertEquals(USER_CRN, captor.getValue().getUserId());
+
+        verify(sdxStatusService, times(1)).setStatusForDatalakeAndNotify(
+                eq(DatalakeStatusEnum.RUNNING),
+                eq(ResourceEvent.DATALAKE_RECOVERY_FINISHED),
+                eq("Recovery finished"),
+                eq(SDX_ID));
+        verify(eventSenderService, times(1))
+                .sendEventAndNotification(eq(sdxCluster), anyString(), eq(ResourceEvent.DATALAKE_RECOVERY_FINISHED));
+    }
+
+    private SdxCluster generateCluster() {
+        SdxCluster sdxCluster = new SdxCluster();
+        sdxCluster.setId(SDX_ID);
+        sdxCluster.setClusterShape(SdxClusterShape.LIGHT_DUTY);
+        sdxCluster.setEnvName("env");
+        sdxCluster.setEnvCrn("crn");
+        sdxCluster.setClusterName(DATALAKE_NAME);
+        return sdxCluster;
+    }
+
+    private void initActionPrivateFields(Action<?, ?> action) {
+        ReflectionTestUtils.setField(action, null, runningFlows, FlowRegister.class);
+        ReflectionTestUtils.setField(action, null, eventBus, EventBus.class);
+        ReflectionTestUtils.setField(action, null, reactorEventFactory, ErrorHandlerAwareReactorEventFactory.class);
+    }
+
+}

--- a/datalake/src/test/java/com/sequenceiq/datalake/flow/loadbalancer/dns/UpdateLoadBalancerDNSActionsTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/flow/loadbalancer/dns/UpdateLoadBalancerDNSActionsTest.java
@@ -1,0 +1,164 @@
+package com.sequenceiq.datalake.flow.loadbalancer.dns;
+
+import static com.sequenceiq.datalake.flow.loadbalancer.dns.UpdateLoadBalancerDNSEvent.UPDATE_LOAD_BALANCER_DNS_EVENT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.statemachine.action.Action;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.sequenceiq.cloudbreak.event.ResourceEvent;
+import com.sequenceiq.datalake.entity.SdxCluster;
+import com.sequenceiq.datalake.events.EventSenderService;
+import com.sequenceiq.datalake.flow.SdxContext;
+import com.sequenceiq.datalake.flow.chain.DatalakeResizeFlowEventChainFactory;
+import com.sequenceiq.datalake.flow.loadbalancer.dns.event.StartUpdateLoadBalancerDNSEvent;
+import com.sequenceiq.datalake.service.loadbalancer.dns.UpdateLoadBalancerDNSService;
+import com.sequenceiq.datalake.service.sdx.SdxService;
+import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
+import com.sequenceiq.flow.core.AbstractAction;
+import com.sequenceiq.flow.core.AbstractActionTestSupport;
+import com.sequenceiq.flow.core.FlowLogService;
+import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.flow.core.FlowRegister;
+import com.sequenceiq.flow.domain.FlowChainLog;
+import com.sequenceiq.flow.domain.FlowLogWithoutPayload;
+import com.sequenceiq.flow.reactor.ErrorHandlerAwareReactorEventFactory;
+import com.sequenceiq.flow.service.flowlog.FlowChainLogService;
+import com.sequenceiq.sdx.api.model.SdxClusterShape;
+
+import reactor.bus.EventBus;
+import reactor.rx.Promise;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateLoadBalancerDNSActionsTest {
+
+    private static final Long SDX_ID = 2L;
+
+    private static final String FLOW_ID = "flow_id";
+
+    private static final String DATALAKE_NAME = "test_dl";
+
+    private static final String USER_CRN = "crn:cdp:iam:us-west-1:1234:user:1";
+
+    private static final String BACKUP_LOCATION = "s3://cloudbreak-bucket/backup-location";
+
+    private static final String BACKUP_ID = "backup_id";
+
+    private static final String RESTORE_ID = "restore_id";
+
+    @Mock
+    private SdxService sdxService;
+
+    @Mock
+    private UpdateLoadBalancerDNSService updateLoadBalancerDNSService;
+
+    @Mock
+    private SdxStatusService sdxStatusService;
+
+    @Mock
+    private EventSenderService eventSenderService;
+
+    @Mock
+    private FlowLogService flowLogService;
+
+    @Mock
+    private FlowChainLogService flowChainLogService;
+
+    @Mock
+    private FlowRegister runningFlows;
+
+    @Mock
+    private EventBus eventBus;
+
+    @Mock
+    private ErrorHandlerAwareReactorEventFactory reactorEventFactory;
+
+    @InjectMocks
+    private UpdateLoadBalancerDNSActions underTest;
+
+    @Test
+    public void updateLoadBalancerDNSActionNotResizeRecovery() throws Exception {
+        SdxCluster sdxCluster = genCluster();
+        FlowParameters flowParameters = new FlowParameters(FLOW_ID, null, null);
+        when(sdxService.getById(eq(SDX_ID))).thenReturn(sdxCluster);
+        when(flowLogService.getLastFlowLog(anyString())).thenReturn(Optional.of(mock(FlowLogWithoutPayload.class)));
+        StartUpdateLoadBalancerDNSEvent event = new StartUpdateLoadBalancerDNSEvent(UPDATE_LOAD_BALANCER_DNS_EVENT.event(), SDX_ID, USER_CRN, new Promise<>());
+        AbstractAction action = (AbstractAction) underTest.updateLoadBalancerDNSAction();
+        initActionPrivateFields(action);
+        AbstractActionTestSupport testSupport = new AbstractActionTestSupport(action);
+        SdxContext sdxContext = SdxContext.from(flowParameters, event);
+        testSupport.doExecute(sdxContext, event, new HashMap<>());
+        verify(updateLoadBalancerDNSService, times(1))
+                .performLoadBalancerDNSUpdate(eq(sdxCluster));
+        verify(eventSenderService, times(1))
+                .notifyEvent(eq(sdxCluster), eq(sdxContext), eq(ResourceEvent.UPDATE_LOAD_BALANCER_DNS_FINISHED));
+        ArgumentCaptor<StartUpdateLoadBalancerDNSEvent> captor = ArgumentCaptor.forClass(StartUpdateLoadBalancerDNSEvent.class);
+        verify(reactorEventFactory, times(1)).createEvent(any(), captor.capture());
+        assertEquals(SDX_ID, captor.getValue().getResourceId());
+        assertEquals(USER_CRN, captor.getValue().getUserId());
+    }
+
+    @Test
+    public void updateLoadBalancerDNSActionResizeRecovery() throws Exception {
+        SdxCluster sdxCluster = genCluster();
+        FlowParameters flowParameters = new FlowParameters(FLOW_ID, null, null);
+        when(sdxService.getById(eq(SDX_ID))).thenReturn(sdxCluster);
+        FlowChainLog mockFlowLog = mock(FlowChainLog.class);
+        FlowLogWithoutPayload flowLogWithoutPayload = mock(FlowLogWithoutPayload.class);
+        when(flowLogService.getLastFlowLog(eq(FLOW_ID)))
+                .thenReturn(Optional.of(flowLogWithoutPayload));
+        when(flowChainLogService.findFirstByFlowChainIdOrderByCreatedDesc(any()))
+                .thenReturn(Optional.of(mockFlowLog));
+        when(mockFlowLog.getFlowChainType()).thenReturn(DatalakeResizeFlowEventChainFactory.class.getSimpleName());
+        StartUpdateLoadBalancerDNSEvent event = new StartUpdateLoadBalancerDNSEvent(UPDATE_LOAD_BALANCER_DNS_EVENT.event(), SDX_ID, USER_CRN, new Promise<>());
+        AbstractAction action = (AbstractAction) underTest.updateLoadBalancerDNSAction();
+        initActionPrivateFields(action);
+        AbstractActionTestSupport testSupport = new AbstractActionTestSupport(action);
+        SdxContext sdxContext = SdxContext.from(flowParameters, event);
+        testSupport.doExecute(sdxContext, event, new HashMap<>());
+        verify(updateLoadBalancerDNSService, times(1))
+                .performLoadBalancerDNSUpdate(eq(sdxCluster));
+        verify(eventSenderService, times(1))
+                .notifyEvent(eq(sdxCluster), eq(sdxContext), eq(ResourceEvent.UPDATE_LOAD_BALANCER_DNS_FINISHED));
+        verify(eventSenderService, times(1))
+                .sendEventAndNotification(eq(sdxCluster), eq(USER_CRN), eq(ResourceEvent.DATALAKE_RECOVERY_FINISHED));
+
+        ArgumentCaptor<StartUpdateLoadBalancerDNSEvent> captor = ArgumentCaptor.forClass(StartUpdateLoadBalancerDNSEvent.class);
+        verify(reactorEventFactory, times(1)).createEvent(any(), captor.capture());
+        assertEquals(SDX_ID, captor.getValue().getResourceId());
+        assertEquals(USER_CRN, captor.getValue().getUserId());
+    }
+
+    private void initActionPrivateFields(Action<?, ?> action) {
+        ReflectionTestUtils.setField(action, null, runningFlows, FlowRegister.class);
+        ReflectionTestUtils.setField(action, null, eventBus, EventBus.class);
+        ReflectionTestUtils.setField(action, null, reactorEventFactory, ErrorHandlerAwareReactorEventFactory.class);
+    }
+
+    private SdxCluster genCluster() {
+        SdxCluster sdxCluster = new SdxCluster();
+        sdxCluster.setId(SDX_ID);
+        sdxCluster.setClusterShape(SdxClusterShape.LIGHT_DUTY);
+        sdxCluster.setEnvName("env");
+        sdxCluster.setEnvCrn("crn");
+        sdxCluster.setClusterName(DATALAKE_NAME);
+        return sdxCluster;
+    }
+
+}


### PR DESCRIPTION
JIRA: https://jira.cloudera.com/browse/CB-16954
Add `eventLog` .eation to the recovery process started, and the recovery process finished state.

This is an improvement to make the track easier for the customer.

Tested:
- 