### PR TITLE
CB-17348 Create e2e test for saltuser password rotation

### DIFF
--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -163,7 +163,7 @@ dependencies {
   implementation (group: 'com.cloudera.api.swagger',     name: 'cloudera-manager-api-swagger',   version: cmClientVersion) {
     transitive = false
   }
-  implementation (group: 'com.hierynomus',                name: 'sshj',                           version: '0.27.0') {
+  implementation (group: 'com.hierynomus',                name: 'sshj',                           version: '0.33.0') {
     exclude group: "net.i2p.crypto"
   }
   implementation group: 'org.jetbrains',                 name: 'annotations',                    version: '20.1.0'

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeipaRotateSaltPasswordAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeipaRotateSaltPasswordAction.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.it.cloudbreak.action.freeipa;
+
+import static java.lang.String.format;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+import com.sequenceiq.it.cloudbreak.FreeIpaClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+
+public class FreeipaRotateSaltPasswordAction implements Action<FreeIpaTestDto, FreeIpaClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FreeIpaDownscaleAction.class);
+
+    @Override
+    public FreeIpaTestDto action(TestContext testContext, FreeIpaTestDto testDto, FreeIpaClient client) throws Exception {
+        Log.whenJson(LOGGER, format(" FreeIPA rotate salt password request for environment %n"), testDto.getEnvironmentCrn());
+        FlowIdentifier flowIdentifier = client.getDefaultClient().getFreeIpaV1Endpoint().rotateSaltPassword(testDto.getEnvironmentCrn());
+        testDto.setFlow("FreeIPA rotate salt password",  flowIdentifier);
+        Log.whenJson(LOGGER, format(" FreeIPA rotate salt password started: %n"), testDto.getEnvironmentCrn());
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRotateSaltPasswordAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRotateSaltPasswordAction.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.it.cloudbreak.action.sdx;
+
+import static java.lang.String.format;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+import com.sequenceiq.it.cloudbreak.SdxClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+
+public class SdxRotateSaltPasswordAction implements Action<SdxInternalTestDto, SdxClient> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxRotateSaltPasswordAction.class);
+
+    @Override
+    public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
+        Log.whenJson(LOGGER, format(" SDX rotate salt password request for crn %n"), testDto.getCrn());
+        FlowIdentifier flowIdentifier = client.getDefaultClient().sdxEndpoint().rotateSaltPasswordByCrn(testDto.getCrn());
+        testDto.setFlow("SDX rotate salt password",  flowIdentifier);
+        Log.whenJson(LOGGER, format(" SDX rotate salt password started: %n"), testDto.getCrn());
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXRotateSaltPasswordAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXRotateSaltPasswordAction.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.it.cloudbreak.action.v1.distrox;
+
+import static java.lang.String.format;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+import com.sequenceiq.it.cloudbreak.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+
+public class DistroXRotateSaltPasswordAction implements Action<DistroXTestDto, CloudbreakClient> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DistroXRotateSaltPasswordAction.class);
+
+    @Override
+    public DistroXTestDto action(TestContext testContext, DistroXTestDto testDto, CloudbreakClient client) throws Exception {
+        Log.whenJson(LOGGER, format(" DistroX rotate salt password request for crn %n"), testDto.getCrn());
+        FlowIdentifier flowIdentifier = client.getDefaultClient().distroXV1Endpoint().rotateSaltPasswordByCrn(testDto.getCrn());
+        testDto.setFlow("DistroX rotate salt password",  flowIdentifier);
+        Log.whenJson(LOGGER, format(" DistroX rotate salt password started: %n"), testDto.getCrn());
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/DistroXTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/DistroXTestClient.java
@@ -15,11 +15,12 @@ import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXCreateInternalActio
 import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXDeleteAction;
 import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXForceDeleteAction;
 import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXGetAction;
-import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXRepairInstancesAction;
 import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXInternalGetAction;
 import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXRefreshAction;
 import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXRemoveInstancesAction;
 import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXRepairAction;
+import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXRepairInstancesAction;
+import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXRotateSaltPasswordAction;
 import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXScaleAction;
 import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXScaleStartInstancesAction;
 import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXScaleStopInstancesAction;
@@ -122,5 +123,9 @@ public class DistroXTestClient {
 
     public Action<DistroXTestDto, CloudbreakClient> checkVariant(String variant) {
         return new CheckVariant(variant);
+    }
+
+    public Action<DistroXTestDto, CloudbreakClient> rotateSaltPassword() {
+        return new DistroXRotateSaltPasswordAction();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/FreeIpaTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/FreeIpaTestClient.java
@@ -29,6 +29,7 @@ import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaSynchronizeAllUsersAct
 import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaSynchronizeAllUsersInternalAction;
 import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaUpgradeAction;
 import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaUpscaleAction;
+import com.sequenceiq.it.cloudbreak.action.freeipa.FreeipaRotateSaltPasswordAction;
 import com.sequenceiq.it.cloudbreak.action.freeipa.FreeipaUsedImagesAction;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaChildEnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaDiagnosticsTestDto;
@@ -132,6 +133,10 @@ public class FreeIpaTestClient {
 
     public Action<FreeIpaDownscaleTestDto, FreeIpaClient> downscale() {
         return new FreeIpaDownscaleAction();
+    }
+
+    public Action<FreeIpaTestDto, FreeIpaClient> rotateSaltPassword() {
+        return new FreeipaRotateSaltPasswordAction();
     }
 
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/SdxTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/SdxTestClient.java
@@ -37,6 +37,7 @@ import com.sequenceiq.it.cloudbreak.action.sdx.SdxRepairInternalAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxResizeAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxRestoreAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxRestoreInternalAction;
+import com.sequenceiq.it.cloudbreak.action.sdx.SdxRotateSaltPasswordAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxStartAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxStatusAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxStopAction;
@@ -219,5 +220,9 @@ public class SdxTestClient {
 
     public Action<SdxEventTestDto, SdxClient> getDatalakeEventsZip() {
         return new SdxGetDatalakeEventsZipAction();
+    }
+
+    public Action<SdxInternalTestDto, SdxClient> rotateSaltPassword() {
+        return new SdxRotateSaltPasswordAction();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/AbstractIntegrationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/AbstractIntegrationTest.java
@@ -178,10 +178,14 @@ public abstract class AbstractIntegrationTest extends AbstractMinimalTest {
                 .validate();
     }
 
-    protected void createDefaultDatahub(TestContext testContext) {
-        createDefaultDatalake(testContext);
+    protected void createDefaultDatahubForExistingDatalake(TestContext testContext) {
         initiateDefaultDatahubCreation(testContext);
         waitForDefaultDatahubCreation(testContext);
+    }
+
+    protected void createDefaultDatahub(TestContext testContext) {
+        createDefaultDatalake(testContext);
+        createDefaultDatahubForExistingDatalake(testContext);
     }
 
     protected void createStorageOptimizedDatahub(TestContext testContext) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/saltpassword/RotateSaltPasswordE2ETest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/saltpassword/RotateSaltPasswordE2ETest.java
@@ -1,0 +1,141 @@
+package com.sequenceiq.it.cloudbreak.testcase.e2e.saltpassword;
+
+import java.time.LocalDate;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
+import com.sequenceiq.common.api.type.InstanceGroupType;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.it.cloudbreak.client.DistroXTestClient;
+import com.sequenceiq.it.cloudbreak.client.FreeIpaTestClient;
+import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
+import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
+import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
+import com.sequenceiq.it.cloudbreak.util.ssh.action.SshSaltPasswordActions;
+import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
+
+public class RotateSaltPasswordE2ETest extends AbstractE2ETest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RotateSaltPasswordE2ETest.class);
+
+    private static final LocalDate PAST_DATE = LocalDate.now().minusMonths(1);
+
+    private static final AtomicReference<String> SHADOW_LINE_REFERENCE = new AtomicReference<>();
+
+    @Inject
+    private SshSaltPasswordActions sshSaltPasswordActions;
+
+    @Inject
+    private FreeIpaTestClient freeIpaTestClient;
+
+    @Inject
+    private SdxTestClient sdxTestClient;
+
+    @Inject
+    private DistroXTestClient distroXTestClient;
+
+    @Override
+    protected void setupTest(TestContext testContext) {
+        createDefaultUser(testContext);
+        createDefaultCredential(testContext);
+        initializeDefaultBlueprints(testContext);
+        createEnvironmentWithFreeIpa(testContext);
+    }
+
+    @Test(dataProvider = TEST_CONTEXT)
+    @UseSpotInstances
+    @Description(
+            given = "there is a running environment with FreeIPA ",
+            when = "rotating a salt password ",
+            then = "FreeIPA should have a new salt password and password expiry ",
+            and = "the same applies to both Datalake and Datahub"
+    )
+    public void testRotateSaltPassword(TestContext testContext) {
+        testContext
+                .given(FreeIpaTestDto.class)
+                .when(freeIpaTestClient.describe())
+                .then((testContext1, testDto, client) -> preSaltPasswordRotation(testDto, getFreeipaIpAddresses(testDto)))
+                .when(freeIpaTestClient.rotateSaltPassword())
+                .awaitForFlow()
+                .await(Status.AVAILABLE)
+                .then((testContext1, testDto, client) -> validateSaltPasswordRotation(testDto, getFreeipaIpAddresses(testDto)))
+                .validate();
+        LOGGER.info("FreeIPA salt password rotation test PASSED");
+
+        createDatalakeWithoutDatabase(testContext);
+        testContext
+                .given(SdxInternalTestDto.class)
+                .then((testContext1, testDto, client) -> preSaltPasswordRotation(testDto, getSdxIpAddresses(testDto)))
+                .when(sdxTestClient.rotateSaltPassword())
+                .awaitForFlow()
+                .await(SdxClusterStatusResponse.RUNNING)
+                .then((testContext1, testDto, client) -> validateSaltPasswordRotation(testDto, getSdxIpAddresses(testDto)))
+                .validate();
+        LOGGER.info("SDX salt password rotation test PASSED");
+
+        createDefaultDatahubForExistingDatalake(testContext);
+        testContext
+                .given(DistroXTestDto.class)
+                .then((testContext1, testDto, client) -> preSaltPasswordRotation(testDto, getDistroXIpAddresses(testDto)))
+                .when(distroXTestClient.rotateSaltPassword())
+                .awaitForFlow()
+                .then((testContext1, testDto, client) -> validateSaltPasswordRotation(testDto, getDistroXIpAddresses(testDto)))
+                .validate();
+        LOGGER.info("DistroX salt password rotation test PASSED");
+    }
+
+    private <T> T preSaltPasswordRotation(T testDto, Set<String> ipAddresses) {
+        sshSaltPasswordActions.setPasswordChangeDate(ipAddresses, PAST_DATE);
+        SHADOW_LINE_REFERENCE.set(sshSaltPasswordActions.getShadowLine(ipAddresses));
+        return testDto;
+    }
+
+    private <T> T validateSaltPasswordRotation(T testDto, Set<String> ipAddresses) {
+        String shadowLine = sshSaltPasswordActions.getShadowLine(ipAddresses);
+        if (shadowLine.equals(SHADOW_LINE_REFERENCE.get())) {
+            throw new TestFailException("Saltuser shadow line was not changed after password rotation");
+        }
+        SHADOW_LINE_REFERENCE.set("");
+
+        LocalDate passwordChange = sshSaltPasswordActions.getPasswordChangeDate(ipAddresses);
+        if (!passwordChange.isEqual(LocalDate.now())) {
+            throw new TestFailException("Saltuser password change date was not modified to today after password rotation");
+        }
+        return testDto;
+    }
+
+    private static Set<String> getFreeipaIpAddresses(FreeIpaTestDto testDto) {
+        return testDto.getResponse().getFreeIpa().getServerIp();
+    }
+
+    private static Set<String> getSdxIpAddresses(SdxInternalTestDto testDto) {
+        return getStackIpAddresses(testDto.getResponse().getStackV4Response());
+    }
+
+    private static Set<String> getDistroXIpAddresses(DistroXTestDto testDto) {
+        return getStackIpAddresses(testDto.getResponse());
+    }
+
+    private static Set<String> getStackIpAddresses(StackV4Response stack) {
+        return stack.getInstanceGroups().stream()
+                .filter(ig -> ig.getType().equals(InstanceGroupType.GATEWAY))
+                .flatMap(ig -> ig.getMetadata().stream())
+                .map(InstanceMetaDataV4Response::getPrivateIp)
+                .collect(Collectors.toSet());
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/action/SshSaltPasswordActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/action/SshSaltPasswordActions.java
@@ -1,0 +1,67 @@
+package com.sequenceiq.it.cloudbreak.util.ssh.action;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.it.cloudbreak.util.ssh.client.SshJClient;
+
+@Component
+public class SshSaltPasswordActions extends SshJClient {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SshSaltPasswordActions.class);
+
+    private static final String PASSWORD_CHANGE_SET_COMMAND_PATTERN = "sudo chage -d \"%s\" saltuser";
+
+    private static final DateTimeFormatter CHAGE_DATE_PATTERN = DateTimeFormatter.ofPattern("MMM dd, yyyy");
+
+    private static final String SALTUSER_SHADOW_LINE_COMMAND = "sudo cat /etc/shadow | grep saltuser";
+
+    private static final String PASSWORD_CHANGE_GET_COMMAND = "sudo chage -l saltuser | grep \"Last password change\" | cut -d \":\" -f2";
+
+    public void setPasswordChangeDate(Set<String> ipAddresses, LocalDate date) {
+        String command = String.format(PASSWORD_CHANGE_SET_COMMAND_PATTERN, CHAGE_DATE_PATTERN.format(date));
+        LOGGER.info("Setting password expiry date on nodes {} to {} with command {}", ipAddresses, date, command);
+        Map<String, Pair<Integer, String>> results = executeCommands(ipAddresses, command);
+        LOGGER.debug("Password expiry set results: {}", results);
+        if (results.values().stream().anyMatch(result -> result.getLeft() != 0)) {
+            throw new TestFailException("Failed to set saltuser password change date");
+        }
+    }
+
+    public String getShadowLine(Set<String> ipAddresses) {
+        LOGGER.info("Getting saltuser shadow line on nodes {}", ipAddresses);
+        Map<String, Pair<Integer, String>> results = executeCommands(ipAddresses, SALTUSER_SHADOW_LINE_COMMAND);
+        LOGGER.debug("Saltuser shadow line result: {}", results);
+        return results.values().stream()
+                .filter(result -> result.getKey() == 0)
+                .map(Pair::getValue)
+                .findFirst()
+                .orElseThrow(() -> new TestFailException("Failed to get saltuser shadow file line on nodes " + ipAddresses));
+    }
+
+    public LocalDate getPasswordChangeDate(Set<String> ipAddresses) {
+        LOGGER.info("Getting saltuser password expiry date on nodes {}", ipAddresses);
+        Map<String, Pair<Integer, String>> results = executeCommands(ipAddresses, PASSWORD_CHANGE_GET_COMMAND);
+        LOGGER.debug("Saltuser password expiry date results: {}", results);
+        return results.values().stream()
+                .filter(result -> result.getKey() == 0)
+                .map(result -> LocalDate.parse(result.getValue().trim(), CHAGE_DATE_PATTERN))
+                .min(LocalDate::compareTo)
+                .orElseThrow(() -> new TestFailException("Failed to get password expiry date on nodes " + ipAddresses));
+    }
+
+    private Map<String, Pair<Integer, String>> executeCommands(Set<String> ipAddresses, String command) {
+        Map<String, Pair<Integer, String>> results = new HashMap<>();
+        ipAddresses.forEach(ipAddress -> results.put(ipAddress, executeCommand(ipAddress, command)));
+        return results;
+    }
+}

--- a/integration-test/src/main/resources/testsuites/e2e/aws-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/aws-e2e-tests.yaml
@@ -16,3 +16,4 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRecipeTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRangerRazEnabledTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.InternalSdxRepairWithRecipeTest
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.saltpassword.RotateSaltPasswordE2ETest

--- a/integration-test/src/main/resources/testsuites/e2e/salt-password-rotation-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/salt-password-rotation-tests.yaml
@@ -1,0 +1,5 @@
+name: "salt-password-rotation-tests"
+tests:
+  - name: "salt_password_rotation_tests"
+    classes:
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.saltpassword.RotateSaltPasswordE2ETest


### PR DESCRIPTION
Verify the changed password and password expiry dates on FreeIPA, Datalake and Datahub clusters with the following steps:
- Set the password change date to a past date (on new clsuters that would be the current day by default)
- Get the saltuser line from the shadow file and save it as a reference
- Call the rotate salt password endpoint
- Verify that the saltuser's line in the shadow file was changed
- Verify that the saltuser's password change date is set to today