### PR TITLE
CDPSDX-3644: change refreshDatahub API response to list all refreshed…

### DIFF
--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxEndpoint.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxEndpoint.java
@@ -44,6 +44,7 @@ import com.sequenceiq.sdx.api.model.SdxCustomClusterRequest;
 import com.sequenceiq.sdx.api.model.SdxDefaultTemplateResponse;
 import com.sequenceiq.sdx.api.model.SdxGenerateImageCatalogResponse;
 import com.sequenceiq.sdx.api.model.SdxRecommendationResponse;
+import com.sequenceiq.sdx.api.model.SdxRefreshDatahubResponse;
 import com.sequenceiq.sdx.api.model.SdxRepairRequest;
 import com.sequenceiq.sdx.api.model.SdxStopValidationResponse;
 import com.sequenceiq.sdx.api.model.SdxSyncComponentVersionsFromCmResponse;
@@ -127,7 +128,7 @@ public interface SdxEndpoint {
     @Path("{datalakeName}/refresh")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Restart and reload all configurations of the data hub by name", produces = "applicaton/json", nickname = "refreshDatahubs")
-    SdxClusterResponse refreshDataHubs(@PathParam("datalakeName") String name, @QueryParam("datahubName") String datahubName);
+    SdxRefreshDatahubResponse refreshDataHubs(@PathParam("datalakeName") String name, @QueryParam("datahubName") String datahubName);
 
     @DELETE
     @Path("/crn/{clusterCrn}")

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/ModelDescriptions.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/ModelDescriptions.java
@@ -174,6 +174,8 @@ public class ModelDescriptions {
 
     public static final String UNSTOPPABLE_REASON = "Reason why the cluster is not stoppable";
 
+    public static final String DATAHUB_CRNS_REFRESHED = "List of Data Hubs that are refreshed with CRN";
+
     private ModelDescriptions() {
     }
 }

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxRefreshDatahubResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxRefreshDatahubResponse.java
@@ -1,0 +1,63 @@
+package com.sequenceiq.sdx.api.model;
+
+import static com.sequenceiq.sdx.api.model.ModelDescriptions.DATAHUB_CRNS_REFRESHED;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Response;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SdxRefreshDatahubResponse {
+
+    @ApiModelProperty(DATAHUB_CRNS_REFRESHED)
+    private List<StackViewV4Response> refreshedDatahubs;
+
+    public SdxRefreshDatahubResponse() {
+        this.refreshedDatahubs = new ArrayList<>();
+    }
+
+    public SdxRefreshDatahubResponse(List<StackViewV4Response> refreshedDatahubs) {
+        this.refreshedDatahubs = refreshedDatahubs;
+    }
+
+    public List<StackViewV4Response> getRefreshedDatahubs() {
+        return refreshedDatahubs;
+    }
+
+    public void setRefreshedDatahubs(List<StackViewV4Response> refreshedDatahubs) {
+        this.refreshedDatahubs = refreshedDatahubs;
+    }
+
+    public void addStacks(List<StackViewV4Response> stacks) {
+        this.refreshedDatahubs.addAll(stacks);
+    }
+
+    public void addStack(StackV4Response stack) {
+        StackViewV4Response response = new StackViewV4Response();
+        response.setCrn(stack.getCrn());
+        response.setName(stack.getName());
+        response.setEnvironmentName(stack.getEnvironmentName());
+        response.setEnvironmentCrn(stack.getEnvironmentCrn());
+        addStack(response);
+    }
+
+    public void addStack(StackViewV4Response stack) {
+        this.refreshedDatahubs.add(stack);
+    }
+
+    @Override
+    public String toString() {
+        return "SdxRefreshDatahubResponse{" +
+                "refreshedDatahubs=" + refreshedDatahubs +
+                '}';
+    }
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
@@ -72,6 +72,7 @@ import com.sequenceiq.sdx.api.model.SdxCustomClusterRequest;
 import com.sequenceiq.sdx.api.model.SdxDefaultTemplateResponse;
 import com.sequenceiq.sdx.api.model.SdxGenerateImageCatalogResponse;
 import com.sequenceiq.sdx.api.model.SdxRecommendationResponse;
+import com.sequenceiq.sdx.api.model.SdxRefreshDatahubResponse;
 import com.sequenceiq.sdx.api.model.SdxRepairRequest;
 import com.sequenceiq.sdx.api.model.SdxStopValidationResponse;
 import com.sequenceiq.sdx.api.model.SdxSyncComponentVersionsFromCmResponse;
@@ -169,9 +170,8 @@ public class SdxController implements SdxEndpoint {
 
     @Override
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.RESIZE_DATALAKE)
-    public SdxClusterResponse refreshDataHubs(@ResourceName String name, String datahubName) {
-        SdxCluster sdxCluster = sdxService.refreshDataHub(name, datahubName);
-        return sdxClusterConverter.sdxClusterToResponse(sdxCluster);
+    public SdxRefreshDatahubResponse refreshDataHubs(@ResourceName String name, String datahubName) {
+        return sdxService.refreshDataHub(name, datahubName);
     }
 
     @Override

--- a/datalake/src/test/java/com/sequenceiq/datalake/controller/sdx/SdxControllerTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/controller/sdx/SdxControllerTest.java
@@ -24,14 +24,18 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackV4Request;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakImageCatalogV3;
 import com.sequenceiq.datalake.entity.DatalakeStatusEnum;
 import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.entity.SdxStatusEntity;
 import com.sequenceiq.datalake.metric.SdxMetricService;
+import com.sequenceiq.datalake.repository.SdxClusterRepository;
+import com.sequenceiq.datalake.service.sdx.DistroxService;
 import com.sequenceiq.datalake.service.sdx.SdxImageCatalogService;
 import com.sequenceiq.datalake.service.sdx.SdxService;
 import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
+import com.sequenceiq.distrox.api.v1.distrox.endpoint.DistroXV1Endpoint;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.flow.api.model.FlowType;
 import com.sequenceiq.sdx.api.model.SdxChangeImageCatalogRequest;
@@ -62,6 +66,18 @@ class SdxControllerTest {
 
     @Mock
     private SdxImageCatalogService sdxImageCatalogService;
+
+    @Mock
+    private SdxClusterRepository sdxClusterRepository;
+
+    @Mock
+    private DistroxService distroxService;
+
+    @Mock
+    private DistroXV1Endpoint distroXV1Endpoint;
+
+    @Mock
+    private EntitlementService entitlementService;
 
     @InjectMocks
     private SdxController sdxController;
@@ -166,6 +182,12 @@ class SdxControllerTest {
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> sdxController.rotateSaltPasswordByCrn(sdxCluster.getCrn()));
 
         verify(sdxService).rotateSaltPassword(sdxCluster);
+    }
+
+    @Test
+    void refreshDatahubs() {
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> sdxController.refreshDataHubs(SDX_CLUSTER_NAME, null));
+        verify(sdxService, times(1)).refreshDataHub(SDX_CLUSTER_NAME, null);
     }
 
     private SdxCluster getValidSdxCluster() {

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxServiceTest.java
@@ -1667,4 +1667,27 @@ class SdxServiceTest {
         verify(sdxReactorFlowManager).triggerSaltPasswordRotationTracker(sdxCluster);
     }
 
+    @Test
+    void refreshDatahubsWithoutName() {
+        SdxCluster sdxCluster = getSdxCluster();
+        when(sdxClusterRepository.findByAccountIdAndClusterNameAndDeletedIsNull(anyString(), anyString()))
+                .thenReturn(Optional.of(sdxCluster));
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.refreshDataHub(CLUSTER_NAME, null));
+        verify(distroxService, times(1)).restartAttachedDistroxClusters(sdxCluster.getEnvCrn());
+        verify(distroxService, times(1)).getAttachedDistroXClusters(sdxCluster.getEnvCrn());
+    }
+
+    @Test
+    void refreshDatahubsWithName() {
+        SdxCluster sdxCluster = getSdxCluster();
+        when(sdxClusterRepository.findByAccountIdAndClusterNameAndDeletedIsNull(anyString(), anyString()))
+                .thenReturn(Optional.of(sdxCluster));
+        StackV4Response stackV4Response = mock(StackV4Response.class);
+        when(stackV4Response.getCrn()).thenReturn(getCrn());
+        when(distroXV1Endpoint.getByName(anyString(), eq(null))).thenReturn(stackV4Response);
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.refreshDataHub(CLUSTER_NAME, "datahubName"));
+        verify(distroXV1Endpoint, times(1)).getByName(anyString(), eq(null));
+        verify(distroxService, times(1)).restartDistroxByCrns(any());
+    }
+
 }


### PR DESCRIPTION
CDPSDX-3644: change refreshDatahub API response to list all refreshed datahub names.

Change the API response for the CDP CLI usage. We should let the customer know which datahubs are refreshed on the CLI side. 

Tested: locally by the postman. The datahubs are refreshed the expected response comes back in the response.