### PR TITLE
CB-17112: Added use of script for automatically verifying if Atlas is fully up to date to DL resize process.

### DIFF
--- a/core/src/main/resources/defaults/vm-logs.json
+++ b/core/src/main/resources/defaults/vm-logs.json
@@ -318,5 +318,17 @@
   {
     "path": "/var/log/mount-instance-storage.log",
     "label": "mount_instance_storage"
+  },
+  {
+    "path": "/var/log/check_atlas_updated.log",
+    "label": "check_atlas_updated_log"
+  },
+  {
+    "path": "/var/log/dl_postgres_restore.log",
+    "label": "dl_restore"
+  },
+  {
+    "path": "/var/log/dl_postgres_backup.log",
+    "label": "dl_backup"
   }
 ]

--- a/orchestrator-salt/src/main/resources/salt/pillar/atlas/check_atlas_updated.sls
+++ b/orchestrator-salt/src/main/resources/salt/pillar/atlas/check_atlas_updated.sls
@@ -1,0 +1,2 @@
+check_atlas_updated:
+  max_retries: 120

--- a/orchestrator-salt/src/main/resources/salt/pillar/top.sls
+++ b/orchestrator-salt/src/main/resources/salt/pillar/top.sls
@@ -90,6 +90,7 @@ base:
 {%- endif %}
     - gateway.settings
     - postgresql.disaster_recovery
+    - atlas.check_atlas_updated
 
   'roles:knox_gateway':
     - match: grain
@@ -110,5 +111,5 @@ base:
     - smartsense.credentials
 
   'roles:startup_mount':
-      - match: grain
-      - mount.startup
+    - match: grain
+    - mount.startup

--- a/orchestrator-salt/src/main/resources/salt/salt/atlas/check_atlas_updated.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/atlas/check_atlas_updated.sls
@@ -1,0 +1,6 @@
+include:
+  - atlas.check_atlas_updated
+
+check_atlas_updated:
+  cmd.run:
+    - name: /opt/salt/scripts/check_atlas_updated.sh {{salt['pillar.get']('check_atlas_updated:max_retries')}}

--- a/orchestrator-salt/src/main/resources/salt/salt/atlas/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/atlas/init.sls
@@ -1,0 +1,5 @@
+/opt/salt/scripts/check_atlas_updated.sh:
+  file.managed:
+    - makedirs: True
+    - mode: 750
+    - source: salt://atlas/scripts/check_atlas_updated.sh

--- a/orchestrator-salt/src/main/resources/salt/salt/atlas/scripts/check_atlas_updated.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/atlas/scripts/check_atlas_updated.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+# Files used by the script.
+LOGFILE=/var/log/check_atlas_updated.log
+JAASFILE=/var/log/jaas.conf
+CONFIGFILE=/var/log/client.config
+
+doLog() {
+  echo "$(date "+%Y-%m-%dT%H:%M:%SZ") $1" >>$LOGFILE
+}
+
+initFiles() {
+  # Setup required configuration files.
+  >$JAASFILE
+  printf "KafkaClient {
+  \tcom.sun.security.auth.module.Krb5LoginModule required
+  \tuseKeyTab=true
+  \tkeyTab=\"%s\"
+  \tprincipal=\"%s\";\n};\n" "${ATLAS_KT}" "${ATLAS_PRINCIPAL}" > "$JAASFILE"
+
+  >$CONFIGFILE
+  printf "security.protocol=SASL_SSL\nsasl.kerberos.service.name=kafka\n" > "$CONFIGFILE"
+
+  doLog "Finished setting up config files: ${JAASFILE} and ${CONFIGFILE}."
+}
+
+cleanupFiles() {
+  rm -f "$JAASFILE"
+  rm -f "$CONFIGFILE"
+}
+
+check_atlas_lineage() {
+  # Obtain Atlas lineage information.
+  LINEAGE_INFO=$(/opt/cloudera/parcels/CDH/lib/kafka/bin/kafka-consumer-groups.sh \
+    --bootstrap-server "${KAFKA_SERVER}" --describe --group atlas \
+    --command-config="${CONFIGFILE}" 2>/dev/null \
+    | awk '{print $2, $6}')
+
+  if [[ -z "$LINEAGE_INFO" ]]; then
+    doLog "*ERROR*: Unable to get lineage info for Atlas. Please look at the created configuration files to make sure they look correct."
+    return 2
+  fi
+
+  # Parse lineage information and determine if Atlas is out of date.
+  LINEAGE_LAG_VALS=($LINEAGE_INFO)
+  NUM_LAG_VALS=${#LINEAGE_LAG_VALS[@]}
+  OUT_OF_DATE_TOPICS=""
+  for (( i = 2; i < ${NUM_LAG_VALS}; i += 2 )); do
+    if [[ ${LINEAGE_LAG_VALS[${i} + 1]} != '-' && ${LINEAGE_LAG_VALS[${i} + 1]} != '0' ]]; then
+      OUT_OF_DATE_TOPICS="${OUT_OF_DATE_TOPICS}${LINEAGE_LAG_VALS[$i]}, "
+    fi
+  done
+
+  if [[ -z "$OUT_OF_DATE_TOPICS" ]]; then
+    doLog "Atlas is now up to date."
+    return 0
+  else
+    doLog "The following Atlas topics are not up to date: ${OUT_OF_DATE_TOPICS%??}."
+    return 1
+  fi
+}
+
+# Empty/create log file.
+>$LOGFILE
+
+# Setup necessary variables for Kafka and the main Atlas check.
+KAFKA_SERVER=$(grep --line-buffered -oP "atlas.kafka.bootstrap.servers=\K.*" \
+  /etc/atlas/conf/atlas-application.properties | awk -F',' '{print $1}')
+doLog "Using Kafka bootstrap server: ${KAFKA_SERVER}."
+
+ATLAS_KT=$(find / -wholename "*atlas-ATLAS_SERVER/atlas.keytab" 2>/dev/null | head -n 1)
+doLog "Using Atlas keytab: ${ATLAS_KT}."
+
+ATLAS_PRINCIPAL=$(klist -kt "${ATLAS_KT}" | grep -o -m 1 "atlas\/\S*")
+doLog "Using Atlas principal: ${ATLAS_PRINCIPAL}."
+
+export KAFKA_HEAP_OPTS="-Xms512m -Xmx1g"
+export KAFKA_OPTS="-Djava.security.auth.login.config=${JAASFILE}"
+
+# File setup.
+$(initFiles)
+
+# Kinit into Atlas before starting check process.
+kinit -kt "$ATLAS_KT" "atlas/$(hostname -f)" 2>/dev/null
+doLog "Finished kinit-ing into Atlas keytab."
+
+# Iteratively check Atlas until it is up to date.
+MAX_RETRIES=$1
+doLog "Starting the waiting process for Atlas being fully up to date. Will retry a max of ${MAX_RETRIES} times."
+RESPONSE=1
+j=0
+while : ; do
+  $(check_atlas_lineage)
+  RESPONSE=$?
+
+  if [[ "$RESPONSE" == "0" ]]; then
+    break
+  elif [[ "$RESPONSE" == "2" ]]; then
+    RESPONSE=1
+    break
+  fi
+
+  ((j++))
+  if [[ "$j" == "$MAX_RETRIES" ]]; then
+    doLog "Timed out while waiting for Atlas to be up to date."
+    break
+  fi
+
+  doLog "Waiting some more for Atlas to be entirely up to date."
+  sleep 5
+done
+
+# Done.
+doLog "Spent $((j * 5)) seconds waiting for Atlas to be up to date."
+$(cleanupFiles)
+exit $RESPONSE

--- a/orchestrator-salt/src/main/resources/salt/salt/top.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/top.sls
@@ -38,6 +38,7 @@ base:
     - cloudera.agent
     - gateway.cm
     - nodestatus
+    - atlas
 
   'G@roles:manager_agent':
     - cloudera.repo


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-17112

Objective of this is to enable customers to run the appropriate salt commands to verify whether Atlas is up to date before initiating the resize process. In the future this will be used within a separate automatic flow within the resize process in order to fully automate and validate this before the core resize logic occurs.

I am opening this PR but have yet to finalize testing due to various issues. I would like eyes on it however since this is my first real Salt addition/change.