### PR TITLE
CDPCP-7442. Usersync set crn in metadata on user_add

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
@@ -229,7 +229,7 @@ public class FreeIpaClient {
     }
 
     public User userAdd(String user, String firstName, String lastName) throws FreeIpaClientException {
-        return userAdd(user, firstName, lastName, USER_ENABLED);
+        return userAdd(user, firstName, lastName, USER_ENABLED, Optional.empty());
     }
 
     /**
@@ -239,10 +239,12 @@ public class FreeIpaClient {
      * @param firstName the user's first name
      * @param lastName  the user's last name
      * @param disabled  whether the user is disabled
+     * @param title     Optional title
      * @return the user model
      */
-    public User userAdd(String user, String firstName, String lastName, boolean disabled) throws FreeIpaClientException {
-        return UserAddOperation.create(user, firstName, lastName, disabled).invoke(this).orElseThrow(() ->
+    public User userAdd(String user, String firstName, String lastName, boolean disabled, Optional<String> title)
+            throws FreeIpaClientException {
+        return UserAddOperation.create(user, firstName, lastName, disabled, title).invoke(this).orElseThrow(() ->
                 new FreeIpaClientException(String.format("User addition failed for user %s", user)));
     }
 

--- a/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/operation/BatchOperationTest.java
+++ b/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/operation/BatchOperationTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -47,7 +48,8 @@ public class BatchOperationTest {
 
         when(freeIpaClient.invoke(any(), anyList(), any(), any())).thenReturn(rpcResponse);
 
-        operations.add(UserAddOperation.create("user", "first", "last", false).getOperationParamsForBatchCall());
+        operations.add(UserAddOperation.create("user", "first", "last", false, Optional.empty())
+                .getOperationParamsForBatchCall());
         BatchOperation.create(operations, warnings::put, Set.of()).invoke(freeIpaClient);
 
         verify(freeIpaClient).invoke(eq("batch"), anyList(), any(), any());
@@ -61,7 +63,8 @@ public class BatchOperationTest {
         when(freeIpaClient.invoke(any(), anyList(), any(), any())).thenThrow(
                 new FreeIpaClientException("error", new JsonRpcClientException(4002, "", null)));
 
-        operations.add(UserAddOperation.create("user", "first", "last", false).getOperationParamsForBatchCall());
+        operations.add(UserAddOperation.create("user", "first", "last", false, Optional.empty())
+                .getOperationParamsForBatchCall());
         BatchOperation.create(operations, warnings::put, Set.of(FreeIpaErrorCodes.DUPLICATE_ENTRY)).invoke(freeIpaClient);
 
         verify(freeIpaClient).invoke(eq("batch"), anyList(), any(), any());
@@ -76,7 +79,8 @@ public class BatchOperationTest {
         when(freeIpaClient.invoke(any(), anyList(), any(), any())).thenThrow(
                 new FreeIpaClientException("error", new JsonRpcClientException(5000, "", null)));
 
-        operations.add(UserAddOperation.create("user", "first", "last", false).getOperationParamsForBatchCall());
+        operations.add(UserAddOperation.create("user", "first", "last", false, Optional.empty())
+                .getOperationParamsForBatchCall());
         BatchOperation.create(operations, warnings::put, Set.of(FreeIpaErrorCodes.NOT_FOUND)).invoke(freeIpaClient);
 
         verify(freeIpaClient).invoke(eq("batch"), anyList(), any(), any());

--- a/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/operation/UserAddOperationTest.java
+++ b/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/operation/UserAddOperationTest.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.freeipa.client.operation;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -10,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -17,6 +19,10 @@ import com.sequenceiq.freeipa.client.FreeIpaClient;
 import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.cloudbreak.client.RPCResponse;
 import com.sequenceiq.freeipa.client.model.User;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
 public class UserAddOperationTest {
@@ -29,7 +35,8 @@ public class UserAddOperationTest {
     @Test
     public void testInvokeWhenUserProtected() {
         assertThrows(FreeIpaClientException.class, () ->
-                UserAddOperation.create("admin", "admin", "admin", false).invoke(freeIpaClient));
+                UserAddOperation.create("admin", "admin", "admin", false, Optional.empty())
+                        .invoke(freeIpaClient));
         verifyNoInteractions(freeIpaClient);
     }
 
@@ -40,8 +47,25 @@ public class UserAddOperationTest {
 
         when(freeIpaClient.invoke(any(), anyList(), any(), any())).thenReturn(rpcResponse);
 
-        UserAddOperation.create(USER_NAME, USER_NAME, USER_NAME, false).invoke(freeIpaClient);
+        UserAddOperation.create(USER_NAME, USER_NAME, USER_NAME, false, Optional.empty()).invoke(freeIpaClient);
 
-        verify(freeIpaClient).invoke(eq("user_add"), anyList(), any(), any());
+        verify(freeIpaClient).invoke(eq("user_add"), eq(List.of(USER_NAME)), any(), any());
+    }
+
+    @Test
+    public void testInvokeWithTitle() throws FreeIpaClientException {
+        RPCResponse<Object> rpcResponse = new RPCResponse<>();
+        rpcResponse.setResult(new User());
+
+        when(freeIpaClient.invoke(any(), anyList(), any(), any())).thenReturn(rpcResponse);
+        String titleString = "title string";
+
+        UserAddOperation.create(USER_NAME, USER_NAME, USER_NAME, false, Optional.of(titleString))
+                .invoke(freeIpaClient);
+
+        ArgumentCaptor<Map<String, Object>> paramCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(freeIpaClient).invoke(eq("user_add"), eq(List.of(USER_NAME)), paramCaptor.capture(), any());
+        Map<String, Object> params = paramCaptor.getValue();
+        assertEquals(titleString, params.get("title"));
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/FmsUser.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/FmsUser.java
@@ -17,6 +17,8 @@ public class FmsUser {
 
     private State state;
 
+    private String crn;
+
     public String getName() {
         return name;
     }
@@ -53,6 +55,15 @@ public class FmsUser {
         return this;
     }
 
+    public String getCrn() {
+        return crn;
+    }
+
+    public FmsUser withCrn(String crn) {
+        this.crn = crn;
+        return this;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -66,12 +77,13 @@ public class FmsUser {
         return Objects.equals(this.name, other.name)
                 && Objects.equals(this.firstName, other.firstName)
                 && Objects.equals(this.lastName, other.lastName)
-                && Objects.equals(this.state, other.state);
+                && Objects.equals(this.state, other.state)
+                && Objects.equals(this.crn, other.crn);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, firstName, lastName, state);
+        return Objects.hash(name, firstName, lastName, state, crn);
     }
 
     @Override
@@ -81,6 +93,7 @@ public class FmsUser {
                 + ", firstName='" + firstName + '\''
                 + ", lastName='" + lastName + '\''
                 + ", state=" + state
+                + ", crn='" + crn + '\''
                 + '}';
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/conversion/FmsUserConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/conversion/FmsUserConverterTest.java
@@ -1,13 +1,18 @@
 package com.sequenceiq.freeipa.service.freeipa.user.conversion;
 
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
+import com.sequenceiq.cloudbreak.auth.crn.CrnTestUtil;
 import com.sequenceiq.freeipa.service.freeipa.user.model.FmsUser;
 import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class FmsUserConverterTest {
+    private static final String ACCOUNT_ID = UUID.randomUUID().toString();
+
     private static final int UNRECOGNIZED_STATE_VALUE = 99;
 
     private FmsUserConverter underTest = new FmsUserConverter();
@@ -17,11 +22,13 @@ class FmsUserConverterTest {
         String firstName = "Foo";
         String lastName = "Bar";
         String workloadUsername = "foobar";
+        String crn = createUserCrn();
         UserManagementProto.User umsUser = UserManagementProto.User.newBuilder()
                 .setFirstName(firstName)
                 .setLastName(lastName)
                 .setWorkloadUsername(workloadUsername)
                 .setState(UserManagementProto.ActorState.Value.ACTIVE)
+                .setCrn(crn)
                 .build();
 
         FmsUser fmsUser = underTest.toFmsUser(umsUser);
@@ -30,6 +37,7 @@ class FmsUserConverterTest {
         assertEquals(firstName, fmsUser.getFirstName());
         assertEquals(lastName, fmsUser.getLastName());
         assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
+        assertEquals(crn, fmsUser.getCrn());
     }
 
     @Test
@@ -37,11 +45,13 @@ class FmsUserConverterTest {
         String firstName = " Foo ";
         String lastName = " Bar ";
         String workloadUsername = "foobar";
+        String crn = createUserCrn();
         UserManagementProto.User umsUser = UserManagementProto.User.newBuilder()
                 .setFirstName(firstName)
                 .setLastName(lastName)
                 .setWorkloadUsername(workloadUsername)
                 .setState(UserManagementProto.ActorState.Value.ACTIVE)
+                .setCrn(crn)
                 .build();
 
         FmsUser fmsUser = underTest.toFmsUser(umsUser);
@@ -50,14 +60,17 @@ class FmsUserConverterTest {
         assertEquals("Foo", fmsUser.getFirstName());
         assertEquals("Bar", fmsUser.getLastName());
         assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
+        assertEquals(crn, fmsUser.getCrn());
     }
 
     @Test
     public void testUserToFmsUserMissingNames() {
         String workloadUsername = "foobar";
+        String crn = createUserCrn();
         UserManagementProto.User umsUser = UserManagementProto.User.newBuilder()
                 .setWorkloadUsername(workloadUsername)
                 .setState(UserManagementProto.ActorState.Value.ACTIVE)
+                .setCrn(crn)
                 .build();
 
         FmsUser fmsUser = underTest.toFmsUser(umsUser);
@@ -66,14 +79,17 @@ class FmsUserConverterTest {
         assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
         assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
         assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
+        assertEquals(crn, fmsUser.getCrn());
     }
 
     @Test
     public void testUserToFmsUserDeactivatedState() {
         String workloadUsername = "foobar";
+        String crn = createUserCrn();
         UserManagementProto.User umsUser = UserManagementProto.User.newBuilder()
                 .setWorkloadUsername(workloadUsername)
                 .setState(UserManagementProto.ActorState.Value.DEACTIVATED)
+                .setCrn(crn)
                 .build();
 
         FmsUser fmsUser = underTest.toFmsUser(umsUser);
@@ -82,14 +98,17 @@ class FmsUserConverterTest {
         assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
         assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
         assertEquals(FmsUser.State.DISABLED, fmsUser.getState());
+        assertEquals(crn, fmsUser.getCrn());
     }
 
     @Test
     public void testUserToFmsUserDeletingState() {
         String workloadUsername = "foobar";
+        String crn = createUserCrn();
         UserManagementProto.User umsUser = UserManagementProto.User.newBuilder()
                 .setWorkloadUsername(workloadUsername)
                 .setState(UserManagementProto.ActorState.Value.DELETING)
+                .setCrn(crn)
                 .build();
 
         FmsUser fmsUser = underTest.toFmsUser(umsUser);
@@ -98,14 +117,17 @@ class FmsUserConverterTest {
         assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
         assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
         assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
+        assertEquals(crn, fmsUser.getCrn());
     }
 
     @Test
     public void testUserToFmsUserControlPlaneLockedOutState() {
         String workloadUsername = "foobar";
+        String crn = createUserCrn();
         UserManagementProto.User umsUser = UserManagementProto.User.newBuilder()
                 .setWorkloadUsername(workloadUsername)
                 .setState(UserManagementProto.ActorState.Value.CONTROL_PLANE_LOCKED_OUT)
+                .setCrn(crn)
                 .build();
 
         FmsUser fmsUser = underTest.toFmsUser(umsUser);
@@ -114,14 +136,17 @@ class FmsUserConverterTest {
         assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
         assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
         assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
+        assertEquals(crn, fmsUser.getCrn());
     }
 
     @Test
     public void testUserToFmsUserUnrecognizedState() {
         String workloadUsername = "foobar";
+        String crn = createUserCrn();
         UserManagementProto.User umsUser = UserManagementProto.User.newBuilder()
                 .setWorkloadUsername(workloadUsername)
                 .setStateValue(UNRECOGNIZED_STATE_VALUE)
+                .setCrn(crn)
                 .build();
 
         FmsUser fmsUser = underTest.toFmsUser(umsUser);
@@ -130,13 +155,16 @@ class FmsUserConverterTest {
         assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
         assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
         assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
+        assertEquals(crn, fmsUser.getCrn());
     }
 
     @Test
     public void testUserToFmsUserMissingState() {
         String workloadUsername = "foobar";
+        String crn = createUserCrn();
         UserManagementProto.User umsUser = UserManagementProto.User.newBuilder()
                 .setWorkloadUsername(workloadUsername)
+                .setCrn(crn)
                 .build();
 
         FmsUser fmsUser = underTest.toFmsUser(umsUser);
@@ -145,16 +173,51 @@ class FmsUserConverterTest {
         assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
         assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
         assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
+        assertEquals(crn, fmsUser.getCrn());
     }
 
     @Test
     public void testUserToUserMissingWorkloadUsername() {
         String firstName = "Foo";
         String lastName = "Bar";
+        String crn = createUserCrn();
         UserManagementProto.User umsUser = UserManagementProto.User.newBuilder()
                 .setFirstName(firstName)
                 .setLastName(lastName)
                 .setState(UserManagementProto.ActorState.Value.ACTIVE)
+                .setCrn(crn)
+                .build();
+
+        assertThrows(IllegalArgumentException.class, () -> underTest.toFmsUser(umsUser));
+    }
+
+    @Test
+    public void testUserToUserMissingCrn() {
+        String workloadUsername = "foobar";
+        String firstName = "Foo";
+        String lastName = "Bar";
+        UserManagementProto.User umsUser = UserManagementProto.User.newBuilder()
+                .setWorkloadUsername(workloadUsername)
+                .setFirstName(firstName)
+                .setLastName(lastName)
+                .setState(UserManagementProto.ActorState.Value.ACTIVE)
+                .build();
+
+        assertThrows(IllegalArgumentException.class, () -> underTest.toFmsUser(umsUser));
+    }
+
+    @Test
+    public void testUserToUserCrnFormat() {
+        String workloadUsername = "foobar";
+        String firstName = "Foo";
+        String lastName = "Bar";
+        String crn = "crn:notacrn";
+        UserManagementProto.User umsUser = UserManagementProto.User.newBuilder()
+                .setWorkloadUsername(workloadUsername)
+                .setFirstName(firstName)
+                .setLastName(lastName)
+                .setState(UserManagementProto.ActorState.Value.ACTIVE)
+                .setCrn(crn)
                 .build();
 
         assertThrows(IllegalArgumentException.class, () -> underTest.toFmsUser(umsUser));
@@ -165,11 +228,13 @@ class FmsUserConverterTest {
         String name = "Foo";
         String id = "Bar";
         String workloadUsername = "foobar";
+        String crn = createMachineUserCrn();
         UserManagementProto.MachineUser umsMachineUser = UserManagementProto.MachineUser.newBuilder()
                 .setMachineUserName(name)
                 .setMachineUserId(id)
                 .setWorkloadUsername(workloadUsername)
                 .setState(UserManagementProto.ActorState.Value.ACTIVE)
+                .setCrn(crn)
                 .build();
 
         FmsUser fmsUser = underTest.toFmsUser(umsMachineUser);
@@ -178,6 +243,7 @@ class FmsUserConverterTest {
         assertEquals(name, fmsUser.getFirstName());
         assertEquals(id, fmsUser.getLastName());
         assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
+        assertEquals(crn, fmsUser.getCrn());
     }
 
     @Test
@@ -185,11 +251,13 @@ class FmsUserConverterTest {
         String name = " Foo ";
         String id = " Bar ";
         String workloadUsername = "foobar";
+        String crn = createMachineUserCrn();
         UserManagementProto.MachineUser umsMachineUser = UserManagementProto.MachineUser.newBuilder()
                 .setMachineUserName(name)
                 .setMachineUserId(id)
                 .setWorkloadUsername(workloadUsername)
                 .setState(UserManagementProto.ActorState.Value.ACTIVE)
+                .setCrn(crn)
                 .build();
 
         FmsUser fmsUser = underTest.toFmsUser(umsMachineUser);
@@ -198,14 +266,17 @@ class FmsUserConverterTest {
         assertEquals("Foo", fmsUser.getFirstName());
         assertEquals("Bar", fmsUser.getLastName());
         assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
+        assertEquals(crn, fmsUser.getCrn());
     }
 
     @Test
     public void testMachineUserToFmsUserMissingNames() {
         String workloadUsername = "foobar";
+        String crn = createMachineUserCrn();
         UserManagementProto.MachineUser umsMachineUser = UserManagementProto.MachineUser.newBuilder()
                 .setWorkloadUsername(workloadUsername)
                 .setState(UserManagementProto.ActorState.Value.ACTIVE)
+                .setCrn(crn)
                 .build();
 
         FmsUser fmsUser = underTest.toFmsUser(umsMachineUser);
@@ -214,14 +285,17 @@ class FmsUserConverterTest {
         assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
         assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
         assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
+        assertEquals(crn, fmsUser.getCrn());
     }
 
     @Test
     public void testMachineUserToFmsUserDeactivatedState() {
         String workloadUsername = "foobar";
+        String crn = createMachineUserCrn();
         UserManagementProto.MachineUser umsMachineUser = UserManagementProto.MachineUser.newBuilder()
                 .setWorkloadUsername(workloadUsername)
                 .setState(UserManagementProto.ActorState.Value.DEACTIVATED)
+                .setCrn(crn)
                 .build();
 
         FmsUser fmsUser = underTest.toFmsUser(umsMachineUser);
@@ -230,14 +304,17 @@ class FmsUserConverterTest {
         assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
         assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
         assertEquals(FmsUser.State.DISABLED, fmsUser.getState());
+        assertEquals(crn, fmsUser.getCrn());
     }
 
     @Test
     public void testMachineUserToFmsUserDeletingState() {
         String workloadUsername = "foobar";
+        String crn = createMachineUserCrn();
         UserManagementProto.MachineUser umsMachineUser = UserManagementProto.MachineUser.newBuilder()
                 .setWorkloadUsername(workloadUsername)
                 .setState(UserManagementProto.ActorState.Value.DELETING)
+                .setCrn(crn)
                 .build();
 
         FmsUser fmsUser = underTest.toFmsUser(umsMachineUser);
@@ -246,14 +323,17 @@ class FmsUserConverterTest {
         assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
         assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
         assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
+        assertEquals(crn, fmsUser.getCrn());
     }
 
     @Test
     public void testMachineUserToFmsUserUnrecognizedState() {
         String workloadUsername = "foobar";
+        String crn = createMachineUserCrn();
         UserManagementProto.MachineUser umsMachineUser = UserManagementProto.MachineUser.newBuilder()
                 .setWorkloadUsername(workloadUsername)
                 .setStateValue(UNRECOGNIZED_STATE_VALUE)
+                .setCrn(crn)
                 .build();
 
         FmsUser fmsUser = underTest.toFmsUser(umsMachineUser);
@@ -262,13 +342,16 @@ class FmsUserConverterTest {
         assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
         assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
         assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
+        assertEquals(crn, fmsUser.getCrn());
     }
 
     @Test
     public void testMachineUserToFmsUserMissingState() {
         String workloadUsername = "foobar";
+        String crn = createMachineUserCrn();
         UserManagementProto.MachineUser umsMachineUser = UserManagementProto.MachineUser.newBuilder()
                 .setWorkloadUsername(workloadUsername)
+                .setCrn(crn)
                 .build();
 
         FmsUser fmsUser = underTest.toFmsUser(umsMachineUser);
@@ -277,13 +360,48 @@ class FmsUserConverterTest {
         assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
         assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
         assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
+        assertEquals(crn, fmsUser.getCrn());
     }
 
     @Test
     public void testMachineUserToFmsUserMissingWorkloadUsername() {
         String name = "Foo";
         String id = "Bar";
+        String crn = createMachineUserCrn();
         UserManagementProto.MachineUser umsMachineUser = UserManagementProto.MachineUser.newBuilder()
+                .setMachineUserName(name)
+                .setMachineUserId(id)
+                .setState(UserManagementProto.ActorState.Value.ACTIVE)
+                .setCrn(crn)
+                .build();
+
+        assertThrows(IllegalArgumentException.class, () -> underTest.toFmsUser(umsMachineUser));
+    }
+
+    @Test
+    public void testMachineUserToFmsUserCrnFormat() {
+        String workloadUsername = "foobar";
+        String name = "Foo";
+        String id = "Bar";
+        String crn = "crn:notacrn";
+        UserManagementProto.MachineUser umsMachineUser = UserManagementProto.MachineUser.newBuilder()
+                .setWorkloadUsername(workloadUsername)
+                .setMachineUserName(name)
+                .setMachineUserId(id)
+                .setState(UserManagementProto.ActorState.Value.ACTIVE)
+                .setCrn(crn)
+                .build();
+
+        assertThrows(IllegalArgumentException.class, () -> underTest.toFmsUser(umsMachineUser));
+    }
+
+    @Test
+    public void testMachineUserToFmsUserMissingCrn() {
+        String workloadUsername = "foobar";
+        String name = "Foo";
+        String id = "Bar";
+        UserManagementProto.MachineUser umsMachineUser = UserManagementProto.MachineUser.newBuilder()
+                .setWorkloadUsername(workloadUsername)
                 .setMachineUserName(name)
                 .setMachineUserId(id)
                 .setState(UserManagementProto.ActorState.Value.ACTIVE)
@@ -297,12 +415,14 @@ class FmsUserConverterTest {
         String firstName = "Foo";
         String lastName = "Bar";
         String workloadUsername = "foobar";
+        String crn = createUserCrn();
         UserManagementProto.UserSyncActorDetails actorDetails =
                 UserManagementProto.UserSyncActorDetails.newBuilder()
                         .setFirstName(firstName)
                         .setLastName(lastName)
                         .setWorkloadUsername(workloadUsername)
                         .setState(UserManagementProto.ActorState.Value.ACTIVE)
+                        .setCrn(crn)
                         .build();
 
         FmsUser fmsUser = underTest.toFmsUser(actorDetails);
@@ -311,6 +431,7 @@ class FmsUserConverterTest {
         assertEquals(firstName, fmsUser.getFirstName());
         assertEquals(lastName, fmsUser.getLastName());
         assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
+        assertEquals(crn, fmsUser.getCrn());
     }
 
     @Test
@@ -318,12 +439,14 @@ class FmsUserConverterTest {
         String firstName = " Foo ";
         String lastName = " Bar ";
         String workloadUsername = "foobar";
+        String crn = createUserCrn();
         UserManagementProto.UserSyncActorDetails actorDetails =
                 UserManagementProto.UserSyncActorDetails.newBuilder()
                         .setFirstName(firstName)
                         .setLastName(lastName)
                         .setWorkloadUsername(workloadUsername)
                         .setState(UserManagementProto.ActorState.Value.ACTIVE)
+                        .setCrn(crn)
                         .build();
 
         FmsUser fmsUser = underTest.toFmsUser(actorDetails);
@@ -332,15 +455,18 @@ class FmsUserConverterTest {
         assertEquals("Foo", fmsUser.getFirstName());
         assertEquals("Bar", fmsUser.getLastName());
         assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
+        assertEquals(crn, fmsUser.getCrn());
     }
 
     @Test
     public void testUserSyncActorDetailsToFmsUserMissingNames() {
         String workloadUsername = "foobar";
+        String crn = createUserCrn();
         UserManagementProto.UserSyncActorDetails actorDetails =
                 UserManagementProto.UserSyncActorDetails.newBuilder()
                         .setWorkloadUsername(workloadUsername)
                         .setState(UserManagementProto.ActorState.Value.ACTIVE)
+                        .setCrn(crn)
                         .build();
 
         FmsUser fmsUser = underTest.toFmsUser(actorDetails);
@@ -349,15 +475,18 @@ class FmsUserConverterTest {
         assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
         assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
         assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
+        assertEquals(crn, fmsUser.getCrn());
     }
 
     @Test
     public void testUserSyncActorDetailsToFmsUserDeactivatedState() {
         String workloadUsername = "foobar";
+        String crn = createUserCrn();
         UserManagementProto.UserSyncActorDetails actorDetails =
                 UserManagementProto.UserSyncActorDetails.newBuilder()
                         .setWorkloadUsername(workloadUsername)
                         .setState(UserManagementProto.ActorState.Value.DEACTIVATED)
+                        .setCrn(crn)
                         .build();
 
         FmsUser fmsUser = underTest.toFmsUser(actorDetails);
@@ -366,15 +495,18 @@ class FmsUserConverterTest {
         assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
         assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
         assertEquals(FmsUser.State.DISABLED, fmsUser.getState());
+        assertEquals(crn, fmsUser.getCrn());
     }
 
     @Test
     public void testUserSyncActorDetailsToFmsUserDeletingState() {
         String workloadUsername = "foobar";
+        String crn = createUserCrn();
         UserManagementProto.UserSyncActorDetails actorDetails =
                 UserManagementProto.UserSyncActorDetails.newBuilder()
                         .setWorkloadUsername(workloadUsername)
                         .setState(UserManagementProto.ActorState.Value.DELETING)
+                        .setCrn(crn)
                         .build();
 
         FmsUser fmsUser = underTest.toFmsUser(actorDetails);
@@ -383,15 +515,18 @@ class FmsUserConverterTest {
         assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
         assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
         assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
+        assertEquals(crn, fmsUser.getCrn());
     }
 
     @Test
     public void testUserSyncActorDetailsToFmsUserUnrecognizedState() {
         String workloadUsername = "foobar";
+        String crn = createUserCrn();
         UserManagementProto.UserSyncActorDetails actorDetails =
                 UserManagementProto.UserSyncActorDetails.newBuilder()
                         .setWorkloadUsername(workloadUsername)
                         .setStateValue(UNRECOGNIZED_STATE_VALUE)
+                        .setCrn(crn)
                         .build();
 
         FmsUser fmsUser = underTest.toFmsUser(actorDetails);
@@ -400,14 +535,17 @@ class FmsUserConverterTest {
         assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
         assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
         assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
+        assertEquals(crn, fmsUser.getCrn());
     }
 
     @Test
     public void testUserSyncActorDetailsToFmsUserMissingState() {
         String workloadUsername = "foobar";
+        String crn = createUserCrn();
         UserManagementProto.UserSyncActorDetails actorDetails =
                 UserManagementProto.UserSyncActorDetails.newBuilder()
                         .setWorkloadUsername(workloadUsername)
+                        .setCrn(crn)
                         .build();
 
         FmsUser fmsUser = underTest.toFmsUser(actorDetails);
@@ -416,17 +554,20 @@ class FmsUserConverterTest {
         assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
         assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
         assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
+        assertEquals(crn, fmsUser.getCrn());
     }
 
     @Test
     public void testUserSyncActorDetailsToFmsUserMissingWorkloadUsername() {
         String firstName = "Foo";
         String lastName = "Bar";
+        String crn = createUserCrn();
         UserManagementProto.UserSyncActorDetails actorDetails =
                 UserManagementProto.UserSyncActorDetails.newBuilder()
                         .setFirstName(firstName)
                         .setLastName(lastName)
                         .setState(UserManagementProto.ActorState.Value.ACTIVE)
+                        .setCrn(crn)
                         .build();
 
         assertThrows(IllegalArgumentException.class, () -> underTest.toFmsUser(actorDetails));
@@ -437,6 +578,24 @@ class FmsUserConverterTest {
         String firstName = "Foo";
         String lastName = "Bar";
         String workloadUserName = " ";
+        String crn = createUserCrn();
+        UserManagementProto.UserSyncActorDetails actorDetails =
+                UserManagementProto.UserSyncActorDetails.newBuilder()
+                        .setFirstName(firstName)
+                        .setLastName(lastName)
+                        .setWorkloadUsername(workloadUserName)
+                        .setState(UserManagementProto.ActorState.Value.ACTIVE)
+                        .setCrn(crn)
+                        .build();
+
+        assertThrows(IllegalArgumentException.class, () -> underTest.toFmsUser(actorDetails));
+    }
+
+    @Test
+    public void testUserSyncActorDetailsToFmsUserMissingCrn() {
+        String firstName = "Foo";
+        String lastName = "Bar";
+        String workloadUserName = "foobar";
         UserManagementProto.UserSyncActorDetails actorDetails =
                 UserManagementProto.UserSyncActorDetails.newBuilder()
                         .setFirstName(firstName)
@@ -446,5 +605,39 @@ class FmsUserConverterTest {
                         .build();
 
         assertThrows(IllegalArgumentException.class, () -> underTest.toFmsUser(actorDetails));
+    }
+
+    @Test
+    public void testUserSyncActorDetailsToFmsUserCrnFormat() {
+        String firstName = "Foo";
+        String lastName = "Bar";
+        String workloadUserName = "foobar";
+        String crn = "crn:notacrn";
+        UserManagementProto.UserSyncActorDetails actorDetails =
+                UserManagementProto.UserSyncActorDetails.newBuilder()
+                        .setFirstName(firstName)
+                        .setLastName(lastName)
+                        .setWorkloadUsername(workloadUserName)
+                        .setState(UserManagementProto.ActorState.Value.ACTIVE)
+                        .setCrn(crn)
+                        .build();
+
+        assertThrows(IllegalArgumentException.class, () -> underTest.toFmsUser(actorDetails));
+    }
+
+    private String createUserCrn() {
+        return CrnTestUtil.getUserCrnBuilder()
+                .setAccountId(ACCOUNT_ID)
+                .setResource(UUID.randomUUID().toString())
+                .build()
+                .toString();
+    }
+
+    private String createMachineUserCrn() {
+        return CrnTestUtil.getMachineUserCrnBuilder()
+                .setAccountId(ACCOUNT_ID)
+                .setResource(UUID.randomUUID().toString())
+                .build()
+                .toString();
     }
 }


### PR DESCRIPTION
Each actor's CRN is stored in the title field of the FreeIPA user
as part of the metadata that is updated when credentials are set. This
process left a time gap between user creation and when the CRN was
added to the user.

This commit elimiates that time gap by setting the CRN in thte title
field upon user creation in FreeIPA.

See detailed description in the commit message.