### PR TITLE
CB-17634 add CM license from CM_LICENSE_FILE env variable for integration test container if it is not empty

### DIFF
--- a/integration-test/docker-compose_template.yml
+++ b/integration-test/docker-compose_template.yml
@@ -8,6 +8,7 @@ services:
       cbreak_default: {}
     ports:
       - 10080:8080
+      - 8982:8982
     volumes:
     - ../mock-thunderhead/build/libs/mock-thunderhead.jar:/mock-thunderhead.jar
     - ./integcb/etc:/etc/auth

--- a/integration-test/scripts/download-cbd.sh
+++ b/integration-test/scripts/download-cbd.sh
@@ -25,4 +25,12 @@ fi
 
 chmod +x cbd
 mkdir etc
-cp ../../mock-thunderhead/src/test/resources/etc/license.txt etc/license.txt
+
+if [ -n "$CM_LICENSE_FILE" ] ; then
+    echo "CM_LICENSE_FILE variable is not empty, creating license file from it's content under etc/license.txt";
+    cp -Rv $CM_LICENSE_FILE etc/
+    sudo chmod -R 755 ./etc
+else
+    echo "CM_LICENSE_FILE variable is empty, copying the license from mock-thunderhead source"
+    cp ../../mock-thunderhead/src/test/resources/etc/license.txt etc/license.txt
+fi


### PR DESCRIPTION
Real AWS and AWS Native PR builds are failing, because of 
```
ERROR main:com.cloudera.cmf.crypto.LicenseLoaderImpl: Cannot load license from input stream
com.cloudera.cmf.crypto.LicenseReadingException: Error reading license.
...
INFO main:com.cloudera.cmf.crypto.LicenseLoaderImpl: The license state of the product is ERROR_DATA
```
So for these PR checks we need to introduce real CM license file.