### PR TITLE
CB-17851 Create possibility to run high node count E2E tests

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDtoBase.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDtoBase.java
@@ -3,6 +3,7 @@ package com.sequenceiq.it.cloudbreak.dto.distrox;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -215,6 +216,11 @@ public class DistroXTestDtoBase<T extends DistroXTestDtoBase> extends AbstractCl
 
     public DistroXTestDtoBase<T> withLoadBalancer() {
         getRequest().setEnableLoadBalancer(true);
+        return this;
+    }
+
+    public DistroXTestDtoBase<T> addTags(Map<String, String> tags) {
+        tags.forEach((key, value) -> getRequest().addTag(key, value));
         return this;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXBigScaleTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXBigScaleTest.java
@@ -1,0 +1,123 @@
+package com.sequenceiq.it.cloudbreak.testcase.e2e.distrox;
+
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.pollingInterval;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import javax.inject.Inject;
+
+import org.testng.ITestContext;
+import org.testng.annotations.Test;
+
+import com.sequenceiq.distrox.api.v1.distrox.model.database.DistroXDatabaseAvailabilityType;
+import com.sequenceiq.distrox.api.v1.distrox.model.database.DistroXDatabaseRequest;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationState;
+import com.sequenceiq.it.cloudbreak.client.DistroXTestClient;
+import com.sequenceiq.it.cloudbreak.client.EnvironmentTestClient;
+import com.sequenceiq.it.cloudbreak.client.FreeIpaTestClient;
+import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
+import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentNetworkTestDto;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaUserSyncTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
+import com.sequenceiq.it.cloudbreak.dto.telemetry.TelemetryTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
+import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
+
+public class DistroXBigScaleTest extends AbstractE2ETest {
+
+    private static final Duration BIG_SCALE_POLLING_INTERVAL = Duration.ofSeconds(30L);
+
+    private static final Map<String, String> COST_REDUCER_TAGS = Map.of("cloud-cost-reducer-ignore", "true");
+
+    @Inject
+    private DistroXTestClient distroXTestClient;
+
+    @Inject
+    private EnvironmentTestClient environmentTestClient;
+
+    @Inject
+    private FreeIpaTestClient freeIpaTestClient;
+
+    @Inject
+    private SdxTestClient sdxTestClient;
+
+    @Override
+    protected void setupTest(TestContext testContext) {
+        testContext.getCloudProvider().getCloudFunctionality().cloudStorageInitialize();
+        createDefaultUser(testContext);
+        initializeDefaultBlueprints(testContext);
+        createDefaultCredential(testContext);
+    }
+
+    @Test(dataProvider = TEST_CONTEXT)
+    @Description(
+            given = "there is a valid credential for the selected provider",
+            when = "new environment with attached freeIpa and SDX should be created along with Cloud Cost Reducer tags",
+                and = "new distroX also should be created for environment",
+            then = "distrox can be scaled up (up to 800 Worker nodes) then down (down to 600 Worker nodes) in 3 rounds")
+    public void testCreateAndBigScaleDistroX(TestContext testContext, ITestContext iTestContext) {
+        DistroXScaleTestParameters params = new DistroXScaleTestParameters(iTestContext.getCurrentXmlTest().getAllParameters());
+        DistroXDatabaseRequest distroXDatabaseRequest = new DistroXDatabaseRequest();
+        distroXDatabaseRequest.setAvailabilityType(DistroXDatabaseAvailabilityType.HA);
+
+        if (params.getTimes() < 1) {
+            throw new TestFailException("Test should execute at least 1 round of scaling");
+        }
+
+        testContext
+                .given(EnvironmentNetworkTestDto.class)
+                .given("telemetry", TelemetryTestDto.class)
+                    .withLogging()
+                    .withReportClusterLogs()
+                .given(EnvironmentTestDto.class)
+                    .withNetwork()
+                    .withTelemetry("telemetry")
+                    .withTunnel(testContext.getTunnel())
+                    .addTags(COST_REDUCER_TAGS)
+                    .withCreateFreeIpa(Boolean.TRUE)
+                .when(environmentTestClient.create())
+                .await(EnvironmentStatus.AVAILABLE)
+                .given(FreeIpaUserSyncTestDto.class)
+                .when(freeIpaTestClient.getLastSyncOperationStatus())
+                .await(OperationState.COMPLETED)
+                .given(EnvironmentTestDto.class)
+                .when(environmentTestClient.describe())
+                .given(SdxTestDto.class)
+                    .withCloudStorage()
+                    .withEnvironment()
+                    .withTags(COST_REDUCER_TAGS)
+                .when(sdxTestClient.create())
+                .await(SdxClusterStatusResponse.RUNNING)
+                .awaitForHealthyInstances()
+                .given(DistroXTestDto.class)
+                    .withEnvironment()
+                    .withExternalDatabase(distroXDatabaseRequest)
+                    .addTags(COST_REDUCER_TAGS)
+                .when(distroXTestClient.create())
+                .await(STACK_AVAILABLE)
+                .awaitForHealthyInstances()
+                .validate();
+        IntStream.range(1, params.getTimes()).forEach(i ->
+                testContext
+                        .given(DistroXTestDto.class)
+                        .when(distroXTestClient.scale(params.getHostGroup(), params.getScaleUpTarget() * i))
+                        .awaitForFlow(pollingInterval(BIG_SCALE_POLLING_INTERVAL))
+                        .validate());
+        IntStream.range(1, params.getTimes()).forEach(i ->
+                testContext
+                        .given(DistroXTestDto.class)
+                        .when(distroXTestClient.scale(params.getHostGroup(), params.getScaleUpTarget()))
+                        .awaitForFlow(pollingInterval(BIG_SCALE_POLLING_INTERVAL))
+                        .when(distroXTestClient.scale(params.getHostGroup(), params.getScaleDownTarget()))
+                        .awaitForFlow(pollingInterval(BIG_SCALE_POLLING_INTERVAL))
+                        .validate());
+    }
+}

--- a/integration-test/src/main/resources/testsuites/e2e/distrox-bigscale-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/distrox-bigscale-tests.yaml
@@ -2,10 +2,10 @@ name: "distrox-bigscale-tests"
 tests:
   - name: "distrox_bigscale_tests"
     parameters: {
-      host_group: compute,
-      scale_up_target: 55,
-      scale_down_target: 5,
-      times: 10,
+      host_group: worker,
+      scale_up_target: 200,
+      scale_down_target: 200,
+      times: 4,
     }
     classes:
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXScaleTest
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXBigScaleTest


### PR DESCRIPTION
This is related to [CB-17828 Support 800 node cluster size for datahubs](https://jira.cloudera.com/browse/CB-17828) epic.

We need to create a special  E2E DistroX scale test where we can add high node count for up and down scale along with the related test suite.