### PR TITLE
CB-17310 Postgres upgrade framework - add the upgrade flow skeleton

### DIFF
--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/UpgradeDatabaseServerV4Request.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/UpgradeDatabaseServerV4Request.java
@@ -1,6 +1,6 @@
 package com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests;
 
-import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.sequenceiq.redbeams.doc.ModelDescriptions;
@@ -12,22 +12,22 @@ import io.swagger.annotations.ApiModelProperty;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class UpgradeDatabaseServerV4Request {
 
-    @NotEmpty
+    @NotNull
     @ApiModelProperty(value = ModelDescriptions.UpgradeModelDescriptions.MAJOR_VERSION, required = true)
-    private String majorVersion;
+    private UpgradeTargetMajorVersion upgradeTargetMajorVersion;
 
-    public String getMajorVersion() {
-        return majorVersion;
+    public UpgradeTargetMajorVersion getUpgradeTargetMajorVersion() {
+        return upgradeTargetMajorVersion;
     }
 
-    public void setMajorVersion(String majorVersion) {
-        this.majorVersion = majorVersion;
+    public void setUpgradeTargetMajorVersion(UpgradeTargetMajorVersion upgradeTargetMajorVersion) {
+        this.upgradeTargetMajorVersion = upgradeTargetMajorVersion;
     }
 
     @Override
     public String toString() {
         return "UpgradeDatabaseServerV4Request{" +
-                "majorVersion='" + majorVersion + '\'' +
+                "majorVersion=" + upgradeTargetMajorVersion +
                 '}';
     }
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/UpgradeTargetMajorVersion.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/UpgradeTargetMajorVersion.java
@@ -1,0 +1,7 @@
+package com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests;
+
+public enum UpgradeTargetMajorVersion {
+
+    VERSION_11;
+
+}

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/UpgradeDatabaseServerV4RequestTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/UpgradeDatabaseServerV4RequestTest.java
@@ -10,7 +10,7 @@ public class UpgradeDatabaseServerV4RequestTest {
 
     @Test
     void testGettersSetters() {
-        underTest.setMajorVersion("majorVersion");
-        assertEquals("majorVersion", underTest.getMajorVersion());
+        underTest.setUpgradeTargetMajorVersion(UpgradeTargetMajorVersion.VERSION_11);
+        assertEquals(UpgradeTargetMajorVersion.VERSION_11, underTest.getUpgradeTargetMajorVersion());
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4Controller.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4Controller.java
@@ -229,6 +229,6 @@ public class DatabaseServerV4Controller implements DatabaseServerV4Endpoint {
     @InternalOnly
     public void upgrade(@TenantAwareParam @NotEmpty @ValidCrn(resource = CrnResourceDescriptor.DATABASE_SERVER) String databaseServerCrn,
             @Valid @NotNull UpgradeDatabaseServerV4Request request) {
-        redbeamsUpgradeService.upgradeDatabaseServer(databaseServerCrn, request.getMajorVersion());
+        redbeamsUpgradeService.upgradeDatabaseServer(databaseServerCrn, request.getUpgradeTargetMajorVersion().name());
     }
 }

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4ControllerTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4ControllerTest.java
@@ -25,6 +25,7 @@ import com.sequenceiq.redbeams.api.endpoint.v4.database.responses.CreateDatabase
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.AllocateDatabaseServerV4Request;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.DatabaseServerV4Request;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.UpgradeDatabaseServerV4Request;
+import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.UpgradeTargetMajorVersion;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerStatusV4Response;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerV4Response;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerV4Responses;
@@ -327,10 +328,10 @@ public class DatabaseServerV4ControllerTest {
     @Test
     public void testUpgrade() {
         UpgradeDatabaseServerV4Request request = new UpgradeDatabaseServerV4Request();
-        request.setMajorVersion("MajorVersion");
+        request.setUpgradeTargetMajorVersion(UpgradeTargetMajorVersion.VERSION_11);
 
         underTest.upgrade(SERVER_CRN, request);
 
-        verify(redbeamsUpgradeService).upgradeDatabaseServer(SERVER_CRN, "MajorVersion");
+        verify(redbeamsUpgradeService).upgradeDatabaseServer(SERVER_CRN, "VERSION_11");
     }
 }


### PR DESCRIPTION
The commit broke the API. To unblock other PRs, just the API part was separated into this commit and is targeted to the current prod branch.

See detailed description in the commit message.