### PR TITLE
Handle CoreSettings and StubDFS for CM 7.7.1+

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
@@ -50,6 +50,8 @@ public class CMRepositoryVersionUtil {
 
     public static final Versioned CLOUDERAMANAGER_VERSION_7_6_0 = () -> "7.6.0";
 
+    public static final Versioned CLOUDERAMANAGER_VERSION_7_7_1 = () -> "7.7.1";
+
     public static final Versioned CLOUDERA_STACK_VERSION_7_2_7 = () -> "7.2.7";
 
     public static final Versioned CLOUDERA_STACK_VERSION_7_2_9 = () -> "7.2.9";

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateComponentConfigProviderProcessor.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateComponentConfigProviderProcessor.java
@@ -23,8 +23,7 @@ public class CmTemplateComponentConfigProviderProcessor {
             cmTemplateProcessor.extendTemplateWithAdditionalServices(provider.getAdditionalServices(cmTemplateProcessor, template));
             if (provider.isConfigurationNeeded(cmTemplateProcessor, template)) {
                 LOGGER.info("{} is configuring", provider.getClass().getSimpleName());
-                cmTemplateProcessor.addServiceConfigs(provider.getServiceType(), provider.getRoleTypes(),
-                        provider.getServiceConfigs(cmTemplateProcessor, template));
+                cmTemplateProcessor.addServiceConfigs(provider.getServiceType(), provider.getServiceConfigs(cmTemplateProcessor, template));
                 cmTemplateProcessor.addVariables(provider.getServiceConfigVariables(template));
                 cmTemplateProcessor.addRoleConfigs(provider.getServiceType(), provider.getRoleConfigs(cmTemplateProcessor, template));
                 cmTemplateProcessor.addVariables(provider.getRoleConfigVariables(cmTemplateProcessor, template));

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessor.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessor.java
@@ -493,7 +493,7 @@ public class CmTemplateProcessor implements BlueprintTextProcessor {
         }
     }
 
-    public void addServiceConfigs(String serviceType, List<String> roleTypes, List<ApiClusterTemplateConfig> configs) {
+    public void addServiceConfigs(String serviceType, List<ApiClusterTemplateConfig> configs) {
         getServiceByType(serviceType).ifPresent(service -> mergeServiceConfigs(service, configs));
     }
 

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/core/CoreRoles.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/core/CoreRoles.java
@@ -10,5 +10,17 @@ public class CoreRoles {
 
     public static final String CORE_SETTINGS_REF_NAME = "core_settings-STORAGEOPERATIONS-BASE";
 
+    public static final String CORE_DEFAULTFS = "core_defaultfs";
+
+    public static final String CORE_SITE_SAFETY_VALVE = "core_site_safety_valve";
+
+    public static final String HADOOP_SECURITY_GROUPS_CACHE_BACKGROUND_RELOAD = "hadoop.security.groups.cache.background.reload";
+
+    public static final String STUB_DFS = "STUB_DFS";
+
+    public static final String STUB_DFS_SERVICE_REF_NAME = "stub_dfs";
+
+    public static final String STUB_DFS_SERVICE_ROLE_STORAGEOPERATIONS_REF_NAME = "stub_dfs-STORAGEOPERATIONS-BASE";
+
     private CoreRoles() { }
 }

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/core/StubDfsConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/core/StubDfsConfigProvider.java
@@ -1,0 +1,86 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.core;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.core.CoreRoles.CORE_DEFAULTFS;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.core.CoreRoles.STORAGEOPERATIONS;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.core.CoreRoles.STUB_DFS;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.core.CoreRoles.STUB_DFS_SERVICE_REF_NAME;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.core.CoreRoles.STUB_DFS_SERVICE_ROLE_STORAGEOPERATIONS_REF_NAME;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.hdfs.HdfsRoles.HDFS;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.hdfs.HdfsRoles.NAMENODE;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.cloudera.api.swagger.model.ApiClusterTemplateRoleConfigGroup;
+import com.cloudera.api.swagger.model.ApiClusterTemplateService;
+import com.google.common.collect.Lists;
+import com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRoleConfigProvider;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.cloudbreak.template.views.HostgroupView;
+import com.sequenceiq.common.api.type.InstanceGroupType;
+
+@Component
+public class StubDfsConfigProvider extends AbstractRoleConfigProvider {
+    private static final Logger LOGGER = LoggerFactory.getLogger(StubDfsConfigProvider.class);
+
+    @Override
+    protected List<ApiClusterTemplateConfig> getRoleConfigs(String roleType, TemplatePreparationObject source) {
+        return List.of();
+    }
+
+    @Override
+    public Map<String, ApiClusterTemplateService> getAdditionalServices(CmTemplateProcessor cmTemplateProcessor, TemplatePreparationObject source) {
+        if (isConfigurationNeeded(cmTemplateProcessor, source)
+                && cmTemplateProcessor.getServiceByType(STUB_DFS).isEmpty()) {
+            LOGGER.info("'{}' is not part of the template so adding it as an additional service with '{}' role.", STUB_DFS, STORAGEOPERATIONS);
+            ApiClusterTemplateService coreSettings = stubDfsSettings();
+            Set<HostgroupView> hostgroupViews = source.getHostgroupViews();
+            return hostgroupViews.stream()
+                    .filter(hg -> InstanceGroupType.GATEWAY.equals(hg.getInstanceGroupType()))
+                    .collect(Collectors.toMap(HostgroupView::getName, v -> coreSettings));
+        }
+        return Map.of();
+    }
+
+    private ApiClusterTemplateService stubDfsSettings() {
+        ApiClusterTemplateService coreSettings = new ApiClusterTemplateService()
+                .serviceType(STUB_DFS)
+                .refName(STUB_DFS_SERVICE_REF_NAME);
+        ApiClusterTemplateRoleConfigGroup coreSettingsRole = new ApiClusterTemplateRoleConfigGroup()
+                .roleType(STORAGEOPERATIONS)
+                .base(true)
+                .refName(STUB_DFS_SERVICE_ROLE_STORAGEOPERATIONS_REF_NAME);
+        coreSettings.roleConfigGroups(List.of(coreSettingsRole));
+        return coreSettings;
+    }
+
+    @Override
+    public String getServiceType() {
+        return STUB_DFS;
+    }
+
+    @Override
+    public List<String> getRoleTypes() {
+        return List.of(STORAGEOPERATIONS);
+    }
+
+    @Override
+    public boolean isConfigurationNeeded(CmTemplateProcessor cmTemplateProcessor, TemplatePreparationObject source) {
+        return cmTemplateProcessor.getCmVersion().isPresent()
+                && isVersionNewerOrEqualThanLimited(cmTemplateProcessor.getCmVersion().get(), CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_7_1)
+                && !cmTemplateProcessor.isRoleTypePresentInService(HDFS, Lists.newArrayList(NAMENODE))
+                && source.getFileSystemConfigurationView().isPresent()
+                && ConfigUtils.getStorageLocationForServiceProperty(source, CORE_DEFAULTFS).isPresent();
+    }
+}

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessorTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessorTest.java
@@ -54,7 +54,7 @@ public class CmTemplateProcessorTest {
         List<ApiClusterTemplateConfig> configs = new ArrayList<>();
         configs.add(new ApiClusterTemplateConfig().name("hive_metastore_database_type").variable("hive-hive_metastore_database_type"));
 
-        underTest.addServiceConfigs("HIVE", List.of("HIVEMETASTORE"), configs);
+        underTest.addServiceConfigs("HIVE", configs);
 
         ApiClusterTemplateService service = underTest.getTemplate().getServices().stream().filter(srv -> "HIVE".equals(srv.getServiceType())).findAny().get();
         List<ApiClusterTemplateConfig> serviceConfigs = service.getServiceConfigs();
@@ -70,7 +70,7 @@ public class CmTemplateProcessorTest {
         configs.add(new ApiClusterTemplateConfig().name("redaction_policy_enabled").value("true"));
         configs.add(new ApiClusterTemplateConfig().name("not_present_in_template").value("some_value"));
 
-        underTest.addServiceConfigs("HDFS", List.of("NAMENODE"), configs);
+        underTest.addServiceConfigs("HDFS", configs);
 
         ApiClusterTemplateService service = underTest.getTemplate().getServices().stream().filter(srv -> "HDFS".equals(srv.getServiceType())).findAny().get();
         List<ApiClusterTemplateConfig> serviceConfigs = service.getServiceConfigs();
@@ -88,7 +88,7 @@ public class CmTemplateProcessorTest {
                             .name("hive_service_config_safety_valve")
                             .value("<property><name>testkey</name><value>testvalue</value></property>"));
 
-        underTest.addServiceConfigs("HIVE", List.of("GATEWAY", "HIVEMETASTORE"), configs);
+        underTest.addServiceConfigs("HIVE", configs);
 
         ApiClusterTemplateService service = underTest.getTemplate().getServices().stream().filter(srv -> "HIVE".equals(srv.getServiceType())).findAny().get();
         List<ApiClusterTemplateConfig> serviceConfigs = service.getServiceConfigs();

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/core/CoreConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/core/CoreConfigProviderTest.java
@@ -1,13 +1,14 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.core;
 
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.core.CoreRoles.CORE_DEFAULTFS;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.core.CoreRoles.CORE_SETTINGS;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.core.CoreRoles.STORAGEOPERATIONS;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.hdfs.HdfsRoles.HDFS;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.hdfs.HdfsRoles.NAMENODE;
-import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaRoles.KAFKA_BROKER;
-import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaRoles.KAFKA_SERVICE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
@@ -15,11 +16,12 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -27,6 +29,8 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.cloudera.api.swagger.model.ApiClusterTemplateService;
+import com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.s3.S3ConfigProvider;
@@ -34,6 +38,8 @@ import com.sequenceiq.cloudbreak.domain.StorageLocation;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.filesystem.BaseFileSystemConfigurationsView;
 import com.sequenceiq.cloudbreak.template.filesystem.StorageLocationView;
+import com.sequenceiq.cloudbreak.template.views.HostgroupView;
+import com.sequenceiq.common.api.type.InstanceGroupType;
 
 @ExtendWith(MockitoExtension.class)
 public class CoreConfigProviderTest {
@@ -44,7 +50,7 @@ public class CoreConfigProviderTest {
     @Mock
     private S3ConfigProvider s3ConfigProvider;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         underTest = new CoreConfigProvider();
         s3ConfigProvider = new S3ConfigProvider();
@@ -67,11 +73,10 @@ public class CoreConfigProviderTest {
         when(fileSystemConfiguration.getLocations()).thenReturn(storageLocationViews);
         Optional<BaseFileSystemConfigurationsView> fileSystemConfigurationView = Optional.of(fileSystemConfiguration);
 
-        when(mockTemplateProcessor.isRoleTypePresentInService(KAFKA_SERVICE, List.of(KAFKA_BROKER))).thenReturn(true);
         when(mockTemplateProcessor.isRoleTypePresentInService(HDFS, List.of(NAMENODE))).thenReturn(false);
         when(templatePreparationObject.getFileSystemConfigurationView()).thenReturn(fileSystemConfigurationView);
 
-        Assert.assertTrue(underTest.isConfigurationNeeded(mockTemplateProcessor, templatePreparationObject));
+        assertTrue(underTest.isConfigurationNeeded(mockTemplateProcessor, templatePreparationObject));
     }
 
     @Test
@@ -93,7 +98,7 @@ public class CoreConfigProviderTest {
         when(mockTemplateProcessor.isRoleTypePresentInService(HDFS, List.of(NAMENODE))).thenReturn(false);
         when(templatePreparationObject.getFileSystemConfigurationView()).thenReturn(fileSystemConfigurationView);
 
-        Assert.assertFalse(underTest.isConfigurationNeeded(mockTemplateProcessor, templatePreparationObject));
+        assertFalse(underTest.isConfigurationNeeded(mockTemplateProcessor, templatePreparationObject));
     }
 
     @Test
@@ -106,21 +111,16 @@ public class CoreConfigProviderTest {
         when(mockTemplateProcessor.isRoleTypePresentInService(HDFS, List.of(NAMENODE))).thenReturn(false);
         when(templatePreparationObject.getFileSystemConfigurationView()).thenReturn(fileSystemConfigurationView);
 
-        Assert.assertFalse(underTest.isConfigurationNeeded(mockTemplateProcessor, templatePreparationObject));
+        assertFalse(underTest.isConfigurationNeeded(mockTemplateProcessor, templatePreparationObject));
     }
 
     @Test
     public void isConfigurationNeededWhenKafkaPresentedHdfsPresentedAndStorageConfiguredMustReturnFalse() {
         CmTemplateProcessor mockTemplateProcessor = mock(CmTemplateProcessor.class);
         TemplatePreparationObject templatePreparationObject = mock(TemplatePreparationObject.class);
-        BaseFileSystemConfigurationsView fileSystemConfiguration = mock(BaseFileSystemConfigurationsView.class);
-        Optional<BaseFileSystemConfigurationsView> fileSystemConfigurationView = Optional.of(fileSystemConfiguration);
-
-        when(mockTemplateProcessor.isRoleTypePresentInService(KAFKA_SERVICE, List.of(KAFKA_BROKER))).thenReturn(true);
         when(mockTemplateProcessor.isRoleTypePresentInService(HDFS, List.of(NAMENODE))).thenReturn(true);
-        when(templatePreparationObject.getFileSystemConfigurationView()).thenReturn(fileSystemConfigurationView);
 
-        Assert.assertFalse(underTest.isConfigurationNeeded(mockTemplateProcessor, templatePreparationObject));
+        assertFalse(underTest.isConfigurationNeeded(mockTemplateProcessor, templatePreparationObject));
     }
 
     @Test
@@ -129,11 +129,10 @@ public class CoreConfigProviderTest {
         TemplatePreparationObject templatePreparationObject = mock(TemplatePreparationObject.class);
         Optional<BaseFileSystemConfigurationsView> fileSystemConfigurationView = Optional.empty();
 
-        when(mockTemplateProcessor.isRoleTypePresentInService(KAFKA_SERVICE, List.of(KAFKA_BROKER))).thenReturn(true);
         when(mockTemplateProcessor.isRoleTypePresentInService(HDFS, List.of(NAMENODE))).thenReturn(false);
         when(templatePreparationObject.getFileSystemConfigurationView()).thenReturn(fileSystemConfigurationView);
 
-        Assert.assertFalse(underTest.isConfigurationNeeded(mockTemplateProcessor, templatePreparationObject));
+        assertFalse(underTest.isConfigurationNeeded(mockTemplateProcessor, templatePreparationObject));
     }
 
     @Test
@@ -143,14 +142,84 @@ public class CoreConfigProviderTest {
         BaseFileSystemConfigurationsView fileSystemConfiguration = mock(BaseFileSystemConfigurationsView.class);
         Optional<BaseFileSystemConfigurationsView> fileSystemConfigurationView = Optional.of(fileSystemConfiguration);
 
-        when(mockTemplateProcessor.isRoleTypePresentInService(KAFKA_SERVICE, List.of(KAFKA_BROKER))).thenReturn(true);
-        when(mockTemplateProcessor.getRoleConfig(CORE_SETTINGS, STORAGEOPERATIONS, CoreConfigProvider.CORE_DEFAULTFS)).thenReturn(Optional.empty());
-        when(mockTemplateProcessor.isRoleTypePresentInService(HDFS, List.of(NAMENODE))).thenReturn(true);
+        when(mockTemplateProcessor.getRoleConfig(CORE_SETTINGS, STORAGEOPERATIONS, CORE_DEFAULTFS)).thenReturn(Optional.empty());
         when(templatePreparationObject.getFileSystemConfigurationView()).thenReturn(fileSystemConfigurationView);
         doNothing().when(s3ConfigProvider).getServiceConfigs(any(TemplatePreparationObject.class), any(StringBuilder.class));
         String coreSafetyValveProperty = ConfigUtils.getSafetyValveProperty("hadoop.security.groups.cache.background.reload", "true");
         List<ApiClusterTemplateConfig> expected = List.of(config("core_site_safety_valve", coreSafetyValveProperty));
 
         assertThat(underTest.getServiceConfigs(mockTemplateProcessor, templatePreparationObject)).hasSameElementsAs(expected);
+    }
+
+    @Test
+    public void testGetAdditionalServicesWhenConfigurationNeededAndCmVersionEarlierThan771() {
+        CmTemplateProcessor mockTemplateProcessor = mock(CmTemplateProcessor.class);
+        TemplatePreparationObject templatePreparationObject = mock(TemplatePreparationObject.class);
+        BaseFileSystemConfigurationsView fileSystemConfiguration = mock(BaseFileSystemConfigurationsView.class);
+        Optional<BaseFileSystemConfigurationsView> fileSystemConfigurationView = Optional.of(fileSystemConfiguration);
+        StorageLocationView storageLocationView = mock(StorageLocationView.class);
+        when(storageLocationView.getProperty()).thenReturn(CORE_DEFAULTFS);
+        when(fileSystemConfiguration.getLocations()).thenReturn(List.of(storageLocationView));
+        when(mockTemplateProcessor.getServiceByType(CORE_SETTINGS)).thenReturn(Optional.empty());
+        when(mockTemplateProcessor.isRoleTypePresentInService(HDFS, List.of(NAMENODE))).thenReturn(false);
+        when(templatePreparationObject.getFileSystemConfigurationView()).thenReturn(fileSystemConfigurationView);
+        when(templatePreparationObject.getHostgroupViews()).thenReturn(Set.of(new HostgroupView("aGateway", 0, InstanceGroupType.GATEWAY, 1)));
+        when(mockTemplateProcessor.getCmVersion()).thenReturn(Optional.of(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_6_0.getVersion()));
+
+        Map<String, ApiClusterTemplateService> additionalServices = underTest.getAdditionalServices(mockTemplateProcessor, templatePreparationObject);
+
+        assertFalse(additionalServices.isEmpty());
+        assertThat(additionalServices).allSatisfy((group, serviceConfig) -> {
+                assertThat(serviceConfig.getServiceType()).isEqualTo(CORE_SETTINGS);
+                assertThat(serviceConfig.getRoleConfigGroups()).anyMatch(templateRole -> STORAGEOPERATIONS.equals(templateRole.getRoleType()));
+        });
+    }
+
+    @Test
+    public void testGetAdditionalServicesWhenConfigurationNeededAndCmVersionNewerOrEqualsThan771() {
+        CmTemplateProcessor mockTemplateProcessor = mock(CmTemplateProcessor.class);
+        TemplatePreparationObject templatePreparationObject = mock(TemplatePreparationObject.class);
+        BaseFileSystemConfigurationsView fileSystemConfiguration = mock(BaseFileSystemConfigurationsView.class);
+        Optional<BaseFileSystemConfigurationsView> fileSystemConfigurationView = Optional.of(fileSystemConfiguration);
+        StorageLocationView storageLocationView = mock(StorageLocationView.class);
+        when(storageLocationView.getProperty()).thenReturn(CORE_DEFAULTFS);
+        when(fileSystemConfiguration.getLocations()).thenReturn(List.of(storageLocationView));
+        when(mockTemplateProcessor.getServiceByType(CORE_SETTINGS)).thenReturn(Optional.empty());
+        when(mockTemplateProcessor.isRoleTypePresentInService(HDFS, List.of(NAMENODE))).thenReturn(false);
+        when(templatePreparationObject.getFileSystemConfigurationView()).thenReturn(fileSystemConfigurationView);
+        when(templatePreparationObject.getHostgroupViews()).thenReturn(Set.of(new HostgroupView("aGateway", 0, InstanceGroupType.GATEWAY, 1)));
+        when(mockTemplateProcessor.getCmVersion()).thenReturn(Optional.of(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_7_1.getVersion()));
+
+        Map<String, ApiClusterTemplateService> additionalServices = underTest.getAdditionalServices(mockTemplateProcessor, templatePreparationObject);
+
+        assertFalse(additionalServices.isEmpty());
+        assertThat(additionalServices).allSatisfy((group, serviceConfig) -> {
+            assertThat(serviceConfig.getServiceType()).isEqualTo(CORE_SETTINGS);
+            assertThat(serviceConfig.getRoleConfigGroups()).noneMatch(templateRole -> STORAGEOPERATIONS.equals(templateRole.getRoleType()));
+        });
+    }
+
+    @Test
+    public void testGetAdditionalServicesWhenConfigurationNeededAndCmVersionIsEmpty() {
+        CmTemplateProcessor mockTemplateProcessor = mock(CmTemplateProcessor.class);
+        TemplatePreparationObject templatePreparationObject = mock(TemplatePreparationObject.class);
+        BaseFileSystemConfigurationsView fileSystemConfiguration = mock(BaseFileSystemConfigurationsView.class);
+        Optional<BaseFileSystemConfigurationsView> fileSystemConfigurationView = Optional.of(fileSystemConfiguration);
+        StorageLocationView storageLocationView = mock(StorageLocationView.class);
+        when(storageLocationView.getProperty()).thenReturn(CORE_DEFAULTFS);
+        when(fileSystemConfiguration.getLocations()).thenReturn(List.of(storageLocationView));
+        when(mockTemplateProcessor.getServiceByType(CORE_SETTINGS)).thenReturn(Optional.empty());
+        when(mockTemplateProcessor.isRoleTypePresentInService(HDFS, List.of(NAMENODE))).thenReturn(false);
+        when(templatePreparationObject.getFileSystemConfigurationView()).thenReturn(fileSystemConfigurationView);
+        when(templatePreparationObject.getHostgroupViews()).thenReturn(Set.of(new HostgroupView("aGateway", 0, InstanceGroupType.GATEWAY, 1)));
+        when(mockTemplateProcessor.getCmVersion()).thenReturn(Optional.empty());
+
+        Map<String, ApiClusterTemplateService> additionalServices = underTest.getAdditionalServices(mockTemplateProcessor, templatePreparationObject);
+
+        assertFalse(additionalServices.isEmpty());
+        assertThat(additionalServices).allSatisfy((group, serviceConfig) -> {
+            assertThat(serviceConfig.getServiceType()).isEqualTo(CORE_SETTINGS);
+            assertThat(serviceConfig.getRoleConfigGroups()).noneMatch(templateRole -> STORAGEOPERATIONS.equals(templateRole.getRoleType()));
+        });
     }
 }

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/core/StubDfsConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/core/StubDfsConfigProviderTest.java
@@ -1,0 +1,141 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.core;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.core.CoreRoles.CORE_DEFAULTFS;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.core.CoreRoles.STORAGEOPERATIONS;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.core.CoreRoles.STUB_DFS;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.hdfs.HdfsRoles.HDFS;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.hdfs.HdfsRoles.NAMENODE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateService;
+import com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.cloudbreak.template.filesystem.BaseFileSystemConfigurationsView;
+import com.sequenceiq.cloudbreak.template.filesystem.StorageLocationView;
+import com.sequenceiq.cloudbreak.template.views.HostgroupView;
+import com.sequenceiq.common.api.type.InstanceGroupType;
+
+@ExtendWith(MockitoExtension.class)
+class StubDfsConfigProviderTest {
+
+    @Mock
+    private CmTemplateProcessor mockTemplateProcessor;
+
+    @Mock
+    private TemplatePreparationObject templatePreparationObject;
+
+    @Mock
+    private BaseFileSystemConfigurationsView fileSystemConfiguration;
+
+    @Mock
+    private StorageLocationView storageLocationView;
+
+    @InjectMocks
+    private StubDfsConfigProvider underTest;
+
+    @Test
+    void getAdditionalServicesWhenConfigurationNeedButStubDfsAlreadyConfigured() {
+        ApiClusterTemplateService apiClusterTemplateService = mock(ApiClusterTemplateService.class);
+        Optional<BaseFileSystemConfigurationsView> fileSystemConfigurationView = Optional.of(fileSystemConfiguration);
+        when(storageLocationView.getProperty()).thenReturn(CORE_DEFAULTFS);
+        when(fileSystemConfiguration.getLocations()).thenReturn(List.of(storageLocationView));
+        when(mockTemplateProcessor.getServiceByType(STUB_DFS)).thenReturn(Optional.of(apiClusterTemplateService));
+        when(mockTemplateProcessor.isRoleTypePresentInService(HDFS, List.of(NAMENODE))).thenReturn(false);
+        when(mockTemplateProcessor.getCmVersion()).thenReturn(Optional.of(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_7_1.getVersion()));
+        when(templatePreparationObject.getFileSystemConfigurationView()).thenReturn(fileSystemConfigurationView);
+
+        Map<String, ApiClusterTemplateService> additionalServices = underTest.getAdditionalServices(mockTemplateProcessor, templatePreparationObject);
+
+        assertTrue(additionalServices.isEmpty());
+    }
+
+    @Test
+    void getAdditionalServicesWhenConfigurationNeedButStubDfsIsNotConfigured() {
+        Optional<BaseFileSystemConfigurationsView> fileSystemConfigurationView = Optional.of(fileSystemConfiguration);
+        when(storageLocationView.getProperty()).thenReturn(CORE_DEFAULTFS);
+        when(fileSystemConfiguration.getLocations()).thenReturn(List.of(storageLocationView));
+        when(mockTemplateProcessor.getServiceByType(STUB_DFS)).thenReturn(Optional.empty());
+        when(mockTemplateProcessor.isRoleTypePresentInService(HDFS, List.of(NAMENODE))).thenReturn(false);
+        when(templatePreparationObject.getFileSystemConfigurationView()).thenReturn(fileSystemConfigurationView);
+        when(templatePreparationObject.getHostgroupViews()).thenReturn(Set.of(new HostgroupView("aGateway", 0, InstanceGroupType.GATEWAY, 1)));
+        when(mockTemplateProcessor.getCmVersion()).thenReturn(Optional.of(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_7_1.getVersion()));
+
+        Map<String, ApiClusterTemplateService> additionalServices = underTest.getAdditionalServices(mockTemplateProcessor, templatePreparationObject);
+
+        assertFalse(additionalServices.isEmpty());
+        assertThat(additionalServices).allSatisfy((group, serviceConfig) -> {
+            assertThat(serviceConfig.getServiceType()).isEqualTo(STUB_DFS);
+            assertThat(serviceConfig.getRoleConfigGroups()).allMatch(templateRole -> STORAGEOPERATIONS.equals(templateRole.getRoleType()));
+        });
+    }
+
+    @Test
+    void isConfigurationNeededWhenCmVersionIsNotSpecified() {
+        when(mockTemplateProcessor.getCmVersion()).thenReturn(Optional.empty());
+
+        assertFalse(underTest.isConfigurationNeeded(mockTemplateProcessor, templatePreparationObject));
+    }
+
+    @Test
+    void isConfigurationNeededWhenCmVersionIsEarlierThan771() {
+        when(mockTemplateProcessor.getCmVersion()).thenReturn(Optional.of(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_6.getVersion()));
+
+        assertFalse(underTest.isConfigurationNeeded(mockTemplateProcessor, templatePreparationObject));
+    }
+
+    @Test
+    void isConfigurationNeededWhenThereIsHdfsServiceWithNameNodeRole() {
+        when(mockTemplateProcessor.getCmVersion()).thenReturn(Optional.of(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_7_1.getVersion()));
+        when(mockTemplateProcessor.isRoleTypePresentInService(HDFS, List.of(NAMENODE))).thenReturn(true);
+
+        assertFalse(underTest.isConfigurationNeeded(mockTemplateProcessor, templatePreparationObject));
+    }
+
+    @Test
+    void isConfigurationNeededWhenNoFileSystemConfigurationProvided() {
+        when(mockTemplateProcessor.getCmVersion()).thenReturn(Optional.of(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_7_1.getVersion()));
+        when(mockTemplateProcessor.isRoleTypePresentInService(HDFS, List.of(NAMENODE))).thenReturn(false);
+        when(templatePreparationObject.getFileSystemConfigurationView()).thenReturn(Optional.empty());
+
+
+        assertFalse(underTest.isConfigurationNeeded(mockTemplateProcessor, templatePreparationObject));
+    }
+
+    @Test
+    void isConfigurationNeededWhenNoCoreDefaultFsConfigured() {
+        when(mockTemplateProcessor.getCmVersion()).thenReturn(Optional.of(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_7_1.getVersion()));
+        when(mockTemplateProcessor.isRoleTypePresentInService(HDFS, List.of(NAMENODE))).thenReturn(false);
+        when(templatePreparationObject.getFileSystemConfigurationView()).thenReturn(Optional.of(fileSystemConfiguration));
+        when(fileSystemConfiguration.getLocations()).thenReturn(List.of(storageLocationView));
+        when(storageLocationView.getProperty()).thenReturn("");
+
+        assertFalse(underTest.isConfigurationNeeded(mockTemplateProcessor, templatePreparationObject));
+    }
+
+    @Test
+    void isConfigurationNeededWhenCmVersionIsEqualsOrNewerThan771AnfFileSystemConfiguredWithoutHdfsAndNameNodeInTheTemplate() {
+        when(mockTemplateProcessor.getCmVersion()).thenReturn(Optional.of(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_7_1.getVersion()));
+        when(mockTemplateProcessor.isRoleTypePresentInService(HDFS, List.of(NAMENODE))).thenReturn(false);
+        when(templatePreparationObject.getFileSystemConfigurationView()).thenReturn(Optional.of(fileSystemConfiguration));
+        when(fileSystemConfiguration.getLocations()).thenReturn(List.of(storageLocationView));
+        when(storageLocationView.getProperty()).thenReturn(CORE_DEFAULTFS);
+
+        assertTrue(underTest.isConfigurationNeeded(mockTemplateProcessor, templatePreparationObject));
+    }
+}

--- a/template-manager-cmtemplate/src/test/resources/input/kafka-without-hdfs-cm-771.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/kafka-without-hdfs-cm-771.bp
@@ -1,7 +1,7 @@
 {
-  "cdhVersion": "7.0.1",
+  "cdhVersion": "7.2.16",
   "displayName": "CDP HA Streaming Cluster",
-  "cmVersion": "7.0.1",
+  "cmVersion": "7.7.1",
   "services": [
     {
       "refName": "streams_messaging_manager",

--- a/template-manager-cmtemplate/src/test/resources/output/kafka-without-hdfs-cm-771.bp
+++ b/template-manager-cmtemplate/src/test/resources/output/kafka-without-hdfs-cm-771.bp
@@ -1,7 +1,7 @@
 {
-  "cdhVersion": "7.0.1",
-  "displayName": "CDP HA Streaming Cluster",
-  "cmVersion": "7.0.1",
+  "cdhVersion": "7.2.16",
+  "displayName": "testcluster",
+  "cmVersion": "7.7.1",
   "services": [
     {
       "refName": "streams_messaging_manager",
@@ -74,6 +74,32 @@
           "base": true
         }
       ]
+    },
+    {
+      "refName": "core_settings",
+      "serviceType": "CORE_SETTINGS",
+      "serviceConfigs": [
+        {
+          "name": "core_defaultfs",
+          "value": "s3a://cloudbreak-bucket/kafka"
+        },
+        {
+          "name": "core_site_safety_valve",
+          "value": "<property><name>hadoop.security.groups.cache.background.reload</name><value>true</value></property>"
+        }
+      ],
+      "roleConfigGroups": []
+    },
+    {
+      "refName": "stub_dfs",
+      "serviceType": "STUB_DFS",
+      "roleConfigGroups": [
+        {
+          "refName": "stub_dfs-STORAGEOPERATIONS-BASE",
+          "roleType": "STORAGEOPERATIONS",
+          "base": true
+        }
+      ]
     }
   ],
   "hostTemplates": [
@@ -83,7 +109,8 @@
       "roleConfigGroupsRefNames": [
         "schemaregistry-SCHEMA_REGISTRY_SERVER-BASE",
         "streams_messaging_manager-STREAMS_MESSAGING_MANAGER_SERVER-BASE",
-        "streams_messaging_manager-STREAMS_MESSAGING_MANAGER_UI-BASE"
+        "streams_messaging_manager-STREAMS_MESSAGING_MANAGER_UI-BASE",
+        "stub_dfs-STORAGEOPERATIONS-BASE"
       ]
     },
     {
@@ -101,5 +128,8 @@
         "zookeeper-SERVER-BASE"
       ]
     }
-  ]
+  ],
+  "instantiator": {
+    "clusterName": "testcluster"
+  }
 }

--- a/template-manager-cmtemplate/src/test/resources/output/kafka-without-hdfs.bp
+++ b/template-manager-cmtemplate/src/test/resources/output/kafka-without-hdfs.bp
@@ -1,7 +1,7 @@
 {
   "cdhVersion": "7.0.1",
   "displayName": "testcluster",
-  "cmVersion": "7.x.0",
+  "cmVersion": "7.0.1",
   "services": [
     {
       "refName": "streams_messaging_manager",


### PR DESCRIPTION
**Changes:**
 -  elminiate unused roletypes list from the CM template processor addServiceConfigs
 - StubDFS service needs to be added with storageoperations role from CM 7.7.1 and CoreSettings could not contain storageoperations role