### PR TITLE
CB-17788. Add new remote_execution api for utils API.

### DIFF
--- a/common-model/src/main/java/com/sequenceiq/common/api/command/RemoteCommandsExecutionRequest.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/command/RemoteCommandsExecutionRequest.java
@@ -1,0 +1,60 @@
+package com.sequenceiq.common.api.command;
+
+import static com.sequenceiq.common.api.command.doc.RemoteCommandsExecutionDescription.COMMAND;
+import static com.sequenceiq.common.api.command.doc.RemoteCommandsExecutionDescription.HOSTS;
+import static com.sequenceiq.common.api.command.doc.RemoteCommandsExecutionDescription.HOST_GROUPS;
+
+import java.io.Serializable;
+import java.util.Set;
+
+import javax.validation.constraints.NotBlank;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel(value = "RemoteCommandsExecutionRequest")
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RemoteCommandsExecutionRequest implements Serializable {
+
+    @ApiModelProperty(COMMAND)
+    @JsonProperty("command")
+    @NotBlank
+    private String command;
+
+    @ApiModelProperty(HOSTS)
+    @JsonProperty("hosts")
+    private Set<String> hosts;
+
+    @ApiModelProperty(HOST_GROUPS)
+    @JsonProperty("hostGroups")
+    private Set<String> hostGroups;
+
+    public void setCommand(String command) {
+        this.command = command;
+    }
+
+    public String getCommand() {
+        return command;
+    }
+
+    public Set<String> getHosts() {
+        return hosts;
+    }
+
+    public void setHosts(Set<String> hosts) {
+        this.hosts = hosts;
+    }
+
+    public Set<String> getHostGroups() {
+        return hostGroups;
+    }
+
+    public void setHostGroups(Set<String> hostGroups) {
+        this.hostGroups = hostGroups;
+    }
+}

--- a/common-model/src/main/java/com/sequenceiq/common/api/command/RemoteCommandsExecutionResponse.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/command/RemoteCommandsExecutionResponse.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.common.api.command;
+
+import static com.sequenceiq.common.api.command.doc.RemoteCommandsExecutionDescription.RESULTS;
+
+import java.io.Serializable;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel(value = "RemoteCommandsExecutionResponse")
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RemoteCommandsExecutionResponse implements Serializable {
+
+    @ApiModelProperty(RESULTS)
+    @JsonProperty("results")
+    private Map<String, String> results;
+
+    public Map<String, String> getResults() {
+        return results;
+    }
+
+    public void setResults(Map<String, String> results) {
+        this.results = results;
+    }
+}

--- a/common-model/src/main/java/com/sequenceiq/common/api/command/doc/RemoteCommandsExecutionDescription.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/command/doc/RemoteCommandsExecutionDescription.java
@@ -1,0 +1,13 @@
+package com.sequenceiq.common.api.command.doc;
+
+public class RemoteCommandsExecutionDescription {
+
+    public static final String COMMAND = "Command that will be executed on hosts remotely.";
+    public static final String RESULTS = "Result of the remotly exeecuted commands - per host.";
+    public static final String HOSTS = "Host (fqdn) filter, use it to run remote commands on only specific hosts.";
+    public static final String HOST_GROUPS = "Host groups (instance groups), used it to run remote commands only those " +
+            "hosts that are included the specific host groups.";
+
+    private RemoteCommandsExecutionDescription() {
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/util/UtilV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/util/UtilV4Endpoint.java
@@ -7,6 +7,7 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
@@ -27,6 +28,8 @@ import com.sequenceiq.cloudbreak.doc.OperationDescriptions.RepositoryConfigsVali
 import com.sequenceiq.cloudbreak.doc.OperationDescriptions.SecurityRuleOpDescription;
 import com.sequenceiq.cloudbreak.doc.OperationDescriptions.UtilityOpDescription;
 import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
+import com.sequenceiq.common.api.command.RemoteCommandsExecutionRequest;
+import com.sequenceiq.common.api.command.RemoteCommandsExecutionResponse;
 import com.sequenceiq.common.api.util.UtilControllerDescription;
 import com.sequenceiq.common.api.util.versionchecker.VersionCheckResult;
 
@@ -101,4 +104,10 @@ public interface UtilV4Endpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = UtilityOpDescription.USED_IMAGES, produces = MediaType.APPLICATION_JSON, nickname = "usedImages")
     UsedImagesListV4Response usedImages(@QueryParam("thresholdInDays") Integer thresholdInDays);
+
+    @POST
+    @Path("remote_execution/{resourceCrn}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = UtilityOpDescription.REMOTE_EXEC, produces = MediaType.APPLICATION_JSON, nickname = "remoteExecV4")
+    RemoteCommandsExecutionResponse remoteCommandExecution(@PathParam("resourceCrn") String resourceCrn, RemoteCommandsExecutionRequest request);
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
@@ -171,6 +171,7 @@ public class OperationDescriptions {
         public static final String NOTIFICATION_TEST = "Trigger a new notification to the notification system could be validated from the begins";
         public static final String RENEW_CERTIFICATE = "Trigger a certificate renewal on the desired cluster which is identified via stack's name";
         public static final String USED_IMAGES = "List the images that are in use";
+        public static final String REMOTE_EXEC = "Execute commands (sync) from API";
     }
 
     public static class DatabaseOpDescription {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/UtilV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/UtilV4Controller.java
@@ -36,9 +36,12 @@ import com.sequenceiq.cloudbreak.service.filesystem.FileSystemSupportMatrixServi
 import com.sequenceiq.cloudbreak.service.image.PlatformStringTransformer;
 import com.sequenceiq.cloudbreak.service.image.UsedImagesProvider;
 import com.sequenceiq.cloudbreak.service.securityrule.SecurityRuleService;
+import com.sequenceiq.cloudbreak.service.stack.RemoteExecutionService;
 import com.sequenceiq.cloudbreak.service.stack.flow.StackOperationService;
 import com.sequenceiq.cloudbreak.structuredevent.CloudbreakRestRequestThreadLocalService;
 import com.sequenceiq.cloudbreak.validation.externaldatabase.SupportedDatabaseProvider;
+import com.sequenceiq.common.api.command.RemoteCommandsExecutionRequest;
+import com.sequenceiq.common.api.command.RemoteCommandsExecutionResponse;
 import com.sequenceiq.common.api.util.versionchecker.ClientVersionUtil;
 import com.sequenceiq.common.api.util.versionchecker.VersionCheckResult;
 
@@ -77,6 +80,9 @@ public class UtilV4Controller extends NotificationController implements UtilV4En
 
     @Inject
     private PlatformStringTransformer platformStringTransformer;
+
+    @Inject
+    private RemoteExecutionService remoteExecutionService;
 
     @Value("${info.app.version:}")
     private String cbVersion;
@@ -151,5 +157,12 @@ public class UtilV4Controller extends NotificationController implements UtilV4En
     @AccountIdNotNeeded
     public UsedImagesListV4Response usedImages(Integer thresholdInDays) {
         return usedImagesProvider.getUsedImages(thresholdInDays);
+    }
+
+    @Override
+    @InternalOnly
+    @AccountIdNotNeeded
+    public RemoteCommandsExecutionResponse remoteCommandExecution(String resourceCrn, RemoteCommandsExecutionRequest request) {
+        return remoteExecutionService.remoteExec(resourceCrn, request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/RemoteExecutionService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/RemoteExecutionService.java
@@ -1,0 +1,61 @@
+package com.sequenceiq.cloudbreak.service.stack;
+
+import java.util.Map;
+import java.util.Set;
+
+import javax.ws.rs.ServiceUnavailableException;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.common.orchestration.Node;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.orchestrator.metadata.OrchestratorMetadata;
+import com.sequenceiq.cloudbreak.orchestrator.metadata.OrchestratorMetadataFilter;
+import com.sequenceiq.cloudbreak.service.orchestrator.OrchestratorService;
+import com.sequenceiq.common.api.command.RemoteCommandsExecutionRequest;
+import com.sequenceiq.common.api.command.RemoteCommandsExecutionResponse;
+
+@Component
+public class RemoteExecutionService {
+
+    private final boolean remoteCommandExecution;
+
+    private final StackService stackService;
+
+    private final HostOrchestrator hostOrchestrator;
+
+    private final OrchestratorService orchestratorService;
+
+    public RemoteExecutionService(StackService stackService, HostOrchestrator hostOrchestrator, OrchestratorService orchestratorService,
+            @Value("${testing.remote-command-execution:false}") boolean remoteCommandExecution) {
+        this.stackService = stackService;
+        this.hostOrchestrator = hostOrchestrator;
+        this.orchestratorService = orchestratorService;
+        this.remoteCommandExecution = remoteCommandExecution;
+    }
+
+    public RemoteCommandsExecutionResponse remoteExec(String resourceCrn, RemoteCommandsExecutionRequest req) {
+        if (!remoteCommandExecution) {
+            throw new ServiceUnavailableException("Remote command execution is not supported!");
+        }
+        Stack stack = stackService.getByCrn(resourceCrn);
+        OrchestratorMetadata metadata = orchestratorService.getOrchestratorMetadata(stack.getId());
+        OrchestratorMetadataFilter filter = OrchestratorMetadataFilter.Builder.newBuilder()
+                .includeHosts(req.getHosts())
+                .includeHostGroups(req.getHostGroups())
+                .build();
+        Set<Node> nodes = filter.apply(metadata.getNodes());
+        try {
+            Map<String, String> results = hostOrchestrator.runCommandOnHosts(metadata.getGatewayConfigs(), nodes, req.getCommand());
+            RemoteCommandsExecutionResponse response = new RemoteCommandsExecutionResponse();
+            response.setResults(results);
+            return response;
+        } catch (CloudbreakOrchestratorFailedException orchestratorFailedException) {
+            throw new CloudbreakServiceException(orchestratorFailedException);
+        }
+    }
+}

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -915,3 +915,6 @@ existing-stack-patcher:
 clusterdns:
   host: localhost
   port: 8982
+
+testing:
+  remote-command-execution: false

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/RemoteExecutionServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/RemoteExecutionServiceTest.java
@@ -1,0 +1,115 @@
+package com.sequenceiq.cloudbreak.service.stack;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.ws.rs.ServiceUnavailableException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.common.orchestration.Node;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.orchestrator.metadata.OrchestratorMetadata;
+import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.cloudbreak.service.orchestrator.OrchestratorService;
+import com.sequenceiq.common.api.command.RemoteCommandsExecutionRequest;
+import com.sequenceiq.common.api.command.RemoteCommandsExecutionResponse;
+
+@ExtendWith(MockitoExtension.class)
+public class RemoteExecutionServiceTest {
+
+    private static final Long STACK_ID = 1L;
+
+    private RemoteExecutionService underTest;
+
+    @Mock
+    private HostOrchestrator hostOrchestrator;
+
+    @Mock
+    private OrchestratorService orchestratorService;
+
+    @Mock
+    private StackService stackService;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        underTest = new RemoteExecutionService(stackService, hostOrchestrator, orchestratorService, true);
+    }
+
+    @Test
+    public void testRemoteExec() throws CloudbreakOrchestratorFailedException {
+        // GIVEN
+        Map<String, String> result = new HashMap<>();
+        result.put("host1", "sample");
+        RemoteCommandsExecutionRequest request = new RemoteCommandsExecutionRequest();
+        String command = "echo sample";
+        request.setCommand(command);
+        List<GatewayConfig> gatewayConfigList = new ArrayList<>();
+        Set<Node> nodes = new HashSet<>();
+        OrchestratorMetadata metadata = new OrchestratorMetadata(gatewayConfigList, nodes, null, null);
+        Stack stack = new Stack();
+        stack.setId(STACK_ID);
+        given(stackService.getByCrn(isNull())).willReturn(stack);
+        given(orchestratorService.getOrchestratorMetadata(anyLong())).willReturn(metadata);
+        given(hostOrchestrator.runCommandOnHosts(gatewayConfigList, nodes, command)).willReturn(result);
+        // WHEN
+        RemoteCommandsExecutionResponse response = underTest.remoteExec(null, request);
+        // THEN
+        assertEquals("sample", response.getResults().get("host1"));
+        verify(hostOrchestrator, times(1)).runCommandOnHosts(gatewayConfigList, nodes, command);
+    }
+
+    @Test
+    public void testRemoteExecWithOrchestrationError() throws CloudbreakOrchestratorFailedException {
+        // GIVEN
+        RemoteCommandsExecutionRequest request = new RemoteCommandsExecutionRequest();
+        String command = "echo sample";
+        request.setCommand(command);
+        List<GatewayConfig> gatewayConfigList = new ArrayList<>();
+        Set<Node> nodes = new HashSet<>();
+        OrchestratorMetadata metadata = new OrchestratorMetadata(gatewayConfigList, nodes, null, null);
+        Stack stack = new Stack();
+        stack.setId(STACK_ID);
+        given(stackService.getByCrn(isNull())).willReturn(stack);
+        given(orchestratorService.getOrchestratorMetadata(anyLong())).willReturn(metadata);
+        given(hostOrchestrator.runCommandOnHosts(gatewayConfigList, nodes, command)).willThrow(new CloudbreakOrchestratorFailedException("ex"));
+        // WHEN
+        CloudbreakServiceException ex = assertThrows(CloudbreakServiceException.class,
+                () -> underTest.remoteExec(null, request));
+        // THEN
+        assertTrue(ex.getMessage().contains("ex"));
+    }
+
+    @Test
+    public void testRemoteExecIsNotSupported() {
+        // GIVEN
+        underTest = new RemoteExecutionService(stackService, hostOrchestrator, orchestratorService, false);
+        // WHEN
+        ServiceUnavailableException ex = assertThrows(ServiceUnavailableException.class,
+                () -> underTest.remoteExec(null, new RemoteCommandsExecutionRequest()));
+        // THEN
+        assertEquals("Remote command execution is not supported!", ex.getMessage());
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/structuredevent/rest/urlparsers/RestUrlParserTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/structuredevent/rest/urlparsers/RestUrlParserTest.java
@@ -90,7 +90,7 @@ public class RestUrlParserTest {
 
     private final String[] excludes = {"/v1/distrox", "/v1/internal/distrox", "/flow-public", "/autoscale",
             "cluster_templates", "/v4/events", "/v4/diagnostics", "/v4/progress", "/v4/operation",
-            "/v4/custom_configurations"};
+            "/v4/custom_configurations", "/v4/utils"};
 
     private final String[] excludePaths = {"/stacks/internal/crn"};
 

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/util/UtilV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/util/UtilV1Endpoint.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -12,6 +13,8 @@ import javax.ws.rs.core.MediaType;
 
 import com.sequenceiq.cloudbreak.auth.security.internal.AccountId;
 import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
+import com.sequenceiq.common.api.command.RemoteCommandsExecutionRequest;
+import com.sequenceiq.common.api.command.RemoteCommandsExecutionResponse;
 import com.sequenceiq.freeipa.api.v1.util.doc.UtilDescriptions;
 import com.sequenceiq.freeipa.api.v1.util.model.UsedImagesListV1Response;
 
@@ -35,4 +38,10 @@ public interface UtilV1Endpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = UtilDescriptions.USED_IMAGES, produces = MediaType.APPLICATION_JSON, nickname = "usedRecipesV1")
     List<String> usedRecipes(@AccountId @PathParam("accountId") String accountId);
+
+    @POST
+    @Path("remote_execution/{environmentCrn}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = UtilDescriptions.REMOTE_EXEC, produces = MediaType.APPLICATION_JSON, nickname = "remoteExecV1")
+    RemoteCommandsExecutionResponse remoteCommandExecution(@PathParam("environmentCrn") String environmentCrn, RemoteCommandsExecutionRequest request);
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/util/doc/UtilDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/util/doc/UtilDescriptions.java
@@ -4,6 +4,7 @@ public final class UtilDescriptions {
     public static final String NOTES = "Miscellaneous utility operations";
     public static final String USED_IMAGES = "List the images that are in use";
     public static final String USED_RECIPES = "List the recipes that are in use by account";
+    public static final String REMOTE_EXEC = "Execute commands (sync) from API";
 
     private UtilDescriptions() {
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/UtilV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/UtilV1Controller.java
@@ -9,10 +9,13 @@ import org.springframework.stereotype.Controller;
 import com.sequenceiq.authorization.annotation.AccountIdNotNeeded;
 import com.sequenceiq.authorization.annotation.InternalOnly;
 import com.sequenceiq.cloudbreak.auth.security.internal.AccountId;
+import com.sequenceiq.common.api.command.RemoteCommandsExecutionRequest;
+import com.sequenceiq.common.api.command.RemoteCommandsExecutionResponse;
 import com.sequenceiq.freeipa.api.v1.util.UtilV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.util.model.UsedImagesListV1Response;
 import com.sequenceiq.freeipa.service.UsedImagesProvider;
 import com.sequenceiq.freeipa.service.recipe.FreeIpaRecipeService;
+import com.sequenceiq.freeipa.service.stack.RemoteExecutionService;
 
 @Controller
 public class UtilV1Controller implements UtilV1Endpoint {
@@ -22,6 +25,9 @@ public class UtilV1Controller implements UtilV1Endpoint {
 
     @Inject
     private FreeIpaRecipeService freeIpaRecipeService;
+
+    @Inject
+    private RemoteExecutionService remoteExecutionService;
 
     @Override
     @InternalOnly
@@ -34,5 +40,12 @@ public class UtilV1Controller implements UtilV1Endpoint {
     @InternalOnly
     public List<String> usedRecipes(@AccountId String accountId) {
         return freeIpaRecipeService.getUsedRecipeNamesForAccount(accountId);
+    }
+
+    @Override
+    @InternalOnly
+    @AccountIdNotNeeded
+    public RemoteCommandsExecutionResponse remoteCommandExecution(String environmentCrn, RemoteCommandsExecutionRequest request) {
+        return remoteExecutionService.remoteExec(environmentCrn, request);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/RemoteExecutionService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/RemoteExecutionService.java
@@ -1,0 +1,63 @@
+package com.sequenceiq.freeipa.service.stack;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.common.orchestration.Node;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.orchestrator.metadata.OrchestratorMetadata;
+import com.sequenceiq.cloudbreak.orchestrator.metadata.OrchestratorMetadataFilter;
+import com.sequenceiq.common.api.command.RemoteCommandsExecutionRequest;
+import com.sequenceiq.common.api.command.RemoteCommandsExecutionResponse;
+import com.sequenceiq.freeipa.controller.exception.UnsupportedException;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.orchestrator.OrchestratorService;
+
+@Component
+public class RemoteExecutionService {
+
+    private final boolean remoteCommandExecution;
+
+    private final StackService stackService;
+
+    private final HostOrchestrator hostOrchestrator;
+
+    private final OrchestratorService orchestratorService;
+
+    public RemoteExecutionService(StackService stackService, HostOrchestrator hostOrchestrator, OrchestratorService orchestratorService,
+            @Value("${testing.remote-command-execution:false}") boolean remoteCommandExecution) {
+        this.stackService = stackService;
+        this.hostOrchestrator = hostOrchestrator;
+        this.orchestratorService = orchestratorService;
+        this.remoteCommandExecution = remoteCommandExecution;
+    }
+
+    public RemoteCommandsExecutionResponse remoteExec(String environmentCrn, RemoteCommandsExecutionRequest req) {
+        if (!remoteCommandExecution) {
+            throw new UnsupportedException("Remote command execution is not supported!");
+        }
+        Crn crn = Crn.safeFromString(environmentCrn);
+        Stack stack = stackService.getByEnvironmentCrnAndAccountId(environmentCrn, crn.getAccountId());
+        OrchestratorMetadata metadata = orchestratorService.getOrchestratorMetadata(stack.getId());
+        OrchestratorMetadataFilter filter = OrchestratorMetadataFilter.Builder.newBuilder()
+                .includeHosts(req.getHosts())
+                .includeHostGroups(req.getHostGroups())
+                .build();
+        Set<Node> nodes = filter.apply(metadata.getNodes());
+        try {
+            Map<String, String> results = hostOrchestrator.runCommandOnHosts(metadata.getGatewayConfigs(), nodes, req.getCommand());
+            RemoteCommandsExecutionResponse response = new RemoteCommandsExecutionResponse();
+            response.setResults(results);
+            return response;
+        } catch (CloudbreakOrchestratorFailedException orchestratorFailedException) {
+            throw new CloudbreakServiceException(orchestratorFailedException);
+        }
+    }
+
+}

--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -333,3 +333,6 @@ crn:
 authdistributor:
   host: localhost
   port: 8982
+
+testing:
+  remote-command-execution: false

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/RemoteExecutionServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/RemoteExecutionServiceTest.java
@@ -1,0 +1,116 @@
+package com.sequenceiq.freeipa.service.stack;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.common.orchestration.Node;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.orchestrator.metadata.OrchestratorMetadata;
+import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.common.api.command.RemoteCommandsExecutionRequest;
+import com.sequenceiq.common.api.command.RemoteCommandsExecutionResponse;
+import com.sequenceiq.freeipa.controller.exception.UnsupportedException;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.orchestrator.OrchestratorService;
+
+@ExtendWith(MockitoExtension.class)
+public class RemoteExecutionServiceTest {
+
+    private static final Long STACK_ID = 1L;
+
+    private static final String ENVIRONMENT_CRN = "crn:cdp:environments:us-west-1:f39af961-e0ce-4f79-826c-45502efb9ca3:environment:12345-6789";
+
+    private RemoteExecutionService underTest;
+
+    @Mock
+    private HostOrchestrator hostOrchestrator;
+
+    @Mock
+    private OrchestratorService orchestratorService;
+
+    @Mock
+    private StackService stackService;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        underTest = new RemoteExecutionService(stackService, hostOrchestrator, orchestratorService, true);
+    }
+
+    @Test
+    public void testRemoteExec() throws CloudbreakOrchestratorFailedException {
+        // GIVEN
+        Map<String, String> result = new HashMap<>();
+        result.put("host1", "sample");
+        RemoteCommandsExecutionRequest request = new RemoteCommandsExecutionRequest();
+        String command = "echo sample";
+        request.setCommand(command);
+        List<GatewayConfig> gatewayConfigList = new ArrayList<>();
+        Set<Node> nodes = new HashSet<>();
+        OrchestratorMetadata metadata = new OrchestratorMetadata(gatewayConfigList, nodes, null, null);
+        Stack stack = new Stack();
+        stack.setId(STACK_ID);
+        given(stackService.getByEnvironmentCrnAndAccountId(anyString(), anyString())).willReturn(stack);
+        given(orchestratorService.getOrchestratorMetadata(anyLong())).willReturn(metadata);
+        given(hostOrchestrator.runCommandOnHosts(gatewayConfigList, nodes, command)).willReturn(result);
+        // WHEN
+        RemoteCommandsExecutionResponse response = underTest.remoteExec(ENVIRONMENT_CRN, request);
+        // THEN
+        assertEquals("sample", response.getResults().get("host1"));
+        verify(hostOrchestrator, times(1)).runCommandOnHosts(gatewayConfigList, nodes, command);
+    }
+
+    @Test
+    public void testRemoteExecWithOrchestrationError() throws CloudbreakOrchestratorFailedException {
+        // GIVEN
+        RemoteCommandsExecutionRequest request = new RemoteCommandsExecutionRequest();
+        String command = "echo sample";
+        request.setCommand(command);
+        List<GatewayConfig> gatewayConfigList = new ArrayList<>();
+        Set<Node> nodes = new HashSet<>();
+        OrchestratorMetadata metadata = new OrchestratorMetadata(gatewayConfigList, nodes, null, null);
+        Stack stack = new Stack();
+        stack.setId(STACK_ID);
+        given(stackService.getByEnvironmentCrnAndAccountId(anyString(), anyString())).willReturn(stack);
+        given(orchestratorService.getOrchestratorMetadata(anyLong())).willReturn(metadata);
+        given(hostOrchestrator.runCommandOnHosts(gatewayConfigList, nodes, command)).willThrow(new CloudbreakOrchestratorFailedException("ex"));
+        // WHEN
+        CloudbreakServiceException ex = assertThrows(CloudbreakServiceException.class,
+                () -> underTest.remoteExec(ENVIRONMENT_CRN, request));
+        // THEN
+        assertTrue(ex.getMessage().contains("ex"));
+    }
+
+    @Test
+    public void testRemoteExecIsNotSupported() {
+        // GIVEN
+        underTest = new RemoteExecutionService(stackService, hostOrchestrator, orchestratorService, false);
+        // WHEN
+        UnsupportedException ex = assertThrows(UnsupportedException.class,
+                () -> underTest.remoteExec(ENVIRONMENT_CRN, new RemoteCommandsExecutionRequest()));
+        // THEN
+        assertEquals("Remote command execution is not supported!", ex.getMessage());
+    }
+}

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
@@ -77,6 +77,8 @@ public interface HostOrchestrator extends HostRecipeExecutor {
 
     Map<String, String> runCommandOnAllHosts(GatewayConfig gateway, String command) throws CloudbreakOrchestratorFailedException;
 
+    Map<String, String> runCommandOnHosts(List<GatewayConfig> allGatewayConfigs, Set<Node> nodes, String command) throws CloudbreakOrchestratorFailedException;
+
     Map<String, String> replacePatternInFileOnAllHosts(GatewayConfig gatewayConfig, String file, String pattern, String replace)
             throws CloudbreakOrchestratorFailedException;
 

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestratorTest.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestratorTest.java
@@ -14,6 +14,7 @@ import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doThrow;
@@ -746,5 +747,15 @@ class SaltOrchestratorTest {
         verify(callable).call();
         SaltUpload saltUpload = saltUploadCaptor.getValue();
         assertEquals(Set.of(gatewayConfig.getPrivateAddress()), saltUpload.getTargets());
+    }
+
+    @Test
+    void testRunCommandOnHosts() throws Exception {
+        List<GatewayConfig> allGatewayConfigs = Collections.singletonList(gatewayConfig);
+        Map<String, String> response = new HashMap<>();
+        response.put("host1", "sample");
+        when(saltStateService.runCommandOnHosts(any(), any(), any(), anyString())).thenReturn(response);
+        Map<String, String> result = saltOrchestrator.runCommandOnHosts(allGatewayConfigs, new HashSet<>(), "echo sample");
+        assertEquals("sample", result.get("host1"));
     }
 }


### PR DESCRIPTION
details:
- add remote_exec api to both core and freeipa
- disable feature by flag, that setting should be the default
- this featue should be only used for testing purposes in order to run specific commands on all or filtered hosts (filter by host or host group)

See detailed description in the commit message.