### PR TITLE
CB-17620 Consumption does not tolerate duplicate location & 404 errors

### DIFF
--- a/cloud-consumption/src/test/java/com/sequenceiq/consumption/endpoint/ConsumptionInternalV1ControllerTest.java
+++ b/cloud-consumption/src/test/java/com/sequenceiq/consumption/endpoint/ConsumptionInternalV1ControllerTest.java
@@ -1,9 +1,17 @@
 package com.sequenceiq.consumption.endpoint;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,7 +19,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.consumption.api.v1.consumption.model.request.StorageConsumptionRequest;
 import com.sequenceiq.consumption.api.v1.consumption.model.response.ConsumptionExistenceResponse;
+import com.sequenceiq.consumption.domain.Consumption;
+import com.sequenceiq.consumption.dto.ConsumptionCreationDto;
 import com.sequenceiq.consumption.endpoint.converter.ConsumptionApiConverter;
 import com.sequenceiq.consumption.job.storage.StorageConsumptionJobService;
 import com.sequenceiq.consumption.service.ConsumptionService;
@@ -24,6 +36,8 @@ public class ConsumptionInternalV1ControllerTest {
     private static final String LOCATION = "s3a://location";
 
     private static final String ACCOUNT_ID = "123";
+
+    private static final Long CONSUMPTION_ID = 123L;
 
     @Mock
     private ConsumptionService consumptionService;
@@ -56,4 +70,81 @@ public class ConsumptionInternalV1ControllerTest {
         verify(consumptionService).isConsumptionPresentForLocationAndMonitoredCrn(MONITORED_CRN, LOCATION);
         assertFalse(response.isExists());
     }
+
+    @Test
+    void scheduleStorageConsumptionCollectionTestWhenSuccessAndConsumptionNotCreated() {
+        StorageConsumptionRequest request = new StorageConsumptionRequest();
+        ConsumptionCreationDto consumptionCreationDto = consumptionCreationDto(LOCATION);
+
+        when(consumptionApiConverter.initCreationDtoForStorage(request)).thenReturn(consumptionCreationDto);
+        when(consumptionService.create(consumptionCreationDto)).thenReturn(Optional.empty());
+
+        underTest.scheduleStorageConsumptionCollection(ACCOUNT_ID, request);
+
+        verify(jobService, never()).schedule(anyLong());
+    }
+
+    @Test
+    void scheduleStorageConsumptionCollectionTestWhenSuccessAndConsumptionCreated() {
+        StorageConsumptionRequest request = new StorageConsumptionRequest();
+        ConsumptionCreationDto consumptionCreationDto = consumptionCreationDto(LOCATION);
+
+        when(consumptionApiConverter.initCreationDtoForStorage(request)).thenReturn(consumptionCreationDto);
+        when(consumptionService.create(consumptionCreationDto)).thenReturn(Optional.of(consumption()));
+
+        underTest.scheduleStorageConsumptionCollection(ACCOUNT_ID, request);
+
+        verify(jobService).schedule(CONSUMPTION_ID);
+    }
+
+    @Test
+    void scheduleStorageConsumptionCollectionTestWhenInvalidLocation() {
+        StorageConsumptionRequest request = new StorageConsumptionRequest();
+
+        when(consumptionApiConverter.initCreationDtoForStorage(request)).thenReturn(consumptionCreationDto("invalid_location"));
+
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> underTest.scheduleStorageConsumptionCollection(ACCOUNT_ID, request));
+
+        assertThat(badRequestException).hasMessage("Storage location validation failed, error: " +
+                "Storage location must start with 's3a' if required file system type is 'S3'!");
+
+        verify(consumptionService, never()).create(any(ConsumptionCreationDto.class));
+        verify(jobService, never()).schedule(anyLong());
+    }
+
+    @Test
+    void unscheduleStorageConsumptionCollectionTestWhenConsumptionAbsent() {
+        when(consumptionService.findStorageConsumptionByMonitoredResourceCrnAndLocation(MONITORED_CRN, LOCATION)).thenReturn(Optional.empty());
+
+        underTest.unscheduleStorageConsumptionCollection(ACCOUNT_ID, MONITORED_CRN, LOCATION);
+
+        verify(jobService, never()).unschedule(anyString());
+        verify(consumptionService, never()).delete(any(Consumption.class));
+    }
+
+    @Test
+    void unscheduleStorageConsumptionCollectionTestWhenConsumptionPresent() {
+        Consumption consumption = consumption();
+        when(consumptionService.findStorageConsumptionByMonitoredResourceCrnAndLocation(MONITORED_CRN, LOCATION)).thenReturn(Optional.of(consumption));
+
+        underTest.unscheduleStorageConsumptionCollection(ACCOUNT_ID, MONITORED_CRN, LOCATION);
+
+        verify(jobService).unschedule("123");
+        verify(consumptionService).delete(consumption);
+    }
+
+    private ConsumptionCreationDto consumptionCreationDto(String location) {
+        return ConsumptionCreationDto.builder()
+                .withStorageLocation(location)
+                .withMonitoredResourceCrn(MONITORED_CRN)
+                .build();
+    }
+
+    private Consumption consumption() {
+        Consumption consumption = new Consumption();
+        consumption.setId(CONSUMPTION_ID);
+        return consumption;
+    }
+
 }


### PR DESCRIPTION
* Adapt `ConsumptionInternalV1Controller.scheduleStorageConsumptionCollection()` to silently proceed when invoked for the same input that has already been registered (instead of throwing a 400 error).
* Adapt `ConsumptionInternalV1Controller.unscheduleStorageConsumptionCollection()` to silently proceed when invoked for a location that was not registered (or has already been unscheduled).
* Testing:
  * Manual testing in local CB.
  * Added new UT and updated existing ones.
