### PR TITLE
CB-18058 Ability to define Postgres version from runtime version X

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/service/database/DatabaseDefaultVersionProvider.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/service/database/DatabaseDefaultVersionProvider.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.cloudbreak.service.database;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.util.VersionComparator;
+
+@Component
+public class DatabaseDefaultVersionProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseDefaultVersionProvider.class);
+
+    @Value("${cb.db.override.minRuntimeVersion}")
+    private String minRuntimeVersion;
+
+    @Value("${cb.db.override.engineVersion}")
+    private String dbEngineVersion;
+
+    private final VersionComparator versionComparator = new VersionComparator();
+
+    public String calculateDbVersionBasedOnRuntimeIfMissing(String runtime, String requestedDbEngineVersion) {
+        if (StringUtils.isNotBlank(requestedDbEngineVersion)) {
+            LOGGER.debug("DB engine version already requested to be [{}]", requestedDbEngineVersion);
+            return requestedDbEngineVersion;
+        } else {
+            if (0 <= versionComparator.compare(() -> runtime, () -> minRuntimeVersion)) {
+                LOGGER.debug("Setting DB engine version to [{}] for runtime [{}]", dbEngineVersion, runtime);
+                return dbEngineVersion;
+            } else {
+                LOGGER.debug("Setting DB engine version to 'null' for runtime [{}]", runtime);
+                return null;
+            }
+        }
+    }
+}

--- a/common/src/main/resources/common-config.yml
+++ b/common/src/main/resources/common-config.yml
@@ -132,3 +132,7 @@ jobs:
     enabled: true
     interval-in-minutes: 60
     password-expiry-threshold-in-days: 14
+cb:
+  db.override:
+    minRuntimeVersion: 7.2.7
+    engineVersion: 11

--- a/common/src/test/java/com/sequenceiq/cloudbreak/service/database/DatabaseDefaultVersionProviderTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/service/database/DatabaseDefaultVersionProviderTest.java
@@ -1,0 +1,42 @@
+package com.sequenceiq.cloudbreak.service.database;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class DatabaseDefaultVersionProviderTest {
+
+    private DatabaseDefaultVersionProvider underTest;
+
+    @BeforeEach
+    public void init() {
+        underTest = new DatabaseDefaultVersionProvider();
+    }
+
+    static Object[][] testInput() {
+        return new Object[][]{
+                {"Version already set, runtime older", "7.2.10", "10", "7.2.12", "11", "10"},
+                {"Version already set, runtime same", "7.2.12", "10", "7.2.12", "11", "10"},
+                {"Version already set, runtime newer", "7.2.14", "10", "7.2.12", "11", "10"},
+                {"Version not set, runtime older", "7.2.10", null, "7.2.12", "11", null},
+                {"Version not set, runtime same", "7.2.12", null, "7.2.12", "11", "11"},
+                {"Version not set, runtime newer", "7.2.14", null, "7.2.12", "11", "11"},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("testInput")
+    public void testCalculateDbVersionBasedOnRuntimeIfMissing(String name, String runtime, String externalDatabaseEngineVersion, String minRuntime,
+            String dbEngineVersion, String expected) {
+        ReflectionTestUtils.setField(underTest, "minRuntimeVersion", minRuntime);
+        ReflectionTestUtils.setField(underTest, "dbEngineVersion", dbEngineVersion);
+
+        String result = underTest.calculateDbVersionBasedOnRuntimeIfMissing(runtime, externalDatabaseEngineVersion);
+
+        assertEquals(expected, result);
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/StackCreatorService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/StackCreatorService.java
@@ -245,7 +245,7 @@ public class StackCreatorService {
                         "Select the correct image took {} ms");
                 stackRuntimeVersionValidator.validate(stackRequest, imgFromCatalog.getImage(), stackType);
                 Stack newStack = measure(() -> stackService.create(
-                            stack, platformString, imgFromCatalog, user, workspace, Optional.ofNullable(stackRequest.getResourceCrn())),
+                            stack, imgFromCatalog, user, workspace, Optional.ofNullable(stackRequest.getResourceCrn())),
                             LOGGER,
                         "Save the remaining stack data took {} ms"
                         );

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
@@ -104,6 +104,7 @@ import com.sequenceiq.cloudbreak.quartz.model.JobResource;
 import com.sequenceiq.cloudbreak.repository.StackRepository;
 import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
+import com.sequenceiq.cloudbreak.service.database.DatabaseDefaultVersionProvider;
 import com.sequenceiq.cloudbreak.service.datalake.SdxClientService;
 import com.sequenceiq.cloudbreak.service.decorator.StackResponseDecorator;
 import com.sequenceiq.cloudbreak.service.environment.credential.OpenSshPublicKeyValidator;
@@ -245,6 +246,9 @@ public class StackService implements ResourceIdProvider, AuthorizationResourceNa
 
     @Inject
     private StackDtoService stackDtoService;
+
+    @Inject
+    private DatabaseDefaultVersionProvider databaseDefaultVersionProvider;
 
     @Value("${cb.nginx.port}")
     private Integer nginxPort;
@@ -543,7 +547,7 @@ public class StackService implements ResourceIdProvider, AuthorizationResourceNa
     }
 
     @Measure(StackService.class)
-    public Stack create(Stack stack, String platformString, StatedImage imgFromCatalog, User user, Workspace workspace, Optional<String> externalCrn) {
+    public Stack create(Stack stack, StatedImage imgFromCatalog, User user, Workspace workspace, Optional<String> externalCrn) {
         if (stack.getGatewayPort() == null) {
             stack.setGatewayPort(nginxPort);
         }
@@ -602,7 +606,7 @@ public class StackService implements ResourceIdProvider, AuthorizationResourceNa
 
         try {
             Set<Component> components = imageService.create(stack, imgFromCatalog);
-            setRuntime(stack, components);
+            setRuntimeAndDbVersion(stack, components);
         } catch (CloudbreakImageNotFoundException e) {
             LOGGER.info("Cloudbreak Image not found", e);
             throw new CloudbreakApiException(e.getMessage(), e);
@@ -617,12 +621,14 @@ public class StackService implements ResourceIdProvider, AuthorizationResourceNa
         return savedStack;
     }
 
-    private void setRuntime(Stack stack, Set<Component> components) {
+    private void setRuntimeAndDbVersion(Stack stack, Set<Component> components) {
         ClouderaManagerProduct runtime = ComponentConfigProviderService.getComponent(components, ClouderaManagerProduct.class, CDH_PRODUCT_DETAILS);
         if (Objects.nonNull(runtime)) {
             String stackVersion = substringBefore(runtime.getVersion(), "-");
             LOGGER.debug("Setting runtime version {} for stack", stackVersion);
             stack.setStackVersion(stackVersion);
+            stack.setExternalDatabaseEngineVersion(databaseDefaultVersionProvider
+                    .calculateDbVersionBasedOnRuntimeIfMissing(stackVersion, stack.getExternalDatabaseEngineVersion()));
             stackRepository.save(stack);
         } else {
             // should not happen ever

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/StackServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/StackServiceTest.java
@@ -238,7 +238,7 @@ public class StackServiceTest {
 
         try {
             stack = ThreadBasedUserCrnProvider.doAs(USER_CRN,
-                    () -> underTest.create(stack, platformString, mock(StatedImage.class), user, workspace, Optional.empty()));
+                    () -> underTest.create(stack, mock(StatedImage.class), user, workspace, Optional.empty()));
         } finally {
             verify(stack, times(1)).setPlatformVariant(eq(VARIANT_VALUE));
         }
@@ -256,7 +256,7 @@ public class StackServiceTest {
 
         try {
             stack = ThreadBasedUserCrnProvider.doAs(USER_CRN,
-                    () -> underTest.create(stack, "AWS", mock(StatedImage.class), user, workspace, Optional.empty()));
+                    () -> underTest.create(stack, mock(StatedImage.class), user, workspace, Optional.empty()));
         } finally {
             verify(stack, times(1)).setPlatformVariant(eq(VARIANT_VALUE));
             verify(stack).setResourceCrn(crnCaptor.capture());

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxExternalDatabaseConfigurerTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxExternalDatabaseConfigurerTest.java
@@ -12,6 +12,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.service.database.DatabaseDefaultVersionProvider;
 import com.sequenceiq.datalake.configuration.PlatformConfig;
 import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.sdx.api.model.SdxDatabaseAvailabilityType;
@@ -23,6 +24,9 @@ public class SdxExternalDatabaseConfigurerTest {
     @Mock
     private PlatformConfig platformConfig;
 
+    @Mock
+    private DatabaseDefaultVersionProvider databaseDefaultVersionProvider;
+
     @InjectMocks
     private SdxExternalDatabaseConfigurer underTest;
 
@@ -31,12 +35,14 @@ public class SdxExternalDatabaseConfigurerTest {
         CloudPlatform cloudPlatform = CloudPlatform.AWS;
         when(platformConfig.isExternalDatabaseSupportedFor(cloudPlatform)).thenReturn(true);
         when(platformConfig.isExternalDatabaseSupportedOrExperimental(cloudPlatform)).thenReturn(true);
+        when(databaseDefaultVersionProvider.calculateDbVersionBasedOnRuntimeIfMissing(null, null)).thenReturn("11");
         SdxCluster sdxCluster = new SdxCluster();
 
         underTest.configure(cloudPlatform, null, sdxCluster);
 
         assertEquals(true, sdxCluster.isCreateDatabase());
         assertEquals(SdxDatabaseAvailabilityType.HA, sdxCluster.getDatabaseAvailabilityType());
+        assertEquals("11", sdxCluster.getDatabaseEngineVersion());
     }
 
     @Test
@@ -45,11 +51,13 @@ public class SdxExternalDatabaseConfigurerTest {
         SdxDatabaseRequest dbRequest = new SdxDatabaseRequest();
         dbRequest.setAvailabilityType(SdxDatabaseAvailabilityType.NONE);
         SdxCluster sdxCluster = new SdxCluster();
+        when(databaseDefaultVersionProvider.calculateDbVersionBasedOnRuntimeIfMissing(null, null)).thenReturn("11");
 
         underTest.configure(cloudPlatform, dbRequest, sdxCluster);
 
         assertEquals(false, sdxCluster.isCreateDatabase());
         assertEquals(SdxDatabaseAvailabilityType.NONE, sdxCluster.getDatabaseAvailabilityType());
+        assertEquals("11", sdxCluster.getDatabaseEngineVersion());
     }
 
     @Test
@@ -59,11 +67,13 @@ public class SdxExternalDatabaseConfigurerTest {
         SdxDatabaseRequest dbRequest = new SdxDatabaseRequest();
         dbRequest.setAvailabilityType(SdxDatabaseAvailabilityType.HA);
         SdxCluster sdxCluster = new SdxCluster();
+        when(databaseDefaultVersionProvider.calculateDbVersionBasedOnRuntimeIfMissing(null, null)).thenReturn("11");
 
         underTest.configure(cloudPlatform, dbRequest, sdxCluster);
 
         assertEquals(true, sdxCluster.isCreateDatabase());
         assertEquals(SdxDatabaseAvailabilityType.HA, sdxCluster.getDatabaseAvailabilityType());
+        assertEquals("11", sdxCluster.getDatabaseEngineVersion());
     }
 
     @Test
@@ -74,11 +84,13 @@ public class SdxExternalDatabaseConfigurerTest {
         SdxDatabaseRequest dbRequest = new SdxDatabaseRequest();
         SdxCluster sdxCluster = new SdxCluster();
         sdxCluster.setClusterName("clusterName");
+        when(databaseDefaultVersionProvider.calculateDbVersionBasedOnRuntimeIfMissing(null, null)).thenReturn("11");
 
         underTest.configure(cloudPlatform, dbRequest, sdxCluster);
 
         assertEquals(true, sdxCluster.isCreateDatabase());
         assertEquals(SdxDatabaseAvailabilityType.HA, sdxCluster.getDatabaseAvailabilityType());
+        assertEquals("11", sdxCluster.getDatabaseEngineVersion());
     }
 
     @Test
@@ -88,11 +100,13 @@ public class SdxExternalDatabaseConfigurerTest {
         dbRequest.setAvailabilityType(SdxDatabaseAvailabilityType.NONE);
         SdxCluster sdxCluster = new SdxCluster();
         sdxCluster.setClusterName("clusterName");
+        when(databaseDefaultVersionProvider.calculateDbVersionBasedOnRuntimeIfMissing(null, null)).thenReturn("11");
 
         underTest.configure(cloudPlatform, dbRequest, sdxCluster);
 
         assertEquals(false, sdxCluster.isCreateDatabase());
         assertEquals(SdxDatabaseAvailabilityType.NONE, sdxCluster.getDatabaseAvailabilityType());
+        assertEquals("11", sdxCluster.getDatabaseEngineVersion());
     }
 
     @Test
@@ -103,11 +117,14 @@ public class SdxExternalDatabaseConfigurerTest {
         SdxCluster sdxCluster = new SdxCluster();
         sdxCluster.setClusterName("clusterName");
         sdxCluster.setRuntime("7.0.2");
+        when(databaseDefaultVersionProvider.calculateDbVersionBasedOnRuntimeIfMissing(sdxCluster.getRuntime(), null)).thenReturn("11");
+
 
         underTest.configure(cloudPlatform, dbRequest, sdxCluster);
 
         assertEquals(false, sdxCluster.isCreateDatabase());
         assertEquals(SdxDatabaseAvailabilityType.NONE, sdxCluster.getDatabaseAvailabilityType());
+        assertEquals("11", sdxCluster.getDatabaseEngineVersion());
     }
 
     @Test
@@ -119,11 +136,13 @@ public class SdxExternalDatabaseConfigurerTest {
         SdxCluster sdxCluster = new SdxCluster();
         sdxCluster.setClusterName("clusterName");
         sdxCluster.setRuntime("7.1.0");
+        when(databaseDefaultVersionProvider.calculateDbVersionBasedOnRuntimeIfMissing(sdxCluster.getRuntime(), null)).thenReturn("11");
 
         underTest.configure(cloudPlatform, dbRequest, sdxCluster);
 
         assertEquals(true, sdxCluster.isCreateDatabase());
         assertEquals(SdxDatabaseAvailabilityType.HA, sdxCluster.getDatabaseAvailabilityType());
+        assertEquals("11", sdxCluster.getDatabaseEngineVersion());
     }
 
     @Test
@@ -135,11 +154,13 @@ public class SdxExternalDatabaseConfigurerTest {
         SdxCluster sdxCluster = new SdxCluster();
         sdxCluster.setClusterName("clusterName");
         sdxCluster.setRuntime("7.2.0");
+        when(databaseDefaultVersionProvider.calculateDbVersionBasedOnRuntimeIfMissing(sdxCluster.getRuntime(), null)).thenReturn("11");
 
         underTest.configure(cloudPlatform, dbRequest, sdxCluster);
 
         assertEquals(true, sdxCluster.isCreateDatabase());
         assertEquals(SdxDatabaseAvailabilityType.HA, sdxCluster.getDatabaseAvailabilityType());
+        assertEquals("11", sdxCluster.getDatabaseEngineVersion());
     }
 
     @Test
@@ -149,10 +170,12 @@ public class SdxExternalDatabaseConfigurerTest {
         SdxDatabaseRequest dbRequest = new SdxDatabaseRequest();
         dbRequest.setAvailabilityType(SdxDatabaseAvailabilityType.HA);
         SdxCluster sdxCluster = new SdxCluster();
+        when(databaseDefaultVersionProvider.calculateDbVersionBasedOnRuntimeIfMissing(null, null)).thenReturn("11");
 
         Assertions.assertThrows(BadRequestException.class, () -> underTest.configure(cloudPlatform, dbRequest, sdxCluster));
 
         assertEquals(true, sdxCluster.isCreateDatabase());
         assertEquals(SdxDatabaseAvailabilityType.HA, sdxCluster.getDatabaseAvailabilityType());
+        assertEquals("11", sdxCluster.getDatabaseEngineVersion());
     }
 }


### PR DESCRIPTION
When the database engine version is not defined in the request, it would be overridden with the defined value if the runtime version is equal or higher than the deifned.
For now it is set to a not existing high veresion number so it doesn't effect anything.

Logic:
- engine version empty and runtime is older: engine version is null, current default behavior
- engine version empty and runtime is equal or new: engine version is overridden with defined version (currently 11)
- engine version is specified in the request: independently from runtime version it will be honored and won't be overridden

See detailed description in the commit message.