### PR TITLE
CB-18121. Refactor salt pillar generation for telemetry related compo…

### DIFF
--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/CdpAccessKeyType.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/CdpAccessKeyType.java
@@ -1,0 +1,15 @@
+package com.sequenceiq.common.api.telemetry.model;
+
+public enum CdpAccessKeyType {
+    ED25519("Ed25519"), ECDSA("ECDSA"), RSA("RSA");
+
+    private final String value;
+
+    CdpAccessKeyType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/CdpCredential.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/CdpCredential.java
@@ -1,0 +1,74 @@
+package com.sequenceiq.common.api.telemetry.model;
+
+import java.io.Serializable;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public abstract class CdpCredential implements Serializable {
+
+    @JsonProperty("machineUserName")
+    private String machineUserName;
+
+    @JsonProperty("accessKey")
+    private String accessKey;
+
+    @JsonProperty("privateKey")
+    private String privateKey;
+
+    @JsonProperty("accessKeyType")
+    private String accessKeyType;
+
+    public String getMachineUserName() {
+        return machineUserName;
+    }
+
+    public void setMachineUserName(String machineUserName) {
+        this.machineUserName = machineUserName;
+    }
+
+    public String getAccessKey() {
+        return accessKey;
+    }
+
+    public void setAccessKey(String accessKey) {
+        this.accessKey = accessKey;
+    }
+
+    public String getPrivateKey() {
+        return privateKey;
+    }
+
+    public void setPrivateKey(String privateKey) {
+        this.privateKey = privateKey;
+    }
+
+    public String getAccessKeyType() {
+        return accessKeyType;
+    }
+
+    public void setAccessKeyType(String accessKeyType) {
+        this.accessKeyType = accessKeyType;
+    }
+
+    @JsonIgnore
+    public boolean isValid() {
+        return StringUtils.isNoneBlank(accessKey, privateKey);
+    }
+
+    @Override
+    public String toString() {
+        return "CdpCredential{" +
+                "machineUserName='" + machineUserName + '\'' +
+                ", accessKey='" + accessKey + '\'' +
+                ", privateKey='*****" + '\'' +
+                ", accessKeyType='" + accessKeyType + '\'' +
+                '}';
+    }
+}

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/DataBusCredential.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/DataBusCredential.java
@@ -1,45 +1,9 @@
 package com.sequenceiq.common.api.telemetry.model;
 
-import java.io.Serializable;
+public class DataBusCredential extends CdpCredential {
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-@JsonIgnoreProperties(ignoreUnknown = true)
-@JsonInclude(JsonInclude.Include.NON_NULL)
-public class DataBusCredential implements Serializable {
-
-    @JsonProperty("machineUserName")
-    private String machineUserName;
-
-    @JsonProperty("accessKey")
-    private String accessKey;
-
-    @JsonProperty("privateKey")
-    private String privateKey;
-
-    public String getMachineUserName() {
-        return machineUserName;
-    }
-
-    public void setMachineUserName(String machineUserName) {
-        this.machineUserName = machineUserName;
-    }
-
-    public String getAccessKey() {
-        return accessKey;
-    }
-
-    public void setAccessKey(String accessKey) {
-        this.accessKey = accessKey;
-    }
-
-    public String getPrivateKey() {
-        return privateKey;
-    }
-
-    public void setPrivateKey(String privateKey) {
-        this.privateKey = privateKey;
+    @Override
+    public String toString() {
+        return "DataBusCredential{} " + super.toString();
     }
 }

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/MonitoringCredential.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/MonitoringCredential.java
@@ -1,45 +1,9 @@
 package com.sequenceiq.common.api.telemetry.model;
 
-import java.io.Serializable;
+public class MonitoringCredential extends CdpCredential {
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-@JsonIgnoreProperties(ignoreUnknown = true)
-@JsonInclude(JsonInclude.Include.NON_NULL)
-public class MonitoringCredential implements Serializable {
-
-    @JsonProperty("machineUserName")
-    private String machineUserName;
-
-    @JsonProperty("accessKey")
-    private String accessKey;
-
-    @JsonProperty("privateKey")
-    private String privateKey;
-
-    public String getMachineUserName() {
-        return machineUserName;
-    }
-
-    public void setMachineUserName(String machineUserName) {
-        this.machineUserName = machineUserName;
-    }
-
-    public String getAccessKey() {
-        return accessKey;
-    }
-
-    public void setAccessKey(String accessKey) {
-        this.accessKey = accessKey;
-    }
-
-    public String getPrivateKey() {
-        return privateKey;
-    }
-
-    public void setPrivateKey(String privateKey) {
-        this.privateKey = privateKey;
+    @Override
+    public String toString() {
+        return "MonitoringCredential{} " + super.toString();
     }
 }

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/Telemetry.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/Telemetry.java
@@ -114,7 +114,7 @@ public class Telemetry implements Serializable {
 
     @JsonIgnore
     public boolean isAnyDataBusBasedFeatureEnablred() {
-        return  isClusterLogsCollectionEnabled() || isMeteringFeatureEnabled() || isComputeMonitoringEnabled();
+        return isClusterLogsCollectionEnabled() || isMeteringFeatureEnabled();
     }
 
     @JsonIgnore

--- a/common-model/src/main/java/com/sequenceiq/common/model/diagnostics/DiagnosticParameters.java
+++ b/common-model/src/main/java/com/sequenceiq/common/model/diagnostics/DiagnosticParameters.java
@@ -77,6 +77,8 @@ public class DiagnosticParameters {
 
     private String supportBundleDbusPrivateKey;
 
+    private String supportBundleDbusAccessKeyType;
+
     private String supportBundleDbusAppName;
 
     private String supportBundleDbusStreamName;
@@ -115,6 +117,7 @@ public class DiagnosticParameters {
         parameters.put("dbusUrl", dbusUrl);
         parameters.put("dbusS3Url", dbusS3Url);
         parameters.put("supportBundleDbusAccessKey", supportBundleDbusAccessKey);
+        parameters.put("supportBundleDbusAccessKeyType", supportBundleDbusAccessKeyType);
         parameters.put("supportBundleDbusPrivateKey", supportBundleDbusPrivateKey);
         parameters.put("supportBundleDbusStreamName", supportBundleDbusStreamName);
         parameters.put("supportBundleDbusAppName", supportBundleDbusAppName);
@@ -233,6 +236,10 @@ public class DiagnosticParameters {
         this.supportBundleDbusPrivateKey = supportBundleDbusPrivateKey;
     }
 
+    public void setSupportBundleDbusAccessKeyType(String supportBundleDbusAccessKeyType) {
+        this.supportBundleDbusAccessKeyType = supportBundleDbusAccessKeyType;
+    }
+
     public void setSupportBundleDbusAppName(String supportBundleDbusAppName) {
         this.supportBundleDbusAppName = supportBundleDbusAppName;
     }
@@ -343,6 +350,10 @@ public class DiagnosticParameters {
 
     public String getSupportBundleDbusPrivateKey() {
         return supportBundleDbusPrivateKey;
+    }
+
+    public String getSupportBundleDbusAccessKeyType() {
+        return supportBundleDbusAccessKeyType;
     }
 
     public String getSupportBundleDbusAppName() {

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/TelemetryContextProvider.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/TelemetryContextProvider.java
@@ -1,0 +1,9 @@
+package com.sequenceiq.cloudbreak.telemetry;
+
+import com.sequenceiq.cloudbreak.common.orchestration.OrchestratorAware;
+import com.sequenceiq.cloudbreak.telemetry.context.TelemetryContext;
+
+public interface TelemetryContextProvider<S extends OrchestratorAware> {
+
+    TelemetryContext createTelemetryContext(S stack);
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/TelemetryPillarConfigGenerator.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/TelemetryPillarConfigGenerator.java
@@ -1,0 +1,18 @@
+package com.sequenceiq.cloudbreak.telemetry;
+
+import java.util.Map;
+
+import com.sequenceiq.cloudbreak.telemetry.context.TelemetryContext;
+
+public interface TelemetryPillarConfigGenerator<O extends TelemetryConfigView> {
+
+    O createConfigs(TelemetryContext context);
+
+    boolean isEnabled(TelemetryContext context);
+
+    String saltStateName();
+
+    default Map<String, Map<String, Map<String, Object>>> getSaltPillars(TelemetryConfigView configView, TelemetryContext context) {
+        return Map.of(saltStateName(), Map.of(String.format("/%s/init.sls", saltStateName()), Map.of(saltStateName(), configView.toMap())));
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/context/DatabusContext.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/context/DatabusContext.java
@@ -1,0 +1,104 @@
+package com.sequenceiq.cloudbreak.telemetry.context;
+
+import com.sequenceiq.common.api.telemetry.model.DataBusCredential;
+
+public class DatabusContext {
+
+    private final boolean enabled;
+
+    private final String endpoint;
+
+    private final String s3Endpoint;
+
+    private final DataBusCredential credential;
+
+    private final boolean validation;
+
+    private DatabusContext(Builder builder) {
+        this.enabled = builder.enabled;
+        this.endpoint = builder.endpoint;
+        this.s3Endpoint = builder.s3Endpoint;
+        this.credential = builder.credential;
+        this.validation = builder.validation;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public DataBusCredential getCredential() {
+        return credential;
+    }
+
+    public String getS3Endpoint() {
+        return s3Endpoint;
+    }
+
+    public boolean isValidation() {
+        return validation;
+    }
+
+    @Override
+    public String toString() {
+        return "DatabusContext{" +
+                "enabled=" + enabled +
+                ", endpoint='" + endpoint + '\'' +
+                ", s3Endpoint='" + s3Endpoint + '\'' +
+                ", validation=" + validation +
+                '}';
+    }
+
+    public static class Builder {
+
+        private boolean enabled;
+
+        private String endpoint;
+
+        private String s3Endpoint;
+
+        private DataBusCredential credential;
+
+        private boolean validation;
+
+        private Builder() {
+        }
+
+        public DatabusContext build() {
+            return new DatabusContext(this);
+        }
+
+        public Builder enabled() {
+            this.enabled = true;
+            return this;
+        }
+
+        public Builder withEndpoint(String endpoint) {
+            this.endpoint = endpoint;
+            return this;
+        }
+
+        public Builder withCredential(DataBusCredential credential) {
+            this.credential = credential;
+            return this;
+        }
+
+        public Builder withValidation() {
+            this.validation = true;
+            return this;
+        }
+
+        public Builder withS3Endpoint(String s3Endpoint) {
+            this.s3Endpoint = s3Endpoint;
+            return this;
+        }
+
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/context/LogShipperContext.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/context/LogShipperContext.java
@@ -1,0 +1,107 @@
+package com.sequenceiq.cloudbreak.telemetry.context;
+
+import java.util.List;
+
+import com.sequenceiq.common.api.telemetry.model.VmLog;
+
+public class LogShipperContext {
+
+    private final boolean enabled;
+
+    private final boolean cloudStorageLogging;
+
+    private final boolean collectDeploymentLogs;
+
+    private final String cloudRegion;
+
+    private final List<VmLog> vmLogs;
+
+    private LogShipperContext(Builder builder) {
+        this.enabled = builder.enabled;
+        this.cloudStorageLogging = builder.cloudStorageLogging;
+        this.collectDeploymentLogs = builder.collectDeploymentLogs;
+        this.cloudRegion = builder.cloudRegion;
+        this.vmLogs = builder.vmLogs;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public boolean isCloudStorageLogging() {
+        return cloudStorageLogging;
+    }
+
+    public boolean isCollectDeploymentLogs() {
+        return collectDeploymentLogs;
+    }
+
+    public List<VmLog> getVmLogs() {
+        return vmLogs;
+    }
+
+    public String getCloudRegion() {
+        return cloudRegion;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public String toString() {
+        return "LogShipperContext{" +
+                "enabled=" + enabled +
+                ", cloudStorageLogging=" + cloudStorageLogging +
+                ", collectDeploymentLogs=" + collectDeploymentLogs +
+                ", cloudRegion='" + cloudRegion + '\'' +
+                ", vmLogs=" + vmLogs +
+                '}';
+    }
+
+    public static class Builder {
+
+        private boolean enabled;
+
+        private boolean cloudStorageLogging;
+
+        private boolean collectDeploymentLogs;
+
+        private String cloudRegion;
+
+        private List<VmLog> vmLogs;
+
+        private Builder() {
+        }
+
+        public LogShipperContext build() {
+            return new LogShipperContext(this);
+        }
+
+        public Builder enabled() {
+            this.enabled = true;
+            return this;
+        }
+
+        public Builder cloudStorageLogging() {
+            this.cloudStorageLogging = true;
+            return this;
+        }
+
+        public Builder collectDeploymentLogs() {
+            this.collectDeploymentLogs = true;
+            return this;
+        }
+
+        public Builder withCloudRegion(String cloudRegion) {
+            this.cloudRegion = cloudRegion;
+            return this;
+        }
+
+        public Builder withVmLogs(List<VmLog> vmLogs) {
+            this.vmLogs = vmLogs;
+            return this;
+        }
+
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/context/MeteringContext.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/context/MeteringContext.java
@@ -1,0 +1,73 @@
+package com.sequenceiq.cloudbreak.telemetry.context;
+
+public class MeteringContext {
+
+    private final boolean enabled;
+
+    private final String serviceType;
+
+    private final String version;
+
+    private MeteringContext(Builder builder) {
+        this.enabled = builder.enabled;
+        this.serviceType = builder.serviceType;
+        this.version = builder.version;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public String getServiceType() {
+        return serviceType;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    @Override
+    public String toString() {
+        return "MeteringContext{" +
+                "enabled=" + enabled +
+                ", serviceType='" + serviceType + '\'' +
+                ", version='" + version + '\'' +
+                '}';
+    }
+
+    public static class Builder {
+
+        private boolean enabled;
+
+        private String serviceType;
+
+        private String version;
+
+        private Builder() {
+        }
+
+        public MeteringContext build() {
+            return new MeteringContext(this);
+        }
+
+        public Builder enabled() {
+            this.enabled = true;
+            return this;
+        }
+
+        public Builder withServiceType(String serviceType) {
+            this.serviceType = serviceType;
+            return this;
+        }
+
+        public Builder withVersion(String version) {
+            this.version = version;
+            return this;
+        }
+
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/context/MonitoringContext.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/context/MonitoringContext.java
@@ -1,0 +1,153 @@
+package com.sequenceiq.cloudbreak.telemetry.context;
+
+import com.sequenceiq.cloudbreak.telemetry.monitoring.MonitoringAuthConfig;
+import com.sequenceiq.cloudbreak.telemetry.monitoring.MonitoringClusterType;
+import com.sequenceiq.cloudbreak.telemetry.monitoring.MonitoringServiceType;
+import com.sequenceiq.common.api.telemetry.model.MonitoringCredential;
+
+public class MonitoringContext {
+
+    private final boolean enabled;
+
+    private final MonitoringServiceType serviceType;
+
+    private final String remoteWriteUrl;
+
+    private final MonitoringCredential credential;
+
+    private final MonitoringClusterType clusterType;
+
+    private final MonitoringAuthConfig cmAuth;
+
+    private final boolean cmAutoTls;
+
+    private final char[] sharedPassword;
+
+    private MonitoringContext(Builder builder) {
+        this.enabled = builder.enabled;
+        this.serviceType = builder.serviceType;
+        this.remoteWriteUrl = builder.remoteWriteUrl;
+        this.credential = builder.credential;
+        this.clusterType = builder.clusterType;
+        this.cmAuth = builder.cmAuth;
+        this.cmAutoTls = builder.cmAutoTls;
+        this.sharedPassword = builder.sharedPassword;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public String getRemoteWriteUrl() {
+        return remoteWriteUrl;
+    }
+
+    public MonitoringServiceType getServiceType() {
+        return serviceType;
+    }
+
+    public MonitoringClusterType getClusterType() {
+        return clusterType;
+    }
+
+    public MonitoringAuthConfig getCmAuth() {
+        return cmAuth;
+    }
+
+    public char[] getSharedPassword() {
+        return sharedPassword;
+    }
+
+    public boolean isCmAutoTls() {
+        return cmAutoTls;
+    }
+
+    public MonitoringCredential getCredential() {
+        return credential;
+    }
+
+    @Override
+    public String toString() {
+        return "MonitoringContext{" +
+                "enabled=" + enabled +
+                ", serviceType=" + serviceType +
+                ", remoteWriteUrl='" + remoteWriteUrl + '\'' +
+                ", credential=" + credential +
+                ", clusterType=" + clusterType +
+                ", cmAuth=" + cmAuth +
+                ", cmAutoTls=" + cmAutoTls +
+                ", sharedPassword=*****" +
+                '}';
+    }
+
+    public static class Builder {
+
+        private boolean enabled;
+
+        private MonitoringServiceType serviceType = MonitoringServiceType.PAAS;
+
+        private String remoteWriteUrl;
+
+        private MonitoringCredential credential;
+
+        private MonitoringAuthConfig cmAuth;
+
+        private char[] sharedPassword;
+
+        private MonitoringClusterType clusterType;
+
+        private boolean cmAutoTls;
+
+        private Builder() {
+        }
+
+        public MonitoringContext build() {
+            return new MonitoringContext(this);
+        }
+
+        public Builder enabled() {
+            this.enabled = true;
+            return this;
+        }
+
+        public Builder withServiceType(MonitoringServiceType serviceType) {
+            this.serviceType = serviceType;
+            return this;
+        }
+
+        public Builder withClusterType(MonitoringClusterType clusterType) {
+            this.clusterType = clusterType;
+            return this;
+        }
+
+        public Builder withRemoteWriteUrl(String remoteWriteUrl) {
+            this.remoteWriteUrl = remoteWriteUrl;
+            return this;
+        }
+
+        public Builder withCredential(MonitoringCredential credential) {
+            this.credential = credential;
+            return this;
+        }
+
+        public Builder withCmAuth(MonitoringAuthConfig cmAuth) {
+            this.cmAuth = cmAuth;
+            return this;
+        }
+
+        public Builder withSharedPassword(char[] sharedPassword) {
+            this.sharedPassword = sharedPassword;
+            return this;
+        }
+
+        public Builder withCmAutoTls(boolean cmAutoTls) {
+            this.cmAutoTls = cmAutoTls;
+            return this;
+        }
+
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/context/NodeStatusContext.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/context/NodeStatusContext.java
@@ -1,0 +1,72 @@
+package com.sequenceiq.cloudbreak.telemetry.context;
+
+public class NodeStatusContext {
+
+    private final String username;
+
+    private final char[] password;
+
+    private final boolean saltPingEnabled;
+
+    private NodeStatusContext(Builder builder) {
+        this.username = builder.username;
+        this.password = builder.password;
+        this.saltPingEnabled = builder.saltPingEnabled;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public char[] getPassword() {
+        return password;
+    }
+
+    public boolean isSaltPingEnabled() {
+        return saltPingEnabled;
+    }
+
+    @Override
+    public String toString() {
+        return "NodeStatusContext{" +
+                "username='" + username + '\'' +
+                ", password=****" +
+                ", saltPingEnabled=" + saltPingEnabled +
+                '}';
+    }
+
+    public static class Builder {
+
+        private String username;
+
+        private char[] password;
+
+        private boolean saltPingEnabled;
+
+        private Builder() {
+        }
+
+        public NodeStatusContext build() {
+            return new NodeStatusContext(this);
+        }
+
+        public Builder withUsername(String username) {
+            this.username = username;
+            return this;
+        }
+
+        public Builder withPassword(char[] password) {
+            this.password = password;
+            return this;
+        }
+
+        public Builder saltPingEnabled() {
+            this.saltPingEnabled = true;
+            return this;
+        }
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/context/TelemetryContext.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/context/TelemetryContext.java
@@ -1,0 +1,128 @@
+package com.sequenceiq.cloudbreak.telemetry.context;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.sequenceiq.cloudbreak.telemetry.TelemetryClusterDetails;
+import com.sequenceiq.cloudbreak.telemetry.TelemetryConfigView;
+import com.sequenceiq.cloudbreak.telemetry.fluent.FluentClusterType;
+import com.sequenceiq.common.api.telemetry.model.Telemetry;
+
+public class TelemetryContext {
+
+    private final Map<Class<? extends TelemetryConfigView>, TelemetryConfigView> configs = new HashMap<>();
+
+    private Telemetry telemetry;
+
+    private FluentClusterType clusterType;
+
+    private DatabusContext databusContext;
+
+    private MonitoringContext monitoringContext;
+
+    private LogShipperContext logShipperContext;
+
+    private MeteringContext meteringContext;
+
+    private NodeStatusContext nodeStatusContext;
+
+    private TelemetryClusterDetails clusterDetails;
+
+    private Map<String, Object> paywallConfigs;
+
+    public <T extends TelemetryConfigView> void addConfigView(T configView) {
+        configs.put(configView.getClass(), configView);
+    }
+
+    public <T extends TelemetryConfigView> T getConfig(Class<T> clazz) {
+        return (T) configs.get(clazz);
+    }
+
+    public Telemetry getTelemetry() {
+        return telemetry;
+    }
+
+    public void setTelemetry(Telemetry telemetry) {
+        this.telemetry = telemetry;
+    }
+
+    public DatabusContext getDatabusContext() {
+        return databusContext;
+    }
+
+    public void setDatabusContext(DatabusContext databusContext) {
+        this.databusContext = databusContext;
+    }
+
+    public MonitoringContext getMonitoringContext() {
+        return monitoringContext;
+    }
+
+    public void setMonitoringContext(MonitoringContext monitoringContext) {
+        this.monitoringContext = monitoringContext;
+    }
+
+    public LogShipperContext getLogShipperContext() {
+        return logShipperContext;
+    }
+
+    public void setLogShipperContext(LogShipperContext logShipperContext) {
+        this.logShipperContext = logShipperContext;
+    }
+
+    public MeteringContext getMeteringContext() {
+        return meteringContext;
+    }
+
+    public void setMeteringContext(MeteringContext meteringContext) {
+        this.meteringContext = meteringContext;
+    }
+
+    public NodeStatusContext getNodeStatusContext() {
+        return nodeStatusContext;
+    }
+
+    public void setNodeStatusContext(NodeStatusContext nodeStatusContext) {
+        this.nodeStatusContext = nodeStatusContext;
+    }
+
+    public FluentClusterType getClusterType() {
+        return clusterType;
+    }
+
+    public void setClusterType(FluentClusterType clusterType) {
+        this.clusterType = clusterType;
+    }
+
+    public TelemetryClusterDetails getClusterDetails() {
+        return clusterDetails;
+    }
+
+    public void setClusterDetails(TelemetryClusterDetails clusterDetails) {
+        this.clusterDetails = clusterDetails;
+    }
+
+    public Map<String, Object> getPaywallConfigs() {
+        return paywallConfigs;
+    }
+
+    public void setPaywallConfigs(Map<String, Object> paywallConfigs) {
+        this.paywallConfigs = paywallConfigs;
+    }
+
+    @Override
+    public String toString() {
+        return "TelemetryContext{" +
+                "configs=" + configs +
+                ", telemetry=" + telemetry +
+                ", clusterType=" + clusterType +
+                ", databusContext=" + databusContext +
+                ", monitoringContext=" + monitoringContext +
+                ", logShipperContext=" + logShipperContext +
+                ", meteringContext=" + meteringContext +
+                ", nodeStatusContext=" + nodeStatusContext +
+                ", clusterDetails=" + clusterDetails +
+                ", paywallConfigs=******" +
+                '}';
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/metering/MeteringConfigService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/metering/MeteringConfigService.java
@@ -3,10 +3,17 @@ package com.sequenceiq.cloudbreak.telemetry.metering;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.telemetry.TelemetryClusterDetails;
+import com.sequenceiq.cloudbreak.telemetry.TelemetryPillarConfigGenerator;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryUpgradeConfiguration;
+import com.sequenceiq.cloudbreak.telemetry.context.MeteringContext;
+import com.sequenceiq.cloudbreak.telemetry.context.TelemetryContext;
+import com.sequenceiq.cloudbreak.telemetry.fluent.FluentClusterType;
 
 @Service
-public class MeteringConfigService {
+public class MeteringConfigService implements TelemetryPillarConfigGenerator<MeteringConfigView> {
+
+    private static final String SALT_STATE = "metering";
 
     private final MeteringConfiguration meteringConfiguration;
 
@@ -17,22 +24,33 @@ public class MeteringConfigService {
         this.telemetryUpgradeConfiguration = telemetryUpgradeConfiguration;
     }
 
-    public MeteringConfigView createMeteringConfigs(boolean enabled, String platform, String clusterCrn, String clusterName, String serviceType,
-            String serviceVersion) {
+    @Override
+    public MeteringConfigView createConfigs(TelemetryContext context) {
+        MeteringContext meteringContext = context.getMeteringContext();
+        TelemetryClusterDetails clusterDetails = context.getClusterDetails();
         MeteringConfigView.Builder builder = new MeteringConfigView.Builder();
-        if (enabled) {
-            builder.withPlatform(platform)
-                    .withClusterCrn(clusterCrn)
-                    .withClusterName(clusterName)
-                    .withServiceType(StringUtils.upperCase(serviceType))
-                    .withServiceVersion(serviceVersion)
-                    .withStreamName(meteringConfiguration.getDbusStreamName());
-        }
         if (telemetryUpgradeConfiguration.isEnabled() && telemetryUpgradeConfiguration.getMeteringAgent() != null) {
             builder.withDesiredMeteringAgentDate(telemetryUpgradeConfiguration.getMeteringAgent().getDesiredDate());
         }
         return builder
-                .withEnabled(enabled)
+                .withEnabled(meteringContext.isEnabled())
+                .withPlatform(clusterDetails.getPlatform())
+                .withClusterCrn(clusterDetails.getCrn())
+                .withClusterName(clusterDetails.getName())
+                .withServiceType(StringUtils.upperCase(meteringContext.getServiceType()))
+                .withServiceVersion(meteringContext.getVersion())
+                .withStreamName(meteringConfiguration.getDbusStreamName())
                 .build();
+    }
+
+    @Override
+    public boolean isEnabled(TelemetryContext context) {
+        return context != null && context.getTelemetry() != null && context.getTelemetry().isMeteringFeatureEnabled()
+                && context.getClusterDetails() != null && FluentClusterType.DATAHUB.equals(context.getClusterType());
+    }
+
+    @Override
+    public String saltStateName() {
+        return SALT_STATE;
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfigView.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfigView.java
@@ -36,6 +36,8 @@ public class MonitoringConfigView implements TelemetryConfigView {
 
     private final Integer cmMetricsExporterPort;
 
+    private final boolean cmAutoTls;
+
     private final String nodeExporterUser;
 
     private final Integer nodeExporterPort;
@@ -118,6 +120,7 @@ public class MonitoringConfigView implements TelemetryConfigView {
         this.accessKeyId = builder.accessKeyId;
         this.privateKey = builder.privateKey;
         this.accessKeyType = builder.accessKeyType;
+        this.cmAutoTls = builder.cmAutoTls;
     }
 
     public boolean isEnabled() {
@@ -204,6 +207,34 @@ public class MonitoringConfigView implements TelemetryConfigView {
         return token;
     }
 
+    public boolean isCmAutoTls() {
+        return cmAutoTls;
+    }
+
+    public String getRetentionMinTime() {
+        return retentionMinTime;
+    }
+
+    public String getRetentionMaxTime() {
+        return retentionMaxTime;
+    }
+
+    public String getWalTruncateFrequency() {
+        return walTruncateFrequency;
+    }
+
+    public String getAccessKeyId() {
+        return accessKeyId;
+    }
+
+    public char[] getPrivateKey() {
+        return privateKey;
+    }
+
+    public String getAccessKeyType() {
+        return accessKeyType;
+    }
+
     public RequestSignerConfigView getRequestSigner() {
         return requestSigner;
     }
@@ -219,6 +250,7 @@ public class MonitoringConfigView implements TelemetryConfigView {
         map.put("cmUsername", defaultIfNull(this.cmUsername, EMPTY_CONFIG_DEFAULT));
         map.put("cmPassword", defaultIfNull(this.cmPassword, EMPTY_CONFIG_DEFAULT));
         map.put("cmMetricsExporterPort", defaultIfNull(this.cmMetricsExporterPort, DEFAULT_CM_SMON_PORT));
+        map.put("cmAutoTls", defaultIfNull(this.cmAutoTls, true));
         map.put("localPassword", this.localPassword != null ? new String(this.localPassword) : EMPTY_CONFIG_DEFAULT);
         map.put("nodeExporterUser", defaultIfNull(this.nodeExporterUser, EMPTY_CONFIG_DEFAULT));
         map.put("nodeExporterPort", this.nodeExporterPort);
@@ -274,6 +306,8 @@ public class MonitoringConfigView implements TelemetryConfigView {
         private char[] localPassword;
 
         private Integer cmMetricsExporterPort;
+
+        private boolean cmAutoTls;
 
         private String nodeExporterUser;
 
@@ -469,6 +503,11 @@ public class MonitoringConfigView implements TelemetryConfigView {
 
         public Builder withAccessKeyType(String accessKeyType) {
             this.accessKeyType = accessKeyType;
+            return this;
+        }
+
+        public Builder withCmAutoTls(boolean cmAutoTls) {
+            this.cmAutoTls = cmAutoTls;
             return this;
         }
     }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfiguration.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfiguration.java
@@ -13,6 +13,10 @@ public class MonitoringConfiguration {
 
     private String remoteWriteInternalUrl;
 
+    private String paasRemoteWriteUrl;
+
+    private String paasRemoteWriteInternalUrl;
+
     private Integer scrapeIntervalSeconds;
 
     private boolean devStack;
@@ -51,6 +55,22 @@ public class MonitoringConfiguration {
 
     public void setRemoteWriteInternalUrl(String remoteWriteInternalUrl) {
         this.remoteWriteInternalUrl = remoteWriteInternalUrl;
+    }
+
+    public String getPaasRemoteWriteUrl() {
+        return paasRemoteWriteUrl;
+    }
+
+    public void setPaasRemoteWriteUrl(String paasRemoteWriteUrl) {
+        this.paasRemoteWriteUrl = paasRemoteWriteUrl;
+    }
+
+    public String getPaasRemoteWriteInternalUrl() {
+        return paasRemoteWriteInternalUrl;
+    }
+
+    public void setPaasRemoteWriteInternalUrl(String paasRemoteWriteInternalUrl) {
+        this.paasRemoteWriteInternalUrl = paasRemoteWriteInternalUrl;
     }
 
     public boolean isDevStack() {

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringServiceType.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringServiceType.java
@@ -1,0 +1,5 @@
+package com.sequenceiq.cloudbreak.telemetry.monitoring;
+
+public enum MonitoringServiceType {
+    PAAS, SAAS;
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/nodestatus/NodeStatusConfigService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/nodestatus/NodeStatusConfigService.java
@@ -5,10 +5,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.telemetry.TelemetryPillarConfigGenerator;
+import com.sequenceiq.cloudbreak.telemetry.context.NodeStatusContext;
+import com.sequenceiq.cloudbreak.telemetry.context.TelemetryContext;
+
 @Service
-public class NodeStatusConfigService {
+public class NodeStatusConfigService implements TelemetryPillarConfigGenerator<NodeStatusConfigView> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NodeStatusConfigService.class);
+
+    private static final String SALT_STATE = "nodestatus";
 
     public NodeStatusConfigView createNodeStatusConfig(String cdpNodeStatusUser, char[] cdpNodeStatusPassword, boolean saltPingEnabled) {
         NodeStatusConfigView.Builder builder = new NodeStatusConfigView.Builder();
@@ -23,4 +29,23 @@ public class NodeStatusConfigService {
         return builder.build();
     }
 
+    @Override
+    public NodeStatusConfigView createConfigs(TelemetryContext context) {
+        NodeStatusContext nodeStatusContext = context.getNodeStatusContext();
+        return new NodeStatusConfigView.Builder()
+                .withServerUsername(nodeStatusContext.getUsername())
+                .withServerPassword(nodeStatusContext.getPassword())
+                .withSaltPingEnabled(nodeStatusContext.isSaltPingEnabled())
+                .build();
+    }
+
+    @Override
+    public boolean isEnabled(TelemetryContext context) {
+        return context != null && context.getNodeStatusContext() != null;
+    }
+
+    @Override
+    public String saltStateName() {
+        return SALT_STATE;
+    }
 }

--- a/common/src/main/resources/common-config.yml
+++ b/common/src/main/resources/common-config.yml
@@ -26,9 +26,11 @@ telemetry:
     gpg-check: 1
   monitoring:
     enabled: false
-    paas-support: false
     remote-write-url: ""
     remote-write-internal-url: ""
+    paas-support: false
+    paas-remote-write-url: ""
+    paas-remote-write-internal-url: ""
     scrape-interval-seconds: 60
     dev-stack: false
     status-processor:

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/databus/DatabusConfigServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/databus/DatabusConfigServiceTest.java
@@ -4,8 +4,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Map;
+
 import org.junit.Before;
 import org.junit.Test;
+
+import com.sequenceiq.cloudbreak.telemetry.context.DatabusContext;
+import com.sequenceiq.cloudbreak.telemetry.context.TelemetryContext;
+import com.sequenceiq.common.api.telemetry.model.DataBusCredential;
 
 public class DatabusConfigServiceTest {
 
@@ -17,46 +23,100 @@ public class DatabusConfigServiceTest {
     }
 
     @Test
+    public void testIsEnabled() {
+        // GIVEN
+        // WHEN
+        boolean result = underTest.isEnabled(telemetryContext());
+        // THEN
+        assertTrue(result);
+    }
+
+    @Test
+    public void testIsEnabledWithoutCredential() {
+        // GIVEN
+        TelemetryContext context = telemetryContext();
+        context.setDatabusContext(DatabusContext.builder()
+                .enabled()
+                .withValidation()
+                .withEndpoint("myendpoint")
+                .build());
+        // WHEN
+        boolean result = underTest.isEnabled(context);
+        // THEN
+        assertFalse(result);
+    }
+
+    @Test
+    public void testIsEnabledWhenDatabusDisabled() {
+        // GIVEN
+        TelemetryContext context = telemetryContext();
+        DataBusCredential credential = new DataBusCredential();
+        credential.setPrivateKey("privateKey");
+        credential.setAccessKey("accessKey");
+        context.setDatabusContext(DatabusContext.builder()
+                .withValidation()
+                .withEndpoint("myendpoint")
+                .withCredential(credential)
+                .build());
+        // WHEN
+        boolean result = underTest.isEnabled(context);
+        // THEN
+        assertFalse(result);
+    }
+
+    @Test
+    public void testIsEnabledWithoutCredentialProperties() {
+        // GIVEN
+        DataBusCredential credential = new DataBusCredential();
+        // WHEN
+        boolean result = underTest.isEnabled(telemetryContext(credential));
+        // THEN
+        assertFalse(result);
+    }
+
+    @Test
     public void testCreateConfig() {
         // GIVEN
         // WHEN
-        DatabusConfigView result = underTest.createDatabusConfigs("accessKey", "secret".toCharArray(), null, "myEndpoint");
+        Map<String, Object> result = underTest.createConfigs(telemetryContext()).toMap();
         // THEN
-        assertTrue(result.isEnabled());
-        assertEquals("accessKey", result.getAccessKeyId());
-        assertEquals("secret", new String(result.getAccessKeySecret()));
-        assertEquals("myEndpoint", result.getEndpoint());
-        assertEquals("Ed25519", result.toMap().get("accessKeySecretAlgorithm"));
+        assertEquals("accessKey", result.get("accessKeyId"));
+        assertEquals("privateKey", result.get("accessKeySecret"));
+        assertEquals("ECDSA", result.get("accessKeySecretAlgorithm"));
+        assertEquals("myendpoint", result.get("endpoint"));
     }
 
     @Test
-    public void testCreateConfigWithAlgorithm() {
+    public void testCreateConfigWithDefaultAccessType() {
         // GIVEN
+        DataBusCredential credential = new DataBusCredential();
+        credential.setPrivateKey("privateKey");
+        credential.setAccessKey("accessKey");
         // WHEN
-        DatabusConfigView result = underTest.createDatabusConfigs("accessKey", "secret".toCharArray(), "RSA", "myEndpoint");
+        Map<String, Object> result = underTest.createConfigs(telemetryContext(credential)).toMap();
         // THEN
-        assertTrue(result.isEnabled());
-        assertEquals("accessKey", result.getAccessKeyId());
-        assertEquals("secret", new String(result.getAccessKeySecret()));
-        assertEquals("myEndpoint", result.getEndpoint());
-        assertEquals("RSA", result.toMap().get("accessKeySecretAlgorithm"));
+        assertEquals("accessKey", result.get("accessKeyId"));
+        assertEquals("privateKey", result.get("accessKeySecret"));
+        assertEquals("Ed25519", result.get("accessKeySecretAlgorithm"));
     }
 
-    @Test
-    public void testCreateConfigWithoutSecret() {
-        // GIVEN
-        // WHEN
-        DatabusConfigView result = underTest.createDatabusConfigs("accessKey", null, null, "myEndpoint");
-        // THEN
-        assertFalse(result.isEnabled());
+    private TelemetryContext telemetryContext() {
+        DataBusCredential credential = new DataBusCredential();
+        credential.setPrivateKey("privateKey");
+        credential.setAccessKey("accessKey");
+        credential.setAccessKeyType("ECDSA");
+        return telemetryContext(credential);
     }
 
-    @Test
-    public void testCreateConfigWithoutEndpoint() {
-        // GIVEN
-        // WHEN
-        DatabusConfigView result = underTest.createDatabusConfigs("accessKey", "secret".toCharArray(), null, null);
-        // THEN
-        assertFalse(result.isEnabled());
+    private TelemetryContext telemetryContext(DataBusCredential credential) {
+        TelemetryContext context = new TelemetryContext();
+        DatabusContext databusContext = DatabusContext.builder()
+                .enabled()
+                .withCredential(credential)
+                .withEndpoint("myendpoint")
+                .withValidation()
+                .build();
+        context.setDatabusContext(databusContext);
+        return context;
     }
 }

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigServiceTest.java
@@ -4,14 +4,18 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
+import java.util.Map;
+
 import org.junit.Before;
 import org.junit.Test;
 
-import com.sequenceiq.cloudbreak.auth.crn.Crn;
-import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryClusterDetails;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.common.AnonymizationRuleResolver;
+import com.sequenceiq.cloudbreak.telemetry.context.LogShipperContext;
+import com.sequenceiq.cloudbreak.telemetry.context.MeteringContext;
+import com.sequenceiq.cloudbreak.telemetry.context.TelemetryContext;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.AdlsGen2ConfigGenerator;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.GcsConfigGenerator;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.S3ConfigGenerator;
@@ -20,7 +24,6 @@ import com.sequenceiq.cloudbreak.telemetry.metering.MeteringConfiguration;
 import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
 import com.sequenceiq.common.api.cloudstorage.old.GcsCloudStorageV1Parameters;
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
-import com.sequenceiq.common.api.telemetry.model.Features;
 import com.sequenceiq.common.api.telemetry.model.Logging;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
 
@@ -42,7 +45,7 @@ public class FluentConfigServiceTest {
     @Before
     public void setUp() {
         MeteringConfiguration meteringConfiguration =
-                new MeteringConfiguration(false, null, null);
+                new MeteringConfiguration(false, "dbusApp", "dbusStream");
         ClusterLogsCollectionConfiguration logCollectionConfig =
                 new ClusterLogsCollectionConfiguration(false, null, null);
         TelemetryConfiguration telemetryConfiguration =
@@ -52,122 +55,112 @@ public class FluentConfigServiceTest {
     }
 
     @Test
-    public void testCreateFluentConfig() {
+    public void testIsEnabled() {
+        // GIVEN
+        // WHEN
+        boolean result = underTest.isEnabled(telemetryContext());
+        // THEN
+        assertTrue(result);
+    }
+
+    @Test
+    public void testIsEnabledWithoutLogAndMeteringContext() {
+        // GIVEN
+        TelemetryContext context = telemetryContext();
+        context.setMeteringContext(null);
+        context.setLogShipperContext(null);
+        // WHEN
+        boolean result = underTest.isEnabled(context);
+        // THEN
+        assertFalse(result);
+    }
+
+    @Test
+    public void testIsEnabledWithoutContext() {
+        // GIVEN
+        // WHEN
+        boolean result = underTest.isEnabled(null);
+        // THEN
+        assertFalse(result);
+    }
+
+    @Test
+    public void testCreateConfigs() {
         // GIVEN
         Logging logging = new Logging();
         logging.setStorageLocation("mybucket/cluster-logs/datahub/cl1");
         logging.setS3(new S3CloudStorageV1Parameters());
-        Telemetry telemetry = new Telemetry();
-        telemetry.setLogging(logging);
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(
-                DEFAULT_FLUENT_CLUSTER_DETAILS, false, false, REGION_SAMPLE, telemetry);
+        Map<String, Object> result = underTest.createConfigs(telemetryContext(logging)).toMap();
         // THEN
-        assertTrue(result.isEnabled());
-        assertTrue(result.isCloudStorageLoggingEnabled());
-        assertEquals("cluster-logs/datahub/cl1", result.getLogFolderName());
-        assertEquals("mybucket", result.getS3LogArchiveBucketName());
-        assertEquals(Crn.Region.EU_1.getName(), result.toMap().get("environmentRegion"));
+        assertEquals(true, result.get("enabled"));
+        assertEquals(true, result.get("cloudStorageLoggingEnabled"));
+        assertEquals(true, result.get("dbusMeteringEnabled"));
+        assertEquals(true, result.get("dbusClusterLogsCollection"));
+        assertEquals("mybucket", result.get("s3LogArchiveBucketName"));
+        assertEquals("cluster-logs/datahub/cl1", result.get("logFolderName"));
+        assertEquals("s3", result.get("providerPrefix"));
+        assertEquals("eu-1", result.get("environmentRegion"));
+        assertEquals("dbusApp", result.get("dbusMeteringAppName"));
     }
 
     @Test
-    public void testCreateFluentConfigWithCustomPath() {
-        // GIVEN
-        Logging logging = new Logging();
-        logging.setStorageLocation("mybucket/custom");
-        logging.setS3(new S3CloudStorageV1Parameters());
-        Telemetry telemetry = new Telemetry();
-        telemetry.setLogging(logging);
-        // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(
-                DEFAULT_FLUENT_CLUSTER_DETAILS, false, false, REGION_SAMPLE, telemetry);
-        // THEN
-        assertTrue(result.isEnabled());
-        assertTrue(result.isCloudStorageLoggingEnabled());
-        assertEquals("custom", result.getLogFolderName());
-        assertEquals("mybucket", result.getS3LogArchiveBucketName());
-    }
-
-    @Test
-    public void testCreateFluentConfigWithS3Path() {
+    public void testCreateConfigsWithS3Scheme() {
         // GIVEN
         Logging logging = new Logging();
         logging.setStorageLocation("s3://mybucket/cluster-logs/datahub/cl1");
         logging.setS3(new S3CloudStorageV1Parameters());
-        Telemetry telemetry = new Telemetry();
-        telemetry.setLogging(logging);
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(
-                DEFAULT_FLUENT_CLUSTER_DETAILS, false, false, REGION_SAMPLE, telemetry);
+        Map<String, Object> result = underTest.createConfigs(telemetryContext(logging)).toMap();
         // THEN
-        assertTrue(result.isEnabled());
-        assertTrue(result.isCloudStorageLoggingEnabled());
-        assertEquals("cluster-logs/datahub/cl1", result.getLogFolderName());
-        assertEquals("mybucket", result.getS3LogArchiveBucketName());
+        assertEquals(true, result.get("enabled"));
+        assertEquals(true, result.get("cloudStorageLoggingEnabled"));
+        assertEquals("mybucket", result.get("s3LogArchiveBucketName"));
+        assertEquals("cluster-logs/datahub/cl1", result.get("logFolderName"));
+        assertEquals("s3", result.get("providerPrefix"));
     }
 
     @Test
-    public void testCreateFluentConfigWithS3APath() {
-        // GIVEN
-        Logging logging = new Logging();
-        logging.setStorageLocation("s3a://mybucket/cluster-logs/datahub/cl1");
-        logging.setS3(new S3CloudStorageV1Parameters());
-        Telemetry telemetry = new Telemetry();
-        telemetry.setLogging(logging);
-        // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(
-                DEFAULT_FLUENT_CLUSTER_DETAILS, false, false, REGION_SAMPLE, telemetry);
-        // THEN
-        assertTrue(result.isEnabled());
-        assertTrue(result.isCloudStorageLoggingEnabled());
-        assertEquals("cluster-logs/datahub/cl1", result.getLogFolderName());
-        assertEquals("mybucket", result.getS3LogArchiveBucketName());
-    }
-
-    @Test
-    public void testCreateFluentConfigWitGcsPath() {
+    public void testCreateConfigsWithGcs() {
         // GIVEN
         Logging logging = new Logging();
         logging.setStorageLocation("gs://mybucket/cluster-logs/datahub/cl1");
         GcsCloudStorageV1Parameters gcsParams = new GcsCloudStorageV1Parameters();
         gcsParams.setServiceAccountEmail("myaccount@myprojectid.iam.gserviceaccount.com");
         logging.setGcs(gcsParams);
-        Telemetry telemetry = new Telemetry();
-        telemetry.setLogging(logging);
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(
-                DEFAULT_FLUENT_CLUSTER_DETAILS, false, false, REGION_SAMPLE, telemetry);
+        Map<String, Object> result = underTest.createConfigs(telemetryContext(logging)).toMap();
         // THEN
-        assertTrue(result.isEnabled());
-        assertTrue(result.isCloudStorageLoggingEnabled());
-        assertEquals("cluster-logs/datahub/cl1", result.getLogFolderName());
-        assertEquals("mybucket", result.getGcsBucket());
-        assertEquals("myprojectid", result.getGcsProjectId());
+        assertEquals(true, result.get("enabled"));
+        assertEquals(true, result.get("cloudStorageLoggingEnabled"));
+        assertEquals("cluster-logs/datahub/cl1", result.get("logFolderName"));
+        assertEquals("mybucket", result.get("gcsBucket"));
+        assertEquals("myprojectid", result.get("gcsProjectId"));
+        assertEquals("gcs", result.get("providerPrefix"));
     }
 
     @Test
-    public void testCreateFluentConfigWithAdlsGen2Path() {
+    public void testCreateConfigsWithAbfs() {
         // GIVEN
         Logging logging = new Logging();
         logging.setStorageLocation("abfs://mycontainer@myaccount.dfs.core.windows.net");
         AdlsGen2CloudStorageV1Parameters parameters = new AdlsGen2CloudStorageV1Parameters();
         parameters.setAccountKey("myAccountKey");
+        parameters.setAccountName("myAccount");
         logging.setAdlsGen2(parameters);
-        Telemetry telemetry = new Telemetry();
-        telemetry.setLogging(logging);
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(
-                DEFAULT_FLUENT_CLUSTER_DETAILS, false, false, REGION_SAMPLE, telemetry);
+        Map<String, Object> result = underTest.createConfigs(telemetryContext(logging)).toMap();
         // THEN
-        assertTrue(result.isEnabled());
-        assertTrue(result.isCloudStorageLoggingEnabled());
-        assertEquals("myAccountKey", result.getAzureStorageAccessKey());
-        assertTrue(result.getLogFolderName().isBlank());
-        assertEquals("mycontainer", result.getAzureContainer());
+        assertEquals(true, result.get("enabled"));
+        assertEquals(true, result.get("cloudStorageLoggingEnabled"));
+        assertEquals("", result.get("logFolderName"));
+        assertEquals("myAccountKey", result.get("azureStorageAccessKey"));
+        assertEquals("myaccount", result.get("azureStorageAccount"));
+        assertEquals("mycontainer", result.get("azureContainer"));
     }
 
     @Test
-    public void testCreateFluentConfigWithFullAdlsGen2Path() {
+    public void testCreateConfigsWithAbfsFullPath() {
         // GIVEN
         Logging logging = new Logging();
         logging.setStorageLocation("abfs://mycontainer@myaccount.dfs.core.windows.net/my/custom/path");
@@ -175,173 +168,65 @@ public class FluentConfigServiceTest {
         parameters.setAccountKey("myAccountKey");
         parameters.setAccountName("myAccount");
         logging.setAdlsGen2(parameters);
-        Telemetry telemetry = new Telemetry();
-        telemetry.setLogging(logging);
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(
-                DEFAULT_FLUENT_CLUSTER_DETAILS, false, false, REGION_SAMPLE, telemetry);
+        Map<String, Object> result = underTest.createConfigs(telemetryContext(logging)).toMap();
         // THEN
-        assertTrue(result.isEnabled());
-        assertEquals("myAccountKey", result.getAzureStorageAccessKey());
-        assertEquals("myaccount", result.getAzureStorageAccount());
-        assertEquals("/my/custom/path", result.getLogFolderName());
-        assertEquals("mycontainer", result.getAzureContainer());
+        assertEquals(true, result.get("enabled"));
+        assertEquals(true, result.get("cloudStorageLoggingEnabled"));
+        assertEquals("/my/custom/path", result.get("logFolderName"));
+        assertEquals("myAccountKey", result.get("azureStorageAccessKey"));
+        assertEquals("myaccount", result.get("azureStorageAccount"));
+        assertEquals("mycontainer", result.get("azureContainer"));
     }
 
     @Test
-    public void testCreateFluentConfigWithFullAdlsGen2PathWithContainer() {
+    public void testCreateConfigsWithAbfsContainerPath() {
         // GIVEN
         Logging logging = new Logging();
         logging.setStorageLocation("abfs://mycontainer/my/custom/path@myaccount.dfs.core.windows.net");
         AdlsGen2CloudStorageV1Parameters parameters = new AdlsGen2CloudStorageV1Parameters();
         parameters.setAccountKey("myAccountKey");
+        parameters.setAccountName("myAccount");
         logging.setAdlsGen2(parameters);
+        // WHEN
+        Map<String, Object> result = underTest.createConfigs(telemetryContext(logging)).toMap();
+        // THEN
+        assertEquals(true, result.get("enabled"));
+        assertEquals(true, result.get("cloudStorageLoggingEnabled"));
+        assertEquals("/my/custom/path", result.get("logFolderName"));
+        assertEquals("myAccountKey", result.get("azureStorageAccessKey"));
+        assertEquals("myaccount", result.get("azureStorageAccount"));
+        assertEquals("mycontainer", result.get("azureContainer"));
+    }
+
+    private TelemetryContext telemetryContext() {
+        return telemetryContext(null);
+    }
+
+    private TelemetryContext telemetryContext(Logging logging) {
+        TelemetryContext telemetryContext = new TelemetryContext();
+        LogShipperContext logShipperContext = LogShipperContext
+                .builder()
+                .enabled()
+                .collectDeploymentLogs()
+                .cloudStorageLogging()
+                .withCloudRegion(REGION_SAMPLE)
+                .withVmLogs(new ArrayList<>())
+                .build();
+        MeteringContext meteringContext = MeteringContext
+                .builder()
+                .enabled()
+                .build();
+        TelemetryClusterDetails clusterDetails = TelemetryClusterDetails.Builder.builder()
+                .withCrn(DATAHUB_CRN)
+                .build();
         Telemetry telemetry = new Telemetry();
         telemetry.setLogging(logging);
-        // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(
-                DEFAULT_FLUENT_CLUSTER_DETAILS, false, false, REGION_SAMPLE, telemetry);
-        // THEN
-        assertTrue(result.isEnabled());
-        assertEquals("myAccountKey", result.getAzureStorageAccessKey());
-        assertEquals("/my/custom/path", result.getLogFolderName());
-        assertEquals("mycontainer", result.getAzureContainer());
-    }
-
-    @Test
-    public void testCreateFluentConfigWithoutScheme() {
-        // GIVEN
-        Logging logging = new Logging();
-        logging.setStorageLocation("mycontainer/cluster-logs/datahub/cl1@myaccount.dfs.core.windows.net");
-        AdlsGen2CloudStorageV1Parameters parameters = new AdlsGen2CloudStorageV1Parameters();
-        parameters.setAccountKey("myAccountKey");
-        logging.setAdlsGen2(parameters);
-        Telemetry telemetry = new Telemetry();
-        telemetry.setLogging(logging);
-        // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(
-                DEFAULT_FLUENT_CLUSTER_DETAILS, false, false, REGION_SAMPLE, telemetry);
-        // THEN
-        assertTrue(result.isEnabled());
-        assertEquals("myAccountKey", result.getAzureStorageAccessKey());
-        assertEquals("/cluster-logs/datahub/cl1", result.getLogFolderName());
-        assertEquals("mycontainer", result.getAzureContainer());
-    }
-
-    @Test
-    public void testCreateFluentConfigMetering() {
-        // GIVEN
-        Telemetry telemetry = new Telemetry();
-        setMetering(telemetry);
-        telemetry.setDatabusEndpoint("myEndpoint");
-        // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(
-                DEFAULT_FLUENT_CLUSTER_DETAILS, true, true, REGION_SAMPLE, telemetry);
-        // THEN
-        assertTrue(result.isEnabled());
-        assertTrue(result.isMeteringEnabled());
-    }
-
-    @Test
-    public void testCreateFluentConfigMeteringWithoutDatabusEndpoint() {
-        // GIVEN
-        Telemetry telemetry = new Telemetry();
-        setMetering(telemetry);
-        // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(
-                DEFAULT_FLUENT_CLUSTER_DETAILS, false, false, REGION_SAMPLE, telemetry);
-        // THEN
-        assertFalse(result.isEnabled());
-        assertFalse(result.isMeteringEnabled());
-    }
-
-    @Test
-    public void testCreateFluentConfigMeteringWithoutDatabusSecret() {
-        // GIVEN
-        Telemetry telemetry = new Telemetry();
-        setMetering(telemetry);
-        // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(DEFAULT_FLUENT_CLUSTER_DETAILS, false, false,
-                REGION_SAMPLE, telemetry);
-        // THEN
-        assertFalse(result.isEnabled());
-        assertFalse(result.isMeteringEnabled());
-    }
-
-    @Test
-    public void testCreateFluentConfigClusterLogsCollection() {
-        // GIVEN
-        Telemetry telemetry = new Telemetry();
-        setClusterLogsCollection(telemetry);
-        // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(DEFAULT_FLUENT_CLUSTER_DETAILS, true, false,
-                REGION_SAMPLE, telemetry);
-        // THEN
-        assertTrue(result.isEnabled());
-        assertTrue(result.isClusterLogsCollection());
-    }
-
-    @Test
-    public void testCreateFluentConfigClusterLogsCollectionWithoutDatabus() {
-        // GIVEN
-        Telemetry telemetry = new Telemetry();
-        setClusterLogsCollection(telemetry);
-        // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(
-                DEFAULT_FLUENT_CLUSTER_DETAILS, false, true,
-                REGION_SAMPLE, telemetry);
-        // THEN
-        assertFalse(result.isEnabled());
-        assertFalse(result.isClusterLogsCollection());
-    }
-
-    @Test(expected = CloudbreakServiceException.class)
-    public void testCreateFluentConfigWithoutLocation() {
-        // GIVEN
-        Logging logging = new Logging();
-        logging.setStorageLocation(null);
-        logging.setAdlsGen2(new AdlsGen2CloudStorageV1Parameters());
-        Telemetry telemetry = new Telemetry();
-        telemetry.setLogging(logging);
-        // WHEN
-        underTest.createFluentConfigs(DEFAULT_FLUENT_CLUSTER_DETAILS, false, false, REGION_SAMPLE, telemetry);
-    }
-
-    @Test(expected = CloudbreakServiceException.class)
-    public void testCreateFluentConfigWithoutGcsProjectId() {
-        // GIVEN
-        Logging logging = new Logging();
-        logging.setStorageLocation("gs://mybucket/mypath");
-        logging.setGcs(new GcsCloudStorageV1Parameters());
-        Telemetry telemetry = new Telemetry();
-        telemetry.setLogging(logging);
-        // WHEN
-        underTest.createFluentConfigs(DEFAULT_FLUENT_CLUSTER_DETAILS, false, false, REGION_SAMPLE, telemetry);
-    }
-
-    @Test(expected = CloudbreakServiceException.class)
-    public void testCreateFluentConfigWithDoublePath() {
-        // GIVEN
-        Logging logging = new Logging();
-        logging.setStorageLocation("abfs://mycontainer/my/custom/path@myaccount.dfs.core.windows.net/my/custom/path");
-        AdlsGen2CloudStorageV1Parameters parameters = new AdlsGen2CloudStorageV1Parameters();
-        parameters.setAccountKey("myAccountKey");
-        logging.setAdlsGen2(parameters);
-        Telemetry telemetry = new Telemetry();
-        telemetry.setLogging(logging);
-        // WHEN
-        underTest.createFluentConfigs(DEFAULT_FLUENT_CLUSTER_DETAILS, false, false, REGION_SAMPLE, telemetry);
-    }
-
-    private void setMetering(Telemetry telemetry) {
-        Features features = new Features();
-        features.addMetering(true);
-        telemetry.setFeatures(features);
-    }
-
-    private void setClusterLogsCollection(Telemetry telemetry) {
-        Features features = new Features();
-        features.addClusterLogsCollection(true);
-        telemetry.setFeatures(features);
+        telemetryContext.setTelemetry(telemetry);
+        telemetryContext.setLogShipperContext(logShipperContext);
+        telemetryContext.setMeteringContext(meteringContext);
+        telemetryContext.setClusterDetails(clusterDetails);
+        telemetryContext.setClusterType(FluentClusterType.DATAHUB);
+        return telemetryContext;
     }
 }

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/nodestatus/NodeStatusConfigServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/nodestatus/NodeStatusConfigServiceTest.java
@@ -1,0 +1,71 @@
+package com.sequenceiq.cloudbreak.telemetry.nodestatus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.telemetry.context.NodeStatusContext;
+import com.sequenceiq.cloudbreak.telemetry.context.TelemetryContext;
+
+public class NodeStatusConfigServiceTest {
+
+    private NodeStatusConfigService underTest;
+
+    @BeforeEach
+    public void setUp() {
+        underTest = new NodeStatusConfigService();
+    }
+
+    @Test
+    public void testIsEnabled() {
+        // GIVEN
+        // WHEN
+        boolean result = underTest.isEnabled(telemetryContext());
+        // THEN
+        assertTrue(result);
+    }
+
+    @Test
+    public void testIsEnabledWithoutContext() {
+        // GIVEN
+        // WHEN
+        boolean result = underTest.isEnabled(null);
+        // THEN
+        assertFalse(result);
+    }
+
+    @Test
+    public void testIsEnabledWithoutNodeStatusContext() {
+        // GIVEN
+        // WHEN
+        boolean result = underTest.isEnabled(new TelemetryContext());
+        // THEN
+        assertFalse(result);
+    }
+
+    @Test
+    public void testCreateConfigs() {
+        // GIVEN
+        // WHEN
+        Map<String, Object> result = underTest.createConfigs(telemetryContext()).toMap();
+        // THEN
+        assertEquals("myuser", result.get("serverUsername"));
+        assertEquals("mypassword", result.get("serverPassword"));
+        assertEquals(true, result.get("saltPingEnabled"));
+    }
+
+    private TelemetryContext telemetryContext() {
+        TelemetryContext context = new TelemetryContext();
+        context.setNodeStatusContext(NodeStatusContext.builder()
+                .withUsername("myuser")
+                .withPassword("mypassword".toCharArray())
+                .saltPingEnabled()
+                .build());
+        return context;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/DiagnosticsEnsureMachineUserHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/DiagnosticsEnsureMachineUserHandler.java
@@ -42,6 +42,7 @@ public class DiagnosticsEnsureMachineUserHandler extends AbstractDiagnosticsOper
             DataBusCredential credential = altusMachineUserService.getOrCreateDataBusCredentialIfNeeded(resourceId);
             parameters.setSupportBundleDbusAccessKey(credential.getAccessKey());
             parameters.setSupportBundleDbusPrivateKey(credential.getPrivateKey());
+            parameters.setSupportBundleDbusAccessKeyType(credential.getAccessKeyType());
         }
         return DiagnosticsCollectionEvent.builder()
                 .withResourceCrn(resourceCrn)

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/telemetry/TelemetryService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/telemetry/TelemetryService.java
@@ -1,29 +1,20 @@
 package com.sequenceiq.cloudbreak.service.telemetry;
 
-import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
 import javax.inject.Inject;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-import com.sequenceiq.cloudbreak.common.json.Json;
-import com.sequenceiq.cloudbreak.core.bootstrap.service.host.decorator.TelemetryDecorator;
+import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
-import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryComponentType;
 import com.sequenceiq.cloudbreak.telemetry.orchestrator.TelemetryConfigProvider;
-import com.sequenceiq.cloudbreak.view.ClusterView;
-import com.sequenceiq.cloudbreak.view.StackView;
-import com.sequenceiq.common.api.telemetry.model.DataBusCredential;
-import com.sequenceiq.common.api.telemetry.model.MonitoringCredential;
-import com.sequenceiq.common.api.telemetry.model.Telemetry;
+import com.sequenceiq.cloudbreak.telemetry.orchestrator.TelemetrySaltPillarDecorator;
 
 @Service
 public class TelemetryService implements TelemetryConfigProvider {
@@ -34,33 +25,12 @@ public class TelemetryService implements TelemetryConfigProvider {
     private StackDtoService stackDtoService;
 
     @Inject
-    private ComponentConfigProviderService componentConfigProviderService;
-
-    @Inject
-    private TelemetryDecorator telemetryDecorator;
+    private TelemetrySaltPillarDecorator telemetrySaltPillarDecorator;
 
     @Override
     public Map<String, SaltPillarProperties> createTelemetryConfigs(Long stackId, Set<TelemetryComponentType> components) {
-        StackView stack = stackDtoService.getStackViewById(stackId);
-        ClusterView cluster = stackDtoService.getClusterViewByStackId(stackId);
-        DataBusCredential dataBusCredential = convertOrNull(cluster.getName(), cluster.getDatabusCredential(), DataBusCredential.class);
-        MonitoringCredential monitoringCredential = convertOrNull(cluster.getName(), cluster.getMonitoringCredential(), MonitoringCredential.class);
-        Telemetry telemetry = componentConfigProviderService.getTelemetry(stackId);
+        StackDto stack = stackDtoService.getById(stackId);
         LOGGER.debug("Generating telemetry configs for stack '{}'", stack.getResourceCrn());
-        return telemetryDecorator.decoratePillar(new HashMap<>(), stack, cluster, telemetry, dataBusCredential, monitoringCredential);
-    }
-
-    private <T> T convertOrNull(String clusterName, String value, Class<T> type) {
-        if (StringUtils.isNotBlank(value)) {
-            try {
-                return new Json(value).get(type);
-            } catch (IOException e) {
-                LOGGER.error("Cannot read {} secrets from cluster entity. Continue without secrets", type.getSimpleName(), e);
-                return null;
-            }
-        } else {
-            LOGGER.debug("Not found any {} for cluster '{}'. Continue without secrets", type.getSimpleName(), clusterName);
-            return null;
-        }
+        return telemetrySaltPillarDecorator.generatePillarConfigMap(stack);
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunnerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunnerTest.java
@@ -62,7 +62,6 @@ import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.container.postgres.PostgresConfigService;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.decorator.CsdParcelDecorator;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.decorator.HostAttributeDecorator;
-import com.sequenceiq.cloudbreak.core.bootstrap.service.host.decorator.TelemetryDecorator;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.domain.Template;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
@@ -98,6 +97,7 @@ import com.sequenceiq.cloudbreak.service.proxy.ProxyConfigProvider;
 import com.sequenceiq.cloudbreak.service.rdsconfig.RdsConfigWithoutClusterService;
 import com.sequenceiq.cloudbreak.service.sharedservice.DatalakeService;
 import com.sequenceiq.cloudbreak.service.stack.flow.MountDisks;
+import com.sequenceiq.cloudbreak.telemetry.orchestrator.TelemetrySaltPillarDecorator;
 import com.sequenceiq.cloudbreak.template.kerberos.KerberosDetailService;
 import com.sequenceiq.cloudbreak.util.FileReaderUtils;
 import com.sequenceiq.cloudbreak.util.NodesUnreachableException;
@@ -161,7 +161,7 @@ class ClusterHostServiceRunnerTest {
     private KerberosConfigService kerberosConfigService;
 
     @Mock
-    private TelemetryDecorator telemetryDecorator;
+    private TelemetrySaltPillarDecorator telemetrySaltPillarDecorator;
 
     @Mock
     private MountDisks mountDisks;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecoratorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecoratorTest.java
@@ -1,13 +1,12 @@
 package com.sequenceiq.cloudbreak.core.bootstrap.service.host.decorator;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -15,8 +14,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 
 import org.junit.Before;
@@ -31,54 +28,30 @@ import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.dto.StackDto;
-import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
+import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
 import com.sequenceiq.cloudbreak.service.altus.AltusMachineUserService;
 import com.sequenceiq.cloudbreak.telemetry.DataBusEndpointProvider;
-import com.sequenceiq.cloudbreak.telemetry.TelemetryClusterDetails;
 import com.sequenceiq.cloudbreak.telemetry.VmLogsService;
-import com.sequenceiq.cloudbreak.telemetry.common.TelemetryCommonConfigService;
-import com.sequenceiq.cloudbreak.telemetry.common.TelemetryCommonConfigView;
-import com.sequenceiq.cloudbreak.telemetry.databus.DatabusConfigService;
-import com.sequenceiq.cloudbreak.telemetry.databus.DatabusConfigView;
-import com.sequenceiq.cloudbreak.telemetry.fluent.FluentConfigService;
-import com.sequenceiq.cloudbreak.telemetry.fluent.FluentConfigView;
-import com.sequenceiq.cloudbreak.telemetry.metering.MeteringConfigService;
-import com.sequenceiq.cloudbreak.telemetry.metering.MeteringConfigView;
+import com.sequenceiq.cloudbreak.telemetry.context.TelemetryContext;
+import com.sequenceiq.cloudbreak.telemetry.fluent.FluentClusterType;
 import com.sequenceiq.cloudbreak.telemetry.monitoring.MonitoringConfigService;
-import com.sequenceiq.cloudbreak.telemetry.monitoring.MonitoringConfigView;
-import com.sequenceiq.cloudbreak.telemetry.nodestatus.NodeStatusConfigService;
-import com.sequenceiq.cloudbreak.telemetry.nodestatus.NodeStatusConfigView;
 import com.sequenceiq.cloudbreak.workspace.model.User;
+import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
 import com.sequenceiq.common.api.telemetry.model.DataBusCredential;
-import com.sequenceiq.common.api.telemetry.model.Features;
+import com.sequenceiq.common.api.telemetry.model.Logging;
 import com.sequenceiq.common.api.telemetry.model.Monitoring;
+import com.sequenceiq.common.api.telemetry.model.MonitoringCredential;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
-import com.sequenceiq.common.api.type.FeatureSetting;
 
 public class TelemetryDecoratorTest {
 
     private TelemetryDecorator underTest;
 
     @Mock
-    private DatabusConfigService databusConfigService;
-
-    @Mock
-    private FluentConfigService fluentConfigService;
-
-    @Mock
-    private MeteringConfigService meteringConfigService;
-
-    @Mock
     private MonitoringConfigService monitoringConfigService;
 
     @Mock
     private AltusMachineUserService altusMachineUserService;
-
-    @Mock
-    private NodeStatusConfigService nodeStatusConfigService;
-
-    @Mock
-    private TelemetryCommonConfigService telemetryCommonConfigService;
 
     @Mock
     private VmLogsService vmLogsService;
@@ -89,212 +62,147 @@ public class TelemetryDecoratorTest {
     @Mock
     private DataBusEndpointProvider dataBusEndpointProvider;
 
+    @Mock
+    private ComponentConfigProviderService componentConfigProviderService;
+
+    @Mock
+    private Telemetry telemetry;
+
+    @Mock
+    private Logging logging;
+
+    @Mock
+    private Monitoring monitoring;
+
     @Before
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        initMocks();
+        underTest = new TelemetryDecorator(altusMachineUserService, vmLogsService, entitlementService,
+                dataBusEndpointProvider, monitoringConfigService, componentConfigProviderService, "1.0.0");
+    }
+
+    @Test
+    public void testCreateTelemetryContext() {
+        // GIVEN
+        given(telemetry.isAnyDataBusBasedFeatureEnablred()).willReturn(true);
+        given(telemetry.isMeteringFeatureEnabled()).willReturn(true);
+        given(telemetry.isComputeMonitoringEnabled()).willReturn(true);
+        given(telemetry.getLogging()).willReturn(logging);
+        given(telemetry.isCloudStorageLoggingEnabled()).willReturn(true);
+        given(telemetry.isClusterLogsCollectionEnabled()).willReturn(true);
+        given(logging.getS3()).willReturn(new S3CloudStorageV1Parameters());
+        given(monitoringConfigService.isMonitoringEnabled(anyBoolean(), anyBoolean())).willReturn(true);
+        given(telemetry.getMonitoring()).willReturn(monitoring);
+        given(monitoring.getRemoteWriteUrl()).willReturn("https://remotewrite:80/api/v1/write");
+        // WHEN
+        TelemetryContext result = underTest.createTelemetryContext(createStack());
+        // THEN
+        assertEquals(FluentClusterType.DATAHUB, result.getClusterType());
+        assertTrue(result.getDatabusContext().isEnabled());
+        assertTrue(result.getLogShipperContext().isEnabled());
+        assertTrue(result.getMeteringContext().isEnabled());
+        assertTrue(result.getMonitoringContext().isEnabled());
+        assertTrue(result.getNodeStatusContext().isSaltPingEnabled());
+        verify(altusMachineUserService, times(1)).storeDataBusCredential(any(Optional.class), any(Stack.class));
+        verify(altusMachineUserService, times(1)).storeMonitoringCredential(any(Optional.class), any(Stack.class));
+    }
+
+    @Test
+    public void testCreateTelemetryContextWithDatalakeMeteringDisabled() {
+        // GIVEN
+        given(telemetry.isAnyDataBusBasedFeatureEnablred()).willReturn(true);
+        given(telemetry.isMeteringFeatureEnabled()).willReturn(true);
+        // WHEN
+        TelemetryContext result = underTest.createTelemetryContext(createStack(StackType.DATALAKE));
+        // THEN
+        assertEquals(FluentClusterType.DATALAKE, result.getClusterType());
+        assertTrue(result.getDatabusContext().isEnabled());
+        assertFalse(result.getMeteringContext().isEnabled());
+    }
+
+    @Test
+    public void testCreateTelemetryContextWithMonitoringOnly() {
+        // GIVEN
+        given(telemetry.isAnyDataBusBasedFeatureEnablred()).willReturn(false);
+        given(telemetry.isComputeMonitoringEnabled()).willReturn(true);
+        given(monitoringConfigService.isMonitoringEnabled(anyBoolean(), anyBoolean())).willReturn(true);
+        given(telemetry.getMonitoring()).willReturn(monitoring);
+        given(monitoring.getRemoteWriteUrl()).willReturn("https://remotewrite:80/api/v1/write");
+        // WHEN
+        TelemetryContext result = underTest.createTelemetryContext(createStack());
+        // THEN
+        assertFalse(result.getDatabusContext().isEnabled());
+        assertFalse(result.getLogShipperContext().isEnabled());
+        assertFalse(result.getMeteringContext().isEnabled());
+        assertTrue(result.getMonitoringContext().isEnabled());
+        verify(altusMachineUserService, times(1)).storeMonitoringCredential(any(Optional.class), any(Stack.class));
+    }
+
+    @Test
+    public void testCreateTelemetryContextLoggingWithoutCloudStorage() {
+        // GIVEN
+        given(telemetry.getLogging()).willReturn(logging);
+        given(telemetry.isCloudStorageLoggingEnabled()).willReturn(true);
+        given(telemetry.isClusterLogsCollectionEnabled()).willReturn(false);
+        // WHEN
+        TelemetryContext result = underTest.createTelemetryContext(createStack());
+        // THEN
+        assertFalse(result.getLogShipperContext().isEnabled());
+    }
+
+    @Test
+    public void testCreateTelemetryContextWithDefaults() {
+        // GIVEN
+        // WHEN
+        TelemetryContext result = underTest.createTelemetryContext(createStack());
+        // THEN
+        assertEquals(FluentClusterType.DATAHUB, result.getClusterType());
+    }
+
+    private void initMocks() {
+        MockitoAnnotations.openMocks(this);
         AltusCredential altusCredential = new AltusCredential("myAccessKey", "mySecretKey".toCharArray());
         DataBusCredential dataBusCredential = new DataBusCredential();
         dataBusCredential.setAccessKey("myAccessKey");
         dataBusCredential.setPrivateKey("mySecretKey");
-        given(altusMachineUserService.isAnyDataBusBasedFeatureSupported(any(Telemetry.class)))
-                .willReturn(true);
-        given(altusMachineUserService.storeDataBusCredential(any(Optional.class), any(Stack.class)))
-                .willReturn(dataBusCredential);
-        given(altusMachineUserService.generateDatabusMachineUserForFluent(any(Stack.class), any(Telemetry.class)))
-                .willReturn(Optional.of(altusCredential));
+        MonitoringCredential monitoringCredential = new MonitoringCredential();
+        monitoringCredential.setAccessKey("myAccessKey");
+        monitoringCredential.setPrivateKey("mySecretKey");
+        given(componentConfigProviderService.getTelemetry(anyLong())).willReturn(telemetry);
+        given(telemetry.getDatabusEndpoint()).willReturn("https://dbus-dev.com");
+        given(altusMachineUserService.isAnyDataBusBasedFeatureSupported(any(Telemetry.class))).willReturn(true);
+        given(altusMachineUserService.isAnyMonitoringFeatureSupported(any(Telemetry.class))).willReturn(true);
+        given(altusMachineUserService.storeDataBusCredential(any(Optional.class), any(Stack.class))).willReturn(dataBusCredential);
+        given(altusMachineUserService.generateDatabusMachineUserForFluent(any(Stack.class), any(Telemetry.class))).willReturn(Optional.of(altusCredential));
+        given(altusMachineUserService.generateMonitoringMachineUser(any(Stack.class), any(Telemetry.class))).willReturn(Optional.of(altusCredential));
+        given(altusMachineUserService.storeMonitoringCredential(any(Optional.class), any(Stack.class))).willReturn(monitoringCredential);
+        given(entitlementService.useDataBusCNameEndpointEnabled(anyString())).willReturn(false);
+        given(entitlementService.isDatahubDatabusEndpointValidationEnabled(anyString())).willReturn(true);
+        given(entitlementService.nodestatusSaltPingEnabled(anyString())).willReturn(true);
+        given(dataBusEndpointProvider.getDataBusEndpoint(anyString(), anyBoolean())).willReturn("https://dbus-dev.com");
+        given(dataBusEndpointProvider.getDatabusS3Endpoint(anyString())).willReturn("https://cloudera-dbus-dev.amazonaws.com");
         given(vmLogsService.getVmLogs()).willReturn(new ArrayList<>());
-        underTest = new TelemetryDecorator(databusConfigService, fluentConfigService,
-                meteringConfigService, monitoringConfigService, nodeStatusConfigService, telemetryCommonConfigService,
-                altusMachineUserService, vmLogsService, entitlementService, dataBusEndpointProvider, "1.0.0");
-    }
-
-    @Test
-    public void testS3DecorateWithDefaultPath() {
-        // GIVEN
-        Map<String, SaltPillarProperties> servicePillar = new HashMap<>();
-        TelemetryClusterDetails clusterDetails = TelemetryClusterDetails.Builder.builder().withPlatform("AWS").build();
-        FluentConfigView fluentConfigView = new FluentConfigView.Builder()
-                .withClusterDetails(clusterDetails)
-                .withEnabled(true)
-                .withS3LogArchiveBucketName("mybucket")
-                .withLogFolderName("cluster-logs/datahub/cl1")
-                .withProviderPrefix("s3")
-                .build();
-        DatabusConfigView dataConfigView = new DatabusConfigView.Builder()
-                .withAccessKeySecretAlgorithm("RSA")
-                .build();
-        mockConfigServiceResults(dataConfigView, fluentConfigView, new MeteringConfigView.Builder().build());
-        // WHEN
-        StackDto stack = createStack();
-        Map<String, SaltPillarProperties> result = underTest.decoratePillar(servicePillar, stack.getStack(), stack.getCluster(), new Telemetry(), null, null);
-        // THEN
-        Map<String, Object> results = createMapFromFluentPillars(result, "fluent");
-        assertEquals(results.get("providerPrefix"), "s3");
-        assertEquals(results.get("s3LogArchiveBucketName"), "mybucket");
-        assertEquals(results.get("logFolderName"), "cluster-logs/datahub/cl1");
-        assertEquals(results.get("enabled"), true);
-        assertEquals(results.get("platform"), CloudPlatform.AWS.name());
-        assertEquals(results.get("user"), "root");
-        verify(fluentConfigService, times(1)).createFluentConfigs(any(TelemetryClusterDetails.class),
-                anyBoolean(), anyBoolean(), isNull(), any(Telemetry.class));
-        verify(meteringConfigService, times(0)).createMeteringConfigs(anyBoolean(), anyString(), anyString(),
-                anyString(), anyString(), anyString());
-    }
-
-    @Test
-    public void testS3DecorateWithOverrides() {
-        // GIVEN
-        Map<String, SaltPillarProperties> servicePillar = new HashMap<>();
-        Map<String, Object> overrides = new HashMap<>();
-        overrides.put("providerPrefix", "s3a");
-        TelemetryClusterDetails clusterDetails = TelemetryClusterDetails.Builder.builder().withPlatform("AWS").build();
-        FluentConfigView fluentConfigView = new FluentConfigView.Builder()
-                .withClusterDetails(clusterDetails)
-                .withEnabled(true)
-                .withS3LogArchiveBucketName("mybucket")
-                .withLogFolderName("cluster-logs/datahub/cl1")
-                .withProviderPrefix("s3")
-                .withOverrideAttributes(overrides)
-                .build();
-        DatabusConfigView dataConfigView = new DatabusConfigView.Builder()
-                .build();
-        mockConfigServiceResults(dataConfigView, fluentConfigView, new MeteringConfigView.Builder().build());
-        // WHEN
-        StackDto stack = createStack();
-        Map<String, SaltPillarProperties> result = underTest.decoratePillar(servicePillar, stack.getStack(), stack.getCluster(), new Telemetry(), null, null);
-        // THEN
-        Map<String, Object> results = createMapFromFluentPillars(result, "fluent");
-        assertEquals(results.get("providerPrefix"), "s3a");
-        assertEquals(results.get("s3LogArchiveBucketName"), "mybucket");
-        assertEquals(results.get("logFolderName"), "cluster-logs/datahub/cl1");
-        assertEquals(results.get("enabled"), true);
-    }
-
-    @Test
-    public void testDecorateWithMetering() {
-        // GIVEN
-        Map<String, SaltPillarProperties> servicePillar = new HashMap<>();
-        Telemetry telemetry = new Telemetry();
-        Features features = new Features();
-        FeatureSetting metering = new FeatureSetting();
-        metering.setEnabled(true);
-        features.setMetering(metering);
-        telemetry.setFeatures(features);
-        MeteringConfigView meteringConfigView = new MeteringConfigView.Builder()
-                .withEnabled(true)
-                .withPlatform("AWS")
-                .withServiceType("DATAHUB")
-                .withServiceVersion("1.0.0")
-                .withClusterCrn("myClusterCrn")
-                .build();
-        DatabusConfigView dataConfigView = new DatabusConfigView.Builder()
-                .build();
-        mockConfigServiceResults(dataConfigView, new FluentConfigView.Builder().build(), meteringConfigView);
-        // WHEN
-        StackDto stack = createStack();
-        Map<String, SaltPillarProperties> result = underTest.decoratePillar(servicePillar, stack.getStack(), stack.getCluster(), telemetry, null, null);
-        // THEN
-        Map<String, Object> results = createMapFromFluentPillars(result, "metering");
-        assertEquals(results.get("serviceType"), "DATAHUB");
-        assertEquals(results.get("serviceVersion"), "1.0.0");
-        assertEquals(results.get("clusterCrn"), "myClusterCrn");
-        assertEquals(results.get("enabled"), true);
-    }
-
-    @Test
-    public void testDecorateWithSaasMonitoring() {
-        // GIVEN
-        Map<String, SaltPillarProperties> servicePillar = new HashMap<>();
-        TelemetryClusterDetails clusterDetails = TelemetryClusterDetails.Builder.builder()
-                .withCrn("myClusterCrn")
-                .withType("datahub")
-                .withVersion("1.0.0")
-                .build();
-        MonitoringConfigView monitoringConfigView = new MonitoringConfigView.Builder()
-                .withEnabled(true)
-                .withClusterDetails(clusterDetails)
-                .build();
-        NodeStatusConfigView nodeStatusConfigView = new NodeStatusConfigView.Builder()
-                .withServerUsername("admin")
-                .withServerPassword("admin".toCharArray())
-                .build();
-        DatabusConfigView dataConfigView = new DatabusConfigView.Builder()
-                .build();
-        TelemetryCommonConfigView telemetryCommonConfigView = new TelemetryCommonConfigView.Builder()
-                .withClusterDetails(clusterDetails)
-                .build();
-        MeteringConfigView meteringConfigView = new MeteringConfigView.Builder().build();
-        mockConfigServiceResults(dataConfigView, new FluentConfigView.Builder().build(), meteringConfigView,
-                monitoringConfigView, nodeStatusConfigView, telemetryCommonConfigView);
-        given(entitlementService.isCdpSaasEnabled(anyString())).willReturn(true);
-        Telemetry telemetry = new Telemetry();
-        telemetry.setMonitoring(new Monitoring());
-        // WHEN
-        StackDto stack = createStack();
-        Map<String, SaltPillarProperties> result = underTest.decoratePillar(servicePillar, stack.getStack(), stack.getCluster(), telemetry, null, null);
-        // THEN
-        Map<String, Object> results = createMapFromFluentPillars(result, "monitoring");
-        assertEquals(results.get("clusterType"), "datahub");
-        assertEquals(results.get("clusterVersion"), "1.0.0");
-        assertEquals(results.get("clusterCrn"), "myClusterCrn");
-        assertEquals(results.get("enabled"), true);
-    }
-
-    @Test
-    public void testDecorateWithDisabledLogging() {
-        // GIVEN
-        Map<String, SaltPillarProperties> servicePillar = new HashMap<>();
-        FluentConfigView fluentConfigView = new FluentConfigView.Builder()
-                .build();
-        DatabusConfigView dataConfigView = new DatabusConfigView.Builder()
-                .build();
-        mockConfigServiceResults(dataConfigView, fluentConfigView, new MeteringConfigView.Builder().build());
-        // WHEN
-        StackDto stack = createStack();
-        Map<String, SaltPillarProperties> result = underTest.decoratePillar(servicePillar, stack.getStack(), stack.getCluster(), new Telemetry(), null, null);
-        // THEN
-        assertNotNull(result.get("telemetry"));
-        assertNull(result.get("fleunt"));
-    }
-
-    @Test
-    public void testDecorateWithDatabus() {
-        // GIVEN
-        Map<String, SaltPillarProperties> servicePillar = new HashMap<>();
-        FluentConfigView fluentConfigView = new FluentConfigView.Builder()
-                .build();
-        DatabusConfigView dataConfigView = new DatabusConfigView.Builder()
-                .withEnabled(true)
-                .withAccessKeyId("myAccessKeyId")
-                .withAccessKeySecret("mySecret".toCharArray())
-                .withEndpoint("databusEndpoint")
-                .build();
-        mockConfigServiceResults(dataConfigView, fluentConfigView, new MeteringConfigView.Builder().build());
-        // WHEN
-        StackDto stack = createStack();
-        Map<String, SaltPillarProperties> result = underTest.decoratePillar(servicePillar, stack.getStack(), stack.getCluster(), new Telemetry(), null, null);
-        // THEN
-        Map<String, Object> results = createMapFromFluentPillars(result, "databus");
-        assertEquals(results.get("accessKeyId"), "myAccessKeyId");
-        assertEquals(results.get("enabled"), true);
-    }
-
-    private Map<String, Object> createMapFromFluentPillars(Map<String, SaltPillarProperties> servicePillar, String pillarType) {
-        return (Map<String, Object>) servicePillar.get(pillarType).getProperties().get(pillarType);
     }
 
     private StackDto createStack() {
+        return createStack(StackType.WORKLOAD);
+    }
+
+    private StackDto createStack(StackType stackType) {
         StackDto stackDto = spy(StackDto.class);
         Stack stack = new Stack();
         stack.setName("my-stack-name");
-        stack.setType(StackType.WORKLOAD);
+        stack.setType(stackType);
         stack.setCloudPlatform("AWS");
-        stack.setResourceCrn("stackCrn");
+        stack.setId(1L);
         Cluster cluster = new Cluster();
         cluster.setName("cl1");
         cluster.setCloudbreakClusterManagerMonitoringUser("myUsr");
         cluster.setCloudbreakClusterManagerMonitoringPassword("myPass");
+        cluster.setCdpNodeStatusMonitorUser("nodeUser");
+        cluster.setCdpNodeStatusMonitorPassword("nodePassword");
         stack.setCluster(cluster);
+        stack.setCloudPlatform(CloudPlatform.AWS.name());
         User creator = new User();
         creator.setUserCrn("crn:cdp:iam:us-west-1:accountId:user:name");
         stack.setCreator(creator);
@@ -302,30 +210,6 @@ public class TelemetryDecoratorTest {
         when(stackDto.getStack()).thenReturn(stack);
         when(stackDto.getCluster()).thenReturn(cluster);
         return stackDto;
-    }
-
-    private void mockConfigServiceResults(DatabusConfigView databusConfigView, FluentConfigView fluentConfigView,
-            MeteringConfigView meteringConfigView) {
-        mockConfigServiceResults(databusConfigView, fluentConfigView, meteringConfigView,
-                new MonitoringConfigView.Builder().build(), new NodeStatusConfigView.Builder().build(), new TelemetryCommonConfigView.Builder().build());
-    }
-
-    private void mockConfigServiceResults(DatabusConfigView databusConfigView, FluentConfigView fluentConfigView,
-            MeteringConfigView meteringConfigView, MonitoringConfigView monitoringConfigView,
-            NodeStatusConfigView nodeStatusConfigView, TelemetryCommonConfigView telemetryCommonConfigView) {
-        given(dataBusEndpointProvider.getDataBusEndpoint(isNull(), anyBoolean())).willReturn("https://dbusapi.us-west-1.sigma.altus.cloudera.com");
-        given(databusConfigService.createDatabusConfigs(anyString(), any(), isNull(), anyString()))
-                .willReturn(databusConfigView);
-        given(fluentConfigService.createFluentConfigs(any(TelemetryClusterDetails.class),
-                anyBoolean(), anyBoolean(), isNull(), any(Telemetry.class)))
-                .willReturn(fluentConfigView);
-        given(meteringConfigService.createMeteringConfigs(anyBoolean(), anyString(), anyString(), anyString(),
-                anyString(), anyString())).willReturn(meteringConfigView);
-        given(monitoringConfigService.createMonitoringConfig(any(), any(), any(), isNull(), anyBoolean(), anyBoolean(), isNull(), any(), isNull()))
-                .willReturn(monitoringConfigView);
-        given(nodeStatusConfigService.createNodeStatusConfig(isNull(), isNull(), anyBoolean())).willReturn(nodeStatusConfigView);
-        given(telemetryCommonConfigService.createTelemetryCommonConfigs(any(), anyList(), any())).willReturn(telemetryCommonConfigView);
-        given(entitlementService.useDataBusCNameEndpointEnabled(anyString())).willReturn(false);
     }
 
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/telemetry/TelemetryServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/telemetry/TelemetryServiceTest.java
@@ -1,10 +1,8 @@
 package com.sequenceiq.cloudbreak.service.telemetry;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.isNotNull;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -17,15 +15,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.sequenceiq.cloudbreak.core.bootstrap.service.host.decorator.TelemetryDecorator;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
-import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
-import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
+import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryComponentType;
-import com.sequenceiq.cloudbreak.view.ClusterView;
-import com.sequenceiq.cloudbreak.view.StackView;
-import com.sequenceiq.common.api.telemetry.model.Telemetry;
+import com.sequenceiq.cloudbreak.telemetry.orchestrator.TelemetrySaltPillarDecorator;
 
 @ExtendWith(MockitoExtension.class)
 public class TelemetryServiceTest {
@@ -39,60 +32,18 @@ public class TelemetryServiceTest {
     private StackDtoService stackDtoService;
 
     @Mock
-    private ComponentConfigProviderService componentConfigProviderService;
-
-    @Mock
-    private TelemetryDecorator telemetryDecorator;
+    private TelemetrySaltPillarDecorator telemetrySaltPillarDecorator;
 
     @Test
     public void testCreateTelemetryConfigs() {
         // GIVEN
-        given(stackDtoService.getStackViewById(STACK_ID)).willReturn(stack());
-        given(stackDtoService.getClusterViewByStackId(STACK_ID)).willReturn(cluster("{}"));
-        given(componentConfigProviderService.getTelemetry(STACK_ID)).willReturn(new Telemetry());
-        given(telemetryDecorator.decoratePillar(anyMap(), any(), any(), any(), any(), any())).willReturn(new HashMap<>());
+        StackDto stack = mock(StackDto.class);
+        given(stackDtoService.getById(STACK_ID)).willReturn(stack);
+        given(telemetrySaltPillarDecorator.generatePillarConfigMap(stack)).willReturn(new HashMap<>());
         // WHEN
         underTest.createTelemetryConfigs(STACK_ID, Set.of(TelemetryComponentType.CDP_TELEMETRY));
         // THEN
-        verify(telemetryDecorator, times(1)).decoratePillar(anyMap(), any(), any(), any(), isNotNull(), any());
-    }
-
-    @Test
-    public void testCreateTelemetryConfigsWithIOException() {
-        // GIVEN
-        given(stackDtoService.getStackViewById(STACK_ID)).willReturn(stack());
-        given(stackDtoService.getClusterViewByStackId(STACK_ID)).willReturn(cluster("wrongJson"));
-        given(componentConfigProviderService.getTelemetry(STACK_ID)).willReturn(new Telemetry());
-        given(telemetryDecorator.decoratePillar(anyMap(), any(), any(), any(), any(), any())).willReturn(new HashMap<>());
-        // WHEN
-        underTest.createTelemetryConfigs(STACK_ID, Set.of(TelemetryComponentType.CDP_TELEMETRY));
-        // THEN
-        verify(telemetryDecorator, times(1)).decoratePillar(anyMap(), any(), any(), any(), isNull(), any());
-    }
-
-    @Test
-    public void testCreateTelemetryConfigsWithEmptyJson() {
-        // GIVEN
-        given(stackDtoService.getStackViewById(STACK_ID)).willReturn(stack());
-        given(stackDtoService.getClusterViewByStackId(STACK_ID)).willReturn(cluster(null));
-        given(componentConfigProviderService.getTelemetry(STACK_ID)).willReturn(new Telemetry());
-        given(telemetryDecorator.decoratePillar(anyMap(), any(), any(), any(), any(), any())).willReturn(new HashMap<>());
-        // WHEN
-        underTest.createTelemetryConfigs(STACK_ID, Set.of(TelemetryComponentType.CDP_TELEMETRY));
-        // THEN
-        verify(telemetryDecorator, times(1)).decoratePillar(anyMap(), any(), any(), any(), isNull(), any());
-    }
-
-    private StackView stack() {
-        Stack stack = new Stack();
-        stack.setId(STACK_ID);
-        return stack;
-    }
-
-    private ClusterView cluster(String databusJson) {
-        Cluster cluster = new Cluster();
-        cluster.setId(STACK_ID);
-        cluster.setDatabusCredential(databusJson);
-        return cluster;
+        verify(stackDtoService, times(1)).getById(STACK_ID);
+        verify(telemetrySaltPillarDecorator, times(1)).generatePillarConfigMap(any(StackDto.class));
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsEnsureMachineUserHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsEnsureMachineUserHandler.java
@@ -44,6 +44,7 @@ public class DiagnosticsEnsureMachineUserHandler extends AbstractDiagnosticsOper
                 DataBusCredential credential = altusMachineUserService.getOrCreateDataBusCredentialIfNeeded(resourceId);
                 parameters.setSupportBundleDbusAccessKey(credential.getAccessKey());
                 parameters.setSupportBundleDbusPrivateKey(credential.getPrivateKey());
+                parameters.setSupportBundleDbusAccessKeyType(credential.getAccessKeyType());
             }
             return DiagnosticsCollectionEvent.builder()
                     .withResourceCrn(resourceCrn)

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/telemetry/TelemetryConfigService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/telemetry/TelemetryConfigService.java
@@ -3,14 +3,14 @@ package com.sequenceiq.freeipa.service.telemetry;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,35 +24,36 @@ import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
-import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
 import com.sequenceiq.cloudbreak.telemetry.DataBusEndpointProvider;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryClusterDetails;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryComponentType;
+import com.sequenceiq.cloudbreak.telemetry.TelemetryContextProvider;
+import com.sequenceiq.cloudbreak.telemetry.context.MeteringContext;
+import com.sequenceiq.cloudbreak.telemetry.monitoring.MonitoringServiceType;
+import com.sequenceiq.cloudbreak.telemetry.orchestrator.TelemetrySaltPillarDecorator;
 import com.sequenceiq.cloudbreak.telemetry.VmLogsService;
-import com.sequenceiq.cloudbreak.telemetry.common.TelemetryCommonConfigService;
-import com.sequenceiq.cloudbreak.telemetry.common.TelemetryCommonConfigView;
-import com.sequenceiq.cloudbreak.telemetry.databus.DatabusConfigService;
-import com.sequenceiq.cloudbreak.telemetry.databus.DatabusConfigView;
+import com.sequenceiq.cloudbreak.telemetry.context.DatabusContext;
+import com.sequenceiq.cloudbreak.telemetry.context.LogShipperContext;
+import com.sequenceiq.cloudbreak.telemetry.context.MonitoringContext;
+import com.sequenceiq.cloudbreak.telemetry.context.NodeStatusContext;
+import com.sequenceiq.cloudbreak.telemetry.context.TelemetryContext;
 import com.sequenceiq.cloudbreak.telemetry.fluent.FluentClusterType;
-import com.sequenceiq.cloudbreak.telemetry.fluent.FluentConfigService;
-import com.sequenceiq.cloudbreak.telemetry.fluent.FluentConfigView;
 import com.sequenceiq.cloudbreak.telemetry.monitoring.MonitoringClusterType;
 import com.sequenceiq.cloudbreak.telemetry.monitoring.MonitoringConfigService;
-import com.sequenceiq.cloudbreak.telemetry.monitoring.MonitoringConfigView;
-import com.sequenceiq.cloudbreak.telemetry.nodestatus.NodeStatusConfigService;
-import com.sequenceiq.cloudbreak.telemetry.nodestatus.NodeStatusConfigView;
 import com.sequenceiq.cloudbreak.telemetry.orchestrator.TelemetryConfigProvider;
 import com.sequenceiq.common.api.telemetry.model.DataBusCredential;
-import com.sequenceiq.common.api.telemetry.model.Monitoring;
+import com.sequenceiq.common.api.telemetry.model.Logging;
 import com.sequenceiq.common.api.telemetry.model.MonitoringCredential;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
+import com.sequenceiq.common.api.telemetry.model.VmLog;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.service.AltusMachineUserService;
 import com.sequenceiq.freeipa.service.stack.StackService;
 
 @Service
-public class TelemetryConfigService implements TelemetryConfigProvider {
+public class TelemetryConfigService implements TelemetryConfigProvider, TelemetryContextProvider<Stack> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TelemetryConfigService.class);
 
@@ -60,19 +61,7 @@ public class TelemetryConfigService implements TelemetryConfigProvider {
     private String version;
 
     @Inject
-    private FluentConfigService fluentConfigService;
-
-    @Inject
-    private DatabusConfigService databusConfigService;
-
-    @Inject
-    private NodeStatusConfigService nodeStatusConfigService;
-
-    @Inject
     private MonitoringConfigService monitoringConfigService;
-
-    @Inject
-    private TelemetryCommonConfigService telemetryCommonConfigService;
 
     @Inject
     private VmLogsService vmLogsService;
@@ -98,133 +87,136 @@ public class TelemetryConfigService implements TelemetryConfigProvider {
     @Inject
     private RegionAwareInternalCrnGeneratorFactory regionAwareInternalCrnGeneratorFactory;
 
+    @Inject
+    private TelemetrySaltPillarDecorator telemetrySaltPillarDecorator;
+
     @Override
-    public Map<String, SaltPillarProperties> createTelemetryConfigs(Long stackId, Set<TelemetryComponentType> components)
-            throws CloudbreakOrchestratorFailedException {
+    public Map<String, SaltPillarProperties> createTelemetryConfigs(Long stackId, Set<TelemetryComponentType> components) {
         Stack stack = stackService.getStackById(stackId);
         return createTelemetryPillarConfig(stack);
     }
 
-    public Map<String, SaltPillarProperties> createTelemetryPillarConfig(Stack stack) throws CloudbreakOrchestratorFailedException {
+    public Map<String, SaltPillarProperties> createTelemetryPillarConfig(Stack stack) {
+        return telemetrySaltPillarDecorator.generatePillarConfigMap(stack);
+    }
+
+    @Override
+    public TelemetryContext createTelemetryContext(Stack stack) {
+        TelemetryContext telemetryContext = new TelemetryContext();
         Telemetry telemetry = stack.getTelemetry();
+        telemetryContext.setTelemetry(telemetry);
+        telemetryContext.setClusterType(FluentClusterType.FREEIPA);
+        DatabusContext databusContext = createDatabusContext(stack, telemetry);
+        telemetryContext.setDatabusContext(databusContext);
+        telemetryContext.setClusterDetails(createClusterDetails(stack, databusContext));
+        NodeStatusContext nodeStatusContext = createNodeStatusContext(stack);
+        telemetryContext.setNodeStatusContext(nodeStatusContext);
         if (telemetry != null) {
-            String databusEndpoint = getDatabusEndpoint(stack, telemetry);
-            boolean databusEnabled = telemetry.isAnyDataBusBasedFeatureEnablred();
-            boolean databusEndpointValidation = entitlementService.isFreeIpaDatabusEndpointValidationEnabled(stack.getAccountId());
-            boolean cdpSaasEnabled = entitlementService.isCdpSaasEnabled(stack.getAccountId());
-            boolean computeMonitoring = entitlementService.isComputeMonitoringEnabled(stack.getAccountId());
-            Map<String, SaltPillarProperties> servicePillarConfig = new HashMap<>();
-            servicePillarConfig.putAll(getTelemetryCommonPillarConfig(stack, telemetry, databusEndpoint, databusEndpointValidation));
-            servicePillarConfig.putAll(getFluentPillarConfig(stack, telemetry, databusEnabled));
-            servicePillarConfig.putAll(getDatabusPillarConfig(stack, databusEndpoint, databusEnabled));
-            char[] passwordInput = null;
-            if (StringUtils.isNotBlank(stack.getCdpNodeStatusMonitorPassword())) {
-                passwordInput = stack.getCdpNodeStatusMonitorPassword().toCharArray();
-            }
-            servicePillarConfig.putAll(getMonitoringPillarConfig(stack, telemetry, passwordInput, cdpSaasEnabled, computeMonitoring));
-            servicePillarConfig.putAll(getCdpNodeStatusPillarConfig(stack, passwordInput));
-            return servicePillarConfig;
-        } else {
-            return Map.of();
+            telemetryContext.setLogShipperContext(createLogShipperContext(stack, telemetry));
+            telemetryContext.setMonitoringContext(createMonitoringContext(stack, telemetry, nodeStatusContext));
+            telemetryContext.setPaywallConfigs(getPaywallConfigs(stack));
+            telemetryContext.setMeteringContext(MeteringContext.builder().build());
         }
+        return telemetryContext;
     }
 
-    private Map<String, SaltPillarProperties> getMonitoringPillarConfig(Stack stack, Telemetry telemetry, char[] passwordInput, boolean cdpSaasEnabled,
-            boolean computeMonitoring) throws CloudbreakOrchestratorFailedException {
-        Map<String, Object> config = new HashMap<>();
-        Monitoring monitoring = telemetry.getMonitoring();
-        if (monitoring != null && telemetry.isMonitoringFeatureEnabled()) {
-            LOGGER.debug("Monitoring is enabled, filling configs ...");
-            String accessKey = null;
-            char[] privateKey = null;
-            if (monitoringConfigService.isMonitoringEnabled(cdpSaasEnabled, computeMonitoring)) {
-                try {
-                    Optional<MonitoringCredential> monitoringCredential = altusMachineUserService.getOrCreateMonitoringCredentialIfNeeded(
-                            stackService.getStackById(stack.getId()));
-                    if (monitoringCredential.isPresent()) {
-                        accessKey = monitoringCredential.get().getAccessKey();
-                        privateKey = Optional.of(monitoringCredential.get().getPrivateKey()).map(String::toCharArray).orElse(null);
-                    }
-                } catch (IOException e) {
-                    throw new CloudbreakOrchestratorFailedException(e);
-                }
-            }
-            MonitoringConfigView configView = monitoringConfigService.createMonitoringConfig(monitoring,
-                    MonitoringClusterType.FREEIPA, null, passwordInput, cdpSaasEnabled, computeMonitoring,
-                    accessKey, privateKey, null);
-            config = configView.toMap();
+    private NodeStatusContext createNodeStatusContext(Stack stack) {
+        NodeStatusContext.Builder builder = NodeStatusContext.builder();
+        boolean saltPingEnabled = entitlementService.nodestatusSaltPingEnabled(stack.getAccountId());
+        if (saltPingEnabled) {
+            builder.saltPingEnabled();
         }
-        return Map.of("monitoring",
-                new SaltPillarProperties("/monitoring/init.sls", Collections.singletonMap("monitoring", config)));
+        if (StringUtils.isNotBlank(stack.getCdpNodeStatusMonitorPassword())) {
+            builder.withPassword(stack.getCdpNodeStatusMonitorPassword().toCharArray());
+        }
+        return builder
+                .withUsername(stack.getCdpNodeStatusMonitorUser())
+                .build();
     }
 
-    private Map<String, SaltPillarProperties> getDatabusPillarConfig(Stack stack, String databusEndpoint, boolean databusEnabled)
-            throws CloudbreakOrchestratorFailedException {
-        if (databusEnabled) {
-            LOGGER.debug("Apply DataBus related pillars.");
+    private MonitoringContext createMonitoringContext(Stack stack, Telemetry telemetry, NodeStatusContext nodeStatusContext) {
+        boolean cdpSaasEnabled = entitlementService.isCdpSaasEnabled(stack.getAccountId());
+        boolean computeMonitoring = entitlementService.isComputeMonitoringEnabled(stack.getAccountId());
+        boolean monitoringEnabled = monitoringConfigService.isMonitoringEnabled(cdpSaasEnabled, computeMonitoring);
+        MonitoringContext.Builder builder = MonitoringContext.builder();
+        if (monitoringEnabled) {
+            builder.enabled();
             try {
-                DataBusCredential dbusCredential = altusMachineUserService.getOrCreateDataBusCredentialIfNeeded(stack);
-                DatabusConfigView databusConfigView =
-                        databusConfigService.createDatabusConfigs(dbusCredential.getAccessKey(), dbusCredential.getPrivateKey().toCharArray(),
-                                null, databusEndpoint);
-                return Map.of("databus",
-                        new SaltPillarProperties("/databus/init.sls", Collections.singletonMap("databus", databusConfigView.toMap())));
+                Optional<MonitoringCredential> monitoringCredential = altusMachineUserService.getOrCreateMonitoringCredentialIfNeeded(stack);
+                builder.withCredential(monitoringCredential.orElse(null));
             } catch (IOException e) {
-                throw new CloudbreakOrchestratorFailedException(e);
+                throw new CloudbreakServiceException(e);
             }
-        } else {
-            return Map.of();
         }
+        if (cdpSaasEnabled) {
+            builder.withServiceType(MonitoringServiceType.SAAS);
+        }
+        builder.withClusterType(MonitoringClusterType.FREEIPA);
+        builder.withSharedPassword(nodeStatusContext.getPassword());
+        if (telemetry.getMonitoring() != null) {
+            builder.withRemoteWriteUrl(telemetry.getMonitoring().getRemoteWriteUrl());
+        }
+        return builder.build();
     }
 
-    private Map<String, SaltPillarProperties> getFluentPillarConfig(Stack stack, Telemetry telemetry, boolean databusEnabled) {
-        FluentConfigView fluentConfigView = getFluentConfigView(stack, telemetry, databusEnabled);
-        return Map.of("fluent", new SaltPillarProperties("/fluent/init.sls", Collections.singletonMap("fluent", fluentConfigView.toMap())));
+    private LogShipperContext createLogShipperContext(Stack stack, Telemetry telemetry) {
+        LogShipperContext.Builder builder = LogShipperContext.builder();
+        List<VmLog> vmLogList = vmLogsService.getVmLogs();
+        Logging logging = telemetry.getLogging();
+        if (telemetry.isCloudStorageLoggingEnabled() && logging != null
+                && ObjectUtils.anyNotNull(logging.getS3(), logging.getAdlsGen2(), logging.getGcs(), logging.getCloudwatch())) {
+            builder.enabled().cloudStorageLogging();
+        }
+        if (telemetry.isClusterLogsCollectionEnabled()) {
+            builder.enabled().collectDeploymentLogs();
+        }
+        return builder
+                .withVmLogs(vmLogList)
+                .withCloudRegion(stack.getRegion())
+                .build();
     }
 
-    private Map<String, SaltPillarProperties> getTelemetryCommonPillarConfig(Stack stack, Telemetry telemetry, String databusEndpoint,
-            boolean databusEndpointValidation) {
-        TelemetryClusterDetails clusterDetails = TelemetryClusterDetails.Builder.builder()
+    private DatabusContext createDatabusContext(Stack stack, Telemetry telemetry) {
+        DatabusContext.Builder builder = DatabusContext.builder();
+        if (telemetry == null) {
+            return builder.build();
+        }
+        if (telemetry.isAnyDataBusBasedFeatureEnablred()) {
+            LOGGER.debug("Apply DataBus related configurations.");
+            builder.enabled();
+            if (entitlementService.isFreeIpaDatabusEndpointValidationEnabled(stack.getAccountId())) {
+                builder.withValidation();
+            }
+            try {
+                DataBusCredential credential = altusMachineUserService.getOrCreateDataBusCredentialIfNeeded(stack);
+                builder.withCredential(credential);
+            } catch (IOException e) {
+                throw new CloudbreakServiceException(e);
+            }
+        }
+        String databusEndpoint = getDatabusEndpoint(stack, telemetry);
+        builder.withEndpoint(databusEndpoint)
+                .withS3Endpoint(dataBusEndpointProvider.getDatabusS3Endpoint(databusEndpoint));
+        return builder.build();
+    }
+
+    private TelemetryClusterDetails createClusterDetails(Stack stack, DatabusContext databusContext) {
+        return TelemetryClusterDetails.Builder.builder()
                 .withVersion(version)
                 .withPlatform(stack.getCloudPlatform())
                 .withCrn(stack.getResourceCrn())
                 .withName(stack.getName())
                 .withType(FluentClusterType.FREEIPA.value())
                 .withOwner(stack.getOwner())
-                .withDatabusEndpoint(databusEndpoint)
-                .withDatabusS3Endpoint(dataBusEndpointProvider.getDatabusS3Endpoint(databusEndpoint))
-                .withDatabusEndpointValidation(databusEndpointValidation)
+                .withDatabusEndpoint(databusContext.getEndpoint())
+                .withDatabusS3Endpoint(databusContext.getS3Endpoint())
+                .withDatabusEndpointValidation(databusContext.isValidation())
                 .build();
-        TelemetryCommonConfigView telemetryCommonConfigs = telemetryCommonConfigService.createTelemetryCommonConfigs(
-                telemetry, vmLogsService.getVmLogs(), clusterDetails);
-        return Map.of("telemetry",
-                new SaltPillarProperties("/telemetry/init.sls", Map.of("telemetry", telemetryCommonConfigs.toMap(),
-                        "cloudera-manager", getPaywallConfigs(stack))));
     }
 
     private String getDatabusEndpoint(Stack stack, Telemetry telemetry) {
         boolean useDbusCnameEndpoint = entitlementService.useDataBusCNameEndpointEnabled(stack.getAccountId());
         return dataBusEndpointProvider.getDataBusEndpoint(telemetry.getDatabusEndpoint(), useDbusCnameEndpoint);
-    }
-
-    private FluentConfigView getFluentConfigView(Stack stack, Telemetry telemetry, boolean databusEnabled) {
-        TelemetryClusterDetails clusterDetails = TelemetryClusterDetails.Builder.builder()
-                .withOwner(stack.getOwner())
-                .withName(stack.getName())
-                .withType(FluentClusterType.FREEIPA.value())
-                .withCrn(stack.getResourceCrn())
-                .withPlatform(stack.getCloudPlatform())
-                .withVersion(version)
-                .build();
-        return fluentConfigService.createFluentConfigs(clusterDetails, databusEnabled, false, stack.getRegion(), telemetry);
-    }
-
-    private Map<String, ? extends SaltPillarProperties> getCdpNodeStatusPillarConfig(Stack stack, char[] passwordInput) {
-        boolean saltPingEnabled = entitlementService.nodestatusSaltPingEnabled(stack.getAccountId());
-        NodeStatusConfigView nodeStatusConfigs = nodeStatusConfigService.createNodeStatusConfig(
-                stack.getCdpNodeStatusMonitorUser(), passwordInput, saltPingEnabled);
-        return Map.of("nodestatus",
-                new SaltPillarProperties("/nodestatus/init.sls", Collections.singletonMap("nodestatus", nodeStatusConfigs.toMap())));
     }
 
     private Map<String, Object> getPaywallConfigs(Stack stack) {

--- a/metrics-client/src/main/java/com/sequenceiq/cloudbreak/metrics/MetricsClient.java
+++ b/metrics-client/src/main/java/com/sequenceiq/cloudbreak/metrics/MetricsClient.java
@@ -60,8 +60,9 @@ public class MetricsClient {
             return;
         }
         Crn crn = Crn.safeFromString(resourceCrn);
-        if (configuration.isPaasSupported() || entitlementService.isCdpSaasEnabled(crn.getAccountId())) {
-            processRequest(resourceCrn, platform, status, statusOrdinal, crn, computeMonitoringEnabled);
+        boolean saas = entitlementService.isCdpSaasEnabled(crn.getAccountId());
+        if (configuration.isPaasSupported() || saas) {
+            processRequest(resourceCrn, platform, status, statusOrdinal, crn, computeMonitoringEnabled, saas);
         } else {
             LOGGER.debug("Compute metrics processing is skipped (no paas or entitlement support )");
         }
@@ -69,7 +70,7 @@ public class MetricsClient {
 
     @VisibleForTesting
     MetricsRecordRequest processRequest(String resourceCrn, String platform, String status, Integer statusOrdinal, Crn crn,
-            Optional<Boolean> computeMonitoringEnabled) {
+            Optional<Boolean> computeMonitoringEnabled, boolean saas) {
         Map<String, String> sortedLabelsMap = new TreeMap<>();
         sortedLabelsMap.put(METRIC_LABEL_NAME, METRIC_NAME_VALUE);
         sortedLabelsMap.put(RESOURCE_CRN_LABEL_NAME, resourceCrn);
@@ -96,7 +97,7 @@ public class MetricsClient {
                         .build())
                 .addTimeseries(timeSeriesBuilder)
                 .build();
-        MetricsRecordRequest request = new MetricsRecordRequest(writeRequest, Crn.safeFromString(resourceCrn).getAccountId());
+        MetricsRecordRequest request = new MetricsRecordRequest(writeRequest, Crn.safeFromString(resourceCrn).getAccountId(), saas);
         metricsRecordProcessor.processRecord(request);
         return request;
     }

--- a/metrics-client/src/main/java/com/sequenceiq/cloudbreak/metrics/processor/MetricsProcessorConfiguration.java
+++ b/metrics-client/src/main/java/com/sequenceiq/cloudbreak/metrics/processor/MetricsProcessorConfiguration.java
@@ -30,6 +30,15 @@ public class MetricsProcessorConfiguration extends AbstractStreamingConfiguratio
                 : monitoringConfiguration.getRemoteWriteUrl();
     }
 
+    public String getRemotePaasWriteUrl() {
+        if (StringUtils.isNotBlank(monitoringConfiguration.getPaasRemoteWriteInternalUrl())) {
+            return monitoringConfiguration.getPaasRemoteWriteUrl();
+        } else if (StringUtils.isNotBlank(monitoringConfiguration.getPaasRemoteWriteInternalUrl())) {
+            return monitoringConfiguration.getPaasRemoteWriteInternalUrl();
+        }
+        return getRemoteWriteUrl();
+    }
+
     public boolean isComputeMonitoringSupported() {
         return monitoringConfiguration.isEnabled() && StringUtils.isNotBlank(monitoringConfiguration.getRemoteWriteUrl());
     }

--- a/metrics-client/src/main/java/com/sequenceiq/cloudbreak/metrics/processor/MetricsRecordRequest.java
+++ b/metrics-client/src/main/java/com/sequenceiq/cloudbreak/metrics/processor/MetricsRecordRequest.java
@@ -11,9 +11,12 @@ public class MetricsRecordRequest extends RecordRequest {
 
     private final String accountId;
 
-    public MetricsRecordRequest(GeneratedMessageV3 messageBody, String accountId) {
+    private final boolean saas;
+
+    public MetricsRecordRequest(GeneratedMessageV3 messageBody, String accountId, boolean saas) {
         super(null, messageBody, 0L, false);
         this.accountId = accountId;
+        this.saas = saas;
     }
 
     public Remote.WriteRequest getWriteRequest() {
@@ -23,5 +26,9 @@ public class MetricsRecordRequest extends RecordRequest {
 
     public String getAccountId() {
         return accountId;
+    }
+
+    public boolean isSaas() {
+        return saas;
     }
 }

--- a/metrics-client/src/test/java/com/sequenceiq/cloudbreak/metrics/MetricsClientTest.java
+++ b/metrics-client/src/test/java/com/sequenceiq/cloudbreak/metrics/MetricsClientTest.java
@@ -118,7 +118,8 @@ public class MetricsClientTest {
     public void testProcessRequestInOrder() {
         // GIVEN
         // WHEN
-        MetricsRecordRequest request = underTest.processRequest(CRN, CLOUD_PLATFORM, STATUS, STATUS_ORDINAL, Crn.safeFromString(CRN), Optional.of(true));
+        MetricsRecordRequest request = underTest.processRequest(CRN, CLOUD_PLATFORM, STATUS, STATUS_ORDINAL,
+                Crn.safeFromString(CRN), Optional.of(true), true);
         Types.TimeSeries timeSeries = request.getWriteRequest().getTimeseries(0);
         // THEN
         List<String> labels = List.of("__name__", "cluster_status", "cluster_type",

--- a/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/settings.sls
@@ -41,6 +41,7 @@
 {% set support_bundle_dbus_stream_name = salt['pillar.get']('filecollector:supportBundleDbusStreamName') %}
 {% set support_bundle_dbus_access_key = salt['pillar.get']('filecollector:supportBundleDbusAccessKey') %}
 {% set support_bundle_dbus_private_key = salt['pillar.get']('filecollector:supportBundleDbusPrivateKey') %}
+{% set support_bundle_dbus_access_key_type = salt['pillar.get']('filecollector:supportBundleDbusAccessKeyType', 'Ed25519') %}
 
 {% if s3_location and not s3_region %}
   {%- set instanceDetails = salt.cmd.run('curl -s http://169.254.169.254/latest/dynamic/instance-identity/document') | load_json %}
@@ -159,6 +160,7 @@
     "supportBundleDbusHeaders": support_bundle_dbus_headers,
     "supportBundleDbusAccessKey": support_bundle_dbus_access_key,
     "supportBundleDbusPrivateKey": support_bundle_dbus_private_key,
+    "supportBundleAccessKeyType": support_bundle_dbus_access_key_type,
     "compressedFilePattern": compressed_file_pattern,
     "dbusUrl": dbus_url,
     "dbusS3Url": dbus_s3_url

--- a/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/template/support_bundle_databus.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/template/support_bundle_databus.conf.j2
@@ -1,4 +1,4 @@
 {%- from 'filecollector/settings.sls' import filecollector with context %}[dbus]
 databus_access_key_id={{ filecollector.supportBundleDbusAccessKey }}
 databus_access_secret_key={{ filecollector.supportBundleDbusPrivateKey }}
-databus_access_secret_key_algo=Ed25519
+databus_access_secret_key_algo={{ filecollector.supportBundleAccessKeyType }}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/settings.sls
@@ -38,6 +38,7 @@
 {% set local_password = salt['pillar.get']('monitoring:localPassword') %}
 {% set scrape_interval_seconds = salt['pillar.get']('monitoring:scrapeIntervalSeconds') %}
 {% set cm_metrics_exporter_port = salt['pillar.get']('monitoring:cmMetricsExporterPort', 61010) %}
+{% set cm_auto_tls = salt['pillar.get']('monitoring:cmAutoTls', True) %}
 
 {% set request_signer_enabled = salt['pillar.get']('monitoring:requestSignerEnabled', False) %}
 {% set request_signer_port = salt['pillar.get']('monitoring:requestSignerPort', 61095) %}
@@ -51,7 +52,7 @@
 
 {% set monitoring_access_key_id = salt['pillar.get']('monitoring:monitoringAccessKeyId') %}
 {% set monitoring_access_key_secret = salt['pillar.get']('monitoring:monitoringPrivateKey') %}
-
+{% set monitoring_access_key_type = salt['pillar.get']('monitoring:monitoringAccessKeyType', 'Ed25519') %}
 {%- if use_dev_stack %}
   {%- if salt['pillar.get']('cloudera-manager:address') %}
     {% set remote_write_url = "http://" + salt['pillar.get']('cloudera-manager:address') + ":9090/api/v1/write" %}
@@ -81,6 +82,7 @@
     "cmPassword": cm_password,
     "cmClusterType": cm_cluster_type,
     "cmMetricsExporterPort": cm_metrics_exporter_port,
+    "cmAutoTls": cm_auto_tls,
     "agentUser": agent_user,
     "agentPort": agent_port,
     "agentMaxDiskUsage": agent_max_disk_usage,
@@ -105,5 +107,6 @@
     "requestSignerTokenValidityMin" : request_signer_token_validity_min,
     "requestSignerUser" : request_signer_user,
     "monitoringAccessKeyId": monitoring_access_key_id,
-    "monitoringPrivateKey": monitoring_access_key_secret
+    "monitoringPrivateKey": monitoring_access_key_secret,
+    "monitoringAccessKeyType": monitoring_access_key_type
 }) %}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/template/monitoring_credential.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/template/monitoring_credential.j2
@@ -1,4 +1,4 @@
 {%- from 'monitoring/settings.sls' import monitoring with context %}[dbus]
 monitoring_access_key_id={{ monitoring.monitoringAccessKeyId }}
 monitoring_access_secret_key={{ monitoring.monitoringPrivateKey }}
-monitoring_access_secret_key_algo=Ed25519
+monitoring_access_secret_key_algo={{ monitoring.monitoringAccessKeyType }}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/template/prometheus.yml.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/template/prometheus.yml.j2
@@ -167,7 +167,7 @@ scrape_configs:
 {%- endif %}
 {%- if monitoring.type == "cloudera_manager" and "manager_server" in grains.get('roles', []) %}
   - job_name: 'smon_health'
-    scheme: 'https'
+    scheme: {% if monitoring.cmAutoTls %}'https'{% else %}'http'{% endif %}
     static_configs:
       - targets: ['localhost:{{ monitoring.cmMetricsExporterPort }}']
         labels:

--- a/telemetry-common/src/main/java/com/sequenceiq/cloudbreak/telemetry/orchestrator/TelemetrySaltPillarDecorator.java
+++ b/telemetry-common/src/main/java/com/sequenceiq/cloudbreak/telemetry/orchestrator/TelemetrySaltPillarDecorator.java
@@ -1,0 +1,88 @@
+package com.sequenceiq.cloudbreak.telemetry.orchestrator;
+
+import java.util.AbstractMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.orchestration.OrchestratorAware;
+import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
+import com.sequenceiq.cloudbreak.telemetry.TelemetryConfigView;
+import com.sequenceiq.cloudbreak.telemetry.TelemetryContextProvider;
+import com.sequenceiq.cloudbreak.telemetry.TelemetryPillarConfigGenerator;
+import com.sequenceiq.cloudbreak.telemetry.context.TelemetryContext;
+
+/**
+ * Decorate telemetry related (fluentd,metering,monitoring,databus) salt pillar configs (in order to ship data to cloud storage or databus)
+ * Currently only S3/WASB cloud storage output supported, right now salt properties are filled based on attributes,
+ * the calculation can be changed based on UI requirements.
+ * The defaults could look like this:
+ * <pre>
+ * fluent:
+ *   enabled: false
+ *   user: root
+ *   group: root
+ *   providerPrefix: "stdout"
+ *   partitionIntervalMin: 5
+ *   s3LogArchiveBucketName:
+ *   s3LogFolderName:
+ * </pre>
+ * Or for metering:
+ * <pre>
+ * metering:
+ *   enabled: true
+ *   serviceType: DATAHUB
+ *   serviceVersion: 2.11.2
+ *   cluserCrn: crn:mycluster:1111...
+ * </pre>
+ * Or for monitoring:
+ * <pre>
+ * monitoring:
+ *   enabled: true
+ *   type: cloudera_manager
+ *   clusterType: DATAHUB
+ *   clusterVersion: 2.11.2
+ *   clusterCrn: crn:mycluster:1111...
+ * </pre>
+ */
+@Component
+public class TelemetrySaltPillarDecorator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TelemetrySaltPillarDecorator.class);
+
+    private final TelemetryContextProvider telemetryContextProvider;
+
+    private final List<? extends TelemetryPillarConfigGenerator<? extends TelemetryConfigView>> generators;
+
+    public TelemetrySaltPillarDecorator(TelemetryContextProvider telemetryContextProvider,
+            List<? extends TelemetryPillarConfigGenerator<? extends TelemetryConfigView>> generators) {
+        this.telemetryContextProvider = telemetryContextProvider;
+        this.generators = generators;
+    }
+
+    public Map<String, SaltPillarProperties> generatePillarConfigMap(OrchestratorAware stack) {
+        Map<String, Map<String, Map<String, Object>>> telemetryPillarsMap = new HashMap<>();
+        TelemetryContext telemetryContext = telemetryContextProvider.createTelemetryContext(stack);
+        LOGGER.debug("Telemetry context: {}", telemetryContext);
+        for (TelemetryPillarConfigGenerator<? extends TelemetryConfigView> pillarConfigGenerator : generators) {
+            if (pillarConfigGenerator.isEnabled(telemetryContext)) {
+                LOGGER.debug("Telemetry decoration is enabled for {}", pillarConfigGenerator.getClass().getCanonicalName());
+                TelemetryConfigView configView = pillarConfigGenerator.createConfigs(telemetryContext);
+                telemetryContext.addConfigView(configView);
+                telemetryPillarsMap.putAll(pillarConfigGenerator.getSaltPillars(configView, telemetryContext));
+            } else {
+                LOGGER.debug("Telemetry decoration is disabled for {}", pillarConfigGenerator.getClass().getCanonicalName());
+            }
+        }
+        return telemetryPillarsMap.entrySet().stream().map(entry -> {
+            SaltPillarProperties pillarProperties = entry.getValue().entrySet()
+                    .stream().map(e -> new SaltPillarProperties(e.getKey(), e.getValue())).findFirst().orElse(null);
+            return new AbstractMap.SimpleEntry<>(entry.getKey(), pillarProperties);
+        }).collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
+    }
+}

--- a/telemetry-common/src/test/java/com/sequenceiq/cloudbreak/telemetry/orchestrator/TelemetrySaltPillarDecoratorTest.java
+++ b/telemetry-common/src/test/java/com/sequenceiq/cloudbreak/telemetry/orchestrator/TelemetrySaltPillarDecoratorTest.java
@@ -1,0 +1,107 @@
+package com.sequenceiq.cloudbreak.telemetry.orchestrator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.orchestration.OrchestratorAware;
+import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
+import com.sequenceiq.cloudbreak.telemetry.TelemetryConfigView;
+import com.sequenceiq.cloudbreak.telemetry.TelemetryContextProvider;
+import com.sequenceiq.cloudbreak.telemetry.TelemetryPillarConfigGenerator;
+import com.sequenceiq.cloudbreak.telemetry.context.TelemetryContext;
+
+@ExtendWith(MockitoExtension.class)
+public class TelemetrySaltPillarDecoratorTest {
+
+    private TelemetrySaltPillarDecorator underTest;
+
+    @Mock
+    private TelemetryContextProvider<OrchestratorAware> telemetryContextProvider;
+
+    @Mock
+    private OrchestratorAware stack;
+
+    @Mock
+    private TelemetryContext context;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        DummyPillarConfigGenerator generator = new DummyPillarConfigGenerator();
+        underTest = new TelemetrySaltPillarDecorator(telemetryContextProvider, List.of(generator));
+    }
+
+    @Test
+    public void testGeneratePillarConfigMap() {
+        // GIVEN
+        given(telemetryContextProvider.createTelemetryContext(stack)).willReturn(context);
+        // WHEN
+        Map<String, SaltPillarProperties> result = underTest.generatePillarConfigMap(stack);
+        // THEN
+        assertTrue(result.containsKey("dummy"));
+        assertTrue(result.get("dummy").getProperties().containsKey("dummy"));
+        assertEquals("/dummy/init.sls", result.get("dummy").getPath());
+    }
+
+    @Test
+    public void testGeneratePillarConfigMapWithoutContext() {
+        // GIVEN
+        given(telemetryContextProvider.createTelemetryContext(stack)).willReturn(null);
+        // WHEN
+        Map<String, SaltPillarProperties> result = underTest.generatePillarConfigMap(stack);
+        // THEN
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testGeneratePillarConfigMapWithoutGenerators() {
+        // GIVE
+        given(telemetryContextProvider.createTelemetryContext(stack)).willReturn(context);
+        underTest = new TelemetrySaltPillarDecorator(telemetryContextProvider, List.of());
+        // WHEN
+        Map<String, SaltPillarProperties> result = underTest.generatePillarConfigMap(stack);
+        // THEN
+        assertTrue(result.isEmpty());
+    }
+
+    private static class DummyPillarConfigGenerator implements TelemetryPillarConfigGenerator<DummyTelemetryView> {
+
+        @Override
+        public DummyTelemetryView createConfigs(TelemetryContext context) {
+            return new DummyTelemetryView();
+        }
+
+        @Override
+        public boolean isEnabled(TelemetryContext context) {
+            return context != null;
+        }
+
+        @Override
+        public String saltStateName() {
+            return "dummy";
+        }
+    }
+
+    private static class DummyTelemetryView implements TelemetryConfigView {
+
+        @Override
+        public Map<String, Object> toMap() {
+            Map<String, Object> properties = new HashMap<>();
+            properties.put("dummyKey1", "dummyValue1");
+            properties.put("dummyKey2", "dummyValue2");
+            return properties;
+        }
+    }
+}


### PR DESCRIPTION
…nents.

details:
- instead of passing more and more parameters for configuration services, pass only a global telemetry context
- telemetry context contains other contexts (used as config service inputs) and can be filled with the config view output
- salt decorator is moved to telemetry-common, the decorator has a new reference called telemetry context provider which needs to be implemented on core/freeipa side (that's the main logic to generate the input for the decorators)
- config view generation can be skipped for different states based on the isEnabled method implementation of the telemetry context provider
- refactor TelemetryDecorator and TelemetryConfigService based on the new changes
- added UTs
Also including a few new changes as config generation was refactored:
- consider cm auto tls feature for SMON prometheus settings (default will be true if the value empty in the pillar)
- added paas url + internal url options - these will fallback to the original monitoring urls (fallback happens on metricsClient side as well)
- pass access key type to monitoring + diagnostics (it has been already passwd for databus) - also add access key type field for Databus/Monitoring credentials
- create CdpCredential object that will be the parent of DataBusCredential and MonitoringCredential (helps for refactor or for future refactor)

See detailed description in the commit message.