### PR TITLE
CB-17805 change volume size and type GCP

### DIFF
--- a/datalake/src/main/resources/duties/7.2.10/gcp/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.10/gcp/light_duty.json
@@ -31,8 +31,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "pd-standard"
+            "size": 512,
+            "type": "pd-ssd"
           }
         ]
       },

--- a/datalake/src/main/resources/duties/7.2.10/gcp/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.10/gcp/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]
@@ -49,8 +49,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "pd-standard"
+            "size": 512,
+            "type": "pd-ssd"
           }
         ]
       },
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.11/gcp/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.11/gcp/light_duty.json
@@ -31,8 +31,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "pd-standard"
+            "size": 512,
+            "type": "pd-ssd"
           }
         ]
       },

--- a/datalake/src/main/resources/duties/7.2.11/gcp/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.11/gcp/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]
@@ -49,8 +49,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "pd-standard"
+            "size": 512,
+            "type": "pd-ssd"
           }
         ]
       },
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.12/gcp/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.12/gcp/light_duty.json
@@ -31,8 +31,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "pd-standard"
+            "size": 512,
+            "type": "pd-ssd"
           }
         ]
       },

--- a/datalake/src/main/resources/duties/7.2.12/gcp/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.12/gcp/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]
@@ -49,8 +49,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "pd-standard"
+            "size": 512,
+            "type": "pd-ssd"
           }
         ]
       },
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.14/gcp/cdp_data_lake_medium_duty_with_profiler/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.14/gcp/cdp_data_lake_medium_duty_with_profiler/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]
@@ -49,8 +49,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "pd-standard"
+            "size": 512,
+            "type": "pd-ssd"
           }
         ]
       },
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.14/gcp/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.14/gcp/light_duty.json
@@ -31,8 +31,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "pd-standard"
+            "size": 512,
+            "type": "pd-ssd"
           }
         ]
       },

--- a/datalake/src/main/resources/duties/7.2.14/gcp/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.14/gcp/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]
@@ -49,8 +49,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "pd-standard"
+            "size": 512,
+            "type": "pd-ssd"
           }
         ]
       },
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.15/gcp/cdp_data_lake_medium_duty_with_profiler/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.15/gcp/cdp_data_lake_medium_duty_with_profiler/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]
@@ -49,8 +49,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "pd-standard"
+            "size": 512,
+            "type": "pd-ssd"
           }
         ]
       },
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.15/gcp/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.15/gcp/light_duty.json
@@ -31,8 +31,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "pd-standard"
+            "size": 512,
+            "type": "pd-ssd"
           }
         ]
       },

--- a/datalake/src/main/resources/duties/7.2.15/gcp/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.15/gcp/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]
@@ -49,8 +49,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "pd-standard"
+            "size": 512,
+            "type": "pd-ssd"
           }
         ]
       },
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.16/gcp/cdp_data_lake_medium_duty_with_profiler/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.16/gcp/cdp_data_lake_medium_duty_with_profiler/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]
@@ -49,8 +49,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "pd-standard"
+            "size": 512,
+            "type": "pd-ssd"
           }
         ]
       },
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.16/gcp/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.16/gcp/light_duty.json
@@ -31,8 +31,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "pd-standard"
+            "size": 512,
+            "type": "pd-ssd"
           }
         ]
       },

--- a/datalake/src/main/resources/duties/7.2.16/gcp/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.16/gcp/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]
@@ -49,8 +49,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "pd-standard"
+            "size": 512,
+            "type": "pd-ssd"
           }
         ]
       },
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.7/gcp/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.7/gcp/light_duty.json
@@ -31,8 +31,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "pd-standard"
+            "size": 512,
+            "type": "pd-ssd"
           }
         ]
       },

--- a/datalake/src/main/resources/duties/7.2.7/gcp/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.7/gcp/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]
@@ -49,8 +49,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "pd-standard"
+            "size": 512,
+            "type": "pd-ssd"
           }
         ]
       },
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.8/gcp/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.8/gcp/light_duty.json
@@ -31,8 +31,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "pd-standard"
+            "size": 512,
+            "type": "pd-ssd"
           }
         ]
       },

--- a/datalake/src/main/resources/duties/7.2.8/gcp/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.8/gcp/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]
@@ -49,8 +49,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "pd-standard"
+            "size": 512,
+            "type": "pd-ssd"
           }
         ]
       },
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.9/gcp/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.9/gcp/light_duty.json
@@ -31,8 +31,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "pd-standard"
+            "size": 512,
+            "type": "pd-ssd"
           }
         ]
       },

--- a/datalake/src/main/resources/duties/7.2.9/gcp/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.9/gcp/medium_duty_ha.json
@@ -15,7 +15,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]
@@ -32,7 +32,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]
@@ -49,8 +49,8 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
-            "type": "pd-standard"
+            "size": 512,
+            "type": "pd-ssd"
           }
         ]
       },
@@ -66,7 +66,7 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 250,
+            "size": 128,
             "type": "pd-standard"
           }
         ]


### PR DESCRIPTION
JIRA: [CB-17805](https://jira.cloudera.com/browse/CB-17805)

Change datalake duty volume type and size at `GCP`.
Versions from: `7.2.7` to `7.2.16`
New medium duty size:
- AUXILIARY - Reduced to `128GB`
- GATEWAY - Reduced to `128GB`
- MASTER - Reduced to `128GB`
- CORE: Increase it to `512GB`

New light duty size:
- Light duty: Increase it to `512GB`

new core type: `ps-ssd`