### PR TITLE
CB-17930 Retrying failed CCM upgrade is impossible

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/DeregisterAgentHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/DeregisterAgentHandler.java
@@ -41,6 +41,7 @@ public class DeregisterAgentHandler extends ExceptionCatcherEventHandler<Upgrade
         UpgradeCcmDeregisterAgentRequest request = event.getData();
         Long stackId = request.getResourceId();
         LOGGER.info("Deregistering agent for CCM upgrade...");
+        upgradeCcmService.updateTunnel(stackId);
         upgradeCcmService.deregisterAgent(stackId, request.getOldTunnel());
         return new UpgradeCcmDeregisterAgentResult(stackId, request.getClusterId(), request.getOldTunnel());
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/HealthCheckHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/HealthCheckHandler.java
@@ -1,13 +1,10 @@
 package com.sequenceiq.cloudbreak.reactor.handler.cluster.upgrade.ccm;
 
-import javax.inject.Inject;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.common.event.Selectable;
-import com.sequenceiq.cloudbreak.core.flow2.cluster.ccm.upgrade.UpgradeCcmService;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmFailedEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmHealthCheckRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmHealthCheckResult;
@@ -21,9 +18,6 @@ import reactor.bus.Event;
 public class HealthCheckHandler extends ExceptionCatcherEventHandler<UpgradeCcmHealthCheckRequest> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HealthCheckHandler.class);
-
-    @Inject
-    private UpgradeCcmService upgradeCcmService;
 
     @Override
     public String selector() {
@@ -40,8 +34,7 @@ public class HealthCheckHandler extends ExceptionCatcherEventHandler<UpgradeCcmH
     public Selectable doAccept(HandlerEvent<UpgradeCcmHealthCheckRequest> event) {
         UpgradeCcmHealthCheckRequest request = event.getData();
         Long stackId = request.getResourceId();
-        LOGGER.info("Health check for CCM upgrade...");
-        upgradeCcmService.healthCheck(stackId);
+        // kept for forward compatibility with CB-14585
         return new UpgradeCcmHealthCheckResult(stackId, request.getClusterId(), request.getOldTunnel());
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/PushSaltStateHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/PushSaltStateHandler.java
@@ -42,6 +42,7 @@ public class PushSaltStateHandler extends ExceptionCatcherEventHandler<UpgradeCc
         Long stackId = request.getResourceId();
         Long clusterId = request.getClusterId();
         LOGGER.info("Pushing salt states for CCM upgrade...");
+        upgradeCcmService.updateTunnel(stackId);
         upgradeCcmService.pushSaltState(stackId, clusterId);
         return new UpgradeCcmPushSaltStatesResult(stackId, clusterId, request.getOldTunnel());
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/ReconfigureNginxHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/ReconfigureNginxHandler.java
@@ -42,6 +42,7 @@ public class ReconfigureNginxHandler extends ExceptionCatcherEventHandler<Upgrad
         UpgradeCcmReconfigureNginxRequest request = event.getData();
         Long stackId = request.getResourceId();
         LOGGER.info("NGINX reconfiguration is needed for previous CCM tunnel type");
+        upgradeCcmService.updateTunnel(stackId);
         try {
             upgradeCcmService.reconfigureNginx(stackId);
         } catch (CloudbreakOrchestratorException e) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/RegisterClusterProxyHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/RegisterClusterProxyHandler.java
@@ -41,7 +41,8 @@ public class RegisterClusterProxyHandler extends ExceptionCatcherEventHandler<Up
         UpgradeCcmRegisterClusterProxyRequest request = event.getData();
         Long stackId = request.getResourceId();
         LOGGER.info("Registering to cluster proxy for CCM upgrade...");
-        upgradeCcmService.registerClusterProxy(stackId);
+        upgradeCcmService.updateTunnel(stackId);
+        upgradeCcmService.registerClusterProxyAndCheckHealth(stackId);
         return new UpgradeCcmRegisterClusterProxyResult(stackId, request.getClusterId(), request.getOldTunnel());
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/RemoveAgentHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/RemoveAgentHandler.java
@@ -42,6 +42,7 @@ public class RemoveAgentHandler extends ExceptionCatcherEventHandler<UpgradeCcmR
         UpgradeCcmRemoveAgentRequest request = event.getData();
         Long stackId = request.getResourceId();
         LOGGER.info("Remove agent for CCM upgrade...");
+        upgradeCcmService.updateTunnel(stackId);
         try {
             upgradeCcmService.removeAgent(stackId, request.getOldTunnel());
         } catch (CloudbreakOrchestratorException e) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/ccm/upgrade/UpgradeCcmFlowIntegrationTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/ccm/upgrade/UpgradeCcmFlowIntegrationTest.java
@@ -143,8 +143,7 @@ class UpgradeCcmFlowIntegrationTest {
         inOrder.verify(upgradeCcmService, times(1)).updateTunnel(STACK_ID);
         inOrder.verify(upgradeCcmService, times(1)).pushSaltState(STACK_ID, CLUSTER_ID);
         inOrder.verify(upgradeCcmService, times(1)).reconfigureNginx(STACK_ID);
-        inOrder.verify(upgradeCcmService, times(1)).registerClusterProxy(STACK_ID);
-        inOrder.verify(upgradeCcmService, times(1)).healthCheck(STACK_ID);
+        inOrder.verify(upgradeCcmService, times(1)).registerClusterProxyAndCheckHealth(STACK_ID);
         inOrder.verify(upgradeCcmService, times(1)).removeAgent(STACK_ID, Tunnel.CCM);
         inOrder.verify(upgradeCcmService, times(1)).deregisterAgent(STACK_ID, Tunnel.CCM);
         verify(upgradeCcmService, never()).ccmUpgradeFailed(eq(STACK_ID), eq(CLUSTER_ID), eq(Tunnel.CCM), any());
@@ -165,15 +164,14 @@ class UpgradeCcmFlowIntegrationTest {
         inOrder.verify(upgradeCcmService, times(1)).ccmUpgradeFailed(STACK_ID, CLUSTER_ID, Tunnel.CCM, TunnelUpdateHandler.class);
         verify(upgradeCcmService, never()).pushSaltState(STACK_ID, CLUSTER_ID);
         verify(upgradeCcmService, never()).reconfigureNginx(STACK_ID);
-        verify(upgradeCcmService, never()).registerClusterProxy(STACK_ID);
-        verify(upgradeCcmService, never()).healthCheck(STACK_ID);
+        verify(upgradeCcmService, never()).registerClusterProxyAndCheckHealth(STACK_ID);
         verify(upgradeCcmService, never()).deregisterAgent(STACK_ID, Tunnel.CCM);
         verify(upgradeCcmService, never()).removeAgent(STACK_ID, Tunnel.CCM);
     }
 
     @Test
     public void testCcmUpgradeWhenRegisterClusterProxyFail() throws CloudbreakOrchestratorException {
-        doThrow(new BadRequestException()).when(upgradeCcmService).registerClusterProxy(STACK_ID);
+        doThrow(new BadRequestException()).when(upgradeCcmService).registerClusterProxyAndCheckHealth(STACK_ID);
 
         FlowIdentifier flowIdentifier = triggerFlow();
         letItFlow(flowIdentifier);
@@ -185,7 +183,7 @@ class UpgradeCcmFlowIntegrationTest {
         inOrder.verify(upgradeCcmService, times(1)).updateTunnel(STACK_ID);
         inOrder.verify(upgradeCcmService, times(1)).pushSaltState(STACK_ID, CLUSTER_ID);
         inOrder.verify(upgradeCcmService, times(1)).reconfigureNginx(STACK_ID);
-        inOrder.verify(upgradeCcmService, times(1)).registerClusterProxy(STACK_ID);
+        inOrder.verify(upgradeCcmService, times(1)).registerClusterProxyAndCheckHealth(STACK_ID);
         inOrder.verify(upgradeCcmService, times(1)).ccmUpgradeFailed(STACK_ID, CLUSTER_ID, Tunnel.CCM, RegisterClusterProxyHandler.class);
         verify(upgradeCcmService, never()).healthCheckState(STACK_ID);
         verify(upgradeCcmService, never()).deregisterAgent(STACK_ID, Tunnel.CCM);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/DeregisterAgentHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/DeregisterAgentHandlerTest.java
@@ -1,12 +1,13 @@
 package com.sequenceiq.cloudbreak.reactor.handler.cluster.upgrade.ccm;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -48,7 +49,9 @@ class DeregisterAgentHandlerTest {
         when(event.getData()).thenReturn(request);
 
         Selectable result = underTest.doAccept(event);
-        verify(upgradeCcmService).deregisterAgent(STACK_ID, Tunnel.CCM);
+        InOrder inOrder = inOrder(upgradeCcmService);
+        inOrder.verify(upgradeCcmService).updateTunnel(STACK_ID);
+        inOrder.verify(upgradeCcmService).deregisterAgent(STACK_ID, Tunnel.CCM);
         assertThat(result.selector()).isEqualTo("UPGRADECCMDEREGISTERAGENTRESULT");
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/HealthCheckHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/HealthCheckHandlerTest.java
@@ -1,7 +1,7 @@
 package com.sequenceiq.cloudbreak.reactor.handler.cluster.upgrade.ccm;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -48,7 +48,7 @@ class HealthCheckHandlerTest {
         when(event.getData()).thenReturn(request);
 
         Selectable result = underTest.doAccept(event);
-        verify(upgradeCcmService).healthCheck(STACK_ID);
+        verifyNoInteractions(upgradeCcmService);
         assertThat(result.selector()).isEqualTo("UPGRADECCMHEALTHCHECKRESULT");
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/PushSaltStateHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/PushSaltStateHandlerTest.java
@@ -1,12 +1,13 @@
 package com.sequenceiq.cloudbreak.reactor.handler.cluster.upgrade.ccm;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -48,7 +49,9 @@ class PushSaltStateHandlerTest {
         when(event.getData()).thenReturn(request);
 
         Selectable result = underTest.doAccept(event);
-        verify(upgradeCcmService).pushSaltState(STACK_ID, CLUSTER_ID);
+        InOrder inOrder = inOrder(upgradeCcmService);
+        inOrder.verify(upgradeCcmService).updateTunnel(STACK_ID);
+        inOrder.verify(upgradeCcmService).pushSaltState(STACK_ID, CLUSTER_ID);
         assertThat(result.selector()).isEqualTo("UPGRADECCMPUSHSALTSTATESRESULT");
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/ReconfigureNginxHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/ReconfigureNginxHandlerTest.java
@@ -3,12 +3,14 @@ package com.sequenceiq.cloudbreak.reactor.handler.cluster.upgrade.ccm;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -53,7 +55,9 @@ class ReconfigureNginxHandlerTest {
         when(event.getData()).thenReturn(request);
 
         Selectable result = underTest.doAccept(event);
-        verify(upgradeCcmService).reconfigureNginx(STACK_ID);
+        InOrder inOrder = inOrder(upgradeCcmService);
+        inOrder.verify(upgradeCcmService).updateTunnel(STACK_ID);
+        inOrder.verify(upgradeCcmService).reconfigureNginx(STACK_ID);
         assertThat(result.selector()).isEqualTo("UPGRADECCMRECONFIGURENGINXRESULT");
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/RegisterClusterProxyHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/RegisterClusterProxyHandlerTest.java
@@ -1,12 +1,13 @@
 package com.sequenceiq.cloudbreak.reactor.handler.cluster.upgrade.ccm;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -48,7 +49,9 @@ class RegisterClusterProxyHandlerTest {
         when(event.getData()).thenReturn(request);
 
         Selectable result = underTest.doAccept(event);
-        verify(upgradeCcmService).registerClusterProxy(STACK_ID);
+        InOrder inOrder = inOrder(upgradeCcmService);
+        inOrder.verify(upgradeCcmService).updateTunnel(STACK_ID);
+        inOrder.verify(upgradeCcmService).registerClusterProxyAndCheckHealth(STACK_ID);
         assertThat(result.selector()).isEqualTo("UPGRADECCMREGISTERCLUSTERPROXYRESULT");
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/RemoveAgentHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ccm/RemoveAgentHandlerTest.java
@@ -3,12 +3,14 @@ package com.sequenceiq.cloudbreak.reactor.handler.cluster.upgrade.ccm;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -53,7 +55,9 @@ class RemoveAgentHandlerTest {
         when(event.getData()).thenReturn(request);
 
         Selectable result = underTest.doAccept(event);
-        verify(upgradeCcmService).removeAgent(STACK_ID, Tunnel.CCM);
+        InOrder inOrder = inOrder(upgradeCcmService);
+        inOrder.verify(upgradeCcmService).updateTunnel(STACK_ID);
+        inOrder.verify(upgradeCcmService).removeAgent(STACK_ID, Tunnel.CCM);
         assertThat(result.selector()).isEqualTo("UPGRADECCMREMOVEAGENTRESULT");
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/handler/UpgradeCcmDeregisterMinaHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/handler/UpgradeCcmDeregisterMinaHandler.java
@@ -40,6 +40,7 @@ public class UpgradeCcmDeregisterMinaHandler extends AbstractUpgradeCcmEventHand
     @Override
     protected Selectable doAccept(HandlerEvent<UpgradeCcmEvent> event) {
         UpgradeCcmEvent request = event.getData();
+        upgradeCcmService.changeTunnel(request.getResourceId());
         if (request.getOldTunnel().useCcmV1()) {
             LOGGER.info("Deregistering mina for CCM upgrade...");
             upgradeCcmService.deregisterMina(request.getResourceId());

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/handler/UpgradeCcmHealthCheckHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/handler/UpgradeCcmHealthCheckHandler.java
@@ -4,15 +4,12 @@ import static com.sequenceiq.freeipa.flow.stack.upgrade.ccm.selector.UpgradeCcmH
 import static com.sequenceiq.freeipa.flow.stack.upgrade.ccm.selector.UpgradeCcmStateSelector.UPGRADE_CCM_FAILED_EVENT;
 import static com.sequenceiq.freeipa.flow.stack.upgrade.ccm.selector.UpgradeCcmStateSelector.UPGRADE_CCM_HEALTH_CHECK_FINISHED_EVENT;
 
-import javax.inject.Inject;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
-import com.sequenceiq.freeipa.flow.stack.upgrade.ccm.UpgradeCcmService;
 import com.sequenceiq.freeipa.flow.stack.upgrade.ccm.event.UpgradeCcmEvent;
 import com.sequenceiq.freeipa.flow.stack.upgrade.ccm.event.UpgradeCcmFailureEvent;
 
@@ -22,9 +19,6 @@ import reactor.bus.Event;
 public class UpgradeCcmHealthCheckHandler extends AbstractUpgradeCcmEventHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UpgradeCcmHealthCheckHandler.class);
-
-    @Inject
-    private UpgradeCcmService upgradeCcmService;
 
     @Override
     public String selector() {
@@ -39,13 +33,8 @@ public class UpgradeCcmHealthCheckHandler extends AbstractUpgradeCcmEventHandler
 
     @Override
     protected Selectable doAccept(HandlerEvent<UpgradeCcmEvent> event) {
+        // kept for forward compatibility with CB-14585
         UpgradeCcmEvent request = event.getData();
-        if (request.getOldTunnel().useCcmV1()) {
-            LOGGER.info("Health check for CCM upgrade...");
-            upgradeCcmService.healthCheck(request.getResourceId());
-        } else {
-            LOGGER.info("Health check is skipped for previous tunnel type '{}'", request.getOldTunnel());
-        }
         return UPGRADE_CCM_HEALTH_CHECK_FINISHED_EVENT.createBasedOn(request);
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/handler/UpgradeCcmObtainAgentDataHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/handler/UpgradeCcmObtainAgentDataHandler.java
@@ -40,6 +40,7 @@ public class UpgradeCcmObtainAgentDataHandler extends AbstractUpgradeCcmEventHan
     @Override
     protected Selectable doAccept(HandlerEvent<UpgradeCcmEvent> event) {
         UpgradeCcmEvent request = event.getData();
+        upgradeCcmService.changeTunnel(request.getResourceId());
         if (request.getOldTunnel().useCcmV1()) {
             LOGGER.info("Obtaining agent data for CCM upgrade...");
             upgradeCcmService.obtainAgentData(request.getResourceId());

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/handler/UpgradeCcmPushSaltStatesHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/handler/UpgradeCcmPushSaltStatesHandler.java
@@ -41,6 +41,7 @@ public class UpgradeCcmPushSaltStatesHandler extends AbstractUpgradeCcmEventHand
     @Override
     protected Selectable doAccept(HandlerEvent<UpgradeCcmEvent> event) {
         UpgradeCcmEvent request = event.getData();
+        upgradeCcmService.changeTunnel(request.getResourceId());
         if (request.getOldTunnel().useCcmV1()) {
             LOGGER.info("Pushing salt states for CCM upgrade...");
             try {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/handler/UpgradeCcmReconfigureNginxHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/handler/UpgradeCcmReconfigureNginxHandler.java
@@ -41,6 +41,7 @@ public class UpgradeCcmReconfigureNginxHandler extends AbstractUpgradeCcmEventHa
     @Override
     protected Selectable doAccept(HandlerEvent<UpgradeCcmEvent> event) {
         UpgradeCcmEvent request = event.getData();
+        upgradeCcmService.changeTunnel(request.getResourceId());
         if (request.getOldTunnel().useCcmV1()) {
             LOGGER.info("NGINX reconfiguration is needed for previous CCM tunnel type");
             try {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/handler/UpgradeCcmRegisterClusterProxyHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/handler/UpgradeCcmRegisterClusterProxyHandler.java
@@ -40,9 +40,10 @@ public class UpgradeCcmRegisterClusterProxyHandler extends AbstractUpgradeCcmEve
     @Override
     protected Selectable doAccept(HandlerEvent<UpgradeCcmEvent> event) {
         UpgradeCcmEvent request = event.getData();
+        upgradeCcmService.changeTunnel(request.getResourceId());
         if (request.getOldTunnel().useCcmV1()) {
             LOGGER.info("Registering to cluster proxy for CCM upgrade...");
-            upgradeCcmService.registerClusterProxy(request.getResourceId());
+            upgradeCcmService.registerClusterProxyAndCheckHealth(request.getResourceId());
         } else {
             LOGGER.info("Registering to cluster proxy step is skipped for previous tunnel type '{}'", request.getOldTunnel());
         }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/handler/UpgradeCcmRemoveMinaHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/handler/UpgradeCcmRemoveMinaHandler.java
@@ -42,6 +42,7 @@ public class UpgradeCcmRemoveMinaHandler extends AbstractUpgradeCcmEventHandler 
     @Override
     protected Selectable doAccept(HandlerEvent<UpgradeCcmEvent> event) {
         UpgradeCcmEvent request = event.getData();
+        upgradeCcmService.changeTunnel(request.getResourceId());
         if (request.getOldTunnel().useCcmV1()) {
             LOGGER.info("Remove Mina for CCM upgrade...");
             try {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/handler/UpgradeCcmUpgradeHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/handler/UpgradeCcmUpgradeHandler.java
@@ -41,6 +41,7 @@ public class UpgradeCcmUpgradeHandler extends AbstractUpgradeCcmEventHandler {
     @Override
     protected Selectable doAccept(HandlerEvent<UpgradeCcmEvent> event) {
         UpgradeCcmEvent request = event.getData();
+        upgradeCcmService.changeTunnel(request.getResourceId());
         if (request.getOldTunnel().useCcmV1()) {
             try {
                 LOGGER.info("Running upgrade state for CCM...");

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/chain/UpgradeCcmFlowChainIntegrationTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/chain/UpgradeCcmFlowChainIntegrationTest.java
@@ -92,11 +92,11 @@ class UpgradeCcmFlowChainIntegrationTest {
 
     private static final long STACK_ID = 1L;
 
-    private static final int ALL_CALLED_ONCE = 22;
+    private static final int ALL_CALLED_ONCE = 21;
 
-    private static final int CALLED_ONCE_TILL_DEREGISTER_MINA = 20;
+    private static final int CALLED_ONCE_TILL_DEREGISTER_MINA = 19;
 
-    private static final int CALLED_ONCE_TILL_GENERATE_USERDATA = 21;
+    private static final int CALLED_ONCE_TILL_GENERATE_USERDATA = 20;
 
     @Inject
     private FlowRegister flowRegister;
@@ -226,9 +226,8 @@ class UpgradeCcmFlowChainIntegrationTest {
         inOrder.verify(upgradeCcmService, times(expected[i++])).reconfigureNginxState(STACK_ID);
         inOrder.verify(upgradeCcmService, times(expected[i++])).reconfigureNginx(STACK_ID);
         inOrder.verify(upgradeCcmService, times(expected[i++])).registerClusterProxyState(STACK_ID);
-        inOrder.verify(upgradeCcmService, times(expected[i++])).registerClusterProxy(STACK_ID);
+        inOrder.verify(upgradeCcmService, times(expected[i++])).registerClusterProxyAndCheckHealth(STACK_ID);
         inOrder.verify(upgradeCcmService, times(expected[i++])).healthCheckState(STACK_ID);
-        inOrder.verify(upgradeCcmService, times(expected[i++])).healthCheck(STACK_ID);
         inOrder.verify(upgradeCcmService, times(expected[i++])).removeMinaState(STACK_ID);
         inOrder.verify(upgradeCcmService, times(expected[i++])).removeMina(STACK_ID);
         inOrder.verify(upgradeCcmService, times(expected[i++])).deregisterMinaState(STACK_ID);

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/UpgradeCcmFlowIntegrationTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/UpgradeCcmFlowIntegrationTest.java
@@ -80,11 +80,9 @@ class UpgradeCcmFlowIntegrationTest {
 
     private static final int CALLED_ONCE_TILL_REGISTER = 14;
 
-    private static final int CALLED_ONCE_TILL_HEALTH_CHECK = 16;
+    private static final int CALLED_ONCE_TILL_REMOVE_MINA = 17;
 
-    private static final int CALLED_ONCE_TILL_REMOVE_MINA = 18;
-
-    private static final int CALLED_ONCE_TILL_DEREGISTER_MINA = 20;
+    private static final int CALLED_ONCE_TILL_DEREGISTER_MINA = 19;
 
     @Inject
     private FlowRegister flowRegister;
@@ -155,14 +153,8 @@ class UpgradeCcmFlowIntegrationTest {
 
     @Test
     public void testCcmUpgradeWhenRegisterCcmFails() throws CloudbreakOrchestratorException {
-        doThrow(new BadRequestException()).when(upgradeCcmService).registerClusterProxy(1L);
+        doThrow(new BadRequestException()).when(upgradeCcmService).registerClusterProxyAndCheckHealth(1L);
         testFlow(CALLED_ONCE_TILL_REGISTER, false);
-    }
-
-    @Test
-    public void testCcmUpgradeWhenHealthCheckFails() throws CloudbreakOrchestratorException {
-        doThrow(new BadRequestException()).when(upgradeCcmService).healthCheck(1L);
-        testFlow(CALLED_ONCE_TILL_HEALTH_CHECK, false);
     }
 
     @Test
@@ -221,9 +213,8 @@ class UpgradeCcmFlowIntegrationTest {
         inOrder.verify(upgradeCcmService, times(expected[i++])).reconfigureNginxState(STACK_ID);
         inOrder.verify(upgradeCcmService, times(expected[i++])).reconfigureNginx(STACK_ID);
         inOrder.verify(upgradeCcmService, times(expected[i++])).registerClusterProxyState(STACK_ID);
-        inOrder.verify(upgradeCcmService, times(expected[i++])).registerClusterProxy(STACK_ID);
+        inOrder.verify(upgradeCcmService, times(expected[i++])).registerClusterProxyAndCheckHealth(STACK_ID);
         inOrder.verify(upgradeCcmService, times(expected[i++])).healthCheckState(STACK_ID);
-        inOrder.verify(upgradeCcmService, times(expected[i++])).healthCheck(STACK_ID);
         inOrder.verify(upgradeCcmService, times(expected[i++])).removeMinaState(STACK_ID);
         inOrder.verify(upgradeCcmService, times(expected[i++])).removeMina(STACK_ID);
         inOrder.verify(upgradeCcmService, times(expected[i++])).deregisterMinaState(STACK_ID);


### PR DESCRIPTION
If the upgrade flow goes into a failed state, the tunnel type is
reverted to the original.
However, in the case of retries at several handlers,
the tunnel type should have been kept on CCMV2_JUMPGATE
(e.g. registering cluster proxy or obtaining inverting proxy data).
This must be corrected: the tunnel must be updated to the
CCMV2_JUMPGATE value at the beginning of each handler.

The second issue is with cluster proxy re-registration's health check.
In case of a failed health status, the cluster proxy registration
must be repeated with the original tunnel type to ensure further
cluster communication.

Also, the cluster proxy registration and health check is merged
because it is idempotent only this way.

See detailed description in the commit message.