### PR TITLE
CB-17615 Add sanity test for compute monitoring on FreeIpa, SDX and Distrox nodes

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CommonCloudProperties.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CommonCloudProperties.java
@@ -31,6 +31,8 @@ public class CommonCloudProperties {
 
     private User user = new User();
 
+    private Telemetry telemetry = new Telemetry();
+
     public String getCloudProvider() {
         return cloudProvider;
     }
@@ -121,6 +123,14 @@ public class CommonCloudProperties {
 
     public void setUser(User user) {
         this.user = user;
+    }
+
+    public Telemetry getTelemetry() {
+        return telemetry;
+    }
+
+    public void setTelemetry(Telemetry telemetry) {
+        this.telemetry = telemetry;
     }
 
     public static class ImageValidation {
@@ -247,6 +257,18 @@ public class CommonCloudProperties {
 
         public void setWorkloadPassword(String workloadPassword) {
             this.workloadPassword = workloadPassword;
+        }
+    }
+
+    public static class Telemetry {
+        private String remoteWriteUrl;
+
+        public String getRemoteWriteUrl() {
+            return remoteWriteUrl;
+        }
+
+        public void setRemoteWriteUrl(String remoteWriteUrl) {
+            this.remoteWriteUrl = remoteWriteUrl;
         }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/telemetry/TelemetryTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/telemetry/TelemetryTestDto.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.common.api.telemetry.request.FeaturesRequest;
+import com.sequenceiq.common.api.telemetry.request.MonitoringRequest;
 import com.sequenceiq.common.api.telemetry.request.TelemetryRequest;
 import com.sequenceiq.common.api.telemetry.response.TelemetryResponse;
 import com.sequenceiq.it.cloudbreak.Prototype;
@@ -55,6 +56,17 @@ public class TelemetryTestDto extends AbstractCloudbreakTestDto<TelemetryRequest
         featuresRequest.addWorkloadAnalytics(false);
         featuresRequest.addCloudStorageLogging(true);
         getRequest().setFeatures(featuresRequest);
+        return this;
+    }
+
+    public TelemetryTestDto withMonitoring(String remoteWriteUrl) {
+        FeaturesRequest featuresRequest = new FeaturesRequest();
+        featuresRequest.addMonitoring(true);
+        getRequest().setFeatures(featuresRequest);
+
+        MonitoringRequest monitoringRequest = new MonitoringRequest();
+        monitoringRequest.setRemoteWriteUrl(remoteWriteUrl);
+        getRequest().setMonitoring(monitoringRequest);
         return this;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/MonitoringTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/MonitoringTests.java
@@ -1,0 +1,186 @@
+package com.sequenceiq.it.cloudbreak.testcase.e2e.l0promotion;
+
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.MASTER;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.testng.annotations.Test;
+
+import com.sequenceiq.distrox.api.v1.distrox.model.database.DistroXDatabaseAvailabilityType;
+import com.sequenceiq.distrox.api.v1.distrox.model.database.DistroXDatabaseRequest;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationState;
+import com.sequenceiq.it.cloudbreak.client.DistroXTestClient;
+import com.sequenceiq.it.cloudbreak.client.EnvironmentTestClient;
+import com.sequenceiq.it.cloudbreak.client.FreeIpaTestClient;
+import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
+import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
+import com.sequenceiq.it.cloudbreak.dto.distrox.image.DistroXImageTestDto;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentNetworkTestDto;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaUserSyncTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.dto.telemetry.TelemetryTestDto;
+import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
+import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
+import com.sequenceiq.it.cloudbreak.util.ssh.SshJUtil;
+import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
+import com.sequenceiq.sdx.api.model.SdxDatabaseAvailabilityType;
+import com.sequenceiq.sdx.api.model.SdxDatabaseRequest;
+
+/**
+ * Creating 7.2.15+ pre-warmed images with Common Monitoring is still in progress.
+ * So in the meantime we can use older images (7.2.12) where some features
+ * (smon-exporter, cm_health_check_info and request-signer's error_count with success_count)
+ * are not working properly or at all (metrics endpoint).
+ *
+ * In these circumstances we cannot add these test cases to the L0 Promotion suite yet. So
+ * these are prepared but not finished for the L0 Monitoring test cases. In the future we can
+ * extend and improve these verifications based on the finalized monitoring feature with the
+ * latest images.
+ */
+public class MonitoringTests extends AbstractE2ETest {
+
+    @Inject
+    private EnvironmentTestClient environmentTestClient;
+
+    @Inject
+    private SdxTestClient sdxTestClient;
+
+    @Inject
+    private DistroXTestClient distroXTestClient;
+
+    @Inject
+    private SshJUtil sshJUtil;
+
+    @Inject
+    private FreeIpaTestClient freeIpaTestClient;
+
+    @Value("${integrationtest.telemetry.remoteWriteUrl:}")
+    private String remoteWriteUrl;
+
+    @Override
+    protected void setupTest(TestContext testContext) {
+        testContext.getCloudProvider().getCloudFunctionality().cloudStorageInitialize();
+        createDefaultUser(testContext);
+        initializeDefaultBlueprints(testContext);
+        createDefaultCredential(testContext);
+    }
+
+    @Test(dataProvider = TEST_CONTEXT)
+    @UseSpotInstances
+    @Description(
+            given = "creating an environment along with freeIpa by metering pre-warmed image",
+            when = "the new environment and attached freeIpa should be created",
+                and = "metering setting should be inherited from environment",
+            then = "Metering Services, Scrapping and Metrics should be up and running on freeIpa")
+    public void testMoniotoringOnEnvironment(TestContext testContext) {
+        testContext
+                .given(EnvironmentNetworkTestDto.class)
+                .given("telemetry", TelemetryTestDto.class)
+                    .withLogging()
+                    .withReportClusterLogs()
+                    .withMonitoring(remoteWriteUrl)
+                .given(EnvironmentTestDto.class)
+                    .withNetwork()
+                    .withTelemetry("telemetry")
+                    .withTunnel(testContext.getTunnel())
+                    .withCreateFreeIpa(Boolean.TRUE)
+                    .withFreeIpaImage(commonCloudProperties().getImageValidation().getFreeIpaImageCatalog(),
+                        commonCloudProperties().getImageValidation().getFreeIpaImageUuid())
+                .when(environmentTestClient.create())
+                .await(EnvironmentStatus.AVAILABLE)
+                .given(FreeIpaUserSyncTestDto.class)
+                .when(freeIpaTestClient.getLastSyncOperationStatus())
+                .await(OperationState.COMPLETED)
+                .given(FreeIpaTestDto.class)
+                    .withEnvironment()
+                .when(freeIpaTestClient.describe())
+                .then((tc, testDto, client) ->
+                        sshJUtil.checkCommonMonitoringStatus(testDto, testDto.getEnvironmentCrn(), client,
+                        List.of("node_filesystem_free_bytes"), List.of("cdp-request-signer")))
+                .given(EnvironmentTestDto.class)
+                .when(environmentTestClient.describe())
+                .validate();
+    }
+
+    @Test(dataProvider = TEST_CONTEXT)
+    @UseSpotInstances
+    @Description(
+            given = "creating sequentally and separatelly environment, FreeIpa then SDX with metering pre-warmed images and no database",
+            when = "when new freeIpa and SDX are up and running then new DistroX should be created also with metering pre-warmed image and no database",
+                and = "metering should be tested on all the Master host groups",
+            then = "Metering Services, Scrapping and Metrics should be up and running on instances")
+    public void testMoniotoringOnFreeIpaSdxDistrox(TestContext testContext) {
+        DistroXDatabaseRequest distroXDatabaseRequest = new DistroXDatabaseRequest();
+        distroXDatabaseRequest.setAvailabilityType(DistroXDatabaseAvailabilityType.NONE);
+        SdxDatabaseRequest sdxDatabaseRequest = new SdxDatabaseRequest();
+        sdxDatabaseRequest.setCreate(false);
+        sdxDatabaseRequest.setAvailabilityType(SdxDatabaseAvailabilityType.NONE);
+
+        testContext
+                .given(EnvironmentNetworkTestDto.class)
+                .given("telemetry", TelemetryTestDto.class)
+                    .withLogging()
+                    .withReportClusterLogs()
+                    .withMonitoring(remoteWriteUrl)
+                .given(EnvironmentTestDto.class)
+                    .withNetwork()
+                    .withTelemetry("telemetry")
+                    .withTunnel(testContext.getTunnel())
+                    .withCreateFreeIpa(Boolean.FALSE)
+                .when(environmentTestClient.create())
+                .await(EnvironmentStatus.AVAILABLE)
+                .given(FreeIpaTestDto.class)
+                    .withEnvironment()
+                    .withTelemetry("telemetry")
+                    .withCatalog(commonCloudProperties().getImageValidation().getFreeIpaImageCatalog(),
+                        commonCloudProperties().getImageValidation().getFreeIpaImageUuid())
+                .when(freeIpaTestClient.create())
+                .await(Status.AVAILABLE)
+                .awaitForHealthyInstances()
+                .given(FreeIpaUserSyncTestDto.class)
+                .when(freeIpaTestClient.getLastSyncOperationStatus())
+                .await(OperationState.COMPLETED)
+                .given(FreeIpaTestDto.class)
+                .when(freeIpaTestClient.describe())
+                .then((tc, testDto, client) -> sshJUtil.checkCommonMonitoringStatus(testDto, testDto.getEnvironmentCrn(), client,
+                        List.of("node_filesystem_free_bytes"), List.of("cdp-request-signer")))
+                .given(EnvironmentTestDto.class)
+                .when(environmentTestClient.describe())
+                .given(SdxInternalTestDto.class)
+                    .withEnvironment()
+                    .withDatabase(sdxDatabaseRequest)
+                    .withImageCatalogNameAndImageId(commonCloudProperties().getImageValidation().getSourceCatalogName(),
+                        commonCloudProperties().getImageValidation().getImageUuid())
+                .when(sdxTestClient.createInternal())
+                .await(SdxClusterStatusResponse.RUNNING)
+                .awaitForHealthyInstances()
+                .when(sdxTestClient.describeInternal())
+                .then((tc, testDto, client) -> sshJUtil.checkCommonMonitoringStatus(testDto, testDto.getResponse().getStackV4Response().getInstanceGroups(),
+                        List.of(MASTER.getName()), List.of("node_filesystem_free_bytes", "cm_health_check_info"), List.of("cdp-request-signer",
+                                "smon-exporter", "cm_health_check_info")))
+                .given(DistroXImageTestDto.class)
+                    .withImageId(commonCloudProperties().getImageValidation().getImageUuid())
+                    .withImageCatalog(commonCloudProperties().getImageValidation().getSourceCatalogName())
+                .given(DistroXTestDto.class)
+                    .withExternalDatabase(distroXDatabaseRequest)
+                    .withEnvironment()
+                    .withImageSettings()
+                .when(distroXTestClient.create())
+                .await(STACK_AVAILABLE)
+                .awaitForHealthyInstances()
+                .when(distroXTestClient.get())
+                .then((tc, testDto, client) -> sshJUtil.checkCommonMonitoringStatus(testDto, testDto.getResponse().getInstanceGroups(),
+                        List.of(MASTER.getName()), List.of("node_filesystem_free_bytes", "cm_health_check_info"), List.of("cdp-request-signer",
+                                "smon-exporter", "cm_health_check_info")))
+                .validate();
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/SshJUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/SshJUtil.java
@@ -11,7 +11,9 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.I
 import com.sequenceiq.it.cloudbreak.FreeIpaClient;
 import com.sequenceiq.it.cloudbreak.dto.AbstractFreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.AbstractSdxTestDto;
+import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
 import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.util.ssh.action.SshJClientActions;
 
 @Component
@@ -48,5 +50,24 @@ public class SshJUtil {
 
     public DistroXTestDto checkMeteringStatus(DistroXTestDto testDto, List<InstanceGroupV4Response> instanceGroups, List<String> hostGroupNames) {
         return sshJClientActions.checkMeteringStatus(testDto, instanceGroups, hostGroupNames);
+    }
+
+    public <T extends CloudbreakTestDto> T checkCommonMonitoringStatus(T testDto, List<InstanceGroupV4Response> instanceGroups, List<String> hostGroupNames,
+            List<String> verifyMetricNames, List<String> acceptableNokNames) {
+        return sshJClientActions.checkMonitoringStatus(testDto, instanceGroups, hostGroupNames, verifyMetricNames, acceptableNokNames);
+    }
+
+    public FreeIpaTestDto checkCommonMonitoringStatus(FreeIpaTestDto testDto, String environmentCrn, FreeIpaClient freeipaClient,
+            List<String> verifyMetricNames, List<String> acceptableNokNames) {
+        return sshJClientActions.checkMonitoringStatus(testDto, environmentCrn, freeipaClient, verifyMetricNames, acceptableNokNames);
+    }
+
+    public <T extends CloudbreakTestDto> T checkFilesystemFreeBytesGeneratedMetric(T testDto, List<InstanceGroupV4Response> instanceGroups,
+            List<String> hostGroupNames) {
+        return sshJClientActions.checkFilesystemFreeBytesGeneratedMetric(testDto, instanceGroups, hostGroupNames);
+    }
+
+    public FreeIpaTestDto checkFilesystemFreeBytesGeneratedMetric(FreeIpaTestDto testDto, String environmentCrn, FreeIpaClient freeipaClient) {
+        return sshJClientActions.checkFilesystemFreeBytesGeneratedMetric(testDto, environmentCrn, freeipaClient);
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/client/SshJClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/client/SshJClient.java
@@ -24,6 +24,7 @@ import net.schmizz.sshj.SSHClient;
 import net.schmizz.sshj.common.IOUtils;
 import net.schmizz.sshj.connection.ConnectionException;
 import net.schmizz.sshj.connection.channel.direct.Session;
+import net.schmizz.sshj.connection.channel.direct.Session.Command;
 import net.schmizz.sshj.transport.TransportException;
 import net.schmizz.sshj.transport.verification.PromiscuousVerifier;
 
@@ -74,7 +75,7 @@ public class SshJClient {
         } else {
             LOGGER.error("Creating SSH client is not possible, because of host: '{}', user: '{}', password: '{}' and privateKey: '{}' are missing!",
                     host, user, password, privateKeyFilePath);
-            throw new TestFailException(String.format("Creating SSH client is not possible, because of host: '%s', user: '%s', password: '%s'" +
+            throw new TestFailException(format("Creating SSH client is not possible, because of host: '%s', user: '%s', password: '%s'" +
                             " and privateKey: '%s' are missing!", host, user, password, privateKeyFilePath));
         }
         return client;
@@ -83,10 +84,10 @@ public class SshJClient {
     protected Pair<Integer, String> execute(SSHClient ssh, String command) throws IOException {
         LOGGER.info("Waiting to SSH command to be executed...");
         try (Session session = startSshSession(ssh);
-            Session.Command cmd = session.exec(command);
+            Command cmd = session.exec(command);
             OutputStream os = IOUtils.readFully(cmd.getInputStream())) {
-            Log.log(LOGGER, format("The following SSH command [%s] is going to be executed on host [%s]", ssh.getConnection().getTransport().getRemoteHost(),
-                    command));
+            Log.log(LOGGER, format("The following SSH command [%s] is going to be executed on host [%s]", command,
+                    ssh.getConnection().getTransport().getRemoteHost()));
             cmd.join(10L, TimeUnit.SECONDS);
             return Pair.of(cmd.getExitStatus(), os.toString());
         }

--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -324,6 +324,9 @@ integrationtest:
   authdistributor:
     host: thunderhead-mock
 
+  telemetry:
+    remoteWriteUrl:
+
 altus:
   audit:
     endpoint: localhost:8982

--- a/integration-test/src/main/resources/testsuites/e2e/l0promotion/common-monitoring-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/l0promotion/common-monitoring-tests.yaml
@@ -1,0 +1,5 @@
+name: "common-monitoring-tests"
+tests:
+  - name: "common_monitoring_tests"
+    classes:
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.l0promotion.MonitoringTests


### PR DESCRIPTION
Common Monitoring related services will run on FreeIPA, Datalake and Datahub nodes. So we need to verify if those services are started properly and running on the nodes.

