### PR TITLE
CB-17707 Remove stack entity from LoadBalancerUpdateRequest/Result

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/CreateCloudLoadBalancersRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/CreateCloudLoadBalancersRequest.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 
 public class CreateCloudLoadBalancersRequest extends StackEvent {
@@ -16,16 +15,13 @@ public class CreateCloudLoadBalancersRequest extends StackEvent {
 
     private final CloudStack cloudStack;
 
-    private final Stack stack;
-
     @JsonCreator
     public CreateCloudLoadBalancersRequest(
-            @JsonProperty("stack") Stack stack,
+            @JsonProperty("resourceId") Long stackId,
             @JsonProperty("cloudContext") CloudContext cloudContext,
             @JsonProperty("cloudCredential") CloudCredential cloudCredential,
             @JsonProperty("cloudStack") CloudStack cloudStack) {
-        super(stack.getId());
-        this.stack = stack;
+        super(stackId);
         this.cloudContext = cloudContext;
         this.cloudCredential = cloudCredential;
         this.cloudStack = cloudStack;
@@ -41,9 +37,5 @@ public class CreateCloudLoadBalancersRequest extends StackEvent {
 
     public CloudStack getCloudStack() {
         return cloudStack;
-    }
-
-    public Stack getStack() {
-        return stack;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/CreateCloudLoadBalancersSuccess.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/CreateCloudLoadBalancersSuccess.java
@@ -2,21 +2,13 @@ package com.sequenceiq.cloudbreak.reactor.api.event.stack.loadbalancer;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 
 public class CreateCloudLoadBalancersSuccess extends StackEvent {
 
-    private final Stack stack;
-
     @JsonCreator
     public CreateCloudLoadBalancersSuccess(
-            @JsonProperty("stack") Stack stack) {
-        super(stack.getId());
-        this.stack = stack;
-    }
-
-    public Stack getStack() {
-        return stack;
+            @JsonProperty("resourceId") Long stackId) {
+        super(stackId);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/CreateLoadBalancerEntityRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/CreateLoadBalancerEntityRequest.java
@@ -2,20 +2,13 @@ package com.sequenceiq.cloudbreak.reactor.api.event.stack.loadbalancer;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 
 public class CreateLoadBalancerEntityRequest extends StackEvent {
-    private final Stack stack;
 
     @JsonCreator
     public CreateLoadBalancerEntityRequest(
-            @JsonProperty("stack") Stack stack) {
-        super(stack.getId());
-        this.stack = stack;
-    }
-
-    public Stack getStack() {
-        return stack;
+            @JsonProperty("resourceId") Long stackId) {
+        super(stackId);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/CreateLoadBalancerEntitySuccess.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/CreateLoadBalancerEntitySuccess.java
@@ -2,22 +2,13 @@ package com.sequenceiq.cloudbreak.reactor.api.event.stack.loadbalancer;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 
 public class CreateLoadBalancerEntitySuccess extends StackEvent {
 
-    private final Stack savedStack;
-
     @JsonCreator
     public CreateLoadBalancerEntitySuccess(
-            @JsonProperty("resourceId") Long stackId,
-            @JsonProperty("savedStack") Stack savedStack) {
+            @JsonProperty("resourceId") Long stackId) {
         super(stackId);
-        this.savedStack = savedStack;
-    }
-
-    public Stack getSavedStack() {
-        return savedStack;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/LoadBalancerMetadataRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/LoadBalancerMetadataRequest.java
@@ -8,7 +8,6 @@ import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.common.api.type.LoadBalancerType;
 
@@ -22,20 +21,17 @@ public class LoadBalancerMetadataRequest extends StackEvent {
 
     private final List<LoadBalancerType> typesPresentInStack;
 
-    private final Stack stack;
-
     private final List<CloudResource> cloudResources;
 
     @JsonCreator
     public LoadBalancerMetadataRequest(
-            @JsonProperty("stack") Stack stack,
+            @JsonProperty("resourceId") Long stackId,
             @JsonProperty("cloudContext") CloudContext cloudContext,
             @JsonProperty("cloudCredential") CloudCredential cloudCredential,
             @JsonProperty("cloudStack") CloudStack cloudStack,
             @JsonProperty("typesPresentInStack") List<LoadBalancerType> typesPresentInStack,
             @JsonProperty("cloudResources") List<CloudResource> cloudResources) {
-        super(stack.getId());
-        this.stack = stack;
+        super(stackId);
         this.cloudContext = cloudContext;
         this.cloudCredential = cloudCredential;
         this.cloudStack = cloudStack;
@@ -57,10 +53,6 @@ public class LoadBalancerMetadataRequest extends StackEvent {
 
     public List<LoadBalancerType> getTypesPresentInStack() {
         return typesPresentInStack;
-    }
-
-    public Stack getStack() {
-        return stack;
     }
 
     public List<CloudResource> getCloudResources() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/RegisterPublicDnsRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/RegisterPublicDnsRequest.java
@@ -2,22 +2,14 @@ package com.sequenceiq.cloudbreak.reactor.api.event.stack.loadbalancer;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 
 public class RegisterPublicDnsRequest extends StackEvent {
 
-    private final Stack stack;
-
     @JsonCreator
     public RegisterPublicDnsRequest(
-            @JsonProperty("stack") Stack stack) {
-        super(stack.getId());
-        this.stack = stack;
-    }
-
-    public Stack getStack() {
-        return stack;
+            @JsonProperty("resourceId") Long stackId) {
+        super(stackId);
     }
 }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/RegisterPublicDnsSuccess.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/RegisterPublicDnsSuccess.java
@@ -2,21 +2,13 @@ package com.sequenceiq.cloudbreak.reactor.api.event.stack.loadbalancer;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 
 public class RegisterPublicDnsSuccess extends StackEvent {
 
-    private final Stack stack;
-
     @JsonCreator
     public RegisterPublicDnsSuccess(
-            @JsonProperty("stack") Stack stack) {
-        super(stack.getId());
-        this.stack = stack;
-    }
-
-    public Stack getStack() {
-        return stack;
+            @JsonProperty("resourceId") Long stackId) {
+        super(stackId);
     }
 }


### PR DESCRIPTION
We don't need to send the entire stack entity as a payload in eventbus. 