### PR TITLE
Revert "Revert "CB-17467 Recipe crn should not have datahub word in it""

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/auth/crn/CrnResourceDescriptor.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/auth/crn/CrnResourceDescriptor.java
@@ -26,7 +26,7 @@ public enum CrnResourceDescriptor {
     CUSTOM_CONFIGURATIONS(Crn.ResourceType.CUSTOM_CONFIGURATIONS, Crn.Service.DATAHUB),
     DATAHUB(Crn.ResourceType.CLUSTER, Crn.Service.DATAHUB),
     IMAGE_CATALOG(Crn.ResourceType.IMAGE_CATALOG, Crn.Service.DATAHUB),
-    RECIPE(Crn.ResourceType.RECIPE, Crn.Service.DATAHUB),
+    RECIPE(Crn.ResourceType.RECIPE, Crn.Service.RECIPE),
     // freeipa management service
     FREEIPA(Crn.ResourceType.FREEIPA, Crn.Service.FREEIPA),
     KERBEROS(Crn.ResourceType.KERBEROS, Crn.Service.FREEIPA),

--- a/common/src/test/java/com/sequenceiq/cloudbreak/auth/crn/CrnTestUtil.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/auth/crn/CrnTestUtil.java
@@ -106,7 +106,7 @@ public class CrnTestUtil {
         return Crn.builder()
                 .setPartition(Crn.Partition.CDP)
                 .setRegion(Crn.Region.US_WEST_1)
-                .setService(Crn.Service.DATAHUB)
+                .setService(Crn.Service.RECIPE)
                 .setResourceType(Crn.ResourceType.RECIPE);
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/recipe/RecipeServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/recipe/RecipeServiceTest.java
@@ -161,7 +161,7 @@ public class RecipeServiceTest {
         ThreadBasedUserCrnProvider.doAs(userCrn, () -> underTest.createForLoggedInUser(recipe, 1L, "account_id", userCrn));
 
         assertThat(recipe.getCreator(), is(userCrn));
-        assertTrue(recipe.getResourceCrn().matches("crn:cdp:datahub:us-west-1:account_id:recipe:.*"));
+        assertTrue(recipe.getResourceCrn().matches("crn:cdp:recipe:us-west-1:account_id:recipe:.*"));
     }
 
     @Test
@@ -177,7 +177,7 @@ public class RecipeServiceTest {
         Recipe savedRecipe = underTest.createWithInternalUser(recipe, 1L, "account_id");
 
         assertThat(recipe.getCreator(), nullValue());
-        assertTrue(recipe.getResourceCrn().matches("crn:cdp:datahub:us-west-1:account_id:recipe:.*"));
+        assertTrue(recipe.getResourceCrn().matches("crn:cdp:recipe:us-west-1:account_id:recipe:.*"));
         assertEquals(workspace, savedRecipe.getWorkspace());
         assertEquals(CreationType.SERVICE, savedRecipe.getCreationType());
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/AuthorizationTestUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/AuthorizationTestUtil.java
@@ -79,7 +79,7 @@ public class AuthorizationTestUtil {
     }
 
     public static String datahubRecipePattern(String recipeName) {
-        return String.format("[\\[]name: %s, crn: crn:cdp:datahub:us-west-1:.*:recipe:.*[]]\\.", recipeName);
+        return String.format("[\\[]name: %s, crn: crn:cdp:recipe:us-west-1:.*:recipe:.*[]]\\.", recipeName);
     }
 
     public static String proxyConfigPattern(String proxyConfig) {


### PR DESCRIPTION
This reverts commit 5fafc7350da155f4690bde5daef7923f59fc02d6.

See detailed description in the commit message.