### PR TITLE
CB-17181 Fallback saltuser password rotation for FreeIPA

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/rotatepassword/RotateSaltPasswordAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/rotatepassword/RotateSaltPasswordAction.java
@@ -21,6 +21,8 @@ public abstract class RotateSaltPasswordAction<P extends Payload>
 
     public static final String REASON = "reason";
 
+    public static final String TYPE = "type";
+
     private static final String PREVIOUS_STACK_STATUS = "previousStackStatus";
 
     @Inject
@@ -37,7 +39,8 @@ public abstract class RotateSaltPasswordAction<P extends Payload>
         Map<Object, Object> variables = stateContext.getExtendedState().getVariables();
         StackStatus previousStackStatus = (StackStatus) variables.computeIfAbsent(PREVIOUS_STACK_STATUS, o -> stack.getStackStatus());
         RotateSaltPasswordReason reason = (RotateSaltPasswordReason) variables.getOrDefault(REASON, RotateSaltPasswordReason.MANUAL);
-        return new RotateSaltPasswordContext(flowParameters, stack, previousStackStatus, reason);
+        RotateSaltPasswordType type = (RotateSaltPasswordType) variables.getOrDefault(TYPE, RotateSaltPasswordType.FALLBACK);
+        return new RotateSaltPasswordContext(flowParameters, stack, previousStackStatus, reason, type);
     }
 
     @Override

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/rotatepassword/RotateSaltPasswordActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/rotatepassword/RotateSaltPasswordActions.java
@@ -44,6 +44,7 @@ public class RotateSaltPasswordActions {
             protected void prepareExecution(RotateSaltPasswordRequest payload, Map<Object, Object> variables) {
                 super.prepareExecution(payload, variables);
                 variables.put(REASON, payload.getReason());
+                variables.put(TYPE, payload.getType());
             }
 
             @Override
@@ -55,7 +56,7 @@ public class RotateSaltPasswordActions {
 
             @Override
             protected Selectable createRequest(RotateSaltPasswordContext context) {
-                return new RotateSaltPasswordRequest(context.getStack().getId(), context.getReason());
+                return new RotateSaltPasswordRequest(context.getStack().getId(), context.getReason(), context.getType());
             }
         };
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/rotatepassword/RotateSaltPasswordContext.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/rotatepassword/RotateSaltPasswordContext.java
@@ -10,26 +10,34 @@ public class RotateSaltPasswordContext extends CommonContext {
 
     private final Stack stack;
 
-    private final RotateSaltPasswordReason reason;
-
     private final StackStatus previousStackStatus;
 
-    public RotateSaltPasswordContext(FlowParameters flowParameters, Stack stack, StackStatus previousStackStatus, RotateSaltPasswordReason reason) {
+    private final RotateSaltPasswordReason reason;
+
+    private final RotateSaltPasswordType type;
+
+    public RotateSaltPasswordContext(FlowParameters flowParameters, Stack stack, StackStatus previousStackStatus, RotateSaltPasswordReason reason,
+            RotateSaltPasswordType type) {
         super(flowParameters);
         this.stack = stack;
         this.previousStackStatus = previousStackStatus;
         this.reason = reason;
+        this.type = type;
     }
 
     public Stack getStack() {
         return stack;
     }
 
+    public StackStatus getPreviousStackStatus() {
+        return previousStackStatus;
+    }
+
     public RotateSaltPasswordReason getReason() {
         return reason;
     }
 
-    public StackStatus getPreviousStackStatus() {
-        return previousStackStatus;
+    public RotateSaltPasswordType getType() {
+        return type;
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/rotatepassword/RotateSaltPasswordType.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/rotatepassword/RotateSaltPasswordType.java
@@ -1,0 +1,6 @@
+package com.sequenceiq.freeipa.flow.freeipa.salt.rotatepassword;
+
+public enum RotateSaltPasswordType {
+    FALLBACK,
+    SALT_BOOTSTRAP_ENDPOINT,
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/rotatepassword/event/RotateSaltPasswordRequest.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/rotatepassword/event/RotateSaltPasswordRequest.java
@@ -2,21 +2,30 @@ package com.sequenceiq.freeipa.flow.freeipa.salt.rotatepassword.event;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.freeipa.flow.freeipa.salt.rotatepassword.RotateSaltPasswordType;
 import com.sequenceiq.freeipa.flow.stack.StackEvent;
 
 public class RotateSaltPasswordRequest extends StackEvent {
 
     private final RotateSaltPasswordReason reason;
 
+    private final RotateSaltPasswordType type;
+
     @JsonCreator
     public RotateSaltPasswordRequest(
             @JsonProperty("resourceId") Long stackId,
-            @JsonProperty("reason") RotateSaltPasswordReason reason) {
+            @JsonProperty("reason") RotateSaltPasswordReason reason,
+            @JsonProperty("type") RotateSaltPasswordType type) {
         super(stackId);
         this.reason = reason;
+        this.type = type;
     }
 
     public RotateSaltPasswordReason getReason() {
         return reason;
+    }
+
+    public RotateSaltPasswordType getType() {
+        return type;
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/BootstrapServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/BootstrapServiceTest.java
@@ -101,6 +101,7 @@ class BootstrapServiceTest {
                 createInstance(INSTANCE_WRONG_DOMAIN, "instance.wrong.domain"),
                 createInstance("filterMe", "filtered" + DOMAIN)));
         Stack stack = new Stack();
+        stack.setId(STACK_ID);
         stack.setCloudPlatform("cloud");
         when(stackRepository.findById(STACK_ID)).thenReturn(Optional.of(stack));
         FreeIpa freeIpa = new FreeIpa();
@@ -165,6 +166,7 @@ class BootstrapServiceTest {
                 createInstance(INSTANCE_WO_FQDN, null),
                 createInstance(INSTANCE_WRONG_DOMAIN, "instance.wrong.domain")));
         Stack stack = new Stack();
+        stack.setId(STACK_ID);
         stack.setCloudPlatform("cloud");
         when(stackRepository.findById(STACK_ID)).thenReturn(Optional.of(stack));
         FreeIpa freeIpa = new FreeIpa();
@@ -223,12 +225,54 @@ class BootstrapServiceTest {
     }
 
     @Test
+    public void testReBootstrap() throws Exception {
+        Stack stack = new Stack();
+        stack.setId(STACK_ID);
+        stack.setCloudPlatform("cloud");
+        InstanceGroup instanceGroup = new InstanceGroup();
+        instanceGroup.setTemplate(new Template());
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+        instanceMetaData.setInstanceGroup(instanceGroup);
+        instanceMetaData.setPrivateIp("8.8.8.8");
+        instanceMetaData.setDiscoveryFQDN("node." + DOMAIN);
+        instanceGroup.setInstanceMetaData(Set.of(instanceMetaData));
+        stack.setInstanceGroups(Set.of(instanceGroup));
+        FreeIpa freeIpa = new FreeIpa();
+        freeIpa.setDomain(DOMAIN);
+        freeIpa.setHostname(HOSTNAME);
+        when(freeIpaService.findByStack(stack)).thenReturn(freeIpa);
+        List<GatewayConfig> gatewayConfigs = List.of();
+        when(gatewayConfigService.getGatewayConfigs(eq(stack), anySet())).thenReturn(gatewayConfigs);
+        ImageEntity image = new ImageEntity();
+        image.setOs("ZOS");
+        when(imageService.getByStack(stack)).thenReturn(image);
+
+        underTest.reBootstrap(stack);
+
+        ArgumentCaptor<Set<Node>> targetCaptor = ArgumentCaptor.forClass((Class) Set.class);
+        ArgumentCaptor<BootstrapParams> bootstrapParamsCaptor = ArgumentCaptor.forClass(BootstrapParams.class);
+        ArgumentCaptor<ExitCriteriaModel> exitCriteriaModelCaptor = ArgumentCaptor.forClass(ExitCriteriaModel.class);
+        verify(hostOrchestrator).bootstrap(eq(gatewayConfigs), targetCaptor.capture(), bootstrapParamsCaptor.capture(), exitCriteriaModelCaptor.capture());
+        Set<Node> targetNodes = targetCaptor.getValue();
+        assertEquals(1, targetNodes.size());
+        assertTrue(targetNodes.stream().allMatch(node -> node.getPrivateIp().equals(instanceMetaData.getPrivateIp())));
+        BootstrapParams bootstrapParams = bootstrapParamsCaptor.getValue();
+        assertTrue(bootstrapParams.isSaltBootstrapFpSupported());
+        assertTrue(bootstrapParams.isRestartNeededFlagSupported());
+        assertEquals(image.getOs(), bootstrapParams.getOs());
+        assertEquals(stack.getCloudPlatform(), bootstrapParams.getCloud());
+        StackBasedExitCriteriaModel exitCriteriaModel = (StackBasedExitCriteriaModel) exitCriteriaModelCaptor.getValue();
+        assertEquals(STACK_ID, exitCriteriaModel.getStackId().get());
+    }
+
+    @Test
     public void testIOExceptionConverted() throws CloudbreakOrchestratorException, IOException {
         when(instanceMetaDataService.findNotTerminatedForStack(STACK_ID)).thenReturn(Set.of(
                 createInstance(INSTANCE_WITH_FQDN, "instance1" + DOMAIN),
                 createInstance(INSTANCE_WO_FQDN, null),
                 createInstance(INSTANCE_WRONG_DOMAIN, "instance.wrong.domain")));
         Stack stack = new Stack();
+        stack.setId(STACK_ID);
         stack.setCloudPlatform("cloud");
         when(stackRepository.findById(STACK_ID)).thenReturn(Optional.of(stack));
         FreeIpa freeIpa = new FreeIpa();
@@ -255,6 +299,7 @@ class BootstrapServiceTest {
                 createInstance(INSTANCE_WO_FQDN, null),
                 createInstance(INSTANCE_WRONG_DOMAIN, "instance.wrong.domain")));
         Stack stack = new Stack();
+        stack.setId(STACK_ID);
         stack.setCloudPlatform("cloud");
         when(stackRepository.findById(STACK_ID)).thenReturn(Optional.of(stack));
         FreeIpa freeIpa = new FreeIpa();


### PR DESCRIPTION
Steps to rotate saltuser password on stacks with older salt-bootstrap version:
- Remove saltuser from gateways (proceed even if it fails, as the error message will give a hint to do this manually)
- Run the boostrap service on gateway nodes, this will recreate the saltuser with the new password

See detailed description in the commit message.