### PR TITLE
CB-17317: Enable Datalake DR for the datalake service permanently, enabling integration tests to perform DR actions. Specifically, resize e2e test is extended to test for expected DR actions.

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/dr/SdxBackupRestoreService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/dr/SdxBackupRestoreService.java
@@ -168,6 +168,15 @@ public class SdxBackupRestoreService {
         return lastSuccessfulBackupInfo;
     }
 
+    public Optional<datalakeDRProto.DatalakeBackupInfo> getLastSuccessfulBackupInfoWithRuntime(String datalakeName, String userCrn, String runtime) {
+        datalakeDRProto.DatalakeBackupInfo lastSuccessfulBackupInfo = datalakeDrClient.getLastSuccessfulBackup(datalakeName, userCrn, Optional.of(runtime));
+        if (lastSuccessfulBackupInfo == null) {
+            LOGGER.error("No successful backup found for data lake: {}", datalakeName);
+            return Optional.empty();
+        }
+        return Optional.of(lastSuccessfulBackupInfo);
+    }
+
     private SdxDatabaseBackupResponse triggerDatalakeDatabaseBackupFlow(SdxCluster cluster, SdxDatabaseBackupRequest backupRequest) {
         String selector = DATALAKE_DATABASE_BACKUP_EVENT.event();
         String userId = ThreadBasedUserCrnProvider.getUserCrn();

--- a/datalake/src/main/resources/application.yml
+++ b/datalake/src/main/resources/application.yml
@@ -86,7 +86,7 @@ altus:
     enabled: true
     endpoint: localhost:8982
   datalakedr:
-    enabled: false
+    enabled: true
     endpoint: localhost:8989
 
 datalake:

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/upgrade/recovery/SdxUpgradeRecoveryServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/upgrade/recovery/SdxUpgradeRecoveryServiceTest.java
@@ -24,10 +24,10 @@ import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGenerator;
 import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
 import com.sequenceiq.cloudbreak.common.exception.WebApplicationExceptionMessageExtractor;
-import com.sequenceiq.cloudbreak.datalakedr.DatalakeDrClient;
 import com.sequenceiq.cloudbreak.exception.CloudbreakApiException;
 import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.flow.SdxReactorFlowManager;
+import com.sequenceiq.datalake.service.sdx.dr.SdxBackupRestoreService;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.flow.api.model.FlowType;
 import com.sequenceiq.sdx.api.model.SdxRecoverableResponse;
@@ -56,7 +56,7 @@ public class SdxUpgradeRecoveryServiceTest {
     private SdxReactorFlowManager sdxReactorFlowManager;
 
     @Mock
-    private DatalakeDrClient datalakeDrClient;
+    private SdxBackupRestoreService backupRestoreService;
 
     @Mock
     private WebApplicationExceptionMessageExtractor exceptionMessageExtractor;
@@ -144,7 +144,7 @@ public class SdxUpgradeRecoveryServiceTest {
 
         when(cluster.getRuntime()).thenReturn(RUNTIME);
         when(stackV4Endpoint.getClusterRecoverableByNameInternal(WORKSPACE_ID, CLUSTER_NAME, USER_CRN)).thenReturn(recoveryV4Response);
-        when(datalakeDrClient.getLastSuccessfulBackup(CLUSTER_NAME, USER_CRN, Optional.of(RUNTIME))).thenReturn(datalakeBackupInfo);
+        when(backupRestoreService.getLastSuccessfulBackupInfoWithRuntime(CLUSTER_NAME, USER_CRN, RUNTIME)).thenReturn(Optional.of(datalakeBackupInfo));
         when(sdxReactorFlowManager.triggerDatalakeRuntimeRecoveryFlow(cluster, SdxRecoveryType.RECOVER_WITH_DATA))
                 .thenReturn(new FlowIdentifier(FlowType.FLOW, "FLOW_ID"));
 
@@ -164,7 +164,7 @@ public class SdxUpgradeRecoveryServiceTest {
         request.setType(SdxRecoveryType.RECOVER_WITH_DATA);
 
         when(cluster.getRuntime()).thenReturn(RUNTIME);
-        when(datalakeDrClient.getLastSuccessfulBackup(CLUSTER_NAME, USER_CRN, Optional.of(RUNTIME))).thenReturn(null);
+        when(backupRestoreService.getLastSuccessfulBackupInfoWithRuntime(CLUSTER_NAME, USER_CRN, RUNTIME)).thenReturn(Optional.empty());
 
         SdxRecoverableResponse sdxRecoverableResponse = ThreadBasedUserCrnProvider.doAs(USER_CRN,
                 () -> underTest.validateRecovery(cluster, request));

--- a/integration-test/docker-compose_template.yml
+++ b/integration-test/docker-compose_template.yml
@@ -9,6 +9,7 @@ services:
     ports:
       - 10080:8080
       - 8982:8982
+      - 8981:8981
     volumes:
     - ../mock-thunderhead/build/libs/mock-thunderhead.jar:/mock-thunderhead.jar
     - ./integcb/etc:/etc/auth

--- a/integration-test/integcb/Profile_template
+++ b/integration-test/integcb/Profile_template
@@ -19,12 +19,14 @@ export CLUSTERPROXY_ENABLED=true
 export ENVIRONMENT_AUTOSYNC_ENABLED=false
 export ENVIRONMENT_FREEIPA_SYNCHRONIZEONSTART=false
 export ENVIRONMENT_EXPERIENCE_SCAN_ENABLED=true
-export CB_LOCAL_DEV_LIST=jaeger,environments2-api,audit-api,distrox-api,thunderhead-api,datalake-api
+export DATALAKE_DR_ENABLED=true
+export CB_LOCAL_DEV_LIST=jaeger,environments2-api,audit-api,distrox-api,thunderhead-api,datalake-api,datalake-dr
 
 export ALTUS_AUDIT_ENDPOINT=thunderhead-mock
 export INTEGRATIONTEST_AUTHDISTRIBUTOR_HOST=thunderhead-mock
 export AUTHDISTRIBUTOR_HOST=thunderhead-mock
 export CLUSTERDNS_HOST=thunderhead-mock
+export DATALAKE_DR_ENDPOINT=thunderhead-mock:8981
 export MOCK_INFRASTRUCTURE_HOST=mock-infrastructure
 
 export CPUS_FOR_CLOUDBREAK=8.0

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxResizeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxResizeTests.java
@@ -1,22 +1,16 @@
 package com.sequenceiq.it.cloudbreak.testcase.e2e.sdx;
 
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
-import static java.lang.String.format;
-
-import java.util.concurrent.atomic.AtomicReference;
 
 import javax.inject.Inject;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
 import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
-import com.sequenceiq.it.cloudbreak.exception.TestFailException;
-import com.sequenceiq.it.cloudbreak.log.Log;
+import com.sequenceiq.it.cloudbreak.util.SdxResizeTestValidator;
 import com.sequenceiq.it.cloudbreak.util.SdxUtil;
 import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
 import com.sequenceiq.sdx.api.model.SdxClusterShape;
@@ -25,9 +19,6 @@ import com.sequenceiq.sdx.api.model.SdxDatabaseAvailabilityType;
 import com.sequenceiq.sdx.api.model.SdxDatabaseRequest;
 
 public class SdxResizeTests extends PreconditionSdxE2ETest {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(SdxResizeTests.class);
-
     private static final String MOCK_UMS_PASSWORD = "Password123!";
 
     @Inject
@@ -45,9 +36,7 @@ public class SdxResizeTests extends PreconditionSdxE2ETest {
     )
     public void testSDXResize(TestContext testContext) {
         String sdx = resourcePropertyProvider().getName();
-        AtomicReference<String> expectedShape = new AtomicReference<>();
-        AtomicReference<String> expectedCrn = new AtomicReference<>();
-        AtomicReference<String> expectedName = new AtomicReference<>();
+        SdxResizeTestValidator resizeTestValidator = new SdxResizeTestValidator(SdxClusterShape.MEDIUM_DUTY_HA);
         SdxDatabaseRequest sdxDatabaseRequest = new SdxDatabaseRequest();
         sdxDatabaseRequest.setAvailabilityType(SdxDatabaseAvailabilityType.NONE);
         testContext
@@ -59,56 +48,20 @@ public class SdxResizeTests extends PreconditionSdxE2ETest {
                 .await(SdxClusterStatusResponse.RUNNING, key(sdx))
                 .awaitForHealthyInstances()
                 .then((tc, testDto, client) -> {
-                    expectedShape.set(sdxUtil.getShape(testDto, client));
-                    expectedCrn.set(sdxUtil.getCrn(testDto, client));
-                    expectedName.set(testDto.getName());
+                    resizeTestValidator.setExpectedCrn(sdxUtil.getCrn(testDto, client));
+                    resizeTestValidator.setExpectedName(testDto.getName());
+                    resizeTestValidator.setExpectedRuntime(sdxUtil.getRuntime(testDto, client));
                     return testDto;
                 })
                 .when(sdxTestClient.resize(), key(sdx))
+                .await(SdxClusterStatusResponse.DATALAKE_BACKUP_INPROGRESS, key(sdx).withWaitForFlow(Boolean.FALSE))
                 .await(SdxClusterStatusResponse.STOP_IN_PROGRESS, key(sdx).withWaitForFlow(Boolean.FALSE))
                 .await(SdxClusterStatusResponse.STACK_CREATION_IN_PROGRESS, key(sdx).withWaitForFlow(Boolean.FALSE))
-                .await(SdxClusterStatusResponse.RUNNING, key(sdx))
+                .await(SdxClusterStatusResponse.RUNNING, key(sdx).withWaitForFlow(Boolean.FALSE))
                 .awaitForHealthyInstances()
-                .then((tc, dto, client) -> validateStackCrn(expectedCrn, dto))
-                .then((tc, dto, client) -> validateCrn(expectedCrn, dto))
-                .then((tc, dto, client) -> validateShape(dto))
-                .then((tc, dto, client) -> validateClusterName(expectedName, dto))
+                .await(SdxClusterStatusResponse.DATALAKE_RESTORE_INPROGRESS, key(sdx).withWaitForFlow(Boolean.FALSE))
+                .await(SdxClusterStatusResponse.RUNNING, key(sdx).withWaitForFlow(Boolean.FALSE))
+                .then((tc, dto, client) -> resizeTestValidator.validateResizedCluster(dto))
                 .validate();
-    }
-
-    private SdxInternalTestDto validateStackCrn(AtomicReference<String> originalCrn, SdxInternalTestDto dto) {
-        String newCrn = dto.getResponse().getStackV4Response().getCrn();
-        Log.log(LOGGER, format(" Stack new crn: %s ", newCrn));
-        if (!newCrn.equals(originalCrn.get())) {
-            throw new TestFailException(" The stack CRN has changed to: " + newCrn + " instead of: " + originalCrn.get());
-        }
-        return dto;
-    }
-
-    private SdxInternalTestDto validateCrn(AtomicReference<String> originalCrn, SdxInternalTestDto dto) {
-        String newCrn = dto.getResponse().getCrn();
-        Log.log(LOGGER, format(" New crn: %s ", newCrn));
-        if (!newCrn.equals(originalCrn.get())) {
-            throw new TestFailException(" The stack CRN has changed to: " + newCrn + " instead of: " + originalCrn.get());
-        }
-        return dto;
-    }
-
-    private SdxInternalTestDto validateShape(SdxInternalTestDto dto) {
-        SdxClusterShape newShape = dto.getResponse().getClusterShape();
-        Log.log(LOGGER, format(" New shape: %s ", newShape.name()));
-        if (!SdxClusterShape.MEDIUM_DUTY_HA.equals(newShape)) {
-            throw new TestFailException(" The datalake shape is : " + newShape + " instead of: " + SdxClusterShape.MEDIUM_DUTY_HA.name());
-        }
-        return dto;
-    }
-
-    private SdxInternalTestDto validateClusterName(AtomicReference<String> originalName, SdxInternalTestDto dto) {
-        String newClusterName = dto.getResponse().getStackV4Response().getCluster().getName();
-        Log.log(LOGGER, format(" New cluster name: %s ", newClusterName));
-        if (!originalName.get().equals(newClusterName)) {
-            throw new TestFailException(" The datalake cluster name is : " + newClusterName + " instead of: " + originalName);
-        }
-        return dto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxResizeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxResizeTests.java
@@ -15,6 +15,8 @@ import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentNetworkTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.util.SdxResizeTestValidator;
+import com.sequenceiq.it.cloudbreak.util.SdxUtil;
 import com.sequenceiq.sdx.api.model.SdxClusterShape;
 import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 
@@ -22,6 +24,9 @@ public class MockSdxResizeTests extends AbstractMockTest {
 
     @Inject
     private SdxTestClient sdxTestClient;
+
+    @Inject
+    private SdxUtil sdxUtil;
 
     private String sdxName;
 
@@ -56,20 +61,22 @@ public class MockSdxResizeTests extends AbstractMockTest {
             then = "Resized SDX should be available AND deletable"
     )
     public void testDefaultSDXResizeSuccessfully(MockedTestContext testContext) {
+        SdxResizeTestValidator resizeTestValidator = new SdxResizeTestValidator(SdxClusterShape.LIGHT_DUTY);
         testContext
                 .given(sdxName, SdxInternalTestDto.class)
+                .then((tc, testDto, client) -> {
+                    resizeTestValidator.setExpectedCrn(sdxUtil.getCrn(testDto, client));
+                    resizeTestValidator.setExpectedName(testDto.getName());
+                    resizeTestValidator.setExpectedRuntime(sdxUtil.getRuntime(testDto, client));
+                    return testDto;
+                })
                 .when(sdxTestClient.resize(), key(sdxName))
+                .await(SdxClusterStatusResponse.DATALAKE_BACKUP_INPROGRESS, key(sdxName).withWaitForFlow(Boolean.FALSE))
                 .await(SdxClusterStatusResponse.STOP_IN_PROGRESS, key(sdxName).withWaitForFlow(Boolean.FALSE))
                 .await(SdxClusterStatusResponse.STACK_CREATION_IN_PROGRESS, key(sdxName).withWaitForFlow(Boolean.FALSE))
+                .await(SdxClusterStatusResponse.DATALAKE_RESTORE_INPROGRESS, key(sdxName).withWaitForFlow(Boolean.FALSE))
                 .await(SdxClusterStatusResponse.RUNNING, key(sdxName).withWaitForFlow(Boolean.FALSE))
-                .withClusterShape(SdxClusterShape.MEDIUM_DUTY_HA)
+                .then((tc, dto, client) -> resizeTestValidator.validateResizedCluster(dto))
                 .validate();
-
-//        testContext
-//                .given(sdxName+"-detached", SdxTestDto.class)
-//                .when(sdxTestClient.checkStatus(sdxName+"-detached"))
-//                .await(SdxClusterStatusResponse.RUNNING, key(sdxName+"-detached"))
-//                .validate();
-                //TODO Make sure that the runtime is same, storage location is also same.
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/SdxResizeTestValidator.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/SdxResizeTestValidator.java
@@ -1,0 +1,83 @@
+package com.sequenceiq.it.cloudbreak.util;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.sdx.api.model.SdxClusterResponse;
+import com.sequenceiq.sdx.api.model.SdxClusterShape;
+
+public class SdxResizeTestValidator {
+    private final SdxClusterShape expectedShape;
+
+    private final AtomicReference<String> expectedCrn;
+
+    private final AtomicReference<String> expectedName;
+
+    private final AtomicReference<String> expectedRuntime;
+
+    public SdxResizeTestValidator(SdxClusterShape expectedShape) {
+        this.expectedShape = expectedShape;
+        expectedCrn = new AtomicReference<>();
+        expectedName = new AtomicReference<>();
+        expectedRuntime = new AtomicReference<>();
+    }
+
+    public void setExpectedCrn(String expectedCrn) {
+        this.expectedCrn.set(expectedCrn);
+    }
+
+    public void setExpectedName(String expectedName) {
+        this.expectedName.set(expectedName);
+    }
+
+    public void setExpectedRuntime(String expectedRuntime) {
+        this.expectedRuntime.set(expectedRuntime);
+    }
+
+    public SdxInternalTestDto validateResizedCluster(SdxInternalTestDto dto) {
+        SdxClusterResponse response = dto.getResponse();
+        validateClusterShape(response.getClusterShape());
+        validateCrn(response.getCrn());
+        validateStackCrn(response.getStackCrn());
+        validateName(response.getName());
+        validateRuntime(response.getRuntime());
+        return dto;
+    }
+
+    private void validateClusterShape(SdxClusterShape shape) {
+        if (!expectedShape.equals(shape)) {
+            fail("cluster shape", expectedShape.name(), shape.name());
+        }
+    }
+
+    private void validateCrn(String crn) {
+        if (!expectedCrn.get().equals(crn)) {
+            fail("crn", expectedCrn.get(), crn);
+        }
+    }
+
+    private void validateStackCrn(String stackCrn) {
+        if (!expectedCrn.get().equals(stackCrn)) {
+            fail("stack crn", expectedCrn.get(), stackCrn);
+        }
+    }
+
+    private void validateName(String name) {
+        if (!expectedName.get().equals(name)) {
+            fail("name", expectedName.get(), name);
+        }
+    }
+
+    private void validateRuntime(String runtime) {
+        if (!expectedRuntime.get().equals(runtime)) {
+            fail("runtime", expectedRuntime.get(), runtime);
+        }
+    }
+
+    private void fail(String testField, String expected, String actual) {
+        throw new TestFailException(
+                " The DL " + testField + " is '" + actual + "' instead of '" + expected + '\''
+        );
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/SdxUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/SdxUtil.java
@@ -34,6 +34,16 @@ public class SdxUtil {
                 .getStackV4Response().getImage().getId();
     }
 
+    public String getRuntime(AbstractSdxTestDto testDto, SdxClient sdxClient) {
+        return getSdxClusterDetailResponse(testDto, sdxClient)
+                .getRuntime();
+    }
+
+    public String getCloudStorageBaseLocation(AbstractSdxTestDto testDto, SdxClient sdxClient) {
+        return getSdxClusterDetailResponse(testDto, sdxClient)
+                .getCloudStorageBaseLocation();
+    }
+
     private SdxClusterDetailResponse getSdxClusterDetailResponse(AbstractSdxTestDto testDto, SdxClient sdxClient) {
         return sdxClient.getDefaultClient().sdxEndpoint().getDetail(testDto.getName(), new HashSet<>());
     }

--- a/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/config/GrpcServerConfig.java
+++ b/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/config/GrpcServerConfig.java
@@ -50,7 +50,7 @@ public class GrpcServerConfig {
     @Value("${grpc.server.port:8982}")
     private int grpcServerPort;
 
-    @Value("${datalakedr.server.port:8989}")
+    @Value("${datalakedr.server.port:8981}")
     private int datalakeDrServerPort;
 
     @Bean


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-17317

The primary objective of this is to enable DR testing during resize integration tests, allowing us to ensure future changes do not break resize as a whole. Previously this was skipped during the tests, which was undesirable as it is not a true full e2e test.

Note that by enabling DR for all of the Datalake service, the only expected consequence is that local runs of flows which call the DR flow will not skip the process.