### PR TITLE
CB-17522 - Cluster upgrade parcel availability validation failed with…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/ClusterUpgradeValidationActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/ClusterUpgradeValidationActions.java
@@ -301,8 +301,9 @@ public class ClusterUpgradeValidationActions {
                 Long resourceId = payload.getResourceId();
                 LOGGER.debug("Cluster upgrade validation failed with validation error: {}", errorMessage);
                 ResourceEvent validationFailedResourceEvent = ResourceEvent.CLUSTER_UPGRADE_VALIDATION_FAILED;
-                cloudbreakEventService.fireCloudbreakEvent(resourceId, UPDATE_FAILED.name(), validationFailedResourceEvent, List.of(errorMessage));
-                String reason = messagesService.getMessage(validationFailedResourceEvent.getMessage(), List.of(errorMessage));
+                List<String> errorMessageAsList = Collections.singletonList(errorMessage);
+                cloudbreakEventService.fireCloudbreakEvent(resourceId, UPDATE_FAILED.name(), validationFailedResourceEvent, errorMessageAsList);
+                String reason = messagesService.getMessage(validationFailedResourceEvent.getMessage(), errorMessageAsList);
                 stackUpdater.updateStackStatus(resourceId, DetailedStackStatus.AVAILABLE, reason);
                 sendEvent(context, HANDLED_FAILED_CLUSTER_UPGRADE_VALIDATION_EVENT.event(), payload);
             }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/parcel/ParcelService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/parcel/ParcelService.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -127,6 +128,7 @@ public class ParcelService {
     private Set<ClusterComponent> getComponentsByRequiredProducts(Map<String, ClusterComponent> cmProductMap, Set<ClouderaManagerProduct> cmProducts) {
         return cmProducts.stream()
                 .map(cmp -> cmProductMap.get(cmp.getName()))
+                .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/ParcelUrlProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/ParcelUrlProvider.java
@@ -32,7 +32,7 @@ public class ParcelUrlProvider {
     public Set<String> getRequiredParcelsFromImage(Image image, Stack stack) {
         LOGGER.debug("Retrieving parcel URLs from image {}", image.getUuid());
         String cdhParcelUrl = getCdhParcelUrl(image);
-        return StackType.DATALAKE.equals(stack.getType()) ? Collections.singleton(cdhParcelUrl) : getAllParcel(cdhParcelUrl, image, stack);
+        return StackType.DATALAKE.equals(stack.getType()) ? Collections.singleton(cdhParcelUrl) : getAllParcels(cdhParcelUrl, image, stack);
     }
 
     private String getCdhParcelUrl(Image image) {
@@ -51,7 +51,7 @@ public class ParcelUrlProvider {
                 .orElseThrow(() -> new CloudbreakServiceException(String.format("Stack repository version is not found on image: %s", imageId)));
     }
 
-    private Set<String> getAllParcel(String cdhRepoUrl, Image image, Stack stack) {
+    private Set<String> getAllParcels(String cdhRepoUrl, Image image, Stack stack) {
         Set<String> requiredParcelNames = getRequiredParcelNames(stack, image);
         Set<String> parcelUrls = getPreWarmParcelUrls(image, requiredParcelNames);
         parcelUrls.addAll(getPreWarmCsdUrls(image, requiredParcelNames));


### PR DESCRIPTION
… NPE

This commit:
 - does not let getComponentsByRequiredProducts() method to add "null" value to its result set
 - corrects `CLUSTER_UPGRADE_VALIDATION_FAILED_STATE` in case of an NPE error would happen

See detailed description in the commit message.