### PR TITLE
CB-17929. Connection is leaked for the internal monitoring endpoint.

### DIFF
--- a/metrics-client/src/main/java/com/sequenceiq/cloudbreak/metrics/processor/MetricsRecordWorker.java
+++ b/metrics-client/src/main/java/com/sequenceiq/cloudbreak/metrics/processor/MetricsRecordWorker.java
@@ -48,6 +48,9 @@ public class MetricsRecordWorker extends RecordWorker<MetricsRecordProcessor, Me
             if (response.code() < STATUS_OK || response.code() > LAST_REDIRECT_CODE) {
                 throw new StreamProcessingException(String.format("Response code is not valid. (status code: %s)", response.code()));
             }
+            if (response.body() != null) {
+                response.body().close();
+            }
         } catch (IOException e) {
             throw new StreamProcessingException(e);
         }


### PR DESCRIPTION
See detailed description in the commit message.

it generate messages like this in the logs:

```text
2022-07-27 10:55:27,717 [OkHttp ConnectionPool] pruneAndGetAllocationCount:305 WARN c.s.o.OkHttpClient - [type:springLog] [crn:] [name:] [flow:] [requestid:] [tenant:] [userCrn:] [environment:] [traceId:] [spanId:] A connection to https://receive-internal-cdp-saas.api.monitoring.cdp.mow-dev.cloudera.com/ was leaked. Did you forget to close a response body?
```