### PR TITLE
CB-17134 Datalake upgrade should also migrate from CF to Native varia…

### DIFF
--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/dto/StackDto.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/dto/StackDto.java
@@ -237,6 +237,14 @@ public class StackDto implements OrchestratorAware, StackDtoDelegate, MdcContext
                 .collect(Collectors.toList());
     }
 
+    public List<InstanceMetadataView> getNotTerminatedGatewayInstanceMetadata() {
+        return instanceGroups.values().stream()
+                .flatMap(ig -> ig.getInstanceMetadataViews().stream())
+                .filter(im -> im.getInstanceGroupType() == InstanceGroupType.GATEWAY)
+                .filter(im -> !im.isTerminated())
+                .collect(Collectors.toList());
+    }
+
     public List<InstanceGroupDto> getNotTerminatedAndNotZombieGatewayInstanceMetadataWithInstanceGroup() {
         List<InstanceGroupDto> ret = new ArrayList<>();
         instanceGroups.values().forEach(ig -> {

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/view/InstanceMetadataView.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/view/InstanceMetadataView.java
@@ -102,6 +102,11 @@ public interface InstanceMetadataView {
         return InstanceStatus.ZOMBIE.equals(getInstanceStatus());
     }
 
+    default boolean isHealthy() {
+        InstanceStatus instanceStatus = getInstanceStatus();
+        return InstanceStatus.SERVICES_HEALTHY.equals(instanceStatus) || InstanceStatus.SERVICES_RUNNING.equals(instanceStatus);
+    }
+
     default String getShortHostname() {
         String discoveryFQDN = getDiscoveryFQDN();
         if (discoveryFQDN == null || discoveryFQDN.isEmpty()) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
@@ -242,20 +242,20 @@ public class StackV4Controller extends NotificationController implements StackV4
     @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.POWERUSER_ONLY)
     public FlowIdentifier upgradeOs(Long workspaceId, String name, @AccountId String accountId) {
-        return stackUpgradeOperations.upgradeOs(NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId());
+        return stackUpgradeOperations.upgradeOs(NameOrCrn.ofName(name), restRequestThreadLocalService.getAccountId());
     }
 
     @Override
     @InternalOnly
     public FlowIdentifier upgradeOsInternal(Long workspaceId, String name, @InitiatorUserCrn String initiatorUserCrn) {
-        return stackUpgradeOperations.upgradeOs(NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId());
+        return stackUpgradeOperations.upgradeOs(NameOrCrn.ofName(name), restRequestThreadLocalService.getAccountId());
     }
 
     @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.POWERUSER_ONLY)
     public UpgradeOptionV4Response checkForOsUpgrade(Long workspaceId, String name, @AccountId String accountId) {
         return stackUpgradeOperations.checkForOsUpgrade(NameOrCrn.ofName(name), restRequestThreadLocalService.getCloudbreakUser(),
-                restRequestThreadLocalService.getRequestedWorkspaceId());
+                restRequestThreadLocalService.getAccountId());
     }
 
     @Override
@@ -348,19 +348,19 @@ public class StackV4Controller extends NotificationController implements StackV4
     @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.POWERUSER_ONLY)
     public FlowIdentifier upgradeClusterByName(Long workspaceId, String name, String imageId, @AccountId String accountId) {
-        return stackUpgradeOperations.upgradeCluster(NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId(), imageId);
+        return stackUpgradeOperations.upgradeCluster(NameOrCrn.ofName(name), restRequestThreadLocalService.getAccountId(), imageId);
     }
 
     @Override
     @InternalOnly
     public FlowIdentifier upgradeClusterByNameInternal(Long workspaceId, String name, String imageId, @InitiatorUserCrn String initiatorUserCrn) {
-        return stackUpgradeOperations.upgradeCluster(NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId(), imageId);
+        return stackUpgradeOperations.upgradeCluster(NameOrCrn.ofName(name), restRequestThreadLocalService.getAccountId(), imageId);
     }
 
     @Override
     @InternalOnly
     public FlowIdentifier prepareClusterUpgradeByCrnInternal(Long workspaceId, String crn, String imageId, @InitiatorUserCrn String initiatorUserCrn) {
-        return stackUpgradeOperations.prepareClusterUpgrade(NameOrCrn.ofCrn(crn), restRequestThreadLocalService.getRequestedWorkspaceId(), imageId);
+        return stackUpgradeOperations.prepareClusterUpgrade(NameOrCrn.ofCrn(crn), restRequestThreadLocalService.getAccountId(), imageId);
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpgradeDatalakeFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpgradeDatalakeFlowEventChainFactory.java
@@ -14,9 +14,9 @@ import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.salt.update.SaltUpdateEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterUpgradeTriggerEvent;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
-import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 import com.sequenceiq.cloudbreak.service.upgrade.image.locked.LockedComponentService;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
 import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
@@ -31,7 +31,7 @@ public class UpgradeDatalakeFlowEventChainFactory implements FlowEventChainFacto
     private LockedComponentService lockedComponentService;
 
     @Inject
-    private StackService stackService;
+    private StackDtoService stackDtoService;
 
     @Override
     public String initEvent() {
@@ -50,7 +50,7 @@ public class UpgradeDatalakeFlowEventChainFactory implements FlowEventChainFacto
 
     private void addUpgradeValidationToChain(ClusterUpgradeTriggerEvent event, Queue<Selectable> flowEventChain) {
         if (upgradeValidationEnabled) {
-            Stack stack = stackService.getById(event.getResourceId());
+            StackDto stack = stackDtoService.getById(event.getResourceId());
             boolean lockComponents = lockedComponentService.isComponentsLocked(stack, event.getImageId());
             flowEventChain.add(new ClusterUpgradeValidationTriggerEvent(event.getResourceId(), event.accepted(), event.getImageId(), lockComponents));
         }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
@@ -332,15 +332,15 @@ public class ReactorFlowManager {
     }
 
     public FlowIdentifier triggerClusterRepairFlow(Long stackId, Map<String, List<String>> failedNodesMap, boolean oneNodeFromEachHostGroupAtOnce,
-            boolean restartServices) {
+            boolean restartServices, String triggeredVariant) {
         return reactorNotifier.notify(stackId, FlowChainTriggers.CLUSTER_REPAIR_TRIGGER_EVENT,
-                new ClusterRepairTriggerEvent(stackId, failedNodesMap, oneNodeFromEachHostGroupAtOnce, restartServices));
+                new ClusterRepairTriggerEvent(stackId, failedNodesMap, oneNodeFromEachHostGroupAtOnce, restartServices, triggeredVariant));
     }
 
     public FlowIdentifier triggerClusterRepairFlow(Long stackId, Map<String, List<String>> failedNodesMap,
             boolean restartServices) {
         return reactorNotifier.notify(stackId, FlowChainTriggers.CLUSTER_REPAIR_TRIGGER_EVENT,
-                new ClusterRepairTriggerEvent(stackId, failedNodesMap, restartServices));
+                new ClusterRepairTriggerEvent(stackId, failedNodesMap, false, restartServices, null));
     }
 
     public FlowIdentifier triggerStackImageUpdate(ImageChangeDto imageChangeDto) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/ClusterRepairTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/ClusterRepairTriggerEvent.java
@@ -24,24 +24,15 @@ public class ClusterRepairTriggerEvent extends StackEvent {
 
     private final String triggeredStackVariant;
 
-    public ClusterRepairTriggerEvent(Long stackId, Map<String, List<String>> failedNodesMap, boolean restartServices) {
-        super(stackId);
-        this.failedNodesMap = copyToSerializableMap(failedNodesMap);
-        this.stackId = stackId;
-        this.oneNodeFromEachHostGroupAtOnce = false;
-        this.restartServices = restartServices;
-        this.upgrade = false;
-        this.triggeredStackVariant = null;
-    }
-
-    public ClusterRepairTriggerEvent(Long stackId, Map<String, List<String>> failedNodesMap, boolean oneNodeFromEachHostGroupAtOnce, boolean restartServices) {
+    public ClusterRepairTriggerEvent(Long stackId, Map<String, List<String>> failedNodesMap, boolean oneNodeFromEachHostGroupAtOnce, boolean restartServices,
+            String triggeredStackVariant) {
         super(stackId);
         this.failedNodesMap = copyToSerializableMap(failedNodesMap);
         this.stackId = stackId;
         this.oneNodeFromEachHostGroupAtOnce = oneNodeFromEachHostGroupAtOnce;
         this.restartServices = restartServices;
-        this.upgrade = false;
-        this.triggeredStackVariant = null;
+        this.upgrade = triggeredStackVariant != null;
+        this.triggeredStackVariant = triggeredStackVariant;
     }
 
     @JsonCreator
@@ -56,7 +47,7 @@ public class ClusterRepairTriggerEvent extends StackEvent {
         this.stackId = stackId;
         this.oneNodeFromEachHostGroupAtOnce = false;
         this.restartServices = restartServices;
-        this.upgrade = true;
+        this.upgrade = triggeredStackVariant != null;
         this.triggeredStackVariant = triggeredStackVariant;
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/blueprint/BlueprintService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/blueprint/BlueprintService.java
@@ -540,7 +540,7 @@ public class BlueprintService extends AbstractWorkspaceAwareResourceService<Blue
         return EnumSet.of(Crn.ResourceType.CLUSTER_TEMPLATE);
     }
 
-    public Optional<Blueprint> getByClusterId(Long stackId) {
-        return blueprintRepository.findByClusterId(stackId);
+    public Optional<Blueprint> getByClusterId(Long clusterId) {
+        return blueprintRepository.findByClusterId(clusterId);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterDBValidationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterDBValidationService.java
@@ -8,8 +8,8 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ResourceStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
-import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.service.rdsconfig.RdsConfigWithoutClusterService;
+import com.sequenceiq.cloudbreak.view.ClusterView;
 
 @Component
 public class ClusterDBValidationService {
@@ -18,11 +18,11 @@ public class ClusterDBValidationService {
     @Inject
     private RdsConfigWithoutClusterService rdsConfigWithoutClusterService;
 
-    public boolean isGatewayRepairEnabled(Cluster cluster) {
-        return cluster.isEmbeddedDatabaseOnAttachedDisk() || isGatewayDatabaseAvailable(cluster);
+    public boolean isGatewayRepairEnabled(ClusterView cluster) {
+        return cluster.getEmbeddedDatabaseOnAttachedDisk() || isGatewayDatabaseAvailable(cluster);
     }
 
-    private Boolean isGatewayDatabaseAvailable(Cluster cluster) {
+    private Boolean isGatewayDatabaseAvailable(ClusterView cluster) {
         if (cluster.getDatabaseServerCrn() != null) {
             return true;
         }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterRepairService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterRepairService.java
@@ -43,10 +43,10 @@ import com.sequenceiq.cloudbreak.core.flow2.service.ReactorFlowManager;
 import com.sequenceiq.cloudbreak.domain.Resource;
 import com.sequenceiq.cloudbreak.domain.StopRestrictionReason;
 import com.sequenceiq.cloudbreak.domain.stack.ManualClusterRepairMode;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
-import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.dto.InstanceGroupDto;
+import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
 import com.sequenceiq.cloudbreak.service.StackUpdater;
 import com.sequenceiq.cloudbreak.service.cluster.model.HostGroupName;
@@ -58,9 +58,14 @@ import com.sequenceiq.cloudbreak.service.hostgroup.HostGroupService;
 import com.sequenceiq.cloudbreak.service.image.ImageCatalogService;
 import com.sequenceiq.cloudbreak.service.rdsconfig.RedbeamsClientService;
 import com.sequenceiq.cloudbreak.service.resource.ResourceService;
+import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.service.stack.StackStopRestrictionService;
+import com.sequenceiq.cloudbreak.service.stack.StackUpgradeService;
+import com.sequenceiq.cloudbreak.structuredevent.CloudbreakRestRequestThreadLocalService;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
+import com.sequenceiq.cloudbreak.view.InstanceMetadataView;
+import com.sequenceiq.cloudbreak.view.StackView;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.model.AwsDiskType;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
@@ -79,7 +84,7 @@ public class ClusterRepairService {
     private static final String RECOVERY_FAILED = "RECOVERY_FAILED";
 
     @Inject
-    private StackService stackService;
+    private StackDtoService stackDtoService;
 
     @Inject
     private StackUpdater stackUpdater;
@@ -123,9 +128,15 @@ public class ClusterRepairService {
     @Inject
     private StackStopRestrictionService stackStopRestrictionService;
 
-    public FlowIdentifier repairAll(Long stackId) {
+    @Inject
+    private StackUpgradeService stackUpgradeService;
+
+    @Inject
+    private CloudbreakRestRequestThreadLocalService restRequestThreadLocalService;
+
+    public FlowIdentifier repairAll(StackView stack) {
         Result<Map<HostGroupName, Set<InstanceMetaData>>, RepairValidation> repairStart =
-                validateRepair(ManualClusterRepairMode.ALL, stackId, Set.of(), false);
+                validateRepair(ManualClusterRepairMode.ALL, stack.getId(), Set.of(), false);
         Set<String> repairableHostGroups;
         if (repairStart.isSuccess()) {
             repairableHostGroups = repairStart.getSuccess()
@@ -136,19 +147,21 @@ public class ClusterRepairService {
         } else {
             repairableHostGroups = Set.of();
         }
-        return triggerRepairOrThrowBadRequest(stackId, repairStart, true, false, repairableHostGroups);
+        String userCrn = restRequestThreadLocalService.getUserCrn();
+        String upgradeVariant = stackUpgradeService.calculateUpgradeVariant(stack, userCrn);
+        return triggerRepairOrThrowBadRequest(stack.getId(), repairStart, true, false, repairableHostGroups, upgradeVariant);
     }
 
     public FlowIdentifier repairHostGroups(Long stackId, Set<String> hostGroups, boolean restartServices) {
         Result<Map<HostGroupName, Set<InstanceMetaData>>, RepairValidation> repairStart =
                 validateRepair(ManualClusterRepairMode.HOST_GROUP, stackId, hostGroups, false);
-        return triggerRepairOrThrowBadRequest(stackId, repairStart, false, restartServices, hostGroups);
+        return triggerRepairOrThrowBadRequest(stackId, repairStart, false, restartServices, hostGroups, null);
     }
 
     public FlowIdentifier repairNodes(Long stackId, Set<String> nodeIds, boolean deleteVolumes, boolean restartServices) {
         Result<Map<HostGroupName, Set<InstanceMetaData>>, RepairValidation> repairStart =
                 validateRepair(ManualClusterRepairMode.NODE_ID, stackId, nodeIds, deleteVolumes);
-        return triggerRepairOrThrowBadRequest(stackId, repairStart, false, restartServices, nodeIds);
+        return triggerRepairOrThrowBadRequest(stackId, repairStart, false, restartServices, nodeIds, null);
     }
 
     public Result<Map<HostGroupName, Set<InstanceMetaData>>, RepairValidation> repairWithDryRun(Long stackId) {
@@ -162,14 +175,19 @@ public class ClusterRepairService {
 
     public Result<Map<HostGroupName, Set<InstanceMetaData>>, RepairValidation> validateRepair(ManualClusterRepairMode repairMode, Long stackId,
             Set<String> selectedParts, boolean deleteVolumes) {
-        Stack stack = stackService.getByIdWithListsInTransaction(stackId);
+        StackDto stack = stackDtoService.getById(stackId);
+        return validateRepair(repairMode, stack, selectedParts, deleteVolumes);
+    }
+
+    public Result<Map<HostGroupName, Set<InstanceMetaData>>, RepairValidation> validateRepair(ManualClusterRepairMode repairMode, StackDto stack,
+            Set<String> selectedParts, boolean deleteVolumes) {
         boolean reattach = !deleteVolumes;
         Result<Map<HostGroupName, Set<InstanceMetaData>>, RepairValidation> repairStartResult;
         List<String> stoppedInstanceIds = getStoppedNotSelectedInstanceIds(stack, repairMode, selectedParts);
         if (!freeipaService.checkFreeipaRunning(stack.getEnvironmentCrn())) {
             repairStartResult = Result.error(RepairValidation
                     .of("Action cannot be performed because the FreeIPA isn't available. Please check the FreeIPA state."));
-        } else if (!environmentService.environmentStatusInDesiredState(stack, Set.of(EnvironmentStatus.AVAILABLE))) {
+        } else if (!environmentService.environmentStatusInDesiredState(stack.getStack(), Set.of(EnvironmentStatus.AVAILABLE))) {
             repairStartResult = Result.error(RepairValidation
                     .of("Action cannot be performed because the Environment isn't available. Please check the Environment state."));
         } else if (!stoppedInstanceIds.isEmpty()) {
@@ -177,7 +195,7 @@ public class ClusterRepairService {
                     .of("Action cannot be performed because there are stopped nodes in the cluster. " +
                             "Stopped nodes: [" + String.join(", ", stoppedInstanceIds) + "]. " +
                             "Please select them for repair or start the stopped nodes."));
-        } else if (!isReattachSupportedOnProvider(stack, reattach)) {
+        } else if (!isReattachSupportedOnProvider(stack.getStack(), reattach)) {
             repairStartResult = Result.error(RepairValidation
                     .of(String.format("Volume reattach currently not supported on %s platform!", stack.getPlatformVariant())));
         } else if (hasNotAvailableDatabase(stack)) {
@@ -189,7 +207,8 @@ public class ClusterRepairService {
         } else if (isAnyGWUnhealthyAndItIsNotSelected(repairMode, selectedParts, stack)) {
             repairStartResult = Result.error(RepairValidation.of("Gateway node is unhealthy, it must be repaired first."));
         } else {
-            Map<HostGroupName, Set<InstanceMetaData>> repairableNodes = selectRepairableNodes(getInstanceSelectors(repairMode, selectedParts), stack);
+            Pair<Predicate<HostGroup>, Predicate<InstanceMetaData>> instanceSelectors = getInstanceSelectors(repairMode, selectedParts);
+            Map<HostGroupName, Set<InstanceMetaData>> repairableNodes = selectRepairableNodes(instanceSelectors, stack.getStack());
             if (repairableNodes.isEmpty()) {
                 repairStartResult = Result.error(RepairValidation.of("Repairable node list is empty. Please check node statuses and try again."));
             } else {
@@ -197,7 +216,7 @@ public class ClusterRepairService {
                 if (!validationBySelectedNodes.getValidationErrors().isEmpty()) {
                     repairStartResult = Result.error(validationBySelectedNodes);
                 } else {
-                    setStackStatusAndMarkDeletableVolumes(repairMode, deleteVolumes, stack, repairableNodes);
+                    setStackStatusAndMarkDeletableVolumes(repairMode, deleteVolumes, stack.getStack(), repairableNodes);
                     repairStartResult = Result.success(repairableNodes);
                 }
             }
@@ -205,13 +224,13 @@ public class ClusterRepairService {
         return repairStartResult;
     }
 
-    private boolean isAnyGWUnhealthyAndItIsNotSelected(ManualClusterRepairMode repairMode, Set<String> selectedParts, Stack stack) {
-        List<InstanceMetaData> gatewayInstances = stack.getNotTerminatedGatewayInstanceMetadata();
+    private boolean isAnyGWUnhealthyAndItIsNotSelected(ManualClusterRepairMode repairMode, Set<String> selectedParts, StackDto stack) {
+        List<InstanceMetadataView> gatewayInstances = stack.getNotTerminatedGatewayInstanceMetadata();
         if (gatewayInstances.size() < 1) {
             LOGGER.info("Stack has no GW");
             return false;
         }
-        List<InstanceMetaData> unhealthyGWs = gatewayInstances.stream().filter(gatewayInstance -> !gatewayInstance.isHealthy()).collect(toList());
+        List<InstanceMetadataView> unhealthyGWs = gatewayInstances.stream().filter(gatewayInstance -> !gatewayInstance.isHealthy()).collect(toList());
         if (ManualClusterRepairMode.HOST_GROUP.equals(repairMode)) {
             LOGGER.info("Host group based repair mode, so GW hostgroup should be selected if any GW is not healthy. Unhealthy GWs: {}. Selected instances: {}",
                     unhealthyGWs, selectedParts);
@@ -226,7 +245,7 @@ public class ClusterRepairService {
         }
     }
 
-    private boolean isHAClusterAndRepairNotAllowed(Stack stack) {
+    private boolean isHAClusterAndRepairNotAllowed(StackDto stack) {
         String accountId = ThreadBasedUserCrnProvider.getAccountId();
         return !entitlementService.haRepairEnabled(accountId)
                 && !entitlementService.haUpgradeEnabled(accountId)
@@ -234,17 +253,17 @@ public class ClusterRepairService {
                 && hasMultipleGatewayInstances(stack);
     }
 
-    private boolean hasMultipleGatewayInstances(Stack stack) {
+    private boolean hasMultipleGatewayInstances(StackDto stack) {
         int gatewayInstanceCount = 0;
-        for (InstanceGroup instanceGroup : stack.getInstanceGroups()) {
-            if (InstanceGroupType.isGateway(instanceGroup.getInstanceGroupType())) {
+        for (InstanceGroupDto instanceGroup : stack.getInstanceGroupDtos()) {
+            if (InstanceGroupType.isGateway(instanceGroup.getInstanceGroup().getInstanceGroupType())) {
                 gatewayInstanceCount += instanceGroup.getNodeCount();
             }
         }
         return gatewayInstanceCount > 1;
     }
 
-    private boolean hasNotAvailableDatabase(Stack stack) {
+    private boolean hasNotAvailableDatabase(StackDto stack) {
         String databaseServerCrn = stack.getCluster().getDatabaseServerCrn();
         if (StringUtils.isNotBlank(databaseServerCrn)) {
             DatabaseServerV4Response databaseServerResponse = redbeamsClientService.getByCrn(databaseServerCrn);
@@ -255,26 +274,26 @@ public class ClusterRepairService {
         return false;
     }
 
-    private List<String> getStoppedNotSelectedInstanceIds(Stack stack, ManualClusterRepairMode repairMode, Set<String> selectedParts) {
+    private List<String> getStoppedNotSelectedInstanceIds(StackDto stack, ManualClusterRepairMode repairMode, Set<String> selectedParts) {
         if (ManualClusterRepairMode.HOST_GROUP.equals(repairMode)) {
-            return stack.getInstanceMetaDataAsList()
+            return stack.getNotTerminatedInstanceMetaData()
                     .stream()
-                    .filter(im -> !selectedParts.contains(im.getInstanceGroup().getGroupName()) &&
+                    .filter(im -> !selectedParts.contains(im.getInstanceGroupName()) &&
                             InstanceStatus.STOPPED.equals(im.getInstanceStatus()))
-                    .map(InstanceMetaData::getInstanceId)
+                    .map(InstanceMetadataView::getInstanceId)
                     .collect(Collectors.toList());
         } else if (ManualClusterRepairMode.NODE_ID.equals(repairMode)) {
-            return stack.getInstanceMetaDataAsList()
+            return stack.getNotTerminatedInstanceMetaData()
                     .stream()
                     .filter(im -> !selectedParts.contains(im.getInstanceId()) &&
                             InstanceStatus.STOPPED.equals(im.getInstanceStatus()))
-                    .map(InstanceMetaData::getInstanceId)
+                    .map(InstanceMetadataView::getInstanceId)
                     .collect(Collectors.toList());
         }
         return Collections.emptyList();
     }
 
-    private boolean isReattachSupportedOnProvider(Stack stack, boolean repairWithReattach) {
+    private boolean isReattachSupportedOnProvider(StackView stack, boolean repairWithReattach) {
         return !repairWithReattach || StackService.REATTACH_COMPATIBLE_PLATFORMS.contains(stack.getPlatformVariant());
     }
 
@@ -314,8 +333,8 @@ public class ClusterRepairService {
 
     private Map<HostGroupName, Set<InstanceMetaData>> selectRepairableNodes(
             Pair<Predicate<HostGroup>, Predicate<InstanceMetaData>> instanceSelectors,
-            Stack stack) {
-        return hostGroupService.getByCluster(stack.getCluster().getId())
+            StackView stack) {
+        return hostGroupService.getByCluster(stack.getClusterId())
                 .stream()
                 .filter(hostGroup -> RecoveryMode.MANUAL.equals(hostGroup.getRecoveryMode()))
                 .filter(instanceSelectors.getLeft())
@@ -330,7 +349,7 @@ public class ClusterRepairService {
                 .collect(toMap(Entry::getKey, Entry::getValue));
     }
 
-    private RepairValidation validateSelectedNodes(Stack stack, Map<HostGroupName, Set<InstanceMetaData>> nodesToRepair, boolean reattach) {
+    private RepairValidation validateSelectedNodes(StackDto stack, Map<HostGroupName, Set<InstanceMetaData>> nodesToRepair, boolean reattach) {
         return new RepairValidation(nodesToRepair
                 .entrySet()
                 .stream()
@@ -340,7 +359,7 @@ public class ClusterRepairService {
         );
     }
 
-    private List<String> validateRepairableNodes(Stack stack, HostGroupName hostGroupName, Set<InstanceMetaData> instances, boolean reattach) {
+    private List<String> validateRepairableNodes(StackDto stack, HostGroupName hostGroupName, Set<InstanceMetaData> instances, boolean reattach) {
         List<String> validationResult = new ArrayList<>();
         if (reattach) {
             for (InstanceMetaData instanceMetaData : instances) {
@@ -353,10 +372,10 @@ public class ClusterRepairService {
         return validationResult;
     }
 
-    private List<String> validateOnGateway(Stack stack, InstanceMetaData instanceMetaData) {
+    private List<String> validateOnGateway(StackDto stack, InstanceMetadataView instanceMetaData) {
         List<String> validationResult = new ArrayList<>();
-        if (instanceMetaData.isGateway()) {
-            if (isCreatedFromBaseImage(stack)) {
+        if (instanceMetaData.isGatewayOrPrimaryGateway()) {
+            if (isCreatedFromBaseImage(stack.getStack())) {
                 validationResult.add("Action is only supported if the image already contains Cloudera Manager and Cloudera Data Platform artifacts.");
             }
             if (!clusterDBValidationService.isGatewayRepairEnabled(stack.getCluster())) {
@@ -367,17 +386,17 @@ public class ClusterRepairService {
         return validationResult;
     }
 
-    private boolean isCreatedFromBaseImage(Stack stack) {
+    private boolean isCreatedFromBaseImage(StackView stack) {
         try {
             Image image = componentConfigProviderService.getImage(stack.getId());
-            return !imageCatalogService.getImage(stack.getWorkspace().getId(), image.getImageCatalogUrl(), image.getImageCatalogName(),
+            return !imageCatalogService.getImage(stack.getWorkspaceId(), image.getImageCatalogUrl(), image.getImageCatalogName(),
                     image.getImageId()).getImage().isPrewarmed();
         } catch (CloudbreakImageNotFoundException | CloudbreakImageCatalogException e) {
             throw new BadRequestException(e.getMessage(), e);
         }
     }
 
-    private void updateVolumesDeleteFlag(Stack stack, Predicate<Resource> resourceFilter, boolean deleteVolumes) {
+    private void updateVolumesDeleteFlag(StackView stack, Predicate<Resource> resourceFilter, boolean deleteVolumes) {
         List<Resource> volumes = resourceService.findByStackIdAndType(stack.getId(), stack.getDiskResourceType());
         volumes = volumes.stream()
                 .filter(resourceFilter)
@@ -407,7 +426,7 @@ public class ClusterRepairService {
         return volumeSet;
     }
 
-    private void setStackStatusAndMarkDeletableVolumes(ManualClusterRepairMode repairMode, boolean deleteVolumes, Stack stack,
+    private void setStackStatusAndMarkDeletableVolumes(ManualClusterRepairMode repairMode, boolean deleteVolumes, StackView stack,
             Map<HostGroupName, Set<InstanceMetaData>> nodesToRepair) {
         if (!ManualClusterRepairMode.DRY_RUN.equals(repairMode) && !nodesToRepair.isEmpty()) {
             LOGGER.info("Repair mode is not a dry run, {}", repairMode);
@@ -423,8 +442,9 @@ public class ClusterRepairService {
         }
     }
 
-    private FlowIdentifier triggerRepairOrThrowBadRequest(Long stackId, Result<Map<HostGroupName, Set<InstanceMetaData>>,
-            RepairValidation> repairValidationResult, boolean oneNodeFromEachHostGroupAtOnce, boolean restartServices, Set<String> recoveryMessageArgument) {
+    private FlowIdentifier triggerRepairOrThrowBadRequest(Long stackId,
+            Result<Map<HostGroupName, Set<InstanceMetaData>>, RepairValidation> repairValidationResult, boolean oneNodeFromEachHostGroupAtOnce,
+            boolean restartServices, Set<String> recoveryMessageArgument, String upgradeVariant) {
         if (repairValidationResult.isError()) {
             eventService.fireCloudbreakEvent(stackId, RECOVERY_FAILED, CLUSTER_MANUALRECOVERY_COULD_NOT_START,
                     repairValidationResult.getError().getValidationErrors());
@@ -432,7 +452,7 @@ public class ClusterRepairService {
         } else {
             if (!repairValidationResult.getSuccess().isEmpty()) {
                 FlowIdentifier flowIdentifier = flowManager.triggerClusterRepairFlow(stackId, toStringMap(repairValidationResult.getSuccess()),
-                        oneNodeFromEachHostGroupAtOnce, restartServices);
+                        oneNodeFromEachHostGroupAtOnce, restartServices, upgradeVariant);
                 eventService.fireCloudbreakEvent(stackId, RECOVERY, CLUSTER_MANUALRECOVERY_REQUESTED,
                         List.of(String.join(",", recoveryMessageArgument)));
                 return flowIdentifier;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackUpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackUpgradeService.java
@@ -1,0 +1,30 @@
+package com.sequenceiq.cloudbreak.service.stack;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
+import com.sequenceiq.cloudbreak.cloud.aws.common.AwsConstants;
+import com.sequenceiq.cloudbreak.view.StackView;
+
+@Component
+public class StackUpgradeService {
+
+    @Inject
+    private EntitlementService entitlementService;
+
+    public String calculateUpgradeVariant(StackView stack, String userCrn) {
+        String variant = stack.getPlatformVariant();
+        String accountId = Crn.safeFromString(userCrn).getAccountId();
+        boolean migrationEnable = entitlementService.awsVariantMigrationEnable(accountId);
+        if (migrationEnable) {
+            if (AwsConstants.AwsVariant.AWS_VARIANT.variant().value().equals(variant)) {
+                variant = AwsConstants.AwsVariant.AWS_NATIVE_VARIANT.variant().value();
+            }
+        }
+        return variant;
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ImageFilterParamsFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ImageFilterParamsFactory.java
@@ -18,6 +18,7 @@ import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.view.ClusterComponentView;
+import com.sequenceiq.cloudbreak.dto.StackDtoDelegate;
 import com.sequenceiq.cloudbreak.service.image.PlatformStringTransformer;
 import com.sequenceiq.cloudbreak.service.parcel.ParcelService;
 import com.sequenceiq.cloudbreak.service.upgrade.image.ImageFilterParams;
@@ -42,9 +43,9 @@ public class ImageFilterParamsFactory {
                 stack.getPlatformVariant()), stack.cloudPlatform(), stack.getRegion());
     }
 
-    public Map<String, String> getStackRelatedParcels(Stack stack) {
+    public Map<String, String> getStackRelatedParcels(StackDtoDelegate stack) {
         Set<ClusterComponentView> componentsByBlueprint = parcelService.getParcelComponentsByBlueprint(stack);
-        if (stack.isDatalake()) {
+        if (stack.getStack().isDatalake()) {
             ClouderaManagerProduct stackProduct = getCdhProduct(componentsByBlueprint);
             LOGGER.debug("For datalake clusters only the CDH parcel is related in CM: {}", stackProduct);
             return Map.of(stackProduct.getName(), stackProduct.getVersion());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/locked/LockedComponentService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/locked/LockedComponentService.java
@@ -7,7 +7,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.cloud.model.Image;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.service.CloudbreakRuntimeException;
 import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
 import com.sequenceiq.cloudbreak.service.image.ImageCatalogService;
@@ -30,9 +30,9 @@ public class LockedComponentService {
     @Inject
     private ImageFilterParamsFactory imageFilterParamsFactory;
 
-    public boolean isComponentsLocked(Stack stack, String targetImageId) {
+    public boolean isComponentsLocked(StackDto stack, String targetImageId) {
         try {
-            Long workspaceId = stack.getWorkspace().getId();
+            Long workspaceId = stack.getWorkspaceId();
             Image currentImage = componentConfigProviderService.getImage(stack.getId());
             com.sequenceiq.cloudbreak.cloud.model.catalog.Image currentCatalogImage = imageCatalogService
                     .getImage(workspaceId, currentImage.getImageCatalogUrl(), currentImage.getImageCatalogName(), currentImage.getImageId())

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackUpgradeOperations.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackUpgradeOperations.java
@@ -74,25 +74,25 @@ public class StackUpgradeOperations {
     @Inject
     private StackOperations stackOperations;
 
-    public FlowIdentifier upgradeOs(@NotNull NameOrCrn nameOrCrn, Long workspaceId) {
+    public FlowIdentifier upgradeOs(@NotNull NameOrCrn nameOrCrn, String accountId) {
         LOGGER.debug("Starting to upgrade OS: " + nameOrCrn);
-        return upgradeService.upgradeOs(workspaceId, nameOrCrn);
+        return upgradeService.upgradeOs(accountId, nameOrCrn);
     }
 
-    public FlowIdentifier upgradeCluster(@NotNull NameOrCrn nameOrCrn, Long workspaceId, String imageId) {
+    public FlowIdentifier upgradeCluster(@NotNull NameOrCrn nameOrCrn, String accountId, String imageId) {
         LOGGER.debug("Starting to upgrade cluster: " + nameOrCrn);
-        return upgradeService.upgradeCluster(workspaceId, nameOrCrn, imageId);
+        return upgradeService.upgradeCluster(accountId, nameOrCrn, imageId);
     }
 
-    public FlowIdentifier prepareClusterUpgrade(@NotNull NameOrCrn nameOrCrn, Long workspaceId, String imageId) {
+    public FlowIdentifier prepareClusterUpgrade(@NotNull NameOrCrn nameOrCrn, String accountId, String imageId) {
         LOGGER.debug("Starting to prepare upgrade for cluster: " + nameOrCrn);
-        return upgradeService.prepareClusterUpgrade(workspaceId, nameOrCrn, imageId);
+        return upgradeService.prepareClusterUpgrade(accountId, nameOrCrn, imageId);
     }
 
-    public UpgradeOptionV4Response checkForOsUpgrade(@NotNull NameOrCrn nameOrCrn, CloudbreakUser cloudbreakUser, Long workspaceId) {
+    public UpgradeOptionV4Response checkForOsUpgrade(@NotNull NameOrCrn nameOrCrn, CloudbreakUser cloudbreakUser, String accountId) {
         User user = userService.getOrCreate(cloudbreakUser);
         if (nameOrCrn.hasName()) {
-            return upgradeService.getOsUpgradeOptionByStackNameOrCrn(workspaceId, nameOrCrn, user);
+            return upgradeService.getOsUpgradeOptionByStackNameOrCrn(accountId, nameOrCrn, user);
         } else {
             LOGGER.debug("No stack name provided for upgrade, found: " + nameOrCrn);
             throw new BadRequestException("Please provide a stack name for upgrade");

--- a/core/src/test/java/com/sequenceiq/cloudbreak/controller/v4/StackV4ControllerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/controller/v4/StackV4ControllerTest.java
@@ -112,8 +112,8 @@ class StackV4ControllerTest {
     public void testPrepareClusterUpgradeByCrnInternal() {
         String imageId = "imageId";
         FlowIdentifier flowIdentifier = new FlowIdentifier(FlowType.FLOW, "pollId");
-        when(stackUpgradeOperations.prepareClusterUpgrade(NameOrCrn.ofCrn(STACK_CRN), WORKSPACE_ID, imageId))
-                .thenReturn(flowIdentifier);
+        when(restRequestThreadLocalService.getAccountId()).thenReturn(ACCOUNT_ID);
+        when(stackUpgradeOperations.prepareClusterUpgrade(NameOrCrn.ofCrn(STACK_CRN), ACCOUNT_ID, imageId)).thenReturn(flowIdentifier);
 
         FlowIdentifier result = underTest.prepareClusterUpgradeByCrnInternal(WORKSPACE_ID, STACK_CRN, imageId, USER_CRN);
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
@@ -140,7 +140,7 @@ public class ReactorFlowManagerTest {
         underTest.triggerManualRepairFlow(STACK_ID);
         underTest.triggerStackRepairFlow(STACK_ID, new UnhealthyInstances());
         underTest.triggerClusterRepairFlow(STACK_ID, new HashMap<>(), false);
-        underTest.triggerClusterRepairFlow(STACK_ID, new HashMap<>(), true, false);
+        underTest.triggerClusterRepairFlow(STACK_ID, new HashMap<>(), true, false, "variant");
         underTest.triggerStackImageUpdate(new ImageChangeDto(STACK_ID, "asdf"));
         underTest.triggerMaintenanceModeValidationFlow(STACK_ID);
         underTest.triggerClusterCertificationRenewal(STACK_ID);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterRepairFlowEventChainFactoryTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterRepairFlowEventChainFactoryTest.java
@@ -42,17 +42,16 @@ import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
-import com.sequenceiq.cloudbreak.domain.view.ClusterView;
 import com.sequenceiq.cloudbreak.domain.view.InstanceGroupView;
-import com.sequenceiq.cloudbreak.domain.view.StackView;
 import com.sequenceiq.cloudbreak.kerberos.KerberosConfigService;
 import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.ClusterRepairTriggerEvent;
 import com.sequenceiq.cloudbreak.service.blueprint.BlueprintService;
 import com.sequenceiq.cloudbreak.service.hostgroup.HostGroupService;
 import com.sequenceiq.cloudbreak.service.stack.InstanceGroupService;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
+import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
-import com.sequenceiq.cloudbreak.service.stack.StackViewService;
+import com.sequenceiq.cloudbreak.view.StackView;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
@@ -80,7 +79,7 @@ public class ClusterRepairFlowEventChainFactoryTest {
     private StackService stackService;
 
     @Mock
-    private StackViewService stackViewService;
+    private StackDtoService stackDtoService;
 
     @Mock
     private HostGroupService hostGroupService;
@@ -357,7 +356,7 @@ public class ClusterRepairFlowEventChainFactoryTest {
         Queue<Selectable> flowTriggers = new ConcurrentLinkedDeque<>();
         String groupName = "groupName";
         StackView stackView = setupStackView();
-        ClusterRepairTriggerEvent triggerEvent = new ClusterRepairTriggerEvent(stackView.getId(), Map.of(), false, false);
+        ClusterRepairTriggerEvent triggerEvent = new ClusterRepairTriggerEvent(stackView.getId(), Map.of(), false, false, "variant");
 
         underTest.addAwsNativeEventMigrationIfNeeded(flowTriggers, triggerEvent, groupName, stackView);
 
@@ -449,16 +448,14 @@ public class ClusterRepairFlowEventChainFactoryTest {
 
     private StackView setupStackView() {
         StackView stack = mock(StackView.class);
-        ClusterView cluster = mock(ClusterView.class);
-        when(stack.getClusterView()).thenReturn(cluster);
+        when(stack.getClusterId()).thenReturn(CLUSTER_ID);
         when(stack.getId()).thenReturn(STACK_ID);
-        when(cluster.getId()).thenReturn(CLUSTER_ID);
         Crn exampleCrn = CrnTestUtil.getDatalakeCrnBuilder()
                 .setResource("aResource")
                 .setAccountId("anAccountId")
                 .build();
         when(stack.getResourceCrn()).thenReturn(exampleCrn.toString());
-        when(stackViewService.getById(STACK_ID)).thenReturn(stack);
+        when(stackDtoService.getStackViewById(STACK_ID)).thenReturn(stack);
         return stack;
     }
 
@@ -536,7 +533,7 @@ public class ClusterRepairFlowEventChainFactoryTest {
                 failedNodes.put("hostGroup-auxiliary", failedAuxiliaryNodes);
             }
 
-            return new ClusterRepairTriggerEvent(stack.getId(), failedNodes, oneNodeFromEachHostGroupAtOnce, false);
+            return new ClusterRepairTriggerEvent(stack.getId(), failedNodes, oneNodeFromEachHostGroupAtOnce, false, "variant");
         }
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpgradeDistroxFlowEventChainFactoryTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpgradeDistroxFlowEventChainFactoryTest.java
@@ -10,6 +10,7 @@ import static com.sequenceiq.cloudbreak.core.flow2.cluster.salt.update.SaltUpdat
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -76,7 +77,7 @@ class UpgradeDistroxFlowEventChainFactoryTest {
     public void testChainQueueForReplaceVms() {
         ReflectionTestUtils.setField(underTest, "upgradeValidationEnabled", true);
         Result<Map<HostGroupName, Set<InstanceMetaData>>, RepairValidation> repairStartResult = Result.success(new HashMap<>());
-        when(clusterRepairService.validateRepair(any(), any(), any(), eq(false))).thenReturn(repairStartResult);
+        when(clusterRepairService.validateRepair(any(), anyLong(), any(), eq(false))).thenReturn(repairStartResult);
 
         DistroXUpgradeTriggerEvent event = new DistroXUpgradeTriggerEvent(FlowChainTriggers.DISTROX_CLUSTER_UPGRADE_CHAIN_TRIGGER_EVENT, STACK_ID,
                 imageChangeDto, true, true, "variant");

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/StackUpgradeServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/StackUpgradeServiceTest.java
@@ -1,0 +1,68 @@
+package com.sequenceiq.cloudbreak.service.stack;
+
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.workspace.model.Tenant;
+import com.sequenceiq.cloudbreak.workspace.model.Workspace;
+
+@ExtendWith(MockitoExtension.class)
+public class StackUpgradeServiceTest {
+
+    private static final String ACCOUNT_ID = "9d74eee4-1cad-45d7-b645-7ccf9edbb73d";
+
+    private static final String USER_CRN = "crn:cdp:iam:us-west-1:9d74eee4-1cad-45d7-b645-7ccf9edbb73d:user:f3b8ed82-e712-4f89-bda7-be07183720d3";
+
+    private static final Long STACK_ID = 3L;
+
+    @InjectMocks
+    private StackUpgradeService underTest;
+
+    @Mock
+    private EntitlementService entitlementService;
+
+    private Stack stack;
+
+    @BeforeEach
+    public void setup() {
+        stack = new Stack();
+        stack.setId(STACK_ID);
+        stack.setPlatformVariant("variant");
+        Workspace workspace = new Workspace();
+        workspace.setTenant(new Tenant());
+        stack.setWorkspace(workspace);
+    }
+
+    @Test
+    public void testCalculateUpgradeVariantWhenMigrationDisabled() {
+        stack.setPlatformVariant("AWS");
+        when(entitlementService.awsVariantMigrationEnable(ACCOUNT_ID)).thenReturn(false);
+        String actual = underTest.calculateUpgradeVariant(stack, USER_CRN);
+        Assertions.assertEquals("AWS", actual);
+    }
+
+    @Test
+    public void testCalculateUpgradeVariantWhenMigrationEnabledAndVariantIsAws() {
+        stack.setPlatformVariant("AWS");
+        when(entitlementService.awsVariantMigrationEnable(ACCOUNT_ID)).thenReturn(true);
+        String actual = underTest.calculateUpgradeVariant(stack, USER_CRN);
+        Assertions.assertEquals("AWS_NATIVE", actual);
+    }
+
+    @Test
+    public void testCalculateUpgradeVariantWhenMigrationEnabledWhenVariantIsNotAWS() {
+        stack.setPlatformVariant("GCP");
+        when(entitlementService.awsVariantMigrationEnable(ACCOUNT_ID)).thenReturn(true);
+        String actual = underTest.calculateUpgradeVariant(stack, USER_CRN);
+        Assertions.assertEquals("GCP", actual);
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/locked/LockedComponentServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/locked/LockedComponentServiceTest.java
@@ -19,12 +19,11 @@ import org.mockito.junit.MockitoJUnitRunner;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
 import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
 import com.sequenceiq.cloudbreak.service.image.ImageCatalogService;
 import com.sequenceiq.cloudbreak.service.image.StatedImage;
 import com.sequenceiq.cloudbreak.service.upgrade.ImageFilterParamsFactory;
-import com.sequenceiq.cloudbreak.workspace.model.Workspace;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LockedComponentServiceTest {
@@ -58,16 +57,14 @@ public class LockedComponentServiceTest {
     @Mock
     private ImageCatalogService imageCatalogService;
 
-    private Stack stack;
+    @Mock
+    private StackDto stack;
 
     @Before
     public void setup() {
-        stack = new Stack();
-        stack.setId(STACK_ID);
-
-        Workspace workspace = new Workspace();
-        workspace.setId(WORKSPACE_ID);
-        stack.setWorkspace(workspace);
+        stack = mock(StackDto.class);
+        when(stack.getId()).thenReturn(STACK_ID);
+        when(stack.getWorkspaceId()).thenReturn(WORKSPACE_ID);
     }
 
     @Test

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/StackUpgradeOperationsTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/StackUpgradeOperationsTest.java
@@ -113,14 +113,14 @@ class StackUpgradeOperationsTest {
 
     @Test
     void testUpgradeOsShouldCallUpgradeService() {
-        underTest.upgradeOs(nameOrCrn, WORKSPACE_ID);
-        verify(upgradeService).upgradeOs(WORKSPACE_ID, nameOrCrn);
+        underTest.upgradeOs(nameOrCrn, ACCOUNT_ID);
+        verify(upgradeService).upgradeOs(ACCOUNT_ID, nameOrCrn);
     }
 
     @Test
     void testUpgradeClusterShouldCallUpgradeService() {
-        underTest.upgradeCluster(nameOrCrn, WORKSPACE_ID, IMAGE_ID);
-        verify(upgradeService).upgradeCluster(WORKSPACE_ID, nameOrCrn, IMAGE_ID);
+        underTest.upgradeCluster(nameOrCrn, ACCOUNT_ID, IMAGE_ID);
+        verify(upgradeService).upgradeCluster(ACCOUNT_ID, nameOrCrn, IMAGE_ID);
     }
 
     @Test
@@ -128,17 +128,17 @@ class StackUpgradeOperationsTest {
         User user = new User();
         when(userService.getOrCreate(cloudbreakUser)).thenReturn(user);
 
-        underTest.checkForOsUpgrade(nameOrCrn, cloudbreakUser, WORKSPACE_ID);
+        underTest.checkForOsUpgrade(nameOrCrn, cloudbreakUser, ACCOUNT_ID);
 
         verify(userService).getOrCreate(cloudbreakUser);
-        verify(upgradeService).getOsUpgradeOptionByStackNameOrCrn(WORKSPACE_ID, nameOrCrn, user);
+        verify(upgradeService).getOsUpgradeOptionByStackNameOrCrn(ACCOUNT_ID, nameOrCrn, user);
     }
 
     @Test
     void testCheckForOsUpgradeShouldThrowExceptionWhenTheClusterNameIsNotAvailable() {
         when(userService.getOrCreate(cloudbreakUser)).thenReturn(new User());
 
-        assertThrows(BadRequestException.class, () -> underTest.checkForOsUpgrade(NameOrCrn.ofCrn("crn"), cloudbreakUser, WORKSPACE_ID));
+        assertThrows(BadRequestException.class, () -> underTest.checkForOsUpgrade(NameOrCrn.ofCrn("crn"), cloudbreakUser, ACCOUNT_ID));
 
         verify(userService).getOrCreate(cloudbreakUser);
         verifyNoInteractions(upgradeService);
@@ -353,9 +353,9 @@ class StackUpgradeOperationsTest {
     @Test
     public void testPrepareUpgrade() {
         FlowIdentifier flowIdentifier = new FlowIdentifier(FlowType.FLOW, "pollId");
-        when(upgradeService.prepareClusterUpgrade(WORKSPACE_ID, nameOrCrn, IMAGE_ID)).thenReturn(flowIdentifier);
+        when(upgradeService.prepareClusterUpgrade(ACCOUNT_ID, nameOrCrn, IMAGE_ID)).thenReturn(flowIdentifier);
 
-        FlowIdentifier result = underTest.prepareClusterUpgrade(nameOrCrn, WORKSPACE_ID, IMAGE_ID);
+        FlowIdentifier result = underTest.prepareClusterUpgrade(nameOrCrn, ACCOUNT_ID, IMAGE_ID);
 
         assertEquals(flowIdentifier, result);
     }

--- a/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/CloudbreakRestRequestThreadLocalService.java
+++ b/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/CloudbreakRestRequestThreadLocalService.java
@@ -67,4 +67,8 @@ public class CloudbreakRestRequestThreadLocalService implements LegacyRestReques
     public String getAccountId() {
         return ThreadBasedUserCrnProvider.getAccountId();
     }
+
+    public String getUserCrn() {
+        return ThreadBasedUserCrnProvider.getUserCrn();
+    }
 }


### PR DESCRIPTION
…nt.  entitlement should also trigger the variant migration in case of DL OS upgrade.

The Entitlement of migration: CDP_CB_AWS_VARIANT_MIGRATION
During the Datalake upgrade, between the downscale and upscale we run the migration if it is not already done:
* create the new security groups and load balancers if these are missing.
* when all the instance groups are downscaled/upscaled we delete the cloudformation with the related resources
* the variant of the stack is changed to AWS_NATIVE

The PR contains a minor refactor, the stack fetched changed to the new way, because we need to avoid and eliminate the multiple stacks fetching in one stack trace.