### PR TITLE
CB-18378 Handle salt password status edge cases

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/SaltPasswordStatus.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/SaltPasswordStatus.java
@@ -4,4 +4,5 @@ public enum SaltPasswordStatus {
     OK,
     INVALID,
     EXPIRES,
+    FAILED_TO_CHECK,
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/RotateSaltPasswordReason.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/RotateSaltPasswordReason.java
@@ -13,6 +13,7 @@ public enum RotateSaltPasswordReason {
     public static Optional<RotateSaltPasswordReason> getForStatus(SaltPasswordStatus status) {
         switch (status) {
             case OK:
+            case FAILED_TO_CHECK:
                 return Optional.empty();
             case EXPIRES:
                 return Optional.of(RotateSaltPasswordReason.EXPIRED);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/SaltPasswordStatusService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/SaltPasswordStatusService.java
@@ -58,7 +58,7 @@ public class SaltPasswordStatusService {
                 result = SaltPasswordStatus.INVALID;
             } else {
                 LOGGER.warn("Received error response from salt on stack {}", stack.getId(), e);
-                throw new CloudbreakRuntimeException(e);
+                result = SaltPasswordStatus.FAILED_TO_CHECK;
             }
         }
         return result;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/RotateSaltPasswordReasonTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/RotateSaltPasswordReasonTest.java
@@ -1,9 +1,17 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.cloudera.thunderhead.service.common.usage.UsageProto;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.SaltPasswordStatus;
 import com.sequenceiq.cloudbreak.api.model.RotateSaltPasswordReason;
 
 class RotateSaltPasswordReasonTest {
@@ -14,4 +22,18 @@ class RotateSaltPasswordReasonTest {
         UsageProto.CDPSaltPasswordRotationEventReason.Value.valueOf(reason.name());
     }
 
+    @ParameterizedTest
+    @MethodSource("getForStatusArguments")
+    void getForStatus(SaltPasswordStatus status, RotateSaltPasswordReason reason) {
+        assertEquals(Optional.ofNullable(reason), RotateSaltPasswordReason.getForStatus(status));
+    }
+
+    private static Stream<Arguments> getForStatusArguments() {
+        return Stream.of(
+                Arguments.of(SaltPasswordStatus.OK, null),
+                Arguments.of(SaltPasswordStatus.FAILED_TO_CHECK, null),
+                Arguments.of(SaltPasswordStatus.EXPIRES, RotateSaltPasswordReason.EXPIRED),
+                Arguments.of(SaltPasswordStatus.INVALID, RotateSaltPasswordReason.UNAUTHORIZED)
+        );
+    }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/SaltPasswordStatusServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/SaltPasswordStatusServiceTest.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.cloudbreak.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
@@ -103,9 +102,9 @@ class SaltPasswordStatusServiceTest {
         CloudbreakOrchestratorFailedException exception = new CloudbreakOrchestratorFailedException("Unexpected failure");
         when(hostOrchestrator.getPasswordExpiryDate(gatewayConfigs, SaltPasswordStatusService.SALTUSER)).thenThrow(exception);
 
-        assertThatThrownBy(() -> underTest.getSaltPasswordStatus(stack))
-                .isInstanceOf(CloudbreakRuntimeException.class)
-                .hasCause(exception);
+        SaltPasswordStatus result = underTest.getSaltPasswordStatus(stack);
+
+        assertThat(result).isEqualTo(SaltPasswordStatus.FAILED_TO_CHECK);
     }
 
 }

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestratorTest.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestratorTest.java
@@ -784,7 +784,8 @@ class SaltOrchestratorTest {
         String user = "saltuser";
         when(saltStateService.runCommandOnHosts(any(), any(), any(), anyString())).thenReturn(Map.of(
                 "host1", " Jan 01, 2022",
-                "host2", " Mar 10, 2022"
+                "host2", " Mar 10, 2022",
+                "host3", " never"
         ));
 
         LocalDate result = saltOrchestrator.getPasswordExpiryDate(allGatewayConfigs, user);


### PR DESCRIPTION
- When password expiry is not set, chage return the value "never" as password expiry date, this is handled as LocalDate.MAX
- When password expiry check fails, instead of failing the call freom SDX, a new FAILED_TO_CHECK status is returned

See detailed description in the commit message.