### PR TITLE
CB-17440 Add InternalSdxRepairWithRecipeTest to the E2E suites

### DIFF
--- a/integration-test/src/main/resources/testsuites/e2e/aws-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/aws-e2e-tests.yaml
@@ -15,3 +15,4 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxSecurityTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRecipeTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRangerRazEnabledTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.InternalSdxRepairWithRecipeTest

--- a/integration-test/src/main/resources/testsuites/e2e/azure-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/azure-e2e-tests.yaml
@@ -12,3 +12,4 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.imagevalidation.PrewarmImageValidatorE2ETest
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxImagesTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.AzureMarketplaceImageTest
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.InternalSdxRepairWithRecipeTest

--- a/integration-test/src/main/resources/testsuites/e2e/gcp-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/gcp-e2e-tests.yaml
@@ -10,3 +10,5 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXRepairTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXScaleTest
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxImagesTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.InternalSdxRepairWithRecipeTest
+


### PR DESCRIPTION
While testing [CB-17184](https://jira.cloudera.com/browse/CB-17184) for the [CB-16055](https://jira.cloudera.com/browse/CB-16055), I've realised one of our E2E test is constantly failing because of did not executed recipes after SDX repair at [InternalSdxRepairWithRecipeTest](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/InternalSdxRepairWithRecipeTest.java).

This is a special kind of E2E test, because of this has been executed only with [aws-sdx-recipe-tests](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/src/main/resources/testsuites/e2e/aws-sdx-recipe-tests.yaml) suite. This suite only applied at [PR time at AWS E2E check](https://github.com/hortonworks/cloudbreak-ansible-playbooks/search?q=aws-sdx-recipe-tests). I think this was the cause we have not realised the issue till now.

So we are going to introduce this test case to the nightly test.