### PR TITLE
CB-17582 Use LDAP instead of PAM as default SASL auth mechanism for Kafka

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaAuthConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaAuthConfigProvider.java
@@ -24,8 +24,8 @@ public class KafkaAuthConfigProvider implements CmTemplateComponentConfigProvide
         switch (authType) {
             case LDAP_AUTH:
                 return ldapConfig(ldapView);
-            case SASL_PAM_AUTH:
-                return ldapAndPamConfig(ldapView);
+            case SASL_LDAP_AUTH:
+                return saslLdapConfig(ldapView);
             case LDAP_BASE_CONFIG:
                 return generalAuthConfig(ldapView);
             default:
@@ -39,9 +39,9 @@ public class KafkaAuthConfigProvider implements CmTemplateComponentConfigProvide
         return config;
     }
 
-    private List<ApiClusterTemplateConfig> ldapAndPamConfig(LdapView ldapView) {
+    private List<ApiClusterTemplateConfig> saslLdapConfig(LdapView ldapView) {
         List<ApiClusterTemplateConfig> config = generalAuthConfig(ldapView);
-        config.add(config(KafkaConfigs.SASL_AUTH_METHOD, "PAM"));
+        config.add(config(KafkaConfigs.SASL_AUTH_METHOD, "LDAP"));
         return config;
     }
 

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaConfigProviderUtils.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaConfigProviderUtils.java
@@ -84,10 +84,10 @@ public class KafkaConfigProviderUtils {
         VERSION_7_0_0(KafkaAuthConfigType.NO_AUTH),
         VERSION_7_0_2(KafkaAuthConfigType.LDAP_AUTH),
         VERSION_7_0_2_MISSING_PATCH_VERSION(KafkaAuthConfigType.LDAP_BASE_CONFIG),
-        VERSION_7_0_2_X(KafkaAuthConfigType.SASL_PAM_AUTH),
+        VERSION_7_0_2_X(KafkaAuthConfigType.SASL_LDAP_AUTH),
         VERSION_7_0_X(KafkaAuthConfigType.LDAP_AUTH),
-        VERSION_7_1_0(KafkaAuthConfigType.SASL_PAM_AUTH),
-        VERSION_7_X_X(KafkaAuthConfigType.SASL_PAM_AUTH);
+        VERSION_7_1_0(KafkaAuthConfigType.SASL_LDAP_AUTH),
+        VERSION_7_X_X(KafkaAuthConfigType.SASL_LDAP_AUTH);
 
         private static final EnumSet<CdhVersionForStreaming> SUPPORTS_RANGER_SERVICE_CREATION = EnumSet.of(
                 VERSION_7_0_2_X, VERSION_7_1_0, VERSION_7_X_X);
@@ -123,7 +123,7 @@ public class KafkaConfigProviderUtils {
         NO_AUTH,
         LDAP_BASE_CONFIG,
         LDAP_AUTH,
-        SASL_PAM_AUTH
+        SASL_LDAP_AUTH
     }
 
 }

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaAuthConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaAuthConfigProviderTest.java
@@ -48,10 +48,10 @@ class KafkaAuthConfigProviderTest {
             config("ldap.auth.user.dn.template", "pattern"),
             config("ldap.auth.enable", "true"));
 
-    private static final Set<ApiClusterTemplateConfig> PAM_AUTH_EXPECTED_CONFIGS = Set.of(
+    private static final Set<ApiClusterTemplateConfig> SASL_LDAP_AUTH_EXPECTED_CONFIGS = Set.of(
             config("ldap.auth.url", "protocol://host:1234"),
             config("ldap.auth.user.dn.template", "pattern"),
-            config("sasl.plain.auth", "PAM"));
+            config("sasl.plain.auth", "LDAP"));
 
     private KafkaAuthConfigProvider underTest;
 
@@ -101,12 +101,12 @@ class KafkaAuthConfigProviderTest {
         return Stream.of(
                 Arguments.of("7.0.1", cdhParcelVersion("7.0.1", 5), NO_AUTH_EXPECTED_CONFIGS),
                 Arguments.of("7.0.2", cdhParcelVersion("7.0.2", 0), LDAP_AUTH_EXPECTED_CONFIGS),
-                Arguments.of("7.0.2", cdhParcelVersion("7.0.2", 2), PAM_AUTH_EXPECTED_CONFIGS),
-                Arguments.of("7.0.2", cdhParcelVersion("7.0.2", 3), PAM_AUTH_EXPECTED_CONFIGS),
+                Arguments.of("7.0.2", cdhParcelVersion("7.0.2", 2), SASL_LDAP_AUTH_EXPECTED_CONFIGS),
+                Arguments.of("7.0.2", cdhParcelVersion("7.0.2", 3), SASL_LDAP_AUTH_EXPECTED_CONFIGS),
                 Arguments.of("7.0.2", "irregularCdhVersion-123", GENERAL_AUTH_EXPECTED_CONFIGS),
                 Arguments.of("7.0.3", cdhParcelVersion("7.0.3", 0), LDAP_AUTH_EXPECTED_CONFIGS),
                 Arguments.of("7.0.3", cdhParcelVersion("7.0.3", 3), LDAP_AUTH_EXPECTED_CONFIGS),
-                Arguments.of("7.1.0", cdhParcelVersion("7.1.0", 0), PAM_AUTH_EXPECTED_CONFIGS));
+                Arguments.of("7.1.0", cdhParcelVersion("7.1.0", 0), SASL_LDAP_AUTH_EXPECTED_CONFIGS));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
We discovered a performance bottleneck with our PAM authenticator (which was backed by LDAP anyway) and switching to using LDAP fixes it.

Testing:
updated unit tests
tested cluster installation manually