### PR TITLE
CB-17866 Fix postgres 11 on attached disk

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/init.sls
@@ -70,8 +70,8 @@ include:
 
 init-db-with-utf8:
   cmd.run:
-    - name: rm -rf {{ postgres_directory }}/data && runuser -l postgres -s /bin/bash sh -c 'initdb --locale=en_US.UTF-8 {{ postgres_directory }}/data > {{ postgres_directory }}/initdb.log' && rm -f {{ postgres_log_directory }}/pgsql_listen_address_configured
-    - unless: grep -q UTF-8 {{ postgres_directory }}/initdb.log
+    - name: rm -rf {{ postgres_directory }}/data/* && runuser -l postgres -s /bin/bash sh -c 'initdb --locale=en_US.UTF-8 {{ postgres_directory }}/data > {{ postgres_directory }}/initdb.log' && rm -f {{ postgres_log_directory }}/pgsql_listen_address_configured
+    - unless: grep -q UTF-8 {{ postgres_directory }}/initdb.log && test -f {{ postgres_directory }}/data/PG_VERSION
 
 {%- if postgres_data_on_attached_disk %}
 

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/pg11.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/pg11.sls
@@ -130,11 +130,6 @@ pgsql-vacuumdbman:
     - target: /usr/pgsql-11/bin/initdb
     - force: True
 
-/var/lib/pgsql/data:
-  file.symlink:
-    - target: /var/lib/pgsql/11/data
-    - force: True
-
 {% if salt['file.file_exists']('/usr/lib/systemd/system/postgresql-10.service') %}
 remove-pg10-alias:
   file.replace:
@@ -148,7 +143,15 @@ disable-postgresql-10:
     - name: postgresql-10
 {% endif %}
 
-{%- if postgres_data_on_attached_disk %}
+/var/lib/pgsql/data:
+  file.symlink:
+    - target: /var/lib/pgsql/11/data
+    - force: True
+    - failhard: True
+    - user: postgres
+    - group: postgres
+    - mode: 700
+    - makedirs: True
 
 change-db-location-11:
   file.replace:
@@ -156,8 +159,6 @@ change-db-location-11:
     - pattern: "Environment=PGDATA=.*"
     - repl: Environment=PGDATA={{ postgres_directory }}/data
     - unless: grep "Environment=PGDATA={{ postgres_directory }}/data" /usr/lib/systemd/system/postgresql-11.service
-
-{%- endif %}
 
 postgresql-systemd-link:
   file.replace:


### PR DESCRIPTION
- init db should run if `PG_VERSION` file missing from data dir
- data dir is updated in systemd unit file in case it's an root disk
- disable postgres 10 prior to modifiying data dir symlink

See detailed description in the commit message.