### PR TITLE
CB-17711 Explicitly set postgresql 11 unit file data directory

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/init.sls
@@ -6,12 +6,6 @@
 {% set postgres_log_directory = salt['pillar.get']('postgres:postgres_log_directory') %}
 {% set postgres_scripts_executed_directory = salt['pillar.get']('postgres:postgres_scripts_executed_directory') %}
 {% set postgres_data_on_attached_disk = salt['pillar.get']('postgres:postgres_data_on_attached_disk', 'False') %}
-
-{%- if 'None' == configure_remote_db and salt['pillar.get']('postgres:postgres_version', '10') | int == 11 %}
-include:
-  - postgresql.pg11
-{%- endif %}
-
 {% set command = 'systemctl show -p FragmentPath postgresql' %}
 {% set unitFile = salt['cmd.run'](command) | replace("FragmentPath=","") %}
 
@@ -67,6 +61,11 @@ init-services-db-remote:
     - group: root
     - mode: 755
 
+{%- endif %}
+
+{%- if salt['pillar.get']('postgres:postgres_version', '10') | int == 11 %}
+include:
+  - postgresql.pg11
 {%- endif %}
 
 init-db-with-utf8:


### PR DESCRIPTION
Salt rendering preceeded postgresql 11 installation/configuration which could result in wrong data dir during the first highstate.
This could cause DB initialization issues.

With this change in case of postgres 11 the database data directory is set.
Also the state include is moved to a more proper place to eliminate extra conditions.

See detailed description in the commit message.