### PR TITLE
CB-18351. Disable 'disable-region-for-fluentd' existing stackpatcher.

### DIFF
--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -923,7 +923,7 @@ existing-stack-patcher:
     logging-agent-auto-restart-v2:
       enabled: false
     disable-region-for-fluentd:
-      enabled: true
+      enabled: false
       affected-version-from: 0.2.16
     metering-azure-metadata:
       enabled: false


### PR DESCRIPTION
details:
- for EU/AP - this stackpatcher constantly fails (every day)
- reason for the failing is  that their endpoints are not registered in cluster proxy
- stackpatcher can be disabled as it seems only happens with cloudera related accounts.

See detailed description in the commit message.