### PR TITLE
CB-18356. Do not use camel case for blackbox exporter configs.

### DIFF
--- a/common/src/main/resources/common-config.yml
+++ b/common/src/main/resources/common-config.yml
@@ -76,9 +76,9 @@ telemetry:
     blackbox-exporter:
       user: blackboxuser
       port: 9115
-      checkOnAllNodes: false
-      cloudIntervalSeconds: 600
-      clouderaIntervalSeconds: 1800
+      check-on-all-nodes: false
+      cloud-interval-seconds: 600
+      cloudera-interval-seconds: 1800
     cloudera-manager-exporter:
       user: cmmonitoring
       port: 61010


### PR DESCRIPTION
details:
- use dashes instead of camel cases for properties
- in case on @ConfigurationProperties spring can tell you camelCases are not valid for using with objects
- both camel case + dashes can work on fields but won't work on classes - do not mix the 2 format, so just go with dashes (as it's true for most of telemetry + all monitoring related configs)