### PR TITLE
CB-17440 Remove InternalSdxRepairWithRecipeTest from the GCP E2E suite

### DIFF
--- a/integration-test/src/main/resources/testsuites/e2e/gcp-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/gcp-e2e-tests.yaml
@@ -10,5 +10,3 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXRepairTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXScaleTest
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxImagesTests
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.InternalSdxRepairWithRecipeTest
-


### PR DESCRIPTION
[API E2E GCP Build #1525--2.60.0-b6-GCP (23-Jun-2022 18:09:02)](http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-gcp/1525/) is failing, because of [testSDXMultiRepairIDBRokerAndMasterWithRecipeFile](http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-gcp/1525/testngreports/com.sequenceiq.it.cloudbreak.testcase.e2e.sdx/InternalSdxRepairWithRecipeTest/testSDXMultiRepairIDBRokerAndMasterWithRecipeFile/). 

**This test case is not supported on GCP, because of GCP doesn't support stopping instances with ephemeral storage.**