### PR TITLE
CB-15453 Use --no-dns-sshfp flag during `ipa-client-install`

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/template/join_ipa.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/template/join_ipa.j2
@@ -15,8 +15,8 @@ ipa-client-install \
   --mkhomedir \
   --principal={{ pillar['sssd-ipa']['principal'] }} \
   {%- if "ID_BROKER_CLOUD_IDENTITY_ROLE" in grains.get('roles', []) %}
-    --no-sshd \
-    --no-ssh \
+  --no-sshd \
+  --no-ssh \
   {%- endif %}
   --password "$PW" \
   --unattended \
@@ -25,6 +25,9 @@ ipa-client-install \
   {%- if salt['pillar.get']('freeipa:host', None) != None %}
   --server={{ pillar['freeipa']['host'] }} \
   {%- endif %}
+{%- if salt['pillar.get']('unbound_elimination_supported',False) == True %}
+  --no-dns-sshfp \
+{%- endif %}
   --no-ntp
 
 echo "$PW" | kinit {{ pillar['sssd-ipa']['principal'] }}


### PR DESCRIPTION
The problem is that if an A record is added and the SSHFP is also added, it is possible that two ldap add commands get run which can result in a conflict. The conflict resolution it to delete both records. The SSHFP uses nsupdate, so it is not guaranteed to be routed to the same instance of FreeIPA.
Thus we have a problem. We really only need to have the DNS A-record.

If unbound doesn't have the static records, then the flag can be safely used, as the A records would be created and the SSHFP records won't.
Without the unbound change, it would be possible that the A records won't be created.

See detailed description in the commit message.