### PR TITLE
CB-18249 Change from object to Optional to handle the null value correctly in MdcContextBuilder

### DIFF
--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/job/storage/StorageConsumptionJob.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/job/storage/StorageConsumptionJob.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.consumption.job.storage;
 
+import java.util.Optional;
+
 import javax.inject.Inject;
 
 import org.quartz.DisallowConcurrentExecution;
@@ -52,7 +54,7 @@ public class StorageConsumptionJob extends StatusCheckerJob {
     }
 
     @Override
-    protected Object getMdcContextObject() {
-        return consumptionService.findConsumptionById(getLocalIdAsLong());
+    protected Optional<Object> getMdcContextObject() {
+        return Optional.ofNullable(consumptionService.findConsumptionById(getLocalIdAsLong()));
     }
 }

--- a/cloud-consumption/src/test/java/com/sequenceiq/consumption/job/storage/StorageConsumptionJobTest.java
+++ b/cloud-consumption/src/test/java/com/sequenceiq/consumption/job/storage/StorageConsumptionJobTest.java
@@ -71,7 +71,7 @@ public class StorageConsumptionJobTest {
     public void testGetMdcContextObject() {
         when(consumptionService.findConsumptionById(LOCAL_ID)).thenReturn(consumption);
 
-        Assertions.assertEquals(consumption, underTest.getMdcContextObject());
+        Assertions.assertEquals(consumption, underTest.getMdcContextObject().orElse(null));
     }
 
     @Test

--- a/common/src/test/java/com/sequenceiq/cloudbreak/quartz/TracedQuartzJobTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/quartz/TracedQuartzJobTest.java
@@ -1,0 +1,49 @@
+package com.sequenceiq.cloudbreak.quartz;
+
+import static org.mockito.Mockito.mock;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.quartz.JobExecutionContext;
+
+import com.sequenceiq.cloudbreak.logger.MdcContextInfoProvider;
+
+@ExtendWith(MockitoExtension.class)
+public class TracedQuartzJobTest {
+
+    @Test
+    public void testFillMdcContextWhenNoBuilderImplemented() {
+        JobExecutionContext context = mock(JobExecutionContext.class);
+        TracedQuartzJobTestClass underTest = new TracedQuartzJobTestClass();
+        IllegalArgumentException actual = Assertions.assertThrows(IllegalArgumentException.class, () -> underTest.fillMdcContext(context));
+        Assertions.assertEquals("Please implement one of them: getMdcContextObject() or getMdcContextConfigProvider()", actual.getMessage());
+    }
+
+    @Test
+    public void testFillMdcContextWhenProviderBuilderImplementedButEmptyAndNoException() {
+        JobExecutionContext context = mock(JobExecutionContext.class);
+        TracedQuartzJobTestClass underTest = new TracedQuartzJobTestClass() {
+            @Override
+            protected Optional<MdcContextInfoProvider> getMdcContextConfigProvider() {
+                return Optional.empty();
+            }
+        };
+        underTest.fillMdcContext(context);
+    }
+
+    @Test
+    public void testFillMdcContextWhenObjectBuilderImplementedButEmptyAndNoException() {
+        JobExecutionContext context = mock(JobExecutionContext.class);
+        TracedQuartzJobTestClass underTest = new TracedQuartzJobTestClass() {
+            @Override
+            protected Optional<Object> getMdcContextObject() {
+                return Optional.empty();
+            }
+        };
+        underTest.fillMdcContext(context);
+    }
+}

--- a/common/src/test/java/com/sequenceiq/cloudbreak/quartz/TracedQuartzJobTestClass.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/quartz/TracedQuartzJobTestClass.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.cloudbreak.quartz;
+
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
+import io.opentracing.Tracer;
+
+public class TracedQuartzJobTestClass extends TracedQuartzJob {
+
+    public TracedQuartzJobTestClass() {
+        super(null, null);
+    }
+
+    public TracedQuartzJobTestClass(Tracer tracer, String jobName) {
+        super(tracer, jobName);
+    }
+
+    @Override
+    protected void executeTracedJob(JobExecutionContext context) throws JobExecutionException {
+
+    }
+
+    public void fillMdcContext(JobExecutionContext context) {
+        super.fillMdcContext(context);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJob.java
@@ -128,8 +128,8 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
     }
 
     @Override
-    protected MdcContextInfoProvider getMdcContextConfigProvider() {
-        return stackDtoService.getStackViewByIdOpt(getStackId()).orElse(null);
+    protected Optional<MdcContextInfoProvider> getMdcContextConfigProvider() {
+        return Optional.ofNullable(stackDtoService.getStackViewByIdOpt(getStackId()).orElse(null));
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/altus/CloudbreakUMSCleanupJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/altus/CloudbreakUMSCleanupJob.java
@@ -6,6 +6,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Component;
 
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
+import com.sequenceiq.cloudbreak.logger.MdcContextInfoProvider;
 import com.sequenceiq.cloudbreak.quartz.cleanup.UMSCleanupConfig;
 import com.sequenceiq.cloudbreak.quartz.cleanup.job.UMSCleanupJob;
 import com.sequenceiq.cloudbreak.service.altus.AltusMachineUserService;
@@ -46,8 +48,8 @@ public class CloudbreakUMSCleanupJob extends UMSCleanupJob {
     }
 
     @Override
-    protected Object getMdcContextObject() {
-        return null;
+    protected Optional<MdcContextInfoProvider> getMdcContextConfigProvider() {
+        return Optional.empty();
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/instancemetadata/ArchiveInstanceMetaDataJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/instancemetadata/ArchiveInstanceMetaDataJob.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.job.instancemetadata;
 
+import java.util.Optional;
+
 import javax.inject.Inject;
 
 import org.quartz.DisallowConcurrentExecution;
@@ -40,8 +42,8 @@ public class ArchiveInstanceMetaDataJob extends StatusCheckerJob {
     }
 
     @Override
-    protected Object getMdcContextObject() {
-        return stackViewService.findById(getStackId()).orElseGet(StackView::new);
+    protected Optional<Object> getMdcContextObject() {
+        return Optional.ofNullable(stackViewService.findById(getStackId()));
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/nodestatus/NodeStatusCheckerJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/nodestatus/NodeStatusCheckerJob.java
@@ -28,7 +28,6 @@ import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.client.RPCResponse;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
-import com.sequenceiq.cloudbreak.domain.view.StackView;
 import com.sequenceiq.cloudbreak.node.status.NodeStatusService;
 import com.sequenceiq.cloudbreak.quartz.statuschecker.job.StatusCheckerJob;
 import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
@@ -70,8 +69,8 @@ public class NodeStatusCheckerJob extends StatusCheckerJob {
     }
 
     @Override
-    protected Object getMdcContextObject() {
-        return stackViewService.findById(getStackId()).orElseGet(StackView::new);
+    protected Optional<Object> getMdcContextObject() {
+        return Optional.ofNullable(stackViewService.findById(getStackId()));
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJob.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.job.stackpatcher;
 
 import static com.sequenceiq.cloudbreak.job.stackpatcher.ExistingStackPatcherJobAdapter.STACK_PATCH_TYPE_NAME;
 
+import java.util.Optional;
+
 import javax.inject.Inject;
 
 import org.quartz.DisallowConcurrentExecution;
@@ -17,7 +19,6 @@ import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.StackPatch;
 import com.sequenceiq.cloudbreak.domain.stack.StackPatchStatus;
 import com.sequenceiq.cloudbreak.domain.stack.StackPatchType;
-import com.sequenceiq.cloudbreak.domain.view.StackView;
 import com.sequenceiq.cloudbreak.quartz.statuschecker.job.StatusCheckerJob;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.service.stack.StackViewService;
@@ -54,8 +55,8 @@ public class ExistingStackPatcherJob extends StatusCheckerJob {
     }
 
     @Override
-    protected Object getMdcContextObject() {
-        return stackViewService.findById(getStackId()).orElseGet(StackView::new);
+    protected Optional<Object> getMdcContextObject() {
+        return Optional.ofNullable(stackViewService.findById(getStackId()));
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/job/StructuredSynchronizerJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/job/StructuredSynchronizerJob.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.structuredevent.job;
 
 import java.util.EnumSet;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -46,8 +47,8 @@ public class StructuredSynchronizerJob extends StatusCheckerJob {
     }
 
     @Override
-    protected Object getMdcContextObject() {
-        return stackService.getById(getLocalIdAsLong());
+    protected Optional<Object> getMdcContextObject() {
+        return Optional.ofNullable(stackService.getById(getLocalIdAsLong()));
     }
 
     @Override

--- a/datalake/src/main/java/com/sequenceiq/datalake/job/SdxClusterStatusCheckerJob.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/job/SdxClusterStatusCheckerJob.java
@@ -53,8 +53,8 @@ public class SdxClusterStatusCheckerJob extends StatusCheckerJob {
     }
 
     @Override
-    protected SdxCluster getMdcContextObject() {
-        return sdxClusterRepository.findById(Long.valueOf(getLocalId())).orElse(null);
+    protected Optional<Object> getMdcContextObject() {
+        return Optional.ofNullable(sdxClusterRepository.findById(Long.valueOf(getLocalId())).orElse(null));
     }
 
     @Override

--- a/environment/src/main/java/com/sequenceiq/environment/environment/sync/EnvironmentStatusCheckerJob.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/sync/EnvironmentStatusCheckerJob.java
@@ -57,8 +57,8 @@ public class EnvironmentStatusCheckerJob extends StatusCheckerJob {
     }
 
     @Override
-    protected Object getMdcContextObject() {
-        return environmentService.findEnvironmentById(getLocalIdAsLong()).orElse(null);
+    protected Optional<Object> getMdcContextObject() {
+        return Optional.ofNullable(environmentService.findEnvironmentById(getLocalIdAsLong()).orElse(null));
     }
 
     @Override

--- a/flow/src/main/java/com/sequenceiq/flow/cleanup/FlowCleanupJob.java
+++ b/flow/src/main/java/com/sequenceiq/flow/cleanup/FlowCleanupJob.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.flow.cleanup;
 
+import java.util.Optional;
+
 import javax.inject.Inject;
 
 import org.quartz.JobExecutionContext;
@@ -9,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
+import com.sequenceiq.cloudbreak.logger.MdcContextInfoProvider;
 import com.sequenceiq.cloudbreak.quartz.TracedQuartzJob;
 import com.sequenceiq.flow.core.FlowLogService;
 import com.sequenceiq.flow.core.FlowRegister;
@@ -42,8 +45,8 @@ public class FlowCleanupJob extends TracedQuartzJob {
     }
 
     @Override
-    protected Object getMdcContextObject() {
-        return null;
+    protected Optional<MdcContextInfoProvider> getMdcContextConfigProvider() {
+        return Optional.empty();
     }
 
     @Override

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/altus/FreeIpaUMSCleanupJob.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/altus/FreeIpaUMSCleanupJob.java
@@ -5,6 +5,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -15,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
+import com.sequenceiq.cloudbreak.logger.MdcContextInfoProvider;
 import com.sequenceiq.cloudbreak.quartz.cleanup.UMSCleanupConfig;
 import com.sequenceiq.cloudbreak.quartz.cleanup.job.UMSCleanupJob;
 import com.sequenceiq.freeipa.entity.Stack;
@@ -43,8 +45,8 @@ public class FreeIpaUMSCleanupJob extends UMSCleanupJob {
     }
 
     @Override
-    protected Object getMdcContextObject() {
-        return null;
+    protected Optional<MdcContextInfoProvider> getMdcContextConfigProvider() {
+        return Optional.empty();
     }
 
     @Override

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/nodestatus/NodeStatusJob.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/nodestatus/NodeStatusJob.java
@@ -3,6 +3,7 @@ package com.sequenceiq.freeipa.nodestatus;
 import static com.sequenceiq.cloudbreak.util.Benchmark.checkedMeasure;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -54,8 +55,8 @@ public class NodeStatusJob extends StatusCheckerJob {
     }
 
     @Override
-    protected Object getMdcContextObject() {
-        return stackService.getStackById(getStackId());
+    protected Optional<Object> getMdcContextObject() {
+        return Optional.ofNullable(stackService.getStackById(getStackId()));
     }
 
     @Override

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/StackStatusCheckerJob.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/StackStatusCheckerJob.java
@@ -4,6 +4,7 @@ import static com.sequenceiq.cloudbreak.util.Benchmark.checkedMeasure;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -77,8 +78,8 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
     }
 
     @Override
-    protected Object getMdcContextObject() {
-        return stackService.getStackById(getStackId());
+    protected Optional<Object> getMdcContextObject() {
+        return Optional.ofNullable(stackService.getStackById(getStackId()));
     }
 
     @Override

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/saltstatus/StackSaltStatusCheckerJob.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/saltstatus/StackSaltStatusCheckerJob.java
@@ -57,8 +57,8 @@ public class StackSaltStatusCheckerJob extends StatusCheckerJob {
     }
 
     @Override
-    protected Object getMdcContextObject() {
-        return stackService.getStackById(getStackId());
+    protected Optional<Object> getMdcContextObject() {
+        return Optional.ofNullable(stackService.getStackById(getStackId()));
     }
 
     private Long getStackId() {

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/sync/DBStackStatusSyncJob.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/sync/DBStackStatusSyncJob.java
@@ -2,6 +2,8 @@ package com.sequenceiq.redbeams.sync;
 
 import static com.sequenceiq.cloudbreak.util.Benchmark.measure;
 
+import java.util.Optional;
+
 import javax.inject.Inject;
 
 import org.quartz.DisallowConcurrentExecution;
@@ -41,9 +43,9 @@ public class DBStackStatusSyncJob extends StatusCheckerJob {
     }
 
     @Override
-    protected Object getMdcContextObject() {
+    protected Optional<Object> getMdcContextObject() {
         Long dbStackId = Long.valueOf(getLocalId());
-        return dbStackService.getById(dbStackId);
+        return Optional.ofNullable(dbStackService.getById(dbStackId));
     }
 
     @Override


### PR DESCRIPTION
In the flow quartz job, the null value is the accepted value. Now, it causes an error because the MdcContextBuilder has two object builders, and both are null we throw a validation error. If the return value is Optional.empty() it means the method implemented but no value

