### PR TITLE
CB-17596 Modify AWS E2E test cases for GOV Cloud testing

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProvider.java
@@ -292,7 +292,7 @@ public class AwsCloudProvider extends AbstractCloudProvider {
         } else {
             parameters = awsCredentialDetailsArn();
         }
-        if (awsProperties.getGovCloud()) {
+        if (getGovCloud()) {
             parameters.setGovCloud(true);
         }
         return credential
@@ -391,13 +391,13 @@ public class AwsCloudProvider extends AbstractCloudProvider {
 
     @Override
     public String getLatestPreWarmedImageID(TestContext testContext, ImageCatalogTestDto imageCatalogTestDto, CloudbreakClient cloudbreakClient) {
-        return getLatestPreWarmedImage(imageCatalogTestDto, cloudbreakClient, CloudPlatform.AWS.name(), false);
+        return getLatestPreWarmedImage(imageCatalogTestDto, cloudbreakClient, CloudPlatform.AWS.name(), getGovCloud());
     }
 
     @Override
     public String getLatestBaseImageID(TestContext testContext, ImageCatalogTestDto imageCatalogTestDto, CloudbreakClient cloudbreakClient) {
         if (awsProperties.getBaseimage().getImageId() == null || awsProperties.getBaseimage().getImageId().isEmpty()) {
-            String imageId = getLatestBaseImage(imageCatalogTestDto, cloudbreakClient, CloudPlatform.AWS.name(), false);
+            String imageId = getLatestBaseImage(imageCatalogTestDto, cloudbreakClient, CloudPlatform.AWS.name(), getGovCloud());
             awsProperties.getBaseimage().setImageId(imageId);
             return imageId;
         } else {
@@ -448,7 +448,7 @@ public class AwsCloudProvider extends AbstractCloudProvider {
     public String getVariant() {
         if (awsProperties.getMultiaz()) {
             return "AWS_NATIVE";
-        } else if (awsProperties.getGovCloud()) {
+        } else if (getGovCloud()) {
             return "AWS_NATIVE_GOV";
         } else {
             return "AWS";

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/MeasuredTestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/MeasuredTestContext.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.it.cloudbreak.context;
 
+import java.time.Duration;
 import java.util.Map;
 
 import org.springframework.beans.BeansException;
@@ -7,6 +8,7 @@ import org.springframework.context.ApplicationContext;
 
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.common.api.type.Tunnel;
 import com.sequenceiq.it.cloudbreak.MicroserviceClient;
 import com.sequenceiq.it.cloudbreak.SdxClient;
 import com.sequenceiq.it.cloudbreak.action.Action;
@@ -283,6 +285,21 @@ public class MeasuredTestContext extends MockedTestContext {
     @Override
     public CloudPlatform getCloudPlatform() {
         return wrappedTestContext.getCloudPlatform();
+    }
+
+    @Override
+    public void waitingFor(Duration duration, String interruptedMessage) {
+        wrappedTestContext.waitingFor(duration, interruptedMessage);
+    }
+
+    @Override
+    public Tunnel getTunnel() {
+        return wrappedTestContext.getTunnel();
+    }
+
+    @Override
+    public void checkNonEmpty(String name, String value) {
+        wrappedTestContext.checkNonEmpty(name, value);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
@@ -113,7 +113,8 @@ public class EnvironmentTestDto
                 .withIdBrokerMappingSource(IdBrokerMappingSource.MOCK)
                 .withResourceGroup(getResourceGroupUsage(), getResourceGroupName())
                 .withNetwork()
-                .withCloudStorageValidation(CloudStorageValidation.ENABLED);
+                .withCloudStorageValidation(CloudStorageValidation.ENABLED)
+                .withTunnel(getTestContext().getTunnel());
     }
 
     public EnvironmentTestDto withCreateFreeIpa(Boolean create) {


### PR DESCRIPTION
Our latest [GOV-Dev AWS API E2E Build #13-dev-2.60.0-b15 (29-Jun-2022 23:44:25)](http://ci-cloudbreak.eng.hortonworks.com/view/e2e-test/job/gov-api-e2e-aws/13/) is failing, because of:
- GOV Cloud default `"tunnel" : "DIRECT"` is the cause of the issue. At the GOV Cloud `export ENVIRONMENT_JAVA_OPTS="...-Denvironment.tunnel.default"` is missing from CB config. So we should define the `Tunnel` in the `EnvironmentTestDto` as well.
- `"The selected image: 'Image{uuid='74a637d1-5c63-49a9-92a7-183d9ef148d0', os='centos7'}' doesn't contain virtual machine image for the selected platform`. Here is the `getLatestPreWarmedImageID` and `getLatestBaseImageID`last parameter `govCloud` is the root cause. So we should replace the `false` default value to `getGovCloud()` at `AwsCloudProvider`. 

Other issues` investigation is still in progress.