### PR TITLE
CB-17476 Collect more hostHealth info from CM APIs

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
@@ -165,4 +165,6 @@ public interface ClusterApi {
     ClusterCommissionService clusterCommissionService();
 
     ClusterDiagnosticsService clusterDiagnosticsService();
+
+    ClusterHealthService clusterHealthService();
 }

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterHealthService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterHealthService.java
@@ -1,0 +1,11 @@
+package com.sequenceiq.cloudbreak.cluster.api;
+
+import com.sequenceiq.cloudbreak.cluster.status.DetailedHostStatuses;
+
+/**
+ * Determine cluster host health info from CM APIs
+ */
+public interface ClusterHealthService {
+
+    DetailedHostStatuses getDetailedHostStatuses();
+}

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/model/stopstart/DetailedCertHealthCheck.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/model/stopstart/DetailedCertHealthCheck.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.cloudbreak.cluster.model.stopstart;
+
+import com.sequenceiq.cloudbreak.common.type.HealthCheckResult;
+
+/**
+ * DetailedCertHealthCheck maintains information about certificate health, along with healthCheck explanation returned by CM
+ */
+public class DetailedCertHealthCheck {
+
+    private final HealthCheckResult healthCheckResult;
+
+    private final String explanation;
+
+    public DetailedCertHealthCheck(HealthCheckResult healthCheckResult, String explanation) {
+        this.healthCheckResult = healthCheckResult;
+        this.explanation = explanation;
+    }
+
+    public HealthCheckResult getHealthCheckResult() {
+        return healthCheckResult;
+    }
+
+    public String getExplanation() {
+        return explanation;
+    }
+
+    @Override
+    public String toString() {
+        return "DetailedCertHealthCheck{" +
+                "healthCheckType=" + healthCheckResult +
+                ", explanation='" + explanation + '\'' +
+                '}';
+    }
+}

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/model/stopstart/DetailedHostHealthCheck.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/model/stopstart/DetailedHostHealthCheck.java
@@ -1,0 +1,50 @@
+package com.sequenceiq.cloudbreak.cluster.model.stopstart;
+
+import com.sequenceiq.cloudbreak.common.type.HealthCheckResult;
+
+/**
+ * DetailedHostHealthCheck maintains information about maintenanceMode, commissionState and healthCheck data retrieved by CM for the host
+ */
+public class DetailedHostHealthCheck {
+    private final HealthCheckResult healthCheckResult;
+
+    private final boolean inMaintenanceMode;
+
+    private final HostCommissionState hostCommissionState;
+
+    private final String lastHeartbeat;
+
+    public DetailedHostHealthCheck(HealthCheckResult healthCheckResult, boolean inMaintenanceMode,
+            HostCommissionState hostCommissionState, String lastHeartbeat) {
+        this.healthCheckResult = healthCheckResult;
+        this.inMaintenanceMode = inMaintenanceMode;
+        this.hostCommissionState = hostCommissionState;
+        this.lastHeartbeat = lastHeartbeat;
+    }
+
+    public HealthCheckResult getHealthCheckResult() {
+        return healthCheckResult;
+    }
+
+    public boolean isInMaintenanceMode() {
+        return inMaintenanceMode;
+    }
+
+    public HostCommissionState getHostCommissionState() {
+        return hostCommissionState;
+    }
+
+    public String getLastHeartbeat() {
+        return lastHeartbeat;
+    }
+
+    @Override
+    public String toString() {
+        return "DetailedHostHealthCheck{" +
+                "healthCheckResult=" + healthCheckResult +
+                ", inMaintenanceMode=" + inMaintenanceMode +
+                ", hostCommissionState=" + hostCommissionState +
+                ", lastHeartbeat=" + lastHeartbeat +
+                '}';
+    }
+}

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/model/stopstart/DetailedServicesHealthCheck.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/model/stopstart/DetailedServicesHealthCheck.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.cloudbreak.cluster.model.stopstart;
+
+import java.util.Set;
+
+import com.sequenceiq.cloudbreak.common.type.HealthCheckResult;
+
+/**
+ * DetailedServicesHealthCheck maintains information about all the services with BAD or CONCERNING health on the cluster.
+ */
+public class DetailedServicesHealthCheck {
+
+    private final HealthCheckResult healthCheckResult;
+
+    private final Set<String> servicesWithBadHealth;
+
+    public DetailedServicesHealthCheck(HealthCheckResult healthCheckResult, Set<String> servicesWithBadHealth) {
+        this.healthCheckResult = healthCheckResult;
+        this.servicesWithBadHealth = servicesWithBadHealth;
+    }
+
+    public Set<String> getServicesWithBadHealth() {
+        return servicesWithBadHealth;
+    }
+
+    public HealthCheckResult getHealthCheckResult() {
+        return healthCheckResult;
+    }
+
+    @Override
+    public String toString() {
+        return "DetailedServicesHealthCheck{" +
+                "servicesWithBadHealth=" + servicesWithBadHealth +
+                '}';
+    }
+}

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/model/stopstart/HostCommissionState.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/model/stopstart/HostCommissionState.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.cloudbreak.cluster.model.stopstart;
+
+public enum HostCommissionState {
+
+    COMMISSIONED("COMMISSIONED"),
+
+    DECOMMISSIONED("DECOMMISSIONED"),
+
+    UNKNOWN("UNKNOWN"),
+
+    OFFLINING("OFFLINING"),
+
+    OFFLINED("OFFLINED");
+
+    private String value;
+
+    HostCommissionState(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return "HostCommissionState{" +
+                "value='" + value + '\'' +
+                '}';
+    }
+}

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/status/DetailedHostStatuses.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/status/DetailedHostStatuses.java
@@ -1,0 +1,82 @@
+package com.sequenceiq.cloudbreak.cluster.status;
+
+
+import java.util.Map;
+import java.util.Optional;
+
+import com.sequenceiq.cloudbreak.cloud.model.HostName;
+import com.sequenceiq.cloudbreak.cluster.model.stopstart.DetailedHostHealthCheck;
+import com.sequenceiq.cloudbreak.cluster.model.stopstart.DetailedCertHealthCheck;
+import com.sequenceiq.cloudbreak.cluster.model.stopstart.DetailedServicesHealthCheck;
+import com.sequenceiq.cloudbreak.common.type.HealthCheckResult;
+import com.sequenceiq.cloudbreak.cluster.model.stopstart.HostCommissionState;
+
+/**
+ * DetailedHostStatuses keeps track of HOST (maintenanceMode, commissionStatus), SERVICES and CERTIFICATE health on the cluster using info retrieved via CM APIs
+ */
+public class DetailedHostStatuses {
+
+    private final Map<HostName, Optional<DetailedHostHealthCheck>> hostsHealth;
+
+    private final Map<HostName, Optional<DetailedServicesHealthCheck>> servicesHealth;
+
+    private final Map<HostName, Optional<DetailedCertHealthCheck>> certHealth;
+
+    public DetailedHostStatuses(Map<HostName, Optional<DetailedHostHealthCheck>> hostsHealth, Map<HostName,
+            Optional<DetailedServicesHealthCheck>> servicesHealth, Map<HostName, Optional<DetailedCertHealthCheck>> certHealth) {
+        this.hostsHealth = hostsHealth;
+        this.servicesHealth = servicesHealth;
+        this.certHealth = certHealth;
+    }
+
+    private boolean isHostUnHealthy(HostName hostName) {
+        return hostsHealth.get(hostName).stream()
+                .anyMatch(dhc -> HealthCheckResult.UNHEALTHY.equals(dhc.getHealthCheckResult()));
+    }
+
+    private boolean areServicesUnhealthy(HostName hostname) {
+        return servicesHealth.get(hostname).stream()
+                .anyMatch(dhc -> HealthCheckResult.UNHEALTHY.equals(dhc.getHealthCheckResult()));
+    }
+
+    public boolean isCertExpiring(HostName hostName) {
+        return certHealth.get(hostName).stream()
+                .anyMatch(dhc -> HealthCheckResult.UNHEALTHY.equals(dhc.getHealthCheckResult()));
+    }
+
+    public boolean isHostHealthy(HostName hostName) {
+        return !isHostUnHealthy(hostName)
+                && !areServicesUnhealthy(hostName);
+    }
+
+    public boolean isHostInMaintenanceMode(HostName hostName) {
+        return hostsHealth.get(hostName).stream()
+                .anyMatch(DetailedHostHealthCheck::isInMaintenanceMode);
+    }
+
+    public boolean isHostDecommissioned(HostName hostName) {
+        return hostsHealth.get(hostName).stream()
+                .anyMatch(dhc -> !HostCommissionState.COMMISSIONED.equals(dhc.getHostCommissionState()));
+    }
+
+    public Map<HostName, Optional<DetailedHostHealthCheck>> getHostsHealth() {
+        return hostsHealth;
+    }
+
+    public Map<HostName, Optional<DetailedServicesHealthCheck>> getServicesHealth() {
+        return servicesHealth;
+    }
+
+    public Map<HostName, Optional<DetailedCertHealthCheck>> getCertHealth() {
+        return certHealth;
+    }
+
+    @Override
+    public String toString() {
+        return "DetailedHostStatuses{" +
+                "hostsHealth=" + hostsHealth +
+                ", servicesHealth=" + servicesHealth +
+                ", certHealth=" + certHealth +
+                '}';
+    }
+}

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterHealthService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterHealthService.java
@@ -1,0 +1,165 @@
+package com.sequenceiq.cloudbreak.cm;
+
+import static com.sequenceiq.cloudbreak.cloud.model.HostName.hostName;
+import static org.apache.commons.collections4.CollectionUtils.emptyIfNull;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Service;
+
+import com.cloudera.api.swagger.HostsResourceApi;
+import com.cloudera.api.swagger.client.ApiClient;
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.model.ApiHealthSummary;
+import com.cloudera.api.swagger.model.ApiHost;
+import com.cloudera.api.swagger.model.ApiHostList;
+import com.cloudera.api.swagger.model.ApiRoleRef;
+import com.google.common.collect.Sets;
+import com.sequenceiq.cloudbreak.client.HttpClientConfig;
+import com.sequenceiq.cloudbreak.cloud.model.HostName;
+import com.sequenceiq.cloudbreak.cluster.api.ClusterHealthService;
+import com.sequenceiq.cloudbreak.cluster.service.ClusterClientInitException;
+import com.sequenceiq.cloudbreak.cluster.status.DetailedHostStatuses;
+import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiClientProvider;
+import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerClientInitException;
+import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
+import com.sequenceiq.cloudbreak.cluster.model.stopstart.DetailedCertHealthCheck;
+import com.sequenceiq.cloudbreak.cluster.model.stopstart.DetailedHostHealthCheck;
+import com.sequenceiq.cloudbreak.cluster.model.stopstart.DetailedServicesHealthCheck;
+import com.sequenceiq.cloudbreak.common.type.HealthCheckResult;
+import com.sequenceiq.cloudbreak.cluster.model.stopstart.HostCommissionState;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+
+@Service
+@Scope("prototype")
+public class ClouderaManagerClusterHealthService implements ClusterHealthService {
+
+    static final String HOST_SCM_HEALTH = "HOST_SCM_HEALTH";
+
+    static final String FULL_WITH_HEALTH_CHECK_EXPLANATION = "FULL_WITH_HEALTH_CHECK_EXPLANATION";
+
+    static final String HOST_AGENT_CERTIFICATE_EXPIRY = "HOST_AGENT_CERTIFICATE_EXPIRY";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerClusterHealthService.class);
+
+    private static final Set<ApiHealthSummary> IGNORED_HEALTH_SUMMARIES = Sets.immutableEnumSet(
+            ApiHealthSummary.DISABLED,
+            ApiHealthSummary.NOT_AVAILABLE,
+            ApiHealthSummary.HISTORY_NOT_AVAILABLE
+    );
+
+    @Inject
+    private ClouderaManagerApiClientProvider clouderaManagerApiClientProvider;
+
+    @Inject
+    private ClouderaManagerApiFactory clouderaManagerApiFactory;
+
+    private Stack stack;
+
+    private ApiClient apiClient;
+
+    private HttpClientConfig httpClientConfig;
+
+    public ClouderaManagerClusterHealthService(Stack stack, HttpClientConfig httpClientConfig) {
+        this.stack = stack;
+        this.httpClientConfig = httpClientConfig;
+    }
+
+    @PostConstruct
+    private void initApiClient() throws ClusterClientInitException {
+        Cluster cluster = stack.getCluster();
+        String user = cluster.getCloudbreakAmbariUser();
+        String password = cluster.getCloudbreakAmbariPassword();
+        try {
+            apiClient = clouderaManagerApiClientProvider.getV31Client(stack.getGatewayPort(), user, password, httpClientConfig);
+        } catch (ClouderaManagerClientInitException e) {
+            throw new ClusterClientInitException(e);
+        }
+    }
+
+    @Override
+    public DetailedHostStatuses getDetailedHostStatuses() {
+        List<ApiHost> apiHosts = getHostsFromCM();
+        Map<HostName, Optional<DetailedHostHealthCheck>> hostsHealth = apiHosts.stream().collect(Collectors.toMap(
+                apiHost -> hostName(apiHost.getHostname()),
+                ClouderaManagerClusterHealthService::getDetailedHostHealthCheck));
+
+        Map<HostName, Optional<DetailedServicesHealthCheck>> servicesHealth = apiHosts.stream().collect(Collectors.toMap(
+                apiHost -> hostName(apiHost.getHostname()),
+                ClouderaManagerClusterHealthService::getDetailedServicesHealthCheck));
+
+        Map<HostName, Optional<DetailedCertHealthCheck>>  certHealth = apiHosts.stream().collect(Collectors.toMap(
+                apiHost -> hostName(apiHost.getHostname()),
+                ClouderaManagerClusterHealthService::getDetailedCertificateCheck));
+
+        DetailedHostStatuses detailedHostStatuses = new DetailedHostStatuses(hostsHealth, servicesHealth, certHealth);
+
+        LOGGER.debug("Creating 'DetailedHostStatuses' with {}", detailedHostStatuses);
+
+        return detailedHostStatuses;
+    }
+
+    private List<ApiHost> getHostsFromCM() {
+        HostsResourceApi hostsResourceApi = clouderaManagerApiFactory.getHostsResourceApi(apiClient);
+        try {
+            ApiHostList apiHostList = hostsResourceApi.readHosts(null, null, FULL_WITH_HEALTH_CHECK_EXPLANATION);
+            LOGGER.info("Retrieved HostsList from CM HostsResourceApi readHosts call: {}", apiHostList);
+            return apiHostList.getItems();
+        } catch (ApiException e) {
+            LOGGER.error("Error when reading hosts from CM: {}", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Optional<DetailedHostHealthCheck> getDetailedHostHealthCheck(ApiHost apiHost) {
+        return emptyIfNull(apiHost.getHealthChecks()).stream()
+                .filter(health -> HOST_SCM_HEALTH.equals(health.getName()))
+                .filter(health -> !IGNORED_HEALTH_SUMMARIES.contains(health.getSummary()))
+                .findFirst()
+                .map(apiHealthCheck -> new DetailedHostHealthCheck(healthSummaryToHealthCheckResult(apiHealthCheck.getSummary()),
+                        Boolean.TRUE.equals(apiHost.getMaintenanceMode()),
+                        HostCommissionState.valueOf(apiHost.getCommissionState().getValue()), apiHost.getLastHeartbeat()));
+    }
+
+    private static Optional<DetailedServicesHealthCheck> getDetailedServicesHealthCheck(ApiHost apiHost) {
+        Set<String> servicesWithBadHealth = emptyIfNull(apiHost.getRoleRefs()).stream()
+                .filter(roleRef -> Objects.nonNull(roleRef.getHealthSummary()))
+                .filter(roleRef -> HealthCheckResult.UNHEALTHY.equals(healthSummaryToHealthCheckResult(roleRef.getHealthSummary())))
+                .map(ApiRoleRef::getServiceName)
+                .collect(Collectors.toSet());
+        if (!servicesWithBadHealth.isEmpty()) {
+            return Optional.of(new DetailedServicesHealthCheck(HealthCheckResult.UNHEALTHY, servicesWithBadHealth));
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<DetailedCertHealthCheck> getDetailedCertificateCheck(ApiHost apiHost) {
+        return emptyIfNull(apiHost.getHealthChecks()).stream()
+                .filter(health -> HOST_AGENT_CERTIFICATE_EXPIRY.equals(health.getName()))
+                .findFirst()
+                .map(apiHealthCheck ->
+                        new DetailedCertHealthCheck(healthSummaryToHealthCheckResult(apiHealthCheck.getSummary()), apiHealthCheck.getExplanation()));
+    }
+
+    private static HealthCheckResult healthSummaryToHealthCheckResult(ApiHealthSummary apiHealthSummary) {
+        switch (apiHealthSummary) {
+            case CONCERNING:
+            case BAD:
+                return HealthCheckResult.UNHEALTHY;
+            default:
+                return HealthCheckResult.HEALTHY;
+        }
+    }
+}

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerConnector.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerConnector.java
@@ -11,6 +11,7 @@ import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterCommissionService;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterDecomissionService;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterDiagnosticsService;
+import com.sequenceiq.cloudbreak.cluster.api.ClusterHealthService;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterModificationService;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterSecurityService;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterSetupService;
@@ -66,5 +67,10 @@ public class ClouderaManagerConnector implements ClusterApi {
     @Override
     public ClusterDiagnosticsService clusterDiagnosticsService() {
         return applicationContext.getBean(ClouderaManagerDiagnosticsService.class, stack, clientConfig);
+    }
+
+    @Override
+    public ClusterHealthService clusterHealthService() {
+        return applicationContext.getBean(ClouderaManagerClusterHealthService.class, stack, clientConfig);
     }
 }

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterHealthServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterHealthServiceTest.java
@@ -1,0 +1,209 @@
+package com.sequenceiq.cloudbreak.cm;
+
+import static com.sequenceiq.cloudbreak.cloud.model.HostName.hostName;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.cloudera.api.swagger.HostsResourceApi;
+import com.cloudera.api.swagger.client.ApiClient;
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.model.ApiCommissionState;
+import com.cloudera.api.swagger.model.ApiHealthCheck;
+import com.cloudera.api.swagger.model.ApiHealthSummary;
+import com.cloudera.api.swagger.model.ApiHost;
+import com.cloudera.api.swagger.model.ApiHostList;
+import com.cloudera.api.swagger.model.ApiRoleRef;
+import com.sequenceiq.cloudbreak.client.HttpClientConfig;
+import com.sequenceiq.cloudbreak.cluster.status.DetailedHostStatuses;
+import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+
+class ClouderaManagerClusterHealthServiceTest {
+
+    private static final String HOST_SCM_HEALTH = "HOST_SCM_HEALTH";
+
+    private static final String HOST_AGENT_CERTIFICATE_EXPIRY = "HOST_AGENT_CERTIFICATE_EXPIRY";
+
+    private static final String FULL_WITH_HEALTH_CHECK_EXPLANATION = "FULL_WITH_HEALTH_CHECK_EXPLANATION";
+
+    @Mock
+    private ApiClient apiClient;
+
+    @Mock
+    private ClouderaManagerApiFactory clouderaManagerApiFactory;
+
+    @Mock
+    private HostsResourceApi hostsResourceApi;
+
+    @InjectMocks
+    private ClouderaManagerClusterHealthService underTest;
+
+    @BeforeEach
+    void setUp() {
+        Stack stack = new Stack();
+        stack.setName("test-cluster");
+        Cluster cluster = new Cluster();
+        cluster.setName("test-cluster");
+        stack.setCluster(cluster);
+
+        HttpClientConfig clientConfig = new HttpClientConfig("1.2.3.4", null, null, null);
+
+        underTest = new ClouderaManagerClusterHealthService(stack, clientConfig);
+
+        MockitoAnnotations.openMocks(this);
+
+        when(clouderaManagerApiFactory.getHostsResourceApi(apiClient)).thenReturn(hostsResourceApi);
+    }
+
+    @Test
+    void testAllGoodHealthChecks() throws ApiException {
+
+        mockHosts(
+                new ApiHost().hostname("host-1")
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.GOOD))
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_AGENT_CERTIFICATE_EXPIRY).summary(ApiHealthSummary.GOOD)),
+                new ApiHost().hostname("host-2")
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.GOOD))
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_AGENT_CERTIFICATE_EXPIRY).summary(ApiHealthSummary.GOOD))
+        );
+
+        DetailedHostStatuses result = underTest.getDetailedHostStatuses();
+
+        assertThat(result.isHostHealthy(hostName("host-1"))).isTrue();
+        assertThat(result.isHostHealthy(hostName("host-2"))).isTrue();
+    }
+
+    @Test
+    void testUnrecognisedHealthCheckItemFiltered() throws ApiException {
+
+        mockHosts(
+                new ApiHost().hostname("host-1")
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.GOOD))
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_AGENT_CERTIFICATE_EXPIRY).summary(ApiHealthSummary.GOOD))
+                        .addHealthChecksItem(new ApiHealthCheck().name("unrecognised health check").summary(ApiHealthSummary.GOOD)),
+                new ApiHost().hostname("host-2")
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.GOOD))
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_AGENT_CERTIFICATE_EXPIRY).summary(ApiHealthSummary.GOOD))
+        );
+
+        DetailedHostStatuses result = underTest.getDetailedHostStatuses();
+
+        assertThat(result.isHostHealthy(hostName("host-1"))).isTrue();
+    }
+
+    @Test
+    void testUnhealthyHostsAndCertificates() throws ApiException {
+
+        mockHosts(
+                new ApiHost().hostname("host-1")
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.GOOD))
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_AGENT_CERTIFICATE_EXPIRY).summary(ApiHealthSummary.CONCERNING)
+                                .explanation("Expiring"))
+                        .addRoleRefsItem(new ApiRoleRef().roleName("role-1").serviceName("service-1").healthSummary(ApiHealthSummary.GOOD))
+                        .addRoleRefsItem(new ApiRoleRef().roleName("role-2").serviceName("service-2").healthSummary(ApiHealthSummary.GOOD)),
+                new ApiHost().hostname("host-2")
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.GOOD))
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_AGENT_CERTIFICATE_EXPIRY).summary(ApiHealthSummary.GOOD))
+                        .addRoleRefsItem(new ApiRoleRef().roleName("role-1").serviceName("service-1").healthSummary(ApiHealthSummary.GOOD))
+                        .addRoleRefsItem(new ApiRoleRef().roleName("role-2").serviceName("service-2").healthSummary(ApiHealthSummary.GOOD)),
+                new ApiHost().hostname("host-3")
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.BAD))
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_AGENT_CERTIFICATE_EXPIRY).summary(ApiHealthSummary.GOOD)),
+                new ApiHost().hostname("host-4")
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.CONCERNING))
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_AGENT_CERTIFICATE_EXPIRY).summary(ApiHealthSummary.GOOD)),
+                new ApiHost().hostname("host-5")
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.GOOD))
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_AGENT_CERTIFICATE_EXPIRY).summary(ApiHealthSummary.GOOD))
+                        .addRoleRefsItem(new ApiRoleRef().roleName("role-1").serviceName("bad-service-1").healthSummary(ApiHealthSummary.BAD))
+                        .addRoleRefsItem(new ApiRoleRef().roleName("role-2").serviceName("bad-service-2").healthSummary(ApiHealthSummary.CONCERNING))
+        );
+
+        DetailedHostStatuses result = underTest.getDetailedHostStatuses();
+
+        assertThat(result.isCertExpiring(hostName("host-1"))).isTrue();
+        assertThat(result.getCertHealth().get(hostName("host-1")).get().getExplanation()).isEqualTo("Expiring");
+        assertThat(result.isHostHealthy(hostName("host-2"))).isTrue();
+        assertThat(result.isHostHealthy(hostName("host-1"))).isTrue();
+        assertThat(result.isHostHealthy(hostName("host-3"))).isFalse();
+        assertThat(result.isHostHealthy(hostName("host-4"))).isFalse();
+        assertThat(result.isHostHealthy(hostName("host-5"))).isFalse();
+        assertThat(result.getServicesHealth().get(hostName("host-5"))
+                .get().getServicesWithBadHealth()).hasSameElementsAs(Arrays.asList("bad-service-1", "bad-service-2"));
+    }
+
+    @Test
+    void testHostsDecommissioned() throws ApiException {
+
+        ApiHost host1 = new ApiHost().hostname("host-1")
+                .addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.GOOD))
+                .addHealthChecksItem(new ApiHealthCheck().name(HOST_AGENT_CERTIFICATE_EXPIRY).summary(ApiHealthSummary.GOOD));
+
+        ApiHost host3 = new ApiHost().hostname("host-3")
+                .addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.GOOD))
+                .addHealthChecksItem(new ApiHealthCheck().name(HOST_AGENT_CERTIFICATE_EXPIRY).summary(ApiHealthSummary.GOOD));
+
+        mockHosts(
+                host1,
+                new ApiHost().hostname("host-2")
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.GOOD))
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_AGENT_CERTIFICATE_EXPIRY).summary(ApiHealthSummary.GOOD)),
+                host3
+        );
+        host1.setCommissionState(ApiCommissionState.DECOMMISSIONED);
+        host3.setCommissionState(ApiCommissionState.OFFLINED);
+
+        DetailedHostStatuses result = underTest.getDetailedHostStatuses();
+
+        assertThat(result.isHostDecommissioned(hostName("host-1"))).isTrue();
+        assertThat(result.isHostDecommissioned(hostName("host-3"))).isTrue();
+        assertThat(result.isHostDecommissioned(hostName("host-2"))).isFalse();
+    }
+
+    @Test
+    void testHostsInMaintenanceMode() throws ApiException {
+
+        mockHosts(
+                new ApiHost().hostname("host-1")
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.GOOD))
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_AGENT_CERTIFICATE_EXPIRY).summary(ApiHealthSummary.GOOD))
+                        .maintenanceMode(Boolean.TRUE),
+                new ApiHost().hostname("host-2")
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.GOOD))
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_AGENT_CERTIFICATE_EXPIRY).summary(ApiHealthSummary.GOOD))
+                        .maintenanceMode(Boolean.FALSE),
+                new ApiHost().hostname("host-3")
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.GOOD))
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_AGENT_CERTIFICATE_EXPIRY).summary(ApiHealthSummary.GOOD))
+                        .maintenanceMode(null),
+                new ApiHost().hostname("host-4")
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.GOOD))
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_AGENT_CERTIFICATE_EXPIRY).summary(ApiHealthSummary.GOOD))
+        );
+
+        DetailedHostStatuses result = underTest.getDetailedHostStatuses();
+
+        assertThat(result.isHostInMaintenanceMode(hostName("host-1"))).isTrue();
+        assertThat(result.isHostInMaintenanceMode(hostName("host-2"))).isFalse();
+        assertThat(result.isHostInMaintenanceMode(hostName("host-3"))).isFalse();
+        assertThat(result.isHostInMaintenanceMode(hostName("host-4"))).isFalse();
+    }
+
+    private void mockHosts(ApiHost... apiHosts) throws ApiException {
+        Arrays.stream(apiHosts).forEach(apihost -> {
+            apihost.setHealthSummary(ApiHealthSummary.GOOD);
+            apihost.setCommissionState(ApiCommissionState.COMMISSIONED);
+        });
+        ApiHostList apiHostList = new ApiHostList().items(Arrays.asList(apiHosts));
+        when(hostsResourceApi.readHosts(null, null, FULL_WITH_HEALTH_CHECK_EXPLANATION)).thenReturn(apiHostList);
+    }
+}


### PR DESCRIPTION
 - Created new model to extract maintenanceMode status and hostCommission status from CM
 - HOST, SERVICES and CERTIFICATE health will be inferred from CM API response

See detailed description in the commit message.