### PR TITLE
CB-16402 set UBI8 base image for Java based docker images

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/config/DatabaseConfig.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/config/DatabaseConfig.java
@@ -3,8 +3,6 @@ package com.sequenceiq.periscope.config;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.sql.SQLException;
 
 import javax.inject.Inject;
@@ -92,9 +90,9 @@ public class DatabaseConfig {
     public DataSource dataSource() throws SQLException {
         DatabaseUtil.createSchemaIfNeeded("postgresql", databaseAddress, dbName, dbUser, dbPassword, dbSchemaName);
         HikariConfig config = new HikariConfig();
-        if (ssl && Files.exists(Paths.get(certFile))) {
+        if (ssl) {
             config.addDataSourceProperty("ssl", "true");
-            config.addDataSourceProperty("sslrootcert", certFile);
+            config.addDataSourceProperty("sslfactory", "org.postgresql.ssl.DefaultJavaSSLFactory");
         }
         if (periscopeNodeConfig.isNodeIdSpecified()) {
             config.addDataSourceProperty("ApplicationName", periscopeNodeConfig.getId());

--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/configuration/DatabaseConfig.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/configuration/DatabaseConfig.java
@@ -3,8 +3,6 @@ package com.sequenceiq.consumption.configuration;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -97,9 +95,9 @@ public class DatabaseConfig {
     public DataSource dataSource() throws SQLException {
         createSchemaIfNeeded("postgresql", databaseAddress, dbName, dbUser, dbPassword, dbSchemaName);
         HikariConfig config = new HikariConfig();
-        if (ssl && Files.exists(Paths.get(certFile))) {
+        if (ssl) {
             config.addDataSourceProperty("ssl", "true");
-            config.addDataSourceProperty("sslrootcert", certFile);
+            config.addDataSourceProperty("sslfactory", "org.postgresql.ssl.DefaultJavaSSLFactory");
         }
         if (nodeConfig.isNodeIdSpecified()) {
             config.addDataSourceProperty("ApplicationName", nodeConfig.getId());

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpHttpClientConfig.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpHttpClientConfig.java
@@ -1,19 +1,33 @@
 package com.sequenceiq.cloudbreak.cloud.gcp.client;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.util.Objects;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.googleapis.GoogleUtils;
 import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.util.SecurityUtils;
 
 @Configuration
 public class GcpHttpClientConfig {
 
     @Bean
     public HttpTransport httpTransport() throws GeneralSecurityException, IOException {
-        return GoogleNetHttpTransport.newTrustedTransport();
+        return new NetHttpTransport.Builder()
+                .trustCertificates(getCertificateTrustStore())
+                .build();
+    }
+
+    private KeyStore getCertificateTrustStore() throws IOException, GeneralSecurityException {
+        KeyStore certTrustStore = SecurityUtils.getDefaultKeyStore();
+        InputStream keyStoreStream = GoogleUtils.class.getResourceAsStream("google.p12");
+        SecurityUtils.loadKeyStore(certTrustStore, Objects.requireNonNull(keyStoreStream), "notasecret");
+        return certTrustStore;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/conf/DatabaseConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/conf/DatabaseConfig.java
@@ -3,8 +3,6 @@ package com.sequenceiq.cloudbreak.conf;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.sql.SQLException;
 
 import javax.inject.Inject;
@@ -108,9 +106,9 @@ public class DatabaseConfig {
     private HikariDataSource getDataSource() throws SQLException {
         DatabaseUtil.createSchemaIfNeeded("postgresql", databaseAddress, dbName, dbUser, dbPassword, dbSchemaName);
         HikariConfig config = new HikariConfig();
-        if (ssl && Files.exists(Paths.get(certFile))) {
+        if (ssl) {
             config.addDataSourceProperty("ssl", "true");
-            config.addDataSourceProperty("sslrootcert", certFile);
+            config.addDataSourceProperty("sslfactory", "org.postgresql.ssl.DefaultJavaSSLFactory");
         }
         if (nodeConfig.isNodeIdSpecified()) {
             config.addDataSourceProperty("ApplicationName", nodeConfig.getId());

--- a/datalake/src/main/java/com/sequenceiq/datalake/configuration/DatabaseConfig.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/configuration/DatabaseConfig.java
@@ -3,8 +3,6 @@ package com.sequenceiq.datalake.configuration;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.sql.SQLException;
 
 import javax.inject.Inject;
@@ -90,9 +88,9 @@ public class DatabaseConfig {
     public DataSource dataSource() throws SQLException {
         DatabaseUtil.createSchemaIfNeeded("postgresql", databaseAddress, dbName, dbUser, dbPassword, dbSchemaName);
         HikariConfig config = new HikariConfig();
-        if (ssl && Files.exists(Paths.get(certFile))) {
+        if (ssl) {
             config.addDataSourceProperty("ssl", "true");
-            config.addDataSourceProperty("sslrootcert", certFile);
+            config.addDataSourceProperty("sslfactory", "org.postgresql.ssl.DefaultJavaSSLFactory");
         }
         if (nodeConfig.isNodeIdSpecified()) {
             config.addDataSourceProperty("ApplicationName", nodeConfig.getId());

--- a/docker-autoscale/Dockerfile
+++ b/docker-autoscale/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.13-cldr-jre-slim-buster-15122021
+FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-ubi-minimal-java:jdk11-ubi8.5-218
 # We can not use alpine based image because of https://github.com/grpc/grpc-java/issues/8751
 MAINTAINER info@cloudera.com
 
@@ -10,7 +10,7 @@ ENV VERSION ${VERSION}
 
 WORKDIR /
 
-RUN apt-get install unzip
+RUN microdnf install unzip
 
 # install the periscope app
 ADD ${REPO_URL}/com/sequenceiq/periscope/$VERSION/periscope-$VERSION.jar /periscope.jar

--- a/docker-autoscale/Dockerfile
+++ b/docker-autoscale/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-ubi-minimal-java:jdk11-ubi8.5-218
+FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-openjdk-11-runtime:1.14-3-03082022
 # We can not use alpine based image because of https://github.com/grpc/grpc-java/issues/8751
 MAINTAINER info@cloudera.com
 

--- a/docker-autoscale/bootstrap/start_autoscale_app.sh
+++ b/docker-autoscale/bootstrap/start_autoscale_app.sh
@@ -14,7 +14,7 @@ echo "Importing certificates to the default Java certificate  trust store."
 if [ -d "$TRUSTED_CERT_DIR" ]; then
     for cert in $(ls -A "$TRUSTED_CERT_DIR"); do
         if [ -f "$TRUSTED_CERT_DIR/$cert" ]; then
-            if keytool -import -alias "$cert" -noprompt -file "$TRUSTED_CERT_DIR/$cert" -keystore /usr/local/openjdk-11/lib/security/cacerts -storepass changeit; then
+            if keytool -import -alias "$cert" -noprompt -file "$TRUSTED_CERT_DIR/$cert" -keystore /etc/pki/java/cacerts -storepass changeit; then
                 echo -e "Certificate added to default Java trust store with alias $cert."
             else
                 echo -e "WARNING: Failed to add $cert to trust store.\n"

--- a/docker-cloudbreak/Dockerfile
+++ b/docker-cloudbreak/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.13-cldr-jre-slim-buster-15122021
+FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-ubi-minimal-java:jdk11-ubi8.5-218
 # We can not use alpine based image because of https://github.com/grpc/grpc-java/issues/8751
 MAINTAINER info@cloudera.com
 
@@ -10,7 +10,7 @@ ENV VERSION ${VERSION}
 
 WORKDIR /
 
-RUN apt-get install unzip
+RUN microdnf install unzip
 
 # install the cloudbreak app
 ADD ${REPO_URL}/com/sequenceiq/cloudbreak/$VERSION/cloudbreak-$VERSION.jar /cloudbreak.jar

--- a/docker-cloudbreak/Dockerfile
+++ b/docker-cloudbreak/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-ubi-minimal-java:jdk11-ubi8.5-218
+FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-openjdk-11-runtime:1.14-3-03082022
 # We can not use alpine based image because of https://github.com/grpc/grpc-java/issues/8751
 MAINTAINER info@cloudera.com
 

--- a/docker-cloudbreak/bootstrap/start_cloudbreak_app.sh
+++ b/docker-cloudbreak/bootstrap/start_cloudbreak_app.sh
@@ -14,7 +14,7 @@ echo "Importing certificates to the default Java certificate  trust store."
 if [ -d "$TRUSTED_CERT_DIR" ]; then
     for cert in $(ls -A "$TRUSTED_CERT_DIR"); do
         if [ -f "$TRUSTED_CERT_DIR/$cert" ]; then
-            if keytool -import -alias "$cert" -noprompt -file "$TRUSTED_CERT_DIR/$cert" -keystore /usr/local/openjdk-11/lib/security/cacerts -storepass changeit; then
+            if keytool -import -alias "$cert" -noprompt -file "$TRUSTED_CERT_DIR/$cert" -keystore /etc/pki/java/cacerts -storepass changeit; then
                 echo -e "Certificate added to default Java trust store with alias $cert."
             else
                 echo -e "WARNING: Failed to add $cert to trust store.\n"

--- a/docker-consumption/Dockerfile
+++ b/docker-consumption/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.13-cldr-jre-slim-buster-15122021
+FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-openjdk-11-runtime:1.14-3-03082022
 # We can not use alpine based image because of https://github.com/grpc/grpc-java/issues/8751
 MAINTAINER info@cloudera.com
 
@@ -10,7 +10,7 @@ ENV VERSION ${VERSION}
 
 WORKDIR /
 
-RUN apt-get install unzip
+RUN microdnf install unzip
 
 # install the consumption app
 ADD ${REPO_URL}/com/sequenceiq/cloud-consumption/$VERSION/cloud-consumption-$VERSION.jar /consumption.jar

--- a/docker-consumption/bootstrap/start_consumption_app.sh
+++ b/docker-consumption/bootstrap/start_consumption_app.sh
@@ -14,7 +14,7 @@ echo "Importing certificates to the default Java certificate  trust store."
 if [ -d "$TRUSTED_CERT_DIR" ]; then
     for cert in $(ls -A "$TRUSTED_CERT_DIR"); do
         if [ -f "$TRUSTED_CERT_DIR/$cert" ]; then
-            if keytool -import -alias "$cert" -noprompt -file "$TRUSTED_CERT_DIR/$cert" -keystore /usr/local/openjdk-11/lib/security/cacerts -storepass changeit; then
+            if keytool -import -alias "$cert" -noprompt -file "$TRUSTED_CERT_DIR/$cert" -keystore /etc/pki/java/cacerts -storepass changeit; then
                 echo -e "Certificate added to default Java trust store with alias $cert."
             else
                 echo -e "WARNING: Failed to add $cert to trust store.\n"

--- a/docker-datalake/Dockerfile
+++ b/docker-datalake/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.13-cldr-jre-slim-buster-15122021
+FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-ubi-minimal-java:jdk11-ubi8.5-218
 # We can not use alpine based image because of https://github.com/grpc/grpc-java/issues/8751
 MAINTAINER info@cloudera.com
 
@@ -10,7 +10,7 @@ ENV VERSION ${VERSION}
 
 WORKDIR /
 
-RUN apt-get install unzip
+RUN microdnf install unzip
 
 # install the datalake app
 ADD ${REPO_URL}/com/sequenceiq/datalake/$VERSION/datalake-$VERSION.jar /datalake.jar

--- a/docker-datalake/Dockerfile
+++ b/docker-datalake/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-ubi-minimal-java:jdk11-ubi8.5-218
+FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-openjdk-11-runtime:1.14-3-03082022
 # We can not use alpine based image because of https://github.com/grpc/grpc-java/issues/8751
 MAINTAINER info@cloudera.com
 

--- a/docker-datalake/bootstrap/start_datalake_app.sh
+++ b/docker-datalake/bootstrap/start_datalake_app.sh
@@ -14,7 +14,7 @@ echo "Importing certificates to the default Java certificate  trust store."
 if [ -d "$TRUSTED_CERT_DIR" ]; then
     for cert in $(ls -A "$TRUSTED_CERT_DIR"); do
         if [ -f "$TRUSTED_CERT_DIR/$cert" ]; then
-            if keytool -import -alias "$cert" -noprompt -file "$TRUSTED_CERT_DIR/$cert" -keystore /usr/local/openjdk-11/lib/security/cacerts -storepass changeit; then
+            if keytool -import -alias "$cert" -noprompt -file "$TRUSTED_CERT_DIR/$cert" -keystore /etc/pki/java/cacerts -storepass changeit; then
                 echo -e "Certificate added to default Java trust store with alias $cert."
             else
                 echo -e "WARNING: Failed to add $cert to trust store.\n"

--- a/docker-environment/Dockerfile
+++ b/docker-environment/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.13-cldr-jre-slim-buster-15122021
+FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-ubi-minimal-java:jdk11-ubi8.5-218
 # We can not use alpine based image because of https://github.com/grpc/grpc-java/issues/8751
 MAINTAINER info@cloudera.com
 
@@ -10,7 +10,7 @@ ENV VERSION ${VERSION}
 
 WORKDIR /
 
-RUN apt-get install unzip
+RUN microdnf install unzip
 
 # install the environment app
 ADD ${REPO_URL}/com/sequenceiq/environment/$VERSION/environment-$VERSION.jar /environment.jar

--- a/docker-environment/Dockerfile
+++ b/docker-environment/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-ubi-minimal-java:jdk11-ubi8.5-218
+FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-openjdk-11-runtime:1.14-3-03082022
 # We can not use alpine based image because of https://github.com/grpc/grpc-java/issues/8751
 MAINTAINER info@cloudera.com
 

--- a/docker-environment/bootstrap/start_environment_app.sh
+++ b/docker-environment/bootstrap/start_environment_app.sh
@@ -14,7 +14,7 @@ echo "Importing certificates to the default Java certificate  trust store."
 if [ -d "$TRUSTED_CERT_DIR" ]; then
     for cert in $(ls -A "$TRUSTED_CERT_DIR"); do
         if [ -f "$TRUSTED_CERT_DIR/$cert" ]; then
-            if keytool -import -alias "$cert" -noprompt -file "$TRUSTED_CERT_DIR/$cert" -keystore /usr/local/openjdk-11/lib/security/cacerts -storepass changeit; then
+            if keytool -import -alias "$cert" -noprompt -file "$TRUSTED_CERT_DIR/$cert" -keystore /etc/pki/java/cacerts -storepass changeit; then
                 echo -e "Certificate added to default Java trust store with alias $cert."
             else
                 echo -e "WARNING: Failed to add $cert to trust store.\n"

--- a/docker-freeipa/Dockerfile
+++ b/docker-freeipa/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.13-cldr-jre-slim-buster-15122021
+FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-ubi-minimal-java:jdk11-ubi8.5-218
 # We can not use alpine based image because of https://github.com/grpc/grpc-java/issues/8751
 MAINTAINER info@cloudera.com
 
@@ -10,7 +10,7 @@ ENV VERSION ${VERSION}
 
 WORKDIR /
 
-RUN apt-get install unzip
+RUN microdnf install unzip
 
 # install the freeipa app
 ADD ${REPO_URL}/com/sequenceiq/freeipa/$VERSION/freeipa-$VERSION.jar /freeipa.jar

--- a/docker-freeipa/Dockerfile
+++ b/docker-freeipa/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-ubi-minimal-java:jdk11-ubi8.5-218
+FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-openjdk-11-runtime:1.14-3-03082022
 # We can not use alpine based image because of https://github.com/grpc/grpc-java/issues/8751
 MAINTAINER info@cloudera.com
 

--- a/docker-freeipa/bootstrap/start_freeipa_app.sh
+++ b/docker-freeipa/bootstrap/start_freeipa_app.sh
@@ -14,7 +14,7 @@ echo "Importing certificates to the default Java certificate  trust store."
 if [ -d "$TRUSTED_CERT_DIR" ]; then
     for cert in $(ls -A "$TRUSTED_CERT_DIR"); do
         if [ -f "$TRUSTED_CERT_DIR/$cert" ]; then
-            if keytool -import -alias "$cert" -noprompt -file "$TRUSTED_CERT_DIR/$cert" -keystore /usr/local/openjdk-11/lib/security/cacerts -storepass changeit; then
+            if keytool -import -alias "$cert" -noprompt -file "$TRUSTED_CERT_DIR/$cert" -keystore /etc/pki/java/cacerts -storepass changeit; then
                 echo -e "Certificate added to default Java trust store with alias $cert."
             else
                 echo -e "WARNING: Failed to add $cert to trust store.\n"

--- a/docker-redbeams/Dockerfile
+++ b/docker-redbeams/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.13-cldr-jre-slim-buster-15122021
+FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-ubi-minimal-java:jdk11-ubi8.5-218
 # We can not use alpine based image because of https://github.com/grpc/grpc-java/issues/8751
 MAINTAINER info@cloudera.com
 
@@ -10,7 +10,7 @@ ENV VERSION ${VERSION}
 
 WORKDIR /
 
-RUN apt-get install unzip
+RUN microdnf install unzip
 
 # install the Redbeams app
 ADD ${REPO_URL}/com/sequenceiq/redbeams/$VERSION/redbeams-$VERSION.jar /redbeams.jar

--- a/docker-redbeams/Dockerfile
+++ b/docker-redbeams/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-ubi-minimal-java:jdk11-ubi8.5-218
+FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-openjdk-11-runtime:1.14-3-03082022
 # We can not use alpine based image because of https://github.com/grpc/grpc-java/issues/8751
 MAINTAINER info@cloudera.com
 

--- a/docker-redbeams/bootstrap/start_redbeams_app.sh
+++ b/docker-redbeams/bootstrap/start_redbeams_app.sh
@@ -14,7 +14,7 @@ echo "Importing certificates to the default Java certificate trust store."
 if [ -d "$TRUSTED_CERT_DIR" ]; then
     for cert in $(ls -A "$TRUSTED_CERT_DIR"); do
         if [ -f "$TRUSTED_CERT_DIR/$cert" ]; then
-            if keytool -import -alias "$cert" -noprompt -file "$TRUSTED_CERT_DIR/$cert" -keystore /usr/local/openjdk-11/lib/security/cacerts -storepass changeit; then
+            if keytool -import -alias "$cert" -noprompt -file "$TRUSTED_CERT_DIR/$cert" -keystore /etc/pki/java/cacerts -storepass changeit; then
                 echo -e "Certificate added to default Java trust store with alias $cert."
             else
                 echo -e "WARNING: Failed to add $cert to trust store.\n"

--- a/environment/src/main/java/com/sequenceiq/environment/configuration/DatabaseConfig.java
+++ b/environment/src/main/java/com/sequenceiq/environment/configuration/DatabaseConfig.java
@@ -3,8 +3,6 @@ package com.sequenceiq.environment.configuration;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -97,9 +95,9 @@ public class DatabaseConfig {
     public DataSource dataSource() throws SQLException {
         createSchemaIfNeeded("postgresql", databaseAddress, dbName, dbUser, dbPassword, dbSchemaName);
         HikariConfig config = new HikariConfig();
-        if (ssl && Files.exists(Paths.get(certFile))) {
+        if (ssl) {
             config.addDataSourceProperty("ssl", "true");
-            config.addDataSourceProperty("sslrootcert", certFile);
+            config.addDataSourceProperty("sslfactory", "org.postgresql.ssl.DefaultJavaSSLFactory");
         }
         if (nodeConfig.isNodeIdSpecified()) {
             config.addDataSourceProperty("ApplicationName", nodeConfig.getId());

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/DatabaseConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/DatabaseConfig.java
@@ -3,8 +3,6 @@ package com.sequenceiq.freeipa.configuration;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.sql.SQLException;
 
 import javax.inject.Inject;
@@ -92,9 +90,9 @@ public class DatabaseConfig {
     public DataSource dataSource() throws SQLException {
         DatabaseUtil.createSchemaIfNeeded("postgresql", databaseAddress, dbName, dbUser, dbPassword, dbSchemaName);
         HikariConfig config = new HikariConfig();
-        if (ssl && Files.exists(Paths.get(certFile))) {
+        if (ssl) {
             config.addDataSourceProperty("ssl", "true");
-            config.addDataSourceProperty("sslrootcert", certFile);
+            config.addDataSourceProperty("sslfactory", "org.postgresql.ssl.DefaultJavaSSLFactory");
         }
         if (nodeConfig.isNodeIdSpecified()) {
             config.addDataSourceProperty("ApplicationName", nodeConfig.getId());

--- a/integration-test/docker-compose_template.yml
+++ b/integration-test/docker-compose_template.yml
@@ -14,7 +14,7 @@ services:
     - ../mock-thunderhead/build/libs/mock-thunderhead.jar:/mock-thunderhead.jar
     - ./integcb/etc:/etc/auth
     command: java -jar /mock-thunderhead.jar
-    image: docker-private.infra.cloudera.com/cloudera_thirdparty/openjdk/openjdk:11-jdk
+    image: docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-openjdk-11-runtime:1.14-3-03082022
     deploy:
       resources:
         limits:
@@ -94,7 +94,7 @@ services:
       - INTEGRATIONTEST_UMS_JSONSECRET_DESTINATIONPATH
       - INTEGRATIONTEST_UMS_JSONSECRET_NAME
       - INTEGRATIONTEST_RUNTIMEVERSION
-    image: openjdk:11-jdk
+    image: docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-openjdk-11-runtime:1.14-3-03082022
     deploy:
       resources:
         limits:

--- a/integration-test/test-image/Dockerfile
+++ b/integration-test/test-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.13-cldr-jre-slim-buster-15122021
+FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-ubi-minimal-java:jdk11-ubi8.5-218
 MAINTAINER info@cloudera.com
 
 WORKDIR /

--- a/integration-test/test-image/Dockerfile
+++ b/integration-test/test-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-ubi-minimal-java:jdk11-ubi8.5-218
+FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-openjdk-11-runtime:1.14-3-03082022
 MAINTAINER info@cloudera.com
 
 WORKDIR /

--- a/mock-infrastructure/Dockerfile
+++ b/mock-infrastructure/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.13-cldr-jre-slim-buster-15122021
+FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-ubi-minimal-java:jdk11-ubi8.5-218
 MAINTAINER info@cloudera.com
 
 # REPO URL to download jar

--- a/mock-infrastructure/Dockerfile
+++ b/mock-infrastructure/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-ubi-minimal-java:jdk11-ubi8.5-218
+FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-openjdk-11-runtime:1.14-3-03082022
 MAINTAINER info@cloudera.com
 
 # REPO URL to download jar

--- a/mock-thunderhead/Dockerfile
+++ b/mock-thunderhead/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.13-cldr-jre-slim-buster-15122021
+FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-ubi-minimal-java:jdk11-ubi8.5-218
 MAINTAINER info@cloudera.com
 
 # REPO URL to download jar

--- a/mock-thunderhead/Dockerfile
+++ b/mock-thunderhead/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-ubi-minimal-java:jdk11-ubi8.5-218
+FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-openjdk-11-runtime:1.14-3-03082022
 MAINTAINER info@cloudera.com
 
 # REPO URL to download jar

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/DatabaseConfig.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/DatabaseConfig.java
@@ -3,8 +3,6 @@ package com.sequenceiq.redbeams.configuration;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.sql.SQLException;
 
 import javax.inject.Inject;
@@ -90,9 +88,9 @@ public class DatabaseConfig {
     public DataSource dataSource() throws SQLException {
         DatabaseUtil.createSchemaIfNeeded("postgresql", databaseAddress, dbName, dbUser, dbPassword, dbSchemaName);
         HikariConfig config = new HikariConfig();
-        if (ssl && Files.exists(Paths.get(certFile))) {
+        if (ssl) {
             config.addDataSourceProperty("ssl", "true");
-            config.addDataSourceProperty("sslrootcert", certFile);
+            config.addDataSourceProperty("sslfactory", "org.postgresql.ssl.DefaultJavaSSLFactory");
         }
         if (nodeConfig.isNodeIdSpecified()) {
             config.addDataSourceProperty("ApplicationName", nodeConfig.getId());


### PR DESCRIPTION
 **Changes:**
  -  Revert "CB-16401 Temporarily revert UBI base image changes in CB Java services"
  - CB-16402 set ubi8/cldr-openjdk-11-runtime as default base image for Environment, FreeIPA, Redbeams, Datalake, Autoscale and Cloudbreak services.
  - CB-16402 Introduce minor fixes to be able to start the mentioned services on FIPS enabled environments like use FIPS compatible `org.postgresql.ssl.DefaultJavaSSLFactory` as Postgres database client SSL factory, GCP client to use JRT default `KeyStore` instead of explicit `PKCS12`, use default `SSLContext` instead of a custom one that accepts everything...