### PR TITLE
CB-18100: Reverts the recent SDX resize E2E test changes which are causing failures.

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxResizeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxResizeTests.java
@@ -54,13 +54,10 @@ public class SdxResizeTests extends PreconditionSdxE2ETest {
                     return testDto;
                 })
                 .when(sdxTestClient.resize(), key(sdx))
-                .await(SdxClusterStatusResponse.DATALAKE_BACKUP_INPROGRESS, key(sdx).withWaitForFlow(Boolean.FALSE))
                 .await(SdxClusterStatusResponse.STOP_IN_PROGRESS, key(sdx).withWaitForFlow(Boolean.FALSE))
                 .await(SdxClusterStatusResponse.STACK_CREATION_IN_PROGRESS, key(sdx).withWaitForFlow(Boolean.FALSE))
-                .await(SdxClusterStatusResponse.RUNNING, key(sdx).withWaitForFlow(Boolean.FALSE))
+                .await(SdxClusterStatusResponse.RUNNING, key(sdx))
                 .awaitForHealthyInstances()
-                .await(SdxClusterStatusResponse.DATALAKE_RESTORE_INPROGRESS, key(sdx).withWaitForFlow(Boolean.FALSE))
-                .await(SdxClusterStatusResponse.RUNNING, key(sdx).withWaitForFlow(Boolean.FALSE))
                 .then((tc, dto, client) -> resizeTestValidator.validateResizedCluster(dto))
                 .validate();
     }


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-18100

This should temporarily fix the existing e2e failures due to the e2e environment not running and enabling the DR service.

In the future I will revert this in order to have this validation occur.