### PR TITLE
CB-18358: Improve ParcelUrlProvider logic to return only the requiredurls

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/parcel/ParcelAvailabilityService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/parcel/ParcelAvailabilityService.java
@@ -23,7 +23,8 @@ import com.sequenceiq.cloudbreak.auth.PaywallCredentialPopulator;
 import com.sequenceiq.cloudbreak.client.RestClientFactory;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.common.exception.UpgradeValidationFailedException;
-import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 import com.sequenceiq.cloudbreak.service.upgrade.validation.CmUrlProvider;
 import com.sequenceiq.cloudbreak.service.upgrade.validation.ParcelUrlProvider;
 
@@ -36,7 +37,7 @@ public class ParcelAvailabilityService {
     private ParcelUrlProvider parcelUrlProvider;
 
     @Inject
-    private StackService stackService;
+    private StackDtoService stackDtoService;
 
     @Inject
     private RestClientFactory restClientFactory;
@@ -48,8 +49,8 @@ public class ParcelAvailabilityService {
     private CmUrlProvider cmUrlProvider;
 
     public Set<Response> validateAvailability(Image image, Long resourceId) {
-        Set<String> requiredParcelsFromImage =
-                new HashSet<>(parcelUrlProvider.getRequiredParcelsFromImage(image, stackService.getByIdWithListsInTransaction(resourceId)));
+        StackDto stackDto = stackDtoService.getById(resourceId);
+        Set<String> requiredParcelsFromImage = new HashSet<>(parcelUrlProvider.getRequiredParcelsFromImage(image, stackDto));
         String cmRpmUrl = cmUrlProvider.getCmRpmUrl(image);
         requiredParcelsFromImage.add(cmRpmUrl);
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmServerQueryService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmServerQueryService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.common.model.PackageInfo;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.dto.StackDtoDelegate;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
@@ -29,8 +30,8 @@ public class CmServerQueryService {
     @Inject
     private CmVersionQueryService cmVersionQueryService;
 
-    public Set<ParcelInfo> queryAllParcels(Stack stack) {
-        Set<ParcelInfo> parcels = apiConnectors.getConnector(stack).getAllParcels(stack.getName());
+    public Set<ParcelInfo> queryAllParcels(StackDto stackDto) {
+        Set<ParcelInfo> parcels = apiConnectors.getConnector(stackDto).getAllParcels(stackDto.getName());
         LOGGER.debug("Reading parcel info from CM server, found parcels: " + parcels);
         return parcels;
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/parcel/ParcelAvailabilityServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/parcel/ParcelAvailabilityServiceTest.java
@@ -26,8 +26,8 @@ import com.sequenceiq.cloudbreak.auth.PaywallCredentialPopulator;
 import com.sequenceiq.cloudbreak.client.RestClientFactory;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.common.exception.UpgradeValidationFailedException;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
-import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 import com.sequenceiq.cloudbreak.service.upgrade.validation.CmUrlProvider;
 import com.sequenceiq.cloudbreak.service.upgrade.validation.ParcelUrlProvider;
 
@@ -51,7 +51,7 @@ public class ParcelAvailabilityServiceTest {
     private ParcelUrlProvider parcelUrlProvider;
 
     @Mock
-    private StackService stackService;
+    private StackDtoService stackDtoService;
 
     @Mock
     private RestClientFactory restClientFactory;
@@ -65,15 +65,16 @@ public class ParcelAvailabilityServiceTest {
     @Mock
     private CmUrlProvider cmUrlProvider;
 
-    private final Image image = createImage();
+    @Mock
+    private StackDto stackDto;
 
-    private final Stack stack = new Stack();
+    private final Image image = createImage();
 
     @Test
     public void testValidateParcelAvailabilityShouldReturnTheAvailableParcels() {
         Set<String> requiredParcelsFromImage = createRequiredParcelsSet();
-        when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
-        when(parcelUrlProvider.getRequiredParcelsFromImage(image, stack)).thenReturn(requiredParcelsFromImage);
+        when(stackDtoService.getById(STACK_ID)).thenReturn(stackDto);
+        when(parcelUrlProvider.getRequiredParcelsFromImage(image, stackDto)).thenReturn(requiredParcelsFromImage);
         when(cmUrlProvider.getCmRpmUrl(image)).thenReturn(CM_RPM);
 
         when(restClientFactory.getOrCreateDefault()).thenReturn(client);
@@ -95,8 +96,8 @@ public class ParcelAvailabilityServiceTest {
     @Test
     public void testValidateParcelAvailabilityShouldNotThrowExceptionWhenANonArchiveParcelIsNotAvailable() {
         Set<String> requiredParcelsFromImage = createRequiredParcelsSet();
-        when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
-        when(parcelUrlProvider.getRequiredParcelsFromImage(image, stack)).thenReturn(requiredParcelsFromImage);
+        when(stackDtoService.getById(STACK_ID)).thenReturn(stackDto);
+        when(parcelUrlProvider.getRequiredParcelsFromImage(image, stackDto)).thenReturn(requiredParcelsFromImage);
         when(cmUrlProvider.getCmRpmUrl(image)).thenReturn(CM_RPM);
 
         when(restClientFactory.getOrCreateDefault()).thenReturn(client);
@@ -118,8 +119,8 @@ public class ParcelAvailabilityServiceTest {
     @Test
     public void testValidateParcelAvailabilityShouldThrowExceptionWhenAParcelIsNotAvailable() {
         Set<String> requiredParcelsFromImage = createRequiredParcelsSet();
-        when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
-        when(parcelUrlProvider.getRequiredParcelsFromImage(image, stack)).thenReturn(requiredParcelsFromImage);
+        when(stackDtoService.getById(STACK_ID)).thenReturn(stackDto);
+        when(parcelUrlProvider.getRequiredParcelsFromImage(image, stackDto)).thenReturn(requiredParcelsFromImage);
         when(cmUrlProvider.getCmRpmUrl(image)).thenReturn(CM_RPM);
 
         when(restClientFactory.getOrCreateDefault()).thenReturn(client);
@@ -135,8 +136,8 @@ public class ParcelAvailabilityServiceTest {
     @Test
     public void testValidateParcelAvailabilityShouldThrowExceptionWhenCmRpmIsNotAvailable() {
         Set<String> requiredParcelsFromImage = createRequiredParcelsSet();
-        when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
-        when(parcelUrlProvider.getRequiredParcelsFromImage(image, stack)).thenReturn(requiredParcelsFromImage);
+        when(stackDtoService.getById(STACK_ID)).thenReturn(stackDto);
+        when(parcelUrlProvider.getRequiredParcelsFromImage(image, stackDto)).thenReturn(requiredParcelsFromImage);
         when(cmUrlProvider.getCmRpmUrl(image)).thenReturn(CM_RPM);
 
         when(restClientFactory.getOrCreateDefault()).thenReturn(client);
@@ -152,8 +153,8 @@ public class ParcelAvailabilityServiceTest {
     @Test
     public void testValidateParcelAvailabilityShouldThrowExceptionWhenTheWebTargetThrowsAnException() {
         Set<String> requiredParcelsFromImage = createRequiredParcelsSet();
-        when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
-        when(parcelUrlProvider.getRequiredParcelsFromImage(image, stack)).thenReturn(requiredParcelsFromImage);
+        when(stackDtoService.getById(STACK_ID)).thenReturn(stackDto);
+        when(parcelUrlProvider.getRequiredParcelsFromImage(image, stackDto)).thenReturn(requiredParcelsFromImage);
         when(cmUrlProvider.getCmRpmUrl(image)).thenReturn(CM_RPM);
 
         when(restClientFactory.getOrCreateDefault()).thenReturn(client);
@@ -174,8 +175,8 @@ public class ParcelAvailabilityServiceTest {
     @Test
     public void testValidateParcelAvailabilityShouldNotThrowExceptionWhenTheWebTargetThrowsAnExceptionInCaseOfNonArchiveParcel() {
         Set<String> requiredParcelsFromImage = createRequiredParcelsSet();
-        when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
-        when(parcelUrlProvider.getRequiredParcelsFromImage(image, stack)).thenReturn(requiredParcelsFromImage);
+        when(stackDtoService.getById(STACK_ID)).thenReturn(stackDto);
+        when(parcelUrlProvider.getRequiredParcelsFromImage(image, stackDto)).thenReturn(requiredParcelsFromImage);
         when(cmUrlProvider.getCmRpmUrl(image)).thenReturn(CM_RPM);
 
         when(restClientFactory.getOrCreateDefault()).thenReturn(client);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmServerQueryServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmServerQueryServiceTest.java
@@ -12,7 +12,6 @@ import static com.sequenceiq.cloudbreak.cluster.model.ParcelStatus.DISTRIBUTED;
 import java.util.Collections;
 import java.util.Set;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -22,6 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
 import com.sequenceiq.cloudbreak.cluster.model.ParcelInfo;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
 
 @ExtendWith(MockitoExtension.class)
@@ -45,16 +45,15 @@ public class CmServerQueryServiceTest {
     @Mock
     private Stack stack;
 
-    @BeforeEach
-    void setup() {
-        when(stack.getName()).thenReturn(STACK_NAME);
-        when(apiConnectors.getConnector(any(Stack.class))).thenReturn(clusterApi);
-    }
+    @Mock
+    private StackDto stackDto;
 
     @Test
     void testGetActiveParcelsWhenParcelReturned() {
+        when(apiConnectors.getConnector(any(Stack.class))).thenReturn(clusterApi);
         ParcelInfo parcel = new ParcelInfo(CDH_PARCEL_NAME, CDH_PARCEL_VERSION, ACTIVATED);
         when(clusterApi.gatherInstalledParcels(STACK_NAME)).thenReturn(Collections.singleton(parcel));
+        when(stack.getName()).thenReturn(STACK_NAME);
 
         Set<ParcelInfo> foundParcels = underTest.queryActiveParcels(stack);
 
@@ -66,7 +65,9 @@ public class CmServerQueryServiceTest {
 
     @Test
     void testGetActiveParcelsWhenNoParcelReturnedThenEmptyList() {
+        when(apiConnectors.getConnector(any(Stack.class))).thenReturn(clusterApi);
         when(clusterApi.gatherInstalledParcels(STACK_NAME)).thenReturn(Collections.emptySet());
+        when(stack.getName()).thenReturn(STACK_NAME);
 
         Set<ParcelInfo> foundParcels = underTest.queryActiveParcels(stack);
 
@@ -75,19 +76,23 @@ public class CmServerQueryServiceTest {
 
     @Test
     void testQueryAllParcelsShouldReturnAllParcel() {
+        when(apiConnectors.getConnector(any(StackDto.class))).thenReturn(clusterApi);
+        when(stackDto.getName()).thenReturn(STACK_NAME);
         Set<ParcelInfo> parcels = Set.of(new ParcelInfo(CDH_PARCEL_NAME, CDH_PARCEL_VERSION, ACTIVATED), new ParcelInfo("NIFI", "123", DISTRIBUTED));
         when(clusterApi.getAllParcels(STACK_NAME)).thenReturn(parcels);
 
-        Set<ParcelInfo> actual = underTest.queryAllParcels(stack);
+        Set<ParcelInfo> actual = underTest.queryAllParcels(stackDto);
 
         assertEquals(parcels, actual);
     }
 
     @Test
     void testQueryAllParcelsShouldReturnEmptySetWhenClusterApiDoesNotReturnAnyParcels() {
+        when(apiConnectors.getConnector(any(StackDto.class))).thenReturn(clusterApi);
+        when(stackDto.getName()).thenReturn(STACK_NAME);
         when(clusterApi.getAllParcels(STACK_NAME)).thenReturn(Collections.emptySet());
 
-        Set<ParcelInfo> actual = underTest.queryAllParcels(stack);
+        Set<ParcelInfo> actual = underTest.queryAllParcels(stackDto);
 
         assertEquals(Collections.emptySet(), actual);
     }


### PR DESCRIPTION
The ParcelUrlProvider is returning all the required parcel URLs for a cluster. After implementing the upgrade-preparation flow, this logic is used multiple times. Therefore it can happen that the required parcels are already downloaded or distributed. In this case, we don't need to return those parcel URLs.