### PR TITLE
CB-17069 Separate internal and external blackbox exporter probes

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/BlackboxExporterConfiguration.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/BlackboxExporterConfiguration.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.cloudbreak.telemetry.monitoring;
+
+public class BlackboxExporterConfiguration extends ExporterConfiguration {
+
+    private Integer clouderaIntervalSeconds;
+
+    private Integer cloudIntervalSeconds;
+
+    private boolean checkOnAllNodes;
+
+    public Integer getClouderaIntervalSeconds() {
+        return clouderaIntervalSeconds;
+    }
+
+    public void setClouderaIntervalSeconds(Integer clouderaIntervalSeconds) {
+        this.clouderaIntervalSeconds = clouderaIntervalSeconds;
+    }
+
+    public Integer getCloudIntervalSeconds() {
+        return cloudIntervalSeconds;
+    }
+
+    public void setCloudIntervalSeconds(Integer cloudIntervalSeconds) {
+        this.cloudIntervalSeconds = cloudIntervalSeconds;
+    }
+
+    public boolean isCheckOnAllNodes() {
+        return checkOnAllNodes;
+    }
+
+    public void setCheckOnAllNodes(boolean checkOnAllNodes) {
+        this.checkOnAllNodes = checkOnAllNodes;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfigService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfigService.java
@@ -74,7 +74,10 @@ public class MonitoringConfigService {
         }
         if (monitoringConfiguration.getBlackboxExporter() != null) {
             builder.withBlackboxExporterUser(monitoringConfiguration.getBlackboxExporter().getUser())
-                    .withBlackboxExporterPort(monitoringConfiguration.getBlackboxExporter().getPort());
+                    .withBlackboxExporterPort(monitoringConfiguration.getBlackboxExporter().getPort())
+                    .withBlackboxExporterCheckOnAllNodes(monitoringConfiguration.getBlackboxExporter().isCheckOnAllNodes())
+                    .withBlackboxExporterClouderaIntervalSeconds(monitoringConfiguration.getBlackboxExporter().getClouderaIntervalSeconds())
+                    .withBlackboxExporterCloudIntervalSeconds(monitoringConfiguration.getBlackboxExporter().getCloudIntervalSeconds());
         }
     }
 

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfigView.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfigView.java
@@ -46,6 +46,12 @@ public class MonitoringConfigView implements TelemetryConfigView {
 
     private final Integer blackboxExporterPort;
 
+    private final Integer blackboxCloudInvervalSeconds;
+
+    private final Integer blackboxClouderaIntervalSeconds;
+
+    private final boolean blackboxCheckOnAllNodes;
+
     private final Integer agentPort;
 
     private final String agentUser;
@@ -92,6 +98,9 @@ public class MonitoringConfigView implements TelemetryConfigView {
         this.nodeExporterCollectors = builder.nodeExporterCollectors;
         this.blackboxExporterUser = builder.blackboxExporterUser;
         this.blackboxExporterPort = builder.blackboxExporterPort;
+        this.blackboxCloudInvervalSeconds = builder.cloudIntervalSeconds;
+        this.blackboxClouderaIntervalSeconds = builder.clouderaIntervalSeconds;
+        this.blackboxCheckOnAllNodes = builder.checkOnAllNodes;
         this.agentUser = builder.agentUser;
         this.agentPort = builder.agentPort;
         this.agentMaxDiskUsage = builder.agentMaxDiskUsage;
@@ -216,6 +225,9 @@ public class MonitoringConfigView implements TelemetryConfigView {
         map.put("nodeExporterCollectors", defaultIfNull(this.nodeExporterCollectors, new ArrayList<>()));
         map.put("blackboxExporterUser", defaultIfNull(this.blackboxExporterUser, EMPTY_CONFIG_DEFAULT));
         map.put("blackboxExporterPort", this.blackboxExporterPort);
+        map.put("blackboxExporterCloudIntervalSeconds", this.blackboxCloudInvervalSeconds);
+        map.put("blackboxExporterClouderaIntervalSeconds", this.blackboxClouderaIntervalSeconds);
+        map.put("blackboxExporterCheckOnAllNodes", this.blackboxCheckOnAllNodes);
         map.put("agentUser", defaultIfNull(this.agentUser, EMPTY_CONFIG_DEFAULT));
         map.put("agentPort", this.agentPort);
         map.put("agentMaxDiskUsage", defaultIfNull(this.agentMaxDiskUsage, AGENT_MAX_DISK_USAGE_DEFAULT));
@@ -272,6 +284,12 @@ public class MonitoringConfigView implements TelemetryConfigView {
         private String blackboxExporterUser;
 
         private Integer blackboxExporterPort;
+
+        private Integer clouderaIntervalSeconds;
+
+        private Integer cloudIntervalSeconds;
+
+        private boolean checkOnAllNodes;
 
         private String agentUser;
 
@@ -391,6 +409,21 @@ public class MonitoringConfigView implements TelemetryConfigView {
 
         public Builder withBlackboxExporterPort(Integer blackboxExporterPort) {
             this.blackboxExporterPort = blackboxExporterPort;
+            return this;
+        }
+
+        public Builder withBlackboxExporterCloudIntervalSeconds(Integer cloudIntervalSeconds) {
+            this.cloudIntervalSeconds = cloudIntervalSeconds;
+            return this;
+        }
+
+        public Builder withBlackboxExporterClouderaIntervalSeconds(Integer clouderaIntervalSeconds) {
+            this.clouderaIntervalSeconds = clouderaIntervalSeconds;
+            return this;
+        }
+
+        public Builder withBlackboxExporterCheckOnAllNodes(boolean checkOnAllNodes) {
+            this.checkOnAllNodes = checkOnAllNodes;
             return this;
         }
 

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfiguration.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfiguration.java
@@ -25,7 +25,7 @@ public class MonitoringConfiguration {
 
     private NodeExporterConfiguration nodeExporter;
 
-    private ExporterConfiguration blackboxExporter;
+    private BlackboxExporterConfiguration blackboxExporter;
 
     private RequestSignerConfiguration requestSigner;
 
@@ -93,11 +93,11 @@ public class MonitoringConfiguration {
         this.nodeExporter = nodeExporter;
     }
 
-    public ExporterConfiguration getBlackboxExporter() {
+    public BlackboxExporterConfiguration getBlackboxExporter() {
         return blackboxExporter;
     }
 
-    public void setBlackboxExporter(ExporterConfiguration blackboxExporter) {
+    public void setBlackboxExporter(BlackboxExporterConfiguration blackboxExporter) {
         this.blackboxExporter = blackboxExporter;
     }
 

--- a/common/src/main/resources/common-config.yml
+++ b/common/src/main/resources/common-config.yml
@@ -76,6 +76,9 @@ telemetry:
     blackbox-exporter:
       user: blackboxuser
       port: 9115
+      checkOnAllNodes: false
+      cloudIntervalSeconds: 600
+      clouderaIntervalSeconds: 1800
     cloudera-manager-exporter:
       user: cmmonitoring
       port: 61010

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfigServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfigServiceTest.java
@@ -37,6 +37,9 @@ public class MonitoringConfigServiceTest {
     private ExporterConfiguration cmMonitoringConfiguration;
 
     @Mock
+    private BlackboxExporterConfiguration blackboxExporterConfiguration;
+
+    @Mock
     private MonitoringGlobalAuthConfig monitoringGlobalAuthConfig;
 
     @Mock
@@ -65,6 +68,10 @@ public class MonitoringConfigServiceTest {
         given(monitoringConfiguration.getAgent()).willReturn(monitoringAgentConfiguration);
         given(cmMonitoringConfiguration.getPort()).willReturn(DEFAULT_CM_SMON_PORT);
         given(monitoringConfiguration.getRequestSigner()).willReturn(requestSignerConfiguration);
+
+        given(monitoringConfiguration.getBlackboxExporter()).willReturn(blackboxExporterConfiguration);
+        given(blackboxExporterConfiguration.getClouderaIntervalSeconds()).willReturn(1000);
+
         given(monitoring.getRemoteWriteUrl()).willReturn("https://myendpoint/api/v1/receive");
         // WHEN
         MonitoringConfigView result = underTest.createMonitoringConfig(monitoring, clusterType, authConfig, null, true, false,
@@ -73,6 +80,7 @@ public class MonitoringConfigServiceTest {
         assertTrue(result.isEnabled());
         assertEquals("https://myendpoint/api/v1/receive", result.getRemoteWriteUrl());
         assertEquals("false", result.toMap().get("useDevStack").toString());
+        assertEquals(1000, result.toMap().get("blackboxExporterClouderaIntervalSeconds"));
         assertEquals(DEFAULT_CM_SMON_PORT, result.getCmMetricsExporterPort());
     }
 

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/settings.sls
@@ -32,6 +32,9 @@
 {% set node_exporter_collectors = salt['pillar.get']('monitoring:nodeExporterCollectors', []) %}
 {% set blackbox_exporter_user = salt['pillar.get']('monitoring:blackboxExporterUser', 'blackboxuser') %}
 {% set blackbox_exporter_port = salt['pillar.get']('monitoring:blackboxExporterPort', 9115) %}
+{% set blackbox_exporter_cloud_interval_seconds = salt['pillar.get']('monitoring:blackboxExporterCloudIntervalSeconds', 600) %}
+{% set blackbox_exporter_cloudera_interval_seconds = salt['pillar.get']('monitoring:blackboxExporterClouderaIntervalSeconds', 1800) %}
+{% set blackbox_exporter_check_on_all_nodes = salt['pillar.get']('monitoring:blackboxExporterCheckOnAllNodes', false) %}
 {% set local_password = salt['pillar.get']('monitoring:localPassword') %}
 {% set scrape_interval_seconds = salt['pillar.get']('monitoring:scrapeIntervalSeconds') %}
 {% set cm_metrics_exporter_port = salt['pillar.get']('monitoring:cmMetricsExporterPort', 61010) %}
@@ -90,6 +93,9 @@
     "nodeExporterExists": node_exporter_exists,
     "blackboxExporterUser": blackbox_exporter_user,
     "blackboxExporterPort": blackbox_exporter_port,
+    "blackboxExporterCloudIntervalSeconds": blackbox_exporter_cloud_interval_seconds,
+    "blackboxExporterClouderaIntervalSeconds": blackbox_exporter_cloudera_interval_seconds,
+    "blackboxExporterCheckOnAllNodes": blackbox_exporter_check_on_all_nodes,
     "blackboxExporterExists" : blackbox_exporter_exists,
     "localPassword": local_password,
     "useDevStack": use_dev_stack,

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/template/prometheus.yml.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/template/prometheus.yml.j2
@@ -9,6 +9,12 @@
   {%- if instance_cmd_output %}
     {%- set instance_name = instance_cmd_output %}
   {%- endif %}
+  {%- if salt['pkg.version_cmp'](telemetry.cdpTelemetryPackageVersion,'0.4.29-1') >= 0 %}
+    {%- set get_doctor_addresses = "cdp-doctor network addresses --format json --cloud-provider {} --databus-url {} --databus-s3-url {}".format(telemetry.platform, telemetry.databusEndpoint, telemetry.databusS3Endpoint) %}
+    {%- set doctorNetworkAddresses = salt.cmd.run(get_doctor_addresses) | load_json %}
+    {%- set blackboxClouderaUrls = doctorNetworkAddresses['cloudera'] %}
+    {%- set blackboxCloudUrls = doctorNetworkAddresses['cloud'] %}
+  {%- endif %}
 {%- endif %}
 global:
   scrape_interval: {{ monitoring.scrapeIntervalSeconds }}s
@@ -59,6 +65,40 @@ scrape_configs:
 {%- endif %}
     tls_config:
        insecure_skip_verify: true
+{%- if (monitoring.type == "cloudera_manager" and "manager_server" in grains.get('roles', [])) or monitoring.blackboxExporterCheckOnAllNodes %}
+{%- if blackboxClouderaUrls is defined and blackboxClouderaUrls|length > 0 %}
+  - job_name: 'blackbox-cloudera'
+    scrape_interval: {{ monitoring.blackboxExporterClouderaIntervalSeconds }}s
+    metrics_path: /probe
+    scheme: 'https'
+    params:
+      module: [http_2xx]
+    static_configs:
+      - targets: {{ blackboxClouderaUrls }}
+        labels:
+          resource_crn: {{ telemetry.clusterCrn }}
+          platform: {{ telemetry.platform }}
+{%- if hostgroup %}
+          hostgroup: {{ hostgroup }}
+{%- endif %}
+          proxy: {% if telemetry.proxyUrl %}yes{%- else %}no{% endif %}
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: address
+      - target_label: __address__
+        replacement: 127.0.0.1:{{ monitoring.blackboxExporterPort }}
+      - target_label: instance
+        replacement: {{ instance_name }}:{{ monitoring.blackboxExporterPort }}
+{%- if monitoring.localPassword %}
+    basic_auth:
+      username: {{ monitoring.blackboxExporterUser }}
+      password: {{ monitoring.localPassword }}
+{%- endif %}
+    tls_config:
+      insecure_skip_verify: true
+{%- else %}
   - job_name: 'blackbox'
     metrics_path: /probe
     scheme: 'https'
@@ -90,6 +130,41 @@ scrape_configs:
 {%- endif %}
     tls_config:
       insecure_skip_verify: true
+{%- endif %}
+{%- if blackboxCloudUrls is defined and blackboxCloudUrls|length > 0 %}
+  - job_name: 'blackbox-cloud'
+    scrape_interval: {{ monitoring.blackboxExporterCloudIntervalSeconds }}s
+    metrics_path: /probe
+    scheme: 'https'
+    params:
+      module: [http_2xx]
+    static_configs:
+      - targets: {{ blackboxCloudUrls }}
+        labels:
+          resource_crn: {{ telemetry.clusterCrn }}
+          platform: {{ telemetry.platform }}
+{%- if hostgroup %}
+          hostgroup: {{ hostgroup }}
+{%- endif %}
+          proxy: {% if telemetry.proxyUrl %}yes{%- else %}no{% endif %}
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: address
+      - target_label: __address__
+        replacement: 127.0.0.1:{{ monitoring.blackboxExporterPort }}
+      - target_label: instance
+        replacement: {{ instance_name }}:{{ monitoring.blackboxExporterPort }}
+{%- if monitoring.localPassword %}
+    basic_auth:
+      username: {{ monitoring.blackboxExporterUser }}
+      password: {{ monitoring.localPassword }}
+{%- endif %}
+    tls_config:
+      insecure_skip_verify: true
+{%- endif %}
+{%- endif %}
 {%- if monitoring.type == "cloudera_manager" and "manager_server" in grains.get('roles', []) %}
   - job_name: 'smon_health'
     scheme: 'https'


### PR DESCRIPTION
Create separate blackbox exporter configurations for internal and external url checks.
Add flag for checking urls only on master or on all nodes.
Add config parameters for defining scrape intervals for external/internal checks.
Fall back to old check if the package version is not high enough.