### PR TITLE
CB-18328 Update service restart salt state after matcher to avoid failures

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/services.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/services.sls
@@ -36,7 +36,7 @@ ipacustodiaRestartSec:
      - name: {{ unitFile | replace("FragmentPath=","") }}
      - mode: ensure
      - content: "Restart=always"
-     - after: \[Service\]
+     - after: ^\[Service\]
      - backup: False
 
 {{ service }}RestartSec:


### PR DESCRIPTION
Extend the 'after' regexp with start string character to avoid failures in case of [Service] exists in a comment as well (it was the case with RHEL8 and httpd.service).