### PR TITLE
CB-17557: Update blueprints for cdp 7.2.16 Streams Messaging clusters

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.16/cdp-streaming-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.16/cdp-streaming-ha.bp
@@ -22,11 +22,11 @@
         ]
       },
       {
-        "refName": "core_settings",
-        "serviceType": "CORE_SETTINGS",
+        "refName": "stub_dfs",
+        "serviceType": "STUB_DFS",
         "roleConfigGroups": [
           {
-            "refName": "core_settings-STORAGEOPERATIONS-BASE",
+            "refName": "stub_dfs-STORAGEOPERATIONS-BASE",
             "roleType": "STORAGEOPERATIONS",
             "base": true
           }
@@ -113,7 +113,7 @@
         "refName": "master",
         "cardinality": 1,
         "roleConfigGroupsRefNames": [
-          "core_settings-STORAGEOPERATIONS-BASE",
+          "stub_dfs-STORAGEOPERATIONS-BASE",
           "cruise_control-CRUISE_CONTROL_SERVER-BASE",
           "streams_messaging_manager-STREAMS_MESSAGING_MANAGER_SERVER-BASE",
           "streams_messaging_manager-STREAMS_MESSAGING_MANAGER_UI-BASE",
@@ -126,7 +126,7 @@
         "roleConfigGroupsRefNames": [
           "zookeeper-SERVER-BASE",
           "schemaregistry-SCHEMA_REGISTRY_SERVER-BASE",
-          "core_settings-STORAGEOPERATIONS-BASE"
+          "stub_dfs-STORAGEOPERATIONS-BASE"
         ]
       },
       {

--- a/core/src/main/resources/defaults/blueprints/7.2.16/cdp-streaming-small.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.16/cdp-streaming-small.bp
@@ -22,11 +22,11 @@
         ]
       },
       {
-        "refName": "core_settings",
-        "serviceType": "CORE_SETTINGS",
+        "refName": "stub_dfs",
+        "serviceType": "STUB_DFS",
         "roleConfigGroups": [
           {
-            "refName": "core_settings-STORAGEOPERATIONS-BASE",
+            "refName": "stub_dfs-STORAGEOPERATIONS-BASE",
             "roleType": "STORAGEOPERATIONS",
             "base": true
           }
@@ -113,7 +113,7 @@
         "refName": "master",
         "cardinality": 1,
         "roleConfigGroupsRefNames": [
-          "core_settings-STORAGEOPERATIONS-BASE",
+          "stub_dfs-STORAGEOPERATIONS-BASE",
           "streams_replication_manager-STREAMS_REPLICATION_MANAGER_SERVICE-BASE",
           "schemaregistry-SCHEMA_REGISTRY_SERVER-BASE",
           "streams_messaging_manager-STREAMS_MESSAGING_MANAGER_SERVER-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.16/cdp-streaming.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.16/cdp-streaming.bp
@@ -22,11 +22,11 @@
         ]
       },
       {
-        "refName": "core_settings",
-        "serviceType": "CORE_SETTINGS",
+        "refName": "stub_dfs",
+        "serviceType": "STUB_DFS",
         "roleConfigGroups": [
           {
-            "refName": "core_settings-STORAGEOPERATIONS-BASE",
+            "refName": "stub_dfs-STORAGEOPERATIONS-BASE",
             "roleType": "STORAGEOPERATIONS",
             "base": true
           }
@@ -114,7 +114,7 @@
         "cardinality": 1,
         "roleConfigGroupsRefNames": [
           "zookeeper-SERVER-BASE",
-          "core_settings-STORAGEOPERATIONS-BASE"
+          "stub_dfs-STORAGEOPERATIONS-BASE"
         ]
       },
       {


### PR DESCRIPTION
The StorageOperations role will now be in StubDfs service, so existing templates that contain CoreSettings need to be updated. This commit updates the streams messaging templates.

Test:
- Manually on provisioned cluster (local)