### PR TITLE
CB-17763 Implement stop and start flow steps

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/rds/StopServicesHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/rds/StopServicesHandler.java
@@ -1,14 +1,28 @@
 package com.sequenceiq.cloudbreak.reactor.handler.cluster.upgrade.rds;
 
+import javax.inject.Inject;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterDeletionBasedExitCriteriaModel;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.cloudbreak.orchestrator.state.ExitCriteriaModel;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.rds.UpgradeRdsFailedEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.rds.UpgradeRdsStopServicesRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.rds.UpgradeRdsStopServicesResult;
+import com.sequenceiq.cloudbreak.service.GatewayConfigService;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
+import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
+import com.sequenceiq.cloudbreak.util.StackUtil;
+import com.sequenceiq.cloudbreak.view.ClusterView;
+import com.sequenceiq.cloudbreak.view.InstanceMetadataView;
+import com.sequenceiq.cloudbreak.view.StackView;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
 import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
@@ -19,6 +33,21 @@ import reactor.bus.Event;
 public class StopServicesHandler extends ExceptionCatcherEventHandler<UpgradeRdsStopServicesRequest> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StopServicesHandler.class);
+
+    @Inject
+    private StackDtoService stackDtoService;
+
+    @Inject
+    private GatewayConfigService gatewayConfigService;
+
+    @Inject
+    private ClusterApiConnectors clusterApiConnectors;
+
+    @Inject
+    private StackUtil stackUtil;
+
+    @Inject
+    private HostOrchestrator hostOrchestrator;
 
     @Override
     public String selector() {
@@ -35,8 +64,21 @@ public class StopServicesHandler extends ExceptionCatcherEventHandler<UpgradeRds
     public Selectable doAccept(HandlerEvent<UpgradeRdsStopServicesRequest> event) {
         UpgradeRdsStopServicesRequest request = event.getData();
         Long stackId = request.getResourceId();
-        LOGGER.info("Stopping services for RDS upgrade...");
-        // TODO: Implement
+        StackDto stackDto = stackDtoService.getById(stackId);
+        ClusterView cluster = stackDto.getCluster();
+        StackView stack = stackDto.getStack();
+        try {
+            LOGGER.info("Stopping services before RDS upgrade...");
+            clusterApiConnectors.getConnector(stackDto).stopCluster(true);
+            InstanceMetadataView gatewayInstance = stackDto.getPrimaryGatewayInstance();
+            GatewayConfig gatewayConfig = gatewayConfigService.getGatewayConfig(stack, stackDto.getSecurityConfig(), gatewayInstance, stackDto.hasGateway());
+            ExitCriteriaModel exitModel = ClusterDeletionBasedExitCriteriaModel.clusterDeletionBasedModel(stack.getId(), cluster.getId());
+            LOGGER.info("Stopping cluster manager server and its agents before RDS upgrade...");
+            hostOrchestrator.stopClusterManagerWithItsAgents(gatewayConfig, stackUtil.collectReachableNodes(stackDto), exitModel);
+        } catch (Exception ex) {
+            LOGGER.warn("Stop services has failed", ex);
+            return new UpgradeRdsFailedEvent(stackId, ex, DetailedStackStatus.DATABASE_UPGRADE_FAILED);
+        }
         return new UpgradeRdsStopServicesResult(stackId, request.getVersion());
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/rds/StartServicesHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/rds/StartServicesHandlerTest.java
@@ -1,0 +1,123 @@
+package com.sequenceiq.cloudbreak.reactor.handler.cluster.upgrade.rds;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
+import com.sequenceiq.cloudbreak.common.database.TargetMajorVersion;
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.common.orchestration.Node;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.cloudbreak.orchestrator.state.ExitCriteriaModel;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.rds.UpgradeRdsStartServicesRequest;
+import com.sequenceiq.cloudbreak.service.CloudbreakException;
+import com.sequenceiq.cloudbreak.service.GatewayConfigService;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
+import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
+import com.sequenceiq.cloudbreak.util.StackUtil;
+import com.sequenceiq.cloudbreak.view.ClusterView;
+import com.sequenceiq.cloudbreak.view.InstanceMetadataView;
+import com.sequenceiq.cloudbreak.view.StackView;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
+
+@ExtendWith(MockitoExtension.class)
+class StartServicesHandlerTest {
+
+    private static final Long STACK_ID = 12L;
+
+    private static final TargetMajorVersion TARGET_MAJOR_VERSION = TargetMajorVersion.VERSION_11;
+
+    @Mock
+    private StackDtoService stackDtoService;
+
+    @Mock
+    private GatewayConfigService gatewayConfigService;
+
+    @Mock
+    private ClusterApiConnectors clusterApiConnectors;
+
+    @Mock
+    private StackUtil stackUtil;
+
+    @Mock
+    private HostOrchestrator hostOrchestrator;
+
+    @Mock
+    private HandlerEvent<UpgradeRdsStartServicesRequest> event;
+
+    @InjectMocks
+    private StartServicesHandler underTest;
+
+    @Test
+    void selector() {
+        assertThat(underTest.selector()).isEqualTo("UPGRADERDSSTARTSERVICESREQUEST");
+    }
+
+    @Test
+    void testDoAccept() throws CloudbreakException {
+        // GIVEN
+        UpgradeRdsStartServicesRequest request = new UpgradeRdsStartServicesRequest(STACK_ID, TARGET_MAJOR_VERSION);
+        when(event.getData()).thenReturn(request);
+        StackDto stackDto = mock(StackDto.class);
+        StackView stackView = mock(StackView.class);
+        ClusterView clusterView = mock(ClusterView.class);
+        when(stackDto.getStack()).thenReturn(stackView);
+        when(stackDto.getCluster()).thenReturn(clusterView);
+        when(stackDto.getPrimaryGatewayInstance()).thenReturn(mock(InstanceMetadataView.class));
+        GatewayConfig gatewayConfig = mock(GatewayConfig.class);
+        when(stackDtoService.getById(STACK_ID)).thenReturn(stackDto);
+        when(gatewayConfigService.getGatewayConfig(stackView, stackDto.getSecurityConfig(), stackDto.getPrimaryGatewayInstance(), stackDto.hasGateway()))
+                .thenReturn(gatewayConfig);
+        when(clusterApiConnectors.getConnector(stackDto)).thenReturn(mock(ClusterApi.class));
+        when(stackUtil.collectReachableNodes(stackDto)).thenReturn(Set.of(mock(Node.class)));
+        // WHEN
+        Selectable actualSelectable = underTest.doAccept(event);
+        // THEN
+        verify(clusterApiConnectors.getConnector(stackDto), times(1)).startCluster();
+        assertThat(actualSelectable.selector()).isEqualTo("UPGRADERDSSTARTSERVICESRESULT");
+    }
+
+    @Test
+    void testDoAcceptThrowsException() throws Exception {
+        // GIVEN
+        UpgradeRdsStartServicesRequest request = new UpgradeRdsStartServicesRequest(STACK_ID, TARGET_MAJOR_VERSION);
+        when(event.getData()).thenReturn(request);
+        StackDto stackDto = mock(StackDto.class);
+        StackView stackView = mock(StackView.class);
+        ClusterView clusterView = mock(ClusterView.class);
+        when(stackDto.getStack()).thenReturn(stackView);
+        when(stackDto.getCluster()).thenReturn(clusterView);
+        when(stackDto.getPrimaryGatewayInstance()).thenReturn(mock(InstanceMetadataView.class));
+        GatewayConfig gatewayConfig = mock(GatewayConfig.class);
+        when(stackDtoService.getById(STACK_ID)).thenReturn(stackDto);
+        when(gatewayConfigService.getGatewayConfig(stackView, stackDto.getSecurityConfig(), stackDto.getPrimaryGatewayInstance(), stackDto.hasGateway()))
+                .thenReturn(gatewayConfig);
+        when(clusterApiConnectors.getConnector(stackDto)).thenReturn(mock(ClusterApi.class));
+        when(stackUtil.collectReachableNodes(stackDto)).thenReturn(Set.of(mock(Node.class)));
+        doThrow(new CloudbreakOrchestratorFailedException("exception")).when(hostOrchestrator).startClusterManagerWithItsAgents(
+                any(GatewayConfig.class), anySet(), any(ExitCriteriaModel.class));
+        // WHEN
+        Selectable actualSelectable = underTest.doAccept(event);
+        // THEN
+        verify(clusterApiConnectors.getConnector(stackDto), never()).startCluster();
+        assertThat(actualSelectable.selector()).isEqualTo("UPGRADERDSFAILEDEVENT");
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/rds/StopServicesHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/rds/StopServicesHandlerTest.java
@@ -1,0 +1,122 @@
+package com.sequenceiq.cloudbreak.reactor.handler.cluster.upgrade.rds;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
+import com.sequenceiq.cloudbreak.common.database.TargetMajorVersion;
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.common.orchestration.Node;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.cloudbreak.orchestrator.state.ExitCriteriaModel;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.rds.UpgradeRdsStopServicesRequest;
+import com.sequenceiq.cloudbreak.service.CloudbreakException;
+import com.sequenceiq.cloudbreak.service.GatewayConfigService;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
+import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
+import com.sequenceiq.cloudbreak.util.StackUtil;
+import com.sequenceiq.cloudbreak.view.ClusterView;
+import com.sequenceiq.cloudbreak.view.InstanceMetadataView;
+import com.sequenceiq.cloudbreak.view.StackView;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
+
+@ExtendWith(MockitoExtension.class)
+class StopServicesHandlerTest {
+
+    private static final Long STACK_ID = 12L;
+
+    private static final TargetMajorVersion TARGET_MAJOR_VERSION = TargetMajorVersion.VERSION_11;
+
+    @Mock
+    private StackDtoService stackDtoService;
+
+    @Mock
+    private GatewayConfigService gatewayConfigService;
+
+    @Mock
+    private ClusterApiConnectors clusterApiConnectors;
+
+    @Mock
+    private StackUtil stackUtil;
+
+    @Mock
+    private HostOrchestrator hostOrchestrator;
+
+    @Mock
+    private HandlerEvent<UpgradeRdsStopServicesRequest> event;
+
+    @InjectMocks
+    private StopServicesHandler underTest;
+
+    @Test
+    void selector() {
+        assertThat(underTest.selector()).isEqualTo("UPGRADERDSSTOPSERVICESREQUEST");
+    }
+
+    @Test
+    void testDoAccept() throws CloudbreakException {
+        // GIVEN
+        UpgradeRdsStopServicesRequest request = new UpgradeRdsStopServicesRequest(STACK_ID, TARGET_MAJOR_VERSION);
+        when(event.getData()).thenReturn(request);
+        StackDto stackDto = mock(StackDto.class);
+        StackView stackView = mock(StackView.class);
+        ClusterView clusterView = mock(ClusterView.class);
+        when(stackDto.getStack()).thenReturn(stackView);
+        when(stackDto.getCluster()).thenReturn(clusterView);
+        when(stackDto.getPrimaryGatewayInstance()).thenReturn(mock(InstanceMetadataView.class));
+        GatewayConfig gatewayConfig = mock(GatewayConfig.class);
+        when(stackDtoService.getById(STACK_ID)).thenReturn(stackDto);
+        when(gatewayConfigService.getGatewayConfig(stackView, stackDto.getSecurityConfig(), stackDto.getPrimaryGatewayInstance(), stackDto.hasGateway()))
+                .thenReturn(gatewayConfig);
+        when(clusterApiConnectors.getConnector(stackDto)).thenReturn(mock(ClusterApi.class));
+        when(stackUtil.collectReachableNodes(stackDto)).thenReturn(Set.of(mock(Node.class)));
+        // WHEN
+        Selectable actualSelectable = underTest.doAccept(event);
+        // THEN
+        verify(clusterApiConnectors.getConnector(stackDto), times(1)).stopCluster(anyBoolean());
+        assertThat(actualSelectable.selector()).isEqualTo("UPGRADERDSSTOPSERVICESRESULT");
+    }
+
+    @Test
+    void testDoAcceptThrowsException() throws Exception {
+        // GIVEN
+        UpgradeRdsStopServicesRequest request = new UpgradeRdsStopServicesRequest(STACK_ID, TARGET_MAJOR_VERSION);
+        when(event.getData()).thenReturn(request);
+        StackDto stackDto = mock(StackDto.class);
+        StackView stackView = mock(StackView.class);
+        ClusterView clusterView = mock(ClusterView.class);
+        when(stackDto.getStack()).thenReturn(stackView);
+        when(stackDto.getCluster()).thenReturn(clusterView);
+        when(stackDto.getPrimaryGatewayInstance()).thenReturn(mock(InstanceMetadataView.class));
+        GatewayConfig gatewayConfig = mock(GatewayConfig.class);
+        when(stackDtoService.getById(STACK_ID)).thenReturn(stackDto);
+        when(gatewayConfigService.getGatewayConfig(stackView, stackDto.getSecurityConfig(), stackDto.getPrimaryGatewayInstance(), stackDto.hasGateway()))
+                .thenReturn(gatewayConfig);
+        when(clusterApiConnectors.getConnector(stackDto)).thenReturn(mock(ClusterApi.class));
+        when(stackUtil.collectReachableNodes(stackDto)).thenReturn(Set.of(mock(Node.class)));
+        doThrow(new CloudbreakOrchestratorFailedException("exception")).when(hostOrchestrator).stopClusterManagerWithItsAgents(
+                any(GatewayConfig.class), anySet(), any(ExitCriteriaModel.class));
+        // WHEN
+        Selectable actualSelectable = underTest.doAccept(event);
+        // THEN
+        assertThat(actualSelectable.selector()).isEqualTo("UPGRADERDSFAILEDEVENT");
+    }
+}

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
@@ -55,6 +55,12 @@ public interface HostOrchestrator extends HostRecipeExecutor {
     void restartClusterManagerOnMaster(GatewayConfig gatewayConfig, Set<String> target, ExitCriteriaModel exitCriteriaModel)
             throws CloudbreakOrchestratorException;
 
+    void stopClusterManagerWithItsAgents(GatewayConfig gatewayConfig, Set<Node> allNodes, ExitCriteriaModel exitCriteriaModel)
+            throws CloudbreakOrchestratorException;
+
+    void startClusterManagerWithItsAgents(GatewayConfig gatewayConfig, Set<Node> allNodes, ExitCriteriaModel exitCriteriaModel)
+            throws CloudbreakOrchestratorException;
+
     void updateAgentCertDirectoryPermission(GatewayConfig gatewayConfig, Set<String> target, ExitCriteriaModel exitCriteriaModel)
             throws CloudbreakOrchestratorException;
 

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/restart.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/restart.sls
@@ -1,7 +1,3 @@
-stop-cloudera-scm-server:
-  service.dead:
-    - name: cloudera-scm-server
-
-start-cloudera-scm-server:
-  service.running:
-    - name: cloudera-scm-server
+include:
+  - cloudera.manager.server-stop
+  - cloudera.manager.server-start

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/server-start.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/server-start.sls
@@ -1,0 +1,7 @@
+{% if "manager_server" in grains.get('roles', []) %}
+
+start-cloudera-scm-server:
+  service.running:
+    - name: cloudera-scm-server
+
+{% endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/server-stop.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/server-stop.sls
@@ -1,0 +1,7 @@
+{% if "manager_server" in grains.get('roles', []) %}
+
+stop-cloudera-scm-server:
+  service.dead:
+    - name: cloudera-scm-server
+
+{% endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/top.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/top.sls
@@ -122,3 +122,13 @@ base:
   'roles:cloudera_manager_agent_stop':
     - match: grain
     - cloudera.agent.agent-stop
+
+  'roles:cloudera_manager_full_stop':
+    - match: grain
+    - cloudera.agent.agent-stop
+    - cloudera.manager.server-stop
+
+  'roles:cloudera_manager_full_start':
+    - match: grain
+    - cloudera.agent.start
+    - cloudera.manager.server-start


### PR DESCRIPTION
[CB-17763 Implement stop and start flow steps](https://github.com/hortonworks/cloudbreak/pull/13305/commits/9c822b6b399a88480e16bced343349268352228e) 

Stop steps:
- Stop the services using CM
- Stop the CM server on PrimaryGateway
- Stopall the CM agents on all hosts

Start steps:
- Start the CM server on PrimaryGateway
- Start all the CM agents on all hosts
- Start the services using CM
