### PR TITLE
CDPCP-7323. Don't batch group_add_member for large groups

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncForStackService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncForStackService.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.Multimap;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
@@ -145,10 +144,8 @@ public class UserSyncForStackService {
                     ipaUserState.getGroups().size());
 
             if (!ipaUserState.getUsers().isEmpty()) {
-                ImmutableCollection<String> groupMembershipsToRemove = ipaUserState.getGroupMembership().get(deletedWorkloadUser);
-                UsersStateDifference usersStateDifference = userStateDifferenceCalculator.forDeletedUser(deletedWorkloadUser, groupMembershipsToRemove);
                 LOGGER.debug("Starting {} ...", APPLY_DIFFERENCE_TO_IPA);
-                stateApplier.applyStateDifferenceToIpa(stack.getEnvironmentCrn(), freeIpaClient, usersStateDifference, warnings::put, false);
+                stateApplier.applyUserDeleteToIpa(stack.getEnvironmentCrn(), freeIpaClient, deletedWorkloadUser, warnings::put, false);
                 LOGGER.debug("Finished {}.", APPLY_DIFFERENCE_TO_IPA);
             }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncGroupAddMemberOperations.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncGroupAddMemberOperations.java
@@ -1,0 +1,45 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.sequenceiq.freeipa.client.FreeIpaClient;
+import com.sequenceiq.freeipa.client.FreeIpaClientException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeoutException;
+import java.util.function.BiConsumer;
+
+@Component
+public class UserSyncGroupAddMemberOperations {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserSyncGroupAddMemberOperations.class);
+
+    @Inject
+    private UserSyncOperations operations;
+
+    public void addMembersToSmallGroups(boolean fmsToFreeipaBatchCallEnabled, FreeIpaClient freeIpaClient, Multimap<String, String> groupMembershipToAdd,
+                                        Set<String> largeGroupNames, BiConsumer<String, String> warnings) throws FreeIpaClientException, TimeoutException {
+        Multimap<String, String> smallGroups = groupMembershipToAdd.entries().stream()
+                .filter(entry -> !largeGroupNames.contains(entry.getKey()))
+                .collect(Multimaps.toMultimap(Map.Entry::getKey, Map.Entry::getValue, HashMultimap::create));
+        operations.addUsersToGroups(fmsToFreeipaBatchCallEnabled, freeIpaClient, smallGroups, warnings);
+    }
+
+    public void addMembersToLargeGroups(FreeIpaClient freeIpaClient, Multimap<String, String> groupMembershipToAdd,
+                                        Set<String> largeGroupNames, BiConsumer<String, String> warnings) throws FreeIpaClientException, TimeoutException {
+        if (!largeGroupNames.isEmpty()) {
+            LOGGER.debug("group membership addition for large groups will not be batched: {}", largeGroupNames);
+            Multimap<String, String> largeGroups = groupMembershipToAdd.entries().stream()
+                    .filter(entry -> largeGroupNames.contains(entry.getKey()))
+                    .collect(Multimaps.toMultimap(Map.Entry::getKey, Map.Entry::getValue, HashMultimap::create));
+            operations.addUsersToGroups(false, freeIpaClient, largeGroups, warnings);
+        }
+    }
+
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/ums/BaseUmsUsersStateProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/ums/BaseUmsUsersStateProvider.java
@@ -17,7 +17,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public class BaseUmsUsersStateProvider {
@@ -100,7 +99,6 @@ public class BaseUmsUsersStateProvider {
         return usersState.getGroupMembership().asMap().entrySet().stream()
                 .filter(entry -> entry.getValue().size() > sizeThreshold)
                 .map(Map.Entry::getKey)
-                .filter(Predicate.not(UserSyncConstants.ALLOWED_LARGE_GROUP_PREDICATE))
                 .collect(Collectors.toSet());
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncGroupAddMemberOperationsTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncGroupAddMemberOperationsTest.java
@@ -1,0 +1,136 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.sequenceiq.freeipa.client.FreeIpaClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class UserSyncGroupAddMemberOperationsTest {
+
+    @Mock
+    private UserSyncOperations operations;
+
+    @InjectMocks
+    private UserSyncGroupAddMemberOperations underTest;
+
+    @Test
+    void addMembersToSmallGroups() throws Exception {
+        boolean fmsToFreeipaBatchCallEnabled = true;
+        FreeIpaClient freeIpaClient = mock(FreeIpaClient.class);
+        Multimap<String, String> groupMembershipToAdd = setupGroupMapping(10, 20);
+        Set<String> largeGroupNames = Set.of(groupMembershipToAdd.entries().stream()
+                .findFirst().get().getKey());
+        BiConsumer<String, String> warnings = mock(BiConsumer.class);
+
+        underTest.addMembersToSmallGroups(fmsToFreeipaBatchCallEnabled, freeIpaClient, groupMembershipToAdd,
+                largeGroupNames, warnings);
+
+        ArgumentCaptor<Multimap<String, String>> groupMembershipCaptor = ArgumentCaptor.forClass(Multimap.class);
+        verify(operations).addUsersToGroups(eq(fmsToFreeipaBatchCallEnabled), eq(freeIpaClient),
+                groupMembershipCaptor.capture(), eq(warnings));
+
+        Map<String, Collection<String>> smallGroupMemberships = groupMembershipCaptor.getValue().asMap();
+        Map<String, Collection<String>> allGroupMemberships = groupMembershipToAdd.asMap();
+        assertEquals(allGroupMemberships.keySet().size() - largeGroupNames.size(),
+                smallGroupMemberships.keySet().size());
+        allGroupMemberships.entrySet().forEach(entry -> {
+            String groupName = entry.getKey();
+            if (largeGroupNames.contains(groupName)) {
+                assertFalse(smallGroupMemberships.containsKey(groupName));
+            } else {
+                assertTrue(smallGroupMemberships.containsKey(groupName));
+                assertEquals(entry.getValue(), smallGroupMemberships.get(groupName));
+            }
+        });
+    }
+
+    @Test
+    void addMembersToSmallGroupsNotBatched() throws Exception {
+        boolean fmsToFreeipaBatchCallEnabled = false;
+        FreeIpaClient freeIpaClient = mock(FreeIpaClient.class);
+        Multimap<String, String> groupMembershipToAdd = setupGroupMapping(10, 20);
+        Set<String> largeGroupNames = Set.of(groupMembershipToAdd.entries().stream()
+                .findFirst().get().getKey());
+        BiConsumer<String, String> warnings = mock(BiConsumer.class);
+
+        underTest.addMembersToSmallGroups(fmsToFreeipaBatchCallEnabled, freeIpaClient, groupMembershipToAdd,
+                largeGroupNames, warnings);
+
+        ArgumentCaptor<Multimap<String, String>> groupMembershipCaptor = ArgumentCaptor.forClass(Multimap.class);
+        verify(operations).addUsersToGroups(eq(fmsToFreeipaBatchCallEnabled), eq(freeIpaClient),
+                groupMembershipCaptor.capture(), eq(warnings));
+
+        Map<String, Collection<String>> smallGroupMemberships = groupMembershipCaptor.getValue().asMap();
+        Map<String, Collection<String>> allGroupMemberships = groupMembershipToAdd.asMap();
+        assertEquals(allGroupMemberships.keySet().size() - largeGroupNames.size(),
+                smallGroupMemberships.keySet().size());
+        allGroupMemberships.entrySet().forEach(entry -> {
+            String groupName = entry.getKey();
+            if (largeGroupNames.contains(groupName)) {
+                assertFalse(smallGroupMemberships.containsKey(groupName));
+            } else {
+                assertTrue(smallGroupMemberships.containsKey(groupName));
+                assertEquals(entry.getValue(), smallGroupMemberships.get(groupName));
+            }
+        });
+    }
+
+    @Test
+    void addMembersToLargeGroups() throws Exception {
+        FreeIpaClient freeIpaClient = mock(FreeIpaClient.class);
+        Multimap<String, String> groupMembershipToAdd = setupGroupMapping(10, 20);
+        Set<String> largeGroupNames = Set.of(groupMembershipToAdd.entries().stream()
+                .findFirst().get().getKey());
+        BiConsumer<String, String> warnings = mock(BiConsumer.class);
+
+        underTest.addMembersToLargeGroups(freeIpaClient, groupMembershipToAdd,
+                largeGroupNames, warnings);
+
+        ArgumentCaptor<Multimap<String, String>> groupMembershipCaptor = ArgumentCaptor.forClass(Multimap.class);
+        verify(operations).addUsersToGroups(eq(false), eq(freeIpaClient),
+                groupMembershipCaptor.capture(), eq(warnings));
+
+        Map<String, Collection<String>> largeGroupMemberships = groupMembershipCaptor.getValue().asMap();
+        Map<String, Collection<String>> allGroupMemberships = groupMembershipToAdd.asMap();
+        assertEquals(largeGroupNames.size(),
+                largeGroupMemberships.keySet().size());
+        allGroupMemberships.entrySet().forEach(entry -> {
+            String groupName = entry.getKey();
+            if (largeGroupNames.contains(groupName)) {
+                assertTrue(largeGroupMemberships.containsKey(groupName));
+                assertEquals(entry.getValue(), largeGroupMemberships.get(groupName));
+            } else {
+                assertFalse(largeGroupMemberships.containsKey(groupName));
+            }
+        });
+    }
+
+    private Multimap<String, String> setupGroupMapping(int numGroups, int numPerGroup) {
+        Multimap<String, String> groupMapping = HashMultimap.create();
+        for (int i = 0; i < numGroups; ++i) {
+            String group = "group" + i;
+            for (int j = 0; j < numPerGroup; ++j) {
+                groupMapping.put(group, "user" + j);
+            }
+        }
+        return groupMapping;
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UsersStateDifferenceCalculatorTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UsersStateDifferenceCalculatorTest.java
@@ -249,6 +249,7 @@ class UsersStateDifferenceCalculatorTest {
         String group = "group";
         String unmanagedGroup = FreeIpaChecks.IPA_UNMANAGED_GROUPS.get(0);
         String largeGroup = "largeGroup";
+        String allowedLargeGroup = UserSyncConstants.ENV_ASSIGNEES_GROUP_PREFIX + UUID.randomUUID().toString();
 
         String userUms = "userUms";
         String userBoth = "userBoth";
@@ -263,6 +264,7 @@ class UsersStateDifferenceCalculatorTest {
 
         for (int i = 0; i <= groupSizeLimit; ++i) {
             usersStateBuilder.addMemberToGroup(largeGroup, userLargeGroupBase + i);
+            usersStateBuilder.addMemberToGroup(allowedLargeGroup, userLargeGroupBase + i);
         }
 
         UmsUsersState umsUsersState = new UmsUsersState.Builder()
@@ -295,6 +297,8 @@ class UsersStateDifferenceCalculatorTest {
         // no members added to large group
         assertFalse(groupMembershipsToAdd.containsKey(largeGroup));
         assertEquals(1, warnings.size());
+        // allowed large group should be in the difference
+        assertTrue(groupMembershipsToAdd.containsKey(allowedLargeGroup));
     }
 
     @Test


### PR DESCRIPTION
This commit adds more guardrails to usersync for handling groups with many members.
Any group that exceeds the large group threshold will not have it's members added
in batch operations. Empirically, we've observed that the batch operations is in
danger of exceeding some timeouts, e.g., in the inverting proxy. Timeouts indicate
that the FreeIPA server is starting to be overloaded and is unable to respond to
requests in a timely manner.

There are two known large groups that are needed in the system, but had been filtered out
of the UmsUsersState listing of groups that exceed the threshold/limits.
Filtering the groups that exceed the group size threshold/limit for allowed large group
names was moved out of the ums users state retrieval. This way we can include the allowed
large groups in any large group handling we have. This includes logging the groups and
not batching group_add_members. The allowed group filtering is moved to the
UserStateDifferenceCalculator to accomodate the change in the UmsUsersState.

We had to touch the usersync delete user codepath, so this was simplified to not go through
the UserStateDifferenceCalculator. The calculator was incorrectly calculating the
group_remove_member Multimap and the code to remove users from the groups was redundant
because the group memberships will be updated automatically when the user is removed
from FreeIPA.

See detailed description in the commit message.