### PR TITLE
CB-14648 Revert CCM rights on environment due to a pending rename in …

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/EnvironmentController.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/EnvironmentController.java
@@ -454,13 +454,13 @@ public class EnvironmentController implements EnvironmentEndpoint {
     }
 
     @Override
-    @CheckPermissionByResourceName(action = AuthorizationResourceAction.UPGRADE_CCM)
+    @CheckPermissionByResourceName(action = AuthorizationResourceAction.EDIT_ENVIRONMENT /* for now */)
     public void upgradeCcmByName(@ResourceName String name) {
         upgradeCcmService.upgradeCcmByName(name);
     }
 
     @Override
-    @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.UPGRADE_CCM)
+    @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.EDIT_ENVIRONMENT /* for now */)
     public void upgradeCcmByCrn(@ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT) @ResourceCrn String crn) {
         upgradeCcmService.upgradeCcmByCrn(crn);
     }


### PR DESCRIPTION
…thunderhead

upgradeCCM -> upgradeCcm renaming needs to reach mow-dev at least with the thunderhead UMS
after that, this commit can be reverted

See detailed description in the commit message.