### PR TITLE
CB-17614: GCP VM Instance should have the property `gcp`

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/template/GcpInstanceTemplateV4Parameters.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/template/GcpInstanceTemplateV4Parameters.java
@@ -28,6 +28,17 @@ public class GcpInstanceTemplateV4Parameters extends InstanceTemplateV4Parameter
     @ApiModelProperty
     private Boolean preemptible;
 
+    @ApiModelProperty(notes = "by default false")
+    private Boolean encrypted = Boolean.FALSE;
+
+    public Boolean getEncrypted() {
+        return encrypted;
+    }
+
+    public void setEncrypted(Boolean encrypted) {
+        this.encrypted = encrypted;
+    }
+
     public GcpEncryptionV4Parameters getEncryption() {
         return encryption;
     }
@@ -52,6 +63,7 @@ public class GcpInstanceTemplateV4Parameters extends InstanceTemplateV4Parameter
             putIfValueNotNull(map, InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, encryption.getType());
         }
         putIfValueNotNull(map, "preemptible", preemptible);
+        putIfValueNotNull(map, "encrypted", encrypted);
         return map;
     }
 
@@ -88,5 +100,6 @@ public class GcpInstanceTemplateV4Parameters extends InstanceTemplateV4Parameter
         if (preemptible != null) {
             this.preemptible = Boolean.valueOf(preemptible);
         }
+        this.encrypted = getBoolean(parameters, "encrypted");
     }
 }

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateParameterConverter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateParameterConverter.java
@@ -137,7 +137,9 @@ public class InstanceTemplateParameterConverter {
             encryption.setKeyEncryptionMethod(KeyEncryptionMethod.KMS);
             encryption.setKey(encryptionKey);
             response.setEncryption(encryption);
+            response.setEncrypted(Boolean.TRUE);
         } else {
+            response.setEncrypted(Boolean.FALSE);
             LOGGER.info("Environment has not requested for Customer-Managed Encryption with CMEK for GCP disks.");
         }
     }

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateParameterConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateParameterConverterTest.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.distrox.v1.distrox.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -153,8 +154,10 @@ class InstanceTemplateParameterConverterTest {
             assertThat(encryption.getType()).isEqualTo(EncryptionType.CUSTOM);
             assertThat(encryption.getKeyEncryptionMethod()).isEqualTo(KeyEncryptionMethod.KMS);
             assertThat(encryption.getKey()).isEqualTo(expectedEncryptionKey);
+            assertEquals(gcpInstanceTemplateV4Parameters.getEncrypted(), Boolean.TRUE);
         } else {
             assertThat(encryption).isNull();
+            assertEquals(gcpInstanceTemplateV4Parameters.getEncrypted(), Boolean.FALSE);
         }
     }
 


### PR DESCRIPTION
CB-17614: GCP VM Instance should have the property `gcp`
Adding a new field `encrpted` to `GcpInstanceTemplateV4Parameters`. This new param is set to true when encryption is set else is set to false. This would ensure that `InstanceGroup.template` will be not empty for gcp and UI can use this value to maintain cloud agnostic code.