### PR TITLE
CB-18224 - DB Upgrade fails with null pointer in RdsUpgradeService.ge…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeService.java
@@ -4,6 +4,7 @@ import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_RDS_UPGRADE_
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_RDS_UPGRADE_NOT_AVAILABLE;
 
 import java.util.List;
+import java.util.Optional;
 
 import javax.inject.Inject;
 
@@ -16,6 +17,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.database.StackDatabaseServerResponse;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.upgrade.RdsUpgradeV4Response;
 import com.sequenceiq.cloudbreak.api.model.RdsUpgradeResponseType;
+import com.sequenceiq.cloudbreak.common.database.MajorVersion;
 import com.sequenceiq.cloudbreak.common.database.TargetMajorVersion;
 import com.sequenceiq.cloudbreak.core.flow2.service.ReactorFlowManager;
 import com.sequenceiq.cloudbreak.event.ResourceEvent;
@@ -62,7 +64,10 @@ public class RdsUpgradeService {
 
     private String getCurrentRdsVersion(NameOrCrn nameOrCrn) {
         StackDatabaseServerResponse databaseServer = databaseService.getDatabaseServer(nameOrCrn);
-        return databaseServer.getMajorVersion().getVersion();
+        return Optional.ofNullable(databaseServer)
+                .map(StackDatabaseServerResponse::getMajorVersion)
+                .map(MajorVersion::getVersion)
+                .orElse(MajorVersion.VERSION_10.getVersion());
     }
 
     private RdsUpgradeV4Response alreadyOnLatestAnswer(TargetMajorVersion targetMajorVersion) {

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/DatabaseServerConverter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/DatabaseServerConverter.java
@@ -37,6 +37,7 @@ public class DatabaseServerConverter {
         }
         stackDatabaseServerResponse.setStatusReason(databaseServerV4Response.getStatusReason());
         stackDatabaseServerResponse.setClusterCrn(databaseServerV4Response.getClusterCrn());
+        stackDatabaseServerResponse.setMajorVersion(databaseServerV4Response.getMajorVersion());
         if (databaseServerV4Response.getSslConfig() != null) {
             SslConfigV4Response sslConfig = databaseServerV4Response.getSslConfig();
             DatabaseServerSslConfig databaseServerSslConfig = new DatabaseServerSslConfig();
@@ -48,7 +49,6 @@ public class DatabaseServerConverter {
                 databaseServerSslConfig.setSslCertificateType(sslCertificateTypeToDatabaseServerSslCertificateType(sslConfig.getSslCertificateType()));
             }
             stackDatabaseServerResponse.setSslConfig(databaseServerSslConfig);
-            stackDatabaseServerResponse.setMajorVersion(databaseServerV4Response.getMajorVersion());
         }
         return stackDatabaseServerResponse;
     }


### PR DESCRIPTION
…tCurrentRdsVersion

This commit
- fixes the place of MajorVersion setter in the converter
- introduces fallback logic if no MajorVersion is set in the RedBeams
side

See detailed description in the commit message.