### PR TITLE
CB-18043 Aggregate storage consumption collection jobs

### DIFF
--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/configuration/repository/ConsumptionRepository.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/configuration/repository/ConsumptionRepository.java
@@ -61,8 +61,13 @@ public interface ConsumptionRepository extends AccountAwareResourceRepository<Co
     boolean doesStorageConsumptionExistWithLocationForMonitoredCrn(@Param("monitoredResourceCrn") String monitoredResourceCrn,
             @Param("storageLocation") String storageLocation);
 
-    @Query("SELECT c.resourceCrn as remoteResourceId, c.id as localId, c.name as name " +
+    @Query("SELECT c " +
+            "FROM Consumption c ")
+    List<Consumption> findAllConsumption();
+
+    @Query("SELECT c " +
             "FROM Consumption c " +
-            "WHERE c.consumptionType = 'STORAGE' ")
-    List<JobResource> findAllStorageConsumptionJobResource();
+            "WHERE c.consumptionType = 'STORAGE' " +
+            "AND c.environmentCrn = :environmentCrn")
+    List<Consumption> findAllStorageConsumptionByEnvironmentCrn(@Param("environmentCrn") String environmentCrn);
 }

--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/converter/metering/ConsumptionToStorageHeartbeatConverter.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/converter/metering/ConsumptionToStorageHeartbeatConverter.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.consumption.converter.metering;
 
+import javax.inject.Inject;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -16,11 +18,14 @@ public class ConsumptionToStorageHeartbeatConverter {
 
     private static final long NO_BYTE_IN_MB = 1000L * 1000L;
 
+    @Inject
+    private CloudStorageLocationUtil cloudStorageLocationUtil;
+
     public MeteringEventsProto.StorageHeartbeat convertToS3StorageHeartBeat(Consumption consumption, StorageConsumptionResult storage) {
         MeteringEventsProto.StorageHeartbeat.Builder storageHeartbeatBuilder = MeteringEventsProto.StorageHeartbeat.newBuilder();
 
         MeteringEventsProto.Storage.Builder storageBuilder = MeteringEventsProto.Storage.newBuilder();
-        storageBuilder.setId(CloudStorageLocationUtil.getS3BucketName(consumption.getStorageLocation()));
+        storageBuilder.setId(cloudStorageLocationUtil.getS3BucketName(consumption.getStorageLocation()));
         storageBuilder.setSizeInMB(storage.getStorageInBytes() / NO_BYTE_IN_MB);
         storageBuilder.setType(MeteringEventsProto.StorageType.Value.S3);
         storageHeartbeatBuilder.addStorages(storageBuilder.build());

--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/endpoint/ConsumptionInternalV1Controller.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/endpoint/ConsumptionInternalV1Controller.java
@@ -54,7 +54,7 @@ public class ConsumptionInternalV1Controller implements ConsumptionInternalEndpo
         LOGGER.info("Registering storage consumption collection for resource with CRN [{}] and location [{}]",
                 consumptionCreationDto.getMonitoredResourceCrn(), consumptionCreationDto.getStorageLocation());
         Optional<Consumption> consumptionOpt = consumptionService.create(consumptionCreationDto);
-        consumptionOpt.ifPresent(consumption -> jobService.schedule(consumption.getId()));
+        consumptionOpt.ifPresent(jobService::schedule);
     }
 
     @Override
@@ -67,7 +67,7 @@ public class ConsumptionInternalV1Controller implements ConsumptionInternalEndpo
         Optional<Consumption> consumptionOpt =
                 consumptionService.findStorageConsumptionByMonitoredResourceCrnAndLocation(monitoredResourceCrn, storageLocation);
         consumptionOpt.ifPresent(consumption -> {
-            jobService.unschedule(consumption.getId().toString());
+            jobService.unschedule(consumption);
             consumptionService.delete(consumption);
         });
     }

--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/flow/consumption/storage/handler/StorageConsumptionCollectionHandler.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/flow/consumption/storage/handler/StorageConsumptionCollectionHandler.java
@@ -62,6 +62,9 @@ public class StorageConsumptionCollectionHandler  extends AbstractStorageOperati
     @Inject
     private EnvironmentService environmentService;
 
+    @Inject
+    private CloudStorageLocationUtil cloudStorageLocationUtil;
+
     @Override
     public Selectable executeOperation(HandlerEvent<StorageConsumptionCollectionHandlerEvent> event) throws Exception {
         StorageConsumptionCollectionHandlerEvent data = event.getData();
@@ -76,8 +79,8 @@ public class StorageConsumptionCollectionHandler  extends AbstractStorageOperati
             String cloudPlatform = detailedEnvironmentResponse.getCloudPlatform();
             if (cloudPlatform.equals(CloudPlatform.AWS.name())) {
                 LOGGER.debug("Validating storage location '{}'.", consumption.getStorageLocation());
-                CloudStorageLocationUtil.validateCloudStorageType(FileSystemType.S3, consumption.getStorageLocation());
-                String bucketName = CloudStorageLocationUtil.getS3BucketName(consumption.getStorageLocation());
+                cloudStorageLocationUtil.validateCloudStorageType(FileSystemType.S3, consumption.getStorageLocation());
+                String bucketName = cloudStorageLocationUtil.getS3BucketName(consumption.getStorageLocation());
 
                 LOGGER.debug("Getting credential for environment with CRN '{}'.", environmentCrn);
                 Credential credential = credentialService.getCredentialByEnvCrn(environmentCrn);

--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/job/storage/StorageConsumptionJobInitializer.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/job/storage/StorageConsumptionJobInitializer.java
@@ -1,5 +1,9 @@
 package com.sequenceiq.consumption.job.storage;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
@@ -7,12 +11,15 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.quartz.model.JobInitializer;
+import com.sequenceiq.consumption.domain.Consumption;
 import com.sequenceiq.consumption.service.ConsumptionService;
 
 @Component
 public class StorageConsumptionJobInitializer implements JobInitializer {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StorageConsumptionJobInitializer.class);
+
+    private static final boolean AGGREGATION_REQUIRED = true;
 
     @Inject
     private StorageConsumptionJobService jobService;
@@ -26,9 +33,22 @@ public class StorageConsumptionJobInitializer implements JobInitializer {
     @Override
     public void initJobs() {
         if (storageConsumptionConfig.isStorageConsumptionEnabled()) {
-            LOGGER.info("Scheduling Storage consumption collection jobs");
-            consumptionService.findAllStorageConsumptionJobResource()
-                    .forEach(storageConsumption -> jobService.schedule(new StorageConsumptionJobAdapter(storageConsumption)));
+            LOGGER.info("Starting storage consumption collection job initialization.");
+            Map<Boolean, List<Consumption>> consumptionsPartitionedByAggregation = consumptionService.findAllConsumption().stream()
+                    .collect(Collectors.partitioningBy(consumptionService::isAggregationRequired));
+
+            List<List<Consumption>> consumptionAggregationGroups = consumptionService
+                    .groupConsumptionsByEnvCrnAndBucketName(consumptionsPartitionedByAggregation.get(AGGREGATION_REQUIRED));
+
+            LOGGER.info("Scheduling consumptions that require aggregation.");
+            consumptionAggregationGroups.forEach(aggregationGroup ->
+                    aggregationGroup.stream()
+                            .findFirst()
+                            .ifPresent(consumption -> jobService.schedule(consumption.getId())));
+
+            LOGGER.info("Scheduling consumptions that do not require aggregation.");
+            consumptionsPartitionedByAggregation.get(!AGGREGATION_REQUIRED)
+                    .forEach(consumption -> jobService.schedule(consumption.getId()));
         } else {
             LOGGER.info("Skipping scheduling storage consumption collection jobs as they are disabled");
         }

--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/service/ConsumptionService.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/service/ConsumptionService.java
@@ -3,9 +3,13 @@ package com.sequenceiq.consumption.service;
 import static com.sequenceiq.cloudbreak.common.exception.NotFoundException.notFound;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
+import javax.validation.ValidationException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,12 +20,13 @@ import com.sequenceiq.cloudbreak.common.dal.repository.AccountAwareResourceRepos
 import com.sequenceiq.cloudbreak.common.event.PayloadContext;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.common.service.account.AbstractAccountAwareResourceService;
-import com.sequenceiq.cloudbreak.quartz.model.JobResource;
+import com.sequenceiq.common.model.FileSystemType;
 import com.sequenceiq.consumption.api.v1.consumption.model.common.ConsumptionType;
 import com.sequenceiq.consumption.configuration.repository.ConsumptionRepository;
 import com.sequenceiq.consumption.domain.Consumption;
 import com.sequenceiq.consumption.dto.ConsumptionCreationDto;
 import com.sequenceiq.consumption.dto.converter.ConsumptionDtoConverter;
+import com.sequenceiq.consumption.util.CloudStorageLocationUtil;
 import com.sequenceiq.flow.core.PayloadContextProvider;
 import com.sequenceiq.flow.core.ResourceIdProvider;
 
@@ -36,6 +41,9 @@ public class ConsumptionService extends AbstractAccountAwareResourceService<Cons
 
     @Inject
     private ConsumptionDtoConverter consumptionDtoConverter;
+
+    @Inject
+    private CloudStorageLocationUtil cloudStorageLocationUtil;
 
     @Override
     public Long getResourceIdByResourceCrn(String resourceCrn) {
@@ -106,8 +114,67 @@ public class ConsumptionService extends AbstractAccountAwareResourceService<Cons
         return consumptionRepository.doesStorageConsumptionExistWithLocationForMonitoredCrn(monitoredResourceCrn, storageLocation);
     }
 
-    public List<JobResource> findAllStorageConsumptionJobResource() {
-        return consumptionRepository.findAllStorageConsumptionJobResource();
+    public List<Consumption> findAllConsumption() {
+        return consumptionRepository.findAllConsumption();
     }
 
+    public List<Consumption> findAllStorageConsumptionForEnvCrnAndBucketName(String environmentCrn, String storageLocation) {
+        List<Consumption> consumptionsForEnv = consumptionRepository.findAllStorageConsumptionByEnvironmentCrn(environmentCrn);
+        try {
+            String bucketName = cloudStorageLocationUtil.getS3BucketName(storageLocation);
+            List<Consumption> consumptionsForEnvAndBucket = consumptionsForEnv.stream()
+                    .filter(consumption -> bucketName.equals(cloudStorageLocationUtil.getS3BucketName(consumption.getStorageLocation())))
+                    .collect(Collectors.toList());
+            LOGGER.info("Number of storage consumptions found for environment CRN '{}' and bucket name '{}': {}.",
+                    environmentCrn, bucketName, consumptionsForEnvAndBucket.size());
+            return consumptionsForEnvAndBucket;
+        } catch (ValidationException e) {
+            LOGGER.error("Cannot extract bucket name from storage location '{}' as it's not a valid S3 location. Reason: {}",
+                    storageLocation, e.getMessage(), e);
+            return List.of();
+        }
+    }
+
+    public List<List<Consumption>> groupConsumptionsByEnvCrnAndBucketName(List<Consumption> consumptions) {
+        Map<String, List<Consumption>> consumptionsGroupedByEnvCrn = consumptions.stream()
+                .collect(Collectors.groupingBy(Consumption::getEnvironmentCrn));
+
+        return consumptionsGroupedByEnvCrn.values().stream()
+                .map(this::groupConsumptionsByBucketName)
+                .flatMap(List::stream)
+                .collect(Collectors.toList());
+    }
+
+    private List<List<Consumption>> groupConsumptionsByBucketName(List<Consumption> consumptions) {
+        Map<String, List<Consumption>> consumptionsGroupedByBucketName = consumptions.stream()
+                .collect(Collectors.groupingBy(consumption -> getBucketNameOrEmpty(consumption.getStorageLocation())));
+
+        return consumptionsGroupedByBucketName.entrySet().stream()
+                .filter(bucketNameGroup -> !bucketNameGroup.getKey().isEmpty())
+                .map(Entry::getValue)
+                .collect(Collectors.toList());
+    }
+
+    private String getBucketNameOrEmpty(String storageLocation) {
+        try {
+            return cloudStorageLocationUtil.getS3BucketName(storageLocation);
+        } catch (ValidationException e) {
+            LOGGER.info("Cannot extract bucket name from storage location '{}' as it's not a valid S3 location. Reason: {}.",
+                    storageLocation, e.getMessage());
+            return "";
+        }
+    }
+
+    public boolean isAggregationRequired(Consumption consumption) {
+        if (ConsumptionType.STORAGE.equals(consumption.getConsumptionType())) {
+            try {
+                cloudStorageLocationUtil.validateCloudStorageType(FileSystemType.S3, consumption.getStorageLocation());
+                return true;
+            } catch (ValidationException e) {
+                return false;
+            }
+        } else {
+            return false;
+        }
+    }
 }

--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/util/CloudStorageLocationUtil.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/util/CloudStorageLocationUtil.java
@@ -2,21 +2,21 @@ package com.sequenceiq.consumption.util;
 
 import javax.validation.ValidationException;
 
+import org.springframework.stereotype.Service;
+
 import com.sequenceiq.common.model.FileSystemType;
 
+@Service
 public class CloudStorageLocationUtil {
 
-    private CloudStorageLocationUtil() {
-    }
-
-    public static void validateCloudStorageType(FileSystemType requiredType, String storageLocation) {
+    public void validateCloudStorageType(FileSystemType requiredType, String storageLocation) {
         if (storageLocation == null || !storageLocation.startsWith(requiredType.getProtocol())) {
             throw new ValidationException(String.format("Storage location must start with '%s' if required file system type is '%s'!",
                     requiredType.getProtocol(), requiredType.name()));
         }
     }
 
-    public static String getS3BucketName(String storageLocation) {
+    public String getS3BucketName(String storageLocation) {
         validateCloudStorageType(FileSystemType.S3, storageLocation);
         storageLocation = storageLocation.replace(FileSystemType.S3.getProtocol() + "://", "");
         return storageLocation.split("/")[0];

--- a/cloud-consumption/src/test/java/com/sequenceiq/consumption/endpoint/ConsumptionInternalV1ControllerTest.java
+++ b/cloud-consumption/src/test/java/com/sequenceiq/consumption/endpoint/ConsumptionInternalV1ControllerTest.java
@@ -3,8 +3,6 @@ package com.sequenceiq.consumption.endpoint;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -80,7 +78,7 @@ public class ConsumptionInternalV1ControllerTest {
 
         underTest.scheduleStorageConsumptionCollection(ACCOUNT_ID, request, INITIATOR_USER_CRN);
 
-        verify(jobService, never()).schedule(anyLong());
+        verify(jobService, never()).schedule(any(Consumption.class));
     }
 
     @Test
@@ -89,11 +87,12 @@ public class ConsumptionInternalV1ControllerTest {
         ConsumptionCreationDto consumptionCreationDto = consumptionCreationDto(LOCATION);
 
         when(consumptionApiConverter.initCreationDtoForStorage(request)).thenReturn(consumptionCreationDto);
-        when(consumptionService.create(consumptionCreationDto)).thenReturn(Optional.of(consumption()));
+        Consumption consumption = consumption();
+        when(consumptionService.create(consumptionCreationDto)).thenReturn(Optional.of(consumption));
 
         underTest.scheduleStorageConsumptionCollection(ACCOUNT_ID, request, INITIATOR_USER_CRN);
 
-        verify(jobService).schedule(CONSUMPTION_ID);
+        verify(jobService).schedule(consumption);
     }
 
     @Test
@@ -102,7 +101,7 @@ public class ConsumptionInternalV1ControllerTest {
 
         underTest.unscheduleStorageConsumptionCollection(ACCOUNT_ID, MONITORED_CRN, LOCATION, INITIATOR_USER_CRN);
 
-        verify(jobService, never()).unschedule(anyString());
+        verify(jobService, never()).unschedule(any(Consumption.class));
         verify(consumptionService, never()).delete(any(Consumption.class));
     }
 
@@ -113,7 +112,7 @@ public class ConsumptionInternalV1ControllerTest {
 
         underTest.unscheduleStorageConsumptionCollection(ACCOUNT_ID, MONITORED_CRN, LOCATION, INITIATOR_USER_CRN);
 
-        verify(jobService).unschedule("123");
+        verify(jobService).unschedule(consumption);
         verify(consumptionService).delete(consumption);
     }
 

--- a/cloud-consumption/src/test/java/com/sequenceiq/consumption/job/storage/StorageConsumptionJobServiceTest.java
+++ b/cloud-consumption/src/test/java/com/sequenceiq/consumption/job/storage/StorageConsumptionJobServiceTest.java
@@ -1,0 +1,201 @@
+package com.sequenceiq.consumption.job.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.springframework.context.ApplicationContext;
+
+import com.sequenceiq.cloudbreak.quartz.model.JobResource;
+import com.sequenceiq.consumption.configuration.repository.ConsumptionRepository;
+import com.sequenceiq.consumption.domain.Consumption;
+import com.sequenceiq.consumption.service.ConsumptionService;
+
+@ExtendWith(MockitoExtension.class)
+public class StorageConsumptionJobServiceTest {
+
+    @Mock
+    private ApplicationContext applicationContext;
+
+    @Mock
+    private Scheduler scheduler;
+
+    @Mock
+    private StorageConsumptionConfig storageConsumptionConfig;
+
+    @Mock
+    private ConsumptionService consumptionService;
+
+    @Mock
+    private ConsumptionRepository consumptionRepository;
+
+    @InjectMocks
+    private StorageConsumptionJobService underTest;
+
+    @Captor
+    private ArgumentCaptor<JobDetail> jobDetailCaptor;
+
+    @Captor
+    private ArgumentCaptor<JobKey> jobKeyCaptor;
+
+    @BeforeEach
+    public void setUp() {
+        lenient().when(applicationContext.getBean(ConsumptionRepository.class)).thenReturn(consumptionRepository);
+        lenient().when(storageConsumptionConfig.getIntervalInMinutes()).thenReturn(30);
+    }
+
+    @Test
+    public void testScheduleByIdDisabled() {
+        when(storageConsumptionConfig.isStorageConsumptionEnabled()).thenReturn(false);
+        JobResource jobResource = mock(JobResource.class);
+        when(consumptionRepository.getJobResource(1L)).thenReturn(Optional.of(jobResource));
+
+        underTest.schedule(1L);
+
+        verifyNoInteractions(scheduler);
+    }
+
+    @Test
+    public void testScheduleByIdJobAlreadyRunning() throws SchedulerException {
+        when(storageConsumptionConfig.isStorageConsumptionEnabled()).thenReturn(true);
+        mockJobResource(1L);
+        when(scheduler.getJobDetail(any())).thenReturn(mock(JobDetail.class));
+
+        underTest.schedule(1L);
+
+        verify(scheduler, never()).scheduleJob(any(), any());
+    }
+
+    @Test
+    public void testScheduleByIdJobNotRunning() throws SchedulerException {
+        when(storageConsumptionConfig.isStorageConsumptionEnabled()).thenReturn(true);
+        mockJobResource(1L);
+        when(scheduler.getJobDetail(any())).thenReturn(null);
+
+        underTest.schedule(1L);
+
+        verify(scheduler, times(1)).scheduleJob(any(), any());
+    }
+
+    @Test
+    public void testScheduleWithAggregationNoJobRunningForGroup() throws SchedulerException {
+        Consumption consumptionToSchedule = consumption(1L);
+        when(consumptionService.isAggregationRequired(consumptionToSchedule)).thenReturn(true);
+        when(consumptionService.findAllStorageConsumptionForEnvCrnAndBucketName(
+                consumptionToSchedule.getEnvironmentCrn(), consumptionToSchedule.getStorageLocation()))
+                .thenReturn(List.of(consumptionToSchedule));
+        mockSchedulingById(1L);
+
+        underTest.schedule(consumptionToSchedule);
+
+        verify(scheduler, times(1)).scheduleJob(jobDetailCaptor.capture(), any());
+        assertEquals("1", jobDetailCaptor.getValue().getKey().getName());
+    }
+
+    @Test
+    public void testScheduleWithAggregationJobAlreadyRunningForGroup() throws SchedulerException {
+        Consumption consumptionToSchedule = consumption(1L);
+        Consumption consumptionOther = consumption(2L);
+        when(consumptionService.isAggregationRequired(consumptionToSchedule)).thenReturn(true);
+        when(consumptionService.findAllStorageConsumptionForEnvCrnAndBucketName(
+                consumptionToSchedule.getEnvironmentCrn(), consumptionToSchedule.getStorageLocation()))
+                .thenReturn(List.of(consumptionToSchedule, consumptionOther));
+        doReturn(null).when(scheduler).getJobDetail(argThat((JobKey jobkey) -> "1".equals(jobkey.getName())));
+        doReturn(mock(JobDetail.class)).when(scheduler).getJobDetail(argThat((JobKey jobkey) -> "2".equals(jobkey.getName())));
+
+        underTest.schedule(consumptionToSchedule);
+
+        verify(scheduler, never()).scheduleJob(any(), any());
+    }
+
+    @Test
+    public void testUnscheduleWithAggregationNoJobRunningForConsumption() throws SchedulerException {
+        Consumption consumptionToUnSchedule = consumption(1L);
+        when(consumptionService.isAggregationRequired(consumptionToUnSchedule)).thenReturn(true);
+        doReturn(null).when(scheduler).getJobDetail(argThat((JobKey jobkey) -> "1".equals(jobkey.getName())));
+
+        underTest.unschedule(consumptionToUnSchedule);
+
+        verify(scheduler, never()).deleteJob(any());
+    }
+
+    @Test
+    public void testUnscheduleWithAggregationJobRunningForConsumptionNoReschedule() throws SchedulerException {
+        Consumption consumptionToUnSchedule = consumption(1L);
+        when(consumptionService.isAggregationRequired(consumptionToUnSchedule)).thenReturn(true);
+        doReturn(mock(JobDetail.class)).when(scheduler).getJobDetail(argThat((JobKey jobkey) -> "1".equals(jobkey.getName())));
+        when(consumptionService.findAllStorageConsumptionForEnvCrnAndBucketName(
+                consumptionToUnSchedule.getEnvironmentCrn(), consumptionToUnSchedule.getStorageLocation()))
+                .thenReturn(List.of(consumptionToUnSchedule));
+
+        underTest.unschedule(consumptionToUnSchedule);
+
+        verify(scheduler, times(1)).deleteJob(jobKeyCaptor.capture());
+        assertEquals("1", jobKeyCaptor.getValue().getName());
+        verify(scheduler, never()).scheduleJob(any(), any());
+    }
+
+    @Test
+    public void testUnscheduleWithAggregationJobRunningForConsumptionWithReschedule() throws SchedulerException {
+        Consumption consumptionToUnSchedule = consumption(1L);
+        Consumption consumptionOther = consumption(2L);
+        when(consumptionService.isAggregationRequired(consumptionToUnSchedule)).thenReturn(true);
+        doReturn(mock(JobDetail.class)).when(scheduler).getJobDetail(argThat((JobKey jobkey) -> "1".equals(jobkey.getName())));
+        when(consumptionService.findAllStorageConsumptionForEnvCrnAndBucketName(
+                consumptionToUnSchedule.getEnvironmentCrn(), consumptionToUnSchedule.getStorageLocation()))
+                .thenReturn(List.of(consumptionToUnSchedule, consumptionOther));
+        mockSchedulingById(2L);
+
+        underTest.unschedule(consumptionToUnSchedule);
+
+        verify(scheduler, times(1)).deleteJob(jobKeyCaptor.capture());
+        assertEquals("1", jobKeyCaptor.getValue().getName());
+        verify(scheduler, times(1)).scheduleJob(jobDetailCaptor.capture(), any());
+        assertEquals("2", jobDetailCaptor.getValue().getKey().getName());
+    }
+
+    private void mockJobResource(Long id) {
+        JobResource jobResource = mock(JobResource.class);
+        when(jobResource.getLocalId()).thenReturn(id.toString());
+        when(jobResource.getRemoteResourceId()).thenReturn("crn");
+        when(consumptionRepository.getJobResource(id)).thenReturn(Optional.of(jobResource));
+    }
+
+    private void mockSchedulingById(Long id) throws SchedulerException {
+        when(storageConsumptionConfig.isStorageConsumptionEnabled()).thenReturn(true);
+        mockJobResource(id);
+    }
+
+    private Consumption consumption(Long id) {
+        Consumption consumption = new Consumption();
+        consumption.setResourceCrn("crn");
+        consumption.setEnvironmentCrn("env-crn");
+        consumption.setStorageLocation("location");
+        consumption.setId(id);
+        return consumption;
+    }
+
+}

--- a/cloud-consumption/src/test/java/com/sequenceiq/consumption/service/ConsumptionServiceTest.java
+++ b/cloud-consumption/src/test/java/com/sequenceiq/consumption/service/ConsumptionServiceTest.java
@@ -2,13 +2,20 @@ package com.sequenceiq.consumption.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Optional;
 
-import org.junit.jupiter.api.BeforeEach;
+import javax.validation.ValidationException;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -16,12 +23,14 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.sequenceiq.common.model.FileSystemType;
 import com.sequenceiq.consumption.api.v1.consumption.model.common.ConsumptionType;
 import com.sequenceiq.consumption.api.v1.consumption.model.common.ResourceType;
 import com.sequenceiq.consumption.configuration.repository.ConsumptionRepository;
 import com.sequenceiq.consumption.domain.Consumption;
 import com.sequenceiq.consumption.dto.ConsumptionCreationDto;
 import com.sequenceiq.consumption.dto.converter.ConsumptionDtoConverter;
+import com.sequenceiq.consumption.util.CloudStorageLocationUtil;
 
 @ExtendWith(MockitoExtension.class)
 public class ConsumptionServiceTest {
@@ -31,6 +40,8 @@ public class ConsumptionServiceTest {
     private static final String NAME = "name_STORAGE";
 
     private static final String ENVIRONMENT_CRN = "env-crn";
+
+    private static final String ENVIRONMENT_CRN_OTHER = "env-crn-other";
 
     private static final String ACCOUNT_ID = "acc-id";
 
@@ -42,21 +53,23 @@ public class ConsumptionServiceTest {
 
     private static final String STORAGE_LOCATION = "location";
 
+    private static final String STORAGE_LOCATION_OTHER = "location-other";
+
+    private static final String BUCKET = "bucket";
+
+    private static final String BUCKET_OTHER = "bucket-other";
+
     @Mock
     private ConsumptionRepository consumptionRepository;
 
     @Mock
     private ConsumptionDtoConverter consumptionDtoConverter;
 
+    @Mock
+    private CloudStorageLocationUtil cloudStorageLocationUtil;
+
     @InjectMocks
     private ConsumptionService underTest;
-
-    private Consumption consumption;
-
-    @BeforeEach
-    void setUp() {
-        consumption = new Consumption();
-    }
 
     @Test
     void testFindStorageConsumptionByMonitoredResourceCrnAndLocationNotFound() {
@@ -73,6 +86,7 @@ public class ConsumptionServiceTest {
 
     @Test
     void testFindStorageConsumptionByMonitoredResourceCrnAndLocationFound() {
+        Consumption consumption = mock(Consumption.class);
         when(consumptionRepository
                 .findStorageConsumptionByMonitoredResourceCrnAndLocation(eq(MONITORED_RESOURCE_CRN), eq(STORAGE_LOCATION)))
                 .thenReturn(Optional.of(consumption));
@@ -144,4 +158,148 @@ public class ConsumptionServiceTest {
         verify(consumptionDtoConverter, Mockito.times(0)).creationDtoToConsumption(eq(consumptionCreationDto));
     }
 
+    @Test
+    public void testFindAllConsumption() {
+        when(consumptionRepository.findAllConsumption()).thenReturn(List.of());
+
+        underTest.findAllConsumption();
+
+        verify(consumptionRepository, times(1)).findAllConsumption();
+    }
+
+    @Test
+    public void testNoAggregationRequiredIfNotStorageType() {
+        Consumption consumption = new Consumption();
+        consumption.setConsumptionType(ConsumptionType.UNKNOWN);
+
+        boolean result = underTest.isAggregationRequired(consumption);
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testNoAggregationRequiredIfLocationValidationFails() {
+        Consumption consumption = consumption("not_s3_location");
+        doThrow(new ValidationException("error")).when(cloudStorageLocationUtil)
+                .validateCloudStorageType(FileSystemType.S3, "not_s3_location");
+
+        boolean result = underTest.isAggregationRequired(consumption);
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testAggregationRequired() {
+        Consumption consumption = consumption("s3_location");
+
+        boolean result = underTest.isAggregationRequired(consumption);
+
+        assertTrue(result);
+    }
+
+    @Test
+    public void testFindAllStorageConsumptionForEnvCrnAndBucketNameNoResult() {
+        when(consumptionRepository.findAllStorageConsumptionByEnvironmentCrn(ENVIRONMENT_CRN)).thenReturn(List.of());
+        when(cloudStorageLocationUtil.getS3BucketName(STORAGE_LOCATION)).thenAnswer(invocation -> BUCKET);
+
+        List<Consumption> result = underTest.findAllStorageConsumptionForEnvCrnAndBucketName(ENVIRONMENT_CRN, STORAGE_LOCATION);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testFindAllStorageConsumptionForEnvCrnAndBucketNameValidationError() {
+        when(consumptionRepository.findAllStorageConsumptionByEnvironmentCrn(ENVIRONMENT_CRN)).thenReturn(
+                List.of(consumption(ENVIRONMENT_CRN, STORAGE_LOCATION)));
+        when(cloudStorageLocationUtil.getS3BucketName(STORAGE_LOCATION)).thenThrow(new ValidationException("error"));
+
+        List<Consumption> result = underTest.findAllStorageConsumptionForEnvCrnAndBucketName(ENVIRONMENT_CRN, STORAGE_LOCATION);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testFindAllStorageConsumptionForEnvCrnAndBucketName() {
+        Consumption consumption1 = consumption(ENVIRONMENT_CRN, STORAGE_LOCATION);
+        Consumption consumption2 = consumption(ENVIRONMENT_CRN, STORAGE_LOCATION);
+        Consumption consumption3 = consumption(ENVIRONMENT_CRN, STORAGE_LOCATION_OTHER);
+        when(consumptionRepository.findAllStorageConsumptionByEnvironmentCrn(ENVIRONMENT_CRN)).thenReturn(
+                List.of(consumption1, consumption2, consumption3));
+        when(cloudStorageLocationUtil.getS3BucketName(STORAGE_LOCATION)).thenAnswer(invocation -> BUCKET);
+        when(cloudStorageLocationUtil.getS3BucketName(STORAGE_LOCATION_OTHER)).thenAnswer(invocation -> BUCKET_OTHER);
+
+        List<Consumption> result = underTest.findAllStorageConsumptionForEnvCrnAndBucketName(ENVIRONMENT_CRN, STORAGE_LOCATION);
+
+        assertEquals(List.of(consumption1, consumption2), result);
+    }
+
+    @Test
+    public void testGroupConsumptionsByEnvCrnAndBucketNameNoConsumptions() {
+        List<List<Consumption>> result = underTest.groupConsumptionsByEnvCrnAndBucketName(List.of());
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testGroupConsumptionsByEnvCrnAndBucketName() {
+        Consumption consumption11 = consumption(ENVIRONMENT_CRN, STORAGE_LOCATION);
+        Consumption consumption12 = consumption(ENVIRONMENT_CRN, STORAGE_LOCATION);
+        Consumption consumption21 = consumption(ENVIRONMENT_CRN, STORAGE_LOCATION_OTHER);
+        Consumption consumption31 = consumption(ENVIRONMENT_CRN_OTHER, STORAGE_LOCATION);
+        Consumption consumption41 = consumption(ENVIRONMENT_CRN_OTHER, STORAGE_LOCATION_OTHER);
+        Consumption consumption42 = consumption(ENVIRONMENT_CRN_OTHER, STORAGE_LOCATION_OTHER);
+
+        when(cloudStorageLocationUtil.getS3BucketName(STORAGE_LOCATION)).thenAnswer(invocation -> BUCKET);
+        when(cloudStorageLocationUtil.getS3BucketName(STORAGE_LOCATION_OTHER)).thenAnswer(invocation -> BUCKET_OTHER);
+
+        List<List<Consumption>> result = underTest.groupConsumptionsByEnvCrnAndBucketName(
+                List.of(consumption11, consumption12, consumption21, consumption31, consumption41, consumption42));
+
+        List<List<Consumption>> expected = List.of(
+                List.of(consumption11, consumption12),
+                List.of(consumption21),
+                List.of(consumption31),
+                List.of(consumption41, consumption42));
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testGroupConsumptionsByEnvCrnAndBucketNameInvalidLocationFilteredOut() {
+        Consumption consumption11 = consumption(ENVIRONMENT_CRN, STORAGE_LOCATION);
+        Consumption consumption12 = consumption(ENVIRONMENT_CRN, STORAGE_LOCATION);
+        Consumption consumption21 = consumption(ENVIRONMENT_CRN, STORAGE_LOCATION_OTHER);
+        Consumption consumptionInvalid1 = consumption(ENVIRONMENT_CRN, "invalid");
+        Consumption consumption31 = consumption(ENVIRONMENT_CRN_OTHER, STORAGE_LOCATION);
+        Consumption consumption41 = consumption(ENVIRONMENT_CRN_OTHER, STORAGE_LOCATION_OTHER);
+        Consumption consumption42 = consumption(ENVIRONMENT_CRN_OTHER, STORAGE_LOCATION_OTHER);
+        Consumption consumptionInvalid2 = consumption(ENVIRONMENT_CRN_OTHER, "invalid");
+
+        when(cloudStorageLocationUtil.getS3BucketName(STORAGE_LOCATION)).thenAnswer(invocation -> BUCKET);
+        when(cloudStorageLocationUtil.getS3BucketName(STORAGE_LOCATION_OTHER)).thenAnswer(invocation -> BUCKET_OTHER);
+        when(cloudStorageLocationUtil.getS3BucketName("invalid")).thenAnswer(invocation -> {
+            throw new ValidationException("error");
+        });
+
+        List<List<Consumption>> result = underTest.groupConsumptionsByEnvCrnAndBucketName(
+                List.of(consumption11, consumption12, consumption21, consumptionInvalid1, consumption31, consumption41, consumption42, consumptionInvalid2));
+
+        List<List<Consumption>> expected = List.of(
+                List.of(consumption11, consumption12),
+                List.of(consumption21),
+                List.of(consumption31),
+                List.of(consumption41, consumption42));
+        assertEquals(expected, result);
+    }
+
+    private Consumption consumption(String location) {
+        return consumption(null, location);
+    }
+
+    private Consumption consumption(String envCrn, String location) {
+        Consumption consumption = new Consumption();
+        consumption.setStorageLocation(location);
+        consumption.setEnvironmentCrn(envCrn);
+        consumption.setConsumptionType(ConsumptionType.STORAGE);
+        return consumption;
+    }
 }

--- a/cloud-consumption/src/test/java/com/sequenceiq/consumption/util/CloudStorageLocationUtilTest.java
+++ b/cloud-consumption/src/test/java/com/sequenceiq/consumption/util/CloudStorageLocationUtilTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import javax.validation.ValidationException;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -18,23 +19,30 @@ public class CloudStorageLocationUtilTest {
 
     private static final String ABFS_OBJECT_PATH = "abfs://FILESYSTEM@STORAGEACCOUNT.dfs.core.windows.net/PATH";
 
+    private CloudStorageLocationUtil underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new CloudStorageLocationUtil();
+    }
+
     @Test
     public void testGetBucketName() {
-        assertEquals("bucket-name", CloudStorageLocationUtil.getS3BucketName(S3_OBJECT_PATH));
+        assertEquals("bucket-name", underTest.getS3BucketName(S3_OBJECT_PATH));
     }
 
     @Test
     public void testGetBucketNameWithInvalidStorageType() {
-        assertThrows(ValidationException.class, () -> CloudStorageLocationUtil.getS3BucketName(ABFS_OBJECT_PATH));
+        assertThrows(ValidationException.class, () -> underTest.getS3BucketName(ABFS_OBJECT_PATH));
     }
 
     @ParameterizedTest(name = "With requiredType={0} and storageLocation={1}, validation should succeed: {2}")
     @MethodSource("scenarios")
     public void testValidateCloudStorageType(FileSystemType requiredType, String storageLocation, boolean valid) {
         if (valid) {
-            assertDoesNotThrow(() -> CloudStorageLocationUtil.validateCloudStorageType(requiredType, storageLocation));
+            assertDoesNotThrow(() -> underTest.validateCloudStorageType(requiredType, storageLocation));
         } else {
-            assertThrows(ValidationException.class, () -> CloudStorageLocationUtil.validateCloudStorageType(requiredType, storageLocation));
+            assertThrows(ValidationException.class, () -> underTest.validateCloudStorageType(requiredType, storageLocation));
         }
     }
 


### PR DESCRIPTION
This commit implements S3 storage conusmption job aggregation. This means that for every environment CRN and bucket name pair only
one quartz job will run even if multiple storage consumptions are registered for the given pair.

Implementation details:
* To avoid changing the DB schema, as there might already be registered storage paths (referring to it as "consumption") in it, an
  implementation is proposed that do not change how consumptions are registered and unregistered in the DB. All separate consumption
  registrations will still be treated as a separate consumption from the DB standpoint.
* The "aggregation" logic is implemented not on the DB side but in the quartz job scheduling, unscheduling and initialization.
    * When a new consumption is saved to the DB and quartz job scheduling service is called the following will happen:
        * The service will reach out to the DB and query every registered consumption that has the same environment CRN and and
          bucket name (not full location as that string is stored in the DB).
        * If the newly registered consumption is the only one that the query returns, then a new quartz job will be scheduled
          for the given environment CRN and bucket name.
        * If there are other consumptions registered besides the new one then no new quartz job will be scheduled for the
          environment CRN + bucket name pair
    * The same logic will happen during unregistration
        * If no other consumption uses the same environment CRN + bucket name pair as the one that is being unregistered
          then the corresponding quartz job will be unscheduled
        * Otherwise the job will continue to run
        * In the special case where multiple consumptions use the same environment CRN + bucket name pair and the consumption
          that is being unregistered is the consumption that the quartz job is running for, then the job corresponding to the
          consumption being unregistered will be unscheduled and from the remaining consumptions another one will be used to
          schedule the quartz job again.
    * The quartz job initialization logic (that restarts the jobs after a service restart) will use the same environment
      CRN + bucket name grouping and start the jobs accordingly
        * For each env CRN + bucket name pair only one consumption will be used to schedule the quartz job for the group
* The quartz job service and initializer are unaware of the consumption grouping logic, they simply get the grouped consumptions
  from the ConsumptionService. This allows for other cloud providers/storage types to use the same aggregated scheduling logic
  without the need to refactor the quartz job service and initializer.

Testing:
* Unit test are present for every newly introduced logic
* Locally tested the changes by starting environments and datalakes that use the same and different buckets and did multiple
  schedules, unschedules, initializations to verify correct behaviour and edge case handling.

Additional change:
* Refactored CloudStorageLocationUtil to be a service instead of a class with only static functions.