### PR TITLE
CB-17453 - CM syncer fails when there are unavailable nodes

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/cmsync/SdxCmSyncEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/cmsync/SdxCmSyncEvent.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.datalake.flow.datalake.cmsync;
 
 import com.sequenceiq.datalake.flow.datalake.cmsync.event.SdxCmSyncFailedEvent;
-import com.sequenceiq.datalake.flow.datalake.cmsync.event.SdxCmSyncWaitEvent;
 import com.sequenceiq.datalake.flow.datalake.cmsync.event.SdxCmSyncStartEvent;
 import com.sequenceiq.flow.core.FlowEvent;
 import com.sequenceiq.flow.event.EventSelectorUtil;
@@ -9,7 +8,6 @@ import com.sequenceiq.flow.event.EventSelectorUtil;
 public enum SdxCmSyncEvent implements FlowEvent {
     SDX_CM_SYNC_START_EVENT(EventSelectorUtil.selector(SdxCmSyncStartEvent.class)),
     SDX_CM_SYNC_IN_PROGRESS_EVENT,
-    SDX_CM_SYNC_WAIT_EVENT(EventSelectorUtil.selector(SdxCmSyncWaitEvent.class)),
     SDX_CM_SYNC_FINISHED_EVENT,
     SDX_CM_SYNC_FAILED_EVENT(EventSelectorUtil.selector(SdxCmSyncFailedEvent.class)),
     SDX_CM_SYNC_FAILED_HANDLED_EVENT,

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/cmsync/handler/SdxCmSyncWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/cmsync/handler/SdxCmSyncWaitHandler.java
@@ -70,5 +70,4 @@ public class SdxCmSyncWaitHandler extends ExceptionCatcherEventHandler<SdxCmSync
             return new SdxCmSyncFailedEvent(sdxCmSyncWaitEvent.getResourceId(), sdxCmSyncWaitEvent.getUserId(), e);
         }
     }
-
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/status/SdxStatusService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/status/SdxStatusService.java
@@ -162,6 +162,10 @@ public class SdxStatusService {
         return sdxStatusRepository.findFirstByDatalakeIsOrderByIdDesc(sdxCluster);
     }
 
+    public Optional<SdxStatusEntity> getActualStatusForSdx(Long id) {
+        return sdxStatusRepository.findById(id);
+    }
+
     public void updateInMemoryStateStore(SdxCluster sdxCluster) {
         SdxStatusEntity actualStatusForSdx = getActualStatusForSdx(sdxCluster);
         if (actualStatusForSdx != null &&

--- a/datalake/src/test/java/com/sequenceiq/datalake/cm/RangerCloudIdentityServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/cm/RangerCloudIdentityServiceTest.java
@@ -10,6 +10,18 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import com.cloudera.api.swagger.client.ApiException;
 import com.cloudera.api.swagger.model.ApiCommand;
 import com.sequenceiq.datalake.entity.DatalakeStatusEnum;
@@ -19,17 +31,6 @@ import com.sequenceiq.datalake.service.sdx.SdxService;
 import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
 import com.sequenceiq.sdx.api.model.RangerCloudIdentitySyncState;
 import com.sequenceiq.sdx.api.model.RangerCloudIdentitySyncStatus;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.math.BigDecimal;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
 class RangerCloudIdentityServiceTest {
@@ -58,7 +59,7 @@ class RangerCloudIdentityServiceTest {
         when(apiCommand.getId()).thenReturn(BigDecimal.ONE);
         when(apiCommand.getSuccess()).thenReturn(true);
         SdxStatusEntity sdxStatus = mockSdxStatus(DatalakeStatusEnum.RUNNING);
-        when(sdxStatusService.getActualStatusForSdx(any())).thenReturn(sdxStatus);
+        when(sdxStatusService.getActualStatusForSdx(any(SdxCluster.class))).thenReturn(sdxStatus);
         testSetAzureCloudIdentityMapping(Optional.of(apiCommand), RangerCloudIdentitySyncState.SUCCESS);
     }
 
@@ -68,7 +69,7 @@ class RangerCloudIdentityServiceTest {
         when(apiCommand.getId()).thenReturn(BigDecimal.ONE);
         when(apiCommand.getActive()).thenReturn(true);
         SdxStatusEntity sdxStatus = mockSdxStatus(DatalakeStatusEnum.RUNNING);
-        when(sdxStatusService.getActualStatusForSdx(any())).thenReturn(sdxStatus);
+        when(sdxStatusService.getActualStatusForSdx(any(SdxCluster.class))).thenReturn(sdxStatus);
         testSetAzureCloudIdentityMapping(Optional.of(apiCommand), RangerCloudIdentitySyncState.ACTIVE);
     }
 
@@ -78,14 +79,14 @@ class RangerCloudIdentityServiceTest {
         when(apiCommand.getId()).thenReturn(BigDecimal.ONE);
         when(apiCommand.getSuccess()).thenReturn(false);
         SdxStatusEntity sdxStatus = mockSdxStatus(DatalakeStatusEnum.RUNNING);
-        when(sdxStatusService.getActualStatusForSdx(any())).thenReturn(sdxStatus);
+        when(sdxStatusService.getActualStatusForSdx(any(SdxCluster.class))).thenReturn(sdxStatus);
         testSetAzureCloudIdentityMapping(Optional.of(apiCommand), RangerCloudIdentitySyncState.FAILED);
     }
 
     @Test
     public void testSetAzureCloudIdentityMappingNoApiCommand() throws ApiException {
         SdxStatusEntity sdxStatus = mockSdxStatus(DatalakeStatusEnum.RUNNING);
-        when(sdxStatusService.getActualStatusForSdx(any())).thenReturn(sdxStatus);
+        when(sdxStatusService.getActualStatusForSdx(any(SdxCluster.class))).thenReturn(sdxStatus);
         testSetAzureCloudIdentityMapping(Optional.empty(), RangerCloudIdentitySyncState.SUCCESS);
     }
 
@@ -104,7 +105,7 @@ class RangerCloudIdentityServiceTest {
     public void testSetAzureCloudIdentityMappingDatalakNotRunning() throws ApiException {
         when(sdxService.listSdxByEnvCrn(anyString())).thenReturn(List.of(mock(SdxCluster.class)));
         SdxStatusEntity sdxStatus = mockSdxStatus(DatalakeStatusEnum.PROVISIONING_FAILED);
-        when(sdxStatusService.getActualStatusForSdx(any())).thenReturn(sdxStatus);
+        when(sdxStatusService.getActualStatusForSdx(any(SdxCluster.class))).thenReturn(sdxStatus);
 
         Map<String, String> userMapping = Map.of("user", "val1");
         RangerCloudIdentitySyncStatus status = underTest.setAzureCloudIdentityMapping("env-crn", userMapping);

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/database/DatabaseServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/database/DatabaseServiceTest.java
@@ -159,7 +159,7 @@ public class DatabaseServiceTest {
         when(regionAwareInternalCrnGeneratorFactory.iam()).thenReturn(regionAwareInternalCrnGenerator);
         SdxStatusEntity status = new SdxStatusEntity();
         status.setStatus(DatalakeStatusEnum.REQUESTED);
-        when(sdxStatusService.getActualStatusForSdx(any())).thenReturn(status);
+        when(sdxStatusService.getActualStatusForSdx(any(SdxCluster.class))).thenReturn(status);
 
         assertThatCode(() -> ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.create(cluster, env))).isInstanceOf(BadRequestException.class);
 
@@ -196,7 +196,7 @@ public class DatabaseServiceTest {
 
         SdxStatusEntity status = new SdxStatusEntity();
         status.setStatus(DatalakeStatusEnum.DELETE_REQUESTED);
-        when(sdxStatusService.getActualStatusForSdx(any())).thenReturn(status);
+        when(sdxStatusService.getActualStatusForSdx(any(SdxCluster.class))).thenReturn(status);
 
         assertThrows(CloudbreakServiceException.class, () -> {
             ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.create(cluster, env));


### PR DESCRIPTION
This commit:
- does not let roll forward happen in case there is a stopped node
- in case of unexpected failure, SDX roll forward flow was not restartable because of invalid line in SdxCmSyncEvent class, it is now removed

See detailed description in the commit message.