### PR TITLE
CDPD-41195: Add Hue service in Spark3 default template

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.16/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.16/cdp-data-engineering-spark3.bp
@@ -300,6 +300,28 @@
         ]
       },
       {
+        "refName": "hue",
+        "serviceType": "HUE",
+        "serviceConfigs": [
+          {
+            "name": "hue_service_safety_valve",
+            "value": "[desktop]\napp_blacklist=zookeeper,hbase,impala,search,sqoop,security,pig"
+          }
+        ],
+        "roleConfigGroups": [
+          {
+            "refName": "hue-HUE_SERVER-BASE",
+            "roleType": "HUE_SERVER",
+            "base": true
+          },
+          {
+            "refName": "hue-HUE_LOAD_BALANCER-BASE",
+            "roleType": "HUE_LOAD_BALANCER",
+            "base": true
+          }
+        ]
+      },
+      {
         "refName": "hive_on_tez",
         "serviceType": "HIVE_ON_TEZ",
         "displayName": "Hive",
@@ -399,6 +421,8 @@
           "hms-HIVEMETASTORE-BASE",
           "hive_on_tez-HIVESERVER2-BASE",
           "hive_on_tez-GATEWAY-BASE",
+          "hue-HUE_LOAD_BALANCER-BASE",
+          "hue-HUE_SERVER-BASE",
           "spark3_on_yarn-GATEWAY-BASE",
           "spark3_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
           "livy_for_spark3-GATEWAY-BASE",


### PR DESCRIPTION
We need to add the Hue service in the default Spark3 template for 7.2.16 since Hue will be supporting SparkSQL from 7.2.16 release.
The fix was manually tested by creating a custom datahub cluster template and then provisioning the cluster with it, Hue service was coming up fine in the cluster.