### PR TITLE
CB-17015 Ephemeral Disk in Data Mart and Real-time Data Mart Data Hub Clusters…

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/InstanceStoreMetadata.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/InstanceStoreMetadata.java
@@ -28,6 +28,11 @@ public class InstanceStoreMetadata {
         return instanceStoreCount != null ? instanceStoreCount : 0;
     }
 
+    public Integer mapInstanceTypeToInstanceSizeNullHandled(String instanceType) {
+        Integer instanceSize = instaceStoreConfigMap.getOrDefault(instanceType, VolumeParameterConfig.EMPTY).minimumSize();
+        return instanceSize != null ? instanceSize : 0;
+    }
+
     public Map<String, VolumeParameterConfig> getInstaceStoreConfigMap() {
         return instaceStoreConfigMap;
     }

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/Template.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/Template.java
@@ -75,6 +75,8 @@ public class Template implements ProvisionEntity, WorkspaceAwareResource {
 
     private Integer instanceStorageCount;
 
+    private Integer instanceStorageSize;
+
     public Template() {
         deleted = false;
     }
@@ -197,5 +199,13 @@ public class Template implements ProvisionEntity, WorkspaceAwareResource {
 
     public void setInstanceStorageCount(Integer instanceStorageCount) {
         this.instanceStorageCount = instanceStorageCount;
+    }
+
+    public Integer getInstanceStorageSize() {
+        return instanceStorageSize;
+    }
+
+    public void setInstanceStorageSize(Integer instanceStorageSize) {
+        this.instanceStorageSize = instanceStorageSize;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/service/StackCreationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/service/StackCreationService.java
@@ -285,6 +285,7 @@ public class StackCreationService {
             Template template = instanceGroup.getTemplate();
             if (template != null) {
                 Integer instanceStorageCount = instanceStoreMetadata.mapInstanceTypeToInstanceStoreCountNullHandled(template.getInstanceType());
+                Integer instanceStorageSize = instanceStoreMetadata.mapInstanceTypeToInstanceSizeNullHandled(template.getInstanceType());
                 if (ephemeralVolumeChecker.instanceGroupContainsOnlyDatabaseAndEphemeralVolumes(instanceGroup)) {
                     LOGGER.debug("Instance storage was already requested. Setting temporary storage in template to: {}. " +
                             "Group name: {}, Template id: {}, instance type: {}",
@@ -299,6 +300,7 @@ public class StackCreationService {
                 LOGGER.debug("Setting instance storage count in template. " +
                         "Group name: {}, Template id: {}, instance type: {}", instanceGroup.getGroupName(), template.getId(), template.getInstanceType());
                 template.setInstanceStorageCount(instanceStorageCount);
+                template.setInstanceStorageSize(instanceStorageSize);
                 templateService.savePure(template);
             }
         }

--- a/core/src/main/resources/schema/app/20220727094806_CB-17015_Add_InstanceStorageSize_to_Template.sql
+++ b/core/src/main/resources/schema/app/20220727094806_CB-17015_Add_InstanceStorageSize_to_Template.sql
@@ -1,0 +1,9 @@
+-- // CB-17015_Add_InstanceStorageSize_to_Template
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE template ADD COLUMN IF NOT EXISTS instancestoragesize INTEGER;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE template DROP COLUMN IF EXISTS instancestoragesize;

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CmHostGroupRoleConfigProviderProcessorTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CmHostGroupRoleConfigProviderProcessorTest.java
@@ -256,9 +256,9 @@ public class CmHostGroupRoleConfigProviderProcessorTest {
     @Test
     public void testGetRoleConfigsWithEphemeralVolumes() {
         HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, Collections.<String>emptySet(),
-                Sets.newHashSet(new VolumeTemplate()), TemporaryStorage.EPHEMERAL_VOLUMES, 1);
+                Sets.newHashSet(new VolumeTemplate()), TemporaryStorage.EPHEMERAL_VOLUMES, 1, 100);
         HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, Collections.<String>emptySet(),
-                Sets.newHashSet(new VolumeTemplate()), TemporaryStorage.EPHEMERAL_VOLUMES, 3);
+                Sets.newHashSet(new VolumeTemplate()), TemporaryStorage.EPHEMERAL_VOLUMES, 3, 300);
         setup("input/clouderamanager.bp", Builder.builder().withHostgroupViews(Set.of(master, worker)));
 
         underTest.process(templateProcessor, templatePreparator);
@@ -282,9 +282,9 @@ public class CmHostGroupRoleConfigProviderProcessorTest {
     @Test
     public void testGetRoleConfigsWithAttachedVolumes() {
         HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, Collections.<String>emptySet(),
-                Sets.newHashSet(new VolumeTemplate()), TemporaryStorage.ATTACHED_VOLUMES, 0);
+                Sets.newHashSet(new VolumeTemplate()), TemporaryStorage.ATTACHED_VOLUMES, 0, 0);
         HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, Collections.<String>emptySet(),
-                Sets.newHashSet(new VolumeTemplate()), TemporaryStorage.ATTACHED_VOLUMES, 0);
+                Sets.newHashSet(new VolumeTemplate()), TemporaryStorage.ATTACHED_VOLUMES, 0, 0);
         setup("input/clouderamanager.bp", Builder.builder().withHostgroupViews(Set.of(master, worker)));
 
         underTest.process(templateProcessor, templatePreparator);

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/VolumeConfigProviderTestHelper.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/VolumeConfigProviderTestHelper.java
@@ -22,9 +22,9 @@ public class VolumeConfigProviderTestHelper {
     }
 
     public static HostgroupView hostGroupWithVolumeTemplatesAndTemporaryStorage(int volumeCount, Set<VolumeTemplate> volumeTemplates,
-            TemporaryStorage temporaryStorage, Integer temporaryStorageVolumeCount) {
+            TemporaryStorage temporaryStorage, Integer temporaryStorageVolumeCount, Integer temporaryStorageVolumeSize) {
         return new HostgroupView("some name", volumeCount, InstanceGroupType.CORE, Collections.EMPTY_SET,
-                volumeTemplates, temporaryStorage, temporaryStorageVolumeCount);
+                volumeTemplates, temporaryStorage, temporaryStorageVolumeCount, temporaryStorageVolumeSize);
     }
 
     public static TemplatePreparationObject preparatorWithHostGroups(HostgroupView... hostGroups) {

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hbase/HbaseVolumeConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hbase/HbaseVolumeConfigProviderTest.java
@@ -22,7 +22,7 @@ public class HbaseVolumeConfigProviderTest {
     @Test
     void getRoleConfigsWithMultipleEphemeralVolumes() {
         HostgroupView worker = hostGroupWithVolumeTemplatesAndTemporaryStorage(2,
-                Sets.newHashSet(new VolumeTemplate()), TemporaryStorage.EPHEMERAL_VOLUMES, 3);
+                Sets.newHashSet(new VolumeTemplate()), TemporaryStorage.EPHEMERAL_VOLUMES, 3, 300);
 
         List<ApiClusterTemplateConfig> roleConfigs = underTest.getRoleConfigs(HbaseRoles.REGIONSERVER, worker, preparatorWithHostGroups(worker));
 
@@ -37,7 +37,7 @@ public class HbaseVolumeConfigProviderTest {
     @Test
     void getRoleConfigsWithMultipleAttachedVolumes() {
         HostgroupView worker = hostGroupWithVolumeTemplatesAndTemporaryStorage(2,
-                Sets.newHashSet(new VolumeTemplate()), TemporaryStorage.ATTACHED_VOLUMES, 0);
+                Sets.newHashSet(new VolumeTemplate()), TemporaryStorage.ATTACHED_VOLUMES, 0, 0);
 
         List<ApiClusterTemplateConfig> roleConfigs = underTest.getRoleConfigs(HbaseRoles.REGIONSERVER, worker, preparatorWithHostGroups(worker));
 

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/yarn/YarnVolumeConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/yarn/YarnVolumeConfigProviderTest.java
@@ -53,7 +53,7 @@ class YarnVolumeConfigProviderTest {
     @Test
     void getRoleConfigsWithMultipleEphemeralVolumes() {
         HostgroupView worker = hostGroupWithVolumeTemplatesAndTemporaryStorage(2,
-                Sets.newHashSet(new VolumeTemplate()), TemporaryStorage.EPHEMERAL_VOLUMES, 3);
+                Sets.newHashSet(new VolumeTemplate()), TemporaryStorage.EPHEMERAL_VOLUMES, 3, 300);
 
         List<ApiClusterTemplateConfig> roleConfigs = subject.getRoleConfigs(YarnRoles.NODEMANAGER, worker, preparatorWithHostGroups(worker));
 
@@ -70,7 +70,7 @@ class YarnVolumeConfigProviderTest {
     @Test
     void getRoleConfigsWithMultipleAttachedVolumes() {
         HostgroupView worker = hostGroupWithVolumeTemplatesAndTemporaryStorage(2,
-                Sets.newHashSet(new VolumeTemplate()), TemporaryStorage.ATTACHED_VOLUMES, 0);
+                Sets.newHashSet(new VolumeTemplate()), TemporaryStorage.ATTACHED_VOLUMES, 0, 0);
 
         List<ApiClusterTemplateConfig> roleConfigs = subject.getRoleConfigs(YarnRoles.NODEMANAGER, worker, preparatorWithHostGroups(worker));
 

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/TemplatePreparationObject.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/TemplatePreparationObject.java
@@ -317,8 +317,10 @@ public class TemplatePreparationObject {
                             .collect(Collectors.toSet());
                     TemporaryStorage temporaryStorage = template == null ? null : template.getTemporaryStorage();
                     Integer temporaryStorageVolumeCount = template == null ? null : template.getInstanceStorageCount();
+                    Integer temporaryStorageVolumeSize = template == null ? null : template.getInstanceStorageSize();
                     hostgroupViews.add(new HostgroupView(hostGroup.getName(), volumeCount,
-                            instanceGroup.getInstanceGroupType(), fqdns, volumeTemplates, temporaryStorage, temporaryStorageVolumeCount));
+                            instanceGroup.getInstanceGroupType(), fqdns, volumeTemplates,
+                            temporaryStorage, temporaryStorageVolumeCount, temporaryStorageVolumeSize));
                 } else {
                     hostgroupViews.add(new HostgroupView(hostGroup.getName()));
                 }

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/views/HostgroupView.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/views/HostgroupView.java
@@ -34,17 +34,20 @@ public class HostgroupView {
 
     private final Integer temporaryStorageVolumeCount;
 
+    private final Integer temporaryStorageVolumeSize;
+
     public HostgroupView(String name, int volumeCount, InstanceGroupType instanceGroupType, Collection<String> hosts) {
         this(name, volumeCount, instanceGroupType, hosts, Collections.emptySet());
     }
 
     public HostgroupView(String name, int volumeCount, InstanceGroupType instanceGroupType,
             Collection<String> hosts, Set<VolumeTemplate> volumeTemplates) {
-        this(name, volumeCount, instanceGroupType, hosts, volumeTemplates, null, null);
+        this(name, volumeCount, instanceGroupType, hosts, volumeTemplates, null, null, null);
     }
 
     public HostgroupView(String name, int volumeCount, InstanceGroupType instanceGroupType,
-            Collection<String> hosts, Set<VolumeTemplate> volumeTemplates, TemporaryStorage temporaryStorage, Integer temporaryStorageVolumeCount) {
+            Collection<String> hosts, Set<VolumeTemplate> volumeTemplates, TemporaryStorage temporaryStorage,
+            Integer temporaryStorageVolumeCount, Integer temporaryStorageVolumeSize) {
         this.name = name;
         this.volumeCount = volumeCount;
         instanceGroupConfigured = true;
@@ -61,6 +64,7 @@ public class HostgroupView {
         this.volumeTemplates = Collections.unmodifiableSet(volumeTemplates);
         this.temporaryStorage = temporaryStorage;
         this.temporaryStorageVolumeCount = temporaryStorageVolumeCount;
+        this.temporaryStorageVolumeSize = temporaryStorageVolumeSize;
     }
 
     public HostgroupView(String name, int volumeCount, InstanceGroupType instanceGroupType, Integer nodeCount) {
@@ -73,6 +77,7 @@ public class HostgroupView {
         volumeTemplates = Collections.emptySet();
         temporaryStorage = null;
         temporaryStorageVolumeCount = null;
+        temporaryStorageVolumeSize = null;
     }
 
     public HostgroupView(String name) {
@@ -85,6 +90,7 @@ public class HostgroupView {
         volumeTemplates = Collections.emptySet();
         temporaryStorage = null;
         temporaryStorageVolumeCount = null;
+        temporaryStorageVolumeSize = null;
     }
 
     public String getName() {
@@ -121,6 +127,10 @@ public class HostgroupView {
 
     public Integer getTemporaryStorageVolumeCount() {
         return temporaryStorageVolumeCount;
+    }
+
+    public Integer getTemporaryStorageVolumeSize() {
+        return temporaryStorageVolumeSize;
     }
 
     private List<String> filterNullOrEmpty(Collection<String> hosts) {


### PR DESCRIPTION
- Added the Ephermeral disk storage size value to IMPALA_DATACACHE_CAPACITY_PARAM.

Testing
- Covered changes with unit tests.

See detailed description in the commit message.