### PR TITLE
CB-17781 Check non-Acceptable but Payload classes for Jackson conformity

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudLoadBalancerMetadata.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudLoadBalancerMetadata.java
@@ -1,8 +1,11 @@
 package com.sequenceiq.cloudbreak.cloud.model;
 
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.model.generic.DynamicModel;
 import com.sequenceiq.common.api.type.LoadBalancerType;
-import java.util.Map;
 
 public class CloudLoadBalancerMetadata extends DynamicModel {
 
@@ -16,8 +19,15 @@ public class CloudLoadBalancerMetadata extends DynamicModel {
 
     private final String name;
 
-    private CloudLoadBalancerMetadata(LoadBalancerType type, String cloudDns, String hostedZoneId, String ip, String name,
-            Map<String, Object> parameters) {
+    @JsonCreator
+    private CloudLoadBalancerMetadata(
+            @JsonProperty("type") LoadBalancerType type,
+            @JsonProperty("cloudDns") String cloudDns,
+            @JsonProperty("hostedZoneId") String hostedZoneId,
+            @JsonProperty("ip") String ip,
+            @JsonProperty("name") String name,
+            @JsonProperty("parameters") Map<String, Object> parameters) {
+
         super(parameters);
         this.type = type;
         this.cloudDns = cloudDns;

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/TlsInfo.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/TlsInfo.java
@@ -1,14 +1,18 @@
 package com.sequenceiq.cloudbreak.cloud.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class TlsInfo {
 
     private final boolean usePrivateIpToTls;
 
-    public TlsInfo(boolean usePrivateIpToTls) {
+    @JsonCreator
+    public TlsInfo(@JsonProperty("usePrivateIpToTls") boolean usePrivateIpToTls) {
         this.usePrivateIpToTls = usePrivateIpToTls;
     }
 
-    public boolean usePrivateIpToTls() {
+    public boolean isUsePrivateIpToTls() {
         return usePrivateIpToTls;
     }
 }

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpResourceConnectorTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpResourceConnectorTest.java
@@ -100,7 +100,7 @@ public class GcpResourceConnectorTest {
     public void testGetTlsInfoWhenEverythingIsfine() {
         AuthenticatedContext authenticatedContext = mock(AuthenticatedContext.class);
         CloudStack cloudStack = mock(CloudStack.class);
-        Assert.assertEquals(false, underTest.getTlsInfo(authenticatedContext,  cloudStack).usePrivateIpToTls());
+        Assert.assertEquals(false, underTest.getTlsInfo(authenticatedContext,  cloudStack).isUsePrivateIpToTls());
     }
 
     @Test

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/instance/CollectMetadataResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/instance/CollectMetadataResult.java
@@ -2,19 +2,26 @@ package com.sequenceiq.cloudbreak.cloud.event.instance;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
 import com.sequenceiq.cloudbreak.cloud.model.CloudVmMetaDataStatus;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 
-public class CollectMetadataResult extends CloudPlatformResult {
-    private List<CloudVmMetaDataStatus> results;
+public class CollectMetadataResult extends CloudPlatformResult implements FlowPayload {
+    private final List<CloudVmMetaDataStatus> results;
 
-    public CollectMetadataResult(Long resourceId, List<CloudVmMetaDataStatus> results) {
+    @JsonCreator
+    public CollectMetadataResult(
+            @JsonProperty("resourceId") Long resourceId,
+            @JsonProperty("results") List<CloudVmMetaDataStatus> results) {
         super(resourceId);
         this.results = results;
     }
 
     public CollectMetadataResult(Exception errorDetails, Long resourceId) {
         super("", errorDetails, resourceId);
+        this.results = null;
     }
 
     public List<CloudVmMetaDataStatus> getResults() {

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/instance/GetSSHFingerprintsResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/instance/GetSSHFingerprintsResult.java
@@ -2,19 +2,27 @@ package com.sequenceiq.cloudbreak.cloud.event.instance;
 
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 
-public class GetSSHFingerprintsResult extends CloudPlatformResult {
+public class GetSSHFingerprintsResult extends CloudPlatformResult implements FlowPayload {
 
-    private Set<String> sshFingerprints;
+    private final Set<String> sshFingerprints;
 
     public GetSSHFingerprintsResult(Long resourceId, Set<String> sshFingerprints) {
         super(resourceId);
         this.sshFingerprints = sshFingerprints;
     }
 
-    public GetSSHFingerprintsResult(String statusReason, Exception errorDetails, Long resourceId) {
+    @JsonCreator
+    public GetSSHFingerprintsResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("resourceId") Long resourceId) {
         super(statusReason, errorDetails, resourceId);
+        this.sshFingerprints = null;
     }
 
     public Set<String> getSshFingerprints() {

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/instance/GetTlsInfoResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/instance/GetTlsInfoResult.java
@@ -1,19 +1,27 @@
 package com.sequenceiq.cloudbreak.cloud.event.instance;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
 import com.sequenceiq.cloudbreak.cloud.model.TlsInfo;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 
-public class GetTlsInfoResult extends CloudPlatformResult {
+public class GetTlsInfoResult extends CloudPlatformResult implements FlowPayload {
 
-    private TlsInfo tlsInfo;
+    private final TlsInfo tlsInfo;
 
     public GetTlsInfoResult(Long resourceId, TlsInfo tlsInfo) {
         super(resourceId);
         this.tlsInfo = tlsInfo;
     }
 
-    public GetTlsInfoResult(String statusReason, Exception errorDetails, Long resourceId) {
+    @JsonCreator
+    public GetTlsInfoResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("resourceId") Long resourceId) {
         super(statusReason, errorDetails, resourceId);
+        this.tlsInfo = null;
     }
 
     public TlsInfo getTlsInfo() {

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/instance/InstancesStatusResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/instance/InstancesStatusResult.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.cloud.event.instance;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudVmInstanceStatus;
 
@@ -11,7 +13,10 @@ public class InstancesStatusResult {
 
     private final List<CloudVmInstanceStatus> results;
 
-    public InstancesStatusResult(CloudContext cloudContext, List<CloudVmInstanceStatus> results) {
+    @JsonCreator
+    public InstancesStatusResult(
+            @JsonProperty("cloudContext") CloudContext cloudContext,
+            @JsonProperty("results") List<CloudVmInstanceStatus> results) {
         this.cloudContext = cloudContext;
         this.results = results;
     }

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/instance/RebootInstancesResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/instance/RebootInstancesResult.java
@@ -2,13 +2,16 @@ package com.sequenceiq.cloudbreak.cloud.event.instance;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 
-public class RebootInstancesResult extends CloudPlatformResult {
+public class RebootInstancesResult extends CloudPlatformResult implements FlowPayload {
 
-    private InstancesStatusResult results;
+    private final InstancesStatusResult results;
 
-    private List<String> instanceIds;
+    private final List<String> instanceIds;
 
     public RebootInstancesResult(Long resourceId, InstancesStatusResult results, List<String> instanceIds) {
         super(resourceId);
@@ -16,9 +19,15 @@ public class RebootInstancesResult extends CloudPlatformResult {
         this.instanceIds = instanceIds;
     }
 
-    public RebootInstancesResult(String statusReason, Exception errorDetails, Long resourceId, List<String> instanceIds) {
+    @JsonCreator
+    public RebootInstancesResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("resourceId") Long resourceId,
+            @JsonProperty("instanceIds") List<String> instanceIds) {
         super(statusReason, errorDetails, resourceId);
         this.instanceIds = instanceIds;
+        this.results = null;
     }
 
     public InstancesStatusResult getResults() {

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/instance/StartInstancesResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/instance/StartInstancesResult.java
@@ -1,19 +1,27 @@
 package com.sequenceiq.cloudbreak.cloud.event.instance;
 
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 
-public class StartInstancesResult extends CloudPlatformResult {
+public class StartInstancesResult extends CloudPlatformResult implements FlowPayload {
 
-    private InstancesStatusResult results;
+    private final InstancesStatusResult results;
 
     public StartInstancesResult(Long resourceId, InstancesStatusResult results) {
         super(resourceId);
         this.results = results;
     }
 
-    public StartInstancesResult(String statusReason, Exception errorDetails, Long resourceId) {
+    @JsonCreator
+    public StartInstancesResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("resourceId") Long resourceId) {
         super(statusReason, errorDetails, resourceId);
+        this.results = null;
     }
 
     public InstancesStatusResult getResults() {

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/instance/StopInstancesResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/instance/StopInstancesResult.java
@@ -1,18 +1,26 @@
 package com.sequenceiq.cloudbreak.cloud.event.instance;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 
-public class StopInstancesResult extends CloudPlatformResult {
+public class StopInstancesResult extends CloudPlatformResult implements FlowPayload {
 
-    private InstancesStatusResult results;
+    private final InstancesStatusResult results;
 
     public StopInstancesResult(Long resourceId, InstancesStatusResult results) {
         super(resourceId);
         this.results = results;
     }
 
-    public StopInstancesResult(String statusReason, Exception errorDetails, Long resourceId) {
+    @JsonCreator
+    public StopInstancesResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("resourceId") Long resourceId) {
         super(statusReason, errorDetails, resourceId);
+        this.results = null;
     }
 
     public InstancesStatusResult getResults() {

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/instance/StopStartDownscaleStopInstancesRequest.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/instance/StopStartDownscaleStopInstancesRequest.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.cloud.event.instance;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.event.resource.CloudStackRequest;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
@@ -12,8 +14,12 @@ public class StopStartDownscaleStopInstancesRequest extends CloudStackRequest<St
 
     private final List<CloudInstance> cloudInstancesToStop;
 
-    public StopStartDownscaleStopInstancesRequest(CloudContext cloudContext, CloudCredential cloudCredential,
-            CloudStack cloudStack, List<CloudInstance> cloudInstancesToStop) {
+    @JsonCreator
+    public StopStartDownscaleStopInstancesRequest(
+            @JsonProperty("cloudContext") CloudContext cloudContext,
+            @JsonProperty("cloudCredential") CloudCredential cloudCredential,
+            @JsonProperty("cloudStack") CloudStack cloudStack,
+            @JsonProperty("cloudInstancesToStop") List<CloudInstance> cloudInstancesToStop) {
         super(cloudContext, cloudCredential, cloudStack);
         this.cloudInstancesToStop = cloudInstancesToStop;
     }

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/instance/StopStartDownscaleStopInstancesResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/instance/StopStartDownscaleStopInstancesResult.java
@@ -3,10 +3,13 @@ package com.sequenceiq.cloudbreak.cloud.event.instance;
 import java.util.Collections;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
 import com.sequenceiq.cloudbreak.cloud.model.CloudVmInstanceStatus;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 
-public class StopStartDownscaleStopInstancesResult extends CloudPlatformResult {
+public class StopStartDownscaleStopInstancesResult extends CloudPlatformResult implements FlowPayload {
 
     private final StopStartDownscaleStopInstancesRequest stopInstancesRequest;
 
@@ -19,8 +22,12 @@ public class StopStartDownscaleStopInstancesResult extends CloudPlatformResult {
         this.affectedInstanceStatuses = affectedInstanceStatuses;
     }
 
-    public StopStartDownscaleStopInstancesResult(String statusReason, Exception errorDetails, Long resourceId,
-            StopStartDownscaleStopInstancesRequest request) {
+    @JsonCreator
+    public StopStartDownscaleStopInstancesResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("resourceId") Long resourceId,
+            @JsonProperty("stopInstancesRequest") StopStartDownscaleStopInstancesRequest request) {
         super(statusReason, errorDetails, resourceId);
         this.stopInstancesRequest = request;
         this.affectedInstanceStatuses = Collections.emptyList();

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/instance/StopStartUpscaleStartInstancesRequest.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/instance/StopStartUpscaleStartInstancesRequest.java
@@ -4,6 +4,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.event.resource.CloudStackRequest;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
@@ -22,9 +24,16 @@ public class StopStartUpscaleStartInstancesRequest extends CloudStackRequest<Sto
 
     private final int numInstancesToStart;
 
-    public StopStartUpscaleStartInstancesRequest(CloudContext cloudContext, CloudCredential cloudCredential, CloudStack cloudStack,
-            String hostGroupName, List<CloudInstance> stoppedCloudInstancesInHg, List<CloudInstance> allInstancesInHg,
-            List<CloudInstance> startedInstancesWithServicesNotRunning, int numInstancesToStart) {
+    @JsonCreator
+    public StopStartUpscaleStartInstancesRequest(
+            @JsonProperty("cloudContext") CloudContext cloudContext,
+            @JsonProperty("cloudCredential") CloudCredential cloudCredential,
+            @JsonProperty("cloudStack") CloudStack cloudStack,
+            @JsonProperty("hostGroupName") String hostGroupName,
+            @JsonProperty("stoppedCloudInstancesInHg") List<CloudInstance> stoppedCloudInstancesInHg,
+            @JsonProperty("allInstancesInHg") List<CloudInstance> allInstancesInHg,
+            @JsonProperty("startedInstancesWithServicesNotRunning") List<CloudInstance> startedInstancesWithServicesNotRunning,
+            @JsonProperty("numInstancesToStart") int numInstancesToStart) {
         super(cloudContext, cloudCredential, cloudStack);
         this.hostGroupName = hostGroupName;
         this.stoppedCloudInstancesInHg = stoppedCloudInstancesInHg;

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/instance/StopStartUpscaleStartInstancesResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/instance/StopStartUpscaleStartInstancesResult.java
@@ -3,10 +3,13 @@ package com.sequenceiq.cloudbreak.cloud.event.instance;
 import java.util.Collections;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
 import com.sequenceiq.cloudbreak.cloud.model.CloudVmInstanceStatus;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 
-public class StopStartUpscaleStartInstancesResult extends CloudPlatformResult {
+public class StopStartUpscaleStartInstancesResult extends CloudPlatformResult implements FlowPayload {
 
     private final StopStartUpscaleStartInstancesRequest startInstanceRequest;
 
@@ -19,7 +22,12 @@ public class StopStartUpscaleStartInstancesResult extends CloudPlatformResult {
         this.affectedInstanceStatuses = affectedInstanceStatuses;
     }
 
-    public StopStartUpscaleStartInstancesResult(String statusReason, Exception errorDetails, Long resourceId, StopStartUpscaleStartInstancesRequest request) {
+    @JsonCreator
+    public StopStartUpscaleStartInstancesResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("resourceId") Long resourceId,
+            @JsonProperty("startInstanceRequest") StopStartUpscaleStartInstancesRequest request) {
         super(statusReason, errorDetails, resourceId);
         this.startInstanceRequest = request;
         this.affectedInstanceStatuses = Collections.emptyList();

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/loadbalancer/CollectLoadBalancerMetadataResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/loadbalancer/CollectLoadBalancerMetadataResult.java
@@ -2,20 +2,27 @@ package com.sequenceiq.cloudbreak.cloud.event.loadbalancer;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
 import com.sequenceiq.cloudbreak.cloud.model.CloudLoadBalancerMetadata;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 
-public class CollectLoadBalancerMetadataResult extends CloudPlatformResult {
+public class CollectLoadBalancerMetadataResult extends CloudPlatformResult implements FlowPayload {
 
-    private List<CloudLoadBalancerMetadata> results;
+    private final List<CloudLoadBalancerMetadata> results;
 
-    public CollectLoadBalancerMetadataResult(Long resourceId, List<CloudLoadBalancerMetadata> results) {
+    @JsonCreator
+    public CollectLoadBalancerMetadataResult(
+            @JsonProperty("resourceId") Long resourceId,
+            @JsonProperty("results") List<CloudLoadBalancerMetadata> results) {
         super(resourceId);
         this.results = results;
     }
 
     public CollectLoadBalancerMetadataResult(Exception errorDetails, Long resourceId) {
         super("", errorDetails, resourceId);
+        this.results = null;
     }
 
     public List<CloudLoadBalancerMetadata> getResults() {

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/resource/CreateCredentialResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/resource/CreateCredentialResult.java
@@ -1,14 +1,20 @@
 package com.sequenceiq.cloudbreak.cloud.event.resource;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 
-public class CreateCredentialResult extends CloudPlatformResult {
+public class CreateCredentialResult extends CloudPlatformResult implements FlowPayload {
 
     public CreateCredentialResult(Long resourceId) {
         super(resourceId);
     }
 
-    public CreateCredentialResult(Exception errorDetails, Long resourceId) {
+    @JsonCreator
+    public CreateCredentialResult(
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("resourceId") Long resourceId) {
         super("", errorDetails, resourceId);
     }
 

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/resource/DownscaleStackCollectResourcesResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/resource/DownscaleStackCollectResourcesResult.java
@@ -2,9 +2,12 @@ package com.sequenceiq.cloudbreak.cloud.event.resource;
 
 import java.util.Collections;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 
-public class DownscaleStackCollectResourcesResult extends CloudPlatformResult {
+public class DownscaleStackCollectResourcesResult extends CloudPlatformResult implements FlowPayload {
 
     private final Object resourcesToScale;
 
@@ -13,7 +16,11 @@ public class DownscaleStackCollectResourcesResult extends CloudPlatformResult {
         this.resourcesToScale = resourcesToScale;
     }
 
-    public DownscaleStackCollectResourcesResult(String statusReason, Exception errorDetails, Long resourceId) {
+    @JsonCreator
+    public DownscaleStackCollectResourcesResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("resourceId") Long resourceId) {
         super(statusReason, errorDetails, resourceId);
         resourcesToScale = Collections.emptyMap();
     }

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/resource/DownscaleStackResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/resource/DownscaleStackResult.java
@@ -4,11 +4,14 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 
-public class DownscaleStackResult extends CloudPlatformResult {
+public class DownscaleStackResult extends CloudPlatformResult implements FlowPayload {
 
     private final List<CloudResource> downscaledResources;
 
@@ -17,7 +20,11 @@ public class DownscaleStackResult extends CloudPlatformResult {
         this.downscaledResources = ImmutableList.copyOf(downscaledResources);
     }
 
-    public DownscaleStackResult(String statusReason, Exception errorDetails, Long resourceId) {
+    @JsonCreator
+    public DownscaleStackResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("resourceId") Long resourceId) {
         super(statusReason, errorDetails, resourceId);
         downscaledResources = Collections.emptyList();
     }

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/resource/GetInstancesStateResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/resource/GetInstancesStateResult.java
@@ -3,10 +3,13 @@ package com.sequenceiq.cloudbreak.cloud.event.resource;
 import java.util.Collections;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
 import com.sequenceiq.cloudbreak.cloud.model.CloudVmInstanceStatus;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 
-public class GetInstancesStateResult extends CloudPlatformResult {
+public class GetInstancesStateResult extends CloudPlatformResult implements FlowPayload {
 
     private final List<CloudVmInstanceStatus> statuses;
 
@@ -20,7 +23,11 @@ public class GetInstancesStateResult extends CloudPlatformResult {
         this.statuses = statuses;
     }
 
-    public GetInstancesStateResult(String statusReason, Exception errorDetails, Long resourceId) {
+    @JsonCreator
+    public GetInstancesStateResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("resourceId") Long resourceId) {
         super(statusReason, errorDetails, resourceId);
         statuses = Collections.emptyList();
     }

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/resource/LaunchLoadBalancerResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/resource/LaunchLoadBalancerResult.java
@@ -2,19 +2,26 @@ package com.sequenceiq.cloudbreak.cloud.event.resource;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 
-public class  LaunchLoadBalancerResult extends CloudPlatformResult {
-    private List<CloudResourceStatus> results;
+public class LaunchLoadBalancerResult extends CloudPlatformResult implements FlowPayload {
+    private final List<CloudResourceStatus> results;
 
-    public LaunchLoadBalancerResult(Long resourceId, List<CloudResourceStatus> results) {
+    @JsonCreator
+    public LaunchLoadBalancerResult(
+            @JsonProperty("resourceId") Long resourceId,
+            @JsonProperty("results") List<CloudResourceStatus> results) {
         super(resourceId);
         this.results = results;
     }
 
     public LaunchLoadBalancerResult(Exception errorDetails, Long resourceId) {
         super("", errorDetails, resourceId);
+        this.results = null;
     }
 
     public List<CloudResourceStatus> getResults() {

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/resource/LaunchStackResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/resource/LaunchStackResult.java
@@ -2,19 +2,26 @@ package com.sequenceiq.cloudbreak.cloud.event.resource;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 
-public class LaunchStackResult extends CloudPlatformResult {
-    private List<CloudResourceStatus> results;
+public class LaunchStackResult extends CloudPlatformResult implements FlowPayload {
+    private final List<CloudResourceStatus> results;
 
-    public LaunchStackResult(Long resourceId, List<CloudResourceStatus> results) {
+    @JsonCreator
+    public LaunchStackResult(
+            @JsonProperty("resourceId") Long resourceId,
+            @JsonProperty("results") List<CloudResourceStatus> results) {
         super(resourceId);
         this.results = results;
     }
 
     public LaunchStackResult(Exception errorDetails, Long resourceId) {
         super("", errorDetails, resourceId);
+        this.results = null;
     }
 
     public List<CloudResourceStatus> getResults() {

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/resource/RemoveInstanceResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/resource/RemoveInstanceResult.java
@@ -6,13 +6,16 @@ import java.util.stream.Collectors;
 
 import org.springframework.util.CollectionUtils;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
 import com.sequenceiq.cloudbreak.cloud.event.InstancePayload;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 
-public class RemoveInstanceResult extends CloudPlatformResult implements InstancePayload {
+public class RemoveInstanceResult extends CloudPlatformResult implements InstancePayload, FlowPayload {
 
-    private List<CloudInstance> instances;
+    private final List<CloudInstance> instances;
 
     public RemoveInstanceResult(DownscaleStackResult result, Long resourceId, List<CloudInstance> instances) {
         super(resourceId);
@@ -20,9 +23,21 @@ public class RemoveInstanceResult extends CloudPlatformResult implements Instanc
         init(result.getStatus(), result.getStatusReason(), result.getErrorDetails());
     }
 
-    public RemoveInstanceResult(String statusReason, Exception errorDetails, Long resourceId, List<CloudInstance> instances) {
+    @JsonCreator
+    public RemoveInstanceResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("resourceId") Long resourceId,
+            @JsonProperty("instances") List<CloudInstance> instances) {
         super(statusReason, errorDetails, resourceId);
         this.instances = instances;
+    }
+
+    /**
+     * Need this for Jackson serialization
+     */
+    private List<CloudInstance> getInstances() {
+        return instances;
     }
 
     @Override

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/resource/TerminateStackResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/resource/TerminateStackResult.java
@@ -1,14 +1,21 @@
 package com.sequenceiq.cloudbreak.cloud.event.resource;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 
-public class TerminateStackResult extends CloudPlatformResult {
+public class TerminateStackResult extends CloudPlatformResult implements FlowPayload {
 
     public TerminateStackResult(Long resourceId) {
         super(resourceId);
     }
 
-    public TerminateStackResult(String statusReason, Exception errorDetails, Long resourceId) {
+    @JsonCreator
+    public TerminateStackResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("resourceId") Long resourceId) {
         super(statusReason, errorDetails, resourceId);
     }
 }

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/resource/UpdateImageResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/resource/UpdateImageResult.java
@@ -1,14 +1,21 @@
 package com.sequenceiq.cloudbreak.cloud.event.resource;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 
-public class UpdateImageResult extends CloudPlatformResult {
+public class UpdateImageResult extends CloudPlatformResult implements FlowPayload {
 
     public UpdateImageResult(Long resourceId) {
         super(resourceId);
     }
 
-    public UpdateImageResult(String statusReason, Exception errorDetails, Long resourceId) {
+    @JsonCreator
+    public UpdateImageResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("resourceId") Long resourceId) {
         super(statusReason, errorDetails, resourceId);
     }
 }

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/resource/UpscaleStackValidationResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/resource/UpscaleStackValidationResult.java
@@ -1,13 +1,20 @@
 package com.sequenceiq.cloudbreak.cloud.event.resource;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 
-public class UpscaleStackValidationResult extends CloudPlatformResult {
+public class UpscaleStackValidationResult extends CloudPlatformResult implements FlowPayload {
     public UpscaleStackValidationResult(Long resourceId) {
         super(resourceId);
     }
 
-    public UpscaleStackValidationResult(String statusReason, Exception errorDetails, Long resourceId) {
+    @JsonCreator
+    public UpscaleStackValidationResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("resourceId") Long resourceId) {
         super(statusReason, errorDetails, resourceId);
     }
 }

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/resource/migration/aws/CreateResourcesResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/resource/migration/aws/CreateResourcesResult.java
@@ -1,9 +1,12 @@
 package com.sequenceiq.cloudbreak.cloud.event.resource.migration.aws;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
 import com.sequenceiq.cloudbreak.cloud.event.model.EventStatus;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 
-public class CreateResourcesResult extends CloudPlatformResult {
+public class CreateResourcesResult extends CloudPlatformResult implements FlowPayload {
 
     public CreateResourcesResult(Long resourceId) {
         super(resourceId);
@@ -13,7 +16,12 @@ public class CreateResourcesResult extends CloudPlatformResult {
         super(statusReason, errorDetails, resourceId);
     }
 
-    public CreateResourcesResult(EventStatus status, String statusReason, Exception errorDetails, Long resourceId) {
+    @JsonCreator
+    public CreateResourcesResult(
+            @JsonProperty("status") EventStatus status,
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("resourceId") Long resourceId) {
         super(status, statusReason, errorDetails, resourceId);
     }
 }

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/resource/migration/aws/DeleteCloudFormationResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/resource/migration/aws/DeleteCloudFormationResult.java
@@ -1,18 +1,26 @@
 package com.sequenceiq.cloudbreak.cloud.event.resource.migration.aws;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 
-public class DeleteCloudFormationResult extends CloudPlatformResult {
+public class DeleteCloudFormationResult extends CloudPlatformResult implements FlowPayload {
 
-    private boolean cloudFormationTemplateDeleted;
+    private final boolean cloudFormationTemplateDeleted;
 
     public DeleteCloudFormationResult(Long resourceId, boolean cloudFormationTemplateDeleted) {
         super(resourceId);
         this.cloudFormationTemplateDeleted = cloudFormationTemplateDeleted;
     }
 
-    public DeleteCloudFormationResult(String statusReason, Exception errorDetails, Long resourceId) {
+    @JsonCreator
+    public DeleteCloudFormationResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("resourceId") Long resourceId) {
         super(statusReason, errorDetails, resourceId);
+        this.cloudFormationTemplateDeleted = false;
     }
 
     public boolean isCloudFormationTemplateDeleted() {

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/setup/CheckImageResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/setup/CheckImageResult.java
@@ -1,9 +1,12 @@
 package com.sequenceiq.cloudbreak.cloud.event.setup;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.common.api.type.ImageStatus;
 
-public class CheckImageResult extends CloudPlatformResult {
+public class CheckImageResult extends CloudPlatformResult implements FlowPayload {
 
     private final ImageStatus imageStatus;
 
@@ -19,7 +22,12 @@ public class CheckImageResult extends CloudPlatformResult {
         this(errorDetails.getMessage(), errorDetails, resourceId, imageStatus);
     }
 
-    public CheckImageResult(String statusReason, Exception errorDetails, Long resourceId, ImageStatus imageStatus) {
+    @JsonCreator
+    public CheckImageResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("resourceId") Long resourceId,
+            @JsonProperty("imageStatus") ImageStatus imageStatus) {
         super(statusReason, errorDetails, resourceId);
         this.imageStatus = imageStatus;
         statusProgressValue = null;

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/setup/PrepareImageResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/setup/PrepareImageResult.java
@@ -1,8 +1,11 @@
 package com.sequenceiq.cloudbreak.cloud.event.setup;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 
-public class PrepareImageResult extends CloudPlatformResult {
+public class PrepareImageResult extends CloudPlatformResult implements FlowPayload {
 
     public PrepareImageResult(Long resourceId) {
         super(resourceId);
@@ -12,7 +15,11 @@ public class PrepareImageResult extends CloudPlatformResult {
         this(errorDetails.getMessage(), errorDetails, resourceId);
     }
 
-    public PrepareImageResult(String statusReason, Exception errorDetails, Long resourceId) {
+    @JsonCreator
+    public PrepareImageResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("resourceId") Long resourceId) {
         super(statusReason, errorDetails, resourceId);
     }
 

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/setup/SetupResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/setup/SetupResult.java
@@ -1,8 +1,11 @@
 package com.sequenceiq.cloudbreak.cloud.event.setup;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 
-public class SetupResult extends CloudPlatformResult {
+public class SetupResult extends CloudPlatformResult implements FlowPayload {
 
     public SetupResult(Long resourceId) {
         super(resourceId);
@@ -12,7 +15,11 @@ public class SetupResult extends CloudPlatformResult {
         this(errorDetails.getMessage(), errorDetails, resourceId);
     }
 
-    public SetupResult(String statusReason, Exception errorDetails, Long resourceId) {
+    @JsonCreator
+    public SetupResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("resourceId") Long resourceId) {
         super(statusReason, errorDetails, resourceId);
     }
 

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/setup/ValidationResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/setup/ValidationResult.java
@@ -2,14 +2,18 @@ package com.sequenceiq.cloudbreak.cloud.event.setup;
 
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 
-public class ValidationResult extends CloudPlatformResult {
+public class ValidationResult extends CloudPlatformResult implements FlowPayload {
 
-    private Set<String> warningMessages;
+    private final Set<String> warningMessages;
 
     public ValidationResult(Long resourceId) {
         super(resourceId);
+        this.warningMessages = null;
     }
 
     public ValidationResult(Long resourceId, Set<String> warningMessages) {
@@ -21,8 +25,13 @@ public class ValidationResult extends CloudPlatformResult {
         this(errorDetails.getMessage(), errorDetails, resourceId);
     }
 
-    public ValidationResult(String statusReason, Exception errorDetails, Long resourceId) {
+    @JsonCreator
+    public ValidationResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("resourceId") Long resourceId) {
         super(statusReason, errorDetails, resourceId);
+        this.warningMessages = null;
     }
 
     public Set<String> getWarningMessages() {

--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/event/FlowPayload.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/event/FlowPayload.java
@@ -1,0 +1,4 @@
+package com.sequenceiq.cloudbreak.common.event;
+
+public interface FlowPayload extends Payload {
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/service/StackCreationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/service/StackCreationService.java
@@ -229,7 +229,7 @@ public class StackCreationService {
     }
 
     public void saveTlsInfo(SecurityConfig securityConfig, TlsInfo tlsInfo) {
-        boolean usePrivateIpToTls = tlsInfo.usePrivateIpToTls();
+        boolean usePrivateIpToTls = tlsInfo.isUsePrivateIpToTls();
         if (usePrivateIpToTls) {
             securityConfig.setUsePrivateIpToTls(true);
             stackUpdater.updateSecurityConfig(securityConfig);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/ClusterPlatformRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/ClusterPlatformRequest.java
@@ -16,6 +16,10 @@ public abstract class ClusterPlatformRequest implements Selectable {
         return stackId;
     }
 
+    public Long getStackId() {
+        return stackId;
+    }
+
     @Override
     public String selector() {
         return EventSelectorUtil.selector(getClass());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/ClusterPlatformResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/ClusterPlatformResult.java
@@ -1,7 +1,7 @@
 package com.sequenceiq.cloudbreak.reactor.api;
 
-import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.cloud.event.model.EventStatus;
+import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 
 public abstract class ClusterPlatformResult<R extends ClusterPlatformRequest> implements Selectable {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/AmbariGatherInstalledComponentsRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/AmbariGatherInstalledComponentsRequest.java
@@ -2,13 +2,19 @@ package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleRequest;
 
 public class AmbariGatherInstalledComponentsRequest extends AbstractClusterScaleRequest {
 
     private final String hostName;
 
-    public AmbariGatherInstalledComponentsRequest(Long stackId, Set<String> hostGroupNames, String hostName) {
+    @JsonCreator
+    public AmbariGatherInstalledComponentsRequest(
+            @JsonProperty("stackId") Long stackId,
+            @JsonProperty("hostGroupNames") Set<String> hostGroupNames,
+            @JsonProperty("hostName") String hostName) {
         super(stackId, hostGroupNames);
         this.hostName = hostName;
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/AmbariGatherInstalledComponentsResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/AmbariGatherInstalledComponentsResult.java
@@ -2,19 +2,28 @@ package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleResult;
 
-public class AmbariGatherInstalledComponentsResult extends AbstractClusterScaleResult<AmbariGatherInstalledComponentsRequest> {
+public class AmbariGatherInstalledComponentsResult
+        extends AbstractClusterScaleResult<AmbariGatherInstalledComponentsRequest> implements FlowPayload {
 
-    private Map<String, String> foundInstalledComponents;
+    private final Map<String, String> foundInstalledComponents;
 
     public AmbariGatherInstalledComponentsResult(AmbariGatherInstalledComponentsRequest request, Map<String, String> foundInstalledComponents) {
         super(request);
         this.foundInstalledComponents = foundInstalledComponents;
     }
 
-    public AmbariGatherInstalledComponentsResult(String statusReason, Exception errorDetails, AmbariGatherInstalledComponentsRequest request) {
+    @JsonCreator
+    public AmbariGatherInstalledComponentsResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") AmbariGatherInstalledComponentsRequest request) {
         super(statusReason, errorDetails, request);
+        this.foundInstalledComponents = null;
     }
 
     public Map<String, String> getFoundInstalledComponents() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/AmbariRestartAllRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/AmbariRestartAllRequest.java
@@ -2,10 +2,16 @@ package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleRequest;
 
-public class AmbariRestartAllRequest extends AbstractClusterScaleRequest {
-    public AmbariRestartAllRequest(Long stackId, Set<String> hostGroups) {
+public class AmbariRestartAllRequest extends AbstractClusterScaleRequest implements FlowPayload {
+    @JsonCreator
+    public AmbariRestartAllRequest(
+            @JsonProperty("stackId") Long stackId,
+            @JsonProperty("hostGroupNames") Set<String> hostGroups) {
         super(stackId, hostGroups);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/AmbariStartServerAndAgentRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/AmbariStartServerAndAgentRequest.java
@@ -2,10 +2,16 @@ package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleRequest;
 
-public class AmbariStartServerAndAgentRequest extends AbstractClusterScaleRequest {
-    public AmbariStartServerAndAgentRequest(Long stackId, Set<String> hostGroups) {
+public class AmbariStartServerAndAgentRequest extends AbstractClusterScaleRequest implements FlowPayload {
+    @JsonCreator
+    public AmbariStartServerAndAgentRequest(
+            @JsonProperty("stackId") Long stackId,
+            @JsonProperty("hostGroupNames") Set<String> hostGroups) {
         super(stackId, hostGroups);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/AmbariStopServerAndAgentRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/AmbariStopServerAndAgentRequest.java
@@ -2,10 +2,15 @@ package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleRequest;
 
 public class AmbariStopServerAndAgentRequest extends AbstractClusterScaleRequest {
-    public AmbariStopServerAndAgentRequest(Long stackId, Set<String> hostGroups) {
+    @JsonCreator
+    public AmbariStopServerAndAgentRequest(
+            @JsonProperty("stackId") Long stackId,
+            @JsonProperty("hostGroupNames") Set<String> hostGroups) {
         super(stackId, hostGroups);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/AmbariStopServerAndAgentResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/AmbariStopServerAndAgentResult.java
@@ -1,13 +1,20 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleResult;
 
-public class AmbariStopServerAndAgentResult extends AbstractClusterScaleResult<AmbariStopServerAndAgentRequest> {
+public class AmbariStopServerAndAgentResult extends AbstractClusterScaleResult<AmbariStopServerAndAgentRequest> implements FlowPayload {
     public AmbariStopServerAndAgentResult(AmbariStopServerAndAgentRequest request) {
         super(request);
     }
 
-    public AmbariStopServerAndAgentResult(String statusReason, Exception errorDetails, AmbariStopServerAndAgentRequest request) {
+    @JsonCreator
+    public AmbariStopServerAndAgentResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") AmbariStopServerAndAgentRequest request) {
         super(statusReason, errorDetails, request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterManagerEnsureComponentsAreStoppedResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterManagerEnsureComponentsAreStoppedResult.java
@@ -1,13 +1,21 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleResult;
 
-public class ClusterManagerEnsureComponentsAreStoppedResult extends AbstractClusterScaleResult<EnsureClusterComponentsAreStoppedRequest> {
+public class ClusterManagerEnsureComponentsAreStoppedResult
+        extends AbstractClusterScaleResult<EnsureClusterComponentsAreStoppedRequest> implements FlowPayload {
     public ClusterManagerEnsureComponentsAreStoppedResult(EnsureClusterComponentsAreStoppedRequest request) {
         super(request);
     }
 
-    public ClusterManagerEnsureComponentsAreStoppedResult(String statusReason, Exception errorDetails, EnsureClusterComponentsAreStoppedRequest request) {
+    @JsonCreator
+    public ClusterManagerEnsureComponentsAreStoppedResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") EnsureClusterComponentsAreStoppedRequest request) {
         super(statusReason, errorDetails, request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterManagerInitComponentsRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterManagerInitComponentsRequest.java
@@ -3,9 +3,17 @@ package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 import java.util.Map;
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class ClusterManagerInitComponentsRequest extends AmbariComponentsRequest {
 
-    public ClusterManagerInitComponentsRequest(Long stackId, Set<String> hostGroups, String hostName, Map<String, String> components) {
+    @JsonCreator
+    public ClusterManagerInitComponentsRequest(
+            @JsonProperty("stackId") Long stackId,
+            @JsonProperty("hostGroupNames") Set<String> hostGroups,
+            @JsonProperty("hostName") String hostName,
+            @JsonProperty("components") Map<String, String> components) {
         super(stackId, hostGroups, hostName, components);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterManagerInitComponentsResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterManagerInitComponentsResult.java
@@ -1,14 +1,21 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleResult;
 
-public class ClusterManagerInitComponentsResult extends AbstractClusterScaleResult<ClusterManagerInitComponentsRequest> {
+public class ClusterManagerInitComponentsResult extends AbstractClusterScaleResult<ClusterManagerInitComponentsRequest> implements FlowPayload {
 
     public ClusterManagerInitComponentsResult(ClusterManagerInitComponentsRequest request) {
         super(request);
     }
 
-    public ClusterManagerInitComponentsResult(String statusReason, Exception errorDetails, ClusterManagerInitComponentsRequest request) {
+    @JsonCreator
+    public ClusterManagerInitComponentsResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") ClusterManagerInitComponentsRequest request) {
         super(statusReason, errorDetails, request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterManagerInstallComponentsRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterManagerInstallComponentsRequest.java
@@ -3,9 +3,17 @@ package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 import java.util.Map;
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class ClusterManagerInstallComponentsRequest extends AmbariComponentsRequest {
 
-    public ClusterManagerInstallComponentsRequest(Long stackId, Set<String> hostGroups, String hostName, Map<String, String> components) {
+    @JsonCreator
+    public ClusterManagerInstallComponentsRequest(
+            @JsonProperty("stackId") Long stackId,
+            @JsonProperty("hostGroupNames") Set<String> hostGroups,
+            @JsonProperty("hostName") String hostName,
+            @JsonProperty("components") Map<String, String> components) {
         super(stackId, hostGroups, hostName, components);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterManagerInstallComponentsResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterManagerInstallComponentsResult.java
@@ -1,13 +1,20 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleResult;
 
-public class ClusterManagerInstallComponentsResult extends AbstractClusterScaleResult<ClusterManagerInstallComponentsRequest> {
+public class ClusterManagerInstallComponentsResult extends AbstractClusterScaleResult<ClusterManagerInstallComponentsRequest> implements FlowPayload {
     public ClusterManagerInstallComponentsResult(ClusterManagerInstallComponentsRequest request) {
         super(request);
     }
 
-    public ClusterManagerInstallComponentsResult(String statusReason, Exception errorDetails, ClusterManagerInstallComponentsRequest request) {
+    @JsonCreator
+    public ClusterManagerInstallComponentsResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") ClusterManagerInstallComponentsRequest request) {
         super(statusReason, errorDetails, request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterManagerRestartAllResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterManagerRestartAllResult.java
@@ -1,13 +1,20 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleResult;
 
-public class ClusterManagerRestartAllResult extends AbstractClusterScaleResult<AmbariRestartAllRequest> {
+public class ClusterManagerRestartAllResult extends AbstractClusterScaleResult<AmbariRestartAllRequest> implements FlowPayload {
     public ClusterManagerRestartAllResult(AmbariRestartAllRequest request) {
         super(request);
     }
 
-    public ClusterManagerRestartAllResult(String statusReason, Exception errorDetails, AmbariRestartAllRequest request) {
+    @JsonCreator
+    public ClusterManagerRestartAllResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") AmbariRestartAllRequest request) {
         super(statusReason, errorDetails, request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterManagerStartComponentsRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterManagerStartComponentsRequest.java
@@ -3,9 +3,17 @@ package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 import java.util.Map;
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class ClusterManagerStartComponentsRequest extends AmbariComponentsRequest {
 
-    public ClusterManagerStartComponentsRequest(Long stackId, Set<String> hostGroups, String hostName, Map<String, String> components) {
+    @JsonCreator
+    public ClusterManagerStartComponentsRequest(
+            @JsonProperty("stackId") Long stackId,
+            @JsonProperty("hostGroupNames") Set<String> hostGroups,
+            @JsonProperty("hostName") String hostName,
+            @JsonProperty("components") Map<String, String> components) {
         super(stackId, hostGroups, hostName, components);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterManagerStartComponentsResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterManagerStartComponentsResult.java
@@ -1,13 +1,20 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleResult;
 
-public class ClusterManagerStartComponentsResult extends AbstractClusterScaleResult<ClusterManagerStartComponentsRequest> {
+public class ClusterManagerStartComponentsResult extends AbstractClusterScaleResult<ClusterManagerStartComponentsRequest> implements FlowPayload {
     public ClusterManagerStartComponentsResult(ClusterManagerStartComponentsRequest request) {
         super(request);
     }
 
-    public ClusterManagerStartComponentsResult(String statusReason, Exception errorDetails, ClusterManagerStartComponentsRequest request) {
+    @JsonCreator
+    public ClusterManagerStartComponentsResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") ClusterManagerStartComponentsRequest request) {
         super(statusReason, errorDetails, request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterManagerStopComponentsRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterManagerStopComponentsRequest.java
@@ -3,8 +3,17 @@ package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 import java.util.Map;
 import java.util.Set;
 
-public class ClusterManagerStopComponentsRequest extends AmbariComponentsRequest {
-    public ClusterManagerStopComponentsRequest(Long stackId, Set<String> hostGroups, String hostName, Map<String, String> components) {
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
+
+public class ClusterManagerStopComponentsRequest extends AmbariComponentsRequest implements FlowPayload {
+    @JsonCreator
+    public ClusterManagerStopComponentsRequest(
+            @JsonProperty("stackId") Long stackId,
+            @JsonProperty("hostGroupNames") Set<String> hostGroups,
+            @JsonProperty("hostName") String hostName,
+            @JsonProperty("components") Map<String, String> components) {
         super(stackId, hostGroups, hostName, components);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterStartPillarConfigUpdateRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterStartPillarConfigUpdateRequest.java
@@ -1,9 +1,13 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformRequest;
 
 public class ClusterStartPillarConfigUpdateRequest extends ClusterPlatformRequest {
-    public ClusterStartPillarConfigUpdateRequest(Long stackId) {
+    @JsonCreator
+    public ClusterStartPillarConfigUpdateRequest(
+            @JsonProperty("stackId") Long stackId) {
         super(stackId);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterStartPillarConfigUpdateResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterStartPillarConfigUpdateResult.java
@@ -1,10 +1,15 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformResult;
 
-public class ClusterStartPillarConfigUpdateResult extends ClusterPlatformResult<ClusterStartPillarConfigUpdateRequest> {
+public class ClusterStartPillarConfigUpdateResult extends ClusterPlatformResult<ClusterStartPillarConfigUpdateRequest> implements FlowPayload {
 
-    public ClusterStartPillarConfigUpdateResult(ClusterStartPillarConfigUpdateRequest request) {
+    @JsonCreator
+    public ClusterStartPillarConfigUpdateResult(
+            @JsonProperty("request") ClusterStartPillarConfigUpdateRequest request) {
         super(request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterStartPollingRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterStartPollingRequest.java
@@ -1,12 +1,18 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformRequest;
 
-public class ClusterStartPollingRequest extends ClusterPlatformRequest {
+public class ClusterStartPollingRequest extends ClusterPlatformRequest implements FlowPayload {
 
     private final Integer requestId;
 
-    public ClusterStartPollingRequest(Long stackId, Integer requestId) {
+    @JsonCreator
+    public ClusterStartPollingRequest(
+            @JsonProperty("stackId") Long stackId,
+            @JsonProperty("requestId") Integer requestId) {
         super(stackId);
         this.requestId = requestId;
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterStartPollingResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterStartPollingResult.java
@@ -1,14 +1,21 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformResult;
 
-public class ClusterStartPollingResult extends ClusterPlatformResult<ClusterStartPollingRequest> {
+public class ClusterStartPollingResult extends ClusterPlatformResult<ClusterStartPollingRequest> implements FlowPayload {
 
     public ClusterStartPollingResult(ClusterStartPollingRequest request) {
         super(request);
     }
 
-    public ClusterStartPollingResult(String statusReason, Exception errorDetails, ClusterStartPollingRequest request) {
+    @JsonCreator
+    public ClusterStartPollingResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") ClusterStartPollingRequest request) {
         super(statusReason, errorDetails, request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterStartRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterStartRequest.java
@@ -1,9 +1,13 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformRequest;
 
 public class ClusterStartRequest extends ClusterPlatformRequest {
-    public ClusterStartRequest(Long stackId) {
+    @JsonCreator
+    public ClusterStartRequest(
+            @JsonProperty("stackId") Long stackId) {
         super(stackId);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterStartResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterStartResult.java
@@ -1,8 +1,11 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformResult;
 
-public class ClusterStartResult extends ClusterPlatformResult<ClusterStartRequest> {
+public class ClusterStartResult extends ClusterPlatformResult<ClusterStartRequest> implements FlowPayload {
 
     private final Integer requestId;
 
@@ -11,7 +14,11 @@ public class ClusterStartResult extends ClusterPlatformResult<ClusterStartReques
         this.requestId = requestId;
     }
 
-    public ClusterStartResult(String statusReason, Exception errorDetails, ClusterStartRequest request) {
+    @JsonCreator
+    public ClusterStartResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") ClusterStartRequest request) {
         super(statusReason, errorDetails, request);
         requestId = null;
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterStopRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterStopRequest.java
@@ -1,9 +1,13 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformRequest;
 
 public class ClusterStopRequest extends ClusterPlatformRequest {
-    public ClusterStopRequest(Long stackId) {
+    @JsonCreator
+    public ClusterStopRequest(
+            @JsonProperty("stackId") Long stackId) {
         super(stackId);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterStopResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterStopResult.java
@@ -1,13 +1,20 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformResult;
 
-public class ClusterStopResult extends ClusterPlatformResult<ClusterStopRequest> {
+public class ClusterStopResult extends ClusterPlatformResult<ClusterStopRequest> implements FlowPayload {
     public ClusterStopResult(ClusterStopRequest request) {
         super(request);
     }
 
-    public ClusterStopResult(String statusReason, Exception errorDetails, ClusterStopRequest request) {
+    @JsonCreator
+    public ClusterStopResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") ClusterStopRequest request) {
         super(statusReason, errorDetails, request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/DeregisterServicesRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/DeregisterServicesRequest.java
@@ -1,10 +1,14 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformRequest;
 
 public class DeregisterServicesRequest extends ClusterPlatformRequest {
 
-    public DeregisterServicesRequest(Long stackId) {
+    @JsonCreator
+    public DeregisterServicesRequest(
+            @JsonProperty("stackId") Long stackId) {
         super(stackId);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/DeregisterServicesResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/DeregisterServicesResult.java
@@ -1,14 +1,21 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformResult;
 
-public class DeregisterServicesResult extends ClusterPlatformResult<DeregisterServicesRequest> {
+public class DeregisterServicesResult extends ClusterPlatformResult<DeregisterServicesRequest> implements FlowPayload {
 
     public DeregisterServicesResult(DeregisterServicesRequest request) {
         super(request);
     }
 
-    public DeregisterServicesResult(String statusReason, Exception errorDetails, DeregisterServicesRequest request) {
+    @JsonCreator
+    public DeregisterServicesResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") DeregisterServicesRequest request) {
         super(statusReason, errorDetails, request);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/EnsureClusterComponentsAreStoppedRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/EnsureClusterComponentsAreStoppedRequest.java
@@ -3,8 +3,17 @@ package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 import java.util.Map;
 import java.util.Set;
 
-public class EnsureClusterComponentsAreStoppedRequest extends AmbariComponentsRequest {
-    public EnsureClusterComponentsAreStoppedRequest(Long stackId, Set<String> hostGroups, String hostname, Map<String, String> components) {
-        super(stackId, hostGroups, hostname, components);
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
+
+public class EnsureClusterComponentsAreStoppedRequest extends AmbariComponentsRequest implements FlowPayload {
+    @JsonCreator
+    public EnsureClusterComponentsAreStoppedRequest(
+            @JsonProperty("stackId") Long stackId,
+            @JsonProperty("hostGroupNames") Set<String> hostGroups,
+            @JsonProperty("hostName") String hostName,
+            @JsonProperty("components") Map<String, String> components) {
+        super(stackId, hostGroups, hostName, components);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/PrepareClusterTerminationRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/PrepareClusterTerminationRequest.java
@@ -1,10 +1,14 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformRequest;
 
 public class PrepareClusterTerminationRequest extends ClusterPlatformRequest {
 
-    public PrepareClusterTerminationRequest(Long stackId) {
+    @JsonCreator
+    public PrepareClusterTerminationRequest(
+            @JsonProperty("stackId") Long stackId) {
         super(stackId);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/PrepareClusterTerminationResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/PrepareClusterTerminationResult.java
@@ -1,14 +1,21 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformResult;
 
-public class PrepareClusterTerminationResult extends ClusterPlatformResult<PrepareClusterTerminationRequest> {
+public class PrepareClusterTerminationResult extends ClusterPlatformResult<PrepareClusterTerminationRequest> implements FlowPayload {
 
     public PrepareClusterTerminationResult(PrepareClusterTerminationRequest request) {
         super(request);
     }
 
-    public PrepareClusterTerminationResult(String statusReason, Exception errorDetails, PrepareClusterTerminationRequest request) {
+    @JsonCreator
+    public PrepareClusterTerminationResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") PrepareClusterTerminationRequest request) {
         super(statusReason, errorDetails, request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/RegenerateKerberosKeytabsRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/RegenerateKerberosKeytabsRequest.java
@@ -2,15 +2,21 @@ package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleRequest;
 
 public class RegenerateKerberosKeytabsRequest extends AbstractClusterScaleRequest {
 
-    private String hostname;
+    private final String hostname;
 
-    public RegenerateKerberosKeytabsRequest(Long stackId, Set<String> hostGroups, String hostName) {
+    @JsonCreator
+    public RegenerateKerberosKeytabsRequest(
+            @JsonProperty("stackId") Long stackId,
+            @JsonProperty("hostGroupNames") Set<String> hostGroups,
+            @JsonProperty("hostname") String hostname) {
         super(stackId, hostGroups);
-        hostname = hostName;
+        this.hostname = hostname;
     }
 
     public String getHostname() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/RegenerateKerberosKeytabsResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/RegenerateKerberosKeytabsResult.java
@@ -1,13 +1,20 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleResult;
 
-public class RegenerateKerberosKeytabsResult extends AbstractClusterScaleResult<RegenerateKerberosKeytabsRequest> {
+public class RegenerateKerberosKeytabsResult extends AbstractClusterScaleResult<RegenerateKerberosKeytabsRequest> implements FlowPayload {
     public RegenerateKerberosKeytabsResult(RegenerateKerberosKeytabsRequest request) {
         super(request);
     }
 
-    public RegenerateKerberosKeytabsResult(String statusReason, Exception errorDetails, RegenerateKerberosKeytabsRequest request) {
+    @JsonCreator
+    public RegenerateKerberosKeytabsResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") RegenerateKerberosKeytabsRequest request) {
         super(statusReason, errorDetails, request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/StartServerAndAgentResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/StartServerAndAgentResult.java
@@ -1,13 +1,20 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleResult;
 
-public class StartServerAndAgentResult extends AbstractClusterScaleResult<AmbariStartServerAndAgentRequest> {
+public class StartServerAndAgentResult extends AbstractClusterScaleResult<AmbariStartServerAndAgentRequest> implements FlowPayload {
     public StartServerAndAgentResult(AmbariStartServerAndAgentRequest request) {
         super(request);
     }
 
-    public StartServerAndAgentResult(String statusReason, Exception errorDetails, AmbariStartServerAndAgentRequest request) {
+    @JsonCreator
+    public StartServerAndAgentResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") AmbariStartServerAndAgentRequest request) {
         super(statusReason, errorDetails, request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/StopClusterComponentsResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/StopClusterComponentsResult.java
@@ -1,14 +1,21 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleResult;
 
-public class StopClusterComponentsResult extends AbstractClusterScaleResult<ClusterManagerStopComponentsRequest> {
+public class StopClusterComponentsResult extends AbstractClusterScaleResult<ClusterManagerStopComponentsRequest> implements FlowPayload {
 
     public StopClusterComponentsResult(ClusterManagerStopComponentsRequest request) {
         super(request);
     }
 
-    public StopClusterComponentsResult(String statusReason, Exception errorDetails, ClusterManagerStopComponentsRequest request) {
+    @JsonCreator
+    public StopClusterComponentsResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") ClusterManagerStopComponentsRequest request) {
         super(statusReason, errorDetails, request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/StopStartDownscaleDecommissionViaCMRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/StopStartDownscaleDecommissionViaCMRequest.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.HostGroupPayload;
 
@@ -11,7 +13,11 @@ public class StopStartDownscaleDecommissionViaCMRequest extends ClusterPlatformR
 
     private final Set<Long> instanceIdsToDecommission;
 
-    public StopStartDownscaleDecommissionViaCMRequest(Long resourceId, String hostGroupName, Set<Long> instanceIdsToDecommission) {
+    @JsonCreator
+    public StopStartDownscaleDecommissionViaCMRequest(
+            @JsonProperty("resourceId") Long resourceId,
+            @JsonProperty("hostGroupName") String hostGroupName,
+            @JsonProperty("instanceIdsToDecommission") Set<Long> instanceIdsToDecommission) {
         super(resourceId);
         this.hostGroupName = hostGroupName;
         this.instanceIdsToDecommission = instanceIdsToDecommission;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/StopStartUpscaleCommissionViaCMRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/StopStartUpscaleCommissionViaCMRequest.java
@@ -3,6 +3,8 @@ package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 import java.util.Collections;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.HostGroupPayload;
 import com.sequenceiq.cloudbreak.view.InstanceMetadataView;
@@ -15,8 +17,12 @@ public class StopStartUpscaleCommissionViaCMRequest extends ClusterPlatformReque
 
     private final List<InstanceMetadataView> servicesNotRunningInstancesToCommission;
 
-    public StopStartUpscaleCommissionViaCMRequest(Long stackId, String hostGroupName, List<InstanceMetadataView> startedInstancesToCommission,
-            List<InstanceMetadataView> servicesNotRunningInstancesToCommission) {
+    @JsonCreator
+    public StopStartUpscaleCommissionViaCMRequest(
+            @JsonProperty("stackId") Long stackId,
+            @JsonProperty("hostGroupName") String hostGroupName,
+            @JsonProperty("startedInstancesToCommission") List<InstanceMetadataView> startedInstancesToCommission,
+            @JsonProperty("servicesNotRunningInstancesToCommission") List<InstanceMetadataView> servicesNotRunningInstancesToCommission) {
         super(stackId);
         this.hostGroupName = hostGroupName;
         this.startedInstancesToCommission = startedInstancesToCommission == null ? Collections.emptyList() : startedInstancesToCommission;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/UpscaleClusterRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/UpscaleClusterRequest.java
@@ -4,17 +4,19 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleRequest;
 
 public class UpscaleClusterRequest extends AbstractClusterScaleRequest {
 
-    private boolean repair;
+    private final boolean repair;
 
-    private boolean restartServices;
+    private final boolean restartServices;
 
-    private Map<String, Set<String>> hostGroupsWithHostNames;
+    private final Map<String, Set<String>> hostGroupsWithHostNames;
 
-    private Map<String, Integer> hostGroupWithAdjustment;
+    private final Map<String, Integer> hostGroupWithAdjustment;
 
     public UpscaleClusterRequest(Long stackId, Set<String> hostGroups, boolean repair, boolean restartServices, Map<String, Integer> hostGroupWithAdjustment) {
         super(stackId, hostGroups);
@@ -24,8 +26,14 @@ public class UpscaleClusterRequest extends AbstractClusterScaleRequest {
         this.hostGroupsWithHostNames = new HashMap<>();
     }
 
-    public UpscaleClusterRequest(Long stackId, Set<String> hostGroups, boolean repair, boolean restartServices,
-            Map<String, Set<String>> hostGroupsWithHostNames, Map<String, Integer> hostGroupWithAdjustment) {
+    @JsonCreator
+    public UpscaleClusterRequest(
+            @JsonProperty("stackId") Long stackId,
+            @JsonProperty("hostGroupNames") Set<String> hostGroups,
+            @JsonProperty("repair") boolean repair,
+            @JsonProperty("restartServices") boolean restartServices,
+            @JsonProperty("hostGroupsWithHostNames") Map<String, Set<String>> hostGroupsWithHostNames,
+            @JsonProperty("hostGroupWithAdjustment") Map<String, Integer> hostGroupWithAdjustment) {
         super(stackId, hostGroups);
         this.repair = repair;
         this.restartServices = restartServices;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/UpscaleClusterResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/UpscaleClusterResult.java
@@ -1,14 +1,21 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleResult;
 
-public class UpscaleClusterResult extends AbstractClusterScaleResult<UpscaleClusterRequest> {
+public class UpscaleClusterResult extends AbstractClusterScaleResult<UpscaleClusterRequest> implements FlowPayload {
 
     public UpscaleClusterResult(UpscaleClusterRequest request) {
         super(request);
     }
 
-    public UpscaleClusterResult(String statusReason, Exception errorDetails, UpscaleClusterRequest request) {
+    @JsonCreator
+    public UpscaleClusterResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") UpscaleClusterRequest request) {
         super(statusReason, errorDetails, request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/restart/ClusterServicesRestartPollingResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/restart/ClusterServicesRestartPollingResult.java
@@ -1,15 +1,22 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.restart;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.ClusterStartPollingRequest;
 
-public class ClusterServicesRestartPollingResult extends ClusterPlatformResult<ClusterStartPollingRequest> {
+public class ClusterServicesRestartPollingResult extends ClusterPlatformResult<ClusterStartPollingRequest> implements FlowPayload {
 
     public ClusterServicesRestartPollingResult(ClusterStartPollingRequest request) {
         super(request);
     }
 
-    public ClusterServicesRestartPollingResult(String statusReason, Exception errorDetails, ClusterStartPollingRequest request) {
+    @JsonCreator
+    public ClusterServicesRestartPollingResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") ClusterStartPollingRequest request) {
         super(statusReason, errorDetails, request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/restart/ClusterServicesRestartRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/restart/ClusterServicesRestartRequest.java
@@ -1,9 +1,13 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.restart;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformRequest;
 
 public class ClusterServicesRestartRequest extends ClusterPlatformRequest {
-    public ClusterServicesRestartRequest(Long stackId) {
+    @JsonCreator
+    public ClusterServicesRestartRequest(
+            @JsonProperty("stackId") Long stackId) {
         super(stackId);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/restart/ClusterServicesRestartResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/restart/ClusterServicesRestartResult.java
@@ -1,8 +1,11 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.restart;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformResult;
 
-public class ClusterServicesRestartResult extends ClusterPlatformResult<ClusterServicesRestartRequest> {
+public class ClusterServicesRestartResult extends ClusterPlatformResult<ClusterServicesRestartRequest> implements FlowPayload {
 
     private final Integer requestId;
 
@@ -11,7 +14,11 @@ public class ClusterServicesRestartResult extends ClusterPlatformResult<ClusterS
         this.requestId = requestId;
     }
 
-    public ClusterServicesRestartResult(String statusReason, Exception errorDetails, ClusterServicesRestartRequest request) {
+    @JsonCreator
+    public ClusterServicesRestartResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") ClusterServicesRestartRequest request) {
         super(statusReason, errorDetails, request);
         requestId = null;
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/ClusterProxyReRegistrationRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/ClusterProxyReRegistrationRequest.java
@@ -1,13 +1,19 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.orchestration;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformRequest;
 
 public class ClusterProxyReRegistrationRequest extends ClusterPlatformRequest {
-    private String cloudPlatform;
+    private final String cloudPlatform;
 
-    private String finishedEvent;
+    private final String finishedEvent;
 
-    public ClusterProxyReRegistrationRequest(Long stackId, String cloudPlatform, String finishedEvent) {
+    @JsonCreator
+    public ClusterProxyReRegistrationRequest(
+            @JsonProperty("stackId") Long stackId,
+            @JsonProperty("cloudPlatform") String cloudPlatform,
+            @JsonProperty("finishedEvent") String finishedEvent) {
         super(stackId);
         this.cloudPlatform = cloudPlatform;
         this.finishedEvent = finishedEvent;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/ClusterProxyReRegistrationResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/ClusterProxyReRegistrationResult.java
@@ -1,13 +1,20 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.orchestration;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformResult;
 
-public class ClusterProxyReRegistrationResult extends ClusterPlatformResult<ClusterProxyReRegistrationRequest> {
+public class ClusterProxyReRegistrationResult extends ClusterPlatformResult<ClusterProxyReRegistrationRequest> implements FlowPayload {
     public ClusterProxyReRegistrationResult(ClusterProxyReRegistrationRequest request) {
         super(request);
     }
 
-    public ClusterProxyReRegistrationResult(String statusReason, Exception errorDetails, ClusterProxyReRegistrationRequest request) {
+    @JsonCreator
+    public ClusterProxyReRegistrationResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") ClusterProxyReRegistrationRequest request) {
         super(statusReason, errorDetails, request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/ClusterTerminationRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/ClusterTerminationRequest.java
@@ -1,11 +1,16 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.orchestration;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformRequest;
 
 public class ClusterTerminationRequest extends ClusterPlatformRequest {
     private final Long clusterId;
 
-    public ClusterTerminationRequest(Long stackId, Long clusterId) {
+    @JsonCreator
+    public ClusterTerminationRequest(
+            @JsonProperty("stackId") Long stackId,
+            @JsonProperty("clusterId") Long clusterId) {
         super(stackId);
         this.clusterId = clusterId;
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/ClusterTerminationResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/ClusterTerminationResult.java
@@ -1,14 +1,21 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.orchestration;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformResult;
 
-public class ClusterTerminationResult extends ClusterPlatformResult<ClusterTerminationRequest> {
+public class ClusterTerminationResult extends ClusterPlatformResult<ClusterTerminationRequest> implements FlowPayload {
 
     public ClusterTerminationResult(ClusterTerminationRequest request) {
         super(request);
     }
 
-    public ClusterTerminationResult(String statusReason, Exception errorDetails, ClusterTerminationRequest request) {
+    @JsonCreator
+    public ClusterTerminationResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") ClusterTerminationRequest request) {
         super(statusReason, errorDetails, request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/StopStartDownscaleDecommissionViaCMResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/StopStartDownscaleDecommissionViaCMResult.java
@@ -4,17 +4,23 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.StopStartDownscaleDecommissionViaCMRequest;
 
-public class StopStartDownscaleDecommissionViaCMResult extends ClusterPlatformResult<StopStartDownscaleDecommissionViaCMRequest> {
+public class StopStartDownscaleDecommissionViaCMResult extends ClusterPlatformResult<StopStartDownscaleDecommissionViaCMRequest> implements FlowPayload {
 
     private final Set<String> decommissionedHostFqdns;
 
     private final List<String> notDecommissionedHostFqdns;
 
-    public StopStartDownscaleDecommissionViaCMResult(StopStartDownscaleDecommissionViaCMRequest request, Set<String> decommissionedHostFqdns,
-            List<String> notDecommissionedHostFqdns) {
+    @JsonCreator
+    public StopStartDownscaleDecommissionViaCMResult(
+            @JsonProperty("request") StopStartDownscaleDecommissionViaCMRequest request,
+            @JsonProperty("decommissionedHostFqdns") Set<String> decommissionedHostFqdns,
+            @JsonProperty("notDecommissionedHostFqdns") List<String> notDecommissionedHostFqdns) {
         super(request);
         this.decommissionedHostFqdns = decommissionedHostFqdns;
         this.notDecommissionedHostFqdns = notDecommissionedHostFqdns == null ? Collections.emptyList() : notDecommissionedHostFqdns;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/StopStartUpscaleCommissionViaCMResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/StopStartUpscaleCommissionViaCMResult.java
@@ -4,20 +4,26 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.StopStartUpscaleCommissionViaCMRequest;
 
-public class StopStartUpscaleCommissionViaCMResult extends ClusterPlatformResult<StopStartUpscaleCommissionViaCMRequest> {
+public class StopStartUpscaleCommissionViaCMResult extends ClusterPlatformResult<StopStartUpscaleCommissionViaCMRequest> implements FlowPayload {
 
     private final Set<String> successfullyCommissionedFqdns;
 
     private final List<String> notRecommissionedFqdns;
 
-    public StopStartUpscaleCommissionViaCMResult(StopStartUpscaleCommissionViaCMRequest request, Set<String> successfullyCommissionedFqdns,
-            List<String> notCommissionedFqdns) {
+    @JsonCreator
+    public StopStartUpscaleCommissionViaCMResult(
+            @JsonProperty("request") StopStartUpscaleCommissionViaCMRequest request,
+            @JsonProperty("successfullyCommissionedFqdns") Set<String> successfullyCommissionedFqdns,
+            @JsonProperty("notRecommissionedFqdns") List<String> notRecommissionedFqdns) {
         super(request);
         this.successfullyCommissionedFqdns = successfullyCommissionedFqdns;
-        this.notRecommissionedFqdns = notCommissionedFqdns == null ? Collections.emptyList() : notCommissionedFqdns;
+        this.notRecommissionedFqdns = notRecommissionedFqdns == null ? Collections.emptyList() : notRecommissionedFqdns;
     }
 
     public StopStartUpscaleCommissionViaCMResult(String statusReason, Exception errorDetails, StopStartUpscaleCommissionViaCMRequest request) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/UpscaleClusterManagerRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/UpscaleClusterManagerRequest.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.reactor.api.event.orchestration;
 
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleRequest;
 
 public class UpscaleClusterManagerRequest extends AbstractClusterScaleRequest {
@@ -12,7 +14,12 @@ public class UpscaleClusterManagerRequest extends AbstractClusterScaleRequest {
 
     private final boolean repair;
 
-    public UpscaleClusterManagerRequest(Long stackId, Map<String, Integer> hostGroupWithAdjustment, boolean primaryGatewayChanged, boolean repair) {
+    @JsonCreator
+    public UpscaleClusterManagerRequest(
+            @JsonProperty("stackId") Long stackId,
+            @JsonProperty("hostGroupWithAdjustment") Map<String, Integer> hostGroupWithAdjustment,
+            @JsonProperty("primaryGatewayChanged") boolean primaryGatewayChanged,
+            @JsonProperty("repair") boolean repair) {
         super(stackId, hostGroupWithAdjustment.keySet());
         this.hostGroupWithAdjustment = hostGroupWithAdjustment;
         this.primaryGatewayChanged = primaryGatewayChanged;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/UpscaleClusterManagerResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/UpscaleClusterManagerResult.java
@@ -1,14 +1,21 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.orchestration;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleResult;
 
-public class UpscaleClusterManagerResult extends AbstractClusterScaleResult<UpscaleClusterManagerRequest> {
+public class UpscaleClusterManagerResult extends AbstractClusterScaleResult<UpscaleClusterManagerRequest> implements FlowPayload {
 
     public UpscaleClusterManagerResult(UpscaleClusterManagerRequest request) {
         super(request);
     }
 
-    public UpscaleClusterManagerResult(String statusReason, Exception errorDetails, UpscaleClusterManagerRequest request) {
+    @JsonCreator
+    public UpscaleClusterManagerResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") UpscaleClusterManagerRequest request) {
         super(statusReason, errorDetails, request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/recipe/UploadRepairSingleMasterRecipesRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/recipe/UploadRepairSingleMasterRecipesRequest.java
@@ -2,10 +2,15 @@ package com.sequenceiq.cloudbreak.reactor.api.event.recipe;
 
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleRequest;
 
 public class UploadRepairSingleMasterRecipesRequest extends AbstractClusterScaleRequest {
-    protected UploadRepairSingleMasterRecipesRequest(Long stackId, Set<String> hostGroups) {
+    @JsonCreator
+    protected UploadRepairSingleMasterRecipesRequest(
+            @JsonProperty("stackId") Long stackId,
+            @JsonProperty("hostGroupNames") Set<String> hostGroups) {
         super(stackId, hostGroups);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/recipe/UploadRepairSingleMasterRecipesResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/recipe/UploadRepairSingleMasterRecipesResult.java
@@ -1,14 +1,21 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.recipe;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleResult;
 
-public class UploadRepairSingleMasterRecipesResult extends AbstractClusterScaleResult<UploadRepairSingleMasterRecipesRequest> {
+public class UploadRepairSingleMasterRecipesResult extends AbstractClusterScaleResult<UploadRepairSingleMasterRecipesRequest> implements FlowPayload {
 
     public UploadRepairSingleMasterRecipesResult(UploadRepairSingleMasterRecipesRequest request) {
         super(request);
     }
 
-    public UploadRepairSingleMasterRecipesResult(String statusReason, Exception errorDetails, UploadRepairSingleMasterRecipesRequest request) {
+    @JsonCreator
+    public UploadRepairSingleMasterRecipesResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") UploadRepairSingleMasterRecipesRequest request) {
         super(statusReason, errorDetails, request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/recipe/UploadUpscaleRecipesRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/recipe/UploadUpscaleRecipesRequest.java
@@ -2,11 +2,16 @@ package com.sequenceiq.cloudbreak.reactor.api.event.recipe;
 
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleRequest;
 
 public class UploadUpscaleRecipesRequest extends AbstractClusterScaleRequest {
 
-    public UploadUpscaleRecipesRequest(Long stackId, Set<String> hostGroups) {
+    @JsonCreator
+    public UploadUpscaleRecipesRequest(
+            @JsonProperty("stackId") Long stackId,
+            @JsonProperty("hostGroupNames") Set<String> hostGroups) {
         super(stackId, hostGroups);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/recipe/UploadUpscaleRecipesResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/recipe/UploadUpscaleRecipesResult.java
@@ -1,14 +1,21 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.recipe;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleResult;
 
-public class UploadUpscaleRecipesResult extends AbstractClusterScaleResult<UploadUpscaleRecipesRequest> {
+public class UploadUpscaleRecipesResult extends AbstractClusterScaleResult<UploadUpscaleRecipesRequest> implements FlowPayload {
 
     public UploadUpscaleRecipesResult(UploadUpscaleRecipesRequest request) {
         super(request);
     }
 
-    public UploadUpscaleRecipesResult(String statusReason, Exception errorDetails, UploadUpscaleRecipesRequest request) {
+    @JsonCreator
+    public UploadUpscaleRecipesResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") UploadUpscaleRecipesRequest request) {
         super(statusReason, errorDetails, request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/recipe/UpscalePostRecipesRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/recipe/UpscalePostRecipesRequest.java
@@ -3,13 +3,19 @@ package com.sequenceiq.cloudbreak.reactor.api.event.recipe;
 import java.util.Map;
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleRequest;
 
 public class UpscalePostRecipesRequest extends AbstractClusterScaleRequest {
 
     private final Map<String, Integer> hostGroupWithAdjustment;
 
-    public UpscalePostRecipesRequest(Long stackId, Set<String> hostGroups, Map<String, Integer> hostGroupWithAdjustment) {
+    @JsonCreator
+    public UpscalePostRecipesRequest(
+            @JsonProperty("stackId") Long stackId,
+            @JsonProperty("hostGroupNames") Set<String> hostGroups,
+            @JsonProperty("hostGroupWithAdjustment") Map<String, Integer> hostGroupWithAdjustment) {
         super(stackId, hostGroups);
         this.hostGroupWithAdjustment = hostGroupWithAdjustment;
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/recipe/UpscalePostRecipesResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/recipe/UpscalePostRecipesResult.java
@@ -1,14 +1,21 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.recipe;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleResult;
 
-public class UpscalePostRecipesResult extends AbstractClusterScaleResult<UpscalePostRecipesRequest> {
+public class UpscalePostRecipesResult extends AbstractClusterScaleResult<UpscalePostRecipesRequest> implements FlowPayload {
 
     public UpscalePostRecipesResult(UpscalePostRecipesRequest request) {
         super(request);
     }
 
-    public UpscalePostRecipesResult(String statusReason, Exception errorDetails, UpscalePostRecipesRequest request) {
+    @JsonCreator
+    public UpscalePostRecipesResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") UpscalePostRecipesRequest request) {
         super(statusReason, errorDetails, request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/BootstrapNewNodesRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/BootstrapNewNodesRequest.java
@@ -2,11 +2,18 @@ package com.sequenceiq.cloudbreak.reactor.api.event.resource;
 
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class BootstrapNewNodesRequest extends AbstractClusterBootstrapRequest {
 
     private final Set<String> hostNames;
 
-    public BootstrapNewNodesRequest(Long stackId, Set<String> upscaleCandidateAddresses, Set<String> hostNames) {
+    @JsonCreator
+    public BootstrapNewNodesRequest(
+            @JsonProperty("stackId") Long stackId,
+            @JsonProperty("upscaleCandidateAddresses") Set<String> upscaleCandidateAddresses,
+            @JsonProperty("hostNames") Set<String> hostNames) {
         super(stackId, upscaleCandidateAddresses);
         this.hostNames = hostNames;
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/BootstrapNewNodesResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/BootstrapNewNodesResult.java
@@ -1,11 +1,19 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.resource;
 
-public class BootstrapNewNodesResult extends AbstractClusterBootstrapResult<BootstrapNewNodesRequest> {
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
+
+public class BootstrapNewNodesResult extends AbstractClusterBootstrapResult<BootstrapNewNodesRequest> implements FlowPayload {
     public BootstrapNewNodesResult(BootstrapNewNodesRequest request) {
         super(request);
     }
 
-    public BootstrapNewNodesResult(String statusReason, Exception errorDetails, BootstrapNewNodesRequest request) {
+    @JsonCreator
+    public BootstrapNewNodesResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") BootstrapNewNodesRequest request) {
         super(statusReason, errorDetails, request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/ClusterCredentialChangeRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/ClusterCredentialChangeRequest.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.resource;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformRequest;
 
 public class ClusterCredentialChangeRequest extends ClusterPlatformRequest {
@@ -9,7 +11,12 @@ public class ClusterCredentialChangeRequest extends ClusterPlatformRequest {
 
     private final Type type;
 
-    public ClusterCredentialChangeRequest(Long stackId, String user, String password, Type type) {
+    @JsonCreator
+    public ClusterCredentialChangeRequest(
+            @JsonProperty("stackId") Long stackId,
+            @JsonProperty("user") String user,
+            @JsonProperty("password") String password,
+            @JsonProperty("type") Type type) {
         super(stackId);
         this.user = user;
         this.password = password;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/ClusterCredentialChangeResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/ClusterCredentialChangeResult.java
@@ -1,13 +1,20 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.resource;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformResult;
 
-public class ClusterCredentialChangeResult extends ClusterPlatformResult<ClusterCredentialChangeRequest> {
+public class ClusterCredentialChangeResult extends ClusterPlatformResult<ClusterCredentialChangeRequest> implements FlowPayload {
     public ClusterCredentialChangeResult(ClusterCredentialChangeRequest request) {
         super(request);
     }
 
-    public ClusterCredentialChangeResult(String statusReason, Exception errorDetails, ClusterCredentialChangeRequest request) {
+    @JsonCreator
+    public ClusterCredentialChangeResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") ClusterCredentialChangeRequest request) {
         super(statusReason, errorDetails, request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/ClusterResetRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/ClusterResetRequest.java
@@ -1,9 +1,13 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.resource;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformRequest;
 
 public class ClusterResetRequest extends ClusterPlatformRequest {
-    public ClusterResetRequest(Long stackId) {
+    @JsonCreator
+    public ClusterResetRequest(
+            @JsonProperty("stackId") Long stackId) {
         super(stackId);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/ClusterResetResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/ClusterResetResult.java
@@ -1,13 +1,20 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.resource;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformResult;
 
-public class ClusterResetResult extends ClusterPlatformResult<ClusterResetRequest> {
+public class ClusterResetResult extends ClusterPlatformResult<ClusterResetRequest> implements FlowPayload {
     public ClusterResetResult(ClusterResetRequest request) {
         super(request);
     }
 
-    public ClusterResetResult(String statusReason, Exception errorDetails, ClusterResetRequest request) {
+    @JsonCreator
+    public ClusterResetResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") ClusterResetRequest request) {
         super(statusReason, errorDetails, request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/ClusterSyncRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/ClusterSyncRequest.java
@@ -1,9 +1,13 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.resource;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformRequest;
 
 public class ClusterSyncRequest extends ClusterPlatformRequest {
-    public ClusterSyncRequest(Long stackId) {
+    @JsonCreator
+    public ClusterSyncRequest(
+            @JsonProperty("stackId") Long stackId) {
         super(stackId);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/ClusterSyncResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/ClusterSyncResult.java
@@ -1,13 +1,20 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.resource;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformResult;
 
-public class ClusterSyncResult extends ClusterPlatformResult<ClusterSyncRequest> {
+public class ClusterSyncResult extends ClusterPlatformResult<ClusterSyncRequest> implements FlowPayload {
     public ClusterSyncResult(ClusterSyncRequest request) {
         super(request);
     }
 
-    public ClusterSyncResult(String statusReason, Exception errorDetails, ClusterSyncRequest request) {
+    @JsonCreator
+    public ClusterSyncResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") ClusterSyncRequest request) {
         super(statusReason, errorDetails, request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/CmSyncRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/CmSyncRequest.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.reactor.api.event.resource;
 
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformRequest;
 
 public class CmSyncRequest extends ClusterPlatformRequest {
@@ -10,7 +12,11 @@ public class CmSyncRequest extends ClusterPlatformRequest {
 
     private final String flowTriggerUserCrn;
 
-    public CmSyncRequest(Long stackId, Set<String> candidateImageUuids, String flowTriggerUserCrn) {
+    @JsonCreator
+    public CmSyncRequest(
+            @JsonProperty("stackId") Long stackId,
+            @JsonProperty("candidateImageUuids") Set<String> candidateImageUuids,
+            @JsonProperty("flowTriggerUserCrn") String flowTriggerUserCrn) {
         super(stackId);
         this.candidateImageUuids = candidateImageUuids;
         this.flowTriggerUserCrn = flowTriggerUserCrn;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/CmSyncResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/CmSyncResult.java
@@ -1,18 +1,26 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.resource;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformResult;
 
-public class CmSyncResult extends ClusterPlatformResult<CmSyncRequest> {
+public class CmSyncResult extends ClusterPlatformResult<CmSyncRequest> implements FlowPayload {
 
-    private String result;
+    private final String result;
 
     public CmSyncResult(CmSyncRequest request, String result) {
         super(request);
         this.result = result;
     }
 
-    public CmSyncResult(String statusReason, Exception errorDetails, CmSyncRequest request) {
+    @JsonCreator
+    public CmSyncResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") CmSyncRequest request) {
         super(statusReason, errorDetails, request);
+        this.result = null;
     }
 
     public String getResult() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/CollectDownscaleCandidatesRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/CollectDownscaleCandidatesRequest.java
@@ -3,6 +3,8 @@ package com.sequenceiq.cloudbreak.reactor.api.event.resource;
 import java.util.Map;
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterDownscaleDetails;
 
 public class CollectDownscaleCandidatesRequest extends AbstractClusterScaleRequest {
@@ -13,9 +15,13 @@ public class CollectDownscaleCandidatesRequest extends AbstractClusterScaleReque
 
     private final Map<String, Set<Long>> hostGroupWithPrivateIds;
 
-    public CollectDownscaleCandidatesRequest(Long stackId, Map<String, Integer> hostGroupWithAdjustment, Map<String, Set<Long>> hostGroupWithPrivateIds,
-            ClusterDownscaleDetails details) {
-        super(stackId, hostGroupWithAdjustment.size() > 0 ? hostGroupWithAdjustment.keySet() : hostGroupWithPrivateIds.keySet());
+    @JsonCreator
+    public CollectDownscaleCandidatesRequest(
+            @JsonProperty("stackId") Long stackId,
+            @JsonProperty("hostGroupWithAdjustment") Map<String, Integer> hostGroupWithAdjustment,
+            @JsonProperty("hostGroupWithPrivateIds") Map<String, Set<Long>> hostGroupWithPrivateIds,
+            @JsonProperty("details") ClusterDownscaleDetails details) {
+        super(stackId, !hostGroupWithAdjustment.isEmpty() ? hostGroupWithAdjustment.keySet() : hostGroupWithPrivateIds.keySet());
         this.hostGroupWithAdjustment = hostGroupWithAdjustment;
         this.hostGroupWithPrivateIds = hostGroupWithPrivateIds;
         this.details = details;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/CollectDownscaleCandidatesResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/CollectDownscaleCandidatesResult.java
@@ -3,7 +3,11 @@ package com.sequenceiq.cloudbreak.reactor.api.event.resource;
 import java.util.Collections;
 import java.util.Set;
 
-public class CollectDownscaleCandidatesResult extends AbstractClusterScaleResult<CollectDownscaleCandidatesRequest> {
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
+
+public class CollectDownscaleCandidatesResult extends AbstractClusterScaleResult<CollectDownscaleCandidatesRequest> implements FlowPayload {
 
     private final Set<Long> privateIds;
 
@@ -12,7 +16,11 @@ public class CollectDownscaleCandidatesResult extends AbstractClusterScaleResult
         this.privateIds = privateIds;
     }
 
-    public CollectDownscaleCandidatesResult(String statusReason, Exception errorDetails, CollectDownscaleCandidatesRequest request) {
+    @JsonCreator
+    public CollectDownscaleCandidatesResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") CollectDownscaleCandidatesRequest request) {
         super(statusReason, errorDetails, request);
         privateIds = Collections.emptySet();
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/DecommissionRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/DecommissionRequest.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.reactor.api.event.resource;
 
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterDownscaleDetails;
 
 public class DecommissionRequest extends AbstractClusterScaleRequest {
@@ -10,7 +12,12 @@ public class DecommissionRequest extends AbstractClusterScaleRequest {
 
     private final ClusterDownscaleDetails details;
 
-    public DecommissionRequest(Long stackId, Set<String> hostGroups, Set<Long> privateIds, ClusterDownscaleDetails details) {
+    @JsonCreator
+    public DecommissionRequest(
+            @JsonProperty("stackId") Long stackId,
+            @JsonProperty("hostGroupNames") Set<String> hostGroups,
+            @JsonProperty("privateIds") Set<Long> privateIds,
+            @JsonProperty("details") ClusterDownscaleDetails details) {
         super(stackId, hostGroups);
         this.privateIds = privateIds;
         this.details = details;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/DecommissionResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/DecommissionResult.java
@@ -3,9 +3,12 @@ package com.sequenceiq.cloudbreak.reactor.api.event.resource;
 import java.util.Collections;
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.event.model.EventStatus;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 
-public class DecommissionResult extends AbstractClusterScaleResult<DecommissionRequest> {
+public class DecommissionResult extends AbstractClusterScaleResult<DecommissionRequest> implements FlowPayload {
 
     public static final String UNKNOWN_ERROR_PHASE = "";
 
@@ -25,7 +28,13 @@ public class DecommissionResult extends AbstractClusterScaleResult<DecommissionR
         errorPhase = null;
     }
 
-    public DecommissionResult(String statusReason, Exception errorDetails, DecommissionRequest request, Set<String> hostNames, String errorPhase) {
+    @JsonCreator
+    public DecommissionResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") DecommissionRequest request,
+            @JsonProperty("hostNames") Set<String> hostNames,
+            @JsonProperty("errorPhase") String errorPhase) {
         super(EventStatus.FAILED, statusReason, errorDetails, request);
         this.hostNames = hostNames;
         this.errorPhase = errorPhase;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/ExtendHostMetadataRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/ExtendHostMetadataRequest.java
@@ -2,9 +2,15 @@ package com.sequenceiq.cloudbreak.reactor.api.event.resource;
 
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class ExtendHostMetadataRequest extends AbstractClusterBootstrapRequest {
 
-    public ExtendHostMetadataRequest(Long stackId, Set<String> upscaleCandidateAddresses) {
+    @JsonCreator
+    public ExtendHostMetadataRequest(
+            @JsonProperty("stackId") Long stackId,
+            @JsonProperty("upscaleCandidateAddresses") Set<String> upscaleCandidateAddresses) {
         super(stackId, upscaleCandidateAddresses);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/ExtendHostMetadataResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/ExtendHostMetadataResult.java
@@ -1,11 +1,19 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.resource;
 
-public class ExtendHostMetadataResult extends AbstractClusterBootstrapResult<ExtendHostMetadataRequest> {
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
+
+public class ExtendHostMetadataResult extends AbstractClusterBootstrapResult<ExtendHostMetadataRequest> implements FlowPayload {
     public ExtendHostMetadataResult(ExtendHostMetadataRequest request) {
         super(request);
     }
 
-    public ExtendHostMetadataResult(String statusReason, Exception errorDetails, ExtendHostMetadataRequest request) {
+    @JsonCreator
+    public ExtendHostMetadataResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") ExtendHostMetadataRequest request) {
         super(statusReason, errorDetails, request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/MountDisksOnNewHostsRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/MountDisksOnNewHostsRequest.java
@@ -2,9 +2,15 @@ package com.sequenceiq.cloudbreak.reactor.api.event.resource;
 
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class MountDisksOnNewHostsRequest extends AbstractClusterBootstrapRequest {
 
-    public MountDisksOnNewHostsRequest(Long stackId, Set<String> upscaleCandidateAddresses) {
+    @JsonCreator
+    public MountDisksOnNewHostsRequest(
+            @JsonProperty("stackId") Long stackId,
+            @JsonProperty("upscaleCandidateAddresses") Set<String> upscaleCandidateAddresses) {
         super(stackId, upscaleCandidateAddresses);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/MountDisksOnNewHostsResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/MountDisksOnNewHostsResult.java
@@ -1,11 +1,19 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.resource;
 
-public class MountDisksOnNewHostsResult extends AbstractClusterBootstrapResult<MountDisksOnNewHostsRequest> {
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
+
+public class MountDisksOnNewHostsResult extends AbstractClusterBootstrapResult<MountDisksOnNewHostsRequest> implements FlowPayload {
     public MountDisksOnNewHostsResult(MountDisksOnNewHostsRequest request) {
         super(request);
     }
 
-    public MountDisksOnNewHostsResult(String statusReason, Exception errorDetails, MountDisksOnNewHostsRequest request) {
+    @JsonCreator
+    public MountDisksOnNewHostsResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") MountDisksOnNewHostsRequest request) {
         super(statusReason, errorDetails, request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/UnhealthyInstancesDetectionRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/UnhealthyInstancesDetectionRequest.java
@@ -1,10 +1,14 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.resource;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformRequest;
 
 public class UnhealthyInstancesDetectionRequest extends ClusterPlatformRequest {
 
-    public UnhealthyInstancesDetectionRequest(Long stackId) {
+    @JsonCreator
+    public UnhealthyInstancesDetectionRequest(
+            @JsonProperty("stackId") Long stackId) {
         super(stackId);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/UnhealthyInstancesDetectionResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/UnhealthyInstancesDetectionResult.java
@@ -4,9 +4,12 @@ import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformResult;
 
-public class UnhealthyInstancesDetectionResult extends ClusterPlatformResult<UnhealthyInstancesDetectionRequest> {
+public class UnhealthyInstancesDetectionResult extends ClusterPlatformResult<UnhealthyInstancesDetectionRequest> implements FlowPayload {
 
     private final Set<String> unhealthyInstanceIds;
 
@@ -15,7 +18,11 @@ public class UnhealthyInstancesDetectionResult extends ClusterPlatformResult<Unh
         this.unhealthyInstanceIds = unhealthyInstanceIds;
     }
 
-    public UnhealthyInstancesDetectionResult(String statusReason, Exception errorDetails, UnhealthyInstancesDetectionRequest request) {
+    @JsonCreator
+    public UnhealthyInstancesDetectionResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") UnhealthyInstancesDetectionRequest request) {
         super(statusReason, errorDetails, request);
         unhealthyInstanceIds = Collections.emptySet();
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/UpscaleCheckHostMetadataRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/UpscaleCheckHostMetadataRequest.java
@@ -2,13 +2,21 @@ package com.sequenceiq.cloudbreak.reactor.api.event.resource;
 
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class UpscaleCheckHostMetadataRequest extends AbstractClusterScaleRequest {
 
     private final String primaryGatewayHostname;
 
     private final boolean singlePrimaryGateway;
 
-    public UpscaleCheckHostMetadataRequest(Long stackId, Set<String> hostGroups, String primaryGatewayHostname, boolean singlePrimaryGateway) {
+    @JsonCreator
+    public UpscaleCheckHostMetadataRequest(
+            @JsonProperty("stackId") Long stackId,
+            @JsonProperty("hostGroupNames") Set<String> hostGroups,
+            @JsonProperty("primaryGatewayHostname") String primaryGatewayHostname,
+            @JsonProperty("singlePrimaryGateway") boolean singlePrimaryGateway) {
         super(stackId, hostGroups);
         this.primaryGatewayHostname = primaryGatewayHostname;
         this.singlePrimaryGateway = singlePrimaryGateway;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/UpscaleCheckHostMetadataResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/UpscaleCheckHostMetadataResult.java
@@ -1,13 +1,20 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.resource;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformResult;
 
-public class UpscaleCheckHostMetadataResult extends ClusterPlatformResult<UpscaleCheckHostMetadataRequest> {
+public class UpscaleCheckHostMetadataResult extends ClusterPlatformResult<UpscaleCheckHostMetadataRequest> implements FlowPayload {
     public UpscaleCheckHostMetadataResult(UpscaleCheckHostMetadataRequest request) {
         super(request);
     }
 
-    public UpscaleCheckHostMetadataResult(String statusReason, Exception errorDetails, UpscaleCheckHostMetadataRequest request) {
+    @JsonCreator
+    public UpscaleCheckHostMetadataResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") UpscaleCheckHostMetadataRequest request) {
         super(statusReason, errorDetails, request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/UpscaleStackResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/UpscaleStackResult.java
@@ -4,17 +4,24 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.StringJoiner;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 
-public class UpscaleStackResult extends CloudPlatformResult {
+public class UpscaleStackResult extends CloudPlatformResult implements FlowPayload {
 
     private final ResourceStatus resourceStatus;
 
     private final List<CloudResourceStatus> results;
 
-    public UpscaleStackResult(Long resourceId, ResourceStatus resourceStatus, List<CloudResourceStatus> results) {
+    @JsonCreator
+    public UpscaleStackResult(
+            @JsonProperty("resourceId") Long resourceId,
+            @JsonProperty("resourceStatus") ResourceStatus resourceStatus,
+            @JsonProperty("results") List<CloudResourceStatus> results) {
         super(resourceId);
         this.resourceStatus = resourceStatus;
         this.results = results;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/userdata/UserDataUpdateOnProviderResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/userdata/UserDataUpdateOnProviderResult.java
@@ -1,10 +1,15 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.stack.userdata;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 
-public class UserDataUpdateOnProviderResult extends CloudPlatformResult implements Selectable {
-    public UserDataUpdateOnProviderResult(Long resourceId) {
+public class UserDataUpdateOnProviderResult extends CloudPlatformResult implements Selectable, FlowPayload {
+    @JsonCreator
+    public UserDataUpdateOnProviderResult(
+            @JsonProperty("resourceId") Long resourceId) {
         super(resourceId);
     }
 }

--- a/flow/src/test/java/com/sequenceiq/flow/helper/FlowPayloadSerializabilityChecker.java
+++ b/flow/src/test/java/com/sequenceiq/flow/helper/FlowPayloadSerializabilityChecker.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.SetUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.reflections.Reflections;
 import org.reflections.scanners.SubTypesScanner;
@@ -31,6 +32,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.sequenceiq.cloudbreak.common.event.Acceptable;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.common.json.JsonIgnoreDeserialization;
 
 public class FlowPayloadSerializabilityChecker {
@@ -47,7 +49,10 @@ public class FlowPayloadSerializabilityChecker {
         Reflections reflections = new Reflections(BASE_PACKAGE, new SubTypesScanner(true));
         Set<Class<? extends Acceptable>> acceptableClasses = reflections.getSubTypesOf(Acceptable.class);
         Set<Class<?>> filteredAcceptables = getClassesToCheck(acceptableClasses);
-        filteredAcceptables.forEach(this::performChecksCache);
+        Set<Class<? extends FlowPayload>> flowPayloadClasses = reflections.getSubTypesOf(FlowPayload.class);
+        Set<Class<?>> flowPayloads = getClassesToCheck(flowPayloadClasses);
+        Set<Class<?>> allClassesToCheck = SetUtils.union(filteredAcceptables, flowPayloads);
+        allClassesToCheck.forEach(this::performChecksCache);
         if (!validationErrors.isEmpty()) {
             fail("There are " + validationErrors.size() + " violations:\n" + String.join("\n", validationErrors));
         }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/event/UpscaleStackResult.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/event/UpscaleStackResult.java
@@ -4,17 +4,25 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.StringJoiner;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 
-public class UpscaleStackResult extends CloudPlatformResult {
+public class UpscaleStackResult extends CloudPlatformResult implements FlowPayload {
 
     private final ResourceStatus resourceStatus;
 
     private final List<CloudResourceStatus> results;
 
-    public UpscaleStackResult(Long resourceId, ResourceStatus resourceStatus, List<CloudResourceStatus> results) {
+    @JsonCreator
+    public UpscaleStackResult(
+            @JsonProperty("resourceId") Long resourceId,
+            @JsonProperty("resourceStatus") ResourceStatus resourceStatus,
+            @JsonProperty("results") List<CloudResourceStatus> results) {
+
         super(resourceId);
         this.resourceStatus = resourceStatus;
         this.results = results;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/provision/action/StackProvisionService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/provision/action/StackProvisionService.java
@@ -106,7 +106,7 @@ public class StackProvisionService {
     }
 
     public Stack saveTlsInfo(StackContext context, TlsInfo tlsInfo) {
-        boolean usePrivateIpToTls = tlsInfo.usePrivateIpToTls();
+        boolean usePrivateIpToTls = tlsInfo.isUsePrivateIpToTls();
         Stack stack = context.getStack();
         if (usePrivateIpToTls) {
             SecurityConfig securityConfig = stack.getSecurityConfig();

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/event/UserDataUpdateOnProviderResult.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/event/UserDataUpdateOnProviderResult.java
@@ -1,10 +1,15 @@
 package com.sequenceiq.freeipa.flow.stack.update.event;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 
-public class UserDataUpdateOnProviderResult extends CloudPlatformResult implements Selectable {
-    public UserDataUpdateOnProviderResult(Long resourceId) {
+public class UserDataUpdateOnProviderResult extends CloudPlatformResult implements Selectable, FlowPayload {
+
+    @JsonCreator
+    public UserDataUpdateOnProviderResult(@JsonProperty("resourceId") Long resourceId) {
         super(resourceId);
     }
 }


### PR DESCRIPTION
As it turned out, flows are saving descendants of CloudPlatformResult
and ClusterPlatformResult classes.
Unfortunately, the same parent classes are used for asynchronous Reactor call
parameters for cloud platform calls that are not part of any flow.
Therefore, these descendant classes must be analyzed directly one by one
and marked with a new interface (FlowPayload).
The Jackson conformity then needs to be examined in the implementations of
the aforementioned interface (FlowPayload)

The interesting class in this PR is `FlowPayloadSerializabilityChecker`