### PR TITLE
CB-17390 Missing message arguments for stack config update failure me…

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/config/update/EnvStackConfigUpdatesActions.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/config/update/EnvStackConfigUpdatesActions.java
@@ -3,6 +3,15 @@ package com.sequenceiq.environment.environment.flow.config.update;
 import static com.sequenceiq.environment.environment.flow.config.update.event.EnvStackConfigUpdatesStateSelectors.FINALIZE_ENV_STACK_CONIFG_UPDATES_EVENT;
 import static com.sequenceiq.environment.environment.flow.config.update.event.EnvStackConfigUpdatesStateSelectors.HANDLE_FAILED_ENV_STACK_CONIFG_UPDATES_EVENT;
 
+import java.util.Map;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.statemachine.action.Action;
+
 import com.sequenceiq.cloudbreak.common.event.ResourceCrnPayload;
 import com.sequenceiq.cloudbreak.event.ResourceEvent;
 import com.sequenceiq.environment.environment.EnvironmentStatus;
@@ -16,12 +25,6 @@ import com.sequenceiq.environment.environment.service.EnvironmentStatusUpdateSer
 import com.sequenceiq.environment.metrics.EnvironmentMetricService;
 import com.sequenceiq.environment.metrics.MetricType;
 import com.sequenceiq.flow.core.CommonContext;
-import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.statemachine.action.Action;
 
 @Configuration
 public class EnvStackConfigUpdatesActions {
@@ -90,6 +93,7 @@ public class EnvStackConfigUpdatesActions {
                     .updateFailedEnvironmentStatusAndNotify(context, payload,
                         getCurrentStatus(payload.getResourceId()),
                         ResourceEvent.ENVIRONMENT_STACK_CONFIGS_UPDATE_FAILED,
+                        Set.of(payload.getException().getMessage()),
                         EnvStackConfigUpdatesState.STACK_CONFIG_UPDATES_FAILED_STATE);
                 metricService.incrementMetricCounter(MetricType.ENV_STACK_CONFIG_UPDATE_FAILED,
                     environmentDto,

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentStatusUpdateService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentStatusUpdateService.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.environment.environment.service;
 
+import java.util.Collection;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -32,6 +33,12 @@ public class EnvironmentStatusUpdateService {
 
     public EnvironmentDto updateEnvironmentStatusAndNotify(CommonContext context, Payload payload, EnvironmentStatus environmentStatus,
             ResourceEvent resourceEvent, Enum<?> envState) {
+
+        return updateEnvironmentStatusAndNotify(context, payload, environmentStatus, resourceEvent, Set.of(), envState);
+    }
+
+    public EnvironmentDto updateEnvironmentStatusAndNotify(CommonContext context, Payload payload, EnvironmentStatus environmentStatus,
+            ResourceEvent resourceEvent, Collection<?> messageArgs, Enum<?> envState) {
         LOGGER.info("Flow entered into {}", envState.name());
         return environmentService
                 .findEnvironmentById(payload.getResourceId())
@@ -40,7 +47,7 @@ public class EnvironmentStatusUpdateService {
                     environment.setStatusReason(null);
                     Environment env = environmentService.save(environment);
                     EnvironmentDto environmentDto = environmentService.getEnvironmentDto(env);
-                    eventService.sendEventAndNotification(environmentDto, context.getFlowTriggerUserCrn(), resourceEvent);
+                    eventService.sendEventAndNotification(environmentDto, context.getFlowTriggerUserCrn(), resourceEvent, messageArgs);
                     return environmentDto;
                 }).orElseThrow(() -> new IllegalStateException(
                         String.format("Cannot update status of environment, because it does not exist: %s. ", payload.getResourceId())
@@ -49,6 +56,13 @@ public class EnvironmentStatusUpdateService {
 
     public EnvironmentDto updateFailedEnvironmentStatusAndNotify(CommonContext context, BaseFailedFlowEvent failedFlowEvent,
             EnvironmentStatus environmentStatus, ResourceEvent resourceEvent, Enum<?> envState) {
+
+        return updateFailedEnvironmentStatusAndNotify(context, failedFlowEvent, environmentStatus, resourceEvent, Set.of(), envState);
+    }
+
+    public EnvironmentDto updateFailedEnvironmentStatusAndNotify(CommonContext context, BaseFailedFlowEvent failedFlowEvent,
+            EnvironmentStatus environmentStatus, ResourceEvent resourceEvent, Collection<?> messageArgs, Enum<?> envState) {
+
         LOGGER.info("Flow entered into {}", envState.name());
         return environmentService
                 .findEnvironmentById(failedFlowEvent.getResourceId())
@@ -57,7 +71,7 @@ public class EnvironmentStatusUpdateService {
                     environment.setStatusReason(failedFlowEvent.getException().getMessage());
                     Environment env = environmentService.save(environment);
                     EnvironmentDto environmentDto = environmentService.getEnvironmentDto(env);
-                    eventService.sendEventAndNotification(environmentDto, context.getFlowTriggerUserCrn(), resourceEvent);
+                    eventService.sendEventAndNotification(environmentDto, context.getFlowTriggerUserCrn(), resourceEvent, messageArgs);
                     return environmentDto;
                 }).orElseThrow(() -> new IllegalStateException(
                         String.format("Cannot update status of environment, because it does not exist: %s. ", failedFlowEvent.getResourceId())


### PR DESCRIPTION
…ssage

Error message for STACK_CONFIG_UPDATES_FAILED_STATE had a placeholder which was not
filled with message arguments as not the proper event sender method was used.
