### PR TITLE
CB-17896 After a failed and fixed upgrade component versions are not …

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/recovery/bringup/DatalakeRecoveryBringupActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/recovery/bringup/DatalakeRecoveryBringupActions.java
@@ -59,7 +59,7 @@ public class DatalakeRecoveryBringupActions {
                 Long stackId = context.getStackId();
                 try {
                     Image image = componentConfigProviderService.getImage(stackId);
-                    imageComponentUpdaterService.updateForUpgrade(image.getImageId(), stackId);
+                    imageComponentUpdaterService.updateComponentsForUpgrade(image.getImageId(), stackId);
                 } catch (CloudbreakImageNotFoundException e) {
                     String message = "Image was not found for current stack, it is not possible to continue recovery. "
                             + "Please open a Cloudera support ticket to fix this issue";

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/ClusterUpgradeActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/ClusterUpgradeActions.java
@@ -54,12 +54,12 @@ public class ClusterUpgradeActions {
     @Inject
     private ClusterUpgradeService clusterUpgradeService;
 
+    @Inject
+    private ImageComponentUpdaterService imageComponentUpdaterService;
+
     @Bean(name = "CLUSTER_UPGRADE_INIT_STATE")
     public Action<?, ?> initClusterUpgrade() {
         return new AbstractClusterUpgradeAction<>(ClusterUpgradeTriggerEvent.class) {
-
-            @Inject
-            private ImageComponentUpdaterService imageComponentUpdaterService;
 
             @Inject
             private ClusterUpgradeTargetImageService clusterUpgradeTargetImageService;
@@ -67,7 +67,7 @@ public class ClusterUpgradeActions {
             @Override
             protected void doExecute(ClusterUpgradeContext context, ClusterUpgradeTriggerEvent payload, Map<Object, Object> variables) {
                 try {
-                    UpgradeImageInfo images = imageComponentUpdaterService.updateForUpgrade(payload.getImageId(), payload.getResourceId());
+                    UpgradeImageInfo images = imageComponentUpdaterService.updateComponentsForUpgrade(payload.getImageId(), payload.getResourceId());
                     variables.put(CURRENT_IMAGE, images.getCurrentStatedImage());
                     variables.put(TARGET_IMAGE, images.getTargetStatedImage());
                     clusterUpgradeTargetImageService.saveImage(context.getStackId(), images.getTargetStatedImage());
@@ -109,7 +109,9 @@ public class ClusterUpgradeActions {
             @Override
             protected void doExecute(ClusterUpgradeContext context, ClusterUpgradeInitSuccess payload, Map<Object, Object> variables) {
                 Image currentImage = getCurrentImage(variables).getImage();
-                Image targetImage = getTargetImage(variables).getImage();
+                StatedImage targetStatedImage = getTargetImage(variables);
+                Image targetImage = targetStatedImage.getImage();
+                imageComponentUpdaterService.updateComponentsForUpgrade(targetStatedImage, payload.getResourceId());
                 clusterUpgradeService.upgradeClusterManager(context.getStackId());
                 Selectable event = new ClusterManagerUpgradeRequest(context.getStackId(),
                         !clusterUpgradeService.isClusterRuntimeUpgradeNeeded(currentImage, targetImage));
@@ -136,7 +138,9 @@ public class ClusterUpgradeActions {
             @Override
             protected void doExecute(ClusterUpgradeContext context, ClusterManagerUpgradeSuccess payload, Map<Object, Object> variables) {
                 Image currentImage = getCurrentImage(variables).getImage();
-                Image targetImage = getTargetImage(variables).getImage();
+                StatedImage targetStatedImage = getTargetImage(variables);
+                Image targetImage = targetStatedImage.getImage();
+                imageComponentUpdaterService.updateComponentsForUpgrade(targetStatedImage, payload.getResourceId());
                 boolean clusterRuntimeUpgradeNeeded = clusterUpgradeService.upgradeCluster(context.getStackId(), currentImage, targetImage);
                 Selectable event;
                 if (clusterRuntimeUpgradeNeeded) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageService.java
@@ -215,7 +215,7 @@ public class ImageService {
     }
 
     public String determineImageName(String cloudPlatform, ImageCatalogPlatform platformString, String region,
-        com.sequenceiq.cloudbreak.cloud.model.catalog.Image imgFromCatalog) throws CloudbreakImageNotFoundException {
+            com.sequenceiq.cloudbreak.cloud.model.catalog.Image imgFromCatalog) throws CloudbreakImageNotFoundException {
         Optional<Map<String, String>> imagesForPlatform = findStringKeyWithEqualsIgnoreCase(
                 platformString.nameToLowerCase(),
                 imgFromCatalog.getImageSetsByProvider());
@@ -243,6 +243,11 @@ public class ImageService {
                 .filter(entry -> entry.getKey().equalsIgnoreCase(key))
                 .map(Entry::getValue)
                 .findFirst();
+    }
+
+    public Set<Component> getComponentsWithoutUserData(Stack stack, StatedImage statedImage)
+            throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
+        return getComponents(stack, null, statedImage, EnumSet.of(CDH_PRODUCT_DETAILS, CM_REPO_DETAILS));
     }
 
     public Set<Component> getComponents(Stack stack, Map<InstanceGroupType, String> userData, StatedImage statedImage,

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ImageComponentUpdaterService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ImageComponentUpdaterService.java
@@ -1,10 +1,7 @@
 package com.sequenceiq.cloudbreak.service.upgrade;
 
 import static com.sequenceiq.cloudbreak.common.exception.NotFoundException.notFoundException;
-import static com.sequenceiq.cloudbreak.common.type.ComponentType.CDH_PRODUCT_DETAILS;
-import static com.sequenceiq.cloudbreak.common.type.ComponentType.CM_REPO_DETAILS;
 
-import java.util.EnumSet;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -18,6 +15,7 @@ import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
 import com.sequenceiq.cloudbreak.domain.stack.Component;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.service.image.ImageService;
+import com.sequenceiq.cloudbreak.service.image.StatedImage;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.structuredevent.CloudbreakRestRequestThreadLocalService;
 
@@ -44,21 +42,39 @@ public class ImageComponentUpdaterService {
     @Inject
     private CloudbreakRestRequestThreadLocalService restRequestThreadLocalService;
 
-    public UpgradeImageInfo updateForUpgrade(String targetImageId, Long stackId) {
+    public UpgradeImageInfo updateComponentsForUpgrade(String targetImageId, Long stackId) {
         Stack stack = stackService.getById(stackId);
+        restRequestThreadLocalService.setWorkspace(stack.getWorkspace());
+        UpgradeImageInfo upgradeImageInfo = getUpgradeImageInfo(targetImageId, stackId, stack);
+        updateComponents(upgradeImageInfo.getTargetStatedImage(), stack, targetImageId);
+
+        return upgradeImageInfo;
+    }
+
+    public void updateComponentsForUpgrade(StatedImage targetStatedImage, Long stackId) {
+        Stack stack = stackService.getById(stackId);
+        restRequestThreadLocalService.setWorkspace(stack.getWorkspace());
+        updateComponents(targetStatedImage, stack, targetStatedImage.getImage().getUuid());
+    }
+
+    private void updateComponents(StatedImage upgradeImageInfo, Stack stack, String targetImageId) {
         try {
-            restRequestThreadLocalService.setWorkspace(stack.getWorkspace());
-            UpgradeImageInfo upgradeImageInfo = upgradeImageInfoFactory.create(targetImageId, stackId);
-            Set<Component> targetComponents = imageService.getComponents(
-                    stack, upgradeImageInfo.getCurrentImage().getUserdata(), upgradeImageInfo.getTargetStatedImage(),
-                    EnumSet.of(CDH_PRODUCT_DETAILS, CM_REPO_DETAILS)
-            );
+            Set<Component> targetComponents = imageService.getComponentsWithoutUserData(stack, upgradeImageInfo);
             stackComponentUpdater.updateComponentsByStackId(stack, targetComponents, true);
             clusterComponentUpdater.updateClusterComponentsByStackId(stack, targetComponents, true);
-            return upgradeImageInfo;
         } catch (CloudbreakImageNotFoundException | CloudbreakImageCatalogException e) {
             LOGGER.warn(String.format("Image was not found for stack %s", stack.getName()), e);
             throw notFoundException("Image", targetImageId);
         }
     }
+
+    private UpgradeImageInfo getUpgradeImageInfo(String targetImageId, Long stackId, Stack stack) {
+        try {
+            return upgradeImageInfoFactory.create(targetImageId, stackId);
+        } catch (CloudbreakImageNotFoundException | CloudbreakImageCatalogException e) {
+            LOGGER.warn(String.format("Image was not found for stack %s", stack.getName()), e);
+            throw notFoundException("Image", targetImageId);
+        }
+    }
+
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ImageComponentUpdaterServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ImageComponentUpdaterServiceTest.java
@@ -1,0 +1,196 @@
+package com.sequenceiq.cloudbreak.service.upgrade;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
+import com.sequenceiq.cloudbreak.domain.stack.Component;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.service.image.ImageService;
+import com.sequenceiq.cloudbreak.service.image.StatedImage;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.structuredevent.CloudbreakRestRequestThreadLocalService;
+import com.sequenceiq.cloudbreak.workspace.model.Workspace;
+
+@ExtendWith(MockitoExtension.class)
+public class ImageComponentUpdaterServiceTest {
+
+    private static final long STACK_ID = 1L;
+
+    private static final String TARGET_IMAGE_ID = "targetImageId";
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private StackComponentUpdater stackComponentUpdater;
+
+    @Mock
+    private ClusterComponentUpdater clusterComponentUpdater;
+
+    @Mock
+    private UpgradeImageInfoFactory upgradeImageInfoFactory;
+
+    @Mock
+    private ImageService imageService;
+
+    @Mock
+    private CloudbreakRestRequestThreadLocalService restRequestThreadLocalService;
+
+    @InjectMocks
+    private ImageComponentUpdaterService underTest;
+
+    @Mock
+    private StatedImage targetStatedImage;
+
+    private final Stack stack = new Stack();
+
+    private final Workspace workspace = new Workspace();
+
+    @BeforeEach
+    void setup() {
+        setupStack();
+        setupWorkspace();
+    }
+
+    @Test
+    void testUpgradeComponentsForUpdateWithImageId() throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
+        UpgradeImageInfo upgradeImageInfo = setupUpgradeImageInfo();
+        when(upgradeImageInfoFactory.create(TARGET_IMAGE_ID, STACK_ID)).thenReturn(upgradeImageInfo);
+        Set<Component> componentsToUpdate = getComponents();
+        when(imageService.getComponentsWithoutUserData(stack, targetStatedImage)).thenReturn(componentsToUpdate);
+
+        underTest.updateComponentsForUpgrade(TARGET_IMAGE_ID, STACK_ID);
+
+        verify(restRequestThreadLocalService).setWorkspace(workspace);
+        verify(stackComponentUpdater).updateComponentsByStackId(stack, componentsToUpdate, true);
+        verify(clusterComponentUpdater).updateClusterComponentsByStackId(stack, componentsToUpdate, true);
+    }
+
+    @Test
+    void testUpgradeComponentsForUpdateWithStatedImage() throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
+        Set<Component> componentsToUpdate = getComponents();
+        when(imageService.getComponentsWithoutUserData(stack, targetStatedImage)).thenReturn(componentsToUpdate);
+        Image image = mock(Image.class);
+        when(targetStatedImage.getImage()).thenReturn(image);
+
+        underTest.updateComponentsForUpgrade(targetStatedImage, STACK_ID);
+
+        verify(restRequestThreadLocalService).setWorkspace(workspace);
+        verify(stackComponentUpdater).updateComponentsByStackId(stack, componentsToUpdate, true);
+        verify(clusterComponentUpdater).updateClusterComponentsByStackId(stack, componentsToUpdate, true);
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "possibleExceptions")
+    void testUpgradeComponentsForUpdateWhenImageNotFoundThenNotFoundException(Class<? extends Exception> thrownException)
+            throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
+        when(upgradeImageInfoFactory.create(TARGET_IMAGE_ID, STACK_ID)).thenThrow(thrownException);
+
+        Assertions.assertThatThrownBy(() -> underTest.updateComponentsForUpgrade(TARGET_IMAGE_ID, STACK_ID))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("Image 'targetImageId' not found.");
+
+        verify(restRequestThreadLocalService).setWorkspace(workspace);
+        verify(stackComponentUpdater, never()).updateComponentsByStackId(any(), any(), anyBoolean());
+        verify(clusterComponentUpdater, never()).updateClusterComponentsByStackId(any(), any(), anyBoolean());
+    }
+
+    @Test
+    void testUpgradeComponentsForUpdateWhenStackNotFoundThenThrows() {
+        when(stackService.getById(STACK_ID)).thenThrow(new NotFoundException("my message"));
+
+        Assertions.assertThatThrownBy(() -> underTest.updateComponentsForUpgrade(TARGET_IMAGE_ID, STACK_ID))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("my message");
+
+        verify(restRequestThreadLocalService, never()).setWorkspace(any());
+        verify(stackComponentUpdater, never()).updateComponentsByStackId(any(), any(), anyBoolean());
+        verify(clusterComponentUpdater, never()).updateClusterComponentsByStackId(any(), any(), anyBoolean());
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "possibleExceptions")
+    void testUpgradeComponentsForUpdateWithImageIdWhenGetComponentsThrows(Class<? extends Exception> thrownException)
+            throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
+        UpgradeImageInfo upgradeImageInfo = setupUpgradeImageInfo();
+        when(upgradeImageInfoFactory.create(TARGET_IMAGE_ID, STACK_ID)).thenReturn(upgradeImageInfo);
+        when(imageService.getComponentsWithoutUserData(stack, targetStatedImage)).thenThrow(thrownException);
+
+        Assertions.assertThatThrownBy(() -> underTest.updateComponentsForUpgrade(TARGET_IMAGE_ID, STACK_ID))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("Image 'targetImageId' not found.");
+
+        verify(restRequestThreadLocalService).setWorkspace(workspace);
+        verify(stackComponentUpdater, never()).updateComponentsByStackId(any(), any(), anyBoolean());
+        verify(clusterComponentUpdater, never()).updateClusterComponentsByStackId(any(), any(), anyBoolean());
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "possibleExceptions")
+    void testUpgradeComponentsForUpdateWhenGetComponentsThrows(Class<? extends Exception> thrownException)
+            throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
+        when(imageService.getComponentsWithoutUserData(stack, targetStatedImage)).thenThrow(thrownException);
+        Image image = mock(Image.class);
+        when(image.getUuid()).thenReturn(TARGET_IMAGE_ID);
+        when(targetStatedImage.getImage()).thenReturn(image);
+
+        Assertions.assertThatThrownBy(() -> underTest.updateComponentsForUpgrade(targetStatedImage, STACK_ID))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("Image 'targetImageId' not found.");
+
+        verify(restRequestThreadLocalService).setWorkspace(workspace);
+        verify(stackComponentUpdater, never()).updateComponentsByStackId(any(), any(), anyBoolean());
+        verify(clusterComponentUpdater, never()).updateClusterComponentsByStackId(any(), any(), anyBoolean());
+    }
+
+    private static Stream<Class<? extends Exception>> possibleExceptions() {
+        return Stream.of(
+                CloudbreakImageNotFoundException.class,
+                CloudbreakImageCatalogException.class
+        );
+    }
+
+    private Set<Component> getComponents() {
+        Component component = new Component();
+        component.setName("myComponent");
+        return Set.of(component);
+    }
+
+    private UpgradeImageInfo setupUpgradeImageInfo() {
+        UpgradeImageInfo upgradeImageInfo = mock(UpgradeImageInfo.class);
+        when(upgradeImageInfo.getTargetStatedImage()).thenReturn(targetStatedImage);
+        return upgradeImageInfo;
+    }
+
+    private void setupStack() {
+        stack.setName("clusterName");
+        stack.setWorkspace(workspace);
+        when(stackService.getById(STACK_ID)).thenReturn(stack);
+    }
+
+    private void setupWorkspace() {
+        workspace.setId(2L);
+    }
+
+}


### PR DESCRIPTION
…updated

When an upgrade fails, roll forward will query the actual CM and parcel versions and persist them to cbdb. If later, however, retry fixes the upgrade, component versions will never be updated any more. As a consequence, during the cluster upscale flow the old parcel will be downloaded, distributed and activated again.

The current commit offers a fix: once the ClusterUpgrade finishes successfully, versions read from the target image will be persisted to the Component and ClusterComponent table, just as it is done at the start of the upgrade. We suppose that whenever the customer fixes a failed upgrade, he installs the parcel version that is present on the target image.

See detailed description in the commit message.