### PR TITLE
CB-17459 Store Jackson-serialized objects in flowlog and flowchainlog…

### DIFF
--- a/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/handler/service/LoadBalancerMetadataService.java
+++ b/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/handler/service/LoadBalancerMetadataService.java
@@ -1,5 +1,13 @@
 package com.sequenceiq.cloudbreak.cloud.handler.service;
 
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
 import com.sequenceiq.cloudbreak.cloud.CloudConnector;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
@@ -8,12 +16,6 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.CloudLoadBalancerMetadata;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.common.api.type.LoadBalancerType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Service;
-
-import javax.inject.Inject;
-import java.util.List;
 
 @Service
 public class LoadBalancerMetadataService {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -37,6 +37,7 @@ dependencies {
   implementation group: 'io.projectreactor',                     name: 'reactor-stream',                 version: eventBusVersion
   implementation group: 'org.mybatis',                           name: 'mybatis-migrations',             version: mybatisMigrationVersion
   implementation group: 'com.fasterxml.jackson.core',            name: 'jackson-databind',               version: jacksonVersion
+  implementation group: 'com.fasterxml.jackson.datatype',        name: 'jackson-datatype-jdk8',          version: jacksonVersion
   implementation group: 'net.sf.json-lib',                       name: 'json-lib',                       version: '2.4',  classifier: 'jdk15'
   api group: 'net.jcip',                              name: 'jcip-annotations',               version: '1.0'
   api group: 'com.github.spotbugs',                   name: 'spotbugs-annotations',           version: '4.4.2'
@@ -85,6 +86,7 @@ dependencies {
   api group: 'org.springframework.security',        name: 'spring-security-jwt',              version: '1.0.8.RELEASE'
   api group: 'org.springframework.security',        name: 'spring-security-core',             version: springSecurityVersion
   api group: 'org.springframework.security',        name: 'spring-security-config',           version: springSecurityVersion
+  implementation group: 'com.cedarsoftware',        name: 'json-io',                          version: '4.9.12'
 
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test',       version: springBootVersion
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation', version: springBootVersion

--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/json/TypedJsonUtil.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/json/TypedJsonUtil.java
@@ -1,0 +1,71 @@
+package com.sequenceiq.cloudbreak.common.json;
+
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.cedarsoftware.util.io.JsonReader;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+
+public class TypedJsonUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TypedJsonUtil.class);
+
+    private static final ObjectMapper TYPED_MAPPER = JsonMapper.builder()
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .enable(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS)
+            .enable(DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY)
+            .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, false)
+            .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+            .activateDefaultTypingAsProperty(LaissezFaireSubTypeValidator.instance, DefaultTyping.JAVA_LANG_OBJECT, "@type")
+            .addModule(new Jdk8Module())
+            .build();
+
+    private TypedJsonUtil() {
+    }
+
+    public static <T> T readValue(String content, Class<T> valueType) throws IOException {
+        return TYPED_MAPPER.readValue(content, valueType);
+    }
+
+    public static String writeValueAsStringSilent(Object object) {
+        if (object != null) {
+            try {
+                return TYPED_MAPPER.writeValueAsString(object);
+            } catch (JsonProcessingException e) {
+                LOGGER.warn("JSON serialization went wrong in silent mode: {}", e.getMessage());
+            }
+        }
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T readValueWithJsonIoFallback(String jackson, String jsonio, Class<T> valueType) {
+        try {
+            return readValue(jackson, valueType);
+        } catch (IOException e) {
+            LOGGER.error("Failed to deserialize with Jackson, falling back to json-io. JSON: {}", jackson, e);
+            return (T) JsonReader.jsonToJava(jsonio);
+        }
+    }
+
+    public static void checkReadability(String jackson, Class<?> valueType) {
+        if (jackson != null) {
+            try {
+                readValue(jackson, valueType);
+            } catch (IOException e) {
+                LOGGER.error("Failed to deserialize with Jackson: {}", jackson, e);
+            }
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/TerminationTriggerService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/TerminationTriggerService.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.cedarsoftware.util.io.JsonReader;
+import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 import com.sequenceiq.cloudbreak.core.flow2.chain.FlowChainTriggers;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.termination.ClusterTerminationState;
 import com.sequenceiq.cloudbreak.core.flow2.stack.termination.StackTerminationState;
@@ -89,7 +90,12 @@ public class TerminationTriggerService {
     private boolean isRunningFlowForced(FlowLog fl) {
         ClassValue payloadType = fl.getPayloadType();
         if (payloadType != null && payloadType.isOnClassPath() && TerminationEvent.class.equals(payloadType.getClassValue())) {
-            TerminationEvent payload = (TerminationEvent) JsonReader.jsonToJava(fl.getPayload());
+            TerminationEvent payload;
+            if (fl.getPayloadJackson() != null) {
+                payload = JsonUtil.readValueWithJsonIoFallback(fl.getPayloadJackson(), fl.getPayload(), TerminationEvent.class);
+            } else {
+                payload = (TerminationEvent) JsonReader.jsonToJava(fl.getPayload());
+            }
             return payload.getTerminationType().isForced();
         } else {
             LOGGER.warn("Payloadtype [{}] is not 'TerminationEvent' for flow [{}]", fl.getPayloadType(), fl.getFlowId());

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/service/TerminationTriggerServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/service/TerminationTriggerServiceTest.java
@@ -1,29 +1,31 @@
 package com.sequenceiq.cloudbreak.core.flow2.service;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.cedarsoftware.util.io.JsonWriter;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.common.event.Acceptable;
+import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 import com.sequenceiq.cloudbreak.core.flow2.chain.FlowChainTriggers;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.termination.ClusterTerminationFlowConfig;
 import com.sequenceiq.cloudbreak.core.flow2.stack.provision.StackCreationFlowConfig;
@@ -39,10 +41,8 @@ import com.sequenceiq.flow.domain.ClassValue;
 import com.sequenceiq.flow.domain.FlowLog;
 import com.sequenceiq.flow.service.FlowCancelService;
 
-@RunWith(MockitoJUnitRunner.class)
-public class TerminationTriggerServiceTest {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(TerminationTriggerServiceTest.class);
+@ExtendWith(MockitoExtension.class)
+class TerminationTriggerServiceTest {
 
     @Mock
     private KerberosConfigService kerberosConfigService;
@@ -62,18 +62,19 @@ public class TerminationTriggerServiceTest {
     @InjectMocks
     private TerminationTriggerService underTest;
 
-    @Before
-    public void init() {
-        when(applicationFlowInformation.getTerminationFlow()).thenReturn(List.of(StackTerminationFlowConfig.class, ClusterTerminationFlowConfig.class));
+    @BeforeEach
+    void init() {
+        lenient().when(applicationFlowInformation.getTerminationFlow())
+                .thenReturn(List.of(StackTerminationFlowConfig.class, ClusterTerminationFlowConfig.class));
     }
 
-    @After
-    public void validateCancelOldterminationFlowsCalled() {
+    @AfterEach
+    void validateCancelOldterminationFlowsCalled() {
         verify(flowCancelService).cancelTooOldTerminationFlowForResource(anyLong(), anyString());
     }
 
     @Test
-    public void whenStackNotDeletedAndNoFlowLogAndKerbAndNotForcedShouldTerminate() {
+    void whenStackNotDeletedAndNoFlowLogAndKerbAndNotForcedShouldTerminate() {
         when(flowLogService.findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(anyLong())).thenReturn(List.of());
         setupKerberized();
 
@@ -83,7 +84,7 @@ public class TerminationTriggerServiceTest {
     }
 
     @Test
-    public void whenStackNotDeletedAndNoFlowLogAndNotKerbAndNotForcedShouldTerminate() {
+    void whenStackNotDeletedAndNoFlowLogAndNotKerbAndNotForcedShouldTerminate() {
         when(flowLogService.findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(anyLong())).thenReturn(List.of());
         setupNotKerberized();
 
@@ -93,7 +94,7 @@ public class TerminationTriggerServiceTest {
     }
 
     @Test
-    public void whenStackNotDeletedAndNoFlowLogAndKerbAndForcedShouldTerminate() {
+    void whenStackNotDeletedAndNoFlowLogAndKerbAndForcedShouldTerminate() {
         when(flowLogService.findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(anyLong())).thenReturn(List.of());
         setupKerberized();
 
@@ -103,7 +104,7 @@ public class TerminationTriggerServiceTest {
     }
 
     @Test
-    public void whenStackNotDeletedAndNoFlowLogAndNotKerbAndForcedShouldTerminate() {
+    void whenStackNotDeletedAndNoFlowLogAndNotKerbAndForcedShouldTerminate() {
         when(flowLogService.findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(anyLong())).thenReturn(List.of());
         setupNotKerberized();
 
@@ -113,7 +114,7 @@ public class TerminationTriggerServiceTest {
     }
 
     @Test
-    public void whenStackNotDeletedAndNotTerminationFlowLogAndKerbAndNotForcedShouldTerminate() {
+    void whenStackNotDeletedAndNotTerminationFlowLogAndKerbAndNotForcedShouldTerminate() {
         FlowLog flowLog = new FlowLog();
         flowLog.setFlowType(ClassValue.of(StackCreationFlowConfig.class));
         when(flowLogService.findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(anyLong())).thenReturn(List.of(flowLog));
@@ -125,7 +126,7 @@ public class TerminationTriggerServiceTest {
     }
 
     @Test
-    public void whenStackNotDeletedAndNotTerminationFlowLogAndKerbAndForcedShouldTerminate() {
+    void whenStackNotDeletedAndNotTerminationFlowLogAndKerbAndForcedShouldTerminate() {
         FlowLog flowLog = new FlowLog();
         flowLog.setFlowType(ClassValue.of(StackCreationFlowConfig.class));
         when(flowLogService.findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(anyLong())).thenReturn(List.of(flowLog));
@@ -137,7 +138,7 @@ public class TerminationTriggerServiceTest {
     }
 
     @Test
-    public void whenStackNotDeletedAndNotTerminationFlowLogAndNotKerbAndNotForcedShouldTerminate() {
+    void whenStackNotDeletedAndNotTerminationFlowLogAndNotKerbAndNotForcedShouldTerminate() {
         FlowLog flowLog = new FlowLog();
         flowLog.setFlowType(ClassValue.of(StackCreationFlowConfig.class));
         when(flowLogService.findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(anyLong())).thenReturn(List.of(flowLog));
@@ -149,7 +150,7 @@ public class TerminationTriggerServiceTest {
     }
 
     @Test
-    public void whenStackNotDeletedAndNotTerminationFlowLogAndNotKerbAndForcedShouldTerminate() {
+    void whenStackNotDeletedAndNotTerminationFlowLogAndNotKerbAndForcedShouldTerminate() {
         FlowLog flowLog = new FlowLog();
         flowLog.setFlowType(ClassValue.of(StackCreationFlowConfig.class));
         when(flowLogService.findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(anyLong())).thenReturn(List.of(flowLog));
@@ -160,36 +161,40 @@ public class TerminationTriggerServiceTest {
         verifyTerminationEventFired(false, true, false);
     }
 
-    @Test
-    public void whenStackNotDeletedAndNotForcedTerminationFlowLogAndNotForcedShouldNotTerminate() {
-        when(flowLogService.findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(anyLong())).thenReturn(List.of(getTerminationFlowLog(false)));
+    @ParameterizedTest(name = "use Jackson = {0}")
+    @ValueSource(booleans = { false, true })
+    void whenStackNotDeletedAndNotForcedTerminationFlowLogAndNotForcedShouldNotTerminate(boolean useJackson) {
+        when(flowLogService.findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(anyLong())).thenReturn(List.of(getTerminationFlowLog(false, useJackson)));
 
         underTest.triggerTermination(getAvailableStack(), false);
 
         verifyNoTerminationEventFired();
     }
 
-    @Test
-    public void whenStackNotDeletedAndForcedTerminationFlowLogAndNotForcedShouldNotTerminate() {
-        when(flowLogService.findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(anyLong())).thenReturn(List.of(getTerminationFlowLog(true)));
+    @ParameterizedTest(name = "use Jackson = {0}")
+    @ValueSource(booleans = { false, true })
+    void whenStackNotDeletedAndForcedTerminationFlowLogAndNotForcedShouldNotTerminate(boolean useJackson) {
+        when(flowLogService.findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(anyLong())).thenReturn(List.of(getTerminationFlowLog(true, useJackson)));
 
         underTest.triggerTermination(getAvailableStack(), false);
 
         verifyNoTerminationEventFired();
     }
 
-    @Test
-    public void whenStackNotDeletedAndForcedTerminationFlowLogAndForcedShouldNotTerminate() {
-        when(flowLogService.findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(anyLong())).thenReturn(List.of(getTerminationFlowLog(true)));
+    @ParameterizedTest(name = "use Jackson = {0}")
+    @ValueSource(booleans = { false, true })
+    void whenStackNotDeletedAndForcedTerminationFlowLogAndForcedShouldNotTerminate(boolean useJackson) {
+        when(flowLogService.findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(anyLong())).thenReturn(List.of(getTerminationFlowLog(true, useJackson)));
 
         underTest.triggerTermination(getAvailableStack(), true);
 
         verifyNoTerminationEventFired();
     }
 
-    @Test
-    public void whenStackNotDeletedAndNotForcedTerminationFlowLogAndForcedShouldTerminate() {
-        FlowLog flowLog = getTerminationFlowLog(false);
+    @ParameterizedTest(name = "use Jackson = {0}")
+    @ValueSource(booleans = { false, true })
+    void whenStackNotDeletedAndNotForcedTerminationFlowLogAndForcedShouldTerminate(boolean useJackson) {
+        FlowLog flowLog = getTerminationFlowLog(false, useJackson);
         when(flowLogService.findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(anyLong())).thenReturn(List.of(flowLog));
         setupKerberized();
 
@@ -200,7 +205,7 @@ public class TerminationTriggerServiceTest {
     }
 
     @Test
-    public void whenStackDeletedShouldNotTerminate() {
+    void whenStackDeletedShouldNotTerminate() {
         Stack stack = stackWithStatus(Status.DELETE_COMPLETED);
         stack.setTerminated(2L);
 
@@ -210,7 +215,7 @@ public class TerminationTriggerServiceTest {
     }
 
     @Test
-    public void whenStackDeletedButTerminationDateDidNotSetThenItShouldTerminate() {
+    void whenStackDeletedButTerminationDateDidNotSetThenItShouldTerminate() {
         Stack stack = stackWithStatus(Status.DELETE_COMPLETED);
 
         underTest.triggerTermination(stack, true);
@@ -219,7 +224,7 @@ public class TerminationTriggerServiceTest {
     }
 
     @Test
-    public void whenStackStoppedAndSecureThenItShouldTerminate() {
+    void whenStackStoppedAndSecureThenItShouldTerminate() {
         Stack stack = stackWithStatus(Status.STOP_REQUESTED);
 
         underTest.triggerTermination(stack, false);
@@ -228,7 +233,7 @@ public class TerminationTriggerServiceTest {
     }
 
     @Test
-    public void whenStackStoppedAndNotSecureThenItShouldTerminate() {
+    void whenStackStoppedAndNotSecureThenItShouldTerminate() {
         Stack stack = stackWithStatus(Status.STOP_REQUESTED);
 
         underTest.triggerTermination(stack, false);
@@ -282,12 +287,15 @@ public class TerminationTriggerServiceTest {
         when(kerberosConfigService.isKerberosConfigExistsForEnvironment(anyString(), anyString())).thenReturn(Boolean.FALSE);
     }
 
-    private FlowLog getTerminationFlowLog(boolean forced) {
+    private FlowLog getTerminationFlowLog(boolean forced, boolean useJackson) {
         FlowLog flowLog = new FlowLog();
         flowLog.setFlowType(ClassValue.of(StackTerminationFlowConfig.class));
         flowLog.setCurrentState("INIT_STATE");
         TerminationEvent event = new TerminationEvent("selector", 1L, forced ? TerminationType.FORCED : TerminationType.REGULAR);
         flowLog.setPayload(JsonWriter.objectToJson(event));
+        if (useJackson) {
+            flowLog.setPayloadJackson(JsonUtil.writeValueAsStringSilent(event));
+        }
         flowLog.setPayloadType(ClassValue.of(TerminationEvent.class));
         return flowLog;
     }

--- a/flow/src/main/java/com/sequenceiq/cloudbreak/service/flowlog/FlowLogUtil.java
+++ b/flow/src/main/java/com/sequenceiq/cloudbreak/service/flowlog/FlowLogUtil.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 
 import com.cedarsoftware.util.io.JsonReader;
 import com.sequenceiq.cloudbreak.common.event.Payload;
+import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 import com.sequenceiq.flow.domain.FlowChainLog;
 import com.sequenceiq.flow.domain.FlowLog;
 import com.sequenceiq.flow.domain.FlowLogWithoutPayload;
@@ -78,11 +79,15 @@ public class FlowLogUtil {
     }
 
     public static Payload tryDeserializeTriggerEvent(FlowChainLog flowChainLog) {
-        if (null == flowChainLog.getTriggerEvent()) {
+        if (null == flowChainLog.getTriggerEvent() && null == flowChainLog.getTriggerEventJackson()) {
             return null;
         } else {
             try {
-                return (Payload) JsonReader.jsonToJava(flowChainLog.getTriggerEvent());
+                if (null != flowChainLog.getTriggerEventJackson()) {
+                    return JsonUtil.readValueWithJsonIoFallback(flowChainLog.getTriggerEventJackson(), flowChainLog.getTriggerEvent(), Payload.class);
+                } else {
+                    return (Payload) JsonReader.jsonToJava(flowChainLog.getTriggerEvent());
+                }
             } catch (Exception exception) {
                 LOGGER.warn("Couldn't deserialize trigger event from flow chain log {}", flowChainLog);
                 return null;
@@ -91,11 +96,16 @@ public class FlowLogUtil {
     }
 
     public static Payload tryDeserializePayload(FlowLog flowLog) {
-        if (null == flowLog.getPayload()) {
+        if (null == flowLog.getPayload() && null == flowLog.getPayloadJackson()) {
             return null;
         } else {
             try {
-                return (Payload) JsonReader.jsonToJava(flowLog.getPayload());
+                if (null != flowLog.getPayloadJackson()) {
+                    return JsonUtil.readValueWithJsonIoFallback(flowLog.getPayloadJackson(), flowLog.getPayload(), Payload.class);
+                } else {
+                    return (Payload) JsonReader.jsonToJava(flowLog.getPayload());
+                }
+
             } catch (Exception exception) {
                 LOGGER.warn("Couldn't deserialize payload from flow log {}", flowLog);
                 return null;

--- a/flow/src/main/java/com/sequenceiq/flow/core/Flow2Handler.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/Flow2Handler.java
@@ -32,6 +32,8 @@ import com.sequenceiq.cloudbreak.common.event.Acceptable;
 import com.sequenceiq.cloudbreak.common.event.IdempotentEvent;
 import com.sequenceiq.cloudbreak.common.event.Payload;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.common.json.JsonUtil;
+import com.sequenceiq.cloudbreak.common.json.TypedJsonUtil;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
 import com.sequenceiq.cloudbreak.common.service.TransactionService.TransactionExecutionException;
 import com.sequenceiq.cloudbreak.common.service.TransactionService.TransactionRuntimeExecutionException;
@@ -506,7 +508,12 @@ public class Flow2Handler implements Consumer<Event<? extends Payload>> {
                     .findFirst();
             try {
                 String flowChainType = flowChainLogService.getFlowChainType(flowLog.getFlowChainId());
-                Payload payload = (Payload) JsonReader.jsonToJava(flowLog.getPayload());
+                Payload payload;
+                if (null != flowLog.getPayloadJackson()) {
+                    payload = JsonUtil.readValueWithJsonIoFallback(flowLog.getPayloadJackson(), flowLog.getPayload(), Payload.class);
+                } else {
+                    payload = (Payload) JsonReader.jsonToJava(flowLog.getPayload());
+                }
                 Flow flow = flowConfig.get().createFlow(flowLog.getFlowId(), flowLog.getFlowChainId(), payload.getResourceId(), flowChainType);
                 runningFlows.put(flow, flowLog.getFlowChainId());
                 flowStatCache.put(flow.getFlowId(), flowLog.getFlowChainId(), payload.getResourceId(),
@@ -514,7 +521,12 @@ public class Flow2Handler implements Consumer<Event<? extends Payload>> {
                 if (flowLog.getFlowChainId() != null) {
                     flowChainHandler.restoreFlowChain(flowLog.getFlowChainId());
                 }
-                Map<Object, Object> variables = (Map<Object, Object>) JsonReader.jsonToJava(flowLog.getVariables());
+                Map<Object, Object> variables;
+                if (null != flowLog.getVariablesJackson()) {
+                    variables = TypedJsonUtil.readValueWithJsonIoFallback(flowLog.getVariablesJackson(), flowLog.getVariables(), Map.class);
+                } else {
+                    variables = (Map<Object, Object>) JsonReader.jsonToJava(flowLog.getVariables());
+                }
                 flow.initialize(flowLog.getCurrentState(), variables);
                 RestartAction restartAction = flowConfig.get().getRestartAction(flowLog.getNextEvent());
                 if (restartAction != null) {
@@ -525,7 +537,7 @@ public class Flow2Handler implements Consumer<Event<? extends Payload>> {
                             flowLog.getOperationType().name(), span.context()), flowLog.getFlowChainId(), flowLog.getNextEvent(), payload);
                     return;
                 }
-            } catch (RuntimeException e) {
+            } catch (Exception e) {
                 String message = String.format("Flow could not be restarted with id: '%s', flow chain id: '%s' and flow type: '%s'", flowLog.getFlowId(),
                         flowLog.getFlowChainId(), flowLog.getFlowType().getClassValue().getSimpleName());
                 LOGGER.error(message, e);

--- a/flow/src/main/java/com/sequenceiq/flow/core/chain/FlowChainHandler.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/chain/FlowChainHandler.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
 import com.cedarsoftware.util.io.JsonReader;
 import com.sequenceiq.cloudbreak.common.event.Payload;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.common.json.TypedJsonUtil;
 import com.sequenceiq.flow.api.model.operation.OperationType;
 import com.sequenceiq.flow.core.FlowConstants;
 import com.sequenceiq.flow.core.FlowLogService;
@@ -60,23 +61,29 @@ public class FlowChainHandler implements Consumer<Event<? extends Payload>> {
     }
 
     public void restoreFlowChain(String flowChainId) {
-        Optional<FlowChainLog> chainLog = flowLogService.findFirstByFlowChainIdOrderByCreatedDesc(flowChainId);
-        if (chainLog.isPresent()) {
-            String flowChainType = chainLog.get().getFlowChainType();
-            Queue<Selectable> queue = (Queue<Selectable>) JsonReader.jsonToJava(chainLog.get().getChain());
-            Payload triggerEvent = tryDeserializeTriggerEvent(chainLog.get());
-            FlowTriggerEventQueue chain = new FlowTriggerEventQueue(flowChainType, triggerEvent, queue);
-            if (chainLog.get().getParentFlowChainId() != null) {
-                chain.setParentFlowChainId(chainLog.get().getParentFlowChainId());
+        Optional<FlowChainLog> chainLogOpt = flowLogService.findFirstByFlowChainIdOrderByCreatedDesc(flowChainId);
+        if (chainLogOpt.isPresent()) {
+            FlowChainLog chainLog = chainLogOpt.get();
+            String flowChainType = chainLog.getFlowChainType();
+            Queue<Selectable> queue;
+            if (null != chainLog.getChainJackson()) {
+                queue = TypedJsonUtil.readValueWithJsonIoFallback(chainLog.getChainJackson(), chainLog.getChain(), Queue.class);
+            } else {
+                queue = (Queue<Selectable>) JsonReader.jsonToJava(chainLog.getChain());
             }
-            flowChains.putFlowChain(flowChainId, chainLog.get().getParentFlowChainId(), chain);
+            Payload triggerEvent = tryDeserializeTriggerEvent(chainLog);
+            FlowTriggerEventQueue chain = new FlowTriggerEventQueue(flowChainType, triggerEvent, queue);
+            if (chainLog.getParentFlowChainId() != null) {
+                chain.setParentFlowChainId(chainLog.getParentFlowChainId());
+            }
+            flowChains.putFlowChain(flowChainId, chainLog.getParentFlowChainId(), chain);
             Selectable selectable = queue.peek();
             if (selectable != null) {
                 OperationType operationType = flowChainOperationTypeConfig.getFlowTypeOperationTypeMap().getOrDefault(flowChainType, OperationType.UNKNOWN);
                 flowStatCache.putByFlowChainId(flowChainId, selectable.getResourceId(), operationType.name(), true);
             }
-            if (chainLog.get().getParentFlowChainId() != null) {
-                restoreFlowChain(chainLog.get().getParentFlowChainId());
+            if (chainLog.getParentFlowChainId() != null) {
+                restoreFlowChain(chainLog.getParentFlowChainId());
             }
         }
     }

--- a/flow/src/main/java/com/sequenceiq/flow/domain/FlowChainLog.java
+++ b/flow/src/main/java/com/sequenceiq/flow/domain/FlowChainLog.java
@@ -29,21 +29,32 @@ public class FlowChainLog {
     @Column(length = Integer.MAX_VALUE, columnDefinition = "TEXT", nullable = false)
     private String chain;
 
+    @Column(length = Integer.MAX_VALUE, columnDefinition = "TEXT")
+    private String chainJackson;
+
     private String flowTriggerUserCrn;
 
+    @Column(length = Integer.MAX_VALUE, columnDefinition = "TEXT")
     private String triggerEvent;
+
+    @Column(length = Integer.MAX_VALUE, columnDefinition = "TEXT")
+    private String triggerEventJackson;
 
     public FlowChainLog() {
 
     }
 
-    public FlowChainLog(String flowChainType, String flowChainId, String parentFlowChainId, String chain, String flowTriggerUserCrn, String triggerEvent) {
+    public FlowChainLog(String flowChainType, String flowChainId, String parentFlowChainId, String chain, String chainJackson, String flowTriggerUserCrn,
+            String triggerEvent, String triggerEventJackson) {
+
         this.flowChainType = flowChainType;
         this.flowChainId = flowChainId;
         this.parentFlowChainId = parentFlowChainId;
         this.chain = chain;
+        this.chainJackson = chainJackson;
         this.flowTriggerUserCrn = flowTriggerUserCrn;
         this.triggerEvent = triggerEvent;
+        this.triggerEventJackson = triggerEventJackson;
     }
 
     public Long getId() {
@@ -108,5 +119,21 @@ public class FlowChainLog {
 
     public void setTriggerEvent(String triggerEvent) {
         this.triggerEvent = triggerEvent;
+    }
+
+    public String getChainJackson() {
+        return chainJackson;
+    }
+
+    public void setChainJackson(String chainJackson) {
+        this.chainJackson = chainJackson;
+    }
+
+    public String getTriggerEventJackson() {
+        return triggerEventJackson;
+    }
+
+    public void setTriggerEventJackson(String triggerEventJackson) {
+        this.triggerEventJackson = triggerEventJackson;
     }
 }

--- a/flow/src/main/java/com/sequenceiq/flow/domain/FlowLog.java
+++ b/flow/src/main/java/com/sequenceiq/flow/domain/FlowLog.java
@@ -39,11 +39,17 @@ public class FlowLog {
     @Column(length = Integer.MAX_VALUE, columnDefinition = "TEXT")
     private String payload;
 
+    @Column(length = Integer.MAX_VALUE, columnDefinition = "TEXT")
+    private String payloadJackson;
+
     @Convert(converter = ClassValueConverter.class)
     private ClassValue payloadType;
 
     @Column(length = Integer.MAX_VALUE, columnDefinition = "TEXT")
     private String variables;
+
+    @Column(length = Integer.MAX_VALUE, columnDefinition = "TEXT")
+    private String variablesJackson;
 
     @Convert(converter = ClassValueConverter.class)
     private ClassValue flowType;
@@ -92,8 +98,10 @@ public class FlowLog {
             String flowTriggerUserCrn,
             String nextEvent,
             String payload,
+            String payloadJackson,
             ClassValue payloadType,
             String variables,
+            String variablesJackson,
             ClassValue flowType,
             String currentState) {
         this.resourceId = resourceId;
@@ -102,8 +110,10 @@ public class FlowLog {
         this.flowTriggerUserCrn = flowTriggerUserCrn;
         this.nextEvent = nextEvent;
         this.payload = payload;
+        this.payloadJackson = payloadJackson;
         this.payloadType = payloadType;
         this.variables = variables;
+        this.variablesJackson = variablesJackson;
         this.flowType = flowType;
         this.currentState = currentState;
     }
@@ -250,6 +260,22 @@ public class FlowLog {
 
     public void setOperationType(OperationType operationType) {
         this.operationType = operationType;
+    }
+
+    public String getPayloadJackson() {
+        return payloadJackson;
+    }
+
+    public void setPayloadJackson(String payloadJackson) {
+        this.payloadJackson = payloadJackson;
+    }
+
+    public String getVariablesJackson() {
+        return variablesJackson;
+    }
+
+    public void setVariablesJackson(String variablesJackson) {
+        this.variablesJackson = variablesJackson;
     }
 
     public String minimizedString() {

--- a/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowChainLogService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowChainLogService.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Service;
 import com.cedarsoftware.util.io.JsonReader;
 import com.google.common.base.Joiner;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.common.json.TypedJsonUtil;
 import com.sequenceiq.flow.domain.FlowChainLog;
 import com.sequenceiq.flow.domain.FlowLogWithoutPayload;
 import com.sequenceiq.flow.repository.FlowChainLogRepository;
@@ -105,7 +106,13 @@ public class FlowChainLogService {
                     .get();
             LOGGER.debug("Checking if chain with id {} has any event in it's queue", latestFlowChain.getFlowChainId());
             LOGGER.trace("Chain string in db: {}", latestFlowChain.getChain());
-            Queue<Selectable> chain = (Queue<Selectable>) JsonReader.jsonToJava(latestFlowChain.getChain());
+            Queue<Selectable> chain;
+            if (null != latestFlowChain.getChainJackson()) {
+                chain = (Queue<Selectable>) TypedJsonUtil.readValueWithJsonIoFallback(
+                        latestFlowChain.getChainJackson(), latestFlowChain.getChain(), Queue.class);
+            } else {
+                chain = (Queue<Selectable>) JsonReader.jsonToJava(latestFlowChain.getChain());
+            }
             return !chain.isEmpty();
         });
     }

--- a/flow/src/main/resources/schema/flow/20220713094831_CB-17459_add_jackson_serialized_target_columns.sql
+++ b/flow/src/main/resources/schema/flow/20220713094831_CB-17459_add_jackson_serialized_target_columns.sql
@@ -1,0 +1,17 @@
+-- // CB-17459 add columns to store Jackson-serialized objects too
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE IF EXISTS flowlog ADD COLUMN IF NOT EXISTS payloadjackson text;
+ALTER TABLE IF EXISTS flowlog ADD COLUMN IF NOT EXISTS variablesjackson text;
+
+ALTER TABLE IF EXISTS flowchainlog ADD COLUMN IF NOT EXISTS triggereventjackson text;
+ALTER TABLE IF EXISTS flowchainlog ADD COLUMN IF NOT EXISTS chainjackson text;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE IF EXISTS flowlog DROP COLUMN IF EXISTS payloadjackson;
+ALTER TABLE IF EXISTS flowlog DROP COLUMN IF EXISTS variablesjackson;
+
+ALTER TABLE IF EXISTS flowchainlog DROP COLUMN IF EXISTS triggereventjackson;
+ALTER TABLE IF EXISTS flowchainlog DROP COLUMN IF EXISTS chainjackson;

--- a/flow/src/test/java/com/sequenceiq/flow/component/FlowComponentTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/component/FlowComponentTest.java
@@ -496,7 +496,9 @@ public class FlowComponentTest {
                 "userCrn",
                 "NEXT_EVENT",
                 "payload",
+                "payload",
                 ClassValue.ofUnknown("nope.NopePayload"),
+                "variables",
                 "variables",
                 ClassValue.ofUnknown("nope.NopeFlowType"),
                 "CURRENT_STATE");

--- a/flow/src/test/java/com/sequenceiq/flow/core/Flow2HandlerTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/core/Flow2HandlerTest.java
@@ -29,6 +29,8 @@ import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.BDDMockito;
@@ -49,6 +51,8 @@ import com.sequenceiq.cloudbreak.common.event.AcceptResult;
 import com.sequenceiq.cloudbreak.common.event.Acceptable;
 import com.sequenceiq.cloudbreak.common.event.Payload;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.common.json.JsonUtil;
+import com.sequenceiq.cloudbreak.common.json.TypedJsonUtil;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
 import com.sequenceiq.cloudbreak.common.service.TransactionService.TransactionExecutionException;
 import com.sequenceiq.flow.api.model.operation.OperationType;
@@ -78,7 +82,7 @@ import reactor.bus.Event.Headers;
 import reactor.rx.Promise;
 
 @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
-public class Flow2HandlerTest {
+class Flow2HandlerTest {
 
     private static final String FLOW_ID = "flowId";
 
@@ -189,7 +193,7 @@ public class Flow2HandlerTest {
     private final Payload payload = () -> 1L;
 
     @BeforeEach
-    public void setUp() throws TransactionExecutionException {
+    void setUp() throws TransactionExecutionException {
         underTest = new Flow2Handler();
         MockitoAnnotations.initMocks(this);
         Map<String, Object> headers = new HashMap<>();
@@ -209,7 +213,7 @@ public class Flow2HandlerTest {
     }
 
     @Test
-    public void testNewFlow() {
+    void testNewFlow() {
         BDDMockito.<FlowConfiguration<?>>given(flowConfigurationMap.get(any())).willReturn(flowConfig);
         given(flowConfig.createFlow(anyString(), any(), anyLong(), any())).willReturn(flow);
         given(flowConfig.getFlowTriggerCondition()).willReturn(flowTriggerCondition);
@@ -227,7 +231,7 @@ public class Flow2HandlerTest {
     }
 
     @Test
-    public void testFlowCanNotBeSaved() {
+    void testFlowCanNotBeSaved() {
         BDDMockito.<FlowConfiguration<?>>given(flowConfigurationMap.get(any())).willReturn(flowConfig);
         given(flowConfig.createFlow(anyString(), any(), anyLong(), any())).willReturn(flow);
         given(flowConfig.getFlowTriggerCondition()).willReturn(flowTriggerCondition);
@@ -249,7 +253,7 @@ public class Flow2HandlerTest {
     }
 
     @Test
-    public void testFlowRejectedBecauseNotTriggerable() {
+    void testFlowRejectedBecauseNotTriggerable() {
         BDDMockito.<FlowConfiguration<?>>given(flowConfigurationMap.get(any())).willReturn(flowConfig);
         given(flowConfig.createFlow(anyString(), any(), anyLong(), any())).willReturn(flow);
         given(flowConfig.getFlowTriggerCondition()).willReturn(flowTriggerCondition);
@@ -278,7 +282,7 @@ public class Flow2HandlerTest {
     }
 
     @Test
-    public void testFlowSkippedBecauseNotTriggerable() {
+    void testFlowSkippedBecauseNotTriggerable() {
         BDDMockito.<FlowConfiguration<?>>given(flowConfigurationMap.get(any())).willReturn(flowConfig);
         given(flowConfig.createFlow(anyString(), any(), anyLong(), any())).willReturn(flow);
         given(flowConfig.getFlowTriggerCondition()).willReturn(flowTriggerCondition);
@@ -305,7 +309,7 @@ public class Flow2HandlerTest {
     }
 
     @Test
-    public void testNewSyncFlowMaintenanceActive() {
+    void testNewSyncFlowMaintenanceActive() {
         HelloWorldFlowConfig helloWorldFlowConfig = mock(HelloWorldFlowConfig.class);
         given(helloWorldFlowConfig.getFlowTriggerCondition()).willReturn(new DefaultFlowTriggerCondition());
 
@@ -327,7 +331,7 @@ public class Flow2HandlerTest {
     }
 
     @Test
-    public void testNewFlowButNotHandled() {
+    void testNewFlowButNotHandled() {
         Event<Payload> event = new Event<>(payload);
         event.setKey("KEY");
         CloudbreakServiceException exception = assertThrows(CloudbreakServiceException.class, () -> underTest.accept(event));
@@ -338,7 +342,7 @@ public class Flow2HandlerTest {
     }
 
     @Test
-    public void testExistingFlow() {
+    void testExistingFlow() {
         FlowLog lastFlowLog = mock(FlowLog.class);
         Optional<FlowLog> flowLogOptional = Optional.of(lastFlowLog);
         BDDMockito.<FlowConfiguration<?>>given(flowConfigurationMap.get(any())).willReturn(flowConfig);
@@ -360,7 +364,7 @@ public class Flow2HandlerTest {
     }
 
     @Test
-    public void testFinalizedFlow() {
+    void testFinalizedFlow() {
         FlowLog lastFlowLog = mock(FlowLog.class);
         Optional<FlowLog> flowLogOptional = Optional.of(lastFlowLog);
         BDDMockito.<FlowConfiguration<?>>given(flowConfigurationMap.get(any())).willReturn(flowConfig);
@@ -382,7 +386,7 @@ public class Flow2HandlerTest {
     }
 
     @Test
-    public void testChangedNodeId() {
+    void testChangedNodeId() {
         FlowLog lastFlowLog = mock(FlowLog.class);
         Optional<FlowLog> flowLogOptional = Optional.of(lastFlowLog);
         BDDMockito.<FlowConfiguration<?>>given(flowConfigurationMap.get(any())).willReturn(flowConfig);
@@ -402,7 +406,7 @@ public class Flow2HandlerTest {
     }
 
     @Test
-    public void testExistingFlowRepeatedState() {
+    void testExistingFlowRepeatedState() {
         BDDMockito.<FlowConfiguration<?>>given(flowConfigurationMap.get(any())).willReturn(flowConfig);
         given(runningFlows.get(anyString())).willReturn(flow);
         given(flow.getCurrentState()).willReturn(flowState);
@@ -424,7 +428,7 @@ public class Flow2HandlerTest {
     }
 
     @Test
-    public void testExistingFlowNotFound() {
+    void testExistingFlowNotFound() {
         BDDMockito.<FlowConfiguration<?>>given(flowConfigurationMap.get(any())).willReturn(flowConfig);
         dummyEvent.setKey("KEY");
         underTest.accept(dummyEvent);
@@ -433,7 +437,7 @@ public class Flow2HandlerTest {
     }
 
     @Test
-    public void testFlowFinalFlowNotChained() throws TransactionExecutionException {
+    void testFlowFinalFlowNotChained() throws TransactionExecutionException {
         given(runningFlows.remove(FLOW_ID)).willReturn(flow);
         dummyEvent.setKey(FlowConstants.FLOW_FINAL);
         underTest.accept(dummyEvent);
@@ -446,7 +450,7 @@ public class Flow2HandlerTest {
     }
 
     @Test
-    public void testFlowFinalFlowChained() throws TransactionExecutionException {
+    void testFlowFinalFlowChained() throws TransactionExecutionException {
         given(runningFlows.remove(FLOW_ID)).willReturn(flow);
         dummyEvent.setKey(FlowConstants.FLOW_FINAL);
         dummyEvent.getHeaders().set(FlowConstants.FLOW_CHAIN_ID, FLOW_CHAIN_ID);
@@ -461,7 +465,7 @@ public class Flow2HandlerTest {
     }
 
     @Test
-    public void testFlowChainFailureOnNotTriggerableFlowCreatesFailedFlow() throws TransactionExecutionException {
+    void testFlowChainFailureOnNotTriggerableFlowCreatesFailedFlow() throws TransactionExecutionException {
         Map<String, Object> headers = new HashMap<>();
         headers.put(FlowConstants.FLOW_CHAIN_ID, FLOW_CHAIN_ID);
         headers.put(FlowConstants.FLOW_TRIGGER_USERCRN, FLOW_TRIGGER_USERCRN);
@@ -484,7 +488,7 @@ public class Flow2HandlerTest {
     }
 
     @Test
-    public void testFlowChainSkipOnNotTriggerableFlowCreatesFinishedFlow() throws TransactionExecutionException {
+    void testFlowChainSkipOnNotTriggerableFlowCreatesFinishedFlow() throws TransactionExecutionException {
         Map<String, Object> headers = new HashMap<>();
         headers.put(FlowConstants.FLOW_CHAIN_ID, FLOW_CHAIN_ID);
         headers.put(FlowConstants.FLOW_TRIGGER_USERCRN, FLOW_TRIGGER_USERCRN);
@@ -506,7 +510,7 @@ public class Flow2HandlerTest {
     }
 
     @Test
-    public void testFlowFinalFlowFailedNoChain() throws TransactionExecutionException {
+    void testFlowFinalFlowFailedNoChain() throws TransactionExecutionException {
         given(flow.isFlowFailed()).willReturn(Boolean.TRUE);
         given(runningFlows.remove(FLOW_ID)).willReturn(flow);
         dummyEvent.setKey(FlowConstants.FLOW_FINAL);
@@ -521,7 +525,7 @@ public class Flow2HandlerTest {
     }
 
     @Test
-    public void testFlowFinalFlowFailedWithChain() throws TransactionExecutionException {
+    void testFlowFinalFlowFailedWithChain() throws TransactionExecutionException {
         given(flow.isFlowFailed()).willReturn(Boolean.TRUE);
         given(runningFlows.remove(FLOW_ID)).willReturn(flow);
         dummyEvent.setKey(FlowConstants.FLOW_FINAL);
@@ -537,7 +541,7 @@ public class Flow2HandlerTest {
     }
 
     @Test
-    public void testCancelRunningFlows() throws TransactionExecutionException {
+    void testCancelRunningFlows() throws TransactionExecutionException {
         given(flowLogService.findAllRunningNonTerminationFlowIdsByStackId(anyLong())).willReturn(Collections.singleton(FLOW_ID));
         given(runningFlows.remove(FLOW_ID)).willReturn(flow);
         given(runningFlows.getFlowChainId(eq(FLOW_ID))).willReturn(FLOW_CHAIN_ID);
@@ -548,7 +552,7 @@ public class Flow2HandlerTest {
     }
 
     @Test
-    public void testRestartFlowNotRestartable() throws TransactionExecutionException {
+    void testRestartFlowNotRestartable() throws TransactionExecutionException {
         FlowLog flowLog = new FlowLog(STACK_ID, FLOW_ID, "START_STATE", true, StateStatus.SUCCESSFUL, OperationType.UNKNOWN);
         flowLog.setFlowType(ClassValue.of(String.class));
         flowLog.setPayloadType(ClassValue.of(TestPayload.class));
@@ -558,12 +562,16 @@ public class Flow2HandlerTest {
         verify(flowLogService, times(1)).terminate(STACK_ID, FLOW_ID);
     }
 
-    @Test
-    public void testRestartFlow() throws TransactionExecutionException {
-        FlowLog flowLog = createFlowLog(FLOW_CHAIN_ID);
+    @ParameterizedTest(name = "use Jackson = {0}")
+    @ValueSource(booleans = { false, true })
+    void testRestartFlow(boolean useJackson) throws TransactionExecutionException {
+        FlowLog flowLog = createFlowLog(FLOW_CHAIN_ID, useJackson);
         Payload payload = new TestPayload(STACK_ID);
         flowLog.setPayloadType(ClassValue.of(TestPayload.class));
         flowLog.setPayload(JsonWriter.objectToJson(payload));
+        if (useJackson) {
+            flowLog.setPayloadJackson(JsonUtil.writeValueAsStringSilent(payload));
+        }
         when(flowLogService.findFirstByFlowIdOrderByCreatedDesc(FLOW_ID)).thenReturn(Optional.of(flowLog));
 
         HelloWorldFlowConfig helloWorldFlowConfig = new HelloWorldFlowConfig();
@@ -590,12 +598,16 @@ public class Flow2HandlerTest {
         assertEquals(FLOW_TRIGGER_USERCRN, flowParameters.getFlowTriggerUserCrn());
     }
 
-    @Test
-    public void testRestartFlowNoRestartAction() throws TransactionExecutionException {
-        FlowLog flowLog = createFlowLog(FLOW_CHAIN_ID);
+    @ParameterizedTest(name = "use Jackson = {0}")
+    @ValueSource(booleans = { false, true })
+    void testRestartFlowNoRestartAction(boolean useJackson) throws TransactionExecutionException {
+        FlowLog flowLog = createFlowLog(FLOW_CHAIN_ID, useJackson);
         Payload payload = new TestPayload(STACK_ID);
         flowLog.setPayloadType(ClassValue.of(TestPayload.class));
         flowLog.setPayload(JsonWriter.objectToJson(payload));
+        if (useJackson) {
+            flowLog.setPayloadJackson(JsonUtil.writeValueAsStringSilent(payload));
+        }
         when(flowLogService.findFirstByFlowIdOrderByCreatedDesc(FLOW_ID)).thenReturn(Optional.of(flowLog));
 
         HelloWorldFlowConfig helloWorldFlowConfig = new HelloWorldFlowConfig();
@@ -612,12 +624,16 @@ public class Flow2HandlerTest {
         verify(defaultRestartAction, never()).restart(any(), any(), any(), any());
     }
 
-    @Test
-    public void testRestartFlowNoRestartActionNoFlowChainId() throws TransactionExecutionException {
-        FlowLog flowLog = createFlowLog(null);
+    @ParameterizedTest(name = "use Jackson = {0}")
+    @ValueSource(booleans = { false, true })
+    void testRestartFlowNoRestartActionNoFlowChainId(boolean useJackson) throws TransactionExecutionException {
+        FlowLog flowLog = createFlowLog(null, useJackson);
         Payload payload = new TestPayload(STACK_ID);
         flowLog.setPayloadType(ClassValue.of(TestPayload.class));
         flowLog.setPayload(JsonWriter.objectToJson(payload));
+        if (useJackson) {
+            flowLog.setPayloadJackson(JsonUtil.writeValueAsStringSilent(payload));
+        }
         when(flowLogService.findFirstByFlowIdOrderByCreatedDesc(FLOW_ID)).thenReturn(Optional.of(flowLog));
         HelloWorldFlowConfig helloWorldFlowConfig = new HelloWorldFlowConfig();
 
@@ -633,10 +649,13 @@ public class Flow2HandlerTest {
         verify(defaultRestartAction, never()).restart(any(), any(), any(), any());
     }
 
-    private FlowLog createFlowLog(String flowChainId) {
+    private FlowLog createFlowLog(String flowChainId, boolean useJackson) {
         FlowLog flowLog = new FlowLog(STACK_ID, FLOW_ID, "START_STATE", true, StateStatus.SUCCESSFUL, OperationType.UNKNOWN);
         flowLog.setFlowType(ClassValue.of(HelloWorldFlowConfig.class));
         flowLog.setVariables(JsonWriter.objectToJson(new HashMap<>()));
+        if (useJackson) {
+            flowLog.setVariablesJackson(TypedJsonUtil.writeValueAsStringSilent(new HashMap<>()));
+        }
         flowLog.setFlowChainId(flowChainId);
         flowLog.setNextEvent(NEXT_EVENT);
         flowLog.setFlowTriggerUserCrn(FLOW_TRIGGER_USERCRN);

--- a/flow/src/test/java/com/sequenceiq/flow/core/chain/FlowChainHandlerTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/core/chain/FlowChainHandlerTest.java
@@ -1,0 +1,163 @@
+package com.sequenceiq.flow.core.chain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.flow.api.model.operation.OperationType;
+import com.sequenceiq.flow.core.FlowLogService;
+import com.sequenceiq.flow.core.cache.FlowStatCache;
+import com.sequenceiq.flow.core.chain.config.FlowChainOperationTypeConfig;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
+import com.sequenceiq.flow.domain.FlowChainLog;
+
+@ExtendWith(MockitoExtension.class)
+class FlowChainHandlerTest {
+
+    private static final String FLOW_CHAIN_ID = "flowchainId";
+
+    private static final String FLOW_CHAIN_TYPE = "type";
+
+    private static final String PARENT_FLOW_CHAIN_ID = "parentId";
+
+    private static final String USER_CRN = "userCrn";
+
+    private static final String TRIGGER_VALUE = "triggerValue";
+
+    private static final String SELECTOR = "simpleSelector";
+
+    private static final String SIMPLE_VALUE = "chainKey";
+
+    private static final Long RESOURCE_ID = 123L;
+
+    @Mock
+    private FlowChains flowChains;
+
+    @Mock
+    private FlowLogService flowLogService;
+
+    @Mock
+    private FlowStatCache flowStatCache;
+
+    @Mock
+    private FlowChainOperationTypeConfig flowChainOperationTypeConfig;
+
+    @InjectMocks
+    private FlowChainHandler underTest;
+
+    @Captor
+    private ArgumentCaptor<FlowTriggerEventQueue> eventQueueCaptor;
+
+    @Test
+    void testRestoreFlowChainNotFound() {
+        when(flowLogService.findFirstByFlowChainIdOrderByCreatedDesc(FLOW_CHAIN_ID)).thenReturn(Optional.empty());
+        underTest.restoreFlowChain(FLOW_CHAIN_ID);
+        verifyNoInteractions(flowChains, flowStatCache, flowChainOperationTypeConfig);
+    }
+
+    @ParameterizedTest(name = "use Jackson = {0}")
+    @ValueSource(booleans = { false, true })
+    void testRestoreFlowChain(boolean useJackson) {
+        FlowChainLog flowChainLog = new FlowChainLog(FLOW_CHAIN_TYPE, FLOW_CHAIN_ID, PARENT_FLOW_CHAIN_ID,
+                "{\"@type\":\"java.util.concurrent.ConcurrentLinkedQueue\",\"@items\":[{\"@type\":\"" +
+                        SimpleSelectable.class.getName() + "\",\"resourceId\":" + RESOURCE_ID + ",\"key\":\"" + SIMPLE_VALUE + "\"," +
+                        "\"selector\":\"" + SELECTOR + "\"}]}",
+                useJackson
+                        ? "[{\"@type\":\"" +
+                            SimpleSelectable.class.getName() + "\",\"resourceId\":" + RESOURCE_ID + ",\"key\":\"" + SIMPLE_VALUE + "\"," +
+                            "\"selector\":\"" + SELECTOR + "\"}]"
+                        : null,
+                USER_CRN,
+                "{\"@type\":\"" + SimpleSelectable.class.getName() + "\",\"key\":\"" + TRIGGER_VALUE + "\"}",
+                useJackson
+                        ? "{\"@type\":\"" + SimpleSelectable.class.getName() + "\",\"key\":\"" + TRIGGER_VALUE + "\"}"
+                        : null);
+        when(flowLogService.findFirstByFlowChainIdOrderByCreatedDesc(FLOW_CHAIN_ID)).thenReturn(Optional.of(flowChainLog));
+        when(flowChainOperationTypeConfig.getFlowTypeOperationTypeMap()).thenReturn(Map.of(FLOW_CHAIN_TYPE, OperationType.PROVISION));
+        underTest.restoreFlowChain(FLOW_CHAIN_ID);
+
+        verify(flowChains).putFlowChain(eq(FLOW_CHAIN_ID), eq(PARENT_FLOW_CHAIN_ID), eventQueueCaptor.capture());
+        FlowTriggerEventQueue eventQueue = eventQueueCaptor.getValue();
+        assertThat(eventQueue.getFlowChainName()).isEqualTo(FLOW_CHAIN_TYPE);
+        assertThat(eventQueue.getParentFlowChainId()).isEqualTo(PARENT_FLOW_CHAIN_ID);
+        assertThat(eventQueue.getTriggerEvent()).isInstanceOf(SimpleSelectable.class);
+        assertThat(((SimpleSelectable) eventQueue.getTriggerEvent()).getKey()).isEqualTo(TRIGGER_VALUE);
+        assertThat(eventQueue.getQueue()).contains(new SimpleSelectable(SELECTOR, RESOURCE_ID, SIMPLE_VALUE));
+        verify(flowStatCache).putByFlowChainId(FLOW_CHAIN_ID, RESOURCE_ID, "PROVISION", true);
+    }
+
+    static class SimpleSelectable implements Selectable {
+
+        private final String selector;
+
+        private final Long resourceId;
+
+        private final String key;
+
+        @JsonCreator
+        SimpleSelectable(@JsonProperty("selector") String selector,
+                @JsonProperty("resourceId") Long resourceId,
+                @JsonProperty("key") String key) {
+            this.selector = selector;
+            this.resourceId = resourceId;
+            this.key = key;
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        @Override
+        public Long getResourceId() {
+            return resourceId;
+        }
+
+        @Override
+        public String toString() {
+            return "Simple{" +
+                    "key='" + key + '\'' +
+                    '}';
+        }
+
+        @Override
+        public String selector() {
+            return selector;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof SimpleSelectable)) {
+                return false;
+            }
+            SimpleSelectable that = (SimpleSelectable) o;
+            return Objects.equals(selector, that.selector) && Objects.equals(key, that.key) && Objects.equals(resourceId, that.resourceId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(selector, key, resourceId);
+        }
+    }
+}


### PR DESCRIPTION
… tables

in parallel to the json-io JSON strings.
On Jackson serialization there will be a log message if
the deserialization cannot be made.

On the Jackson reading (deserialization) if an exception is thrown then falling back
to json-io.

Payloads are serialized with regular settings but Objects and Collections of Objects are serialized with Typed serializer.