### PR TITLE
CB-17932 Remove type info from Exception properties in Payload classes

### DIFF
--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/flow/consumption/storage/event/StorageConsumptionCollectionFailureEvent.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/flow/consumption/storage/event/StorageConsumptionCollectionFailureEvent.java
@@ -1,15 +1,12 @@
 package com.sequenceiq.consumption.flow.consumption.storage.event;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
 import static com.sequenceiq.consumption.flow.consumption.storage.event.StorageConsumptionCollectionStateSelectors.STORAGE_CONSUMPTION_COLLECTION_FAILED_EVENT;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 public class StorageConsumptionCollectionFailureEvent extends StorageConsumptionCollectionEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/CloudPlatformResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/CloudPlatformResult.java
@@ -1,8 +1,5 @@
 package com.sequenceiq.cloudbreak.cloud.event;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.cloud.event.model.EventStatus;
 import com.sequenceiq.cloudbreak.common.event.Payload;
 
@@ -14,7 +11,6 @@ public class CloudPlatformResult implements Payload {
 
     private String statusReason;
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private Exception errorDetails;
 
     public CloudPlatformResult(Long resourceId) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/preparation/event/ClusterUpgradePreparationFailureEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/preparation/event/ClusterUpgradePreparationFailureEvent.java
@@ -1,16 +1,13 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.preparation.event;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.preparation.ClusterUpgradePreparationStateSelectors.FAILED_CLUSTER_UPGRADE_PREPARATION_EVENT;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackFailureEvent;
 
 public class ClusterUpgradePreparationFailureEvent extends StackFailureEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/event/ClusterUpgradeValidationFailureEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/event/ClusterUpgradeValidationFailureEvent.java
@@ -1,16 +1,13 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationStateSelectors.FAILED_CLUSTER_UPGRADE_VALIDATION_EVENT;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 
 public class ClusterUpgradeValidationFailureEvent extends StackEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/event/ClusterUpgradeValidationFinishedEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/event/ClusterUpgradeValidationFinishedEvent.java
@@ -1,16 +1,13 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationStateSelectors.FINISH_CLUSTER_UPGRADE_VALIDATION_EVENT;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 
 public class ClusterUpgradeValidationFinishedEvent extends StackEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     public ClusterUpgradeValidationFinishedEvent(Long resourceId) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cmdiagnostics/event/CmDiagnosticsCollectionFailureEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cmdiagnostics/event/CmDiagnosticsCollectionFailureEvent.java
@@ -1,17 +1,14 @@
 package com.sequenceiq.cloudbreak.core.flow2.cmdiagnostics.event;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
 import static com.sequenceiq.cloudbreak.core.flow2.cmdiagnostics.event.CmDiagnosticsCollectionStateSelectors.FAILED_CM_DIAGNOSTICS_COLLECTION_EVENT;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.common.model.diagnostics.CmDiagnosticsParameters;
 
 public class CmDiagnosticsCollectionFailureEvent extends CmDiagnosticsCollectionEvent implements Selectable {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/event/DiagnosticsCollectionFailureEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/event/DiagnosticsCollectionFailureEvent.java
@@ -1,17 +1,14 @@
 package com.sequenceiq.cloudbreak.core.flow2.diagnostics.event;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.DiagnosticsCollectionStateSelectors.FAILED_DIAGNOSTICS_COLLECTION_EVENT;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.common.model.diagnostics.DiagnosticParameters;
 
 public class DiagnosticsCollectionFailureEvent extends DiagnosticsCollectionEvent implements Selectable {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     private final String failureType;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/ClusterPlatformResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/ClusterPlatformResult.java
@@ -1,8 +1,5 @@
 package com.sequenceiq.cloudbreak.reactor.api;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.cloud.event.model.EventStatus;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.flow.event.EventSelectorUtil;
@@ -13,7 +10,6 @@ public abstract class ClusterPlatformResult<R extends ClusterPlatformRequest> im
 
     private String statusReason;
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private Exception errorDetails;
 
     private R request;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/StackFailureEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/StackFailureEvent.java
@@ -1,14 +1,10 @@
 package com.sequenceiq.cloudbreak.reactor.api.event;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 public class StackFailureEvent extends StackEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     public StackFailureEvent(Long stackId, Exception exception) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/dr/backup/DatabaseBackupFailedEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/dr/backup/DatabaseBackupFailedEvent.java
@@ -1,17 +1,13 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.dr.backup;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.dr.BackupRestoreEvent;
 
 public class DatabaseBackupFailedEvent extends BackupRestoreEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     private final DetailedStackStatus detailedStatus;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/dr/restore/DatabaseRestoreFailedEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/dr/restore/DatabaseRestoreFailedEvent.java
@@ -1,17 +1,13 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.dr.restore;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.dr.BackupRestoreEvent;
 
 public class DatabaseRestoreFailedEvent extends BackupRestoreEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     private final DetailedStackStatus detailedStatus;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ClusterUpgradeFailHandledRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ClusterUpgradeFailHandledRequest.java
@@ -1,17 +1,14 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.ClusterUpgradeEvent.CLUSTER_UPGRADE_FAIL_HANDLED_EVENT;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 
 public class ClusterUpgradeFailHandledRequest  extends StackEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     private final DetailedStackStatus detailedStatus;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ClusterUpgradeFailedCmSyncRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ClusterUpgradeFailedCmSyncRequest.java
@@ -1,19 +1,15 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 
 public class ClusterUpgradeFailedCmSyncRequest extends StackEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     private final DetailedStackStatus detailedStatus;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ClusterUpgradeFailedEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ClusterUpgradeFailedEvent.java
@@ -1,17 +1,14 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.ClusterUpgradeEvent.CLUSTER_UPGRADE_FAILED_EVENT;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 
 public class ClusterUpgradeFailedEvent extends StackEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     private final DetailedStackStatus detailedStatus;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/recovery/bringup/DatalakeRecoverySetupNewInstancesFailedEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/recovery/bringup/DatalakeRecoverySetupNewInstancesFailedEvent.java
@@ -1,16 +1,12 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.recovery.bringup;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 
 public class DatalakeRecoverySetupNewInstancesFailedEvent extends StackEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     private final DetailedStackStatus detailedStatus;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/externaldatabase/CreateExternalDatabaseFailed.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/externaldatabase/CreateExternalDatabaseFailed.java
@@ -1,15 +1,11 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.core.flow2.externaldatabase.ExternalDatabaseSelectableEvent;
 
 public class CreateExternalDatabaseFailed extends ExternalDatabaseSelectableEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/externaldatabase/StartExternalDatabaseFailed.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/externaldatabase/StartExternalDatabaseFailed.java
@@ -1,15 +1,11 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.core.flow2.externaldatabase.ExternalDatabaseSelectableEvent;
 
 public class StartExternalDatabaseFailed extends ExternalDatabaseSelectableEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/externaldatabase/StopExternalDatabaseFailed.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/externaldatabase/StopExternalDatabaseFailed.java
@@ -1,15 +1,11 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.core.flow2.externaldatabase.ExternalDatabaseSelectableEvent;
 
 public class StopExternalDatabaseFailed extends ExternalDatabaseSelectableEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/externaldatabase/TerminateExternalDatabaseFailed.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/externaldatabase/TerminateExternalDatabaseFailed.java
@@ -1,15 +1,11 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.core.flow2.externaldatabase.ExternalDatabaseSelectableEvent;
 
 public class TerminateExternalDatabaseFailed extends ExternalDatabaseSelectableEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxFailedEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxFailedEvent.java
@@ -1,12 +1,7 @@
 package com.sequenceiq.datalake.flow;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-
 public abstract class SdxFailedEvent extends SdxEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     public SdxFailedEvent(Long sdxId, String userId, Exception exception) {

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/cert/rotation/event/SdxCertRotationFailedEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/cert/rotation/event/SdxCertRotationFailedEvent.java
@@ -1,15 +1,11 @@
 package com.sequenceiq.datalake.flow.cert.rotation.event;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.datalake.flow.SdxEvent;
 
 public class SdxCertRotationFailedEvent extends SdxEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/recovery/event/DatalakeRecoveryCouldNotStartEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/recovery/event/DatalakeRecoveryCouldNotStartEvent.java
@@ -1,15 +1,11 @@
 package com.sequenceiq.datalake.flow.datalake.recovery.event;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.datalake.flow.SdxEvent;
 
 public class DatalakeRecoveryCouldNotStartEvent extends SdxEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/event/DatalakeUpgradeCouldNotStartEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/event/DatalakeUpgradeCouldNotStartEvent.java
@@ -1,16 +1,13 @@
 package com.sequenceiq.datalake.flow.datalake.upgrade.event;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
 import static com.sequenceiq.datalake.flow.datalake.upgrade.DatalakeUpgradeEvent.DATALAKE_UPGRADE_COULD_NOT_START_EVENT;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.datalake.flow.SdxEvent;
 
 public class DatalakeUpgradeCouldNotStartEvent extends SdxEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeBackupFailedEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeBackupFailedEvent.java
@@ -1,15 +1,11 @@
 package com.sequenceiq.datalake.flow.dr.backup.event;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.datalake.flow.SdxEvent;
 
 public class DatalakeBackupFailedEvent extends SdxEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeDatabaseBackupCouldNotStartEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeDatabaseBackupCouldNotStartEvent.java
@@ -1,14 +1,11 @@
 package com.sequenceiq.datalake.flow.dr.backup.event;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.datalake.flow.SdxEvent;
 
 public class DatalakeDatabaseBackupCouldNotStartEvent extends SdxEvent {
-    @JsonTypeInfo(use = CLASS, property = "@type")
+
     private final Exception exception;
 
     @JsonCreator

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeDatabaseBackupFailedEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeDatabaseBackupFailedEvent.java
@@ -1,15 +1,11 @@
 package com.sequenceiq.datalake.flow.dr.backup.event;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.datalake.flow.SdxEvent;
 
 public class DatalakeDatabaseBackupFailedEvent extends SdxEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/event/DatalakeDatabaseRestoreCouldNotStartEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/event/DatalakeDatabaseRestoreCouldNotStartEvent.java
@@ -1,15 +1,11 @@
 package com.sequenceiq.datalake.flow.dr.restore.event;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.datalake.flow.SdxEvent;
 
 public class DatalakeDatabaseRestoreCouldNotStartEvent extends SdxEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/event/DatalakeDatabaseRestoreFailedEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/event/DatalakeDatabaseRestoreFailedEvent.java
@@ -1,15 +1,11 @@
 package com.sequenceiq.datalake.flow.dr.restore.event;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.datalake.flow.SdxEvent;
 
 public class DatalakeDatabaseRestoreFailedEvent extends SdxEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/event/DatalakeRestoreFailedEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/event/DatalakeRestoreFailedEvent.java
@@ -1,18 +1,14 @@
 package com.sequenceiq.datalake.flow.dr.restore.event;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
 import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.datalake.flow.SdxContext;
 import com.sequenceiq.datalake.flow.SdxEvent;
 
 public class DatalakeRestoreFailedEvent extends SdxEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/repair/event/SdxRepairCouldNotStartEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/repair/event/SdxRepairCouldNotStartEvent.java
@@ -1,15 +1,11 @@
 package com.sequenceiq.datalake.flow.repair.event;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.datalake.flow.SdxEvent;
 
 public class SdxRepairCouldNotStartEvent extends SdxEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/event/EnvCreationFailureEvent.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/event/EnvCreationFailureEvent.java
@@ -1,16 +1,13 @@
 package com.sequenceiq.environment.environment.flow.creation.event;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
 import static com.sequenceiq.environment.environment.flow.creation.event.EnvCreationStateSelectors.FAILED_ENV_CREATION_EVENT;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.flow.reactor.api.event.BaseNamedFlowEvent;
 
 public class EnvCreationFailureEvent extends BaseNamedFlowEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/deletion/event/EnvClusterDeleteFailedEvent.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/deletion/event/EnvClusterDeleteFailedEvent.java
@@ -1,9 +1,7 @@
 package com.sequenceiq.environment.environment.flow.deletion.event;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
 import static com.sequenceiq.environment.environment.flow.deletion.event.EnvClustersDeleteStateSelectors.FAILED_ENV_CLUSTERS_DELETE_EVENT;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
@@ -12,7 +10,6 @@ import com.sequenceiq.flow.reactor.api.event.BaseNamedFlowEvent;
 @JsonDeserialize(builder = EnvClusterDeleteFailedEvent.EnvClusterDeleteFailedEventBuilder.class)
 public class EnvClusterDeleteFailedEvent extends BaseNamedFlowEvent implements Selectable {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     private final String message;

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/start/event/EnvStartFailedEvent.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/start/event/EnvStartFailedEvent.java
@@ -1,11 +1,9 @@
 package com.sequenceiq.environment.environment.flow.start.event;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
 import static com.sequenceiq.environment.environment.flow.start.event.EnvStartStateSelectors.FAILED_ENV_START_EVENT;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.environment.environment.EnvironmentStatus;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
@@ -13,7 +11,6 @@ import com.sequenceiq.flow.reactor.api.event.BaseFailedFlowEvent;
 
 public class EnvStartFailedEvent extends BaseFailedFlowEvent implements Selectable {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     private final EnvironmentDto environmentDto;

--- a/flow/src/main/java/com/sequenceiq/flow/core/chain/finalize/flowevents/FlowChainFinalizeFailedPayload.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/chain/finalize/flowevents/FlowChainFinalizeFailedPayload.java
@@ -1,16 +1,12 @@
 package com.sequenceiq.flow.core.chain.finalize.flowevents;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import reactor.rx.Promise;
 
 public class FlowChainFinalizeFailedPayload extends FlowChainFinalizePayload {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/flow/src/main/java/com/sequenceiq/flow/core/chain/init/flowevents/FlowChainInitFailedPayload.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/chain/init/flowevents/FlowChainInitFailedPayload.java
@@ -1,16 +1,12 @@
 package com.sequenceiq.flow.core.chain.init.flowevents;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import reactor.rx.Promise;
 
 public class FlowChainInitFailedPayload extends FlowChainInitPayload {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/flow/src/main/java/com/sequenceiq/flow/core/helloworld/flowevents/HelloWorldFailedEvent.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/helloworld/flowevents/HelloWorldFailedEvent.java
@@ -1,15 +1,11 @@
 package com.sequenceiq.flow.core.helloworld.flowevents;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.flow.core.helloworld.HelloWorldSelectableEvent;
 
 public class HelloWorldFailedEvent extends HelloWorldSelectableEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/flow/src/main/java/com/sequenceiq/flow/reactor/api/event/BaseFailedFlowEvent.java
+++ b/flow/src/main/java/com/sequenceiq/flow/reactor/api/event/BaseFailedFlowEvent.java
@@ -1,10 +1,7 @@
 package com.sequenceiq.flow.reactor.api.event;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.common.event.AcceptResult;
 import com.sequenceiq.cloudbreak.common.json.JsonIgnoreDeserialization;
 
@@ -12,7 +9,6 @@ import reactor.rx.Promise;
 
 public class BaseFailedFlowEvent extends BaseNamedFlowEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     public BaseFailedFlowEvent(String selector, Long resourceId, String resourceName, String resourceCrn, Exception exception) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/event/CreateBindUserFailureEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/event/CreateBindUserFailureEvent.java
@@ -1,16 +1,12 @@
 package com.sequenceiq.freeipa.flow.freeipa.binduser.create.event;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 public class CreateBindUserFailureEvent extends CreateBindUserEvent {
 
     private final String failureMessage;
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/event/DiagnosticsCollectionFailureEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/event/DiagnosticsCollectionFailureEvent.java
@@ -1,17 +1,14 @@
 package com.sequenceiq.freeipa.flow.freeipa.diagnostics.event;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
 import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.event.DiagnosticsCollectionStateSelectors.FAILED_DIAGNOSTICS_COLLECTION_EVENT;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.common.model.diagnostics.DiagnosticParameters;
 
 public class DiagnosticsCollectionFailureEvent extends DiagnosticsCollectionEvent implements Selectable {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     private final String failureType;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/event/DownscaleFailureEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/event/DownscaleFailureEvent.java
@@ -1,18 +1,14 @@
 package com.sequenceiq.freeipa.flow.freeipa.downscale.event;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
 import java.util.Map;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.freeipa.flow.stack.StackEvent;
 
 public class DownscaleFailureEvent extends StackEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     private final String failedPhase;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/repair/changeprimarygw/event/ChangePrimaryGatewayFailureEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/repair/changeprimarygw/event/ChangePrimaryGatewayFailureEvent.java
@@ -1,18 +1,14 @@
 package com.sequenceiq.freeipa.flow.freeipa.repair.changeprimarygw.event;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
 import java.util.Map;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.freeipa.flow.stack.StackEvent;
 
 public class ChangePrimaryGatewayFailureEvent extends StackEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     private final String failedPhase;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/event/UpscaleFailureEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/event/UpscaleFailureEvent.java
@@ -1,18 +1,14 @@
 package com.sequenceiq.freeipa.flow.freeipa.upscale.event;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
 import java.util.Map;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.sequenceiq.freeipa.flow.stack.StackEvent;
 
 public class UpscaleFailureEvent extends StackEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     private final String failedPhase;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/InstanceFailureEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/InstanceFailureEvent.java
@@ -1,16 +1,12 @@
 package com.sequenceiq.freeipa.flow.instance;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 public class InstanceFailureEvent extends InstanceEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     @JsonCreator

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/StackFailureEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/StackFailureEvent.java
@@ -1,14 +1,10 @@
 package com.sequenceiq.freeipa.flow.stack;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 public class StackFailureEvent extends StackEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     public StackFailureEvent(Long stackId, Exception exception) {

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/common/RedbeamsFailureEvent.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/common/RedbeamsFailureEvent.java
@@ -1,14 +1,10 @@
 package com.sequenceiq.redbeams.flow.redbeams.common;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 public class RedbeamsFailureEvent extends RedbeamsEvent {
 
-    @JsonTypeInfo(use = CLASS, property = "@type")
     private final Exception exception;
 
     public RedbeamsFailureEvent(Long resourceId, Exception exception) {


### PR DESCRIPTION
Adding type info for exceptions seems a dead-end.
It turned out that some exception types cannot be deserialized
(e.g. Jersey exceptions)
Thus, type information should be omitted (as it is the default
behavior anyway).

See detailed description in the commit message.