### PR TITLE
CB-17581 Extract environment consumption logic from handlers into a separate service

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/StorageConsumptionCollectionSchedulingHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/StorageConsumptionCollectionSchedulingHandler.java
@@ -3,22 +3,11 @@ package com.sequenceiq.environment.environment.flow.creation.handler;
 import static com.sequenceiq.environment.environment.flow.creation.event.EnvCreationHandlerSelectors.SCHEDULE_STORAGE_CONSUMPTION_COLLECTION_EVENT;
 import static com.sequenceiq.environment.environment.flow.creation.event.EnvCreationStateSelectors.START_NETWORK_CREATION_EVENT;
 
-import java.util.Optional;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import com.google.common.base.Strings;
-import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
-import com.sequenceiq.consumption.api.v1.consumption.model.common.ResourceType;
-import com.sequenceiq.consumption.api.v1.consumption.model.request.StorageConsumptionRequest;
-import com.sequenceiq.environment.environment.dto.EnvironmentBackup;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
-import com.sequenceiq.environment.environment.dto.EnvironmentDtoBase;
-import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentLogging;
-import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentTelemetry;
 import com.sequenceiq.environment.environment.flow.creation.event.EnvCreationEvent;
 import com.sequenceiq.environment.environment.flow.creation.event.EnvCreationFailureEvent;
 import com.sequenceiq.environment.environment.service.EnvironmentService;
@@ -38,25 +27,17 @@ public class StorageConsumptionCollectionSchedulingHandler extends EventSenderAw
 
     private final EventBus eventBus;
 
-    private final EntitlementService entitlementService;
-
     private final ConsumptionService consumptionService;
-
-    private final boolean consumptionEnabled;
 
     protected StorageConsumptionCollectionSchedulingHandler(
             EventSender eventSender,
             EnvironmentService environmentService,
             EventBus eventBus,
-            EntitlementService entitlementService,
-            ConsumptionService consumptionService,
-            @Value("${environment.consumption.enabled:false}") boolean consumptionEnabled) {
+            ConsumptionService consumptionService) {
         super(eventSender);
         this.environmentService = environmentService;
         this.eventBus = eventBus;
-        this.entitlementService = entitlementService;
         this.consumptionService = consumptionService;
-        this.consumptionEnabled = consumptionEnabled;
     }
 
     @Override
@@ -66,7 +47,7 @@ public class StorageConsumptionCollectionSchedulingHandler extends EventSenderAw
         try {
             environmentService.findEnvironmentById(environmentDto.getId())
                     .ifPresentOrElse(environment -> {
-                                scheduleStorageConsumptionCollectionIfNeeded(environmentDto);
+                                consumptionService.scheduleStorageConsumptionCollectionIfNeeded(environmentDto);
                                 goToNextState(environmentDtoEvent, environmentDto);
                             }, () -> goToFailedState(environmentDtoEvent, environmentDto,
                                     new IllegalStateException(String.format("Environment was not found with id '%s'.", environmentDto.getId())))
@@ -76,59 +57,6 @@ public class StorageConsumptionCollectionSchedulingHandler extends EventSenderAw
             goToFailedState(environmentDtoEvent, environmentDto, e);
         }
         LOGGER.debug("Storage consumption collection scheduling flow step finished.");
-    }
-
-    private void scheduleStorageConsumptionCollectionIfNeeded(EnvironmentDto environmentDto) {
-        String accountId = environmentDto.getAccountId();
-        if (consumptionEnabled && entitlementService.isCdpSaasEnabled(accountId)) {
-            scheduleStorageConsumptionCollection(environmentDto);
-        } else {
-            LOGGER.info("Skipping storage consumption collection scheduling because " +
-                    (consumptionEnabled ? String.format("CDP_SAAS entitlement is missing for account '%s'", accountId) : "it is disabled for the deployment"));
-        }
-    }
-
-    private void scheduleStorageConsumptionCollection(EnvironmentDto environmentDto) {
-        String loggingStorageLocation = Optional.of(environmentDto)
-                .map(EnvironmentDtoBase::getTelemetry)
-                .map(EnvironmentTelemetry::getLogging)
-                .map(EnvironmentLogging::getStorageLocation)
-                .orElse(null);
-        if (!Strings.isNullOrEmpty(loggingStorageLocation)) {
-            scheduleStorageConsumptionCollectionForStorageLocation(environmentDto, loggingStorageLocation, "logging");
-        } else {
-            LOGGER.warn("Skipping storage consumption collection scheduling for logging storage location because it is not provided: telemetry='{}'",
-                    environmentDto.getTelemetry());
-        }
-
-        String backupStorageLocation = Optional.of(environmentDto)
-                .map(EnvironmentDtoBase::getBackup)
-                .map(EnvironmentBackup::getStorageLocation)
-                .orElse(null);
-        if (!Strings.isNullOrEmpty(backupStorageLocation)) {
-            if (!backupStorageLocation.equals(loggingStorageLocation)) {
-                scheduleStorageConsumptionCollectionForStorageLocation(environmentDto, backupStorageLocation, "backup");
-            } else {
-                LOGGER.warn("Skipping storage consumption collection scheduling for backup storage location because it matches the logging storage location");
-            }
-        } else {
-            LOGGER.warn("Skipping storage consumption collection scheduling for backup storage location because it is not provided: backup='{}'",
-                    environmentDto.getBackup());
-        }
-    }
-
-    private void scheduleStorageConsumptionCollectionForStorageLocation(EnvironmentDto environmentDto, String storageLocation, String locationKind) {
-        StorageConsumptionRequest request = new StorageConsumptionRequest();
-        String resourceCrn = environmentDto.getResourceCrn();
-        request.setEnvironmentCrn(resourceCrn);
-        request.setMonitoredResourceCrn(resourceCrn);
-        request.setMonitoredResourceName(environmentDto.getName());
-        request.setMonitoredResourceType(ResourceType.ENVIRONMENT);
-        request.setStorageLocation(storageLocation);
-        String accountId = environmentDto.getAccountId();
-        LOGGER.info("Executing storage consumption collection scheduling for {} storage location: account '{}' and request '{}'", locationKind, accountId,
-                request);
-        consumptionService.scheduleStorageConsumptionCollection(accountId, request);
     }
 
     private void goToFailedState(Event<EnvironmentDto> environmentDtoEvent, EnvironmentDto environmentDto, Exception e) {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/deletion/handler/StorageConsumptionCollectionUnschedulingHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/deletion/handler/StorageConsumptionCollectionUnschedulingHandler.java
@@ -3,21 +3,12 @@ package com.sequenceiq.environment.environment.flow.deletion.handler;
 import static com.sequenceiq.environment.environment.flow.deletion.event.EnvDeleteHandlerSelectors.UNSCHEDULE_STORAGE_CONSUMPTION_COLLECTION_EVENT;
 import static com.sequenceiq.environment.environment.flow.deletion.event.EnvDeleteStateSelectors.START_RDBMS_DELETE_EVENT;
 
-import java.util.Optional;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import com.google.common.base.Strings;
-import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
-import com.sequenceiq.environment.environment.dto.EnvironmentBackup;
 import com.sequenceiq.environment.environment.dto.EnvironmentDeletionDto;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
-import com.sequenceiq.environment.environment.dto.EnvironmentDtoBase;
-import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentLogging;
-import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentTelemetry;
 import com.sequenceiq.environment.environment.flow.deletion.event.EnvDeleteEvent;
 import com.sequenceiq.environment.environment.service.EnvironmentService;
 import com.sequenceiq.environment.environment.service.consumption.ConsumptionService;
@@ -35,25 +26,17 @@ public class StorageConsumptionCollectionUnschedulingHandler extends EventSender
 
     private final HandlerExceptionProcessor exceptionProcessor;
 
-    private final EntitlementService entitlementService;
-
     private final ConsumptionService consumptionService;
-
-    private final boolean consumptionEnabled;
 
     protected StorageConsumptionCollectionUnschedulingHandler(
             EventSender eventSender,
             EnvironmentService environmentService,
             HandlerExceptionProcessor exceptionProcessor,
-            EntitlementService entitlementService,
-            ConsumptionService consumptionService,
-            @Value("${environment.consumption.enabled:false}") boolean consumptionEnabled) {
+            ConsumptionService consumptionService) {
         super(eventSender);
         this.environmentService = environmentService;
         this.exceptionProcessor = exceptionProcessor;
-        this.entitlementService = entitlementService;
         this.consumptionService = consumptionService;
-        this.consumptionEnabled = consumptionEnabled;
     }
 
     @Override
@@ -69,62 +52,13 @@ public class StorageConsumptionCollectionUnschedulingHandler extends EventSender
         EnvDeleteEvent nextStateEvent = getNextStateEvent(environmentDeletionDto);
         try {
             environmentService.findEnvironmentById(environmentDto.getId())
-                    .ifPresent(environment -> unscheduleStorageConsumptionCollectionIfNeeded(environmentDto));
+                    .ifPresent(environment -> consumptionService.unscheduleStorageConsumptionCollectionIfNeeded(environmentDto));
             eventSender().sendEvent(nextStateEvent, environmentDtoEvent.getHeaders());
         } catch (Exception e) {
             LOGGER.error("Storage consumption collection unscheduling failed", e);
             exceptionProcessor.handle(new HandlerFailureConjoiner(e, environmentDtoEvent, nextStateEvent), LOGGER, eventSender(), selector());
         }
         LOGGER.debug("Storage consumption collection unscheduling flow step finished.");
-    }
-
-    private void unscheduleStorageConsumptionCollectionIfNeeded(EnvironmentDto environmentDto) {
-        String accountId = environmentDto.getAccountId();
-        if (consumptionEnabled && entitlementService.isCdpSaasEnabled(accountId)) {
-            unscheduleStorageConsumptionCollection(environmentDto);
-        } else {
-            LOGGER.info("Skipping storage consumption collection unscheduling because " +
-                    (consumptionEnabled ? String.format("CDP_SAAS entitlement is missing for account '%s'", accountId) : "it is disabled for the deployment"));
-        }
-    }
-
-    private void unscheduleStorageConsumptionCollection(EnvironmentDto environmentDto) {
-        String accountId = environmentDto.getAccountId();
-        String monitoredResourceCrn = environmentDto.getResourceCrn();
-
-        String loggingStorageLocation = Optional.of(environmentDto)
-                .map(EnvironmentDtoBase::getTelemetry)
-                .map(EnvironmentTelemetry::getLogging)
-                .map(EnvironmentLogging::getStorageLocation)
-                .orElse(null);
-        if (!Strings.isNullOrEmpty(loggingStorageLocation)) {
-            unscheduleStorageConsumptionCollectionForStorageLocation(accountId, monitoredResourceCrn, loggingStorageLocation, "logging");
-        } else {
-            LOGGER.warn("Skipping storage consumption collection unscheduling for logging storage location because it is not provided: telemetry='{}'",
-                    environmentDto.getTelemetry());
-        }
-
-        String backupStorageLocation = Optional.of(environmentDto)
-                .map(EnvironmentDtoBase::getBackup)
-                .map(EnvironmentBackup::getStorageLocation)
-                .orElse(null);
-        if (!Strings.isNullOrEmpty(backupStorageLocation)) {
-            if (!backupStorageLocation.equals(loggingStorageLocation)) {
-                unscheduleStorageConsumptionCollectionForStorageLocation(accountId, monitoredResourceCrn, backupStorageLocation, "backup");
-            } else {
-                LOGGER.warn("Skipping storage consumption collection unscheduling for backup storage location because it matches the logging storage location");
-            }
-        } else {
-            LOGGER.warn("Skipping storage consumption collection unscheduling for backup storage location because it is not provided: backup='{}'",
-                    environmentDto.getBackup());
-        }
-    }
-
-    private void unscheduleStorageConsumptionCollectionForStorageLocation(String accountId, String monitoredResourceCrn, String storageLocation,
-            String locationKind) {
-        LOGGER.info("Executing storage consumption collection unscheduling for {} storage location: account '{}', resource '{}' and storage location '{}'",
-                locationKind, accountId, monitoredResourceCrn, storageLocation);
-        consumptionService.unscheduleStorageConsumptionCollection(accountId, monitoredResourceCrn, storageLocation);
     }
 
     private EnvDeleteEvent getNextStateEvent(EnvironmentDeletionDto environmentDeletionDto) {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/consumption/ConsumptionClientService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/consumption/ConsumptionClientService.java
@@ -1,0 +1,62 @@
+package com.sequenceiq.environment.environment.service.consumption;
+
+import javax.ws.rs.WebApplicationException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.common.exception.WebApplicationExceptionMessageExtractor;
+import com.sequenceiq.consumption.api.v1.consumption.model.request.StorageConsumptionRequest;
+import com.sequenceiq.consumption.client.ConsumptionInternalCrnClient;
+import com.sequenceiq.environment.exception.ConsumptionOperationFailedException;
+
+@Service
+public class ConsumptionClientService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConsumptionClientService.class);
+
+    private final ConsumptionInternalCrnClient consumptionInternalCrnClient;
+
+    private final WebApplicationExceptionMessageExtractor webApplicationExceptionMessageExtractor;
+
+    public ConsumptionClientService(ConsumptionInternalCrnClient consumptionInternalCrnClient,
+            WebApplicationExceptionMessageExtractor webApplicationExceptionMessageExtractor) {
+        this.consumptionInternalCrnClient = consumptionInternalCrnClient;
+        this.webApplicationExceptionMessageExtractor = webApplicationExceptionMessageExtractor;
+    }
+
+    public void scheduleStorageConsumptionCollection(String accountId, StorageConsumptionRequest request) {
+        String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
+        try {
+            LOGGER.info("Executing storage consumption collection scheduling: account '{}', user '{}' and request '{}'", accountId, userCrn, request);
+            consumptionInternalCrnClient.withInternalCrn()
+                    .consumptionEndpoint()
+                    .scheduleStorageConsumptionCollection(accountId, request, userCrn);
+        } catch (WebApplicationException e) {
+            String errorMessage = webApplicationExceptionMessageExtractor.getErrorMessage(e);
+            LOGGER.error(String.format("Failed to schedule storage consumption collection for account '%s' with user '%s' and request '%s' due to '%s'.",
+                    accountId, userCrn, request, errorMessage), e);
+            throw new ConsumptionOperationFailedException(errorMessage, e);
+        }
+    }
+
+    public void unscheduleStorageConsumptionCollection(String accountId, String monitoredResourceCrn, String storageLocation) {
+        String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
+        try {
+            LOGGER.info("Executing storage consumption collection unscheduling: account '{}', user '{} , resource '{}' and storage location '{}'",
+                    accountId, userCrn, monitoredResourceCrn, storageLocation);
+            consumptionInternalCrnClient.withInternalCrn()
+                    .consumptionEndpoint()
+                    .unscheduleStorageConsumptionCollection(accountId, monitoredResourceCrn, storageLocation, userCrn);
+        } catch (WebApplicationException e) {
+            String errorMessage = webApplicationExceptionMessageExtractor.getErrorMessage(e);
+            LOGGER.error(
+                    String.format("Failed to unschedule storage consumption collection for account '%s', user '%s', resource '%s' " +
+                            "and storage location '%s' due to '%s'.", accountId, userCrn, monitoredResourceCrn, storageLocation, errorMessage), e);
+            throw new ConsumptionOperationFailedException(errorMessage, e);
+        }
+    }
+
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/consumption/ConsumptionService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/consumption/ConsumptionService.java
@@ -1,62 +1,142 @@
 package com.sequenceiq.environment.environment.service.consumption;
 
-import javax.ws.rs.WebApplicationException;
+import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
-import com.sequenceiq.cloudbreak.common.exception.WebApplicationExceptionMessageExtractor;
+import com.google.common.base.Strings;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.consumption.api.v1.consumption.model.common.ResourceType;
 import com.sequenceiq.consumption.api.v1.consumption.model.request.StorageConsumptionRequest;
-import com.sequenceiq.consumption.client.ConsumptionInternalCrnClient;
-import com.sequenceiq.environment.exception.ConsumptionOperationFailedException;
+import com.sequenceiq.environment.environment.dto.EnvironmentBackup;
+import com.sequenceiq.environment.environment.dto.EnvironmentDto;
+import com.sequenceiq.environment.environment.dto.EnvironmentDtoBase;
+import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentLogging;
+import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentTelemetry;
 
 @Service
 public class ConsumptionService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ConsumptionService.class);
 
-    private final ConsumptionInternalCrnClient consumptionInternalCrnClient;
+    private final EntitlementService entitlementService;
 
-    private final WebApplicationExceptionMessageExtractor webApplicationExceptionMessageExtractor;
+    private final ConsumptionClientService consumptionClientService;
 
-    public ConsumptionService(ConsumptionInternalCrnClient consumptionInternalCrnClient,
-            WebApplicationExceptionMessageExtractor webApplicationExceptionMessageExtractor) {
-        this.consumptionInternalCrnClient = consumptionInternalCrnClient;
-        this.webApplicationExceptionMessageExtractor = webApplicationExceptionMessageExtractor;
+    private final boolean consumptionEnabled;
+
+    public ConsumptionService(
+            EntitlementService entitlementService,
+            ConsumptionClientService consumptionClientService,
+            @Value("${environment.consumption.enabled:false}") boolean consumptionEnabled) {
+        this.entitlementService = entitlementService;
+        this.consumptionClientService = consumptionClientService;
+        this.consumptionEnabled = consumptionEnabled;
     }
 
-    public void scheduleStorageConsumptionCollection(String accountId, StorageConsumptionRequest request) {
-        String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
-        try {
-            LOGGER.info("Executing storage consumption collection scheduling: account '{}', user '{}' and request '{}'", accountId, userCrn, request);
-            consumptionInternalCrnClient.withInternalCrn()
-                    .consumptionEndpoint()
-                        .scheduleStorageConsumptionCollection(accountId, request, userCrn);
-        } catch (WebApplicationException e) {
-            String errorMessage = webApplicationExceptionMessageExtractor.getErrorMessage(e);
-            LOGGER.error(String.format("Failed to schedule storage consumption collection for account '%s' with user '%s' and request '%s' due to '%s'.",
-                    accountId, userCrn, request, errorMessage), e);
-            throw new ConsumptionOperationFailedException(errorMessage, e);
+    public void scheduleStorageConsumptionCollectionIfNeeded(EnvironmentDto environmentDto) {
+        String accountId = environmentDto.getAccountId();
+        if (consumptionEnabled && entitlementService.isCdpSaasEnabled(accountId)) {
+            scheduleStorageConsumptionCollection(environmentDto);
+        } else {
+            LOGGER.info("Skipping storage consumption collection scheduling because " +
+                    (consumptionEnabled ? String.format("CDP_SAAS entitlement is missing for account '%s'", accountId) : "it is disabled for the deployment"));
         }
     }
 
-    public void unscheduleStorageConsumptionCollection(String accountId, String monitoredResourceCrn, String storageLocation) {
-        String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
-        try {
-            LOGGER.info("Executing storage consumption collection unscheduling: account '{}', user '{} , resource '{}' and storage location '{}'",
-                    accountId, userCrn, monitoredResourceCrn, storageLocation);
-            consumptionInternalCrnClient.withInternalCrn()
-                    .consumptionEndpoint()
-                    .unscheduleStorageConsumptionCollection(accountId, monitoredResourceCrn, storageLocation, userCrn);
-        } catch (WebApplicationException e) {
-            String errorMessage = webApplicationExceptionMessageExtractor.getErrorMessage(e);
-            LOGGER.error(
-                    String.format("Failed to unschedule storage consumption collection for account '%s', user '%s', resource '%s' " +
-                            "and storage location '%s' due to '%s'.", accountId, userCrn, monitoredResourceCrn, storageLocation, errorMessage), e);
-            throw new ConsumptionOperationFailedException(errorMessage, e);
+    private void scheduleStorageConsumptionCollection(EnvironmentDto environmentDto) {
+        String loggingStorageLocation = Optional.of(environmentDto)
+                .map(EnvironmentDtoBase::getTelemetry)
+                .map(EnvironmentTelemetry::getLogging)
+                .map(EnvironmentLogging::getStorageLocation)
+                .orElse(null);
+        if (!Strings.isNullOrEmpty(loggingStorageLocation)) {
+            scheduleStorageConsumptionCollectionForStorageLocation(environmentDto, loggingStorageLocation, "logging");
+        } else {
+            LOGGER.warn("Skipping storage consumption collection scheduling for logging storage location because it is not provided: telemetry='{}'",
+                    environmentDto.getTelemetry());
         }
+
+        String backupStorageLocation = Optional.of(environmentDto)
+                .map(EnvironmentDtoBase::getBackup)
+                .map(EnvironmentBackup::getStorageLocation)
+                .orElse(null);
+        if (!Strings.isNullOrEmpty(backupStorageLocation)) {
+            if (!backupStorageLocation.equals(loggingStorageLocation)) {
+                scheduleStorageConsumptionCollectionForStorageLocation(environmentDto, backupStorageLocation, "backup");
+            } else {
+                LOGGER.warn("Skipping storage consumption collection scheduling for backup storage location because it matches the logging storage location");
+            }
+        } else {
+            LOGGER.warn("Skipping storage consumption collection scheduling for backup storage location because it is not provided: backup='{}'",
+                    environmentDto.getBackup());
+        }
+    }
+
+    private void scheduleStorageConsumptionCollectionForStorageLocation(EnvironmentDto environmentDto, String storageLocation, String locationKind) {
+        StorageConsumptionRequest request = new StorageConsumptionRequest();
+        String resourceCrn = environmentDto.getResourceCrn();
+        request.setEnvironmentCrn(resourceCrn);
+        request.setMonitoredResourceCrn(resourceCrn);
+        request.setMonitoredResourceName(environmentDto.getName());
+        request.setMonitoredResourceType(ResourceType.ENVIRONMENT);
+        request.setStorageLocation(storageLocation);
+        String accountId = environmentDto.getAccountId();
+        LOGGER.info("Executing storage consumption collection scheduling for {} storage location: account '{}' and request '{}'", locationKind, accountId,
+                request);
+        consumptionClientService.scheduleStorageConsumptionCollection(accountId, request);
+    }
+
+    public void unscheduleStorageConsumptionCollectionIfNeeded(EnvironmentDto environmentDto) {
+        String accountId = environmentDto.getAccountId();
+        if (consumptionEnabled && entitlementService.isCdpSaasEnabled(accountId)) {
+            unscheduleStorageConsumptionCollection(environmentDto);
+        } else {
+            LOGGER.info("Skipping storage consumption collection unscheduling because " +
+                    (consumptionEnabled ? String.format("CDP_SAAS entitlement is missing for account '%s'", accountId) : "it is disabled for the deployment"));
+        }
+    }
+
+    private void unscheduleStorageConsumptionCollection(EnvironmentDto environmentDto) {
+        String accountId = environmentDto.getAccountId();
+        String monitoredResourceCrn = environmentDto.getResourceCrn();
+
+        String loggingStorageLocation = Optional.of(environmentDto)
+                .map(EnvironmentDtoBase::getTelemetry)
+                .map(EnvironmentTelemetry::getLogging)
+                .map(EnvironmentLogging::getStorageLocation)
+                .orElse(null);
+        if (!Strings.isNullOrEmpty(loggingStorageLocation)) {
+            unscheduleStorageConsumptionCollectionForStorageLocation(accountId, monitoredResourceCrn, loggingStorageLocation, "logging");
+        } else {
+            LOGGER.warn("Skipping storage consumption collection unscheduling for logging storage location because it is not provided: telemetry='{}'",
+                    environmentDto.getTelemetry());
+        }
+
+        String backupStorageLocation = Optional.of(environmentDto)
+                .map(EnvironmentDtoBase::getBackup)
+                .map(EnvironmentBackup::getStorageLocation)
+                .orElse(null);
+        if (!Strings.isNullOrEmpty(backupStorageLocation)) {
+            if (!backupStorageLocation.equals(loggingStorageLocation)) {
+                unscheduleStorageConsumptionCollectionForStorageLocation(accountId, monitoredResourceCrn, backupStorageLocation, "backup");
+            } else {
+                LOGGER.warn("Skipping storage consumption collection unscheduling for backup storage location because it matches the logging storage location");
+            }
+        } else {
+            LOGGER.warn("Skipping storage consumption collection unscheduling for backup storage location because it is not provided: backup='{}'",
+                    environmentDto.getBackup());
+        }
+    }
+
+    private void unscheduleStorageConsumptionCollectionForStorageLocation(String accountId, String monitoredResourceCrn, String storageLocation,
+            String locationKind) {
+        LOGGER.info("Executing storage consumption collection unscheduling for {} storage location: account '{}', resource '{}' and storage location '{}'",
+                locationKind, accountId, monitoredResourceCrn, storageLocation);
+        consumptionClientService.unscheduleStorageConsumptionCollection(accountId, monitoredResourceCrn, storageLocation);
     }
 
 }

--- a/environment/src/test/java/com/sequenceiq/environment/environment/flow/creation/handler/StorageConsumptionCollectionSchedulingHandlerTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/flow/creation/handler/StorageConsumptionCollectionSchedulingHandlerTest.java
@@ -2,36 +2,25 @@ package com.sequenceiq.environment.environment.flow.creation.handler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
-import com.sequenceiq.consumption.api.v1.consumption.model.common.ResourceType;
-import com.sequenceiq.consumption.api.v1.consumption.model.request.StorageConsumptionRequest;
 import com.sequenceiq.environment.environment.domain.Environment;
-import com.sequenceiq.environment.environment.dto.EnvironmentBackup;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
-import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentLogging;
-import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentTelemetry;
 import com.sequenceiq.environment.environment.flow.creation.event.EnvCreationEvent;
 import com.sequenceiq.environment.environment.flow.creation.event.EnvCreationFailureEvent;
 import com.sequenceiq.environment.environment.service.EnvironmentService;
@@ -45,23 +34,11 @@ import reactor.bus.EventBus;
 @ExtendWith(MockitoExtension.class)
 class StorageConsumptionCollectionSchedulingHandlerTest {
 
-    private static final boolean CONSUMPTION_ENABLED = true;
-
-    private static final boolean CONSUMPTION_DISABLED = false;
-
     private static final long ENVIRONMENT_ID = 12L;
-
-    private static final String ACCOUNT_ID = "accountId";
 
     private static final String ENVIRONMENT_CRN = "environmentCrn";
 
     private static final String ENVIRONMENT_NAME = "environmentName";
-
-    private static final String LOGGING_STORAGE_LOCATION = "s3a://foo/bar";
-
-    private static final String BACKUP_STORAGE_LOCATION = "s3a://baz";
-
-    private static final String EMPTY_STORAGE_LOCATION = "";
 
     @Mock
     private EventSender eventSender;
@@ -73,11 +50,9 @@ class StorageConsumptionCollectionSchedulingHandlerTest {
     private EventBus eventBus;
 
     @Mock
-    private EntitlementService entitlementService;
-
-    @Mock
     private ConsumptionService consumptionService;
 
+    @InjectMocks
     private StorageConsumptionCollectionSchedulingHandler underTest;
 
     @Mock
@@ -97,27 +72,12 @@ class StorageConsumptionCollectionSchedulingHandlerTest {
     @Captor
     private ArgumentCaptor<Event.Headers> headersCaptor;
 
-    @Captor
-    private ArgumentCaptor<StorageConsumptionRequest> storageConsumptionRequestCaptor;
-
     @BeforeEach
     void setUp() {
-        underTest = new StorageConsumptionCollectionSchedulingHandler(eventSender, environmentService, eventBus, entitlementService, consumptionService,
-                CONSUMPTION_ENABLED);
-
-        EnvironmentLogging environmentLogging = new EnvironmentLogging();
-        environmentLogging.setStorageLocation(LOGGING_STORAGE_LOCATION);
-        EnvironmentTelemetry environmentTelemetry = new EnvironmentTelemetry();
-        environmentTelemetry.setLogging(environmentLogging);
-        EnvironmentBackup backup = new EnvironmentBackup();
-        backup.setStorageLocation(BACKUP_STORAGE_LOCATION);
         environmentDto = EnvironmentDto.builder()
                 .withId(ENVIRONMENT_ID)
-                .withAccountId(ACCOUNT_ID)
                 .withResourceCrn(ENVIRONMENT_CRN)
                 .withName(ENVIRONMENT_NAME)
-                .withTelemetry(environmentTelemetry)
-                .withBackup(backup)
                 .build();
         lenient().when(environmentDtoEvent.getData()).thenReturn(environmentDto);
         lenient().when(environmentDtoEvent.getHeaders()).thenReturn(headers);
@@ -135,6 +95,8 @@ class StorageConsumptionCollectionSchedulingHandlerTest {
         underTest.accept(environmentDtoEvent);
 
         verifyFailureEvent(IllegalStateException.class, "Environment was not found with id '12'.");
+        verify(consumptionService, never()).scheduleStorageConsumptionCollectionIfNeeded(any(EnvironmentDto.class));
+        verify(eventSender, never()).sendEvent(any(BaseNamedFlowEvent.class), any(Event.Headers.class));
     }
 
     private <E extends Exception> void verifyFailureEvent(Class<E> exceptionClassExpected, String exceptionMessageExpected) {
@@ -164,19 +126,19 @@ class StorageConsumptionCollectionSchedulingHandlerTest {
         underTest.accept(environmentDtoEvent);
 
         verifyFailureEvent(UnsupportedOperationException.class, "This is not supported");
+        verify(consumptionService, never()).scheduleStorageConsumptionCollectionIfNeeded(any(EnvironmentDto.class));
+        verify(eventSender, never()).sendEvent(any(BaseNamedFlowEvent.class), any(Event.Headers.class));
     }
 
     @Test
-    void acceptTestSkipWhenDeploymentFlagDisabled() {
-        underTest = new StorageConsumptionCollectionSchedulingHandler(eventSender, environmentService, eventBus, entitlementService, consumptionService,
-                CONSUMPTION_DISABLED);
+    void acceptTestSuccess() {
         when(environmentService.findEnvironmentById(ENVIRONMENT_ID)).thenReturn(Optional.of(new Environment()));
 
         underTest.accept(environmentDtoEvent);
 
         verifySuccessEvent();
-        verify(entitlementService, never()).isCdpSaasEnabled(anyString());
-        verify(consumptionService, never()).scheduleStorageConsumptionCollection(anyString(), any(StorageConsumptionRequest.class));
+        verify(consumptionService).scheduleStorageConsumptionCollectionIfNeeded(environmentDto);
+        verify(eventBus, never()).notify((Object) any(), any(Event.class));
     }
 
     private void verifySuccessEvent() {
@@ -192,171 +154,6 @@ class StorageConsumptionCollectionSchedulingHandlerTest {
         assertThat(successEvent.getResourceName()).isEqualTo(ENVIRONMENT_NAME);
 
         assertThat(headersCaptor.getValue()).isSameAs(headers);
-    }
-
-    @Test
-    void acceptTestSkipWhenEntitlementDisabled() {
-        when(environmentService.findEnvironmentById(ENVIRONMENT_ID)).thenReturn(Optional.of(new Environment()));
-        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(false);
-
-        underTest.accept(environmentDtoEvent);
-
-        verifySuccessEvent();
-        verify(consumptionService, never()).scheduleStorageConsumptionCollection(anyString(), any(StorageConsumptionRequest.class));
-    }
-
-    @Test
-    void acceptTestSkipWhenNoTelemetryAndNoBackup() {
-        when(environmentService.findEnvironmentById(ENVIRONMENT_ID)).thenReturn(Optional.of(new Environment()));
-        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
-        environmentDto.setTelemetry(null);
-        environmentDto.setBackup(null);
-
-        underTest.accept(environmentDtoEvent);
-
-        verifySuccessEvent();
-        verify(consumptionService, never()).scheduleStorageConsumptionCollection(anyString(), any(StorageConsumptionRequest.class));
-    }
-
-    @Test
-    void acceptTestSkipWhenNoLoggingAndNoBackup() {
-        when(environmentService.findEnvironmentById(ENVIRONMENT_ID)).thenReturn(Optional.of(new Environment()));
-        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
-        environmentDto.getTelemetry().setLogging(null);
-        environmentDto.setBackup(null);
-
-        underTest.accept(environmentDtoEvent);
-
-        verifySuccessEvent();
-        verify(consumptionService, never()).scheduleStorageConsumptionCollection(anyString(), any(StorageConsumptionRequest.class));
-    }
-
-    @ParameterizedTest(name = "storageLocation={0}")
-    @ValueSource(strings = {EMPTY_STORAGE_LOCATION})
-    @NullSource
-    void acceptTestSkipWhenNoStorageLocations(String storageLocation) {
-        when(environmentService.findEnvironmentById(ENVIRONMENT_ID)).thenReturn(Optional.of(new Environment()));
-        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
-        environmentDto.getTelemetry().getLogging().setStorageLocation(storageLocation);
-        environmentDto.getBackup().setStorageLocation(storageLocation);
-
-        underTest.accept(environmentDtoEvent);
-
-        verifySuccessEvent();
-        verify(consumptionService, never()).scheduleStorageConsumptionCollection(anyString(), any(StorageConsumptionRequest.class));
-    }
-
-    @Test
-    void acceptTestSuccessWhenBothLocationsProvidedAndDifferent() {
-        when(environmentService.findEnvironmentById(ENVIRONMENT_ID)).thenReturn(Optional.of(new Environment()));
-        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
-
-        underTest.accept(environmentDtoEvent);
-
-        verifySuccessEvent();
-
-        verify(consumptionService, times(2)).scheduleStorageConsumptionCollection(eq(ACCOUNT_ID), storageConsumptionRequestCaptor.capture());
-        List<StorageConsumptionRequest> storageConsumptionRequests = storageConsumptionRequestCaptor.getAllValues();
-        assertThat(storageConsumptionRequests).hasSize(2);
-        verifyStorageConsumptionRequest(storageConsumptionRequests.get(0), LOGGING_STORAGE_LOCATION);
-        verifyStorageConsumptionRequest(storageConsumptionRequests.get(1), BACKUP_STORAGE_LOCATION);
-    }
-
-    private void verifyStorageConsumptionRequest(StorageConsumptionRequest storageConsumptionRequest, String storageLocation) {
-        assertThat(storageConsumptionRequest).isNotNull();
-        assertThat(storageConsumptionRequest.getEnvironmentCrn()).isEqualTo(ENVIRONMENT_CRN);
-        assertThat(storageConsumptionRequest.getMonitoredResourceCrn()).isEqualTo(ENVIRONMENT_CRN);
-        assertThat(storageConsumptionRequest.getMonitoredResourceName()).isEqualTo(ENVIRONMENT_NAME);
-        assertThat(storageConsumptionRequest.getMonitoredResourceType()).isEqualTo(ResourceType.ENVIRONMENT);
-        assertThat(storageConsumptionRequest.getStorageLocation()).isEqualTo(storageLocation);
-    }
-
-    @Test
-    void acceptTestSuccessWhenBothLocationsProvidedAndSameSoBackupIsSkipped() {
-        when(environmentService.findEnvironmentById(ENVIRONMENT_ID)).thenReturn(Optional.of(new Environment()));
-        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
-        environmentDto.getBackup().setStorageLocation(LOGGING_STORAGE_LOCATION);
-
-        underTest.accept(environmentDtoEvent);
-
-        verifySuccessEvent();
-
-        verify(consumptionService).scheduleStorageConsumptionCollection(eq(ACCOUNT_ID), storageConsumptionRequestCaptor.capture());
-        verifyStorageConsumptionRequest(storageConsumptionRequestCaptor.getValue(), LOGGING_STORAGE_LOCATION);
-    }
-
-    @Test
-    void acceptTestSuccessWhenOnlyLoggingLocationProvidedAndNoBackup() {
-        when(environmentService.findEnvironmentById(ENVIRONMENT_ID)).thenReturn(Optional.of(new Environment()));
-        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
-        environmentDto.setBackup(null);
-
-        underTest.accept(environmentDtoEvent);
-
-        verifySuccessEvent();
-
-        verify(consumptionService).scheduleStorageConsumptionCollection(eq(ACCOUNT_ID), storageConsumptionRequestCaptor.capture());
-        verifyStorageConsumptionRequest(storageConsumptionRequestCaptor.getValue(), LOGGING_STORAGE_LOCATION);
-    }
-
-    @ParameterizedTest(name = "backupStorageLocation={0}")
-    @ValueSource(strings = {EMPTY_STORAGE_LOCATION})
-    @NullSource
-    void acceptTestSuccessWhenOnlyLoggingLocationProvided(String backupStorageLocation) {
-        when(environmentService.findEnvironmentById(ENVIRONMENT_ID)).thenReturn(Optional.of(new Environment()));
-        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
-        environmentDto.getBackup().setStorageLocation(backupStorageLocation);
-
-        underTest.accept(environmentDtoEvent);
-
-        verifySuccessEvent();
-
-        verify(consumptionService).scheduleStorageConsumptionCollection(eq(ACCOUNT_ID), storageConsumptionRequestCaptor.capture());
-        verifyStorageConsumptionRequest(storageConsumptionRequestCaptor.getValue(), LOGGING_STORAGE_LOCATION);
-    }
-
-    @Test
-    void acceptTestSuccessWhenOnlyBackupLocationProvidedAndNoTelemetry() {
-        when(environmentService.findEnvironmentById(ENVIRONMENT_ID)).thenReturn(Optional.of(new Environment()));
-        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
-        environmentDto.setTelemetry(null);
-
-        underTest.accept(environmentDtoEvent);
-
-        verifySuccessEvent();
-
-        verify(consumptionService).scheduleStorageConsumptionCollection(eq(ACCOUNT_ID), storageConsumptionRequestCaptor.capture());
-        verifyStorageConsumptionRequest(storageConsumptionRequestCaptor.getValue(), BACKUP_STORAGE_LOCATION);
-    }
-
-    @Test
-    void acceptTestSuccessWhenOnlyBackupLocationProvidedAndNoLogging() {
-        when(environmentService.findEnvironmentById(ENVIRONMENT_ID)).thenReturn(Optional.of(new Environment()));
-        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
-        environmentDto.getTelemetry().setLogging(null);
-
-        underTest.accept(environmentDtoEvent);
-
-        verifySuccessEvent();
-
-        verify(consumptionService).scheduleStorageConsumptionCollection(eq(ACCOUNT_ID), storageConsumptionRequestCaptor.capture());
-        verifyStorageConsumptionRequest(storageConsumptionRequestCaptor.getValue(), BACKUP_STORAGE_LOCATION);
-    }
-
-    @ParameterizedTest(name = "loggingStorageLocation={0}")
-    @ValueSource(strings = {EMPTY_STORAGE_LOCATION})
-    @NullSource
-    void acceptTestSuccessWhenOnlyBackupLocationProvided(String loggingStorageLocation) {
-        when(environmentService.findEnvironmentById(ENVIRONMENT_ID)).thenReturn(Optional.of(new Environment()));
-        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
-        environmentDto.getTelemetry().getLogging().setStorageLocation(loggingStorageLocation);
-
-        underTest.accept(environmentDtoEvent);
-
-        verifySuccessEvent();
-
-        verify(consumptionService).scheduleStorageConsumptionCollection(eq(ACCOUNT_ID), storageConsumptionRequestCaptor.capture());
-        verifyStorageConsumptionRequest(storageConsumptionRequestCaptor.getValue(), BACKUP_STORAGE_LOCATION);
     }
 
 }

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/consumption/ConsumptionClientServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/consumption/ConsumptionClientServiceTest.java
@@ -1,0 +1,111 @@
+package com.sequenceiq.environment.environment.service.consumption;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import javax.ws.rs.WebApplicationException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.common.exception.WebApplicationExceptionMessageExtractor;
+import com.sequenceiq.consumption.api.v1.consumption.endpoint.ConsumptionInternalEndpoint;
+import com.sequenceiq.consumption.api.v1.consumption.model.request.StorageConsumptionRequest;
+import com.sequenceiq.consumption.client.ConsumptionInternalCrnClient;
+import com.sequenceiq.consumption.client.ConsumptionServiceCrnEndpoints;
+import com.sequenceiq.environment.exception.ConsumptionOperationFailedException;
+
+@ExtendWith(MockitoExtension.class)
+class ConsumptionClientServiceTest {
+
+    private static final String ACCOUNT_ID = "accountId";
+
+    private static final String INITIATOR_USER_CRN = "initiatorUserCrn";
+
+    private static final String MONITORED_RESOURCE_CRN = "monitoredResourceCrn";
+
+    private static final String STORAGE_LOCATION = "s3a://foo/bar";
+
+    private static final String ERROR_MESSAGE = "Bad luck";
+
+    @Mock
+    private ConsumptionInternalCrnClient consumptionInternalCrnClient;
+
+    @Mock
+    private WebApplicationExceptionMessageExtractor webApplicationExceptionMessageExtractor;
+
+    @InjectMocks
+    private ConsumptionClientService underTest;
+
+    @Mock
+    private ConsumptionServiceCrnEndpoints consumptionServiceCrnEndpoints;
+
+    @Mock
+    private ConsumptionInternalEndpoint consumptionInternalEndpoint;
+
+    @BeforeEach
+    void setUp() {
+        when(consumptionInternalCrnClient.withInternalCrn()).thenReturn(consumptionServiceCrnEndpoints);
+        when(consumptionServiceCrnEndpoints.consumptionEndpoint()).thenReturn(consumptionInternalEndpoint);
+    }
+
+    @Test
+    void scheduleStorageConsumptionCollectionTestWhenSuccess() {
+        StorageConsumptionRequest storageConsumptionRequest = new StorageConsumptionRequest();
+
+        ThreadBasedUserCrnProvider.doAs(INITIATOR_USER_CRN, () -> underTest.scheduleStorageConsumptionCollection(ACCOUNT_ID, storageConsumptionRequest));
+
+        verify(consumptionInternalEndpoint).scheduleStorageConsumptionCollection(ACCOUNT_ID, storageConsumptionRequest, INITIATOR_USER_CRN);
+    }
+
+    @Test
+    void scheduleStorageConsumptionCollectionTestWhenFailure() {
+        StorageConsumptionRequest storageConsumptionRequest = new StorageConsumptionRequest();
+        WebApplicationException e = new WebApplicationException();
+        doThrow(e).when(consumptionInternalEndpoint).scheduleStorageConsumptionCollection(ACCOUNT_ID, storageConsumptionRequest, INITIATOR_USER_CRN);
+        when(webApplicationExceptionMessageExtractor.getErrorMessage(e)).thenReturn(ERROR_MESSAGE);
+
+        ConsumptionOperationFailedException consumptionOperationFailedException = assertThrows(ConsumptionOperationFailedException.class,
+                () -> ThreadBasedUserCrnProvider.doAs(INITIATOR_USER_CRN, () -> underTest.scheduleStorageConsumptionCollection(
+                        ACCOUNT_ID, storageConsumptionRequest)));
+
+        verifyException(e, consumptionOperationFailedException);
+    }
+
+    private void verifyException(WebApplicationException e, ConsumptionOperationFailedException consumptionOperationFailedException) {
+        assertThat(consumptionOperationFailedException).isNotNull();
+        assertThat(consumptionOperationFailedException).hasMessage(ERROR_MESSAGE);
+        assertThat(consumptionOperationFailedException).hasCauseReference(e);
+    }
+
+    @Test
+    void unscheduleStorageConsumptionCollectionTestWhenSuccess() {
+        ThreadBasedUserCrnProvider.doAs(INITIATOR_USER_CRN, () -> underTest.unscheduleStorageConsumptionCollection(
+                ACCOUNT_ID, MONITORED_RESOURCE_CRN, STORAGE_LOCATION));
+
+        verify(consumptionInternalEndpoint).unscheduleStorageConsumptionCollection(ACCOUNT_ID, MONITORED_RESOURCE_CRN, STORAGE_LOCATION, INITIATOR_USER_CRN);
+    }
+
+    @Test
+    void unscheduleStorageConsumptionCollectionTestWhenFailure() {
+        WebApplicationException e = new WebApplicationException();
+        doThrow(e).when(consumptionInternalEndpoint).unscheduleStorageConsumptionCollection(
+                ACCOUNT_ID, MONITORED_RESOURCE_CRN, STORAGE_LOCATION, INITIATOR_USER_CRN);
+        when(webApplicationExceptionMessageExtractor.getErrorMessage(e)).thenReturn(ERROR_MESSAGE);
+
+        ConsumptionOperationFailedException consumptionOperationFailedException = assertThrows(ConsumptionOperationFailedException.class,
+                () -> ThreadBasedUserCrnProvider.doAs(INITIATOR_USER_CRN, () -> underTest.unscheduleStorageConsumptionCollection(
+                        ACCOUNT_ID, MONITORED_RESOURCE_CRN, STORAGE_LOCATION)));
+
+        verifyException(e, consumptionOperationFailedException);
+    }
+
+}

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/consumption/ConsumptionServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/consumption/ConsumptionServiceTest.java
@@ -1,111 +1,361 @@
 package com.sequenceiq.environment.environment.service.consumption;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.doThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import javax.ws.rs.WebApplicationException;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
-import com.sequenceiq.cloudbreak.common.exception.WebApplicationExceptionMessageExtractor;
-import com.sequenceiq.consumption.api.v1.consumption.endpoint.ConsumptionInternalEndpoint;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.consumption.api.v1.consumption.model.common.ResourceType;
 import com.sequenceiq.consumption.api.v1.consumption.model.request.StorageConsumptionRequest;
-import com.sequenceiq.consumption.client.ConsumptionInternalCrnClient;
-import com.sequenceiq.consumption.client.ConsumptionServiceCrnEndpoints;
-import com.sequenceiq.environment.exception.ConsumptionOperationFailedException;
+import com.sequenceiq.environment.environment.dto.EnvironmentBackup;
+import com.sequenceiq.environment.environment.dto.EnvironmentDto;
+import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentLogging;
+import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentTelemetry;
 
 @ExtendWith(MockitoExtension.class)
 class ConsumptionServiceTest {
 
+    private static final boolean CONSUMPTION_ENABLED = true;
+
+    private static final boolean CONSUMPTION_DISABLED = false;
+
+    private static final long ENVIRONMENT_ID = 12L;
+
     private static final String ACCOUNT_ID = "accountId";
 
-    private static final String INITIATOR_USER_CRN = "initiatorUserCrn";
+    private static final String ENVIRONMENT_CRN = "environmentCrn";
 
-    private static final String MONITORED_RESOURCE_CRN = "monitoredResourceCrn";
+    private static final String ENVIRONMENT_NAME = "environmentName";
 
-    private static final String STORAGE_LOCATION = "s3a://foo/bar";
+    private static final String LOGGING_STORAGE_LOCATION = "s3a://foo/bar";
 
-    private static final String ERROR_MESSAGE = "Bad luck";
+    private static final String BACKUP_STORAGE_LOCATION = "s3a://baz";
+
+    private static final String EMPTY_STORAGE_LOCATION = "";
 
     @Mock
-    private ConsumptionInternalCrnClient consumptionInternalCrnClient;
+    private EntitlementService entitlementService;
 
     @Mock
-    private WebApplicationExceptionMessageExtractor webApplicationExceptionMessageExtractor;
+    private ConsumptionClientService consumptionClientService;
 
-    @InjectMocks
     private ConsumptionService underTest;
 
-    @Mock
-    private ConsumptionServiceCrnEndpoints consumptionServiceCrnEndpoints;
+    private EnvironmentDto environmentDto;
 
-    @Mock
-    private ConsumptionInternalEndpoint consumptionInternalEndpoint;
+    @Captor
+    private ArgumentCaptor<StorageConsumptionRequest> storageConsumptionRequestCaptor;
 
     @BeforeEach
     void setUp() {
-        when(consumptionInternalCrnClient.withInternalCrn()).thenReturn(consumptionServiceCrnEndpoints);
-        when(consumptionServiceCrnEndpoints.consumptionEndpoint()).thenReturn(consumptionInternalEndpoint);
+        underTest = new ConsumptionService(entitlementService, consumptionClientService, CONSUMPTION_ENABLED);
+
+        EnvironmentLogging environmentLogging = new EnvironmentLogging();
+        environmentLogging.setStorageLocation(LOGGING_STORAGE_LOCATION);
+        EnvironmentTelemetry environmentTelemetry = new EnvironmentTelemetry();
+        environmentTelemetry.setLogging(environmentLogging);
+        EnvironmentBackup backup = new EnvironmentBackup();
+        backup.setStorageLocation(BACKUP_STORAGE_LOCATION);
+        environmentDto = EnvironmentDto.builder()
+                .withId(ENVIRONMENT_ID)
+                .withAccountId(ACCOUNT_ID)
+                .withResourceCrn(ENVIRONMENT_CRN)
+                .withName(ENVIRONMENT_NAME)
+                .withTelemetry(environmentTelemetry)
+                .withBackup(backup)
+                .build();
     }
 
     @Test
-    void scheduleStorageConsumptionCollectionTestWhenSuccess() {
-        StorageConsumptionRequest storageConsumptionRequest = new StorageConsumptionRequest();
+    void scheduleStorageConsumptionCollectionIfNeededTestSkipWhenDeploymentFlagDisabled() {
+        underTest = new ConsumptionService(entitlementService, consumptionClientService, CONSUMPTION_DISABLED);
 
-        ThreadBasedUserCrnProvider.doAs(INITIATOR_USER_CRN, () -> underTest.scheduleStorageConsumptionCollection(ACCOUNT_ID, storageConsumptionRequest));
+        underTest.scheduleStorageConsumptionCollectionIfNeeded(environmentDto);
 
-        verify(consumptionInternalEndpoint).scheduleStorageConsumptionCollection(ACCOUNT_ID, storageConsumptionRequest, INITIATOR_USER_CRN);
+        verify(entitlementService, never()).isCdpSaasEnabled(anyString());
+        verify(consumptionClientService, never()).scheduleStorageConsumptionCollection(anyString(), any(StorageConsumptionRequest.class));
     }
 
     @Test
-    void scheduleStorageConsumptionCollectionTestWhenFailure() {
-        StorageConsumptionRequest storageConsumptionRequest = new StorageConsumptionRequest();
-        WebApplicationException e = new WebApplicationException();
-        doThrow(e).when(consumptionInternalEndpoint).scheduleStorageConsumptionCollection(ACCOUNT_ID, storageConsumptionRequest, INITIATOR_USER_CRN);
-        when(webApplicationExceptionMessageExtractor.getErrorMessage(e)).thenReturn(ERROR_MESSAGE);
+    void scheduleStorageConsumptionCollectionIfNeededTestSkipWhenEntitlementDisabled() {
+        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(false);
 
-        ConsumptionOperationFailedException consumptionOperationFailedException = assertThrows(ConsumptionOperationFailedException.class,
-                () -> ThreadBasedUserCrnProvider.doAs(INITIATOR_USER_CRN, () -> underTest.scheduleStorageConsumptionCollection(
-                        ACCOUNT_ID, storageConsumptionRequest)));
+        underTest.scheduleStorageConsumptionCollectionIfNeeded(environmentDto);
 
-        verifyException(e, consumptionOperationFailedException);
-    }
-
-    private void verifyException(WebApplicationException e, ConsumptionOperationFailedException consumptionOperationFailedException) {
-        assertThat(consumptionOperationFailedException).isNotNull();
-        assertThat(consumptionOperationFailedException).hasMessage(ERROR_MESSAGE);
-        assertThat(consumptionOperationFailedException).hasCauseReference(e);
+        verify(consumptionClientService, never()).scheduleStorageConsumptionCollection(anyString(), any(StorageConsumptionRequest.class));
     }
 
     @Test
-    void unscheduleStorageConsumptionCollectionTestWhenSuccess() {
-        ThreadBasedUserCrnProvider.doAs(INITIATOR_USER_CRN, () -> underTest.unscheduleStorageConsumptionCollection(
-                ACCOUNT_ID, MONITORED_RESOURCE_CRN, STORAGE_LOCATION));
+    void scheduleStorageConsumptionCollectionIfNeededTestSkipWhenNoTelemetryAndNoBackup() {
+        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
+        environmentDto.setTelemetry(null);
+        environmentDto.setBackup(null);
 
-        verify(consumptionInternalEndpoint).unscheduleStorageConsumptionCollection(ACCOUNT_ID, MONITORED_RESOURCE_CRN, STORAGE_LOCATION, INITIATOR_USER_CRN);
+        underTest.scheduleStorageConsumptionCollectionIfNeeded(environmentDto);
+
+        verify(consumptionClientService, never()).scheduleStorageConsumptionCollection(anyString(), any(StorageConsumptionRequest.class));
     }
 
     @Test
-    void unscheduleStorageConsumptionCollectionTestWhenFailure() {
-        WebApplicationException e = new WebApplicationException();
-        doThrow(e).when(consumptionInternalEndpoint).unscheduleStorageConsumptionCollection(
-                ACCOUNT_ID, MONITORED_RESOURCE_CRN, STORAGE_LOCATION, INITIATOR_USER_CRN);
-        when(webApplicationExceptionMessageExtractor.getErrorMessage(e)).thenReturn(ERROR_MESSAGE);
+    void scheduleStorageConsumptionCollectionIfNeededTestSkipWhenNoLoggingAndNoBackup() {
+        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
+        environmentDto.getTelemetry().setLogging(null);
+        environmentDto.setBackup(null);
 
-        ConsumptionOperationFailedException consumptionOperationFailedException = assertThrows(ConsumptionOperationFailedException.class,
-                () -> ThreadBasedUserCrnProvider.doAs(INITIATOR_USER_CRN, () -> underTest.unscheduleStorageConsumptionCollection(
-                        ACCOUNT_ID, MONITORED_RESOURCE_CRN, STORAGE_LOCATION)));
+        underTest.scheduleStorageConsumptionCollectionIfNeeded(environmentDto);
 
-        verifyException(e, consumptionOperationFailedException);
+        verify(consumptionClientService, never()).scheduleStorageConsumptionCollection(anyString(), any(StorageConsumptionRequest.class));
+    }
+
+    @ParameterizedTest(name = "storageLocation={0}")
+    @ValueSource(strings = {EMPTY_STORAGE_LOCATION})
+    @NullSource
+    void scheduleStorageConsumptionCollectionIfNeededTestSkipWhenNoStorageLocations(String storageLocation) {
+        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
+        environmentDto.getTelemetry().getLogging().setStorageLocation(storageLocation);
+        environmentDto.getBackup().setStorageLocation(storageLocation);
+
+        underTest.scheduleStorageConsumptionCollectionIfNeeded(environmentDto);
+
+        verify(consumptionClientService, never()).scheduleStorageConsumptionCollection(anyString(), any(StorageConsumptionRequest.class));
+    }
+
+    @Test
+    void scheduleStorageConsumptionCollectionIfNeededTestSuccessWhenBothLocationsProvidedAndDifferent() {
+        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
+
+        underTest.scheduleStorageConsumptionCollectionIfNeeded(environmentDto);
+
+        verify(consumptionClientService, times(2)).scheduleStorageConsumptionCollection(eq(ACCOUNT_ID), storageConsumptionRequestCaptor.capture());
+        List<StorageConsumptionRequest> storageConsumptionRequests = storageConsumptionRequestCaptor.getAllValues();
+        assertThat(storageConsumptionRequests).hasSize(2);
+        verifyStorageConsumptionRequest(storageConsumptionRequests.get(0), LOGGING_STORAGE_LOCATION);
+        verifyStorageConsumptionRequest(storageConsumptionRequests.get(1), BACKUP_STORAGE_LOCATION);
+    }
+
+    private void verifyStorageConsumptionRequest(StorageConsumptionRequest storageConsumptionRequest, String storageLocation) {
+        assertThat(storageConsumptionRequest).isNotNull();
+        assertThat(storageConsumptionRequest.getEnvironmentCrn()).isEqualTo(ENVIRONMENT_CRN);
+        assertThat(storageConsumptionRequest.getMonitoredResourceCrn()).isEqualTo(ENVIRONMENT_CRN);
+        assertThat(storageConsumptionRequest.getMonitoredResourceName()).isEqualTo(ENVIRONMENT_NAME);
+        assertThat(storageConsumptionRequest.getMonitoredResourceType()).isEqualTo(ResourceType.ENVIRONMENT);
+        assertThat(storageConsumptionRequest.getStorageLocation()).isEqualTo(storageLocation);
+    }
+
+    @Test
+    void scheduleStorageConsumptionCollectionIfNeededTestSuccessWhenBothLocationsProvidedAndSameSoBackupIsSkipped() {
+        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
+        environmentDto.getBackup().setStorageLocation(LOGGING_STORAGE_LOCATION);
+
+        underTest.scheduleStorageConsumptionCollectionIfNeeded(environmentDto);
+
+        verify(consumptionClientService).scheduleStorageConsumptionCollection(eq(ACCOUNT_ID), storageConsumptionRequestCaptor.capture());
+        verifyStorageConsumptionRequest(storageConsumptionRequestCaptor.getValue(), LOGGING_STORAGE_LOCATION);
+    }
+
+    @Test
+    void scheduleStorageConsumptionCollectionIfNeededTestSuccessWhenOnlyLoggingLocationProvidedAndNoBackup() {
+        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
+        environmentDto.setBackup(null);
+
+        underTest.scheduleStorageConsumptionCollectionIfNeeded(environmentDto);
+
+        verify(consumptionClientService).scheduleStorageConsumptionCollection(eq(ACCOUNT_ID), storageConsumptionRequestCaptor.capture());
+        verifyStorageConsumptionRequest(storageConsumptionRequestCaptor.getValue(), LOGGING_STORAGE_LOCATION);
+    }
+
+    @ParameterizedTest(name = "backupStorageLocation={0}")
+    @ValueSource(strings = {EMPTY_STORAGE_LOCATION})
+    @NullSource
+    void scheduleStorageConsumptionCollectionIfNeededTestSuccessWhenOnlyLoggingLocationProvided(String backupStorageLocation) {
+        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
+        environmentDto.getBackup().setStorageLocation(backupStorageLocation);
+
+        underTest.scheduleStorageConsumptionCollectionIfNeeded(environmentDto);
+
+        verify(consumptionClientService).scheduleStorageConsumptionCollection(eq(ACCOUNT_ID), storageConsumptionRequestCaptor.capture());
+        verifyStorageConsumptionRequest(storageConsumptionRequestCaptor.getValue(), LOGGING_STORAGE_LOCATION);
+    }
+
+    @Test
+    void scheduleStorageConsumptionCollectionIfNeededTestSuccessWhenOnlyBackupLocationProvidedAndNoTelemetry() {
+        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
+        environmentDto.setTelemetry(null);
+
+        underTest.scheduleStorageConsumptionCollectionIfNeeded(environmentDto);
+
+        verify(consumptionClientService).scheduleStorageConsumptionCollection(eq(ACCOUNT_ID), storageConsumptionRequestCaptor.capture());
+        verifyStorageConsumptionRequest(storageConsumptionRequestCaptor.getValue(), BACKUP_STORAGE_LOCATION);
+    }
+
+    @Test
+    void scheduleStorageConsumptionCollectionIfNeededTestSuccessWhenOnlyBackupLocationProvidedAndNoLogging() {
+        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
+        environmentDto.getTelemetry().setLogging(null);
+
+        underTest.scheduleStorageConsumptionCollectionIfNeeded(environmentDto);
+
+        verify(consumptionClientService).scheduleStorageConsumptionCollection(eq(ACCOUNT_ID), storageConsumptionRequestCaptor.capture());
+        verifyStorageConsumptionRequest(storageConsumptionRequestCaptor.getValue(), BACKUP_STORAGE_LOCATION);
+    }
+
+    @ParameterizedTest(name = "loggingStorageLocation={0}")
+    @ValueSource(strings = {EMPTY_STORAGE_LOCATION})
+    @NullSource
+    void scheduleStorageConsumptionCollectionIfNeededTestSuccessWhenOnlyBackupLocationProvided(String loggingStorageLocation) {
+        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
+        environmentDto.getTelemetry().getLogging().setStorageLocation(loggingStorageLocation);
+
+        underTest.scheduleStorageConsumptionCollectionIfNeeded(environmentDto);
+
+        verify(consumptionClientService).scheduleStorageConsumptionCollection(eq(ACCOUNT_ID), storageConsumptionRequestCaptor.capture());
+        verifyStorageConsumptionRequest(storageConsumptionRequestCaptor.getValue(), BACKUP_STORAGE_LOCATION);
+    }
+
+    @Test
+    void unscheduleStorageConsumptionCollectionIfNeededTestSkipWhenDeploymentFlagDisabled() {
+        underTest = new ConsumptionService(entitlementService, consumptionClientService, CONSUMPTION_DISABLED);
+
+        underTest.unscheduleStorageConsumptionCollectionIfNeeded(environmentDto);
+
+        verify(entitlementService, never()).isCdpSaasEnabled(anyString());
+        verify(consumptionClientService, never()).unscheduleStorageConsumptionCollection(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void unscheduleStorageConsumptionCollectionIfNeededTestSkipWhenEntitlementDisabled() {
+        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(false);
+
+        underTest.unscheduleStorageConsumptionCollectionIfNeeded(environmentDto);
+
+        verify(consumptionClientService, never()).unscheduleStorageConsumptionCollection(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void unscheduleStorageConsumptionCollectionIfNeededTestSkipWhenNoTelemetryAndNoBackup() {
+        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
+        environmentDto.setTelemetry(null);
+        environmentDto.setBackup(null);
+
+        underTest.unscheduleStorageConsumptionCollectionIfNeeded(environmentDto);
+
+        verify(consumptionClientService, never()).unscheduleStorageConsumptionCollection(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void unscheduleStorageConsumptionCollectionIfNeededTestSkipWhenNoLoggingAndNoBackup() {
+        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
+        environmentDto.getTelemetry().setLogging(null);
+        environmentDto.setBackup(null);
+
+        underTest.unscheduleStorageConsumptionCollectionIfNeeded(environmentDto);
+
+        verify(consumptionClientService, never()).unscheduleStorageConsumptionCollection(anyString(), anyString(), anyString());
+    }
+
+    @ParameterizedTest(name = "storageLocation={0}")
+    @ValueSource(strings = {EMPTY_STORAGE_LOCATION})
+    @NullSource
+    void unscheduleStorageConsumptionCollectionIfNeededTestSkipWhenNoStorageLocations(String storageLocation) {
+        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
+        environmentDto.getTelemetry().getLogging().setStorageLocation(storageLocation);
+        environmentDto.getBackup().setStorageLocation(storageLocation);
+
+        underTest.unscheduleStorageConsumptionCollectionIfNeeded(environmentDto);
+
+        verify(consumptionClientService, never()).unscheduleStorageConsumptionCollection(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void unscheduleStorageConsumptionCollectionIfNeededTestSuccessWhenBothLocationsProvidedAndDifferent() {
+        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
+
+        underTest.unscheduleStorageConsumptionCollectionIfNeeded(environmentDto);
+
+        verify(consumptionClientService).unscheduleStorageConsumptionCollection(ACCOUNT_ID, ENVIRONMENT_CRN, LOGGING_STORAGE_LOCATION);
+        verify(consumptionClientService).unscheduleStorageConsumptionCollection(ACCOUNT_ID, ENVIRONMENT_CRN, BACKUP_STORAGE_LOCATION);
+    }
+
+    @Test
+    void unscheduleStorageConsumptionCollectionIfNeededTestSuccessWhenBothLocationsProvidedAndSameSoBackupIsSkipped() {
+        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
+        environmentDto.getBackup().setStorageLocation(LOGGING_STORAGE_LOCATION);
+
+        underTest.unscheduleStorageConsumptionCollectionIfNeeded(environmentDto);
+
+        verify(consumptionClientService).unscheduleStorageConsumptionCollection(ACCOUNT_ID, ENVIRONMENT_CRN, LOGGING_STORAGE_LOCATION);
+    }
+
+    @Test
+    void unscheduleStorageConsumptionCollectionIfNeededTestSuccessWhenOnlyLoggingLocationProvidedAndNoBackup() {
+        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
+        environmentDto.setBackup(null);
+
+        underTest.unscheduleStorageConsumptionCollectionIfNeeded(environmentDto);
+
+        verify(consumptionClientService).unscheduleStorageConsumptionCollection(ACCOUNT_ID, ENVIRONMENT_CRN, LOGGING_STORAGE_LOCATION);
+    }
+
+    @ParameterizedTest(name = "backupStorageLocation={0}")
+    @ValueSource(strings = {EMPTY_STORAGE_LOCATION})
+    @NullSource
+    void unscheduleStorageConsumptionCollectionIfNeededTestSuccessWhenOnlyLoggingLocationProvided(String backupStorageLocation) {
+        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
+        environmentDto.getBackup().setStorageLocation(backupStorageLocation);
+
+        underTest.unscheduleStorageConsumptionCollectionIfNeeded(environmentDto);
+
+        verify(consumptionClientService).unscheduleStorageConsumptionCollection(ACCOUNT_ID, ENVIRONMENT_CRN, LOGGING_STORAGE_LOCATION);
+    }
+
+    @Test
+    void unscheduleStorageConsumptionCollectionIfNeededTestSuccessWhenOnlyBackupLocationProvidedAndNoTelemetry() {
+        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
+        environmentDto.setTelemetry(null);
+
+        underTest.unscheduleStorageConsumptionCollectionIfNeeded(environmentDto);
+
+        verify(consumptionClientService).unscheduleStorageConsumptionCollection(ACCOUNT_ID, ENVIRONMENT_CRN, BACKUP_STORAGE_LOCATION);
+    }
+
+    @Test
+    void unscheduleStorageConsumptionCollectionIfNeededTestSuccessWhenOnlyBackupLocationProvidedAndNoLogging() {
+        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
+        environmentDto.getTelemetry().setLogging(null);
+
+        underTest.unscheduleStorageConsumptionCollectionIfNeeded(environmentDto);
+
+        verify(consumptionClientService).unscheduleStorageConsumptionCollection(ACCOUNT_ID, ENVIRONMENT_CRN, BACKUP_STORAGE_LOCATION);
+    }
+
+    @ParameterizedTest(name = "loggingStorageLocation={0}")
+    @ValueSource(strings = {EMPTY_STORAGE_LOCATION})
+    @NullSource
+    void unscheduleStorageConsumptionCollectionIfNeededTestSuccessWhenOnlyBackupLocationProvided(String loggingStorageLocation) {
+        when(entitlementService.isCdpSaasEnabled(ACCOUNT_ID)).thenReturn(true);
+        environmentDto.getTelemetry().getLogging().setStorageLocation(loggingStorageLocation);
+
+        underTest.unscheduleStorageConsumptionCollectionIfNeeded(environmentDto);
+
+        verify(consumptionClientService).unscheduleStorageConsumptionCollection(ACCOUNT_ID, ENVIRONMENT_CRN, BACKUP_STORAGE_LOCATION);
     }
 
 }


### PR DESCRIPTION
* Follow-up to [CB-17216](https://jira.cloudera.com/browse/CB-17216) / #12807.
* Rename the current `com.sequenceiq.environment.environment.service.consumption.ConsumptionService` to `ConsumptionClientService` (keeping the package unchanged), so that the latter new service only encapsulates the web service calls, nothing else.
* Extract all the consumption-related logic from `com.sequenceiq.environment.environment.flow.creation.handler.StorageConsumptionCollectionSchedulingHandler` and `com.sequenceiq.environment.environment.flow.deletion.handler.StorageConsumptionCollectionUnschedulingHandler` into `com.sequenceiq.environment.environment.service.consumption.ConsumptionService`. (This is the same service mentioned in the first bullet item.)
* Testing:
  * Manual testing in local CB.
  * Added new UT and updated existing ones.
