### PR TITLE
CB-18191 Handle `null` runtime in `DatabaseDefaultVersionProvider`

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/service/database/DatabaseDefaultVersionProvider.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/service/database/DatabaseDefaultVersionProvider.java
@@ -25,7 +25,7 @@ public class DatabaseDefaultVersionProvider {
         if (StringUtils.isNotBlank(requestedDbEngineVersion)) {
             LOGGER.debug("DB engine version already requested to be [{}]", requestedDbEngineVersion);
             return requestedDbEngineVersion;
-        } else {
+        } else if (StringUtils.isNotBlank(runtime)) {
             if (0 <= versionComparator.compare(() -> runtime, () -> minRuntimeVersion)) {
                 LOGGER.debug("Setting DB engine version to [{}] for runtime [{}]", dbEngineVersion, runtime);
                 return dbEngineVersion;
@@ -33,6 +33,9 @@ public class DatabaseDefaultVersionProvider {
                 LOGGER.debug("Setting DB engine version to 'null' for runtime [{}]", runtime);
                 return null;
             }
+        } else {
+            LOGGER.warn("Runtime is null, cannot provide default db engine version. Setting it to 'null'");
+            return null;
         }
     }
 }

--- a/common/src/test/java/com/sequenceiq/cloudbreak/service/database/DatabaseDefaultVersionProviderTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/service/database/DatabaseDefaultVersionProviderTest.java
@@ -24,6 +24,8 @@ class DatabaseDefaultVersionProviderTest {
                 {"Version not set, runtime older", "7.2.10", null, "7.2.12", "11", null},
                 {"Version not set, runtime same", "7.2.12", null, "7.2.12", "11", "11"},
                 {"Version not set, runtime newer", "7.2.14", null, "7.2.12", "11", "11"},
+                {"Version not set, runtime null", null, null, "7.2.12", "11", null},
+                {"Version already set, runtime null", null, "10", "7.2.12", "11", "10"},
         };
     }
 


### PR DESCRIPTION
In some edge cases runtime version is not available to define the default db engine version.
In these cases we leave it as null and go with the default version.

See detailed description in the commit message.