### PR TITLE
CB-14321: Call the CM syncer before upscale

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/CmSyncTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/CmSyncTriggerEvent.java
@@ -13,6 +13,11 @@ public class CmSyncTriggerEvent extends StackEvent {
         this.candidateImageUuids = candidateImageUuids;
     }
 
+    public CmSyncTriggerEvent(String selector, Long stackId, Set<String> candidateImageUuids) {
+        super(selector, stackId);
+        this.candidateImageUuids = candidateImageUuids;
+    }
+
     public Set<String> getCandidateImageUuids() {
         return candidateImageUuids;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/util/cleanup/ParcelGeneratorUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/util/cleanup/ParcelGeneratorUtil.java
@@ -2,13 +2,19 @@ package com.sequenceiq.it.util.cleanup;
 
 import java.math.BigDecimal;
 
+import javax.inject.Inject;
+
 import org.springframework.stereotype.Component;
 
 import com.cloudera.api.swagger.model.ApiParcel;
 import com.cloudera.api.swagger.model.ApiParcelState;
+import com.sequenceiq.it.cloudbreak.cloud.v4.CommonClusterManagerProperties;
 
 @Component
 public class ParcelGeneratorUtil {
+
+    @Inject
+    private CommonClusterManagerProperties commonClusterManagerProperties;
 
     /**
      * Provides a CDH <code>ApiParcel</code> instance with some predefined values with the status if <code>ACTIVATED</code>.
@@ -16,7 +22,8 @@ public class ParcelGeneratorUtil {
      * @return a minimal configuration of a CDH ApiParcel instance
      */
     public ApiParcel getActivatedCDHParcel() {
-        return getActivatedCDHParcelWithVersion("someParcelVersion");
+        String runtimeVersion = commonClusterManagerProperties.getRuntimeVersion();
+        return getActivatedCDHParcelWithVersion(runtimeVersion.concat("-1.cdh").concat(runtimeVersion).concat(".p0.1454941"));
     }
 
     public ApiParcel getActivatedCDHParcelWithVersion(String version) {


### PR DESCRIPTION
In this commit we're adding the CM sync flow to the upscale flow chain.
With this extra flow we can make sure that the runtime versions are correct.