### PR TITLE
CB-17399. Create simple custom metrics by nodexporter textfiles.

### DIFF
--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/exporters.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/exporters.sls
@@ -3,6 +3,24 @@
 
 {%- if monitoring.enabled and monitoring.nodeExporterExists and monitoring.blackboxExporterExists %}
 
+/var/lib/node_exporter/files:
+  file.directory:
+    - name: /var/lib/node_exporter/files
+    - user: "root"
+    - group: "root"
+    - mode: 750
+    - failhard: True
+    - makedirs: True
+
+/var/lib/node_exporter/scripts:
+  file.directory:
+    - name: /var/lib/node_exporter/scripts
+    - user: "root"
+    - group: "root"
+    - mode: 750
+    - failhard: True
+    - makedirs: True
+
 /etc/systemd/system/cdp-node-exporter.service:
   file.managed:
     - source: salt://monitoring/systemd/cdp-node-exporter.service.j2

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/init.sls
@@ -7,6 +7,7 @@ include:
   - monitoring.dev-stack
   {%- endif %}
   - monitoring.exporters
+  - monitoring.textfiles
   - monitoring.vmagent
 
 /etc/cron.d/monitoring_cert_check:

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/systemd/cdp-node-exporter.service.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/systemd/cdp-node-exporter.service.j2
@@ -37,6 +37,7 @@ ExecStart=/opt/node_exporter/node_exporter --web.config=/opt/node_exporter/node_
      {%- endif %}
      {%- endfor %}
 {%- endif %}
+     --collector.textfile --collector.textfile.directory=/var/lib/node_exporter/files \
      --web.disable-exporter-metrics \
      --web.listen-address=:{{ monitoring.nodeExporterPort }}
 

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/textfiles.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/textfiles.sls
@@ -1,0 +1,22 @@
+{%- from 'monitoring/settings.sls' import monitoring with context %}
+
+{%- if monitoring.enabled and monitoring.nodeExporterExists %}
+
+/var/lib/node_exporter/scripts/salt-key-check.sh:
+  file.managed:
+    - name: /var/lib/node_exporter/scripts/salt-key-check.sh
+    - source: salt://monitoring/textfiles/salt-key-check.sh
+    - user: "root"
+    - group: "root"
+    - mode: 700
+    - onlyif: test -d /srv/salt
+
+salt_key_check:
+  cron.present:
+    - name: /var/lib/node_exporter/scripts/salt-key-check.sh
+    - user: root
+    - minute: '*/20'
+    - require:
+        - file: /var/lib/node_exporter/scripts/salt-key-check.sh
+
+{%- endif %}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/textfiles/salt-key-check.sh
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/textfiles/salt-key-check.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+/opt/salt_*/bin/salt-key --list-all --out=json --out-file=/tmp/salt_keys.txt
+result=$?
+if [[ "$result" == "0" && -f /tmp/salt_keys.txt ]]; then
+  minions=$(jq '.minions | length' /tmp/salt_keys.txt)
+  minions_rejected=$(jq '.minions_rejected | length' /tmp/salt_keys.txt)
+  minions_unaccepted=$(jq '.minions_pre | length' /tmp/salt_keys.txt)
+  minions_denied=$(jq '.minions_denied | length' /tmp/salt_keys.txt)
+  echo "salt_minion_accepted $minions" > /var/lib/node_exporter/files/salt_keys.prom.$$
+  echo "salt_minion_unaccepted $minions_unaccepted" >> /var/lib/node_exporter/files/salt_keys.prom.$$
+  echo "salt_minion_rejected $minions_rejected" >> /var/lib/node_exporter/files/salt_keys.prom.$$
+  echo "salt_minion_denied $minions_denied" >> /var/lib/node_exporter/files/salt_keys.prom.$$
+  mv /var/lib/node_exporter/files/salt_keys.prom.$$ /var/lib/node_exporter/files/salt_keys.prom
+  rm -rf /tmp/salt_keys.txt
+fi


### PR DESCRIPTION
details:
- add textfiles support for node exporter
- follow the same example for any custom metrics
- the simple example is: gathere salt keys, and put the output numbers for different types to a .prom file

See detailed description in the commit message.