### PR TITLE
CB-18345 Fix Impala URLs in Knox topology

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
@@ -831,7 +831,9 @@ public class ClusterHostServiceRunner {
                     List.copyOf(componentLocation.get(impalaService.getServiceName())));
             Map<String, List<String>> impalaLocations = componentLocator.getImpalaCoordinatorLocations(stackDto);
             List<String> locations = impalaLocations.values().stream().flatMap(List::stream).collect(Collectors.toList());
-            componentLocation.replace(impalaService.getServiceName(), locations);
+            if (!locations.isEmpty()) {
+                componentLocation.replace(impalaService.getServiceName(), locations);
+            }
         }
         return componentLocation;
     }


### PR DESCRIPTION
Because of the assumption that Impala always have a
dedicated coordinator, the Impala URLs were replaced with
the coordinator URLs.
In reality there are custom templates where no dedicated
Impala coordinator exists, thus the empty list should not be
placed as the Impala URL list.
