### PR TITLE
 CB-18129 Extend API to trigger permission checks on backup location. Added changes to accept the backup location of the validation API. When the backup location is provided, validation is performed on the backup location provided. If not, validation is performed on the backup location configured with the environment.

### DIFF
--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxBackupLocationValidationRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxBackupLocationValidationRequest.java
@@ -18,6 +18,9 @@ public class SdxBackupLocationValidationRequest {
     @ApiModelProperty(ModelDescriptions.DATA_LAKE_NAME)
     private String clusterName;
 
+    @ApiModelProperty(value = ModelDescriptions.BACKUP_LOCATION)
+    private String backupLocation;
+
     public SdxBackupLocationValidationRequest() {
     }
 
@@ -25,7 +28,24 @@ public class SdxBackupLocationValidationRequest {
         this.clusterName = clusterName;
     }
 
+    public SdxBackupLocationValidationRequest(String clusterName, String backupLocation) {
+        this.clusterName = clusterName;
+        this.backupLocation = backupLocation;
+    }
+
+    public String getBackupLocation() {
+        return backupLocation;
+    }
+
     public String getClusterName() {
         return clusterName;
+    }
+
+    @Override
+    public String toString() {
+        return "SdxBackupLocationValidationRequest{" +
+                "ClusterName='" + clusterName + '\'' +
+                "BackupLocation='" + backupLocation + '\'' +
+                '}';
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
@@ -191,7 +191,7 @@ public class SdxController implements SdxEndpoint {
     @CheckPermissionByRequestProperty(path = "clusterName", type = NAME, action = DESCRIBE_DATALAKE)
     public ValidationResult validateBackupStorage(@RequestObject @Valid SdxBackupLocationValidationRequest sdxBackupLocationValidationRequest) {
         SdxCluster sdxCluster = getSdxClusterByName(sdxBackupLocationValidationRequest.getClusterName());
-        return storageValidationService.validateBackupStorage(sdxCluster);
+        return storageValidationService.validateBackupStorage(sdxCluster, sdxBackupLocationValidationRequest.getBackupLocation());
     }
 
     @Override

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StorageValidationService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StorageValidationService.java
@@ -94,7 +94,7 @@ public class StorageValidationService {
                 () -> cloudProviderServicesV4Endpoint.validateObjectStorage(objectStorageValidateRequest));
     }
 
-    public ValidationResult validateBackupStorage(SdxCluster sdxCluster) {
+    public ValidationResult validateBackupStorage(SdxCluster sdxCluster, String backupLocation) {
         DetailedEnvironmentResponse environmentResponse = environmentService.getDetailedEnvironmentResponseByName(sdxCluster.getEnvName());
         CloudStorageRequest cloudStorageRequest = null;
         try {
@@ -112,7 +112,7 @@ public class StorageValidationService {
         }
         ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
         try {
-            cloudStorageValidator.validateBackupLocation(cloudStorageRequest, environmentResponse, validationResultBuilder);
+            cloudStorageValidator.validateBackupLocation(cloudStorageRequest, environmentResponse, backupLocation, validationResultBuilder);
         } catch (Exception e) {
             String message = String.format("Error occured during object storage validation, validation skipped. Error: %s", e.getMessage());
             LOGGER.warn(message);

--- a/datalake/src/test/java/com/sequenceiq/datalake/controller/sdx/SdxControllerTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/controller/sdx/SdxControllerTest.java
@@ -55,6 +55,8 @@ class SdxControllerTest {
 
     private static final String SDX_CLUSTER_NAME = "test-sdx-cluster";
 
+    private static final String BACKUP_LOCATION = "abfs://backup@location/to/backup";
+
     @Mock
     private SdxStatusService sdxStatusService;
 
@@ -197,22 +199,39 @@ class SdxControllerTest {
     }
 
     @Test
-    void validateBackupStorage() {
+    void validateBackupStorageWithDefaultLocation() {
         ValidationResult.ValidationResultBuilder resultBuilder = new ValidationResult.ValidationResultBuilder();
         ValidationResult validationResult = resultBuilder.build();
 
         SdxCluster sdxCluster = getValidSdxCluster();
         sdxCluster.setClusterName(SDX_CLUSTER_NAME);
         SdxBackupLocationValidationRequest sdxBackupLocationValidationRequest = new SdxBackupLocationValidationRequest(SDX_CLUSTER_NAME);
-        when(storageValidationService.validateBackupStorage(sdxCluster)).thenReturn(validationResult);
+        when(storageValidationService.validateBackupStorage(sdxCluster, null)).thenReturn(validationResult);
         when(sdxService.getByNameInAccount(USER_CRN, SDX_CLUSTER_NAME)).thenReturn(sdxCluster);
 
         ValidationResult result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> sdxController.validateBackupStorage(sdxBackupLocationValidationRequest));
 
         verify(sdxService, times(1)).getByNameInAccount(USER_CRN, SDX_CLUSTER_NAME);
-        verify(storageValidationService, times(1)).validateBackupStorage(sdxCluster);
+        verify(storageValidationService, times(1)).validateBackupStorage(sdxCluster, null);
         assertEquals(ValidationResult.State.VALID, result.getState());
+    }
 
+    @Test
+    void validateBackupStorageWithNonDefaultLocation() {
+        ValidationResult.ValidationResultBuilder resultBuilder = new ValidationResult.ValidationResultBuilder();
+        ValidationResult validationResult = resultBuilder.build();
+
+        SdxCluster sdxCluster = getValidSdxCluster();
+        sdxCluster.setClusterName(SDX_CLUSTER_NAME);
+        SdxBackupLocationValidationRequest sdxBackupLocationValidationRequest = new SdxBackupLocationValidationRequest(SDX_CLUSTER_NAME, BACKUP_LOCATION);
+        when(storageValidationService.validateBackupStorage(sdxCluster, BACKUP_LOCATION)).thenReturn(validationResult);
+        when(sdxService.getByNameInAccount(USER_CRN, SDX_CLUSTER_NAME)).thenReturn(sdxCluster);
+
+        ValidationResult result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> sdxController.validateBackupStorage(sdxBackupLocationValidationRequest));
+
+        verify(sdxService, times(1)).getByNameInAccount(USER_CRN, SDX_CLUSTER_NAME);
+        verify(storageValidationService, times(1)).validateBackupStorage(sdxCluster, BACKUP_LOCATION);
+        assertEquals(ValidationResult.State.VALID, result.getState());
     }
 
     private SdxCluster getValidSdxCluster() {


### PR DESCRIPTION
Added changes to accept the backup location of the validation API.
When the backup location is provided, validation is performed on the backup location provided. If not, validation is performed on the backup location configured with the environment.

Added unit tests to cover new functionality added.