### PR TITLE
CB-18195 `BlueprintUtilV4Endpoint.createRecommendationByCredCrn` yields…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/BlueprintUtilV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/BlueprintUtilV4Controller.java
@@ -92,7 +92,7 @@ public class BlueprintUtilV4Controller extends NotificationController implements
     @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.DESCRIBE_CREDENTIAL)
     public RecommendationV4Response createRecommendationByCredCrn(Long workspaceId, String blueprintName,
             @TenantAwareParam @ResourceCrn String credentialCrn, String region, String platformVariant,
-            String availabilityZone, CdpResourceType cdpResourceType) {
+            String availabilityZone, CdpResourceType resourceType) {
         PlatformRecommendation recommendation = blueprintService.getRecommendationByCredentialCrn(
                 threadLocalService.getRequestedWorkspaceId(),
                 blueprintName,
@@ -100,7 +100,7 @@ public class BlueprintUtilV4Controller extends NotificationController implements
                 region,
                 platformVariant,
                 availabilityZone,
-                cdpResourceType);
+                resourceType);
         return platformRecommendationToPlatformRecommendationV4ResponseConverter.convert(recommendation);
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/controller/v4/BlueprintUtilV4ControllerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/controller/v4/BlueprintUtilV4ControllerTest.java
@@ -1,0 +1,89 @@
+package com.sequenceiq.cloudbreak.controller.v4;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.blueprint.responses.RecommendationV4Response;
+import com.sequenceiq.cloudbreak.cloud.model.PlatformRecommendation;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateGeneratorService;
+import com.sequenceiq.cloudbreak.converter.v4.clustertemplate.GeneratedCmTemplateToGeneratedCmTemplateV4Response;
+import com.sequenceiq.cloudbreak.converter.v4.clustertemplate.PlatformRecommendationToPlatformRecommendationV4ResponseConverter;
+import com.sequenceiq.cloudbreak.converter.v4.clustertemplate.ScaleRecommendationToScaleRecommendationV4ResponseConverter;
+import com.sequenceiq.cloudbreak.converter.v4.clustertemplate.ServiceDependencyMatrixToServiceDependencyMatrixV4Response;
+import com.sequenceiq.cloudbreak.converter.v4.clustertemplate.SupportedServicesToBlueprintServicesV4ResponseConverter;
+import com.sequenceiq.cloudbreak.converter.v4.clustertemplate.SupportedVersionsToSupportedVersionsV4ResponseConverter;
+import com.sequenceiq.cloudbreak.service.blueprint.BlueprintService;
+import com.sequenceiq.cloudbreak.structuredevent.CloudbreakRestRequestThreadLocalService;
+import com.sequenceiq.common.api.type.CdpResourceType;
+
+@ExtendWith(MockitoExtension.class)
+class BlueprintUtilV4ControllerTest {
+
+    private static final Long WORKSPACE_ID = 12L;
+
+    private static final String BLUEPRINT_NAME = "blueprintName";
+
+    private static final String CREDENTIAL_CRN = "credentialCrn";
+
+    private static final String REGION = "region";
+
+    private static final String PLATFORM_VARIANT = "platformVariant";
+
+    private static final String AVAILABILITY_ZONE = "availabilityZone";
+
+    private static final CdpResourceType RESOURCE_TYPE = CdpResourceType.DATAHUB;
+
+    @Mock
+    private CmTemplateGeneratorService clusterTemplateGeneratorService;
+
+    @Mock
+    private BlueprintService blueprintService;
+
+    @Mock
+    private CloudbreakRestRequestThreadLocalService threadLocalService;
+
+    @Mock
+    private ScaleRecommendationToScaleRecommendationV4ResponseConverter scaleRecommendationToScaleRecommendationV4ResponseConverter;
+
+    @Mock
+    private PlatformRecommendationToPlatformRecommendationV4ResponseConverter platformRecommendationToPlatformRecommendationV4ResponseConverter;
+
+    @Mock
+    private ServiceDependencyMatrixToServiceDependencyMatrixV4Response serviceDependencyMatrixToServiceDependencyMatrixV4Response;
+
+    @Mock
+    private SupportedVersionsToSupportedVersionsV4ResponseConverter supportedVersionsToSupportedVersionsV4ResponseConverter;
+
+    @Mock
+    private SupportedServicesToBlueprintServicesV4ResponseConverter supportedServicesToBlueprintServicesV4ResponseConverter;
+
+    @Mock
+    private GeneratedCmTemplateToGeneratedCmTemplateV4Response generatedCmTemplateToGeneratedCmTemplateV4Response;
+
+    @InjectMocks
+    private BlueprintUtilV4Controller underTest;
+
+    @Mock
+    private PlatformRecommendation recommendation;
+
+    @Test
+    void createRecommendationByCredCrnTest() {
+        when(threadLocalService.getRequestedWorkspaceId()).thenReturn(WORKSPACE_ID);
+        when(blueprintService.getRecommendationByCredentialCrn(WORKSPACE_ID, BLUEPRINT_NAME, CREDENTIAL_CRN, REGION, PLATFORM_VARIANT, AVAILABILITY_ZONE,
+                RESOURCE_TYPE)).thenReturn(recommendation);
+        RecommendationV4Response recommendationV4Response = new RecommendationV4Response();
+        when(platformRecommendationToPlatformRecommendationV4ResponseConverter.convert(recommendation)).thenReturn(recommendationV4Response);
+
+        RecommendationV4Response result = underTest.createRecommendationByCredCrn(WORKSPACE_ID, BLUEPRINT_NAME, CREDENTIAL_CRN, REGION,
+                PLATFORM_VARIANT, AVAILABILITY_ZONE, RESOURCE_TYPE);
+
+        assertThat(result).isSameAs(recommendationV4Response);
+    }
+
+}

--- a/template-manager-cmtemplate/src/test/resources/input/namenode-ha-single-worker-with-knox-of-0.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/namenode-ha-single-worker-with-knox-of-0.bp
@@ -1,0 +1,99 @@
+{
+  "cdhVersion": "6.1.0",
+  "displayName": "simple_template",
+  "cmVersion": "6.1.0",
+  "repositories": [
+    "https://archive.cloudera.com/cdh6/{latest_supported}/parcels/"
+  ],
+  "products": [
+    {
+      "version": "6.1.0-1.cdh6.1.0.p0.770702",
+      "product": "CDH"
+    }
+  ],
+  "services": [
+    {
+      "refName": "zookeeper",
+      "serviceType": "ZOOKEEPER",
+      "roleConfigGroups": [
+        {
+          "refName": "zookeeper-SERVER-BASE",
+          "roleType": "SERVER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "hdfs",
+      "serviceType": "HDFS",
+      "roleConfigGroups": [
+        {
+          "refName": "hdfs-NAMENODE-BASE",
+          "roleType": "NAMENODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-DATANODE-BASE",
+          "roleType": "DATANODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-JOURNALNODE-BASE",
+          "roleType": "JOURNALNODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-FAILOVERCONTROLLER-BASE",
+          "roleType": "FAILOVERCONTROLLER",
+          "base": true
+        },
+        {
+          "refName": "hdfs-BALANCER-BASE",
+          "roleType": "BALANCER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "knox",
+      "roleConfigGroups": [
+        {
+          "base": true,
+          "refName": "knox-KNOX_GATEWAY-BASE",
+          "roleType": "KNOX_GATEWAY"
+        }
+      ],
+      "serviceType": "KNOX"
+    }
+  ],
+  "hostTemplates": [
+    {
+      "refName": "master",
+      "cardinality": 2,
+      "roleConfigGroupsRefNames": [
+        "hdfs-NAMENODE-BASE"
+      ]
+    },
+    {
+      "refName": "quorum",
+      "cardinality": 3,
+      "roleConfigGroupsRefNames": [
+        "zookeeper-SERVER-BASE"
+      ]
+    },
+    {
+      "refName": "worker",
+      "cardinality": 1,
+      "roleConfigGroupsRefNames": [
+        "hdfs-DATANODE-BASE"
+      ]
+    },
+    {
+      "refName": "zero",
+      "cardinality": 0,
+      "roleConfigGroupsRefNames": [
+        "knox-KNOX_GATEWAY-BASE"
+      ]
+    }
+  ]
+}

--- a/template-manager-cmtemplate/src/test/resources/input/namenode-ha-single-worker-with-knox-of-2.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/namenode-ha-single-worker-with-knox-of-2.bp
@@ -1,0 +1,99 @@
+{
+  "cdhVersion": "6.1.0",
+  "displayName": "simple_template",
+  "cmVersion": "6.1.0",
+  "repositories": [
+    "https://archive.cloudera.com/cdh6/{latest_supported}/parcels/"
+  ],
+  "products": [
+    {
+      "version": "6.1.0-1.cdh6.1.0.p0.770702",
+      "product": "CDH"
+    }
+  ],
+  "services": [
+    {
+      "refName": "zookeeper",
+      "serviceType": "ZOOKEEPER",
+      "roleConfigGroups": [
+        {
+          "refName": "zookeeper-SERVER-BASE",
+          "roleType": "SERVER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "hdfs",
+      "serviceType": "HDFS",
+      "roleConfigGroups": [
+        {
+          "refName": "hdfs-NAMENODE-BASE",
+          "roleType": "NAMENODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-DATANODE-BASE",
+          "roleType": "DATANODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-JOURNALNODE-BASE",
+          "roleType": "JOURNALNODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-FAILOVERCONTROLLER-BASE",
+          "roleType": "FAILOVERCONTROLLER",
+          "base": true
+        },
+        {
+          "refName": "hdfs-BALANCER-BASE",
+          "roleType": "BALANCER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "knox",
+      "roleConfigGroups": [
+        {
+          "base": true,
+          "refName": "knox-KNOX_GATEWAY-BASE",
+          "roleType": "KNOX_GATEWAY"
+        }
+      ],
+      "serviceType": "KNOX"
+    }
+  ],
+  "hostTemplates": [
+    {
+      "refName": "master",
+      "cardinality": 2,
+      "roleConfigGroupsRefNames": [
+        "hdfs-NAMENODE-BASE"
+      ]
+    },
+    {
+      "refName": "quorum",
+      "cardinality": 3,
+      "roleConfigGroupsRefNames": [
+        "zookeeper-SERVER-BASE"
+      ]
+    },
+    {
+      "refName": "worker",
+      "cardinality": 1,
+      "roleConfigGroupsRefNames": [
+        "hdfs-DATANODE-BASE"
+      ]
+    },
+    {
+      "refName": "yolo",
+      "cardinality": 2,
+      "roleConfigGroupsRefNames": [
+        "knox-KNOX_GATEWAY-BASE"
+      ]
+    }
+  ]
+}

--- a/template-manager-cmtemplate/src/test/resources/input/namenode-ha-single-worker-with-knoxes-of-0-0.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/namenode-ha-single-worker-with-knoxes-of-0-0.bp
@@ -1,0 +1,106 @@
+{
+  "cdhVersion": "6.1.0",
+  "displayName": "simple_template",
+  "cmVersion": "6.1.0",
+  "repositories": [
+    "https://archive.cloudera.com/cdh6/{latest_supported}/parcels/"
+  ],
+  "products": [
+    {
+      "version": "6.1.0-1.cdh6.1.0.p0.770702",
+      "product": "CDH"
+    }
+  ],
+  "services": [
+    {
+      "refName": "zookeeper",
+      "serviceType": "ZOOKEEPER",
+      "roleConfigGroups": [
+        {
+          "refName": "zookeeper-SERVER-BASE",
+          "roleType": "SERVER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "hdfs",
+      "serviceType": "HDFS",
+      "roleConfigGroups": [
+        {
+          "refName": "hdfs-NAMENODE-BASE",
+          "roleType": "NAMENODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-DATANODE-BASE",
+          "roleType": "DATANODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-JOURNALNODE-BASE",
+          "roleType": "JOURNALNODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-FAILOVERCONTROLLER-BASE",
+          "roleType": "FAILOVERCONTROLLER",
+          "base": true
+        },
+        {
+          "refName": "hdfs-BALANCER-BASE",
+          "roleType": "BALANCER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "knox",
+      "roleConfigGroups": [
+        {
+          "base": true,
+          "refName": "knox-KNOX_GATEWAY-BASE",
+          "roleType": "KNOX_GATEWAY"
+        }
+      ],
+      "serviceType": "KNOX"
+    }
+  ],
+  "hostTemplates": [
+    {
+      "refName": "master",
+      "cardinality": 2,
+      "roleConfigGroupsRefNames": [
+        "hdfs-NAMENODE-BASE"
+      ]
+    },
+    {
+      "refName": "quorum",
+      "cardinality": 3,
+      "roleConfigGroupsRefNames": [
+        "zookeeper-SERVER-BASE"
+      ]
+    },
+    {
+      "refName": "worker",
+      "cardinality": 1,
+      "roleConfigGroupsRefNames": [
+        "hdfs-DATANODE-BASE"
+      ]
+    },
+    {
+      "refName": "zero1",
+      "cardinality": 0,
+      "roleConfigGroupsRefNames": [
+        "knox-KNOX_GATEWAY-BASE"
+      ]
+    },
+    {
+      "refName": "zero2",
+      "cardinality": 0,
+      "roleConfigGroupsRefNames": [
+        "knox-KNOX_GATEWAY-BASE"
+      ]
+    }
+  ]
+}

--- a/template-manager-cmtemplate/src/test/resources/input/namenode-ha-single-worker-with-knoxes-of-0-2.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/namenode-ha-single-worker-with-knoxes-of-0-2.bp
@@ -1,0 +1,106 @@
+{
+  "cdhVersion": "6.1.0",
+  "displayName": "simple_template",
+  "cmVersion": "6.1.0",
+  "repositories": [
+    "https://archive.cloudera.com/cdh6/{latest_supported}/parcels/"
+  ],
+  "products": [
+    {
+      "version": "6.1.0-1.cdh6.1.0.p0.770702",
+      "product": "CDH"
+    }
+  ],
+  "services": [
+    {
+      "refName": "zookeeper",
+      "serviceType": "ZOOKEEPER",
+      "roleConfigGroups": [
+        {
+          "refName": "zookeeper-SERVER-BASE",
+          "roleType": "SERVER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "hdfs",
+      "serviceType": "HDFS",
+      "roleConfigGroups": [
+        {
+          "refName": "hdfs-NAMENODE-BASE",
+          "roleType": "NAMENODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-DATANODE-BASE",
+          "roleType": "DATANODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-JOURNALNODE-BASE",
+          "roleType": "JOURNALNODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-FAILOVERCONTROLLER-BASE",
+          "roleType": "FAILOVERCONTROLLER",
+          "base": true
+        },
+        {
+          "refName": "hdfs-BALANCER-BASE",
+          "roleType": "BALANCER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "knox",
+      "roleConfigGroups": [
+        {
+          "base": true,
+          "refName": "knox-KNOX_GATEWAY-BASE",
+          "roleType": "KNOX_GATEWAY"
+        }
+      ],
+      "serviceType": "KNOX"
+    }
+  ],
+  "hostTemplates": [
+    {
+      "refName": "master",
+      "cardinality": 2,
+      "roleConfigGroupsRefNames": [
+        "hdfs-NAMENODE-BASE"
+      ]
+    },
+    {
+      "refName": "quorum",
+      "cardinality": 3,
+      "roleConfigGroupsRefNames": [
+        "zookeeper-SERVER-BASE"
+      ]
+    },
+    {
+      "refName": "worker",
+      "cardinality": 1,
+      "roleConfigGroupsRefNames": [
+        "hdfs-DATANODE-BASE"
+      ]
+    },
+    {
+      "refName": "zero",
+      "cardinality": 0,
+      "roleConfigGroupsRefNames": [
+        "knox-KNOX_GATEWAY-BASE"
+      ]
+    },
+    {
+      "refName": "entrance",
+      "cardinality": 2,
+      "roleConfigGroupsRefNames": [
+        "knox-KNOX_GATEWAY-BASE"
+      ]
+    }
+  ]
+}

--- a/template-manager-cmtemplate/src/test/resources/input/namenode-ha-single-worker-with-knoxes-of-1-1-2.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/namenode-ha-single-worker-with-knoxes-of-1-1-2.bp
@@ -1,0 +1,113 @@
+{
+  "cdhVersion": "6.1.0",
+  "displayName": "simple_template",
+  "cmVersion": "6.1.0",
+  "repositories": [
+    "https://archive.cloudera.com/cdh6/{latest_supported}/parcels/"
+  ],
+  "products": [
+    {
+      "version": "6.1.0-1.cdh6.1.0.p0.770702",
+      "product": "CDH"
+    }
+  ],
+  "services": [
+    {
+      "refName": "zookeeper",
+      "serviceType": "ZOOKEEPER",
+      "roleConfigGroups": [
+        {
+          "refName": "zookeeper-SERVER-BASE",
+          "roleType": "SERVER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "hdfs",
+      "serviceType": "HDFS",
+      "roleConfigGroups": [
+        {
+          "refName": "hdfs-NAMENODE-BASE",
+          "roleType": "NAMENODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-DATANODE-BASE",
+          "roleType": "DATANODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-JOURNALNODE-BASE",
+          "roleType": "JOURNALNODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-FAILOVERCONTROLLER-BASE",
+          "roleType": "FAILOVERCONTROLLER",
+          "base": true
+        },
+        {
+          "refName": "hdfs-BALANCER-BASE",
+          "roleType": "BALANCER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "knox",
+      "roleConfigGroups": [
+        {
+          "base": true,
+          "refName": "knox-KNOX_GATEWAY-BASE",
+          "roleType": "KNOX_GATEWAY"
+        }
+      ],
+      "serviceType": "KNOX"
+    }
+  ],
+  "hostTemplates": [
+    {
+      "refName": "master",
+      "cardinality": 2,
+      "roleConfigGroupsRefNames": [
+        "hdfs-NAMENODE-BASE"
+      ]
+    },
+    {
+      "refName": "quorum",
+      "cardinality": 3,
+      "roleConfigGroupsRefNames": [
+        "zookeeper-SERVER-BASE"
+      ]
+    },
+    {
+      "refName": "worker",
+      "cardinality": 1,
+      "roleConfigGroupsRefNames": [
+        "hdfs-DATANODE-BASE"
+      ]
+    },
+    {
+      "refName": "door",
+      "cardinality": 2,
+      "roleConfigGroupsRefNames": [
+        "knox-KNOX_GATEWAY-BASE"
+      ]
+    },
+    {
+      "refName": "entrance",
+      "cardinality": 1,
+      "roleConfigGroupsRefNames": [
+        "knox-KNOX_GATEWAY-BASE"
+      ]
+    },
+    {
+      "refName": "window",
+      "cardinality": 1,
+      "roleConfigGroupsRefNames": [
+        "knox-KNOX_GATEWAY-BASE"
+      ]
+    }
+  ]
+}

--- a/template-manager-cmtemplate/src/test/resources/input/namenode-ha-single-worker-with-knoxes-of-1-2-3.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/namenode-ha-single-worker-with-knoxes-of-1-2-3.bp
@@ -1,0 +1,113 @@
+{
+  "cdhVersion": "6.1.0",
+  "displayName": "simple_template",
+  "cmVersion": "6.1.0",
+  "repositories": [
+    "https://archive.cloudera.com/cdh6/{latest_supported}/parcels/"
+  ],
+  "products": [
+    {
+      "version": "6.1.0-1.cdh6.1.0.p0.770702",
+      "product": "CDH"
+    }
+  ],
+  "services": [
+    {
+      "refName": "zookeeper",
+      "serviceType": "ZOOKEEPER",
+      "roleConfigGroups": [
+        {
+          "refName": "zookeeper-SERVER-BASE",
+          "roleType": "SERVER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "hdfs",
+      "serviceType": "HDFS",
+      "roleConfigGroups": [
+        {
+          "refName": "hdfs-NAMENODE-BASE",
+          "roleType": "NAMENODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-DATANODE-BASE",
+          "roleType": "DATANODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-JOURNALNODE-BASE",
+          "roleType": "JOURNALNODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-FAILOVERCONTROLLER-BASE",
+          "roleType": "FAILOVERCONTROLLER",
+          "base": true
+        },
+        {
+          "refName": "hdfs-BALANCER-BASE",
+          "roleType": "BALANCER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "knox",
+      "roleConfigGroups": [
+        {
+          "base": true,
+          "refName": "knox-KNOX_GATEWAY-BASE",
+          "roleType": "KNOX_GATEWAY"
+        }
+      ],
+      "serviceType": "KNOX"
+    }
+  ],
+  "hostTemplates": [
+    {
+      "refName": "master",
+      "cardinality": 2,
+      "roleConfigGroupsRefNames": [
+        "hdfs-NAMENODE-BASE"
+      ]
+    },
+    {
+      "refName": "quorum",
+      "cardinality": 3,
+      "roleConfigGroupsRefNames": [
+        "zookeeper-SERVER-BASE"
+      ]
+    },
+    {
+      "refName": "worker",
+      "cardinality": 1,
+      "roleConfigGroupsRefNames": [
+        "hdfs-DATANODE-BASE"
+      ]
+    },
+    {
+      "refName": "door",
+      "cardinality": 3,
+      "roleConfigGroupsRefNames": [
+        "knox-KNOX_GATEWAY-BASE"
+      ]
+    },
+    {
+      "refName": "entrance",
+      "cardinality": 1,
+      "roleConfigGroupsRefNames": [
+        "knox-KNOX_GATEWAY-BASE"
+      ]
+    },
+    {
+      "refName": "window",
+      "cardinality": 2,
+      "roleConfigGroupsRefNames": [
+        "knox-KNOX_GATEWAY-BASE"
+      ]
+    }
+  ]
+}

--- a/template-manager-cmtemplate/src/test/resources/input/namenode-ha-single-worker-with-knoxes-of-1-2.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/namenode-ha-single-worker-with-knoxes-of-1-2.bp
@@ -1,0 +1,106 @@
+{
+  "cdhVersion": "6.1.0",
+  "displayName": "simple_template",
+  "cmVersion": "6.1.0",
+  "repositories": [
+    "https://archive.cloudera.com/cdh6/{latest_supported}/parcels/"
+  ],
+  "products": [
+    {
+      "version": "6.1.0-1.cdh6.1.0.p0.770702",
+      "product": "CDH"
+    }
+  ],
+  "services": [
+    {
+      "refName": "zookeeper",
+      "serviceType": "ZOOKEEPER",
+      "roleConfigGroups": [
+        {
+          "refName": "zookeeper-SERVER-BASE",
+          "roleType": "SERVER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "hdfs",
+      "serviceType": "HDFS",
+      "roleConfigGroups": [
+        {
+          "refName": "hdfs-NAMENODE-BASE",
+          "roleType": "NAMENODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-DATANODE-BASE",
+          "roleType": "DATANODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-JOURNALNODE-BASE",
+          "roleType": "JOURNALNODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-FAILOVERCONTROLLER-BASE",
+          "roleType": "FAILOVERCONTROLLER",
+          "base": true
+        },
+        {
+          "refName": "hdfs-BALANCER-BASE",
+          "roleType": "BALANCER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "knox",
+      "roleConfigGroups": [
+        {
+          "base": true,
+          "refName": "knox-KNOX_GATEWAY-BASE",
+          "roleType": "KNOX_GATEWAY"
+        }
+      ],
+      "serviceType": "KNOX"
+    }
+  ],
+  "hostTemplates": [
+    {
+      "refName": "master",
+      "cardinality": 2,
+      "roleConfigGroupsRefNames": [
+        "hdfs-NAMENODE-BASE"
+      ]
+    },
+    {
+      "refName": "quorum",
+      "cardinality": 3,
+      "roleConfigGroupsRefNames": [
+        "zookeeper-SERVER-BASE"
+      ]
+    },
+    {
+      "refName": "worker",
+      "cardinality": 1,
+      "roleConfigGroupsRefNames": [
+        "hdfs-DATANODE-BASE"
+      ]
+    },
+    {
+      "refName": "door",
+      "cardinality": 2,
+      "roleConfigGroupsRefNames": [
+        "knox-KNOX_GATEWAY-BASE"
+      ]
+    },
+    {
+      "refName": "window",
+      "cardinality": 1,
+      "roleConfigGroupsRefNames": [
+        "knox-KNOX_GATEWAY-BASE"
+      ]
+    }
+  ]
+}

--- a/template-manager-cmtemplate/src/test/resources/input/namenode-ha-single-worker-with-knoxes-of-2-2.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/namenode-ha-single-worker-with-knoxes-of-2-2.bp
@@ -1,0 +1,106 @@
+{
+  "cdhVersion": "6.1.0",
+  "displayName": "simple_template",
+  "cmVersion": "6.1.0",
+  "repositories": [
+    "https://archive.cloudera.com/cdh6/{latest_supported}/parcels/"
+  ],
+  "products": [
+    {
+      "version": "6.1.0-1.cdh6.1.0.p0.770702",
+      "product": "CDH"
+    }
+  ],
+  "services": [
+    {
+      "refName": "zookeeper",
+      "serviceType": "ZOOKEEPER",
+      "roleConfigGroups": [
+        {
+          "refName": "zookeeper-SERVER-BASE",
+          "roleType": "SERVER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "hdfs",
+      "serviceType": "HDFS",
+      "roleConfigGroups": [
+        {
+          "refName": "hdfs-NAMENODE-BASE",
+          "roleType": "NAMENODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-DATANODE-BASE",
+          "roleType": "DATANODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-JOURNALNODE-BASE",
+          "roleType": "JOURNALNODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-FAILOVERCONTROLLER-BASE",
+          "roleType": "FAILOVERCONTROLLER",
+          "base": true
+        },
+        {
+          "refName": "hdfs-BALANCER-BASE",
+          "roleType": "BALANCER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "knox",
+      "roleConfigGroups": [
+        {
+          "base": true,
+          "refName": "knox-KNOX_GATEWAY-BASE",
+          "roleType": "KNOX_GATEWAY"
+        }
+      ],
+      "serviceType": "KNOX"
+    }
+  ],
+  "hostTemplates": [
+    {
+      "refName": "master",
+      "cardinality": 2,
+      "roleConfigGroupsRefNames": [
+        "hdfs-NAMENODE-BASE"
+      ]
+    },
+    {
+      "refName": "quorum",
+      "cardinality": 3,
+      "roleConfigGroupsRefNames": [
+        "zookeeper-SERVER-BASE"
+      ]
+    },
+    {
+      "refName": "worker",
+      "cardinality": 1,
+      "roleConfigGroupsRefNames": [
+        "hdfs-DATANODE-BASE"
+      ]
+    },
+    {
+      "refName": "door",
+      "cardinality": 2,
+      "roleConfigGroupsRefNames": [
+        "knox-KNOX_GATEWAY-BASE"
+      ]
+    },
+    {
+      "refName": "entrance",
+      "cardinality": 2,
+      "roleConfigGroupsRefNames": [
+        "knox-KNOX_GATEWAY-BASE"
+      ]
+    }
+  ]
+}

--- a/template-manager-cmtemplate/src/test/resources/input/namenode-ha-with-knox.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/namenode-ha-with-knox.bp
@@ -1,0 +1,106 @@
+{
+  "cdhVersion": "6.1.0",
+  "displayName": "simple_template",
+  "cmVersion": "6.1.0",
+  "repositories": [
+    "https://archive.cloudera.com/cdh6/{latest_supported}/parcels/"
+  ],
+  "products": [
+    {
+      "version": "6.1.0-1.cdh6.1.0.p0.770702",
+      "product": "CDH"
+    }
+  ],
+  "services": [
+    {
+      "refName": "zookeeper",
+      "serviceType": "ZOOKEEPER",
+      "roleConfigGroups": [
+        {
+          "refName": "zookeeper-SERVER-BASE",
+          "roleType": "SERVER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "hdfs",
+      "serviceType": "HDFS",
+      "roleConfigGroups": [
+        {
+          "refName": "hdfs-NAMENODE-BASE",
+          "roleType": "NAMENODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-DATANODE-BASE",
+          "roleType": "DATANODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-JOURNALNODE-BASE",
+          "roleType": "JOURNALNODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-FAILOVERCONTROLLER-BASE",
+          "roleType": "FAILOVERCONTROLLER",
+          "base": true
+        },
+        {
+          "refName": "hdfs-BALANCER-BASE",
+          "roleType": "BALANCER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "knox",
+      "roleConfigGroups": [
+        {
+          "base": true,
+          "refName": "knox-KNOX_GATEWAY-BASE",
+          "roleType": "KNOX_GATEWAY"
+        }
+      ],
+      "serviceType": "KNOX"
+    }
+  ],
+  "hostTemplates": [
+    {
+      "refName": "master",
+      "cardinality": 2,
+      "roleConfigGroupsRefNames": [
+        "hdfs-NAMENODE-BASE"
+      ]
+    },
+    {
+      "refName": "quorum",
+      "cardinality": 3,
+      "roleConfigGroupsRefNames": [
+        "zookeeper-SERVER-BASE"
+      ]
+    },
+    {
+      "refName": "gateway",
+      "cardinality": 1,
+      "roleConfigGroupsRefNames": [
+        "hdfs-BALANCER-BASE"
+      ]
+    },
+    {
+      "refName": "worker",
+      "cardinality": 3,
+      "roleConfigGroupsRefNames": [
+        "hdfs-DATANODE-BASE"
+      ]
+    },
+    {
+      "refName": "yolo",
+      "cardinality": 2,
+      "roleConfigGroupsRefNames": [
+        "knox-KNOX_GATEWAY-BASE"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
… bogus GW recommendation even if the blueprint explicitly contains `KNOX_GATEWAY`

* Prefer the host group(s) of role `KNOX_GATEWAY` as the `GATEWAY` whenever possible, falling back to the former decision strategy based on host group name & cardinality in the lack of a proper `KNOX_GATEWAY` match.
  * A match in some host group is considered feasible only if its cardinality is positive. Matches with a zero cardinality are simply ignored.
  * In case of multiple feasible matches, the one with the smallest (positive) cardinality wins. If there are more than one such host groups, the choice among them is made based on the lexicographic order of their names (the smallest name picked from the ascending order).
* Some code cleanup.
* Testing:
  * Manual testing in local CB using DataEng HA 7.2.7, 7.2.8 and 7.2.15.
  * Added new UT and updated existing ones.
