### PR TITLE
CB-17555: Remove the usage of Entitlement CDP_DATALAKE_BACKUP_ON_RESIZE

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
@@ -40,7 +40,6 @@ import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.CDP_CONCLUS
 import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.CDP_DATAHUB_CUSTOM_CONFIGS;
 import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.CDP_DATAHUB_DATABUS_ENDPOINT_VALIDATION;
 import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.CDP_DATAHUB_NODESTATUS_CHECK;
-import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.CDP_DATALAKE_BACKUP_ON_RESIZE;
 import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.CDP_DATALAKE_BACKUP_ON_UPGRADE;
 import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.CDP_DATALAKE_RESIZE_RECOVERY;
 import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.CDP_DATALAKE_SELECT_INSTANCE_TYPE;
@@ -356,10 +355,6 @@ public class EntitlementService {
 
     public boolean isDatalakeBackupOnUpgradeEnabled(String accountId) {
         return isEntitlementRegistered(accountId, CDP_DATALAKE_BACKUP_ON_UPGRADE);
-    }
-
-    public boolean isDatalakeBackupOnResizeEnabled(String accountId) {
-        return isEntitlementRegistered(accountId, CDP_DATALAKE_BACKUP_ON_RESIZE);
     }
 
     public boolean isDatalakeResizeRecoveryEnabled(String accountId) {

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxReactorFlowManager.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxReactorFlowManager.java
@@ -108,12 +108,8 @@ public class SdxReactorFlowManager {
     public FlowIdentifier triggerSdxResize(Long sdxClusterId, SdxCluster newSdxCluster) {
         LOGGER.info("Trigger Datalake resizing for: {}", sdxClusterId);
         String userId = ThreadBasedUserCrnProvider.getUserCrn();
-        boolean performBackup = sdxBackupRestoreService.shouldSdxBackupBePerformed(
-                newSdxCluster, entitlementService.isDatalakeBackupOnResizeEnabled(ThreadBasedUserCrnProvider.getAccountId())
-        );
-        boolean performRestore = sdxBackupRestoreService.shouldSdxRestoreBePerformed(
-                newSdxCluster, entitlementService.isDatalakeBackupOnResizeEnabled(ThreadBasedUserCrnProvider.getAccountId())
-        );
+        boolean performBackup = sdxBackupRestoreService.shouldSdxBackupBePerformed(newSdxCluster);
+        boolean performRestore = sdxBackupRestoreService.shouldSdxRestoreBePerformed(newSdxCluster);
         eventSenderService.sendEventAndNotification(newSdxCluster, userId, DATALAKE_RESIZE_TRIGGERED);
         return notify(SDX_RESIZE_FLOW_CHAIN_START_EVENT, new DatalakeResizeFlowChainStartEvent(sdxClusterId, newSdxCluster, userId,
                 environmentClientService.getBackupLocation(newSdxCluster.getEnvCrn()), performBackup, performRestore), newSdxCluster.getClusterName());

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/dr/SdxBackupRestoreService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/dr/SdxBackupRestoreService.java
@@ -517,6 +517,16 @@ public class SdxBackupRestoreService {
      * Checks if Sdx backup can be performed.
      *
      * @param cluster Sdx cluster.
+     * @return true if backup can be performed, False otherwise.
+     */
+    public boolean shouldSdxBackupBePerformed(SdxCluster cluster) {
+        return shouldSdxBackupBePerformed(cluster, true);
+    }
+
+    /**
+     * Checks if Sdx backup can be performed.
+     *
+     * @param cluster Sdx cluster.
      * @param entitlementEnabled Whether the entitlement required for backups with this operation is enabled.
      * @return true if backup can be performed, False otherwise.
      */
@@ -549,6 +559,16 @@ public class SdxBackupRestoreService {
             return false;
         }
         return true;
+    }
+
+    /**
+     * Checks if Sdx restore can be performed.
+     *
+     * @param cluster Sdx cluster.
+     * @return true if restore can be performed, False otherwise.
+     */
+    public boolean shouldSdxRestoreBePerformed(SdxCluster cluster) {
+        return shouldSdxRestoreBePerformed(cluster, true);
     }
 
     /**


### PR DESCRIPTION
Currently backup on resize is under an entitlement. This might get us into a bad situation if the customer is not granted this entitlement but is granted entitlement to resize.

 

Resize is performed but the data will be lost. Having an entitlement would be of value if we have a validation to check if there was a backup that is available to restore from.

As such logic is not available we should not have a situation where back might be skipped.