### PR TITLE
CB-17700 If the flow event timed out we don't handle it. In this case…

### DIFF
--- a/flow/src/main/java/com/sequenceiq/flow/reactor/api/event/EventSender.java
+++ b/flow/src/main/java/com/sequenceiq/flow/reactor/api/event/EventSender.java
@@ -63,7 +63,11 @@ public class EventSender {
         if (accepted != null) {
             try {
                 FlowAcceptResult acceptResult = (FlowAcceptResult) accepted.await(TIMEOUT, TimeUnit.SECONDS);
-                return createFlowIdentifier(acceptResult, resourceCrn);
+                if (acceptResult != null) {
+                    return createFlowIdentifier(acceptResult, resourceCrn);
+                } else {
+                    LOGGER.info("The acceptedResult is null, the flow identifier couldn't be created");
+                }
             } catch (InterruptedException e) {
                 throw new IllegalStateException(e.getMessage());
             }


### PR DESCRIPTION
… the EventBus respnd with null and we throw a FlowNotAcceptedException

See detailed description in the commit message.