### PR TITLE
CB-17181 Fallback saltuser password rotation

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
@@ -388,6 +388,7 @@ public enum ResourceEvent {
     CLUSTER_PILLAR_CONFIG_UPDATE_FINISHED("cluster.pillar.config.update.finished"),
     CLUSTER_PILLAR_CONFIG_UPDATE_STARTED("cluster.pillar.config.update.started"),
     CLUSTER_SALT_PASSWORD_ROTATE_STARTED("cluster.salt.passwordrotate.started"),
+    CLUSTER_SALT_PASSWORD_ROTATE_STARTED_FALLBACK("cluster.salt.passwordrotate.started.fallback"),
     CLUSTER_SALT_PASSWORD_ROTATE_FINISHED("cluster.salt.passwordrotate.finished"),
     CLUSTER_SALT_PASSWORD_ROTATE_FAILED("cluster.salt.passwordrotate.failed"),
     CLUSTER_STOPPING("cluster.stopping"),

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -354,6 +354,7 @@ cluster.pillar.config.update.finished=Cluster configuration successfully updated
 cluster.pillar.config.update.failed=Failed to update cluster configuration,
 
 cluster.salt.passwordrotate.started=SaltStack user password rotation started
+cluster.salt.passwordrotate.started.fallback=SaltStack user password rotation started with fallback implementation, please upgrade your cluster for a better user experience
 cluster.salt.passwordrotate.finished=SaltStack user password successfully rotated
 cluster.salt.passwordrotate.failed=SaltStack user password rotation failed with error: {0}
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/salt/rotatepassword/RotateSaltPasswordAction.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/salt/rotatepassword/RotateSaltPasswordAction.java
@@ -11,6 +11,7 @@ import com.sequenceiq.cloudbreak.common.event.Payload;
 import com.sequenceiq.cloudbreak.core.flow2.AbstractStackAction;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordFailureResponse;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordReason;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordType;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 import com.sequenceiq.cloudbreak.view.StackView;
 import com.sequenceiq.flow.core.FlowParameters;
@@ -19,6 +20,8 @@ public abstract class RotateSaltPasswordAction<P extends Payload>
         extends AbstractStackAction<RotateSaltPasswordState, RotateSaltPasswordEvent, RotateSaltPasswordContext, P> {
 
     public static final String REASON = "reason";
+
+    public static final String TYPE = "type";
 
     @Inject
     private StackDtoService stackDtoService;
@@ -33,7 +36,8 @@ public abstract class RotateSaltPasswordAction<P extends Payload>
         StackView stack = stackDtoService.getStackViewById(payload.getResourceId());
         Map<Object, Object> variables = stateContext.getExtendedState().getVariables();
         RotateSaltPasswordReason reason = (RotateSaltPasswordReason) variables.getOrDefault(REASON, RotateSaltPasswordReason.MANUAL);
-        return new RotateSaltPasswordContext(flowParameters, stack, reason);
+        RotateSaltPasswordType type = (RotateSaltPasswordType) variables.getOrDefault(TYPE, RotateSaltPasswordType.FALLBACK);
+        return new RotateSaltPasswordContext(flowParameters, stack, reason, type);
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/salt/rotatepassword/RotateSaltPasswordActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/salt/rotatepassword/RotateSaltPasswordActions.java
@@ -45,18 +45,19 @@ public class RotateSaltPasswordActions {
             protected void prepareExecution(RotateSaltPasswordRequest payload, Map<Object, Object> variables) {
                 super.prepareExecution(payload, variables);
                 variables.put(REASON, payload.getReason());
+                variables.put(TYPE, payload.getType());
             }
 
             @Override
             protected void doExecute(RotateSaltPasswordContext context, RotateSaltPasswordRequest payload, Map<Object, Object> variables) throws Exception {
                 LOGGER.info("Rotating salt password for stack {}", context.getStack().getResourceCrn());
-                saltUpdateService.rotateSaltPassword(context.getStackId());
+                saltUpdateService.rotateSaltPassword(context.getStackId(), context.getType());
                 sendEvent(context);
             }
 
             @Override
             protected Selectable createRequest(RotateSaltPasswordContext context) {
-                return new RotateSaltPasswordRequest(context.getStack().getId(), context.getReason());
+                return new RotateSaltPasswordRequest(context.getStack().getId(), context.getReason(), context.getType());
             }
         };
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/salt/rotatepassword/RotateSaltPasswordContext.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/salt/rotatepassword/RotateSaltPasswordContext.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.salt.rotatepassword;
 
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordReason;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordType;
 import com.sequenceiq.cloudbreak.view.StackView;
 import com.sequenceiq.flow.core.CommonContext;
 import com.sequenceiq.flow.core.FlowParameters;
@@ -11,10 +12,13 @@ public class RotateSaltPasswordContext extends CommonContext {
 
     private final RotateSaltPasswordReason reason;
 
-    public RotateSaltPasswordContext(FlowParameters flowParameters, StackView stack, RotateSaltPasswordReason reason) {
+    private final RotateSaltPasswordType type;
+
+    public RotateSaltPasswordContext(FlowParameters flowParameters, StackView stack, RotateSaltPasswordReason reason, RotateSaltPasswordType type) {
         super(flowParameters);
         this.stack = stack;
         this.reason = reason;
+        this.type = type;
     }
 
     public StackView getStack() {
@@ -27,5 +31,9 @@ public class RotateSaltPasswordContext extends CommonContext {
 
     public RotateSaltPasswordReason getReason() {
         return reason;
+    }
+
+    public RotateSaltPasswordType getType() {
+        return type;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/salt/update/SaltUpdateService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/salt/update/SaltUpdateService.java
@@ -6,6 +6,7 @@ import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.UPDATE_FAI
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.UPDATE_IN_PROGRESS;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_RUN_SERVICES;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SALT_PASSWORD_ROTATE_STARTED;
+import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SALT_PASSWORD_ROTATE_STARTED_FALLBACK;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SALT_UPDATE_FAILED;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SALT_UPDATE_FINISHED;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SALT_UPDATE_STARTED;
@@ -20,6 +21,8 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.provision.service.ClusterCreationService;
 import com.sequenceiq.cloudbreak.core.flow2.stack.CloudbreakFlowMessageService;
+import com.sequenceiq.cloudbreak.event.ResourceEvent;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordType;
 import com.sequenceiq.cloudbreak.service.StackUpdater;
 import com.sequenceiq.cloudbreak.view.StackView;
 
@@ -47,8 +50,12 @@ public class SaltUpdateService {
         flowMessageService.fireEventAndLog(stackId, UPDATE_IN_PROGRESS.name(), CLUSTER_RUN_SERVICES);
     }
 
-    public void rotateSaltPassword(Long stackId) {
-        flowMessageService.fireEventAndLog(stackId, UPDATE_IN_PROGRESS.name(), CLUSTER_SALT_PASSWORD_ROTATE_STARTED);
+    public void rotateSaltPassword(Long stackId, RotateSaltPasswordType type) {
+        stackUpdater.updateStackStatus(stackId, DetailedStackStatus.BOOTSTRAPPING_MACHINES);
+        ResourceEvent event = type.equals(RotateSaltPasswordType.FALLBACK)
+                ? CLUSTER_SALT_PASSWORD_ROTATE_STARTED_FALLBACK
+                : CLUSTER_SALT_PASSWORD_ROTATE_STARTED;
+        flowMessageService.fireEventAndLog(stackId, UPDATE_IN_PROGRESS.name(), event);
     }
 
     public void clusterInstallationFinished(Long stackId) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
@@ -53,7 +53,6 @@ import com.sequenceiq.cloudbreak.core.flow2.event.ClusterScaleTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterUpgradeTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.DatabaseBackupTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.DatabaseRestoreTriggerEvent;
-import com.sequenceiq.cloudbreak.core.flow2.event.UpgradePreparationChainTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.DistroXUpgradeTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.MaintenanceModeValidationTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.MultiHostgroupClusterAndStackDownscaleTriggerEvent;
@@ -62,6 +61,7 @@ import com.sequenceiq.cloudbreak.core.flow2.event.StackDownscaleTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.StackImageUpdateTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.StackLoadBalancerUpdateTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.StackSyncTriggerEvent;
+import com.sequenceiq.cloudbreak.core.flow2.event.UpgradePreparationChainTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.stack.clusterproxy.reregister.ClusterProxyReRegistrationEvent;
 import com.sequenceiq.cloudbreak.core.flow2.stack.termination.StackTerminationEvent;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
@@ -69,6 +69,7 @@ import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordReason;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordRequest;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordType;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.rds.UpgradeRdsTriggerRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.ClusterRepairTriggerEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.CmSyncTriggerEvent;
@@ -218,9 +219,9 @@ public class ReactorFlowManager {
         return reactorNotifier.notify(stackId, selector, new StackEvent(selector, stackId));
     }
 
-    public FlowIdentifier triggerRotateSaltPassword(Long stackId, RotateSaltPasswordReason reason) {
+    public FlowIdentifier triggerRotateSaltPassword(Long stackId, RotateSaltPasswordReason reason, RotateSaltPasswordType type) {
         String selector = RotateSaltPasswordEvent.ROTATE_SALT_PASSWORD_EVENT.event();
-        return reactorNotifier.notify(stackId, selector, new RotateSaltPasswordRequest(stackId, reason));
+        return reactorNotifier.notify(stackId, selector, new RotateSaltPasswordRequest(stackId, reason, type));
     }
 
     public FlowIdentifier triggerClusterReInstall(Long stackId) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/RotateSaltPasswordRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/RotateSaltPasswordRequest.java
@@ -8,15 +8,32 @@ public class RotateSaltPasswordRequest extends StackEvent {
 
     private final RotateSaltPasswordReason reason;
 
+    private final RotateSaltPasswordType type;
+
     @JsonCreator
     public RotateSaltPasswordRequest(
             @JsonProperty("resourceId") Long stackId,
-            @JsonProperty("reason") RotateSaltPasswordReason reason) {
+            @JsonProperty("reason") RotateSaltPasswordReason reason,
+            @JsonProperty("type") RotateSaltPasswordType type) {
         super(stackId);
         this.reason = reason;
+        this.type = type;
     }
 
     public RotateSaltPasswordReason getReason() {
         return reason;
+    }
+
+    public RotateSaltPasswordType getType() {
+        return type;
+    }
+
+    @Override
+    public String toString() {
+        return "RotateSaltPasswordRequest{" +
+                super.toString() +
+                ", reason=" + reason +
+                ", type=" + type +
+                '}';
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/RotateSaltPasswordType.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/RotateSaltPasswordType.java
@@ -1,0 +1,6 @@
+package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
+
+public enum RotateSaltPasswordType {
+    FALLBACK,
+    SALT_BOOTSTRAP_ENDPOINT,
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/RotateSaltPasswordService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/RotateSaltPasswordService.java
@@ -3,8 +3,11 @@ package com.sequenceiq.cloudbreak.service;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -16,15 +19,18 @@ import com.cloudera.thunderhead.service.common.usage.UsageProto;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.service.Clock;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterBootstrapper;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.SaltBootstrapVersionChecker;
 import com.sequenceiq.cloudbreak.core.flow2.service.ReactorFlowManager;
 import com.sequenceiq.cloudbreak.domain.SecurityConfig;
 import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.quartz.saltstatuschecker.SaltStatusCheckerConfig;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordReason;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordType;
 import com.sequenceiq.cloudbreak.service.securityconfig.SecurityConfigService;
 import com.sequenceiq.cloudbreak.usage.UsageReporter;
 import com.sequenceiq.cloudbreak.util.PasswordUtil;
@@ -39,6 +45,8 @@ public class RotateSaltPasswordService {
     protected static final String UNAUTHORIZED_RESPONSE = "Status: 401 Unauthorized Response";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RotateSaltPasswordService.class);
+
+    private static final String SALTUSER_DELETE_COMMAND = "userdel saltuser";
 
     @Inject
     private SaltStatusCheckerConfig saltStatusCheckerConfig;
@@ -62,6 +70,9 @@ public class RotateSaltPasswordService {
     private UsageReporter usageReporter;
 
     @Inject
+    private ClusterBootstrapper clusterBootstrapper;
+
+    @Inject
     private EntitlementService entitlementService;
 
     @Inject
@@ -71,10 +82,8 @@ public class RotateSaltPasswordService {
         if (!entitlementService.isSaltUserPasswordRotationEnabled(stack.getAccountId())) {
             throw new BadRequestException("Rotating SaltStack user password is not supported in your account");
         }
-        if (!isChangeSaltuserPasswordSupported(stack)) {
-            throw new BadRequestException(String.format("Rotating SaltStack user password is not supported with your image version, " +
-                            "please upgrade to an image with salt-bootstrap version >= %s (you can find this information in the image catalog)",
-                    SaltBootstrapVersionChecker.CHANGE_SALTUSER_PASSWORD_SUPPORT_MIN_VERSION));
+        if (stack.getNotTerminatedAndNotZombieGatewayInstanceMetadata().isEmpty()) {
+            throw new IllegalStateException("There are no available gateway instances");
         }
     }
 
@@ -86,17 +95,57 @@ public class RotateSaltPasswordService {
 
     public FlowIdentifier triggerRotateSaltPassword(StackDto stack, RotateSaltPasswordReason reason) {
         validateRotateSaltPassword(stack);
-        return flowManager.triggerRotateSaltPassword(stack.getId(), reason);
+        RotateSaltPasswordType rotateSaltPasswordType = getRotateSaltPasswordType(stack);
+        LOGGER.info("Triggering rotate salt password for stack {} with type {}", stack.getId(), rotateSaltPasswordType);
+        return flowManager.triggerRotateSaltPassword(stack.getId(), reason, rotateSaltPasswordType);
+    }
+
+    private RotateSaltPasswordType getRotateSaltPasswordType(StackDto stack) {
+        return isChangeSaltuserPasswordSupported(stack) ? RotateSaltPasswordType.SALT_BOOTSTRAP_ENDPOINT : RotateSaltPasswordType.FALLBACK;
     }
 
     public void rotateSaltPassword(StackDto stack) throws CloudbreakOrchestratorException {
         validateRotateSaltPassword(stack);
-        SecurityConfig securityConfig = securityConfigService.getOneByStackId(stack.getId());
+        SecurityConfig securityConfig = stack.getSecurityConfig();
         String oldPassword = securityConfig.getSaltSecurityConfig().getSaltPassword();
         String newPassword = PasswordUtil.generatePassword();
         List<GatewayConfig> allGatewayConfig = gatewayConfigService.getAllGatewayConfigs(stack);
         hostOrchestrator.changePassword(allGatewayConfig, newPassword, oldPassword);
         securityConfigService.changeSaltPassword(securityConfig, newPassword);
+    }
+
+    public void rotateSaltPasswordFallback(StackDto stack) throws CloudbreakOrchestratorFailedException {
+        List<GatewayConfig> allGatewayConfig = gatewayConfigService.getAllGatewayConfigs(stack);
+        tryRemoveSaltuserFromGateways(stack, allGatewayConfig);
+
+        String newPassword = PasswordUtil.generatePassword();
+        SecurityConfig securityConfig = stack.getSecurityConfig();
+        securityConfig.getSaltSecurityConfig().setSaltPassword(newPassword);
+        try {
+            clusterBootstrapper.reBootstrapOnHost(stack);
+            securityConfigService.changeSaltPassword(securityConfig, newPassword);
+        } catch (CloudbreakException e) {
+            Set<String> gatewayConfigAddresses = allGatewayConfig.stream()
+                    .map(GatewayConfig::getPrivateAddress)
+                    .collect(Collectors.toSet());
+            LOGGER.warn("Failed to re-bootstrap gateway nodes after saltuser password delete", e);
+            String message = String.format("Failed to re-bootstrap gateway nodes after saltuser password delete. " +
+                            "Please check the salt-bootstrap service status on node(s) %s. " +
+                            "If the saltuser password was changed manually, " +
+                            "please remove the user manually with the command '%s' on node(s) %s and retry the operation.",
+                    gatewayConfigAddresses, SALTUSER_DELETE_COMMAND, gatewayConfigAddresses);
+            throw new CloudbreakOrchestratorFailedException(message, e);
+        }
+    }
+
+    private void tryRemoveSaltuserFromGateways(StackDto stack, List<GatewayConfig> allGatewayConfig) {
+        try {
+            Map<String, String> response = hostOrchestrator.runCommandOnHosts(allGatewayConfig, stack.getAllPrimaryGatewayInstanceNodes(),
+                    SALTUSER_DELETE_COMMAND);
+            LOGGER.debug("Saltuser delete command response: {}", response);
+        } catch (CloudbreakOrchestratorFailedException e) {
+            LOGGER.warn("Failed to run saltuser delete command, assuming it is already deleted", e);
+        }
     }
 
     public void sendSuccessUsageReport(String resourceCrn, RotateSaltPasswordReason reason) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
@@ -452,6 +452,7 @@ public class StackOperationService {
     public FlowIdentifier rotateSaltPassword(@NotNull NameOrCrn nameOrCrn, String accountId, RotateSaltPasswordReason reason) {
         StackDto stack = stackDtoService.getByNameOrCrn(nameOrCrn, accountId);
         MDCBuilder.buildMdcContext(stack);
+        rotateSaltPasswordService.validateRotateSaltPassword(stack);
         return rotateSaltPasswordService.triggerRotateSaltPassword(stack, reason);
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
@@ -46,6 +46,7 @@ import com.sequenceiq.cloudbreak.core.flow2.service.ReactorNotifier;
 import com.sequenceiq.cloudbreak.core.flow2.service.TerminationTriggerService;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordReason;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordType;
 import com.sequenceiq.cloudbreak.service.image.ImageChangeDto;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.service.stack.repair.UnhealthyInstances;
@@ -159,8 +160,8 @@ public class ReactorFlowManagerTest {
         underTest.triggerStopStartStackDownscale(STACK_ID, instanceIdsByHostgroup, false);
         underTest.triggerClusterServicesRestart(STACK_ID);
         underTest.triggerClusterProxyConfigReRegistration(STACK_ID);
-        underTest.triggerRotateSaltPassword(STACK_ID, RotateSaltPasswordReason.MANUAL);
         underTest.triggerRdsUpgrade(STACK_ID, TargetMajorVersion.VERSION_11);
+        underTest.triggerRotateSaltPassword(STACK_ID, RotateSaltPasswordReason.MANUAL, RotateSaltPasswordType.FALLBACK);
 
         int count = 0;
         for (Method method : underTest.getClass().getDeclaredMethods()) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/RotateSaltPasswordServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/RotateSaltPasswordServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -15,6 +16,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,19 +31,23 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.cloudera.thunderhead.service.common.usage.UsageProto;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.common.orchestration.Node;
 import com.sequenceiq.cloudbreak.common.service.Clock;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterBootstrapper;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.SaltBootstrapVersionChecker;
+import com.sequenceiq.cloudbreak.core.flow2.service.ReactorFlowManager;
 import com.sequenceiq.cloudbreak.domain.SaltSecurityConfig;
 import com.sequenceiq.cloudbreak.domain.SecurityConfig;
-import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.quartz.saltstatuschecker.SaltStatusCheckerConfig;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordReason;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordType;
 import com.sequenceiq.cloudbreak.service.securityconfig.SecurityConfigService;
 import com.sequenceiq.cloudbreak.usage.UsageReporter;
+import com.sequenceiq.cloudbreak.view.InstanceMetadataView;
 
 @ExtendWith(MockitoExtension.class)
 class RotateSaltPasswordServiceTest {
@@ -49,6 +55,8 @@ class RotateSaltPasswordServiceTest {
     private static final String STACK_CRN = "crn:cdp:datalake:us-west-1:cloudera:datalake:33071a14-d605-4b2d-9a55-218c0dbc95e3";
 
     private static final String ACCOUNT_ID = "0";
+
+    private static final String OLD_PASSWORD = "old-password";
 
     @Mock
     private UsageReporter usageReporter;
@@ -69,6 +77,9 @@ class RotateSaltPasswordServiceTest {
     private EntitlementService entitlementService;
 
     @Mock
+    private ClusterBootstrapper clusterBootstrapper;
+
+    @Mock
     private Clock clock;
 
     @Mock
@@ -78,7 +89,7 @@ class RotateSaltPasswordServiceTest {
     private StackDto stack;
 
     @Mock
-    private List<GatewayConfig> gatewayConfigs;
+    private ReactorFlowManager flowManager;
 
     @Captor
     private ArgumentCaptor<String> stringArgumentCaptor;
@@ -89,29 +100,37 @@ class RotateSaltPasswordServiceTest {
     @InjectMocks
     private RotateSaltPasswordService underTest;
 
+    private List<GatewayConfig> gatewayConfigs;
+
+    private SecurityConfig securityConfig;
+
     @BeforeEach
     void setUp() {
+        lenient().when(stack.isAvailable()).thenReturn(true);
         lenient().when(stack.getAccountId()).thenReturn(ACCOUNT_ID);
         lenient().when(entitlementService.isSaltUserPasswordRotationEnabled(ACCOUNT_ID)).thenReturn(true);
+
+        GatewayConfig gw1 = new GatewayConfig("host1", "1.1.1.1", "1.1.1.1", 22, "i-1839", false);
+        GatewayConfig gw2 = new GatewayConfig("host2", "1.1.1.2", "1.1.1.2", 22, "i-1839", false);
+        gatewayConfigs = List.of(gw1, gw2);
+        lenient().when(gatewayConfigService.getAllGatewayConfigs(any())).thenReturn(gatewayConfigs);
+
+        SaltSecurityConfig saltSecurityConfig = new SaltSecurityConfig();
+        saltSecurityConfig.setSaltPassword(OLD_PASSWORD);
+        securityConfig = new SecurityConfig();
+        securityConfig.setSaltSecurityConfig(saltSecurityConfig);
+        lenient().when(stack.getSecurityConfig()).thenReturn(securityConfig);
+
+        lenient().when(stack.getNotTerminatedAndNotZombieGatewayInstanceMetadata()).thenReturn(List.of(mock(InstanceMetadataView.class)));
     }
 
     @Test
     public void testRotateSaltPasswordSuccess() throws Exception {
-        GatewayConfig gw1 = new GatewayConfig("host1", "1.1.1.1", "1.1.1.1", 22, "i-1839", false);
-        GatewayConfig gw2 = new GatewayConfig("host2", "1.1.1.2", "1.1.1.2", 22, "i-1839", false);
-        List<GatewayConfig> gatewayConfigs = List.of(gw1, gw2);
-        when(gatewayConfigService.getAllGatewayConfigs(any())).thenReturn(gatewayConfigs);
-
-        SaltSecurityConfig saltSecurityConfig = new SaltSecurityConfig();
-        saltSecurityConfig.setSaltPassword("old-password");
-        SecurityConfig securityConfig = new SecurityConfig();
-        securityConfig.setSaltSecurityConfig(saltSecurityConfig);
-        when(securityConfigService.getOneByStackId(stack.getId())).thenReturn(securityConfig);
-
         underTest.rotateSaltPassword(stack);
 
         verify(gatewayConfigService).getAllGatewayConfigs(stack);
-        verify(hostOrchestrator).changePassword(eq(gatewayConfigs), stringArgumentCaptor.capture(), eq(saltSecurityConfig.getSaltPassword()));
+        verify(hostOrchestrator).changePassword(eq(gatewayConfigs), stringArgumentCaptor.capture(),
+                eq(securityConfig.getSaltSecurityConfig().getSaltPassword()));
         String newPassword = stringArgumentCaptor.getValue();
         verify(securityConfigService).changeSaltPassword(securityConfig, newPassword);
     }
@@ -126,26 +145,18 @@ class RotateSaltPasswordServiceTest {
     }
 
     @Test
-    public void testRotateSaltPasswordOnStackWithOldSBVersion() {
-        when(stack.getNotTerminatedAndNotZombieGatewayInstanceMetadata()).thenReturn(List.of(new InstanceMetaData()));
-        when(saltBootstrapVersionChecker.isChangeSaltuserPasswordSupported(any())).thenReturn(false);
+    public void testRotateSaltPasswordOnStackWithoutAvailableGateway() {
+        when(stack.getNotTerminatedAndNotZombieGatewayInstanceMetadata()).thenReturn(List.of());
 
         Assertions.assertThatThrownBy(() -> underTest.rotateSaltPassword(stack))
-                .isInstanceOf(BadRequestException.class)
-                .hasMessage("Rotating SaltStack user password is not supported with your image version, " +
-                        "please upgrade to an image with salt-bootstrap version >= 0.13.6 (you can find this information in the image catalog)");
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("There are no available gateway instances");
     }
 
     @Test
     public void testRotateSaltPasswordFailure() throws Exception {
-        SaltSecurityConfig saltSecurityConfig = new SaltSecurityConfig();
-        saltSecurityConfig.setSaltPassword("old-password");
-        SecurityConfig securityConfig = new SecurityConfig();
-        securityConfig.setSaltSecurityConfig(saltSecurityConfig);
-        when(securityConfigService.getOneByStackId(stack.getId())).thenReturn(securityConfig);
-
         CloudbreakOrchestratorFailedException cause = new CloudbreakOrchestratorFailedException("reason");
-        doThrow(cause).when(hostOrchestrator).changePassword(any(), anyString(), eq(saltSecurityConfig.getSaltPassword()));
+        doThrow(cause).when(hostOrchestrator).changePassword(any(), anyString(), eq(securityConfig.getSaltSecurityConfig().getSaltPassword()));
 
         Assertions.assertThatThrownBy(() -> underTest.rotateSaltPassword(stack))
                 .isEqualTo(cause);
@@ -153,6 +164,70 @@ class RotateSaltPasswordServiceTest {
         verify(gatewayConfigService).getAllGatewayConfigs(stack);
         verify(hostOrchestrator).changePassword(any(), anyString(), anyString());
         verify(securityConfigService, never()).changeSaltPassword(eq(securityConfig), anyString());
+    }
+
+    @Test
+    void rotateSaltPasswordFallbackSuccess() throws Exception {
+        Set<Node> nodes = Set.of(mock(Node.class));
+        when(stack.getAllPrimaryGatewayInstanceNodes()).thenReturn(nodes);
+
+        underTest.rotateSaltPasswordFallback(stack);
+
+        String newPassword = stack.getSecurityConfig().getSaltSecurityConfig().getSaltPassword();
+        assertThat(newPassword).isNotEqualTo(OLD_PASSWORD);
+        verify(hostOrchestrator).runCommandOnHosts(gatewayConfigs, nodes, "userdel saltuser");
+        verify(clusterBootstrapper).reBootstrapOnHost(stack);
+        verify(securityConfigService).changeSaltPassword(securityConfig, newPassword);
+    }
+
+    @Test
+    void rotateSaltPasswordFallbackUserDeleteFails() throws Exception {
+        Set<Node> nodes = Set.of(mock(Node.class));
+        when(stack.getAllPrimaryGatewayInstanceNodes()).thenReturn(nodes);
+        when(hostOrchestrator.runCommandOnHosts(gatewayConfigs, nodes, "userdel saltuser")).thenThrow(CloudbreakOrchestratorFailedException.class);
+
+        underTest.rotateSaltPasswordFallback(stack);
+
+        String newPassword = stack.getSecurityConfig().getSaltSecurityConfig().getSaltPassword();
+        assertThat(newPassword).isNotEqualTo(OLD_PASSWORD);
+        verify(hostOrchestrator).runCommandOnHosts(gatewayConfigs, nodes, "userdel saltuser");
+        verify(clusterBootstrapper).reBootstrapOnHost(stack);
+        verify(securityConfigService).changeSaltPassword(securityConfig, newPassword);
+    }
+
+    @Test
+    void rotateSaltPasswordFallbackFailure() throws Exception {
+        Set<Node> nodes = Set.of(mock(Node.class));
+        when(stack.getAllPrimaryGatewayInstanceNodes()).thenReturn(nodes);
+        doThrow(CloudbreakException.class).when(clusterBootstrapper).reBootstrapOnHost(stack);
+
+        assertThatThrownBy(() -> underTest.rotateSaltPasswordFallback(stack))
+                .isInstanceOf(CloudbreakOrchestratorFailedException.class)
+                .hasCauseInstanceOf(CloudbreakException.class)
+                .hasMessage("Failed to re-bootstrap gateway nodes after saltuser password delete. " +
+                        "Please check the salt-bootstrap service status on node(s) [1.1.1.1, 1.1.1.2]. " +
+                        "If the saltuser password was changed manually, " +
+                        "please remove the user manually with the command 'userdel saltuser' on node(s) [1.1.1.1, 1.1.1.2] and retry the operation.");
+
+        verify(securityConfigService, never()).changeSaltPassword(eq(securityConfig), any());
+    }
+
+    @Test
+    void getRotateSaltPasswordTypeFallback() {
+        when(saltBootstrapVersionChecker.isChangeSaltuserPasswordSupported(any())).thenReturn(false);
+
+        underTest.triggerRotateSaltPassword(stack, RotateSaltPasswordReason.MANUAL);
+
+        verify(flowManager).triggerRotateSaltPassword(stack.getId(), RotateSaltPasswordReason.MANUAL, RotateSaltPasswordType.FALLBACK);
+    }
+
+    @Test
+    void getRotateSaltPasswordTypeSaltBootstrapEndpoint() {
+        when(saltBootstrapVersionChecker.isChangeSaltuserPasswordSupported(any())).thenReturn(true);
+
+        underTest.triggerRotateSaltPassword(stack, RotateSaltPasswordReason.MANUAL);
+
+        verify(flowManager).triggerRotateSaltPassword(stack.getId(), RotateSaltPasswordReason.MANUAL, RotateSaltPasswordType.SALT_BOOTSTRAP_ENDPOINT);
     }
 
     @Test

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationServiceTest.java
@@ -60,9 +60,9 @@ import com.sequenceiq.cloudbreak.domain.stack.StackStatus;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordReason;
 import com.sequenceiq.cloudbreak.service.RotateSaltPasswordService;
-import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.service.StackUpdater;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
 import com.sequenceiq.cloudbreak.service.cluster.flow.ClusterOperationService;
@@ -472,6 +472,7 @@ public class StackOperationServiceTest {
 
         assertEquals(flowIdentifier, result);
         verify(stackDtoService).getByNameOrCrn(nameOrCrn, ACCOUNT_ID);
+        verify(rotateSaltPasswordService).validateRotateSaltPassword(stackDto);
         verify(rotateSaltPasswordService).triggerRotateSaltPassword(stackDto, REASON);
     }
 

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
@@ -81,6 +81,9 @@ public interface HostOrchestrator extends HostRecipeExecutor {
     Map<String, String> replacePatternInFileOnAllHosts(GatewayConfig gatewayConfig, String file, String pattern, String replace)
             throws CloudbreakOrchestratorFailedException;
 
+    Map<String, String> runCommandOnHosts(List<GatewayConfig> allGatewayConfigs, Set<Node> nodes, String command)
+            throws CloudbreakOrchestratorFailedException;
+
     Map<String, JsonNode> getGrainOnAllHosts(GatewayConfig gateway, String grain) throws CloudbreakOrchestratorFailedException;
 
     Map<String, String> getMembers(GatewayConfig gatewayConfig, List<String> privateIps) throws CloudbreakOrchestratorException;

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
@@ -901,6 +901,20 @@ public class SaltOrchestrator implements HostOrchestrator {
     }
 
     @Override
+    public Map<String, String> runCommandOnHosts(List<GatewayConfig> allGatewayConfigs, Set<Node> nodes, String command)
+            throws CloudbreakOrchestratorFailedException {
+        GatewayConfig primaryGateway = saltService.getPrimaryGatewayConfig(allGatewayConfigs);
+        Target<String> hosts = new HostList(nodes.stream().map(Node::getHostname).collect(Collectors.toSet()));
+        LOGGER.debug("Execute command: {}, on hosts: {}", command, hosts);
+        try (SaltConnector saltConnector = saltService.createSaltConnector(primaryGateway)) {
+            return saltStateService.runCommandOnHosts(retry, saltConnector, hosts, command);
+        } catch (RuntimeException e) {
+            LOGGER.warn("Error occurred during command execution: " + command, e);
+            throw new CloudbreakOrchestratorFailedException(e.getMessage(), e);
+        }
+    }
+
+    @Override
     public Map<String, JsonNode> getGrainOnAllHosts(GatewayConfig gateway, String grain) throws CloudbreakOrchestratorFailedException {
         try (SaltConnector saltConnector = saltService.createSaltConnector(gateway)) {
             return saltStateService.getGrains(saltConnector, grain);


### PR DESCRIPTION
Steps to rotate saltuser password on stacks with older salt-bootstrap version:
- Remove saltuser from gateways (proceed even if it fails, as the error message will give a hint to do this manually)
- Run the boostrap service on gateway nodes, this will recreate the saltuser with the new password

See detailed description in the commit message.