### PR TITLE
CB-18174 Cloudbreak uses old Azure SDK that is relying on old nimbusd…

### DIFF
--- a/cloud-azure/build.gradle
+++ b/cloud-azure/build.gradle
@@ -27,7 +27,7 @@ dependencies {
   implementation group: 'com.squareup.okhttp3',          name: 'okhttp-urlconnection',       version: okhttpVersion
   implementation group: 'com.squareup.okhttp3',          name: 'logging-interceptor',        version: okhttpVersion
 
-  implementation (group: 'com.microsoft.azure',         name: 'azure-client-authentication') {
+  implementation (group: 'com.microsoft.azure',         name: 'azure-client-authentication', version: azureClientAuthVersion) {
     exclude group: 'org.slf4j'
   }
   implementation (group: 'com.microsoft.azure',         name: 'azure',                      version: azureSdkVersion) {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -229,12 +229,6 @@ dependencies {
   implementation group: 'org.apache.commons',                 name: 'commons-lang3',                    version: '3.12.0'
   implementation group: 'com.google.guava',                   name: 'guava',                            version: guavaVersion
 
-  implementation(group: 'com.nimbusds', name: 'oauth2-oidc-sdk') {
-    version {
-      strictly oauth2OidcSdkVersion
-    }
-    because 'java.lang.NoClassDefFoundError: com/nimbusds/oauth2/sdk/http/CommonContentTypes caused by multiple oauth2-oidc-sdk versions on classpath.'
-  }
   implementation(group: 'net.minidev', name: 'json-smart') {
     version {
       strictly jsonSmartVersion

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpscaleFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpscaleFlowEventChainFactory.java
@@ -17,7 +17,7 @@ import javax.inject.Inject;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import com.nimbusds.oauth2.sdk.util.MapUtils;
+import org.apache.commons.collections4.MapUtils;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.common.type.ScalingType;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterDownscaleDetails;

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,8 @@ org.gradle.logging.level=lifecycle
 # Version definition
 springBootVersion=2.5.12
 awsSdkVersion=1.11.952
-azureSdkVersion=1.41.2
+azureClientAuthVersion=1.7.14
+azureSdkVersion=1.41.4
 azureStorageSdkVersion=8.4.0
 caffeineVersion=2.8.1
 eventBusVersion=2.0.7.RELEASE
@@ -69,7 +70,6 @@ hamcrestVersion=2.2
 sonarVersion=3.3
 jsonSmartVersion=2.4.5
 accessorSmartVersion=2.4.7
-oauth2OidcSdkVersion=6.5
 protobufVersion=3.19.1
 grpcVersion=1.42.1
 dyngrPollingVersion=1.1.3

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -168,12 +168,6 @@ dependencies {
   }
   implementation group: 'org.jetbrains',                 name: 'annotations',                    version: '20.1.0'
 
-  implementation(group: 'com.nimbusds', name: 'oauth2-oidc-sdk') {
-    version {
-      strictly oauth2OidcSdkVersion
-    }
-    because 'java.lang.NoClassDefFoundError: com/nimbusds/oauth2/sdk/http/CommonContentTypes caused by multiple oauth2-oidc-sdk versions on classpath.'
-  }
   implementation(group: 'net.minidev', name: 'json-smart') {
     version {
       strictly jsonSmartVersion


### PR DESCRIPTION
…s libraries, and therefore the cert based authentication failed with NoSuchMethodError.

 Main problem, that it looks like that:
  - com.nimbusds:oauth2-oidc-sdk:6.5
  - com.nimbusds:nimbus-jose-jwt:[6.0.1,) -> 9.23 are incompatible

  Solution is to update Azure SDK and Azure Client Auth version

See detailed description in the commit message.