### PR TITLE
CB-18400 QA Command Runner script improvements with command selector

### DIFF
--- a/integration-test/src/main/resources/commandrunner/sample-command.json
+++ b/integration-test/src/main/resources/commandrunner/sample-command.json
@@ -1,8 +1,10 @@
 [
   {
+    "name": "log_size",
     "description":  "Check log size",
     "command":  "du -h /var/log"},
   {
+    "name": "hello_world",
     "description": "Hello world",
     "command":  "echo hello"
   }


### PR DESCRIPTION
This is a follow-up improvement for the [CB-18046 Introduce a command runner for Cloudbreak API Test project to multiple SSH #13252](https://github.com/hortonworks/cloudbreak/pull/13252) PR

We should introduce further improvements for the `integration-test/src/main/resources/commandrunner/qa-command-runner.py` script. Where we should be able to select the command(s) what we finally would like to run from commands Json file.

See detailed description in the commit message.