### PR TITLE
ENGESC-16407: Missing paywall authentication from CSD downloader script

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/csd/csd-downloader.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/csd/csd-downloader.sh
@@ -10,6 +10,10 @@ csdUrls=({%- for url in salt['pillar.get']('cloudera-manager:csd-urls') -%}
 {{ url + " " }}
 {%- endfor %})
 
+{%- if salt['pillar.get']('cloudera-manager:paywall_username') %}
+AUTHENTICATION="-u {{ salt['pillar.get']('cloudera-manager:paywall_username') }}:{{ salt['pillar.get']('cloudera-manager:paywall_password') }}"
+{%- endif %}
+
 for url in ${csdUrls[@]}
 do
   fileName=$(basename $url)
@@ -21,7 +25,7 @@ do
   else
     echo "$(date '+%d/%m/%Y %H:%M:%S') - Downloading ($url) " |& tee -a /var/log/csd_downloader.log
 
-    curl -L -O -R $url
+    curl -L -O -R --fail $AUTHENTICATION $url
   fi
 done
 


### PR DESCRIPTION
In order to download the required CSD jars during the runtime upgrade, we need to use paywall access.
For some reason, the current script does not contain any authentication when trying to download the files.

In this commit, I added paywall authentication to the CURL command which is responsible to download the CSD files.
I also extended the CURL command with the --fail option because without this we saved the authentication failure response into the jar files.