### PR TITLE
CB-17311 Adding ExceptionMappers to Consumption Service

### DIFF
--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/configuration/api/EndpointConfig.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/configuration/api/EndpointConfig.java
@@ -11,6 +11,7 @@ import org.springframework.context.annotation.Configuration;
 
 import com.sequenceiq.authorization.controller.AuthorizationInfoController;
 import com.sequenceiq.authorization.info.AuthorizationUtilEndpoint;
+import com.sequenceiq.cloudbreak.exception.mapper.DefaultExceptionMapper;
 import com.sequenceiq.cloudbreak.structuredevent.rest.controller.CDPStructuredEventV1Controller;
 import com.sequenceiq.cloudbreak.structuredevent.rest.filter.CDPStructuredEventFilter;
 import com.sequenceiq.consumption.api.v1.ConsumptionApi;
@@ -78,6 +79,7 @@ public class EndpointConfig extends ResourceConfig {
         for (ExceptionMapper<?> mapper : exceptionMappers) {
             register(mapper);
         }
+        register(DefaultExceptionMapper.class);
     }
 
     private void registerEndpoints() {

--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/endpoint/mapper/BadRequestExceptionMapper.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/endpoint/mapper/BadRequestExceptionMapper.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.consumption.endpoint.mapper;
+
+
+import org.springframework.stereotype.Component;
+import javax.ws.rs.core.Response.Status;
+
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.exception.mapper.BaseExceptionMapper;
+
+@Component
+public class BadRequestExceptionMapper extends BaseExceptionMapper<BadRequestException> {
+
+    @Override
+    public Status getResponseStatus(BadRequestException exception) {
+        return Status.BAD_REQUEST;
+    }
+
+    @Override
+    public Class<BadRequestException> getExceptionType() {
+        return BadRequestException.class;
+    }
+
+}

--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/endpoint/mapper/NotFoundExceptionMapper.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/endpoint/mapper/NotFoundExceptionMapper.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.consumption.endpoint.mapper;
+
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
+import com.sequenceiq.cloudbreak.exception.mapper.BaseExceptionMapper;
+
+@Component
+public class NotFoundExceptionMapper extends BaseExceptionMapper<NotFoundException> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NotFoundExceptionMapper.class);
+
+    @Override
+    public Status getResponseStatus(NotFoundException exception) {
+        return Status.NOT_FOUND;
+    }
+
+    @Override
+    public Class<NotFoundException> getExceptionType() {
+        return NotFoundException.class;
+    }
+
+    @Override
+    public Response toResponse(NotFoundException exception) {
+        LOGGER.info("Resource not found: {}", getErrorMessage(exception));
+        return Response.status(getResponseStatus(exception)).entity(getEntity(exception)).build();
+    }
+}


### PR DESCRIPTION
Consumption service didn't have any ExceptionMapper as a result calling an endpoint from environment was giving HTTP 500 error as a response as default. Now it gives correct response(HTTP 404) in case you want call unscheduleStorageConsumptionCollection with wrong storage location. I also added BadReqestExceptionMapper so when you want to schedule consumption collection with empty storage location it gives HTTP 400. I have tested the solution by calling the endpoint in order to trigger the error.