### PR TITLE
CB-17890 Salt password rotation for non-available stacks

### DIFF
--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -359,7 +359,7 @@ cluster.pillar.config.update.failed=Failed to update cluster configuration,
 
 cluster.salt.passwordrotate.started=SaltStack user password rotation started
 cluster.salt.passwordrotate.started.fallback=SaltStack user password rotation started with fallback implementation, please upgrade your cluster for a better user experience
-cluster.salt.passwordrotate.finished=SaltStack user password successfully rotated
+cluster.salt.passwordrotate.finished=SaltStack user password successfully rotated, restored previous status
 cluster.salt.passwordrotate.failed=SaltStack user password rotation failed with error: {0}
 
 resource.blueprint.created=Blueprint created.

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/view/StackView.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/view/StackView.java
@@ -29,6 +29,7 @@ import com.sequenceiq.cloudbreak.common.type.CloudConstants;
 import com.sequenceiq.cloudbreak.domain.FailurePolicy;
 import com.sequenceiq.cloudbreak.domain.StackAuthentication;
 import com.sequenceiq.cloudbreak.domain.stack.DnsResolverType;
+import com.sequenceiq.cloudbreak.domain.stack.StackStatus;
 import com.sequenceiq.cloudbreak.logger.MdcContextInfoProvider;
 import com.sequenceiq.cloudbreak.workspace.model.User;
 import com.sequenceiq.common.api.type.ResourceType;
@@ -59,6 +60,10 @@ public interface StackView extends MdcContextInfoProvider {
     DetailedStackStatus getDetailedStatus();
 
     String getStatusReason();
+
+    default StackStatus getStackStatus() {
+        return new StackStatus(null, getStatus(), getStatusReason(), getDetailedStatus());
+    }
 
     String getCloudPlatform();
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/salt/rotatepassword/RotateSaltPasswordContext.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/salt/rotatepassword/RotateSaltPasswordContext.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.salt.rotatepassword;
 
+import com.sequenceiq.cloudbreak.domain.stack.StackStatus;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordReason;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordType;
 import com.sequenceiq.cloudbreak.view.StackView;
@@ -14,9 +15,13 @@ public class RotateSaltPasswordContext extends CommonContext {
 
     private final RotateSaltPasswordType type;
 
-    public RotateSaltPasswordContext(FlowParameters flowParameters, StackView stack, RotateSaltPasswordReason reason, RotateSaltPasswordType type) {
+    private final StackStatus previousStackStatus;
+
+    public RotateSaltPasswordContext(FlowParameters flowParameters, StackView stack, StackStatus previousStackStatus,
+            RotateSaltPasswordReason reason, RotateSaltPasswordType type) {
         super(flowParameters);
         this.stack = stack;
+        this.previousStackStatus = previousStackStatus;
         this.reason = reason;
         this.type = type;
     }
@@ -35,5 +40,9 @@ public class RotateSaltPasswordContext extends CommonContext {
 
     public RotateSaltPasswordType getType() {
         return type;
+    }
+
+    public StackStatus getPreviousStackStatus() {
+        return previousStackStatus;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/RotateSaltPasswordService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/RotateSaltPasswordService.java
@@ -80,6 +80,9 @@ public class RotateSaltPasswordService {
     private ReactorFlowManager flowManager;
 
     public void validateRotateSaltPassword(StackDto stack) {
+        if (stack.getStatus().isStopped()) {
+            throw new BadRequestException("Rotating SaltStack user password is not supported for stopped clusters");
+        }
         if (!entitlementService.isSaltUserPasswordRotationEnabled(stack.getAccountId())) {
             throw new BadRequestException("Rotating SaltStack user password is not supported in your account");
         }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/rotatepassword/RotateSaltPasswordContext.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/rotatepassword/RotateSaltPasswordContext.java
@@ -3,6 +3,7 @@ package com.sequenceiq.freeipa.flow.freeipa.salt.rotatepassword;
 import com.sequenceiq.flow.core.CommonContext;
 import com.sequenceiq.flow.core.FlowParameters;
 import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.entity.StackStatus;
 import com.sequenceiq.freeipa.flow.freeipa.salt.rotatepassword.event.RotateSaltPasswordReason;
 
 public class RotateSaltPasswordContext extends CommonContext {
@@ -11,9 +12,12 @@ public class RotateSaltPasswordContext extends CommonContext {
 
     private final RotateSaltPasswordReason reason;
 
-    public RotateSaltPasswordContext(FlowParameters flowParameters, Stack stack, RotateSaltPasswordReason reason) {
+    private final StackStatus previousStackStatus;
+
+    public RotateSaltPasswordContext(FlowParameters flowParameters, Stack stack, StackStatus previousStackStatus, RotateSaltPasswordReason reason) {
         super(flowParameters);
         this.stack = stack;
+        this.previousStackStatus = previousStackStatus;
         this.reason = reason;
     }
 
@@ -23,5 +27,9 @@ public class RotateSaltPasswordContext extends CommonContext {
 
     public RotateSaltPasswordReason getReason() {
         return reason;
+    }
+
+    public StackStatus getPreviousStackStatus() {
+        return previousStackStatus;
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/orchestrator/RotateSaltPasswordService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/orchestrator/RotateSaltPasswordService.java
@@ -98,6 +98,9 @@ public class RotateSaltPasswordService {
 
     public void validateRotateSaltPassword(Stack stack) {
         MDCBuilder.buildMdcContext(stack);
+        if (stack.isStopped()) {
+            throw new BadRequestException("Rotating SaltStack user password is not supported for stopped clusters");
+        }
         if (!entitlementService.isSaltUserPasswordRotationEnabled(stack.getAccountId())) {
             throw new BadRequestException("Rotating SaltStack user password is not supported in your account");
         }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/orchestrator/RotateSaltPasswordServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/orchestrator/RotateSaltPasswordServiceTest.java
@@ -117,12 +117,22 @@ class RotateSaltPasswordServiceTest {
 
         lenient().when(stack.getId()).thenReturn(STACK_ID);
         lenient().when(stack.getAccountId()).thenReturn(ACCOUNT_ID);
+        lenient().when(stack.isStopped()).thenReturn(false);
 
         SaltSecurityConfig saltSecurityConfig = new SaltSecurityConfig();
         saltSecurityConfig.setSaltPassword(OLD_PASSWORD);
         SecurityConfig securityConfig = new SecurityConfig();
         securityConfig.setSaltSecurityConfig(saltSecurityConfig);
         lenient().when(stack.getSecurityConfig()).thenReturn(securityConfig);
+    }
+
+    @Test
+    void  rotateSaltPasswordForStoppedStack() {
+        lenient().when(stack.isStopped()).thenReturn(true);
+
+        Assertions.assertThatThrownBy(() -> underTest.rotateSaltPassword(stack))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("Rotating SaltStack user password is not supported for stopped clusters");
     }
 
     @Test


### PR DESCRIPTION
Only check if the stack is not stopped instead of is it available
Save the starting status and re-aplly it after successful salt password rotation

See detailed description in the commit message.