### PR TITLE
CB-17542 In case of Java11, extend the resolv.conf with the current domain

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/ipa.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/ipa.sls
@@ -152,11 +152,15 @@ restore_systemctl:
     - mode: 755
     - force: True
 
+{% endif %}
+
 dns_resolution_fix:
   file.append:
     - name: /etc/resolv.conf
-    - text: "domain {{ salt['grains.get']('domain') }}"
+{% if metadata.platform != 'YARN' %}
+    - onlyif: java -version |& grep 'openjdk version "11.0'
 {% endif %}
+    - text: "domain {{ salt['grains.get']('domain') }}"
 
 include:
     - sssd.ssh


### PR DESCRIPTION
* the idea is coming from bugfixes for YARN platform (CB-1367 CB-5721)
* this way we can elliminate the DNS healthcheck issue in CM