### PR TITLE
CB-17558 testSDXMultiRepairIDBRokerAndMasterWithRecipeFile E2E test failed because DL was created from base image

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProvider.java
@@ -61,7 +61,7 @@ public interface CloudProvider {
 
     DistroXImageTestDto imageSettings(DistroXImageTestDto imageSettings);
 
-    String getPreviousPreWarmedImageID(TestContext testContext, ImageCatalogTestDto imageCatalogTestDto, CloudbreakClient cloudbreakClient);
+    String getLatestPreWarmedImageID(TestContext testContext, ImageCatalogTestDto imageCatalogTestDto, CloudbreakClient cloudbreakClient);
 
     String getLatestBaseImageID(TestContext testContext, ImageCatalogTestDto imageCatalogTestDto, CloudbreakClient cloudbreakClient);
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProviderProxy.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProviderProxy.java
@@ -113,8 +113,8 @@ public class CloudProviderProxy implements CloudProvider {
     }
 
     @Override
-    public String getPreviousPreWarmedImageID(TestContext testContext, ImageCatalogTestDto imageCatalogTestDto, CloudbreakClient cloudbreakClient) {
-        return getDelegate(imageCatalogTestDto).getPreviousPreWarmedImageID(testContext, imageCatalogTestDto, cloudbreakClient);
+    public String getLatestPreWarmedImageID(TestContext testContext, ImageCatalogTestDto imageCatalogTestDto, CloudbreakClient cloudbreakClient) {
+        return getDelegate(imageCatalogTestDto).getLatestPreWarmedImageID(testContext, imageCatalogTestDto, cloudbreakClient);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProvider.java
@@ -14,7 +14,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImageV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.network.AwsNetworkV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.stack.AwsStackV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AwsInstanceTemplateV4Parameters;
@@ -391,33 +390,8 @@ public class AwsCloudProvider extends AbstractCloudProvider {
     }
 
     @Override
-    public String getPreviousPreWarmedImageID(TestContext testContext, ImageCatalogTestDto imageCatalogTestDto, CloudbreakClient cloudbreakClient) {
-        if (awsProperties.getBaseimage().getImageId() == null || awsProperties.getBaseimage().getImageId().isEmpty()) {
-            try {
-                List<ImageV4Response> images = cloudbreakClient
-                        .getDefaultClient()
-                        .imageCatalogV4Endpoint()
-                        .getImagesByName(cloudbreakClient.getWorkspaceId(), imageCatalogTestDto.getRequest().getName(), null,
-                                CloudPlatform.AWS.name(), null, null, false).getCdhImages();
-
-                ImageV4Response olderImage = images.get(images.size() - 2);
-                Log.log(LOGGER, format(" Image Catalog Name: %s ", imageCatalogTestDto.getRequest().getName()));
-                Log.log(LOGGER, format(" Image Catalog URL: %s ", imageCatalogTestDto.getRequest().getUrl()));
-                Log.log(LOGGER, format(" Selected Pre-warmed Image Date: %s | ID: %s | Description: %s | Stack Version: %s ", olderImage.getDate(),
-                        olderImage.getUuid(), olderImage.getStackDetails().getVersion(), olderImage.getDescription()));
-                awsProperties.getBaseimage().setImageId(olderImage.getUuid());
-
-                return olderImage.getUuid();
-            } catch (Exception e) {
-                LOGGER.error("Cannot fetch pre-warmed images of {} image catalog!", imageCatalogTestDto.getRequest().getName());
-                throw new TestFailException(" Cannot fetch pre-warmed images of " + imageCatalogTestDto.getRequest().getName() + " image catalog!", e);
-            }
-        } else {
-            Log.log(LOGGER, format(" Image Catalog Name: %s ", commonCloudProperties().getImageCatalogName()));
-            Log.log(LOGGER, format(" Image Catalog URL: %s ", commonCloudProperties().getImageCatalogUrl()));
-            Log.log(LOGGER, format(" Image ID for SDX create: %s ", awsProperties.getBaseimage().getImageId()));
-            return awsProperties.getBaseimage().getImageId();
-        }
+    public String getLatestPreWarmedImageID(TestContext testContext, ImageCatalogTestDto imageCatalogTestDto, CloudbreakClient cloudbreakClient) {
+        return getLatestPreWarmedImage(imageCatalogTestDto, cloudbreakClient, CloudPlatform.AWS.name(), false);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
@@ -14,7 +14,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImageV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.network.AzureNetworkV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.stack.AzureStackV4Parameters;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
@@ -381,33 +380,8 @@ public class AzureCloudProvider extends AbstractCloudProvider {
     }
 
     @Override
-    public String getPreviousPreWarmedImageID(TestContext testContext, ImageCatalogTestDto imageCatalogTestDto, CloudbreakClient cloudbreakClient) {
-        if (azureProperties.getBaseimage().getImageId() == null || azureProperties.getBaseimage().getImageId().isEmpty()) {
-            try {
-                List<ImageV4Response> images = cloudbreakClient
-                        .getDefaultClient()
-                        .imageCatalogV4Endpoint()
-                        .getImagesByName(cloudbreakClient.getWorkspaceId(), imageCatalogTestDto.getRequest().getName(), null,
-                                CloudPlatform.AZURE.name(), null, null, false).getCdhImages();
-
-                ImageV4Response olderImage = images.get(images.size() - 2);
-                Log.log(LOGGER, format(" Image Catalog Name: %s ", imageCatalogTestDto.getRequest().getName()));
-                Log.log(LOGGER, format(" Image Catalog URL: %s ", imageCatalogTestDto.getRequest().getUrl()));
-                Log.log(LOGGER, format(" Selected Pre-warmed Image Date: %s | ID: %s | Description: %s | Stack Version: %s ", olderImage.getDate(),
-                        olderImage.getUuid(), olderImage.getStackDetails().getVersion(), olderImage.getDescription()));
-                azureProperties.getBaseimage().setImageId(olderImage.getUuid());
-
-                return olderImage.getUuid();
-            } catch (Exception e) {
-                LOGGER.error("Cannot fetch pre-warmed images of {} image catalog!", imageCatalogTestDto.getRequest().getName());
-                throw new TestFailException(" Cannot fetch pre-warmed images of " + imageCatalogTestDto.getRequest().getName() + " image catalog!", e);
-            }
-        } else {
-            Log.log(LOGGER, format(" Image Catalog Name: %s ", commonCloudProperties().getImageCatalogName()));
-            Log.log(LOGGER, format(" Image Catalog URL: %s ", commonCloudProperties().getImageCatalogUrl()));
-            Log.log(LOGGER, format(" Image ID for SDX create: %s ", azureProperties.getBaseimage().getImageId()));
-            return azureProperties.getBaseimage().getImageId();
-        }
+    public String getLatestPreWarmedImageID(TestContext testContext, ImageCatalogTestDto imageCatalogTestDto, CloudbreakClient cloudbreakClient) {
+        return getLatestPreWarmedImage(imageCatalogTestDto, cloudbreakClient, CloudPlatform.AZURE.name(), false);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpCloudProvider.java
@@ -15,7 +15,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImageV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.network.GcpNetworkV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.stack.GcpStackV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.network.InstanceGroupNetworkV4Request;
@@ -405,33 +404,8 @@ public class GcpCloudProvider extends AbstractCloudProvider {
     }
 
     @Override
-    public String getPreviousPreWarmedImageID(TestContext testContext, ImageCatalogTestDto imageCatalogTestDto, CloudbreakClient cloudbreakClient) {
-        if (gcpProperties.getBaseimage().getImageId() == null || gcpProperties.getBaseimage().getImageId().isEmpty()) {
-            try {
-                List<ImageV4Response> images = cloudbreakClient
-                        .getDefaultClient()
-                        .imageCatalogV4Endpoint()
-                        .getImagesByName(cloudbreakClient.getWorkspaceId(), imageCatalogTestDto.getRequest().getName(), null,
-                                CloudPlatform.GCP.name(), null, null, false).getCdhImages();
-
-                ImageV4Response olderImage = images.get(images.size() - 2);
-                Log.log(LOGGER, format(" Image Catalog Name: %s ", imageCatalogTestDto.getRequest().getName()));
-                Log.log(LOGGER, format(" Image Catalog URL: %s ", imageCatalogTestDto.getRequest().getUrl()));
-                Log.log(LOGGER, format(" Selected Pre-warmed Image Date: %s | ID: %s | Description: %s | Stack Version: %s ", olderImage.getDate(),
-                        olderImage.getUuid(), olderImage.getStackDetails().getVersion(), olderImage.getDescription()));
-                gcpProperties.getBaseimage().setImageId(olderImage.getUuid());
-
-                return olderImage.getUuid();
-            } catch (Exception e) {
-                LOGGER.error("Cannot fetch pre-warmed images of {} image catalog!", imageCatalogTestDto.getRequest().getName());
-                throw new TestFailException(" Cannot fetch pre-warmed images of " + imageCatalogTestDto.getRequest().getName() + " image catalog!", e);
-            }
-        } else {
-            Log.log(LOGGER, format(" Image Catalog Name: %s ", commonCloudProperties().getImageCatalogName()));
-            Log.log(LOGGER, format(" Image Catalog URL: %s ", commonCloudProperties().getImageCatalogUrl()));
-            Log.log(LOGGER, format(" Image ID for SDX create: %s ", gcpProperties.getBaseimage().getImageId()));
-            return gcpProperties.getBaseimage().getImageId();
-        }
+    public String getLatestPreWarmedImageID(TestContext testContext, ImageCatalogTestDto imageCatalogTestDto, CloudbreakClient cloudbreakClient) {
+        return getLatestPreWarmedImage(imageCatalogTestDto, cloudbreakClient, CloudPlatform.GCP.name(), false);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/yarn/YarnCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/yarn/YarnCloudProvider.java
@@ -206,7 +206,9 @@ public class YarnCloudProvider extends AbstractCloudProvider {
     }
 
     @Override
-    public String getPreviousPreWarmedImageID(TestContext testContext, ImageCatalogTestDto imageCatalogTestDto, CloudbreakClient cloudbreakClient) {
+    public String getLatestPreWarmedImageID(TestContext testContext, ImageCatalogTestDto imageCatalogTestDto, CloudbreakClient cloudbreakClient) {
+        // At cloudbreak-default (https://cloudbreak-imagecatalog.s3.amazonaws.com/v3-test-cb-image-catalog.jsonDelete) catalog we have only
+        // Base Image for YCloud provider.
         return throwNotImplementedException();
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/PreconditionSdxE2ETest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/PreconditionSdxE2ETest.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.it.cloudbreak.testcase.e2e.sdx;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
@@ -7,6 +9,7 @@ import org.slf4j.LoggerFactory;
 
 import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
 import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
 import com.sequenceiq.it.cloudbreak.util.CloudFunctionality;
@@ -41,5 +44,16 @@ public class PreconditionSdxE2ETest extends AbstractE2ETest {
 
     protected CloudFunctionality getCloudFunctionality(TestContext testContext) {
         return testContext.getCloudProvider().getCloudFunctionality();
+    }
+
+    protected String getLatestPrewarmedImageId(TestContext testContext) {
+        AtomicReference<String> selectedImageID = new AtomicReference<>();
+        testContext
+                .given(ImageCatalogTestDto.class)
+                .when((tc, dto, client) -> {
+                    selectedImageID.set(tc.getCloudProvider().getLatestPreWarmedImageID(tc, dto, client));
+                    return dto;
+                });
+        return selectedImageID.get();
     }
 }


### PR DESCRIPTION
[API E2E AWS Build #4407--2.60.0-b6-AWS (23-Jun-2022 17:39:23)](http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-aws/4407/) where [testSDXMultiRepairIDBRokerAndMasterWithRecipeFile](http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-aws/4407/testngreports/com.sequenceiq.it.cloudbreak.testcase.e2e.sdx/InternalSdxRepairWithRecipeTest/testSDXMultiRepairIDBRokerAndMasterWithRecipeFile/) test is failing, because of:
```
"Cluster instance replacement requested on entities could not start for nodes due to the following reason: Action is only supported if the image already contains Cloudera Manager and Cloudera Data Platform artifacts."
```

So in case of this test case we should introduce prewarmed image selection test step for SDX.