### PR TITLE
CB-17889 Mark events as ignored from restartable flows

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/salt/rotatepassword/RotateSaltPasswordFlowConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/salt/rotatepassword/RotateSaltPasswordFlowConfig.java
@@ -7,13 +7,16 @@ import static com.sequenceiq.cloudbreak.core.flow2.cluster.salt.rotatepassword.R
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.salt.rotatepassword.RotateSaltPasswordState.ROTATE_SALT_PASSWORD_SUCCESS_STATE;
 
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.core.flow2.StackStatusFinalizerAbstractFlowConfig;
+import com.sequenceiq.flow.core.config.IgnoreFromRetryableFlowConfiguration;
 
 @Component
-public class RotateSaltPasswordFlowConfig extends StackStatusFinalizerAbstractFlowConfig<RotateSaltPasswordState, RotateSaltPasswordEvent> {
+public class RotateSaltPasswordFlowConfig extends StackStatusFinalizerAbstractFlowConfig<RotateSaltPasswordState, RotateSaltPasswordEvent>
+        implements IgnoreFromRetryableFlowConfiguration<RotateSaltPasswordEvent> {
 
     private static final List<Transition<RotateSaltPasswordState, RotateSaltPasswordEvent>> TRANSITIONS =
             new Transition.Builder<RotateSaltPasswordState, RotateSaltPasswordEvent>()
@@ -59,5 +62,10 @@ public class RotateSaltPasswordFlowConfig extends StackStatusFinalizerAbstractFl
     @Override
     public String getDisplayName() {
         return "Rotate SaltStack user password";
+    }
+
+    @Override
+    public Set<RotateSaltPasswordEvent> getIgnoredEvents() {
+        return Set.of(RotateSaltPasswordEvent.values());
     }
 }

--- a/flow/src/main/java/com/sequenceiq/flow/core/config/Flow2Config.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/config/Flow2Config.java
@@ -38,6 +38,14 @@ public class Flow2Config {
     }
 
     @Bean
+    public Set<String> ignoredFromRetryEvents(List<IgnoreFromRetryableFlowConfiguration<?>> ignoreFromRetryableFlowConfigurations) {
+        return ignoreFromRetryableFlowConfigurations.stream()
+                .map(IgnoreFromRetryableFlowConfiguration::getIgnoredEvents)
+                .flatMap(events -> events.stream().map(FlowEvent::event))
+                .collect(Collectors.toSet());
+    }
+
+    @Bean
     public Set<String> failHandledEvents(List<AbstractFlowConfiguration<?, ?>> flowConfigurations) {
         return flowConfigurations.stream()
                 .map(AbstractFlowConfiguration::getFailHandledEvent)

--- a/flow/src/main/java/com/sequenceiq/flow/core/config/IgnoreFromRetryableFlowConfiguration.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/config/IgnoreFromRetryableFlowConfiguration.java
@@ -1,0 +1,9 @@
+package com.sequenceiq.flow.core.config;
+
+import java.util.Set;
+
+import com.sequenceiq.flow.core.FlowEvent;
+
+public interface IgnoreFromRetryableFlowConfiguration<E extends FlowEvent> {
+    Set<E> getIgnoredEvents();
+}

--- a/flow/src/main/java/com/sequenceiq/flow/service/FlowRetryService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/service/FlowRetryService.java
@@ -3,7 +3,9 @@ package com.sequenceiq.flow.service;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import javax.annotation.Resource;
 import javax.inject.Inject;
@@ -34,6 +36,10 @@ public class FlowRetryService {
 
     private static final int INDEX_BEFORE_FINISHED_STATE = 1;
 
+    private static final int MIN_FLOW_LOGS_IN_RETRYABLE_FLOW = 2;
+
+    private static final int RETRYABLE_FLOW_LIMIT = 1;
+
     private static final int LAST_FIFTY_FLOWLOGS = 50;
 
     @Inject
@@ -44,6 +50,9 @@ public class FlowRetryService {
 
     @Resource
     private List<String> retryableEvents;
+
+    @Resource
+    private Set<String> ignoredFromRetryEvents;
 
     @Resource
     private List<FlowConfiguration<?>> flowConfigs;
@@ -143,12 +152,14 @@ public class FlowRetryService {
     }
 
     private List<RetryableFlow> getRetryableFlows(List<FlowLog> flowLogs) {
-        if (flowLogs.size() > 2) {
-            return Optional.ofNullable(flowLogs.get(INDEX_BEFORE_FINISHED_STATE))
+        if (flowLogs.size() > MIN_FLOW_LOGS_IN_RETRYABLE_FLOW) {
+            return flowLogs.stream()
+                    .filter(flowLog -> flowLog.getNextEvent() != null)
+                    .filter(flowLog -> !ignoredFromRetryEvents.contains(flowLog.getNextEvent()))
+                    .limit(RETRYABLE_FLOW_LIMIT)
                     .filter(log -> retryableEvents.contains(log.getNextEvent()))
                     .map(toRetryableFlow())
-                    .map(List::of)
-                    .orElse(List.of());
+                    .collect(Collectors.toList());
         } else {
             return Collections.emptyList();
         }


### PR DESCRIPTION
Some flows use events that should not interfere with restartable flows, like salt password rotation.
To achieve this, a new IgnoreFromRetryableFlowConfiguration interface was added to collect the events that should be ignored while checking for retryable flows.

See detailed description in the commit message.