### PR TITLE
CB-18303: Allow changing LogRetentionPolicy for Cloudwatch Logs

### DIFF
--- a/cloud-aws-cloudformation/src/main/resources/definitions/aws-cb-policy.json
+++ b/cloud-aws-cloudformation/src/main/resources/definitions/aws-cb-policy.json
@@ -47,7 +47,8 @@
       "Action": [
         "logs:CreateLogStream",
         "logs:DescribeLogStreams",
-        "logs:PutLogEvents"
+        "logs:PutLogEvents",
+        "logs:PutRetentionPolicy"
       ],
       "Effect": "Allow",
       "Resource": [

--- a/cloud-aws-common/src/main/resources/definitions/aws-cb-policy.json
+++ b/cloud-aws-common/src/main/resources/definitions/aws-cb-policy.json
@@ -47,7 +47,8 @@
       "Action": [
         "logs:CreateLogStream",
         "logs:DescribeLogStreams",
-        "logs:PutLogEvents"
+        "logs:PutLogEvents",
+        "logs:PutRetentionPolicy"
       ],
       "Effect": "Allow",
       "Resource": [


### PR DESCRIPTION
This commit allows chaning Log Retention Policy for Cloudwatch
logs. By default, cloudwatch log group has infinite log retention
policy, in DWX , we are making the default as 7 days and as such
we need this permission.

