### PR TITLE
CB-17359 Add logs to flow termination and finalization

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/CloudbreakFlowInformation.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/CloudbreakFlowInformation.java
@@ -7,6 +7,8 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.core.flow2.cluster.termination.ClusterTerminationEvent;
@@ -24,6 +26,8 @@ import com.sequenceiq.flow.domain.FlowLog;
 
 @Component
 public class CloudbreakFlowInformation implements ApplicationFlowInformation {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CloudbreakFlowInformation.class);
 
     private static final List<String> ALLOWED_PARALLEL_FLOWS = List.of(
             ClusterTerminationEvent.TERMINATION_EVENT.event(),
@@ -47,6 +51,7 @@ public class CloudbreakFlowInformation implements ApplicationFlowInformation {
     @Override
     public void handleFlowFail(FlowLog flowLog) {
         Stack stack = stackService.getById(flowLog.getResourceId());
+        LOGGER.info("Handling failed flow {} for {}", flowLog, stack);
         if (stack.getStackStatus() != null && stack.getStackStatus().getDetailedStackStatus() != null) {
             stack.setStackStatus(new StackStatus(stack, stack.getStackStatus().getStatus().mapToFailedIfInProgress(), "Flow failed", UNKNOWN));
             stackService.save(stack);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxFlowInformation.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxFlowInformation.java
@@ -48,8 +48,10 @@ public class SdxFlowInformation implements ApplicationFlowInformation {
     @Override
     public void handleFlowFail(FlowLog flowLog) {
         SdxCluster sdxCluster = sdxService.getById(flowLog.getResourceId());
+        LOGGER.info("Handling failed flow {} for {}", flowLog, sdxCluster);
         if (sdxCluster != null)  {
             SdxStatusEntity actualStatusForSdx = sdxStatusService.getActualStatusForSdx(sdxCluster);
+            LOGGER.debug("Sdx status {} while handling flow failure", actualStatusForSdx);
             if (actualStatusForSdx != null) {
                 DatalakeStatusEnum status = actualStatusForSdx.getStatus();
                 if (status != null) {

--- a/flow/src/main/java/com/sequenceiq/flow/core/ApplicationFlowInformation.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/ApplicationFlowInformation.java
@@ -2,16 +2,21 @@ package com.sequenceiq.flow.core;
 
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.sequenceiq.flow.core.config.FlowConfiguration;
 import com.sequenceiq.flow.domain.FlowLog;
 
 public interface ApplicationFlowInformation  {
+
+    Logger LOGGER = LoggerFactory.getLogger(ApplicationFlowInformation.class);
 
     List<String> getAllowedParallelFlows();
 
     List<Class<? extends FlowConfiguration<?>>> getTerminationFlow();
 
     default void handleFlowFail(FlowLog flowLog) {
-
+        LOGGER.debug("'handleFlowFail' is not implemented, affected flow: {}", flowLog);
     }
 }

--- a/flow/src/main/java/com/sequenceiq/flow/service/FlowService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/service/FlowService.java
@@ -31,9 +31,7 @@ import com.sequenceiq.flow.api.model.operation.OperationFlowsView;
 import com.sequenceiq.flow.converter.FlowLogConverter;
 import com.sequenceiq.flow.converter.FlowProgressResponseConverter;
 import com.sequenceiq.flow.core.FlowConstants;
-import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
 import com.sequenceiq.flow.core.stats.FlowOperationStatisticsService;
-import com.sequenceiq.flow.domain.ClassValue;
 import com.sequenceiq.flow.domain.FlowChainLog;
 import com.sequenceiq.flow.domain.FlowLog;
 import com.sequenceiq.flow.domain.StateStatus;
@@ -99,13 +97,6 @@ public class FlowService {
         return flowLogs.stream().map(flowLog -> flowLogConverter.convert(flowLog)).collect(Collectors.toList());
     }
 
-    public <T extends AbstractFlowConfiguration> List<FlowLogResponse> getFlowLogsByCrnAndType(String resourceCrn, ClassValue classValue) {
-        checkState(Crn.isCrn(resourceCrn));
-        LOGGER.info("Getting flow logs by resource crn {} and type {}", resourceCrn, classValue.getClassValue().getCanonicalName());
-        List<FlowLog> flowLogs = flowLogDBService.getFlowLogsByCrnAndType(resourceCrn, classValue);
-        return flowLogs.stream().map(flowLog -> flowLogConverter.convert(flowLog)).collect(Collectors.toList());
-    }
-
     public List<FlowLogResponse> getFlowLogsByResourceName(String resourceName) {
         checkState(!Crn.isCrn(resourceName));
         LOGGER.info("Getting flow logs by resource name {}", resourceName);
@@ -125,7 +116,7 @@ public class FlowService {
                 resourceIds = Collections.singletonList(resourceId);
             }
         } catch (CrnParseException crnParseException) {
-            resourceIds = Collections.EMPTY_LIST;
+            resourceIds = Collections.emptyList();
         }
 
         return getFlowChainStateSafe(resourceIds, chainId);
@@ -250,19 +241,6 @@ public class FlowService {
         LOGGER.info("Getting flow logs (progress) for all recent flows by resource crn {}", resourceCrn);
         List<FlowLog> flowLogs = flowLogDBService.getAllFlowLogsByResourceCrnOrName(resourceCrn);
         return flowProgressResponseConverter.convertList(flowLogs, resourceCrn);
-    }
-
-    public <T extends AbstractFlowConfiguration> Optional<FlowProgressResponse> getLastFlowProgressByResourceCrnAndType(
-            String resourceCrn, ClassValue classValue) {
-        checkState(Crn.isCrn(resourceCrn));
-        LOGGER.info("Getting flow logs (progress) by resource crn {} and type {}", resourceCrn, classValue.getClassValue().getCanonicalName());
-        List<FlowLog> flowLogs = flowLogDBService.getFlowLogsByCrnAndType(resourceCrn, classValue);
-        FlowProgressResponse response = flowProgressResponseConverter.convert(flowLogs, resourceCrn);
-        if (StringUtils.isBlank(response.getFlowId())) {
-            LOGGER.debug("Not found any historical flow data for requested resource (crn: {})", resourceCrn);
-            return Optional.empty();
-        }
-        return Optional.ofNullable(flowProgressResponseConverter.convert(flowLogs, resourceCrn));
     }
 
     public Optional<OperationFlowsView> getLastFlowOperationByResourceCrn(String resourceCrn) {


### PR DESCRIPTION
To make easier to find failing flow some extra logs have been added. Also non-used method removed.

See detailed description in the commit message.