### PR TITLE
CB-16693 Last time timeouts have been increased to 5 minutes under CB…

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -615,7 +615,7 @@
         </param>
         <param>
                <name>httpclient.socketTimeout</name>
-               <value>5m</value>
+               <value>15m</value>
         </param>
     </service>
     <service>
@@ -633,7 +633,7 @@
         </param>
         <param>
                <name>httpclient.socketTimeout</name>
-               <value>5m</value>
+               <value>15m</value>
         </param>
     </service>
     {%- endif %}
@@ -684,7 +684,7 @@
         </param>
         <param>
             <name>httpclient.socketTimeout</name>
-            <value>5m</value>
+            <value>15m</value>
         </param>
         {%- endfor %}
     </service>

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
@@ -350,7 +350,7 @@
         </param>
         <param>
                <name>httpclient.socketTimeout</name>
-               <value>5m</value>
+               <value>15m</value>
         </param>
     </service>
     {%- endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/ssl-locations.d/knox.conf
+++ b/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/ssl-locations.d/knox.conf
@@ -2,9 +2,9 @@ location /knox/ {
   rewrite /knox/(.*) /$1  break;
   proxy_pass         https://knox;
   proxy_connect_timeout       300;
-  proxy_send_timeout          300;
-  proxy_read_timeout          300;
-  send_timeout                300;
+  proxy_send_timeout          900;
+  proxy_read_timeout          900;
+  send_timeout                900;
   proxy_buffer_size  32k;
   proxy_buffers      8 32k;
   proxy_redirect     off;


### PR DESCRIPTION
…-12550. This time we were asked to set it to 15m. I am going to set only the socket timeout since the connection timeout has impact only when build up the connection, and it is very unlikely that connection cannot be built up in 5 mins.

Anyway, I will set it to 15 mins, but I consider such large timeouts as a workaround for the shortcomings of Atlas and Hue socket handling: CDPD-40768.

See detailed description in the commit message.