### PR TITLE
CB-17630 Make CCMV2_JUMPGATE default if entitled

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentCreationService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentCreationService.java
@@ -169,7 +169,7 @@ public class EnvironmentCreationService {
         boolean ccmV2JumpgateEnabled = entitlementService.ccmV2JumpgateEnabled(environment.getAccountId());
         checkCcmEntitlements(tunnel, ccmV2Enabled, ccmV2JumpgateEnabled);
         if (!overrideTunnel) {
-            if (Tunnel.CCM == tunnel) {
+            if (Tunnel.CCM == tunnel || Tunnel.CCMV2 == tunnel) {
                 if (ccmV2JumpgateEnabled) {
                     tunnel = Tunnel.CCMV2_JUMPGATE;
                 } else if (ccmV2Enabled) {
@@ -178,7 +178,6 @@ public class EnvironmentCreationService {
                 experimentalFeatures.setTunnel(tunnel);
                 environment.setExperimentalFeaturesJson(experimentalFeatures);
             }
-            // TODO: if we want the Jumpgate to be default then this logic needs to be added for CCMV2 as well
         }
         LOGGER.info("Environment is initialized with [{}] tunnel.", tunnel);
     }

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentCreationServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentCreationServiceTest.java
@@ -172,7 +172,7 @@ class EnvironmentCreationServiceTest {
                 { Tunnel.CCMV2,           false,    false,       false,                false, null,                   BadRequestException.class, "CCMV2 not enabled for account." },
                 { Tunnel.CCMV2,           false,    false,       true,                 false, null,                   BadRequestException.class, "CCMV2 not enabled for account." },
                 { Tunnel.CCMV2,           false,    true,        false,                true,  Tunnel.CCMV2,           null,              null },
-                { Tunnel.CCMV2,           false,    true,        true,                 true,  Tunnel.CCMV2,           null,              null },
+                { Tunnel.CCMV2,           false,    true,        true,                 true,  Tunnel.CCMV2_JUMPGATE,  null,              null },
                 { Tunnel.CCMV2,           true,     false,       false,                false, null,                   BadRequestException.class, "CCMV2 not enabled for account." },
                 { Tunnel.CCMV2,           true,     false,       true,                 false, null,                   BadRequestException.class, "CCMV2 not enabled for account." },
                 { Tunnel.CCMV2,           true,     true,        false,                true,  Tunnel.CCMV2,           null,              null },


### PR DESCRIPTION
Previously if the request contained CCMV2 then it was not changed to CCMv_JUMPGATE,
opposite like in the case of CCM.
Now Jumpgate is defaulted if entitled. Override is still possible