### PR TITLE
CB-17762 - Return RDS engine version via Redbeams API

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/database/MajorVersion.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/database/MajorVersion.java
@@ -1,5 +1,9 @@
 package com.sequenceiq.cloudbreak.common.database;
 
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+
 public enum MajorVersion {
 
     VERSION_10("10"),
@@ -16,6 +20,20 @@ public enum MajorVersion {
 
     public String getVersion() {
         return version;
+    }
+
+    public static Optional<MajorVersion> get(String version) {
+        return Arrays.stream(values())
+                .filter(ver -> exactMatch(version, ver) || nonExactMatch(version, ver))
+                .findFirst();
+    }
+
+    private static boolean exactMatch(String version, MajorVersion ver) {
+        return ver.version.equals(version);
+    }
+
+    private static boolean nonExactMatch(String version, MajorVersion ver) {
+        return Objects.nonNull(version) && version.startsWith(ver.version + ".");
     }
 
 }

--- a/common/src/test/java/com/sequenceiq/cloudbreak/common/database/MajorVersionTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/common/database/MajorVersionTest.java
@@ -1,0 +1,40 @@
+package com.sequenceiq.cloudbreak.common.database;
+
+import static com.sequenceiq.cloudbreak.common.database.MajorVersion.VERSION_10;
+import static com.sequenceiq.cloudbreak.common.database.MajorVersion.VERSION_11;
+import static com.sequenceiq.cloudbreak.common.database.MajorVersion.VERSION_13;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Optional;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class MajorVersionTest {
+
+    @ParameterizedTest
+    @MethodSource("majorVersionDataProvider")
+    void testGetMajorVersion(String fullVersion, MajorVersion expectedMajorVersion) {
+        Optional<MajorVersion> majorVersion = MajorVersion.get(fullVersion);
+        Optional<MajorVersion> expected = Optional.ofNullable(expectedMajorVersion);
+        assertEquals(expected, majorVersion);
+    }
+
+    static Object[][] majorVersionDataProvider() {
+        return new Object[][]{
+                // fullVersion expectedMajorVersion
+                {"10", VERSION_10},
+                {"10.6", VERSION_10},
+                {"10.14", VERSION_10},
+                {"11", VERSION_11},
+                {"13", VERSION_13},
+                {"13.2", VERSION_13},
+                {"13.2.4.2.1", VERSION_13},
+                {"13.234567", VERSION_13},
+                {"13.asdf", VERSION_13},
+                {"13.0", VERSION_13},
+                {"130", null},
+                {"asd", null},
+        };
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeService.java
@@ -53,14 +53,14 @@ public class RdsUpgradeService {
         MDCBuilder.buildMdcContext(stack);
         LOGGER.info("RDS upgrade has been initiated for stack {}", nameOrCrn.getNameOrCrn());
 
-        if (checkCurrentRdsVersion(nameOrCrn).equals(targetMajorVersion.getVersion())) {
+        if (getCurrentRdsVersion(nameOrCrn).equals(targetMajorVersion.getVersion())) {
             return alreadyOnLatestAnswer(targetMajorVersion);
         } else {
             return checkStackStatusAndTrigger(stack, targetMajorVersion);
         }
     }
 
-    private String checkCurrentRdsVersion(NameOrCrn nameOrCrn) {
+    private String getCurrentRdsVersion(NameOrCrn nameOrCrn) {
         StackDatabaseServerResponse databaseServer = databaseService.getDatabaseServer(nameOrCrn);
         return databaseServer.getMajorVersion().getVersion();
     }

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/DatabaseServerConverter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/DatabaseServerConverter.java
@@ -6,9 +6,8 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.database.Databa
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.database.DatabaseServerSslCertificateType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.database.DatabaseServerSslConfig;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.database.DatabaseServerSslMode;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.database.StackDatabaseServerResponse;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.database.DatabaseServerStatus;
-import com.sequenceiq.cloudbreak.common.database.MajorVersion;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.database.StackDatabaseServerResponse;
 import com.sequenceiq.redbeams.api.endpoint.v4.ResourceStatus;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.SslMode;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerV4Response;
@@ -49,8 +48,7 @@ public class DatabaseServerConverter {
                 databaseServerSslConfig.setSslCertificateType(sslCertificateTypeToDatabaseServerSslCertificateType(sslConfig.getSslCertificateType()));
             }
             stackDatabaseServerResponse.setSslConfig(databaseServerSslConfig);
-            // TODO: Wire in major version parameter into databaseServerV4Response
-            stackDatabaseServerResponse.setMajorVersion(MajorVersion.VERSION_10);
+            stackDatabaseServerResponse.setMajorVersion(databaseServerV4Response.getMajorVersion());
         }
         return stackDatabaseServerResponse;
     }

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/DatabaseServerConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/DatabaseServerConverterTest.java
@@ -48,6 +48,7 @@ class DatabaseServerConverterTest {
         sourceSslConfig.setSslMode(SslMode.ENABLED);
         sourceSslConfig.setSslCertificateType(SslCertificateType.CLOUD_PROVIDER_OWNED);
         source.setSslConfig(sourceSslConfig);
+        source.setMajorVersion(MajorVersion.VERSION_10);
 
         StackDatabaseServerResponse result = underTest.convert(source);
         assertThat(result.getCrn()).isEqualTo(source.getCrn());
@@ -58,8 +59,7 @@ class DatabaseServerConverterTest {
         assertThat(result.getPort()).isEqualTo(source.getPort());
         assertThat(result.getDatabaseVendor()).isEqualTo(source.getDatabaseVendor());
         assertThat(result.getDatabaseVendorDisplayName()).isEqualTo(source.getDatabaseVendorDisplayName());
-        // TODO: re-wire to fetch this from source once available
-        assertThat(result.getMajorVersion()).isEqualTo(MajorVersion.VERSION_10);
+        assertThat(result.getMajorVersion()).isEqualTo(source.getMajorVersion());
         assertThat(result.getCreationDate()).isEqualTo(source.getCreationDate());
         assertThat(result.getResourceStatus()).isEqualTo(DatabaseServerResourceStatus.SERVICE_MANAGED);
         assertThat(result.getStatus()).isEqualTo(DatabaseServerStatus.AVAILABLE);

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/responses/DatabaseServerV4Response.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/responses/DatabaseServerV4Response.java
@@ -4,6 +4,7 @@ import java.util.StringJoiner;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.sequenceiq.cloudbreak.common.database.MajorVersion;
 import com.sequenceiq.cloudbreak.service.secret.model.SecretResponse;
 import com.sequenceiq.redbeams.api.endpoint.v4.ResourceStatus;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.base.DatabaseServerV4Base;
@@ -53,6 +54,9 @@ public class DatabaseServerV4Response extends DatabaseServerV4Base {
 
     @ApiModelProperty(DatabaseServer.CLUSTER_CRN)
     private String clusterCrn;
+
+    @ApiModelProperty(DatabaseServer.MAJOR_VERSION)
+    private MajorVersion majorVersion;
 
     public Long getId() {
         return id;
@@ -150,6 +154,14 @@ public class DatabaseServerV4Response extends DatabaseServerV4Base {
         this.clusterCrn = clusterCrn;
     }
 
+    public MajorVersion getMajorVersion() {
+        return majorVersion;
+    }
+
+    public void setMajorVersion(MajorVersion majorVersion) {
+        this.majorVersion = majorVersion;
+    }
+
     @Override
     public String toString() {
         return new StringJoiner(", ", DatabaseServerV4Response.class.getSimpleName() + "[", "]")
@@ -162,9 +174,10 @@ public class DatabaseServerV4Response extends DatabaseServerV4Base {
                 .add("creationDate=" + creationDate)
                 .add("resourceStatus=" + resourceStatus)
                 .add("status=" + status)
-                .add("sslConfig=" + sslConfig)
-                .add("clusterCrn=" + clusterCrn)
                 .add("statusReason='" + statusReason + "'")
+                .add("sslConfig=" + sslConfig)
+                .add("clusterCrn='" + clusterCrn + "'")
+                .add("majorVersion=" + majorVersion)
                 .toString();
     }
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/ModelDescriptions.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/ModelDescriptions.java
@@ -78,6 +78,7 @@ public final class ModelDescriptions {
         public static final String SSL_CERTIFICATE_ACTIVE_CLOUD_PROVIDER_IDENTIFIER =
                 "Cloud provider specific identifier of the SSL certificate currently active for the database server";
         public static final String TAGS = "UserDefined tags for the DB";
+        public static final String MAJOR_VERSION = "Major version of the database server engine";
     }
 
     public static class DatabaseServerTest {

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/converter/v4/databaseserver/DatabaseServerConfigToDatabaseServerV4ResponseConverter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/converter/v4/databaseserver/DatabaseServerConfigToDatabaseServerV4ResponseConverter.java
@@ -51,6 +51,7 @@ public class DatabaseServerConfigToDatabaseServerV4ResponseConverter {
             DBStack dbStack = source.getDbStack().get();
             response.setStatus(dbStack.getStatus());
             response.setStatusReason(dbStack.getStatusReason());
+            response.setMajorVersion(dbStack.getMajorVersion());
             if (dbStack.getSslConfig() != null) {
                 SslConfig sslConfig = dbStack.getSslConfig();
                 SslConfigV4Response sslConfigV4Response = new SslConfigV4Response();

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/domain/stack/DBStack.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/domain/stack/DBStack.java
@@ -21,11 +21,14 @@ import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
+import com.sequenceiq.cloudbreak.common.database.MajorVersion;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.json.JsonToString;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.service.secret.SecretValue;
 import com.sequenceiq.redbeams.api.endpoint.v4.stacks.aws.AwsDatabaseServerV4Parameters;
+import com.sequenceiq.redbeams.api.endpoint.v4.stacks.azure.AzureDatabaseServerV4Parameters;
+import com.sequenceiq.redbeams.api.endpoint.v4.stacks.gcp.GcpDatabaseServerV4Parameters;
 import com.sequenceiq.redbeams.api.model.common.Status;
 import com.sequenceiq.redbeams.converter.CrnConverter;
 
@@ -181,6 +184,26 @@ public class DBStack {
             ha = parameters == null || !Boolean.FALSE.toString().equalsIgnoreCase(parameters.get(AwsDatabaseServerV4Parameters.MULTI_AZ));
         }
         return ha;
+    }
+
+    public MajorVersion getMajorVersion() {
+        Map<String, Object> attributes = databaseServer.getAttributes().getMap();
+        switch (CloudPlatform.valueOf(cloudPlatform)) {
+            case AZURE:
+                AzureDatabaseServerV4Parameters azure = new AzureDatabaseServerV4Parameters();
+                azure.parse(attributes);
+                return MajorVersion.get(azure.getDbVersion()).orElse(MajorVersion.VERSION_10);
+            case AWS:
+                AwsDatabaseServerV4Parameters aws = new AwsDatabaseServerV4Parameters();
+                aws.parse(attributes);
+                return MajorVersion.get(aws.getEngineVersion()).orElse(MajorVersion.VERSION_10);
+            case GCP:
+                GcpDatabaseServerV4Parameters gcp = new GcpDatabaseServerV4Parameters();
+                gcp.parse(attributes);
+                return MajorVersion.get(gcp.getEngineVersion()).orElse(MajorVersion.VERSION_10);
+            default:
+                return MajorVersion.VERSION_10;
+        }
     }
 
     public String getCloudPlatform() {

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/domain/stack/DBStackTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/domain/stack/DBStackTest.java
@@ -1,18 +1,19 @@
 package com.sequenceiq.redbeams.domain.stack;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import com.google.common.collect.ImmutableMap;
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
+import com.sequenceiq.cloudbreak.common.database.MajorVersion;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.redbeams.api.model.common.Status;
@@ -28,6 +29,10 @@ public class DBStackTest {
     private static final Map<String, String> PARAMETERS = ImmutableMap.of("foo", "bar");
 
     private static final DBStackStatus STATUS = new DBStackStatus();
+
+    private static final String DATABASE_SERVER_ATTRIBUTES_WITH_ENGINE = "{ \"engineVersion\": \"10\", \"this\": \"that\" }";
+
+    private static final String DATABASE_SERVER_ATTRIBUTES_WITH_DB = "{ \"dbVersion\": \"10\", \"this\": \"that\" }";
 
     static {
         STATUS.setStatus(Status.AVAILABLE);
@@ -130,5 +135,22 @@ public class DBStackTest {
         dbStack.setParameters(Map.of("multiAZ", Boolean.FALSE.toString()));
 
         assertFalse(dbStack.isHa());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = CloudPlatform.class)
+    public void testGetMajorVersion(CloudPlatform cloudPlatform) {
+        dbStack.setCloudPlatform(cloudPlatform.name());
+        setDatabaseServer(dbStack, cloudPlatform);
+        assertEquals(MajorVersion.VERSION_10, dbStack.getMajorVersion());
+    }
+
+    private static void setDatabaseServer(DBStack dbStack, CloudPlatform cloudPlatform) {
+        DatabaseServer databaseServer = new DatabaseServer();
+        databaseServer.setAttributes(new Json(
+                CloudPlatform.AZURE == cloudPlatform ?
+                        DATABASE_SERVER_ATTRIBUTES_WITH_DB :
+                        DATABASE_SERVER_ATTRIBUTES_WITH_ENGINE));
+        dbStack.setDatabaseServer(databaseServer);
     }
 }


### PR DESCRIPTION
This commit:
 - parses Postgres server engine version from entity `databaseServer`
 - returns the engine info in `DatabaseServerV4Response`

See detailed description in the commit message.