### PR TITLE
CB-17912. Collect salt process cpu and memory details (children as we…

### DIFF
--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/scripts/logging-agent.sh.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/scripts/logging-agent.sh.j2
@@ -17,21 +17,23 @@ if [[ -f "/var/run/cdp-logging-agent/cdp-logging-agent.pid" ]]; then
       # processes that contains under-supervisor in their command: fluentd workers/processes (cloud storage shipper, metering shipper, deployment log shipper)
       if [[ "$logging_agent_process" == *"under-supervisor"* ]]; then
          logging_type="${logging_types_arr[$i]}"
-         if [[ -d "/var/log/cdp-logging-agent/${logging_type}" ]]; then
-           buffer_size=$(du -b "/var/log/cdp-logging-agent/${logging_type}" | cut -f1)
-           if [[ -d "/var/log/cdp-logging-agent/${logging_type}_CM_COMMAND" ]]; then
-             buffer_size_cm=$(du -b "/var/log/cdp-logging-agent/${logging_type}_CM_COMMAND" | cut -f1)
-             echo "cb_fluentd_${logging_type}_cm_buffer_size_bytes $buffer_size_cm" >> /var/lib/node_exporter/files/logging_agent.prom.$$
+         if [[ "$logging_type" != "" ]]; then
+           if [[ -d "/var/log/cdp-logging-agent/${logging_type}" ]]; then
+             buffer_size=$(du -b "/var/log/cdp-logging-agent/${logging_type}" | cut -f1)
+             if [[ -d "/var/log/cdp-logging-agent/${logging_type}_CM_COMMAND" ]]; then
+               buffer_size_cm=$(du -b "/var/log/cdp-logging-agent/${logging_type}_CM_COMMAND" | cut -f1)
+               echo "cb_fluentd_${logging_type}_cm_buffer_size_bytes_total $buffer_size_cm" >> /var/lib/node_exporter/files/logging_agent.prom.$$
+             fi
+           else
+             buffer_size=0
            fi
-         else
-           buffer_size=0
+           echo "cb_fluentd_${logging_type}_buffer_size_bytes_total $buffer_size" >> /var/lib/node_exporter/files/logging_agent.prom.$$
+           echo "cb_fluentd_${logging_type}_memory_rss_bytes_total $rss_bytes" >> /var/lib/node_exporter/files/logging_agent.prom.$$
+           echo "cb_fluentd_${logging_type}_open_fd_total $fds_num" >> /var/lib/node_exporter/files/logging_agent.prom.$$
          fi
-         echo "cb_fluentd_${logging_type}_buffer_size_bytes $buffer_size" >> /var/lib/node_exporter/files/logging_agent.prom.$$
-         echo "cb_fluentd_${logging_type}_memory_rss_bytes $rss_bytes" >> /var/lib/node_exporter/files/logging_agent.prom.$$
-         echo "cb_fluentd_${logging_type}_open_fd $fds_num" >> /var/lib/node_exporter/files/logging_agent.prom.$$
          i=$((i+1))
       else
-        echo "cb_fluentd_supervisor_memory_rss_bytes $rss_bytes" >> /var/lib/node_exporter/files/logging_agent.prom.$$
+        echo "cb_fluentd_supervisor_memory_rss_bytes_total $rss_bytes" >> /var/lib/node_exporter/files/logging_agent.prom.$$
       fi
     done
   if [[ -f /var/lib/node_exporter/files/logging_agent.prom.$$ ]]; then

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/scripts/salt-key.sh
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/scripts/salt-key.sh
@@ -7,10 +7,10 @@ if [[ "$result" == "0" && -f /tmp/salt_keys.txt ]]; then
   minions_rejected=$(jq '.minions_rejected | length' /tmp/salt_keys.txt)
   minions_unaccepted=$(jq '.minions_pre | length' /tmp/salt_keys.txt)
   minions_denied=$(jq '.minions_denied | length' /tmp/salt_keys.txt)
-  echo "cb_salt_minion_accepted $minions" > /var/lib/node_exporter/files/salt_keys.prom.$$
-  echo "cb_salt_minion_unaccepted $minions_unaccepted" >> /var/lib/node_exporter/files/salt_keys.prom.$$
-  echo "cb_salt_minion_rejected $minions_rejected" >> /var/lib/node_exporter/files/salt_keys.prom.$$
-  echo "cb_salt_minion_denied $minions_denied" >> /var/lib/node_exporter/files/salt_keys.prom.$$
+  echo "cb_salt_minion_accepted_total $minions" > /var/lib/node_exporter/files/salt_keys.prom.$$
+  echo "cb_salt_minion_unaccepted_total $minions_unaccepted" >> /var/lib/node_exporter/files/salt_keys.prom.$$
+  echo "cb_salt_minion_rejected_total $minions_rejected" >> /var/lib/node_exporter/files/salt_keys.prom.$$
+  echo "cb_salt_minion_denied_total $minions_denied" >> /var/lib/node_exporter/files/salt_keys.prom.$$
   mv /var/lib/node_exporter/files/salt_keys.prom.$$ /var/lib/node_exporter/files/salt_keys.prom
   rm -rf /tmp/salt_keys.txt
 fi

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/scripts/salt.sh
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/scripts/salt.sh
@@ -1,35 +1,68 @@
 #!/bin/bash
 
-function get_memory() {
-  mem_in_kb=$(ps v $1 | tail -1 | tr -s " " | cut -d " " -f9)
+function get_memory_in_bytes() {
+  mem_in_kb=$1
   mem_in_bytes=$(($mem_in_kb*1024))
   echo "$mem_in_bytes"
 }
 
-function get_children_memory() {
-  mem_in_kb=$(ps -o pid,rss --no-headers --ppid $1 | cut -d ' ' -f3 | awk 'NF{sum+=$1} END {print sum}')
-  if [[ -z "${mem_in_kb// }" ]]; then
-    echo "0"
-  else
-    mem_in_bytes=$(($mem_in_kb*1024))
-    echo "$mem_in_bytes"
+function get_ps_output() {
+  local component=$1
+  ps_out=$(ps aux | grep "bin/$component" | grep -v grep | awk {'sumCpu+=$3;sumMem+=$4;sumVsz+=$5;sumRss+=$6} END{print sumCpu,sumMem,sumVsz,sumRss;'})
+  echo "$ps_out"
+}
+
+function get_top_output() {
+  local component=$1
+  top_out=$(top -n 1 -b -c | grep "bin/$component" | grep -v grep | awk {'sumCpu+=$9;sumMem+=$10} END{print sumCpu,sumMem;'})
+  echo "$top_out"
+}
+
+function write_metric() {
+  local metric_name=$1
+  local metric_value=$2
+
+  if [[ "$metric_name" != "" && "$metric_value" != "" ]]; then
+    echo "$metric_name $metric_value" >> /var/lib/node_exporter/files/salt.prom.$$
   fi
 }
 
 if [[ -f /var/run/salt-master.pid ]]; then
-  master_pid=$(cat /var/run/salt-master.pid)
-  mem_in_bytes=$(get_memory $master_pid)
-  children_mem_in_bytes=$(get_children_memory $master_pid)
-  echo "cb_salt_master_parent_memory_rss_bytes $mem_in_bytes" >> /var/lib/node_exporter/files/salt.prom.$$
-  echo "cb_salt_master_children_memory_rss_bytes $mem_in_bytes" >> /var/lib/node_exporter/files/salt.prom.$$
+  master_ps_out=$(get_ps_output "salt-master")
+  master_top_out=$(get_top_output "salt-master")
+  master_ps_cpu=$(echo $master_ps_out | cut -d ' ' -f1)
+  master_top_cpu=$(echo $master_top_out | cut -d ' ' -f1)
+  master_ps_memory=$(echo $master_ps_out | cut -d ' ' -f2)
+  master_top_memory=$(echo $master_top_out | cut -d ' ' -f2)
+  master_vsz=$(echo $master_ps_out | cut -d ' ' -f3)
+  master_rss=$(echo $master_ps_out | cut -d ' ' -f4)
+  master_vsz_in_bytes=$(get_memory_in_bytes $master_vsz)
+  master_rss_in_bytes=$(get_memory_in_bytes $master_rss)
+  write_metric "cb_salt_master_cpu_usage_ps_total" "$master_ps_cpu"
+  write_metric "cb_salt_master_cpu_usage_top_total" "$master_top_cpu"
+  write_metric "cb_salt_master_memory_usage_ps_total" "$master_ps_memory"
+  write_metric "cb_salt_master_memory_usage_top_total" "$master_top_memory"
+  write_metric "cb_salt_master_memory_vsz_bytes_total" "$master_vsz_in_bytes"
+  write_metric "cb_salt_master_memory_rss_bytes_total" "$master_rss_in_bytes"
 fi
 
 if [[ -f /var/run/salt-minion.pid ]]; then
-  minion_pid=$(cat /var/run/salt-minion.pid)
-  mem_in_bytes=$(get_memory $minion_pid)
-  children_mem_in_bytes=$(get_children_memory $minion_pid)
-  echo "cb_salt_minion_parent_memory_rss_bytes $mem_in_bytes" >> /var/lib/node_exporter/files/salt.prom.$$
-  echo "cb_salt_minion_children_memory_rss_bytes $mem_in_bytes" >> /var/lib/node_exporter/files/salt.prom.$$
+  minion_ps_out=$(get_ps_output "salt-minion")
+  minion_top_out=$(get_top_output "salt-minion")
+  minion_ps_cpu=$(echo $minion_ps_out | cut -d ' ' -f1)
+  minion_top_cpu=$(echo $minion_top_out | cut -d ' ' -f1)
+  minion_ps_memory=$(echo $minion_ps_out | cut -d ' ' -f2)
+  minion_top_memory=$(echo $minion_top_out | cut -d ' ' -f2)
+  minion_vsz=$(echo $minion_ps_out | cut -d ' ' -f3)
+  minion_rss=$(echo $minion_ps_out | cut -d ' ' -f4)
+  minion_vsz_in_bytes=$(get_memory_in_bytes $minion_vsz)
+  minion_rss_in_bytes=$(get_memory_in_bytes $minion_rss)
+  write_metric "cb_salt_minion_cpu_usage_ps_total" "$minion_ps_cpu"
+  write_metric "cb_salt_minion_cpu_usage_top_total" "$minion_top_cpu"
+  write_metric "cb_salt_minion_memory_usage_ps_total" "$minion_ps_memory"
+  write_metric "cb_salt_minion_memory_usage_top_total" "$minion_top_memory"
+  write_metric "cb_salt_minion_memory_vsz_bytes_total" "$minion_vsz_in_bytes"
+  write_metric "cb_salt_minion_memory_rss_bytes_total" "$minion_rss_in_bytes"
 fi
 
 if [[ -f /var/lib/node_exporter/files/salt.prom.$$ ]]; then


### PR DESCRIPTION
…ll).

details:
- collect cpu and memory related metrics for salt-master and minion (all of the child processes as well)
- as top and ps command show different values (actual + average) -> collect both, show ps and top in the metrics name (could be avg + act but the source of the metrics probably more clear)
- also add vsz and rss values as well (for top and ps, those are exactly the same so no need to collect from both)
- also add some renaming of metrics -> total was missing from the ending, and based on the prometheus conventions, that would be needed.

See detailed description in the commit message.