### PR TITLE
CB-18046 Introduce a command runner for Cloudbreak API Test project to multiple SSH

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/action/SshCommandRunnerActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/action/SshCommandRunnerActions.java
@@ -1,0 +1,199 @@
+package com.sequenceiq.it.cloudbreak.util.ssh.action;
+
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceMetadataType.GATEWAY_PRIMARY;
+import static com.sequenceiq.common.api.type.InstanceGroupType.GATEWAY;
+import static java.lang.String.format;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
+import com.sequenceiq.cloudbreak.common.json.JsonUtil;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupResponse;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupType;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceMetaDataResponse;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceMetadataType;
+import com.sequenceiq.it.cloudbreak.FreeIpaClient;
+import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.it.cloudbreak.log.Log;
+
+import net.schmizz.sshj.SSHClient;
+
+@Component
+public class SshCommandRunnerActions extends SshJClientActions {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SshCommandRunnerActions.class);
+
+    private String getGatewayPrivateIp(String environmentCrn, FreeIpaClient freeipaClient) {
+        return freeipaClient.getDefaultClient().getFreeIpaV1Endpoint()
+                .describe(environmentCrn).getInstanceGroups().stream()
+                .filter(instanceGroup -> instanceGroup.getType().equals(InstanceGroupType.MASTER))
+                .map(InstanceGroupResponse::getMetaData)
+                .filter(Objects::nonNull)
+                .flatMap(Collection::stream)
+                .filter(instanceMetaData -> instanceMetaData.getInstanceType().equals(InstanceMetadataType.GATEWAY_PRIMARY))
+                .map(InstanceMetaDataResponse::getPrivateIp)
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElseThrow(() -> new TestFailException(format("Cannot determine FreeIpa Gateway IP at environment: %s", environmentCrn)));
+    }
+
+    private String getGatewayPrivateIp(String clusterCrn, List<InstanceGroupV4Response> instanceGroups) {
+        return instanceGroups.stream()
+                .filter(instanceGroup -> instanceGroup.getType().equals(GATEWAY))
+                .map(InstanceGroupV4Response::getMetadata)
+                .filter(Objects::nonNull)
+                .flatMap(Collection::stream)
+                .filter(instanceMetaData -> instanceMetaData.getInstanceType().equals(GATEWAY_PRIMARY))
+                .map(InstanceMetaDataV4Response::getPrivateIp)
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElseThrow(() -> new TestFailException(format("Cannot determine Gateway IP for cluster: %s", clusterCrn)));
+    }
+
+    private String getFileName(Map<String, String> fileNames, String key) {
+        return fileNames.entrySet().stream()
+                .filter(names -> names.getKey().equalsIgnoreCase(key))
+                .map(Entry::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private void upload(String instanceIp, String sourceFilePath, String destinationPath) {
+        upload(instanceIp, null, null, null, sourceFilePath, destinationPath);
+    }
+
+    private void upload(String instanceIp, String user, String password, String privateKeyFilePath, String sourceFilePath, String destinationPath) {
+        try (SSHClient sshClient = createSshClient(instanceIp, user, password, privateKeyFilePath)) {
+            upload(sshClient, sourceFilePath, destinationPath);
+            Log.log(LOGGER, format("File upload [%s] to host [%s] has been done.", sourceFilePath, instanceIp));
+        } catch (Exception e) {
+            Log.error(LOGGER, format("File upload [%s] to host [%s] is failing! %s", sourceFilePath, instanceIp, e.getMessage()));
+            throw new TestFailException(format("File upload [%s] to host [%s] is failing!", sourceFilePath, instanceIp), e);
+        }
+    }
+
+    private List<File> createCommandRunner() {
+        List<String> commandRunnerFilePathes = List.of("commandrunner/qa-command-runner.py", "commandrunner/sample-command.json");
+        List<File> createdTmpFiles = new ArrayList<>();
+
+        commandRunnerFilePathes.forEach(filePath -> {
+            File tmpFile;
+            URL url = Thread.currentThread().getContextClassLoader().getResource(filePath);
+            if (url != null) {
+                String fileName = url.getFile();
+                InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(filePath);
+                try {
+                    String name = Arrays.stream(StringUtils.substringsBetween(fileName, "/", ".")).reduce((first, last) -> last).get();
+                    String extension = StringUtils.substringAfterLast(fileName, ".");
+                    LOGGER.info("Creating tmp file as: {}.{}...", name, extension);
+                    tmpFile = File.createTempFile(name, '.' + extension);
+                    FileUtils.copyInputStreamToFile(inputStream, tmpFile);
+                    String tmpFileContent = Files.readString(Path.of(tmpFile.getPath()).normalize().toAbsolutePath());
+                    LOGGER.info(format("Temporary file has been created at '%s' path with content:%n%s!", tmpFile.getAbsolutePath(), tmpFileContent));
+                    createdTmpFiles.add(tmpFile);
+                } catch (IOException e) {
+                    Log.error(LOGGER, format("'%s' file cannot be created for tests, because of: %s", filePath, e.getMessage()));
+                    throw new TestFailException(format("'%s' file cannot be created for tests!", filePath), e);
+                }
+            } else {
+                Log.error(LOGGER, format("Cannot find file at path: '%s'!", filePath));
+                throw new TestFailException(format("Cannot find file at path: '%s'!", filePath));
+            }
+        });
+        return createdTmpFiles;
+    }
+
+    private Map<String, String> uploadCommandRunner(String gatewayPrivateIp) {
+        Map<String, String> fileNames = new HashMap<>();
+
+        if (StringUtils.isBlank(gatewayPrivateIp) || StringUtils.containsIgnoreCase(gatewayPrivateIp, "N/A")) {
+            Log.error(LOGGER, "FreeIPA GATEWAY Private IP is not available!");
+            throw new TestFailException("FreeIPA GATEWAY Private IP is not available!");
+        }
+
+        createCommandRunner().forEach(file -> {
+            if (file.exists()) {
+                String tmpPath = Path.of(file.getPath()).normalize().toAbsolutePath().toString();
+                String destPath = "/home/cloudbreak/";
+                LOGGER.info("Uploading file from path '{}' to host '{}' and path '{}'...", tmpPath, gatewayPrivateIp, destPath);
+                upload(gatewayPrivateIp, tmpPath, destPath);
+                if (file.getName().contains("command-runner")) {
+                    fileNames.put("runner", file.getName());
+                } else {
+                    fileNames.put("command", file.getName());
+                }
+            } else {
+                Log.error(LOGGER, "Cannot find command runner folder at classpath!");
+                throw new TestFailException("Cannot find command runner folder at classpath!");
+            }
+        });
+
+        return fileNames;
+    }
+
+    private void executeCommandRunner(String gatewayPrivateIp) {
+        Map<String, String> fileNames = uploadCommandRunner(gatewayPrivateIp);
+        String commandRunnerFileName = getFileName(fileNames, "runner");
+        String sampleCommandFileName = getFileName(fileNames, "command");
+
+        Pair<Integer, String> cmdOut = executeSshCommand(gatewayPrivateIp, format("sudo mkdir -p /srv/salt/qa && sudo cp %s /srv/salt/qa" +
+                        " && sudo cp %s /srv/salt/qa && sudo python3 /srv/salt/qa/%s -c /srv/salt/qa/%s",
+                commandRunnerFileName, sampleCommandFileName, commandRunnerFileName, sampleCommandFileName));
+
+        try {
+            Map<String, List<Map<String, String>>> fetchedResult =
+                    JsonUtil.readValue(cmdOut.getValue(), new TypeReference<Map<String, List<Map<String, String>>>>() { });
+            fetchedResult.forEach((key, value) -> {
+                value.forEach(resultMaps -> {
+                    List<String> exitCodes = resultMaps.entrySet().stream()
+                            .filter(results -> "code".equalsIgnoreCase(results.getKey()))
+                            .map(Entry::getValue)
+                            .collect(Collectors.toList());
+                    if (exitCodes.stream().anyMatch(codes -> Integer.parseInt(codes) != 0)) {
+                        Log.error(LOGGER, "One or more command has been failed on nodes!");
+                        throw new TestFailException("One or more command has been failed on nodes!");
+                    }
+                });
+            });
+        } catch (IOException e) {
+            Log.error(LOGGER, "Cannot find command runner folder at classpath!");
+            throw new TestFailException("Cannot find command runner folder at classpath!");
+        }
+    }
+
+    public FreeIpaTestDto executeCommandRunner(FreeIpaTestDto testDto, String environmentCrn, FreeIpaClient freeipaClient) {
+        String gatewayPrivateIp = getGatewayPrivateIp(environmentCrn, freeipaClient);
+        executeCommandRunner(gatewayPrivateIp);
+        return testDto;
+    }
+
+    public <T extends CloudbreakTestDto> T executeCommandRunner(T testDto, List<InstanceGroupV4Response> instanceGroups) {
+        String gatewayPrivateIp = getGatewayPrivateIp(testDto.getCrn(), instanceGroups);
+        executeCommandRunner(gatewayPrivateIp);
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/action/SshJClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/action/SshJClientActions.java
@@ -245,7 +245,7 @@ public class SshJClientActions extends SshJClient {
         }
     }
 
-    private Pair<Integer, String> executeSshCommand(String instanceIp, String command) {
+    protected Pair<Integer, String> executeSshCommand(String instanceIp, String command) {
         return executeSshCommand(instanceIp, null, null, null, command);
     }
 

--- a/integration-test/src/main/resources/commandrunner/qa-command-runner.py
+++ b/integration-test/src/main/resources/commandrunner/qa-command-runner.py
@@ -1,0 +1,120 @@
+#!/bin/env python3
+
+import sys
+import subprocess
+import optparse
+import json
+import os
+import shutil
+
+SALT_CMD_PREFIX = '/opt/salt_*/bin/salt'
+
+
+def run_command(cmd):
+    proc = subprocess.Popen(cmd,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            shell=True,
+                            universal_newlines=True)
+    std_out, std_err = proc.communicate()
+    return proc.returncode, std_out, std_err
+
+
+def read_json_line_file(file):
+    data = {}
+    with open(file, 'r') as json_file:
+        json_list = list(json_file)
+    for json_str in json_list:
+        if json_str:
+            json_data = json.loads(json_str)
+            for key, json_dict_elem in json_data.items():
+                data[key] = json_dict_elem
+    return data
+
+
+def execute_local_commands(config):
+    results = list()
+    for c in config:
+        result = {}
+        description = c["description"]
+        command = c["command"]
+        code, out, err = run_command(command)
+        result["command"] = c["command"]
+        result["description"] = c["description"]
+        result["code"] = code
+        result["out"] = out.rstrip() if out else out
+        result["err"] = err.rstrip() if err else err
+        results.append(result)
+    print(json.dumps(results))
+
+
+def execute_salt_commands(command_file_location, config, hosts, host_groups):
+    global SALT_CMD_PREFIX
+    ping_out_file = "/tmp/qa_test_ping.json"
+    test_cmd = "%s '*' test.ping --out=json --out-file=%s --out-indent=-1" % (SALT_CMD_PREFIX, ping_out_file)
+    available_nodes = []
+    test_code, _, _ = run_command(test_cmd)
+    test_json = read_json_line_file(ping_out_file)
+    if test_json:
+        for key in test_json:
+            if str(test_json[key]) == "True":
+                available_nodes.append(key)
+    qa_path = '/srv/salt/qa'
+    if os.path.exists('/srv/salt') and not os.path.exists(qa_path):
+        os.mkdir(qa_path)
+    script_file = os.path.abspath(__file__)
+    script_file_basename = os.path.basename(script_file)
+    command_file_basename = os.path.basename(command_file_location)
+    try:
+        shutil.copy(command_file_location, os.path.join(qa_path, command_file_basename))
+    except shutil.SameFileError:
+        pass
+    try:
+        shutil.copy(script_file, os.path.join(qa_path, script_file_basename))
+    except shutil.SameFileError:
+        pass
+    available_nodes_str = ",".join(available_nodes)
+    cmd_copy_script_file = "%s -L %s cp.get_file salt:///qa/%s /tmp/%s" % (
+    SALT_CMD_PREFIX, available_nodes_str, script_file_basename, script_file_basename)
+    cmd_copy_command_file = "%s -L %s cp.get_file salt:///qa/%s /tmp/%s" % (
+    SALT_CMD_PREFIX, available_nodes_str, command_file_basename, command_file_basename)
+    run_command(cmd_copy_script_file)
+    run_command(cmd_copy_command_file)
+    final_output = '/tmp/qa_test_results.json'
+    run_all_commands_cmd = \
+        "%s -L %s cmd.run 'python3 /tmp/%s -c /tmp/%s -l' --out=json --out-file=%s --out-indent=-1" % (
+    SALT_CMD_PREFIX, available_nodes_str, script_file_basename, command_file_basename, final_output)
+    run_command(run_all_commands_cmd)
+    final_json = read_json_line_file(final_output)
+    outputs = {}
+    if final_json:
+        for key in final_json:
+            outputs[key] = json.loads(final_json[key])
+    print(json.dumps(outputs))
+
+
+if __name__ == "__main__":
+    parser = optparse.OptionParser("usage: %prog [options]")
+    parser.add_option("-c", "--config", dest="config", default=None, type="string",
+                      help="Configuration file for executing salt commands.")
+    parser.add_option("--hosts", dest="hosts", default=None, type="string", help="Comma separated hosts filter,")
+    parser.add_option("--host-groups", dest="host_groups", default=None, type="string",
+                      help="Comma separated host groups filter.")
+    parser.add_option("-l", "--local", action="store_true", dest="local", help="Run commands locally,")
+    (options, args) = parser.parse_args()
+    if not options.config:
+        print("Configuration option -c / --config is required!")
+        parser.print_help()
+        sys.exit(1)
+    hosts_arr = options.hosts.split(",") if options.hosts else list()
+    host_groups_arr = options.host_groups.split(",") if options.host_groups else list()
+    if not os.path.exists(options.config):
+        print("Configuration file %s does not exist!" % options.config)
+        sys.exit(1)
+    config = {}
+    with open(options.config) as f:
+        config = json.load(f)
+    if options.local:
+        execute_local_commands(config)
+    else:
+        execute_salt_commands(options.config, config, hosts_arr, host_groups_arr)

--- a/integration-test/src/main/resources/commandrunner/sample-command.json
+++ b/integration-test/src/main/resources/commandrunner/sample-command.json
@@ -1,0 +1,10 @@
+[
+  {
+    "description":  "Check log size",
+    "command":  "du -h /var/log"},
+  {
+    "description": "Hello world",
+    "command":  "echo hello"
+  }
+]
+


### PR DESCRIPTION
Currently we have integrated [SSHJClient](https://github.com/hierynomus/sshj) to connect VMs and execute commands there.
Instead of connect to VMs multiple times during test executions, we can use a simple combined command runner for checking results in one round.

Basically we should be able:
- execute commands on VMs remotely, like we do in case of diagnostics
    - on SDX, Distrox, FreeIpa and their instances and hostrgroups
- then get the results (for example in JSON format):
    - need to parse the JSON result