### PR TITLE
CB-17807: change volume size of the datalake duties on Azure

### DIFF
--- a/datalake/src/main/resources/duties/7.2.10/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.10/azure/light_duty.json
@@ -31,7 +31,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 512,
             "type": "StandardSSD_LRS"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.10/azure/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.10/azure/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -49,7 +49,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 512,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.11/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.11/azure/light_duty.json
@@ -31,7 +31,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 512,
             "type": "StandardSSD_LRS"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.11/azure/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.11/azure/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -49,7 +49,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 512,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.12/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.12/azure/light_duty.json
@@ -31,7 +31,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 512,
             "type": "StandardSSD_LRS"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.12/azure/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.12/azure/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -49,7 +49,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 512,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.14/azure/cdp_data_lake_medium_duty_with_profiler/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.14/azure/cdp_data_lake_medium_duty_with_profiler/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -49,7 +49,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 512,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.14/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.14/azure/light_duty.json
@@ -31,7 +31,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 512,
             "type": "StandardSSD_LRS"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.14/azure/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.14/azure/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -49,7 +49,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 512,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.15/azure/cdp_data_lake_medium_duty_with_profiler/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.15/azure/cdp_data_lake_medium_duty_with_profiler/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -49,7 +49,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 512,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.15/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.15/azure/light_duty.json
@@ -31,7 +31,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 512,
             "type": "StandardSSD_LRS"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.15/azure/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.15/azure/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -49,7 +49,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 512,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.16/azure/cdp_data_lake_medium_duty_with_profiler/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.16/azure/cdp_data_lake_medium_duty_with_profiler/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -49,7 +49,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 512,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.16/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.16/azure/light_duty.json
@@ -31,7 +31,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 512,
             "type": "StandardSSD_LRS"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.16/azure/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.16/azure/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -49,7 +49,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 512,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.7/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.7/azure/light_duty.json
@@ -31,7 +31,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 512,
             "type": "StandardSSD_LRS"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.7/azure/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.7/azure/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -49,7 +49,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 512,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.8/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.8/azure/light_duty.json
@@ -31,7 +31,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 512,
             "type": "StandardSSD_LRS"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.8/azure/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.8/azure/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -49,7 +49,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 512,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.9/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.9/azure/light_duty.json
@@ -31,7 +31,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 512,
             "type": "StandardSSD_LRS"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.9/azure/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.9/azure/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -49,7 +49,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 512,
             "type": "StandardSSD_LRS"
           }
         ]
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "StandardSSD_LRS"
           }
         ]


### PR DESCRIPTION
JIRA: CB-17807: Change volume size of the datalake duties on Azure.
- new size: 
  - AUXILIARY - Reduced to 128GB
  - GATEWAY - Reduced to 128GB
  - MASTER - Reduced to 128GB
  - Core: Increase it to 512GB
  - Light duty: Increase it to 512GB

Tested:

Locally with CBD & IDE:
- create a new datalake version `7.2.15`, and `medium duty`, the newly created nodes were the expected size. 
- create a new datalake version `7.2.15` with `light duty`, the newly created nodes were the expected size.