### PR TITLE
CB-17788. Addendum: remove internalOnly annotation from remote exec (…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/UtilV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/UtilV4Controller.java
@@ -160,8 +160,7 @@ public class UtilV4Controller extends NotificationController implements UtilV4En
     }
 
     @Override
-    @InternalOnly
-    @AccountIdNotNeeded
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.POWERUSER_ONLY)
     public RemoteCommandsExecutionResponse remoteCommandExecution(String resourceCrn, RemoteCommandsExecutionRequest request) {
         return remoteExecutionService.remoteExec(resourceCrn, request);
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/UtilV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/UtilV1Controller.java
@@ -7,7 +7,9 @@ import javax.inject.Inject;
 import org.springframework.stereotype.Controller;
 
 import com.sequenceiq.authorization.annotation.AccountIdNotNeeded;
+import com.sequenceiq.authorization.annotation.CheckPermissionByAccount;
 import com.sequenceiq.authorization.annotation.InternalOnly;
+import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
 import com.sequenceiq.cloudbreak.auth.security.internal.AccountId;
 import com.sequenceiq.common.api.command.RemoteCommandsExecutionRequest;
 import com.sequenceiq.common.api.command.RemoteCommandsExecutionResponse;
@@ -43,8 +45,7 @@ public class UtilV1Controller implements UtilV1Endpoint {
     }
 
     @Override
-    @InternalOnly
-    @AccountIdNotNeeded
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.POWERUSER_ONLY)
     public RemoteCommandsExecutionResponse remoteCommandExecution(String environmentCrn, RemoteCommandsExecutionRequest request) {
         return remoteExecutionService.remoteExec(environmentCrn, request);
     }


### PR DESCRIPTION
…as it is disabled by default anyway) - and set power user requirement (next to the required testing config)

See detailed description in the commit message.