### PR TITLE
CB-17822 Cannot upscale the cluster because the CM respond with an un…

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/model/ParcelStatus.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/model/ParcelStatus.java
@@ -9,5 +9,7 @@ public enum ParcelStatus {
     DISTRIBUTED,
     UNDISTRIBUTING,
     ACTIVATING,
-    ACTIVATED
+    ACTIVATED,
+    UNAVAILABLE,
+    UNKNOWN
 }

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerParcelManagementServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerParcelManagementServiceTest.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.cm;
 
+import static com.sequenceiq.cloudbreak.cluster.model.ParcelStatus.UNKNOWN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -143,6 +144,17 @@ class ClouderaManagerParcelManagementServiceTest {
         assertParcel(actual, CDH, "7.2.15", DISTRIBUTED);
         assertParcel(actual, SPARK3, "5.4.1", AVAILABLE_REMOTELY);
         assertParcel(actual, FLINK, "1.2.2", DOWNLOADED);
+    }
+
+    @Test
+    void testGetAllParcelsShouldReturnUnknownWhenUnknownStatus() throws ApiException {
+        when(parcelsResourceApi.readParcels(STACK_NAME, VIEW)).thenReturn(new ApiParcelList()
+                .addItemsItem(createApiParcel(CDH, "7.2.7", "anUnknownStatus")));
+
+        Set<ParcelInfo> actual = underTest.getAllParcels(parcelsResourceApi, STACK_NAME);
+
+        assertEquals(1, actual.size());
+        assertParcel(actual, CDH, "7.2.7", UNKNOWN);
     }
 
     @Test


### PR DESCRIPTION
…known parcelstatus

Parcel status, retrieved from CM when reading all parcels, is mapped to an enum in cloudbreak. The mapping uses the valueOf method, that throws whenever an unknown enum value is found. There was a status, UAVAILBLE, not yet in cloudbreak's ParcelStatus enum, breaking all upscales.
The present commit introduces two new statuses:
- the UNAVAILABLE status that is sent from CM
- the UNKOWN status, used whenever the CM introduces a new status. If that occurs, it is logged, but is not reported anywhere else.

See detailed description in the commit message.