### PR TITLE
CB-16160 notify user if decommission took long

### DIFF
--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/polling/PollingService.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/polling/PollingService.java
@@ -73,6 +73,7 @@ public class PollingService<T> {
             attempts++;
             timeout = timeoutChecker.checkTimeout();
             exit = statusCheckerTask.exitPolling(t);
+            statusCheckerTask.sendWarningTimeoutEventIfNecessary(t);
         }
         if (timeout) {
             LOGGER.debug("Poller timeout.");

--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/polling/StatusCheckerTask.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/polling/StatusCheckerTask.java
@@ -32,6 +32,9 @@ public interface StatusCheckerTask<T> {
 
     }
 
+    default void sendWarningTimeoutEventIfNecessary(T t) {
+    }
+
     default Optional<String> additionalTimeoutErrorMessage() {
         return Optional.empty();
     }

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/ClouderaManagerPollingServiceProvider.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/ClouderaManagerPollingServiceProvider.java
@@ -27,6 +27,7 @@ import com.sequenceiq.cloudbreak.cm.polling.task.AbstractClouderaManagerApiCheck
 import com.sequenceiq.cloudbreak.cm.polling.task.AbstractClouderaManagerCommandCheckerTask;
 import com.sequenceiq.cloudbreak.cm.polling.task.AbstractClouderaManagerCommandListCheckerTask;
 import com.sequenceiq.cloudbreak.cm.polling.task.ClouderaManagerBatchCommandsListenerTask;
+import com.sequenceiq.cloudbreak.cm.polling.task.ClouderaManagerDecommissionWarningListenerTask;
 import com.sequenceiq.cloudbreak.cm.polling.task.ClouderaManagerDefaultListenerTask;
 import com.sequenceiq.cloudbreak.cm.polling.task.ClouderaManagerHostHealthyStatusChecker;
 import com.sequenceiq.cloudbreak.cm.polling.task.ClouderaManagerHostStatusChecker;
@@ -211,7 +212,7 @@ public class ClouderaManagerPollingServiceProvider {
                     new SilentCMDecommissionHostListenerTask(clouderaManagerApiPojoFactory, clusterEventService));
         } else {
             return pollCommandWithAttemptListener(stack, apiClient, commandId, INFINITE_ATTEMPT,
-                    new ClouderaManagerDefaultListenerTask(clouderaManagerApiPojoFactory, clusterEventService, "Decommission host"));
+                    new ClouderaManagerDecommissionWarningListenerTask(clouderaManagerApiPojoFactory, clusterEventService, "Decommission host"));
         }
     }
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerDecommissionWarningListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerDecommissionWarningListenerTask.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.cloudbreak.cm.polling.task;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import com.sequenceiq.cloudbreak.cluster.service.ClusterEventService;
+import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
+import com.sequenceiq.cloudbreak.event.ResourceEvent;
+import com.sequenceiq.cloudbreak.polling.AbsolutTimeBasedTimeoutChecker;
+
+public class ClouderaManagerDecommissionWarningListenerTask extends ClouderaManagerDefaultListenerTask {
+
+    private static final long POLL_FOR_90_MINUTES = TimeUnit.MINUTES.toSeconds(90);
+
+    private AbsolutTimeBasedTimeoutChecker warningTimeoutChecker = new AbsolutTimeBasedTimeoutChecker(POLL_FOR_90_MINUTES);
+
+    private boolean warningSent;
+
+    public ClouderaManagerDecommissionWarningListenerTask(
+            ClouderaManagerApiPojoFactory clouderaManagerApiPojoFactory, ClusterEventService clusterEventService, String commandName) {
+        super(clouderaManagerApiPojoFactory, clusterEventService, commandName);
+    }
+
+    @Override
+    public void sendWarningTimeoutEventIfNecessary(ClouderaManagerCommandPollerObject pollerObject) {
+        if (pollerObject.getId() != null && warningTimeoutChecker.checkTimeout() && !warningSent) {
+            getClusterEventService().fireClusterManagerEvent(pollerObject.getStack(),
+                    ResourceEvent.CLUSTER_CM_COMMAND_TIMEOUT_WARNING, getCommandName(), Optional.of(pollerObject.getId()));
+            warningSent = true;
+        }
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
@@ -408,6 +408,7 @@ public enum ResourceEvent {
     CLUSTER_CM_SERVICE_DEREGISTER_FAILED("cm.cluster.service.deregister.failed"),
     CLUSTER_CM_COMMAND_FAILED("cm.cluster.command.failed"),
     CLUSTER_CM_COMMAND_TIMEOUT("cm.cluster.command.timeout"),
+    CLUSTER_CM_COMMAND_TIMEOUT_WARNING("cm.cluster.command.timeout.warning"),
     CLUSTER_MANAGER_CLUSTER_DECOMMISSIONING_TIME("cluster.ambari.cluster.decommissioning.time"),
     CLUSTER_MANAGER_CLUSTER_SERVICES_STOPPING("cluster.ambari.cluster.services.stopping"),
     CLUSTER_MANAGER_CLUSTER_SERVICES_STOPPED("cluster.ambari.cluster.services.stopped"),

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -218,6 +218,7 @@ cluster.provider.validation.warning=Cloud platform validation succeeded with the
 
 cm.cluster.command.failed=Cloudera Manager command [{0}] failed, you can check the command here: {1}
 cm.cluster.command.timeout=Cloudera Manager command [{0}] timed out, you can check the command here: {1}
+cm.cluster.command.timeout.warning=Cloudera Manager command [{0}] takes unusually long time, you can check the command here: {1}
 cm.cluster.services.started=Cloudera Manager services have been started.
 cm.cluster.services.starting=Starting Cloudera Manager services.
 cm.cluster.services.restarting=Restarting Cloudera Manager services.


### PR DESCRIPTION
Decommission could take very long in case of older clusters, this change will send a warning to the user after 90 minutes.