### PR TITLE
CB-18412. Use min_backoff and max_backoff values for remote writes by…

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringAgentConfiguration.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringAgentConfiguration.java
@@ -14,6 +14,10 @@ public class MonitoringAgentConfiguration {
 
     private String walTruncateFrequency;
 
+    private String minBackoff;
+
+    private String maxBackoff;
+
     public Integer getPort() {
         return port;
     }
@@ -60,5 +64,21 @@ public class MonitoringAgentConfiguration {
 
     public void setWalTruncateFrequency(String walTruncateFrequency) {
         this.walTruncateFrequency = walTruncateFrequency;
+    }
+
+    public String getMinBackoff() {
+        return minBackoff;
+    }
+
+    public void setMinBackoff(String minBackoff) {
+        this.minBackoff = minBackoff;
+    }
+
+    public String getMaxBackoff() {
+        return maxBackoff;
+    }
+
+    public void setMaxBackoff(String maxBackoff) {
+        this.maxBackoff = maxBackoff;
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfigService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfigService.java
@@ -47,6 +47,8 @@ public class MonitoringConfigService implements TelemetryPillarConfigGenerator<M
         builder.withRetentionMinTime(monitoringConfiguration.getAgent().getRetentionMinTime());
         builder.withRetentionMaxTime(monitoringConfiguration.getAgent().getRetentionMaxTime());
         builder.withWalTruncateFrequency(monitoringConfiguration.getAgent().getWalTruncateFrequency());
+        builder.withMinBackoff(monitoringConfiguration.getAgent().getMinBackoff());
+        builder.withMaxBackoff(monitoringConfiguration.getAgent().getMaxBackoff());
         if (monitoringContext.getCredential() != null) {
             builder.withAccessKeyId(monitoringContext.getCredential().getAccessKey())
                     .withPrivateKey(monitoringContext.getCredential().getPrivateKey().toCharArray())

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfigView.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfigView.java
@@ -20,6 +20,10 @@ public class MonitoringConfigView implements TelemetryConfigView {
 
     private static final String RETENTION_MAX_TIME = "4h";
 
+    private static final String MIN_BACKOFF = "1s";
+
+    private static final String MAX_BACKOFF = "20m";
+
     private static final String WAL_TRUNCATE_FREQUENCY = "2h";
 
     private static final Integer DEFAULT_CM_SMON_PORT = 61010;
@@ -63,6 +67,10 @@ public class MonitoringConfigView implements TelemetryConfigView {
     private final String retentionMinTime;
 
     private final String retentionMaxTime;
+
+    private final String minBackoff;
+
+    private final String maxBackoff;
 
     private final String walTruncateFrequency;
 
@@ -116,6 +124,8 @@ public class MonitoringConfigView implements TelemetryConfigView {
         this.requestSigner = builder.requestSigner;
         this.retentionMinTime = builder.retentionMinTime;
         this.retentionMaxTime = builder.retentionMaxTime;
+        this.minBackoff = builder.minBackoff;
+        this.maxBackoff = builder.maxBackoff;
         this.walTruncateFrequency = builder.walTruncateFrequency;
         this.accessKeyId = builder.accessKeyId;
         this.privateKey = builder.privateKey;
@@ -265,6 +275,8 @@ public class MonitoringConfigView implements TelemetryConfigView {
         map.put("agentMaxDiskUsage", defaultIfNull(this.agentMaxDiskUsage, AGENT_MAX_DISK_USAGE_DEFAULT));
         map.put("retentionMinTime", defaultIfNull(this.retentionMinTime, RETENTION_MIN_TIME));
         map.put("retentionMaxTime", defaultIfNull(this.retentionMaxTime, RETENTION_MAX_TIME));
+        map.put("minBackoff", defaultIfNull(this.minBackoff, MIN_BACKOFF));
+        map.put("maxBackoff", defaultIfNull(this.maxBackoff, MAX_BACKOFF));
         map.put("walTruncateFrequency", defaultIfNull(this.walTruncateFrequency, WAL_TRUNCATE_FREQUENCY));
         map.put("username", defaultIfNull(this.username, EMPTY_CONFIG_DEFAULT));
         map.put("password", this.password != null ? new String(this.password) : EMPTY_CONFIG_DEFAULT);
@@ -334,6 +346,10 @@ public class MonitoringConfigView implements TelemetryConfigView {
         private String retentionMinTime;
 
         private String retentionMaxTime;
+
+        private String minBackoff;
+
+        private String maxBackoff;
 
         private String walTruncateFrequency;
 
@@ -488,6 +504,16 @@ public class MonitoringConfigView implements TelemetryConfigView {
 
         public Builder withWalTruncateFrequency(String walTruncateFrequency) {
             this.walTruncateFrequency = walTruncateFrequency;
+            return this;
+        }
+
+        public Builder withMinBackoff(String minBackoff) {
+            this.minBackoff = minBackoff;
+            return this;
+        }
+
+        public Builder withMaxBackoff(String maxBackoff) {
+            this.maxBackoff = maxBackoff;
             return this;
         }
 

--- a/common/src/main/resources/common-config.yml
+++ b/common/src/main/resources/common-config.yml
@@ -50,6 +50,8 @@ telemetry:
       retention-min-time: "5m"
       retention-max-time: "4h"
       wal-truncate-frequency: "2h"
+      min-backoff: "1s"
+      max-backoff: "20m"
     request-signer:
       enabled: true
       port: 61095

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/settings.sls
@@ -26,6 +26,8 @@
 {% set agent_max_disk_usage = salt['pillar.get']('monitoring:agentMaxDiskUsage', '4GB') %}
 {% set retention_min_time = salt['pillar.get']('monitoring:retentionMinTime', '5m') %}
 {% set retention_max_time = salt['pillar.get']('monitoring:retentionMaxTime', '4h') %}
+{% set min_backoff = salt['pillar.get']('monitoring:minBackoff', '1s') %}
+{% set max_backoff = salt['pillar.get']('monitoring:maxBackoff', '20m') %}
 {% set wal_truncate_frequency = salt['pillar.get']('monitoring:walTruncateFrequency', '2h') %}
 {% set node_exporter_user = salt['pillar.get']('monitoring:nodeExporterUser', 'nodeuser') %}
 {% set node_exporter_port = salt['pillar.get']('monitoring:nodeExporterPort', 9100) %}
@@ -88,6 +90,8 @@
     "agentMaxDiskUsage": agent_max_disk_usage,
     "retentionMinTime": retention_min_time,
     "retentionMaxTime": retention_max_time,
+    "minBackoff": min_backoff,
+    "maxBackoff": max_backoff,
     "walTruncateFrequency": wal_truncate_frequency,
     "nodeExporterUser": node_exporter_user,
     "nodeExporterPort": node_exporter_port,

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/template/prometheus.yml.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/template/prometheus.yml.j2
@@ -41,6 +41,9 @@ remote_write:
       credentials_file: /opt/cdp-prometheus/remote_token_file
     {%- endif %}
   {%- endif %}
+    queue_config:
+      min_backoff: {{ monitoring.minBackoff }}
+      max_backoff: {{ monitoring.maxBackoff }}
     tls_config:
       insecure_skip_verify: true
 {%- endif %}


### PR DESCRIPTION
… prometheus agents.

details:
- there was a 3 day outage for thanos on last week, the load grew really huge during that time because of the remote write request replays.
- increase default min/max backoff (15ms / 5s to 1s / 20m)
- see: https://prometheus.io/docs/practices/remote_write/

See detailed description in the commit message.