### PR TITLE
CB-17407 Support postgres 11 on embedded database

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/container/postgres/EmbeddedDatabaseConfigProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/container/postgres/EmbeddedDatabaseConfigProvider.java
@@ -1,9 +1,11 @@
 package com.sequenceiq.cloudbreak.core.bootstrap.service.container.postgres;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -14,25 +16,27 @@ import com.sequenceiq.cloudbreak.template.VolumeUtils;
 
 @Component
 public class EmbeddedDatabaseConfigProvider {
-    public static final String POSTGRES_DIRECTORY_KEY = "postgres_directory";
+    private static final String POSTGRES_DIRECTORY_KEY = "postgres_directory";
 
-    public static final String POSTGRES_LOG_DIRECTORY_KEY = "postgres_log_directory";
+    private static final String POSTGRES_LOG_DIRECTORY_KEY = "postgres_log_directory";
 
-    public static final String POSTGRES_SCRIPTS_EXECUTED_DIRECTORY_KEY = "postgres_scripts_executed_directory";
+    private static final String POSTGRES_SCRIPTS_EXECUTED_DIRECTORY_KEY = "postgres_scripts_executed_directory";
 
-    public static final String POSTGRES_DATA_ON_ATTACHED_DISK_KEY = "postgres_data_on_attached_disk";
+    private static final String POSTGRES_DATA_ON_ATTACHED_DISK_KEY = "postgres_data_on_attached_disk";
 
-    public static final String POSTGRES_SUBDIRECTORY_ON_ATTACHED_DISK = "pgsql";
+    private static final String POSTGRES_SUBDIRECTORY_ON_ATTACHED_DISK = "pgsql";
 
-    public static final String POSTGRES_LOG_SUBDIRECTORY_ON_ATTACHED_DISK = "pgsql/log";
+    private static final String POSTGRES_VERSION = "postgres_version";
 
-    public static final String POSTGRES_SCRIPTS_EXECUTED_SUBDIRECTORY_ON_ATTACHED_DISK = "pgsql/scripts";
+    private static final String POSTGRES_LOG_SUBDIRECTORY_ON_ATTACHED_DISK = "pgsql/log";
 
-    public static final String POSTGRES_DEFAULT_DIRECTORY = "/var/lib/pgsql";
+    private static final String POSTGRES_SCRIPTS_EXECUTED_SUBDIRECTORY_ON_ATTACHED_DISK = "pgsql/scripts";
 
-    public static final String POSTGRES_DEFAULT_LOG_DIRECTORY = "/var/log";
+    private static final String POSTGRES_DEFAULT_DIRECTORY = "/var/lib/pgsql";
 
-    public static final String POSTGRES_DEFAULT_SCRIPTS_EXECUTED_DIRECTORY = "/opt/salt/scripts";
+    private static final String POSTGRES_DEFAULT_LOG_DIRECTORY = "/var/log";
+
+    private static final String POSTGRES_DEFAULT_SCRIPTS_EXECUTED_DIRECTORY = "/opt/salt/scripts";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EmbeddedDatabaseConfigProvider.class);
 
@@ -40,17 +44,21 @@ public class EmbeddedDatabaseConfigProvider {
     private EmbeddedDatabaseService embeddedDatabaseService;
 
     public Map<String, Object> collectEmbeddedDatabaseConfigs(Stack stack) {
-        Map<String, Object> result;
+        Map<String, Object> result = new HashMap<>();
+        if (StringUtils.isNotBlank(stack.getExternalDatabaseEngineVersion())) {
+            LOGGER.debug("Configuring embedded DB version to [{}]", stack.getExternalDatabaseEngineVersion());
+            result.put(POSTGRES_VERSION, stack.getExternalDatabaseEngineVersion());
+        }
         if (embeddedDatabaseService.isAttachedDiskForEmbeddedDatabaseCreated(stack)) {
             LOGGER.info("Attached disk will be used to store data for postgres sql server");
-            result = createEmbeddedDbOnAttachedDiskConfig();
+            result.putAll(createEmbeddedDbOnAttachedDiskConfig());
         } else {
             LOGGER.info("Default settings for data storage will be used for postgres sql server as no disks are attached");
-            result = Map.of(
+            result.putAll(Map.of(
                     POSTGRES_DIRECTORY_KEY, POSTGRES_DEFAULT_DIRECTORY,
                     POSTGRES_LOG_DIRECTORY_KEY, POSTGRES_DEFAULT_LOG_DIRECTORY,
                     POSTGRES_SCRIPTS_EXECUTED_DIRECTORY_KEY, POSTGRES_DEFAULT_SCRIPTS_EXECUTED_DIRECTORY,
-                    POSTGRES_DATA_ON_ATTACHED_DISK_KEY, false);
+                    POSTGRES_DATA_ON_ATTACHED_DISK_KEY, false));
         }
         LOGGER.debug("Embedded Postgres sql server pillar parameters: {}", result);
         return result;

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/init.sls
@@ -6,6 +6,12 @@
 {% set postgres_log_directory = salt['pillar.get']('postgres:postgres_log_directory') %}
 {% set postgres_scripts_executed_directory = salt['pillar.get']('postgres:postgres_scripts_executed_directory') %}
 {% set postgres_data_on_attached_disk = salt['pillar.get']('postgres:postgres_data_on_attached_disk', 'False') %}
+
+{%- if 'None' == configure_remote_db and salt['pillar.get']('postgres:postgres_version', '10') | int == 11 %}
+include:
+  - postgresql.pg11
+{%- endif %}
+
 {% set command = 'systemctl show -p FragmentPath postgresql' %}
 {% set unitFile = salt['cmd.run'](command) | replace("FragmentPath=","") %}
 

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/pg11.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/pg11.sls
@@ -1,0 +1,141 @@
+{%- from 'metadata/settings.sls' import metadata with context %}
+
+pgsql-ld-conf:
+  alternatives.set:
+    - path: /usr/pgsql-11/share/postgresql-11-libs.conf
+
+pgsql-psql:
+  alternatives.set:
+    - path: /usr/pgsql-11/bin/psql
+
+pgsql-clusterdb:
+  alternatives.set:
+    - path: /usr/pgsql-11/bin/clusterdb
+
+pgsql-createdb:
+  alternatives.set:
+    - path: /usr/pgsql-11/bin/createdb
+
+pgsql-createuser:
+  alternatives.set:
+    - path: /usr/pgsql-11/bin/createuser
+
+pgsql-dropdb:
+  alternatives.set:
+    - path: /usr/pgsql-11/bin/dropdb
+
+pgsql-dropuser:
+  alternatives.set:
+    - path: /usr/pgsql-11/bin/dropuser
+
+pgsql-pg_basebackup:
+  alternatives.set:
+    - path: /usr/pgsql-11/bin/pg_basebackup
+
+pgsql-pg_dump:
+  alternatives.set:
+    - path: /usr/pgsql-11/bin/pg_dump
+
+pgsql-pg_dumpall:
+  alternatives.set:
+    - path: /usr/pgsql-11/bin/pg_dumpall
+
+pgsql-pg_restore:
+  alternatives.set:
+    - path: /usr/pgsql-11/bin/pg_restore
+
+pgsql-reindexdb:
+  alternatives.set:
+    - path: /usr/pgsql-11/bin/reindexdb
+
+pgsql-vacuumdb:
+  alternatives.set:
+    - path: /usr/pgsql-11/bin/vacuumdb
+
+pgsql-clusterdbman:
+  alternatives.set:
+    - path: /usr/pgsql-11/share/man/man1/clusterdb.1
+
+pgsql-createdbman:
+  alternatives.set:
+    - path: /usr/pgsql-11/share/man/man1/createdb.1
+
+pgsql-createuserman:
+  alternatives.set:
+    - path: /usr/pgsql-11/share/man/man1/createuser.1
+
+pgsql-dropdbman:
+  alternatives.set:
+    - path: /usr/pgsql-11/share/man/man1/dropdb.1
+
+pgsql-dropuserman:
+  alternatives.set:
+    - path: /usr/pgsql-11/share/man/man1/dropuser.1
+
+pgsql-pg_basebackupman:
+  alternatives.set:
+    - path: /usr/pgsql-11/share/man/man1/pg_basebackup.1
+
+pgsql-pg_dumpman:
+  alternatives.set:
+    - path: /usr/pgsql-11/share/man/man1/pg_dump.1
+
+pgsql-pg_dumpallman:
+  alternatives.set:
+    - path: /usr/pgsql-11/share/man/man1/pg_dumpall.1
+
+pgsql-pg_restoreman:
+  alternatives.set:
+    - path: /usr/pgsql-11/share/man/man1/pg_restore.1
+
+pgsql-psqlman:
+  alternatives.set:
+    - path: /usr/pgsql-11/share/man/man1/psql.1
+
+pgsql-reindexdbman:
+  alternatives.set:
+    - path: /usr/pgsql-11/share/man/man1/reindexdb.1
+
+pgsql-vacuumdbman:
+  alternatives.set:
+    - path: /usr/pgsql-11/share/man/man1/vacuumdb.1
+
+/bin/initdb:
+  file.symlink:
+    - target: /usr/pgsql-11/bin/initdb
+    - force: True
+
+/var/lib/pgsql/data:
+  file.symlink:
+    - target: /var/lib/pgsql/11/data
+    - force: True
+
+{% if salt['file.file_exists']('/usr/lib/systemd/system/postgresql-10.service') %}
+remove-pg10-alias:
+  file.replace:
+    - name: /usr/lib/systemd/system/postgresql-10.service
+    - pattern: "Alias=postgresql.service"
+    - repl: ""
+
+disable-postgresql-10:
+  service.dead:
+    - enable: False
+    - name: postgresql-10
+{% endif %}
+
+postgresql-systemd-link:
+  file.replace:
+    - name: /usr/lib/systemd/system/postgresql-11.service
+    - pattern: "\\[Install\\]"
+    - repl: "[Install]\nAlias=postgresql.service"
+    - unless: cat /usr/lib/systemd/system/postgresql-11.service | grep postgresql.service
+
+{% if metadata.platform == 'YARN' %}  # systemctl reenable does not work on ycloud so we create the symlink manually
+create-postgres-service-link:
+  cmd.run:
+    - name: ln -sf /usr/lib/systemd/system/postgresql-11.service /usr/lib/systemd/system/postgresql.service && systemctl disable postgresql-11 && systemctl enable postgresql
+{% else %}
+reenable-postgres:
+  cmd.run:
+    - name: systemctl reenable postgresql-11.service
+{% endif %}


### PR DESCRIPTION
If the `DistroXV1Request->externalDatabase` has the `databaseEngineVersion` set to `11` and `availabilityType1 set to `NONE` or `ON_ROOT_VOLUME`,
then use postgresql 11 version.

- this will stop the postgresql-10 service and disable it
- set the postgres related alternatives like `pgsql` to the `11` version binary
- relink `postgresql` service to `postgresql-11`
- relink `/var/lib/pgsql/data` to `/var/lib/pgsql/11/data`

None of these happens if remote database is configured.

See detailed description in the commit message.