### PR TITLE
CB-17836 - Roll forward sync fails after upgrade because of cloudera-…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/PackageName.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/PackageName.java
@@ -5,6 +5,8 @@ public class PackageName {
 
     private String pattern;
 
+    private boolean validateForMultipleVersions;
+
     public String getName() {
         return name;
     }
@@ -19,6 +21,14 @@ public class PackageName {
 
     public void setPattern(String pattern) {
         this.pattern = pattern;
+    }
+
+    public boolean getValidateForMultipleVersions() {
+        return validateForMultipleVersions;
+    }
+
+    public void setValidateForMultipleVersions(boolean validateForMultipleVersions) {
+        this.validateForMultipleVersions = validateForMultipleVersions;
     }
 
     @Override

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -793,8 +793,10 @@ cb:
         pkg:
           - name: cloudera-manager-agent
             pattern: "(.*)-([0-9]+)[a-zA-z]*\\..*"
+            validateForMultipleVersions: true
           - name: cloudera-manager-server
             pattern: "(.*)-([0-9]+)[a-zA-z]*\\..*"
+            validateForMultipleVersions: false
         prewarmed: true
   paywall.url: "https://archive.cloudera.com/p/cdp-public/"
   nodestatus:


### PR DESCRIPTION
…manager-server version consistency validation

This commit:
 - removes CM server and agent consistency check as there might be
different server versions in the CM Server and the other nodes
 - introduces parameter for multiple version consistency check for the
same reason

See detailed description in the commit message.