### PR TITLE
Implementation for start/stopLimitedRetry:AzureInstanceConnector

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureInstanceConnector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureInstanceConnector.java
@@ -121,27 +121,6 @@ public class AzureInstanceConnector implements InstanceConnector {
     @Override
     public List<CloudVmInstanceStatus> stopWithLimitedRetry(AuthenticatedContext ac, List<CloudResource> resources,
             List<CloudInstance> vms, Long timeboundInMs) {
-//        LOGGER.info("Stopping vms on Azure: {}", vms.stream().map(CloudInstance::getInstanceId).collect(Collectors.toList()));
-//        List<CloudVmInstanceStatus> statuses = new ArrayList<>();
-//        List<Completable> startCompletables = new ArrayList<>();
-//        for (CloudInstance vm : vms) {
-//            String resourceGroupName = azureResourceGroupMetadataProvider.getResourceGroupName(ac.getCloudContext(), vm);
-//            AzureClient azureClient = ac.getParameter(AzureClient.class);
-//            startCompletables.add(azureClient.deallocateVirtualMachineAsync(resourceGroupName, vm.getInstanceId(), timeboundInMs)
-//                    .doOnError(throwable -> {
-//                        if (throwable instanceof TimeoutException) {
-//                            LOGGER.error("Timeout Error happened on azure instance stop: {}", vm, throwable);
-//                            statuses.add(new CloudVmInstanceStatus(vm, InstanceStatus.UNKNOWN, throwable.getMessage()));
-//                        } else {
-//                            LOGGER.error("Error happened on azure instance start: {}", vm, throwable);
-//                            statuses.add(new CloudVmInstanceStatus(vm, InstanceStatus.FAILED, throwable.getMessage()));
-//                        }})
-//                    .doOnCompleted(() -> statuses.add(new CloudVmInstanceStatus(vm, InstanceStatus.STOPPED)))
-//                    .subscribeOn(Schedulers.io()));
-//        }
-//        Completable.merge(startCompletables).await();
-//        return statuses;
-
         return azureUtils.deallocateInstances(ac, vms, timeboundInMs);
     }
 

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureInstanceConnector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureInstanceConnector.java
@@ -121,26 +121,28 @@ public class AzureInstanceConnector implements InstanceConnector {
     @Override
     public List<CloudVmInstanceStatus> stopWithLimitedRetry(AuthenticatedContext ac, List<CloudResource> resources,
             List<CloudInstance> vms, Long timeboundInMs) {
-        LOGGER.info("Stopping vms on Azure: {}", vms.stream().map(CloudInstance::getInstanceId).collect(Collectors.toList()));
-        List<CloudVmInstanceStatus> statuses = new ArrayList<>();
-        List<Completable> startCompletables = new ArrayList<>();
-        for (CloudInstance vm : vms) {
-            String resourceGroupName = azureResourceGroupMetadataProvider.getResourceGroupName(ac.getCloudContext(), vm);
-            AzureClient azureClient = ac.getParameter(AzureClient.class);
-            startCompletables.add(azureClient.deallocateVirtualMachineAsync(resourceGroupName, vm.getInstanceId(), timeboundInMs)
-                    .doOnError(throwable -> {
-                        if (throwable instanceof TimeoutException) {
-                            LOGGER.error("Timeout Error happened on azure instance stop: {}", vm, throwable);
-                            statuses.add(new CloudVmInstanceStatus(vm, InstanceStatus.UNKNOWN, throwable.getMessage()));
-                        } else {
-                            LOGGER.error("Error happened on azure instance start: {}", vm, throwable);
-                            statuses.add(new CloudVmInstanceStatus(vm, InstanceStatus.FAILED, throwable.getMessage()));
-                        }})
-                    .doOnCompleted(() -> statuses.add(new CloudVmInstanceStatus(vm, InstanceStatus.STOPPED)))
-                    .subscribeOn(Schedulers.io()));
-        }
-        Completable.merge(startCompletables).await();
-        return statuses;
+//        LOGGER.info("Stopping vms on Azure: {}", vms.stream().map(CloudInstance::getInstanceId).collect(Collectors.toList()));
+//        List<CloudVmInstanceStatus> statuses = new ArrayList<>();
+//        List<Completable> startCompletables = new ArrayList<>();
+//        for (CloudInstance vm : vms) {
+//            String resourceGroupName = azureResourceGroupMetadataProvider.getResourceGroupName(ac.getCloudContext(), vm);
+//            AzureClient azureClient = ac.getParameter(AzureClient.class);
+//            startCompletables.add(azureClient.deallocateVirtualMachineAsync(resourceGroupName, vm.getInstanceId(), timeboundInMs)
+//                    .doOnError(throwable -> {
+//                        if (throwable instanceof TimeoutException) {
+//                            LOGGER.error("Timeout Error happened on azure instance stop: {}", vm, throwable);
+//                            statuses.add(new CloudVmInstanceStatus(vm, InstanceStatus.UNKNOWN, throwable.getMessage()));
+//                        } else {
+//                            LOGGER.error("Error happened on azure instance start: {}", vm, throwable);
+//                            statuses.add(new CloudVmInstanceStatus(vm, InstanceStatus.FAILED, throwable.getMessage()));
+//                        }})
+//                    .doOnCompleted(() -> statuses.add(new CloudVmInstanceStatus(vm, InstanceStatus.STOPPED)))
+//                    .subscribeOn(Schedulers.io()));
+//        }
+//        Completable.merge(startCompletables).await();
+//        return statuses;
+
+        return azureUtils.deallocateInstances(ac, vms, timeboundInMs);
     }
 
     @Override

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -577,12 +578,27 @@ public class AzureClient {
         return handleAuthException(() -> azure.virtualMachines().deallocateAsync(resourceGroup, vmName));
     }
 
+    public Completable deallocateVirtualMachineAsync(String resourceGroup, String vmName, Long timeboundInMs) {
+        if(timeboundInMs==null) {
+            return deallocateVirtualMachineAsync(resourceGroup, vmName);
+        }
+        return handleAuthException(() -> azure.virtualMachines().deallocateAsync(resourceGroup, vmName)).timeout(timeboundInMs, TimeUnit.MILLISECONDS);
+    }
+
     public Completable deleteVirtualMachine(String resourceGroup, String vmName) {
         return handleAuthException(() -> azure.virtualMachines().deleteByResourceGroupAsync(resourceGroup, vmName));
     }
 
     public Completable startVirtualMachineAsync(String resourceGroup, String vmName) {
         return handleAuthException(() -> azure.virtualMachines().startAsync(resourceGroup, vmName));
+    }
+
+    public Completable startVirtualMachineAsync(String resourceGroup, String vmName, Long timeboundInMs) {
+        if(timeboundInMs==null)
+        {
+            return startVirtualMachineAsync(resourceGroup, vmName);
+        }
+        return handleAuthException(() -> azure.virtualMachines().startAsync(resourceGroup, vmName).timeout(timeboundInMs, TimeUnit.MILLISECONDS));
     }
 
     public Completable rebootVirtualMachineAsync(String resourceGroup, String vmName) {


### PR DESCRIPTION
See detailed description in the commit message.
https://jira.cloudera.com/browse/CB-18055# 

The start/stop method accepts a list of virtual machines that need to be started/stopped within the timebound specified. Asynchronous calls are made to start/stop the virtual machines along with passing a specific timeout value as one of the parameter.
For each asynchronous call, the behavior of the code is such that if time elapses before the completion of job then we update the status of instance as UNKNOWN, else if there is some other error then we update the status of instance as FAILED and if the job completes within the specified time then we update the instance status as STARTED. Finally, the method returns the statuses of all the virtual machines.
