### PR TITLE
CB-17635 EDH: scaling does not always report the exact node count

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/ClusterOperationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/ClusterOperationService.java
@@ -246,10 +246,14 @@ public class ClusterOperationService {
         }
         boolean downscaleRequest = updateHostsValidator.validateRequest(stack, hostGroupAdjustment);
         if (downscaleRequest) {
+            stackUpdater.updateStackStatus(stackId, DetailedStackStatus.DOWNSCALE_REQUESTED,
+                    String.format("Requested node count for downscaling: %s, instance group: %s",
+                            hostGroupAdjustment.getScalingAdjustment(), hostGroupAdjustment.getHostGroup()));
             return flowManager.triggerClusterDownscale(stackId, hostGroupAdjustment);
         } else {
             stackUpdater.updateStackStatus(stackId, DetailedStackStatus.UPSCALE_REQUESTED,
-                    "Requested node count for upscaling: " + hostGroupAdjustment.getScalingAdjustment());
+                    String.format("Requested node count for upscaling: %s, instance group: %s",
+                            hostGroupAdjustment.getScalingAdjustment(), hostGroupAdjustment.getHostGroup()));
             return flowManager.triggerClusterUpscale(stackId, hostGroupAdjustment);
         }
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
@@ -146,6 +146,9 @@ public class StackOperationService {
                 updateNodeCountValidator.validateScalingAdjustment(instanceGroupName, scalingAdjustment, stack);
             }
         }
+        stackUpdater.updateStackStatus(stack.getId(), DetailedStackStatus.DOWNSCALE_REQUESTED,
+                String.format("Requested node count for downscaling: %s, instance group(s): %s",
+                        instanceIds.size(), instanceIdsByHostgroupMap.keySet()));
         return flowManager.triggerStackRemoveInstances(stack.getId(), instanceIdsByHostgroupMap, forced);
     }
 
@@ -351,14 +354,16 @@ public class StackOperationService {
                 }
                 if (upscale) {
                     stackUpdater.updateStackStatus(stackDto.getId(), DetailedStackStatus.UPSCALE_REQUESTED,
-                            "Requested node count for upscaling: " + instanceGroupAdjustmentJson.getScalingAdjustment());
+                            String.format("Requested node count for upscaling: %s, instance group: %s",
+                                    instanceGroupAdjustmentJson.getScalingAdjustment(), instanceGroupAdjustmentJson.getInstanceGroup()));
                     return flowManager.triggerStackUpscale(
                             stackDto.getId(),
                             instanceGroupAdjustmentJson,
                             withClusterEvent);
                 } else {
                     stackUpdater.updateStackStatus(stackDto.getId(), DetailedStackStatus.DOWNSCALE_REQUESTED,
-                            "Requested node count for downscaling: " + abs(instanceGroupAdjustmentJson.getScalingAdjustment()));
+                            String.format("Requested node count for downscaling: %s, instance group: %s",
+                                    abs(instanceGroupAdjustmentJson.getScalingAdjustment()), instanceGroupAdjustmentJson.getInstanceGroup()));
                     return flowManager.triggerStackDownscale(stackDto.getId(), instanceGroupAdjustmentJson);
                 }
             });

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/flow/ClusterOperationServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/flow/ClusterOperationServiceTest.java
@@ -281,7 +281,7 @@ public class ClusterOperationServiceTest {
         when(updateHostsValidator.validateRequest(stack, upscaleHostGroupAdjustment)).thenReturn(false);
         underTest.updateHosts(STACK_ID, upscaleHostGroupAdjustment);
         verify(stackUpdater, times(1)).updateStackStatus(STACK_ID, DetailedStackStatus.UPSCALE_REQUESTED,
-                "Requested node count for upscaling: " + 5);
+                "Requested node count for upscaling: " + 5 + ", instance group: worker");
         verify(flowManager, times(1)).triggerClusterUpscale(STACK_ID, upscaleHostGroupAdjustment);
     }
 


### PR DESCRIPTION
EDH reporting happens when the flow triggers.
If the stack status change happens only in the first flow step, the EDH event will contain the status from the previous flow, which could be almost anything.

See detailed description in the commit message.