### PR TITLE
Cb 18253 & CB-18257: [API E2E] QA Command Runner script - improvements (hosts/hostgroups) and add one more layer

### DIFF
--- a/integration-test/src/main/resources/commandrunner/qa-command-runner.py
+++ b/integration-test/src/main/resources/commandrunner/qa-command-runner.py
@@ -44,50 +44,77 @@ def execute_local_commands(config):
         results.append(result)
     return results
 
+def copy_file(source, dest):
+    try:
+        shutil.copy(source, dest)
+    except shutil.SameFileError:
+        pass
+
+def get_hg_grain_per_host(avilable_nodes, host_groups, nodes_str):
+    filtered_hostnames=[]
+    grain_out_file = "/tmp/hg_grains.json"
+    get_hostgroup_grains_cmd = "%s -L %s grains.get hostgroup --out=json --out-file=%s --out-indent=-1" % (SALT_CMD_PREFIX, nodes_str, grain_out_file)
+    grains_code, _, _ = run_command(get_hostgroup_grains_cmd)
+    grains_json = read_json_line_file(grain_out_file)
+    if grains_json:
+        for key in grains_json:
+            if str(grains_json[key]) in host_groups:
+                filtered_hostnames.append(key)
+    return filtered_hostnames
 
 def execute_salt_commands(command_file_location, config, hosts, host_groups):
     global SALT_CMD_PREFIX
     ping_out_file = "/tmp/qa_test_ping.json"
     test_cmd = "%s '*' test.ping --out=json --out-file=%s --out-indent=-1" % (SALT_CMD_PREFIX, ping_out_file)
     available_nodes = []
+    unreachable_nodes = []
     test_code, _, _ = run_command(test_cmd)
     test_json = read_json_line_file(ping_out_file)
     if test_json:
         for key in test_json:
             if str(test_json[key]) == "True":
                 available_nodes.append(key)
+            else:
+                unreachable_nodes.append(key)
     qa_path = '/srv/salt/qa'
     if os.path.exists('/srv/salt') and not os.path.exists(qa_path):
         os.mkdir(qa_path)
     script_file = os.path.abspath(__file__)
     script_file_basename = os.path.basename(script_file)
     command_file_basename = os.path.basename(command_file_location)
-    try:
-        shutil.copy(command_file_location, os.path.join(qa_path, command_file_basename))
-    except shutil.SameFileError:
-        pass
-    try:
-        shutil.copy(script_file, os.path.join(qa_path, script_file_basename))
-    except shutil.SameFileError:
-        pass
-    available_nodes_str = ",".join(available_nodes)
+    copy_file(command_file_location, os.path.join(qa_path, command_file_basename))
+    copy_file(script_file, os.path.join(qa_path, script_file_basename))
+    nodes = []
+    if hosts:
+        for node in available_nodes:
+            if node in hosts:
+                nodes.append(node)
+    else:
+        nodes = available_nodes
+    if host_groups:
+        nodes=get_hg_grain_per_host(nodes, host_groups, ",".join(nodes))
+    nodes_str = ",".join(nodes)
+    skipped = []
+    for node in available_nodes:
+        if node not in nodes:
+            skipped.append(node)
     cmd_copy_script_file = "%s -L %s cp.get_file salt:///qa/%s /tmp/%s" % (
-    SALT_CMD_PREFIX, available_nodes_str, script_file_basename, script_file_basename)
+    SALT_CMD_PREFIX, nodes_str, script_file_basename, script_file_basename)
     cmd_copy_command_file = "%s -L %s cp.get_file salt:///qa/%s /tmp/%s" % (
-    SALT_CMD_PREFIX, available_nodes_str, command_file_basename, command_file_basename)
+    SALT_CMD_PREFIX, nodes_str, command_file_basename, command_file_basename)
     run_command(cmd_copy_script_file)
     run_command(cmd_copy_command_file)
     final_output = '/tmp/qa_test_results.json'
     run_all_commands_cmd = \
         "%s -L %s cmd.run 'python3 /tmp/%s -c /tmp/%s -l' --out=json --out-file=%s --out-indent=-1" % (
-    SALT_CMD_PREFIX, available_nodes_str, script_file_basename, command_file_basename, final_output)
+    SALT_CMD_PREFIX, nodes_str, script_file_basename, command_file_basename, final_output)
     run_command(run_all_commands_cmd)
     final_json = read_json_line_file(final_output)
     outputs = {}
     if final_json:
         for key in final_json:
             outputs[key] = json.loads(final_json[key])
-    return outputs
+    return outputs, unreachable_nodes, skipped
 
 if __name__ == "__main__":
     main_result={}
@@ -104,6 +131,8 @@ if __name__ == "__main__":
             raise ValueError("Configuration option -c / --config is required!")
         hosts_arr = options.hosts.split(",") if options.hosts else list()
         host_groups_arr = options.host_groups.split(",") if options.host_groups else list()
+        main_result['hosts_filter']=hosts_arr
+        main_result['host_groups_filter']=host_groups_arr
         if not os.path.exists(options.config):
             raise ValueError("Configuration file %s does not exist!" % options.config)
         config = {}
@@ -114,8 +143,10 @@ if __name__ == "__main__":
             print(json.dumps(local_results))
             sys.exit(0)
         else:
-            responses=execute_salt_commands(options.config, config, hosts_arr, host_groups_arr)
+            responses, unreachable_nodes, skipped=execute_salt_commands(options.config, config, hosts_arr, host_groups_arr)
             main_result['responses']=responses
+            main_result['unreachable_nodes']=unreachable_nodes
+            main_result['skipped']=skipped
             main_result['code']=0
     except Exception as e:
         main_result['code']=1


### PR DESCRIPTION
Cb 18253 details:
- if qa-command-runner script fails it throws an exception by ssh java client
- instead of throwing an exception, add an extra layer to the script
- catch all the exception and return with a json + exit code + error message so won't cause java exceptions if the command fails
- use err for the error message as the same is used per node.

CB-18257 details:
- use hosts and host-groups options
- output will contain the hosts and host-group filter options
- if a node is unreachable that will be added to unreachable_nodes output
- if a node is filered out by hosts or host-groups filter, the host name will appear in the skipped field of the output.