### PR TITLE
CB-17772 AWS upgrade to postgres 11: call upgrade

### DIFF
--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnector.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnector.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
 import com.sequenceiq.cloudbreak.cloud.ResourceConnector;
 import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsNetworkView;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.AwsRdsUpgradeService;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
@@ -75,6 +76,9 @@ public class AwsResourceConnector implements ResourceConnector<Object> {
     private AwsRdsModifyService awsRdsModifyService;
 
     @Inject
+    private AwsRdsUpgradeService awsRdsUpgradeService;
+
+    @Inject
     private AwsTerminateService awsTerminateService;
 
     @Inject
@@ -118,7 +122,7 @@ public class AwsResourceConnector implements ResourceConnector<Object> {
     @Override
     public List<CloudResourceStatus> upgradeDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
             PersistenceNotifier persistenceNotifier, TargetMajorVersion targetMajorVersion) throws Exception {
-        return null;
+        return awsRdsUpgradeService.upgrade(authenticatedContext, stack, targetMajorVersion);
     }
 
     private boolean deployingToSameVPC(AwsNetworkView awsNetworkView, boolean existingVPC) {

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/AwsRdsUpgradeService.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/AwsRdsUpgradeService.java
@@ -1,0 +1,56 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade;
+
+import java.util.List;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cloud.aws.AwsCloudFormationClient;
+import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonRdsClient;
+import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsCredentialView;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.AwsRdsUpgradeOperations;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.AwsRdsVersionOperations;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
+import com.sequenceiq.cloudbreak.common.database.MajorVersion;
+
+@Service
+public class AwsRdsUpgradeService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsRdsUpgradeOperations.class);
+
+    @Inject
+    private AwsCloudFormationClient awsClient;
+
+    @Inject
+    private AwsRdsUpgradeOperations awsRdsUpgradeOperations;
+
+    @Inject
+    private AwsRdsVersionOperations awsRdsVersionOperations;
+
+    public List<CloudResourceStatus> upgrade(AuthenticatedContext ac, DatabaseStack dbStack, MajorVersion targetMajorVersion) {
+        AwsCredentialView credentialView = new AwsCredentialView(ac.getCloudCredential());
+        String regionName = ac.getCloudContext().getLocation().getRegion().value();
+        AmazonRdsClient rdsClient = awsClient.createRdsClient(credentialView, regionName);
+        String dbInstanceIdentifier = dbStack.getDatabaseServer().getServerId();
+
+        return upgradeRds(ac, targetMajorVersion, rdsClient, dbInstanceIdentifier);
+    }
+
+    private List<CloudResourceStatus> upgradeRds(AuthenticatedContext ac, MajorVersion targetMajorVersion, AmazonRdsClient rdsClient,
+            String dbInstanceIdentifier) {
+        String currentDbEngineVersion = awsRdsUpgradeOperations.getCurrentDbEngineVersion(rdsClient, dbInstanceIdentifier);
+        Set<String> upgradeTargets = awsRdsUpgradeOperations.getUpgradeTargetVersions(rdsClient, currentDbEngineVersion);
+        String highestAvailableTargetVersion = awsRdsVersionOperations.getHighestUpgradeVersion(upgradeTargets, targetMajorVersion);
+        awsRdsUpgradeOperations.upgradeRds(rdsClient, highestAvailableTargetVersion, dbInstanceIdentifier);
+        awsRdsUpgradeOperations.waitForRdsUpgrade(ac, rdsClient, dbInstanceIdentifier);
+        LOGGER.debug("RDS upgrade done for DB: {}", dbInstanceIdentifier);
+        return List.of();
+    }
+
+}

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsUpgradeOperations.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsUpgradeOperations.java
@@ -1,0 +1,136 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation;
+
+import static com.sequenceiq.cloudbreak.cloud.aws.scheduler.WaiterRunner.run;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.amazonaws.services.rds.model.DBInstance;
+import com.amazonaws.services.rds.model.DescribeDBEngineVersionsRequest;
+import com.amazonaws.services.rds.model.DescribeDBEngineVersionsResult;
+import com.amazonaws.services.rds.model.DescribeDBInstancesRequest;
+import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
+import com.amazonaws.services.rds.model.ModifyDBInstanceRequest;
+import com.amazonaws.services.rds.model.UpgradeTarget;
+import com.amazonaws.waiters.Waiter;
+import com.dyngr.exception.PollerException;
+import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonRdsClient;
+import com.sequenceiq.cloudbreak.cloud.aws.scheduler.CustomAmazonWaiterProvider;
+import com.sequenceiq.cloudbreak.cloud.aws.scheduler.StackCancellationCheck;
+import com.sequenceiq.cloudbreak.cloud.aws.util.poller.upgrade.UpgradeStartPoller;
+import com.sequenceiq.cloudbreak.cloud.aws.util.poller.upgrade.UpgradeStartWaitTask;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+
+@Service
+public class AwsRdsUpgradeOperations {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsRdsUpgradeOperations.class);
+
+    @Inject
+    private CustomAmazonWaiterProvider customAmazonWaiterProvider;
+
+    @Inject
+    private UpgradeStartPoller upgradeStartPoller;
+
+    public String getCurrentDbEngineVersion(AmazonRdsClient rdsClient, String dbInstanceIdentifier) {
+        DescribeDBInstancesRequest describeDBInstancesRequest = new DescribeDBInstancesRequest().withDBInstanceIdentifier(dbInstanceIdentifier);
+        DescribeDBInstancesResult describeDBInstancesResult = rdsClient.describeDBInstances(describeDBInstancesRequest);
+        Set<String> currentDbEngineVersions = describeDBInstancesResult.getDBInstances().stream()
+                .map(DBInstance::getEngineVersion)
+                .collect(Collectors.toSet());
+        LOGGER.debug("Current RDS DB engine versions {}", currentDbEngineVersions);
+
+        validateClusterHasASingleVersion(currentDbEngineVersions);
+        String currentDbEngineVersion = currentDbEngineVersions.stream().findFirst().get();
+        LOGGER.debug("Current DB engine version: {}", currentDbEngineVersion);
+
+        return currentDbEngineVersion;
+    }
+
+    public Set<String> getUpgradeTargetVersions(AmazonRdsClient rdsClient, String dbVersion) {
+        DescribeDBEngineVersionsRequest describeDBEngineVersionsRequest = new DescribeDBEngineVersionsRequest();
+        describeDBEngineVersionsRequest.setEngine("postgres");
+        describeDBEngineVersionsRequest.setEngineVersion(dbVersion);
+        try {
+            DescribeDBEngineVersionsResult result = rdsClient.describeDBEngineVersions(describeDBEngineVersionsRequest);
+            LOGGER.debug("Filtering DB upgrade targets for current version {}, results are: {}", dbVersion, result);
+            Set<String> validUpgradeTargets = result.getDBEngineVersions().stream()
+                    .filter(ver -> dbVersion.equals(ver.getEngineVersion()))
+                    .flatMap(ver -> ver.getValidUpgradeTarget().stream())
+                    .map(UpgradeTarget::getEngineVersion)
+                    .collect(Collectors.toSet());
+            LOGGER.debug("The following valid AWS RDS upgrade targets were found: {}", validUpgradeTargets);
+            return validUpgradeTargets;
+        } catch (Exception e) {
+            String message = String.format("Exception occurred when querying valid upgrade targets: %s", e);
+            LOGGER.warn(message);
+            throw new CloudConnectorException(message, e);
+        }
+    }
+
+    public void upgradeRds(AmazonRdsClient rdsClient, String targetVersion, String dbInstanceIdentifier) {
+        ModifyDBInstanceRequest modifyDBInstanceRequest = new ModifyDBInstanceRequest();
+        modifyDBInstanceRequest.setDBInstanceIdentifier(dbInstanceIdentifier);
+        modifyDBInstanceRequest.setEngineVersion(targetVersion);
+        modifyDBInstanceRequest.setAllowMajorVersionUpgrade(true);
+        modifyDBInstanceRequest.setApplyImmediately(true);
+
+        LOGGER.debug("RDS modify request to upgrade engine version to {}: {}", targetVersion, dbInstanceIdentifier);
+        try {
+            rdsClient.modifyDBInstance(modifyDBInstanceRequest);
+        } catch (RuntimeException ex) {
+            String message = String.format("Error when starting the upgrade of RDS: %s", ex);
+            LOGGER.warn(message);
+            throw new CloudConnectorException(message, ex);
+        }
+    }
+
+    public void waitForRdsUpgrade(AuthenticatedContext ac, AmazonRdsClient rdsClient, String dbInstanceIdentifier) {
+        LOGGER.debug("Waiting until RDS enters upgrading state");
+        DescribeDBInstancesRequest describeDBInstancesRequest = new DescribeDBInstancesRequest().withDBInstanceIdentifier(dbInstanceIdentifier);
+        waitUntilUpgradeStarts(rdsClient, describeDBInstancesRequest);
+        waitUntilUpgradeFinishes(ac, rdsClient, describeDBInstancesRequest);
+    }
+
+    private void waitUntilUpgradeStarts(AmazonRdsClient rdsClient, DescribeDBInstancesRequest describeDBInstancesRequest) {
+        UpgradeStartWaitTask upgradeStartWaitTask = new UpgradeStartWaitTask(describeDBInstancesRequest, rdsClient);
+        try {
+            upgradeStartPoller.waitForUpgradeToStart(upgradeStartWaitTask);
+            LOGGER.debug("RDS entered the upgrading state");
+        } catch (PollerException e) {
+            String message = String.format("Error when waiting for upgrade to start: %s", e);
+            LOGGER.warn(message);
+            throw new CloudConnectorException(message, e);
+        }
+    }
+
+    private void waitUntilUpgradeFinishes(AuthenticatedContext ac, AmazonRdsClient rdsClient, DescribeDBInstancesRequest describeDBInstancesRequest) {
+        Waiter<DescribeDBInstancesRequest> rdsWaiter = customAmazonWaiterProvider.getDbInstanceModifyWaiter(rdsClient);
+        StackCancellationCheck stackCancellationCheck = new StackCancellationCheck(ac.getCloudContext().getId());
+        LOGGER.debug("Starting waiting on RDS upgrade");
+        run(rdsWaiter, describeDBInstancesRequest, stackCancellationCheck);
+        LOGGER.debug("Finished waiting on RDS upgrade");
+    }
+
+    private void validateClusterHasASingleVersion(Set<String> dbVersions) {
+        if (dbVersions.isEmpty()) {
+            String message = "Current DB version could not be obtained";
+            LOGGER.warn(message);
+            throw new CloudConnectorException(message);
+        }
+
+        if (dbVersions.size() > 1) {
+            String message = String.format("RDS is on multiple versions (%s), cannot proceed with its upgrade", dbVersions);
+            LOGGER.warn(message);
+            throw new CloudConnectorException(message);
+        }
+    }
+
+}

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsVersionOperations.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsVersionOperations.java
@@ -1,0 +1,92 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.common.database.MajorVersion;
+import com.sequenceiq.cloudbreak.common.type.Versioned;
+import com.sequenceiq.cloudbreak.util.VersionComparator;
+
+@Service
+public class AwsRdsVersionOperations {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsRdsVersionOperations.class);
+
+    public String getHighestUpgradeVersion(Set<String> allUpgradeTargetVersions, MajorVersion targetMajorVersion) {
+        Set<DbEngineVersion> upgradeTargetsForMajorVersion = getUpgradeVersionsForTargetMajor(allUpgradeTargetVersions, targetMajorVersion);
+        checkUpgradePresentForTargetMajorVersion(allUpgradeTargetVersions, upgradeTargetsForMajorVersion);
+        String highestUpgradeTargetVersion = getHighestUpgradeTargetVersion(upgradeTargetsForMajorVersion);
+        LOGGER.debug("The highest available upgrade target version for major version {} is: {}", upgradeTargetsForMajorVersion, highestUpgradeTargetVersion);
+        return highestUpgradeTargetVersion;
+    }
+
+    private void checkUpgradePresentForTargetMajorVersion(Set<String> validUpgradeTargetVersions, Set<DbEngineVersion> upgradeTargetsForMajorVersion) {
+        if (upgradeTargetsForMajorVersion.isEmpty()) {
+            String message = String.format("There are no matching RDS upgrade versions to choose from. Available versions: %s", validUpgradeTargetVersions);
+            LOGGER.warn(message);
+            throw new CloudConnectorException(message);
+        }
+    }
+
+    private String getHighestUpgradeTargetVersion(Set<DbEngineVersion> upgradeTargetsForMajorVersion) {
+        VersionComparator versionComparator = new VersionComparator();
+        List<DbEngineVersion> sortedUpgradeTargetVersion = upgradeTargetsForMajorVersion.stream()
+                .sorted(versionComparator)
+                .collect(Collectors.toList());
+        return sortedUpgradeTargetVersion.get(sortedUpgradeTargetVersion.size() - 1).getVersion();
+    }
+
+    private Set<DbEngineVersion> getUpgradeVersionsForTargetMajor(Set<String> validUpgradeTargetVersions, MajorVersion targetMajorVersion) {
+        String targetMajorVersionString = targetMajorVersion.getMajorVersion() + ".";
+        Set<DbEngineVersion> upgradeTargetsForMajorVersion = validUpgradeTargetVersions.stream()
+                .filter(version -> version.startsWith(targetMajorVersionString))
+                .map(DbEngineVersion::new)
+                .collect(Collectors.toSet());
+        LOGGER.debug("DB engine versions applicable for the current major version {} are: {}", targetMajorVersion.getMajorVersion(),
+                upgradeTargetsForMajorVersion);
+        return upgradeTargetsForMajorVersion;
+    }
+
+    private void validateClusterHasASingleVersion(Set<String> dbVersions) {
+        if (dbVersions.size() > 1) {
+            String message = String.format("RDS is on multiple versions (), cannot proceed with its upgrade", dbVersions);
+            LOGGER.warn(message);
+            throw new CloudConnectorException(message);
+        }
+    }
+
+    private void validateClusterHasVersion(Set<String> dbVersions) {
+        if (dbVersions.isEmpty()) {
+            String message = String.format("Current DB version could not be obtained");
+            throw new CloudConnectorException(message);
+        }
+    }
+
+    private static class DbEngineVersion implements Versioned {
+
+        private final String version;
+
+        DbEngineVersion(String version) {
+            this.version = version;
+        }
+
+        @Override
+        public String getVersion() {
+            return version;
+        }
+
+        @Override
+        public String toString() {
+            return "DbEngineVersion{" +
+                    "version='" + version + '\'' +
+                    '}';
+        }
+    }
+
+}

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/WaiterRunner.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/WaiterRunner.java
@@ -39,6 +39,7 @@ public class WaiterRunner {
                     .withPollingStrategy(getBackoffCancellablePollingStrategy(cancellationCheck))
             );
         } catch (Exception e) {
+            LOGGER.warn("Exception in AWS RDS waiter: ", e);
             List<String> messages = new ArrayList<>();
             if (StringUtils.hasText(exceptionMessage)) {
                 messages.add(exceptionMessage);

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/util/poller/Poller.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/util/poller/Poller.java
@@ -1,0 +1,20 @@
+package com.sequenceiq.cloudbreak.cloud.aws.util.poller;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.stereotype.Component;
+
+import com.dyngr.Polling;
+import com.dyngr.core.AttemptMaker;
+
+@Component
+public class Poller<V> {
+
+    public void runPoller(long sleepTimeInSeconds, long durationInMinutes, AttemptMaker<V> attemptMaker) {
+        Polling.waitPeriodly(sleepTimeInSeconds, TimeUnit.SECONDS)
+                .stopIfException(true)
+                .stopAfterDelay(durationInMinutes, TimeUnit.MINUTES)
+                .run(attemptMaker);
+
+    }
+}

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/util/poller/upgrade/UpgradeStartPoller.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/util/poller/upgrade/UpgradeStartPoller.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.cloudbreak.cloud.aws.util.poller.upgrade;
+
+import javax.inject.Inject;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.aws.util.poller.Poller;
+
+@Component
+public class UpgradeStartPoller {
+
+    @Value("${cb.aws.rds.upgrade.start.wait.sleep:15}")
+    private long sleepTimeSeconds;
+
+    @Value("${cb.aws.rds.upgrade.start.wait.duration:5}")
+    private long durationMinutes;
+
+    @Inject
+    private Poller<Boolean> poller;
+
+    public void waitForUpgradeToStart(UpgradeStartWaitTask upgradeStartWaitTask) {
+        poller.runPoller(sleepTimeSeconds, durationMinutes, upgradeStartWaitTask);
+    }
+
+}

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/util/poller/upgrade/UpgradeStartWaitTask.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/util/poller/upgrade/UpgradeStartWaitTask.java
@@ -1,0 +1,49 @@
+package com.sequenceiq.cloudbreak.cloud.aws.util.poller.upgrade;
+
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.amazonaws.services.rds.model.DBInstance;
+import com.amazonaws.services.rds.model.DescribeDBInstancesRequest;
+import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
+import com.dyngr.core.AttemptMaker;
+import com.dyngr.core.AttemptResult;
+import com.dyngr.core.AttemptResults;
+import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonRdsClient;
+
+public class UpgradeStartWaitTask implements AttemptMaker<Boolean> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UpgradeStartWaitTask.class);
+
+    private static final String RDS_UPGRADE_STATE = "upgrading";
+
+    private final DescribeDBInstancesRequest describeDBInstancesRequest;
+
+    private final AmazonRdsClient rdsClient;
+
+    public UpgradeStartWaitTask(DescribeDBInstancesRequest request, AmazonRdsClient rdsClient) {
+        this.describeDBInstancesRequest = request;
+        this.rdsClient = rdsClient;
+    }
+
+    @Override
+    public AttemptResult<Boolean> process() {
+        DescribeDBInstancesResult result = rdsClient.describeDBInstances(describeDBInstancesRequest);
+        return isRdsInUpgradeState(result)
+                ? AttemptResults.finishWith(Boolean.TRUE)
+                : AttemptResults.justContinue();
+    }
+
+    private boolean isRdsInUpgradeState(DescribeDBInstancesResult result) {
+        Set<String> statuses = result.getDBInstances().stream().map(DBInstance::getDBInstanceStatus).collect(Collectors.toSet());
+        LOGGER.debug("AWS RDS upgrade start check: status queried: {}", statuses);
+        return result.getDBInstances().stream()
+                .map(DBInstance::getDBInstanceStatus)
+                .anyMatch(st -> RDS_UPGRADE_STATE.equals(st.toLowerCase(Locale.ROOT)));
+    }
+
+}

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/AwsRdsUpgradeServiceTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/AwsRdsUpgradeServiceTest.java
@@ -1,0 +1,186 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cloud.aws.AwsCloudFormationClient;
+import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonRdsClient;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.AwsRdsUpgradeOperations;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.AwsRdsVersionOperations;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseServer;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
+import com.sequenceiq.cloudbreak.cloud.model.Location;
+import com.sequenceiq.cloudbreak.cloud.model.Region;
+import com.sequenceiq.cloudbreak.common.database.MajorVersion;
+
+@ExtendWith(MockitoExtension.class)
+public class AwsRdsUpgradeServiceTest {
+
+    private static final String REGION_NAME = "MyRegion";
+
+    private static final String DB_INSTANCE_IDENTIFIER = "dbInstanceIdentifier";
+
+    private static final String CURRENT_DB_VERSION = "currentDbVersion";
+
+    private static final String UPGRADE_TARGET_VERSION = "upgradeTargetVersion";
+
+    private static final String UPGRADE_TARGET_MAJOR_VERSION = "upgradeTargetMajorVersion";
+
+    @Mock
+    private AwsCloudFormationClient awsClient;
+
+    @Mock
+    private AwsRdsUpgradeOperations awsRdsUpgradeOperations;
+
+    @Mock
+    private AwsRdsVersionOperations awsRdsVersionOperations;
+
+    @InjectMocks
+    private AwsRdsUpgradeService underTest;
+
+    @Mock
+    private AmazonRdsClient rdsClient;
+
+    @Test
+    void testUpgrade() {
+        AuthenticatedContext ac = setupAuthenticatedContext();
+        when(awsClient.createRdsClient(any(), eq(REGION_NAME))).thenReturn(rdsClient);
+        DatabaseStack databaseStack = setupDbStack();
+        when(awsRdsUpgradeOperations.getCurrentDbEngineVersion(rdsClient, DB_INSTANCE_IDENTIFIER)).thenReturn(CURRENT_DB_VERSION);
+        Set<String> upgradeTargets = Set.of(UPGRADE_TARGET_VERSION);
+        when(awsRdsUpgradeOperations.getUpgradeTargetVersions(rdsClient, CURRENT_DB_VERSION)).thenReturn(upgradeTargets);
+        MajorVersion upgradeTargetMajorVersion = () -> UPGRADE_TARGET_MAJOR_VERSION;
+        when(awsRdsVersionOperations.getHighestUpgradeVersion(upgradeTargets, upgradeTargetMajorVersion)).thenReturn(UPGRADE_TARGET_VERSION);
+
+        underTest.upgrade(ac, databaseStack, upgradeTargetMajorVersion);
+
+        verify(awsRdsUpgradeOperations).upgradeRds(rdsClient, UPGRADE_TARGET_VERSION, DB_INSTANCE_IDENTIFIER);
+        verify(awsRdsUpgradeOperations).waitForRdsUpgrade(ac, rdsClient, DB_INSTANCE_IDENTIFIER);
+    }
+
+    @Test
+    void testUpgradeWhenGetCurrentDbEngineVersionThrowsThenThrows() {
+        AuthenticatedContext ac = setupAuthenticatedContext();
+        when(awsClient.createRdsClient(any(), eq(REGION_NAME))).thenReturn(rdsClient);
+        DatabaseStack databaseStack = setupDbStack();
+        when(awsRdsUpgradeOperations.getCurrentDbEngineVersion(rdsClient, DB_INSTANCE_IDENTIFIER)).thenThrow(new CloudConnectorException("My exception"));
+        MajorVersion upgradeTargetMajorVersion = () -> UPGRADE_TARGET_MAJOR_VERSION;
+
+        Assertions.assertThrows(CloudConnectorException.class, () ->
+                underTest.upgrade(ac, databaseStack, upgradeTargetMajorVersion)
+        );
+
+        verify(awsRdsUpgradeOperations, never()).getUpgradeTargetVersions(any(), any());
+        verify(awsRdsVersionOperations, never()).getHighestUpgradeVersion(any(), any());
+        verify(awsRdsUpgradeOperations, never()).upgradeRds(rdsClient, UPGRADE_TARGET_VERSION, DB_INSTANCE_IDENTIFIER);
+        verify(awsRdsUpgradeOperations, never()).waitForRdsUpgrade(ac, rdsClient, DB_INSTANCE_IDENTIFIER);
+    }
+
+    @Test
+    void testUpgradeWhenGetUpgradeTargetVersionThrowsThenThrows() {
+        AuthenticatedContext ac = setupAuthenticatedContext();
+        when(awsClient.createRdsClient(any(), eq(REGION_NAME))).thenReturn(rdsClient);
+        DatabaseStack databaseStack = setupDbStack();
+        when(awsRdsUpgradeOperations.getCurrentDbEngineVersion(rdsClient, DB_INSTANCE_IDENTIFIER)).thenReturn(CURRENT_DB_VERSION);
+        when(awsRdsUpgradeOperations.getUpgradeTargetVersions(rdsClient, CURRENT_DB_VERSION)).thenThrow(new CloudConnectorException("My Exception"));
+        MajorVersion upgradeTargetMajorVersion = () -> UPGRADE_TARGET_MAJOR_VERSION;
+
+        Assertions.assertThrows(CloudConnectorException.class, () ->
+                underTest.upgrade(ac, databaseStack, upgradeTargetMajorVersion)
+        );
+
+        verify(awsRdsVersionOperations, never()).getHighestUpgradeVersion(any(), any());
+        verify(awsRdsUpgradeOperations, never()).upgradeRds(rdsClient, UPGRADE_TARGET_VERSION, DB_INSTANCE_IDENTIFIER);
+        verify(awsRdsUpgradeOperations, never()).waitForRdsUpgrade(ac, rdsClient, DB_INSTANCE_IDENTIFIER);
+    }
+
+    @Test
+    void testUpgradeWhenGetHighestUpgradeVersionThrowsThenThrows() {
+        AuthenticatedContext ac = setupAuthenticatedContext();
+        when(awsClient.createRdsClient(any(), eq(REGION_NAME))).thenReturn(rdsClient);
+        DatabaseStack databaseStack = setupDbStack();
+        when(awsRdsUpgradeOperations.getCurrentDbEngineVersion(rdsClient, DB_INSTANCE_IDENTIFIER)).thenReturn(CURRENT_DB_VERSION);
+        Set<String> upgradeTargets = Set.of(UPGRADE_TARGET_VERSION);
+        when(awsRdsUpgradeOperations.getUpgradeTargetVersions(rdsClient, CURRENT_DB_VERSION)).thenReturn(upgradeTargets);
+        MajorVersion upgradeTargetMajorVersion = () -> UPGRADE_TARGET_MAJOR_VERSION;
+        when(awsRdsVersionOperations.getHighestUpgradeVersion(upgradeTargets, upgradeTargetMajorVersion)).thenThrow(new CloudConnectorException("My Exception"));
+
+        Assertions.assertThrows(CloudConnectorException.class, () ->
+                underTest.upgrade(ac, databaseStack, upgradeTargetMajorVersion)
+        );
+
+        verify(awsRdsUpgradeOperations, never()).upgradeRds(rdsClient, UPGRADE_TARGET_VERSION, DB_INSTANCE_IDENTIFIER);
+        verify(awsRdsUpgradeOperations, never()).waitForRdsUpgrade(ac, rdsClient, DB_INSTANCE_IDENTIFIER);
+    }
+
+    @Test
+    void testUpgradeWhenUpgradeRdsThrowsThenThrows() {
+        AuthenticatedContext ac = setupAuthenticatedContext();
+        when(awsClient.createRdsClient(any(), eq(REGION_NAME))).thenReturn(rdsClient);
+        DatabaseStack databaseStack = setupDbStack();
+        when(awsRdsUpgradeOperations.getCurrentDbEngineVersion(rdsClient, DB_INSTANCE_IDENTIFIER)).thenReturn(CURRENT_DB_VERSION);
+        Set<String> upgradeTargets = Set.of(UPGRADE_TARGET_VERSION);
+        when(awsRdsUpgradeOperations.getUpgradeTargetVersions(rdsClient, CURRENT_DB_VERSION)).thenReturn(upgradeTargets);
+        MajorVersion upgradeTargetMajorVersion = () -> UPGRADE_TARGET_MAJOR_VERSION;
+        when(awsRdsVersionOperations.getHighestUpgradeVersion(upgradeTargets, upgradeTargetMajorVersion)).thenReturn(UPGRADE_TARGET_VERSION);
+        doThrow(new CloudConnectorException("My exception")).when(awsRdsUpgradeOperations).upgradeRds(rdsClient, UPGRADE_TARGET_VERSION, DB_INSTANCE_IDENTIFIER);
+
+        Assertions.assertThrows(CloudConnectorException.class, () ->
+                underTest.upgrade(ac, databaseStack, upgradeTargetMajorVersion)
+        );
+
+        verify(awsRdsUpgradeOperations, never()).waitForRdsUpgrade(ac, rdsClient, DB_INSTANCE_IDENTIFIER);
+    }
+
+    @Test
+    void testUpgradeWhenWaitForRdsUpgradeThrowsThenThrows() {
+        AuthenticatedContext ac = setupAuthenticatedContext();
+        when(awsClient.createRdsClient(any(), eq(REGION_NAME))).thenReturn(rdsClient);
+        DatabaseStack databaseStack = setupDbStack();
+        when(awsRdsUpgradeOperations.getCurrentDbEngineVersion(rdsClient, DB_INSTANCE_IDENTIFIER)).thenReturn(CURRENT_DB_VERSION);
+        Set<String> upgradeTargets = Set.of(UPGRADE_TARGET_VERSION);
+        when(awsRdsUpgradeOperations.getUpgradeTargetVersions(rdsClient, CURRENT_DB_VERSION)).thenReturn(upgradeTargets);
+        MajorVersion upgradeTargetMajorVersion = () -> UPGRADE_TARGET_MAJOR_VERSION;
+        when(awsRdsVersionOperations.getHighestUpgradeVersion(upgradeTargets, upgradeTargetMajorVersion)).thenReturn(UPGRADE_TARGET_VERSION);
+        doThrow(new CloudConnectorException("myException")).when(awsRdsUpgradeOperations).waitForRdsUpgrade(ac, rdsClient, DB_INSTANCE_IDENTIFIER);
+
+        Assertions.assertThrows(CloudConnectorException.class, () ->
+                underTest.upgrade(ac, databaseStack, upgradeTargetMajorVersion)
+        );
+    }
+
+    private DatabaseStack setupDbStack() {
+        DatabaseStack dbStack = mock(DatabaseStack.class);
+        DatabaseServer databaseServer = mock(DatabaseServer.class);
+        when(databaseServer.getServerId()).thenReturn(DB_INSTANCE_IDENTIFIER);
+        when(dbStack.getDatabaseServer()).thenReturn(databaseServer);
+        return dbStack;
+    }
+
+    private AuthenticatedContext setupAuthenticatedContext() {
+        AuthenticatedContext ac = mock(AuthenticatedContext.class);
+        CloudContext cc = mock(CloudContext.class);
+        Location location = Location.location(Region.region(REGION_NAME));
+        when(cc.getLocation()).thenReturn(location);
+        when(ac.getCloudContext()).thenReturn(cc);
+        return ac;
+    }
+
+}

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsUpgradeOperationsTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsUpgradeOperationsTest.java
@@ -1,0 +1,219 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.amazonaws.services.rds.model.DBEngineVersion;
+import com.amazonaws.services.rds.model.DBInstance;
+import com.amazonaws.services.rds.model.DescribeDBEngineVersionsResult;
+import com.amazonaws.services.rds.model.DescribeDBInstancesRequest;
+import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
+import com.amazonaws.services.rds.model.ModifyDBInstanceRequest;
+import com.amazonaws.services.rds.model.UpgradeTarget;
+import com.amazonaws.waiters.Waiter;
+import com.dyngr.exception.PollerException;
+import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonRdsClient;
+import com.sequenceiq.cloudbreak.cloud.aws.scheduler.CustomAmazonWaiterProvider;
+import com.sequenceiq.cloudbreak.cloud.aws.util.poller.upgrade.UpgradeStartPoller;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+
+import reactor.fn.tuple.Tuple2;
+
+@ExtendWith(MockitoExtension.class)
+public class AwsRdsUpgradeOperationsTest {
+
+    private static final String ENGINE_VERSION_1_2 = "1.2";
+
+    private static final String ENGINE_VERSION_1_3 = "1.3";
+
+    private static final String DB_INSTANCE_IDENTIFIER = "dbInstanceIdentifier";
+
+    @Mock
+    private CustomAmazonWaiterProvider customAmazonWaiterProvider;
+
+    @Mock
+    private UpgradeStartPoller upgradeStartPoller;
+
+    @InjectMocks
+    private AwsRdsUpgradeOperations underTest;
+
+    @Mock
+    private AmazonRdsClient rdsClient;
+
+    @Test
+    void testGetCurrentDbEngineVersions() {
+        when(rdsClient.describeDBInstances(any())).thenReturn(setupDescribeDbInstancesResult(ENGINE_VERSION_1_2));
+
+        String currentDbEngineVersion = underTest.getCurrentDbEngineVersion(rdsClient, DB_INSTANCE_IDENTIFIER);
+
+        assertEquals(ENGINE_VERSION_1_2, currentDbEngineVersion);
+    }
+
+    @Test
+    void testGetCurrentDbEngineVersionsWhenNoResultThenException() {
+        when(rdsClient.describeDBInstances(any())).thenReturn(setupDescribeDbInstancesResult());
+
+        Assertions.assertThrows(CloudConnectorException.class, () ->
+                underTest.getCurrentDbEngineVersion(rdsClient, DB_INSTANCE_IDENTIFIER)
+        );
+
+    }
+
+    @Test
+    void testGetCurrentDbEngineVersionsWhenMultipleResultsThenException() {
+        when(rdsClient.describeDBInstances(any())).thenReturn(setupDescribeDbInstancesResult(ENGINE_VERSION_1_2, ENGINE_VERSION_1_3));
+
+        Assertions.assertThrows(CloudConnectorException.class, () ->
+                underTest.getCurrentDbEngineVersion(rdsClient, DB_INSTANCE_IDENTIFIER)
+        );
+
+    }
+
+    @Test
+    void testGetUpgradeTargetVersions() {
+        when(rdsClient.describeDBEngineVersions(any())).thenReturn(setupDescribeDbEngineVersionResults(Tuple2.of(ENGINE_VERSION_1_2, Set.of("2.1", "2.2"))));
+
+        Set<String> upgradeTargetVersionList = underTest.getUpgradeTargetVersions(rdsClient, ENGINE_VERSION_1_2);
+
+        assertThat(upgradeTargetVersionList, hasSize(2));
+        assertThat(upgradeTargetVersionList, contains("2.1", "2.2"));
+    }
+
+    @Test
+    void testGetUpgradeTargetVersionsWhenCurrentVersionIsNotPresentThenReturnsEmptySet() {
+        when(rdsClient.describeDBEngineVersions(any())).thenReturn(setupDescribeDbEngineVersionResults(Tuple2.of(ENGINE_VERSION_1_3, Set.of("2.1"))));
+
+        Set<String> upgradeTargetVersionList = underTest.getUpgradeTargetVersions(rdsClient, ENGINE_VERSION_1_2);
+
+        assertThat(upgradeTargetVersionList, is(empty()));
+    }
+
+    @Test
+    void testGetUpgradeTargetVersionsWhenMultipleMatchesThenReturnsAll() {
+        when(rdsClient.describeDBEngineVersions(any())).thenReturn(setupDescribeDbEngineVersionResults(
+                        Tuple2.of(ENGINE_VERSION_1_2, Set.of("2.1")),
+                        Tuple2.of(ENGINE_VERSION_1_2, Set.of("2.2"))
+                )
+        );
+
+        Set<String> upgradeTargetVersionList = underTest.getUpgradeTargetVersions(rdsClient, ENGINE_VERSION_1_2);
+
+        assertThat(upgradeTargetVersionList, hasSize(2));
+        assertThat(upgradeTargetVersionList, contains("2.1", "2.2"));
+    }
+
+    @Test
+    void testGetUpgradeTargetVersionsWhenExceptionThenThrows() {
+        when(rdsClient.describeDBEngineVersions(any())).thenThrow(new RuntimeException("MyException"));
+
+        Assertions.assertThrows(CloudConnectorException.class, () ->
+                underTest.getUpgradeTargetVersions(rdsClient, ENGINE_VERSION_1_2)
+        );
+    }
+
+    @Test
+    void testUpgradeRds() {
+        underTest.upgradeRds(rdsClient, "2.2", DB_INSTANCE_IDENTIFIER);
+
+        ArgumentCaptor<ModifyDBInstanceRequest> modifyRequestCaptor = ArgumentCaptor.forClass(ModifyDBInstanceRequest.class);
+        verify(rdsClient).modifyDBInstance(modifyRequestCaptor.capture());
+        ModifyDBInstanceRequest firedRequest = modifyRequestCaptor.getValue();
+        assertEquals(DB_INSTANCE_IDENTIFIER, firedRequest.getDBInstanceIdentifier());
+        assertEquals("2.2", firedRequest.getEngineVersion());
+        assertTrue(firedRequest.getAllowMajorVersionUpgrade());
+        assertTrue(firedRequest.getApplyImmediately());
+    }
+
+    @Test
+    void testUpgradeRdsWhenExceptionThenThrows() {
+        when(rdsClient.modifyDBInstance(any())).thenThrow(new RuntimeException("myException"));
+
+        Assertions.assertThrows(CloudConnectorException.class, () ->
+                underTest.upgradeRds(rdsClient, "2.2", DB_INSTANCE_IDENTIFIER)
+        );
+    }
+
+    @Test
+    void testWaitForUpgrade() {
+        AuthenticatedContext ac = setupAuthenticatedContext();
+        Waiter<DescribeDBInstancesRequest> awsWaiter = mock(Waiter.class);
+        when(customAmazonWaiterProvider.getDbInstanceModifyWaiter(rdsClient)).thenReturn(awsWaiter);
+
+        underTest.waitForRdsUpgrade(ac, rdsClient, DB_INSTANCE_IDENTIFIER);
+
+        verify(upgradeStartPoller).waitForUpgradeToStart(any());
+        verify(awsWaiter).run(any());
+    }
+
+    @Test
+    void testWaitForUpgradeWhenWaitForUpgradeTimesOut() {
+        AuthenticatedContext ac = mock(AuthenticatedContext.class);
+        doThrow(new PollerException("myException")).when(upgradeStartPoller).waitForUpgradeToStart(any());
+
+        Assertions.assertThrows(CloudConnectorException.class, () ->
+                underTest.waitForRdsUpgrade(ac, rdsClient, DB_INSTANCE_IDENTIFIER)
+        );
+
+        verify(upgradeStartPoller).waitForUpgradeToStart(any());
+        verify(customAmazonWaiterProvider, never()).getDbInstanceModifyWaiter(any());
+    }
+
+    private AuthenticatedContext setupAuthenticatedContext() {
+        AuthenticatedContext ac = mock(AuthenticatedContext.class);
+        CloudContext cc = mock(CloudContext.class);
+        when(ac.getCloudContext()).thenReturn(cc);
+        return ac;
+    }
+
+    @SafeVarargs
+    private DescribeDBEngineVersionsResult setupDescribeDbEngineVersionResults(Tuple2<String, Set<String>>... currentAndTargetVersions) {
+        DescribeDBEngineVersionsResult describeDBEngineVersionsResult = new DescribeDBEngineVersionsResult();
+        Set<DBEngineVersion> dbEngineVersions = new HashSet<>();
+        for (Tuple2<String, Set<String>> engineAndTargetVersion : currentAndTargetVersions) {
+            DBEngineVersion dbEngineVersion = new DBEngineVersion();
+            dbEngineVersion.setEngineVersion(engineAndTargetVersion.t1);
+            Set<UpgradeTarget> targets = engineAndTargetVersion.t2.stream().map(tv -> new UpgradeTarget().withEngineVersion(tv)).collect(Collectors.toSet());
+            dbEngineVersion.setValidUpgradeTarget(targets);
+            dbEngineVersions.add(dbEngineVersion);
+        }
+        describeDBEngineVersionsResult.setDBEngineVersions(dbEngineVersions);
+        return describeDBEngineVersionsResult;
+    }
+
+    private DescribeDBInstancesResult setupDescribeDbInstancesResult(String... engineVersions) {
+        DescribeDBInstancesResult describeDBInstancesResult = new DescribeDBInstancesResult();
+        Set<DBInstance> dbInstances = new HashSet<>();
+        for (String engineVersion : engineVersions) {
+            DBInstance dbInstance = new DBInstance();
+            dbInstance.setEngineVersion(engineVersion);
+            dbInstances.add(dbInstance);
+        }
+        describeDBInstancesResult.setDBInstances(dbInstances);
+        return describeDBInstancesResult;
+    }
+}

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsVersionOperationsTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsVersionOperationsTest.java
@@ -1,0 +1,56 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+
+@ExtendWith(MockitoExtension.class)
+public class AwsRdsVersionOperationsTest {
+
+    private final AwsRdsVersionOperations underTest = new AwsRdsVersionOperations();
+
+    @Test
+    void testGetHighestUpgradeVersion() {
+        Set<String> validUpgradeVersions = Set.of("1.2");
+
+        String selectedTargetVersion = underTest.getHighestUpgradeVersion(validUpgradeVersions, () -> "1");
+
+        assertEquals("1.2", selectedTargetVersion);
+    }
+
+    @Test
+    void testGetHighestUpgradeVersionWhenMultipleWithSameMajorThenHighestSelected() {
+        Set<String> validUpgradeVersions = Set.of("1.2", "1.3");
+
+        String selectedTargetVersion = underTest.getHighestUpgradeVersion(validUpgradeVersions, () -> "1");
+
+        assertEquals("1.3", selectedTargetVersion);
+    }
+
+    @Test
+    void testGetHighestUpgradeVersionWhenMultipleMajorsThenHighestSelected() {
+        Set<String> validUpgradeVersions = Set.of("1.2", "2.3", "3.4");
+
+        String selectedTargetVersion = underTest.getHighestUpgradeVersion(validUpgradeVersions, () -> "2");
+
+        assertEquals("2.3", selectedTargetVersion);
+    }
+
+    @Test
+    void testGetHighestUpgradeVersionWhenNoMatchingMajorVersion() {
+        Set<String> validUpgradeVersions = Set.of("1.2", "1.3");
+
+        Assertions.assertThrows(CloudConnectorException.class, () ->
+                underTest.getHighestUpgradeVersion(validUpgradeVersions, () -> "2")
+        );
+    }
+
+}

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/util/poller/upgrade/UpgradeStartWaitTaskTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/util/poller/upgrade/UpgradeStartWaitTaskTest.java
@@ -1,0 +1,85 @@
+package com.sequenceiq.cloudbreak.cloud.aws.util.poller.upgrade;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.amazonaws.services.rds.model.DBInstance;
+import com.amazonaws.services.rds.model.DescribeDBInstancesRequest;
+import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
+import com.dyngr.core.AttemptResult;
+import com.dyngr.core.AttemptState;
+import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonRdsClient;
+
+@ExtendWith(MockitoExtension.class)
+public class UpgradeStartWaitTaskTest {
+
+    @Mock
+    private DescribeDBInstancesRequest describeDBInstancesRequest;
+
+    @Mock
+    private AmazonRdsClient rdsClient;
+
+    @InjectMocks
+    private UpgradeStartWaitTask underTest;
+
+    @Test
+    void testProcessWhenUpgradingThenFinishes() {
+        when(rdsClient.describeDBInstances(any())).thenReturn(setupDescribeDbInstancesResult("upgrading"));
+
+        AttemptResult<Boolean> result = underTest.process();
+
+        assertEquals(AttemptState.FINISH, result.getState());
+        assertTrue(result.getResult());
+    }
+
+    @Test
+    void testProcessWhenMultipleUpgradingStateThenFinishes() {
+        when(rdsClient.describeDBInstances(any())).thenReturn(setupDescribeDbInstancesResult("upgrading", "upgrading"));
+
+        AttemptResult<Boolean> result = underTest.process();
+
+        assertEquals(AttemptState.FINISH, result.getState());
+        assertTrue(result.getResult());
+    }
+
+    @Test
+    void testProcessWhenMixedStatesWithOneUpgradingThenFinishes() {
+        when(rdsClient.describeDBInstances(any())).thenReturn(setupDescribeDbInstancesResult("upgrading", "a state"));
+
+        AttemptResult<Boolean> result = underTest.process();
+
+        assertEquals(AttemptState.FINISH, result.getState());
+        assertTrue(result.getResult());
+    }
+
+    @Test
+    void testProcessWhenNotUpgradingThenContinue() {
+        when(rdsClient.describeDBInstances(any())).thenReturn(setupDescribeDbInstancesResult("a state"));
+
+        AttemptResult<Boolean> result = underTest.process();
+
+        assertEquals(AttemptState.CONTINUE, result.getState());
+    }
+
+    private DescribeDBInstancesResult setupDescribeDbInstancesResult(String... instanceStates) {
+        DescribeDBInstancesResult describeDBInstancesResult = new DescribeDBInstancesResult();
+        Set<DBInstance> dbInstances = new HashSet<>();
+        for (String instanceState : instanceStates) {
+            dbInstances.add(new DBInstance().withDBInstanceStatus(instanceState));
+        }
+        describeDBInstancesResult.setDBInstances(dbInstances);
+        return describeDBInstancesResult;
+    }
+
+}

--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/client/AmazonRdsClient.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/client/AmazonRdsClient.java
@@ -7,6 +7,8 @@ import com.amazonaws.services.rds.model.Certificate;
 import com.amazonaws.services.rds.model.DBInstance;
 import com.amazonaws.services.rds.model.DescribeCertificatesRequest;
 import com.amazonaws.services.rds.model.DescribeCertificatesResult;
+import com.amazonaws.services.rds.model.DescribeDBEngineVersionsRequest;
+import com.amazonaws.services.rds.model.DescribeDBEngineVersionsResult;
 import com.amazonaws.services.rds.model.DescribeDBInstancesRequest;
 import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
 import com.amazonaws.services.rds.model.ModifyDBInstanceRequest;
@@ -57,6 +59,10 @@ public class AmazonRdsClient extends AmazonClient {
                 DescribeCertificatesResult::getCertificates,
                 DescribeCertificatesResult::getMarker,
                 DescribeCertificatesRequest::setMarker);
+    }
+
+    public DescribeDBEngineVersionsResult describeDBEngineVersions(DescribeDBEngineVersionsRequest describeDBEngineVersionsRequest) {
+        return client.describeDBEngineVersions(describeDBEngineVersionsRequest);
     }
 
     private DescribeCertificatesResult describeCertificatesInternal(DescribeCertificatesRequest request) {

--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/database/MajorVersion.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/database/MajorVersion.java
@@ -1,0 +1,6 @@
+package com.sequenceiq.cloudbreak.common.database;
+
+public interface MajorVersion {
+
+    String getMajorVersion();
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/database/TargetMajorVersion.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/database/TargetMajorVersion.java
@@ -1,6 +1,6 @@
 package com.sequenceiq.cloudbreak.common.database;
 
-public enum TargetMajorVersion {
+public enum TargetMajorVersion implements MajorVersion {
 
     VERSION_11("11");
 
@@ -10,7 +10,8 @@ public enum TargetMajorVersion {
         this.version = version;
     }
 
-    public String getVersion() {
+    @Override
+    public String getMajorVersion() {
         return version;
     }
 


### PR DESCRIPTION
The goal was to:
- get the list of upgrade candidate versions, and select the highest from them
- call the upgrade via the SDK
- wait until the upgrade finishes

On AWS when upgrading Postgres to a different major version, the minor is predefined in an upgrade matrix that needs to be queried first via a describeDBEngineVersionsRequest. That will offer one or more upgrade options - it makes sense to select the highest version.
After calling the upgrade method the RDS does not enter instantly the upgrading state - the AWS waiter thus exits immediately. Therefore a custom poller was introduced to wait until the RDS enters the upgrading state.

It was tested both on non-HA and HA setups. Cluster setups (3 instances) are not yet available for version 11.

See detailed description in the commit message.