### PR TITLE
CB-17772 AWS upgrade to postgres 11: call upgrade

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/ResourceConnector.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/ResourceConnector.java
@@ -106,10 +106,9 @@ public interface ResourceConnector {
      * @param authenticatedContext the authenticated context which holds the client object
      * @param stack                contains the full description of infrastructure
      * @param persistenceNotifier  notifier for when a resource is allocated on the cloud platfrom
-     * @return the status of resources allocated on the cloud platform
      * @throws Exception in case of any error
      */
-    List<CloudResourceStatus> upgradeDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack, PersistenceNotifier persistenceNotifier,
+    void upgradeDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack, PersistenceNotifier persistenceNotifier,
             TargetMajorVersion targetMajorVersion) throws Exception;
 
     /**

--- a/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/ResourceConnectorTest.java
+++ b/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/ResourceConnectorTest.java
@@ -54,9 +54,8 @@ class ResourceConnectorTest {
         }
 
         @Override
-        public List<CloudResourceStatus> upgradeDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
+        public void upgradeDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
                 PersistenceNotifier persistenceNotifier, TargetMajorVersion targetMajorVersion) {
-            return null;
         }
 
         @Override

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsStackRequestHelper.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsStackRequestHelper.java
@@ -29,6 +29,7 @@ import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonEc2Client;
 import com.sequenceiq.cloudbreak.cloud.aws.common.view.AuthenticatedContextView;
 import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsInstanceProfileView;
 import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsNetworkView;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.AwsRdsVersionOperations;
 import com.sequenceiq.cloudbreak.cloud.aws.view.AwsRdsDbParameterGroupView;
 import com.sequenceiq.cloudbreak.cloud.aws.view.AwsRdsDbSubnetGroupView;
 import com.sequenceiq.cloudbreak.cloud.aws.view.AwsRdsInstanceView;
@@ -56,6 +57,9 @@ public class AwsStackRequestHelper {
 
     @Inject
     private AwsCloudFormationClient awsClient;
+
+    @Inject
+    private AwsRdsVersionOperations awsRdsVersionOperations;
 
     public CreateStackRequest createCreateStackRequest(AuthenticatedContext ac, CloudStack stack, String cFStackName, String subnet, String cfTemplate) {
         return new CreateStackRequest()
@@ -226,7 +230,7 @@ public class AwsStackRequestHelper {
         AwsRdsInstanceView awsRdsInstanceView = new AwsRdsInstanceView(databaseServer);
         AwsRdsDbSubnetGroupView awsRdsDbSubnetGroupView = new AwsRdsDbSubnetGroupView(databaseServer);
         AwsRdsVpcSecurityGroupView awsRdsVpcSecurityGroupView = new AwsRdsVpcSecurityGroupView(databaseServer);
-        AwsRdsDbParameterGroupView awsRdsDbParameterGroupView = new AwsRdsDbParameterGroupView(databaseServer);
+        AwsRdsDbParameterGroupView awsRdsDbParameterGroupView = new AwsRdsDbParameterGroupView(databaseServer, awsRdsVersionOperations);
         List<Parameter> parameters = new ArrayList<>(asList(
                 new Parameter().withParameterKey("DBInstanceClassParameter").withParameterValue(awsRdsInstanceView.getDBInstanceClass()),
                 new Parameter().withParameterKey("DBInstanceIdentifierParameter").withParameterValue(awsRdsInstanceView.getDBInstanceIdentifier()),

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnector.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnector.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
 import com.sequenceiq.cloudbreak.cloud.ResourceConnector;
 import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsNetworkView;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.AwsRdsUpgradeService;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
@@ -75,6 +76,9 @@ public class AwsResourceConnector implements ResourceConnector {
     private AwsRdsModifyService awsRdsModifyService;
 
     @Inject
+    private AwsRdsUpgradeService awsRdsUpgradeService;
+
+    @Inject
     private AwsTerminateService awsTerminateService;
 
     @Inject
@@ -116,9 +120,10 @@ public class AwsResourceConnector implements ResourceConnector {
     }
 
     @Override
-    public List<CloudResourceStatus> upgradeDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
-            PersistenceNotifier persistenceNotifier, TargetMajorVersion targetMajorVersion) throws Exception {
-        return null;
+    public void upgradeDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
+            PersistenceNotifier persistenceNotifier, TargetMajorVersion targetMajorVersion) {
+        LOGGER.debug("Starting the upgrade of database server to {}", targetMajorVersion);
+        awsRdsUpgradeService.upgrade(authenticatedContext, stack, targetMajorVersion);
     }
 
     private boolean deployingToSameVPC(AwsNetworkView awsNetworkView, boolean existingVPC) {

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/AwsRdsUpgradeService.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/AwsRdsUpgradeService.java
@@ -1,0 +1,75 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade;
+
+import static com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.RdsState.AVAILABLE;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cloud.aws.AwsCloudFormationClient;
+import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonRdsClient;
+import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsCredentialView;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.AwsRdsUpgradeValidatorService;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.RdsInfo;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseServer;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
+import com.sequenceiq.cloudbreak.common.database.Version;
+
+@Service
+public class AwsRdsUpgradeService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsRdsUpgradeService.class);
+
+    @Inject
+    private AwsCloudFormationClient awsClient;
+
+    @Inject
+    private AwsRdsUpgradeSteps awsRdsUpgradeSteps;
+
+    @Inject
+    private AwsRdsUpgradeValidatorService awsRdsUpgradeValidatorService;
+
+    public void upgrade(AuthenticatedContext ac, DatabaseStack dbStack, Version targetMajorVersion) {
+        DatabaseServer databaseServer = dbStack.getDatabaseServer();
+        String dbInstanceIdentifier = databaseServer.getServerId();
+        LOGGER.debug("Starting the upgrade of RDS {} to target major version of {}", dbInstanceIdentifier, targetMajorVersion);
+
+        AmazonRdsClient rdsClient = getAmazonRdsClient(ac);
+        RdsInfo rdsInfo = getRdsInfo(dbInstanceIdentifier, rdsClient);
+        validateIfRdsCanBeUpgraded(targetMajorVersion, rdsInfo);
+        upgadeRdsIfNeeded(targetMajorVersion, databaseServer, rdsClient, rdsInfo);
+        waitForRdsUpgrade(ac, databaseServer, rdsClient);
+        LOGGER.debug("RDS upgrade done for DB: {}", dbInstanceIdentifier);
+    }
+
+    private RdsInfo getRdsInfo(String dbInstanceIdentifier, AmazonRdsClient rdsClient) {
+        return awsRdsUpgradeSteps.getRdsInfo(rdsClient, dbInstanceIdentifier);
+    }
+
+    private void validateIfRdsCanBeUpgraded(Version targetMajorVersion, RdsInfo rdsInfo) {
+        awsRdsUpgradeValidatorService.validateRdsCanBeUpgraded(rdsInfo, targetMajorVersion);
+    }
+
+    private void upgadeRdsIfNeeded(Version targetMajorVersion, DatabaseServer databaseServer, AmazonRdsClient rdsClient, RdsInfo rdsInfo) {
+        if (AVAILABLE == rdsInfo.getRdsState()) {
+            LOGGER.debug("RDS {} is in available state, calling upgrade.", databaseServer.getServerId());
+            awsRdsUpgradeSteps.upgradeRds(rdsClient, databaseServer, rdsInfo, targetMajorVersion);
+        } else {
+            LOGGER.debug("RDS {} is already upgrading, proceeding to wait for upgrade", databaseServer.getServerId());
+        }
+    }
+
+    private void waitForRdsUpgrade(AuthenticatedContext ac, DatabaseServer databaseServer, AmazonRdsClient rdsClient) {
+        awsRdsUpgradeSteps.waitForUpgrade(ac, rdsClient, databaseServer);
+    }
+
+    private AmazonRdsClient getAmazonRdsClient(AuthenticatedContext ac) {
+        AwsCredentialView credentialView = new AwsCredentialView(ac.getCloudCredential());
+        String regionName = ac.getCloudContext().getLocation().getRegion().value();
+        return awsClient.createRdsClient(credentialView, regionName);
+    }
+
+}

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/AwsRdsUpgradeSteps.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/AwsRdsUpgradeSteps.java
@@ -1,0 +1,69 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.amazonaws.services.rds.model.DBInstance;
+import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
+import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonRdsClient;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.AwsRdsUpgradeOperations;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.AwsRdsUpgradeValidatorService;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.RdsEngineVersion;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.RdsInfo;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.RdsInstanceStatusesToRdsStateConverter;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.RdsState;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseServer;
+import com.sequenceiq.cloudbreak.common.database.Version;
+
+@Component
+public class AwsRdsUpgradeSteps {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsRdsUpgradeSteps.class);
+
+    @Inject
+    private AwsRdsUpgradeOperations awsRdsUpgradeOperations;
+
+    @Inject
+    private AwsRdsUpgradeValidatorService awsRdsUpgradeValidatorService;
+
+    @Inject
+    private RdsInstanceStatusesToRdsStateConverter rdsInstanceStatusesToRdsStateConverter;
+
+    public RdsInfo getRdsInfo(AmazonRdsClient rdsClient, String dbInstanceIdentifier) {
+        LOGGER.debug("Started to retrieve RDS info for upgrade, dbInstanceIdentifier: {}", dbInstanceIdentifier);
+        DescribeDBInstancesResult describeDBInstanceResult = awsRdsUpgradeOperations.describeRds(rdsClient, dbInstanceIdentifier);
+
+        Set<String> currentDbEngineVersions = describeDBInstanceResult.getDBInstances().stream()
+                .map(DBInstance::getEngineVersion)
+                .collect(Collectors.toSet());
+        awsRdsUpgradeValidatorService.validateClusterHasASingleVersion(currentDbEngineVersions);
+
+        Map<String, String> dbArnToInstanceStatuses = describeDBInstanceResult.getDBInstances().stream()
+                .collect(Collectors.toMap(DBInstance::getDBInstanceArn, DBInstance::getDBInstanceStatus));
+        RdsState rdsState = rdsInstanceStatusesToRdsStateConverter.convert(dbArnToInstanceStatuses);
+        RdsInfo rdsInfo = new RdsInfo(rdsState, dbArnToInstanceStatuses, new RdsEngineVersion(currentDbEngineVersions.iterator().next()));
+
+        LOGGER.debug("Collected the following info on RDS before starting to upgrade: {}", rdsInfo);
+        return rdsInfo;
+    }
+
+    public void upgradeRds(AmazonRdsClient rdsClient, DatabaseServer databaseServer, RdsInfo rdsInfo, Version targetMajorVersion) {
+        RdsEngineVersion currentRdsVersion = rdsInfo.getRdsEngineVersion();
+        RdsEngineVersion upgradeTargetVersion = awsRdsUpgradeOperations.getHighestUpgradeTargetVersion(rdsClient, targetMajorVersion, currentRdsVersion);
+        String dbParameterGroupName = awsRdsUpgradeOperations.createParameterGroupWithCustomSettings(rdsClient, databaseServer, upgradeTargetVersion);
+        awsRdsUpgradeOperations.upgradeRds(rdsClient, upgradeTargetVersion, databaseServer.getServerId(), dbParameterGroupName);
+    }
+
+    public void waitForUpgrade(AuthenticatedContext ac, AmazonRdsClient rdsClient, DatabaseServer databaseServer) {
+        awsRdsUpgradeOperations.waitForRdsUpgrade(ac, rdsClient, databaseServer.getServerId());
+    }
+
+}

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsCustomParameterSupplier.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsCustomParameterSupplier.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.amazonaws.services.rds.model.ApplyMethod;
+import com.amazonaws.services.rds.model.Parameter;
+
+@Component
+public class AwsRdsCustomParameterSupplier {
+
+    private  static final String RDS_FORCE_SSL_PARAMETER_NAME = "rds.force_ssl";
+
+    private static final String RDS_FORCE_SSL_PARAMETER_ON = "1";
+
+    public List<Parameter> getParametersToChange() {
+        return List.of(createForceSslParameter());
+    }
+
+    private Parameter createForceSslParameter() {
+        return new Parameter()
+                .withParameterName(RDS_FORCE_SSL_PARAMETER_NAME)
+                .withParameterValue(RDS_FORCE_SSL_PARAMETER_ON)
+                .withApplyMethod(ApplyMethod.Immediate);
+    }
+
+}

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsState.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsState.java
@@ -1,0 +1,18 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation;
+
+public enum AwsRdsState {
+    AVAILABLE("available"),
+
+    UPGRADING("upgrading");
+
+    private final String state;
+
+    AwsRdsState(String state) {
+        this.state = state;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+}

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsUpgradeOperations.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsUpgradeOperations.java
@@ -1,0 +1,114 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.amazonaws.services.rds.model.DescribeDBInstancesRequest;
+import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
+import com.amazonaws.services.rds.model.ModifyDBInstanceRequest;
+import com.amazonaws.services.rds.model.Parameter;
+import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonRdsClient;
+import com.sequenceiq.cloudbreak.cloud.aws.view.AwsRdsDbParameterGroupView;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseServer;
+import com.sequenceiq.cloudbreak.common.database.Version;
+
+@Service
+public class AwsRdsUpgradeOperations {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsRdsUpgradeOperations.class);
+
+    @Inject
+    private AwsRdsVersionOperations awsRdsVersionOperations;
+
+    @Inject
+    private AwsRdsUpgradeValidatorService awsRdsUpgradeValidatorService;
+
+    @Inject
+    private AwsRdsUpgradeWaitOperations awsRdsUpgradeWaitOperations;
+
+    @Inject
+    private AwsRdsCustomParameterSupplier awsRdsCustomParameterSupplier;
+
+    public DescribeDBInstancesResult describeRds(AmazonRdsClient rdsClient, String dbInstanceIdentifier) {
+        DescribeDBInstancesRequest describeDBInstancesRequest = new DescribeDBInstancesRequest().withDBInstanceIdentifier(dbInstanceIdentifier);
+        DescribeDBInstancesResult result = rdsClient.describeDBInstances(describeDBInstancesRequest);
+        LOGGER.debug("Describing RDS with dbInstanceIdentifier {}, result: {}", dbInstanceIdentifier, result);
+        return result;
+    }
+
+    public RdsEngineVersion getHighestUpgradeTargetVersion(AmazonRdsClient rdsClient, Version targetMajorVersion, RdsEngineVersion currentDbVersion) {
+        Set<String> validUpgradeTargets = awsRdsVersionOperations.getAllUpgradeTargetVersions(rdsClient, currentDbVersion);
+        Optional<RdsEngineVersion> upgradeTargetForMajorVersion = awsRdsVersionOperations.getHighestUpgradeVersionForTargetMajorVersion(validUpgradeTargets,
+                targetMajorVersion);
+        awsRdsUpgradeValidatorService.validateUpgradePresentForTargetMajorVersion(upgradeTargetForMajorVersion);
+        LOGGER.debug("The highest available RDS upgrade target version for major version {} is: {}", targetMajorVersion, upgradeTargetForMajorVersion);
+        return upgradeTargetForMajorVersion.get();
+    }
+
+    public void upgradeRds(AmazonRdsClient rdsClient, RdsEngineVersion targetVersion, String dbInstanceIdentifier, String dbParameterGroupName) {
+        ModifyDBInstanceRequest modifyDBInstanceRequest = new ModifyDBInstanceRequest()
+                .withDBInstanceIdentifier(dbInstanceIdentifier)
+                .withEngineVersion(targetVersion.getVersion())
+                .withAllowMajorVersionUpgrade(true)
+                .withApplyImmediately(true)
+                .withDBParameterGroupName(dbParameterGroupName);
+
+        LOGGER.debug("RDS modify request to upgrade engine version to {} for DB {}, request: {}", targetVersion, dbInstanceIdentifier, modifyDBInstanceRequest);
+        try {
+            rdsClient.modifyDBInstance(modifyDBInstanceRequest);
+        } catch (Exception ex) {
+            if (ex.getMessage().contains("Cannot modify engine version because another engine version upgrade is already in progress")) {
+                LOGGER.info("The upgrade has already been started");
+            } else {
+                String message = String.format("Error when starting the upgrade of RDS: %s", ex);
+                LOGGER.warn(message);
+                throw new CloudConnectorException(message, ex);
+            }
+        }
+    }
+
+    public void waitForRdsUpgrade(AuthenticatedContext ac, AmazonRdsClient rdsClient, String dbInstanceIdentifier) {
+        LOGGER.debug("Waiting until RDS enters upgrading state, dbInstanceIdentifier: {}", dbInstanceIdentifier);
+        DescribeDBInstancesRequest describeDBInstancesRequest = new DescribeDBInstancesRequest().withDBInstanceIdentifier(dbInstanceIdentifier);
+        awsRdsUpgradeWaitOperations.waitUntilUpgradeStarts(rdsClient, describeDBInstancesRequest);
+        awsRdsUpgradeWaitOperations.waitUntilUpgradeFinishes(ac, rdsClient, describeDBInstancesRequest);
+    }
+
+    public String createParameterGroupWithCustomSettings(AmazonRdsClient rdsClient, DatabaseServer databaseServer, RdsEngineVersion upgradeTargetVersion) {
+        AwsRdsDbParameterGroupView awsRdsDbParameterGroupView = new AwsRdsDbParameterGroupView(databaseServer, awsRdsVersionOperations);
+        String dbParameterGroupName = String.format("%s-v%s", awsRdsDbParameterGroupView.getDBParameterGroupName(), upgradeTargetVersion.getMajorVersion());
+        String dbParameterGroupFamily = awsRdsVersionOperations.getDBParameterGroupFamily(databaseServer.getEngine(), upgradeTargetVersion.getVersion());
+        String serverId = databaseServer.getServerId();
+        String dbParameterGroupDescription = String.format("DB parameter group for %s", serverId);
+
+        createParameterGroupIfNeeded(rdsClient, dbParameterGroupName, dbParameterGroupFamily, dbParameterGroupDescription);
+        changeParameterInGroup(rdsClient, dbParameterGroupName);
+        return dbParameterGroupName;
+    }
+
+    private void changeParameterInGroup(AmazonRdsClient rdsClient, String dbParameterGroupName) {
+        List<Parameter> parametersToChange = awsRdsCustomParameterSupplier.getParametersToChange();
+        rdsClient.changeParameterInGroup(dbParameterGroupName, parametersToChange);
+        LOGGER.debug("Changed RDS parameters in parameters group. Parameter group name: {}. parameters: {}", dbParameterGroupName, parametersToChange);
+    }
+
+    private void createParameterGroupIfNeeded(AmazonRdsClient rdsClient, String dbParameterGroupName, String dbParameterGroupFamily, String
+            dbParameterGroupDescription) {
+        if (!rdsClient.isDbParameterGroupPresent(dbParameterGroupName)) {
+            LOGGER.debug("Creating a custom parameter group for RDS. DbParameterGroupName: {}, family: {}", dbParameterGroupName, dbParameterGroupFamily);
+            rdsClient.createParameterGroup(dbParameterGroupFamily, dbParameterGroupName, dbParameterGroupDescription);
+        } else {
+            LOGGER.debug("Custom parameter group with name {} already exists", dbParameterGroupName);
+        }
+    }
+
+}

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsUpgradeValidatorService.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsUpgradeValidatorService.java
@@ -1,0 +1,81 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation;
+
+import static com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.AwsRdsState.AVAILABLE;
+import static com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.AwsRdsState.UPGRADING;
+import static com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.RdsState.OTHER;
+import static com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.RdsState.UNKNOWN;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.common.database.Version;
+import com.sequenceiq.cloudbreak.util.MajorVersionComparator;
+
+@Service
+public class AwsRdsUpgradeValidatorService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsRdsUpgradeValidatorService.class);
+
+    public void validateRdsCanBeUpgraded(RdsInfo rdsInfo, Version targetMajorVersion) {
+        LOGGER.debug("Rds state is: {} and db instance statuses are: {} ", rdsInfo.getRdsState(), rdsInfo.getDbArnToInstanceStatuses());
+
+        validateRdsIsAvailableOrUpgrading(rdsInfo);
+        validateRdsMajorVersionIsSmallerThanTarget(rdsInfo, targetMajorVersion);
+    }
+
+    public void validateUpgradePresentForTargetMajorVersion(Optional<RdsEngineVersion> upgradeTargetForMajorVersion) {
+        if (upgradeTargetForMajorVersion.isEmpty()) {
+            String message = "There are no matching RDS upgrade versions to choose from.";
+            LOGGER.warn(message);
+            throw new CloudConnectorException(message);
+        }
+    }
+
+    public void validateClusterHasASingleVersion(Set<String> dbVersions) {
+        if (dbVersions.isEmpty()) {
+            String message = "Current DB version could not be obtained";
+            LOGGER.warn(message);
+            throw new CloudConnectorException(message);
+        }
+
+        if (dbVersions.size() > 1) {
+            String message = String.format("RDS is on multiple versions (%s), cannot proceed with its upgrade", dbVersions);
+            LOGGER.warn(message);
+            throw new CloudConnectorException(message);
+        }
+    }
+
+    private void validateRdsIsAvailableOrUpgrading(RdsInfo rdsInfo) {
+        if (OTHER == rdsInfo.getRdsState() || UNKNOWN == rdsInfo.getRdsState()) {
+            String message = String.format("RDS upgrade is not possible as one or more instances are not in a correct state: %s",
+                    getNotApplicableStates(rdsInfo.getDbArnToInstanceStatuses()));
+            LOGGER.warn(message);
+            throw new CloudConnectorException(message);
+        }
+    }
+
+    private void validateRdsMajorVersionIsSmallerThanTarget(RdsInfo rdsInfo, Version targetMajorVersion) {
+        if (new MajorVersionComparator().compare(rdsInfo.getRdsEngineVersion(), new RdsEngineVersion(targetMajorVersion.getMajorVersion())) >= 0) {
+            String message = String.format("Cannot start upgrade as the RDS major version %s is not smaller than the target version %s",
+                    rdsInfo.getRdsEngineVersion(), targetMajorVersion);
+            LOGGER.debug(message);
+            throw new CloudConnectorException(message);
+        }
+    }
+
+    private Set<String> getNotApplicableStates(Map<String, String> dbArnToInstanceStatuses) {
+        return dbArnToInstanceStatuses.entrySet().stream()
+                .filter(entry -> !AVAILABLE.getState().equals(entry.getValue())
+                        && !UPGRADING.getState().equals(entry.getValue()))
+                .map(entry -> String.format("arn: %s => status: %s", entry.getKey(), entry.getValue()))
+                .collect(Collectors.toSet());
+    }
+
+}

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsUpgradeWaitOperations.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsUpgradeWaitOperations.java
@@ -1,0 +1,54 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation;
+
+import static com.sequenceiq.cloudbreak.cloud.aws.scheduler.WaiterRunner.run;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.amazonaws.services.rds.model.DescribeDBInstancesRequest;
+import com.amazonaws.waiters.Waiter;
+import com.dyngr.exception.PollerException;
+import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonRdsClient;
+import com.sequenceiq.cloudbreak.cloud.aws.scheduler.CustomAmazonWaiterProvider;
+import com.sequenceiq.cloudbreak.cloud.aws.scheduler.StackCancellationCheck;
+import com.sequenceiq.cloudbreak.cloud.aws.util.poller.upgrade.UpgradeStartPoller;
+import com.sequenceiq.cloudbreak.cloud.aws.util.poller.upgrade.UpgradeStartWaitTask;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+
+@Component
+public class AwsRdsUpgradeWaitOperations {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsRdsUpgradeWaitOperations.class);
+
+    @Inject
+    private UpgradeStartPoller upgradeStartPoller;
+
+    @Inject
+    private CustomAmazonWaiterProvider customAmazonWaiterProvider;
+
+    public void waitUntilUpgradeStarts(AmazonRdsClient rdsClient, DescribeDBInstancesRequest describeDBInstancesRequest) {
+        LOGGER.debug("Starting RDS state polling until RDS start the upgrade, dbInstanceIdentifier: {}", describeDBInstancesRequest.getDBInstanceIdentifier());
+        UpgradeStartWaitTask upgradeStartWaitTask = new UpgradeStartWaitTask(describeDBInstancesRequest, rdsClient);
+        try {
+            upgradeStartPoller.waitForUpgradeToStart(upgradeStartWaitTask);
+            LOGGER.debug("RDS entered the upgrading state");
+        } catch (PollerException e) {
+            String message = String.format("Error when waiting for upgrade to start: %s", e);
+            LOGGER.warn(message);
+            throw new CloudConnectorException(message, e);
+        }
+    }
+
+    public void waitUntilUpgradeFinishes(AuthenticatedContext ac, AmazonRdsClient rdsClient, DescribeDBInstancesRequest describeDBInstancesRequest) {
+        Waiter<DescribeDBInstancesRequest> rdsWaiter = customAmazonWaiterProvider.getDbInstanceModifyWaiter(rdsClient);
+        StackCancellationCheck stackCancellationCheck = new StackCancellationCheck(ac.getCloudContext().getId());
+        LOGGER.debug("Starting waiting on RDS upgrade");
+        run(rdsWaiter, describeDBInstancesRequest, stackCancellationCheck);
+        LOGGER.debug("Finished waiting on RDS upgrade");
+    }
+
+}

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsVersionOperations.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsVersionOperations.java
@@ -1,0 +1,120 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation;
+
+import static com.sequenceiq.cloudbreak.cloud.model.DatabaseEngine.POSTGRESQL;
+import static com.sequenceiq.cloudbreak.common.database.MajorVersion.VERSION_13;
+import static com.sequenceiq.cloudbreak.common.database.MajorVersion.VERSION_FAMILY_9;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.amazonaws.services.rds.model.DescribeDBEngineVersionsRequest;
+import com.amazonaws.services.rds.model.DescribeDBEngineVersionsResult;
+import com.amazonaws.services.rds.model.UpgradeTarget;
+import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonRdsClient;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseEngine;
+import com.sequenceiq.cloudbreak.common.database.Version;
+import com.sequenceiq.cloudbreak.util.VersionComparator;
+
+@Service
+public class AwsRdsVersionOperations {
+
+    private static final Pattern ENGINE_VERSION_PATTERN = Pattern.compile("^(\\d+)(?:\\.\\d+)?$");
+
+    private static final int GROUP_MAJOR_VERSION = 1;
+
+    private static final String POSTGRES = "postgres";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsRdsVersionOperations.class);
+
+    public String getDBParameterGroupFamily(DatabaseEngine engine, String engineVersion) {
+        LOGGER.debug("Getting the DB parameter group family for engine {} and version {}", engine, engineVersion);
+        if (POSTGRESQL == engine) {
+            return getPostgresFamilyVersion(engineVersion);
+        } else {
+            String message = String.format("Unsupported RDS engine: %s", engine);
+            LOGGER.warn(message);
+            throw new IllegalStateException(message);
+        }
+    }
+
+    private String getPostgresFamilyVersion(String engineVersion) {
+        String familyVersion = null;
+        if (engineVersion != null) {
+            Matcher engineVersionMatcher = ENGINE_VERSION_PATTERN.matcher(engineVersion);
+            if (engineVersionMatcher.matches()) {
+                String engineMajorVersion = engineVersionMatcher.group(GROUP_MAJOR_VERSION);
+                int engineMajorVersionNumber = Integer.parseInt(engineMajorVersion);
+                if (VERSION_FAMILY_9.getMajorVersionFamily() <= engineMajorVersionNumber && VERSION_13.getMajorVersionFamily() >= engineMajorVersionNumber) {
+                    // Family version matches the engine version for 9.5 and 9.6, and simply equals the major version otherwise
+                    familyVersion = VERSION_FAMILY_9.getMajorVersionFamily() == engineMajorVersionNumber ? engineVersion : engineMajorVersion;
+                } else {
+                    throwEngineVersionError(String.format("Unsupported RDS POSTGRESQL engine version %s, it is expected to be between %s and %s",
+                            engineVersion, VERSION_FAMILY_9, VERSION_13));
+                }
+            } else {
+                throwEngineVersionError(String.format("Unsupported RDS POSTGRESQL engine version %s", engineVersion));
+            }
+        } else {
+            throwEngineVersionError("RDS POSTGRESQL engine version is null, not able to determine postgres family");
+        }
+        String postgresFamilyVersion = POSTGRES + familyVersion;
+        LOGGER.debug("Get the postgres family version returns {}", postgresFamilyVersion);
+        return postgresFamilyVersion;
+    }
+
+    private void throwEngineVersionError(String message) {
+        LOGGER.warn(message);
+        throw new IllegalStateException(message);
+    }
+
+    public RdsEngineVersion getHighestUpgradeTargetVersion(Set<RdsEngineVersion> upgradeTargetsForMajorVersion) {
+        List<RdsEngineVersion> sortedUpgradeTargetVersion = upgradeTargetsForMajorVersion.stream()
+                .sorted(new VersionComparator())
+                .collect(Collectors.toList());
+        return sortedUpgradeTargetVersion.get(sortedUpgradeTargetVersion.size() - 1);
+    }
+
+    public Set<String> getAllUpgradeTargetVersions(AmazonRdsClient rdsClient, RdsEngineVersion dbVersion) {
+        DescribeDBEngineVersionsRequest describeDBEngineVersionsRequest = new DescribeDBEngineVersionsRequest();
+        describeDBEngineVersionsRequest.setEngine("postgres");
+        describeDBEngineVersionsRequest.setEngineVersion(dbVersion.getVersion());
+        try {
+            DescribeDBEngineVersionsResult result = rdsClient.describeDBEngineVersions(describeDBEngineVersionsRequest);
+            LOGGER.debug("Filtering DB upgrade targets for current version {}, results are: {}", dbVersion, result);
+            Set<String> validUpgradeTargets = result.getDBEngineVersions().stream()
+                    .flatMap(ver -> ver.getValidUpgradeTarget().stream())
+                    .map(UpgradeTarget::getEngineVersion)
+                    .collect(Collectors.toSet());
+            LOGGER.debug("The following valid AWS RDS upgrade targets were found: {}", validUpgradeTargets);
+            return validUpgradeTargets;
+        } catch (Exception e) {
+            String message = String.format("Exception occurred when querying valid upgrade targets: %s", e);
+            LOGGER.warn(message);
+            throw new CloudConnectorException(message, e);
+        }
+    }
+
+    public Optional<RdsEngineVersion> getHighestUpgradeVersionForTargetMajorVersion(Set<String> validUpgradeTargetVersions, Version targetMajorVersion) {
+        String targetMajorVersionString = targetMajorVersion.getMajorVersion() + ".";
+        List<RdsEngineVersion> upgradeTargetsForMajorVersion = validUpgradeTargetVersions.stream()
+                .filter(version -> version.startsWith(targetMajorVersionString))
+                .map(RdsEngineVersion::new)
+                .sorted(new VersionComparator())
+                .collect(Collectors.toList());
+        LOGGER.debug("DB engine versions applicable for the current major version {} are: {}", targetMajorVersion.getMajorVersion(),
+                upgradeTargetsForMajorVersion);
+        return upgradeTargetsForMajorVersion.isEmpty()
+                ? Optional.empty()
+                : Optional.of(upgradeTargetsForMajorVersion.get(upgradeTargetsForMajorVersion.size() - 1));
+    }
+
+}

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/RdsEngineVersion.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/RdsEngineVersion.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation;
+
+import com.sequenceiq.cloudbreak.common.type.Versioned;
+
+public class RdsEngineVersion implements Versioned {
+
+    private final String version;
+
+    private final String majorVersion;
+
+    public RdsEngineVersion(String version) {
+        this.version = version;
+        majorVersion = version.split("\\.")[0];
+    }
+
+    @Override
+    public String getVersion() {
+        return version;
+    }
+
+    public String getMajorVersion() {
+        return majorVersion;
+    }
+
+    @Override
+    public String toString() {
+        return "RdsEngineVersion{" +
+                "version='" + version + '\'' +
+                ", major='" + majorVersion + '\'' +
+                '}';
+    }
+}

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/RdsInfo.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/RdsInfo.java
@@ -1,0 +1,40 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation;
+
+import java.util.Map;
+
+public class RdsInfo {
+
+    private final Map<String, String> dbArnToInstanceStatuses;
+
+    private final RdsEngineVersion dbEngineVersion;
+
+    private final RdsState rdsState;
+
+    public RdsInfo(RdsState rdsState, Map<String, String> dbArnToInstanceStatuses, RdsEngineVersion dbEngineVersion) {
+        this.rdsState = rdsState;
+        this.dbArnToInstanceStatuses = dbArnToInstanceStatuses;
+        this.dbEngineVersion = dbEngineVersion;
+    }
+
+    public RdsState getRdsState() {
+        return rdsState;
+    }
+
+    public Map<String, String> getDbArnToInstanceStatuses() {
+        return dbArnToInstanceStatuses;
+    }
+
+    public RdsEngineVersion getRdsEngineVersion() {
+        return dbEngineVersion;
+    }
+
+    @Override
+    public String toString() {
+        return "RdsInfo{" +
+                "dbArnToInstanceStatuses=" + dbArnToInstanceStatuses +
+                ", dbEngineVersions=" + dbEngineVersion +
+                ", rdsState=" + rdsState +
+                '}';
+    }
+
+}

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/RdsInstanceStatusesToRdsStateConverter.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/RdsInstanceStatusesToRdsStateConverter.java
@@ -1,0 +1,49 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation;
+
+import static com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.RdsState.AVAILABLE;
+import static com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.RdsState.OTHER;
+import static com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.RdsState.UNKNOWN;
+import static com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.RdsState.UPGRADING;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RdsInstanceStatusesToRdsStateConverter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RdsInstanceStatusesToRdsStateConverter.class);
+
+    public RdsState convert(Map<String, String> dbArnToInstanceStatusesMap) {
+        if (dbArnToInstanceStatusesMap.isEmpty()) {
+            LOGGER.debug("There is no info from RDS instances, returning {}", UNKNOWN);
+            return UNKNOWN;
+        }
+
+        Map<String, String> notAvailableInstances = getNotAvailableInstances(dbArnToInstanceStatusesMap);
+        if (notAvailableInstances.isEmpty()) {
+            LOGGER.debug("There are no unavailable RDS instances, returning {}", AVAILABLE);
+            return AVAILABLE;
+        }
+
+        if (notAvailableInstances.values().stream().anyMatch(AwsRdsState.UPGRADING.getState()::equals)) {
+            LOGGER.debug("At least one RDS instance is in upgrading state, returning {}", UPGRADING);
+            return UPGRADING;
+        }
+
+        LOGGER.debug("Returning {} for the RDS instance states of {}", OTHER, dbArnToInstanceStatusesMap);
+        return OTHER;
+    }
+
+    private Map<String, String> getNotAvailableInstances(Map<String, String> dbArnToInstanceStatuses) {
+        Map<String, String> notAvailableInstances = dbArnToInstanceStatuses.entrySet().stream()
+                .filter(entry -> !AwsRdsState.AVAILABLE.getState().equals(entry.getValue()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        LOGGER.debug("Not available instances on RDS were: {}, all instances: {}", notAvailableInstances, dbArnToInstanceStatuses);
+        return notAvailableInstances;
+    }
+
+}

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/RdsState.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/RdsState.java
@@ -1,0 +1,12 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation;
+
+public enum RdsState {
+
+    AVAILABLE,
+
+    UPGRADING,
+
+    OTHER,
+
+    UNKNOWN
+}

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/WaiterRunner.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/WaiterRunner.java
@@ -39,6 +39,7 @@ public class WaiterRunner {
                     .withPollingStrategy(getBackoffCancellablePollingStrategy(cancellationCheck))
             );
         } catch (Exception e) {
+            LOGGER.warn("Exception in AWS RDS waiter: ", e);
             List<String> messages = new ArrayList<>();
             if (StringUtils.hasText(exceptionMessage)) {
                 messages.add(exceptionMessage);

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/util/poller/Poller.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/util/poller/Poller.java
@@ -1,0 +1,20 @@
+package com.sequenceiq.cloudbreak.cloud.aws.util.poller;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.stereotype.Component;
+
+import com.dyngr.Polling;
+import com.dyngr.core.AttemptMaker;
+
+@Component
+public class Poller<V> {
+
+    public void runPoller(long sleepTimeInSeconds, long durationInMinutes, AttemptMaker<V> attemptMaker) {
+        Polling.waitPeriodly(sleepTimeInSeconds, TimeUnit.SECONDS)
+                .stopIfException(true)
+                .stopAfterDelay(durationInMinutes, TimeUnit.MINUTES)
+                .run(attemptMaker);
+
+    }
+}

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/util/poller/upgrade/UpgradeStartPoller.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/util/poller/upgrade/UpgradeStartPoller.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.cloudbreak.cloud.aws.util.poller.upgrade;
+
+import javax.inject.Inject;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.aws.util.poller.Poller;
+
+@Component
+public class UpgradeStartPoller {
+
+    @Value("${cb.aws.rds.upgrade.start.wait.sleep:15}")
+    private long sleepTimeSeconds;
+
+    @Value("${cb.aws.rds.upgrade.start.wait.duration:5}")
+    private long durationMinutes;
+
+    @Inject
+    private Poller<Boolean> poller;
+
+    public void waitForUpgradeToStart(UpgradeStartWaitTask upgradeStartWaitTask) {
+        poller.runPoller(sleepTimeSeconds, durationMinutes, upgradeStartWaitTask);
+    }
+
+}

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/util/poller/upgrade/UpgradeStartWaitTask.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/util/poller/upgrade/UpgradeStartWaitTask.java
@@ -1,0 +1,49 @@
+package com.sequenceiq.cloudbreak.cloud.aws.util.poller.upgrade;
+
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.amazonaws.services.rds.model.DBInstance;
+import com.amazonaws.services.rds.model.DescribeDBInstancesRequest;
+import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
+import com.dyngr.core.AttemptMaker;
+import com.dyngr.core.AttemptResult;
+import com.dyngr.core.AttemptResults;
+import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonRdsClient;
+
+public class UpgradeStartWaitTask implements AttemptMaker<Boolean> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UpgradeStartWaitTask.class);
+
+    private static final String RDS_UPGRADE_STATE = "upgrading";
+
+    private final DescribeDBInstancesRequest describeDBInstancesRequest;
+
+    private final AmazonRdsClient rdsClient;
+
+    public UpgradeStartWaitTask(DescribeDBInstancesRequest request, AmazonRdsClient rdsClient) {
+        this.describeDBInstancesRequest = request;
+        this.rdsClient = rdsClient;
+    }
+
+    @Override
+    public AttemptResult<Boolean> process() {
+        DescribeDBInstancesResult result = rdsClient.describeDBInstances(describeDBInstancesRequest);
+        return isRdsInUpgradeState(result)
+                ? AttemptResults.finishWith(Boolean.TRUE)
+                : AttemptResults.justContinue();
+    }
+
+    private boolean isRdsInUpgradeState(DescribeDBInstancesResult result) {
+        Set<String> statuses = result.getDBInstances().stream().map(DBInstance::getDBInstanceStatus).collect(Collectors.toSet());
+        LOGGER.debug("AWS RDS upgrade start check: status queried: {}", statuses);
+        return result.getDBInstances().stream()
+                .map(DBInstance::getDBInstanceStatus)
+                .anyMatch(st -> RDS_UPGRADE_STATE.equals(st.toLowerCase(Locale.ROOT)));
+    }
+
+}

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsStackRequestHelperTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsStackRequestHelperTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -37,6 +38,7 @@ import com.google.common.collect.Lists;
 import com.sequenceiq.cloudbreak.cloud.aws.common.AwsTaggingService;
 import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonEc2Client;
 import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsCredentialView;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.AwsRdsVersionOperations;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.AvailabilityZone;
@@ -61,6 +63,9 @@ public class AwsStackRequestHelperTest {
 
     @Mock
     private AwsCloudFormationClient awsClient;
+
+    @Mock
+    private AwsRdsVersionOperations awsRdsVersionOperations;
 
     @Mock
     private AuthenticatedContext authenticatedContext;
@@ -168,6 +173,8 @@ public class AwsStackRequestHelperTest {
     void testGetStackParametersDb(String testCaseName, String sslCertificateIdentifier, boolean sslCertificateIdentifierParameterDefinedExpected,
             String sslCertificateIdentifierParameterExpected, String engineVersion, String expectedEngineVersion, String expectedFamily) {
         when(network.getStringParameter("subnetId")).thenReturn("subnet-1234");
+        when(databaseServer.getEngine()).thenReturn(DatabaseEngine.POSTGRESQL);
+        when(awsRdsVersionOperations.getDBParameterGroupFamily(eq(DatabaseEngine.POSTGRESQL), anyString())).thenReturn("postgres10");
 
         when(databaseServer.getStorageSize()).thenReturn(50L);
         when(databaseServer.getParameter("backupRetentionPeriod", Integer.class)).thenReturn(1);

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/AwsRdsUpgradeServiceTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/AwsRdsUpgradeServiceTest.java
@@ -1,0 +1,140 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cloud.aws.AwsCloudFormationClient;
+import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonRdsClient;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.AwsRdsUpgradeValidatorService;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.RdsInfo;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.RdsState;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseServer;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
+import com.sequenceiq.cloudbreak.cloud.model.Location;
+import com.sequenceiq.cloudbreak.cloud.model.Region;
+import com.sequenceiq.cloudbreak.common.database.Version;
+
+@ExtendWith(MockitoExtension.class)
+public class AwsRdsUpgradeServiceTest {
+
+    private static final String REGION_NAME = "MyRegion";
+
+    private static final String DB_INSTANCE_IDENTIFIER = "dbInstanceIdentifier";
+
+    private static final String TARGET_VERSION = "targetVersion";
+
+    @Mock
+    private AwsCloudFormationClient awsClient;
+
+    @Mock
+    private AwsRdsUpgradeSteps awsRdsUpgradeSteps;
+
+    @Mock
+    private AwsRdsUpgradeValidatorService awsRdsUpgradeValidatorService;
+
+    @InjectMocks
+    private AwsRdsUpgradeService underTest;
+
+    @Mock
+    private AmazonRdsClient rdsClient;
+
+    @Mock
+    private DatabaseStack databaseStack;
+
+    @Mock
+    private DatabaseServer databaseServer;
+
+    @Mock
+    private AuthenticatedContext ac;
+
+    private final Version targetMajorVersion = () -> TARGET_VERSION;
+
+    @BeforeEach
+    void setupDbStack() {
+        when(databaseStack.getDatabaseServer()).thenReturn(databaseServer);
+        when(databaseServer.getServerId()).thenReturn(DB_INSTANCE_IDENTIFIER);
+        when(awsClient.createRdsClient(any(), any())).thenReturn(rdsClient);
+        setupAuthenticatedContext();
+    }
+
+    @Test
+    void testUpgrade() {
+        RdsInfo rdsInfo = new RdsInfo(RdsState.AVAILABLE, null, null);
+        when(awsRdsUpgradeSteps.getRdsInfo(rdsClient, DB_INSTANCE_IDENTIFIER)).thenReturn(rdsInfo);
+
+        underTest.upgrade(ac, databaseStack, targetMajorVersion);
+
+        InOrder inOrder = Mockito.inOrder(awsRdsUpgradeValidatorService, awsRdsUpgradeSteps);
+        inOrder.verify(awsRdsUpgradeValidatorService).validateRdsCanBeUpgraded(rdsInfo, targetMajorVersion);
+        inOrder.verify(awsRdsUpgradeSteps).upgradeRds(rdsClient, databaseServer, rdsInfo, targetMajorVersion);
+        inOrder.verify(awsRdsUpgradeSteps).waitForUpgrade(ac, rdsClient, databaseServer);
+    }
+
+    @Test
+    void testUpgradeWhenRdsIsUpgradingThenUpgradeIsNotCalled() {
+        RdsInfo rdsInfo = new RdsInfo(RdsState.UPGRADING, null, null);
+        when(awsRdsUpgradeSteps.getRdsInfo(rdsClient, DB_INSTANCE_IDENTIFIER)).thenReturn(rdsInfo);
+
+        underTest.upgrade(ac, databaseStack, targetMajorVersion);
+
+        InOrder inOrder = Mockito.inOrder(awsRdsUpgradeValidatorService, awsRdsUpgradeSteps);
+        inOrder.verify(awsRdsUpgradeValidatorService).validateRdsCanBeUpgraded(rdsInfo, targetMajorVersion);
+        inOrder.verify(awsRdsUpgradeSteps).waitForUpgrade(ac, rdsClient, databaseServer);
+        verify(awsRdsUpgradeSteps, never()).upgradeRds(rdsClient, databaseServer, rdsInfo, targetMajorVersion);
+    }
+
+    @Test
+    void testUpgradeIfValidateThrowsThenNoUpgrade() {
+        RdsInfo rdsInfo = new RdsInfo(RdsState.UNKNOWN, null, null);
+        when(awsRdsUpgradeSteps.getRdsInfo(rdsClient, DB_INSTANCE_IDENTIFIER)).thenReturn(rdsInfo);
+        doThrow(CloudConnectorException.class).when(awsRdsUpgradeValidatorService).validateRdsCanBeUpgraded(rdsInfo, targetMajorVersion);
+
+        Assertions.assertThrows(CloudConnectorException.class, () ->
+            underTest.upgrade(ac, databaseStack, targetMajorVersion)
+        );
+
+        verify(awsRdsUpgradeSteps, never()).upgradeRds(rdsClient, databaseServer, rdsInfo, targetMajorVersion);
+        verify(awsRdsUpgradeSteps, never()).waitForUpgrade(ac, rdsClient, databaseServer);
+    }
+
+    @Test
+    void testUpgradeWhenUpgradeThrowsThenDoNotWait() {
+        RdsInfo rdsInfo = new RdsInfo(RdsState.AVAILABLE, null, null);
+        when(awsRdsUpgradeSteps.getRdsInfo(rdsClient, DB_INSTANCE_IDENTIFIER)).thenReturn(rdsInfo);
+        doThrow(CloudConnectorException.class).when(awsRdsUpgradeSteps).upgradeRds(rdsClient, databaseServer, rdsInfo, targetMajorVersion);
+
+        Assertions.assertThrows(CloudConnectorException.class, () ->
+                underTest.upgrade(ac, databaseStack, targetMajorVersion)
+        );
+
+        InOrder inOrder = Mockito.inOrder(awsRdsUpgradeValidatorService, awsRdsUpgradeSteps);
+        inOrder.verify(awsRdsUpgradeValidatorService).validateRdsCanBeUpgraded(rdsInfo, targetMajorVersion);
+        inOrder.verify(awsRdsUpgradeSteps).upgradeRds(rdsClient, databaseServer, rdsInfo, targetMajorVersion);
+        verify(awsRdsUpgradeSteps, never()).waitForUpgrade(ac, rdsClient, databaseServer);
+    }
+
+    private void setupAuthenticatedContext() {
+        CloudContext cc = mock(CloudContext.class);
+        Location location = Location.location(Region.region(REGION_NAME));
+        when(cc.getLocation()).thenReturn(location);
+        when(ac.getCloudContext()).thenReturn(cc);
+    }
+
+}

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/AwsRdsUpgradeStepsTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/AwsRdsUpgradeStepsTest.java
@@ -1,0 +1,165 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.assertj.core.data.MapEntry;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.amazonaws.services.rds.model.DBInstance;
+import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
+import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonRdsClient;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.AwsRdsUpgradeOperations;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.AwsRdsUpgradeValidatorService;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.RdsEngineVersion;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.RdsInfo;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.RdsInstanceStatusesToRdsStateConverter;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.RdsState;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseServer;
+import com.sequenceiq.cloudbreak.common.database.Version;
+
+@ExtendWith(MockitoExtension.class)
+public class AwsRdsUpgradeStepsTest {
+
+    private static final String DB_INSTANCE_IDENTIFIER = "dbInstanceIdentifier";
+
+    private static final String INSTANCE_ARN = "instanceArn";
+
+    private static final String STATUS_AVAILABLE = "available";
+
+    private static final String ENGINE_VERSION = "engineVersion";
+
+    private static final String CURRENT_VERSION = "currentVersion";
+
+    private static final String TARGET_VERSION = "targetVersion";
+
+    private static final String DB_PARAMETER_GROUP_NAME = "dbParameterGroupName";
+
+    @Mock
+    private AwsRdsUpgradeOperations awsRdsUpgradeOperations;
+
+    @Mock
+    private RdsInstanceStatusesToRdsStateConverter rdsInstanceStatusesToRdsStateConverter;
+
+    @Mock
+    private AwsRdsUpgradeValidatorService awsRdsUpgradeValidatorService;
+
+    @InjectMocks
+    private AwsRdsUpgradeSteps underTest;
+
+    @Mock
+    private AmazonRdsClient rdsClient;
+
+    @Mock
+    private DatabaseServer databaseServer;
+
+    private final Version targetMajorVersion = () -> "majorVersion";
+
+    @Test
+    void testGetRdsInfo() {
+        DescribeDBInstancesResult describeDBInstancesResult = getDescribeDBInstancesResult(true);
+        when(awsRdsUpgradeOperations.describeRds(rdsClient, DB_INSTANCE_IDENTIFIER)).thenReturn(describeDBInstancesResult);
+        when(rdsInstanceStatusesToRdsStateConverter.convert(any())).thenReturn(RdsState.AVAILABLE);
+
+        RdsInfo rdsInfo = underTest.getRdsInfo(rdsClient, DB_INSTANCE_IDENTIFIER);
+
+        assertEquals(RdsState.AVAILABLE, rdsInfo.getRdsState());
+        assertThat(rdsInfo.getDbArnToInstanceStatuses()).containsExactly(MapEntry.entry(INSTANCE_ARN, STATUS_AVAILABLE));
+        assertThat(rdsInfo.getRdsEngineVersion().getVersion()).isEqualTo(ENGINE_VERSION);
+    }
+
+    @Test
+    void testGetRdsInfoWhenValidationThrows() {
+        DescribeDBInstancesResult describeDBInstancesResult = getDescribeDBInstancesResult(false);
+        when(awsRdsUpgradeOperations.describeRds(rdsClient, DB_INSTANCE_IDENTIFIER)).thenReturn(describeDBInstancesResult);
+        doThrow(CloudConnectorException.class).when(awsRdsUpgradeValidatorService).validateClusterHasASingleVersion(any());
+
+        Assertions.assertThrows(CloudConnectorException.class, () ->
+                underTest.getRdsInfo(rdsClient, DB_INSTANCE_IDENTIFIER)
+        );
+    }
+
+    @Test
+    void testUpgradeRds() {
+        RdsEngineVersion currentVersion = new RdsEngineVersion(CURRENT_VERSION);
+        RdsEngineVersion targetVersion = new RdsEngineVersion(TARGET_VERSION);
+        RdsInfo rdsInfo = new RdsInfo(RdsState.AVAILABLE, null, currentVersion);
+        when(databaseServer.getServerId()).thenReturn(DB_INSTANCE_IDENTIFIER);
+        when(awsRdsUpgradeOperations.getHighestUpgradeTargetVersion(rdsClient, targetMajorVersion, currentVersion)).thenReturn(targetVersion);
+        when(awsRdsUpgradeOperations.createParameterGroupWithCustomSettings(rdsClient, databaseServer, targetVersion)).thenReturn(DB_PARAMETER_GROUP_NAME);
+
+        underTest.upgradeRds(rdsClient, databaseServer, rdsInfo, targetMajorVersion);
+
+        verify(awsRdsUpgradeOperations).upgradeRds(rdsClient, targetVersion, DB_INSTANCE_IDENTIFIER, DB_PARAMETER_GROUP_NAME);
+    }
+
+    @Test
+    void testUpgradeRdsWhenGetHighestUpgradeThrowsThenNoUpgrade() {
+        RdsEngineVersion currentVersion = new RdsEngineVersion(CURRENT_VERSION);
+        RdsInfo rdsInfo = new RdsInfo(RdsState.AVAILABLE, null, currentVersion);
+        when(awsRdsUpgradeOperations.getHighestUpgradeTargetVersion(rdsClient, targetMajorVersion, currentVersion)).thenThrow(CloudConnectorException.class);
+
+        Assertions.assertThrows(CloudConnectorException.class, () ->
+                underTest.upgradeRds(rdsClient, databaseServer, rdsInfo, targetMajorVersion)
+        );
+
+        verify(awsRdsUpgradeOperations, never()).createParameterGroupWithCustomSettings(any(), any(), any());
+        verify(awsRdsUpgradeOperations, never()).upgradeRds(any(), any(), anyString(), any());
+    }
+
+    @Test
+    void testUpgradeRdsWhenCreateParameterGroupThrowsThenNoUpgrade() {
+        RdsEngineVersion currentVersion = new RdsEngineVersion(CURRENT_VERSION);
+        RdsEngineVersion targetVersion = new RdsEngineVersion(TARGET_VERSION);
+        RdsInfo rdsInfo = new RdsInfo(RdsState.AVAILABLE, null, currentVersion);
+        when(awsRdsUpgradeOperations.getHighestUpgradeTargetVersion(rdsClient, targetMajorVersion, currentVersion)).thenReturn(targetVersion);
+        when(awsRdsUpgradeOperations.createParameterGroupWithCustomSettings(rdsClient, databaseServer, targetVersion)).thenThrow(RuntimeException.class);
+
+        Assertions.assertThrows(RuntimeException.class, () ->
+                underTest.upgradeRds(rdsClient, databaseServer, rdsInfo, targetMajorVersion)
+        );
+
+        verify(awsRdsUpgradeOperations, never()).upgradeRds(any(), any(), anyString(), any());
+    }
+
+    @Test
+    void testWaitForUpgrade() {
+        AuthenticatedContext ac = mock(AuthenticatedContext.class);
+
+        underTest.waitForUpgrade(ac, rdsClient, databaseServer);
+
+        verify(awsRdsUpgradeOperations).waitForRdsUpgrade(ac, rdsClient, databaseServer.getServerId());
+    }
+
+    private DescribeDBInstancesResult getDescribeDBInstancesResult(boolean containsResult) {
+        DescribeDBInstancesResult describeDBInstancesResult = new DescribeDBInstancesResult();
+        List<DBInstance> dbInstaces = new ArrayList<>();
+        if (containsResult) {
+            DBInstance dbInstance = new DBInstance();
+            dbInstance.setDBInstanceStatus(STATUS_AVAILABLE);
+            dbInstance.setDBInstanceArn(INSTANCE_ARN);
+            dbInstance.setEngineVersion(ENGINE_VERSION);
+            dbInstaces.add(dbInstance);
+        }
+        describeDBInstancesResult.setDBInstances(dbInstaces);
+        return describeDBInstancesResult;
+    }
+
+}

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsCustomParameterSupplierTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsCustomParameterSupplierTest.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.amazonaws.services.rds.model.ApplyMethod;
+import com.amazonaws.services.rds.model.Parameter;
+
+public class AwsRdsCustomParameterSupplierTest {
+
+    private static final String RDS_FORCE_SSL_PARAMETER_NAME = "rds.force_ssl";
+
+    private static final String RDS_FORCE_SSL_PARAMETER_VALUE = "1";
+
+    private final AwsRdsCustomParameterSupplier underTest = new AwsRdsCustomParameterSupplier();
+
+    @Test
+    void testParameters() {
+        List<Parameter> parametersToChange = underTest.getParametersToChange();
+
+        assertThat(parametersToChange).asList()
+                .hasSize(1)
+                .contains(createParameter(RDS_FORCE_SSL_PARAMETER_NAME, RDS_FORCE_SSL_PARAMETER_VALUE));
+    }
+
+    private Parameter createParameter(String name, String value) {
+        return new Parameter()
+                .withParameterName(name)
+                .withParameterValue(value)
+                .withApplyMethod(ApplyMethod.Immediate);
+
+    }
+
+}

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsStateTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsStateTest.java
@@ -1,0 +1,15 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class AwsRdsStateTest {
+
+    @Test
+    void testEnumValues() {
+        assertEquals("available", AwsRdsState.AVAILABLE.getState());
+        assertEquals("upgrading", AwsRdsState.UPGRADING.getState());
+    }
+
+}

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsUpgradeOperationsTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsUpgradeOperationsTest.java
@@ -1,0 +1,207 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.amazonaws.services.rds.model.DescribeDBInstancesRequest;
+import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
+import com.amazonaws.services.rds.model.ModifyDBInstanceRequest;
+import com.amazonaws.services.rds.model.Parameter;
+import com.dyngr.exception.PollerStoppedException;
+import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonRdsClient;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseEngine;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseServer;
+import com.sequenceiq.cloudbreak.common.database.Version;
+
+@ExtendWith(MockitoExtension.class)
+public class AwsRdsUpgradeOperationsTest {
+
+    private static final String DB_INSTANCE_IDENTIFIER = "dbInstanceIdentifier";
+
+    private static final String DB_PARAMETER_GROUP_NAME = "dbParameterGroupName";
+
+    private static final String DB_SERVER_ID = "dbServerId";
+
+    private static final String PARAMETER_GROUP_FAMILY = "parameterGroupFamily";
+
+    private static final String TARGET_VERSION = "targetVersion";
+
+    @Mock
+    private AwsRdsVersionOperations awsRdsVersionOperations;
+
+    @Mock
+    private AwsRdsUpgradeWaitOperations awsRdsUpgradeWaitOperations;
+
+    @Mock
+    private AwsRdsUpgradeValidatorService awsRdsUpgradeValidatorService;
+
+    @Mock
+    private AwsRdsCustomParameterSupplier awsRdsCustomParameterSupplier;
+
+    @InjectMocks
+    private AwsRdsUpgradeOperations underTest;
+
+    @Mock
+    private AmazonRdsClient rdsClient;
+
+    @Test
+    void testDescribeRds() {
+        DescribeDBInstancesResult describeDBInstancesResult = new DescribeDBInstancesResult();
+        when(rdsClient.describeDBInstances(any())).thenReturn(describeDBInstancesResult);
+
+        DescribeDBInstancesResult result = underTest.describeRds(rdsClient, DB_INSTANCE_IDENTIFIER);
+
+        assertEquals(result, describeDBInstancesResult);
+        ArgumentCaptor<DescribeDBInstancesRequest> describeDBInstancesRequestArgumentCaptor = ArgumentCaptor.forClass(DescribeDBInstancesRequest.class);
+        verify(rdsClient).describeDBInstances(describeDBInstancesRequestArgumentCaptor.capture());
+        DescribeDBInstancesRequest request = describeDBInstancesRequestArgumentCaptor.getValue();
+        assertEquals(DB_INSTANCE_IDENTIFIER, request.getDBInstanceIdentifier());
+    }
+
+    @Test
+    void testGetHighestUpgradeVersion() {
+        Version targetVersion = () -> TARGET_VERSION;
+        RdsEngineVersion currentVersion = new RdsEngineVersion("currentVersion");
+        Set<String> validUpgradeTargets = Set.of("v1", "v2");
+        when(awsRdsVersionOperations.getAllUpgradeTargetVersions(rdsClient, currentVersion)).thenReturn(validUpgradeTargets);
+        RdsEngineVersion highestUpgradeTargetForMajorVersion = new RdsEngineVersion("v1");
+        when(awsRdsVersionOperations.getHighestUpgradeVersionForTargetMajorVersion(validUpgradeTargets, targetVersion))
+                .thenReturn(Optional.of(highestUpgradeTargetForMajorVersion));
+
+        RdsEngineVersion result = underTest.getHighestUpgradeTargetVersion(rdsClient, targetVersion, currentVersion);
+
+        assertEquals(highestUpgradeTargetForMajorVersion, result);
+        verify(awsRdsUpgradeValidatorService).validateUpgradePresentForTargetMajorVersion(Optional.of(highestUpgradeTargetForMajorVersion));
+    }
+
+    @Test
+    void testGetHighestUpgradeVersionWhenValidationThrows() {
+        Version targetVersion = () -> TARGET_VERSION;
+        RdsEngineVersion currentVersion = new RdsEngineVersion("currentVersion");
+        Set<String> validUpgradeTargets = Set.of("v1", "v2");
+        when(awsRdsVersionOperations.getAllUpgradeTargetVersions(rdsClient, currentVersion)).thenReturn(validUpgradeTargets);
+        when(awsRdsVersionOperations.getHighestUpgradeVersionForTargetMajorVersion(validUpgradeTargets, targetVersion)).thenReturn(Optional.empty());
+        doThrow(CloudConnectorException.class).when(awsRdsUpgradeValidatorService)
+                .validateUpgradePresentForTargetMajorVersion(Optional.empty());
+
+        Assertions.assertThrows(CloudConnectorException.class, () ->
+                underTest.getHighestUpgradeTargetVersion(rdsClient, targetVersion, currentVersion)
+        );
+    }
+
+    @Test
+    void testUpgradeRds() {
+        RdsEngineVersion targetVersion = new RdsEngineVersion(TARGET_VERSION);
+
+        underTest.upgradeRds(rdsClient, targetVersion, DB_INSTANCE_IDENTIFIER, DB_PARAMETER_GROUP_NAME);
+
+        ArgumentCaptor<ModifyDBInstanceRequest> modifyRequestCaptor = ArgumentCaptor.forClass(ModifyDBInstanceRequest.class);
+        verify(rdsClient).modifyDBInstance(modifyRequestCaptor.capture());
+        ModifyDBInstanceRequest firedRequest = modifyRequestCaptor.getValue();
+        assertEquals(DB_INSTANCE_IDENTIFIER, firedRequest.getDBInstanceIdentifier());
+        assertEquals(TARGET_VERSION, firedRequest.getEngineVersion());
+        assertTrue(firedRequest.getAllowMajorVersionUpgrade());
+        assertTrue(firedRequest.getApplyImmediately());
+    }
+
+    @Test
+    void testUpgradeRdsWhenExceptionThenThrows() {
+        RdsEngineVersion targetVersion = new RdsEngineVersion(TARGET_VERSION);
+        when(rdsClient.modifyDBInstance(any())).thenThrow(new RuntimeException("myException"));
+
+        org.assertj.core.api.Assertions.assertThatCode(() -> underTest.upgradeRds(rdsClient, targetVersion, DB_INSTANCE_IDENTIFIER, DB_PARAMETER_GROUP_NAME))
+                .isInstanceOf(CloudConnectorException.class)
+                .hasMessageContaining("myException");
+    }
+
+    @Test
+    void testWaitForUpgrade() {
+        AuthenticatedContext ac = mock(AuthenticatedContext.class);
+
+        underTest.waitForRdsUpgrade(ac, rdsClient, DB_INSTANCE_IDENTIFIER);
+
+        InOrder inOrder = Mockito.inOrder(awsRdsUpgradeWaitOperations);
+        ArgumentCaptor<DescribeDBInstancesRequest> describeDBInstancesRequestCaptor = ArgumentCaptor.forClass(DescribeDBInstancesRequest.class);
+        inOrder.verify(awsRdsUpgradeWaitOperations).waitUntilUpgradeStarts(eq(rdsClient), describeDBInstancesRequestCaptor.capture());
+        inOrder.verify(awsRdsUpgradeWaitOperations).waitUntilUpgradeFinishes(eq(ac), eq(rdsClient), describeDBInstancesRequestCaptor.capture());
+
+        Set<String> dbInstanceIdentifiers = describeDBInstancesRequestCaptor.getAllValues().stream()
+                .map(DescribeDBInstancesRequest::getDBInstanceIdentifier)
+                .collect(Collectors.toSet());
+        assertThat(dbInstanceIdentifiers, hasSize(1));
+        assertThat(dbInstanceIdentifiers, hasItem(DB_INSTANCE_IDENTIFIER));
+    }
+
+    @Test
+    void testWaitForUpgradeWhenWaitingOnUpgradeStartTimesOut() {
+        AuthenticatedContext ac = mock(AuthenticatedContext.class);
+        doThrow(PollerStoppedException.class).when(awsRdsUpgradeWaitOperations).waitUntilUpgradeStarts(eq(rdsClient), any());
+
+        Assertions.assertThrows(PollerStoppedException.class, () ->
+                underTest.waitForRdsUpgrade(ac, rdsClient, DB_INSTANCE_IDENTIFIER)
+        );
+
+        verify(awsRdsUpgradeWaitOperations, never()).waitUntilUpgradeFinishes(any(), any(), any());
+    }
+
+    @Test
+    void testCreateParameterGroupWithCustomSettings() {
+        DatabaseServer databaseServer = mock(DatabaseServer.class);
+        when(databaseServer.getServerId()).thenReturn(DB_SERVER_ID);
+        when(databaseServer.getEngine()).thenReturn(DatabaseEngine.POSTGRESQL);
+        when(awsRdsVersionOperations.getDBParameterGroupFamily(DatabaseEngine.POSTGRESQL, "highestVersion")).thenReturn(PARAMETER_GROUP_FAMILY);
+        String dbParameterGroupName = "dpg-" + DB_SERVER_ID + "-vhighestVersion";
+        when(rdsClient.isDbParameterGroupPresent(dbParameterGroupName)).thenReturn(false);
+        List<Parameter> customParameterList = List.of(new Parameter());
+        when(awsRdsCustomParameterSupplier.getParametersToChange()).thenReturn(customParameterList);
+
+        underTest.createParameterGroupWithCustomSettings(rdsClient, databaseServer, new RdsEngineVersion("highestVersion"));
+
+        verify(rdsClient).createParameterGroup(PARAMETER_GROUP_FAMILY, dbParameterGroupName, "DB parameter group for " + DB_SERVER_ID);
+        verify(rdsClient).changeParameterInGroup(dbParameterGroupName, customParameterList);
+    }
+
+    @Test
+    void testCreateParameterGroupWithCustomSettingsWhenParameterGroupIsFound() {
+        DatabaseServer databaseServer = mock(DatabaseServer.class);
+        when(databaseServer.getServerId()).thenReturn(DB_SERVER_ID);
+        when(databaseServer.getEngine()).thenReturn(DatabaseEngine.POSTGRESQL);
+        when(awsRdsVersionOperations.getDBParameterGroupFamily(DatabaseEngine.POSTGRESQL, "highestVersion")).thenReturn(PARAMETER_GROUP_FAMILY);
+        String dbParameterGroupName = "dpg-" + DB_SERVER_ID + "-vhighestVersion";
+        when(rdsClient.isDbParameterGroupPresent(dbParameterGroupName)).thenReturn(true);
+
+        underTest.createParameterGroupWithCustomSettings(rdsClient, databaseServer, new RdsEngineVersion("highestVersion"));
+
+        verify(rdsClient, never()).createParameterGroup(anyString(), anyString(), anyString());
+        verify(rdsClient).changeParameterInGroup(eq(dbParameterGroupName), any());
+    }
+
+}

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsUpgradeValidatorServiceTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsUpgradeValidatorServiceTest.java
@@ -1,0 +1,95 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.common.database.Version;
+
+public class AwsRdsUpgradeValidatorServiceTest {
+
+    private final AwsRdsUpgradeValidatorService underTest = new AwsRdsUpgradeValidatorService();
+
+    @Test
+    void testValidateRdsCanBeUpgraded() {
+        RdsInfo rdsInfo = new RdsInfo(RdsState.AVAILABLE, Map.of(), new RdsEngineVersion("10"));
+        Version targetMajorVersion = () -> "11";
+
+        Assertions.assertDoesNotThrow(() ->
+                underTest.validateRdsCanBeUpgraded(rdsInfo, targetMajorVersion)
+        );
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = RdsState.class, names = {"AVAILABLE", "UPGRADING"}, mode = EnumSource.Mode.EXCLUDE)
+    void testValidateRdsCanBeUpgradedWhenStateNotOk(RdsState rdsState) {
+        RdsInfo rdsInfo = new RdsInfo(rdsState, Map.of(), new RdsEngineVersion("10"));
+        Version targetMajorVersion = () -> "11";
+
+        Assertions.assertThrows(CloudConnectorException.class, () ->
+                underTest.validateRdsCanBeUpgraded(rdsInfo, targetMajorVersion)
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"11", "12"})
+    void testValidateRdsCanBeUpgradedWhenVersionGreaterOrEqualToTarget(String currentEngineVersion) {
+        RdsInfo rdsInfo = new RdsInfo(RdsState.AVAILABLE, Map.of(), new RdsEngineVersion(currentEngineVersion));
+        Version targetMajorVersion = () -> "11";
+
+        Assertions.assertThrows(CloudConnectorException.class, () ->
+                underTest.validateRdsCanBeUpgraded(rdsInfo, targetMajorVersion)
+        );
+    }
+
+    @Test
+    void testValidateUpgradePresentForTargetMajorVersion() {
+        Optional<RdsEngineVersion> upgradeTargetsForMajorVersion = Optional.of(new RdsEngineVersion("v1"));
+
+        Assertions.assertDoesNotThrow(() ->
+                underTest.validateUpgradePresentForTargetMajorVersion(upgradeTargetsForMajorVersion)
+        );
+    }
+
+    @Test
+    void testValidateUpgradePresentForTargetMajorVersionWhenNoTargetVersionPresent() {
+        Optional<RdsEngineVersion> upgradeTargetsForMajorVersion = Optional.empty();
+
+        Assertions.assertThrows(CloudConnectorException.class, () ->
+                underTest.validateUpgradePresentForTargetMajorVersion(upgradeTargetsForMajorVersion)
+        );
+    }
+
+    @Test
+    void testClusterHasSingleVersion() {
+        Set<String> dbVersions = Set.of("version");
+
+        underTest.validateClusterHasASingleVersion(dbVersions);
+    }
+
+    @Test
+    void testClusterHasSingleVersionWhenMultipleVersions() {
+        Set<String> dbVersions = Set.of("v1", "v2");
+
+        Assertions.assertThrows(CloudConnectorException.class, () ->
+                underTest.validateClusterHasASingleVersion(dbVersions)
+        );
+    }
+
+    @Test
+    void testClusterHasSingleVersionWhenVersionsEmpty() {
+        Set<String> dbVersions = Set.of();
+
+        Assertions.assertThrows(CloudConnectorException.class, () ->
+                underTest.validateClusterHasASingleVersion(dbVersions)
+        );
+    }
+
+}

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsUpgradeWaitOperationsTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsUpgradeWaitOperationsTest.java
@@ -1,0 +1,74 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.amazonaws.services.rds.model.DescribeDBInstancesRequest;
+import com.amazonaws.waiters.Waiter;
+import com.dyngr.exception.PollerException;
+import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonRdsClient;
+import com.sequenceiq.cloudbreak.cloud.aws.scheduler.CustomAmazonWaiterProvider;
+import com.sequenceiq.cloudbreak.cloud.aws.util.poller.upgrade.UpgradeStartPoller;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+
+@ExtendWith(MockitoExtension.class)
+public class AwsRdsUpgradeWaitOperationsTest {
+
+    @Mock
+    private UpgradeStartPoller upgradeStartPoller;
+
+    @Mock
+    private CustomAmazonWaiterProvider customAmazonWaiterProvider;
+
+    @InjectMocks
+    private AwsRdsUpgradeWaitOperations underTest;
+
+    @Mock
+    private AmazonRdsClient rdsClient;
+
+    @Test
+    void testWaitUntilUpgradeStarts() {
+        DescribeDBInstancesRequest describeDBInstancesRequest = new DescribeDBInstancesRequest();
+
+        underTest.waitUntilUpgradeStarts(rdsClient, describeDBInstancesRequest);
+
+        verify(upgradeStartPoller).waitForUpgradeToStart(any());
+    }
+
+    @Test
+    void testWaitUntilUpgradeStartsWhenPollingThrows() {
+        DescribeDBInstancesRequest describeDBInstancesRequest = new DescribeDBInstancesRequest();
+        doThrow(PollerException.class).when(upgradeStartPoller).waitForUpgradeToStart(any());
+
+        Assertions.assertThrows(CloudConnectorException.class, () ->
+            underTest.waitUntilUpgradeStarts(rdsClient, describeDBInstancesRequest)
+        );
+    }
+
+    @Test
+    void testWaitUntilUpgradeFinishes() {
+        CloudContext cloudContext = mock(CloudContext.class);
+        when(cloudContext.getId()).thenReturn(1L);
+        AuthenticatedContext ac = mock(AuthenticatedContext.class);
+        when(ac.getCloudContext()).thenReturn(cloudContext);
+        DescribeDBInstancesRequest describeDBInstancesRequest = new DescribeDBInstancesRequest();
+        Waiter<DescribeDBInstancesRequest> rdsWaiter = mock(Waiter.class);
+        when(customAmazonWaiterProvider.getDbInstanceModifyWaiter(rdsClient)).thenReturn(rdsWaiter);
+
+        underTest.waitUntilUpgradeFinishes(ac, rdsClient, describeDBInstancesRequest);
+
+        verify(rdsWaiter).run(any());
+    }
+}

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsVersionOperationsTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsVersionOperationsTest.java
@@ -1,0 +1,172 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.amazonaws.services.rds.model.DBEngineVersion;
+import com.amazonaws.services.rds.model.DescribeDBEngineVersionsRequest;
+import com.amazonaws.services.rds.model.DescribeDBEngineVersionsResult;
+import com.amazonaws.services.rds.model.UpgradeTarget;
+import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonRdsClient;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseEngine;
+import com.sequenceiq.cloudbreak.common.database.Version;
+
+@ExtendWith(MockitoExtension.class)
+public class AwsRdsVersionOperationsTest {
+
+    private final AwsRdsVersionOperations underTest = new AwsRdsVersionOperations();
+
+    @Test
+    void testGetHighestUpgradeVersion() {
+        Set<RdsEngineVersion> validUpgradeVersions = Set.of(new RdsEngineVersion("1.1"), new RdsEngineVersion("1.2"));
+
+        RdsEngineVersion selectedTargetVersion = underTest.getHighestUpgradeTargetVersion(validUpgradeVersions);
+
+        assertEquals("1.2", selectedTargetVersion.getVersion());
+    }
+
+    @Test
+    void getDBParameterGroupFamilyTestWhenPgSqlAndVersionIsNull() {
+        Assertions.assertThrows(IllegalStateException.class, () ->
+                underTest.getDBParameterGroupFamily(DatabaseEngine.POSTGRESQL, null)
+        );
+    }
+
+    @Test
+    void getDBParameterGroupFamilyTestWhenPgSqlAndVersionIsEmpty() {
+        Assertions.assertThrows(IllegalStateException.class, () ->
+                underTest.getDBParameterGroupFamily(DatabaseEngine.POSTGRESQL, "")
+        );
+    }
+
+    // Note: There is no easy way to test the "bad engine variant" case as enum classes are final and hard to mock.
+    @Test
+    void getDBParameterGroupFamilyTestWhenPgSqlAndBadVersionFormat() {
+        Assertions.assertThrows(IllegalStateException.class, () ->
+                underTest.getDBParameterGroupFamily(DatabaseEngine.POSTGRESQL, "latest")
+        );
+    }
+
+    @Test
+    void getDBParameterGroupFamilyTestWhenPgSqlAndMissingMinorVersion() {
+        String dbFamily = underTest.getDBParameterGroupFamily(DatabaseEngine.POSTGRESQL, "10");
+
+        assertEquals("postgres10", dbFamily);
+    }
+
+    @Test
+    void getDBParameterGroupFamilyTestWhenPgSqlAndMajorVersionNumericOverflow() {
+        Assertions.assertThrows(NumberFormatException.class, () ->
+                underTest.getDBParameterGroupFamily(DatabaseEngine.POSTGRESQL, "12345678901234567890.1")
+        );
+    }
+
+    static Object[][] unsupportedMajorVersionDataProvider() {
+        return new Object[][]{
+                // testCaseName version
+                {"version 0.1", "0.1"},
+                {"version 1.1", "1.1"},
+                {"version 2.1", "2.1"},
+                {"version 3.1", "3.1"},
+                {"version 4.1", "4.1"},
+                {"version 5.1", "5.1"},
+                {"version 6.1", "6.1"},
+                {"version 7.1", "7.1"},
+                {"version 8.1", "8.1"},
+                {"version 123.1", "123.1"},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("unsupportedMajorVersionDataProvider")
+    void getDBParameterGroupFamilyTestWhenPgSqlAndUnsupportedMajorVersion(String testCaseName, String version) {
+        Assertions.assertThrows(IllegalStateException.class, () ->
+                underTest.getDBParameterGroupFamily(DatabaseEngine.POSTGRESQL, version)
+        );
+    }
+
+    static Object[][] validVersionDataProvider() {
+        return new Object[][]{
+                // testCaseName version familyExpected
+                {"version 9.5", "9.5", "postgres9.5"},
+                {"version 9.6", "9.6", "postgres9.6"},
+                {"version 10.1", "10.1", "postgres10"},
+                {"version 11.1", "11.1", "postgres11"},
+                {"version 12.1", "12.1", "postgres12"},
+                {"version 13.1", "13.1", "postgres13"},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("validVersionDataProvider")
+    void getDBParameterGroupFamilyTestWhenPgSqlAndValidVersion(String testCaseName, String version, String familyExpected) {
+        String dbFamily = underTest.getDBParameterGroupFamily(DatabaseEngine.POSTGRESQL, version);
+
+        assertEquals(familyExpected, dbFamily);
+    }
+
+    @Test
+    void testGetAllUpgradeTargets() {
+        AmazonRdsClient rdsClient = mock(AmazonRdsClient.class);
+        RdsEngineVersion rdsEngineVersion = new RdsEngineVersion("1.2");
+        DBEngineVersion dbEngineVersionV1 = new DBEngineVersion().withValidUpgradeTarget(
+                new UpgradeTarget().withEngineVersion("1.1"),
+                new UpgradeTarget().withEngineVersion("1.3"));
+        DBEngineVersion dbEngineVersionV2 = new DBEngineVersion().withValidUpgradeTarget(
+                new UpgradeTarget().withEngineVersion("2.1"),
+                new UpgradeTarget().withEngineVersion("2.3"));
+        DescribeDBEngineVersionsResult describeDBEngineVersionsResult = new DescribeDBEngineVersionsResult()
+                .withDBEngineVersions(dbEngineVersionV1, dbEngineVersionV2);
+        when(rdsClient.describeDBEngineVersions(any())).thenReturn(describeDBEngineVersionsResult);
+
+        Set<String> upgradeTargetVersions = underTest.getAllUpgradeTargetVersions(rdsClient, rdsEngineVersion);
+
+        assertThat(upgradeTargetVersions).hasSize(4);
+        assertThat(upgradeTargetVersions).containsOnly("1.1", "1.3", "2.1", "2.3");
+        ArgumentCaptor<DescribeDBEngineVersionsRequest> rdsEngineVersionArgumentCaptor = ArgumentCaptor.forClass(DescribeDBEngineVersionsRequest.class);
+        verify(rdsClient).describeDBEngineVersions(rdsEngineVersionArgumentCaptor.capture());
+        DescribeDBEngineVersionsRequest describeDBEngineVersionsRequest = rdsEngineVersionArgumentCaptor.getValue();
+        assertEquals("1.2", describeDBEngineVersionsRequest.getEngineVersion());
+        assertEquals("postgres", describeDBEngineVersionsRequest.getEngine());
+    }
+
+    @Test
+    void testGetAllUpgradeTargetsWhenRdsClientThrows() {
+        AmazonRdsClient rdsClient = mock(AmazonRdsClient.class);
+        RdsEngineVersion rdsEngineVersion = new RdsEngineVersion("1.0");
+        when(rdsClient.describeDBEngineVersions(any())).thenThrow(RuntimeException.class);
+
+        Assertions.assertThrows(CloudConnectorException.class, () ->
+                underTest.getAllUpgradeTargetVersions(rdsClient, rdsEngineVersion)
+        );
+    }
+
+    @Test
+    void testGetUpgradeVersionsForTargetMajor() {
+        Set<String> validUpgradeTargetVersions = Set.of("1.1", "1.2", "2.1", "2.2");
+        Version targetVersion = () -> "2";
+
+        Optional<RdsEngineVersion> validTargetVersions = underTest.getHighestUpgradeVersionForTargetMajorVersion(validUpgradeTargetVersions, targetVersion);
+
+        assertTrue(validTargetVersions.isPresent());
+        assertEquals("2.2", validTargetVersions.get().getVersion());
+    }
+}

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/RdsEngineVersionTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/RdsEngineVersionTest.java
@@ -1,0 +1,16 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class RdsEngineVersionTest {
+
+    @Test
+    void testGetters() {
+        RdsEngineVersion rdsEngineVersion = new RdsEngineVersion("major.minor");
+
+        assertEquals("major", rdsEngineVersion.getMajorVersion());
+        assertEquals("major.minor", rdsEngineVersion.getVersion());
+    }
+}

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/RdsInfoTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/RdsInfoTest.java
@@ -1,0 +1,24 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+public class RdsInfoTest {
+
+    @Test
+    void testCtorAndGetters() {
+        RdsState rdsState = RdsState.UNKNOWN;
+        Map<String, String> instancesToStatusMap = Map.of("instance", "status");
+        RdsEngineVersion rdsEngineVersion = new RdsEngineVersion("engineVersion");
+
+        RdsInfo rdsInfo = new RdsInfo(rdsState, instancesToStatusMap, rdsEngineVersion);
+
+        assertEquals(RdsState.UNKNOWN, rdsInfo.getRdsState());
+        assertEquals(rdsEngineVersion, rdsInfo.getRdsEngineVersion());
+        assertEquals(instancesToStatusMap, rdsInfo.getDbArnToInstanceStatuses());
+    }
+
+}

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/RdsInstanceStatusesToRdsStateConverterTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/RdsInstanceStatusesToRdsStateConverterTest.java
@@ -1,0 +1,65 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class RdsInstanceStatusesToRdsStateConverterTest {
+
+    private RdsInstanceStatusesToRdsStateConverter underTest = new RdsInstanceStatusesToRdsStateConverter();
+
+    @Test
+    void testConvertWhenNoInstanceStatus() {
+        Map<String, String> dbArnToInstanceStatusesMap = Map.of();
+
+        assertEquals(RdsState.UNKNOWN, underTest.convert(dbArnToInstanceStatusesMap));
+    }
+
+    @Test
+    void testConvertWhenInstancesAvailable() {
+        Map<String, String> dbArnToInstanceStatusesMap = Map.of("instance1", "available");
+
+        assertEquals(RdsState.AVAILABLE, underTest.convert(dbArnToInstanceStatusesMap));
+    }
+
+    @Test
+    void testConvertWhenInstancesUpgrading() {
+        Map<String, String> dbArnToInstanceStatusesMap = Map.of("instance1", "upgrading");
+
+        assertEquals(RdsState.UPGRADING, underTest.convert(dbArnToInstanceStatusesMap));
+    }
+
+    @Test
+    void testConvertWhenAtLeastOneInstanceIsNotAvailable() {
+        Map<String, String> dbArnToInstanceStatusesMap = Map.of("instance1", "available", "instance2", "anotherState");
+
+        assertEquals(RdsState.OTHER, underTest.convert(dbArnToInstanceStatusesMap));
+    }
+
+    @Test
+    void testConvertWhenAtLeastOneInstanceIsUpgrading() {
+        Map<String, String> dbArnToInstanceStatusesMap = Map.of("instance1", "upgrading", "instance2", "anotherState");
+
+        assertEquals(RdsState.UPGRADING, underTest.convert(dbArnToInstanceStatusesMap));
+    }
+
+    @Test
+    void testConvertWhenInstancesAnyOtherState() {
+        Map<String, String> dbArnToInstanceStatusesMap = Map.of("instance1", "any other state");
+
+        assertEquals(RdsState.OTHER, underTest.convert(dbArnToInstanceStatusesMap));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"availablePlusSomething", "upgradingPlusSomething"})
+    void testConvertWhenInstanceStateResemblesMappedStatus(String resemblingState) {
+        Map<String, String> dbArnToInstanceStatusesMap = Map.of("instance1", resemblingState);
+
+        assertEquals(RdsState.OTHER, underTest.convert(dbArnToInstanceStatusesMap));
+    }
+
+}

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/util/poller/upgrade/UpgradeStartWaitTaskTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/util/poller/upgrade/UpgradeStartWaitTaskTest.java
@@ -1,0 +1,85 @@
+package com.sequenceiq.cloudbreak.cloud.aws.util.poller.upgrade;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.amazonaws.services.rds.model.DBInstance;
+import com.amazonaws.services.rds.model.DescribeDBInstancesRequest;
+import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
+import com.dyngr.core.AttemptResult;
+import com.dyngr.core.AttemptState;
+import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonRdsClient;
+
+@ExtendWith(MockitoExtension.class)
+public class UpgradeStartWaitTaskTest {
+
+    @Mock
+    private DescribeDBInstancesRequest describeDBInstancesRequest;
+
+    @Mock
+    private AmazonRdsClient rdsClient;
+
+    @InjectMocks
+    private UpgradeStartWaitTask underTest;
+
+    @Test
+    void testProcessWhenUpgradingThenFinishes() {
+        when(rdsClient.describeDBInstances(any())).thenReturn(setupDescribeDbInstancesResult("upgrading"));
+
+        AttemptResult<Boolean> result = underTest.process();
+
+        assertEquals(AttemptState.FINISH, result.getState());
+        assertTrue(result.getResult());
+    }
+
+    @Test
+    void testProcessWhenMultipleUpgradingStateThenFinishes() {
+        when(rdsClient.describeDBInstances(any())).thenReturn(setupDescribeDbInstancesResult("upgrading", "upgrading"));
+
+        AttemptResult<Boolean> result = underTest.process();
+
+        assertEquals(AttemptState.FINISH, result.getState());
+        assertTrue(result.getResult());
+    }
+
+    @Test
+    void testProcessWhenMixedStatesWithOneUpgradingThenFinishes() {
+        when(rdsClient.describeDBInstances(any())).thenReturn(setupDescribeDbInstancesResult("upgrading", "a state"));
+
+        AttemptResult<Boolean> result = underTest.process();
+
+        assertEquals(AttemptState.FINISH, result.getState());
+        assertTrue(result.getResult());
+    }
+
+    @Test
+    void testProcessWhenNotUpgradingThenContinue() {
+        when(rdsClient.describeDBInstances(any())).thenReturn(setupDescribeDbInstancesResult("a state"));
+
+        AttemptResult<Boolean> result = underTest.process();
+
+        assertEquals(AttemptState.CONTINUE, result.getState());
+    }
+
+    private DescribeDBInstancesResult setupDescribeDbInstancesResult(String... instanceStates) {
+        DescribeDBInstancesResult describeDBInstancesResult = new DescribeDBInstancesResult();
+        Set<DBInstance> dbInstances = new HashSet<>();
+        for (String instanceState : instanceStates) {
+            dbInstances.add(new DBInstance().withDBInstanceStatus(instanceState));
+        }
+        describeDBInstancesResult.setDBInstances(dbInstances);
+        return describeDBInstancesResult;
+    }
+
+}

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsRdsDbParameterGroupViewTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsRdsDbParameterGroupViewTest.java
@@ -1,19 +1,14 @@
 package com.sequenceiq.cloudbreak.cloud.aws.view;
 
-import static com.sequenceiq.cloudbreak.cloud.aws.view.AwsRdsDbParameterGroupView.ENGINE_VERSION;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.AwsRdsVersionOperations;
 import com.sequenceiq.cloudbreak.cloud.model.DatabaseEngine;
 import com.sequenceiq.cloudbreak.cloud.model.DatabaseServer;
 
@@ -29,7 +24,7 @@ class AwsRdsDbParameterGroupViewTest {
     void getDBParameterGroupNameTestWhenNullServerId() {
         DatabaseServer databaseServer = DatabaseServer.builder().build();
 
-        AwsRdsDbParameterGroupView underTest = new AwsRdsDbParameterGroupView(databaseServer);
+        AwsRdsDbParameterGroupView underTest = new AwsRdsDbParameterGroupView(databaseServer, null);
 
         assertThat(underTest.getDBParameterGroupName()).isNull();
     }
@@ -38,124 +33,32 @@ class AwsRdsDbParameterGroupViewTest {
     void getDBParameterGroupNameTestWhenHasServerId() {
         DatabaseServer databaseServer = DatabaseServer.builder().withServerId("myserver").build();
 
-        AwsRdsDbParameterGroupView underTest = new AwsRdsDbParameterGroupView(databaseServer);
+        AwsRdsDbParameterGroupView underTest = new AwsRdsDbParameterGroupView(databaseServer, null);
 
         assertThat(underTest.getDBParameterGroupName()).isEqualTo("dpg-myserver");
+    }
+
+    @Test
+    void getDBParameterGroupFamilyTest() {
+        DatabaseServer databaseServer = DatabaseServer.builder()
+                .withEngine(DatabaseEngine.POSTGRESQL)
+                .build();
+        databaseServer.putParameter("engineVersion", "myEngineVersion");
+        AwsRdsVersionOperations awsRdsVersionOperations = mock(AwsRdsVersionOperations.class);
+        AwsRdsDbParameterGroupView underTest = new AwsRdsDbParameterGroupView(databaseServer, awsRdsVersionOperations);
+
+        underTest.getDBParameterGroupFamily();
+
+        verify(awsRdsVersionOperations).getDBParameterGroupFamily(DatabaseEngine.POSTGRESQL, "myEngineVersion");
     }
 
     @Test
     void getDBParameterGroupFamilyTestWhenNullEngine() {
         DatabaseServer databaseServer = DatabaseServer.builder().build();
 
-        AwsRdsDbParameterGroupView underTest = new AwsRdsDbParameterGroupView(databaseServer);
+        AwsRdsDbParameterGroupView underTest = new AwsRdsDbParameterGroupView(databaseServer, null);
 
         assertThat(underTest.getDBParameterGroupFamily()).isNull();
-    }
-
-    // Note: There is no easy way to test the "bad engine variant" case as enum classes are final and hard to mock.
-
-    @Test
-    void getDBParameterGroupFamilyTestWhenPgSqlAndBadVersionFormat() {
-        DatabaseServer databaseServer = DatabaseServer.builder().withEngine(DatabaseEngine.POSTGRESQL).build();
-        databaseServer.putParameter(ENGINE_VERSION, "latest");
-
-        AwsRdsDbParameterGroupView underTest = new AwsRdsDbParameterGroupView(databaseServer);
-
-        assertThatCode(underTest::getDBParameterGroupFamily).isInstanceOf(IllegalStateException.class);
-    }
-
-    @Test
-    void getDBParameterGroupFamilyTestWhenPgSqlAndMissingMinorVersion() {
-        DatabaseServer databaseServer = DatabaseServer.builder().withEngine(DatabaseEngine.POSTGRESQL).build();
-        databaseServer.putParameter(ENGINE_VERSION, "10");
-
-        AwsRdsDbParameterGroupView underTest = new AwsRdsDbParameterGroupView(databaseServer);
-
-        assertThat(underTest.getDBParameterGroupFamily()).isEqualTo("postgres10");
-    }
-
-    @Test
-    void getDBParameterGroupFamilyTestWhenPgSqlAndMajorVersionNumericOverflow() {
-        DatabaseServer databaseServer = DatabaseServer.builder().withEngine(DatabaseEngine.POSTGRESQL).build();
-        databaseServer.putParameter(ENGINE_VERSION, "12345678901234567890.1");
-
-        AwsRdsDbParameterGroupView underTest = new AwsRdsDbParameterGroupView(databaseServer);
-
-        assertThatCode(underTest::getDBParameterGroupFamily).isInstanceOf(NumberFormatException.class);
-    }
-
-    static Object[][] unsupportedMajorVersionDataProvider() {
-        return new Object[][]{
-                // testCaseName version
-                {"version 0.1", "0.1"},
-                {"version 1.1", "1.1"},
-                {"version 2.1", "2.1"},
-                {"version 3.1", "3.1"},
-                {"version 4.1", "4.1"},
-                {"version 5.1", "5.1"},
-                {"version 6.1", "6.1"},
-                {"version 7.1", "7.1"},
-                {"version 8.1", "8.1"},
-                {"version 123.1", "123.1"},
-        };
-    }
-
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("unsupportedMajorVersionDataProvider")
-    void getDBParameterGroupFamilyTestWhenPgSqlAndUnsupportedMajorVersion(String testCaseName, String version) {
-        DatabaseServer databaseServer = DatabaseServer.builder().withEngine(DatabaseEngine.POSTGRESQL).build();
-        databaseServer.putParameter(ENGINE_VERSION, version);
-
-        AwsRdsDbParameterGroupView underTest = new AwsRdsDbParameterGroupView(databaseServer);
-
-        assertThatCode(underTest::getDBParameterGroupFamily).isInstanceOf(IllegalStateException.class);
-    }
-
-    static Object[][] validVersionDataProvider() {
-        return new Object[][]{
-                // testCaseName version familyExpected
-                {"version 9.5", "9.5", "postgres9.5"},
-                {"version 9.6", "9.6", "postgres9.6"},
-                {"version 10.1", "10.1", "postgres10"},
-                {"version 11.1", "11.1", "postgres11"},
-                {"version 12.1", "12.1", "postgres12"},
-                {"version 13.1", "13.1", "postgres13"},
-        };
-    }
-
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("validVersionDataProvider")
-    void getDBParameterGroupFamilyTestWhenPgSqlAndValidVersion(String testCaseName, String version, String familyExpected) {
-        DatabaseServer databaseServer = DatabaseServer.builder().withEngine(DatabaseEngine.POSTGRESQL).build();
-        databaseServer.putParameter(ENGINE_VERSION, version);
-
-        AwsRdsDbParameterGroupView underTest = new AwsRdsDbParameterGroupView(databaseServer);
-
-        assertThat(underTest.getDBParameterGroupFamily()).isEqualTo(familyExpected);
-    }
-
-    private String getDefaultEngineVersionFromTemplate() throws IOException {
-        String template = getTemplate();
-        Matcher engineVersionMatcher = DEFAULT_ENGINE_VERSION.matcher(template);
-        String version = null;
-        if (engineVersionMatcher.matches()) {
-            version = engineVersionMatcher.group(1);
-        }
-        return version;
-    }
-
-    private String getTemplate() throws IOException {
-        String template;
-        try (BufferedReader bs = new BufferedReader(
-                new InputStreamReader(AwsRdsDbParameterGroupViewTest.class.getClassLoader().getResourceAsStream(DBSTACK_TEMPLATE_FILE)))) {
-            StringBuilder out = new StringBuilder();
-            String line;
-            while ((line = bs.readLine()) != null) {
-                out.append(line);
-            }
-            template = out.toString();
-        }
-        return template;
     }
 
 }

--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/client/AmazonRdsClient.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/client/AmazonRdsClient.java
@@ -2,20 +2,35 @@ package com.sequenceiq.cloudbreak.cloud.aws.common.client;
 
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.amazonaws.services.rds.AmazonRDS;
 import com.amazonaws.services.rds.model.Certificate;
+import com.amazonaws.services.rds.model.CreateDBParameterGroupRequest;
 import com.amazonaws.services.rds.model.DBInstance;
+import com.amazonaws.services.rds.model.DBParameterGroup;
+import com.amazonaws.services.rds.model.DBParameterGroupNotFoundException;
 import com.amazonaws.services.rds.model.DescribeCertificatesRequest;
 import com.amazonaws.services.rds.model.DescribeCertificatesResult;
+import com.amazonaws.services.rds.model.DescribeDBEngineVersionsRequest;
+import com.amazonaws.services.rds.model.DescribeDBEngineVersionsResult;
 import com.amazonaws.services.rds.model.DescribeDBInstancesRequest;
 import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
+import com.amazonaws.services.rds.model.DescribeDBParameterGroupsRequest;
+import com.amazonaws.services.rds.model.DescribeDBParameterGroupsResult;
 import com.amazonaws.services.rds.model.ModifyDBInstanceRequest;
+import com.amazonaws.services.rds.model.ModifyDBParameterGroupRequest;
+import com.amazonaws.services.rds.model.ModifyDBParameterGroupResult;
+import com.amazonaws.services.rds.model.Parameter;
 import com.amazonaws.services.rds.model.StartDBInstanceRequest;
 import com.amazonaws.services.rds.model.StopDBInstanceRequest;
 import com.amazonaws.services.rds.waiters.AmazonRDSWaiters;
 import com.sequenceiq.cloudbreak.cloud.aws.common.util.AwsPageCollector;
 
 public class AmazonRdsClient extends AmazonClient {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AmazonRdsClient.class);
 
     private final AmazonRDS client;
 
@@ -47,6 +62,35 @@ public class AmazonRdsClient extends AmazonClient {
         return client.describeDBInstances(describeDBInstancesRequest);
     }
 
+    public boolean isDbParameterGroupPresent(String dbParameterGroupName) {
+        DescribeDBParameterGroupsRequest describeDBParameterGroupsRequest = new DescribeDBParameterGroupsRequest()
+                .withDBParameterGroupName(dbParameterGroupName);
+        try {
+            DescribeDBParameterGroupsResult result = client.describeDBParameterGroups(describeDBParameterGroupsRequest);
+            LOGGER.debug("DB parameter group was found: {}, result: {}", dbParameterGroupName, result);
+            return true;
+        } catch (DBParameterGroupNotFoundException e) {
+            LOGGER.debug("DB parameter group was not found: {}", dbParameterGroupName);
+            return false;
+        }
+    }
+
+    public DBParameterGroup createParameterGroup(String dbParameterGroupFamily, String dbParameterGroupName, String dbParameterGroupDescription) {
+        CreateDBParameterGroupRequest createDBParameterGroupRequest = new CreateDBParameterGroupRequest()
+                .withDBParameterGroupFamily(dbParameterGroupFamily)
+                .withDBParameterGroupName(dbParameterGroupName)
+                .withDescription(dbParameterGroupDescription);
+        return client.createDBParameterGroup(createDBParameterGroupRequest);
+    }
+
+    public ModifyDBParameterGroupResult changeParameterInGroup(String dbParameterGroupName, List<Parameter> parameters) {
+        ModifyDBParameterGroupRequest modifyDBParameterGroupRequest = new ModifyDBParameterGroupRequest()
+                .withDBParameterGroupName(dbParameterGroupName)
+                .withParameters(parameters);
+
+        return client.modifyDBParameterGroup(modifyDBParameterGroupRequest);
+    }
+
     public DBInstance stopDBInstance(StopDBInstanceRequest stopDBInstanceRequest) {
         return client.stopDBInstance(stopDBInstanceRequest);
     }
@@ -57,6 +101,10 @@ public class AmazonRdsClient extends AmazonClient {
                 DescribeCertificatesResult::getCertificates,
                 DescribeCertificatesResult::getMarker,
                 DescribeCertificatesRequest::setMarker);
+    }
+
+    public DescribeDBEngineVersionsResult describeDBEngineVersions(DescribeDBEngineVersionsRequest describeDBEngineVersionsRequest) {
+        return client.describeDBEngineVersions(describeDBEngineVersionsRequest);
     }
 
     private DescribeCertificatesResult describeCertificatesInternal(DescribeCertificatesRequest request) {

--- a/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/client/AmazonRdsClientTest.java
+++ b/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/client/AmazonRdsClientTest.java
@@ -1,13 +1,16 @@
 package com.sequenceiq.cloudbreak.cloud.aws.common.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -15,14 +18,25 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.amazonaws.services.rds.AmazonRDS;
 import com.amazonaws.services.rds.model.Certificate;
+import com.amazonaws.services.rds.model.CreateDBParameterGroupRequest;
 import com.amazonaws.services.rds.model.DescribeCertificatesRequest;
 import com.amazonaws.services.rds.model.DescribeCertificatesResult;
+import com.amazonaws.services.rds.model.ModifyDBParameterGroupRequest;
+import com.amazonaws.services.rds.model.Parameter;
 import com.sequenceiq.cloudbreak.cloud.aws.common.util.AwsPageCollector;
 
 @ExtendWith(MockitoExtension.class)
 class AmazonRdsClientTest {
 
     private static final String MARKER = "marker";
+
+    private static final String DB_INSTANCE_IDENTIFIER = "dbInstanceIdentifier";
+
+    private static final String DB_PARAMETER_GROUP_NAME = "dbParameterGroupName";
+
+    private static final String DB_PARAMETER_GROUP_FAMILY = "dbParameterGroupFamily";
+
+    private static final String DATABASE_SERVER_ID = "databaseServerId";
 
     @Mock
     private AmazonRDS client;
@@ -71,6 +85,30 @@ class AmazonRdsClientTest {
 
         assertThat(certificates).isNotNull();
         assertThat(certificates).isEqualTo(List.of(cert1, cert2));
+    }
+
+    @Test
+    void testCreateParameterGroup() {
+        underTest.createParameterGroup(DB_PARAMETER_GROUP_FAMILY, DB_PARAMETER_GROUP_NAME, DATABASE_SERVER_ID);
+
+        ArgumentCaptor<CreateDBParameterGroupRequest> requestArgumentCaptor = ArgumentCaptor.forClass(CreateDBParameterGroupRequest.class);
+        verify(client).createDBParameterGroup(requestArgumentCaptor.capture());
+        CreateDBParameterGroupRequest request = requestArgumentCaptor.getValue();
+        assertEquals(DB_PARAMETER_GROUP_FAMILY, request.getDBParameterGroupFamily());
+        assertEquals(DB_PARAMETER_GROUP_NAME, request.getDBParameterGroupName());
+    }
+
+    @Test
+    void testChangeParameterGroupEntries() {
+        Parameter parameter = new Parameter();
+
+        underTest.changeParameterInGroup(DB_INSTANCE_IDENTIFIER, List.of(parameter));
+
+        ArgumentCaptor<ModifyDBParameterGroupRequest> modifyRequestCaptor = ArgumentCaptor.forClass(ModifyDBParameterGroupRequest.class);
+        verify(client).modifyDBParameterGroup(modifyRequestCaptor.capture());
+        ModifyDBParameterGroupRequest request = modifyRequestCaptor.getValue();
+        assertEquals(parameter, request.getParameters().get(0));
+        assertEquals(DB_INSTANCE_IDENTIFIER, request.getDBParameterGroupName());
     }
 
 }

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/sql/GcpDatabaseServerUpgradeServiceTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/sql/GcpDatabaseServerUpgradeServiceTest.java
@@ -17,9 +17,10 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -105,9 +106,12 @@ public class GcpDatabaseServerUpgradeServiceTest {
 
         doNothing().when(databasePollerService).upgradeDatabasePoller(any(AuthenticatedContext.class), anyList());
 
-        List<CloudResource> upgrade = underTest.upgrade(authenticatedContext, databaseStack, persistenceNotifier, TargetMajorVersion.VERSION_11);
-        Assert.assertEquals(1, upgrade.size());
-        Assert.assertEquals("server-1", upgrade.get(0).getName());
+        underTest.upgrade(authenticatedContext, databaseStack, persistenceNotifier, TargetMajorVersion.VERSION_11);
+
+        ArgumentCaptor<CloudResource> notifyUpdateArgumentCaptor = ArgumentCaptor.forClass(CloudResource.class);
+        verify(persistenceNotifier).notifyUpdate(notifyUpdateArgumentCaptor.capture(), any());
+        CloudResource updatedResource = notifyUpdateArgumentCaptor.getValue();
+        Assertions.assertEquals("server-1", updatedResource.getName());
     }
 
     @Test

--- a/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockResourceConnector.java
+++ b/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockResourceConnector.java
@@ -110,9 +110,8 @@ public class MockResourceConnector implements ResourceConnector {
     }
 
     @Override
-    public List<CloudResourceStatus> upgradeDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
-            PersistenceNotifier persistenceNotifier, TargetMajorVersion targetMajorVersion) throws Exception {
-        return null;
+    public void upgradeDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
+            PersistenceNotifier persistenceNotifier, TargetMajorVersion targetMajorVersion) {
     }
 
     @Override

--- a/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/AbstractResourceConnector.java
+++ b/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/AbstractResourceConnector.java
@@ -130,12 +130,9 @@ public abstract class AbstractResourceConnector implements ResourceConnector {
     }
 
     @Override
-    public List<CloudResourceStatus> upgradeDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
+    public void upgradeDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
             PersistenceNotifier persistenceNotifier, TargetMajorVersion targetMajorVersion) throws Exception {
-        List<CloudResource> cloudResources = databaseServerUpgradeService.upgrade(authenticatedContext, stack, persistenceNotifier, targetMajorVersion);
-        return cloudResources.stream()
-                .map(e -> new CloudResourceStatus(e, ResourceStatus.CREATED))
-                .collect(Collectors.toList());
+        databaseServerUpgradeService.upgrade(authenticatedContext, stack, persistenceNotifier, targetMajorVersion);
     }
 
     @Override

--- a/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/compute/DatabaseServerUpgradeService.java
+++ b/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/compute/DatabaseServerUpgradeService.java
@@ -1,16 +1,13 @@
 package com.sequenceiq.cloudbreak.cloud.template.compute;
 
-import java.util.List;
-
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
-import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
 import com.sequenceiq.cloudbreak.common.database.TargetMajorVersion;
 
 public interface DatabaseServerUpgradeService {
 
-    List<CloudResource> upgrade(
+    void upgrade(
             AuthenticatedContext ac,
             DatabaseStack stack,
             PersistenceNotifier resourceNotifier,

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnResourceConnector.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnResourceConnector.java
@@ -108,8 +108,8 @@ public class YarnResourceConnector implements ResourceConnector {
     }
 
     @Override
-    public List<CloudResourceStatus> upgradeDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
-            PersistenceNotifier persistenceNotifier, TargetMajorVersion targetMajorVersion) throws Exception {
+    public void upgradeDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
+            PersistenceNotifier persistenceNotifier, TargetMajorVersion targetMajorVersion) {
         throw new UnsupportedOperationException("Database server upgrade is not supported for " + getClass().getName());
     }
 

--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/database/MajorVersion.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/database/MajorVersion.java
@@ -4,8 +4,14 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
 
-public enum MajorVersion {
+/**
+    Represents the major version of a postgreSql instance.
+ */
+public enum MajorVersion implements Version {
 
+    // VERSIONS_9 is not a concrete PostgreSql version, but the collection of 9.0 to 9.6 versions.
+    VERSION_FAMILY_9("9"),
+    VERSION_9_6("9.6"),
     VERSION_10("10"),
     VERSION_11("11"),
     VERSION_12("12"),
@@ -14,12 +20,19 @@ public enum MajorVersion {
 
     private final String version;
 
+    private final int majorVersionFamily;
+
     MajorVersion(String version) {
         this.version = version;
+        this.majorVersionFamily = Integer.parseInt(version.split("\\.")[0]);
     }
 
-    public String getVersion() {
+    public String getMajorVersion() {
         return version;
+    }
+
+    public int getMajorVersionFamily() {
+        return majorVersionFamily;
     }
 
     public static Optional<MajorVersion> get(String version) {

--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/database/TargetMajorVersion.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/database/TargetMajorVersion.java
@@ -1,6 +1,9 @@
 package com.sequenceiq.cloudbreak.common.database;
 
-public enum TargetMajorVersion {
+/**
+ * Represents the RDS major versions that are available as upgrade targets in CDP.
+ */
+public enum TargetMajorVersion implements Version {
 
     VERSION_11("11");
 
@@ -10,7 +13,8 @@ public enum TargetMajorVersion {
         this.version = version;
     }
 
-    public String getVersion() {
+    @Override
+    public String getMajorVersion() {
         return version;
     }
 

--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/database/Version.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/database/Version.java
@@ -1,0 +1,6 @@
+package com.sequenceiq.cloudbreak.common.database;
+
+public interface Version {
+
+    String getMajorVersion();
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/util/MajorVersionComparator.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/util/MajorVersionComparator.java
@@ -1,0 +1,20 @@
+package com.sequenceiq.cloudbreak.util;
+
+import java.io.Serializable;
+import java.util.Comparator;
+
+import com.sequenceiq.cloudbreak.common.type.Versioned;
+
+public class MajorVersionComparator implements Comparator<Versioned>, Serializable {
+
+    @Override
+    public int compare(Versioned o1, Versioned o2) {
+        String[] parts1 = o1.getVersion().split(VersionComparator.VERSION_SPLITTER_REGEX);
+        String[] parts2 = o2.getVersion().split(VersionComparator.VERSION_SPLITTER_REGEX);
+
+        Integer major1 = Integer.parseInt(parts1[0]);
+        Integer major2 = Integer.parseInt(parts2[0]);
+        return Integer.signum(major1.compareTo(major2));
+    }
+
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/util/VersionComparator.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/util/VersionComparator.java
@@ -10,7 +10,7 @@ import com.sequenceiq.cloudbreak.common.type.Versioned;
 
 public class VersionComparator implements Comparator<Versioned>, Serializable {
 
-    private static final String VERSION_SPLITTER_REGEX = "[\\.\\-]|(?<=b)(?=\\d)";
+    public static final String VERSION_SPLITTER_REGEX = "[\\.\\-]|(?<=b)(?=\\d)";
 
     @Override
     public int compare(Versioned o1, Versioned o2) {

--- a/common/src/test/java/com/sequenceiq/cloudbreak/common/database/MajorVersionTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/common/database/MajorVersionTest.java
@@ -1,8 +1,12 @@
 package com.sequenceiq.cloudbreak.common.database;
 
+import static com.sequenceiq.cloudbreak.common.database.MajorVersion.VERSION_FAMILY_9;
 import static com.sequenceiq.cloudbreak.common.database.MajorVersion.VERSION_10;
 import static com.sequenceiq.cloudbreak.common.database.MajorVersion.VERSION_11;
+import static com.sequenceiq.cloudbreak.common.database.MajorVersion.VERSION_12;
 import static com.sequenceiq.cloudbreak.common.database.MajorVersion.VERSION_13;
+import static com.sequenceiq.cloudbreak.common.database.MajorVersion.VERSION_14;
+import static com.sequenceiq.cloudbreak.common.database.MajorVersion.VERSION_9_6;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Optional;
@@ -24,6 +28,7 @@ class MajorVersionTest {
         return new Object[][]{
                 // fullVersion expectedMajorVersion
                 {"10", VERSION_10},
+                {"9.6", VERSION_FAMILY_9},
                 {"10.6", VERSION_10},
                 {"10.14", VERSION_10},
                 {"11", VERSION_11},
@@ -37,4 +42,24 @@ class MajorVersionTest {
                 {"asd", null},
         };
     }
+
+    @ParameterizedTest
+    @MethodSource("majorVersionValues")
+    void testGetMajorVersionCorrespondsToEnumName(MajorVersion majorVersion, String expectedStringValue, int expectedMajorVersionFamily) {
+        assertEquals(expectedStringValue, majorVersion.getMajorVersion());
+        assertEquals(expectedMajorVersionFamily, majorVersion.getMajorVersionFamily());
+    }
+
+    static Object[][] majorVersionValues() {
+        return new Object[][]{
+                {VERSION_FAMILY_9, "9", 9},
+                {VERSION_9_6, "9.6", 9},
+                {VERSION_10, "10", 10},
+                {VERSION_11, "11", 11},
+                {VERSION_12, "12", 12},
+                {VERSION_13, "13", 13},
+                {VERSION_14, "14", 14}
+        };
+    }
+
 }

--- a/common/src/test/java/com/sequenceiq/cloudbreak/util/MajorVersionComparatorTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/util/MajorVersionComparatorTest.java
@@ -1,0 +1,83 @@
+package com.sequenceiq.cloudbreak.util;
+
+import static com.sequenceiq.cloudbreak.util.MajorVersionComparatorTest.VersionedImpl.versioned;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.sequenceiq.cloudbreak.common.type.Versioned;
+
+public class MajorVersionComparatorTest {
+
+    private final MajorVersionComparator underTest = new MajorVersionComparator();
+
+    @ParameterizedTest
+    @MethodSource(value = "getVersions")
+    void test(Versioned v1, Versioned v2, int expectedOutcome) {
+        assertEquals(expectedOutcome, underTest.compare(v1, v2));
+    }
+
+    @Test
+    void testCompareWhenFirstNotANumber() {
+        Versioned v1 = versioned("notANumber.13");
+        Versioned v2 = versioned("10.11");
+
+        Assertions.assertThrows(NumberFormatException.class, () ->
+            underTest.compare(v1, v2)
+        );
+    }
+
+    @Test
+    void testCompareWhenSecondNotANumber() {
+        Versioned v1 = versioned("10.11");
+        Versioned v2 = versioned("notANumber.13");
+
+        Assertions.assertThrows(NumberFormatException.class, () ->
+                underTest.compare(v1, v2)
+        );
+    }
+
+    private static Object[][] getVersions() {
+        return new Object[][] {
+                { versioned("10"), versioned("10"), 0},
+                { versioned("10"), versioned("1"), 1},
+                { versioned("2"), versioned("10"), -1},
+                { versioned("10.2"), versioned("10.2"), 0},
+                { versioned("10.1"), versioned("10.23"), 0},
+                { versioned("10.23"), versioned("10.2"), 0},
+                { versioned("10.23.4"), versioned("10.45.14"), 0},
+                { versioned("10.whatever"), versioned("10.foo"), 0},
+                { versioned("0.1"), versioned("0.2"), 0},
+                { versioned("10"), versioned("10.13"), 0},
+                { versioned("10.54"), versioned("10"), 0},
+        };
+    }
+
+    static class VersionedImpl implements Versioned {
+
+        private final String version;
+
+        VersionedImpl(String version) {
+            this.version = version;
+        }
+
+        static VersionedImpl versioned(String version) {
+            return new VersionedImpl(version);
+        }
+
+        @Override
+        public String getVersion() {
+            return version;
+        }
+
+        @Override
+        public String toString() {
+            return "VersionedImpl{" +
+                    "version='" + version + '\'' +
+                    '}';
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterRepairFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterRepairFlowEventChainFactory.java
@@ -341,7 +341,7 @@ public class ClusterRepairFlowEventChainFactory implements FlowEventChainFactory
         boolean embeddedDBOnAttachedDisk = embeddedDatabaseService.isAttachedDiskForEmbeddedDatabaseCreated(stackDto);
         String currentDbVersion = StringUtils.isNotEmpty(stackView.getExternalDatabaseEngineVersion())
                 ? stackView.getExternalDatabaseEngineVersion() : DEFAULT_DB_VERSION;
-        boolean versionsAreDifferent = !targetMajorVersion.getVersion().equals(currentDbVersion);
+        boolean versionsAreDifferent = !targetMajorVersion.getMajorVersion().equals(currentDbVersion);
         if (embeddedPostgresUpgradeEnabled && upgradeRequested && embeddedDBOnAttachedDisk && versionsAreDifferent) {
             LOGGER.debug("Embedded db upgrade is possible and needed.");
             return true;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/rds/upgrade/UpgradeRdsService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/rds/upgrade/UpgradeRdsService.java
@@ -80,7 +80,7 @@ public class UpgradeRdsService {
         InMemoryStateStore.deleteCluster(clusterId);
         stackUpdater.updateStackStatus(stackId, DetailedStackStatus.AVAILABLE, statusReason);
         flowMessageService.fireEventAndLog(stackId, AVAILABLE.name(), ResourceEvent.CLUSTER_RDS_UPGRADE_FINISHED);
-        stackUpdater.updateExternalDatabaseEngineVersion(stackId, targetMajorVersion.getVersion());
+        stackUpdater.updateExternalDatabaseEngineVersion(stackId, targetMajorVersion.getMajorVersion());
     }
 
     public void rdsUpgradeFailed(Long stackId, Long clusterId, Exception exception) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeService.java
@@ -55,7 +55,7 @@ public class RdsUpgradeService {
         MDCBuilder.buildMdcContext(stack);
         LOGGER.info("RDS upgrade has been initiated for stack {}", nameOrCrn.getNameOrCrn());
 
-        if (getCurrentRdsVersion(nameOrCrn).equals(targetMajorVersion.getVersion())) {
+        if (getCurrentRdsVersion(nameOrCrn).equals(targetMajorVersion.getMajorVersion())) {
             return alreadyOnLatestAnswer(targetMajorVersion);
         } else {
             return checkStackStatusAndTrigger(stack, targetMajorVersion);
@@ -66,14 +66,14 @@ public class RdsUpgradeService {
         StackDatabaseServerResponse databaseServer = databaseService.getDatabaseServer(nameOrCrn);
         return Optional.ofNullable(databaseServer)
                 .map(StackDatabaseServerResponse::getMajorVersion)
-                .map(MajorVersion::getVersion)
-                .orElse(MajorVersion.VERSION_10.getVersion());
+                .map(MajorVersion::getMajorVersion)
+                .orElse(MajorVersion.VERSION_10.getMajorVersion());
     }
 
     private RdsUpgradeV4Response alreadyOnLatestAnswer(TargetMajorVersion targetMajorVersion) {
         LOGGER.info("External database is already on version {}", targetMajorVersion);
         return new RdsUpgradeV4Response(RdsUpgradeResponseType.SKIP, FlowIdentifier.notTriggered(),
-                getMessage(CLUSTER_RDS_UPGRADE_ALREADY_UPGRADED, List.of(targetMajorVersion.getVersion())), targetMajorVersion);
+                getMessage(CLUSTER_RDS_UPGRADE_ALREADY_UPGRADED, List.of(targetMajorVersion.getMajorVersion())), targetMajorVersion);
     }
 
     private RdsUpgradeV4Response checkStackStatusAndTrigger(StackView stack, TargetMajorVersion targetMajorVersion) {
@@ -83,7 +83,7 @@ public class RdsUpgradeService {
                     getMessage(CLUSTER_RDS_UPGRADE_NOT_AVAILABLE), targetMajorVersion);
         }
 
-        LOGGER.info("External database for stack {} will be upgraded to version {}", stack.getName(), targetMajorVersion.getVersion());
+        LOGGER.info("External database for stack {} will be upgraded to version {}", stack.getName(), targetMajorVersion.getMajorVersion());
         return triggerRdsUpgradeFlow(stack, targetMajorVersion);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/UpgradeEmbeddedDBPreparationStateParamsProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/UpgradeEmbeddedDBPreparationStateParamsProvider.java
@@ -38,7 +38,7 @@ public class UpgradeEmbeddedDBPreparationStateParamsProvider {
         upgradeParams.put(ORIGINAL_POSTGRES_VERSION_KEY, originalVersion);
         upgradeParams.put(ORIGINAL_POSTGRES_BINARIES_KEY, "/usr/pgsql-" + originalVersion);
         upgradeParams.put(TEMP_DIRECTORY_KEY, VolumeUtils.DATABASE_VOLUME + "/tmp");
-        upgradeParams.put(NEW_POSTGRES_VERSION_KEY, targetMajorVersion.getVersion());
+        upgradeParams.put(NEW_POSTGRES_VERSION_KEY, targetMajorVersion.getMajorVersion());
         return params;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/UpgradeEmbeddedDBStateParamsProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/UpgradeEmbeddedDBStateParamsProvider.java
@@ -42,7 +42,7 @@ public class UpgradeEmbeddedDBStateParamsProvider {
         upgradeParams.put(ORIGINAL_POSTGRES_VERSION_KEY, originalVersion);
         upgradeParams.put(ORIGINAL_POSTGRES_DIRECTORY_KEY, VolumeUtils.DATABASE_VOLUME + "/" + ORIGINAL_POSTGRES_SUBDIRECTORY);
         upgradeParams.put(ORIGINAL_POSTGRES_BINARIES_KEY, VolumeUtils.DATABASE_VOLUME + "/" + ORIGINAL_POSTGRES_BINARIES_SUBDIRECTORY_PREFIX + originalVersion);
-        upgradeParams.put(NEW_POSTGRES_VERSION_KEY, targetMajorVersion.getVersion());
+        upgradeParams.put(NEW_POSTGRES_VERSION_KEY, targetMajorVersion.getMajorVersion());
         return params;
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeServiceTest.java
@@ -118,7 +118,7 @@ class RdsUpgradeServiceTest {
         when(databaseService.getDatabaseServer(eq(STACK_NAME_OR_CRN))).thenReturn(createDatabaseServerResponse(MajorVersion.VERSION_11));
         when(stackDtoService.getStackViewByNameOrCrn(eq(NameOrCrn.ofCrn(STACK_CRN)), any())).thenReturn(stack);
         when(messagesService.getMessage(CLUSTER_RDS_UPGRADE_ALREADY_UPGRADED.getMessage(),
-                List.of(MajorVersion.VERSION_11.getVersion()))).thenReturn(ERROR_REASON);
+                List.of(MajorVersion.VERSION_11.getMajorVersion()))).thenReturn(ERROR_REASON);
 
         RdsUpgradeV4Response response = underTest.upgradeRds(NameOrCrn.ofCrn(STACK_CRN), TARGET_VERSION);
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/rds/UpgradeEmbeddedDBPreparationStateParamsProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/rds/UpgradeEmbeddedDBPreparationStateParamsProviderTest.java
@@ -34,7 +34,7 @@ class UpgradeEmbeddedDBPreparationStateParamsProviderTest {
         Assertions.assertEquals(upgradeParams.get("original_postgres_version"), "version");
         Assertions.assertEquals(upgradeParams.get("original_postgres_binaries"), "/usr/pgsql-version");
         Assertions.assertEquals(upgradeParams.get("temp_directory"), "/dbfs/tmp");
-        Assertions.assertEquals(upgradeParams.get("new_postgres_version"), TargetMajorVersion.VERSION_11.getVersion());
+        Assertions.assertEquals(upgradeParams.get("new_postgres_version"), TargetMajorVersion.VERSION_11.getMajorVersion());
     }
 
     @Test

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/rds/UpgradeEmbeddedDBStateParamsProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/rds/UpgradeEmbeddedDBStateParamsProviderTest.java
@@ -34,7 +34,7 @@ class UpgradeEmbeddedDBStateParamsProviderTest {
         Assertions.assertEquals(upgradeParams.get("original_postgres_version"), "version");
         Assertions.assertEquals(upgradeParams.get("original_postgres_binaries"), "/dbfs/tmp/pgsql-version");
         Assertions.assertEquals(upgradeParams.get("original_postgres_directory"), "/dbfs/pgsql");
-        Assertions.assertEquals(upgradeParams.get("new_postgres_version"), TargetMajorVersion.VERSION_11.getVersion());
+        Assertions.assertEquals(upgradeParams.get("new_postgres_version"), TargetMajorVersion.VERSION_11.getMajorVersion());
     }
 
     @Test


### PR DESCRIPTION
CB-17772 CB-17774 CB-17775 CB-17776 Postgres upgrade on AWS

    This commit enables the upgrade of postgres RDS on AWS:
    - will query the state of the RDS. If it is available, and the version can be read out, then proceeds to upgrade
    - creates a custom parameterset with the target version
    - upgrade is called, submitting the custom parameterset as well, and then
    - it will wait until the upgrade finishes.

    Notes:
    - the code is written to be restartable
    - once upgrade is posted, with execution requested immediately, the RDS will need another 10-20s to enter upgrading state. There is a custom poller to check the RDS has entered the upgrading state, and then it will launch the AWS waiter.

See detailed description in the commit message.