### PR TITLE
CB-16420 Make sure the varint is not null in the Core module. The Clo…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/validation/ParametersValidator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/validation/ParametersValidator.java
@@ -28,13 +28,15 @@ public class ParametersValidator {
     @Inject
     private ErrorHandlerAwareReactorEventFactory eventFactory;
 
-    public ParametersValidationRequest validate(String platform, CloudCredential cloudCredential, Map<String, String> parameters, Long workspaceId) {
+    public ParametersValidationRequest validate(String platform, String variant, CloudCredential cloudCredential, Map<String, String> parameters,
+            Long workspaceId) {
         if (parameters == null || parameters.isEmpty()) {
             return null;
         }
         LOGGER.info("Validate the parameters: {}", parameters);
         CloudContext cloudContext = CloudContext.Builder.builder()
                 .withPlatform(platform)
+                .withVariant(variant)
                 .withWorkspaceId(workspaceId)
                 .build();
         ParametersValidationRequest request = new ParametersValidationRequest(cloudCredential, cloudContext, parameters);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/validate/cloud/handler/ValidateCloudConfigHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/validate/cloud/handler/ValidateCloudConfigHandler.java
@@ -109,6 +109,7 @@ public class ValidateCloudConfigHandler extends ExceptionCatcherEventHandler<Val
 
         ParametersValidationRequest parametersValidationRequest = parametersValidator.validate(
                 stack.getCloudPlatform(),
+                stack.getPlatformVariant(),
                 cloudCredential,
                 stack.getParameters(),
                 stack.getWorkspaceId());


### PR DESCRIPTION
…udPlatformConnector#getDefault couldn't be deleted because in Environment service the resources doesn't have variant

See detailed description in the commit message.