### PR TITLE
CB-17521 Validate CM version after upgrade

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
@@ -843,7 +843,8 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
         Collection<ApiService> apiServices = readServices(stack);
         boolean anyServiceNotStopped = apiServices.stream()
                 .anyMatch(service -> !ApiServiceState.STOPPED.equals(service.getServiceState())
-                        && !ApiServiceState.STOPPING.equals(service.getServiceState()));
+                        && !ApiServiceState.STOPPING.equals(service.getServiceState())
+                        && !ApiServiceState.NA.equals(service.getServiceState()));
         if (anyServiceNotStopped) {
             ApiCommand apiCommand = clustersResourceApi.stopCommand(cluster.getName());
             ExtendedPollingResult pollingResult = clouderaManagerPollingServiceProvider.startPollingCmShutdown(stack, apiClient, apiCommand.getId());

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationServiceTest.java
@@ -1298,7 +1298,8 @@ class ClouderaManagerModificationServiceTest {
         List<ApiService> services = List.of(
                 new ApiService().type("RANGER_RAZ").serviceState(ApiServiceState.STOPPED),
                 new ApiService().type("ATLAS").serviceState(ApiServiceState.STOPPED),
-                new ApiService().type("HDFS").serviceState(ApiServiceState.STOPPED));
+                new ApiService().type("TEZ").serviceState(ApiServiceState.NA),
+                new ApiService().type("HDFS").serviceState(ApiServiceState.STOPPING));
         when(clouderaManagerApiFactory.getServicesResourceApi(apiClientMock)).thenReturn(servicesResourceApi);
         when(servicesResourceApi.readServices(anyString(), anyString())).thenReturn(new ApiServiceList().items(services));
         underTest.stopCluster(disableKnoxAutorestart);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.orchestration.Node;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.ClusterHostServiceRunner;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.decorator.CsdParcelDecorator;
@@ -34,6 +35,7 @@ import com.sequenceiq.cloudbreak.service.CloudbreakRuntimeException;
 import com.sequenceiq.cloudbreak.service.GatewayConfigService;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.service.upgrade.sync.component.CmServerQueryService;
 import com.sequenceiq.cloudbreak.util.NodesUnreachableException;
 import com.sequenceiq.cloudbreak.util.StackUtil;
 
@@ -66,25 +68,42 @@ public class ClusterManagerUpgradeService {
     @Inject
     private CsdParcelDecorator csdParcelDecorator;
 
+    @Inject
+    private CmServerQueryService cmServerQueryService;
+
     public void upgradeClusterManager(Long stackId, boolean runtimeServicesStartNeeded) throws CloudbreakOrchestratorException, CloudbreakException {
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
         stopClusterServices(stack);
-        upgradeClusterManager(stack);
+        ClouderaManagerRepo clouderaManagerRepo = clusterComponentConfigProvider.getClouderaManagerRepoDetails(stack.getCluster().getId());
+        upgradeClusterManager(stack, clouderaManagerRepo);
         if (runtimeServicesStartNeeded) {
             LOGGER.info("Starting cluster runtime services after CM upgrade, it's needed if cluster runtime version hasn't been changed");
             startClusterServices(stack);
         } else {
             LOGGER.info("Runtime services won't be started after CM upgrade, it's not needed if cluster runtime version has been changed");
         }
+        validateCmVersionAfterUpgrade(stack, clouderaManagerRepo);
     }
 
-    private void upgradeClusterManager(Stack stack) throws CloudbreakOrchestratorException {
+    private void validateCmVersionAfterUpgrade(Stack stack, ClouderaManagerRepo clouderaManagerRepo) {
+        Optional<String> cmVersion = cmServerQueryService.queryCmVersion(stack);
+        if (cmVersion.isPresent()) {
+            if (!clouderaManagerRepo.getFullVersion().equals(cmVersion.get())) {
+                throw new CloudbreakServiceException(String.format("Cloudera manager version on host is [%s], while the expected is [%s]",
+                        cmVersion.get(), clouderaManagerRepo.getFullVersion()));
+            }
+        } else {
+            LOGGER.warn("Couldn't get CM version after upgrade");
+        }
+    }
+
+    private void upgradeClusterManager(Stack stack, ClouderaManagerRepo clouderaManagerRepo) throws CloudbreakOrchestratorException {
         Cluster cluster = stack.getCluster();
         InstanceMetaData gatewayInstance = stack.getPrimaryGatewayInstance();
         GatewayConfig primaryGatewayConfig = gatewayConfigService.getGatewayConfig(stack, gatewayInstance, cluster.getGateway() != null);
         Set<String> gatewayFQDN = Collections.singleton(gatewayInstance.getDiscoveryFQDN());
         ExitCriteriaModel exitCriteriaModel = clusterDeletionBasedModel(stack.getId(), cluster.getId());
-        SaltConfig pillar = createSaltConfig(stack, cluster.getId(), primaryGatewayConfig);
+        SaltConfig pillar = createSaltConfig(stack, primaryGatewayConfig, clouderaManagerRepo);
         Set<String> allNode = stackUtil.collectNodes(stack).stream().map(Node::getHostname).collect(Collectors.toSet());
         try {
             Set<Node> reachableNodes = stackUtil.collectAndCheckReachableNodes(stack, allNode);
@@ -105,9 +124,8 @@ public class ClusterManagerUpgradeService {
         clusterApiConnectors.getConnector(stack).startCluster();
     }
 
-    private SaltConfig createSaltConfig(Stack stack, Long clusterId, GatewayConfig primaryGatewayConfig) {
+    private SaltConfig createSaltConfig(Stack stack, GatewayConfig primaryGatewayConfig, ClouderaManagerRepo clouderaManagerRepo) {
         Map<String, SaltPillarProperties> servicePillar = new HashMap<>();
-        ClouderaManagerRepo clouderaManagerRepo = clusterComponentConfigProvider.getClouderaManagerRepoDetails(clusterId);
         Optional<String> license = clusterHostServiceRunner.decoratePillarWithClouderaManagerLicense(stack.getId(), servicePillar);
         clusterHostServiceRunner.decoratePillarWithClouderaManagerRepo(clouderaManagerRepo, servicePillar, license);
         servicePillar.putAll(clusterHostServiceRunner.createPillarWithClouderaManagerSettings(clouderaManagerRepo, stack, primaryGatewayConfig));

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ClusterManagerUpgradeHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ClusterManagerUpgradeHandler.java
@@ -39,14 +39,12 @@ public class ClusterManagerUpgradeHandler extends ExceptionCatcherEventHandler<C
     protected Selectable doAccept(HandlerEvent<ClusterManagerUpgradeRequest> event) {
         LOGGER.debug("Accepting Cluster Manager upgrade event..");
         ClusterManagerUpgradeRequest request = event.getData();
-        Selectable result;
         try {
             clusterManagerUpgradeService.upgradeClusterManager(request.getResourceId(), request.isRuntimeServicesStartNeeded());
-            result = new ClusterManagerUpgradeSuccess(request.getResourceId());
+            return new ClusterManagerUpgradeSuccess(request.getResourceId());
         } catch (Exception e) {
             LOGGER.info("Cluster Manager upgrade event failed", e);
-            result = new ClusterUpgradeFailedEvent(request.getResourceId(), e, DetailedStackStatus.CLUSTER_MANAGER_UPGRADE_FAILED);
+            return new ClusterUpgradeFailedEvent(request.getResourceId(), e, DetailedStackStatus.CLUSTER_MANAGER_UPGRADE_FAILED);
         }
-        return result;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmServerQueryService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmServerQueryService.java
@@ -38,7 +38,7 @@ public class CmServerQueryService {
      * @param stack The stack, to get the coordinates of the CM to query
      * @return List of parcels found in the CM
      */
-    Set<ParcelInfo> queryActiveParcels(Stack stack) {
+    public Set<ParcelInfo> queryActiveParcels(Stack stack) {
         Map<String, String> activeParcels = apiConnectors.getConnector(stack).gatherInstalledParcels(stack.getName());
         LOGGER.debug("Reading parcel info from CM server, found parcels: " + activeParcels);
         return activeParcels.entrySet().stream()
@@ -51,7 +51,7 @@ public class CmServerQueryService {
      * @param stack The stack, with metadata to be able to build the client to query package versions
      * @return The actual CM version, in format version-build number e.g. 7.2.2-13072522
      */
-    Optional<String> queryCmVersion(Stack stack) {
+    public Optional<String> queryCmVersion(Stack stack) {
         try {
             Map<String, List<PackageInfo>> packageVersions = cmVersionQueryService.queryCmPackageInfo(stack);
             PackageInfo cmPackageInfo = cmVersionQueryService.checkCmPackageInfoConsistency(packageVersions);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmVersionQueryService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmVersionQueryService.java
@@ -56,7 +56,7 @@ public class CmVersionQueryService {
      * @param stack The stack, with metadata to be able to build the client to query package versions
      * @return List of package info found in each host (map key is host fqdn)
      */
-    Map<String, List<PackageInfo>> queryCmPackageInfo(Stack stack) throws CloudbreakOrchestratorFailedException {
+    public Map<String, List<PackageInfo>> queryCmPackageInfo(Stack stack) throws CloudbreakOrchestratorFailedException {
         GatewayConfig gatewayConfig = gatewayConfigService.getPrimaryGatewayConfig(stack);
         Map<String, Optional<String>> packageMap = packages.stream()
                 .filter(aPackage -> aPackage.getName().equals(ImagePackageVersion.CM.getKey()))
@@ -68,7 +68,7 @@ public class CmVersionQueryService {
         return fullPackageVersionsFromAllHosts;
     }
 
-    PackageInfo checkCmPackageInfoConsistency(Map<String, List<PackageInfo>> cmPackageVersionsFromAllHosts) {
+    public PackageInfo checkCmPackageInfoConsistency(Map<String, List<PackageInfo>> cmPackageVersionsFromAllHosts) {
         Multimap<String, PackageInfo> pkgVersionsMMap = HashMultimap.create();
         cmPackageVersionsFromAllHosts.values()
                 .forEach(packageInfoList -> packageInfoList.forEach(

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeServiceTest.java
@@ -1,23 +1,29 @@
 package com.sequenceiq.cloudbreak.core.cluster;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.when;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.TestUtil;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.ClusterHostServiceRunner;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.decorator.CsdParcelDecorator;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
@@ -28,12 +34,15 @@ import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.cloudbreak.service.GatewayConfigService;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.service.upgrade.sync.component.CmServerQueryService;
 import com.sequenceiq.cloudbreak.util.StackUtil;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ClusterManagerUpgradeServiceTest {
 
     private static final Long STACK_ID = 1L;
+
+    private static final String CM_VERSION = "7.2.6-12345";
 
     @Mock
     private GatewayConfigService gatewayConfigService;
@@ -62,28 +71,53 @@ public class ClusterManagerUpgradeServiceTest {
     @Mock
     private CsdParcelDecorator csdParcelDecorator;
 
+    @Mock
+    private CmServerQueryService cmServerQueryService;
+
     @InjectMocks
     private ClusterManagerUpgradeService underTest;
 
     private Stack stack;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         stack = TestUtil.stack(Status.AVAILABLE, TestUtil.awsCredential());
         Cluster cluster = TestUtil.cluster();
         stack.setCluster(cluster);
         when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
         when(clusterApiConnectors.getConnector(stack)).thenReturn(clusterApi);
+        when(cmServerQueryService.queryCmVersion(stack)).thenReturn(Optional.empty());
     }
 
     @Test
     public void testUpgradeClusterManager() throws CloudbreakOrchestratorException, CloudbreakException {
         Cluster cluster = stack.getCluster();
+        ClouderaManagerRepo clouderaManagerRepo = mock(ClouderaManagerRepo.class);
+        when(clouderaManagerRepo.getFullVersion()).thenReturn(CM_VERSION);
+        when(clusterComponentConfigProvider.getClouderaManagerRepoDetails(cluster.getId())).thenReturn(clouderaManagerRepo);
+        when(cmServerQueryService.queryCmVersion(stack)).thenReturn(Optional.of(CM_VERSION));
 
         underTest.upgradeClusterManager(STACK_ID, true);
 
         verify(gatewayConfigService, times(1)).getGatewayConfig(stack, stack.getPrimaryGatewayInstance(), cluster.getGateway() != null);
-        verify(clusterComponentConfigProvider, times(1)).getClouderaManagerRepoDetails(cluster.getId());
+        verify(hostOrchestrator, times(1)).upgradeClusterManager(any(), any(), any(), any(), any());
+        verify(clusterApi).stopCluster(true);
+        verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerRepo(any(), any(), any());
+        verify(clusterHostServiceRunner, times(1)).createPillarWithClouderaManagerSettings(any(), any(), any());
+        verify(clusterApi).startCluster();
+    }
+
+    @Test
+    public void testUpgradeClusterManagerVersionIsDifferent() throws CloudbreakOrchestratorException, CloudbreakException {
+        Cluster cluster = stack.getCluster();
+        ClouderaManagerRepo clouderaManagerRepo = mock(ClouderaManagerRepo.class);
+        when(clouderaManagerRepo.getFullVersion()).thenReturn(CM_VERSION);
+        when(clusterComponentConfigProvider.getClouderaManagerRepoDetails(cluster.getId())).thenReturn(clouderaManagerRepo);
+        when(cmServerQueryService.queryCmVersion(stack)).thenReturn(Optional.of("wrong"));
+
+        assertThrows(CloudbreakServiceException.class, () -> underTest.upgradeClusterManager(STACK_ID, true));
+
+        verify(gatewayConfigService, times(1)).getGatewayConfig(stack, stack.getPrimaryGatewayInstance(), cluster.getGateway() != null);
         verify(hostOrchestrator, times(1)).upgradeClusterManager(any(), any(), any(), any(), any());
         verify(clusterApi).stopCluster(true);
         verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerRepo(any(), any(), any());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/datalake/SdxUpgradeTestAssertion.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/datalake/SdxUpgradeTestAssertion.java
@@ -29,7 +29,7 @@ public class SdxUpgradeTestAssertion {
         };
     }
 
-    public static Assertion<SdxInternalTestDto, SdxClient> validateSuccessfulUpgrade() {
+    public static Assertion<SdxInternalTestDto, SdxClient> validateUpgradeCandidateWithLockedComponentIsAvailable() {
         return (testContext, entity, sdxClient) -> {
             SdxUpgradeRequest request = new SdxUpgradeRequest();
             request.setLockComponents(true);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/mock/endpoint/ClouderaManagerEndpoints.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/mock/endpoint/ClouderaManagerEndpoints.java
@@ -1,5 +1,12 @@
 package com.sequenceiq.it.cloudbreak.dto.mock.endpoint;
 
+import java.util.Map;
+import java.util.Objects;
+
+import javax.ws.rs.client.Entity;
+
+import org.springframework.http.HttpMethod;
+
 import com.cloudera.api.swagger.model.ApiAuthRoleMetadataList;
 import com.cloudera.api.swagger.model.ApiCommand;
 import com.cloudera.api.swagger.model.ApiCommandList;
@@ -16,6 +23,7 @@ import com.cloudera.api.swagger.model.ApiServiceList;
 import com.cloudera.api.swagger.model.ApiUser2;
 import com.cloudera.api.swagger.model.ApiUser2List;
 import com.cloudera.api.swagger.model.ApiVersionInfo;
+import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
 import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
 import com.sequenceiq.it.cloudbreak.dto.mock.MockUri;
@@ -80,11 +88,19 @@ public final class ClouderaManagerEndpoints<T extends CloudbreakTestDto> {
         return testDto;
     }
 
+    public T setCmVersion(String cmVersion) {
+        Objects.requireNonNull(cmVersion);
+        mockedTestContext.getExecuteQueryToMockInfrastructure()
+                .executeMethod(HttpMethod.PUT, testDto.getCrn() + "/cmversion", Map.of("version", cmVersion),
+                        Entity.json(JsonUtil.createJsonTree(Map.of("version", cmVersion))), r -> r, w -> w);
+        return testDto;
+    }
+
     public interface CmActiveCommandsApi {
         interface Cm {
 
             @MockUri(url = ACTIVE_COMMANDS)
-            interface ActiveCommandTable<T extends  CloudbreakTestDto> extends VerificationEndpoint<T> {
+            interface ActiveCommandTable<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
                 DefaultResponseConfigure<T, String> get();
             }
         }
@@ -94,7 +110,7 @@ public final class ClouderaManagerEndpoints<T extends CloudbreakTestDto> {
         interface Cm {
 
             @MockUri(url = RECENT_COMMANDS)
-            interface RecentCommandTable<T extends  CloudbreakTestDto> extends VerificationEndpoint<T> {
+            interface RecentCommandTable<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
                 DefaultResponseConfigure<T, String> get();
             }
         }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXUpgradeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXUpgradeTests.java
@@ -50,6 +50,10 @@ public class DistroXUpgradeTests extends AbstractMockTest {
                 .given(DistroXUpgradeTestDto.class)
                 .withRuntime(targetRuntimeVersion)
                 .given(distroXName, DistroXTestDto.class)
+                .then((tc, entity, client) ->  {
+                    entity.mockCm().setCmVersion(targetRuntimeVersion);
+                    return entity;
+                })
                 .when(distroXTestClient.upgrade(), key(distroXName))
                 .await(STACK_AVAILABLE, key(distroXName))
                 .awaitForHealthyInstances()

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxUpgradeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxUpgradeTests.java
@@ -9,9 +9,12 @@ import javax.inject.Inject;
 
 import org.testng.annotations.Test;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.image.ImageComponentVersions;
 import com.sequenceiq.cloudbreak.auth.crn.TestCrnGenerator;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkMockParams;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
+import com.sequenceiq.it.cloudbreak.SdxClient;
+import com.sequenceiq.it.cloudbreak.assertion.Assertion;
 import com.sequenceiq.it.cloudbreak.assertion.datalake.SdxUpgradeTestAssertion;
 import com.sequenceiq.it.cloudbreak.client.FreeIpaTestClient;
 import com.sequenceiq.it.cloudbreak.client.ImageCatalogTestClient;
@@ -39,6 +42,8 @@ import com.sequenceiq.redbeams.api.model.common.Status;
 import com.sequenceiq.sdx.api.model.SdxClusterShape;
 import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 import com.sequenceiq.sdx.api.model.SdxUpgradeReplaceVms;
+import com.sequenceiq.sdx.api.model.SdxUpgradeRequest;
+import com.sequenceiq.sdx.api.model.SdxUpgradeResponse;
 
 public class MockSdxUpgradeTests extends AbstractMockTest {
 
@@ -103,7 +108,7 @@ public class MockSdxUpgradeTests extends AbstractMockTest {
                 .withStackRequest(key(cluster), key(stack))
                 .when(sdxTestClient.createInternal(), key(sdxInternal))
                 .await(SdxClusterStatusResponse.RUNNING)
-                .then(SdxUpgradeTestAssertion.validateSuccessfulUpgrade())
+                .then(SdxUpgradeTestAssertion.validateUpgradeCandidateWithLockedComponentIsAvailable())
                 .validate();
     }
 
@@ -155,17 +160,30 @@ public class MockSdxUpgradeTests extends AbstractMockTest {
                 .withStackRequest(key(cluster), key(stack))
                 .when(sdxTestClient.createInternal(), key(sdxInternal))
                 .await(SdxClusterStatusResponse.RUNNING)
-                .then(SdxUpgradeTestAssertion.validateSuccessfulUpgrade())
                 .given(SdxUpgradeTestDto.class)
                 .withRuntime(null)
                 .withLockComponents(true)
                 .withReplaceVms(SdxUpgradeReplaceVms.ENABLED)
                 .given(sdxInternal, SdxInternalTestDto.class)
+                .then(setCmVersionInMockToUpgradedVersion())
                 .when(sdxTestClient.upgradeInternal(), key(sdxInternal))
                 .await(SdxClusterStatusResponse.DATALAKE_UPGRADE_IN_PROGRESS, key(sdxInternal).withWaitForFlow(Boolean.FALSE))
                 .await(SdxClusterStatusResponse.RUNNING, key(sdxInternal).withPollingInterval(Duration.ofSeconds(5L)))
                 .awaitForHealthyInstances()
                 .validate();
+    }
+
+    private Assertion<SdxInternalTestDto, SdxClient> setCmVersionInMockToUpgradedVersion() {
+        return (tc, entity, sdxClient) -> {
+            SdxUpgradeRequest request = new SdxUpgradeRequest();
+            request.setLockComponents(true);
+            request.setDryRun(true);
+            SdxUpgradeResponse upgradeResponse =
+                    sdxClient.getDefaultClient().sdxUpgradeEndpoint().upgradeClusterByName(entity.getName(), request);
+            ImageComponentVersions componentVersions = upgradeResponse.getUpgradeCandidates().get(0).getComponentVersions();
+            entity.mockCm().setCmVersion(componentVersions.getCm() + "-" + componentVersions.getCmGBN());
+            return entity;
+        };
     }
 
     @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
@@ -207,7 +225,7 @@ public class MockSdxUpgradeTests extends AbstractMockTest {
                 .withStackRequest(key(cluster), key(stack))
                 .when(sdxTestClient.createInternal(), key(sdxInternal))
                 .await(SdxClusterStatusResponse.RUNNING)
-                .then(SdxUpgradeTestAssertion.validateSuccessfulUpgrade())
+                .then(SdxUpgradeTestAssertion.validateUpgradeCandidateWithLockedComponentIsAvailable())
                 .validate();
     }
 
@@ -261,7 +279,7 @@ public class MockSdxUpgradeTests extends AbstractMockTest {
                 .await(SdxClusterStatusResponse.STACK_CREATION_IN_PROGRESS, key(sdxInternal).withWaitForFlow(Boolean.FALSE))
                 .await(SdxClusterStatusResponse.RUNNING, key(sdxInternal).withWaitForFlow(Boolean.FALSE))
                 .withClusterShape(SdxClusterShape.MEDIUM_DUTY_HA)
-                .then(SdxUpgradeTestAssertion.validateSuccessfulUpgrade())
+                .then(SdxUpgradeTestAssertion.validateUpgradeCandidateWithLockedComponentIsAvailable())
                 .validate();
     }
 

--- a/mock-infrastructure/src/main/java/com/sequenceiq/mock/controller/ConfigureController.java
+++ b/mock-infrastructure/src/main/java/com/sequenceiq/mock/controller/ConfigureController.java
@@ -8,7 +8,9 @@ import javax.inject.Inject;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.sequenceiq.mock.clouderamanager.ClouderaManagerStoreService;
@@ -53,5 +55,10 @@ public class ConfigureController {
         } else {
             activeProfiles.add(new CmProfile(profile, times));
         }
+    }
+
+    @PutMapping("/{mockUuid}/cmversion")
+    public void setCmVersion(@PathVariable("mockUuid") String mockUuid, @RequestParam("version") String version) {
+        clouderaManagerStoreService.read(mockUuid).getClusterTemplate().setCmVersion(version);
     }
 }

--- a/mock-infrastructure/src/main/java/com/sequenceiq/mock/service/ImageCatalogMockService.java
+++ b/mock-infrastructure/src/main/java/com/sequenceiq/mock/service/ImageCatalogMockService.java
@@ -30,7 +30,7 @@ public class ImageCatalogMockService {
                 .replace("MOCK_SERVER_ADDRESS", mockServerAddress);
     }
 
-    private String getNextRuntimeVersion(String runtime) {
+    public String getNextRuntimeVersion(String runtime) {
         String[] splitted = runtime.split("\\.");
         int last = Integer.parseInt(splitted[splitted.length - 1]);
         List<String> elements = new ArrayList<>(Arrays.asList(splitted).subList(0, splitted.length - 1));


### PR DESCRIPTION
After the CM upgrade is finished (packages on the instances should have the new version) a validation is performed that this has really happened.
If not, then an exception is thrown to stop the upgrade process which can be retried after the issue is resolved.

`NA` status is handled as stopped when checking if stopping of the cluster services is necessary, as this was blocking retrying the upgrade.

See detailed description in the commit message.