### PR TITLE
CB-16621: Added E2E test for resize recovery from a Datalake Restore failure.

### DIFF
--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterDetailResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterDetailResponse.java
@@ -43,7 +43,8 @@ public class SdxClusterDetailResponse extends SdxClusterResponse implements Tagg
                     .withSdxClusterServiceVersion(sdxClusterResponse.getSdxClusterServiceVersion())
                     .withDetached(sdxClusterResponse.isDetached())
                     .withEnableMultiAz(sdxClusterResponse.isEnableMultiAz())
-                    .withDatabaseEngineVersion(sdxClusterResponse.getDatabaseEngineVersion());
+                    .withDatabaseEngineVersion(sdxClusterResponse.getDatabaseEngineVersion())
+                    .withCreated(sdxClusterResponse.getCreated());
         }
         return builder.withStackV4Response(stackV4Response).build();
     }

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/delete/SdxDeleteActions.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/delete/SdxDeleteActions.java
@@ -43,7 +43,6 @@ import com.sequenceiq.flow.core.FlowEvent;
 import com.sequenceiq.flow.core.FlowLogService;
 import com.sequenceiq.flow.core.FlowParameters;
 import com.sequenceiq.flow.core.FlowState;
-import com.sequenceiq.flow.domain.FlowLogWithoutPayload;
 import com.sequenceiq.flow.service.flowlog.FlowChainLogService;
 
 @Configuration
@@ -165,9 +164,9 @@ public class SdxDeleteActions {
                     metricService.incrementMetricCounter(MetricType.SDX_DELETION_FINISHED, sdxCluster);
                 }
                 eventSenderService.notifyEvent(context, ResourceEvent.SDX_CLUSTER_DELETION_FINISHED);
-                Optional<FlowLogWithoutPayload> lastFlowLog = flowLogService.getLastFlowLog(context.getFlowParameters().getFlowId());
-                if (lastFlowLog.isPresent() && flowChainLogService.isFlowTriggeredByFlowChain(DatalakeResizeFlowEventChainFactory.class.getSimpleName(),
-                        lastFlowLog.get())) {
+                if (flowChainLogService.isFlowTriggeredByFlowChain(
+                        DatalakeResizeFlowEventChainFactory.class.getSimpleName(),
+                        flowLogService.getLastFlowLog(context.getFlowParameters().getFlowId()))) {
                     eventSenderService.notifyEvent(context, ResourceEvent.DATALAKE_RESIZE_COMPLETE);
                 }
                 sendEvent(context, SDX_DELETE_FINALIZED_EVENT.event(), payload);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/DatalakeRestoreActions.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/DatalakeRestoreActions.java
@@ -49,8 +49,6 @@ import com.sequenceiq.flow.core.FlowEvent;
 import com.sequenceiq.flow.core.FlowLogService;
 import com.sequenceiq.flow.core.FlowParameters;
 import com.sequenceiq.flow.core.FlowState;
-import com.sequenceiq.flow.domain.FlowChainLog;
-import com.sequenceiq.flow.domain.FlowLogWithoutPayload;
 import com.sequenceiq.flow.service.flowlog.FlowChainLogService;
 import com.sequenceiq.sdx.api.model.DatalakeDatabaseDrStatus;
 import com.sequenceiq.sdx.api.model.SdxDatabaseRestoreStatusResponse;
@@ -92,22 +90,18 @@ public class DatalakeRestoreActions {
             @Override
             protected SdxContext createFlowContext(FlowParameters flowParameters, StateContext<FlowState, FlowEvent> stateContext,
                     DatalakeTriggerRestoreEvent payload) {
+                SdxContext sdxContext = SdxContext.from(flowParameters, payload);
 
                 // When SDX is created as part of re-size flow chain, SDX in payload will not have the correct ID.
-                Optional<FlowLogWithoutPayload> lastFlowLog = flowLogService.getLastFlowLog(flowParameters.getFlowId());
-                if (lastFlowLog.isPresent()) {
-                    SdxContext sdxContext;
-                    Optional<FlowChainLog> flowChainLog = flowChainLogService.findFirstByFlowChainIdOrderByCreatedDesc(lastFlowLog.get().getFlowChainId());
-                    if (flowChainLog.isPresent() && flowChainLog.get().getFlowChainType().equals(DatalakeResizeFlowEventChainFactory.class.getSimpleName())) {
-                        SdxCluster sdxCluster = sdxService.getByNameInAccount(payload.getUserId(), payload.getSdxName());
-                        LOGGER.info("Updating the Sdx-id in context from {} to {}", payload.getResourceId(), sdxCluster.getId());
-                        payload.getDrStatus().setSdxClusterId(sdxCluster.getId());
-                        sdxContext = SdxContext.from(flowParameters, payload);
-                        sdxContext.setSdxId(sdxCluster.getId());
-                        return sdxContext;
-                    }
+                if (flowChainLogService.isFlowTriggeredByFlowChain(
+                        DatalakeResizeFlowEventChainFactory.class.getSimpleName(),
+                        flowLogService.getLastFlowLog(flowParameters.getFlowId()))) {
+                    SdxCluster sdxCluster = sdxService.getByNameInAccount(payload.getUserId(), payload.getSdxName());
+                    LOGGER.info("Updating the Sdx-id in context from {} to {}", payload.getResourceId(), sdxCluster.getId());
+                    payload.getDrStatus().setSdxClusterId(sdxCluster.getId());
+                    sdxContext.setSdxId(sdxCluster.getId());
                 }
-                return SdxContext.from(flowParameters, payload);
+                return sdxContext;
             }
 
             @Override

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/stop/SdxStopActions.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/stop/SdxStopActions.java
@@ -40,8 +40,6 @@ import com.sequenceiq.flow.core.FlowEvent;
 import com.sequenceiq.flow.core.FlowLogService;
 import com.sequenceiq.flow.core.FlowParameters;
 import com.sequenceiq.flow.core.FlowState;
-import com.sequenceiq.flow.domain.FlowChainLog;
-import com.sequenceiq.flow.domain.FlowLogWithoutPayload;
 import com.sequenceiq.flow.service.flowlog.FlowChainLogService;
 
 @Configuration
@@ -217,12 +215,10 @@ public class SdxStopActions {
                 flow.setFlowFailed(payload.getException());
 
                 // If this is part of DL resize, mark failure as such in order to enable proper recovery.
-                Optional<FlowLogWithoutPayload> lastFlowLog = flowLogService.getLastFlowLog(context.getFlowParameters().getFlowId());
-                if (lastFlowLog.isPresent()) {
-                    Optional<FlowChainLog> flowChainLog = flowChainLogService.findFirstByFlowChainIdOrderByCreatedDesc(lastFlowLog.get().getFlowChainId());
-                    if (flowChainLog.isPresent() && flowChainLog.get().getFlowChainType().equals(DatalakeResizeFlowEventChainFactory.class.getSimpleName())) {
-                        statusReason = "Datalake resize failure: " + statusReason;
-                    }
+                if (flowChainLogService.isFlowTriggeredByFlowChain(
+                        DatalakeResizeFlowEventChainFactory.class.getSimpleName(),
+                        flowLogService.getLastFlowLog(context.getFlowParameters().getFlowId()))) {
+                    statusReason = "Datalake resize failure: " + statusReason;
                 }
 
                 eventSenderService.notifyEvent(context, ResourceEvent.SDX_STOP_FAILED);

--- a/datalake/src/main/java/com/sequenceiq/datalake/repository/SdxClusterRepository.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/repository/SdxClusterRepository.java
@@ -43,9 +43,9 @@ public interface SdxClusterRepository extends AccountAwareResourceRepository<Sdx
 
     Optional<SdxCluster> findByAccountIdAndCrnAndDeletedIsNull(String accountId, String crn);
 
-    Optional<SdxCluster> findByAccountIdAndOriginalCrnAndDeletedIsNull(String accountId, String crn);
+    List<SdxCluster> findByAccountIdAndOriginalCrnAndDeletedIsNull(String accountId, String crn);
 
-    Optional<SdxCluster> findByAccountIdAndOriginalCrn(String accountId, String crn);
+    List<SdxCluster> findByAccountIdAndOriginalCrn(String accountId, String crn);
 
     Optional<SdxCluster> findByCrnAndDeletedIsNull(String crn);
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -285,16 +285,11 @@ public class SdxService implements ResourceIdProvider, PayloadContextProvider, H
         Optional<SdxCluster> sdxCluster = sdxClusterRepository.findByAccountIdAndCrnAndDeletedIsNull(accountIdFromCrn, clusterCrn);
         if (sdxCluster.isPresent()) {
             sdxClusterList.add(sdxCluster.get());
-            if (includeDeleted) {
-                sdxCluster = sdxClusterRepository.findByAccountIdAndOriginalCrn(accountIdFromCrn, clusterCrn);
-            } else {
-                sdxCluster = sdxClusterRepository.findByAccountIdAndOriginalCrnAndDeletedIsNull(accountIdFromCrn, clusterCrn);
-
-            }
-            if (sdxCluster.isPresent()) {
-                LOGGER.info("Found a detached data lake associated with crn:{}", clusterCrn);
-                sdxClusterList.add(sdxCluster.get());
-            }
+        }
+        if (includeDeleted) {
+            sdxClusterList.addAll(sdxClusterRepository.findByAccountIdAndOriginalCrn(accountIdFromCrn, clusterCrn));
+        } else {
+            sdxClusterList.addAll(sdxClusterRepository.findByAccountIdAndOriginalCrnAndDeletedIsNull(accountIdFromCrn, clusterCrn));
         }
         if (sdxClusterList.isEmpty()) {
             throw notFound("SDX cluster", clusterCrn).get();

--- a/datalake/src/test/java/com/sequenceiq/datalake/flow/dr/restore/DatalakeRestoreActionsTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/flow/dr/restore/DatalakeRestoreActionsTest.java
@@ -28,7 +28,6 @@ import com.sequenceiq.cloudbreak.datalakedr.model.DatalakeRestoreStatusResponse;
 import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.flow.SdxContext;
 import com.sequenceiq.datalake.flow.chain.DatalakeResizeFlowEventChainFactory;
-import com.sequenceiq.datalake.flow.chain.DatalakeUpgradeFlowEventChainFactory;
 import com.sequenceiq.datalake.flow.dr.restore.event.DatalakeDatabaseRestoreStartEvent;
 import com.sequenceiq.datalake.flow.dr.restore.event.DatalakeTriggerRestoreEvent;
 import com.sequenceiq.datalake.service.sdx.SdxService;
@@ -38,7 +37,6 @@ import com.sequenceiq.flow.core.AbstractActionTestSupport;
 import com.sequenceiq.flow.core.FlowLogService;
 import com.sequenceiq.flow.core.FlowParameters;
 import com.sequenceiq.flow.core.FlowRegister;
-import com.sequenceiq.flow.domain.FlowChainLog;
 import com.sequenceiq.flow.domain.FlowLogWithoutPayload;
 import com.sequenceiq.flow.reactor.ErrorHandlerAwareReactorEventFactory;
 import com.sequenceiq.flow.service.flowlog.FlowChainLogService;
@@ -115,9 +113,7 @@ public class DatalakeRestoreActionsTest {
         FlowParameters flowParameters = new FlowParameters(FLOW_ID, null, null);
         when(sdxService.getByNameInAccount(eq(USER_CRN), eq(DATALAKE_NAME))).thenReturn(sdxCluster);
         when(flowLogService.getLastFlowLog(anyString())).thenReturn(Optional.of(mock(FlowLogWithoutPayload.class)));
-        FlowChainLog flowChainLog = new FlowChainLog();
-        flowChainLog.setFlowChainType(DatalakeResizeFlowEventChainFactory.class.getSimpleName());
-        when(flowChainLogService.findFirstByFlowChainIdOrderByCreatedDesc(any())).thenReturn(Optional.of(flowChainLog));
+        when(flowChainLogService.isFlowTriggeredByFlowChain(eq(DatalakeResizeFlowEventChainFactory.class.getSimpleName()), any())).thenReturn(true);
 
         DatalakeTriggerRestoreEvent event = new DatalakeTriggerRestoreEvent(DATALAKE_TRIGGER_RESTORE_EVENT.event(), OLD_SDX_ID, DATALAKE_NAME,
                 USER_CRN, null, BACKUP_LOCATION, null, DatalakeRestoreFailureReason.RESTORE_ON_RESIZE);
@@ -131,7 +127,7 @@ public class DatalakeRestoreActionsTest {
         assertEquals(FLOW_ID, context.getFlowId());
         assertEquals(NEW_SDX_ID, event.getDrStatus().getSdxClusterId());
 
-        flowChainLog.setFlowChainType(DatalakeUpgradeFlowEventChainFactory.class.getSimpleName());
+        when(flowChainLogService.isFlowTriggeredByFlowChain(eq(DatalakeResizeFlowEventChainFactory.class.getSimpleName()), any())).thenReturn(false);
         context = (SdxContext) testSupport.createFlowContext(flowParameters, null, event);
         assertEquals(OLD_SDX_ID, context.getSdxId());
     }

--- a/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowChainLogService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowChainLogService.java
@@ -134,8 +134,11 @@ public class FlowChainLogService {
         return repository.save(chainLog);
     }
 
-    public boolean isFlowTriggeredByFlowChain(String flowChainType, FlowLogWithoutPayload lastFlowLog) {
-        Optional<FlowChainLog> flowChainLog = findFirstByFlowChainIdOrderByCreatedDesc(lastFlowLog.getFlowChainId());
-        return flowChainLog.isPresent() && flowChainLog.get().getFlowChainType().equals(flowChainType);
+    public boolean isFlowTriggeredByFlowChain(String flowChainType, Optional<FlowLogWithoutPayload> lastFlowLog) {
+        if (lastFlowLog.isPresent()) {
+            Optional<FlowChainLog> flowChainLog = findFirstByFlowChainIdOrderByCreatedDesc(lastFlowLog.get().getFlowChainId());
+            return flowChainLog.isPresent() && flowChainLog.get().getFlowChainType().equals(flowChainType);
+        }
+        return false;
     }
 }

--- a/flow/src/test/java/com/sequenceiq/flow/service/flowlog/FlowChainLogServiceTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/service/flowlog/FlowChainLogServiceTest.java
@@ -147,9 +147,9 @@ class FlowChainLogServiceTest {
         flowChainLog.setFlowChainType("flowChainType");
         when(flowLogRepository.findFirstByFlowChainIdOrderByCreatedDesc("chainId"))
                 .thenReturn(Optional.of(flowChainLog));
-        assertTrue(underTest.isFlowTriggeredByFlowChain("flowChainType", flowLog));
+        assertTrue(underTest.isFlowTriggeredByFlowChain("flowChainType", Optional.of(flowLog)));
 
-        assertFalse(underTest.isFlowTriggeredByFlowChain("flowChainType1", flowLog));
+        assertFalse(underTest.isFlowTriggeredByFlowChain("flowChainType1", Optional.of(flowLog)));
     }
 
     private FlowChainLog flowChainLog(String flowChainId, String parentFlowChainId, long created) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxInternalResizeRecoveryAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxInternalResizeRecoveryAction.java
@@ -1,38 +1,27 @@
 package com.sequenceiq.it.cloudbreak.action.sdx;
 
-import java.util.Collections;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sequenceiq.it.cloudbreak.SdxClient;
 import com.sequenceiq.it.cloudbreak.action.Action;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
-import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.log.Log;
-import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
 import com.sequenceiq.sdx.api.model.SdxRecoveryRequest;
 import com.sequenceiq.sdx.api.model.SdxRecoveryResponse;
 
-public class SdxRecoveryAction implements Action<SdxTestDto, SdxClient> {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(SdxRecoveryAction.class);
+public class SdxInternalResizeRecoveryAction implements Action<SdxInternalTestDto, SdxClient>  {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxInternalResizeRecoveryAction.class);
 
     @Override
-    public SdxTestDto action(TestContext testContext, SdxTestDto testDto, SdxClient client) throws Exception {
+    public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
         SdxRecoveryRequest recoveryRequest = testDto.getSdxRecoveryRequest();
-
         Log.when(LOGGER, " SDX endpoint: %s" + client.getDefaultClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
-        Log.whenJson(LOGGER, " SDX recovery request: ", recoveryRequest);
         SdxRecoveryResponse recoveryResponse = client.getDefaultClient()
                 .sdxRecoveryEndpoint()
                 .recoverClusterByName(testDto.getName(), recoveryRequest);
-        testDto.setFlow("SDX recovery", recoveryResponse.getFlowIdentifier());
-        SdxClusterDetailResponse detailedResponse = client.getDefaultClient()
-                .sdxEndpoint()
-                .getDetail(testDto.getName(), Collections.emptySet());
-        testDto.setResponse(detailedResponse);
-        Log.whenJson(LOGGER, " SDX recovery response: ", detailedResponse);
+        testDto.setFlow("SDX resize recovery", recoveryResponse.getFlowIdentifier());
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxUpgradeRecoveryAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxUpgradeRecoveryAction.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.it.cloudbreak.action.sdx;
+
+import java.util.Collections;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.SdxClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
+import com.sequenceiq.sdx.api.model.SdxRecoveryRequest;
+import com.sequenceiq.sdx.api.model.SdxRecoveryResponse;
+
+public class SdxUpgradeRecoveryAction implements Action<SdxTestDto, SdxClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxUpgradeRecoveryAction.class);
+
+    @Override
+    public SdxTestDto action(TestContext testContext, SdxTestDto testDto, SdxClient client) throws Exception {
+        SdxRecoveryRequest recoveryRequest = testDto.getSdxRecoveryRequest();
+
+        Log.when(LOGGER, " SDX endpoint: %s" + client.getDefaultClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
+        Log.whenJson(LOGGER, " SDX recovery request: ", recoveryRequest);
+        SdxRecoveryResponse recoveryResponse = client.getDefaultClient()
+                .sdxRecoveryEndpoint()
+                .recoverClusterByName(testDto.getName(), recoveryRequest);
+        testDto.setFlow("SDX upgrade recovery", recoveryResponse.getFlowIdentifier());
+        SdxClusterDetailResponse detailedResponse = client.getDefaultClient()
+                .sdxEndpoint()
+                .getDetail(testDto.getName(), Collections.emptySet());
+        testDto.setResponse(detailedResponse);
+        Log.whenJson(LOGGER, " SDX recovery response: ", detailedResponse);
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/SdxTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/SdxTestClient.java
@@ -26,9 +26,10 @@ import com.sequenceiq.it.cloudbreak.action.sdx.SdxForceDeleteCustomAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxForceDeleteInternalAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxGetAuditsAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxGetDatalakeEventsZipAction;
+import com.sequenceiq.it.cloudbreak.action.sdx.SdxInternalResizeRecoveryAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxInternalUpgradeAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxListAction;
-import com.sequenceiq.it.cloudbreak.action.sdx.SdxRecoveryAction;
+import com.sequenceiq.it.cloudbreak.action.sdx.SdxUpgradeRecoveryAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxRefreshAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxRefreshCustomAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxRefreshInternalAction;
@@ -145,8 +146,12 @@ public class SdxTestClient {
         return new SdxInternalUpgradeAction();
     }
 
-    public Action<SdxTestDto, SdxClient> recover() {
-        return new SdxRecoveryAction();
+    public Action<SdxTestDto, SdxClient> recoverFromUpgrade() {
+        return new SdxUpgradeRecoveryAction();
+    }
+
+    public Action<SdxInternalTestDto, SdxClient> recoverFromResizeInternal() {
+        return new SdxInternalResizeRecoveryAction();
     }
 
     public Action<SdxInternalTestDto, SdxClient> resize() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxInternalTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxInternalTestDto.java
@@ -61,6 +61,7 @@ import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 import com.sequenceiq.sdx.api.model.SdxDatabaseAvailabilityType;
 import com.sequenceiq.sdx.api.model.SdxDatabaseRequest;
 import com.sequenceiq.sdx.api.model.SdxInternalClusterRequest;
+import com.sequenceiq.sdx.api.model.SdxRecoveryRequest;
 import com.sequenceiq.sdx.api.model.SdxRepairRequest;
 import com.sequenceiq.sdx.api.model.SdxUpgradeRequest;
 
@@ -337,7 +338,7 @@ public class SdxInternalTestDto extends AbstractSdxTestDto<SdxInternalClusterReq
         if (checkResponseHasInstanceGroups()) {
             return instanceStatusMapSupplier.get();
         } else {
-            LOGGER.info("Response doesn't has instance groups");
+            LOGGER.info("Response doesn't have instance groups");
             return Collections.emptyMap();
         }
     }
@@ -482,6 +483,14 @@ public class SdxInternalTestDto extends AbstractSdxTestDto<SdxInternalClusterReq
         return resize.getRequest();
     }
 
+    public SdxRecoveryRequest getSdxRecoveryRequest() {
+        SdxRecoveryTestDto recovery = given(SdxRecoveryTestDto.class);
+        if (recovery == null) {
+            throw new IllegalArgumentException("SDX Recovery does not exist!");
+        }
+        return recovery.getRequest();
+    }
+
     @Override
     public Clue investigate() {
         if (getResponse() == null || getResponse().getCrn() == null) {
@@ -492,7 +501,7 @@ public class SdxInternalTestDto extends AbstractSdxTestDto<SdxInternalClusterReq
                 CloudbreakEventService.DATALAKE_RESOURCE_TYPE,
                 null,
                 getResponse().getCrn());
-        boolean hasSpotTermination = (getResponse().getStackV4Response() == null) ? false : getResponse().getStackV4Response().getInstanceGroups().stream()
+        boolean hasSpotTermination = getResponse().getStackV4Response() != null && getResponse().getStackV4Response().getInstanceGroups().stream()
                 .flatMap(ig -> ig.getMetadata().stream())
                 .anyMatch(metadata -> InstanceStatus.DELETED_BY_PROVIDER == metadata.getInstanceStatus());
         return new Clue("SDX", auditEvents, getResponse(), hasSpotTermination);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxResizeRecoveryTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxResizeRecoveryTests.java
@@ -1,0 +1,92 @@
+package com.sequenceiq.it.cloudbreak.testcase.e2e.sdx;
+
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.MASTER;
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.testng.annotations.Test;
+
+import com.sequenceiq.it.cloudbreak.SdxClient;
+import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
+import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.it.cloudbreak.util.resize.SdxResizeTestValidator;
+import com.sequenceiq.it.cloudbreak.util.SdxUtil;
+import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
+import com.sequenceiq.sdx.api.model.SdxClusterShape;
+import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
+import com.sequenceiq.sdx.api.model.SdxDatabaseAvailabilityType;
+import com.sequenceiq.sdx.api.model.SdxDatabaseRequest;
+
+public class SdxResizeRecoveryTests extends PreconditionSdxE2ETest {
+    private static final String RESTORE_FAILURE_RESPONSE = "Datalake restore failed";
+
+    @Inject
+    private SdxTestClient sdxTestClient;
+
+    @Inject
+    private SdxUtil sdxUtil;
+
+    @Test(dataProvider = TEST_CONTEXT)
+    @UseSpotInstances
+    @Description(
+            given = "there is a running Cloudbreak, and an SDX cluster in available state",
+            when = "resize is performed on the SDX cluster but fails during restore",
+            then = "recovery should be available and successful when run, the original cluster should be up and running"
+    )
+    public void testSdxResizeRecoveryFromRestoreFailure(TestContext testContext) {
+        String sdx = resourcePropertyProvider().getName();
+        SdxResizeTestValidator resizeTestValidator = new SdxResizeTestValidator(SdxClusterShape.CUSTOM);
+        SdxDatabaseRequest sdxDatabaseRequest = new SdxDatabaseRequest();
+        sdxDatabaseRequest.setAvailabilityType(SdxDatabaseAvailabilityType.NONE);
+        testContext
+                .given(sdx, SdxInternalTestDto.class)
+                .withDatabase(sdxDatabaseRequest)
+                .withCloudStorage(getCloudStorageRequest(testContext))
+                .withClusterShape(SdxClusterShape.CUSTOM)
+                .when(sdxTestClient.createInternal(), key(sdx))
+                .await(SdxClusterStatusResponse.RUNNING, key(sdx))
+                .awaitForHealthyInstances()
+                .then((tc, testDto, client) -> {
+                    resizeTestValidator.setExpectedCrn(sdxUtil.getCrn(testDto, client));
+                    resizeTestValidator.setExpectedName(testDto.getName());
+                    resizeTestValidator.setExpectedRuntime(sdxUtil.getRuntime(testDto, client));
+                    resizeTestValidator.setExpectedCreationTimestamp(sdxUtil.getCreated(testDto, client));
+                    return testDto;
+                })
+                .when(sdxTestClient.resize(), key(sdx))
+                .await(SdxClusterStatusResponse.DATALAKE_BACKUP_INPROGRESS, key(sdx).withoutWaitForFlow())
+                .await(SdxClusterStatusResponse.STOP_IN_PROGRESS, key(sdx).withoutWaitForFlow())
+                .await(SdxClusterStatusResponse.STACK_CREATION_IN_PROGRESS, key(sdx).withoutWaitForFlow())
+                .await(SdxClusterStatusResponse.RUNNING, key(sdx).withoutWaitForFlow())
+                .then((tc, testDto, client) -> deleteMasterNode(testDto, client, tc))
+                .await(SdxClusterStatusResponse.RUNNING, key(sdx).withoutWaitForFlow())
+                .then((tc, testDto, client) -> validateRestoreFailure(testDto, client))
+                .when(sdxTestClient.recoverFromResizeInternal(), key(sdx))
+                .await(SdxClusterStatusResponse.RUNNING, key(sdx))
+                .awaitForHealthyInstances()
+                .then((tc, dto, client) -> resizeTestValidator.validateRecoveredCluster(dto))
+                .validate();
+    }
+
+    private SdxInternalTestDto deleteMasterNode(SdxInternalTestDto testDto, SdxClient client, TestContext testContext) {
+        List<String> instanceIdsToDelete = sdxUtil.getInstanceIds(testDto, client, MASTER.getName());
+        getCloudFunctionality(testContext).deleteInstances(testDto.getName(), instanceIdsToDelete);
+        return testDto;
+    }
+
+    private SdxInternalTestDto validateRestoreFailure(SdxInternalTestDto testDto, SdxClient client) {
+        String statusReason = sdxUtil.getStatusReason(testDto, client);
+        if (!statusReason.contains(RESTORE_FAILURE_RESPONSE)) {
+            throw new TestFailException(
+                    "SDX cluster being resized should have had a restore failure! Instead status reason is: " + statusReason
+            );
+        }
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxResizeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxResizeTests.java
@@ -10,7 +10,7 @@ import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
-import com.sequenceiq.it.cloudbreak.util.SdxResizeTestValidator;
+import com.sequenceiq.it.cloudbreak.util.resize.SdxResizeTestValidator;
 import com.sequenceiq.it.cloudbreak.util.SdxUtil;
 import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
 import com.sequenceiq.sdx.api.model.SdxClusterShape;
@@ -19,8 +19,6 @@ import com.sequenceiq.sdx.api.model.SdxDatabaseAvailabilityType;
 import com.sequenceiq.sdx.api.model.SdxDatabaseRequest;
 
 public class SdxResizeTests extends PreconditionSdxE2ETest {
-    private static final String MOCK_UMS_PASSWORD = "Password123!";
-
     @Inject
     private SdxTestClient sdxTestClient;
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxUpgradeRecoveryTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxUpgradeRecoveryTests.java
@@ -30,7 +30,7 @@ import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
 import com.sequenceiq.it.cloudbreak.util.ssh.action.SshJClientActions;
 import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 
-public class SdxRecoveryTests extends PreconditionSdxE2ETest {
+public class SdxUpgradeRecoveryTests extends PreconditionSdxE2ETest {
 
     private static final String INJECT_UPGRADE_FAILURE_CMD =
             "sudo sh -c \"echo -e '"
@@ -42,7 +42,7 @@ public class SdxRecoveryTests extends PreconditionSdxE2ETest {
                     + "\\n127.0.0.1 cache-test1.vpc.cloudera.com'"
                     + " >> /etc/hosts\"";
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SdxRecoveryTests.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxUpgradeRecoveryTests.class);
 
     @Inject
     private SshJClientActions sshJClientActions;
@@ -80,7 +80,7 @@ public class SdxRecoveryTests extends PreconditionSdxE2ETest {
                 .then((tc, testDto, client) -> executeCommandToCauseUpgradeFailure(testDto, client))
                 .when(sdxTestClient.upgrade(), key(sdx))
                 .awaitForFlowFail()
-                .when(sdxTestClient.recover(), key(sdx))
+                .when(sdxTestClient.recoverFromUpgrade(), key(sdx))
                 .awaitForFlow(emptyRunningParameter().withWaitForFlowSuccess())
                 .then((tc, dto, client) -> validateStackCrn(originalCrn, dto))
                 .then((tc, dto, client) -> validateImageId(originalImageId, dto))

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxResizeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxResizeTests.java
@@ -15,7 +15,7 @@ import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentNetworkTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
-import com.sequenceiq.it.cloudbreak.util.SdxResizeTestValidator;
+import com.sequenceiq.it.cloudbreak.util.resize.SdxResizeTestValidator;
 import com.sequenceiq.it.cloudbreak.util.SdxUtil;
 import com.sequenceiq.sdx.api.model.SdxClusterShape;
 import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/SdxUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/SdxUtil.java
@@ -44,6 +44,16 @@ public class SdxUtil {
                 .getCloudStorageBaseLocation();
     }
 
+    public Long getCreated(AbstractSdxTestDto testDto, SdxClient sdxClient) {
+        return getSdxClusterDetailResponse(testDto, sdxClient)
+                .getCreated();
+    }
+
+    public String getStatusReason(AbstractSdxTestDto testDto, SdxClient sdxClient) {
+        return getSdxClusterDetailResponse(testDto, sdxClient)
+                .getStatusReason();
+    }
+
     private SdxClusterDetailResponse getSdxClusterDetailResponse(AbstractSdxTestDto testDto, SdxClient sdxClient) {
         return sdxClient.getDefaultClient().sdxEndpoint().getDetail(testDto.getName(), new HashSet<>());
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/resize/SdxResizeTestValidator.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/resize/SdxResizeTestValidator.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.it.cloudbreak.util;
+package com.sequenceiq.it.cloudbreak.util.resize;
 
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -16,11 +16,14 @@ public class SdxResizeTestValidator {
 
     private final AtomicReference<String> expectedRuntime;
 
+    private final AtomicReference<Long> expectedCreationTimestamp;
+
     public SdxResizeTestValidator(SdxClusterShape expectedShape) {
         this.expectedShape = expectedShape;
         expectedCrn = new AtomicReference<>();
         expectedName = new AtomicReference<>();
         expectedRuntime = new AtomicReference<>();
+        expectedCreationTimestamp = new AtomicReference<>();
     }
 
     public void setExpectedCrn(String expectedCrn) {
@@ -35,6 +38,10 @@ public class SdxResizeTestValidator {
         this.expectedRuntime.set(expectedRuntime);
     }
 
+    public void setExpectedCreationTimestamp(Long expectedCreationTimestamp) {
+        this.expectedCreationTimestamp.set(expectedCreationTimestamp);
+    }
+
     public SdxInternalTestDto validateResizedCluster(SdxInternalTestDto dto) {
         SdxClusterResponse response = dto.getResponse();
         validateClusterShape(response.getClusterShape());
@@ -42,6 +49,14 @@ public class SdxResizeTestValidator {
         validateStackCrn(response.getStackCrn());
         validateName(response.getName());
         validateRuntime(response.getRuntime());
+        return dto;
+    }
+
+    public SdxInternalTestDto validateRecoveredCluster(SdxInternalTestDto dto) {
+        validateResizedCluster(dto);
+        SdxClusterResponse response = dto.getResponse();
+        validateNotDetached(response.isDetached());
+        validateCreationTimestamp(response.getCreated());
         return dto;
     }
 
@@ -75,9 +90,21 @@ public class SdxResizeTestValidator {
         }
     }
 
+    private void validateNotDetached(boolean detached) {
+        if (detached) {
+            fail("detached", "false", "true");
+        }
+    }
+
+    private void validateCreationTimestamp(Long creationTimestamp) {
+        if (!expectedCreationTimestamp.get().equals(creationTimestamp)) {
+            fail("creation timestamp", expectedCreationTimestamp.get().toString(), creationTimestamp.toString());
+        }
+    }
+
     private void fail(String testField, String expected, String actual) {
         throw new TestFailException(
-                " The DL " + testField + " is '" + actual + "' instead of '" + expected + '\''
+                " The DL's field '" + testField + "' is '" + actual + "' instead of '" + expected + '\''
         );
     }
 }

--- a/integration-test/src/main/resources/testsuites/e2e/aws-longrunning-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/aws-longrunning-e2e-tests.yaml
@@ -3,7 +3,7 @@ tests:
   - name: "aws_longrunning_e2e_tests"
     classes:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxUpgradeTests
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRecoveryTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxUpgradeRecoveryTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.EnvironmentStopStartTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXUpgradeTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.ephemeral.DistroXStopStartTest
@@ -12,3 +12,4 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRepairTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.freeipa.FreeIpaUpgradeTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxResizeTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxResizeRecoveryTests

--- a/integration-test/src/main/resources/testsuites/e2e/azure-longrunning-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/azure-longrunning-e2e-tests.yaml
@@ -3,11 +3,13 @@ tests:
   - name: "azure_longrunning_e2e_tests"
     classes:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxUpgradeTests
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRecoveryTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxUpgradeRecoveryTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.EnvironmentStopStartTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXUpgradeTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRepairTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.freeipa.FreeIpaUpgradeTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxResizeTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxResizeRecoveryTests
         excludedMethods:
           # CB-15466 Azure FreeIPA Upgrade operation has been timed out with no error message
           - testHAFreeIpaInstanceUpgrade

--- a/integration-test/src/main/resources/testsuites/e2e/gcp-longrunning-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/gcp-longrunning-e2e-tests.yaml
@@ -3,7 +3,7 @@ tests:
   - name: "gcp_longrunning_e2e_tests"
     classes:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.EnvironmentStopStartTests
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRecoveryTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxUpgradeRecoveryTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.freeipa.FreeIpaUpgradeTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRepairTests
           excludedMethods:

--- a/integration-test/src/main/resources/testsuites/e2e/sdx-recovery-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/sdx-recovery-tests.yaml
@@ -2,4 +2,4 @@ name: "sdx-recovery-tests"
 tests:
   - name: "sdx_e2e_recovery_tests"
     classes:
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRecoveryTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxUpgradeRecoveryTests


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-16621

Objective: Add e2e testing for recovery from general resize failures. This change adds the required changes for these tests as well as the specific data restore failure recovery test.

I have verified that the few methods I changed outside of the integration test directory are only called by the integration test logic.

Part of my changes also include adding both the `SdxResizeTests` and `SdxResizeRecoveryTests` to the AWS longrunning (just recovery for this one) and Azure longrunning testsuites as we would like to ensure they are continuously verified for both.

I have tested this locally and ensured that everything is working as desired.