### PR TITLE
CB-18059 Environment delete with cascading == false && forced == true…

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/EnvironmentReactorFlowManager.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/EnvironmentReactorFlowManager.java
@@ -73,7 +73,7 @@ public class EnvironmentReactorFlowManager {
     }
 
     public FlowIdentifier triggerDeleteFlow(EnvironmentView environment, String userCrn, boolean forced) {
-        LOGGER.info("Environment deletion flow triggered for '{}'.", environment.getName());
+        LOGGER.info("Environment simple (FreeIPA) deletion flow triggered for '{}', forced={}.", environment.getName(), forced);
         flowCancelService.cancelRunningFlows(environment.getId());
         EnvDeleteEvent envDeleteEvent = EnvDeleteEvent.builder()
                 .withAccepted(new Promise<>())
@@ -87,7 +87,7 @@ public class EnvironmentReactorFlowManager {
     }
 
     public FlowIdentifier triggerCascadingDeleteFlow(EnvironmentView environment, String userCrn, boolean forced) {
-        LOGGER.info("Environment forced deletion flow triggered for '{}'.", environment.getName());
+        LOGGER.info("Environment cascading deletion flow triggered for '{}', forced={}.", environment.getName(), forced);
         flowCancelService.cancelRunningFlows(environment.getId());
         EnvDeleteEvent envDeleteEvent = EnvDeleteEvent.builder()
                 .withAccepted(new Promise<>())
@@ -114,7 +114,7 @@ public class EnvironmentReactorFlowManager {
 
     public FlowIdentifier triggerStartFlow(long envId, String envName, String userCrn, DataHubStartAction dataHubStartAction) {
         LOGGER.info("Environment start flow triggered.");
-        EnvStartEvent envSrartEvent = EnvStartEvent.EnvStartEventBuilder.anEnvStartEvent()
+        EnvStartEvent envStartEvent = EnvStartEvent.EnvStartEventBuilder.anEnvStartEvent()
                 .withAccepted(new Promise<>())
                 .withSelector(EnvStartStateSelectors.ENV_START_FREEIPA_EVENT.selector())
                 .withResourceId(envId)
@@ -122,7 +122,7 @@ public class EnvironmentReactorFlowManager {
                 .withDataHubStartAction(dataHubStartAction)
                 .build();
 
-        return eventSender.sendEvent(envSrartEvent, new Event.Headers(getFlowTriggerUsercrn(userCrn)));
+        return eventSender.sendEvent(envStartEvent, new Event.Headers(getFlowTriggerUsercrn(userCrn)));
     }
 
     public FlowIdentifier triggerStackConfigUpdatesFlow(EnvironmentView environment, String userCrn) {

--- a/environment/src/test/java/com/sequenceiq/environment/environment/flow/EnvironmentReactorFlowManagerTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/flow/EnvironmentReactorFlowManagerTest.java
@@ -1,0 +1,113 @@
+package com.sequenceiq.environment.environment.flow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.environment.environment.domain.EnvironmentView;
+import com.sequenceiq.environment.environment.flow.deletion.event.EnvDeleteEvent;
+import com.sequenceiq.environment.environment.service.stack.StackService;
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+import com.sequenceiq.flow.core.FlowConstants;
+import com.sequenceiq.flow.reactor.api.event.BaseNamedFlowEvent;
+import com.sequenceiq.flow.reactor.api.event.EventSender;
+import com.sequenceiq.flow.service.FlowCancelService;
+
+import reactor.bus.Event;
+
+@ExtendWith(MockitoExtension.class)
+class EnvironmentReactorFlowManagerTest {
+
+    private static final long ENVIRONMENT_ID = 12L;
+
+    private static final String ENVIRONMENT_NAME = "environmentName";
+
+    private static final String USER_CRN = "userCrn";
+
+    @Mock
+    private EventSender eventSender;
+
+    @Mock
+    private FlowCancelService flowCancelService;
+
+    @Mock
+    private StackService stackService;
+
+    @InjectMocks
+    private EnvironmentReactorFlowManager underTest;
+
+    @Mock
+    private FlowIdentifier flowIdentifier;
+
+    @Captor
+    private ArgumentCaptor<EnvDeleteEvent> envDeleteEventCaptor;
+
+    @Captor
+    private ArgumentCaptor<Event.Headers> headersCaptor;
+
+    @ParameterizedTest(name = "forced={0}")
+    @ValueSource(booleans = {false, true})
+    void triggerDeleteFlowTest(boolean forced) {
+        EnvironmentView environment = environmentView();
+        when(eventSender.sendEvent(any(BaseNamedFlowEvent.class), any(Event.Headers.class))).thenReturn(flowIdentifier);
+
+        FlowIdentifier result = underTest.triggerDeleteFlow(environment, USER_CRN, forced);
+
+        assertThat(result).isSameAs(flowIdentifier);
+        verify(flowCancelService).cancelRunningFlows(ENVIRONMENT_ID);
+        verify(eventSender).sendEvent(envDeleteEventCaptor.capture(), headersCaptor.capture());
+        verifyEnvDeleteEvent(forced, "START_FREEIPA_DELETE_EVENT");
+        verifyHeaders();
+    }
+
+    @ParameterizedTest(name = "forced={0}")
+    @ValueSource(booleans = {false, true})
+    void triggerCascadingDeleteFlowTest(boolean forced) {
+        EnvironmentView environment = environmentView();
+        when(eventSender.sendEvent(any(BaseNamedFlowEvent.class), any(Event.Headers.class))).thenReturn(flowIdentifier);
+
+        FlowIdentifier result = underTest.triggerCascadingDeleteFlow(environment, USER_CRN, forced);
+
+        assertThat(result).isSameAs(flowIdentifier);
+        verify(flowCancelService).cancelRunningFlows(ENVIRONMENT_ID);
+        verify(eventSender).sendEvent(envDeleteEventCaptor.capture(), headersCaptor.capture());
+        verifyEnvDeleteEvent(forced, "ENV_DELETE_CLUSTERS_TRIGGER_EVENT");
+        verifyHeaders();
+    }
+
+    private void verifyEnvDeleteEvent(boolean forcedExpected, String selectorExpected) {
+        EnvDeleteEvent envDeleteEvent = envDeleteEventCaptor.getValue();
+        assertThat(envDeleteEvent).isNotNull();
+        assertThat(envDeleteEvent.accepted()).isNotNull();
+        assertThat(envDeleteEvent.getSelector()).isEqualTo(selectorExpected);
+        assertThat(envDeleteEvent.getResourceId()).isEqualTo(ENVIRONMENT_ID);
+        assertThat(envDeleteEvent.getResourceName()).isEqualTo(ENVIRONMENT_NAME);
+        assertThat(envDeleteEvent.isForceDelete()).isEqualTo(forcedExpected);
+    }
+
+    private void verifyHeaders() {
+        Event.Headers headers = headersCaptor.getValue();
+        assertThat(headers).isNotNull();
+        assertThat(headers.asMap()).containsOnly(Map.entry(FlowConstants.FLOW_TRIGGER_USERCRN, USER_CRN));
+    }
+
+    private EnvironmentView environmentView() {
+        EnvironmentView environment = new EnvironmentView();
+        environment.setId(ENVIRONMENT_ID);
+        environment.setName(ENVIRONMENT_NAME);
+        return environment;
+    }
+
+}


### PR DESCRIPTION
… leaves behind orphan DL/DH clusters and experiences

* If `cascading == false`:
  * Checks for attached resources are always executed, irrespective of the `forced` flag. (The same applies to the checks for child environments, there is no change in that respect.)
  * `updateEnvironmentDeletionType()` and `environmentJobService.unschedule()` are only invoked if there are no child environments nor any resources attached to the environment.
* Enhance error messages thrown for the aforementioned validations.
* Some code cleanup.
* Testing:
  * Manual testing in local CB.
  * Added new UT and updated existing ones.
