### PR TITLE
CB-17866 Reload systemd config files after changing unit files

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/init.sls
@@ -88,16 +88,21 @@ change-db-location:
     - repl: Environment=PGDATA={{ postgres_directory }}/data
     - unless: grep "Environment=PGDATA={{ postgres_directory }}/data" {{ unitFile }}
 
+systemctl-reload-on-pg-unit-change:
+  cmd.run:
+    - name: systemctl --system daemon-reload
+    - onchanges:
+        - file: change-db-location
 {%- endif %}
 
 start-postgresql:
   service.running:
     - enable: True
-    - require:
-      - cmd: init-db-with-utf8
 {%- if postgres_data_on_attached_disk %}
     - watch:
-      - file: {{ unitFile }}
+        - file: change-db-location
+    - require:
+        - cmd: systemctl-reload-on-pg-unit-change
 {%- endif %}
     - name: postgresql
 


### PR DESCRIPTION
Changes in postgresql unit file was ignored when starting/restarting postgresql.
Adding daemon-reload after unit file change.
Start/restart is modified, init-db requirement removed, only daemon reload is required when on attached disk.

See detailed description in the commit message.