### PR TITLE
CB-17113: Improved mock SDX resize tests by adding checks for datalake DR and validation of final SDX cluster.

### DIFF
--- a/datalake/src/main/resources/application.yml
+++ b/datalake/src/main/resources/application.yml
@@ -86,7 +86,7 @@ altus:
     enabled: true
     endpoint: localhost:8982
   datalakedr:
-    enabled: false
+    enabled: true
     endpoint: localhost:8989
 
 datalake:

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxResizeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxResizeTests.java
@@ -1,22 +1,16 @@
 package com.sequenceiq.it.cloudbreak.testcase.e2e.sdx;
 
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
-import static java.lang.String.format;
-
-import java.util.concurrent.atomic.AtomicReference;
 
 import javax.inject.Inject;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
 import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
-import com.sequenceiq.it.cloudbreak.exception.TestFailException;
-import com.sequenceiq.it.cloudbreak.log.Log;
+import com.sequenceiq.it.cloudbreak.util.SdxResizeTestValidator;
 import com.sequenceiq.it.cloudbreak.util.SdxUtil;
 import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
 import com.sequenceiq.sdx.api.model.SdxClusterShape;
@@ -25,9 +19,6 @@ import com.sequenceiq.sdx.api.model.SdxDatabaseAvailabilityType;
 import com.sequenceiq.sdx.api.model.SdxDatabaseRequest;
 
 public class SdxResizeTests extends PreconditionSdxE2ETest {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(SdxResizeTests.class);
-
     private static final String MOCK_UMS_PASSWORD = "Password123!";
 
     @Inject
@@ -45,9 +36,7 @@ public class SdxResizeTests extends PreconditionSdxE2ETest {
     )
     public void testSDXResize(TestContext testContext) {
         String sdx = resourcePropertyProvider().getName();
-        AtomicReference<String> expectedShape = new AtomicReference<>();
-        AtomicReference<String> expectedCrn = new AtomicReference<>();
-        AtomicReference<String> expectedName = new AtomicReference<>();
+        SdxResizeTestValidator resizeTestValidator = new SdxResizeTestValidator(SdxClusterShape.MEDIUM_DUTY_HA);
         SdxDatabaseRequest sdxDatabaseRequest = new SdxDatabaseRequest();
         sdxDatabaseRequest.setAvailabilityType(SdxDatabaseAvailabilityType.NONE);
         testContext
@@ -59,9 +48,10 @@ public class SdxResizeTests extends PreconditionSdxE2ETest {
                 .await(SdxClusterStatusResponse.RUNNING, key(sdx))
                 .awaitForHealthyInstances()
                 .then((tc, testDto, client) -> {
-                    expectedShape.set(sdxUtil.getShape(testDto, client));
-                    expectedCrn.set(sdxUtil.getCrn(testDto, client));
-                    expectedName.set(testDto.getName());
+                    resizeTestValidator.setExpectedCrn(sdxUtil.getCrn(testDto, client));
+                    resizeTestValidator.setExpectedName(testDto.getName());
+                    resizeTestValidator.setExpectedRuntime(sdxUtil.getRuntime(testDto, client));
+                    resizeTestValidator.setExpectedStorageLocation(sdxUtil.getCloudStorageBaseLocation(testDto, client));
                     return testDto;
                 })
                 .when(sdxTestClient.resize(), key(sdx))
@@ -71,46 +61,7 @@ public class SdxResizeTests extends PreconditionSdxE2ETest {
                 .await(SdxClusterStatusResponse.RUNNING, key(sdx).withWaitForFlow(Boolean.FALSE))
                 .awaitForHealthyInstances()
                 .await(SdxClusterStatusResponse.DATALAKE_RESTORE_INPROGRESS, key(sdx).withWaitForFlow(Boolean.FALSE))
-                .then((tc, dto, client) -> validateStackCrn(expectedCrn, dto))
-                .then((tc, dto, client) -> validateCrn(expectedCrn, dto))
-                .then((tc, dto, client) -> validateShape(dto))
-                .then((tc, dto, client) -> validateClusterName(expectedName, dto))
+                .then((tc, dto, client) -> resizeTestValidator.validateResizedCluster(dto))
                 .validate();
-    }
-
-    private SdxInternalTestDto validateStackCrn(AtomicReference<String> originalCrn, SdxInternalTestDto dto) {
-        String newCrn = dto.getResponse().getStackV4Response().getCrn();
-        Log.log(LOGGER, format(" Stack new crn: %s ", newCrn));
-        if (!newCrn.equals(originalCrn.get())) {
-            throw new TestFailException(" The stack CRN has changed to: " + newCrn + " instead of: " + originalCrn.get());
-        }
-        return dto;
-    }
-
-    private SdxInternalTestDto validateCrn(AtomicReference<String> originalCrn, SdxInternalTestDto dto) {
-        String newCrn = dto.getResponse().getCrn();
-        Log.log(LOGGER, format(" New crn: %s ", newCrn));
-        if (!newCrn.equals(originalCrn.get())) {
-            throw new TestFailException(" The stack CRN has changed to: " + newCrn + " instead of: " + originalCrn.get());
-        }
-        return dto;
-    }
-
-    private SdxInternalTestDto validateShape(SdxInternalTestDto dto) {
-        SdxClusterShape newShape = dto.getResponse().getClusterShape();
-        Log.log(LOGGER, format(" New shape: %s ", newShape.name()));
-        if (!SdxClusterShape.MEDIUM_DUTY_HA.equals(newShape)) {
-            throw new TestFailException(" The datalake shape is : " + newShape + " instead of: " + SdxClusterShape.MEDIUM_DUTY_HA.name());
-        }
-        return dto;
-    }
-
-    private SdxInternalTestDto validateClusterName(AtomicReference<String> originalName, SdxInternalTestDto dto) {
-        String newClusterName = dto.getResponse().getStackV4Response().getCluster().getName();
-        Log.log(LOGGER, format(" New cluster name: %s ", newClusterName));
-        if (!originalName.get().equals(newClusterName)) {
-            throw new TestFailException(" The datalake cluster name is : " + newClusterName + " instead of: " + originalName);
-        }
-        return dto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxResizeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxResizeTests.java
@@ -65,10 +65,12 @@ public class SdxResizeTests extends PreconditionSdxE2ETest {
                     return testDto;
                 })
                 .when(sdxTestClient.resize(), key(sdx))
+                .await(SdxClusterStatusResponse.DATALAKE_BACKUP_INPROGRESS, key(sdx).withWaitForFlow(Boolean.FALSE))
                 .await(SdxClusterStatusResponse.STOP_IN_PROGRESS, key(sdx).withWaitForFlow(Boolean.FALSE))
                 .await(SdxClusterStatusResponse.STACK_CREATION_IN_PROGRESS, key(sdx).withWaitForFlow(Boolean.FALSE))
-                .await(SdxClusterStatusResponse.RUNNING, key(sdx))
+                .await(SdxClusterStatusResponse.RUNNING, key(sdx).withWaitForFlow(Boolean.FALSE))
                 .awaitForHealthyInstances()
+                .await(SdxClusterStatusResponse.DATALAKE_RESTORE_INPROGRESS, key(sdx).withWaitForFlow(Boolean.FALSE))
                 .then((tc, dto, client) -> validateStackCrn(expectedCrn, dto))
                 .then((tc, dto, client) -> validateCrn(expectedCrn, dto))
                 .then((tc, dto, client) -> validateShape(dto))

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/SdxResizeTestValidator.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/SdxResizeTestValidator.java
@@ -1,0 +1,97 @@
+package com.sequenceiq.it.cloudbreak.util;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.sdx.api.model.SdxClusterResponse;
+import com.sequenceiq.sdx.api.model.SdxClusterShape;
+
+public class SdxResizeTestValidator {
+    private final SdxClusterShape expectedShape;
+
+    private final AtomicReference<String> expectedCrn;
+
+    private final AtomicReference<String> expectedName;
+
+    private final AtomicReference<String> expectedRuntime;
+
+    private final AtomicReference<String> expectedStorageLocation;
+
+    public SdxResizeTestValidator(SdxClusterShape expectedShape) {
+        this.expectedShape = expectedShape;
+        expectedCrn = new AtomicReference<>();
+        expectedName = new AtomicReference<>();
+        expectedRuntime = new AtomicReference<>();
+        expectedStorageLocation = new AtomicReference<>();
+    }
+
+    public void setExpectedCrn(String expectedCrn) {
+        this.expectedCrn.set(expectedCrn);
+    }
+
+    public void setExpectedName(String expectedName) {
+        this.expectedName.set(expectedName);
+    }
+
+    public void setExpectedRuntime(String expectedRuntime) {
+        this.expectedRuntime.set(expectedRuntime);
+    }
+
+    public void setExpectedStorageLocation(String expectedStorageLocation) {
+        this.expectedStorageLocation.set(expectedStorageLocation);
+    }
+
+    public SdxInternalTestDto validateResizedCluster(SdxInternalTestDto dto) {
+        SdxClusterResponse response = dto.getResponse();
+        validateClusterShape(response.getClusterShape());
+        validateCrn(response.getCrn());
+        validateStackCrn(response.getStackCrn());
+        validateName(response.getName());
+        validateRuntime(response.getRuntime());
+        validateStorageLocation(response.getCloudStorageBaseLocation());
+        return dto;
+    }
+
+    private void validateClusterShape(SdxClusterShape shape) {
+        if (!expectedShape.equals(shape)) {
+            fail("cluster shape", expectedShape.name(), shape.name());
+        }
+    }
+
+    private void validateCrn(String crn) {
+        if (!expectedCrn.get().equals(crn)) {
+            fail("crn", expectedCrn.get(), crn);
+        }
+    }
+
+    private void validateStackCrn(String stackCrn) {
+        if (!expectedCrn.get().equals(stackCrn)) {
+            fail("stack crn", expectedCrn.get(), stackCrn);
+        }
+    }
+
+    private void validateName(String name) {
+        if (!expectedName.get().equals(name)) {
+            fail("name", expectedName.get(), name);
+        }
+    }
+
+    private void validateRuntime(String runtime) {
+        if (!expectedRuntime.get().equals(runtime)) {
+            fail("runtime", expectedRuntime.get(), runtime);
+        }
+    }
+
+    private void validateStorageLocation(String storageLocation) {
+        if (!expectedStorageLocation.get().equals(storageLocation)) {
+            fail("storage location", expectedStorageLocation.get(), storageLocation);
+        }
+    }
+
+    private void fail(String testField, String expected, String actual) {
+        throw new TestFailException(
+                " The DL " + testField + " is '" + actual + "' instead of '" + expected + '\''
+        );
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/SdxUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/SdxUtil.java
@@ -34,6 +34,16 @@ public class SdxUtil {
                 .getStackV4Response().getImage().getId();
     }
 
+    public String getRuntime(AbstractSdxTestDto testDto, SdxClient sdxClient) {
+        return getSdxClusterDetailResponse(testDto, sdxClient)
+                .getRuntime();
+    }
+
+    public String getCloudStorageBaseLocation(AbstractSdxTestDto testDto, SdxClient sdxClient) {
+        return getSdxClusterDetailResponse(testDto, sdxClient)
+                .getCloudStorageBaseLocation();
+    }
+
     private SdxClusterDetailResponse getSdxClusterDetailResponse(AbstractSdxTestDto testDto, SdxClient sdxClient) {
         return sdxClient.getDefaultClient().sdxEndpoint().getDetail(testDto.getName(), new HashSet<>());
     }


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-17113

Change consists of:

- Creation of new class which handles the SDX resize success test validation
- Clean up of normal e2e resize test to use above validation
- Addition of validation to mock resize test
- Addition of checks for backup/restore steps in resize flow to mock test