### PR TITLE
CB-17180 Detect and fix Freeipa saltuser password errors

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/service/Clock.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/service/Clock.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.common.service;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.temporal.TemporalAmount;
 
 import org.springframework.stereotype.Service;
@@ -18,5 +19,9 @@ public class Clock {
 
     public Instant nowMinus(TemporalAmount amount) {
         return Instant.now().minus(amount);
+    }
+
+    public LocalDateTime getCurrentLocalDateTime() {
+        return LocalDateTime.now();
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/quartz/saltstatuschecker/SaltStatusCheckerConfig.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/quartz/saltstatuschecker/SaltStatusCheckerConfig.java
@@ -1,0 +1,55 @@
+package com.sequenceiq.cloudbreak.quartz.saltstatuschecker;
+
+import javax.annotation.PostConstruct;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties("jobs.salt-status-checker")
+public class SaltStatusCheckerConfig {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SaltStatusCheckerConfig.class);
+
+    private boolean enabled;
+
+    private int intervalInMinutes;
+
+    private int passwordExpiryThresholdInDays;
+
+    @PostConstruct
+    void logEnablement() {
+        if (enabled) {
+            LOGGER.info("Salt status checker is enabled. Job running interval is {} minutes. Password expiry threshold is {} days.",
+                    intervalInMinutes, passwordExpiryThresholdInDays);
+        } else {
+            LOGGER.info("Salt status checker is disabled.");
+        }
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public int getIntervalInMinutes() {
+        return intervalInMinutes;
+    }
+
+    public void setIntervalInMinutes(int intervalInMinutes) {
+        this.intervalInMinutes = intervalInMinutes;
+    }
+
+    public int getPasswordExpiryThresholdInDays() {
+        return passwordExpiryThresholdInDays;
+    }
+
+    public void setPasswordExpiryThresholdInDays(int passwordExpiryThresholdInDays) {
+        this.passwordExpiryThresholdInDays = passwordExpiryThresholdInDays;
+    }
+}

--- a/common/src/main/resources/common-config.yml
+++ b/common/src/main/resources/common-config.yml
@@ -127,3 +127,8 @@ telemetry:
       diagnostics-collect: 360
       metering-upgrade: 5
       telemetry-upgrade: 50
+jobs:
+  salt-status-checker:
+    enabled: true
+    interval-in-minutes: 60
+    password-expiry-threshold-in-days: 14

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/rotatepassword/RotateSaltPasswordActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/rotatepassword/RotateSaltPasswordActions.java
@@ -56,8 +56,7 @@ public class RotateSaltPasswordActions {
 
             @Override
             protected Selectable createRequest(RotateSaltPasswordContext context) {
-                return new RotateSaltPasswordRequest(
-                        RotateSaltPasswordEvent.ROTATE_SALT_PASSWORD_EVENT.selector(), context.getStack().getId(), context.getReason());
+                return new RotateSaltPasswordRequest(context.getStack().getId(), context.getReason());
             }
         };
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/rotatepassword/event/RotateSaltPasswordReason.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/rotatepassword/event/RotateSaltPasswordReason.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.freeipa.flow.freeipa.salt.rotatepassword.event;
 
 public enum RotateSaltPasswordReason {
+    UNSET,
     MANUAL,
     EXPIRED,
     UNAUTHORIZED

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/rotatepassword/event/RotateSaltPasswordRequest.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/rotatepassword/event/RotateSaltPasswordRequest.java
@@ -10,10 +10,9 @@ public class RotateSaltPasswordRequest extends StackEvent {
 
     @JsonCreator
     public RotateSaltPasswordRequest(
-            @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long stackId,
             @JsonProperty("reason") RotateSaltPasswordReason reason) {
-        super(selector, stackId);
+        super(stackId);
         this.reason = reason;
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/orchestrator/RotateSaltPasswordService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/orchestrator/RotateSaltPasswordService.java
@@ -1,7 +1,10 @@
 package com.sequenceiq.freeipa.orchestrator;
 
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import javax.inject.Inject;
 
@@ -13,10 +16,13 @@ import com.cloudera.thunderhead.service.common.usage.UsageProto;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.common.service.Clock;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.cloudbreak.quartz.saltstatuschecker.SaltStatusCheckerConfig;
+import com.sequenceiq.cloudbreak.service.CloudbreakRuntimeException;
 import com.sequenceiq.cloudbreak.usage.UsageReporter;
 import com.sequenceiq.cloudbreak.util.PasswordUtil;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
@@ -33,7 +39,17 @@ import com.sequenceiq.freeipa.util.SaltBootstrapVersionChecker;
 @Service
 public class RotateSaltPasswordService {
 
+    protected static final String SALTUSER = "saltuser";
+
+    protected static final String UNAUTHORIZED_RESPONSE = "Status: 401 Unauthorized Response";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(RotateSaltPasswordService.class);
+
+    @Inject
+    private SaltStatusCheckerConfig saltStatusCheckerConfig;
+
+    @Inject
+    private Clock clock;
 
     @Inject
     private StackService stackService;
@@ -63,7 +79,7 @@ public class RotateSaltPasswordService {
         Stack stack = stackService.getByEnvironmentCrnAndAccountId(environmentCrn, accountId);
         validateRotateSaltPassword(stack);
         String selector = RotateSaltPasswordEvent.ROTATE_SALT_PASSWORD_EVENT.event();
-        return flowManager.notify(selector, new RotateSaltPasswordRequest(selector, stack.getId(), reason));
+        return flowManager.notify(selector, new RotateSaltPasswordRequest(stack.getId(), reason));
     }
 
     public void rotateSaltPassword(Stack stack) {
@@ -80,7 +96,7 @@ public class RotateSaltPasswordService {
         }
     }
 
-    private void validateRotateSaltPassword(Stack stack) {
+    public void validateRotateSaltPassword(Stack stack) {
         MDCBuilder.buildMdcContext(stack);
         if (!entitlementService.isSaltUserPasswordRotationEnabled(stack.getAccountId())) {
             throw new BadRequestException("Rotating SaltStack user password is not supported in your account");
@@ -115,5 +131,41 @@ public class RotateSaltPasswordService {
             LOGGER.error("Failed to report rotate salt password event with resource crn {}, reason {}, result {} and message {}",
                     resourceCrn, reason, result, message, e);
         }
+    }
+
+    public Optional<RotateSaltPasswordReason> checkIfSaltPasswordRotationNeeded(Stack stack) {
+        Optional<RotateSaltPasswordReason> result;
+        try {
+            List<GatewayConfig> allGatewayConfigs = gatewayConfigService.getNotDeletedGatewayConfigs(stack);
+            LocalDate passwordExpiryDate = hostOrchestrator.getPasswordExpiryDate(allGatewayConfigs, SALTUSER);
+            if (isPasswordExpiresSoon(passwordExpiryDate)) {
+                LOGGER.info("Stack {} user {} password expires at {}, password rotation is needed", stack.getId(), SALTUSER, passwordExpiryDate);
+                result = Optional.of(RotateSaltPasswordReason.EXPIRED);
+            } else {
+                LOGGER.info("Stack {} user {} password expires at {}, nothing to do", stack.getId(), SALTUSER, passwordExpiryDate);
+                result = Optional.empty();
+            }
+        } catch (CloudbreakOrchestratorException e) {
+            if (isUnauthorizedException(e)) {
+                LOGGER.info("Received unauthorized response from salt on stack {}", stack.getId());
+                result = Optional.of(RotateSaltPasswordReason.UNAUTHORIZED);
+            } else {
+                LOGGER.warn("Received error response from salt on stack {}", stack.getId(), e);
+                throw new CloudbreakRuntimeException(e);
+            }
+        }
+        return result;
+    }
+
+    private boolean isPasswordExpiresSoon(LocalDate passwordExpiryDate) {
+        long daysUntilPasswordExpires = ChronoUnit.DAYS.between(clock.getCurrentLocalDateTime(), passwordExpiryDate.atStartOfDay());
+        return daysUntilPasswordExpires <= saltStatusCheckerConfig.getPasswordExpiryThresholdInDays();
+    }
+
+    private static boolean isUnauthorizedException(CloudbreakOrchestratorException e) {
+        return Optional.ofNullable(e.getCause())
+                .map(Throwable::getCause)
+                .filter(ex -> ex.getMessage().startsWith(UNAUTHORIZED_RESPONSE))
+                .isPresent();
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
@@ -57,6 +57,10 @@ public class StackService implements EnvironmentPropertyProvider, PayloadContext
         return stackRepository.findAllRunning();
     }
 
+    public JobResource getJobResource(Long resourceId) {
+        return stackRepository.getJobResource(resourceId).orElseThrow(() -> new NotFoundException(String.format("FreeIPA stack [%s] not found", resourceId)));
+    }
+
     public List<JobResource> findAllForAutoSync() {
         return stackRepository.findAllRunningAndStatusIn(List.of(
                 Status.AVAILABLE,

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/saltstatus/StackSaltStatusCheckerJob.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/saltstatus/StackSaltStatusCheckerJob.java
@@ -1,0 +1,107 @@
+package com.sequenceiq.freeipa.sync.saltstatus;
+
+import static com.sequenceiq.cloudbreak.util.Benchmark.checkedMeasure;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.quartz.statuschecker.job.StatusCheckerJob;
+import com.sequenceiq.flow.core.FlowLogService;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.flow.freeipa.salt.rotatepassword.event.RotateSaltPasswordReason;
+import com.sequenceiq.freeipa.orchestrator.RotateSaltPasswordService;
+import com.sequenceiq.freeipa.service.GatewayConfigService;
+import com.sequenceiq.freeipa.service.stack.StackService;
+import com.sequenceiq.freeipa.sync.InterruptSyncingException;
+
+import io.opentracing.Tracer;
+
+@DisallowConcurrentExecution
+@Component
+public class StackSaltStatusCheckerJob extends StatusCheckerJob {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StackSaltStatusCheckerJob.class);
+
+    @Inject
+    private StackSaltStatusCheckerJobService jobService;
+
+    @Inject
+    private FlowLogService flowLogService;
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private HostOrchestrator hostOrchestrator;
+
+    @Inject
+    private GatewayConfigService gatewayConfigService;
+
+    @Inject
+    private RotateSaltPasswordService rotateSaltPasswordService;
+
+    public StackSaltStatusCheckerJob(Tracer tracer) {
+        super(tracer, "Stack Salt Status Checker Job");
+    }
+
+    @Override
+    protected Object getMdcContextObject() {
+        return stackService.getStackById(getStackId());
+    }
+
+    private Long getStackId() {
+        return Long.valueOf(getLocalId());
+    }
+
+    @Override
+    protected void executeTracedJob(JobExecutionContext context) throws JobExecutionException {
+        Long stackId = getStackId();
+        Stack stack = stackService.getByIdWithListsInTransaction(stackId);
+        MDCBuilder.buildMdcContext(stack);
+        try {
+            rotateSaltPasswordService.validateRotateSaltPassword(stack);
+            Status status = stack.getStackStatus().getStatus();
+            if (status.isDeletionInProgress() || status.isSuccessfullyDeleted()) {
+                LOGGER.debug("Stack {} is deleted, unscheduling", stack.getResourceCrn());
+                jobService.unschedule(context.getJobDetail().getKey());
+            } else if (status.isStopInProgressPhase() || status.isStoppedPhase()) {
+                LOGGER.debug("StackSaltStatusCheckerJob cannot run, because stack {} is in stopped", stackId);
+            } else if (flowLogService.isOtherFlowRunning(stackId)) {
+                LOGGER.debug("StackSaltStatusCheckerJob cannot run, because flow is running for freeipa stack: {}", stackId);
+            } else {
+                LOGGER.debug("No flows running, trying to sync freeipa salt");
+                syncAStack(stack);
+            }
+        } catch (BadRequestException e) {
+            LOGGER.info("StackSaltStatusCheckerJob cannot run, because validation failed for stack {} with message: {}", stackId, e.getMessage());
+            jobService.unschedule(context.getJobDetail().getKey());
+        } catch (InterruptSyncingException e) {
+            LOGGER.info("Syncing salt was interrupted", e);
+        }
+    }
+
+    private void syncAStack(Stack stack) {
+        try {
+            checkedMeasure(() -> {
+                Optional<RotateSaltPasswordReason> rotateSaltPasswordReason = rotateSaltPasswordService.checkIfSaltPasswordRotationNeeded(stack);
+                rotateSaltPasswordReason.ifPresent(reason ->
+                        rotateSaltPasswordService.triggerRotateSaltPassword(stack.getEnvironmentCrn(), stack.getAccountId(), reason));
+            }, LOGGER, ":::Auto sync::: freeipa stack salt sync in {}ms");
+        } catch (Exception e) {
+            rotateSaltPasswordService.sendFailureUsageReport(stack.getResourceCrn(), RotateSaltPasswordReason.UNSET, e.getMessage());
+            LOGGER.warn(":::Auto sync::: Error occurred during freeipa salt sync: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/saltstatus/StackSaltStatusCheckerJobAdapter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/saltstatus/StackSaltStatusCheckerJobAdapter.java
@@ -1,0 +1,30 @@
+package com.sequenceiq.freeipa.sync.saltstatus;
+
+import org.quartz.Job;
+import org.springframework.context.ApplicationContext;
+
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
+import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.repository.StackRepository;
+
+public class StackSaltStatusCheckerJobAdapter extends JobResourceAdapter<Stack> {
+
+    public StackSaltStatusCheckerJobAdapter(Long id, ApplicationContext context) {
+        super(id, context);
+    }
+
+    public StackSaltStatusCheckerJobAdapter(JobResource jobResource) {
+        super(jobResource);
+    }
+
+    @Override
+    public Class<? extends Job> getJobClassForResource() {
+        return StackSaltStatusCheckerJob.class;
+    }
+
+    @Override
+    public Class<StackRepository> getRepositoryClassForResource() {
+        return StackRepository.class;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/saltstatus/StackSaltStatusCheckerJobService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/saltstatus/StackSaltStatusCheckerJobService.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.freeipa.sync.saltstatus;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
+import com.sequenceiq.cloudbreak.quartz.saltstatuschecker.SaltStatusCheckerJobService;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+@Service
+public class StackSaltStatusCheckerJobService extends SaltStatusCheckerJobService<StackSaltStatusCheckerJobAdapter> {
+
+    @Inject
+    private StackService stackService;
+
+    public void schedule(Long stackId) {
+        JobResource jobResource = stackService.getJobResource(stackId);
+        schedule(new StackSaltStatusCheckerJobAdapter(jobResource));
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/saltstatus/StackSaltStatusJobInitializer.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/saltstatus/StackSaltStatusJobInitializer.java
@@ -1,0 +1,43 @@
+package com.sequenceiq.freeipa.sync.saltstatus;
+
+import static com.sequenceiq.cloudbreak.util.Benchmark.checkedMeasure;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.quartz.model.JobInitializer;
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
+import com.sequenceiq.cloudbreak.quartz.saltstatuschecker.SaltStatusCheckerConfig;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+@Component
+public class StackSaltStatusJobInitializer implements JobInitializer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StackSaltStatusJobInitializer.class);
+
+    @Inject
+    private SaltStatusCheckerConfig saltStatusCheckerConfig;
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private StackSaltStatusCheckerJobService stackSaltStatusCheckerJobService;
+
+    @Override
+    public void initJobs() {
+        if (saltStatusCheckerConfig.isEnabled()) {
+            List<JobResource> jobResources = checkedMeasure(() ->
+                    stackService.findAllForAutoSync(), LOGGER, ":::Auto sync::: Stacks are fetched from db in {}ms");
+            for (JobResource jobResource : jobResources) {
+                stackSaltStatusCheckerJobService.schedule(new StackSaltStatusCheckerJobAdapter(jobResource));
+            }
+            LOGGER.info("StackSaltStatusJobInitializer is inited with {} stacks on start", jobResources.size());
+        }
+    }
+}

--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -151,6 +151,7 @@ freeipa:
       /**/*
     denyCommands: >
       /bin/su
+
 info:
   app:
     capabilities:

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/freeipa/salt/rotatepassword/handler/RotateSaltPasswordHandlerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/freeipa/salt/rotatepassword/handler/RotateSaltPasswordHandlerTest.java
@@ -17,7 +17,6 @@ import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 import com.sequenceiq.freeipa.entity.Stack;
-import com.sequenceiq.freeipa.flow.freeipa.salt.rotatepassword.RotateSaltPasswordEvent;
 import com.sequenceiq.freeipa.flow.freeipa.salt.rotatepassword.event.RotateSaltPasswordFailureResponse;
 import com.sequenceiq.freeipa.flow.freeipa.salt.rotatepassword.event.RotateSaltPasswordReason;
 import com.sequenceiq.freeipa.flow.freeipa.salt.rotatepassword.event.RotateSaltPasswordRequest;
@@ -35,7 +34,7 @@ class RotateSaltPasswordHandlerTest {
     private static final long STACK_ID = 1L;
 
     private static final HandlerEvent<RotateSaltPasswordRequest> EVENT = new HandlerEvent<>(new Event<>(
-                    new RotateSaltPasswordRequest(RotateSaltPasswordEvent.ROTATE_SALT_PASSWORD_EVENT.selector(), STACK_ID, RotateSaltPasswordReason.MANUAL)));
+            new RotateSaltPasswordRequest(STACK_ID, RotateSaltPasswordReason.MANUAL)));
 
     @Mock
     private EventBus eventBus;

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/orchestrator/RotateSaltPasswordServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/orchestrator/RotateSaltPasswordServiceTest.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.freeipa.orchestrator;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -10,7 +11,10 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,10 +30,13 @@ import com.cloudera.thunderhead.service.common.usage.UsageProto;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.common.service.Clock;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.cloudbreak.quartz.saltstatuschecker.SaltStatusCheckerConfig;
+import com.sequenceiq.cloudbreak.service.CloudbreakRuntimeException;
 import com.sequenceiq.cloudbreak.usage.UsageReporter;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.flow.api.model.FlowType;
@@ -79,6 +86,12 @@ class RotateSaltPasswordServiceTest {
 
     @Mock
     private UsageReporter usageReporter;
+
+    @Mock
+    private Clock clock;
+
+    @Mock
+    private SaltStatusCheckerConfig saltStatusCheckerConfig;
 
     @Mock
     private Stack stack;
@@ -166,7 +179,6 @@ class RotateSaltPasswordServiceTest {
         verify(flowManager).notify(eq(selector), stackEventArgumentCaptor.capture());
         StackEvent stackEvent = stackEventArgumentCaptor.getValue();
         assertThat(stackEvent)
-                .returns(selector, StackEvent::selector)
                 .returns(stack.getId(), StackEvent::getResourceId);
     }
 
@@ -195,6 +207,50 @@ class RotateSaltPasswordServiceTest {
                 .returns(UsageProto.CDPSaltPasswordRotationEventReason.Value.EXPIRED, UsageProto.CDPSaltPasswordRotationEvent::getReason)
                 .returns(UsageProto.CDPSaltPasswordRotationEventResult.Value.FAILURE, UsageProto.CDPSaltPasswordRotationEvent::getEventResult)
                 .returns(message, UsageProto.CDPSaltPasswordRotationEvent::getMessage);
+    }
+
+    @Test
+    void expiredSaltPasswordRotationNeeded() throws Exception {
+        when(clock.getCurrentLocalDateTime()).thenReturn(LocalDateTime.now());
+        when(saltStatusCheckerConfig.getPasswordExpiryThresholdInDays()).thenReturn(14);
+        when(hostOrchestrator.getPasswordExpiryDate(List.of(gatewayConfig), RotateSaltPasswordService.SALTUSER)).thenReturn(LocalDate.now().minusMonths(2));
+
+        Optional<RotateSaltPasswordReason> result = underTest.checkIfSaltPasswordRotationNeeded(stack);
+
+        assertThat(result).hasValue(RotateSaltPasswordReason.EXPIRED);
+    }
+
+    @Test
+    void noSaltPasswordRotationNeeded() throws Exception {
+        when(clock.getCurrentLocalDateTime()).thenReturn(LocalDateTime.now());
+        when(saltStatusCheckerConfig.getPasswordExpiryThresholdInDays()).thenReturn(14);
+        when(hostOrchestrator.getPasswordExpiryDate(List.of(gatewayConfig), RotateSaltPasswordService.SALTUSER)).thenReturn(LocalDate.now().plusMonths(2));
+
+        Optional<RotateSaltPasswordReason> result = underTest.checkIfSaltPasswordRotationNeeded(stack);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void unauthorizedSaltPasswordRotationNeeded() throws Exception {
+        RuntimeException causeCause = new RuntimeException(RotateSaltPasswordService.UNAUTHORIZED_RESPONSE);
+        RuntimeException cause = new RuntimeException("Ooops", causeCause);
+        CloudbreakOrchestratorFailedException exception = new CloudbreakOrchestratorFailedException("Failed", cause);
+        when(hostOrchestrator.getPasswordExpiryDate(List.of(gatewayConfig), RotateSaltPasswordService.SALTUSER)).thenThrow(exception);
+
+        Optional<RotateSaltPasswordReason> result = underTest.checkIfSaltPasswordRotationNeeded(stack);
+
+        assertThat(result).hasValue(RotateSaltPasswordReason.UNAUTHORIZED);
+    }
+
+    @Test
+    void errorWhileSaltPasswordRotationNeeded() throws Exception {
+        CloudbreakOrchestratorFailedException exception = new CloudbreakOrchestratorFailedException("Unexpected failure");
+        when(hostOrchestrator.getPasswordExpiryDate(List.of(gatewayConfig), RotateSaltPasswordService.SALTUSER)).thenThrow(exception);
+
+        assertThatThrownBy(() -> underTest.checkIfSaltPasswordRotationNeeded(stack))
+                .isInstanceOf(CloudbreakRuntimeException.class)
+                .hasCause(exception);
     }
 
 }

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.orchestrator.host;
 
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -135,4 +136,6 @@ public interface HostOrchestrator extends HostRecipeExecutor {
     boolean unboundClusterConfigPresentOnAnyNodes(GatewayConfig primaryGateway, Set<String> nodes);
 
     void uploadStates(List<GatewayConfig> allGatewayConfigs, ExitCriteriaModel exitModel) throws CloudbreakOrchestratorException;
+
+    LocalDate getPasswordExpiryDate(List<GatewayConfig> allGatewayConfigs, String user) throws CloudbreakOrchestratorException;
 }

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStateService.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStateService.java
@@ -374,7 +374,7 @@ public class SaltStateService {
                 return CollectionUtils.isEmpty(result) ? new HashMap<>() : result.get(0);
             } catch (RuntimeException e) {
                 LOGGER.error("Salt run command on hosts failed", e);
-                throw new Retry.ActionFailedException("Salt run command on hosts failed");
+                throw new Retry.ActionFailedException("Salt run command on hosts failed", e);
             }
         });
     }


### PR DESCRIPTION
A salt command querying the saltuser password expiry date is sent to all gateway instances of a stack:
- If the password expires sooner than a set threshold, a salt password rotation is started.
- If it responds with an unauthorized response, a salt password rotation is started.
- Other types of errors are only logged.

See detailed description in the commit message.