### PR TITLE
CB-17634 fix FreeIPA repair on AWS_NATIVE variant, enhanced component tests and logs around it

### DIFF
--- a/cloud-aws-native/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/resource/instance/AwsNativeInstanceResourceBuilder.java
+++ b/cloud-aws-native/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/resource/instance/AwsNativeInstanceResourceBuilder.java
@@ -135,7 +135,7 @@ public class AwsNativeInstanceResourceBuilder extends AbstractAwsNativeComputeBu
                     .withKeyName(cloudStack.getInstanceAuthentication().getPublicKeyId());
             RunInstancesResult instanceResult = amazonEc2Client.createInstance(request);
             instance = instanceResult.getReservation().getInstances().get(0);
-            LOGGER.info("Instance creation inited with name: {} and instance id: {}", cloudResource.getName(), instance.getInstanceId());
+            LOGGER.info("Instance creation initiated for resource: {} and instance id: {}", cloudResource, instance.getInstanceId());
         }
         cloudResource.setInstanceId(instance.getInstanceId());
         return buildableResource;
@@ -150,13 +150,16 @@ public class AwsNativeInstanceResourceBuilder extends AbstractAwsNativeComputeBu
                     .findFirst()
                     .map(CloudResource::getReference)
                     .orElse(null);
+            LOGGER.debug("Selected security group id from CloudResource: {}", securityGroupId);
         }
-        if (securityGroupId == null) {
+        if (StringUtils.isEmpty(securityGroupId)) {
             securityGroupId = group.getSecurity().getCloudSecurityId();
+            LOGGER.debug("Selected security group id from group's security domain: {}", securityGroupId);
         }
-        if (securityGroupId == null) {
+        if (StringUtils.isEmpty(securityGroupId)) {
             LOGGER.debug("Cannot determine the security group, so it will be created in the default sec group");
         }
+        LOGGER.info("Security group id: {}", securityGroupId);
         return securityGroupId;
     }
 


### PR DESCRIPTION
With this fix and component test coverage the `com.sequenceiq.it.cloudbreak.testcase.e2e.freeipa.FreeIpaTests#testCreateStopStartRepairFreeIpaWithTwoInstances` test case ran successfully on `AWS_NATIVE_GOV` cloud platform variant:
<img width="784" alt="image" src="https://user-images.githubusercontent.com/2011396/178300079-289449e9-2a6b-4ee3-b807-856c301ade53.png">
