### PR TITLE
ENGESC-15269 Environment default SG gets ignored

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/environment/domain/Environment.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/domain/Environment.java
@@ -498,11 +498,7 @@ public class Environment implements AuthResource, AccountAwareResource {
     }
 
     public EnvironmentTags getEnvironmentTags() {
-        if (tags != null && tags.getValue() != null) {
-            return JsonUtil.readValueOpt(tags.getValue(), EnvironmentTags.class)
-                    .orElse(new EnvironmentTags(new HashMap<>(), new HashMap<>()));
-        }
-        return new EnvironmentTags(new HashMap<>(), new HashMap<>());
+        return EnvironmentTags.fromJson(tags);
     }
 
     public Environment getParentEnvironment() {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/domain/EnvironmentTags.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/domain/EnvironmentTags.java
@@ -3,11 +3,14 @@ package com.sequenceiq.environment.environment.domain;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -38,4 +41,13 @@ public class EnvironmentTags {
                 + ", defaultTags=" + defaultTags
                 + '}';
     }
+
+    static EnvironmentTags fromJson(Json tags) {
+        if (tags != null && tags.getValue() != null) {
+            return JsonUtil.readValueOpt(tags.getValue(), EnvironmentTags.class)
+                    .orElse(new EnvironmentTags(new HashMap<>(), new HashMap<>()));
+        }
+        return new EnvironmentTags(new HashMap<>(), new HashMap<>());
+    }
+
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/domain/EnvironmentView.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/domain/EnvironmentView.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.environment.environment.domain;
 
-import java.util.HashMap;
 import java.util.Objects;
 import java.util.Set;
 
@@ -402,11 +401,7 @@ public class EnvironmentView extends CompactView implements AuthResource {
     }
 
     public EnvironmentTags getEnvironmentTags() {
-        if (tags != null && tags.getValue() != null) {
-            return JsonUtil.readValueOpt(tags.getValue(), EnvironmentTags.class)
-                    .orElse(new EnvironmentTags(new HashMap<>(), new HashMap<>()));
-        }
-        return new EnvironmentTags(new HashMap<>(), new HashMap<>());
+        return EnvironmentTags.fromJson(tags);
     }
 
     public String getAdminGroupName() {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/domain/ExperimentalFeatures.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/domain/ExperimentalFeatures.java
@@ -79,6 +79,17 @@ public class ExperimentalFeatures implements Serializable {
         return tunnel == null && idBrokerMappingSource == null && cloudStorageValidation == null && ccmV2TlsType == null;
     }
 
+    @Override
+    public String toString() {
+        return "ExperimentalFeatures{" +
+                "tunnel=" + tunnel +
+                ", overrideTunnel=" + overrideTunnel +
+                ", idBrokerMappingSource=" + idBrokerMappingSource +
+                ", cloudStorageValidation=" + cloudStorageValidation +
+                ", ccmV2TlsType=" + ccmV2TlsType +
+                '}';
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -104,11 +115,7 @@ public class ExperimentalFeatures implements Serializable {
         }
 
         public Builder withOverrideTunnel(Boolean overrideTunnel) {
-            if (overrideTunnel == null || !overrideTunnel) {
-                this.overrideTunnel = false;
-            } else {
-                this.overrideTunnel = true;
-            }
+            this.overrideTunnel = Boolean.TRUE.equals(overrideTunnel);
             return this;
         }
 

--- a/environment/src/test/java/com/sequenceiq/environment/environment/domain/EnvironmentTagsTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/domain/EnvironmentTagsTest.java
@@ -1,0 +1,73 @@
+package com.sequenceiq.environment.environment.domain;
+
+import static java.util.Map.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.common.json.Json;
+
+class EnvironmentTagsTest {
+
+    @Test
+    void fromJsonTestWhenNullJson() {
+        EnvironmentTags result = EnvironmentTags.fromJson(null);
+
+        verifyEmptyResult(result);
+    }
+
+    private void verifyEmptyResult(EnvironmentTags result) {
+        assertThat(result).isNotNull();
+        assertThat(result.getDefaultTags()).isNotNull();
+        assertThat(result.getDefaultTags()).isEmpty();
+        assertThat(result.getUserDefinedTags()).isNotNull();
+        assertThat(result.getUserDefinedTags()).isEmpty();
+    }
+
+    @Test
+    void fromJsonTestWhenNullJsonValue() {
+        Json json = new Json(null);
+
+        EnvironmentTags result = EnvironmentTags.fromJson(json);
+
+        verifyEmptyResult(result);
+    }
+
+    @Test
+    void fromJsonTestWhenInvalidJsonValue() {
+        Json json = new Json("");
+
+        EnvironmentTags result = EnvironmentTags.fromJson(json);
+
+        verifyEmptyResult(result);
+    }
+
+    @Test
+    void fromJsonTestWhenJsonValueEmptyObject() {
+        Json json = new Json("{}");
+
+        EnvironmentTags result = EnvironmentTags.fromJson(json);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getDefaultTags()).isNull();
+        assertThat(result.getUserDefinedTags()).isNull();
+    }
+
+    @Test
+    void fromJsonTestWhenSuccess() {
+        Map<String, String> userDefinedTags = Map.ofEntries(entry("userKey1", "userValue1"), entry("userKey2", "userValue2"));
+        Map<String, String> defaultTags = Map.ofEntries(entry("defaultKey1", "defaultValue1"), entry("defaultKey2", "defaultValue2"));
+        Json json = new Json(new EnvironmentTags(userDefinedTags, defaultTags));
+
+        EnvironmentTags result = EnvironmentTags.fromJson(json);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getDefaultTags()).isNotNull();
+        assertThat(result.getDefaultTags()).isEqualTo(defaultTags);
+        assertThat(result.getUserDefinedTags()).isNotNull();
+        assertThat(result.getUserDefinedTags()).isEqualTo(userDefinedTags);
+    }
+
+}

--- a/environment/src/test/java/com/sequenceiq/environment/environment/domain/ExperimentalFeaturesTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/domain/ExperimentalFeaturesTest.java
@@ -1,0 +1,43 @@
+package com.sequenceiq.environment.environment.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.sequenceiq.common.api.type.CcmV2TlsType;
+import com.sequenceiq.common.api.type.Tunnel;
+import com.sequenceiq.environment.api.v1.environment.model.base.CloudStorageValidation;
+import com.sequenceiq.environment.api.v1.environment.model.base.IdBrokerMappingSource;
+
+class ExperimentalFeaturesTest {
+
+    static Object[][] overrideTunnelDataProvider() {
+        return new Object[][]{
+                // overrideTunnel overrideTunnelExpected
+                {null, false},
+                {false, false},
+                {true, true},
+        };
+    }
+
+    @ParameterizedTest(name = "overrideTunnel={0}")
+    @MethodSource("overrideTunnelDataProvider")
+    void builderTest(Boolean overrideTunnel, boolean overrideTunnelExpected) {
+        ExperimentalFeatures result = ExperimentalFeatures.builder()
+                .withOverrideTunnel(overrideTunnel)
+                .withTunnel(Tunnel.CCM)
+                .withIdBrokerMappingSource(IdBrokerMappingSource.IDBMMS)
+                .withCloudStorageValidation(CloudStorageValidation.ENABLED)
+                .withCcmV2TlsType(CcmV2TlsType.TWO_WAY_TLS)
+                .build();
+
+        assertThat(result).isNotNull();
+        assertThat(result.isOverrideTunnel()).isEqualTo(overrideTunnelExpected);
+        assertThat(result.getTunnel()).isEqualTo(Tunnel.CCM);
+        assertThat(result.getIdBrokerMappingSource()).isEqualTo(IdBrokerMappingSource.IDBMMS);
+        assertThat(result.getCloudStorageValidation()).isEqualTo(CloudStorageValidation.ENABLED);
+        assertThat(result.getCcmV2TlsType()).isEqualTo(CcmV2TlsType.TWO_WAY_TLS);
+    }
+
+}

--- a/environment/src/test/java/com/sequenceiq/environment/environment/dto/EnvironmentDtoConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/dto/EnvironmentDtoConverterTest.java
@@ -1,31 +1,150 @@
 package com.sequenceiq.environment.environment.dto;
 
+import static java.util.Map.entry;
+import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import com.sequenceiq.cloudbreak.auth.CrnUser;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.auth.security.CrnUserDetailsService;
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.tag.AccountTagValidationFailed;
 import com.sequenceiq.cloudbreak.tag.CostTagging;
+import com.sequenceiq.cloudbreak.tag.request.CDPTagGenerationRequest;
+import com.sequenceiq.common.api.type.Tunnel;
+import com.sequenceiq.environment.api.v1.tags.model.response.AccountTagResponse;
+import com.sequenceiq.environment.credential.domain.Credential;
+import com.sequenceiq.environment.credential.domain.CredentialView;
+import com.sequenceiq.environment.environment.EnvironmentDeletionType;
+import com.sequenceiq.environment.environment.EnvironmentStatus;
 import com.sequenceiq.environment.environment.domain.Environment;
 import com.sequenceiq.environment.environment.domain.EnvironmentAuthentication;
+import com.sequenceiq.environment.environment.domain.EnvironmentTags;
+import com.sequenceiq.environment.environment.domain.EnvironmentView;
+import com.sequenceiq.environment.environment.domain.ExperimentalFeatures;
+import com.sequenceiq.environment.environment.domain.ParentEnvironmentView;
+import com.sequenceiq.environment.environment.domain.Region;
+import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentTelemetry;
 import com.sequenceiq.environment.environment.service.recipe.EnvironmentRecipeService;
+import com.sequenceiq.environment.network.dao.domain.AwsNetwork;
+import com.sequenceiq.environment.network.dto.NetworkDto;
+import com.sequenceiq.environment.network.v1.converter.EnvironmentNetworkConverter;
+import com.sequenceiq.environment.parameter.dto.ParametersDto;
+import com.sequenceiq.environment.parameters.dao.domain.AwsParameters;
+import com.sequenceiq.environment.parameters.dao.domain.AzureParameters;
+import com.sequenceiq.environment.parameters.v1.converter.EnvironmentParametersConverter;
+import com.sequenceiq.environment.proxy.domain.ProxyConfig;
+import com.sequenceiq.environment.proxy.domain.ProxyConfigView;
+import com.sequenceiq.environment.tags.domain.AccountTag;
 import com.sequenceiq.environment.tags.service.AccountTagService;
 import com.sequenceiq.environment.tags.service.DefaultInternalAccountTagService;
+import com.sequenceiq.environment.tags.v1.converter.AccountTagToAccountTagResponsesConverter;
 
 @ExtendWith(MockitoExtension.class)
 class EnvironmentDtoConverterTest {
+
+    private static final Long ID = 123L;
+
+    private static final String RESOURCE_CRN = "resourceCrn";
+
+    private static final String NAME = "name";
+
+    private static final String ORIGINAL_NAME = "originalName";
+
+    private static final String DESCRIPTION = "description";
+
+    private static final String ACCOUNT_ID = "accountId";
+
+    private static final boolean ARCHIVED = true;
+
+    private static final String CLOUD_PLATFORM_AWS = "AWS";
+
+    private static final String CLOUD_PLATFORM_AZURE = "AZURE";
+
+    private static final Long DELETION_TIMESTAMP = 9876543210L;
+
+    private static final String LOCATION = "location";
+
+    private static final String LOCATION_DISPLAY_NAME = "locationDisplayName";
+
+    private static final Double LONGITUDE = 12.34;
+
+    private static final Double LATITUDE = -56.78;
+
+    private static final EnvironmentStatus STATUS = EnvironmentStatus.AVAILABLE;
+
+    private static final String CREATOR = "creator";
+
+    private static final boolean CREATE_FREE_IPA = true;
+
+    private static final Integer FREE_IPA_INSTANCE_COUNT_BY_GROUP = 2;
+
+    private static final String FREE_IPA_INSTANCE_TYPE = "freeIpaInstanceType";
+
+    private static final String FREE_IPA_IMAGE_CATALOG = "freeIpaImageCatalog";
+
+    private static final String FREE_IPA_IMAGE_ID = "freeIpaImageId";
+
+    private static final boolean FREE_IPA_ENABLE_MULTI_AZ = true;
+
+    private static final Integer FREE_IPA_SPOT_PERCENTAGE = 23;
+
+    private static final Double FREE_IPA_SPOT_MAX_PRICE = 567.0;
+
+    private static final Long CREATED = 1234567890L;
+
+    private static final String STATUS_REASON = "statusReason";
+
+    private static final String CIDR = "cidr";
+
+    private static final String SECURITY_GROUP_ID_FOR_KNOX = "securityGroupIdForKnox";
+
+    private static final String DEFAULT_SECURITY_GROUP_ID = "defaultSecurityGroupId";
+
+    private static final String ADMIN_GROUP_NAME = "adminGroupName";
+
+    private static final EnvironmentDeletionType DELETION_TYPE = EnvironmentDeletionType.SIMPLE;
+
+    private static final String ENVIRONMENT_SERVICE_VERSION = "environmentServiceVersion";
+
+    private static final String DOMAIN = "domain";
+
+    private static final String PARENT_RESOURCE_CRN = "parentResourceCrn";
+
+    private static final String PARENT_NAME = "parentName";
+
+    private static final String PARENT_CLOUD_PLATFORM = "GCP";
+
+    private static final boolean INTERNAL_TENANT = true;
+
+    private static final String USER_NAME = "userName";
+
+    private static final String STORAGE_LOCATION = "storageLocation";
 
     @Mock
     private AuthenticationDtoConverter authenticationDtoConverter;
@@ -40,6 +159,9 @@ class EnvironmentDtoConverterTest {
     private DefaultInternalAccountTagService defaultInternalAccountTagService;
 
     @Mock
+    private AccountTagToAccountTagResponsesConverter accountTagToAccountTagResponsesConverter;
+
+    @Mock
     private AccountTagService accountTagService;
 
     @Mock
@@ -51,8 +173,26 @@ class EnvironmentDtoConverterTest {
     @InjectMocks
     private EnvironmentDtoConverter underTest;
 
+    @Mock
+    private EnvironmentView environmentView;
+
+    @Mock
+    private Environment environment;
+
+    @Mock
+    private Environment parentEnvironment;
+
+    @Mock
+    private EnvironmentParametersConverter environmentParametersConverter;
+
+    @Mock
+    private EnvironmentNetworkConverter environmentNetworkConverter;
+
+    @Captor
+    private ArgumentCaptor<CDPTagGenerationRequest> cdpTagGenerationRequestCaptor;
+
     @Test
-    public void testEnvironmentToEnvironmentDtoFreeIpaCreationWithoutAwsParameters() {
+    void testEnvironmentToEnvironmentDtoFreeIpaCreationWithoutAwsParameters() {
         Environment source = new Environment();
         source.setId(1L);
         source.setFreeIpaInstanceType("large");
@@ -65,7 +205,10 @@ class EnvironmentDtoConverterTest {
         source.setAuthentication(new EnvironmentAuthentication());
 
         when(environmentRecipeService.getRecipes(1L)).thenReturn(Set.of("recipe1", "recipe2"));
+
         EnvironmentDto environmentDto = underTest.environmentToDto(source);
+
+        assertThat(environmentDto).isNotNull();
         FreeIpaCreationDto freeIpaCreation = environmentDto.getFreeIpaCreation();
         assertNotNull(freeIpaCreation);
         assertEquals("large", freeIpaCreation.getInstanceType());
@@ -76,6 +219,664 @@ class EnvironmentDtoConverterTest {
         assertTrue(freeIpaCreation.getCreate());
         assertNull(freeIpaCreation.getAws());
         assertThat(freeIpaCreation.getRecipes()).containsExactlyInAnyOrder("recipe1", "recipe2");
+    }
+
+    @Test
+    void environmentViewToViewDtoTestBasic() {
+        CredentialView credential = new CredentialView();
+        Region region = new Region();
+        Set<Region> regionSet = Set.of(region);
+        EnvironmentTelemetry environmentTelemetry = new EnvironmentTelemetry();
+        EnvironmentBackup environmentBackup = new EnvironmentBackup();
+        EnvironmentAuthentication authentication = new EnvironmentAuthentication();
+        AuthenticationDto authenticationDto = AuthenticationDto.builder().build();
+        Set<String> freeipaRecipes = Set.of("recipe");
+        ExperimentalFeatures experimentalFeatures = ExperimentalFeatures.builder().build();
+        EnvironmentTags environmentTags = new EnvironmentTags(Map.of(), Map.of());
+        ProxyConfigView proxyConfig = new ProxyConfigView();
+
+        when(environmentView.getId()).thenReturn(ID);
+        when(environmentView.getResourceCrn()).thenReturn(RESOURCE_CRN);
+        when(environmentView.getName()).thenReturn(NAME);
+        when(environmentView.getOriginalName()).thenReturn(ORIGINAL_NAME);
+        when(environmentView.getDescription()).thenReturn(DESCRIPTION);
+        when(environmentView.getAccountId()).thenReturn(ACCOUNT_ID);
+        when(environmentView.isArchived()).thenReturn(ARCHIVED);
+        when(environmentView.getCloudPlatform()).thenReturn(CLOUD_PLATFORM_AWS);
+        when(environmentView.getCredential()).thenReturn(credential);
+        when(environmentView.getDeletionTimestamp()).thenReturn(DELETION_TIMESTAMP);
+        when(environmentView.getLocation()).thenReturn(LOCATION);
+        when(environmentView.getLocationDisplayName()).thenReturn(LOCATION_DISPLAY_NAME);
+        when(environmentView.getLongitude()).thenReturn(LONGITUDE);
+        when(environmentView.getLatitude()).thenReturn(LATITUDE);
+        when(environmentView.getRegionSet()).thenReturn(regionSet);
+        when(environmentView.getTelemetry()).thenReturn(environmentTelemetry);
+        when(environmentView.getBackup()).thenReturn(environmentBackup);
+        when(environmentView.getStatus()).thenReturn(STATUS);
+        when(environmentView.getCreator()).thenReturn(CREATOR);
+        when(environmentView.getAuthentication()).thenReturn(authentication);
+        when(environmentView.isCreateFreeIpa()).thenReturn(CREATE_FREE_IPA);
+        when(environmentView.getFreeIpaInstanceCountByGroup()).thenReturn(FREE_IPA_INSTANCE_COUNT_BY_GROUP);
+        when(environmentView.getFreeIpaInstanceType()).thenReturn(FREE_IPA_INSTANCE_TYPE);
+        when(environmentView.getFreeIpaImageCatalog()).thenReturn(FREE_IPA_IMAGE_CATALOG);
+        when(environmentView.getFreeIpaImageId()).thenReturn(FREE_IPA_IMAGE_ID);
+        when(environmentView.isFreeIpaEnableMultiAz()).thenReturn(FREE_IPA_ENABLE_MULTI_AZ);
+        when(environmentView.getFreeipaRecipes()).thenReturn(freeipaRecipes);
+        when(environmentView.getParameters()).thenReturn(null);
+        when(environmentView.getCreated()).thenReturn(CREATED);
+        when(environmentView.getStatusReason()).thenReturn(STATUS_REASON);
+        when(environmentView.getExperimentalFeaturesJson()).thenReturn(experimentalFeatures);
+        when(environmentView.getEnvironmentTags()).thenReturn(environmentTags);
+        when(environmentView.getCidr()).thenReturn(CIDR);
+        when(environmentView.getSecurityGroupIdForKnox()).thenReturn(SECURITY_GROUP_ID_FOR_KNOX);
+        when(environmentView.getDefaultSecurityGroupId()).thenReturn(DEFAULT_SECURITY_GROUP_ID);
+        when(environmentView.getAdminGroupName()).thenReturn(ADMIN_GROUP_NAME);
+        when(environmentView.getProxyConfig()).thenReturn(proxyConfig);
+        when(environmentView.getDeletionType()).thenReturn(DELETION_TYPE);
+        when(environmentView.getEnvironmentServiceVersion()).thenReturn(ENVIRONMENT_SERVICE_VERSION);
+        when(environmentView.getDomain()).thenReturn(DOMAIN);
+        when(environmentView.getNetwork()).thenReturn(null);
+        when(environmentView.getParentEnvironment()).thenReturn(null);
+
+        when(authenticationDtoConverter.authenticationToDto(authentication)).thenReturn(authenticationDto);
+
+        EnvironmentViewDto result = underTest.environmentViewToViewDto(environmentView);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(ID);
+        assertThat(result.getResourceCrn()).isEqualTo(RESOURCE_CRN);
+        assertThat(result.getName()).isEqualTo(NAME);
+        assertThat(result.getOriginalName()).isEqualTo(ORIGINAL_NAME);
+        assertThat(result.getDescription()).isEqualTo(DESCRIPTION);
+        assertThat(result.getAccountId()).isEqualTo(ACCOUNT_ID);
+        assertThat(result.isArchived()).isEqualTo(ARCHIVED);
+        assertThat(result.getCloudPlatform()).isEqualTo(CLOUD_PLATFORM_AWS);
+        assertThat(result.getCredentialView()).isSameAs(credential);
+        assertThat(result.getDeletionTimestamp()).isEqualTo(DELETION_TIMESTAMP);
+        assertThat(result.getRegions()).isSameAs(regionSet);
+        assertThat(result.getTelemetry()).isSameAs(environmentTelemetry);
+        assertThat(result.getBackup()).isSameAs(environmentBackup);
+        assertThat(result.getStatus()).isEqualTo(STATUS);
+        assertThat(result.getCreator()).isEqualTo(CREATOR);
+        assertThat(result.getAuthentication()).isSameAs(authenticationDto);
+        assertThat(result.getCreated()).isEqualTo(CREATED);
+        assertThat(result.getStatusReason()).isEqualTo(STATUS_REASON);
+        assertThat(result.getExperimentalFeatures()).isSameAs(experimentalFeatures);
+        assertThat(result.getTags()).isSameAs(environmentTags);
+        assertThat(result.getAdminGroupName()).isEqualTo(ADMIN_GROUP_NAME);
+        assertThat(result.getProxyConfig()).isSameAs(proxyConfig);
+        assertThat(result.getDeletionType()).isEqualTo(DELETION_TYPE);
+        assertThat(result.getEnvironmentServiceVersion()).isEqualTo(ENVIRONMENT_SERVICE_VERSION);
+        assertThat(result.getDomain()).isEqualTo(DOMAIN);
+
+        LocationDto locationDto = result.getLocation();
+        assertThat(locationDto).isNotNull();
+        assertThat(locationDto.getName()).isEqualTo(LOCATION);
+        assertThat(locationDto.getDisplayName()).isEqualTo(LOCATION_DISPLAY_NAME);
+        assertThat(locationDto.getLongitude()).isEqualTo(LONGITUDE);
+        assertThat(locationDto.getLatitude()).isEqualTo(LATITUDE);
+
+        FreeIpaCreationDto freeIpaCreationDto = result.getFreeIpaCreation();
+        assertThat(freeIpaCreationDto).isNotNull();
+        assertThat(freeIpaCreationDto.getCreate()).isEqualTo(CREATE_FREE_IPA);
+        assertThat(freeIpaCreationDto.getInstanceCountByGroup()).isEqualTo(FREE_IPA_INSTANCE_COUNT_BY_GROUP);
+        assertThat(freeIpaCreationDto.getInstanceType()).isEqualTo(FREE_IPA_INSTANCE_TYPE);
+        assertThat(freeIpaCreationDto.isEnableMultiAz()).isEqualTo(FREE_IPA_ENABLE_MULTI_AZ);
+        assertThat(freeIpaCreationDto.getRecipes()).isSameAs(freeipaRecipes);
+        assertThat(freeIpaCreationDto.getAws()).isNull();
+
+        SecurityAccessDto securityAccessDto = result.getSecurityAccess();
+        assertThat(securityAccessDto).isNotNull();
+        assertThat(securityAccessDto.getCidr()).isEqualTo(CIDR);
+        assertThat(securityAccessDto.getSecurityGroupIdForKnox()).isEqualTo(SECURITY_GROUP_ID_FOR_KNOX);
+        assertThat(securityAccessDto.getDefaultSecurityGroupId()).isEqualTo(DEFAULT_SECURITY_GROUP_ID);
+
+        assertThat(result.getParameters()).isNull();
+        assertThat(result.getNetwork()).isNull();
+        assertThat(result.getParentEnvironmentCrn()).isNull();
+        assertThat(result.getParentEnvironmentName()).isNull();
+        assertThat(result.getParentEnvironmentCloudPlatform()).isNull();
+
+        verify(environmentRecipeService, never()).getRecipes(anyLong());
+    }
+
+    @Test
+    void environmentViewToViewDtoTestAwsParameters() {
+        AwsParameters awsParameters = new AwsParameters();
+        awsParameters.setFreeIpaSpotPercentage(FREE_IPA_SPOT_PERCENTAGE);
+        awsParameters.setFreeIpaSpotMaxPrice(FREE_IPA_SPOT_MAX_PRICE);
+
+        ReflectionTestUtils.setField(underTest, "environmentParamsConverterMap", Map.ofEntries(entry(CloudPlatform.AWS, environmentParametersConverter)));
+        ParametersDto parametersDto = ParametersDto.builder().build();
+        when(environmentParametersConverter.convertToDto(awsParameters)).thenReturn(parametersDto);
+
+        when(environmentView.getCloudPlatform()).thenReturn(CLOUD_PLATFORM_AWS);
+        when(environmentView.getParameters()).thenReturn(awsParameters);
+
+        EnvironmentViewDto result = underTest.environmentViewToViewDto(environmentView);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getParameters()).isSameAs(parametersDto);
+
+        FreeIpaCreationDto freeIpaCreationDto = result.getFreeIpaCreation();
+        assertThat(freeIpaCreationDto).isNotNull();
+
+        FreeIpaCreationAwsParametersDto freeIpaCreationAwsParametersDto = freeIpaCreationDto.getAws();
+        assertThat(freeIpaCreationAwsParametersDto).isNotNull();
+
+        FreeIpaCreationAwsSpotParametersDto freeIpaCreationAwsSpotParametersDto = freeIpaCreationAwsParametersDto.getSpot();
+        assertThat(freeIpaCreationAwsSpotParametersDto.getPercentage()).isEqualTo(FREE_IPA_SPOT_PERCENTAGE);
+        assertThat(freeIpaCreationAwsSpotParametersDto.getMaxPrice()).isEqualTo(FREE_IPA_SPOT_MAX_PRICE);
+    }
+
+    @Test
+    void environmentViewToViewDtoTestAzureParameters() {
+        AzureParameters azureParameters = new AzureParameters();
+
+        ReflectionTestUtils.setField(underTest, "environmentParamsConverterMap", Map.ofEntries(entry(CloudPlatform.AZURE, environmentParametersConverter)));
+        ParametersDto parametersDto = ParametersDto.builder().build();
+        when(environmentParametersConverter.convertToDto(azureParameters)).thenReturn(parametersDto);
+
+        when(environmentView.getCloudPlatform()).thenReturn(CLOUD_PLATFORM_AZURE);
+        when(environmentView.getParameters()).thenReturn(azureParameters);
+
+        EnvironmentViewDto result = underTest.environmentViewToViewDto(environmentView);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getParameters()).isSameAs(parametersDto);
+
+        FreeIpaCreationDto freeIpaCreationDto = result.getFreeIpaCreation();
+        assertThat(freeIpaCreationDto).isNotNull();
+        assertThat(freeIpaCreationDto.getAws()).isNull();
+    }
+
+    @Test
+    void environmentViewToViewDtoTestNetwork() {
+        AwsNetwork awsNetwork = new AwsNetwork();
+
+        ReflectionTestUtils.setField(underTest, "environmentNetworkConverterMap", Map.ofEntries(entry(CloudPlatform.AWS, environmentNetworkConverter)));
+        NetworkDto networkDto = NetworkDto.builder().build();
+        when(environmentNetworkConverter.convertToDto(awsNetwork)).thenReturn(networkDto);
+
+        when(environmentView.getCloudPlatform()).thenReturn(CLOUD_PLATFORM_AWS);
+        when(environmentView.getParameters()).thenReturn(null);
+        when(environmentView.getNetwork()).thenReturn(awsNetwork);
+
+        EnvironmentViewDto result = underTest.environmentViewToViewDto(environmentView);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getNetwork()).isSameAs(networkDto);
+
+        FreeIpaCreationDto freeIpaCreationDto = result.getFreeIpaCreation();
+        assertThat(freeIpaCreationDto).isNotNull();
+        assertThat(freeIpaCreationDto.getAws()).isNull();
+
+        assertThat(result.getParameters()).isNull();
+    }
+
+    @Test
+    void environmentViewToViewDtoTestParentEnvironment() {
+        ParentEnvironmentView parentEnvironment = new ParentEnvironmentView();
+        parentEnvironment.setResourceCrn(PARENT_RESOURCE_CRN);
+        parentEnvironment.setName(PARENT_NAME);
+        parentEnvironment.setCloudPlatform(PARENT_CLOUD_PLATFORM);
+
+        when(environmentView.getCloudPlatform()).thenReturn(CLOUD_PLATFORM_AWS);
+        when(environmentView.getParentEnvironment()).thenReturn(parentEnvironment);
+
+        EnvironmentViewDto result = underTest.environmentViewToViewDto(environmentView);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getParentEnvironmentCrn()).isEqualTo(PARENT_RESOURCE_CRN);
+        assertThat(result.getParentEnvironmentName()).isEqualTo(PARENT_NAME);
+        assertThat(result.getParentEnvironmentCloudPlatform()).isEqualTo(PARENT_CLOUD_PLATFORM);
+    }
+
+    @Test
+    void environmentToDtoTestBasic() {
+        Credential credential = new Credential();
+        Region region = new Region();
+        Set<Region> regionSet = Set.of(region);
+        EnvironmentTelemetry environmentTelemetry = new EnvironmentTelemetry();
+        EnvironmentBackup environmentBackup = new EnvironmentBackup();
+        EnvironmentAuthentication authentication = new EnvironmentAuthentication();
+        AuthenticationDto authenticationDto = AuthenticationDto.builder().build();
+        Set<String> freeipaRecipes = Set.of("recipe");
+        ExperimentalFeatures experimentalFeatures = ExperimentalFeatures.builder().build();
+        EnvironmentTags environmentTags = new EnvironmentTags(Map.of(), Map.of());
+        ProxyConfig proxyConfig = new ProxyConfig();
+
+        when(environment.getId()).thenReturn(ID);
+        when(environment.getResourceCrn()).thenReturn(RESOURCE_CRN);
+        when(environment.getName()).thenReturn(NAME);
+        when(environment.getOriginalName()).thenReturn(ORIGINAL_NAME);
+        when(environment.getDescription()).thenReturn(DESCRIPTION);
+        when(environment.getAccountId()).thenReturn(ACCOUNT_ID);
+        when(environment.isArchived()).thenReturn(ARCHIVED);
+        when(environment.getCloudPlatform()).thenReturn(CLOUD_PLATFORM_AWS);
+        when(environment.getCredential()).thenReturn(credential);
+        when(environment.getDeletionTimestamp()).thenReturn(DELETION_TIMESTAMP);
+        when(environment.getLocation()).thenReturn(LOCATION);
+        when(environment.getLocationDisplayName()).thenReturn(LOCATION_DISPLAY_NAME);
+        when(environment.getLongitude()).thenReturn(LONGITUDE);
+        when(environment.getLatitude()).thenReturn(LATITUDE);
+        when(environment.getRegionSet()).thenReturn(regionSet);
+        when(environment.getTelemetry()).thenReturn(environmentTelemetry);
+        when(environment.getBackup()).thenReturn(environmentBackup);
+        when(environment.getStatus()).thenReturn(STATUS);
+        when(environment.getCreator()).thenReturn(CREATOR);
+        when(environment.getAuthentication()).thenReturn(authentication);
+        when(environment.isCreateFreeIpa()).thenReturn(CREATE_FREE_IPA);
+        when(environment.getFreeIpaInstanceCountByGroup()).thenReturn(FREE_IPA_INSTANCE_COUNT_BY_GROUP);
+        when(environment.getFreeIpaInstanceType()).thenReturn(FREE_IPA_INSTANCE_TYPE);
+        when(environment.getFreeIpaImageCatalog()).thenReturn(FREE_IPA_IMAGE_CATALOG);
+        when(environment.getFreeIpaImageId()).thenReturn(FREE_IPA_IMAGE_ID);
+        when(environment.isFreeIpaEnableMultiAz()).thenReturn(FREE_IPA_ENABLE_MULTI_AZ);
+        when(environment.getParameters()).thenReturn(null);
+        when(environment.getCreated()).thenReturn(CREATED);
+        when(environment.getStatusReason()).thenReturn(STATUS_REASON);
+        when(environment.getExperimentalFeaturesJson()).thenReturn(experimentalFeatures);
+        when(environment.getEnvironmentTags()).thenReturn(environmentTags);
+        when(environment.getCidr()).thenReturn(CIDR);
+        when(environment.getSecurityGroupIdForKnox()).thenReturn(SECURITY_GROUP_ID_FOR_KNOX);
+        when(environment.getDefaultSecurityGroupId()).thenReturn(DEFAULT_SECURITY_GROUP_ID);
+        when(environment.getAdminGroupName()).thenReturn(ADMIN_GROUP_NAME);
+        when(environment.getProxyConfig()).thenReturn(proxyConfig);
+        when(environment.getDeletionType()).thenReturn(DELETION_TYPE);
+        when(environment.getEnvironmentServiceVersion()).thenReturn(ENVIRONMENT_SERVICE_VERSION);
+        when(environment.getDomain()).thenReturn(DOMAIN);
+        when(environment.getNetwork()).thenReturn(null);
+        when(environment.getParentEnvironment()).thenReturn(null);
+
+        when(authenticationDtoConverter.authenticationToDto(authentication)).thenReturn(authenticationDto);
+        when(environmentRecipeService.getRecipes(ID)).thenReturn(freeipaRecipes);
+
+        EnvironmentDto result = underTest.environmentToDto(environment);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(ID);
+        assertThat(result.getResourceCrn()).isEqualTo(RESOURCE_CRN);
+        assertThat(result.getName()).isEqualTo(NAME);
+        assertThat(result.getOriginalName()).isEqualTo(ORIGINAL_NAME);
+        assertThat(result.getDescription()).isEqualTo(DESCRIPTION);
+        assertThat(result.getAccountId()).isEqualTo(ACCOUNT_ID);
+        assertThat(result.isArchived()).isEqualTo(ARCHIVED);
+        assertThat(result.getCloudPlatform()).isEqualTo(CLOUD_PLATFORM_AWS);
+        assertThat(result.getCredential()).isSameAs(credential);
+        assertThat(result.getDeletionTimestamp()).isEqualTo(DELETION_TIMESTAMP);
+        assertThat(result.getRegions()).isSameAs(regionSet);
+        assertThat(result.getTelemetry()).isSameAs(environmentTelemetry);
+        assertThat(result.getBackup()).isSameAs(environmentBackup);
+        assertThat(result.getStatus()).isEqualTo(STATUS);
+        assertThat(result.getCreator()).isEqualTo(CREATOR);
+        assertThat(result.getAuthentication()).isSameAs(authenticationDto);
+        assertThat(result.getCreated()).isEqualTo(CREATED);
+        assertThat(result.getStatusReason()).isEqualTo(STATUS_REASON);
+        assertThat(result.getExperimentalFeatures()).isSameAs(experimentalFeatures);
+        assertThat(result.getTags()).isSameAs(environmentTags);
+        assertThat(result.getAdminGroupName()).isEqualTo(ADMIN_GROUP_NAME);
+        assertThat(result.getProxyConfig()).isSameAs(proxyConfig);
+        assertThat(result.getDeletionType()).isEqualTo(DELETION_TYPE);
+        assertThat(result.getEnvironmentServiceVersion()).isEqualTo(ENVIRONMENT_SERVICE_VERSION);
+        assertThat(result.getDomain()).isEqualTo(DOMAIN);
+
+        LocationDto locationDto = result.getLocation();
+        assertThat(locationDto).isNotNull();
+        assertThat(locationDto.getName()).isEqualTo(LOCATION);
+        assertThat(locationDto.getDisplayName()).isEqualTo(LOCATION_DISPLAY_NAME);
+        assertThat(locationDto.getLongitude()).isEqualTo(LONGITUDE);
+        assertThat(locationDto.getLatitude()).isEqualTo(LATITUDE);
+
+        FreeIpaCreationDto freeIpaCreationDto = result.getFreeIpaCreation();
+        assertThat(freeIpaCreationDto).isNotNull();
+        assertThat(freeIpaCreationDto.getCreate()).isEqualTo(CREATE_FREE_IPA);
+        assertThat(freeIpaCreationDto.getInstanceCountByGroup()).isEqualTo(FREE_IPA_INSTANCE_COUNT_BY_GROUP);
+        assertThat(freeIpaCreationDto.getInstanceType()).isEqualTo(FREE_IPA_INSTANCE_TYPE);
+        assertThat(freeIpaCreationDto.isEnableMultiAz()).isEqualTo(FREE_IPA_ENABLE_MULTI_AZ);
+        assertThat(freeIpaCreationDto.getRecipes()).isSameAs(freeipaRecipes);
+        assertThat(freeIpaCreationDto.getAws()).isNull();
+
+        SecurityAccessDto securityAccessDto = result.getSecurityAccess();
+        assertThat(securityAccessDto).isNotNull();
+        assertThat(securityAccessDto.getCidr()).isEqualTo(CIDR);
+        assertThat(securityAccessDto.getSecurityGroupIdForKnox()).isEqualTo(SECURITY_GROUP_ID_FOR_KNOX);
+        assertThat(securityAccessDto.getDefaultSecurityGroupId()).isEqualTo(DEFAULT_SECURITY_GROUP_ID);
+
+        assertThat(result.getParameters()).isNull();
+        assertThat(result.getNetwork()).isNull();
+        assertThat(result.getParentEnvironmentCrn()).isNull();
+        assertThat(result.getParentEnvironmentName()).isNull();
+        assertThat(result.getParentEnvironmentCloudPlatform()).isNull();
+    }
+
+    @Test
+    void environmentToDtoTestAwsParameters() {
+        AwsParameters awsParameters = new AwsParameters();
+        awsParameters.setFreeIpaSpotPercentage(FREE_IPA_SPOT_PERCENTAGE);
+        awsParameters.setFreeIpaSpotMaxPrice(FREE_IPA_SPOT_MAX_PRICE);
+
+        ReflectionTestUtils.setField(underTest, "environmentParamsConverterMap", Map.ofEntries(entry(CloudPlatform.AWS, environmentParametersConverter)));
+        ParametersDto parametersDto = ParametersDto.builder().build();
+        when(environmentParametersConverter.convertToDto(awsParameters)).thenReturn(parametersDto);
+
+        when(environment.getCloudPlatform()).thenReturn(CLOUD_PLATFORM_AWS);
+        when(environment.getParameters()).thenReturn(awsParameters);
+
+        EnvironmentDto result = underTest.environmentToDto(environment);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getParameters()).isSameAs(parametersDto);
+
+        FreeIpaCreationDto freeIpaCreationDto = result.getFreeIpaCreation();
+        assertThat(freeIpaCreationDto).isNotNull();
+
+        FreeIpaCreationAwsParametersDto freeIpaCreationAwsParametersDto = freeIpaCreationDto.getAws();
+        assertThat(freeIpaCreationAwsParametersDto).isNotNull();
+
+        FreeIpaCreationAwsSpotParametersDto freeIpaCreationAwsSpotParametersDto = freeIpaCreationAwsParametersDto.getSpot();
+        assertThat(freeIpaCreationAwsSpotParametersDto.getPercentage()).isEqualTo(FREE_IPA_SPOT_PERCENTAGE);
+        assertThat(freeIpaCreationAwsSpotParametersDto.getMaxPrice()).isEqualTo(FREE_IPA_SPOT_MAX_PRICE);
+    }
+
+    @Test
+    void environmentToDtoTestAzureParameters() {
+        AzureParameters azureParameters = new AzureParameters();
+
+        ReflectionTestUtils.setField(underTest, "environmentParamsConverterMap", Map.ofEntries(entry(CloudPlatform.AZURE, environmentParametersConverter)));
+        ParametersDto parametersDto = ParametersDto.builder().build();
+        when(environmentParametersConverter.convertToDto(azureParameters)).thenReturn(parametersDto);
+
+        when(environment.getCloudPlatform()).thenReturn(CLOUD_PLATFORM_AZURE);
+        when(environment.getParameters()).thenReturn(azureParameters);
+
+        EnvironmentDto result = underTest.environmentToDto(environment);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getParameters()).isSameAs(parametersDto);
+
+        FreeIpaCreationDto freeIpaCreationDto = result.getFreeIpaCreation();
+        assertThat(freeIpaCreationDto).isNotNull();
+        assertThat(freeIpaCreationDto.getAws()).isNull();
+    }
+
+    @Test
+    void environmentToDtoTestNetwork() {
+        AwsNetwork awsNetwork = new AwsNetwork();
+
+        ReflectionTestUtils.setField(underTest, "environmentNetworkConverterMap", Map.ofEntries(entry(CloudPlatform.AWS, environmentNetworkConverter)));
+        NetworkDto networkDto = NetworkDto.builder().build();
+        when(environmentNetworkConverter.convertToDto(awsNetwork)).thenReturn(networkDto);
+
+        when(environment.getCloudPlatform()).thenReturn(CLOUD_PLATFORM_AWS);
+        when(environment.getParameters()).thenReturn(null);
+        when(environment.getNetwork()).thenReturn(awsNetwork);
+
+        EnvironmentDto result = underTest.environmentToDto(environment);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getNetwork()).isSameAs(networkDto);
+
+        FreeIpaCreationDto freeIpaCreationDto = result.getFreeIpaCreation();
+        assertThat(freeIpaCreationDto).isNotNull();
+        assertThat(freeIpaCreationDto.getAws()).isNull();
+
+        assertThat(result.getParameters()).isNull();
+    }
+
+    @Test
+    void environmentToDtoTestParentEnvironment() {
+        when(parentEnvironment.getResourceCrn()).thenReturn(PARENT_RESOURCE_CRN);
+        when(parentEnvironment.getName()).thenReturn(PARENT_NAME);
+        when(parentEnvironment.getCloudPlatform()).thenReturn(PARENT_CLOUD_PLATFORM);
+
+        when(environment.getCloudPlatform()).thenReturn(CLOUD_PLATFORM_AWS);
+        when(environment.getParentEnvironment()).thenReturn(parentEnvironment);
+
+        EnvironmentDto result = underTest.environmentToDto(environment);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getParentEnvironmentCrn()).isEqualTo(PARENT_RESOURCE_CRN);
+        assertThat(result.getParentEnvironmentName()).isEqualTo(PARENT_NAME);
+        assertThat(result.getParentEnvironmentCloudPlatform()).isEqualTo(PARENT_CLOUD_PLATFORM);
+    }
+
+    @Test
+    void environmentToLocationDtoTest() {
+        when(environment.getLocation()).thenReturn(LOCATION);
+        when(environment.getLocationDisplayName()).thenReturn(LOCATION_DISPLAY_NAME);
+        when(environment.getLongitude()).thenReturn(LONGITUDE);
+        when(environment.getLatitude()).thenReturn(LATITUDE);
+
+        LocationDto result = underTest.environmentToLocationDto(environment);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getName()).isEqualTo(LOCATION);
+        assertThat(result.getDisplayName()).isEqualTo(LOCATION_DISPLAY_NAME);
+        assertThat(result.getLongitude()).isEqualTo(LONGITUDE);
+        assertThat(result.getLatitude()).isEqualTo(LATITUDE);
+    }
+
+    @Test
+    void creationDtoToEnvironmentTestWhenSuccessAndUserDefinedTagsArePresent() {
+        LocationDto location = LocationDto.builder()
+                .withLatitude(LATITUDE)
+                .withLongitude(LONGITUDE)
+                .withName(LOCATION)
+                .withDisplayName(LOCATION_DISPLAY_NAME)
+                .build();
+        Map<String, Object> fluentAttributes = Map.ofEntries(entry("fluentKey1", "fluentValue1"), entry("fluentKey2", "fluentValue2"));
+        EnvironmentTelemetry environmentTelemetry = new EnvironmentTelemetry();
+        environmentTelemetry.setFluentAttributes(fluentAttributes);
+        EnvironmentBackup environmentBackup = new EnvironmentBackup();
+        environmentBackup.setStorageLocation(STORAGE_LOCATION);
+        FreeIpaCreationDto freeIpaCreation = FreeIpaCreationDto.builder()
+                .withCreate(CREATE_FREE_IPA)
+                .withInstanceCountByGroup(FREE_IPA_INSTANCE_COUNT_BY_GROUP)
+                .withInstanceType(FREE_IPA_INSTANCE_TYPE)
+                .withImageCatalog(FREE_IPA_IMAGE_CATALOG)
+                .withEnableMultiAz(FREE_IPA_ENABLE_MULTI_AZ)
+                .withImageId(FREE_IPA_IMAGE_ID)
+                .build();
+        ExperimentalFeatures experimentalFeatures = ExperimentalFeatures.builder()
+                .withTunnel(Tunnel.CCMV2_JUMPGATE)
+                .build();
+        Set<String> regions = Set.of("region1", "region2");
+
+        Map<String, String> userDefinedTags = Map.ofEntries(entry("userKey1", "userValue1"), entry("userKey2", "userValue2"));
+        AccountTag accountTag = new AccountTag();
+        AccountTagResponse accountTagResponse = new AccountTagResponse();
+        accountTagResponse.setKey("accountKey");
+        accountTagResponse.setValue("accountValue");
+        Map<String, String> defaultTags = Map.ofEntries(entry("defaultKey1", "defaultValue1"), entry("defaultKey2", "defaultValue2"));
+
+        EnvironmentCreationDto creationDto = EnvironmentCreationDto.builder()
+                .withAccountId(ACCOUNT_ID)
+                .withCreator(CREATOR)
+                .withName(NAME)
+                .withCloudPlatform(CLOUD_PLATFORM_AWS)
+                .withDescription(DESCRIPTION)
+                .withLocation(location)
+                .withTelemetry(environmentTelemetry)
+                .withBackup(environmentBackup)
+                .withFreeIpaCreation(freeIpaCreation)
+                .withAdminGroupName(ADMIN_GROUP_NAME)
+                .withExperimentalFeatures(experimentalFeatures)
+                .withRegions(regions)
+                .withTags(userDefinedTags)
+                .withCrn(RESOURCE_CRN)
+                .build();
+
+        when(entitlementService.internalTenant(ACCOUNT_ID)).thenReturn(INTERNAL_TENANT);
+        when(accountTagService.get(ACCOUNT_ID)).thenReturn(Set.of(accountTag));
+        when(accountTagToAccountTagResponsesConverter.convert(accountTag)).thenReturn(accountTagResponse);
+        when(crnUserDetailsService.loadUserByUsername(CREATOR)).thenReturn(new CrnUser(null, CREATOR, USER_NAME, null, ACCOUNT_ID, null));
+        when(costTagging.prepareDefaultTags(any(CDPTagGenerationRequest.class))).thenReturn(defaultTags);
+
+        Environment result = underTest.creationDtoToEnvironment(creationDto);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getAccountId()).isEqualTo(ACCOUNT_ID);
+        assertThat(result.getCreator()).isEqualTo(CREATOR);
+        assertThat(result.getName()).isEqualTo(NAME);
+        assertThat(result.getOriginalName()).isEqualTo(NAME);
+        assertThat(result.isArchived()).isFalse();
+        assertThat(result.getCloudPlatform()).isEqualTo(CLOUD_PLATFORM_AWS);
+        assertThat(result.getDescription()).isEqualTo(DESCRIPTION);
+        assertThat(result.getLatitude()).isEqualTo(LATITUDE);
+        assertThat(result.getLongitude()).isEqualTo(LONGITUDE);
+        assertThat(result.getLocation()).isEqualTo(LOCATION);
+        assertThat(result.getLocationDisplayName()).isEqualTo(LOCATION_DISPLAY_NAME);
+        assertThat(result.getStatus()).isEqualTo(EnvironmentStatus.CREATION_INITIATED);
+        assertThat(result.getStatusReason()).isNull();
+        assertThat(result.getFreeIpaInstanceCountByGroup()).isEqualTo(FREE_IPA_INSTANCE_COUNT_BY_GROUP);
+        assertThat(result.getFreeIpaInstanceType()).isEqualTo(FREE_IPA_INSTANCE_TYPE);
+        assertThat(result.getFreeIpaImageCatalog()).isEqualTo(FREE_IPA_IMAGE_CATALOG);
+        assertThat(result.isFreeIpaEnableMultiAz()).isEqualTo(FREE_IPA_ENABLE_MULTI_AZ);
+        assertThat(result.getDeletionType()).isEqualTo(EnvironmentDeletionType.NONE);
+        assertThat(result.getFreeIpaImageId()).isEqualTo(FREE_IPA_IMAGE_ID);
+        assertThat(result.getAdminGroupName()).isEqualTo(ADMIN_GROUP_NAME);
+        assertThat(result.getCreated()).isPositive();
+
+        EnvironmentTelemetry resultTelemetry = result.getTelemetry();
+        assertThat(resultTelemetry).isNotNull();
+        assertThat(resultTelemetry.getFluentAttributes()).isEqualTo(fluentAttributes);
+
+        EnvironmentBackup resultBackup = result.getBackup();
+        assertThat(resultBackup).isNotNull();
+        assertThat(resultBackup.getStorageLocation()).isEqualTo(STORAGE_LOCATION);
+
+        ExperimentalFeatures resultExperimentalFeaturesJson = result.getExperimentalFeaturesJson();
+        assertThat(resultExperimentalFeaturesJson).isNotNull();
+        assertThat(resultExperimentalFeaturesJson.getTunnel()).isEqualTo(Tunnel.CCMV2_JUMPGATE);
+
+        Json tags = result.getTags();
+        assertThat(tags).isNotNull();
+        assertThat(tags.getValue()).isNotNull();
+
+        EnvironmentTags environmentTags = result.getEnvironmentTags();
+        assertThat(environmentTags).isNotNull();
+        assertThat(environmentTags.getUserDefinedTags()).isEqualTo(userDefinedTags);
+        assertThat(environmentTags.getDefaultTags()).isEqualTo(defaultTags);
+
+        verify(defaultInternalAccountTagService).merge(List.of(accountTagResponse));
+        verify(costTagging).prepareDefaultTags(cdpTagGenerationRequestCaptor.capture());
+
+        CDPTagGenerationRequest cdpTagGenerationRequest = cdpTagGenerationRequestCaptor.getValue();
+        assertThat(cdpTagGenerationRequest).isNotNull();
+        assertThat(cdpTagGenerationRequest.getCreatorCrn()).isEqualTo(CREATOR);
+        assertThat(cdpTagGenerationRequest.getEnvironmentCrn()).isEqualTo(RESOURCE_CRN);
+        assertThat(cdpTagGenerationRequest.getAccountId()).isEqualTo(ACCOUNT_ID);
+        assertThat(cdpTagGenerationRequest.getPlatform()).isEqualTo(CLOUD_PLATFORM_AWS);
+        assertThat(cdpTagGenerationRequest.getResourceCrn()).isEqualTo(RESOURCE_CRN);
+        assertThat(cdpTagGenerationRequest.isInternalTenant()).isEqualTo(INTERNAL_TENANT);
+        assertThat(cdpTagGenerationRequest.getUserName()).isEqualTo(USER_NAME);
+        assertThat(cdpTagGenerationRequest.getAccountTags()).isEqualTo(Map.ofEntries(entry("accountKey", "accountValue")));
+        assertThat(cdpTagGenerationRequest.getUserDefinedTags()).isEqualTo(userDefinedTags);
+
+        Set<Region> regionSet = result.getRegionSet();
+        assertThat(regionSet).isNotNull();
+        assertThat(regionSet.stream()
+                .map(Region::getName)
+                .collect(toSet())).isEqualTo(regions);
+    }
+
+    @Test
+    void creationDtoToEnvironmentTestWhenSuccessAndUserDefinedTagsAreAbsent() {
+        LocationDto location = LocationDto.builder()
+                .withLatitude(LATITUDE)
+                .withLongitude(LONGITUDE)
+                .withName(LOCATION)
+                .withDisplayName(LOCATION_DISPLAY_NAME)
+                .build();
+        FreeIpaCreationDto freeIpaCreation = FreeIpaCreationDto.builder()
+                .build();
+        Map<String, String> defaultTags = Map.ofEntries(entry("defaultKey1", "defaultValue1"), entry("defaultKey2", "defaultValue2"));
+        EnvironmentCreationDto creationDto = EnvironmentCreationDto.builder()
+                .withAccountId(ACCOUNT_ID)
+                .withCreator(CREATOR)
+                .withCloudPlatform(CLOUD_PLATFORM_AWS)
+                .withLocation(location)
+                .withFreeIpaCreation(freeIpaCreation)
+                .withTags(null)
+                .withCrn(RESOURCE_CRN)
+                .build();
+
+        when(crnUserDetailsService.loadUserByUsername(CREATOR)).thenReturn(new CrnUser(null, CREATOR, USER_NAME, null, ACCOUNT_ID, null));
+        when(costTagging.prepareDefaultTags(any(CDPTagGenerationRequest.class))).thenReturn(defaultTags);
+
+        Environment result = underTest.creationDtoToEnvironment(creationDto);
+
+        assertThat(result).isNotNull();
+
+        Json tags = result.getTags();
+        assertThat(tags).isNotNull();
+        assertThat(tags.getValue()).isNotNull();
+
+        EnvironmentTags environmentTags = result.getEnvironmentTags();
+        assertThat(environmentTags).isNotNull();
+        assertThat(environmentTags.getUserDefinedTags()).isNotNull();
+        assertThat(environmentTags.getUserDefinedTags()).isEmpty();
+        assertThat(environmentTags.getDefaultTags()).isEqualTo(defaultTags);
+    }
+
+    @Test
+    void creationDtoToEnvironmentTestWhenErrorAndAccountTagValidationFailed() {
+        LocationDto location = LocationDto.builder()
+                .withLatitude(LATITUDE)
+                .withLongitude(LONGITUDE)
+                .withName(LOCATION)
+                .withDisplayName(LOCATION_DISPLAY_NAME)
+                .build();
+        FreeIpaCreationDto freeIpaCreation = FreeIpaCreationDto.builder()
+                .build();
+        EnvironmentCreationDto creationDto = EnvironmentCreationDto.builder()
+                .withAccountId(ACCOUNT_ID)
+                .withCreator(CREATOR)
+                .withCloudPlatform(CLOUD_PLATFORM_AWS)
+                .withLocation(location)
+                .withFreeIpaCreation(freeIpaCreation)
+                .withTags(null)
+                .withCrn(RESOURCE_CRN)
+                .build();
+
+        when(crnUserDetailsService.loadUserByUsername(CREATOR)).thenReturn(new CrnUser(null, CREATOR, USER_NAME, null, ACCOUNT_ID, null));
+        when(costTagging.prepareDefaultTags(any(CDPTagGenerationRequest.class))).thenThrow(new AccountTagValidationFailed("Error validating tags"));
+
+        BadRequestException badRequestException = Assertions.assertThrows(BadRequestException.class,
+                () -> underTest.creationDtoToEnvironment(creationDto));
+
+        assertThat(badRequestException).hasMessage("Error validating tags");
+    }
+
+    @Test
+    void creationDtoToEnvironmentTestWhenErrorAndOtherException() {
+        LocationDto location = LocationDto.builder()
+                .withLatitude(LATITUDE)
+                .withLongitude(LONGITUDE)
+                .withName(LOCATION)
+                .withDisplayName(LOCATION_DISPLAY_NAME)
+                .build();
+        FreeIpaCreationDto freeIpaCreation = FreeIpaCreationDto.builder()
+                .build();
+        EnvironmentCreationDto creationDto = EnvironmentCreationDto.builder()
+                .withAccountId(ACCOUNT_ID)
+                .withCreator(CREATOR)
+                .withCloudPlatform(CLOUD_PLATFORM_AWS)
+                .withLocation(location)
+                .withFreeIpaCreation(freeIpaCreation)
+                .withTags(null)
+                .withCrn(RESOURCE_CRN)
+                .build();
+
+        when(crnUserDetailsService.loadUserByUsername(CREATOR)).thenReturn(new CrnUser(null, CREATOR, USER_NAME, null, ACCOUNT_ID, null));
+        UnsupportedOperationException unsupportedOperationException = new UnsupportedOperationException("This operation is not supported");
+        when(costTagging.prepareDefaultTags(any(CDPTagGenerationRequest.class))).thenThrow(unsupportedOperationException);
+
+        BadRequestException badRequestException = Assertions.assertThrows(BadRequestException.class,
+                () -> underTest.creationDtoToEnvironment(creationDto));
+
+        assertThat(badRequestException).hasMessage("Failed to convert dynamic tags. This operation is not supported");
+        assertThat(badRequestException).hasCauseReference(unsupportedOperationException);
     }
 
 }


### PR DESCRIPTION
* `com.sequenceiq.environment.environment.dto.EnvironmentDtoConverter`:
  * Correct copy-paste errors in `environmentViewToViewDto()` and `environmentToDto()` so that the default SG also gets used from the respective source entities.
  * Add extensive UT coverage in order to check every functionality of the class.
* Extract common logic from
  `com.sequenceiq.environment.environment.domain.Environment.getEnvironmentTags()` and `com.sequenceiq.environment.environment.domain.EnvironmentView.getEnvironmentTags()` into the new package-private method `com.sequenceiq.environment.environment.domain.EnvironmentTags.fromJson()`.
* Some code cleanups:
  * Naming corrections
  * Remove unnecessary code
  * Logic simplifications
* Testing:
  * Manual testing in local CB.
  * Added new UT and updated existing ones.
