### PR TITLE
CB-17323 - Implement dump and restore logic

### DIFF
--- a/core/src/main/resources/defaults/vm-logs.json
+++ b/core/src/main/resources/defaults/vm-logs.json
@@ -56,6 +56,14 @@
     "label": "waagent"
   },
   {
+    "path": "/var/log/postgres_upgrade_backup.log",
+    "label": "rds_upgrade_backup"
+  },
+  {
+    "path": "/var/log/postgres_upgrade_restore.log",
+    "label": "rds_upgrade_restore"
+  },
+  {
     "path": "${serverLogFolderPrefix}/cloudera-scm-server/cloudera-scm-server.log*",
     "label": "cloudera_server_log"
   },

--- a/orchestrator-salt/src/main/resources/salt/pillar/postgresql/upgrade.sls
+++ b/orchestrator-salt/src/main/resources/salt/pillar/postgresql/upgrade.sls
@@ -1,0 +1,6 @@
+upgrade:
+  backup:
+    logfile: /var/log/postgres_upgrade_backup.log
+    directory: /var/tmp/postges_upgrade_backup
+  restore:
+    logfile: /var/log/postgres_upgrade_restore.log

--- a/orchestrator-salt/src/main/resources/salt/pillar/top.sls
+++ b/orchestrator-salt/src/main/resources/salt/pillar/top.sls
@@ -90,6 +90,7 @@ base:
 {%- endif %}
     - gateway.settings
     - postgresql.disaster_recovery
+    - postgresql.upgrade
     - atlas.check_atlas_updated
 
   'roles:knox_gateway':

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/init.sls
@@ -1,3 +1,10 @@
+/opt/salt/scripts/common_utils.sh:
+  file.managed:
+    - makedirs: True
+    - mode: 750
+    - source: salt://postgresql/scripts/common_utils.sh
+    - template: jinja
+
 /opt/salt/scripts/backup_db.sh:
   file.managed:
     - makedirs: True

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/common_utils.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/common_utils.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+doLog() {
+  type_of_msg=$(echo "$@" | cut -d" " -f1)
+  msg=$(echo "$*" | cut -d" " -f2-)
+  [[ $type_of_msg == INFO ]] && type_of_msg="INFO   " # three space for aligning
+  [[ $type_of_msg == WARN ]] && type_of_msg="WARN   " # three space for aligning
+  [[ $type_of_msg == ERROR ]] && type_of_msg="ERROR " # one space for aligning
+
+  # print to the terminal if we have one
+  test -t 1 && echo "$(date "+%Y-%m-%dT%H:%M:%SZ") $type_of_msg ""$msg"
+  echo "$(date "+%Y-%m-%dT%H:%M:%SZ") $type_of_msg ""$msg" >>$LOGFILE
+}
+
+errorExit() {
+  doLog "ERROR $1"
+  exit 1
+}
+
+close_existing_connections() {
+  SERVICE=$1
+  doLog "INFO Closing existing connections to ${SERVICE}"
+  psql --host="$HOST" --port="$PORT" --dbname="postgres" --username="$USERNAME" -c "SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = '${SERVICE}' AND pid <> pg_backend_pid();" > >(tee -a $LOGFILE) 2> >(tee -a $LOGFILE >&2) || errorExit "Unable to close connections to ${SERVICE}"
+}
+
+limit_incomming_connection() {
+  SERVICE=$1
+  COUNT=$2
+  doLog "INFO limit existing connections to ${COUNT}"
+  psql --host="$HOST" --port="$PORT" --dbname="postgres" --username="$USERNAME" -c "alter user ${SERVICE} connection limit ${COUNT};" > >(tee -a $LOGFILE) 2> >(tee -a $LOGFILE >&2) || errorExit "Unable to limit connections to ${SERVICE}"
+}
+
+is_database_exists() {
+  SERVICE=$1
+  doLog "INFO Checking the existence of database ${SERVICE}"
+  database_name=$(psql --host="$HOST" --port="$PORT" --dbname="postgres" --username="$USERNAME" -c "SELECT datname FROM pg_catalog.pg_database WHERE datname = '$SERVICE';" -At > >(tee -a $LOGFILE) 2> >(tee -a $LOGFILE >&2) || errorExit "Unable to check the existence of database $SERVICE")
+  if [[ "$database_name" != "$SERVICE" ]];then
+    return 1
+  fi
+  return 0
+}

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/upgrade/backup.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/upgrade/backup.sls
@@ -1,0 +1,10 @@
+{% set configure_remote_db = salt['pillar.get']('postgres:configure_remote_db', 'None') %}
+
+include:
+  - postgresql.upgrade
+
+backup_postgresql_db:
+  cmd.run:
+    - name: /opt/salt/scripts/backup_db.sh -h {{salt['pillar.get']('postgres:clouderamanager:remote_db_url')}} -p {{salt['pillar.get']('postgres:clouderamanager:remote_db_port')}} -u {{salt['pillar.get']('postgres:clouderamanager:remote_admin')}}
+    - require:
+        - sls: postgresql.upgrade

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/upgrade/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/upgrade/init.sls
@@ -1,0 +1,26 @@
+/opt/salt/scripts/common_utils.sh:
+  file.managed:
+    - makedirs: True
+    - mode: 750
+    - source: salt://postgresql/scripts/common_utils.sh
+    - template: jinja
+
+/opt/salt/scripts/backup_db.sh:
+  file.managed:
+    - makedirs: True
+    - mode: 750
+    - source: salt://postgresql/upgrade/scripts/backup_db.sh
+    - template: jinja
+
+/opt/salt/scripts/restore_db.sh:
+  file.managed:
+    - makedirs: True
+    - mode: 750
+    - source: salt://postgresql/upgrade/scripts/restore_db.sh
+    - template: jinja
+
+set_pgpassword:
+  environ.setenv:
+    - name: PGPASSWORD
+    - value: {{ pillar['postgres']['clouderamanager']['remote_admin_pw'] }}
+    - update_minion: True

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/upgrade/restore.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/upgrade/restore.sls
@@ -1,0 +1,10 @@
+{% set configure_remote_db = salt['pillar.get']('postgres:configure_remote_db', 'None') %}
+
+include:
+  - postgresql.upgrade
+
+restore_postgresql_db:
+  cmd.run:
+    - name: /opt/salt/scripts/restore_db.sh -h {{salt['pillar.get']('postgres:clouderamanager:remote_db_url')}} -p {{salt['pillar.get']('postgres:clouderamanager:remote_db_port')}} -u {{salt['pillar.get']('postgres:clouderamanager:remote_admin')}}
+    - require:
+        - sls: postgresql.upgrade

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/upgrade/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/upgrade/scripts/backup_db.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# backup_db.sh
+# This script is needed as Azure does not support in place RDS upgrade
+# This script:
+#  - creates backup local temp directory
+#  - dumps the global objects and roles to a SQL file with `psql`
+#  - for each service:
+#     - backs up service data in a parallel manner with `pg_dump` to the temp directory
+
+LOGFILE={{salt['pillar.get']('upgrade:backup:logfile')}}
+[ -z "LOGFILE" ] && echo "LOGFILE variable is not defined, check the pillar values!" && exit 1
+echo "Logs at ${LOGFILE}"
+
+source /opt/salt/scripts/common_utils.sh
+
+print_usage() {
+  echo "Script accepts 3 input parameters:"
+  echo "  -h PostgreSQL host name."
+  echo "  -p PostgreSQL port."
+  echo "  -u PostgreSQL user name."
+}
+
+while getopts ":h:p:u:" OPTION; do
+    case $OPTION in
+    h  )
+        HOST="$OPTARG"
+        ;;
+    p  )
+        PORT="$OPTARG"
+        ;;
+    u  )
+        USERNAME="$OPTARG"
+        ;;
+    \? ) echo "Unknown option: -$OPTARG" >&2;
+         print_usage
+         exit 1;;
+    :  ) echo "Missing option argument for -$OPTARG" >&2; exit 1;;
+    esac
+done
+[ -z "$HOST" ] || [ -z "$PORT" ] || [ -z "$USERNAME" ] && echo "At least one mandatory parameter is not set!" && print_usage && exit 1
+
+set -o nounset
+set -o pipefail
+
+exec 3>&1 4>&2
+trap 'exec 2>&4 1>&3' 0 1 2 3
+exec 1> >(tee -a "${LOGFILE}") 2> >(tee -a "${LOGFILE}" >&2)
+
+{%- from 'postgresql/settings.sls' import postgresql with context %}
+{% if postgresql.ssl_enabled == True %}
+export PGSSLROOTCERT="{{ postgresql.root_certs_file }}"
+export PGSSLMODE=verify-full
+{%- endif %}
+
+dump_global_objects() {
+  GLOBAL_OBJECT_BACKUP=${DATE_DIR}/roles.sql
+  doLog "INFO Dumping the global objects from database to ${GLOBAL_OBJECT_BACKUP}"
+  pg_dumpall -r --host="$HOST" --port="$PORT" --username="$USERNAME" --database=postgres > $GLOBAL_OBJECT_BACKUP 2> >(tee -a $LOGFILE >&2) || errorExit "Unable to dump global objects"
+}
+
+backup_database_for_service() {
+  SERVICE="$1"
+
+  is_database_exists $SERVICE
+  if [ "$?" -eq 1 ];then
+    doLog "WARN database for $SERVICE doesn't exists"
+    return 0
+  fi
+
+  limit_incomming_connection $SERVICE 0
+  close_existing_connections $SERVICE
+
+  doLog "INFO Dumping ${SERVICE} ..."
+
+  LOCAL_BACKUP=${DATE_DIR}/${SERVICE}_backup
+  pg_dump -Fd -v  --host="$HOST" --port="$PORT" --username="$USERNAME" --dbname=$SERVICE -j 8 -f $LOCAL_BACKUP > >(tee -a $LOGFILE) 2> >(tee -a $LOGFILE >&2) || errorExit "Unable to dump ${SERVICE}"
+
+  doLog "INFO ${SERVICE} dumped to ${LOCAL_BACKUP} finished"
+
+  limit_incomming_connection $SERVICE -1
+
+}
+
+run_backup() {
+  BACKUPS_DIR="{{salt['pillar.get']('upgrade:backup:directory')}}"
+  [ -z "$BACKUPS_DIR" ] && errorExit "BACKUPS_DIR variable is not defined, check the pillar values!"
+  rm -rfv ${BACKUPS_DIR}/* > >(tee -a $LOGFILE) 2> >(tee -a $LOGFILE >&2)
+  DATE_DIR=${BACKUPS_DIR}/$(date '+%Y-%m-%d_%H:%M:%S')
+  mkdir -p "$DATE_DIR" || error_exit "Could not create local directory for backups."
+
+  dump_global_objects
+  {% for service, values in pillar.get('postgres', {}).items()  %}
+  {% if values['user'] is defined %}
+  backup_database_for_service {{ service }}
+  {% endif %}
+  {% endfor %}
+
+}
+
+doLog "INFO Starting backup"
+run_backup
+doLog "INFO Completed backup"

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/upgrade/scripts/restore_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/upgrade/scripts/restore_db.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# restore_db.sh
+# This script is needed as Azure does not support in place RDS upgrade
+# This script:
+#  - expects the output of a successful backup, in a specific location
+#  - loads the global objects and roles from a SQL file with `psql`,
+#     - if the file does not exist then aborts
+#     - some errors are expected to happen due to already existing objects in the target database
+#  - for each service:
+#     - drops and creates the respective database of the service
+#     - loads the backup data in a parallel manner with `pg_restore`
+#  - if all is successful, then it removes the backup
+
+LOGFILE={{salt['pillar.get']('upgrade:restore:logfile')}}
+[ -z "LOGFILE" ] && echo "LOGFILE variable is not defined, check the pillar values!" && exit 1
+echo "Logs at ${LOGFILE}"
+
+source /opt/salt/scripts/common_utils.sh
+
+print_usage() {
+  echo "Script accepts 3 input parameters:"
+  echo "  -h PostgreSQL host name."
+  echo "  -p PostgreSQL port."
+  echo "  -u PostgreSQL user name."
+}
+
+while getopts ":h:p:u:" OPTION; do
+    case $OPTION in
+    h  )
+        HOST="$OPTARG"
+        ;;
+    p  )
+        PORT="$OPTARG"
+        ;;
+    u  )
+        USERNAME="$OPTARG"
+        ;;
+    \? ) echo "Unknown option: -$OPTARG" >&2;
+         print_usage
+         exit 1;;
+    :  ) echo "Missing option argument for -$OPTARG" >&2; exit 1;;
+    esac
+done
+[ -z "$HOST" ] || [ -z "$PORT" ] || [ -z "$USERNAME" ] && echo "At least one mandatory parameter is not set!" && print_usage && exit 1
+
+set -o nounset
+set -o pipefail
+
+exec 3>&1 4>&2
+trap 'exec 2>&4 1>&3' 0 1 2 3
+exec 1> >(tee -a "${LOGFILE}") 2> >(tee -a "${LOGFILE}" >&2)
+
+BACKUPS_DIR="{{salt['pillar.get']('upgrade:backup:directory')}}"
+[ -z "$BACKUPS_DIR" ] && errorExit "BACKUPS_DIR variable is not defined, check the pillar values!"
+
+{%- from 'postgresql/settings.sls' import postgresql with context %}
+{% if postgresql.ssl_enabled == True %}
+export PGSSLROOTCERT="{{ postgresql.root_certs_file }}"
+export PGSSLMODE=verify-full
+{%- endif %}
+
+restore_global_objects() {
+  GLOBAL_OBJECT_BACKUP="${BACKUP_DIR}"/roles.sql
+  if [ -f "${GLOBAL_OBJECT_BACKUP}" ]; then
+    psql -f ${GLOBAL_OBJECT_BACKUP} --host="$HOST" --port="$PORT" --dbname="postgres" --username="$USERNAME" > >(tee -a $LOGFILE) 2> >(tee -a $LOGFILE >&2) || errorExit "Unable to restore global objects from ${GLOBAL_OBJECT_BACKUP}"
+  else
+      errorExit "INFO Not restoring global objects as ${GLOBAL_OBJECT_BACKUP} does not exist"
+  fi
+}
+
+restore_database_for_service() {
+    SERVICE="$1"
+
+    BACKUP="${BACKUP_DIR}/${SERVICE}_backup"
+
+    if [ -d "$BACKUP" ]; then
+      limit_incomming_connection $SERVICE 0
+      close_existing_connections $SERVICE
+      doLog "INFO Restoring $SERVICE"
+      psql --host="$HOST" --port="$PORT" --dbname="postgres" --username="$USERNAME" -c "drop database ${SERVICE} --if-exists;" > >(tee -a $LOGFILE) 2> >(tee -a $LOGFILE >&2) || errorExit "Unable to drop database ${SERVICE}"
+      psql --host="$HOST" --port="$PORT" --dbname="postgres" --username="$USERNAME" -c "create database ${SERVICE};" > >(tee -a $LOGFILE) 2> >(tee -a $LOGFILE >&2) || errorExit "Unable to re-create database ${SERVICE}"
+      pg_restore -v --host="$HOST" --port="$PORT" --dbname="$SERVICE" --username="$USERNAME" -j 8 ${BACKUP} > >(tee -a $LOGFILE) 2> >(tee -a $LOGFILE >&2) || errorExit "Unable to restore ${SERVICE}"
+      doLog "INFO Successfully restored ${SERVICE}"
+      limit_incomming_connection $SERVICE -1
+  else
+      doLog "INFO Not restoring ${SERVICE} as ${BACKUP} does not exist"
+  fi
+}
+
+run_restore() {
+
+  BACKUP_DIR=$(ls -td $BACKUPS_DIR/*/ | head -1)
+  restore_global_objects
+  {% for service, values in pillar.get('postgres', {}).items()  %}
+  {% if values['user'] is defined %}
+  restore_database_for_service {{ service }}
+  {% endif %}
+  {% endfor %}
+  # TODO: Commented only for test cases, uncomment before feature is released
+  #rm -rfv "$BACKUPS_DIR/*" > >(tee -a $LOGFILE) 2> >(tee -a $LOGFILE >&2)
+
+}
+
+doLog "INFO Initiating restore"
+run_restore
+doLog "INFO Completed restore."


### PR DESCRIPTION
This commit contains 2 scripts and related salt states
 - for dumping and restoring global DB objects
 - for dumping and restoring data parallel

Tested via backing up and restoring into the same RDS instance via the following salt states:
`postgresql.upgrade.backup` and `postgresql.upgrade.restore`

These are needed as Azure does not support in place RDS upgrade

This logic is going to be wired in the near future as part of https://jira.cloudera.com/browse/CB-17316

