### PR TITLE
CB-18300 Try to install postgresql 11 if missing in case of external …

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/init.sls
@@ -13,6 +13,9 @@
 
 include:
 {%- if salt[ 'pillar.get' ]('postgres:postgres_version', '10') | int == 11 %}
+{%- if not salt['file.file_exists']('/usr/pgsql-11/bin/psql') %}
+  - postgresql.pg11-install
+{%- endif %}
   - postgresql.pg11-alternatives
 {%- endif %}
   - postgresql.disaster_recovery.recover


### PR DESCRIPTION
…database

Previous commit sets the alternatives to pg11 if the external DB is on version 11, but it depended on pg11 being available on the image.
From now on if the pg11 is missing, then first the packages would be installed.

See detailed description in the commit message.