### PR TITLE
CB-17866 Stop postgres before initdb script

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/init.sls
@@ -68,10 +68,16 @@ include:
   - postgresql.pg11
 {%- endif %}
 
+ensure-postgres-stopped-before-initdb:
+  service.dead:
+    - name: postgresql
+    - unless: grep -q UTF-8 {{ postgres_directory }}/initdb.log && test -f {{ postgres_directory }}/data/PG_VERSION
+
 init-db-with-utf8:
   cmd.run:
     - name: rm -rf {{ postgres_directory }}/data/* && runuser -l postgres -s /bin/bash sh -c 'initdb --locale=en_US.UTF-8 {{ postgres_directory }}/data > {{ postgres_directory }}/initdb.log' && rm -f {{ postgres_log_directory }}/pgsql_listen_address_configured
     - unless: grep -q UTF-8 {{ postgres_directory }}/initdb.log && test -f {{ postgres_directory }}/data/PG_VERSION
+    - failhard: True
 
 {%- if postgres_data_on_attached_disk %}
 


### PR DESCRIPTION
The previous commit: https://github.com/hortonworks/cloudbreak/commit/3b68a8897479ba4c4bb2ab7f2a4d25056b8cd4b0
Fixed an issue where the symlink was deleted instead of the actual data. But running postgres 10 can cause issues when deleting data,
so postgres is stopped before deleted.

Tested with:
- AWS DH pg10 attached disk
- AWS DH pg10 root disk
- AWS DH pg11 attached disk
- AWS DH pg11 root disk
- ycloud sdx pg10
- ycloud sdx pg11

See detailed description in the commit message.