### PR TITLE
CB-18030 - Run backup-restore flow steps only for Azure - fix

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/rds/upgrade/UpgradeRdsActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/rds/upgrade/UpgradeRdsActions.java
@@ -73,9 +73,9 @@ public class UpgradeRdsActions {
 
             @Override
             protected Selectable createRequest(UpgradeRdsContext context) {
-                return context.getCluster().getEmbeddedDatabaseOnAttachedDisk() ?
-                    new UpgradeRdsDataBackupResult(context.getStackId(), context.getVersion()) :
-                    new UpgradeRdsDataBackupRequest(context.getStackId(), context.getVersion());
+                return runDataBackupRestore(context) ?
+                        new UpgradeRdsDataBackupRequest(context.getStackId(), context.getVersion()) :
+                        new UpgradeRdsDataBackupResult(context.getStackId(), context.getVersion());
             }
         };
     }
@@ -109,9 +109,9 @@ public class UpgradeRdsActions {
 
             @Override
             protected Selectable createRequest(UpgradeRdsContext context) {
-                return context.getCluster().getEmbeddedDatabaseOnAttachedDisk() ?
-                        new UpgradeRdsDataRestoreResult(context.getStackId(), context.getVersion()) :
-                        new UpgradeRdsDataRestoreRequest(context.getStackId(), context.getVersion());
+                return runDataBackupRestore(context) ?
+                        new UpgradeRdsDataRestoreRequest(context.getStackId(), context.getVersion()) :
+                        new UpgradeRdsDataRestoreResult(context.getStackId(), context.getVersion());
             }
         };
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/rds/upgrade/UpgradeRdsActionsTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/rds/upgrade/UpgradeRdsActionsTest.java
@@ -32,6 +32,10 @@ import org.springframework.util.ReflectionUtils;
 import com.sequenceiq.cloudbreak.common.database.TargetMajorVersion;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.rds.AbstractUpgradeRdsEvent;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.rds.UpgradeRdsDataBackupRequest;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.rds.UpgradeRdsDataBackupResult;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.rds.UpgradeRdsDataRestoreRequest;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.rds.UpgradeRdsDataRestoreResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.rds.UpgradeRdsStopServicesResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.rds.UpgradeRdsUpgradeDatabaseServerResult;
 import com.sequenceiq.cloudbreak.view.ClusterView;
@@ -93,6 +97,11 @@ class UpgradeRdsActionsTest {
         ArgumentCaptor<AbstractUpgradeRdsEvent> captor = ArgumentCaptor.forClass(AbstractUpgradeRdsEvent.class);
         verify(reactorEventFactory, times(1)).createEvent(any(), captor.capture());
         AbstractUpgradeRdsEvent captorValue = captor.getValue();
+        if (runBackup) {
+            assertEquals(UpgradeRdsDataBackupRequest.class, captorValue.getClass());
+        } else {
+            assertEquals(UpgradeRdsDataBackupResult.class, captorValue.getClass());
+        }
         assertEquals(STACK_ID, captorValue.getResourceId());
         assertEquals(TargetMajorVersion.VERSION_11, captorValue.getVersion());
     }
@@ -124,6 +133,11 @@ class UpgradeRdsActionsTest {
         ArgumentCaptor<AbstractUpgradeRdsEvent> captor = ArgumentCaptor.forClass(AbstractUpgradeRdsEvent.class);
         verify(reactorEventFactory, times(1)).createEvent(any(), captor.capture());
         AbstractUpgradeRdsEvent captorValue = captor.getValue();
+        if (runRestore) {
+            assertEquals(UpgradeRdsDataRestoreRequest.class, captorValue.getClass());
+        } else {
+            assertEquals(UpgradeRdsDataRestoreResult.class, captorValue.getClass());
+        }
         assertEquals(STACK_ID, captorValue.getResourceId());
         assertEquals(TargetMajorVersion.VERSION_11, captorValue.getVersion());
     }


### PR DESCRIPTION
Fix to include the platform selection logic in the requests sent to the handlers and not only in `doExecute`.

See detailed description in the commit message.