### PR TITLE
CB-17217 Integrate `consumption` into `datalake` (create & terminate)

### DIFF
--- a/datalake/build.gradle
+++ b/datalake/build.gradle
@@ -51,6 +51,7 @@ dependencies {
   implementation project(':idbmms-connector')
   implementation project(':datalake-dr-connector')
 
+  implementation project(":cloud-consumption-api")
   implementation project(':core-api')
   implementation project(':datalake-api')
   implementation project(':environment-api')

--- a/datalake/src/main/java/com/sequenceiq/datalake/configuration/ConsumptionApiConfig.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/configuration/ConsumptionApiConfig.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.datalake.configuration;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.sequenceiq.consumption.client.internal.ConsumptionApiClientParams;
+
+@Configuration
+public class ConsumptionApiConfig {
+
+    @Value("${rest.debug:false}")
+    private boolean restDebug;
+
+    @Value("${cert.validation:true}")
+    private boolean certificateValidation;
+
+    @Value("${cert.ignorePreValidation:true}")
+    private boolean ignorePreValidation;
+
+    @Inject
+    @Named("consumptionServerUrl")
+    private String consumptionServerUrl;
+
+    @Bean
+    public ConsumptionApiClientParams consumptionApiClientParams() {
+        return new ConsumptionApiClientParams(restDebug, certificateValidation, ignorePreValidation, consumptionServerUrl);
+    }
+
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/configuration/ConsumptionInternalClientConfiguration.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/configuration/ConsumptionInternalClientConfiguration.java
@@ -1,0 +1,42 @@
+package com.sequenceiq.datalake.configuration;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGenerator;
+import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
+import com.sequenceiq.consumption.client.ConsumptionInternalCrnClient;
+import com.sequenceiq.consumption.client.ConsumptionServiceUserCrnClient;
+import com.sequenceiq.consumption.client.ConsumptionServiceUserCrnClientBuilder;
+
+@Configuration
+public class ConsumptionInternalClientConfiguration {
+
+    @Inject
+    @Named("consumptionServerUrl")
+    private String consumptionServerUrl;
+
+    @Inject
+    private RegionAwareInternalCrnGeneratorFactory regionAwareInternalCrnGeneratorFactory;
+
+    private ConsumptionServiceUserCrnClient consumptionClient() {
+        return new ConsumptionServiceUserCrnClientBuilder(consumptionServerUrl)
+                .withCertificateValidation(false)
+                .withIgnorePreValidation(true)
+                .withDebug(true)
+                .build();
+    }
+
+    private RegionAwareInternalCrnGenerator internalCrnBuilder() {
+        return regionAwareInternalCrnGeneratorFactory.iam();
+    }
+
+    @Bean
+    public ConsumptionInternalCrnClient consumptionInternalCrnClient() {
+        return new ConsumptionInternalCrnClient(consumptionClient(), internalCrnBuilder());
+    }
+
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/configuration/ServiceEndpointConfig.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/configuration/ServiceEndpointConfig.java
@@ -60,6 +60,15 @@ public class ServiceEndpointConfig {
     @Value("${datalake.freeipa.serviceId:}")
     private String freeipaServiceId;
 
+    @Value("${datalake.consumption.url:}")
+    private String consumptionServiceUrl;
+
+    @Value("${datalake.consumption.serviceId:}")
+    private String consumptionServiceId;
+
+    @Value("${datalake.consumption.contextPath}")
+    private String consumptionRootContextPath;
+
     @Bean
     public ServiceAddressResolver serviceAddressResolver() {
         return new RetryingServiceAddressResolver(new DNSServiceAddressResolver(), resolvingTimeout);
@@ -93,5 +102,10 @@ public class ServiceEndpointConfig {
     @DependsOn("serviceAddressResolver")
     public String freeIpaServerUrl(ServiceAddressResolver serviceAddressResolver) throws ServiceAddressResolvingException {
         return serviceAddressResolver.resolveUrl(freeipaServiceUrl + freeipaRootContextPath, "http", freeipaServiceId);
+    }
+
+    @Bean
+    public String consumptionServerUrl() throws ServiceAddressResolvingException {
+        return serviceAddressResolver().resolveUrl(consumptionServiceUrl + consumptionRootContextPath, "http", consumptionServiceId);
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/create/handler/EnvWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/create/handler/EnvWaitHandler.java
@@ -1,6 +1,6 @@
 package com.sequenceiq.datalake.flow.create.handler;
 
-import javax.inject.Inject;
+import static com.sequenceiq.cloudbreak.common.exception.NotFoundException.notFound;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,6 +15,8 @@ import com.sequenceiq.datalake.entity.DatalakeStatusEnum;
 import com.sequenceiq.datalake.flow.create.event.EnvWaitRequest;
 import com.sequenceiq.datalake.flow.create.event.EnvWaitSuccessEvent;
 import com.sequenceiq.datalake.flow.create.event.SdxCreateFailedEvent;
+import com.sequenceiq.datalake.repository.SdxClusterRepository;
+import com.sequenceiq.datalake.service.consumption.ConsumptionService;
 import com.sequenceiq.datalake.service.sdx.EnvironmentService;
 import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
@@ -28,14 +30,24 @@ public class EnvWaitHandler extends ExceptionCatcherEventHandler<EnvWaitRequest>
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EnvWaitHandler.class);
 
-    @Value("${sdx.environment.duration_min:60}")
-    private int durationInMinutes;
+    private final int durationInMinutes;
 
-    @Inject
-    private EnvironmentService environmentService;
+    private final EnvironmentService environmentService;
 
-    @Inject
-    private SdxStatusService sdxStatusService;
+    private final SdxStatusService sdxStatusService;
+
+    private final SdxClusterRepository sdxClusterRepository;
+
+    private final ConsumptionService consumptionService;
+
+    public EnvWaitHandler(@Value("${sdx.environment.duration_min:60}") int durationInMinutes, EnvironmentService environmentService,
+            SdxStatusService sdxStatusService, SdxClusterRepository sdxClusterRepository, ConsumptionService consumptionService) {
+        this.durationInMinutes = durationInMinutes;
+        this.environmentService = environmentService;
+        this.sdxStatusService = sdxStatusService;
+        this.sdxClusterRepository = sdxClusterRepository;
+        this.consumptionService = consumptionService;
+    }
 
     @Override
     public String selector() {
@@ -56,20 +68,27 @@ public class EnvWaitHandler extends ExceptionCatcherEventHandler<EnvWaitRequest>
         try {
             LOGGER.debug("start polling env for sdx: {}", datalakeId);
             DetailedEnvironmentResponse detailedEnvironmentResponse = environmentService.waitAndGetEnvironment(datalakeId);
+
+            sdxClusterRepository.findById(datalakeId)
+                    .ifPresentOrElse(consumptionService::scheduleStorageConsumptionCollectionIfNeeded,
+                            () -> {
+                                throw notFound("SDX cluster", datalakeId).get();
+                            });
+
             response = new EnvWaitSuccessEvent(datalakeId, userId, detailedEnvironmentResponse);
             setEnvCreatedStatus(datalakeId);
         } catch (UserBreakException userBreakException) {
             LOGGER.error("Env polling exited before timeout. Cause: ", userBreakException);
             response = new SdxCreateFailedEvent(datalakeId, userId, userBreakException);
         } catch (PollerStoppedException pollerStoppedException) {
-            LOGGER.error("Env poller stopped for sdx: {}", datalakeId, pollerStoppedException);
+            LOGGER.error("Env poller stopped for SDX: {}", datalakeId, pollerStoppedException);
             response = new SdxCreateFailedEvent(datalakeId, userId,
                     new PollerStoppedException("Env wait timed out after " + durationInMinutes + " minutes"));
         } catch (PollerException exception) {
-            LOGGER.error("Env polling failed for sdx: {}", datalakeId, exception);
+            LOGGER.error("Env polling failed for SDX: {}", datalakeId, exception);
             response = new SdxCreateFailedEvent(datalakeId, userId, exception);
         } catch (Exception anotherException) {
-            LOGGER.error("Something wrong happened in sdx creation wait phase", anotherException);
+            LOGGER.error("Something wrong happened in SDX creation wait phase", anotherException);
             response = new SdxCreateFailedEvent(datalakeId, userId, anotherException);
         }
         return response;
@@ -78,4 +97,5 @@ public class EnvWaitHandler extends ExceptionCatcherEventHandler<EnvWaitRequest>
     private void setEnvCreatedStatus(Long datalakeId) {
         sdxStatusService.setStatusForDatalakeAndNotify(DatalakeStatusEnum.ENVIRONMENT_CREATED, "Environment created", datalakeId);
     }
+
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/consumption/ConsumptionClientService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/consumption/ConsumptionClientService.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.environment.environment.service.consumption;
+package com.sequenceiq.datalake.service.consumption;
 
 import javax.ws.rs.WebApplicationException;
 
@@ -9,18 +9,17 @@ import org.springframework.stereotype.Service;
 import com.sequenceiq.cloudbreak.common.exception.WebApplicationExceptionMessageExtractor;
 import com.sequenceiq.consumption.api.v1.consumption.model.request.StorageConsumptionRequest;
 import com.sequenceiq.consumption.client.ConsumptionInternalCrnClient;
-import com.sequenceiq.environment.exception.ConsumptionOperationFailedException;
 
 @Service
-public class ConsumptionService {
+public class ConsumptionClientService {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ConsumptionService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConsumptionClientService.class);
 
     private final ConsumptionInternalCrnClient consumptionInternalCrnClient;
 
     private final WebApplicationExceptionMessageExtractor webApplicationExceptionMessageExtractor;
 
-    public ConsumptionService(ConsumptionInternalCrnClient consumptionInternalCrnClient,
+    public ConsumptionClientService(ConsumptionInternalCrnClient consumptionInternalCrnClient,
             WebApplicationExceptionMessageExtractor webApplicationExceptionMessageExtractor) {
         this.consumptionInternalCrnClient = consumptionInternalCrnClient;
         this.webApplicationExceptionMessageExtractor = webApplicationExceptionMessageExtractor;

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/consumption/ConsumptionOperationFailedException.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/consumption/ConsumptionOperationFailedException.java
@@ -1,0 +1,13 @@
+package com.sequenceiq.datalake.service.consumption;
+
+public class ConsumptionOperationFailedException extends RuntimeException {
+
+    public ConsumptionOperationFailedException(String message) {
+        super(message);
+    }
+
+    public ConsumptionOperationFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/consumption/ConsumptionService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/consumption/ConsumptionService.java
@@ -1,0 +1,90 @@
+package com.sequenceiq.datalake.service.consumption;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.google.common.base.Strings;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.consumption.api.v1.consumption.model.common.ResourceType;
+import com.sequenceiq.consumption.api.v1.consumption.model.request.StorageConsumptionRequest;
+import com.sequenceiq.datalake.entity.SdxCluster;
+
+@Service
+public class ConsumptionService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConsumptionService.class);
+
+    private final EntitlementService entitlementService;
+
+    private final ConsumptionClientService consumptionClientService;
+
+    private final boolean consumptionEnabled;
+
+    public ConsumptionService(EntitlementService entitlementService, ConsumptionClientService consumptionClientService,
+            @Value("${datalake.consumption.enabled:false}") boolean consumptionEnabled) {
+        this.entitlementService = entitlementService;
+        this.consumptionClientService = consumptionClientService;
+        this.consumptionEnabled = consumptionEnabled;
+    }
+
+    public void scheduleStorageConsumptionCollectionIfNeeded(SdxCluster sdxCluster) {
+        String accountId = sdxCluster.getAccountId();
+        if (consumptionEnabled && entitlementService.isCdpSaasEnabled(accountId)) {
+            scheduleStorageConsumptionCollection(sdxCluster);
+        } else {
+            LOGGER.info("Skipping storage consumption collection scheduling because " +
+                    (consumptionEnabled ? String.format("CDP_SAAS entitlement is missing for account '%s'", accountId) : "it is disabled for the deployment"));
+        }
+    }
+
+    private void scheduleStorageConsumptionCollection(SdxCluster sdxCluster) {
+        String storageBaseLocation = sdxCluster.getCloudStorageBaseLocation();
+        if (!Strings.isNullOrEmpty(storageBaseLocation)) {
+            scheduleStorageConsumptionCollectionForStorageLocation(sdxCluster, storageBaseLocation);
+        } else {
+            LOGGER.warn("Skipping storage consumption collection scheduling for storage base location because it is not provided: " +
+                            "cloudStorageBaseLocation='{}'", storageBaseLocation);
+        }
+    }
+
+    private void scheduleStorageConsumptionCollectionForStorageLocation(SdxCluster sdxCluster, String storageLocation) {
+        StorageConsumptionRequest request = new StorageConsumptionRequest();
+        request.setEnvironmentCrn(sdxCluster.getEnvCrn());
+        request.setMonitoredResourceCrn(sdxCluster.getResourceCrn());
+        request.setMonitoredResourceName(sdxCluster.getName());
+        request.setMonitoredResourceType(ResourceType.DATALAKE);
+        request.setStorageLocation(storageLocation);
+        String accountId = sdxCluster.getAccountId();
+        LOGGER.info("Executing storage consumption collection scheduling for storage base location: account '{}' and request '{}'", accountId, request);
+        consumptionClientService.scheduleStorageConsumptionCollection(accountId, request);
+    }
+
+    public void unscheduleStorageConsumptionCollectionIfNeeded(SdxCluster sdxCluster) {
+        String accountId = sdxCluster.getAccountId();
+        if (consumptionEnabled && entitlementService.isCdpSaasEnabled(accountId)) {
+            unscheduleStorageConsumptionCollection(sdxCluster);
+        } else {
+            LOGGER.info("Skipping storage consumption collection unscheduling because " +
+                    (consumptionEnabled ? String.format("CDP_SAAS entitlement is missing for account '%s'", accountId) : "it is disabled for the deployment"));
+        }
+    }
+
+    private void unscheduleStorageConsumptionCollection(SdxCluster sdxCluster) {
+        String storageBaseLocation = sdxCluster.getCloudStorageBaseLocation();
+        if (!Strings.isNullOrEmpty(storageBaseLocation)) {
+            unscheduleStorageConsumptionCollectionForStorageLocation(sdxCluster.getAccountId(), sdxCluster.getResourceCrn(), storageBaseLocation);
+        } else {
+            LOGGER.warn("Skipping storage consumption collection unscheduling for storage base location because it is not provided: " +
+                            "cloudStorageBaseLocation='{}'", storageBaseLocation);
+        }
+    }
+
+    private void unscheduleStorageConsumptionCollectionForStorageLocation(String accountId, String monitoredResourceCrn, String storageLocation) {
+        LOGGER.info("Executing storage consumption collection unscheduling for storage base location: account '{}', resource '{}' and storage location '{}'",
+                accountId, monitoredResourceCrn, storageLocation);
+        consumptionClientService.unscheduleStorageConsumptionCollection(accountId, monitoredResourceCrn, storageLocation);
+    }
+
+}

--- a/datalake/src/main/resources/application.yml
+++ b/datalake/src/main/resources/application.yml
@@ -101,6 +101,10 @@ datalake:
   freeipa:
     url: http://localhost:8090
     contextPath: /freeipa
+  consumption:
+    url: http://localhost:8099
+    contextPath: /consumption
+    enabled: false
   db:
     port.5432.tcp:
       port: 5432

--- a/datalake/src/test/java/com/sequenceiq/datalake/flow/create/handler/EnvWaitHandlerTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/flow/create/handler/EnvWaitHandlerTest.java
@@ -1,0 +1,214 @@
+package com.sequenceiq.datalake.flow.create.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.dyngr.exception.PollerException;
+import com.dyngr.exception.PollerStoppedException;
+import com.dyngr.exception.UserBreakException;
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
+import com.sequenceiq.datalake.entity.DatalakeStatusEnum;
+import com.sequenceiq.datalake.entity.SdxCluster;
+import com.sequenceiq.datalake.flow.create.event.EnvWaitRequest;
+import com.sequenceiq.datalake.flow.create.event.EnvWaitSuccessEvent;
+import com.sequenceiq.datalake.flow.create.event.SdxCreateFailedEvent;
+import com.sequenceiq.datalake.repository.SdxClusterRepository;
+import com.sequenceiq.datalake.service.consumption.ConsumptionService;
+import com.sequenceiq.datalake.service.sdx.EnvironmentService;
+import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
+import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
+
+import reactor.bus.Event;
+
+@ExtendWith(MockitoExtension.class)
+class EnvWaitHandlerTest {
+
+    private static final int DURATION_IN_MINUTES = 15;
+
+    private static final long DATALAKE_ID = 12L;
+
+    private static final String USER_ID = "userId";
+
+    private static final String ACCOUNT_ID = "accountId";
+
+    private static final String ENVIRONMENT_CRN = "environmentCrn";
+
+    private static final String DATALAKE_CRN = "datalakeCrn";
+
+    @Mock
+    private EnvironmentService environmentService;
+
+    @Mock
+    private SdxStatusService sdxStatusService;
+
+    @Mock
+    private SdxClusterRepository sdxClusterRepository;
+
+    @Mock
+    private ConsumptionService consumptionService;
+
+    private EnvWaitHandler underTest;
+
+    @Mock
+    private Event<EnvWaitRequest> event;
+
+    @Mock
+    private HandlerEvent<EnvWaitRequest> handlerEvent;
+
+    private DetailedEnvironmentResponse detailedEnvironmentResponse;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new EnvWaitHandler(DURATION_IN_MINUTES, environmentService, sdxStatusService, sdxClusterRepository, consumptionService);
+
+        lenient().when(handlerEvent.getData()).thenReturn(new EnvWaitRequest(DATALAKE_ID, USER_ID));
+
+        detailedEnvironmentResponse = new DetailedEnvironmentResponse();
+    }
+
+    @Test
+    void selectorTest() {
+        assertThat(underTest.selector()).isEqualTo("EnvWaitRequest");
+    }
+
+    @Test
+    void defaultFailureEventTest() {
+        UnsupportedOperationException exception = new UnsupportedOperationException("Bang!");
+
+        Selectable result = underTest.defaultFailureEvent(DATALAKE_ID, exception, event);
+
+        verifyFailedEvent(result, null, exception);
+    }
+
+    private void verifyFailedEvent(Selectable result, String userIdExpected, Exception exceptionExpected) {
+        verifyFailedEventInternal(result, userIdExpected, exceptionExpected, null, null);
+    }
+
+    private <E extends Exception> void verifyFailedEvent(Selectable result, String userIdExpected, Class<E> exceptionClassExpected,
+            String exceptionMessageExpected) {
+        verifyFailedEventInternal(result, userIdExpected, null, exceptionClassExpected, exceptionMessageExpected);
+    }
+
+    private <E extends Exception> void verifyFailedEventInternal(Selectable result, String userIdExpected, Exception exceptionExpected,
+            Class<E> exceptionClassExpected, String exceptionMessageExpected) {
+        assertThat(result).isInstanceOf(SdxCreateFailedEvent.class);
+
+        SdxCreateFailedEvent sdxCreateFailedEvent = (SdxCreateFailedEvent) result;
+        assertThat(sdxCreateFailedEvent.getResourceId()).isEqualTo(DATALAKE_ID);
+        assertThat(sdxCreateFailedEvent.getUserId()).isEqualTo(userIdExpected);
+        if (exceptionExpected != null) {
+            assertThat(sdxCreateFailedEvent.getException()).isSameAs(exceptionExpected);
+        } else {
+            assertThat(sdxCreateFailedEvent.getException()).isInstanceOf(exceptionClassExpected);
+            assertThat(sdxCreateFailedEvent.getException()).hasMessage(exceptionMessageExpected);
+        }
+        assertThat(sdxCreateFailedEvent.getSdxName()).isNull();
+    }
+
+    @Test
+    void doAcceptTestErrorWhenUserBreakException() {
+        UserBreakException userBreakException = new UserBreakException("Problem");
+        when(environmentService.waitAndGetEnvironment(DATALAKE_ID)).thenThrow(userBreakException);
+
+        Selectable result = underTest.doAccept(handlerEvent);
+
+        verifyFailedEvent(result, USER_ID, userBreakException);
+        verify(sdxClusterRepository, never()).findById(anyLong());
+        verify(consumptionService, never()).scheduleStorageConsumptionCollectionIfNeeded(any(SdxCluster.class));
+    }
+
+    @Test
+    void doAcceptTestErrorWhenPollerStoppedException() {
+        PollerStoppedException pollerStoppedException = new PollerStoppedException("Problem");
+        when(environmentService.waitAndGetEnvironment(DATALAKE_ID)).thenThrow(pollerStoppedException);
+
+        Selectable result = underTest.doAccept(handlerEvent);
+
+        verifyFailedEvent(result, USER_ID, PollerStoppedException.class, "Env wait timed out after 15 minutes");
+        verify(sdxClusterRepository, never()).findById(anyLong());
+        verify(consumptionService, never()).scheduleStorageConsumptionCollectionIfNeeded(any(SdxCluster.class));
+    }
+
+    @Test
+    void doAcceptTestErrorWhenPollerException() {
+        PollerException pollerException = new PollerException("Problem");
+        when(environmentService.waitAndGetEnvironment(DATALAKE_ID)).thenThrow(pollerException);
+
+        Selectable result = underTest.doAccept(handlerEvent);
+
+        verifyFailedEvent(result, USER_ID, pollerException);
+        verify(sdxClusterRepository, never()).findById(anyLong());
+        verify(consumptionService, never()).scheduleStorageConsumptionCollectionIfNeeded(any(SdxCluster.class));
+    }
+
+    @Test
+    void doAcceptTestErrorWhenOtherException() {
+        IllegalStateException exception = new IllegalStateException("Problem");
+        when(environmentService.waitAndGetEnvironment(DATALAKE_ID)).thenThrow(exception);
+
+        Selectable result = underTest.doAccept(handlerEvent);
+
+        verifyFailedEvent(result, USER_ID, exception);
+        verify(sdxClusterRepository, never()).findById(anyLong());
+        verify(consumptionService, never()).scheduleStorageConsumptionCollectionIfNeeded(any(SdxCluster.class));
+    }
+
+    @Test
+    void doAcceptTestErrorWhenSdxClusterAbsent() {
+        when(environmentService.waitAndGetEnvironment(DATALAKE_ID)).thenReturn(detailedEnvironmentResponse);
+        when(sdxClusterRepository.findById(DATALAKE_ID)).thenReturn(Optional.empty());
+
+        Selectable result = underTest.doAccept(handlerEvent);
+
+        verifyFailedEvent(result, USER_ID, NotFoundException.class, "SDX cluster '12' not found.");
+        verify(environmentService).waitAndGetEnvironment(DATALAKE_ID);
+        verify(consumptionService, never()).scheduleStorageConsumptionCollectionIfNeeded(any(SdxCluster.class));
+    }
+
+    @Test
+    void doAcceptTestExecuteConsumption() {
+        when(environmentService.waitAndGetEnvironment(DATALAKE_ID)).thenReturn(detailedEnvironmentResponse);
+        SdxCluster sdxCluster = sdxCluster();
+        when(sdxClusterRepository.findById(DATALAKE_ID)).thenReturn(Optional.of(sdxCluster));
+
+        Selectable result = underTest.doAccept(handlerEvent);
+
+        verifySuccessEvent(result);
+        verify(sdxStatusService).setStatusForDatalakeAndNotify(DatalakeStatusEnum.ENVIRONMENT_CREATED, "Environment created", DATALAKE_ID);
+        verify(consumptionService).scheduleStorageConsumptionCollectionIfNeeded(sdxCluster);
+    }
+
+    private SdxCluster sdxCluster() {
+        SdxCluster sdxCluster = new SdxCluster();
+        sdxCluster.setAccountId(ACCOUNT_ID);
+        sdxCluster.setEnvCrn(ENVIRONMENT_CRN);
+        sdxCluster.setCrn(DATALAKE_CRN);
+        return sdxCluster;
+    }
+
+    private void verifySuccessEvent(Selectable result) {
+        assertThat(result).isInstanceOf(EnvWaitSuccessEvent.class);
+
+        EnvWaitSuccessEvent envWaitSuccessEvent = (EnvWaitSuccessEvent) result;
+        assertThat(envWaitSuccessEvent.getResourceId()).isEqualTo(DATALAKE_ID);
+        assertThat(envWaitSuccessEvent.getUserId()).isEqualTo(USER_ID);
+        assertThat(envWaitSuccessEvent.getDetailedEnvironmentResponse()).isEqualTo(detailedEnvironmentResponse);
+        assertThat(envWaitSuccessEvent.getSdxName()).isNull();
+    }
+
+}

--- a/datalake/src/test/java/com/sequenceiq/datalake/flow/delete/handler/RdsDeletionHandlerTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/flow/delete/handler/RdsDeletionHandlerTest.java
@@ -1,0 +1,356 @@
+package com.sequenceiq.datalake.flow.delete.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.dyngr.exception.PollerException;
+import com.dyngr.exception.PollerStoppedException;
+import com.dyngr.exception.UserBreakException;
+import com.sequenceiq.authorization.service.OwnerAssignmentService;
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.datalake.entity.DatalakeStatusEnum;
+import com.sequenceiq.datalake.entity.SdxCluster;
+import com.sequenceiq.datalake.flow.delete.event.RdsDeletionSuccessEvent;
+import com.sequenceiq.datalake.flow.delete.event.RdsDeletionWaitRequest;
+import com.sequenceiq.datalake.flow.delete.event.SdxDeletionFailedEvent;
+import com.sequenceiq.datalake.repository.SdxClusterRepository;
+import com.sequenceiq.datalake.service.consumption.ConsumptionService;
+import com.sequenceiq.datalake.service.sdx.database.DatabaseService;
+import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
+import com.sequenceiq.sdx.api.model.SdxDatabaseAvailabilityType;
+
+import reactor.bus.Event;
+
+@ExtendWith(MockitoExtension.class)
+class RdsDeletionHandlerTest {
+
+    private static final int DURATION_IN_MINUTES = 15;
+
+    private static final long DATALAKE_ID = 12L;
+
+    private static final String USER_ID = "userId";
+
+    private static final String DATALAKE_CRN = "datalakeCrn";
+
+    private static final String REQUEST_ID = "requestId";
+
+    private static final String DATABASE_CRN = "databaseCrn";
+
+    private static final String EMPTY_DATABASE_CRN = "";
+
+    @Mock
+    private SdxClusterRepository sdxClusterRepository;
+
+    @Mock
+    private DatabaseService databaseService;
+
+    @Mock
+    private SdxStatusService sdxStatusService;
+
+    @Mock
+    private OwnerAssignmentService ownerAssignmentService;
+
+    @Mock
+    private ConsumptionService consumptionService;
+
+    private RdsDeletionHandler underTest;
+
+    @Mock
+    private Event<RdsDeletionWaitRequest> event;
+
+    @Mock
+    private HandlerEvent<RdsDeletionWaitRequest> handlerEvent;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new RdsDeletionHandler(DURATION_IN_MINUTES, sdxClusterRepository, databaseService, sdxStatusService, ownerAssignmentService,
+                consumptionService);
+
+        MDCBuilder.addRequestId(REQUEST_ID);
+    }
+
+    @Test
+    void selectorTest() {
+        assertThat(underTest.selector()).isEqualTo("RdsDeletionWaitRequest");
+    }
+
+    @ParameterizedTest(name = "forceDelete={0}")
+    @ValueSource(booleans = {false, true})
+    void defaultFailureEventTest(boolean forceDelete) {
+        UnsupportedOperationException exception = new UnsupportedOperationException("Bang!");
+        RdsDeletionWaitRequest rdsDeletionWaitRequest = new RdsDeletionWaitRequest(DATALAKE_ID, USER_ID, forceDelete);
+        when(event.getData()).thenReturn(rdsDeletionWaitRequest);
+
+        Selectable result = underTest.defaultFailureEvent(DATALAKE_ID, exception, event);
+
+        verifyFailedEvent(result, null, exception, forceDelete);
+    }
+
+    private void verifyFailedEvent(Selectable result, String userIdExpected, Exception exceptionExpected, boolean forceDeleteExpected) {
+        verifyFailedEventInternal(result, userIdExpected, exceptionExpected, null, null, forceDeleteExpected);
+    }
+
+    private <E extends Exception> void verifyFailedEvent(Selectable result, String userIdExpected, Class<E> exceptionClassExpected,
+            String exceptionMessageExpected, boolean forceDeleteExpected) {
+        verifyFailedEventInternal(result, userIdExpected, null, exceptionClassExpected, exceptionMessageExpected, forceDeleteExpected);
+    }
+
+    private <E extends Exception> void verifyFailedEventInternal(Selectable result, String userIdExpected, Exception exceptionExpected,
+            Class<E> exceptionClassExpected, String exceptionMessageExpected, boolean forceDeleteExpected) {
+        assertThat(result).isInstanceOf(SdxDeletionFailedEvent.class);
+
+        SdxDeletionFailedEvent sdxDeletionFailedEvent = (SdxDeletionFailedEvent) result;
+        assertThat(sdxDeletionFailedEvent.getResourceId()).isEqualTo(DATALAKE_ID);
+        assertThat(sdxDeletionFailedEvent.getUserId()).isEqualTo(userIdExpected);
+        if (exceptionExpected != null) {
+            assertThat(sdxDeletionFailedEvent.getException()).isSameAs(exceptionExpected);
+        } else {
+            assertThat(sdxDeletionFailedEvent.getException()).isInstanceOf(exceptionClassExpected);
+            assertThat(sdxDeletionFailedEvent.getException()).hasMessage(exceptionMessageExpected);
+        }
+        assertThat(sdxDeletionFailedEvent.getSdxName()).isNull();
+        assertThat(sdxDeletionFailedEvent.isForced()).isEqualTo(forceDeleteExpected);
+    }
+
+    @ParameterizedTest(name = "forceDelete={0}")
+    @ValueSource(booleans = {false, true})
+    void doAcceptTestErrorWhenUserBreakException(boolean forceDelete) {
+        initHandlerEvent(forceDelete);
+        UserBreakException userBreakException = new UserBreakException("Problem");
+        when(sdxClusterRepository.findById(DATALAKE_ID)).thenThrow(userBreakException);
+
+        Selectable result = underTest.doAccept(handlerEvent);
+
+        verifyFailedEvent(result, USER_ID, userBreakException, forceDelete);
+        verify(consumptionService, never()).unscheduleStorageConsumptionCollectionIfNeeded(any(SdxCluster.class));
+        verify(databaseService, never()).terminate(any(SdxCluster.class), anyBoolean());
+        verify(sdxStatusService, never()).setStatusForDatalakeAndNotify(any(DatalakeStatusEnum.class), anyString(), any(SdxCluster.class));
+        verify(ownerAssignmentService, never()).notifyResourceDeleted(anyString(), any(Optional.class));
+    }
+
+    private void initHandlerEvent(boolean forceDelete) {
+        when(handlerEvent.getData()).thenReturn(new RdsDeletionWaitRequest(DATALAKE_ID, USER_ID, forceDelete));
+    }
+
+    @ParameterizedTest(name = "forceDelete={0}")
+    @ValueSource(booleans = {false, true})
+    void doAcceptTestErrorWhenPollerStoppedException(boolean forceDelete) {
+        initHandlerEvent(forceDelete);
+        PollerStoppedException pollerStoppedException = new PollerStoppedException("Problem");
+        when(sdxClusterRepository.findById(DATALAKE_ID)).thenThrow(pollerStoppedException);
+
+        Selectable result = underTest.doAccept(handlerEvent);
+
+        verifyFailedEvent(result, USER_ID, PollerStoppedException.class, "Database deletion timed out after 15 minutes", forceDelete);
+        verify(consumptionService, never()).unscheduleStorageConsumptionCollectionIfNeeded(any(SdxCluster.class));
+        verify(databaseService, never()).terminate(any(SdxCluster.class), anyBoolean());
+        verify(sdxStatusService, never()).setStatusForDatalakeAndNotify(any(DatalakeStatusEnum.class), anyString(), any(SdxCluster.class));
+        verify(ownerAssignmentService, never()).notifyResourceDeleted(anyString(), any(Optional.class));
+    }
+
+    @ParameterizedTest(name = "forceDelete={0}")
+    @ValueSource(booleans = {false, true})
+    void doAcceptTestErrorWhenPollerException(boolean forceDelete) {
+        initHandlerEvent(forceDelete);
+        PollerException pollerException = new PollerException("Problem");
+        when(sdxClusterRepository.findById(DATALAKE_ID)).thenThrow(pollerException);
+
+        Selectable result = underTest.doAccept(handlerEvent);
+
+        verifyFailedEvent(result, USER_ID, pollerException, forceDelete);
+        verify(consumptionService, never()).unscheduleStorageConsumptionCollectionIfNeeded(any(SdxCluster.class));
+        verify(databaseService, never()).terminate(any(SdxCluster.class), anyBoolean());
+        verify(sdxStatusService, never()).setStatusForDatalakeAndNotify(any(DatalakeStatusEnum.class), anyString(), any(SdxCluster.class));
+        verify(ownerAssignmentService, never()).notifyResourceDeleted(anyString(), any(Optional.class));
+    }
+
+    @ParameterizedTest(name = "forceDelete={0}")
+    @ValueSource(booleans = {false, true})
+    void doAcceptTestErrorWhenOtherException(boolean forceDelete) {
+        initHandlerEvent(forceDelete);
+        IllegalStateException exception = new IllegalStateException("Problem");
+        when(sdxClusterRepository.findById(DATALAKE_ID)).thenThrow(exception);
+
+        Selectable result = underTest.doAccept(handlerEvent);
+
+        verifyFailedEvent(result, USER_ID, exception, forceDelete);
+        verify(consumptionService, never()).unscheduleStorageConsumptionCollectionIfNeeded(any(SdxCluster.class));
+        verify(databaseService, never()).terminate(any(SdxCluster.class), anyBoolean());
+        verify(sdxStatusService, never()).setStatusForDatalakeAndNotify(any(DatalakeStatusEnum.class), anyString(), any(SdxCluster.class));
+        verify(ownerAssignmentService, never()).notifyResourceDeleted(anyString(), any(Optional.class));
+    }
+
+    @ParameterizedTest(name = "forceDelete={0}")
+    @ValueSource(booleans = {false, true})
+    void doAcceptTestSkipTerminateAndConsumptionWhenEnvironmentAbsent(boolean forceDelete) {
+        initHandlerEvent(forceDelete);
+        when(sdxClusterRepository.findById(DATALAKE_ID)).thenReturn(Optional.empty());
+
+        Selectable result = underTest.doAccept(handlerEvent);
+
+        verifySuccessEvent(result);
+        verify(consumptionService, never()).unscheduleStorageConsumptionCollectionIfNeeded(any(SdxCluster.class));
+        verify(databaseService, never()).terminate(any(SdxCluster.class), anyBoolean());
+        verify(sdxStatusService, never()).setStatusForDatalakeAndNotify(any(DatalakeStatusEnum.class), anyString(), any(SdxCluster.class));
+        verify(ownerAssignmentService, never()).notifyResourceDeleted(anyString(), any(Optional.class));
+    }
+
+    private void verifySuccessEvent(Selectable result) {
+        assertThat(result).isInstanceOf(RdsDeletionSuccessEvent.class);
+
+        RdsDeletionSuccessEvent rdsDeletionSuccessEvent = (RdsDeletionSuccessEvent) result;
+        assertThat(rdsDeletionSuccessEvent.getResourceId()).isEqualTo(DATALAKE_ID);
+        assertThat(rdsDeletionSuccessEvent.getUserId()).isEqualTo(USER_ID);
+        assertThat(rdsDeletionSuccessEvent.getSdxName()).isNull();
+    }
+
+    static Object[][] skipTerminateDataProvider() {
+        return new Object[][]{
+                // forceDelete sdxDatabaseAvailabilityType createDatabase databaseCrn
+                {false, SdxDatabaseAvailabilityType.NON_HA, false, null},
+                {false, SdxDatabaseAvailabilityType.NON_HA, true, null},
+                {true, SdxDatabaseAvailabilityType.NON_HA, false, null},
+                {true, SdxDatabaseAvailabilityType.NON_HA, true, null},
+                {false, SdxDatabaseAvailabilityType.HA, false, null},
+                {false, SdxDatabaseAvailabilityType.HA, true, null},
+                {true, SdxDatabaseAvailabilityType.HA, false, null},
+                {true, SdxDatabaseAvailabilityType.HA, true, null},
+                {false, null, true, null},
+                {true, null, true, null},
+                {false, SdxDatabaseAvailabilityType.NON_HA, false, EMPTY_DATABASE_CRN},
+                {false, SdxDatabaseAvailabilityType.NON_HA, true, EMPTY_DATABASE_CRN},
+                {true, SdxDatabaseAvailabilityType.NON_HA, false, EMPTY_DATABASE_CRN},
+                {true, SdxDatabaseAvailabilityType.NON_HA, true, EMPTY_DATABASE_CRN},
+                {false, SdxDatabaseAvailabilityType.HA, false, EMPTY_DATABASE_CRN},
+                {false, SdxDatabaseAvailabilityType.HA, true, EMPTY_DATABASE_CRN},
+                {true, SdxDatabaseAvailabilityType.HA, false, EMPTY_DATABASE_CRN},
+                {true, SdxDatabaseAvailabilityType.HA, true, EMPTY_DATABASE_CRN},
+                {false, null, true, EMPTY_DATABASE_CRN},
+                {true, null, true, EMPTY_DATABASE_CRN},
+                {false, SdxDatabaseAvailabilityType.NONE, false, null},
+                {false, SdxDatabaseAvailabilityType.NONE, true, null},
+                {true, SdxDatabaseAvailabilityType.NONE, false, null},
+                {true, SdxDatabaseAvailabilityType.NONE, true, null},
+                {false, SdxDatabaseAvailabilityType.NONE, false, EMPTY_DATABASE_CRN},
+                {false, SdxDatabaseAvailabilityType.NONE, true, EMPTY_DATABASE_CRN},
+                {true, SdxDatabaseAvailabilityType.NONE, false, EMPTY_DATABASE_CRN},
+                {true, SdxDatabaseAvailabilityType.NONE, true, EMPTY_DATABASE_CRN},
+                {false, SdxDatabaseAvailabilityType.NONE, false, DATABASE_CRN},
+                {false, SdxDatabaseAvailabilityType.NONE, true, DATABASE_CRN},
+                {true, SdxDatabaseAvailabilityType.NONE, false, DATABASE_CRN},
+                {true, SdxDatabaseAvailabilityType.NONE, true, DATABASE_CRN},
+                {false, null, false, null},
+                {true, null, false, null},
+                {false, null, false, EMPTY_DATABASE_CRN},
+                {true, null, false, EMPTY_DATABASE_CRN},
+                {false, null, false, DATABASE_CRN},
+                {true, null, false, DATABASE_CRN},
+        };
+    }
+
+    @ParameterizedTest(name = "forceDelete={0}, sdxDatabaseAvailabilityType={1}, createDatabase={2}, databaseCrn={3}")
+    @MethodSource("skipTerminateDataProvider")
+    void doAcceptTestSkipTerminate(boolean forceDelete, SdxDatabaseAvailabilityType sdxDatabaseAvailabilityType, boolean createDatabase, String databaseCrn) {
+        initHandlerEvent(forceDelete);
+        SdxCluster sdxCluster = sdxCluster(sdxDatabaseAvailabilityType, createDatabase, databaseCrn);
+        when(sdxClusterRepository.findById(DATALAKE_ID)).thenReturn(Optional.of(sdxCluster));
+
+        Selectable result = underTest.doAccept(handlerEvent);
+
+        verifySuccessEvent(result);
+        verify(consumptionService).unscheduleStorageConsumptionCollectionIfNeeded(sdxCluster);
+        verify(databaseService, never()).terminate(any(SdxCluster.class), anyBoolean());
+        verifyDeletedStatus(sdxCluster);
+    }
+
+    private SdxCluster sdxCluster(SdxDatabaseAvailabilityType databaseAvailabilityType, boolean createDatabase, String databaseCrn) {
+        SdxCluster sdxCluster = new SdxCluster();
+        sdxCluster.setCrn(DATALAKE_CRN);
+        sdxCluster.setDatabaseAvailabilityType(databaseAvailabilityType);
+        sdxCluster.setCreateDatabase(createDatabase);
+        sdxCluster.setDatabaseCrn(databaseCrn);
+        return sdxCluster;
+    }
+
+    private void verifyDeletedStatus(SdxCluster sdxCluster) {
+        verify(sdxStatusService).setStatusForDatalakeAndNotify(DatalakeStatusEnum.DELETED, "Datalake External RDS deleted", sdxCluster);
+        verify(ownerAssignmentService).notifyResourceDeleted(DATALAKE_CRN, Optional.of(REQUEST_ID));
+    }
+
+    static Object[][] executeTerminateDataProvider() {
+        return new Object[][]{
+                // forceDelete sdxDatabaseAvailabilityType createDatabase
+                {false, SdxDatabaseAvailabilityType.NON_HA, false},
+                {false, SdxDatabaseAvailabilityType.NON_HA, true},
+                {true, SdxDatabaseAvailabilityType.NON_HA, false},
+                {true, SdxDatabaseAvailabilityType.NON_HA, true},
+                {false, SdxDatabaseAvailabilityType.HA, false},
+                {false, SdxDatabaseAvailabilityType.HA, true},
+                {true, SdxDatabaseAvailabilityType.HA, false},
+                {true, SdxDatabaseAvailabilityType.HA, true},
+                {false, null, true},
+                {true, null, true},
+        };
+    }
+
+    @ParameterizedTest(name = "forceDelete={0}, sdxDatabaseAvailabilityType={1}, createDatabase={2}")
+    @MethodSource("executeTerminateDataProvider")
+    void doAcceptTestExecuteTerminate(boolean forceDelete, SdxDatabaseAvailabilityType sdxDatabaseAvailabilityType, boolean createDatabase) {
+        initHandlerEvent(forceDelete);
+        SdxCluster sdxCluster = sdxCluster(sdxDatabaseAvailabilityType, createDatabase);
+        when(sdxClusterRepository.findById(DATALAKE_ID)).thenReturn(Optional.of(sdxCluster));
+
+        Selectable result = underTest.doAccept(handlerEvent);
+
+        verifySuccessEvent(result);
+        verify(consumptionService).unscheduleStorageConsumptionCollectionIfNeeded(sdxCluster);
+        verifyTerminateExecutedAndDeletedStatus(forceDelete, sdxCluster);
+    }
+
+    private SdxCluster sdxCluster(SdxDatabaseAvailabilityType sdxDatabaseAvailabilityType, boolean createDatabase) {
+        return sdxCluster(sdxDatabaseAvailabilityType, createDatabase, DATABASE_CRN);
+    }
+
+    private void verifyTerminateExecutedAndDeletedStatus(boolean forceDelete, SdxCluster sdxCluster) {
+        verify(databaseService).terminate(sdxCluster, forceDelete);
+        verifyDeletedStatus(sdxCluster);
+    }
+
+    @ParameterizedTest(name = "forceDelete={0}, sdxDatabaseAvailabilityType={1}, createDatabase={2}")
+    @MethodSource("executeTerminateDataProvider")
+    void doAcceptTestExecuteTerminateAndNotFoundExceptionWhenSetStatusForDatalakeAndNotify(boolean forceDelete,
+            SdxDatabaseAvailabilityType sdxDatabaseAvailabilityType, boolean createDatabase) {
+        initHandlerEvent(forceDelete);
+        SdxCluster sdxCluster = sdxCluster(sdxDatabaseAvailabilityType, createDatabase);
+        when(sdxClusterRepository.findById(DATALAKE_ID)).thenReturn(Optional.of(sdxCluster));
+        doThrow(new NotFoundException("Data Lake not found"))
+                .when(sdxStatusService).setStatusForDatalakeAndNotify(DatalakeStatusEnum.DELETED, "Datalake External RDS deleted", sdxCluster);
+
+        Selectable result = underTest.doAccept(handlerEvent);
+
+        verifySuccessEvent(result);
+        verify(consumptionService).unscheduleStorageConsumptionCollectionIfNeeded(sdxCluster);
+        verifyTerminateExecutedAndDeletedStatus(forceDelete, sdxCluster);
+    }
+
+}

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/consumption/ConsumptionClientServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/consumption/ConsumptionClientServiceTest.java
@@ -1,0 +1,103 @@
+package com.sequenceiq.datalake.service.consumption;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import javax.ws.rs.WebApplicationException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.exception.WebApplicationExceptionMessageExtractor;
+import com.sequenceiq.consumption.api.v1.consumption.endpoint.ConsumptionInternalEndpoint;
+import com.sequenceiq.consumption.api.v1.consumption.model.request.StorageConsumptionRequest;
+import com.sequenceiq.consumption.client.ConsumptionInternalCrnClient;
+import com.sequenceiq.consumption.client.ConsumptionServiceCrnEndpoints;
+
+@ExtendWith(MockitoExtension.class)
+class ConsumptionClientServiceTest {
+
+    private static final String ACCOUNT_ID = "accountId";
+
+    private static final String MONITORED_RESOURCE_CRN = "monitoredResourceCrn";
+
+    private static final String STORAGE_LOCATION = "s3a://foo/bar";
+
+    private static final String ERROR_MESSAGE = "Bad luck";
+
+    @Mock
+    private ConsumptionInternalCrnClient consumptionInternalCrnClient;
+
+    @Mock
+    private WebApplicationExceptionMessageExtractor webApplicationExceptionMessageExtractor;
+
+    @InjectMocks
+    private ConsumptionClientService underTest;
+
+    @Mock
+    private ConsumptionServiceCrnEndpoints consumptionServiceCrnEndpoints;
+
+    @Mock
+    private ConsumptionInternalEndpoint consumptionInternalEndpoint;
+
+    @BeforeEach
+    void setUp() {
+        when(consumptionInternalCrnClient.withInternalCrn()).thenReturn(consumptionServiceCrnEndpoints);
+        when(consumptionServiceCrnEndpoints.consumptionEndpoint()).thenReturn(consumptionInternalEndpoint);
+    }
+
+    @Test
+    void scheduleStorageConsumptionCollectionTestWhenSuccess() {
+        StorageConsumptionRequest storageConsumptionRequest = new StorageConsumptionRequest();
+
+        underTest.scheduleStorageConsumptionCollection(ACCOUNT_ID, storageConsumptionRequest);
+
+        verify(consumptionInternalEndpoint).scheduleStorageConsumptionCollection(ACCOUNT_ID, storageConsumptionRequest);
+    }
+
+    @Test
+    void scheduleStorageConsumptionCollectionTestWhenFailure() {
+        StorageConsumptionRequest storageConsumptionRequest = new StorageConsumptionRequest();
+        WebApplicationException e = new WebApplicationException();
+        doThrow(e).when(consumptionInternalEndpoint).scheduleStorageConsumptionCollection(ACCOUNT_ID, storageConsumptionRequest);
+        when(webApplicationExceptionMessageExtractor.getErrorMessage(e)).thenReturn(ERROR_MESSAGE);
+
+        ConsumptionOperationFailedException consumptionOperationFailedException = assertThrows(ConsumptionOperationFailedException.class,
+                () -> underTest.scheduleStorageConsumptionCollection(ACCOUNT_ID, storageConsumptionRequest));
+
+        verifyException(e, consumptionOperationFailedException);
+    }
+
+    private void verifyException(WebApplicationException e, ConsumptionOperationFailedException consumptionOperationFailedException) {
+        assertThat(consumptionOperationFailedException).isNotNull();
+        assertThat(consumptionOperationFailedException).hasMessage(ERROR_MESSAGE);
+        assertThat(consumptionOperationFailedException).hasCauseReference(e);
+    }
+
+    @Test
+    void unscheduleStorageConsumptionCollectionTestWhenSuccess() {
+        underTest.unscheduleStorageConsumptionCollection(ACCOUNT_ID, MONITORED_RESOURCE_CRN, STORAGE_LOCATION);
+
+        verify(consumptionInternalEndpoint).unscheduleStorageConsumptionCollection(ACCOUNT_ID, MONITORED_RESOURCE_CRN, STORAGE_LOCATION);
+    }
+
+    @Test
+    void unscheduleStorageConsumptionCollectionTestWhenFailure() {
+        WebApplicationException e = new WebApplicationException();
+        doThrow(e).when(consumptionInternalEndpoint).unscheduleStorageConsumptionCollection(ACCOUNT_ID, MONITORED_RESOURCE_CRN, STORAGE_LOCATION);
+        when(webApplicationExceptionMessageExtractor.getErrorMessage(e)).thenReturn(ERROR_MESSAGE);
+
+        ConsumptionOperationFailedException consumptionOperationFailedException = assertThrows(ConsumptionOperationFailedException.class,
+                () -> underTest.unscheduleStorageConsumptionCollection(ACCOUNT_ID, MONITORED_RESOURCE_CRN, STORAGE_LOCATION));
+
+        verifyException(e, consumptionOperationFailedException);
+    }
+
+}

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/consumption/ConsumptionServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/consumption/ConsumptionServiceTest.java
@@ -1,0 +1,164 @@
+package com.sequenceiq.datalake.service.consumption;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.consumption.api.v1.consumption.model.common.ResourceType;
+import com.sequenceiq.consumption.api.v1.consumption.model.request.StorageConsumptionRequest;
+import com.sequenceiq.datalake.entity.SdxCluster;
+
+@ExtendWith(MockitoExtension.class)
+class ConsumptionServiceTest {
+
+    private static final boolean CONSUMPTION_ENABLED = true;
+
+    private static final boolean CONSUMPTION_DISABLED = false;
+
+    private static final String ACCOUNT_ID = "accountId";
+
+    private static final String ENVIRONMENT_CRN = "environmentCrn";
+
+    private static final String DATALAKE_CRN = "datalakeCrn";
+
+    private static final String DATALAKE_NAME = "datalakeName";
+
+    private static final String STORAGE_BASE_LOCATION = "s3a://foo/bar";
+
+    private static final String EMPTY_STORAGE_BASE_LOCATION = "";
+
+    @Mock
+    private EntitlementService entitlementService;
+
+    @Mock
+    private ConsumptionClientService consumptionClientService;
+
+    private ConsumptionService underTest;
+
+    @Captor
+    private ArgumentCaptor<StorageConsumptionRequest> storageConsumptionRequestCaptor;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new ConsumptionService(entitlementService, consumptionClientService, CONSUMPTION_ENABLED);
+    }
+
+    @Test
+    void scheduleStorageConsumptionCollectionIfNeededTestSkipWhenDeploymentFlagDisabled() {
+        underTest = new ConsumptionService(entitlementService, consumptionClientService, CONSUMPTION_DISABLED);
+
+        underTest.scheduleStorageConsumptionCollectionIfNeeded(sdxCluster());
+
+        verify(entitlementService, never()).isCdpSaasEnabled(anyString());
+        verify(consumptionClientService, never()).scheduleStorageConsumptionCollection(anyString(), any(StorageConsumptionRequest.class));
+    }
+
+    private SdxCluster sdxCluster(String cloudStorageBaseLocation) {
+        SdxCluster sdxCluster = new SdxCluster();
+        sdxCluster.setAccountId(ACCOUNT_ID);
+        sdxCluster.setCloudStorageBaseLocation(cloudStorageBaseLocation);
+        sdxCluster.setEnvCrn(ENVIRONMENT_CRN);
+        sdxCluster.setCrn(DATALAKE_CRN);
+        sdxCluster.setClusterName(DATALAKE_NAME);
+        return sdxCluster;
+    }
+
+    @Test
+    void scheduleStorageConsumptionCollectionIfNeededTestSkipWhenEntitlementDisabled() {
+        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(false);
+
+        underTest.scheduleStorageConsumptionCollectionIfNeeded(sdxCluster());
+
+        verify(consumptionClientService, never()).scheduleStorageConsumptionCollection(anyString(), any(StorageConsumptionRequest.class));
+    }
+
+    @ParameterizedTest(name = "cloudStorageBaseLocation={0}")
+    @ValueSource(strings = {EMPTY_STORAGE_BASE_LOCATION})
+    @NullSource
+    void scheduleStorageConsumptionCollectionIfNeededTestSkipWhenNoStorageBaseLocation(String cloudStorageBaseLocation) {
+        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
+
+        underTest.scheduleStorageConsumptionCollectionIfNeeded(sdxCluster(cloudStorageBaseLocation));
+
+        verify(consumptionClientService, never()).scheduleStorageConsumptionCollection(anyString(), any(StorageConsumptionRequest.class));
+    }
+
+    @Test
+    void scheduleStorageConsumptionCollectionIfNeededTestExecute() {
+        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
+
+        underTest.scheduleStorageConsumptionCollectionIfNeeded(sdxCluster());
+
+        verify(consumptionClientService).scheduleStorageConsumptionCollection(eq(ACCOUNT_ID), storageConsumptionRequestCaptor.capture());
+        verifyStorageConsumptionRequest(storageConsumptionRequestCaptor.getValue());
+    }
+
+    private void verifyStorageConsumptionRequest(StorageConsumptionRequest storageConsumptionRequest) {
+        assertThat(storageConsumptionRequest).isNotNull();
+        assertThat(storageConsumptionRequest.getEnvironmentCrn()).isEqualTo(ENVIRONMENT_CRN);
+        assertThat(storageConsumptionRequest.getMonitoredResourceCrn()).isEqualTo(DATALAKE_CRN);
+        assertThat(storageConsumptionRequest.getMonitoredResourceName()).isEqualTo(DATALAKE_NAME);
+        assertThat(storageConsumptionRequest.getMonitoredResourceType()).isEqualTo(ResourceType.DATALAKE);
+        assertThat(storageConsumptionRequest.getStorageLocation()).isEqualTo(STORAGE_BASE_LOCATION);
+    }
+
+    @Test
+    void unscheduleStorageConsumptionCollectionIfNeededTestSkipWhenDeploymentFlagDisabled() {
+        underTest = new ConsumptionService(entitlementService, consumptionClientService, CONSUMPTION_DISABLED);
+
+        underTest.unscheduleStorageConsumptionCollectionIfNeeded(sdxCluster());
+
+        verify(entitlementService, never()).isCdpSaasEnabled(anyString());
+        verify(consumptionClientService, never()).unscheduleStorageConsumptionCollection(anyString(), anyString(), anyString());
+    }
+
+    private SdxCluster sdxCluster() {
+        return sdxCluster(STORAGE_BASE_LOCATION);
+    }
+
+    @Test
+    void unscheduleStorageConsumptionCollectionIfNeededTestSkipWhenEntitlementDisabled() {
+        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(false);
+
+        underTest.unscheduleStorageConsumptionCollectionIfNeeded(sdxCluster());
+
+        verify(consumptionClientService, never()).unscheduleStorageConsumptionCollection(anyString(), anyString(), anyString());
+    }
+
+    @ParameterizedTest(name = "cloudStorageBaseLocation={0}")
+    @ValueSource(strings = {EMPTY_STORAGE_BASE_LOCATION})
+    @NullSource
+    void unscheduleStorageConsumptionCollectionIfNeededTestSkipWhenNoStorageBaseLocation(String cloudStorageBaseLocation) {
+        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
+
+        underTest.unscheduleStorageConsumptionCollectionIfNeeded(sdxCluster(cloudStorageBaseLocation));
+
+        verify(consumptionClientService, never()).unscheduleStorageConsumptionCollection(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void unscheduleStorageConsumptionCollectionIfNeededTestExecute() {
+        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
+
+        underTest.unscheduleStorageConsumptionCollectionIfNeeded(sdxCluster());
+
+        verify(consumptionClientService).unscheduleStorageConsumptionCollection(ACCOUNT_ID, DATALAKE_CRN, STORAGE_BASE_LOCATION);
+    }
+
+}


### PR DESCRIPTION
* Add `cloud-consumption-api` as new compile dependency for `datalake` service.
* Integrate consumption schedule / unschedule invocations into datalake create & terminate flows.
  * In order to meet the tight delivery schedule, it was decided that the initial implementation will re-use existing flow steps &
    handlers. The proper refactoring to extract the logic into new flow steps (along with any new DL states and related notification messages) will be done later in [CB-17514](https://jira.cloudera.com/browse/CB-17514).
  * For now, the consumption schedule invocation is placed right before the DL stack create step, at the end of `EnvWaitHandler`. Similarly, the consumption unschedule invocation is executed right after the DL stack terminate step, at the beginning of `RdsDeletionHandler`.
  * Just like for its `environment` counterpart ([CB-17216](https://jira.cloudera.com/browse/CB-17216) / #12807, property `environment.consumption.enabled`), consumption schedule / unschedule invocations are guarded by two checks: application property in `application.yml` (`datalake.consumption.enabled`) and entitlement (`CDP_SAAS`). The properties are disabled by default in both cases and are enabled separately in CBD ([CB-17265](https://jira.cloudera.com/browse/CB-17265)) and helm charts ([CB-17264](https://jira.cloudera.com/browse/CB-17264)).
* Some code cleanup.
* Testing:
  * Manual testing in local CB.
  * Added new UT and updated existing ones.
