### PR TITLE
CB-18217 SDX E2E resource cleanup refactor

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractSdxTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractSdxTestDto.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
-import javax.ws.rs.NotFoundException;
 
 import org.apache.commons.lang3.NotImplementedException;
 
@@ -114,15 +113,5 @@ public abstract class AbstractSdxTestDto<R, S, T extends CloudbreakTestDto> exte
         }
         return getTestContext().then((T) this, SdxClient.class, assertions.get(assertions.size() - 1),
                 runningParameters.get(runningParameters.size() - 1));
-    }
-
-    @Override
-    public void deleteForCleanup() {
-        try {
-            setFlow("SDX deletion", getClientForCleanup().getDefaultClient().sdxEndpoint().deleteByCrn(getCrn(), true));
-            awaitForFlow();
-        } catch (NotFoundException nfe) {
-            LOGGER.info("resource not found, thus cleanup not needed.");
-        }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxCustomTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxCustomTestDto.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
+import javax.ws.rs.NotFoundException;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.audits.responses.AuditEventV4Responses;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
@@ -262,6 +263,16 @@ public class SdxCustomTestDto extends AbstractSdxTestDto<SdxCustomClusterRequest
     @Override
     public String getSearchId() {
         return getName();
+    }
+
+    @Override
+    public void deleteForCleanup() {
+        try {
+            setFlow("SDX Custom deletion", getClientForCleanup().getDefaultClient().sdxEndpoint().deleteByCrn(getCrn(), true));
+            awaitForFlow();
+        } catch (NotFoundException nfe) {
+            LOGGER.info("SDX Custom resource not found, thus cleanup not needed.");
+        }
     }
 }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxInternalTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxInternalTestDto.java
@@ -16,6 +16,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
+import javax.ws.rs.NotFoundException;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -505,5 +506,15 @@ public class SdxInternalTestDto extends AbstractSdxTestDto<SdxInternalClusterReq
     @Override
     public String getSearchId() {
         return getName();
+    }
+
+    @Override
+    public void deleteForCleanup() {
+        try {
+            setFlow("SDX Internal deletion", getClientForCleanup().getDefaultClient().sdxEndpoint().deleteByCrn(getCrn(), true));
+            awaitForFlow();
+        } catch (NotFoundException nfe) {
+            LOGGER.info("SDX Internal resource not found, thus cleanup not needed.");
+        }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxSaasTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxSaasTestDto.java
@@ -3,6 +3,7 @@ package com.sequenceiq.it.cloudbreak.dto.sdx;
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.emptyRunningParameter;
 
 import javax.inject.Inject;
+import javax.ws.rs.NotFoundException;
 
 import com.cloudera.thunderhead.service.sdxsvcadmin.SDXSvcAdminProto;
 import com.cloudera.thunderhead.service.sdxsvccommon.SDXSvcCommonProto;
@@ -71,5 +72,14 @@ public class SdxSaasTestDto extends AbstractTestDto<SDXSvcAdminProto.CreateInsta
     @Override
     public SdxSaasTestDto when(Action<SdxSaasTestDto, SdxSaasItClient> action) {
         return getTestContext().when(this, SdxSaasItClient.class, action, emptyRunningParameter());
+    }
+
+    @Override
+    public void deleteForCleanup() {
+        try {
+            getClientForCleanup().getDefaultClient().deleteInstance(crn);
+        } catch (NotFoundException nfe) {
+            LOGGER.info("SDX SaaS resource not found, thus cleanup not needed.");
+        }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
@@ -17,6 +17,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
+import javax.ws.rs.NotFoundException;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
@@ -380,5 +381,15 @@ public class SdxTestDto extends AbstractSdxTestDto<SdxClusterRequest, SdxCluster
                 .flatMap(ig -> ig.getMetadata().stream())
                 .anyMatch(metadata -> InstanceStatus.DELETED_BY_PROVIDER == metadata.getInstanceStatus());
         return new Clue("SDX", auditEvents, getResponse(), hasSpotTermination);
+    }
+
+    @Override
+    public void deleteForCleanup() {
+        try {
+            setFlow("SDX deletion", getClientForCleanup().getDefaultClient().sdxEndpoint().deleteByCrn(getCrn(), true));
+            awaitForFlow();
+        } catch (NotFoundException nfe) {
+            LOGGER.info("SDX resource not found, thus cleanup not needed.");
+        }
     }
 }


### PR DESCRIPTION
In case of [DistroXEncryptedVolumeTest](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXEncryptedVolumeTest.java) and [DistroXRepairTests](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXRepairTests.java) teardown we've observed exception on the test console:
```
java.lang.IllegalStateException: Error happened, getCrn() is not implemented for TestDto: SdxCloudStorageTestDto[name: null]  at com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto.getCrn(CloudbreakTestDto.java:59)  at com.sequenceiq.it.cloudbreak.dto.AbstractTestDto.getClientForCleanup(AbstractTestDto.java:409)  at com.sequenceiq.it.cloudbreak.dto.AbstractSdxTestDto.deleteForCleanup(AbstractSdxTestDto.java:122)  at com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto.cleanUp(CloudbreakTestDto.java:34)
...
```
The exception does not cause neither direct nor indirect test failure.

This is happening in case of SDX related TestDTOs, because of [AbstractSdxTestDto class](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractSdxTestDto.java#L119-L127) contains the
deleteForCleanup() override instead of the [SdxTestDto](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java) and [SdxInternalTestDto.java](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxInternalTestDto.java) where the `getCrn()` is valid and implemented.