### PR TITLE
CB-16345: Fixed EventEndpoint Zip exception handling for Jersey client.

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/audits/AuditEventV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/audits/AuditEventV4Endpoint.java
@@ -36,8 +36,8 @@ public interface AuditEventV4Endpoint {
 
     @GET
     @Path("zip")
-    @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    @ApiOperation(value = AuditOpDescription.LIST_IN_WORKSPACE_ZIP, produces = MediaType.APPLICATION_OCTET_STREAM, notes = Notes.AUDIT_EVENTS_NOTES,
+    @Produces({MediaType.APPLICATION_OCTET_STREAM, MediaType.APPLICATION_JSON})
+    @ApiOperation(value = AuditOpDescription.LIST_IN_WORKSPACE_ZIP, notes = Notes.AUDIT_EVENTS_NOTES,
             nickname = "getAuditEventsZipInWorkspace")
     Response getAuditEventsZip(@PathParam("workspaceId") Long workspaceId, @QueryParam("resourceType") String resourceType,
             @QueryParam("resourceId") Long resourceId, @QueryParam("resourceCrn") String resourceCrn);

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/events/EventV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/events/EventV4Endpoint.java
@@ -88,8 +88,8 @@ public interface EventV4Endpoint {
 
     @GET
     @Path("{name}/zip")
-    @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    @ApiOperation(value = EventOpDescription.GET_EVENTS_ZIP_BY_NAME, produces = MediaType.APPLICATION_JSON, notes = Notes.EVENT_NOTES,
+    @Produces({MediaType.APPLICATION_OCTET_STREAM, MediaType.APPLICATION_JSON})
+    @ApiOperation(value = EventOpDescription.GET_EVENTS_ZIP_BY_NAME, notes = Notes.EVENT_NOTES,
             nickname = "getStructuredEventsZipInWorkspace")
     Response download(@PathParam("name") String name, @AccountId @QueryParam("accountId") String accountId);
 }

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxEventEndpoint.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxEventEndpoint.java
@@ -45,9 +45,8 @@ public interface SdxEventEndpoint {
 
     @GET
     @Path("zip")
-    @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    @ApiOperation(value = LIST_FOR_RESOURCE_ZIP, produces = MediaType.APPLICATION_OCTET_STREAM, notes = AUDIT_EVENTS_NOTES,
-            nickname = "getDatalakeEventsZipForResource")
+    @Produces({MediaType.APPLICATION_OCTET_STREAM, MediaType.APPLICATION_JSON})
+    @ApiOperation(value = LIST_FOR_RESOURCE_ZIP, notes = AUDIT_EVENTS_NOTES, nickname = "getDatalakeEventsZipForResource")
     Response getDatalakeEventsZip(
             @QueryParam("environmentCrn") @NotNull(message = "The 'environmentCrn' query parameter must be specified.") String environmentCrn,
             @QueryParam("types") List<StructuredEventType> types);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/SdxEventControllerAuthTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/SdxEventControllerAuthTest.java
@@ -107,14 +107,14 @@ public class SdxEventControllerAuthTest extends AbstractIntegrationTest {
                 .whenException(
                         sdxTestClient.getAuditEvents(), ForbiddenException.class, expectedMessage("Doesn't have 'environments/describeEnvironment' " +
                                 "right on environment " + environmentPattern(testContext)
-                ).withWho(cloudbreakActor.useRealUmsUser(AuthUserKeys.ZERO_RIGHTS)))
+                        ).withWho(cloudbreakActor.useRealUmsUser(AuthUserKeys.ZERO_RIGHTS))
+                )
                 .when(sdxTestClient.getDatalakeEventsZip(), RunningParameter.who(cloudbreakActor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_A)))
                 .then(checkZipEndpointStatusManually(200))
                 .when(sdxTestClient.getDatalakeEventsZip(), RunningParameter.who(cloudbreakActor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_B)))
                 .then(checkZipEndpointStatusManually(200))
-                // CB-16345 to fix http 500 in this case
                 .when(sdxTestClient.getDatalakeEventsZip(), RunningParameter.who(cloudbreakActor.useRealUmsUser(AuthUserKeys.ZERO_RIGHTS)))
-                .then(checkZipEndpointStatusManually(500))
+                .then(checkZipEndpointStatusManually(403))
                 .validate();
     }
 

--- a/structuredevent-api-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/rest/endpoint/CDPEventV1Endpoint.java
+++ b/structuredevent-api-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/rest/endpoint/CDPEventV1Endpoint.java
@@ -57,8 +57,7 @@ public interface CDPEventV1Endpoint {
 
     @GET
     @Path("{name}/zip")
-    @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    @ApiOperation(value = GET_EVENTS_ZIP_BY_NAME, produces = MediaType.APPLICATION_JSON, notes = EVENT_NOTES,
-            nickname = "getStructuredEventsZipInAccount")
+    @Produces({MediaType.APPLICATION_OCTET_STREAM, MediaType.APPLICATION_JSON})
+    @ApiOperation(value = GET_EVENTS_ZIP_BY_NAME, notes = EVENT_NOTES, nickname = "getStructuredEventsZipInAccount")
     Response download(@PathParam("name") String name);
 }

--- a/structuredevent-api-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/rest/endpoint/CDPStructuredEventV1Endpoint.java
+++ b/structuredevent-api-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/rest/endpoint/CDPStructuredEventV1Endpoint.java
@@ -42,9 +42,8 @@ public interface CDPStructuredEventV1Endpoint {
 
     @GET
     @Path("zip")
-    @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    @ApiOperation(value = LIST_FOR_RESOURCE_ZIP, produces = MediaType.APPLICATION_JSON, notes = AUDIT_EVENTS_NOTES,
-            nickname = "getAuditEventsZipForResource")
+    @Produces({MediaType.APPLICATION_OCTET_STREAM, MediaType.APPLICATION_JSON})
+    @ApiOperation(value = LIST_FOR_RESOURCE_ZIP, notes = AUDIT_EVENTS_NOTES, nickname = "getAuditEventsZipForResource")
     Response getAuditEventsZip(
             @QueryParam("resourceCrn") @NotNull(message = "The 'resourceCrn' query parameter must be specified.") String resourceCrn,
             @QueryParam("types") List<StructuredEventType> types);


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-16345

Essentially the REST API used here for the Zip endpoints expects an OCTET_STREAM response type on success but a JSON for failures. We were not defining this correctly in the endpoint classes so exceptions were not being parsed the right way, resulting in an automatic 500 internal server error for any exception.