### PR TITLE
CB-18241 Fix SdxStatusService.getActualStatusForSdx

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/cmsync/SdxCmSyncActions.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/cmsync/SdxCmSyncActions.java
@@ -16,7 +16,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.statemachine.StateContext;
 import org.springframework.statemachine.action.Action;
 
-import com.sequenceiq.datalake.entity.DatalakeStatusEnum;
 import com.sequenceiq.datalake.entity.SdxStatusEntity;
 import com.sequenceiq.datalake.flow.SdxContext;
 import com.sequenceiq.datalake.flow.SdxEvent;
@@ -106,9 +105,9 @@ public class SdxCmSyncActions {
             }
 
             private void setStatusForDatalakeAndNotify(Long resourceId, String exceptionMessage) {
-                Optional<SdxStatusEntity> actualStatus = sdxStatusService.getActualStatusForSdx(resourceId);
+                SdxStatusEntity actualStatus = sdxStatusService.getActualStatusForSdx(resourceId);
                 sdxStatusService.setStatusForDatalakeAndNotify(
-                        actualStatus.map(SdxStatusEntity::getStatus).orElse(DatalakeStatusEnum.RUNNING),
+                        actualStatus.getStatus(),
                         exceptionMessage,
                         resourceId);
             }

--- a/datalake/src/main/java/com/sequenceiq/datalake/repository/SdxStatusRepository.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/repository/SdxStatusRepository.java
@@ -15,6 +15,8 @@ public interface SdxStatusRepository extends CrudRepository<SdxStatusEntity, Lon
 
     SdxStatusEntity findFirstByDatalakeIsOrderByIdDesc(SdxCluster sdxCluster);
 
+    SdxStatusEntity findFirstByDatalakeIdIsOrderByIdDesc(Long id);
+
     List<SdxStatusEntity> findDistinctFirstByStatusInAndDatalakeIdInOrderByIdDesc(Collection<DatalakeStatusEnum> datalakeStatusEnums,
             Collection<Long> datalakeId);
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/status/SdxStatusService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/status/SdxStatusService.java
@@ -170,8 +170,8 @@ public class SdxStatusService {
         return sdxStatusRepository.findFirstByDatalakeIsOrderByIdDesc(sdxCluster);
     }
 
-    public Optional<SdxStatusEntity> getActualStatusForSdx(Long id) {
-        return sdxStatusRepository.findById(id);
+    public SdxStatusEntity getActualStatusForSdx(Long id) {
+        return sdxStatusRepository.findFirstByDatalakeIdIsOrderByIdDesc(id);
     }
 
     public void updateInMemoryStateStore(SdxCluster sdxCluster) {


### PR DESCRIPTION
The input parameter is the SDX id, not the SDX status id

See detailed description in the commit message.