### PR TITLE
CB-18301: Extend AWS minimal policy with a required policy for RDS upgrade

### DIFF
--- a/cloud-aws-cloudformation/src/main/resources/definitions/aws-environment-minimal-policy.json
+++ b/cloud-aws-cloudformation/src/main/resources/definitions/aws-environment-minimal-policy.json
@@ -166,6 +166,7 @@
         "rds:CreateDBParameterGroup",
         "rds:DeleteDBParameterGroup",
         "rds:DescribeEngineDefaultParameters",
+        "rds:DescribeDBEngineVersions",
         "rds:ModifyDBParameterGroup",
         "rds:DescribeDBParameters",
         "rds:DescribeDBParameterGroups",

--- a/cloud-aws-common/src/main/resources/definitions/aws-environment-minimal-policy.json
+++ b/cloud-aws-common/src/main/resources/definitions/aws-environment-minimal-policy.json
@@ -169,6 +169,7 @@
         "rds:CreateDBParameterGroup",
         "rds:DeleteDBParameterGroup",
         "rds:DescribeEngineDefaultParameters",
+        "rds:DescribeDBEngineVersions",
         "rds:ModifyDBParameterGroup",
         "rds:DescribeDBParameters",
         "rds:DescribeDBParameterGroups",


### PR DESCRIPTION
This commit contains the following changes:

- Extend the AWS minimal policy definitions with the rds:DescribeDBEngineVersions permission because this is required for the RDS upgrade.
- Make the error message more user-friendly when this new policy is missing from the customer's policies.