### PR TITLE
CB-17180 Detect and fix Datahub saltuser password errors

### DIFF
--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/dto/StackDto.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/dto/StackDto.java
@@ -17,6 +17,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceMetadataType;
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.common.domain.IdAware;
 import com.sequenceiq.cloudbreak.common.orchestration.Node;
 import com.sequenceiq.cloudbreak.common.orchestration.OrchestratorAware;
@@ -191,6 +192,10 @@ public class StackDto implements OrchestratorAware, StackDtoDelegate, MdcContext
 
     public SecurityConfig getSecurityConfig() {
         return securityConfig;
+    }
+
+    public String getAccountId() {
+        return Crn.safeFromString(getResourceCrn()).getAccountId();
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/salt/StackSaltStatusCheckerJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/salt/StackSaltStatusCheckerJob.java
@@ -1,0 +1,141 @@
+package com.sequenceiq.cloudbreak.job.salt;
+
+import static com.sequenceiq.cloudbreak.util.Benchmark.measure;
+
+import java.util.EnumSet;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGenerator;
+import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.quartz.statuschecker.job.StatusCheckerJob;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordReason;
+import com.sequenceiq.cloudbreak.service.RotateSaltPasswordService;
+import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
+
+import io.opentracing.Tracer;
+
+@DisallowConcurrentExecution
+@Component
+public class StackSaltStatusCheckerJob extends StatusCheckerJob {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StackSaltStatusCheckerJob.class);
+
+    private static final EnumSet<Status> IGNORED_STATES = EnumSet.of(
+            Status.REQUESTED,
+            Status.CREATE_IN_PROGRESS,
+            Status.UPDATE_IN_PROGRESS,
+            Status.UPDATE_REQUESTED,
+            Status.STOP_REQUESTED,
+            Status.START_REQUESTED,
+            Status.STOP_IN_PROGRESS,
+            Status.START_IN_PROGRESS,
+            Status.WAIT_FOR_SYNC,
+            Status.MAINTENANCE_MODE_ENABLED,
+            Status.EXTERNAL_DATABASE_CREATION_IN_PROGRESS,
+            Status.BACKUP_IN_PROGRESS,
+            Status.RESTORE_IN_PROGRESS,
+            Status.LOAD_BALANCER_UPDATE_IN_PROGRESS,
+            Status.RECOVERY_IN_PROGRESS,
+            Status.RECOVERY_REQUESTED
+    );
+
+    private static final EnumSet<Status> SYNCABLE_STATES = EnumSet.of(
+            Status.AVAILABLE,
+            Status.UPDATE_FAILED,
+            Status.ENABLE_SECURITY_FAILED,
+            Status.START_FAILED,
+            Status.STOP_FAILED,
+            Status.AMBIGUOUS,
+            Status.UNREACHABLE,
+            Status.NODE_FAILURE,
+            Status.RESTORE_FAILED,
+            Status.BACKUP_FAILED,
+            Status.BACKUP_FINISHED,
+            Status.RESTORE_FINISHED,
+            Status.EXTERNAL_DATABASE_START_FAILED,
+            Status.EXTERNAL_DATABASE_START_IN_PROGRESS,
+            Status.EXTERNAL_DATABASE_START_FINISHED,
+            Status.EXTERNAL_DATABASE_STOP_FAILED,
+            Status.EXTERNAL_DATABASE_STOP_IN_PROGRESS,
+            Status.EXTERNAL_DATABASE_STOP_FINISHED,
+            Status.RECOVERY_FAILED,
+            Status.UPGRADE_CCM_FAILED,
+            Status.UPGRADE_CCM_FINISHED,
+            Status.UPGRADE_CCM_IN_PROGRESS
+    );
+
+    @Inject
+    private StackSaltStatusCheckerJobService jobService;
+
+    @Inject
+    private StackDtoService stackDtoService;
+
+    @Inject
+    private RegionAwareInternalCrnGeneratorFactory regionAwareInternalCrnGeneratorFactory;
+
+    @Inject
+    private RotateSaltPasswordService rotateSaltPasswordService;
+
+    public StackSaltStatusCheckerJob(Tracer tracer) {
+        super(tracer, "Stack Salt Status Checker Job");
+    }
+
+    @Override
+    protected Object getMdcContextObject() {
+        return stackDtoService.getStackViewById(getStackId());
+    }
+
+    @Override
+    protected void executeTracedJob(JobExecutionContext context) throws JobExecutionException {
+        try {
+            measure(() -> {
+                StackDto stack = stackDtoService.getById(getStackId());
+                rotateSaltPasswordService.validateRotateSaltPassword(stack);
+                Status stackStatus = stack.getStatus();
+                if (Status.getUnschedulableStatuses().contains(stackStatus)) {
+                    LOGGER.debug("Stack salt sync will be unscheduled, stack state is {}", stackStatus);
+                    jobService.unschedule(context.getJobDetail().getKey());
+                } else if (null == stackStatus || IGNORED_STATES.contains(stackStatus)) {
+                    LOGGER.debug("Stack salt sync is skipped, stack state is {}", stackStatus);
+                } else if (SYNCABLE_STATES.contains(stackStatus)) {
+                    RegionAwareInternalCrnGenerator dataHub = regionAwareInternalCrnGeneratorFactory.datahub();
+                    ThreadBasedUserCrnProvider.doAs(dataHub.getInternalCrnForServiceAsString(), () -> rotateSaltPasswordIfNeeded(stack));
+                } else {
+                    LOGGER.warn("Unhandled stack status, {}", stackStatus);
+                }
+            }, LOGGER, "Check salt status took {} ms for stack {}.", getStackId());
+        } catch (BadRequestException e) {
+            LOGGER.info("StackSaltStatusCheckerJob cannot run, because validation failed for stack {} with message: {}", getStackId(), e.getMessage());
+            jobService.unschedule(context.getJobDetail().getKey());
+        } catch (Exception e) {
+            LOGGER.info("Exception during stack salt status check.", e);
+        }
+    }
+
+    private void rotateSaltPasswordIfNeeded(StackDto stack) {
+        try {
+            Optional<RotateSaltPasswordReason> rotateSaltPasswordReason = rotateSaltPasswordService.checkIfSaltPasswordRotationNeeded(stack);
+            rotateSaltPasswordReason.ifPresent(reason -> rotateSaltPasswordService.triggerRotateSaltPassword(stack, reason));
+        } catch (Exception e) {
+            rotateSaltPasswordService.sendFailureUsageReport(stack.getResourceCrn(), RotateSaltPasswordReason.UNSET, e.getMessage());
+            throw e;
+        }
+    }
+
+    private Long getStackId() {
+        return Long.valueOf(getLocalId());
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/salt/StackSaltStatusCheckerJobAdapter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/salt/StackSaltStatusCheckerJobAdapter.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.cloudbreak.job.salt;
+
+import org.quartz.Job;
+import org.springframework.context.ApplicationContext;
+
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
+import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
+import com.sequenceiq.cloudbreak.quartz.model.JobResourceRepository;
+import com.sequenceiq.cloudbreak.repository.StackRepository;
+
+public class StackSaltStatusCheckerJobAdapter extends JobResourceAdapter<Stack>  {
+
+    public StackSaltStatusCheckerJobAdapter(Long id, ApplicationContext context) {
+        super(id, context);
+    }
+
+    public StackSaltStatusCheckerJobAdapter(JobResource jobResource) {
+        super(jobResource);
+    }
+
+    @Override
+    public Class<? extends Job> getJobClassForResource() {
+        return StackSaltStatusCheckerJob.class;
+    }
+
+    @Override
+    public Class<? extends JobResourceRepository<Stack, Long>> getRepositoryClassForResource() {
+        return StackRepository.class;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/salt/StackSaltStatusCheckerJobInitializer.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/salt/StackSaltStatusCheckerJobInitializer.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.cloudbreak.job.salt;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.job.AbstractStackJobInitializer;
+import com.sequenceiq.cloudbreak.quartz.saltstatuschecker.SaltStatusCheckerConfig;
+
+@Component
+public class StackSaltStatusCheckerJobInitializer extends AbstractStackJobInitializer {
+
+    @Inject
+    private SaltStatusCheckerConfig saltStatusCheckerConfig;
+
+    @Inject
+    private StackSaltStatusCheckerJobService jobService;
+
+    @Override
+    public void initJobs() {
+        if (saltStatusCheckerConfig.isEnabled()) {
+            getAliveJobResources()
+                    .forEach(s -> jobService.schedule(new StackSaltStatusCheckerJobAdapter(s)));
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/salt/StackSaltStatusCheckerJobService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/salt/StackSaltStatusCheckerJobService.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.cloudbreak.job.salt;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
+import com.sequenceiq.cloudbreak.quartz.saltstatuschecker.SaltStatusCheckerJobService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+
+@Service
+public class StackSaltStatusCheckerJobService extends SaltStatusCheckerJobService<StackSaltStatusCheckerJobAdapter> {
+
+    @Inject
+    private StackService stackService;
+
+    public void schedule(Long stackId) {
+        JobResource jobResource = stackService.getJobResource(stackId);
+        schedule(new StackSaltStatusCheckerJobAdapter(jobResource));
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/RotateSaltPasswordReason.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/RotateSaltPasswordReason.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
 public enum RotateSaltPasswordReason {
+    UNSET,
     MANUAL,
     EXPIRED,
     UNAUTHORIZED

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/RotateSaltPasswordService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/RotateSaltPasswordService.java
@@ -1,7 +1,10 @@
 package com.sequenceiq.cloudbreak.service;
 
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import javax.inject.Inject;
 
@@ -10,23 +13,38 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.cloudera.thunderhead.service.common.usage.UsageProto;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.common.service.Clock;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.SaltBootstrapVersionChecker;
+import com.sequenceiq.cloudbreak.core.flow2.service.ReactorFlowManager;
 import com.sequenceiq.cloudbreak.domain.SecurityConfig;
 import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.cloudbreak.quartz.saltstatuschecker.SaltStatusCheckerConfig;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordReason;
 import com.sequenceiq.cloudbreak.service.securityconfig.SecurityConfigService;
 import com.sequenceiq.cloudbreak.usage.UsageReporter;
 import com.sequenceiq.cloudbreak.util.PasswordUtil;
 import com.sequenceiq.cloudbreak.view.InstanceMetadataView;
+import com.sequenceiq.flow.api.model.FlowIdentifier;
 
 @Service
 public class RotateSaltPasswordService {
 
+    protected static final String SALTUSER = "saltuser";
+
+    protected static final String UNAUTHORIZED_RESPONSE = "Status: 401 Unauthorized Response";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(RotateSaltPasswordService.class);
+
+    @Inject
+    private SaltStatusCheckerConfig saltStatusCheckerConfig;
+
+    @Inject
+    private Clock clock;
 
     @Inject
     private HostOrchestrator hostOrchestrator;
@@ -43,9 +61,15 @@ public class RotateSaltPasswordService {
     @Inject
     private UsageReporter usageReporter;
 
+    @Inject
+    private EntitlementService entitlementService;
+
+    @Inject
+    private ReactorFlowManager flowManager;
+
     public void validateRotateSaltPassword(StackDto stack) {
-        if (!stack.isAvailable()) {
-            throw new BadRequestException("Rotating SaltStack user password is only available for stacks in available status");
+        if (!entitlementService.isSaltUserPasswordRotationEnabled(stack.getAccountId())) {
+            throw new BadRequestException("Rotating SaltStack user password is not supported in your account");
         }
         if (!isChangeSaltuserPasswordSupported(stack)) {
             throw new BadRequestException(String.format("Rotating SaltStack user password is not supported with your image version, " +
@@ -58,6 +82,11 @@ public class RotateSaltPasswordService {
         return stack.getNotTerminatedAndNotZombieGatewayInstanceMetadata().stream()
                 .map(InstanceMetadataView::getImage)
                 .allMatch(image -> saltBootstrapVersionChecker.isChangeSaltuserPasswordSupported(image));
+    }
+
+    public FlowIdentifier triggerRotateSaltPassword(StackDto stack, RotateSaltPasswordReason reason) {
+        validateRotateSaltPassword(stack);
+        return flowManager.triggerRotateSaltPassword(stack.getId(), reason);
     }
 
     public void rotateSaltPassword(StackDto stack) throws CloudbreakOrchestratorException {
@@ -94,5 +123,41 @@ public class RotateSaltPasswordService {
             LOGGER.error("Failed to report rotate salt password event with resource crn {}, reason {}, result {} and message {}",
                     resourceCrn, reason, result, message, e);
         }
+    }
+
+    public Optional<RotateSaltPasswordReason> checkIfSaltPasswordRotationNeeded(StackDto stack) {
+        Optional<RotateSaltPasswordReason> result;
+        try {
+            List<GatewayConfig> allGatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
+            LocalDate passwordExpiryDate = hostOrchestrator.getPasswordExpiryDate(allGatewayConfigs, SALTUSER);
+            if (isPasswordExpiresSoon(passwordExpiryDate)) {
+                LOGGER.info("Stack {} user {} password expires at {}, password rotation is needed", stack.getId(), SALTUSER, passwordExpiryDate);
+                result = Optional.of(RotateSaltPasswordReason.EXPIRED);
+            } else {
+                LOGGER.info("Stack {} user {} password expires at {}, nothing to do", stack.getId(), SALTUSER, passwordExpiryDate);
+                result = Optional.empty();
+            }
+        } catch (CloudbreakOrchestratorException e) {
+            if (isUnauthorizedException(e)) {
+                LOGGER.info("Received unauthorized response from salt on stack {}", stack.getId());
+                result = Optional.of(RotateSaltPasswordReason.UNAUTHORIZED);
+            } else {
+                LOGGER.warn("Received error response from salt on stack {}", stack.getId(), e);
+                throw new CloudbreakRuntimeException(e);
+            }
+        }
+        return result;
+    }
+
+    private boolean isPasswordExpiresSoon(LocalDate passwordExpiryDate) {
+        long daysUntilPasswordExpires = ChronoUnit.DAYS.between(clock.getCurrentLocalDateTime(), passwordExpiryDate.atStartOfDay());
+        return daysUntilPasswordExpires <= saltStatusCheckerConfig.getPasswordExpiryThresholdInDays();
+    }
+
+    private static boolean isUnauthorizedException(CloudbreakOrchestratorException e) {
+        return Optional.ofNullable(e.getCause())
+                .map(Throwable::getCause)
+                .filter(ex -> ex.getMessage().startsWith(UNAUTHORIZED_RESPONSE))
+                .isPresent();
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/StackCommonService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/StackCommonService.java
@@ -31,8 +31,6 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.network.NetworkS
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.AutoscaleStackV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.GeneratedBlueprintV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
-import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
-import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
 import com.sequenceiq.cloudbreak.common.ScalingHardLimitsService;
@@ -144,9 +142,6 @@ public class StackCommonService {
     @Inject
     private InstanceMetaDataService instanceMetaDataService;
 
-    @Inject
-    private EntitlementService entitlementService;
-
     public StackV4Response createInWorkspace(StackV4Request stackRequest, User user, Workspace workspace, boolean distroxRequest) {
         return stackCreatorService.createStack(user, workspace, stackRequest, distroxRequest);
     }
@@ -255,9 +250,6 @@ public class StackCommonService {
     }
 
     public FlowIdentifier rotateSaltPassword(NameOrCrn nameOrCrn, String accountId, RotateSaltPasswordReason reason) {
-        if (!entitlementService.isSaltUserPasswordRotationEnabled(ThreadBasedUserCrnProvider.getAccountId())) {
-            throw new BadRequestException("Rotating SaltStack user password is not supported in your account");
-        }
         return stackOperationService.rotateSaltPassword(nameOrCrn, accountId, reason);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
@@ -452,7 +452,6 @@ public class StackOperationService {
     public FlowIdentifier rotateSaltPassword(@NotNull NameOrCrn nameOrCrn, String accountId, RotateSaltPasswordReason reason) {
         StackDto stack = stackDtoService.getByNameOrCrn(nameOrCrn, accountId);
         MDCBuilder.buildMdcContext(stack);
-        rotateSaltPasswordService.validateRotateSaltPassword(stack);
-        return flowManager.triggerRotateSaltPassword(stack.getId(), reason);
+        return rotateSaltPasswordService.triggerRotateSaltPassword(stack, reason);
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/RotateSaltPasswordServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/RotateSaltPasswordServiceTest.java
@@ -1,17 +1,23 @@
 package com.sequenceiq.cloudbreak.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -23,6 +29,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.cloudera.thunderhead.service.common.usage.UsageProto;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.common.service.Clock;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.SaltBootstrapVersionChecker;
 import com.sequenceiq.cloudbreak.domain.SaltSecurityConfig;
 import com.sequenceiq.cloudbreak.domain.SecurityConfig;
@@ -31,6 +38,7 @@ import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.cloudbreak.quartz.saltstatuschecker.SaltStatusCheckerConfig;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordReason;
 import com.sequenceiq.cloudbreak.service.securityconfig.SecurityConfigService;
 import com.sequenceiq.cloudbreak.usage.UsageReporter;
@@ -61,7 +69,16 @@ class RotateSaltPasswordServiceTest {
     private EntitlementService entitlementService;
 
     @Mock
+    private Clock clock;
+
+    @Mock
+    private SaltStatusCheckerConfig saltStatusCheckerConfig;
+
+    @Mock
     private StackDto stack;
+
+    @Mock
+    private List<GatewayConfig> gatewayConfigs;
 
     @Captor
     private ArgumentCaptor<String> stringArgumentCaptor;
@@ -72,10 +89,14 @@ class RotateSaltPasswordServiceTest {
     @InjectMocks
     private RotateSaltPasswordService underTest;
 
+    @BeforeEach
+    void setUp() {
+        lenient().when(stack.getAccountId()).thenReturn(ACCOUNT_ID);
+        lenient().when(entitlementService.isSaltUserPasswordRotationEnabled(ACCOUNT_ID)).thenReturn(true);
+    }
+
     @Test
     public void testRotateSaltPasswordSuccess() throws Exception {
-        when(stack.isAvailable()).thenReturn(true);
-
         GatewayConfig gw1 = new GatewayConfig("host1", "1.1.1.1", "1.1.1.1", 22, "i-1839", false);
         GatewayConfig gw2 = new GatewayConfig("host2", "1.1.1.2", "1.1.1.2", 22, "i-1839", false);
         List<GatewayConfig> gatewayConfigs = List.of(gw1, gw2);
@@ -96,18 +117,16 @@ class RotateSaltPasswordServiceTest {
     }
 
     @Test
-    public void testRotateSaltPasswordOnNonAvailableStack() {
-        when(stack.isAvailable()).thenReturn(false);
+    public void testRotateSaltPasswordOnStackInAccountWithoutEntitlement() {
+        when(entitlementService.isSaltUserPasswordRotationEnabled(ACCOUNT_ID)).thenReturn(false);
 
         Assertions.assertThatThrownBy(() -> underTest.rotateSaltPassword(stack))
                 .isInstanceOf(BadRequestException.class)
-                .hasMessage("Rotating SaltStack user password is only available for stacks in available status");
+                .hasMessage("Rotating SaltStack user password is not supported in your account");
     }
 
     @Test
     public void testRotateSaltPasswordOnStackWithOldSBVersion() {
-        when(stack.isAvailable()).thenReturn(true);
-
         when(stack.getNotTerminatedAndNotZombieGatewayInstanceMetadata()).thenReturn(List.of(new InstanceMetaData()));
         when(saltBootstrapVersionChecker.isChangeSaltuserPasswordSupported(any())).thenReturn(false);
 
@@ -119,8 +138,6 @@ class RotateSaltPasswordServiceTest {
 
     @Test
     public void testRotateSaltPasswordFailure() throws Exception {
-        when(stack.isAvailable()).thenReturn(true);
-
         SaltSecurityConfig saltSecurityConfig = new SaltSecurityConfig();
         saltSecurityConfig.setSaltPassword("old-password");
         SecurityConfig securityConfig = new SecurityConfig();
@@ -164,5 +181,53 @@ class RotateSaltPasswordServiceTest {
                 .returns(UsageProto.CDPSaltPasswordRotationEventReason.Value.EXPIRED, UsageProto.CDPSaltPasswordRotationEvent::getReason)
                 .returns(UsageProto.CDPSaltPasswordRotationEventResult.Value.FAILURE, UsageProto.CDPSaltPasswordRotationEvent::getEventResult)
                 .returns(message, UsageProto.CDPSaltPasswordRotationEvent::getMessage);
+    }
+
+    @Test
+    void expiredSaltPasswordRotationNeeded() throws Exception {
+        when(clock.getCurrentLocalDateTime()).thenReturn(LocalDateTime.now());
+        when(saltStatusCheckerConfig.getPasswordExpiryThresholdInDays()).thenReturn(14);
+        when(gatewayConfigService.getAllGatewayConfigs(stack)).thenReturn(gatewayConfigs);
+        when(hostOrchestrator.getPasswordExpiryDate(gatewayConfigs, RotateSaltPasswordService.SALTUSER)).thenReturn(LocalDate.now().minusMonths(2));
+
+        Optional<RotateSaltPasswordReason> result = underTest.checkIfSaltPasswordRotationNeeded(stack);
+
+        assertThat(result).hasValue(RotateSaltPasswordReason.EXPIRED);
+    }
+
+    @Test
+    void noSaltPasswordRotationNeeded() throws Exception {
+        when(clock.getCurrentLocalDateTime()).thenReturn(LocalDateTime.now());
+        when(saltStatusCheckerConfig.getPasswordExpiryThresholdInDays()).thenReturn(14);
+        when(gatewayConfigService.getAllGatewayConfigs(stack)).thenReturn(gatewayConfigs);
+        when(hostOrchestrator.getPasswordExpiryDate(gatewayConfigs, RotateSaltPasswordService.SALTUSER)).thenReturn(LocalDate.now().plusMonths(2));
+
+        Optional<RotateSaltPasswordReason> result = underTest.checkIfSaltPasswordRotationNeeded(stack);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void unauthorizedSaltPasswordRotationNeeded() throws Exception {
+        when(gatewayConfigService.getAllGatewayConfigs(stack)).thenReturn(gatewayConfigs);
+        RuntimeException causeCause = new RuntimeException(RotateSaltPasswordService.UNAUTHORIZED_RESPONSE);
+        RuntimeException cause = new RuntimeException("Ooops", causeCause);
+        CloudbreakOrchestratorFailedException exception = new CloudbreakOrchestratorFailedException("Failed", cause);
+        when(hostOrchestrator.getPasswordExpiryDate(gatewayConfigs, RotateSaltPasswordService.SALTUSER)).thenThrow(exception);
+
+        Optional<RotateSaltPasswordReason> result = underTest.checkIfSaltPasswordRotationNeeded(stack);
+
+        assertThat(result).hasValue(RotateSaltPasswordReason.UNAUTHORIZED);
+    }
+
+    @Test
+    void errorWhileSaltPasswordRotationNeeded() throws Exception {
+        when(gatewayConfigService.getAllGatewayConfigs(stack)).thenReturn(gatewayConfigs);
+        CloudbreakOrchestratorFailedException exception = new CloudbreakOrchestratorFailedException("Unexpected failure");
+        when(hostOrchestrator.getPasswordExpiryDate(gatewayConfigs, RotateSaltPasswordService.SALTUSER)).thenThrow(exception);
+
+        assertThatThrownBy(() -> underTest.checkIfSaltPasswordRotationNeeded(stack))
+                .isInstanceOf(CloudbreakRuntimeException.class)
+                .hasCause(exception);
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/StackCommonServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/StackCommonServiceTest.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.cloudbreak.service;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -51,9 +50,9 @@ import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterBootstrapper;
 import com.sequenceiq.cloudbreak.domain.ImageCatalog;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.StackStatus;
-import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordReason;
 import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordReason;
 import com.sequenceiq.cloudbreak.service.image.ImageCatalogService;
 import com.sequenceiq.cloudbreak.service.image.ImageChangeDto;
 import com.sequenceiq.cloudbreak.service.stack.CloudParameterCache;
@@ -383,22 +382,9 @@ class StackCommonServiceTest {
     }
 
     @Test
-    public void testRotateSaltPasswordWithoutEntitlement() {
-        when(entitlementService.isSaltUserPasswordRotationEnabled(any())).thenReturn(false);
-
-        assertThatThrownBy(() ->
-                ThreadBasedUserCrnProvider.doAs(ACTOR_CRN, () -> underTest.rotateSaltPassword(STACK_CRN, ACCOUNT_ID, RotateSaltPasswordReason.MANUAL)))
-                .isInstanceOf(BadRequestException.class)
-                .hasMessage("Rotating SaltStack user password is not supported in your account");
-    }
-
-    @Test
     public void testRotateSaltPassword() throws CloudbreakOrchestratorException {
-        when(entitlementService.isSaltUserPasswordRotationEnabled(any())).thenReturn(true);
-
         ThreadBasedUserCrnProvider.doAs(ACTOR_CRN, () -> underTest.rotateSaltPassword(STACK_CRN, ACCOUNT_ID, RotateSaltPasswordReason.MANUAL));
 
-        verify(entitlementService).isSaltUserPasswordRotationEnabled(any());
         verify(stackOperationService).rotateSaltPassword(STACK_CRN, ACCOUNT_ID, RotateSaltPasswordReason.MANUAL);
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationServiceTest.java
@@ -464,17 +464,15 @@ public class StackOperationServiceTest {
     public void testRotateSaltPassword() {
         NameOrCrn nameOrCrn = NameOrCrn.ofCrn("crn");
         StackDto stackDto = mock(StackDto.class);
-        when(stackDto.getId()).thenReturn(5L);
         when(stackDtoService.getByNameOrCrn(nameOrCrn, ACCOUNT_ID)).thenReturn(stackDto);
         FlowIdentifier flowIdentifier = new FlowIdentifier(FlowType.FLOW, "pollableId");
-        when(flowManager.triggerRotateSaltPassword(stackDto.getId(), REASON)).thenReturn(flowIdentifier);
+        when(rotateSaltPasswordService.triggerRotateSaltPassword(stackDto, REASON)).thenReturn(flowIdentifier);
 
         FlowIdentifier result = underTest.rotateSaltPassword(nameOrCrn, ACCOUNT_ID, REASON);
 
         assertEquals(flowIdentifier, result);
         verify(stackDtoService).getByNameOrCrn(nameOrCrn, ACCOUNT_ID);
-        verify(rotateSaltPasswordService).validateRotateSaltPassword(stackDto);
-        verify(flowManager).triggerRotateSaltPassword(stackDto.getId(), REASON);
+        verify(rotateSaltPasswordService).triggerRotateSaltPassword(stackDto, REASON);
     }
 
     private InstanceMetaData createInstanceMetadataForTest(Long privateId, String instanceGroupName) {


### PR DESCRIPTION
Works the same as in casse of FreeIPA: a salt command querying the saltuser password expiry date is sent to all gateway instances of a stack:
- If the password expires sooner than a set threshold, a salt password rotation is started.
- If it responds with an unauthorized response, a salt password rotation is started.
- Other types of errors are only logged.