### PR TITLE
CB-17870 Even more Jackson payload fixes

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/context/CloudContext.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/context/CloudContext.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.cloud.context;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.sequenceiq.cloudbreak.cloud.model.CloudPlatformVariant;
@@ -179,8 +180,20 @@ public class CloudContext {
             return this;
         }
 
+        @JsonProperty("platform")
+        public Builder withPlatform(Platform platform) {
+            this.platform = platform.getValue();
+            return this;
+        }
+
         public Builder withVariant(String variant) {
             this.variant = variant;
+            return this;
+        }
+
+        @JsonProperty("variant")
+        public Builder withVariant(Variant variant) {
+            this.variant = variant.getValue();
             return this;
         }
 

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudLoadBalancer.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudLoadBalancer.java
@@ -6,6 +6,8 @@ import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.sequenceiq.common.api.type.LoadBalancerSku;
 import com.sequenceiq.common.api.type.LoadBalancerType;
 
@@ -13,6 +15,8 @@ public class CloudLoadBalancer {
 
     private final LoadBalancerType type;
 
+    @JsonSerialize(keyUsing = TargetGroupPortPair.TargetGroupPortPairSerializer.class)
+    @JsonDeserialize(keyUsing = TargetGroupPortPair.TargetGroupPortPairDeserializer.class)
     private final Map<TargetGroupPortPair, Set<Group>> portToTargetGroupMapping;
 
     private final LoadBalancerSku sku;
@@ -54,9 +58,9 @@ public class CloudLoadBalancer {
     @Override
     public String toString() {
         return "CloudLoadBalancer{" +
-            "type=" + type +
-            "sku=" + sku +
-            ", portToTargetGroupMapping=" + portToTargetGroupMapping +
-            '}';
+                "type=" + type +
+                ", portToTargetGroupMapping=" + portToTargetGroupMapping +
+                ", sku=" + sku +
+                '}';
     }
 }

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/TargetGroupPortPair.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/TargetGroupPortPair.java
@@ -1,6 +1,16 @@
 package com.sequenceiq.cloudbreak.cloud.model;
 
+import java.io.IOException;
 import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.KeyDeserializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 
 /**
  * A joining of ports related to target groups. Target groups are groups of instances that a load balancer routes traffic
@@ -15,7 +25,11 @@ public class TargetGroupPortPair {
 
     private final int healthCheckPort;
 
-    public TargetGroupPortPair(int trafficPort, int healthCheckPort) {
+    @JsonCreator
+    public TargetGroupPortPair(
+            @JsonProperty("trafficPort") int trafficPort,
+            @JsonProperty("healthCheckPort") int healthCheckPort) {
+
         this.trafficPort = trafficPort;
         this.healthCheckPort = healthCheckPort;
     }
@@ -49,8 +63,22 @@ public class TargetGroupPortPair {
     @Override
     public String toString() {
         return "TargetGroupPortPair{" +
-            "trafficPort=" + trafficPort +
-            ", healthCheckPort=" + healthCheckPort +
-            '}';
+                "trafficPort=" + trafficPort +
+                ", healthCheckPort=" + healthCheckPort +
+                '}';
+    }
+
+    public static class TargetGroupPortPairDeserializer extends KeyDeserializer {
+        @Override
+        public Object deserializeKey(String key, DeserializationContext ctxt) throws IOException {
+            return JsonUtil.readValue(key, TargetGroupPortPair.class);
+        }
+    }
+
+    public static class TargetGroupPortPairSerializer extends JsonSerializer<TargetGroupPortPair> {
+        @Override
+        public void serialize(TargetGroupPortPair value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+            gen.writeFieldName(JsonUtil.writeValueAsStringUnchecked(value));
+        }
     }
 }

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/CloudPlatformResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/CloudPlatformResult.java
@@ -1,5 +1,8 @@
 package com.sequenceiq.cloudbreak.cloud.event;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.cloud.event.model.EventStatus;
 import com.sequenceiq.cloudbreak.common.event.Payload;
 
@@ -11,6 +14,7 @@ public class CloudPlatformResult implements Payload {
 
     private String statusReason;
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private Exception errorDetails;
 
     public CloudPlatformResult(Long resourceId) {

--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/event/Acceptable.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/event/Acceptable.java
@@ -1,7 +1,10 @@
 package com.sequenceiq.cloudbreak.common.event;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import reactor.rx.Promise;
 
 public interface Acceptable extends Payload {
+    @JsonIgnore
     Promise<AcceptResult> accepted();
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/json/JsonUtil.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/json/JsonUtil.java
@@ -88,6 +88,14 @@ public class JsonUtil {
         return MAPPER.writeValueAsString(object);
     }
 
+    public static String writeValueAsStringUnchecked(Object object) {
+        try {
+            return MAPPER.writeValueAsString(object);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Cannot convert object to Json string.", e);
+        }
+    }
+
     public static String writeValueAsStringSilent(Object object) {
         return writeValueAsStringSilent(object, false);
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/preparation/event/ClusterUpgradePreparationFailureEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/preparation/event/ClusterUpgradePreparationFailureEvent.java
@@ -1,13 +1,16 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.preparation.event;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.preparation.ClusterUpgradePreparationStateSelectors.FAILED_CLUSTER_UPGRADE_PREPARATION_EVENT;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackFailureEvent;
 
 public class ClusterUpgradePreparationFailureEvent extends StackFailureEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/preparation/event/ClusterUpgradePreparationTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/preparation/event/ClusterUpgradePreparationTriggerEvent.java
@@ -18,7 +18,7 @@ public class ClusterUpgradePreparationTriggerEvent extends StackEvent {
     @JsonCreator
     public ClusterUpgradePreparationTriggerEvent(
             @JsonProperty("resourceId") Long resourceId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted,
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted,
             @JsonProperty("imageChangeDto") ImageChangeDto imageChangeDto) {
         super(START_CLUSTER_UPGRADE_PREPARATION_INIT_EVENT.event(), resourceId, accepted);
         this.imageChangeDto = imageChangeDto;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/event/ClusterUpgradeValidationFailureEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/event/ClusterUpgradeValidationFailureEvent.java
@@ -1,13 +1,16 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationStateSelectors.FAILED_CLUSTER_UPGRADE_VALIDATION_EVENT;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 
 public class ClusterUpgradeValidationFailureEvent extends StackEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/event/ClusterUpgradeValidationFinishedEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/event/ClusterUpgradeValidationFinishedEvent.java
@@ -1,13 +1,16 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationStateSelectors.FINISH_CLUSTER_UPGRADE_VALIDATION_EVENT;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 
 public class ClusterUpgradeValidationFinishedEvent extends StackEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     public ClusterUpgradeValidationFinishedEvent(Long resourceId) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/event/ClusterUpgradeValidationTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/event/ClusterUpgradeValidationTriggerEvent.java
@@ -19,7 +19,7 @@ public class ClusterUpgradeValidationTriggerEvent extends StackEvent {
     @JsonCreator
     public ClusterUpgradeValidationTriggerEvent(
             @JsonProperty("resourceId") Long resourceId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted,
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted,
             @JsonProperty("imageId") String imageId,
             @JsonProperty("lockComponents") boolean lockComponents) {
         super(START_CLUSTER_UPGRADE_VALIDATION_INIT_EVENT.event(), resourceId, accepted);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cmdiagnostics/event/CmDiagnosticsCollectionEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cmdiagnostics/event/CmDiagnosticsCollectionEvent.java
@@ -23,7 +23,7 @@ public class CmDiagnosticsCollectionEvent extends BaseFlowEvent {
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long resourceId,
             @JsonProperty("resourceCrn") String resourceCrn,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted,
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted,
             @JsonProperty("parameters") CmDiagnosticsParameters parameters) {
         super(selector, resourceId, resourceCrn, accepted);
         this.parameters = parameters;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cmdiagnostics/event/CmDiagnosticsCollectionFailureEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cmdiagnostics/event/CmDiagnosticsCollectionFailureEvent.java
@@ -1,14 +1,17 @@
 package com.sequenceiq.cloudbreak.core.flow2.cmdiagnostics.event;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
 import static com.sequenceiq.cloudbreak.core.flow2.cmdiagnostics.event.CmDiagnosticsCollectionStateSelectors.FAILED_CM_DIAGNOSTICS_COLLECTION_EVENT;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.common.model.diagnostics.CmDiagnosticsParameters;
 
 public class CmDiagnosticsCollectionFailureEvent extends CmDiagnosticsCollectionEvent implements Selectable {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/event/DiagnosticsCollectionEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/event/DiagnosticsCollectionEvent.java
@@ -35,7 +35,7 @@ public class DiagnosticsCollectionEvent extends BaseFlowEvent {
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long resourceId,
             @JsonProperty("resourceCrn") String resourceCrn,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted,
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted,
             @JsonProperty("parameters") DiagnosticParameters parameters,
             @JsonProperty("hosts") Set<String> hosts,
             @JsonProperty("hostGroups") Set<String> hostGroups,

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/event/DiagnosticsCollectionFailureEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/event/DiagnosticsCollectionFailureEvent.java
@@ -1,14 +1,17 @@
 package com.sequenceiq.cloudbreak.core.flow2.diagnostics.event;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.DiagnosticsCollectionStateSelectors.FAILED_DIAGNOSTICS_COLLECTION_EVENT;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.common.model.diagnostics.DiagnosticParameters;
 
 public class DiagnosticsCollectionFailureEvent extends DiagnosticsCollectionEvent implements Selectable {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     private final String failureType;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterAndStackDownscaleTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterAndStackDownscaleTriggerEvent.java
@@ -47,7 +47,7 @@ public class ClusterAndStackDownscaleTriggerEvent extends ClusterDownscaleTrigge
             @JsonProperty("hostGroupsWithPrivateIds") Map<String, Set<Long>> hostGroupWithPrivateIds,
             @JsonProperty("hostGroupsWithHostNames") Map<String, Set<String>> hostGroupWithHostNames,
             @JsonProperty("scalingType") ScalingType scalingType,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted,
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted,
             @JsonProperty("details") ClusterDownscaleDetails details) {
         super(selector, stackId, hostGroupWithAdjustment, hostGroupWithPrivateIds, hostGroupWithHostNames, accepted, details);
         this.scalingType = scalingType;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterCertificatesRotationTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterCertificatesRotationTriggerEvent.java
@@ -23,7 +23,7 @@ public class ClusterCertificatesRotationTriggerEvent extends StackEvent {
     public ClusterCertificatesRotationTriggerEvent(
             @JsonProperty("selector") String event,
             @JsonProperty("resourceId") Long resourceId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted,
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted,
             @JsonProperty("certificateRotationType") CertificateRotationType certificateRotationType) {
         super(event, resourceId, accepted);
         this.certificateRotationType = certificateRotationType;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterDownscaleTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterDownscaleTriggerEvent.java
@@ -31,7 +31,7 @@ public class ClusterDownscaleTriggerEvent extends ClusterScaleTriggerEvent {
             @JsonProperty("hostGroupsWithAdjustment") Map<String, Integer> hostGroupWithAdjustment,
             @JsonProperty("hostGroupsWithPrivateIds") Map<String, Set<Long>> hostGroupWithPrivateIds,
             @JsonProperty("hostGroupsWithHostNames") Map<String, Set<String>> hostGroupWithHostNames,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted,
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted,
             @JsonProperty("details") ClusterDownscaleDetails details) {
         super(selector, stackId, hostGroupWithAdjustment, hostGroupWithPrivateIds, hostGroupWithHostNames, accepted);
         this.details = details;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterRecoveryTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterRecoveryTriggerEvent.java
@@ -18,7 +18,7 @@ public class ClusterRecoveryTriggerEvent extends StackEvent {
     public ClusterRecoveryTriggerEvent(
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long stackId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, stackId, accepted);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterScaleTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterScaleTriggerEvent.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.common.event.AcceptResult;
 import com.sequenceiq.cloudbreak.common.type.ClusterManagerType;
@@ -84,6 +85,7 @@ public class ClusterScaleTriggerEvent extends StackEvent {
         return hostGroupsWithHostNames;
     }
 
+    @JsonIgnore
     public Set<String> getHostGroups() {
         return getHostGroupsWithAdjustment().keySet();
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterUpgradeTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterUpgradeTriggerEvent.java
@@ -23,7 +23,7 @@ public class ClusterUpgradeTriggerEvent extends StackEvent {
     public ClusterUpgradeTriggerEvent(
             @JsonProperty("selector") String event,
             @JsonProperty("resourceId") Long resourceId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted,
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted,
             @JsonProperty("imageId") String imageId) {
         super(event, resourceId, accepted);
         this.imageId = imageId;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/DatabaseBackupTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/DatabaseBackupTriggerEvent.java
@@ -25,7 +25,7 @@ public class DatabaseBackupTriggerEvent extends BackupRestoreEvent {
     public DatabaseBackupTriggerEvent(
             @JsonProperty("selector") String event,
             @JsonProperty("resourceId") Long resourceId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted,
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted,
             @JsonProperty("backupLocation") String backupLocation,
             @JsonProperty("backupId") String backupId,
             @JsonProperty("closeConnections") boolean closeConnections) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/DatabaseRestoreTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/DatabaseRestoreTriggerEvent.java
@@ -21,7 +21,7 @@ public class DatabaseRestoreTriggerEvent extends BackupRestoreEvent {
     public DatabaseRestoreTriggerEvent(
             @JsonProperty("selector") String event,
             @JsonProperty("resourceId") Long resourceId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted,
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted,
             @JsonProperty("backupLocation") String backupLocation,
             @JsonProperty("backupId") String backupId) {
         super(event, resourceId, accepted, backupLocation, backupId);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/MaintenanceModeValidationTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/MaintenanceModeValidationTriggerEvent.java
@@ -18,7 +18,7 @@ public class MaintenanceModeValidationTriggerEvent extends StackEvent {
     public MaintenanceModeValidationTriggerEvent(
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long stackId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, stackId, accepted);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/MultiHostgroupClusterAndStackDownscaleTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/MultiHostgroupClusterAndStackDownscaleTriggerEvent.java
@@ -26,7 +26,7 @@ public class MultiHostgroupClusterAndStackDownscaleTriggerEvent extends StackEve
             @JsonProperty("privateIdsByHostgroupMap") Map<String, Set<Long>> privateIdsByHostgroupMap,
             @JsonProperty("details") ClusterDownscaleDetails details,
             @JsonProperty("scalingType") ScalingType scalingType,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, stackId, accepted);
         this.privateIdsByHostgroupMap = privateIdsByHostgroupMap;
         this.details = details;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/StackAndClusterUpscaleTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/StackAndClusterUpscaleTriggerEvent.java
@@ -51,7 +51,7 @@ public class StackAndClusterUpscaleTriggerEvent extends StackScaleTriggerEvent {
             @JsonProperty("scalingType") ScalingType scalingType,
             @JsonProperty("singleMasterGateway") boolean singlePrimaryGateway,
             @JsonProperty("kerberosSecured") boolean kerberosSecured,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted,
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted,
             @JsonProperty("singleNodeCluster") boolean singleNodeCluster,
             @JsonProperty("restartServices") boolean restartServices,
             @JsonProperty("clusterManagerType") ClusterManagerType clusterManagerType,

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/StackDownscaleTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/StackDownscaleTriggerEvent.java
@@ -34,7 +34,7 @@ public class StackDownscaleTriggerEvent extends StackScaleTriggerEvent {
             @JsonProperty("hostGroupsWithPrivateIds") Map<String, Set<Long>> hostGroupWithPrivateIds,
             @JsonProperty("hostGroupsWithHostNames") Map<String, Set<String>> hostGroupWithHostNames,
             @JsonProperty("triggeredStackVariant") String triggeredStackVariant,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, stackId, hostGroupWithAdjustment, hostGroupWithPrivateIds, hostGroupWithHostNames,
                 new AdjustmentTypeWithThreshold(AdjustmentType.BEST_EFFORT, null), triggeredStackVariant, accepted);
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/StackLoadBalancerUpdateTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/StackLoadBalancerUpdateTriggerEvent.java
@@ -22,7 +22,7 @@ public class StackLoadBalancerUpdateTriggerEvent extends StackEvent {
     public StackLoadBalancerUpdateTriggerEvent(
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long stackId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, stackId, accepted);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/StackSyncTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/StackSyncTriggerEvent.java
@@ -24,7 +24,7 @@ public class StackSyncTriggerEvent extends StackEvent {
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long stackId,
             @JsonProperty("statusUpdateEnabled") Boolean statusUpdateEnabled,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, stackId, accepted);
         this.statusUpdateEnabled = statusUpdateEnabled;
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/validate/cloud/event/ValidateCloudConfigRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/validate/cloud/event/ValidateCloudConfigRequest.java
@@ -22,7 +22,7 @@ public class ValidateCloudConfigRequest extends StackEvent {
     public ValidateCloudConfigRequest(
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long stackId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, stackId, accepted);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/ClusterPlatformResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/ClusterPlatformResult.java
@@ -1,5 +1,8 @@
 package com.sequenceiq.cloudbreak.reactor.api;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.cloud.event.model.EventStatus;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.flow.event.EventSelectorUtil;
@@ -10,6 +13,7 @@ public abstract class ClusterPlatformResult<R extends ClusterPlatformRequest> im
 
     private String statusReason;
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private Exception errorDetails;
 
     private R request;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/StackEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/StackEvent.java
@@ -35,7 +35,7 @@ public class StackEvent implements IdempotentEvent<StackEvent> {
     public StackEvent(
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long stackId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         this.selector = selector;
         this.stackId = stackId;
         this.accepted = accepted;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/StackFailureEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/StackFailureEvent.java
@@ -1,10 +1,14 @@
 package com.sequenceiq.cloudbreak.reactor.api.event;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 public class StackFailureEvent extends StackEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     public StackFailureEvent(Long stackId, Exception exception) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/DisableKerberosRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/DisableKerberosRequest.java
@@ -1,10 +1,13 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformRequest;
 
 public class DisableKerberosRequest extends ClusterPlatformRequest {
 
-    public DisableKerberosRequest(Long stackId) {
+    @JsonCreator
+    public DisableKerberosRequest(@JsonProperty("stackId") Long stackId) {
         super(stackId);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/DisableKerberosResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/DisableKerberosResult.java
@@ -1,14 +1,22 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformResult;
 
-public class DisableKerberosResult extends ClusterPlatformResult<DisableKerberosRequest> {
+public class DisableKerberosResult extends ClusterPlatformResult<DisableKerberosRequest> implements FlowPayload {
 
     public DisableKerberosResult(DisableKerberosRequest request) {
         super(request);
     }
 
-    public DisableKerberosResult(String statusReason, Exception errorDetails, DisableKerberosRequest request) {
+    @JsonCreator
+    public DisableKerberosResult(
+            @JsonProperty("statusReason") String statusReason,
+            @JsonProperty("errorDetails") Exception errorDetails,
+            @JsonProperty("request") DisableKerberosRequest request) {
+
         super(statusReason, errorDetails, request);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/DnsUpdateFinished.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/DnsUpdateFinished.java
@@ -1,9 +1,14 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.FlowPayload;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformRequest;
 
-public class DnsUpdateFinished extends ClusterPlatformRequest {
-    public DnsUpdateFinished(Long stackId) {
+public class DnsUpdateFinished extends ClusterPlatformRequest implements FlowPayload {
+
+    @JsonCreator
+    public DnsUpdateFinished(@JsonProperty("stackId") Long stackId) {
         super(stackId);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/RepairSingleMasterInstanceEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/RepairSingleMasterInstanceEvent.java
@@ -17,7 +17,7 @@ public class RepairSingleMasterInstanceEvent extends StackEvent {
     public RepairSingleMasterInstanceEvent(
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long stackId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, stackId, accepted);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/WaitForClusterServerRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/WaitForClusterServerRequest.java
@@ -21,7 +21,7 @@ public class WaitForClusterServerRequest extends StackEvent {
     public WaitForClusterServerRequest(
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long stackId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, stackId, accepted);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/dr/BackupRestoreEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/dr/BackupRestoreEvent.java
@@ -49,7 +49,7 @@ public class BackupRestoreEvent extends StackEvent {
     public BackupRestoreEvent(
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long stackId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted,
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted,
             @JsonProperty("backupLocation") String backupLocation,
             @JsonProperty("backupId") String backupId,
             @JsonProperty("closeConnections") boolean closeConnections) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/dr/backup/DatabaseBackupFailedEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/dr/backup/DatabaseBackupFailedEvent.java
@@ -1,13 +1,17 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.dr.backup;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.dr.BackupRestoreEvent;
 
 public class DatabaseBackupFailedEvent extends BackupRestoreEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     private final DetailedStackStatus detailedStatus;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/dr/restore/DatabaseRestoreFailedEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/dr/restore/DatabaseRestoreFailedEvent.java
@@ -1,13 +1,17 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.dr.restore;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.dr.BackupRestoreEvent;
 
 public class DatabaseRestoreFailedEvent extends BackupRestoreEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     private final DetailedStackStatus detailedStatus;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ClusterUpgradeFailHandledRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ClusterUpgradeFailHandledRequest.java
@@ -1,14 +1,17 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.ClusterUpgradeEvent.CLUSTER_UPGRADE_FAIL_HANDLED_EVENT;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 
 public class ClusterUpgradeFailHandledRequest  extends StackEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     private final DetailedStackStatus detailedStatus;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ClusterUpgradeFailedCmSyncRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ClusterUpgradeFailedCmSyncRequest.java
@@ -1,15 +1,19 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 
 public class ClusterUpgradeFailedCmSyncRequest extends StackEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     private final DetailedStackStatus detailedStatus;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ClusterUpgradeFailedEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ClusterUpgradeFailedEvent.java
@@ -1,14 +1,17 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.ClusterUpgradeEvent.CLUSTER_UPGRADE_FAILED_EVENT;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 
 public class ClusterUpgradeFailedEvent extends StackEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     private final DetailedStackStatus detailedStatus;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmFlowChainTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmFlowChainTriggerEvent.java
@@ -27,7 +27,7 @@ public class UpgradeCcmFlowChainTriggerEvent extends StackEvent {
             @JsonProperty("resourceId") Long stackId,
             @JsonProperty("clusterId") Long clusterId,
             @JsonProperty("oldTunnel") Tunnel oldTunnel,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, stackId, accepted);
         this.clusterId = clusterId;
         this.oldTunnel = oldTunnel;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmTriggerRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ccm/UpgradeCcmTriggerRequest.java
@@ -20,7 +20,7 @@ public class UpgradeCcmTriggerRequest extends AbstractUpgradeCcmEvent {
             @JsonProperty("resourceId") Long stackId,
             @JsonProperty("clusterId") Long clusterId,
             @JsonProperty("oldTunnel") Tunnel oldTunnel,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, stackId, clusterId, oldTunnel, accepted);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/recovery/bringup/DatalakeRecoverySetupNewInstancesFailedEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/recovery/bringup/DatalakeRecoverySetupNewInstancesFailedEvent.java
@@ -1,12 +1,16 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.recovery.bringup;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 
 public class DatalakeRecoverySetupNewInstancesFailedEvent extends StackEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     private final DetailedStackStatus detailedStatus;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/externaldatabase/CreateExternalDatabaseFailed.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/externaldatabase/CreateExternalDatabaseFailed.java
@@ -1,11 +1,15 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.core.flow2.externaldatabase.ExternalDatabaseSelectableEvent;
 
 public class CreateExternalDatabaseFailed extends ExternalDatabaseSelectableEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/externaldatabase/StartExternalDatabaseFailed.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/externaldatabase/StartExternalDatabaseFailed.java
@@ -1,11 +1,15 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.core.flow2.externaldatabase.ExternalDatabaseSelectableEvent;
 
 public class StartExternalDatabaseFailed extends ExternalDatabaseSelectableEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/externaldatabase/StopExternalDatabaseFailed.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/externaldatabase/StopExternalDatabaseFailed.java
@@ -1,11 +1,15 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.core.flow2.externaldatabase.ExternalDatabaseSelectableEvent;
 
 public class StopExternalDatabaseFailed extends ExternalDatabaseSelectableEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/externaldatabase/TerminateExternalDatabaseFailed.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/externaldatabase/TerminateExternalDatabaseFailed.java
@@ -1,11 +1,15 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.core.flow2.externaldatabase.ExternalDatabaseSelectableEvent;
 
 public class TerminateExternalDatabaseFailed extends ExternalDatabaseSelectableEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/ChangePrimaryGatewayTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/ChangePrimaryGatewayTriggerEvent.java
@@ -13,7 +13,7 @@ public class ChangePrimaryGatewayTriggerEvent extends StackEvent {
     public ChangePrimaryGatewayTriggerEvent(
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long stackId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, stackId, accepted);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/RemoveHostsRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/RemoveHostsRequest.java
@@ -2,12 +2,19 @@ package com.sequenceiq.cloudbreak.reactor.api.event.orchestration;
 
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleRequest;
 
 public class RemoveHostsRequest extends AbstractClusterScaleRequest {
-    private Set<String> hostNames;
+    private final Set<String> hostNames;
 
-    public RemoveHostsRequest(Long stackId, Set<String> hostGroups, Set<String> hostNames) {
+    @JsonCreator
+    public RemoveHostsRequest(
+            @JsonProperty("stackId") Long stackId,
+            @JsonProperty("hostGroupNames") Set<String> hostGroups,
+            @JsonProperty("hostNames") Set<String> hostNames) {
+
         super(stackId, hostGroups);
         this.hostNames = hostNames;
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/RepairSingleMasterInstanceEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/RepairSingleMasterInstanceEvent.java
@@ -13,7 +13,7 @@ public class RepairSingleMasterInstanceEvent extends StackEvent {
     public RepairSingleMasterInstanceEvent(
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long stackId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, stackId, accepted);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/RescheduleStatusCheckTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/RescheduleStatusCheckTriggerEvent.java
@@ -13,7 +13,7 @@ public class RescheduleStatusCheckTriggerEvent extends StackEvent {
     public RescheduleStatusCheckTriggerEvent(
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long stackId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, stackId, accepted);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/UpscaleClusterManagerRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/UpscaleClusterManagerRequest.java
@@ -1,8 +1,10 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.orchestration;
 
 import java.util.Map;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleRequest;
 
@@ -38,4 +40,9 @@ public class UpscaleClusterManagerRequest extends AbstractClusterScaleRequest {
         return repair;
     }
 
+    @JsonIgnore
+    @Override
+    public Set<String> getHostGroupNames() {
+        return super.getHostGroupNames();
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/AbstractClusterScaleResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/AbstractClusterScaleResult.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.reactor.api.event.resource;
 
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.sequenceiq.cloudbreak.cloud.event.model.EventStatus;
 import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformResult;
 
@@ -19,6 +20,7 @@ public abstract class AbstractClusterScaleResult<R extends AbstractClusterScaleR
         super(status, statusReason, errorDetails, request);
     }
 
+    @JsonIgnore
     public Set<String> getHostGroupNames() {
         return getRequest().getHostGroupNames();
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/CollectDownscaleCandidatesRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/CollectDownscaleCandidatesRequest.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterDownscaleDetails;
 
@@ -37,6 +38,12 @@ public class CollectDownscaleCandidatesRequest extends AbstractClusterScaleReque
 
     public ClusterDownscaleDetails getDetails() {
         return details;
+    }
+
+    @JsonIgnore
+    @Override
+    public Set<String> getHostGroupNames() {
+        return super.getHostGroupNames();
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/CleanupFreeIpaEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/CleanupFreeIpaEvent.java
@@ -36,7 +36,7 @@ public class CleanupFreeIpaEvent extends StackEvent {
     public CleanupFreeIpaEvent(
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long stackId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted,
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted,
             @JsonProperty("hostNames") Set<String> hostNames,
             @JsonProperty("ips") Set<String> ips,
             @JsonProperty("recover") boolean recover) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/ImageUpdateEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/ImageUpdateEvent.java
@@ -22,7 +22,7 @@ public class ImageUpdateEvent extends StackEvent {
     public ImageUpdateEvent(
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long stackId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted,
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted,
             @JsonProperty("image") StatedImage image) {
         super(selector, stackId, accepted);
         this.image = image;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/ProvisionEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/ProvisionEvent.java
@@ -24,7 +24,7 @@ public class ProvisionEvent extends StackEvent {
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long stackId,
             @JsonProperty("provisionType") ProvisionType provisionType,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, stackId, accepted);
         this.provisionType = provisionType;
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/TerminationEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/TerminationEvent.java
@@ -22,7 +22,7 @@ public class TerminationEvent extends StackEvent {
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long stackId,
             @JsonProperty("terminationType") TerminationType terminationType,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, stackId, accepted);
         this.terminationType = terminationType;
     }

--- a/datalake/src/main/java/com/sequenceiq/datalake/entity/SdxCluster.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/entity/SdxCluster.java
@@ -273,6 +273,13 @@ public class SdxCluster implements AccountAwareResource {
         }
     }
 
+    /**
+     * Need this for Jackson deserialization
+     */
+    private void setStackRequest(String rawRequest) {
+        this.stackRequest = new Secret(rawRequest);
+    }
+
     public String getStackRequestToCloudbreak() {
         return stackRequestToCloudbreak.getRaw();
     }

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxFailedEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxFailedEvent.java
@@ -1,8 +1,13 @@
 package com.sequenceiq.datalake.flow;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 public abstract class SdxFailedEvent extends SdxEvent {
 
-    private Exception exception;
+    @JsonTypeInfo(use = CLASS, property = "@type")
+    private final Exception exception;
 
     public SdxFailedEvent(Long sdxId, String userId, Exception exception) {
         super(sdxId, userId);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/cert/rotation/event/SdxCertRotationFailedEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/cert/rotation/event/SdxCertRotationFailedEvent.java
@@ -1,11 +1,15 @@
 package com.sequenceiq.datalake.flow.cert.rotation.event;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.datalake.flow.SdxEvent;
 
 public class SdxCertRotationFailedEvent extends SdxEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/cert/rotation/event/SdxCertRotationWaitEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/cert/rotation/event/SdxCertRotationWaitEvent.java
@@ -31,7 +31,7 @@ public class SdxCertRotationWaitEvent extends SdxEvent {
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long sdxId,
             @JsonProperty("userId") String userId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, sdxId, userId, accepted);
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/cert/rotation/event/SdxStartCertRotationEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/cert/rotation/event/SdxStartCertRotationEvent.java
@@ -41,7 +41,7 @@ public class SdxStartCertRotationEvent extends SdxEvent {
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long sdxId,
             @JsonProperty("userId") String userId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted,
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted,
             @JsonProperty("request") CertificatesRotationV4Request request) {
         super(selector, sdxId, userId, accepted);
         this.request = request;

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/recovery/event/DatalakeRecoveryCouldNotStartEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/recovery/event/DatalakeRecoveryCouldNotStartEvent.java
@@ -1,11 +1,15 @@
 package com.sequenceiq.datalake.flow.datalake.recovery.event;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.datalake.flow.SdxEvent;
 
 public class DatalakeRecoveryCouldNotStartEvent extends SdxEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/event/DatalakeUpgradeCouldNotStartEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/event/DatalakeUpgradeCouldNotStartEvent.java
@@ -1,11 +1,15 @@
 package com.sequenceiq.datalake.flow.datalake.upgrade.event;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.datalake.flow.SdxEvent;
 
 public class DatalakeUpgradeCouldNotStartEvent extends SdxEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/detach/event/SdxStartDetachEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/detach/event/SdxStartDetachEvent.java
@@ -28,7 +28,7 @@ public class SdxStartDetachEvent extends SdxEvent {
             @JsonProperty("resourceId") Long sdxId,
             @JsonProperty("sdxCluster") SdxCluster sdxCluster,
             @JsonProperty("userId") String userId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, sdxId, userId, accepted);
         this.sdxCluster = sdxCluster;
     }

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/detach/event/SdxStartDetachRecoveryEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/detach/event/SdxStartDetachRecoveryEvent.java
@@ -16,7 +16,7 @@ public class SdxStartDetachRecoveryEvent extends SdxEvent {
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long detachedSdxId,
             @JsonProperty("userId") String userId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, detachedSdxId, userId, accepted);
     }
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeBackupFailedEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeBackupFailedEvent.java
@@ -1,11 +1,15 @@
 package com.sequenceiq.datalake.flow.dr.backup.event;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.datalake.flow.SdxEvent;
 
 public class DatalakeBackupFailedEvent extends SdxEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeDatabaseBackupCouldNotStartEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeDatabaseBackupCouldNotStartEvent.java
@@ -1,10 +1,14 @@
 package com.sequenceiq.datalake.flow.dr.backup.event;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.datalake.flow.SdxEvent;
 
 public class DatalakeDatabaseBackupCouldNotStartEvent extends SdxEvent {
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeDatabaseBackupFailedEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeDatabaseBackupFailedEvent.java
@@ -1,11 +1,15 @@
 package com.sequenceiq.datalake.flow.dr.backup.event;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.datalake.flow.SdxEvent;
 
 public class DatalakeDatabaseBackupFailedEvent extends SdxEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeTriggerBackupEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeTriggerBackupEvent.java
@@ -29,7 +29,7 @@ public class DatalakeTriggerBackupEvent extends DatalakeDatabaseDrStartBaseEvent
             @JsonProperty("backupLocation") String backupLocation,
             @JsonProperty("backupName") String backupName,
             @JsonProperty("reason") DatalakeBackupFailureReason reason,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, sdxId, userId, SdxOperationType.BACKUP, accepted);
         this.backupLocation = backupLocation;
         this.backupName = backupName;

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/event/DatalakeDatabaseDrStartBaseEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/event/DatalakeDatabaseDrStartBaseEvent.java
@@ -20,7 +20,7 @@ public class DatalakeDatabaseDrStartBaseEvent extends SdxEvent  {
             @JsonProperty("resourceId") Long sdxId,
             @JsonProperty("userId") String userId,
             @JsonProperty("operationType") SdxOperationType operationType,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, sdxId, userId, accepted);
         drStatus = new SdxOperation(operationType, sdxId);
     }

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/event/DatalakeDatabaseRestoreCouldNotStartEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/event/DatalakeDatabaseRestoreCouldNotStartEvent.java
@@ -1,10 +1,15 @@
 package com.sequenceiq.datalake.flow.dr.restore.event;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.datalake.flow.SdxEvent;
 
 public class DatalakeDatabaseRestoreCouldNotStartEvent extends SdxEvent {
+
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/event/DatalakeDatabaseRestoreFailedEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/event/DatalakeDatabaseRestoreFailedEvent.java
@@ -1,11 +1,15 @@
 package com.sequenceiq.datalake.flow.dr.restore.event;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.datalake.flow.SdxEvent;
 
 public class DatalakeDatabaseRestoreFailedEvent extends SdxEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/event/DatalakeRestoreFailedEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/event/DatalakeRestoreFailedEvent.java
@@ -1,14 +1,18 @@
 package com.sequenceiq.datalake.flow.dr.restore.event;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
 import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.datalake.flow.SdxContext;
 import com.sequenceiq.datalake.flow.SdxEvent;
 
 public class DatalakeRestoreFailedEvent extends SdxEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/loadbalancer/dns/event/StartUpdateLoadBalancerDNSEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/loadbalancer/dns/event/StartUpdateLoadBalancerDNSEvent.java
@@ -16,7 +16,7 @@ public class StartUpdateLoadBalancerDNSEvent extends SdxEvent {
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long sdxId,
             @JsonProperty("userId") String userId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, sdxId, userId, accepted);
     }
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/repair/event/SdxRepairCouldNotStartEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/repair/event/SdxRepairCouldNotStartEvent.java
@@ -1,11 +1,15 @@
 package com.sequenceiq.datalake.flow.repair.event;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.datalake.flow.SdxEvent;
 
 public class SdxRepairCouldNotStartEvent extends SdxEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/start/event/SdxStartStartEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/start/event/SdxStartStartEvent.java
@@ -19,7 +19,7 @@ public class SdxStartStartEvent extends SdxEvent {
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long sdxId,
             @JsonProperty("userId") String userId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, sdxId, userId, accepted);
     }
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/stop/event/SdxStartStopEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/stop/event/SdxStartStopEvent.java
@@ -29,7 +29,7 @@ public class SdxStartStopEvent extends SdxEvent {
             @JsonProperty("resourceId") Long sdxId,
             @JsonProperty("userId") String userId,
             @JsonProperty("stopDataHubs") boolean stopDataHubs,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, sdxId, userId, accepted);
         this.stopDataHubs = stopDataHubs;
     }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/event/EnvCreationFailureEvent.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/event/EnvCreationFailureEvent.java
@@ -1,13 +1,16 @@
 package com.sequenceiq.environment.environment.flow.creation.event;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
 import static com.sequenceiq.environment.environment.flow.creation.event.EnvCreationStateSelectors.FAILED_ENV_CREATION_EVENT;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.flow.reactor.api.event.BaseNamedFlowEvent;
 
 public class EnvCreationFailureEvent extends BaseNamedFlowEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/deletion/event/EnvClusterDeleteFailedEvent.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/deletion/event/EnvClusterDeleteFailedEvent.java
@@ -1,7 +1,9 @@
 package com.sequenceiq.environment.environment.flow.deletion.event;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
 import static com.sequenceiq.environment.environment.flow.deletion.event.EnvClustersDeleteStateSelectors.FAILED_ENV_CLUSTERS_DELETE_EVENT;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
@@ -10,6 +12,7 @@ import com.sequenceiq.flow.reactor.api.event.BaseNamedFlowEvent;
 @JsonDeserialize(builder = EnvClusterDeleteFailedEvent.EnvClusterDeleteFailedEventBuilder.class)
 public class EnvClusterDeleteFailedEvent extends BaseNamedFlowEvent implements Selectable {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     private final String message;

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/start/event/EnvStartFailedEvent.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/start/event/EnvStartFailedEvent.java
@@ -1,9 +1,11 @@
 package com.sequenceiq.environment.environment.flow.start.event;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
 import static com.sequenceiq.environment.environment.flow.start.event.EnvStartStateSelectors.FAILED_ENV_START_EVENT;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.environment.environment.EnvironmentStatus;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
@@ -11,6 +13,7 @@ import com.sequenceiq.flow.reactor.api.event.BaseFailedFlowEvent;
 
 public class EnvStartFailedEvent extends BaseFailedFlowEvent implements Selectable {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     private final EnvironmentDto environmentDto;

--- a/flow/src/main/java/com/sequenceiq/flow/core/chain/finalize/flowevents/FlowChainFinalizeFailedPayload.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/chain/finalize/flowevents/FlowChainFinalizeFailedPayload.java
@@ -1,12 +1,16 @@
 package com.sequenceiq.flow.core.chain.finalize.flowevents;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import reactor.rx.Promise;
 
 public class FlowChainFinalizeFailedPayload extends FlowChainFinalizePayload {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/flow/src/main/java/com/sequenceiq/flow/core/chain/finalize/flowevents/FlowChainFinalizePayload.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/chain/finalize/flowevents/FlowChainFinalizePayload.java
@@ -22,7 +22,7 @@ public class FlowChainFinalizePayload implements Selectable, Acceptable {
     public FlowChainFinalizePayload(
             @JsonProperty("flowChainName") String flowChainName,
             @JsonProperty("resourceId") Long resourceId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
 
         this.flowChainName = flowChainName;
         this.resourceId = resourceId;

--- a/flow/src/main/java/com/sequenceiq/flow/core/chain/init/flowevents/FlowChainInitFailedPayload.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/chain/init/flowevents/FlowChainInitFailedPayload.java
@@ -1,12 +1,16 @@
 package com.sequenceiq.flow.core.chain.init.flowevents;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import reactor.rx.Promise;
 
 public class FlowChainInitFailedPayload extends FlowChainInitPayload {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/flow/src/main/java/com/sequenceiq/flow/core/chain/init/flowevents/FlowChainInitPayload.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/chain/init/flowevents/FlowChainInitPayload.java
@@ -22,7 +22,7 @@ public class FlowChainInitPayload implements Selectable, Acceptable {
     public FlowChainInitPayload(
             @JsonProperty("flowChainName") String flowChainName,
             @JsonProperty("resourceId") Long resourceId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
 
         this.flowChainName = flowChainName;
         this.resourceId = resourceId;

--- a/flow/src/main/java/com/sequenceiq/flow/core/helloworld/flowevents/HelloWorldFailedEvent.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/helloworld/flowevents/HelloWorldFailedEvent.java
@@ -1,11 +1,15 @@
 package com.sequenceiq.flow.core.helloworld.flowevents;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.flow.core.helloworld.HelloWorldSelectableEvent;
 
 public class HelloWorldFailedEvent extends HelloWorldSelectableEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/flow/src/main/java/com/sequenceiq/flow/reactor/api/event/BaseFailedFlowEvent.java
+++ b/flow/src/main/java/com/sequenceiq/flow/reactor/api/event/BaseFailedFlowEvent.java
@@ -1,7 +1,10 @@
 package com.sequenceiq.flow.reactor.api.event;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.common.event.AcceptResult;
 import com.sequenceiq.cloudbreak.common.json.JsonIgnoreDeserialization;
 
@@ -9,6 +12,7 @@ import reactor.rx.Promise;
 
 public class BaseFailedFlowEvent extends BaseNamedFlowEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     public BaseFailedFlowEvent(String selector, Long resourceId, String resourceName, String resourceCrn, Exception exception) {
@@ -20,7 +24,7 @@ public class BaseFailedFlowEvent extends BaseNamedFlowEvent {
     public BaseFailedFlowEvent(
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long resourceId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted,
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted,
             @JsonProperty("resourceName") String resourceName,
             @JsonProperty("resourceCrn") String resourceCrn,
             @JsonProperty("exception") Exception exception) {

--- a/flow/src/main/java/com/sequenceiq/flow/reactor/api/event/BaseFlowEvent.java
+++ b/flow/src/main/java/com/sequenceiq/flow/reactor/api/event/BaseFlowEvent.java
@@ -31,7 +31,7 @@ public class BaseFlowEvent implements IdempotentEvent<BaseFlowEvent>, ResourceCr
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long resourceId,
             @JsonProperty("resourceCrn") String resourceCrn,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
 
         this.selector = selector;
         this.resourceId = resourceId;

--- a/flow/src/main/java/com/sequenceiq/flow/reactor/api/event/BaseNamedFlowEvent.java
+++ b/flow/src/main/java/com/sequenceiq/flow/reactor/api/event/BaseNamedFlowEvent.java
@@ -20,7 +20,7 @@ public class BaseNamedFlowEvent extends BaseFlowEvent {
     public BaseNamedFlowEvent(
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long resourceId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted,
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted,
             @JsonProperty("resourceName") String resourceName,
             @JsonProperty("resourceCrn") String resourceCrn) {
 

--- a/flow/src/test/java/com/sequenceiq/flow/component/sleep/event/NestedSleepChainTriggerEvent.java
+++ b/flow/src/test/java/com/sequenceiq/flow/component/sleep/event/NestedSleepChainTriggerEvent.java
@@ -25,7 +25,7 @@ public class NestedSleepChainTriggerEvent implements IdempotentEvent<NestedSleep
     public NestedSleepChainTriggerEvent(
             @JsonProperty("resourceId") Long resourceId,
             @JsonProperty("sleepChainTriggerEvents") ArrayList<SleepChainTriggerEvent> sleepChainTriggerEvents,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         this.resourceId = resourceId;
         this.sleepChainTriggerEvents = sleepChainTriggerEvents;
         this.accepted = accepted;

--- a/flow/src/test/java/com/sequenceiq/flow/component/sleep/event/SleepChainTriggerEvent.java
+++ b/flow/src/test/java/com/sequenceiq/flow/component/sleep/event/SleepChainTriggerEvent.java
@@ -30,7 +30,7 @@ public class SleepChainTriggerEvent implements IdempotentEvent<SleepChainTrigger
     public SleepChainTriggerEvent(
             @JsonProperty("resourceId") Long resourceId,
             @JsonProperty("sleepConfigs") ArrayList<SleepConfig> sleepConfigs,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
 
         this.resourceId = resourceId;
         this.sleepConfigs = sleepConfigs;

--- a/flow/src/test/java/com/sequenceiq/flow/component/sleep/event/SleepStartEvent.java
+++ b/flow/src/test/java/com/sequenceiq/flow/component/sleep/event/SleepStartEvent.java
@@ -38,7 +38,7 @@ public class SleepStartEvent implements IdempotentEvent<SleepStartEvent> {
             @JsonProperty("resourceId") Long resourceId,
             @JsonProperty("sleepDuration") Duration sleepDuration,
             @JsonProperty("failUntil") LocalDateTime failUntil,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
 
         this.resourceId = resourceId;
         this.sleepDuration = sleepDuration;

--- a/flow/src/test/java/com/sequenceiq/flow/core/TestPayload.java
+++ b/flow/src/test/java/com/sequenceiq/flow/core/TestPayload.java
@@ -1,11 +1,14 @@
 package com.sequenceiq.flow.core;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.common.event.Payload;
 
 public class TestPayload implements Payload {
-    private Long stackId;
+    private final Long stackId;
 
-    public TestPayload(Long stackId) {
+    @JsonCreator
+    public TestPayload(@JsonProperty("resourceId") Long stackId) {
         this.stackId = stackId;
     }
 

--- a/flow/src/test/java/com/sequenceiq/flow/helper/FlowPayloadSerializabilityChecker.java
+++ b/flow/src/test/java/com/sequenceiq/flow/helper/FlowPayloadSerializabilityChecker.java
@@ -159,16 +159,16 @@ public class FlowPayloadSerializabilityChecker {
         int jsonPropertyCount = 0;
         for (Parameter param : creator.getParameters()) {
             JsonIgnoreDeserialization ignoreDeserialization = param.getAnnotation(JsonIgnoreDeserialization.class);
-            if (ignoreDeserialization == null) {
-                JsonProperty jsonProperty = param.getAnnotation(JsonProperty.class);
-                if (jsonProperty == null || StringUtils.isBlank(jsonProperty.value())) {
-                    missingJsonPropertyParams.add(param.getName());
+            JsonProperty jsonProperty = param.getAnnotation(JsonProperty.class);
+            if (jsonProperty == null || StringUtils.isBlank(jsonProperty.value())) {
+                missingJsonPropertyParams.add(param.getName());
+            } else {
+                jsonPropertyCount++;
+                if (uniqueNamesCheck.contains(jsonProperty.value())) {
+                    duplicateNames.add(jsonProperty.value());
                 } else {
-                    jsonPropertyCount++;
-                    if (uniqueNamesCheck.contains(jsonProperty.value())) {
-                        duplicateNames.add(jsonProperty.value());
-                    } else {
-                        uniqueNamesCheck.add(jsonProperty.value());
+                    uniqueNamesCheck.add(jsonProperty.value());
+                    if (ignoreDeserialization == null) {
                         if (!isGetterFoundRecursive(clazz, jsonProperty.value(), isBooleanType(param.getType()))) {
                             missingGetters.add(jsonProperty.value());
                         }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/Stack.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/Stack.java
@@ -494,6 +494,13 @@ public class Stack implements AccountAwareResource, OrchestratorAware, IdAware {
         this.ccmParameters = new Secret(JsonUtil.writeValueAsStringSilent(ccmParameters));
     }
 
+    /**
+     * Need this for Jackson deserialization
+     */
+    private void setCcmParameters(String rawCcmParameters) {
+        this.ccmParameters = new Secret(rawCcmParameters);
+    }
+
     @Override
     public String toString() {
         return "Stack{" +

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/event/CreateBindUserFailureEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/event/CreateBindUserFailureEvent.java
@@ -1,12 +1,16 @@
 package com.sequenceiq.freeipa.flow.freeipa.binduser.create.event;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 public class CreateBindUserFailureEvent extends CreateBindUserEvent {
 
     private final String failureMessage;
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/AbstractCleanupEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/AbstractCleanupEvent.java
@@ -4,23 +4,34 @@ import com.sequenceiq.freeipa.flow.freeipa.cleanup.CleanupEvent;
 
 public abstract class AbstractCleanupEvent extends CleanupEvent {
 
+    /**
+     * Need this for Jackson serialization.
+     */
+    private final CleanupEvent cleanupEvent;
+
     protected AbstractCleanupEvent(Long stackId) {
         super(stackId);
+        this.cleanupEvent = null;
     }
 
     public AbstractCleanupEvent(CleanupEvent cleanupEvent) {
         super(cleanupEvent.getResourceId(), cleanupEvent.getUsers(), cleanupEvent.getHosts(), cleanupEvent.getRoles(), cleanupEvent.getIps(),
                 cleanupEvent.getStatesToSkip(), cleanupEvent.getAccountId(), cleanupEvent.getOperationId(), cleanupEvent.getClusterName(),
                 cleanupEvent.getEnvironmentCrn());
+        this.cleanupEvent = cleanupEvent;
     }
 
     public AbstractCleanupEvent(String selector, CleanupEvent cleanupEvent) {
         super(selector, cleanupEvent.getResourceId(), cleanupEvent.getUsers(), cleanupEvent.getHosts(), cleanupEvent.getRoles(), cleanupEvent.getIps(),
                 cleanupEvent.getStatesToSkip(), cleanupEvent.getAccountId(), cleanupEvent.getOperationId(), cleanupEvent.getClusterName(),
                 cleanupEvent.getEnvironmentCrn());
+        this.cleanupEvent = cleanupEvent;
     }
 
-    private CleanupEvent getCleanupEvent() {
-        return this;
+    /**
+     * Need this for Jackson serialization. This must be public.
+     */
+    public CleanupEvent getCleanupEvent() {
+        return cleanupEvent;
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/event/DiagnosticsCollectionEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/event/DiagnosticsCollectionEvent.java
@@ -23,7 +23,7 @@ public class DiagnosticsCollectionEvent extends BaseFlowEvent {
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long resourceId,
             @JsonProperty("resourceCrn") String resourceCrn,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted,
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted,
             @JsonProperty("parameters") DiagnosticParameters parameters) {
         super(selector, resourceId, resourceCrn, accepted);
         this.parameters = parameters;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/event/DiagnosticsCollectionFailureEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/event/DiagnosticsCollectionFailureEvent.java
@@ -1,14 +1,17 @@
 package com.sequenceiq.freeipa.flow.freeipa.diagnostics.event;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
 import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.event.DiagnosticsCollectionStateSelectors.FAILED_DIAGNOSTICS_COLLECTION_EVENT;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.common.model.diagnostics.DiagnosticParameters;
 
 public class DiagnosticsCollectionFailureEvent extends DiagnosticsCollectionEvent implements Selectable {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     private final String failureType;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/event/DownscaleEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/event/DownscaleEvent.java
@@ -41,7 +41,7 @@ public class DownscaleEvent extends StackEvent {
             @JsonProperty("chained") boolean chained,
             @JsonProperty("finalChain") boolean finalChain,
             @JsonProperty("operationId") String operationId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, stackId, accepted);
         this.instanceIds = instanceIds;
         this.instanceCountByGroup = instanceCountByGroup;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/event/DownscaleFailureEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/event/DownscaleFailureEvent.java
@@ -1,14 +1,18 @@
 package com.sequenceiq.freeipa.flow.freeipa.downscale.event;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.sequenceiq.freeipa.flow.stack.StackEvent;
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
 
 import java.util.Map;
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.sequenceiq.freeipa.flow.stack.StackEvent;
+
 public class DownscaleFailureEvent extends StackEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     private final String failedPhase;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/repair/changeprimarygw/event/ChangePrimaryGatewayEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/repair/changeprimarygw/event/ChangePrimaryGatewayEvent.java
@@ -33,7 +33,7 @@ public class ChangePrimaryGatewayEvent extends StackEvent {
             @JsonProperty("repairInstanceIds") List<String> repairInstanceIds,
             @JsonProperty("finalChain") Boolean finalChain,
             @JsonProperty("operationId") String operationId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, stackId, accepted);
         this.repairInstanceIds = repairInstanceIds;
         this.finalChain = finalChain;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/repair/changeprimarygw/event/ChangePrimaryGatewayFailureEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/repair/changeprimarygw/event/ChangePrimaryGatewayFailureEvent.java
@@ -1,14 +1,18 @@
 package com.sequenceiq.freeipa.flow.freeipa.repair.changeprimarygw.event;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
 import java.util.Map;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.freeipa.flow.stack.StackEvent;
 
 public class ChangePrimaryGatewayFailureEvent extends StackEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     private final String failedPhase;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/update/SaltUpdateTriggerEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/update/SaltUpdateTriggerEvent.java
@@ -28,7 +28,7 @@ public class SaltUpdateTriggerEvent extends StackEvent {
     public SaltUpdateTriggerEvent(
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long stackId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted,
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted,
             @JsonProperty("chained") boolean chained,
             @JsonProperty("finalChain") boolean finalChain) {
         super(selector, stackId, accepted);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/event/UpscaleFailureEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/event/UpscaleFailureEvent.java
@@ -1,14 +1,18 @@
 package com.sequenceiq.freeipa.flow.freeipa.upscale.event;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
 import java.util.Map;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.freeipa.flow.stack.StackEvent;
 
 public class UpscaleFailureEvent extends StackEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     private final String failedPhase;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/InstanceFailureEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/InstanceFailureEvent.java
@@ -1,12 +1,16 @@
 package com.sequenceiq.freeipa.flow.instance;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 public class InstanceFailureEvent extends InstanceEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/StackEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/StackEvent.java
@@ -36,7 +36,7 @@ public class StackEvent implements IdempotentEvent<StackEvent> {
     public StackEvent(
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long stackId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         this.selector = selector;
         this.stackId = stackId;
         this.accepted = accepted;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/StackFailureEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/StackFailureEvent.java
@@ -1,10 +1,14 @@
 package com.sequenceiq.freeipa.flow.stack;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 public class StackFailureEvent extends StackEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     public StackFailureEvent(Long stackId, Exception exception) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/image/change/event/ImageChangeEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/image/change/event/ImageChangeEvent.java
@@ -31,7 +31,7 @@ public class ImageChangeEvent extends StackEvent {
     public ImageChangeEvent(
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long stackId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted,
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted,
             @JsonProperty("request") ImageSettingsRequest request) {
         super(selector, stackId, accepted);
         this.request = request;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/event/UpgradeCcmFlowChainTriggerEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/event/UpgradeCcmFlowChainTriggerEvent.java
@@ -29,7 +29,7 @@ public class UpgradeCcmFlowChainTriggerEvent extends StackEvent {
             @JsonProperty("operationId") String operationId,
             @JsonProperty("resourceId") Long stackId,
             @JsonProperty("oldTunnel") Tunnel oldTunnel,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, stackId, accepted);
         this.operationId = operationId;
         this.oldTunnel = oldTunnel;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/event/UpgradeCcmTriggerEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/event/UpgradeCcmTriggerEvent.java
@@ -33,7 +33,7 @@ public class UpgradeCcmTriggerEvent extends StackEvent {
             @JsonProperty("operationId") String operationId,
             @JsonProperty("resourceId") Long stackId,
             @JsonProperty("oldTunnel") Tunnel oldTunnel,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, stackId, accepted);
         this.operationId = operationId;
         this.oldTunnel = oldTunnel;

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/common/RedbeamsEvent.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/common/RedbeamsEvent.java
@@ -44,7 +44,7 @@ public class RedbeamsEvent implements IdempotentEvent<RedbeamsEvent> {
     public RedbeamsEvent(
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long resourceId,
-            @JsonIgnoreDeserialization Promise<AcceptResult> accepted,
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted,
             @JsonProperty("forced") boolean forced) {
 
         this.selector = selector;

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/common/RedbeamsFailureEvent.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/common/RedbeamsFailureEvent.java
@@ -1,10 +1,14 @@
 package com.sequenceiq.redbeams.flow.redbeams.common;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 public class RedbeamsFailureEvent extends RedbeamsEvent {
 
+    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     public RedbeamsFailureEvent(Long resourceId, Exception exception) {


### PR DESCRIPTION
Based on an integration test result, another round of deeper investigation was made.
As a result, some fixes were needed for `@JsonCreator`-annotated constructors:
it turned out that all parameters must have the `@JsonProperty` annontation,
but for Acceptables we still need to exclude the `accepted` property.

There were 2 special cases (`Stack` and `SdxCluster`) where the getters
returned different data types than setters, this is also fixed by providing
extra setter with string parameter.

Exceptions are now typed.

See detailed description in the commit message.