### PR TITLE
CB-18423 UpgradeCcmState FlowState implementation should be an enum

### DIFF
--- a/cloud-consumption/src/test/java/com/sequenceiq/consumption/FlowStateEnumTest.java
+++ b/cloud-consumption/src/test/java/com/sequenceiq/consumption/FlowStateEnumTest.java
@@ -1,0 +1,13 @@
+package com.sequenceiq.consumption;
+
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.flow.helper.FlowStateEnumChecker;
+
+public class FlowStateEnumTest {
+
+    @Test
+    void allFlowStateIsEnum() {
+        new FlowStateEnumChecker().checkFlowStateClasses();
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/FlowStateEnumTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/FlowStateEnumTest.java
@@ -1,0 +1,13 @@
+package com.sequenceiq.cloudbreak;
+
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.flow.helper.FlowStateEnumChecker;
+
+public class FlowStateEnumTest {
+
+    @Test
+    void allFlowStateIsEnum() {
+        new FlowStateEnumChecker().checkFlowStateClasses();
+    }
+}

--- a/datalake/src/test/java/com/sequenceiq/datalake/FlowStateEnumTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/FlowStateEnumTest.java
@@ -1,0 +1,13 @@
+package com.sequenceiq.datalake;
+
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.flow.helper.FlowStateEnumChecker;
+
+public class FlowStateEnumTest {
+
+    @Test
+    void allFlowStateIsEnum() {
+        new FlowStateEnumChecker().checkFlowStateClasses();
+    }
+}

--- a/environment/src/test/java/com/sequenceiq/environment/FlowStateEnumTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/FlowStateEnumTest.java
@@ -1,0 +1,13 @@
+package com.sequenceiq.environment;
+
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.flow.helper.FlowStateEnumChecker;
+
+public class FlowStateEnumTest {
+
+    @Test
+    void allFlowStateIsEnum() {
+        new FlowStateEnumChecker().checkFlowStateClasses();
+    }
+}

--- a/flow/src/test/java/com/sequenceiq/flow/helper/FlowStateEnumChecker.java
+++ b/flow/src/test/java/com/sequenceiq/flow/helper/FlowStateEnumChecker.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.flow.helper;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.reflections.Reflections;
+import org.reflections.scanners.SubTypesScanner;
+
+import com.sequenceiq.flow.core.FlowState;
+
+public class FlowStateEnumChecker {
+
+    private static final String BASE_PACKAGE = "com.sequenceiq.";
+
+    private final List<String> validationErrors = new ArrayList<>();
+
+    public void checkFlowStateClasses() {
+        Reflections reflections = new Reflections(BASE_PACKAGE, new SubTypesScanner(true));
+        Set<Class<? extends FlowState>> flowStateClasses = reflections.getSubTypesOf(FlowState.class);
+        flowStateClasses.forEach(this::performCheck);
+        if (!validationErrors.isEmpty()) {
+            fail("There are " + validationErrors.size() + " violations:\n" + String.join("\n", validationErrors));
+        }
+    }
+
+    private void performCheck(Class<? extends FlowState> clazz) {
+        if (!clazz.getName().contains("Test") && !clazz.isEnum()) {
+            validationErrors.add(String.format("Class %s is not an enum. Implementers of FlowState must be enums.", clazz.getName()));
+        }
+    }
+
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/UpgradeCcmState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/UpgradeCcmState.java
@@ -4,72 +4,26 @@ import com.sequenceiq.flow.core.FlowState;
 import com.sequenceiq.flow.core.RestartAction;
 import com.sequenceiq.freeipa.flow.FillInMemoryStateStoreRestartAction;
 
-public class UpgradeCcmState implements FlowState {
-    public static final String UPGRADE_CCM_CHECK_PREREQUISITES_STATE_NAME = "UPGRADE_CCM_CHECK_PREREQUISITES_STATE";
+public enum UpgradeCcmState implements FlowState {
 
-    public static final String UPGRADE_CCM_CHANGE_TUNNEL_STATE_NAME = "UPGRADE_CCM_CHANGE_TUNNEL_STATE";
-
-    public static final String UPGRADE_CCM_OBTAIN_AGENT_DATA_STATE_NAME = "UPGRADE_CCM_OBTAIN_AGENT_DATA_STATE";
-
-    public static final String UPGRADE_CCM_FINISHED_STATE_NAME = "UPGRADE_CCM_FINISHED_STATE";
-
-    public static final String UPGRADE_CCM_FAILED_STATE_NAME = "UPGRADE_CCM_FAILED_STATE";
-
-    public static final String UPGRADE_CCM_PUSH_SALT_STATES_STATE_NAME = "UPGRADE_CCM_PUSH_SALT_STATES_STATE";
-
-    public static final String UPGRADE_CCM_UPGRADE_STATE_NAME = "UPGRADE_CCM_UPGRADE_STATE";
-
-    public static final String UPGRADE_CCM_RECONFIGURE_NGINX_STATE_NAME = "UPGRADE_CCM_RECONFIGURE_NGINX_STATE";
-
-    public static final String UPGRADE_CCM_REGISTER_CLUSTER_PROXY_STATE_NAME = "UPGRADE_CCM_REGISTER_CLUSTER_PROXY_STATE";
-
-    public static final String UPGRADE_CCM_HEALTH_CHECK_STATE_NAME = "UPGRADE_CCM_HEALTH_CHECK_STATE";
-
-    public static final String UPGRADE_CCM_REMOVE_MINA_STATE_NAME = "UPGRADE_CCM_REMOVE_MINA_STATE";
-
-    public static final String UPGRADE_CCM_DEREGISTER_MINA_STATE_NAME = "UPGRADE_CCM_DEREGISTER_MINA_STATE";
-
-    public static final UpgradeCcmState INIT_STATE = new UpgradeCcmState("INIT_STATE");
-
-    public static final UpgradeCcmState UPGRADE_CCM_CHECK_PREREQUISITES_STATE = new UpgradeCcmState(UPGRADE_CCM_CHECK_PREREQUISITES_STATE_NAME);
-
-    public static final UpgradeCcmState UPGRADE_CCM_CHANGE_TUNNEL_STATE = new UpgradeCcmState(UPGRADE_CCM_CHANGE_TUNNEL_STATE_NAME);
-
-    public static final UpgradeCcmState UPGRADE_CCM_OBTAIN_AGENT_DATA_STATE = new UpgradeCcmState(UPGRADE_CCM_OBTAIN_AGENT_DATA_STATE_NAME);
-
-    public static final UpgradeCcmState UPGRADE_CCM_FAILED_STATE = new UpgradeCcmState(UPGRADE_CCM_FAILED_STATE_NAME);
-
-    public static final UpgradeCcmState UPGRADE_CCM_FINISHED_STATE = new UpgradeCcmState(UPGRADE_CCM_FINISHED_STATE_NAME);
-
-    public static final UpgradeCcmState UPGRADE_CCM_PUSH_SALT_STATES_STATE = new UpgradeCcmState(UPGRADE_CCM_PUSH_SALT_STATES_STATE_NAME);
-
-    public static final UpgradeCcmState UPGRADE_CCM_UPGRADE_STATE = new UpgradeCcmState(UPGRADE_CCM_UPGRADE_STATE_NAME);
-
-    public static final UpgradeCcmState UPGRADE_CCM_RECONFIGURE_NGINX_STATE = new UpgradeCcmState(UPGRADE_CCM_RECONFIGURE_NGINX_STATE_NAME);
-
-    public static final UpgradeCcmState UPGRADE_CCM_REGISTER_CLUSTER_PROXY_STATE = new UpgradeCcmState(UPGRADE_CCM_REGISTER_CLUSTER_PROXY_STATE_NAME);
-
-    public static final UpgradeCcmState UPGRADE_CCM_HEALTH_CHECK_STATE = new UpgradeCcmState(UPGRADE_CCM_HEALTH_CHECK_STATE_NAME);
-
-    public static final UpgradeCcmState UPGRADE_CCM_REMOVE_MINA_STATE = new UpgradeCcmState(UPGRADE_CCM_REMOVE_MINA_STATE_NAME);
-
-    public static final UpgradeCcmState UPGRADE_CCM_DEREGISTER_MINA_STATE = new UpgradeCcmState(UPGRADE_CCM_DEREGISTER_MINA_STATE_NAME);
-
-    public static final UpgradeCcmState FINAL_STATE = new UpgradeCcmState("FINAL_STATE");
-
-    private final String name;
-
-    UpgradeCcmState(String name) {
-        this.name = name;
-    }
+    INIT_STATE,
+    UPGRADE_CCM_CHECK_PREREQUISITES_STATE,
+    UPGRADE_CCM_CHANGE_TUNNEL_STATE,
+    UPGRADE_CCM_OBTAIN_AGENT_DATA_STATE,
+    UPGRADE_CCM_FAILED_STATE,
+    UPGRADE_CCM_FINISHED_STATE,
+    UPGRADE_CCM_PUSH_SALT_STATES_STATE,
+    UPGRADE_CCM_UPGRADE_STATE,
+    UPGRADE_CCM_RECONFIGURE_NGINX_STATE,
+    UPGRADE_CCM_REGISTER_CLUSTER_PROXY_STATE,
+    UPGRADE_CCM_HEALTH_CHECK_STATE,
+    UPGRADE_CCM_REMOVE_MINA_STATE,
+    UPGRADE_CCM_DEREGISTER_MINA_STATE,
+    FINAL_STATE;
 
     @Override
     public Class<? extends RestartAction> restartAction() {
         return FillInMemoryStateStoreRestartAction.class;
     }
 
-    @Override
-    public String name() {
-        return name;
-    }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/action/UpgradeCcmActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/action/UpgradeCcmActions.java
@@ -1,17 +1,6 @@
 package com.sequenceiq.freeipa.flow.stack.upgrade.ccm.action;
 
-import static com.sequenceiq.freeipa.flow.stack.upgrade.ccm.UpgradeCcmState.UPGRADE_CCM_CHANGE_TUNNEL_STATE_NAME;
-import static com.sequenceiq.freeipa.flow.stack.upgrade.ccm.UpgradeCcmState.UPGRADE_CCM_CHECK_PREREQUISITES_STATE_NAME;
-import static com.sequenceiq.freeipa.flow.stack.upgrade.ccm.UpgradeCcmState.UPGRADE_CCM_DEREGISTER_MINA_STATE_NAME;
-import static com.sequenceiq.freeipa.flow.stack.upgrade.ccm.UpgradeCcmState.UPGRADE_CCM_FAILED_STATE_NAME;
-import static com.sequenceiq.freeipa.flow.stack.upgrade.ccm.UpgradeCcmState.UPGRADE_CCM_FINISHED_STATE_NAME;
-import static com.sequenceiq.freeipa.flow.stack.upgrade.ccm.UpgradeCcmState.UPGRADE_CCM_HEALTH_CHECK_STATE_NAME;
-import static com.sequenceiq.freeipa.flow.stack.upgrade.ccm.UpgradeCcmState.UPGRADE_CCM_OBTAIN_AGENT_DATA_STATE_NAME;
-import static com.sequenceiq.freeipa.flow.stack.upgrade.ccm.UpgradeCcmState.UPGRADE_CCM_PUSH_SALT_STATES_STATE_NAME;
-import static com.sequenceiq.freeipa.flow.stack.upgrade.ccm.UpgradeCcmState.UPGRADE_CCM_RECONFIGURE_NGINX_STATE_NAME;
-import static com.sequenceiq.freeipa.flow.stack.upgrade.ccm.UpgradeCcmState.UPGRADE_CCM_REGISTER_CLUSTER_PROXY_STATE_NAME;
-import static com.sequenceiq.freeipa.flow.stack.upgrade.ccm.UpgradeCcmState.UPGRADE_CCM_REMOVE_MINA_STATE_NAME;
-import static com.sequenceiq.freeipa.flow.stack.upgrade.ccm.UpgradeCcmState.UPGRADE_CCM_UPGRADE_STATE_NAME;
+import static com.sequenceiq.freeipa.flow.stack.upgrade.ccm.selector.UpgradeCcmHandlerSelector.UPGRADE_CCM_APPLY_UPGRADE_EVENT;
 import static com.sequenceiq.freeipa.flow.stack.upgrade.ccm.selector.UpgradeCcmHandlerSelector.UPGRADE_CCM_CHANGE_TUNNEL_EVENT;
 import static com.sequenceiq.freeipa.flow.stack.upgrade.ccm.selector.UpgradeCcmHandlerSelector.UPGRADE_CCM_CHECK_PREREQUISITES_EVENT;
 import static com.sequenceiq.freeipa.flow.stack.upgrade.ccm.selector.UpgradeCcmHandlerSelector.UPGRADE_CCM_DEREGISTER_MINA_EVENT;
@@ -21,7 +10,6 @@ import static com.sequenceiq.freeipa.flow.stack.upgrade.ccm.selector.UpgradeCcmH
 import static com.sequenceiq.freeipa.flow.stack.upgrade.ccm.selector.UpgradeCcmHandlerSelector.UPGRADE_CCM_RECONFIGURE_NGINX_EVENT;
 import static com.sequenceiq.freeipa.flow.stack.upgrade.ccm.selector.UpgradeCcmHandlerSelector.UPGRADE_CCM_REGISTER_CLUSTER_PROXY_EVENT;
 import static com.sequenceiq.freeipa.flow.stack.upgrade.ccm.selector.UpgradeCcmHandlerSelector.UPGRADE_CCM_REMOVE_MINA_EVENT;
-import static com.sequenceiq.freeipa.flow.stack.upgrade.ccm.selector.UpgradeCcmHandlerSelector.UPGRADE_CCM_APPLY_UPGRADE_EVENT;
 import static com.sequenceiq.freeipa.flow.stack.upgrade.ccm.selector.UpgradeCcmStateSelector.UPGRADE_CCM_FAILURE_HANDLED_EVENT;
 import static com.sequenceiq.freeipa.flow.stack.upgrade.ccm.selector.UpgradeCcmStateSelector.UPGRADE_CCM_FINISHED_EVENT;
 
@@ -54,7 +42,7 @@ public class UpgradeCcmActions {
     @Inject
     private UpgradeCcmService upgradeCcmService;
 
-    @Bean(name = UPGRADE_CCM_CHECK_PREREQUISITES_STATE_NAME)
+    @Bean(name = "UPGRADE_CCM_CHECK_PREREQUISITES_STATE")
     public Action<?, ?> checkPrerequisites() {
         return new AbstractUpgradeCcmAction<>(UpgradeCcmTriggerEvent.class) {
             @Override
@@ -69,7 +57,7 @@ public class UpgradeCcmActions {
         };
     }
 
-    @Bean(name = UPGRADE_CCM_CHANGE_TUNNEL_STATE_NAME)
+    @Bean(name = "UPGRADE_CCM_CHANGE_TUNNEL_STATE")
     public Action<?, ?> changeTunnel() {
         return new AbstractUpgradeCcmEventAction() {
             @Override
@@ -81,7 +69,7 @@ public class UpgradeCcmActions {
         };
     }
 
-    @Bean(name = UPGRADE_CCM_OBTAIN_AGENT_DATA_STATE_NAME)
+    @Bean(name = "UPGRADE_CCM_OBTAIN_AGENT_DATA_STATE")
     public Action<?, ?> obtainAgentData() {
         return new AbstractUpgradeCcmEventAction() {
             @Override
@@ -93,7 +81,7 @@ public class UpgradeCcmActions {
         };
     }
 
-    @Bean(name = UPGRADE_CCM_PUSH_SALT_STATES_STATE_NAME)
+    @Bean(name = "UPGRADE_CCM_PUSH_SALT_STATES_STATE")
     public Action<?, ?> pushSaltStates() {
         return new AbstractUpgradeCcmEventAction() {
             @Override
@@ -105,7 +93,7 @@ public class UpgradeCcmActions {
         };
     }
 
-    @Bean(name = UPGRADE_CCM_UPGRADE_STATE_NAME)
+    @Bean(name = "UPGRADE_CCM_UPGRADE_STATE")
     public Action<?, ?> upgrade() {
         return new AbstractUpgradeCcmEventAction() {
             @Override
@@ -117,7 +105,7 @@ public class UpgradeCcmActions {
         };
     }
 
-    @Bean(name = UPGRADE_CCM_RECONFIGURE_NGINX_STATE_NAME)
+    @Bean(name = "UPGRADE_CCM_RECONFIGURE_NGINX_STATE")
     public Action<?, ?> reconfigure() {
         return new AbstractUpgradeCcmEventAction() {
             @Override
@@ -129,7 +117,7 @@ public class UpgradeCcmActions {
         };
     }
 
-    @Bean(name = UPGRADE_CCM_REGISTER_CLUSTER_PROXY_STATE_NAME)
+    @Bean(name = "UPGRADE_CCM_REGISTER_CLUSTER_PROXY_STATE")
     public Action<?, ?> registerCcm() {
         return new AbstractUpgradeCcmEventAction() {
             @Override
@@ -141,7 +129,7 @@ public class UpgradeCcmActions {
         };
     }
 
-    @Bean(name = UPGRADE_CCM_HEALTH_CHECK_STATE_NAME)
+    @Bean(name = "UPGRADE_CCM_HEALTH_CHECK_STATE")
     public Action<?, ?> healthCheck() {
         return new AbstractUpgradeCcmEventAction() {
             @Override
@@ -153,7 +141,7 @@ public class UpgradeCcmActions {
         };
     }
 
-    @Bean(name = UPGRADE_CCM_REMOVE_MINA_STATE_NAME)
+    @Bean(name = "UPGRADE_CCM_REMOVE_MINA_STATE")
     public Action<?, ?> removeMina() {
         return new AbstractUpgradeCcmEventAction() {
             @Override
@@ -165,7 +153,7 @@ public class UpgradeCcmActions {
         };
     }
 
-    @Bean(name = UPGRADE_CCM_DEREGISTER_MINA_STATE_NAME)
+    @Bean(name = "UPGRADE_CCM_DEREGISTER_MINA_STATE")
     public Action<?, ?> deregisterMina() {
         return new AbstractUpgradeCcmEventAction() {
             @Override
@@ -177,7 +165,7 @@ public class UpgradeCcmActions {
         };
     }
 
-    @Bean(name = UPGRADE_CCM_FINISHED_STATE_NAME)
+    @Bean(name = "UPGRADE_CCM_FINISHED_STATE")
     public Action<?, ?> finished() {
         return new AbstractUpgradeCcmEventAction() {
             @Override
@@ -190,7 +178,7 @@ public class UpgradeCcmActions {
         };
     }
 
-    @Bean(name = UPGRADE_CCM_FAILED_STATE_NAME)
+    @Bean(name = "UPGRADE_CCM_FAILED_STATE")
     public Action<?, ?> failed() {
         return new AbstractUpgradeCcmAction<>(UpgradeCcmFailureEvent.class) {
             @Override

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/FlowStateEnumTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/FlowStateEnumTest.java
@@ -1,0 +1,13 @@
+package com.sequenceiq.freeipa;
+
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.flow.helper.FlowStateEnumChecker;
+
+public class FlowStateEnumTest {
+
+    @Test
+    void allFlowStateIsEnum() {
+        new FlowStateEnumChecker().checkFlowStateClasses();
+    }
+}

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/FlowStateEnumTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/FlowStateEnumTest.java
@@ -1,0 +1,13 @@
+package com.sequenceiq.redbeams;
+
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.flow.helper.FlowStateEnumChecker;
+
+public class FlowStateEnumTest {
+
+    @Test
+    void allFlowStateIsEnum() {
+        new FlowStateEnumChecker().checkFlowStateClasses();
+    }
+}


### PR DESCRIPTION
Add unit tests to check for all services this requirement.
FlowLog table has data (currentstate and variables) dependent on these classes being enums.

This needs a hotfix for 2.61 and the forward merge.