### PR TITLE
CDPSDX-3366: Added validation during Environment and SDX stop process so as to not perform stop during resize.

### DIFF
--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxEndpoint.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxEndpoint.java
@@ -45,6 +45,7 @@ import com.sequenceiq.sdx.api.model.SdxDefaultTemplateResponse;
 import com.sequenceiq.sdx.api.model.SdxGenerateImageCatalogResponse;
 import com.sequenceiq.sdx.api.model.SdxRecommendationResponse;
 import com.sequenceiq.sdx.api.model.SdxRepairRequest;
+import com.sequenceiq.sdx.api.model.SdxStopValidationResponse;
 import com.sequenceiq.sdx.api.model.SdxSyncComponentVersionsFromCmResponse;
 import com.sequenceiq.sdx.api.model.SdxValidateCloudStorageRequest;
 import com.sequenceiq.sdx.api.model.SetRangerCloudIdentityMappingRequest;
@@ -317,4 +318,10 @@ public interface SdxEndpoint {
             @NotNull(message = "The 'cloudPlatform' query parameter must be specified.") @QueryParam("cloudPlatform") String cloudPlatform,
             @NotNull(message = "The 'region' query parameter must be specified.") @QueryParam("region") String region,
             @QueryParam("availabilityZone") String availabilityZone);
+
+    @GET
+    @Path("crn/{crn}/internal/stoppable")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Determines if the datalake can be stopped", nickname = "isStoppable")
+    SdxStopValidationResponse isStoppableInternal(@PathParam("crn") String crn, @QueryParam("initiatorUserCrn") String initiatorUserCrn);
 }

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/ModelDescriptions.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/ModelDescriptions.java
@@ -170,6 +170,10 @@ public class ModelDescriptions {
 
     public static final String VOLUME_MAXIMUM_NUMBER = "Volume maximum number";
 
+    public static final String STOPPABLE = "Whether the cluster is stoppable or not";
+
+    public static final String UNSTOPPABLE_REASON = "Reason why the cluster is not stoppable";
+
     private ModelDescriptions() {
     }
 }

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxStopValidationResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxStopValidationResponse.java
@@ -1,0 +1,49 @@
+package com.sequenceiq.sdx.api.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SdxStopValidationResponse {
+    @ApiModelProperty(ModelDescriptions.STOPPABLE)
+    private boolean stoppable;
+
+    @ApiModelProperty(ModelDescriptions.UNSTOPPABLE_REASON)
+    private String unstoppableReason;
+
+    public SdxStopValidationResponse() {
+    }
+
+    public SdxStopValidationResponse(boolean stoppable, String unstoppableReason) {
+        this.stoppable = stoppable;
+        this.unstoppableReason = unstoppableReason;
+    }
+
+    public boolean isStoppable() {
+        return stoppable;
+    }
+
+    public void setStoppable(boolean stoppable) {
+        this.stoppable = stoppable;
+    }
+
+    public String getUnstoppableReason() {
+        return unstoppableReason;
+    }
+
+    public void setUnstoppableReason(String unstoppableReason) {
+        this.unstoppableReason = unstoppableReason;
+    }
+
+    @Override
+    public String toString() {
+        return "SdxStopValidationResponse{" +
+                (stoppable ? ("stoppable=true, unstoppableReason='" + unstoppableReason + '\'') : "stoppable=false") +
+                '}';
+    }
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
@@ -6,6 +6,7 @@ import static com.sequenceiq.authorization.resource.AuthorizationVariableType.CR
 import static com.sequenceiq.authorization.resource.AuthorizationVariableType.NAME;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -32,6 +33,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.crn.CrnResourceDescriptor;
 import com.sequenceiq.cloudbreak.auth.security.internal.AccountId;
+import com.sequenceiq.cloudbreak.auth.security.internal.InitiatorUserCrn;
 import com.sequenceiq.cloudbreak.auth.security.internal.TenantAwareParam;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakImageCatalogV3;
 import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageValidateResponse;
@@ -71,6 +73,7 @@ import com.sequenceiq.sdx.api.model.SdxDefaultTemplateResponse;
 import com.sequenceiq.sdx.api.model.SdxGenerateImageCatalogResponse;
 import com.sequenceiq.sdx.api.model.SdxRecommendationResponse;
 import com.sequenceiq.sdx.api.model.SdxRepairRequest;
+import com.sequenceiq.sdx.api.model.SdxStopValidationResponse;
 import com.sequenceiq.sdx.api.model.SdxSyncComponentVersionsFromCmResponse;
 import com.sequenceiq.sdx.api.model.SdxValidateCloudStorageRequest;
 import com.sequenceiq.sdx.api.model.SetRangerCloudIdentityMappingRequest;
@@ -428,6 +431,14 @@ public class SdxController implements SdxEndpoint {
     public SdxRecommendationResponse getRecommendation(@ResourceCrn String credentialCrn, SdxClusterShape clusterShape, String runtimeVersion,
             String cloudPlatform, String region, String availabilityZone) {
         return sdxRecommendationService.getRecommendation(credentialCrn, clusterShape, runtimeVersion, cloudPlatform, region, availabilityZone);
+    }
+
+    @Override
+    @InternalOnly
+    public SdxStopValidationResponse isStoppableInternal(@TenantAwareParam String crn, @InitiatorUserCrn String initiatorUserCrn) {
+        SdxCluster sdxCluster = sdxService.getByCrn(initiatorUserCrn, crn);
+        Optional<String> unstoppableReason = sdxStopService.checkIfStoppable(sdxCluster);
+        return new SdxStopValidationResponse(unstoppableReason.isEmpty(), unstoppableReason.orElse(null));
     }
 
     private SdxCluster getSdxClusterByName(String name) {

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/resize/recovery/ResizeRecoveryService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/resize/recovery/ResizeRecoveryService.java
@@ -146,7 +146,7 @@ public class ResizeRecoveryService implements RecoveryService {
 
     private SdxRecoverableResponse validateRecoveryResizedClusterPresent(SdxCluster sdxCluster, DatalakeStatusEnum status, String statusReason) {
         if (FAILURE_STATES.contains(status)) {
-            return new SdxRecoverableResponse("Resized data lake is in failed state. Recovery will restart original data lake, " +
+            return new SdxRecoverableResponse("Resized data lake is in a failed state. Recovery will restart the original data lake, " +
                     "and delete the new one", RecoveryStatus.RECOVERABLE);
         } else if (RUNNING.equals(status) && statusReason.contains("Datalake restore failed")) {
             return new SdxRecoverableResponse(

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentStopServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentStopServiceTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -22,6 +23,9 @@ import com.sequenceiq.environment.environment.dto.FreeIpaCreationAwsParametersDt
 import com.sequenceiq.environment.environment.dto.FreeIpaCreationAwsSpotParametersDto;
 import com.sequenceiq.environment.environment.dto.FreeIpaCreationDto;
 import com.sequenceiq.environment.environment.flow.EnvironmentReactorFlowManager;
+import com.sequenceiq.environment.environment.service.sdx.SdxService;
+import com.sequenceiq.sdx.api.model.SdxClusterResponse;
+import com.sequenceiq.sdx.api.model.SdxStopValidationResponse;
 
 @ExtendWith(MockitoExtension.class)
 class EnvironmentStopServiceTest {
@@ -36,30 +40,41 @@ class EnvironmentStopServiceTest {
 
     private static final String ENV_NAME = "name";
 
+    private static final String SDX_CRN = "crn:datalake";
+
+    private static final String SDX_NAME = "sdx_name";
+
     @Mock
     private EnvironmentReactorFlowManager reactorFlowManager;
 
     @Mock
     private EnvironmentService environmentService;
 
+    @Mock
+    private SdxService sdxService;
+
     @InjectMocks
     private EnvironmentStopService underTest;
 
-    @Test
-    public void shouldStopEnvWithoutChildren() {
+    @BeforeEach
+    public void setup() {
         EnvironmentDto environmentDto = getEnvironmentDto();
+        environmentDto.setName(ENV_NAME);
         when(environmentService.getByCrnAndAccountId(ENV_CRN, ACCOUNT_ID)).thenReturn(environmentDto);
         when(environmentService.findAllByAccountIdAndParentEnvIdAndArchivedIsFalse(ACCOUNT_ID, ENV_ID)).thenReturn(Lists.emptyList());
+    }
 
+    @Test
+    public void shouldStopEnvWithoutChildren() {
+        when(sdxService.list(ENV_NAME)).thenReturn(Lists.list());
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.stopByCrn(ENV_CRN));
-
         verify(reactorFlowManager).triggerStopFlow(ENV_ID, ENV_NAME, USER_CRN);
     }
 
     @Test
     public void shouldStopEnvWithOnlyStoppedChildren() {
-        EnvironmentDto environmentDto = getEnvironmentDto();
-        when(environmentService.getByCrnAndAccountId(ENV_CRN, ACCOUNT_ID)).thenReturn(environmentDto);
+        when(sdxService.list(ENV_NAME)).thenReturn(Lists.list());
+
         Environment childEnvironment = new Environment();
         childEnvironment.setStatus(EnvironmentStatus.ENV_STOPPED);
         when(environmentService.findAllByAccountIdAndParentEnvIdAndArchivedIsFalse(ACCOUNT_ID, ENV_ID)).thenReturn(List.of(childEnvironment));
@@ -70,9 +85,19 @@ class EnvironmentStopServiceTest {
     }
 
     @Test
+    public void shouldStopEnvWithNoUnstoppableSdxCluster() {
+        SdxClusterResponse clusterResponse = new SdxClusterResponse();
+        clusterResponse.setCrn(SDX_CRN);
+        when(sdxService.list(ENV_NAME)).thenReturn(Lists.list(clusterResponse));
+        SdxStopValidationResponse sdxStopValidationResponse = new SdxStopValidationResponse(true, null);
+        when(sdxService.isStoppable(SDX_CRN)).thenReturn(sdxStopValidationResponse);
+
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.stopByCrn(ENV_CRN));
+        verify(reactorFlowManager).triggerStopFlow(ENV_ID, ENV_NAME, USER_CRN);
+    }
+
+    @Test
     public void shouldThrowBadRequestExceptionGivenEnvHasRunningChildren() {
-        EnvironmentDto environmentDto = getEnvironmentDto();
-        when(environmentService.getByCrnAndAccountId(ENV_CRN, ACCOUNT_ID)).thenReturn(environmentDto);
         Environment childEnvironment = new Environment();
         childEnvironment.setStatus(EnvironmentStatus.AVAILABLE);
         childEnvironment.setName("Child-env-name");
@@ -94,11 +119,24 @@ class EnvironmentStopServiceTest {
                         .build())
                 .build());
         when(environmentService.getByCrnAndAccountId(ENV_CRN, ACCOUNT_ID)).thenReturn(environmentDto);
-        when(environmentService.findAllByAccountIdAndParentEnvIdAndArchivedIsFalse(ACCOUNT_ID, ENV_ID)).thenReturn(Lists.emptyList());
 
         Assertions.assertThatThrownBy(() -> ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.stopByCrn(ENV_CRN)))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage("Environment [name] can not be stopped because FreeIpa is running on spot instances.");
+    }
+
+    @Test
+    public void shouldThrowBadRequestExceptionGivenCantStopDatalakes() {
+        SdxClusterResponse clusterResponse = new SdxClusterResponse();
+        clusterResponse.setCrn(SDX_CRN);
+        clusterResponse.setName(SDX_NAME);
+        when(sdxService.list(ENV_NAME)).thenReturn(Lists.list(clusterResponse));
+        SdxStopValidationResponse sdxStopValidationResponse = new SdxStopValidationResponse(false, SDX_NAME + "can't be stopped!");
+        when(sdxService.isStoppable(SDX_CRN)).thenReturn(sdxStopValidationResponse);
+
+        Assertions.assertThatThrownBy(() -> ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.stopByCrn(ENV_CRN)))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining(SDX_NAME);
     }
 
     private EnvironmentDto getEnvironmentDto() {


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CDPSDX-3366

Objective is to not allow users to stop the datalake during a resize operation as this may result in difficulty in recovering the datalake. To be perfectly clear, our recovery process for resize is fairly exhaustive and should cover most cases, this is simply to ensure that nothing goes wrong during migration.

Changes consist of:

- Adding a validation check to the stop service which verifies if the datalake has any "unstoppable flow" currently running
- This is done at the beginning of each stop and simply throws an exception, which should stop the overall stop flow (whether for the environment or just the DL)