### PR TITLE
CB-17751; Change the volume size and type

### DIFF
--- a/datalake/src/main/resources/duties/7.2.10/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.10/aws/light_duty.json
@@ -31,8 +31,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "standard"
+            "size": 512,
+            "type": "gp2"
           }
         ]
       },

--- a/datalake/src/main/resources/duties/7.2.10/aws/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.10/aws/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]
@@ -49,8 +49,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "standard"
+            "size": 512,
+            "type": "gp2"
           }
         ]
       },
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.11/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.11/aws/light_duty.json
@@ -31,8 +31,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "standard"
+            "size": 512,
+            "type": "gp2"
           }
         ]
       },

--- a/datalake/src/main/resources/duties/7.2.11/aws/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.11/aws/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]
@@ -49,8 +49,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "standard"
+            "size": 512,
+            "type": "gp2"
           }
         ]
       },
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.12/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.12/aws/light_duty.json
@@ -31,8 +31,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "standard"
+            "size": 512,
+            "type": "gp2"
           }
         ]
       },

--- a/datalake/src/main/resources/duties/7.2.12/aws/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.12/aws/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]
@@ -49,8 +49,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "standard"
+            "size": 512,
+            "type": "gp2"
           }
         ]
       },
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.14/aws/cdp_data_lake_medium_duty_with_profiler/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.14/aws/cdp_data_lake_medium_duty_with_profiler/medium_duty_ha.json
@@ -49,8 +49,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "standard"
+            "size": 512,
+            "type": "gp2"
           }
         ]
       },

--- a/datalake/src/main/resources/duties/7.2.14/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.14/aws/light_duty.json
@@ -31,8 +31,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "standard"
+            "size": 512,
+            "type": "gp2"
           }
         ]
       },

--- a/datalake/src/main/resources/duties/7.2.14/aws/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.14/aws/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]
@@ -49,8 +49,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "standard"
+            "size": 512,
+            "type": "gp2"
           }
         ]
       },
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.15/aws/cdp_data_lake_medium_duty_with_profiler/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.15/aws/cdp_data_lake_medium_duty_with_profiler/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]
@@ -49,8 +49,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "standard"
+            "size": 512,
+            "type": "gp2"
           }
         ]
       },
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.15/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.15/aws/light_duty.json
@@ -31,8 +31,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "standard"
+            "size": 512,
+            "type": "gp2"
           }
         ]
       },

--- a/datalake/src/main/resources/duties/7.2.15/aws/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.15/aws/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]
@@ -49,8 +49,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "standard"
+            "size": 512,
+            "type": "gp2"
           }
         ]
       },
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.16/aws/cdp_data_lake_medium_duty_with_profiler/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.16/aws/cdp_data_lake_medium_duty_with_profiler/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]
@@ -49,8 +49,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "standard"
+            "size": 512,
+            "type": "gp2"
           }
         ]
       },
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.16/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.16/aws/light_duty.json
@@ -31,8 +31,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "standard"
+            "size": 512,
+            "type": "gp2"
           }
         ]
       },

--- a/datalake/src/main/resources/duties/7.2.16/aws/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.16/aws/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]
@@ -49,8 +49,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "standard"
+            "size": 512,
+            "type": "gp2"
           }
         ]
       },
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.7/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.7/aws/light_duty.json
@@ -31,8 +31,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "standard"
+            "size": 512,
+            "type": "gp2"
           }
         ]
       },

--- a/datalake/src/main/resources/duties/7.2.7/aws/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.7/aws/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]
@@ -49,8 +49,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "standard"
+            "size": 512,
+            "type": "gp2"
           }
         ]
       },
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.8/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.8/aws/light_duty.json
@@ -31,8 +31,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "standard"
+            "size": 512,
+            "type": "gp2"
           }
         ]
       },

--- a/datalake/src/main/resources/duties/7.2.8/aws/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.8/aws/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]
@@ -49,8 +49,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "standard"
+            "size": 512,
+            "type": "gp2"
           }
         ]
       },
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.9/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.9/aws/light_duty.json
@@ -31,8 +31,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "standard"
+            "size": 512,
+            "type": "gp2"
           }
         ]
       },

--- a/datalake/src/main/resources/duties/7.2.9/aws/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.9/aws/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]
@@ -49,8 +49,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "standard"
+            "size": 512,
+            "type": "gp2"
           }
         ]
       },
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "standard"
           }
         ]


### PR DESCRIPTION
JIRA: CB-17751; Update datalake duties config for attached storage; 
- `AUXILIARY` - Reduced to 128GB
- `GATEWAY` - Reduced to 128GB
- `MASTER` - Reduced to 128GB
- `Core`: Increase it to 512GB
- `Light duty`: Increase it to 512GB
- change the `AWS` type to `GP2`;

Tested:
with CBD
* create a new medium-duty instance, Provider `AWS`; Run time version `7.2.16`
  * result: the attached volume size is `512 GB` and the type is GP2
* resize micro duty to medium duty, Provider `AWS`; Run time version `7.2.16`
  * result: the attached volume size is `512 GB` and the type is `GP2`