### PR TITLE
CB-18330 Stop Error for Real Time Data Mart and Data Mart Clusters in AWS and Template changes for Data Mart Clusters in Azure

### DIFF
--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -875,6 +875,9 @@ cb:
           - service: YARN
             role: NODEMANAGER
             required: false
+          - service: IMPALA
+            role: IMPALAD
+            required: false
         roles:
           - role: GATEWAY
             required: false

--- a/core/src/main/resources/defaults/clustertemplates/7.2.15/azure/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.15/azure/datamart.json
@@ -36,7 +36,7 @@
         "template": {
           "attachedVolumes": [
             {
-              "count": 1,
+              "count": 0,
               "size": 300,
               "type": "StandardSSD_LRS"
             }
@@ -59,7 +59,7 @@
         "template": {
           "attachedVolumes": [
             {
-              "count": 1,
+              "count": 0,
               "size": 300,
               "type": "StandardSSD_LRS"
             }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.16/azure/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.16/azure/datamart.json
@@ -36,7 +36,7 @@
         "template": {
           "attachedVolumes": [
             {
-              "count": 1,
+              "count": 0,
               "size": 300,
               "type": "StandardSSD_LRS"
             }
@@ -59,7 +59,7 @@
         "template": {
           "attachedVolumes": [
             {
-              "count": 1,
+              "count": 0,
               "size": 300,
               "type": "StandardSSD_LRS"
             }

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/impala/ImpalaVolumeConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/impala/ImpalaVolumeConfigProvider.java
@@ -64,7 +64,7 @@ public class ImpalaVolumeConfigProvider implements CmHostGroupRoleConfigProvider
                 }
 
                 if (minAttachedVolumeSize > MIN_ATTACHED_VOLUME_SIZE_TO_ENABLE_CACHE_IN_GB
-                        && volumeCount > 0) {
+                        && volumeCount >= 0) {
                     configs.add(config(IMPALA_DATACACHE_ENABLED_PARAM, "true"));
 
                     if (checkTemporaryStorage(hostGroupView, temporaryStorageVolumeCount)) {


### PR DESCRIPTION
- We can stop the Real time data mart and data mart clusters in AWS, the error is resolved.

- Template changes for Data Mart cluster in Azure where the node count for attached volumes is changed to 0 and now in this case ephemeral volume from the instance would be used which is of comparable size of attached volumes.



