### PR TITLE
CB-18354 Postgres 11 upgrade: EDH tracking

### DIFF
--- a/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/mapper/ClusterUseCaseMapper.java
+++ b/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/mapper/ClusterUseCaseMapper.java
@@ -62,6 +62,8 @@ public class ClusterUseCaseMapper {
                 UsageProto.CDPClusterStatus.Value.CCM_UPGRADE_STARTED);
         firstStepUseCaseMap.put(Pair.of("", "CoreVerticalScaleFlowConfig"),
                 UsageProto.CDPClusterStatus.Value.VERTICAL_SCALE_STARTED);
+        firstStepUseCaseMap.put(Pair.of("UpgradeRdsFlowEventChainFactory", "ValidateRdsUpgradeFlowConfig"),
+                UsageProto.CDPClusterStatus.Value.DATABASE_UPGRADE_STARTED);
     }
 
     // At the moment we need to introduce a complex logic to figure out the use case
@@ -175,6 +177,10 @@ public class ClusterUseCaseMapper {
                 case "PrepareClusterUpgradeFlowEventChainFactory":
                     useCase = getClusterStatus(nextFlowState, "CLUSTER_UPGRADE_PREPARATION_FINISHED_STATE",
                             UsageProto.CDPClusterStatus.Value.UPGRADE_PREPARE_FINISHED, UsageProto.CDPClusterStatus.Value.UPGRADE_PREPARE_FAILED);
+                    break;
+                case "UpgradeRdsFlowEventChainFactory":
+                    useCase = getClusterStatus(nextFlowState, "UPGRADE_RDS_FINISHED_STATE",
+                            UsageProto.CDPClusterStatus.Value.DATABASE_UPGRADE_FINISHED, UsageProto.CDPClusterStatus.Value.DATABASE_UPGRADE_FAILED);
                     break;
                 default:
                     LOGGER.debug("Next flow state: {}", nextFlowState);

--- a/usage-collection/src/main/proto/usage.proto
+++ b/usage-collection/src/main/proto/usage.proto
@@ -212,6 +212,10 @@ message Event {
     CDPAssignTrialAccount cdpAssignTrialAccount = 101;
     // A CDP trial account status is changed/updated.
     CDPTrialAccountStatusChanged cdpTrialAccountStatusChanged = 102;
+    // A recipe is created/attached/detached/deleted.
+    CDPRecipeEvent cdpRecipeEvent = 103;
+    // A cluster (FreeIPA, Data Lake, Data Hub) creation event with recipe related details.
+    CDPClusterCreationRecipeEvent cdpClusterCreationRecipeEvent = 104;
   }
 }
 
@@ -1519,6 +1523,13 @@ message CDPClusterStatus {
     CCM_UPGRADE_FINISHED = 53;
     // The status when a cluster ccm upgrade operation failed.
     CCM_UPGRADE_FAILED = 54;
+
+    // The status when the database server upgrade is started for a DL / DH
+    DATABASE_UPGRADE_STARTED = 55;
+    // The status when the database server upgrade is finished for a DL / DH
+    DATABASE_UPGRADE_FINISHED = 56;
+    // The status when the database server upgrade fails for a DL / DH
+    DATABASE_UPGRADE_FAILED = 57;
   }
 }
 
@@ -3598,5 +3609,69 @@ message CDPAssignTrialStatus {
 // Generated after vertical scale.
 message CDPVerticalScaleDetails {
   string newInstanceType = 1;
+}
+
+// Type of recipe
+message CDPRecipeType {
+  enum Value {
+      // Indicates there is some error, type cannot be recognized
+      UNKNOWN = 0;
+      // Indicates that recipe will be executed before CM start, deprecated status
+      PRE_CLOUDERA_MANAGER_START = 1;
+      // Indicates that recipe will be executed before service starts
+      PRE_SERVICE_DEPLOYMENT = 2;
+      // Indicates that recipe will be executed before termination
+      PRE_TERMINATION = 3;
+      // Indicates that recipe will be executed after CM start, deprecated
+      POST_CLOUDERA_MANAGER_START = 4;
+      // Indicates that recipe will be executed after cluster provision
+      POST_CLUSTER_INSTALL = 5;
+    // Indicates that recipe will be executed after service starts
+      POST_SERVICE_DEPLOYMENT = 6;
+  }
+}
+
+// Status of recipe event
+message CDPRecipeStatus {
+  enum Value {
+    // Indicates that status cannot be recognized
+    UNKNOWN = 0;
+    // Indicates that it is a recipe creation event
+    CREATED = 1;
+    // Indicates that it is a recipe attachment event
+    ATTACHED = 2;
+    // Indicates that it is a recipe detachment event
+    DETACHED = 3;
+    // Indicates that it is a recipe deletion event
+    DELETED = 4;
+  }
+}
+
+// Event about recipe
+message CDPRecipeEvent {
+  // Status of recipe
+  CDPRecipeStatus.Value status = 1;
+  // CRN of recipe
+  string recipeCrn = 2;
+  // Name of recipe
+  string name = 3;
+  // Type of recipe
+  CDPRecipeType.Value type = 4;
+  // Name of host group in case of attachment/detachment, otherwise it is empty
+  string hostGroup = 5;
+  // CRN of related stack in case of attachment/detachment, otherwise it is empty
+  string stackCrn = 6;
+}
+
+// Recipe related event about cluster creation
+message CDPClusterCreationRecipeEvent {
+  // CRN of related stack
+  string stackCrn = 1;
+  // Overall recipe count of related stack
+  int32 recipeCount = 2;
+  // Details of recipe count by type in JSON format
+  string typeDetails = 3;
+  // Details of recipe count by host group in JSON format
+  string hostGroupDetails = 4;
 }
 


### PR DESCRIPTION
Adding EDH tracking for postgres upgrade feature. It starts with a validation (first step), and finished with the core upgrade flow. SDX upgrade is also tracked in core.

See detailed description in the commit message.