### PR TITLE
CB-18324: Fix resize recovery e2e test by removing wait for backup state.

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxResizeRecoveryTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxResizeRecoveryTests.java
@@ -64,16 +64,8 @@ public class SdxResizeRecoveryTests extends PreconditionSdxE2ETest {
                     return testDto;
                 })
                 .when(sdxTestClient.resize(), key(sdxKey))
-                .await(SdxClusterStatusResponse.DATALAKE_BACKUP_INPROGRESS, key(sdxKey).withoutWaitForFlow())
                 .await(SdxClusterStatusResponse.STOP_IN_PROGRESS, key(sdxKey).withoutWaitForFlow())
                 .await(SdxClusterStatusResponse.STACK_CREATION_IN_PROGRESS, key(sdxKey).withoutWaitForFlow());
-    }
-
-    private SdxInternalTestDto performResizeRecoveryAndValidate(SdxInternalTestDto testDto, String sdxKey, SdxResizeTestValidator validator) {
-        return testDto.when(sdxTestClient.recoverFromResizeInternal(), key(sdxKey))
-                .await(SdxClusterStatusResponse.RUNNING, key(sdxKey))
-                .awaitForHealthyInstances()
-                .then((tc, dto, client) -> validator.validateRecoveredCluster(dto));
     }
 
     private SdxInternalTestDto causeProvisioningFailureAndAwait(SdxInternalTestDto testDto, String sdxKey) {
@@ -81,6 +73,13 @@ public class SdxResizeRecoveryTests extends PreconditionSdxE2ETest {
                 .awaitForStartingInstances()
                 .then((tc, dto, client) -> deleteMasterNode(dto, client, tc))
                 .await(SdxClusterStatusResponse.PROVISIONING_FAILED, key(sdxKey).withoutWaitForFlow());
+    }
+
+    private SdxInternalTestDto performResizeRecoveryAndValidate(SdxInternalTestDto testDto, String sdxKey, SdxResizeTestValidator validator) {
+        return testDto.when(sdxTestClient.recoverFromResizeInternal(), key(sdxKey))
+                .await(SdxClusterStatusResponse.RUNNING, key(sdxKey))
+                .awaitForHealthyInstances()
+                .then((tc, dto, client) -> validator.validateRecoveredCluster(dto));
     }
 
     private SdxInternalTestDto deleteMasterNode(SdxInternalTestDto testDto, SdxClient client, TestContext testContext) {


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-18324

I was supposed to remove the DR checks before but it seems this one slipped through and is naturally causing e2e failures. I apologize for this.