### PR TITLE
CB-17176 Add more sophisticated constructor checker

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudCredential.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudCredential.java
@@ -64,6 +64,10 @@ public class CloudCredential extends DynamicModel {
         return accountId;
     }
 
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
+    }
+
     // Must not reveal any secrets, hence not including DynamicModel.toString()!
     @Override
     public String toString() {

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/DatabaseServer.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/DatabaseServer.java
@@ -12,7 +12,7 @@ public class DatabaseServer extends DynamicModel {
      * The exact interpretation of this setting is up to the target cloud provider. Relevant only if {@code useSslEnforcement == true}.
      *
      * <p>
-     *     When set, the value shall be a nonempty {@link String} containing the SSL root certificate identifier in a cloud provider specific syntax.
+     * When set, the value shall be a nonempty {@link String} containing the SSL root certificate identifier in a cloud provider specific syntax.
      * </p>
      *
      * @see #isUseSslEnforcement()
@@ -47,6 +47,29 @@ public class DatabaseServer extends DynamicModel {
     private final String location;
 
     private final boolean highAvailability;
+
+    /*
+     * We need this constructor because flow request objects use this class, and it can not be deserialized to object
+     */
+    private DatabaseServer(String serverId, String flavor, DatabaseEngine engine, String connectionDriver, String connectorJarUrl, String rootUserName,
+            String rootPassword, Integer port, boolean useSslEnforcement, Long storageSize, Security security, InstanceStatus status, String location,
+            boolean highAvailability, Map<String, Object> params) {
+        super(params);
+        this.serverId = serverId;
+        this.flavor = flavor;
+        this.engine = engine;
+        this.connectionDriver = connectionDriver;
+        this.connectorJarUrl = connectorJarUrl;
+        this.rootUserName = rootUserName;
+        this.rootPassword = rootPassword;
+        this.port = port;
+        this.useSslEnforcement = useSslEnforcement;
+        this.storageSize = storageSize;
+        this.security = security;
+        this.status = status;
+        this.location = location;
+        this.highAvailability = highAvailability;
+    }
 
     private DatabaseServer(Builder builder) {
         super(builder.params);

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/CertificatesRotationV4Request.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/CertificatesRotationV4Request.java
@@ -17,11 +17,11 @@ public class CertificatesRotationV4Request implements JsonEntity {
     @ApiModelProperty(value = ClusterModelDescription.CERTIFICATE_ROTATION_TYPE, allowableValues = "HOST_CERTS")
     private CertificateRotationType certificateRotationType = CertificateRotationType.HOST_CERTS;
 
-    public CertificateRotationType getRotateCertificatesType() {
+    public CertificateRotationType getCertificateRotationType() {
         return certificateRotationType;
     }
 
-    public void setRotateCertificatesType(CertificateRotationType certificateRotationType) {
+    public void setCertificateRotationType(CertificateRotationType certificateRotationType) {
         this.certificateRotationType = certificateRotationType;
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
@@ -378,7 +378,7 @@ public class ReactorFlowManager {
     public FlowIdentifier triggerAutoTlsCertificatesRotation(Long stackId, CertificatesRotationV4Request certificatesRotationV4Request) {
         String selector = FlowChainTriggers.ROTATE_CLUSTER_CERTIFICATES_CHAIN_TRIGGER_EVENT;
         ClusterCertificatesRotationTriggerEvent clusterCertificatesRotationTriggerEvent = new ClusterCertificatesRotationTriggerEvent(selector, stackId,
-                certificatesRotationV4Request.getRotateCertificatesType());
+                certificatesRotationV4Request.getCertificateRotationType());
         return reactorNotifier.notify(stackId, selector, clusterCertificatesRotationTriggerEvent);
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/FlowPayloadConstructorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/FlowPayloadConstructorTest.java
@@ -1,40 +1,14 @@
 package com.sequenceiq.cloudbreak;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Modifier;
-import java.util.Set;
-
 import org.junit.jupiter.api.Test;
-import org.reflections.ReflectionUtils;
-import org.reflections.Reflections;
-import org.reflections.scanners.SubTypesScanner;
 
-import com.sequenceiq.cloudbreak.common.event.Acceptable;
+import com.sequenceiq.flow.helper.FlowPayloadConstructorChecker;
 
 class FlowPayloadConstructorTest {
 
     @Test
-    void constructorAccessible() {
-        Reflections reflections = new Reflections("com.sequenceiq", new SubTypesScanner(true));
-        Set<Class<? extends Acceptable>> eventClasses = reflections.getSubTypesOf(Acceptable.class);
-        eventClasses.stream()
-                .filter(c -> !c.isInterface() && !isAbstract(c) && !c.isAnonymousClass() && !c.isLocalClass() && !c.isMemberClass())
-                .filter(c -> !c.getName().endsWith("Test"))
-                .forEach(this::checkForConstructor);
+    void constructorTest() {
+        new FlowPayloadConstructorChecker().checkConstructorOnAcceptableClasses();
     }
 
-    private void checkForConstructor(Class<? extends Acceptable> clazz) {
-        Set<Constructor> constructors = ReflectionUtils.getConstructors(clazz, this::isPublic);
-        assertFalse(constructors.isEmpty(), String.format("%s class has no visible public constructor!", clazz.getName()));
-    }
-
-    private boolean isPublic(Constructor<?> c) {
-        return Modifier.isPublic(c.getModifiers());
-    }
-
-    private boolean isAbstract(Class<?> clazz) {
-        return Modifier.isAbstract(clazz.getModifiers());
-    }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/entity/SdxCluster.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/entity/SdxCluster.java
@@ -430,6 +430,18 @@ public class SdxCluster implements AccountAwareResource {
         this.databaseEngineVersion = databaseEngineVersion;
     }
 
+    public void setResourceCrn(String resourceCrn) {
+        this.resourceCrn = resourceCrn;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setRepairFlowChainId(String repairFlowChainId) {
+        this.repairFlowChainId = repairFlowChainId;
+    }
+
     //CHECKSTYLE:OFF
     @Override
     public boolean equals(Object o) {

--- a/datalake/src/main/java/com/sequenceiq/datalake/entity/operation/SdxOperation.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/entity/operation/SdxOperation.java
@@ -49,6 +49,14 @@ public class SdxOperation {
         this.status = SdxOperationStatus.INIT;
     }
 
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
     public String getOperationId() {
         return operationId;
     }

--- a/datalake/src/main/java/com/sequenceiq/datalake/settings/SdxRepairSettings.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/settings/SdxRepairSettings.java
@@ -14,9 +14,9 @@ import com.sequenceiq.sdx.api.model.SdxRepairRequest;
 
 public class SdxRepairSettings {
 
-    private List<String> hostGroupNames = new ArrayList<>();
+    private final List<String> hostGroupNames = new ArrayList<>();
 
-    private List<String> nodeIds = new ArrayList<>();
+    private final List<String> nodeIds = new ArrayList<>();
 
     private boolean deleteVolumes;
 
@@ -58,6 +58,10 @@ public class SdxRepairSettings {
 
     public boolean isDeleteVolumes() {
         return deleteVolumes;
+    }
+
+    public void setDeleteVolumes(boolean deleteVolumes) {
+        this.deleteVolumes = deleteVolumes;
     }
 
     @Override

--- a/datalake/src/test/java/com/sequenceiq/datalake/FlowPayloadConstructorTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/FlowPayloadConstructorTest.java
@@ -1,40 +1,14 @@
 package com.sequenceiq.datalake;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Modifier;
-import java.util.Set;
-
 import org.junit.jupiter.api.Test;
-import org.reflections.ReflectionUtils;
-import org.reflections.Reflections;
-import org.reflections.scanners.SubTypesScanner;
 
-import com.sequenceiq.cloudbreak.common.event.Acceptable;
+import com.sequenceiq.flow.helper.FlowPayloadConstructorChecker;
 
 class FlowPayloadConstructorTest {
 
     @Test
-    void constructorAccessible() {
-        Reflections reflections = new Reflections("com.sequenceiq", new SubTypesScanner(true));
-        Set<Class<? extends Acceptable>> eventClasses = reflections.getSubTypesOf(Acceptable.class);
-        eventClasses.stream()
-                .filter(c -> !c.isInterface() && !isAbstract(c) && !c.isAnonymousClass() && !c.isLocalClass() && !c.isMemberClass())
-                .filter(c -> !c.getName().endsWith("Test"))
-                .forEach(this::checkForConstructor);
+    void constructorTest() {
+        new FlowPayloadConstructorChecker().checkConstructorOnAcceptableClasses();
     }
 
-    private void checkForConstructor(Class<? extends Acceptable> clazz) {
-        Set<Constructor> constructors = ReflectionUtils.getConstructors(clazz, this::isPublic);
-        assertFalse(constructors.isEmpty(), String.format("%s class has no visible public constructor!", clazz.getName()));
-    }
-
-    private boolean isPublic(Constructor<?> c) {
-        return Modifier.isPublic(c.getModifiers());
-    }
-
-    private boolean isAbstract(Class<?> clazz) {
-        return Modifier.isAbstract(clazz.getModifiers());
-    }
 }

--- a/environment/src/test/java/com/sequenceiq/environment/FlowPayloadConstructorTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/FlowPayloadConstructorTest.java
@@ -1,40 +1,14 @@
 package com.sequenceiq.environment;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Modifier;
-import java.util.Set;
-
 import org.junit.jupiter.api.Test;
-import org.reflections.ReflectionUtils;
-import org.reflections.Reflections;
-import org.reflections.scanners.SubTypesScanner;
 
-import com.sequenceiq.cloudbreak.common.event.Acceptable;
+import com.sequenceiq.flow.helper.FlowPayloadConstructorChecker;
 
 class FlowPayloadConstructorTest {
 
     @Test
-    void constructorAccessible() {
-        Reflections reflections = new Reflections("com.sequenceiq", new SubTypesScanner(true));
-        Set<Class<? extends Acceptable>> eventClasses = reflections.getSubTypesOf(Acceptable.class);
-        eventClasses.stream()
-                .filter(c -> !c.isInterface() && !isAbstract(c) && !c.isAnonymousClass() && !c.isLocalClass() && !c.isMemberClass())
-                .filter(c -> !c.getName().endsWith("Test"))
-                .forEach(this::checkForConstructor);
+    void constructorTest() {
+        new FlowPayloadConstructorChecker().checkConstructorOnAcceptableClasses();
     }
 
-    private void checkForConstructor(Class<? extends Acceptable> clazz) {
-        Set<Constructor> constructors = ReflectionUtils.getConstructors(clazz, this::isPublic);
-        assertFalse(constructors.isEmpty(), String.format("%s class has no visible public constructor!", clazz.getName()));
-    }
-
-    private boolean isPublic(Constructor<?> c) {
-        return Modifier.isPublic(c.getModifiers());
-    }
-
-    private boolean isAbstract(Class<?> clazz) {
-        return Modifier.isAbstract(clazz.getModifiers());
-    }
 }

--- a/flow/src/test/java/com/sequenceiq/flow/helper/FlowPayloadConstructorChecker.java
+++ b/flow/src/test/java/com/sequenceiq/flow/helper/FlowPayloadConstructorChecker.java
@@ -1,0 +1,187 @@
+package com.sequenceiq.flow.helper;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.commons.lang3.ClassUtils;
+import org.reflections.Reflections;
+import org.reflections.scanners.SubTypesScanner;
+
+import com.sequenceiq.cloudbreak.common.event.Acceptable;
+
+public class FlowPayloadConstructorChecker {
+
+    private final Set<Class<?>> checked = new HashSet<>();
+
+    private final List<String> validationErrors = new ArrayList<>();
+
+    public void checkConstructorOnAcceptableClasses() {
+        Reflections reflections = new Reflections("com.sequenceiq", new SubTypesScanner(true));
+        Set<Class<? extends Acceptable>> eventClasses = reflections.getSubTypesOf(Acceptable.class);
+        eventClasses.stream()
+                .filter(c -> !c.isInterface() && !isAbstract(c) && !c.isAnonymousClass() && !c.isLocalClass() && !c.isMemberClass())
+                .filter(c -> !c.getName().endsWith("Test") && !c.getName().endsWith("Builder"))
+                .forEach(this::checkForConstructorAndCache);
+        if (!validationErrors.isEmpty()) {
+            fail(String.join("\n", validationErrors));
+        }
+    }
+
+    private void checkForConstructorAndCache(Class<?> clazz) {
+        if (!checked.contains(clazz)) {
+            checked.add(clazz);
+            checkForConstructor(clazz);
+        }
+    }
+
+    private void checkForConstructor(Class<?> clazz) {
+        Constructor<?>[] constructors = clazz.getDeclaredConstructors();
+        checkDefaultConstructor(clazz, constructors);
+        checkSoloBuilder(clazz, constructors);
+
+        Optional<Constructor<?>> maxParamCtor = getConstructorWithMaximalPositiveParameterCount(constructors);
+        if (maxParamCtor.isPresent()) {
+            for (Class<?> paramType : maxParamCtor.get().getParameterTypes()) {
+                if (paramType.getPackageName().startsWith("com.sequenceiq.") &&
+                        !paramType.isEnum() &&
+                        !ClassUtils.isPrimitiveOrWrapper(paramType)) {
+
+                    checkForConstructorAndCache(paramType);
+                }
+            }
+        }
+    }
+
+    private void checkDefaultConstructor(Class<?> clazz, Constructor<?>[] constructors) {
+        if (hasDefaultConstructor(constructors)) {
+            List<String> setterNames = checkAllSetters(clazz);
+            if (!setterNames.isEmpty()) {
+                validationErrors.add(String.format("Class %s with default constructor has setter(s) [%s] with no corresponding backing field(s)",
+                        clazz.getName(), String.join(",", setterNames)));
+            }
+
+            List<String> fieldNames = checkAllPrivateFields(clazz);
+            if (!fieldNames.isEmpty()) {
+                validationErrors.add(String.format("Class %s with default constructor has field(s) [%s] with no setter",
+                        clazz.getName(), String.join(",", fieldNames)));
+            }
+        }
+    }
+
+    private boolean hasDefaultConstructor(Constructor<?>[] constructors) {
+        for (Constructor<?> c : constructors) {
+            if (c.getParameterCount() == 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void checkSoloBuilder(Class<?> clazz, Constructor<?>[] constructors) {
+        if (constructors.length == 1 &&
+                constructors[0].getParameterCount() == 1 &&
+                getBuilderClass(clazz).isPresent() &&
+                constructors[0].getParameterTypes()[0].equals(getBuilderClass(clazz).get())) {
+
+            validationErrors.add(
+                    String.format("Class %s has only a constructor for its builder thus it cannot be deserialized without proper annotation", clazz.getName()));
+        }
+    }
+
+    private Optional<Constructor<?>> getConstructorWithMaximalPositiveParameterCount(Constructor<?>[] declaredConstructors) {
+        int maxParam = 0;
+        Constructor<?> maxParamCtor = null;
+        for (Constructor<?> c : declaredConstructors) {
+            if (c.getParameterCount() > maxParam) {
+                maxParam = c.getParameterCount();
+                maxParamCtor = c;
+            }
+        }
+        return Optional.ofNullable(maxParamCtor);
+    }
+
+    private Optional<Class<?>> getBuilderClass(Class<?> clazz) {
+        for (Class<?> innerClass : clazz.getDeclaredClasses()) {
+            if (isStatic(innerClass) && isPublic(innerClass) &&
+                    innerClass.getSimpleName().toLowerCase().contains("builder")) {
+                return Optional.of(innerClass);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private List<String> checkAllSetters(Class<?> clazz) {
+        List<String> setterNames = new ArrayList<>();
+        for (Method m : clazz.getDeclaredMethods()) {
+            if (isSetterForClass(m)) {
+                boolean fieldPresent = isFieldForSetterPresent(clazz, m.getName());
+                if (!fieldPresent) {
+                    setterNames.add(m.getName());
+                }
+            }
+        }
+        return setterNames;
+    }
+
+    private List<String> checkAllPrivateFields(Class<?> clazz) {
+        List<String> fieldNames = new ArrayList<>();
+        for (Field f : clazz.getDeclaredFields()) {
+            if (!Modifier.isFinal(f.getModifiers())) {
+                boolean setterPresent = isSetterForFieldPresent(clazz, f.getName());
+                if (!setterPresent) {
+                    fieldNames.add(f.getName());
+                }
+            }
+        }
+        return fieldNames;
+    }
+
+    private boolean isSetterForFieldPresent(Class<?> clazz, String fieldName) {
+        String expectedSetterName = "set" + fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1);
+        for (Method m : clazz.getDeclaredMethods()) {
+            if (expectedSetterName.equals(m.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isFieldForSetterPresent(Class<?> clazz, String setterName) {
+        String expectedBackingFieldName = setterName.substring(3, 4).toLowerCase() + setterName.substring(4);
+        for (Field f : clazz.getDeclaredFields()) {
+            if (f.getName().equals(expectedBackingFieldName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean isSetterForClass(Method method) {
+        if (!method.getName().startsWith("set")) {
+            return false;
+        }
+        return method.getParameterTypes().length == 1;
+    }
+
+    private boolean isAbstract(Class<?> clazz) {
+        return Modifier.isAbstract(clazz.getModifiers());
+    }
+
+    private boolean isPublic(Class<?> clazz) {
+        return Modifier.isPublic(clazz.getModifiers());
+    }
+
+    private boolean isStatic(Class<?> clazz) {
+        return Modifier.isStatic(clazz.getModifiers());
+    }
+
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/FlowPayloadConstructorTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/FlowPayloadConstructorTest.java
@@ -1,40 +1,14 @@
 package com.sequenceiq.freeipa;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Modifier;
-import java.util.Set;
-
 import org.junit.jupiter.api.Test;
-import org.reflections.ReflectionUtils;
-import org.reflections.Reflections;
-import org.reflections.scanners.SubTypesScanner;
 
-import com.sequenceiq.cloudbreak.common.event.Acceptable;
+import com.sequenceiq.flow.helper.FlowPayloadConstructorChecker;
 
 class FlowPayloadConstructorTest {
 
     @Test
-    void constructorAccessible() {
-        Reflections reflections = new Reflections("com.sequenceiq", new SubTypesScanner(true));
-        Set<Class<? extends Acceptable>> eventClasses = reflections.getSubTypesOf(Acceptable.class);
-        eventClasses.stream()
-                .filter(c -> !c.isInterface() && !isAbstract(c) && !c.isAnonymousClass() && !c.isLocalClass() && !c.isMemberClass())
-                .filter(c -> !c.getName().endsWith("Test"))
-                .forEach(this::checkForConstructor);
+    void constructorTest() {
+        new FlowPayloadConstructorChecker().checkConstructorOnAcceptableClasses();
     }
 
-    private void checkForConstructor(Class<? extends Acceptable> clazz) {
-        Set<Constructor> constructors = ReflectionUtils.getConstructors(clazz, this::isPublic);
-        assertFalse(constructors.isEmpty(), String.format("%s class has no visible public constructor!", clazz.getName()));
-    }
-
-    private boolean isPublic(Constructor<?> c) {
-        return Modifier.isPublic(c.getModifiers());
-    }
-
-    private boolean isAbstract(Class<?> clazz) {
-        return Modifier.isAbstract(clazz.getModifiers());
-    }
 }

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/FlowPayloadConstructorTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/FlowPayloadConstructorTest.java
@@ -1,40 +1,14 @@
 package com.sequenceiq.redbeams;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Modifier;
-import java.util.Set;
-
 import org.junit.jupiter.api.Test;
-import org.reflections.ReflectionUtils;
-import org.reflections.Reflections;
-import org.reflections.scanners.SubTypesScanner;
 
-import com.sequenceiq.cloudbreak.common.event.Acceptable;
+import com.sequenceiq.flow.helper.FlowPayloadConstructorChecker;
 
 class FlowPayloadConstructorTest {
 
     @Test
-    void constructorAccessible() {
-        Reflections reflections = new Reflections("com.sequenceiq", new SubTypesScanner(true));
-        Set<Class<? extends Acceptable>> eventClasses = reflections.getSubTypesOf(Acceptable.class);
-        eventClasses.stream()
-                .filter(c -> !c.isInterface() && !isAbstract(c) && !c.isAnonymousClass() && !c.isLocalClass() && !c.isMemberClass())
-                .filter(c -> !c.getName().endsWith("Test"))
-                .forEach(this::checkForConstructor);
+    void constructorTest() {
+        new FlowPayloadConstructorChecker().checkConstructorOnAcceptableClasses();
     }
 
-    private void checkForConstructor(Class<? extends Acceptable> clazz) {
-        Set<Constructor> constructors = ReflectionUtils.getConstructors(clazz, this::isPublic);
-        assertFalse(constructors.isEmpty(), String.format("%s class has no visible public constructor!", clazz.getName()));
-    }
-
-    private boolean isPublic(Constructor<?> c) {
-        return Modifier.isPublic(c.getModifiers());
-    }
-
-    private boolean isAbstract(Class<?> clazz) {
-        return Modifier.isAbstract(clazz.getModifiers());
-    }
 }


### PR DESCRIPTION
Moved it to a common place and used it from all other modules.
It checks for flow payload (implementing `Acceptable` interface) classes' constructors:
- if only the builder constructor exists
- if it has default constructor with no proper setters and no corresponding backing fields
- recursively checks constructor parameters' type for the same above

See detailed description in the commit message.