### PR TITLE
CB-17024 Automatically bring DH clusters into a favourable state when…

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/model/ScalingAdjustmentType.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/model/ScalingAdjustmentType.java
@@ -1,0 +1,6 @@
+package com.sequenceiq.periscope.model;
+
+public enum ScalingAdjustmentType {
+    REGULAR,
+    STOPSTART
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/model/adjustment/MandatoryScalingAdjustmentParameters.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/model/adjustment/MandatoryScalingAdjustmentParameters.java
@@ -1,0 +1,8 @@
+package com.sequenceiq.periscope.model.adjustment;
+
+public interface MandatoryScalingAdjustmentParameters {
+
+    Integer getUpscaleAdjustment();
+
+    Integer getDownscaleAdjustment();
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/model/adjustment/RegularScalingAdjustmentParameters.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/model/adjustment/RegularScalingAdjustmentParameters.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.periscope.model.adjustment;
+
+public class RegularScalingAdjustmentParameters implements MandatoryScalingAdjustmentParameters {
+
+    private Integer upscaleAdjustment;
+
+    private Integer downscaleAdjustment;
+
+    @Override
+    public Integer getUpscaleAdjustment() {
+        return upscaleAdjustment;
+    }
+
+    public void setUpscaleAdjustment(Integer upscaleAdjustment) {
+        this.upscaleAdjustment = upscaleAdjustment;
+    }
+
+    @Override
+    public Integer getDownscaleAdjustment() {
+        return downscaleAdjustment;
+    }
+
+    public void setDownscaleAdjustment(Integer downscaleAdjustment) {
+        this.downscaleAdjustment = downscaleAdjustment;
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/model/adjustment/StopStartScalingAdjustmentParameters.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/model/adjustment/StopStartScalingAdjustmentParameters.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.periscope.model.adjustment;
+
+public class StopStartScalingAdjustmentParameters implements MandatoryScalingAdjustmentParameters {
+
+    private Integer upscaleAdjustment;
+
+    private Integer downscaleAdjustment;
+
+    @Override
+    public Integer getUpscaleAdjustment() {
+        return upscaleAdjustment;
+    }
+
+    public void setUpscaleAdjustment(Integer upscaleAdjustment) {
+        this.upscaleAdjustment = upscaleAdjustment;
+    }
+
+    @Override
+    public Integer getDownscaleAdjustment() {
+        return downscaleAdjustment;
+    }
+
+    public void setDownscaleAdjustment(Integer downscaleAdjustment) {
+        this.downscaleAdjustment = downscaleAdjustment;
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/client/YarnMetricsClient.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/client/YarnMetricsClient.java
@@ -55,7 +55,7 @@ public class YarnMetricsClient {
 
     @Retryable(value = Exception.class, maxAttempts = 2, backoff = @Backoff(delay = 5000))
     public YarnScalingServiceV1Response getYarnMetricsForCluster(Cluster cluster, StackV4Response stackV4Response,
-            String hostGroup, String pollingUserCrn, Optional<Integer> mandatoryDownScaleCount) throws Exception {
+            String hostGroup, String pollingUserCrn, Optional<Integer> maxDecommissionNodeCount) throws Exception {
         TlsConfiguration tlsConfig = tlsSecurityService.getTls(cluster.getId());
         String clusterProxyUrl = clusterProxyConfigurationService.getClusterProxyUrl()
                 .orElseThrow(() -> new RuntimeException(String.format("ClusterProxy Not Configured for Cluster %s, " +
@@ -76,7 +76,7 @@ public class YarnMetricsClient {
         UriBuilder yarnMetricsURI = UriBuilder.fromPath(yarnApiUrl)
                 .queryParam(PARAM_UPSCALE_FACTOR_NODE_RESOURCE_TYPE, DEFAULT_UPSCALE_RESOURCE_TYPE);
 
-        mandatoryDownScaleCount.ifPresent(
+        maxDecommissionNodeCount.ifPresent(
                 scaleDownCount -> yarnMetricsURI.queryParam(PARAM_DOWNSCALE_FACTOR_IN_NODE_COUNT, stackV4Response.getNodeCount()));
 
         YarnScalingServiceV1Response yarnResponse = requestLogging.logResponseTime(

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/event/ScalingEvent.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/event/ScalingEvent.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.context.ApplicationEvent;
 
 import com.sequenceiq.periscope.domain.BaseAlert;
+import com.sequenceiq.periscope.model.ScalingAdjustmentType;
 
 public class ScalingEvent extends ApplicationEvent {
 
@@ -17,6 +18,10 @@ public class ScalingEvent extends ApplicationEvent {
     private transient Integer existingClusterNodeCount;
 
     private transient Integer desiredAbsoluteHostGroupNodeCount;
+
+    private transient Integer existingServiceHealthyHostGroupNodeCount;
+
+    private transient ScalingAdjustmentType scalingAdjustmentType;
 
     public ScalingEvent(BaseAlert alert) {
         super(alert);
@@ -56,5 +61,21 @@ public class ScalingEvent extends ApplicationEvent {
 
     public void setExistingClusterNodeCount(Integer existingClusterNodeCount) {
         this.existingClusterNodeCount = existingClusterNodeCount;
+    }
+
+    public Integer getExistingServiceHealthyHostGroupNodeCount() {
+        return existingServiceHealthyHostGroupNodeCount;
+    }
+
+    public void setExistingServiceHealthyHostGroupNodeCount(Integer existingServiceHealthyHostGroupNodeCount) {
+        this.existingServiceHealthyHostGroupNodeCount = existingServiceHealthyHostGroupNodeCount;
+    }
+
+    public ScalingAdjustmentType getScalingAdjustmentType() {
+        return scalingAdjustmentType;
+    }
+
+    public void setScalingAdjustmentType(ScalingAdjustmentType scalingAdjustmentType) {
+        this.scalingAdjustmentType = scalingAdjustmentType;
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ScalingHandler.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ScalingHandler.java
@@ -60,7 +60,9 @@ public class ScalingHandler implements ApplicationListener<ScalingEvent> {
         int desiredAbsoluteHostGroupNodeCount = event.getDesiredAbsoluteHostGroupNodeCount();
         if (hostGroupNodeCount != desiredAbsoluteHostGroupNodeCount) {
             Runnable scalingRequest = (Runnable) applicationContext.getBean("ScalingRequest", cluster, policy,
-                    event.getExistingClusterNodeCount(), hostGroupNodeCount, desiredAbsoluteHostGroupNodeCount, event.getDecommissionNodeIds());
+                    event.getExistingClusterNodeCount(), hostGroupNodeCount, desiredAbsoluteHostGroupNodeCount,
+                    event.getDecommissionNodeIds(),
+                    event.getExistingServiceHealthyHostGroupNodeCount(), event.getScalingAdjustmentType());
 
             executorService.submit(scalingRequest);
             rejectedThreadService.remove(cluster.getId());

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/sender/ScalingEventSender.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/sender/ScalingEventSender.java
@@ -1,0 +1,62 @@
+package com.sequenceiq.periscope.monitor.sender;
+
+import static com.sequenceiq.periscope.model.ScalingAdjustmentType.REGULAR;
+import static com.sequenceiq.periscope.model.ScalingAdjustmentType.STOPSTART;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.periscope.domain.BaseAlert;
+import com.sequenceiq.periscope.model.ScalingAdjustmentType;
+import com.sequenceiq.periscope.monitor.evaluator.EventPublisher;
+import com.sequenceiq.periscope.monitor.event.ScalingEvent;
+
+@Component
+public class ScalingEventSender {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ScalingEventSender.class);
+
+    @Inject
+    private EventPublisher eventPublisher;
+
+    public void sendScaleUpEvent(BaseAlert baseAlert, Integer existingClusterNodeCount, Integer existingHostGroupSize, Integer servicesHealthyHostGroupSize,
+            Integer targetScaleUpCount) {
+        ScalingEvent scalingEvent = new ScalingEvent(baseAlert);
+        scalingEvent.setExistingHostGroupNodeCount(existingHostGroupSize);
+        scalingEvent.setExistingServiceHealthyHostGroupNodeCount(servicesHealthyHostGroupSize);
+        scalingEvent.setExistingClusterNodeCount(existingClusterNodeCount);
+        scalingEvent.setDesiredAbsoluteHostGroupNodeCount(existingHostGroupSize + targetScaleUpCount);
+        scalingEvent.setScalingAdjustmentType(REGULAR);
+        LOGGER.info("Triggering scaleUp event: {} for cluster: {}", scalingEvent, baseAlert.getCluster().getStackCrn());
+        eventPublisher.publishEvent(scalingEvent);
+    }
+
+    public void sendStopStartScaleUpEvent(BaseAlert baseAlert, Integer existingClusterNodeCount, Integer servicesHealthyHostGroupSize,
+            Integer targetScaleUpCount) {
+        ScalingEvent scalingEvent = new ScalingEvent(baseAlert);
+        scalingEvent.setExistingHostGroupNodeCount(servicesHealthyHostGroupSize);
+        scalingEvent.setExistingServiceHealthyHostGroupNodeCount(servicesHealthyHostGroupSize);
+        scalingEvent.setExistingClusterNodeCount(existingClusterNodeCount);
+        scalingEvent.setDesiredAbsoluteHostGroupNodeCount(servicesHealthyHostGroupSize + targetScaleUpCount);
+        scalingEvent.setScalingAdjustmentType(STOPSTART);
+        LOGGER.info("Triggering stop-start scaleUp event: {} for cluster: {}", scalingEvent, baseAlert.getCluster().getStackCrn());
+        eventPublisher.publishEvent(scalingEvent);
+    }
+
+    public void sendScaleDownEvent(BaseAlert baseAlert, Integer existingHostGroupSize, List<String> yarnRecommendedDecommissionHosts,
+            Integer servicesHealthyHostGroupSize, ScalingAdjustmentType adjustmentType) {
+        ScalingEvent scalingEvent = new ScalingEvent(baseAlert);
+        scalingEvent.setExistingHostGroupNodeCount(existingHostGroupSize);
+        scalingEvent.setExistingServiceHealthyHostGroupNodeCount(servicesHealthyHostGroupSize);
+        scalingEvent.setDesiredAbsoluteHostGroupNodeCount(existingHostGroupSize - yarnRecommendedDecommissionHosts.size());
+        scalingEvent.setDecommissionNodeIds(yarnRecommendedDecommissionHosts);
+        scalingEvent.setScalingAdjustmentType(adjustmentType);
+        LOGGER.info("Triggering scaleDown event: {} for cluster: {}", scalingEvent, baseAlert.getCluster().getStackCrn());
+        eventPublisher.publishEvent(scalingEvent);
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/MandatoryScalingAdjustmentService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/MandatoryScalingAdjustmentService.java
@@ -1,0 +1,11 @@
+package com.sequenceiq.periscope.service;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.model.adjustment.MandatoryScalingAdjustmentParameters;
+
+public interface MandatoryScalingAdjustmentService {
+
+    void performMandatoryAdjustment(Cluster cluster, String pollingUserCrn, StackV4Response stackResponse,
+            MandatoryScalingAdjustmentParameters adjustmentParameters);
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/RegularScalingAdjustmentService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/RegularScalingAdjustmentService.java
@@ -1,0 +1,112 @@
+package com.sequenceiq.periscope.service;
+
+import static com.sequenceiq.periscope.model.ScalingAdjustmentType.REGULAR;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.LoadAlert;
+import com.sequenceiq.periscope.domain.LoadAlertConfiguration;
+import com.sequenceiq.periscope.model.adjustment.MandatoryScalingAdjustmentParameters;
+import com.sequenceiq.periscope.model.yarn.YarnScalingServiceV1Response;
+import com.sequenceiq.periscope.monitor.client.YarnMetricsClient;
+import com.sequenceiq.periscope.monitor.evaluator.load.YarnResponseUtils;
+import com.sequenceiq.periscope.monitor.sender.ScalingEventSender;
+import com.sequenceiq.periscope.utils.StackResponseUtils;
+
+@Service
+public class RegularScalingAdjustmentService implements MandatoryScalingAdjustmentService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RegularScalingAdjustmentService.class);
+
+    @Inject
+    private ScalingEventSender scalingEventSender;
+
+    @Inject
+    private StackResponseUtils stackResponseUtils;
+
+    @Inject
+    private YarnMetricsClient yarnMetricsClient;
+
+    @Inject
+    private YarnResponseUtils yarnResponseUtils;
+
+    private LoadAlert loadAlert;
+
+    private LoadAlertConfiguration loadAlertConfiguration;
+
+    private String policyHostGroup;
+
+    private Map<String, String> hostFqdnsToInstanceId;
+
+    private List<String> servicesHealthyHostInstanceIds;
+
+    @Override
+    public void performMandatoryAdjustment(Cluster cluster, String pollingUserCrn, StackV4Response stackResponse,
+            MandatoryScalingAdjustmentParameters scalingAdjustmentParameters) {
+        loadAlert = cluster.getLoadAlerts().iterator().next();
+        loadAlertConfiguration = loadAlert.getLoadAlertConfiguration();
+        policyHostGroup = loadAlert.getScalingPolicy().getHostGroup();
+
+        hostFqdnsToInstanceId = stackResponseUtils.getCloudInstanceIdsForHostGroup(stackResponse, policyHostGroup);
+        servicesHealthyHostInstanceIds = stackResponseUtils.getCloudInstanceIdsWithServicesHealthyForHostGroup(stackResponse,
+                policyHostGroup);
+
+        int existingClusterNodeCount = stackResponse.getNodeCount();
+
+        publishScalingEventIfNeeded(cluster, existingClusterNodeCount, pollingUserCrn, stackResponse, scalingAdjustmentParameters);
+    }
+
+    private void publishScalingEventIfNeeded(Cluster cluster, int existingClusterNodeCount, String pollingUserCrn, StackV4Response stackV4Response,
+            MandatoryScalingAdjustmentParameters scalingAdjustmentParameters) {
+
+        if (scalingAdjustmentParameters.getUpscaleAdjustment() != null) {
+            Integer targetScaleUpCount = Math.min(scalingAdjustmentParameters.getUpscaleAdjustment(), loadAlertConfiguration.getMaxScaleUpStepSize());
+
+            scalingEventSender.sendScaleUpEvent(loadAlert, existingClusterNodeCount, hostFqdnsToInstanceId.size(), servicesHealthyHostInstanceIds.size(),
+                    targetScaleUpCount);
+            LOGGER.info("Triggered mandatory adjustment ScaleUp for Cluster '{}', NodeCount '{}', HostGroup '{}'", cluster.getStackCrn(),
+                    targetScaleUpCount, policyHostGroup);
+        } else if (scalingAdjustmentParameters.getDownscaleAdjustment() != null) {
+            List<String> hostsToDecommission = collectRegularDownscaleRecommendations(cluster, hostFqdnsToInstanceId, pollingUserCrn, stackV4Response,
+                    scalingAdjustmentParameters.getDownscaleAdjustment());
+
+            scalingEventSender.sendScaleDownEvent(loadAlert, hostFqdnsToInstanceId.size(), hostsToDecommission, servicesHealthyHostInstanceIds.size(), REGULAR);
+            LOGGER.info("Triggered mandatory adjustment ScaleDown for Cluster '{}', HostsToDecommission '{}', HostGroup '{}'",
+                    cluster.getStackCrn(), hostsToDecommission, policyHostGroup);
+        }
+    }
+
+    private List<String> collectRegularDownscaleRecommendations(Cluster cluster, Map<String, String> hostFqdnsToInstanceId, String pollingUserCrn,
+            StackV4Response stackResponse, Integer mandatoryDownscaleCount) {
+        try {
+            int maxAllowedDownscale = Math.max(0, hostFqdnsToInstanceId.size() - loadAlertConfiguration.getMinResourceValue());
+            int allowedDownscale = IntStream.of(mandatoryDownscaleCount, maxAllowedDownscale,
+                    loadAlertConfiguration.getMaxScaleDownStepSize()).min().getAsInt();
+
+            YarnScalingServiceV1Response yarnResponse = yarnMetricsClient.getYarnMetricsForCluster(cluster, stackResponse, policyHostGroup,
+                    pollingUserCrn, Optional.of(mandatoryDownscaleCount));
+            List<String> yarnRecommendedDecommissionHosts =
+                    yarnResponseUtils.getYarnRecommendedDecommissionHostsForHostGroup(yarnResponse, hostFqdnsToInstanceId);
+            return yarnRecommendedDecommissionHosts.stream()
+                    .limit(allowedDownscale)
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            LOGGER.error("Error when invoking YARN for mandatory regular downscale recommendations for cluster '{}', hostGroup '{}'", cluster.getStackCrn(),
+                    policyHostGroup, e);
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/StopStartScalingAdjustmentService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/StopStartScalingAdjustmentService.java
@@ -1,0 +1,130 @@
+package com.sequenceiq.periscope.service;
+
+import static com.sequenceiq.periscope.model.ScalingAdjustmentType.REGULAR;
+import static java.util.Collections.emptyList;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.LoadAlert;
+import com.sequenceiq.periscope.domain.LoadAlertConfiguration;
+import com.sequenceiq.periscope.model.adjustment.MandatoryScalingAdjustmentParameters;
+import com.sequenceiq.periscope.model.yarn.YarnScalingServiceV1Response;
+import com.sequenceiq.periscope.monitor.client.YarnMetricsClient;
+import com.sequenceiq.periscope.monitor.evaluator.load.YarnResponseUtils;
+import com.sequenceiq.periscope.monitor.sender.ScalingEventSender;
+import com.sequenceiq.periscope.utils.StackResponseUtils;
+
+@Service
+public class StopStartScalingAdjustmentService implements MandatoryScalingAdjustmentService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StopStartScalingAdjustmentService.class);
+
+    @Inject
+    private ScalingEventSender scalingEventSender;
+
+    @Inject
+    private StackResponseUtils stackResponseUtils;
+
+    @Inject
+    private YarnMetricsClient yarnMetricsClient;
+
+    @Inject
+    private YarnResponseUtils yarnResponseUtils;
+
+    private LoadAlert loadAlert;
+
+    private LoadAlertConfiguration loadAlertConfiguration;
+
+    private String policyHostGroup;
+
+    private Map<String, String> hostFqdnsToInstanceId;
+
+    private List<String> servicesHealthyHostInstanceIds;
+
+    private List<String> stoppedHostInstanceIds;
+
+    @Override
+    public void performMandatoryAdjustment(Cluster cluster, String pollingUserCrn, StackV4Response stackResponse,
+            MandatoryScalingAdjustmentParameters scalingAdjustmentParameters) {
+
+        loadAlert = cluster.getLoadAlerts().iterator().next();
+        loadAlertConfiguration = loadAlert.getLoadAlertConfiguration();
+        policyHostGroup = loadAlert.getScalingPolicy().getHostGroup();
+
+        hostFqdnsToInstanceId = stackResponseUtils.getCloudInstanceIdsForHostGroup(stackResponse, policyHostGroup);
+        servicesHealthyHostInstanceIds = stackResponseUtils.getCloudInstanceIdsWithServicesHealthyForHostGroup(stackResponse,
+                policyHostGroup);
+        stoppedHostInstanceIds = stackResponseUtils.getStoppedCloudInstanceIdsInHostGroup(stackResponse, policyHostGroup);
+
+        int stoppedNodeCount = stoppedHostInstanceIds.size();
+        int existingClusterNodeCount = stackResponse.getNodeCount() - stoppedNodeCount;
+
+        publishScalingEventIfNeeded(cluster, existingClusterNodeCount, pollingUserCrn, stackResponse, scalingAdjustmentParameters);
+    }
+
+    private void publishScalingEventIfNeeded(Cluster cluster, int existingClusterNodeCount, String pollingUserCrn, StackV4Response stackV4Response,
+            MandatoryScalingAdjustmentParameters scalingAdjustmentParameters) {
+
+        if (scalingAdjustmentParameters.getUpscaleAdjustment() != null) {
+            Integer targetScaleUpCount = Math.min(scalingAdjustmentParameters.getUpscaleAdjustment(), loadAlertConfiguration.getMaxScaleUpStepSize());
+            if (stoppedHostInstanceIds.isEmpty()) {
+                scalingEventSender.sendScaleUpEvent(loadAlert, existingClusterNodeCount, hostFqdnsToInstanceId.size(), servicesHealthyHostInstanceIds.size(),
+                        targetScaleUpCount);
+                LOGGER.info("Triggered mandatory adjustment ScaleUp for Cluster '{}', NodeCount '{}', HostGroup '{}'",
+                        cluster.getStackCrn(), targetScaleUpCount, policyHostGroup);
+            } else {
+                scalingEventSender.sendStopStartScaleUpEvent(loadAlert, existingClusterNodeCount, servicesHealthyHostInstanceIds.size(),
+                        stoppedHostInstanceIds.size());
+                LOGGER.info("Triggered mandatory adjustment stop-start ScaleUp for Cluster '{}', NodeCount '{}', HostGroup '{}'",
+                        cluster.getStackCrn(), stoppedHostInstanceIds.size(), policyHostGroup);
+            }
+        } else if (scalingAdjustmentParameters.getDownscaleAdjustment() != null) {
+            List<String> hostsToDecommission = collectStopStartDownscaleRecommendations(cluster, hostFqdnsToInstanceId, stoppedHostInstanceIds,
+                    pollingUserCrn, stackV4Response, scalingAdjustmentParameters.getDownscaleAdjustment());
+
+            scalingEventSender.sendScaleDownEvent(loadAlert, hostFqdnsToInstanceId.size(), hostsToDecommission, servicesHealthyHostInstanceIds.size(), REGULAR);
+            LOGGER.info("Triggered mandatory adjustment ScaleDown for Cluster '{}', HostsToDecommission '{}', HostGroup '{}'",
+                    cluster.getStackCrn(), hostsToDecommission, policyHostGroup);
+        }
+    }
+
+    private List<String> collectStopStartDownscaleRecommendations(Cluster cluster, Map<String, String> hostFqdnsToInstanceId,
+            List<String> stoppedHostIds, String pollingUserCrn, StackV4Response stackResponse, Integer mandatoryDownscaleCount) {
+        try {
+            int maxAllowedDownscale = Math.max(0, hostFqdnsToInstanceId.size() - loadAlertConfiguration.getMinResourceValue());
+            int allowedDownscale = IntStream.of(mandatoryDownscaleCount, maxAllowedDownscale,
+                            loadAlertConfiguration.getMaxScaleDownStepSize()).min().getAsInt();
+
+            List<String> yarnRecommendedDecommissionHosts = emptyList();
+
+            if (stoppedHostIds.size() < allowedDownscale) {
+                YarnScalingServiceV1Response yarnResponse = yarnMetricsClient.getYarnMetricsForCluster(cluster, stackResponse, policyHostGroup,
+                        pollingUserCrn, Optional.of(mandatoryDownscaleCount));
+                yarnRecommendedDecommissionHosts =
+                        yarnResponseUtils.getYarnRecommendedDecommissionHostsForHostGroup(yarnResponse, hostFqdnsToInstanceId);
+            }
+
+            return Stream.concat(stoppedHostIds.stream(), yarnRecommendedDecommissionHosts.stream())
+                    .limit(allowedDownscale)
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            LOGGER.error("Error when invoking YARN for mandatory stop-start downscale recommendations for cluster '{}', hostGroup '{}'", cluster.getStackCrn(),
+                    policyHostGroup, e);
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/YarnBasedScalingAdjustmentService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/YarnBasedScalingAdjustmentService.java
@@ -1,0 +1,158 @@
+package com.sequenceiq.periscope.service;
+
+import static com.sequenceiq.periscope.model.ScalingAdjustmentType.REGULAR;
+import static com.sequenceiq.periscope.model.ScalingAdjustmentType.STOPSTART;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.LoadAlert;
+import com.sequenceiq.periscope.domain.LoadAlertConfiguration;
+import com.sequenceiq.periscope.model.ScalingAdjustmentType;
+import com.sequenceiq.periscope.model.yarn.YarnScalingServiceV1Response;
+import com.sequenceiq.periscope.monitor.client.YarnMetricsClient;
+import com.sequenceiq.periscope.monitor.evaluator.load.YarnResponseUtils;
+import com.sequenceiq.periscope.monitor.sender.ScalingEventSender;
+import com.sequenceiq.periscope.utils.ClusterUtils;
+import com.sequenceiq.periscope.utils.StackResponseUtils;
+import com.sequenceiq.periscope.utils.TimeUtil;
+
+@Service
+public class YarnBasedScalingAdjustmentService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(YarnBasedScalingAdjustmentService.class);
+
+    @Inject
+    private YarnResponseUtils yarnResponseUtils;
+
+    @Inject
+    private StackResponseUtils stackResponseUtils;
+
+    @Inject
+    private YarnMetricsClient yarnMetricsClient;
+
+    @Inject
+    private ClusterService clusterService;
+
+    @Inject
+    private ScalingEventSender eventSender;
+
+    private LoadAlert loadAlert;
+
+    private LoadAlertConfiguration loadAlertConfiguration;
+
+    private String policyHostGroup;
+
+    private Map<String, String> hostFqdnsToInstanceId;
+
+    private List<String> servicesHealthyInstanceIds;
+
+    private List<String> stoppedHostInstanceIds;
+
+    public void pollYarnMetricsAndScaleCluster(Cluster cluster, String pollingUserCrn, boolean stopStartEnabled, StackV4Response stackV4Response)
+            throws Exception {
+
+        loadAlert = cluster.getLoadAlerts().iterator().next();
+        policyHostGroup = loadAlert.getScalingPolicy().getHostGroup();
+        loadAlertConfiguration = loadAlert.getLoadAlertConfiguration();
+
+        hostFqdnsToInstanceId = stackResponseUtils.getCloudInstanceIdsForHostGroup(stackV4Response, policyHostGroup);
+        servicesHealthyInstanceIds = stackResponseUtils.getCloudInstanceIdsWithServicesHealthyForHostGroup(stackV4Response, policyHostGroup);
+        stoppedHostInstanceIds = stackResponseUtils.getStoppedCloudInstanceIdsInHostGroup(stackV4Response, policyHostGroup);
+
+        int serviceHealthyHostGroupSize = servicesHealthyInstanceIds.size();
+        int existingHostGroupSize = hostFqdnsToInstanceId.size();
+
+        int maxResourceValueOffset = loadAlertConfiguration.getMaxResourceValue() - (stopStartEnabled ? serviceHealthyHostGroupSize : existingHostGroupSize);
+        int minResourceValueOffset = serviceHealthyHostGroupSize - loadAlertConfiguration.getMinResourceValue();
+
+        int maxAllowedUpScale = Math.max(maxResourceValueOffset, 0);
+        int maxAllowedDownScale = Math.max(minResourceValueOffset, 0);
+
+        LOGGER.info("Various counts: hostFqdnsToInstanceId={}, servicesHealthyHostFqdnsToInstanceId: {}, stoppedHostFqdnsToInstanceId: {}, " +
+                        "maxResourceValueOffset={}, minResourceValueOffset={}, maxAllowedUpScale={}, maxAllowedDownScale={}",
+                existingHostGroupSize, serviceHealthyHostGroupSize, stoppedHostInstanceIds.size(),
+                maxResourceValueOffset, minResourceValueOffset, maxAllowedUpScale, maxAllowedDownScale);
+
+        Optional<Integer> maxDecommissionNodeCount = Optional.of(maxResourceValueOffset)
+                .filter(mandatoryDownscale -> mandatoryDownscale < 0).map(downscale -> -1 * downscale);
+
+        YarnScalingServiceV1Response yarnResponse =
+                yarnMetricsClient.getYarnMetricsForCluster(cluster, stackV4Response, policyHostGroup, pollingUserCrn, maxDecommissionNodeCount);
+
+        if (cluster.getUpdateFailedDetails() != null && pollingUserCrn.equals(cluster.getMachineUserCrn())) {
+            // Successful YARN API call
+            clusterService.setUpdateFailedDetails(cluster.getId(), null);
+        }
+
+        int yarnRecommendedScaleUpCount = yarnResponseUtils.getYarnRecommendedScaleUpCount(yarnResponse, policyHostGroup);
+        int finalScaleUpCount = IntStream.of(yarnRecommendedScaleUpCount,
+                maxAllowedUpScale, loadAlertConfiguration.getMaxScaleUpStepSize()).min().getAsInt();
+
+        int allowedDownscale = maxDecommissionNodeCount.orElse(maxAllowedDownScale);
+        allowedDownscale = Math.min(allowedDownscale, loadAlertConfiguration.getMaxScaleDownStepSize());
+        List<String> yarnRecommendedDecommissionHosts =
+                yarnResponseUtils.getYarnRecommendedDecommissionHostsForHostGroup(yarnResponse, hostFqdnsToInstanceId);
+        List<String> finalHostsToDecommission = yarnRecommendedDecommissionHosts.stream()
+                .limit(allowedDownscale).collect(Collectors.toList());
+
+        LOGGER.info("yarnRecommendedScaleUpCount={}, yarnRecommendedDecommission={}, determinedScaleUpCount (based on step-size and maxAllowedUpscale): {}, " +
+                        "determinedDecommissionHosts (based on step-size and maxAllowedDownscale): {}",
+                yarnRecommendedScaleUpCount, yarnRecommendedDecommissionHosts, finalScaleUpCount, finalHostsToDecommission);
+
+        ScalingAdjustmentType adjustmentType = !stopStartEnabled ? REGULAR : STOPSTART;
+
+        publishScalingEventIfNeeded(cluster, finalScaleUpCount, stackV4Response, finalHostsToDecommission, adjustmentType);
+    }
+
+    protected boolean isCoolDownTimeElapsed(String clusterCrn, String coolDownAction, long expectedCoolDownMillis, long lastClusterScalingActivity) {
+        long remainingTime = ClusterUtils.getRemainingCooldownTime(
+                expectedCoolDownMillis, lastClusterScalingActivity);
+
+        if (remainingTime <= 0) {
+            return true;
+        } else {
+            LOGGER.debug("Cluster {} cannot be {} for {} min(s)", clusterCrn, coolDownAction,
+                    ClusterUtils.TIME_FORMAT.format((double) remainingTime / TimeUtil.MIN_IN_MS));
+        }
+        return false;
+    }
+
+    private void publishScalingEventIfNeeded(Cluster cluster, int finalScaleUpCount, StackV4Response stackV4Response, List<String> hostsToDecommission,
+            ScalingAdjustmentType adjustmentType) {
+        if (upscalable(cluster, finalScaleUpCount))  {
+            if (STOPSTART.equals(adjustmentType)) {
+                Integer existingClusterNodeCount = stackV4Response.getNodeCount() - stoppedHostInstanceIds.size();
+                eventSender.sendStopStartScaleUpEvent(loadAlert, existingClusterNodeCount, servicesHealthyInstanceIds.size(), finalScaleUpCount);
+            } else {
+                eventSender.sendScaleUpEvent(loadAlert, stackV4Response.getNodeCount(), hostFqdnsToInstanceId.size(), servicesHealthyInstanceIds.size(),
+                        finalScaleUpCount);
+            }
+        } else if (downscalable(cluster, hostsToDecommission)) {
+            eventSender.sendScaleDownEvent(loadAlert, servicesHealthyInstanceIds.size(), hostsToDecommission, servicesHealthyInstanceIds.size(),
+                    adjustmentType);
+        }
+    }
+
+    private boolean upscalable(Cluster cluster, int finalScaleUpCount) {
+        return finalScaleUpCount > 0 && isCoolDownTimeElapsed(cluster.getStackCrn(), "scaled-up",
+                loadAlertConfiguration.getScaleUpCoolDownMillis(), cluster.getLastScalingActivity());
+    }
+
+    private boolean downscalable(Cluster cluster, List<String> hostsToDecommission) {
+        return !hostsToDecommission.isEmpty() && isCoolDownTimeElapsed(cluster.getStackCrn(), "scaled-down",
+                loadAlertConfiguration.getScaleDownCoolDownMillis(), cluster.getLastScalingActivity());
+    }
+
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/utils/StackResponseUtils.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/utils/StackResponseUtils.java
@@ -37,24 +37,24 @@ public class StackResponseUtils {
                         InstanceMetaDataV4Response::getInstanceId));
     }
 
-    public Integer getCloudInstanceIdsWithServicesHealthyForHostGroup(StackV4Response stackResponse, String hostGroup) {
+    public List<String> getCloudInstanceIdsWithServicesHealthyForHostGroup(StackV4Response stackResponse, String hostGroup) {
         return stackResponse.getInstanceGroups().stream()
                 .filter(instanceGroupV4Response -> instanceGroupV4Response.getName().equalsIgnoreCase(hostGroup))
                 .flatMap(instanceGroupV4Response -> instanceGroupV4Response.getMetadata().stream())
                 .filter(instanceMetaData -> instanceMetaData.getDiscoveryFQDN() != null)
                 .filter(instanceMetaData -> InstanceStatus.SERVICES_HEALTHY.equals(instanceMetaData.getInstanceStatus()))
-                .collect(Collectors.counting())
-                .intValue();
+                .map(InstanceMetaDataV4Response::getInstanceId)
+                .collect(Collectors.toList());
     }
 
-    public Integer getStoppedInstanceCountInHostGroup(StackV4Response stackV4Response, String policyHostGroup) {
+    public List<String> getStoppedCloudInstanceIdsInHostGroup(StackV4Response stackV4Response, String policyHostGroup) {
         return stackV4Response.getInstanceGroups().stream()
                 .filter(instanceGroupV4Response -> instanceGroupV4Response.getName().equalsIgnoreCase(policyHostGroup))
                 .flatMap(instanceGroupV4Response -> instanceGroupV4Response.getMetadata().stream())
                 .filter(instanceMetaData -> instanceMetaData.getDiscoveryFQDN() != null)
                 .filter(instanceMetaData -> InstanceStatus.STOPPED.equals(instanceMetaData.getInstanceStatus()))
-                .collect(Collectors.counting())
-                .intValue();
+                .map(InstanceMetaDataV4Response::getInstanceId)
+                .collect(Collectors.toList());
     }
 
     public Integer getNodeCountForHostGroup(StackV4Response stackResponse, String hostGroup) {

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/CronTimeEvaluatorTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/CronTimeEvaluatorTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -183,8 +184,8 @@ public class CronTimeEvaluatorTest {
             when(stackResponseUtils.getCloudInstanceIdsForHostGroup(any(), any())).thenCallRealMethod();
             when(yarnMetricsClient.getYarnMetricsForCluster(any(Cluster.class), any(StackV4Response.class), anyString(), any(), any(Optional.class)))
                     .thenReturn(yarnScalingServiceV1Response);
-            when(yarnResponseUtils.getYarnRecommendedDecommissionHostsForHostGroup(anyString(), any(YarnScalingServiceV1Response.class),
-                    any(Map.class), anyInt(), any(Optional.class), anyInt())).thenCallRealMethod();
+            when(yarnResponseUtils.getYarnRecommendedDecommissionHostsForHostGroup(any(YarnScalingServiceV1Response.class),
+                    anyMap())).thenCallRealMethod();
         }
 
         underTest.publishIfNeeded(List.of(alert));
@@ -195,8 +196,8 @@ public class CronTimeEvaluatorTest {
         verify(stackResponseUtils, verificationMode).getCloudInstanceIdsForHostGroup(any(), any());
         verify(yarnMetricsClient, verificationMode).getYarnMetricsForCluster(any(Cluster.class), any(StackV4Response.class), anyString(), anyString(),
                 any(Optional.class));
-        verify(yarnResponseUtils, verificationMode).getYarnRecommendedDecommissionHostsForHostGroup(anyString(), any(YarnScalingServiceV1Response.class),
-                any(Map.class), anyInt(), any(Optional.class), anyInt());
+        verify(yarnResponseUtils, verificationMode).getYarnRecommendedDecommissionHostsForHostGroup(any(YarnScalingServiceV1Response.class),
+                anyMap());
 
         return captor.getValue();
     }

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/load/YarnLoadEvaluatorTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/load/YarnLoadEvaluatorTest.java
@@ -1,35 +1,27 @@
 package com.sequenceiq.periscope.monitor.evaluator.load;
 
-import static com.sequenceiq.periscope.monitor.evaluator.ScalingConstants.DEFAULT_MAX_SCALE_UP_STEP_SIZE;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.never;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Stream;
 
-import org.junit.Before;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
@@ -40,17 +32,19 @@ import com.sequenceiq.periscope.domain.ClusterPertain;
 import com.sequenceiq.periscope.domain.LoadAlert;
 import com.sequenceiq.periscope.domain.LoadAlertConfiguration;
 import com.sequenceiq.periscope.domain.ScalingPolicy;
-import com.sequenceiq.periscope.model.yarn.YarnScalingServiceV1Response;
-import com.sequenceiq.periscope.model.yarn.YarnScalingServiceV1Response.DecommissionCandidate;
-import com.sequenceiq.periscope.model.yarn.YarnScalingServiceV1Response.NewNodeManagerCandidates;
-import com.sequenceiq.periscope.monitor.client.YarnMetricsClient;
+import com.sequenceiq.periscope.domain.UpdateFailedDetails;
+import com.sequenceiq.periscope.model.adjustment.MandatoryScalingAdjustmentParameters;
+import com.sequenceiq.periscope.model.adjustment.RegularScalingAdjustmentParameters;
+import com.sequenceiq.periscope.model.adjustment.StopStartScalingAdjustmentParameters;
 import com.sequenceiq.periscope.monitor.context.ClusterIdEvaluatorContext;
 import com.sequenceiq.periscope.monitor.evaluator.EventPublisher;
-import com.sequenceiq.periscope.monitor.event.ScalingEvent;
 import com.sequenceiq.periscope.monitor.event.UpdateFailedEvent;
 import com.sequenceiq.periscope.monitor.executor.ExecutorServiceWithRegistry;
 import com.sequenceiq.periscope.monitor.handler.CloudbreakCommunicator;
 import com.sequenceiq.periscope.service.ClusterService;
+import com.sequenceiq.periscope.service.RegularScalingAdjustmentService;
+import com.sequenceiq.periscope.service.StopStartScalingAdjustmentService;
+import com.sequenceiq.periscope.service.YarnBasedScalingAdjustmentService;
 import com.sequenceiq.periscope.utils.MockStackResponseGenerator;
 import com.sequenceiq.periscope.utils.StackResponseUtils;
 
@@ -61,11 +55,17 @@ public class YarnLoadEvaluatorTest {
 
     private static final String CLOUDBREAK_STACK_CRN = "someCrn";
 
-    private static final int TEST_HOSTGROUP_MIN_SIZE = 3;
+    private static final String HOSTGROUP = "compute";
 
-    private static final int TEST_HOSTGROUP_MAX_SIZE = 200;
+    private static final Integer HOSTGROUP_MIN_SIZE = 15;
 
-    private static final String MACHINE_USER_CNR = "machineUserCrn";
+    private static final Integer HOSTGROUP_MAX_SIZE = 75;
+
+    private static final String FQDN_BASE = "test_fqdn";
+
+    private static final String MACHINE_USER_CRN = "machineUserCrn";
+
+    private static final String USER_CRN = "someUserCrn";
 
     @InjectMocks
     private YarnLoadEvaluator underTest;
@@ -86,263 +86,211 @@ public class YarnLoadEvaluatorTest {
     private EventPublisher eventPublisher;
 
     @Mock
-    private YarnMetricsClient yarnMetricsClient;
+    private YarnBasedScalingAdjustmentService yarnBasedScalingAdjustmentService;
 
     @Mock
-    private YarnResponseUtils yarnResponseUtils;
+    private StopStartScalingAdjustmentService stopStartScalingAdjustmentService;
 
-    private String fqdnBase = "test_fqdn";
+    @Mock
+    private RegularScalingAdjustmentService regularScalingAdjustmentService;
 
-    @Before
-    public void setup() {
-        MockitoAnnotations.initMocks(this);
-    }
+    @Captor
+    private ArgumentCaptor<MandatoryScalingAdjustmentParameters> adjustmentParamsCaptor;
 
     @Test
-    public void testRunCallsFinished() {
+    void testRunCallsFinished() {
         underTest.setContext(new ClusterIdEvaluatorContext(AUTOSCALE_CLUSTER_ID));
-        when(clusterService.findById(anyLong())).thenThrow(new RuntimeException("exception from the test"));
-
+        doThrow(new RuntimeException("exception from the test")).when(clusterService).findById(anyLong());
 
         underTest.run();
+
         verify(executorServiceWithRegistry).finished(underTest, AUTOSCALE_CLUSTER_ID);
         verify(eventPublisher).publishEvent(any(UpdateFailedEvent.class));
     }
 
     @Test
-    public void testExecuteBeforeCoolDownPeriod() {
+    void testExecuteBeforeCoolDownPeriod() {
         Cluster cluster = getARunningCluster();
         cluster.setLastScalingActivity(Instant.now()
                 .minus(2, ChronoUnit.MINUTES).toEpochMilli());
-        when(clusterService.findById(anyLong())).thenReturn(cluster);
+        doReturn(cluster).when(clusterService).findById(anyLong());
         underTest.setContext(new ClusterIdEvaluatorContext(AUTOSCALE_CLUSTER_ID));
+
         underTest.execute();
-        verify(eventPublisher, never()).publishEvent(any());
+
+        verifyNoInteractions(cloudbreakCommunicator, stopStartScalingAdjustmentService, yarnBasedScalingAdjustmentService);
     }
 
-    public static Stream<Arguments> dataUpScaling() {
-        return Stream.of(
-                //TestCase,CurrentHostGroupCount,YarnRecommendedUpScaleCount,ExpectedDesiredNodeCount
-                Arguments.of("SCALE_UP_ALLOWED", 3, 5, 8),
-                Arguments.of("SCALE_UP_ALLOWED_AT_LIMIT", TEST_HOSTGROUP_MAX_SIZE - 10, 10, TEST_HOSTGROUP_MAX_SIZE),
-                Arguments.of("SCALE_UP_BEYOND_MAX_LIMIT", TEST_HOSTGROUP_MAX_SIZE - 10, 20, TEST_HOSTGROUP_MAX_SIZE),
-                Arguments.of("SCALE_UP_BEYOND_STEP_LIMIT", 10, 500, 10 + DEFAULT_MAX_SCALE_UP_STEP_SIZE),
-                Arguments.of("SCALE_UP_NOT_ALLOWED", TEST_HOSTGROUP_MAX_SIZE + 2, 10, 0),
-                Arguments.of("SCALE_UP_FORCED", 0, 0, 3),
-                Arguments.of("SCALE_UP_FORCED", 1, 0, 3),
-                Arguments.of("SCALE_UP_FORCED", 0, 1, 3),
-                Arguments.of("SCALE_UP_WHEN_HOST_SIZE_BELOW_MIN", 1, 10, 11),
-                Arguments.of("SCALE_UP_WHEN_HOST_SIZE_BELOW_MIN", 1, 1, 3)
-        );
-    }
-
-    @ParameterizedTest(name = "{0}: With currentHostGroupCount={1}, yarnRecommendedUpScaleCount ={2}, expectedUpScaleCount={3} ")
-    @MethodSource("dataUpScaling")
-    public void testLoadBasedUpScaling(String testType, int currentHostGroupCount,
-            int yarnRecommendedUpScaleCount, int expectedUpScaleCount) throws Exception {
-        testUpScaleBasedOnYarnResponse(currentHostGroupCount, yarnRecommendedUpScaleCount, expectedUpScaleCount);
-    }
-
-    public static Stream<Arguments> dataUpScalingWithUnhealthyInstances() {
-        return Stream.of(
-                // TestCase, HealthyHostGroupNodeCount, UnhealthyHostGroupNodeCount, YarnRecommendedUpScaleCount, ExpectedDesiredNodeCount
-                Arguments.of("SCALE_UP_ALLOWED", 3, 2, 2, 7),
-                Arguments.of("SCALE_UP_ALLOWED_2", 5, 2, 3, 10),
-                Arguments.of("SCALE_UP_ALLOWED_AT_LIMIT", TEST_HOSTGROUP_MAX_SIZE - 15, 10, 5, TEST_HOSTGROUP_MAX_SIZE),
-                Arguments.of("SCALE_UP_BEYOND_MAX_LIMIT", TEST_HOSTGROUP_MAX_SIZE - 20, 15, 10, TEST_HOSTGROUP_MAX_SIZE),
-                Arguments.of("SCALE_UP_WHEN_SIZE_BELOW_MIN", 2, 1, 3, 6)
-        );
-    }
-
-    @ParameterizedTest(name = "{0}: With healthyHostGroupNodeCount={1}, unhealthyHostGroupNodeCount={2}, yarnRecommendedUpScaleCount={3}, " +
-            "expectedUpScaledCount={4} ")
-    @MethodSource("dataUpScalingWithUnhealthyInstances")
-    public void testLoadBasedScalingWithUnhealthyInstances(String testType, int healthyHostGroupNodeCount, int unhealthyHostGroupNodeCount,
-            int yarnRecommendedUpScaleCount, int expectedUpScaledCount) throws Exception {
-        testUpScaleWithUnhealthyInstancesBasedOnYarnResponse(healthyHostGroupNodeCount, unhealthyHostGroupNodeCount, yarnRecommendedUpScaleCount,
-                expectedUpScaledCount);
-    }
-
-    // TODO CB-15142: Add more scenarios for this parameterized test
-    public static Stream<Arguments> dataUpScalingForStopStart() {
-        return Stream.of(
-                //TestCase,runningHostGroupNodeCount, stoppedHostGroupNodeCount, YarnRecommendedUpScaleCount, ExpectedDesiredNodeCount
-                Arguments.of("STOP_START_SCALE_UP_ALLOWED", 1, 3, 3, 4),
-                Arguments.of("STOP_START_SCALE_UP_ALLOWED_AT_LIMIT", TEST_HOSTGROUP_MAX_SIZE - 10, 10, 10, TEST_HOSTGROUP_MAX_SIZE),
-                Arguments.of("STOP_START_SCALE_UP_BEYOND_MAX_LIMIT", TEST_HOSTGROUP_MAX_SIZE - 10, 10, 20, TEST_HOSTGROUP_MAX_SIZE)
-        );
-    }
-
-    @ParameterizedTest(name = "{0}: With runningHostGroupNodeCount={1}, stoppedHostGroupNodeCount={2}, yarnRecommendedUpscaleCount={3}, " +
-            "expectedUpscaleCount={4}")
-    @MethodSource("dataUpScalingForStopStart")
-    public void testLoadBasedStopStartScaling(String testType, int runningHostGroupNodeCount, int stoppedHostGroupNodeCount,
-            int yarnRecommendedUpscaleCount, int expectedUpscaleCount) throws Exception {
-        testUpscaleBasedOnYarnResponseForStopStart(runningHostGroupNodeCount, stoppedHostGroupNodeCount, yarnRecommendedUpscaleCount, expectedUpscaleCount);
-    }
-
-    public static Stream<Arguments> dataDownScaling() {
-        return Stream.of(
-                //TestCase,CurrentHostGroupCount,YarnRecommendedDecommissionCount,ExpectedDecommissionCount
-                Arguments.of("DOWN_SCALE_ALLOWED", 7, 5, 7 - TEST_HOSTGROUP_MIN_SIZE),
-                Arguments.of("DOWN_SCALE_FORCED", TEST_HOSTGROUP_MAX_SIZE + 20, 20, 20),
-                Arguments.of("DOWN_SCALE_FORCED_AND_EXTRA", TEST_HOSTGROUP_MAX_SIZE + 20, 30, 20),
-                Arguments.of("DOWN_SCALE_RECOMMENDED", TEST_HOSTGROUP_MAX_SIZE, 100, 100),
-                Arguments.of("DOWN_SCALE_BEYOND_STEP_LIMIT", 200, 150, 100),
-                Arguments.of("DOWN_SCALE_ALLOWED_MIN_LIMIT", 10, 10, 10 - TEST_HOSTGROUP_MIN_SIZE),
-                Arguments.of("DOWN_SCALE_ALLOWED_AT_MIN_LIMIT", 20, 20 - TEST_HOSTGROUP_MIN_SIZE, 20 - TEST_HOSTGROUP_MIN_SIZE),
-                Arguments.of("DOWN_SCALE_BEYOND_MIN_LIMIT", 10, 52, 10 - TEST_HOSTGROUP_MIN_SIZE),
-                Arguments.of("DOWN_SCALE_NOT_ALLOWED", 0, 5, 0)
-        );
-    }
-
-    @ParameterizedTest(name = "{0}: With currentHostGroupCount={1}, yarnRecommendedDecommissionCount ={2}, expectedDecommissionCount={3} ")
-    @MethodSource("dataDownScaling")
-    public void testLoadBasedDownScaling(String testType, int currentHostGroupCount,
-            int yarnRecommendedDecommissionCount, int expectedDecommissionCount) throws Exception {
-        boolean forcedDownScale = testType.contains("FORCED") ? true : false;
-        testDownScaleBasedOnYarnResponse(currentHostGroupCount, yarnRecommendedDecommissionCount, expectedDecommissionCount, forcedDownScale);
-    }
-
-    private void testDownScaleBasedOnYarnResponse(int currentHostGroupCount, int yarnDecommissionCount,
-            int expectedDownScaleCount, boolean forcedDownScale) throws Exception {
-        boolean scalingEventExpected = expectedDownScaleCount != 0 ? true : false;
-        Optional<ScalingEvent> scalingEvent = captureScalingEvent(currentHostGroupCount, 0, yarnDecommissionCount, scalingEventExpected, 0);
-
-        if (scalingEventExpected) {
-            int actualDownScaleCount = scalingEvent.get().getDecommissionNodeIds().size();
-            assertEquals("ScaleDown Node Count should match.", expectedDownScaleCount, actualDownScaleCount);
-        }
-    }
-
-    private void testUpScaleBasedOnYarnResponse(int currentHostGroupCount, int yarnUpScaleCount, int expectedUpscaleCount) throws Exception {
-        boolean scalingEventExpected = expectedUpscaleCount != 0 ? true : false;
-
-        Optional<ScalingEvent> scalingEvent = captureScalingEvent(currentHostGroupCount, yarnUpScaleCount, 0, scalingEventExpected, 0);
-        if (scalingEventExpected) {
-            assertEquals("ScaleUp Node Count should match.", expectedUpscaleCount,
-                    scalingEvent.get().getDesiredAbsoluteHostGroupNodeCount().intValue());
-        }
-    }
-
-    private void testUpScaleWithUnhealthyInstancesBasedOnYarnResponse(int healthyHostGroupNodeCount, int unhealthyHostGroupNodeCount,
-            int yarnRecommendedUpScaleCount, int expectedUpScaledCount) throws Exception {
-        boolean scalingEventExpected = expectedUpScaledCount != 0;
-
-        Optional<ScalingEvent> scalingEvent = captureScalingEvent(healthyHostGroupNodeCount + unhealthyHostGroupNodeCount, yarnRecommendedUpScaleCount, 0,
-                scalingEventExpected, unhealthyHostGroupNodeCount);
-        if (scalingEventExpected) {
-            assertEquals("ScaleUp Node Count should match.", expectedUpScaledCount,
-                    scalingEvent.get().getDesiredAbsoluteHostGroupNodeCount().intValue());
-            assertEquals("Existing host group node count must recognise and include unhealthy instances",
-                    healthyHostGroupNodeCount + unhealthyHostGroupNodeCount, scalingEvent.get().getExistingHostGroupNodeCount().intValue());
-        }
-    }
-
-    private void testUpscaleBasedOnYarnResponseForStopStart(int runningHostGroupNodeCount, int stoppedHostGroupNodeCount, int yarnUpscaleCount,
-            int expectedUpscaleCount) throws Exception {
-        boolean scalingEventExpected = expectedUpscaleCount != 0;
-
-        Optional<ScalingEvent> scalingEvent = captureScalingEvent(runningHostGroupNodeCount, stoppedHostGroupNodeCount, yarnUpscaleCount, 0,
-                scalingEventExpected);
-        if (scalingEventExpected) {
-            assertEquals(expectedUpscaleCount, scalingEvent.get().getDesiredAbsoluteHostGroupNodeCount().intValue());
-            // including the 2 worker and 1 master node from MockStackResponseGenerator
-            assertEquals(runningHostGroupNodeCount + 3, scalingEvent.get().getExistingClusterNodeCount().intValue());
-        }
-    }
-
-    private Optional<ScalingEvent> captureScalingEvent(int currentHostGroupCount, int yarnUpScaleCount,
-            int yarnDownScaleCount, boolean scalingEventExpected, int unHealthyInstancesCount) throws Exception {
-        MockitoAnnotations.initMocks(this);
+    @Test
+    void testExecutePollingUserCrnFallsBackToUserCrnIfMachineUserNotInitialised() throws Exception {
         Cluster cluster = getARunningCluster();
-        String hostGroup = "compute";
-        StackV4Response stackV4Response = MockStackResponseGenerator
-                .getMockStackV4Response(CLOUDBREAK_STACK_CRN, hostGroup, fqdnBase, currentHostGroupCount, unHealthyInstancesCount);
+        cluster.setMachineUserCrn(null);
+        StackV4Response stackResponse = MockStackResponseGenerator.getMockStackV4ResponseWithStoppedAndRunningNodes(CLOUDBREAK_STACK_CRN, HOSTGROUP, FQDN_BASE,
+                26, HOSTGROUP_MAX_SIZE - 26);
 
-        YarnScalingServiceV1Response upScale = getMockYarnScalingResponse(hostGroup, yarnUpScaleCount, yarnDownScaleCount);
+        setupBasicMocks(cluster, stackResponse);
 
-        setupMocks(cluster, upScale, stackV4Response);
-
-        underTest.setContext(new ClusterIdEvaluatorContext(AUTOSCALE_CLUSTER_ID));
         underTest.execute();
 
-        Optional scalingEventCaptured = Optional.empty();
-        if (scalingEventExpected) {
-            ArgumentCaptor<ScalingEvent> captor = ArgumentCaptor.forClass(ScalingEvent.class);
-            verify(eventPublisher).publishEvent(captor.capture());
-            scalingEventCaptured = Optional.of(captor.getValue());
-        }
-        return scalingEventCaptured;
+        verifyNoInteractions(stopStartScalingAdjustmentService);
+        verify(yarnBasedScalingAdjustmentService, times(1)).pollYarnMetricsAndScaleCluster(cluster, USER_CRN, Boolean.TRUE, stackResponse);
     }
 
-    private Optional<ScalingEvent> captureScalingEvent(int runningNodeHostGroupCount, int stoppedNodeHostGroupCount, int yarnUpscaleCount,
-            int yarnDownscaleCount, boolean scalingEventExpected) throws Exception {
-        MockitoAnnotations.openMocks(this);
+    @Test
+    void testExecutePollingUserCrnIsEqualToUserCrnIfLastExceptionIsLessThan1Hour() throws Exception {
         Cluster cluster = getARunningCluster();
-        cluster.setStopStartScalingEnabled(true);
-        String hostGroup = "compute";
-        StackV4Response stackV4Response = MockStackResponseGenerator
-                .getMockStackV4ResponseWithStoppedAndRunningNodes(CLOUDBREAK_STACK_CRN, hostGroup, fqdnBase, runningNodeHostGroupCount,
-                        stoppedNodeHostGroupCount);
+        cluster.setMachineUserCrn(MACHINE_USER_CRN);
+        UpdateFailedDetails updateFailedDetails = new UpdateFailedDetails(Instant.now().minus(59, ChronoUnit.MINUTES).toEpochMilli(),
+                3L, Boolean.TRUE);
+        cluster.setUpdateFailedDetails(updateFailedDetails);
+        StackV4Response stackResponse = MockStackResponseGenerator.getMockStackV4ResponseWithStoppedAndRunningNodes(CLOUDBREAK_STACK_CRN, HOSTGROUP, FQDN_BASE,
+                34, HOSTGROUP_MAX_SIZE - 34);
 
-        YarnScalingServiceV1Response upScale = getMockYarnScalingResponse(hostGroup, yarnUpscaleCount, yarnDownscaleCount);
+        setupBasicMocks(cluster, stackResponse);
 
-        setupMocks(cluster, upScale, stackV4Response);
-
-        underTest.setContext(new ClusterIdEvaluatorContext(AUTOSCALE_CLUSTER_ID));
         underTest.execute();
 
-        Optional<ScalingEvent> scalingEventCaptured = Optional.empty();
-        if (scalingEventExpected) {
-            ArgumentCaptor<ScalingEvent> captor = ArgumentCaptor.forClass(ScalingEvent.class);
-            verify(eventPublisher).publishEvent(captor.capture());
-            scalingEventCaptured = Optional.of(captor.getValue());
-        }
-        return scalingEventCaptured;
+        verifyNoInteractions(stopStartScalingAdjustmentService);
+        verify(yarnBasedScalingAdjustmentService, times(1)).pollYarnMetricsAndScaleCluster(cluster, USER_CRN, Boolean.TRUE, stackResponse);
     }
 
-    private YarnScalingServiceV1Response getMockYarnScalingResponse(String instanceType, int upScaleCount, int downScaleCount) {
-        NewNodeManagerCandidates.Candidate candidate = new NewNodeManagerCandidates.Candidate();
-        candidate.setCount(upScaleCount);
-        candidate.setModelName(instanceType);
-        NewNodeManagerCandidates candidates = new NewNodeManagerCandidates();
-        candidates.setCandidates(List.of(candidate));
+    @Test
+    void testExecutePollingUserCrnIsEqualToMachineUserCrnIfLastExceptionIsMoreThan1Hour() throws Exception {
+        Cluster cluster = getARunningCluster();
+        cluster.setMachineUserCrn(MACHINE_USER_CRN);
+        UpdateFailedDetails updateFailedDetails = new UpdateFailedDetails(Instant.now().minus(61, ChronoUnit.MINUTES).toEpochMilli(),
+                2L, Boolean.TRUE);
+        cluster.setUpdateFailedDetails(updateFailedDetails);
+        StackV4Response stackResponse = MockStackResponseGenerator.getMockStackV4ResponseWithStoppedAndRunningNodes(CLOUDBREAK_STACK_CRN, HOSTGROUP, FQDN_BASE,
+                57, HOSTGROUP_MAX_SIZE - 57);
 
-        YarnScalingServiceV1Response yarnScalingReponse = new YarnScalingServiceV1Response();
-        if (upScaleCount > 0) {
-            yarnScalingReponse.setNewNMCandidates(candidates);
-        }
+        setupBasicMocks(cluster, stackResponse);
 
-        List decommissionCandidates = new ArrayList();
-        for (int i = 1; i <= downScaleCount; i++) {
-            DecommissionCandidate decommissionCandidate = new DecommissionCandidate();
-            decommissionCandidate.setAmCount(2);
-            decommissionCandidate.setNodeId(fqdnBase + i + ":8042");
-            decommissionCandidates.add(decommissionCandidate);
-        }
-        yarnScalingReponse.setDecommissionCandidates(Map.of("candidates", decommissionCandidates));
-        return yarnScalingReponse;
+        underTest.execute();
+
+        verifyNoInteractions(stopStartScalingAdjustmentService);
+        verify(yarnBasedScalingAdjustmentService, times(1)).pollYarnMetricsAndScaleCluster(cluster, MACHINE_USER_CRN, Boolean.TRUE,
+                stackResponse);
+    }
+
+    @Test
+    void testExecuteWithMandatoryStopStartUpscaleAdjustment() {
+        Cluster cluster = getARunningCluster();
+        StackV4Response stackResponse = MockStackResponseGenerator.getMockStackV4ResponseWithStoppedAndRunningNodes(CLOUDBREAK_STACK_CRN, HOSTGROUP, FQDN_BASE,
+                37, 25);
+
+        setupBasicMocks(cluster, stackResponse);
+
+        underTest.execute();
+
+        verify(stopStartScalingAdjustmentService, times(1)).performMandatoryAdjustment(eq(cluster), eq(MACHINE_USER_CRN),
+                eq(stackResponse), adjustmentParamsCaptor.capture());
+        verifyNoInteractions(yarnBasedScalingAdjustmentService);
+
+        MandatoryScalingAdjustmentParameters adjustmentParams = adjustmentParamsCaptor.getValue();
+        assertThat(adjustmentParams.getUpscaleAdjustment()).isNotNull().isEqualTo(HOSTGROUP_MAX_SIZE - 37 - 25);
+        assertThat(adjustmentParams.getDownscaleAdjustment()).isNull();
+        assertThat(adjustmentParams).isInstanceOf(StopStartScalingAdjustmentParameters.class);
+    }
+
+    @Test
+    void testExecuteWithMandatoryStopStartDownscaleAdjustment() {
+        Cluster cluster = getARunningCluster();
+        StackV4Response stackResponse = MockStackResponseGenerator.getMockStackV4ResponseWithStoppedAndRunningNodes(CLOUDBREAK_STACK_CRN, HOSTGROUP, FQDN_BASE,
+                45, 68);
+
+        setupBasicMocks(cluster, stackResponse);
+
+        underTest.execute();
+
+        verify(stopStartScalingAdjustmentService, times(1)).performMandatoryAdjustment(eq(cluster), eq(MACHINE_USER_CRN),
+                eq(stackResponse), adjustmentParamsCaptor.capture());
+        verifyNoInteractions(yarnBasedScalingAdjustmentService);
+
+        MandatoryScalingAdjustmentParameters adjustmentParams = adjustmentParamsCaptor.getValue();
+        assertThat(adjustmentParams.getUpscaleAdjustment()).isNull();
+        assertThat(adjustmentParams.getDownscaleAdjustment()).isNotNull().isEqualTo(45 + 68 - HOSTGROUP_MAX_SIZE);
+        assertThat(adjustmentParams).isInstanceOf(StopStartScalingAdjustmentParameters.class);
+    }
+
+    @Test
+    void testExecuteWithMandatoryUpscaleAdjustment() {
+        Cluster cluster = getARunningCluster();
+        cluster.setStopStartScalingEnabled(Boolean.FALSE);
+        StackV4Response stackResponse = MockStackResponseGenerator.getMockStackV4Response(CLOUDBREAK_STACK_CRN, HOSTGROUP, FQDN_BASE,
+                10, 0);
+
+        setupBasicMocks(cluster, stackResponse);
+
+        underTest.execute();
+
+        verify(regularScalingAdjustmentService, times(1)).performMandatoryAdjustment(eq(cluster), eq(MACHINE_USER_CRN),
+                eq(stackResponse), adjustmentParamsCaptor.capture());
+        verifyNoInteractions(yarnBasedScalingAdjustmentService);
+
+        MandatoryScalingAdjustmentParameters adjustmentParams = adjustmentParamsCaptor.getValue();
+        assertThat(adjustmentParams.getUpscaleAdjustment()).isEqualTo(HOSTGROUP_MIN_SIZE - 10);
+        assertThat(adjustmentParams.getDownscaleAdjustment()).isNull();
+        assertThat(adjustmentParams).isInstanceOf(RegularScalingAdjustmentParameters.class);
+    }
+
+    @Test
+    void testExecuteWithMandatoryDownscaleAdjustment() {
+        Cluster cluster = getARunningCluster();
+        cluster.setStopStartScalingEnabled(Boolean.FALSE);
+        StackV4Response stackResponse = MockStackResponseGenerator.getMockStackV4Response(CLOUDBREAK_STACK_CRN, HOSTGROUP, FQDN_BASE,
+                100, 0);
+
+        setupBasicMocks(cluster, stackResponse);
+
+        underTest.execute();
+
+        verify(regularScalingAdjustmentService, times(1)).performMandatoryAdjustment(eq(cluster), eq(MACHINE_USER_CRN),
+                eq(stackResponse), adjustmentParamsCaptor.capture());
+        verifyNoInteractions(yarnBasedScalingAdjustmentService);
+
+        MandatoryScalingAdjustmentParameters adjustmentParams = adjustmentParamsCaptor.getValue();
+        assertThat(adjustmentParams.getDownscaleAdjustment()).isNotNull().isEqualTo(100 - HOSTGROUP_MAX_SIZE);
+        assertThat(adjustmentParams.getUpscaleAdjustment()).isNull();
+        assertThat(adjustmentParams).isInstanceOf(RegularScalingAdjustmentParameters.class);
+    }
+
+    @Test
+    void testExecuteWhenNoMandatoryAdjustmentRequired() throws Exception {
+        Cluster cluster = getARunningCluster();
+        StackV4Response stackV4Response = MockStackResponseGenerator.getMockStackV4ResponseWithStoppedAndRunningNodes(CLOUDBREAK_STACK_CRN, HOSTGROUP,
+                FQDN_BASE, 42, HOSTGROUP_MAX_SIZE - 42);
+
+        setupBasicMocks(cluster, stackV4Response);
+
+        underTest.execute();
+
+        verifyNoInteractions(stopStartScalingAdjustmentService);
+        verify(yarnBasedScalingAdjustmentService, times(1)).pollYarnMetricsAndScaleCluster(cluster, MACHINE_USER_CRN, Boolean.TRUE,
+                stackV4Response);
     }
 
     private Cluster getARunningCluster() {
         Cluster cluster = new Cluster();
+        cluster.setAutoscalingEnabled(Boolean.TRUE);
         cluster.setId(AUTOSCALE_CLUSTER_ID);
         cluster.setStackCrn(CLOUDBREAK_STACK_CRN);
         cluster.setState(ClusterState.RUNNING);
+        cluster.setStopStartScalingEnabled(Boolean.TRUE);
 
         ClusterPertain clusterPertain = new ClusterPertain();
+        clusterPertain.setUserCrn(USER_CRN);
         clusterPertain.setTenant("testtenant");
         cluster.setClusterPertain(clusterPertain);
 
         ScalingPolicy scalingPolicy = new ScalingPolicy();
         scalingPolicy.setAdjustmentType(AdjustmentType.LOAD_BASED);
-        scalingPolicy.setHostGroup("compute");
+        scalingPolicy.setHostGroup(HOSTGROUP);
 
         LoadAlertConfiguration alertConfiguration = new LoadAlertConfiguration();
         alertConfiguration.setCoolDownMinutes(10);
-        alertConfiguration.setMaxResourceValue(TEST_HOSTGROUP_MAX_SIZE);
-        alertConfiguration.setMinResourceValue(TEST_HOSTGROUP_MIN_SIZE);
+        alertConfiguration.setMaxResourceValue(HOSTGROUP_MAX_SIZE);
+        alertConfiguration.setMinResourceValue(HOSTGROUP_MIN_SIZE);
 
         LoadAlert loadAlert = new LoadAlert();
         loadAlert.setScalingPolicy(scalingPolicy);
@@ -351,21 +299,16 @@ public class YarnLoadEvaluatorTest {
         cluster.setLoadAlerts(Set.of(loadAlert));
         cluster.setLastScalingActivity(Instant.now()
                 .minus(45, ChronoUnit.MINUTES).toEpochMilli());
-        cluster.setMachineUserCrn(MACHINE_USER_CNR);
+        cluster.setMachineUserCrn(MACHINE_USER_CRN);
         return cluster;
     }
 
-    private void setupMocks(Cluster cluster, YarnScalingServiceV1Response upScale, StackV4Response stackV4Response) throws Exception {
-        when(clusterService.findById(anyLong())).thenReturn(cluster);
-        when(cloudbreakCommunicator.getByCrn(anyString())).thenReturn(stackV4Response);
-        when(stackResponseUtils.getCloudInstanceIdsForHostGroup(any(), any())).thenCallRealMethod();
-        when(stackResponseUtils.getCloudInstanceIdsWithServicesHealthyForHostGroup(any(), any())).thenCallRealMethod();
-        lenient().when(stackResponseUtils.getStoppedInstanceCountInHostGroup(any(), any())).thenCallRealMethod();
-        when(yarnMetricsClient.getYarnMetricsForCluster(any(Cluster.class), any(StackV4Response.class), anyString(), anyString(), any(Optional.class)))
-                .thenReturn(upScale);
-        when(yarnResponseUtils.getYarnRecommendedScaleUpCount(any(YarnScalingServiceV1Response.class), anyString(), anyInt(), any(Optional.class), anyInt()))
-                .thenCallRealMethod();
-        when(yarnResponseUtils.getYarnRecommendedDecommissionHostsForHostGroup(anyString(), any(YarnScalingServiceV1Response.class),
-                any(Map.class), anyInt(), any(Optional.class), anyInt())).thenCallRealMethod();
+    private void setupBasicMocks(Cluster cluster, StackV4Response stackResponse) {
+        doReturn(cluster).when(clusterService).findById(anyLong());
+        doReturn(stackResponse).when(cloudbreakCommunicator).getByCrn(CLOUDBREAK_STACK_CRN);
+        doCallRealMethod().when(stackResponseUtils).getCloudInstanceIdsWithServicesHealthyForHostGroup(any(StackV4Response.class), anyString());
+        doCallRealMethod().when(stackResponseUtils).getCloudInstanceIdsForHostGroup(any(StackV4Response.class), anyString());
+        underTest.setContext(new ClusterIdEvaluatorContext(AUTOSCALE_CLUSTER_ID));
     }
+
 }

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/handler/ScalingHandlerTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/handler/ScalingHandlerTest.java
@@ -38,6 +38,7 @@ import com.sequenceiq.periscope.domain.ClusterPertain;
 import com.sequenceiq.periscope.domain.LoadAlert;
 import com.sequenceiq.periscope.domain.ScalingPolicy;
 import com.sequenceiq.periscope.domain.TimeAlert;
+import com.sequenceiq.periscope.model.ScalingAdjustmentType;
 import com.sequenceiq.periscope.monitor.event.ScalingEvent;
 import com.sequenceiq.periscope.service.ClusterService;
 import com.sequenceiq.periscope.service.HistoryService;
@@ -89,6 +90,7 @@ public class ScalingHandlerTest {
         int hostGroupNodeCount = 10;
         List nodeIds = List.of("nodeId1", "nodeId2", "nodeId3");
         int expectedNodeCount = hostGroupNodeCount - nodeIds.size();
+        ScalingAdjustmentType scalingType = ScalingAdjustmentType.REGULAR;
 
         when(scalingEventMock.getAlert()).thenReturn(loadAlertMock);
         when(loadAlertMock.getCluster()).thenReturn(cluster);
@@ -99,8 +101,10 @@ public class ScalingHandlerTest {
         when(scalingEventMock.getExistingHostGroupNodeCount()).thenReturn(hostGroupNodeCount);
         when(scalingEventMock.getDesiredAbsoluteHostGroupNodeCount()).thenReturn(expectedNodeCount);
         when(scalingEventMock.getDecommissionNodeIds()).thenReturn(nodeIds);
+        when(scalingEventMock.getExistingServiceHealthyHostGroupNodeCount()).thenReturn(hostGroupNodeCount);
+        when(scalingEventMock.getScalingAdjustmentType()).thenReturn(scalingType);
         when(applicationContext.getBean("ScalingRequest", cluster, scalingPolicyMock,
-                clusterNodeSize, hostGroupNodeCount, expectedNodeCount, nodeIds)).thenReturn(runnableMock);
+                clusterNodeSize, hostGroupNodeCount, expectedNodeCount, nodeIds, hostGroupNodeCount, scalingType)).thenReturn(runnableMock);
 
         underTest.onApplicationEvent(scalingEventMock);
 
@@ -164,6 +168,8 @@ public class ScalingHandlerTest {
         when(scalingEventMock.getExistingClusterNodeCount()).thenReturn(currentClusterNodeCount);
         when(scalingEventMock.getExistingHostGroupNodeCount()).thenReturn(currentHostGroupCount);
         when(scalingEventMock.getDesiredAbsoluteHostGroupNodeCount()).thenReturn(currentHostGroupCount + scalingAdjument);
+        when(scalingEventMock.getExistingServiceHealthyHostGroupNodeCount()).thenReturn(currentHostGroupCount);
+        when(scalingEventMock.getScalingAdjustmentType()).thenReturn(ScalingAdjustmentType.REGULAR);
 
         when(clusterService.findById(anyLong())).thenReturn(cluster);
         when(baseAlertMock.getCluster()).thenReturn(cluster);
@@ -171,7 +177,8 @@ public class ScalingHandlerTest {
 
         when(scalingEventMock.getDecommissionNodeIds()).thenCallRealMethod();
         when(applicationContext.getBean("ScalingRequest", cluster, scalingPolicyMock,
-                currentClusterNodeCount, currentHostGroupCount, expectedScaleUpCount, List.of())).thenReturn(runnableMock);
+                currentClusterNodeCount, currentHostGroupCount, expectedScaleUpCount, List.of(), currentHostGroupCount, ScalingAdjustmentType.REGULAR))
+                .thenReturn(runnableMock);
 
         underTest.onApplicationEvent(scalingEventMock);
 

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/handler/ScalingRequestTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/handler/ScalingRequestTest.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.periscope.monitor.handler;
 
-import static org.junit.Assert.assertEquals;
+import static com.sequenceiq.periscope.model.ScalingAdjustmentType.REGULAR;
+import static com.sequenceiq.periscope.model.ScalingAdjustmentType.STOPSTART;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -11,10 +13,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -23,6 +26,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.AutoscaleV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.UpdateStackV4Request;
@@ -31,11 +35,13 @@ import com.sequenceiq.cloudbreak.client.CloudbreakServiceCrnEndpoints;
 import com.sequenceiq.cloudbreak.common.ScalingHardLimitsService;
 import com.sequenceiq.cloudbreak.message.CloudbreakMessagesService;
 import com.sequenceiq.periscope.api.model.AlertType;
+import com.sequenceiq.periscope.aspects.RequestLogging;
 import com.sequenceiq.periscope.domain.BaseAlert;
 import com.sequenceiq.periscope.domain.Cluster;
 import com.sequenceiq.periscope.domain.ClusterPertain;
 import com.sequenceiq.periscope.domain.MetricType;
 import com.sequenceiq.periscope.domain.ScalingPolicy;
+import com.sequenceiq.periscope.model.ScalingAdjustmentType;
 import com.sequenceiq.periscope.notification.HttpNotificationSender;
 import com.sequenceiq.periscope.service.AuditService;
 import com.sequenceiq.periscope.service.HistoryService;
@@ -52,7 +58,13 @@ public class ScalingRequestTest {
     private CloudbreakInternalCrnClient cloudbreakCrnClient;
 
     @Mock
+    private CloudbreakCommunicator cloudbreakCommunicator;
+
+    @Mock
     private LimitsConfigurationService limitsConfigurationService;
+
+    @Mock
+    private RequestLogging requestLogging;
 
     @Mock
     private Cluster cluster;
@@ -84,9 +96,11 @@ public class ScalingRequestTest {
     @Mock
     private UsageReportingService usageReportingService;
 
-    @Before
+    @BeforeEach
     public void setup() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
+        ReflectionTestUtils.setField(cloudbreakCommunicator, "cloudbreakInternalCrnClient", cloudbreakCrnClient);
+        ReflectionTestUtils.setField(cloudbreakCommunicator, "requestLogging", requestLogging);
     }
 
     public static Stream<Arguments> scaleUpNodeCountTesting() {
@@ -112,35 +126,52 @@ public class ScalingRequestTest {
 
         if (expectedNodeCount > 0) {
             initScaleUpMocks();
-            when(cluster.isStopStartScalingEnabled()).thenReturn(false);
             when(limitsConfigurationService.getMaxNodeCountLimit(anyString())).thenReturn(TEST_CLUSTER_MAX_NODE_COUNT);
-            ScalingRequest scalingRequest = initializeTestRequest(existingClusterNodeCount, existingHostGroupNodeCount, desiredHostGroupNodeCount, List.of());
+            ScalingRequest scalingRequest = initializeTestRequest(existingClusterNodeCount, existingHostGroupNodeCount, existingHostGroupNodeCount,
+                    desiredHostGroupNodeCount, Collections.emptyList(), REGULAR);
             scalingRequest.run();
 
             verify(autoscaleV4Endpoint, times(1)).putStack(anyString(), anyString(), captor.capture());
             UpdateStackV4Request request = captor.getValue();
-            assertEquals("Upscale nodecount should match", expectedNodeCount, request.getInstanceGroupAdjustment().getScalingAdjustment().intValue());
+            assertEquals(expectedNodeCount, request.getInstanceGroupAdjustment().getScalingAdjustment().intValue(), "Upscale nodecount should match");
         } else {
             verify(autoscaleV4Endpoint, times(0)).putStack(anyString(), anyString(), captor.capture());
         }
     }
 
+    public static Stream<Arguments> scaleUpNodeCountTestingForStopStart() {
+        return Stream.of(
+                //TestCase,ExistingClusterNodeCount,runningHostGroupNodeCount,stoppedHostGroupNodeCount,desiredHostGroupNodeCount,expectedScalingAdjustment
+                Arguments.of("SCALE_UP", 21, 3, 15, 10, 7),
+                Arguments.of("SCALE_UP", 52, 6, 43, 40, 34),
+                Arguments.of("SCALE_UP", 25, 19, 3, 20, 1),
+                Arguments.of("SCALE_UP", 160, 12, 145, 100, 88),
+                Arguments.of("SCALE_UP", 103, 97, 60, 140, 43),
+
+                Arguments.of("SCALE_UP_AT_MAX", 400, 73, 27, 140, 0),
+                Arguments.of("SCALE_UP_AT_MAX", 300, 16, 34, 200, 100),
+                Arguments.of("SCALE_UP_AT_MAX", 398, 29, 11, 52, 2),
+                Arguments.of("SCALE_UP_AT_MAX", 399, 43, 7, 52, 1)
+        );
+    }
+
     @ParameterizedTest(name = "{0}: With existingClusterNodeCount={1}, existingHostGroupNodeCount={2}, desiredHostGroupNodeCount ={3}, expectedNodeCount={4} ")
-    @MethodSource("scaleUpNodeCountTesting")
-    public void testScaleUpNodeCountWithStopStartScaling(String testCaseName, int existingClusterNodeCount, int existingHostGroupNodeCount,
-            int desiredHostGroupNodeCount, int expectedNodeCount) {
+    @MethodSource("scaleUpNodeCountTestingForStopStart")
+    public void testScaleUpNodeCountWithStopStartScaling(String testCaseName, int existingClusterNodeCount, int runningHostGroupNodeCount,
+            int stoppedHostGroupNodeCount, int desiredHostGroupNodeCount, int expectedNodeCount) {
         ArgumentCaptor<UpdateStackV4Request> captor = ArgumentCaptor.forClass(UpdateStackV4Request.class);
 
         if (expectedNodeCount > 0) {
             initScaleUpMocks();
-            when(cluster.isStopStartScalingEnabled()).thenReturn(true);
             when(limitsConfigurationService.getMaxNodeCountLimit(anyString())).thenReturn(TEST_CLUSTER_MAX_NODE_COUNT);
-            ScalingRequest scalingRequest = initializeTestRequest(existingClusterNodeCount, existingHostGroupNodeCount, desiredHostGroupNodeCount, List.of());
+            ScalingRequest scalingRequest = initializeTestRequest(existingClusterNodeCount,
+                    runningHostGroupNodeCount + stoppedHostGroupNodeCount, runningHostGroupNodeCount, desiredHostGroupNodeCount,
+                    Collections.emptyList(), STOPSTART);
             scalingRequest.run();
 
             verify(autoscaleV4Endpoint, times(1)).putStackStartInstancesByCrn(anyString(), captor.capture());
             UpdateStackV4Request request = captor.getValue();
-            assertEquals("Upscale nodecount should match", expectedNodeCount, request.getInstanceGroupAdjustment().getScalingAdjustment().intValue());
+            assertEquals(expectedNodeCount, request.getInstanceGroupAdjustment().getScalingAdjustment().intValue(), "Upscale nodecount should match");
         } else {
             verify(autoscaleV4Endpoint, times(0)).putStackStartInstancesByCrn(anyString(), captor.capture());
         }
@@ -165,12 +196,15 @@ public class ScalingRequestTest {
         when(cloudbreakCrnClient.withInternalCrn()).thenReturn(cloudbreakServiceCrnEndpoints);
         when(cloudbreakMessagesService.getMessage(anyString(), any(List.class))).thenReturn("test");
 
+        lenient().doCallRealMethod().when(requestLogging).logResponseTime(any(), anyString());
+        lenient().doCallRealMethod().when(cloudbreakCommunicator).putStackForCluster(any(Cluster.class), any(UpdateStackV4Request.class));
+        lenient().doCallRealMethod().when(cloudbreakCommunicator).putStackStartInstancesForCluster(any(Cluster.class), any(UpdateStackV4Request.class));
     }
 
-    private ScalingRequest initializeTestRequest(int existingClusterNodeCount, int hostGroupNodeCount,
-            int desiredHostGroupNodeCount, List<String> decommissionNodeId) {
+    private ScalingRequest initializeTestRequest(int existingClusterNodeCount, int hostGroupNodeCount, int servicesHealthyHostGroupNodeCount,
+            int desiredHostGroupNodeCount, List<String> decommissionNodeId, ScalingAdjustmentType adjustmentType) {
         ScalingRequest scalingRequest = new ScalingRequest(cluster, scalingPolicy, existingClusterNodeCount,
-                hostGroupNodeCount, desiredHostGroupNodeCount, decommissionNodeId);
+                hostGroupNodeCount, desiredHostGroupNodeCount, decommissionNodeId, servicesHealthyHostGroupNodeCount, adjustmentType);
         scalingRequest.setMetricService(metricService);
         scalingRequest.setScalingHardLimitsService(scalingHardLimitsService);
         scalingRequest.setCloudbreakInternalCrnClient(cloudbreakCrnClient);
@@ -180,6 +214,7 @@ public class ScalingRequestTest {
         scalingRequest.setHttpNotificationSender(notificationSender);
         scalingRequest.setAuditService(auditService);
         scalingRequest.setUsageReportingService(usageReportingService);
+        scalingRequest.setCloudbreakCommunicator(cloudbreakCommunicator);
         return scalingRequest;
     }
 }

--- a/autoscale/src/test/java/com/sequenceiq/periscope/service/RegularScalingAdjustmentServiceTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/service/RegularScalingAdjustmentServiceTest.java
@@ -1,0 +1,228 @@
+package com.sequenceiq.periscope.service;
+
+import static com.sequenceiq.periscope.model.ScalingAdjustmentType.REGULAR;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.periscope.api.model.AdjustmentType;
+import com.sequenceiq.periscope.api.model.ClusterState;
+import com.sequenceiq.periscope.domain.BaseAlert;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.LoadAlert;
+import com.sequenceiq.periscope.domain.LoadAlertConfiguration;
+import com.sequenceiq.periscope.domain.ScalingPolicy;
+import com.sequenceiq.periscope.model.ScalingAdjustmentType;
+import com.sequenceiq.periscope.model.adjustment.MandatoryScalingAdjustmentParameters;
+import com.sequenceiq.periscope.model.yarn.YarnScalingServiceV1Response;
+import com.sequenceiq.periscope.monitor.client.YarnMetricsClient;
+import com.sequenceiq.periscope.monitor.evaluator.EventPublisher;
+import com.sequenceiq.periscope.monitor.evaluator.load.YarnResponseUtils;
+import com.sequenceiq.periscope.monitor.event.ScalingEvent;
+import com.sequenceiq.periscope.monitor.sender.ScalingEventSender;
+import com.sequenceiq.periscope.utils.MockStackResponseGenerator;
+import com.sequenceiq.periscope.utils.StackResponseUtils;
+
+@ExtendWith(MockitoExtension.class)
+class RegularScalingAdjustmentServiceTest {
+
+    private static final Long CLUSTER_ID = 1L;
+
+    private static final String STACK_CRN = "crn:cdp:datahub:us-west-1:9d74eee4-1cad-46d7-b645-7ccf9edbb73d:cluster:1ce07c57-74be-4egd-820d-e81a98d9e151";
+
+    private static final Integer COOLDOWN_MINUTES = 2;
+
+    private static final String HOSTGROUP = "compute";
+
+    private static final String FQDN_BASE = "fqdn-";
+
+    private static final String POLLING_USER_CRN = "someUserCrn";
+
+    @Mock
+    private YarnMetricsClient yarnMetricsClient;
+
+    @Mock
+    private StackResponseUtils stackResponseUtils;
+
+    @Mock
+    private YarnResponseUtils yarnResponseUtils;
+
+    @Mock
+    private ScalingEventSender scalingEventSender;
+
+    @Mock
+    private EventPublisher eventPublisher;
+
+    @Captor
+    private ArgumentCaptor<ScalingEvent> eventCaptor;
+
+    @InjectMocks
+    private RegularScalingAdjustmentService underTest;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(scalingEventSender, "eventPublisher", eventPublisher);
+    }
+
+    public static Stream<Arguments> dataForMandatoryRegularAdjustment() {
+        return Stream.of(
+                //TestCase,minResourceValue,maxResourceValue,currentHostGroupNodeCount,expectedUpscaleAdjustment,expectedDownscaleAdjustment
+                Arguments.of("MANDATORY_UPSCALE_1", 4, 26, 2, 2, 0),
+                Arguments.of("MANDATORY_UPSCALE_2", 15, 45, 11, 4, 0),
+                Arguments.of("MANDATORY_DOWNSCALE_1", 73, 138, 150, 0, 12),
+                Arguments.of("MANDATORY_DOWNSCALE_2", 45, 49, 53, 0, 4),
+                Arguments.of("MANDATORY_ADJ_NOT_REQD_1", 17, 33, 26, 0, 0),
+                Arguments.of("MANDATORY_ADJ_NOT_REQD_2", 20, 56, 37, 0, 0)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("dataForMandatoryRegularAdjustment")
+    void testRegularUpscaleAndDownscaleAdjustments(String testCase, int minResourceValue, int maxResourceValue, int currentHostGroupNodeCount,
+            int expectedUpscaleAdjustment, int expectedDownscaleAdjustment) throws Exception {
+        Cluster cluster = getCluster(minResourceValue, maxResourceValue);
+        StackV4Response stackResponse = MockStackResponseGenerator.getMockStackV4Response(STACK_CRN, HOSTGROUP, FQDN_BASE, currentHostGroupNodeCount, 0);
+        YarnScalingServiceV1Response yarnResponse = getMockYarnScalingResponse(HOSTGROUP, expectedUpscaleAdjustment, expectedDownscaleAdjustment);
+        MandatoryScalingAdjustmentParameters mandatoryAdjustmentParams = mockAdjustmentParams(minResourceValue, maxResourceValue,
+                currentHostGroupNodeCount, currentHostGroupNodeCount);
+
+        setupBasicMocks(yarnResponse);
+
+        underTest.performMandatoryAdjustment(cluster, POLLING_USER_CRN, stackResponse, mandatoryAdjustmentParams);
+
+        if (expectedUpscaleAdjustment > 0) {
+            verify(eventPublisher).publishEvent(eventCaptor.capture());
+            verifyNoInteractions(yarnMetricsClient);
+            ScalingEvent result = eventCaptor.getValue();
+            assertThat(result.getAlert()).isInstanceOf(LoadAlert.class);
+            assertThat(result.getScalingAdjustmentType()).isEqualTo(REGULAR);
+            assertThat(result.getDesiredAbsoluteHostGroupNodeCount()).isEqualTo(currentHostGroupNodeCount + expectedUpscaleAdjustment);
+            assertThat(result.getExistingServiceHealthyHostGroupNodeCount()).isEqualTo(currentHostGroupNodeCount);
+            assertThat(result.getExistingClusterNodeCount()).isEqualTo(currentHostGroupNodeCount + 3);
+            assertThat(result.getExistingHostGroupNodeCount()).isEqualTo(currentHostGroupNodeCount);
+        } else if (expectedDownscaleAdjustment > 0) {
+            verify(eventPublisher).publishEvent(eventCaptor.capture());
+            verify(yarnMetricsClient, times(1)).getYarnMetricsForCluster(cluster, stackResponse, HOSTGROUP, POLLING_USER_CRN,
+                    Optional.of(mandatoryAdjustmentParams.getDownscaleAdjustment()));
+            ScalingEvent result = eventCaptor.getValue();
+            assertThat(result.getAlert()).isInstanceOf(LoadAlert.class);
+            assertThat(result.getScalingAdjustmentType()).isEqualTo(REGULAR);
+            assertThat(result.getDecommissionNodeIds()).hasSize(expectedDownscaleAdjustment);
+            assertThat(result.getExistingServiceHealthyHostGroupNodeCount()).isEqualTo(currentHostGroupNodeCount);
+            assertThat(result.getDesiredAbsoluteHostGroupNodeCount()).isEqualTo(currentHostGroupNodeCount - expectedDownscaleAdjustment);
+            assertThat(result.getExistingHostGroupNodeCount()).isEqualTo(currentHostGroupNodeCount);
+        } else {
+            verifyNoInteractions(eventPublisher, yarnMetricsClient);
+        }
+    }
+
+    private MandatoryScalingAdjustmentParameters mockAdjustmentParams(int minResourceValue, int maxResourceValue,
+            int serviceHealthyHostGroupNodeCount, int existingHostGroupNodeCount) {
+        MandatoryScalingAdjustmentParameters adjustmentParams = mock(MandatoryScalingAdjustmentParameters.class);
+
+        lenient()
+                .doReturn(Optional.of(serviceHealthyHostGroupNodeCount - minResourceValue).filter(val -> val < 0).map(Math::abs).orElse(null))
+                .when(adjustmentParams).getUpscaleAdjustment();
+
+        lenient()
+                .doReturn(Optional.of(maxResourceValue - existingHostGroupNodeCount).filter(val -> val < 0).map(Math::abs).orElse(null))
+                .when(adjustmentParams).getDownscaleAdjustment();
+
+        return adjustmentParams;
+    }
+
+    private YarnScalingServiceV1Response getMockYarnScalingResponse(String hostGroup, int upScaleCount, int downScaleCount) {
+        YarnScalingServiceV1Response.NewNodeManagerCandidates.Candidate candidate = new YarnScalingServiceV1Response.NewNodeManagerCandidates.Candidate();
+        candidate.setCount(upScaleCount);
+        candidate.setModelName(hostGroup);
+        YarnScalingServiceV1Response.NewNodeManagerCandidates candidates = new YarnScalingServiceV1Response.NewNodeManagerCandidates();
+        candidates.setCandidates(List.of(candidate));
+
+        YarnScalingServiceV1Response yarnScalingReponse = new YarnScalingServiceV1Response();
+        if (upScaleCount > 0) {
+            yarnScalingReponse.setNewNMCandidates(candidates);
+        }
+
+        List<YarnScalingServiceV1Response.DecommissionCandidate> decommissionCandidates = new ArrayList<>();
+        IntStream.range(1, downScaleCount + 1).forEach(i -> {
+            YarnScalingServiceV1Response.DecommissionCandidate decommissionCandidate = new YarnScalingServiceV1Response.DecommissionCandidate();
+            decommissionCandidate.setAmCount(2);
+            decommissionCandidate.setNodeId(FQDN_BASE + i + ":8042");
+            decommissionCandidates.add(decommissionCandidate);
+        });
+        yarnScalingReponse.setDecommissionCandidates(Map.of("candidates", decommissionCandidates));
+
+        return yarnScalingReponse;
+    }
+
+    private Cluster getCluster(int minResourceValue, int maxResourceValue) {
+        Cluster cluster = new Cluster();
+        cluster.setId(CLUSTER_ID);
+        cluster.setStackCrn(STACK_CRN);
+        cluster.setAutoscalingEnabled(Boolean.TRUE);
+        cluster.setStopStartScalingEnabled(Boolean.FALSE);
+        cluster.setState(ClusterState.RUNNING);
+        cluster.setLastScalingActivity(Instant.now().minus(45, ChronoUnit.MINUTES).toEpochMilli());
+
+        ScalingPolicy scalingPolicy = new ScalingPolicy();
+        scalingPolicy.setAdjustmentType(AdjustmentType.LOAD_BASED);
+        scalingPolicy.setHostGroup(HOSTGROUP);
+
+        LoadAlert loadAlert = new LoadAlert();
+        loadAlert.setScalingPolicy(scalingPolicy);
+        loadAlert.setCluster(cluster);
+
+        LoadAlertConfiguration loadAlertConfiguration = new LoadAlertConfiguration();
+        loadAlertConfiguration.setMinResourceValue(minResourceValue);
+        loadAlertConfiguration.setMaxResourceValue(maxResourceValue);
+        loadAlertConfiguration.setCoolDownMinutes(COOLDOWN_MINUTES);
+        loadAlert.setLoadAlertConfiguration(loadAlertConfiguration);
+
+        cluster.setLoadAlerts(Set.of(loadAlert));
+        return cluster;
+    }
+
+    private void setupBasicMocks(YarnScalingServiceV1Response yarnResponse) throws Exception {
+        lenient().doCallRealMethod().when(scalingEventSender).sendScaleUpEvent(any(BaseAlert.class), anyInt(), anyInt(), anyInt(), anyInt());
+        lenient().doCallRealMethod().when(scalingEventSender).sendStopStartScaleUpEvent(any(BaseAlert.class), anyInt(), anyInt(), anyInt());
+        lenient().doCallRealMethod().when(scalingEventSender).sendScaleDownEvent(any(BaseAlert.class), anyInt(), anyList(), anyInt(),
+                any(ScalingAdjustmentType.class));
+        doCallRealMethod().when(stackResponseUtils).getCloudInstanceIdsForHostGroup(any(StackV4Response.class), anyString());
+        doCallRealMethod().when(stackResponseUtils).getCloudInstanceIdsWithServicesHealthyForHostGroup(any(StackV4Response.class), anyString());
+        lenient().doReturn(yarnResponse).when(yarnMetricsClient).getYarnMetricsForCluster(any(Cluster.class), any(StackV4Response.class), anyString(),
+                anyString(), any(Optional.class));
+        lenient().doCallRealMethod().when(yarnResponseUtils).getYarnRecommendedDecommissionHostsForHostGroup(any(YarnScalingServiceV1Response.class), anyMap());
+    }
+}

--- a/autoscale/src/test/java/com/sequenceiq/periscope/service/StopStartScalingAdjustmentServiceTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/service/StopStartScalingAdjustmentServiceTest.java
@@ -1,0 +1,247 @@
+package com.sequenceiq.periscope.service;
+
+import static com.sequenceiq.periscope.model.ScalingAdjustmentType.REGULAR;
+import static com.sequenceiq.periscope.model.ScalingAdjustmentType.STOPSTART;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.periscope.api.model.AdjustmentType;
+import com.sequenceiq.periscope.api.model.ClusterState;
+import com.sequenceiq.periscope.domain.BaseAlert;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.LoadAlert;
+import com.sequenceiq.periscope.domain.LoadAlertConfiguration;
+import com.sequenceiq.periscope.domain.ScalingPolicy;
+import com.sequenceiq.periscope.model.adjustment.MandatoryScalingAdjustmentParameters;
+import com.sequenceiq.periscope.model.ScalingAdjustmentType;
+import com.sequenceiq.periscope.model.yarn.YarnScalingServiceV1Response;
+import com.sequenceiq.periscope.monitor.client.YarnMetricsClient;
+import com.sequenceiq.periscope.monitor.evaluator.EventPublisher;
+import com.sequenceiq.periscope.monitor.evaluator.load.YarnResponseUtils;
+import com.sequenceiq.periscope.monitor.event.ScalingEvent;
+import com.sequenceiq.periscope.monitor.sender.ScalingEventSender;
+import com.sequenceiq.periscope.utils.MockStackResponseGenerator;
+import com.sequenceiq.periscope.utils.StackResponseUtils;
+
+@ExtendWith(MockitoExtension.class)
+class StopStartScalingAdjustmentServiceTest {
+
+    private static final Long CLUSTER_ID = 1L;
+
+    private static final String STACK_CRN = "crn:cdp:datahub:us-west-1:9d74eee4-1cad-46d7-b645-7ccf9edbb73d:cluster:1ce07c57-74be-4egd-820d-e81a98d9e151";
+
+    private static final Integer COOLDOWN_MINUTES = 2;
+
+    private static final String HOSTGROUP = "compute";
+
+    private static final String FQDN_BASE = "fqdn-";
+
+    private static final String POLLING_USER_CRN = "someUserCrn";
+
+    @Mock
+    private YarnMetricsClient yarnMetricsClient;
+
+    @Mock
+    private StackResponseUtils stackResponseUtils;
+
+    @Mock
+    private YarnResponseUtils yarnResponseUtils;
+
+    @Mock
+    private ScalingEventSender scalingEventSender;
+
+    @Mock
+    private EventPublisher eventPublisher;
+
+    @Captor
+    private ArgumentCaptor<ScalingEvent> eventCaptor;
+
+    @InjectMocks
+    private StopStartScalingAdjustmentService underTest;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(scalingEventSender, "eventPublisher", eventPublisher);
+    }
+
+    public static Stream<Arguments> dataForMandatoryStopStartAdjustments() {
+        return Stream.of(
+                // Testcase,int minResourceValue, int maxResourceValue, int runningHostGroupNodeCount,int stoppedHostGroupNodeCount,
+                // int expectedUpscaleAdjustment, int expectedDownscaleAdjustment
+                Arguments.of("MANDATORY_STOP_START_UPSCALE_ALLOWED_1", 15, 89, 24, 34, 34, 0),
+                Arguments.of("MANDATORY_STOP_START_UPSCALE_ALLOWED_2", 20, 70, 15, 20, 20, 0),
+                Arguments.of("MANDATORY_STOP_START_UPSCALE_ALLOWED_3", 20, 100, 34, 0, 66, 0),
+                Arguments.of("MANDATORY_STOP_START_UPSCALE_ALLOWED_4", 30, 150, 60, 0, 90, 0),
+                Arguments.of("MANDATORY_STOP_START_DOWNSCALE_ALLOWED_1", 18, 50, 34, 70, 0, 54),
+                Arguments.of("MANDATORY_STOP_START_DOWNSCALE_ALLOWED_2", 10, 70, 30, 100, 0, 60),
+                Arguments.of("MANDATORY_STOP_START_DOWNSCALE_ALLOWED_3", 17, 47, 66, 14, 0, 33),
+                Arguments.of("MANDATORY_STOP_START_DOWNSCALE_ALLOWED_4", 40, 50, 60, 10, 0, 20),
+                Arguments.of("MANDATORY_STOP_START_ADJ_NOT_REQD_1", 19, 37, 23, 14, 0, 0),
+                Arguments.of("MANDATORY_STOP_START_ADJ_NOT_REQD_2", 23, 57, 34, 23, 0, 0)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("dataForMandatoryStopStartAdjustments")
+    void testStopStartUpscaleAndDownscaleAdjustments(String testCase, int minResourceValue, int maxResourceValue, int runningHostGroupNodeCount,
+            int stoppedHostGroupNodeCount, int expectedUpscaleAdjustment, int expectedDownscaleAdjustment) throws Exception {
+        Cluster cluster = getCluster(minResourceValue, maxResourceValue);
+        cluster.setStopStartScalingEnabled(Boolean.TRUE);
+        StackV4Response stackResponse = MockStackResponseGenerator.getMockStackV4ResponseWithStoppedAndRunningNodes(STACK_CRN, HOSTGROUP, FQDN_BASE,
+                runningHostGroupNodeCount, stoppedHostGroupNodeCount);
+        YarnScalingServiceV1Response yarnResponse = getMockYarnScalingResponse(HOSTGROUP, expectedUpscaleAdjustment, expectedDownscaleAdjustment);
+        MandatoryScalingAdjustmentParameters mandatoryAdjustmentParams = mockAdjustmentParams(maxResourceValue,
+                runningHostGroupNodeCount + stoppedHostGroupNodeCount);
+
+        setupBasicMocks(yarnResponse);
+
+        underTest.performMandatoryAdjustment(cluster, POLLING_USER_CRN, stackResponse, mandatoryAdjustmentParams);
+
+        if (expectedUpscaleAdjustment > 0) {
+            verify(eventPublisher).publishEvent(eventCaptor.capture());
+            verifyNoInteractions(yarnMetricsClient);
+            ScalingEvent result = eventCaptor.getValue();
+            assertThat(result.getAlert()).isInstanceOf(LoadAlert.class);
+            assertThat(result.getExistingServiceHealthyHostGroupNodeCount()).isEqualTo(runningHostGroupNodeCount);
+            assertThat(result.getExistingClusterNodeCount()).isEqualTo(runningHostGroupNodeCount + 3);
+            assertThat(result.getExistingHostGroupNodeCount()).isEqualTo(runningHostGroupNodeCount);
+            assertThat(result.getDesiredAbsoluteHostGroupNodeCount()).isEqualTo(runningHostGroupNodeCount + expectedUpscaleAdjustment);
+            if (stoppedHostGroupNodeCount > 0) {
+                assertThat(result.getScalingAdjustmentType()).isEqualTo(STOPSTART);
+            } else {
+                assertThat(result.getScalingAdjustmentType()).isEqualTo(REGULAR);
+            }
+        } else if (expectedDownscaleAdjustment > 0) {
+            verify(eventPublisher).publishEvent(eventCaptor.capture());
+            ScalingEvent result = eventCaptor.getValue();
+            assertThat(result.getAlert()).isInstanceOf(LoadAlert.class);
+            assertThat(result.getScalingAdjustmentType()).isEqualTo(REGULAR);
+            assertThat(result.getExistingServiceHealthyHostGroupNodeCount()).isEqualTo(runningHostGroupNodeCount);
+            assertThat(result.getDesiredAbsoluteHostGroupNodeCount()).isEqualTo(maxResourceValue);
+            assertThat(result.getExistingHostGroupNodeCount()).isEqualTo(runningHostGroupNodeCount + stoppedHostGroupNodeCount);
+            assertThat(result.getDecommissionNodeIds()).hasSize(expectedDownscaleAdjustment);
+            if (stoppedHostGroupNodeCount >= expectedDownscaleAdjustment) {
+                verifyNoInteractions(yarnMetricsClient);
+            } else {
+                verify(yarnMetricsClient, times(1)).getYarnMetricsForCluster(cluster, stackResponse, HOSTGROUP, POLLING_USER_CRN,
+                        Optional.of(mandatoryAdjustmentParams.getDownscaleAdjustment()));
+            }
+        } else {
+            verifyNoInteractions(eventPublisher, yarnMetricsClient);
+        }
+
+    }
+
+    private MandatoryScalingAdjustmentParameters mockAdjustmentParams(int maxResourceValue, int existingHostGroupNodeCount) {
+        MandatoryScalingAdjustmentParameters adjustmentParams = mock(MandatoryScalingAdjustmentParameters.class);
+
+        int stopStartAdjustment = maxResourceValue - existingHostGroupNodeCount;
+
+        lenient()
+                .doReturn(Optional.of(stopStartAdjustment).filter(val -> val > 0).orElse(null))
+                .when(adjustmentParams).getUpscaleAdjustment();
+
+        lenient()
+                .doReturn(Optional.of(stopStartAdjustment).filter(val -> val < 0).map(Math::abs).orElse(null))
+                .when(adjustmentParams).getDownscaleAdjustment();
+
+        return adjustmentParams;
+    }
+
+    private YarnScalingServiceV1Response getMockYarnScalingResponse(String hostGroup, int upScaleCount, int downScaleCount) {
+        YarnScalingServiceV1Response.NewNodeManagerCandidates.Candidate candidate = new YarnScalingServiceV1Response.NewNodeManagerCandidates.Candidate();
+        candidate.setCount(upScaleCount);
+        candidate.setModelName(hostGroup);
+        YarnScalingServiceV1Response.NewNodeManagerCandidates candidates = new YarnScalingServiceV1Response.NewNodeManagerCandidates();
+        candidates.setCandidates(List.of(candidate));
+
+        YarnScalingServiceV1Response yarnScalingReponse = new YarnScalingServiceV1Response();
+        if (upScaleCount > 0) {
+            yarnScalingReponse.setNewNMCandidates(candidates);
+        }
+
+        List<YarnScalingServiceV1Response.DecommissionCandidate> decommissionCandidates = new ArrayList<>();
+        IntStream.range(1, downScaleCount + 1).forEach(i -> {
+            YarnScalingServiceV1Response.DecommissionCandidate decommissionCandidate = new YarnScalingServiceV1Response.DecommissionCandidate();
+            decommissionCandidate.setAmCount(2);
+            decommissionCandidate.setNodeId(FQDN_BASE + i + ":8042");
+            decommissionCandidates.add(decommissionCandidate);
+        });
+        yarnScalingReponse.setDecommissionCandidates(Map.of("candidates", decommissionCandidates));
+
+        return yarnScalingReponse;
+    }
+
+    private Cluster getCluster(int minResourceValue, int maxResourceValue) {
+        Cluster cluster = new Cluster();
+        cluster.setId(CLUSTER_ID);
+        cluster.setStackCrn(STACK_CRN);
+        cluster.setAutoscalingEnabled(Boolean.TRUE);
+        cluster.setStopStartScalingEnabled(Boolean.FALSE);
+        cluster.setState(ClusterState.RUNNING);
+        cluster.setLastScalingActivity(Instant.now().minus(45, ChronoUnit.MINUTES).toEpochMilli());
+
+        ScalingPolicy scalingPolicy = new ScalingPolicy();
+        scalingPolicy.setAdjustmentType(AdjustmentType.LOAD_BASED);
+        scalingPolicy.setHostGroup(HOSTGROUP);
+
+        LoadAlert loadAlert = new LoadAlert();
+        loadAlert.setScalingPolicy(scalingPolicy);
+        loadAlert.setCluster(cluster);
+
+        LoadAlertConfiguration loadAlertConfiguration = new LoadAlertConfiguration();
+        loadAlertConfiguration.setMinResourceValue(minResourceValue);
+        loadAlertConfiguration.setMaxResourceValue(maxResourceValue);
+        loadAlertConfiguration.setCoolDownMinutes(COOLDOWN_MINUTES);
+        loadAlert.setLoadAlertConfiguration(loadAlertConfiguration);
+
+        cluster.setLoadAlerts(Set.of(loadAlert));
+        return cluster;
+    }
+
+    private void setupBasicMocks(YarnScalingServiceV1Response yarnResponse) throws Exception {
+        lenient().doCallRealMethod().when(scalingEventSender).sendScaleUpEvent(any(BaseAlert.class), anyInt(), anyInt(), anyInt(), anyInt());
+        lenient().doCallRealMethod().when(scalingEventSender).sendStopStartScaleUpEvent(any(BaseAlert.class), anyInt(), anyInt(), anyInt());
+        lenient().doCallRealMethod().when(scalingEventSender).sendScaleDownEvent(any(BaseAlert.class), anyInt(), anyList(), anyInt(),
+                any(ScalingAdjustmentType.class));
+        doCallRealMethod().when(stackResponseUtils).getCloudInstanceIdsForHostGroup(any(StackV4Response.class), anyString());
+        doCallRealMethod().when(stackResponseUtils).getCloudInstanceIdsWithServicesHealthyForHostGroup(any(StackV4Response.class), anyString());
+        doCallRealMethod().when(stackResponseUtils).getStoppedCloudInstanceIdsInHostGroup(any(StackV4Response.class), anyString());
+        lenient().doReturn(yarnResponse).when(yarnMetricsClient).getYarnMetricsForCluster(any(Cluster.class), any(StackV4Response.class), anyString(),
+                anyString(), any(Optional.class));
+        lenient().doCallRealMethod().when(yarnResponseUtils).getYarnRecommendedDecommissionHostsForHostGroup(any(YarnScalingServiceV1Response.class), anyMap());
+    }
+}

--- a/autoscale/src/test/java/com/sequenceiq/periscope/service/YarnBasedScalingAdjustmentServiceTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/service/YarnBasedScalingAdjustmentServiceTest.java
@@ -1,0 +1,424 @@
+package com.sequenceiq.periscope.service;
+
+import static com.sequenceiq.periscope.model.ScalingAdjustmentType.REGULAR;
+import static com.sequenceiq.periscope.model.ScalingAdjustmentType.STOPSTART;
+import static com.sequenceiq.periscope.monitor.evaluator.ScalingConstants.DEFAULT_MAX_SCALE_DOWN_STEP_SIZE;
+import static com.sequenceiq.periscope.monitor.evaluator.ScalingConstants.DEFAULT_MAX_SCALE_UP_STEP_SIZE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.periscope.api.model.AdjustmentType;
+import com.sequenceiq.periscope.api.model.ClusterState;
+import com.sequenceiq.periscope.domain.BaseAlert;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.LoadAlert;
+import com.sequenceiq.periscope.domain.LoadAlertConfiguration;
+import com.sequenceiq.periscope.domain.ScalingPolicy;
+import com.sequenceiq.periscope.model.ScalingAdjustmentType;
+import com.sequenceiq.periscope.model.yarn.YarnScalingServiceV1Response;
+import com.sequenceiq.periscope.monitor.client.YarnMetricsClient;
+import com.sequenceiq.periscope.monitor.evaluator.EventPublisher;
+import com.sequenceiq.periscope.monitor.evaluator.load.YarnResponseUtils;
+import com.sequenceiq.periscope.monitor.event.ScalingEvent;
+import com.sequenceiq.periscope.monitor.sender.ScalingEventSender;
+import com.sequenceiq.periscope.utils.MockStackResponseGenerator;
+import com.sequenceiq.periscope.utils.StackResponseUtils;
+
+@ExtendWith(MockitoExtension.class)
+class YarnBasedScalingAdjustmentServiceTest {
+
+    private static final Long CLUSTER_ID = 1L;
+
+    private static final String STACK_CRN = "crn:cdp:datahub:us-west-1:9d74eee4-1cad-46d7-b645-7ccf9edbb73d:cluster:1ce07c57-74be-4egd-820d-e81a98d9e151";
+
+    private static final int HOSTGROUP_MIN_SIZE = 3;
+
+    private static final int HOSTGROUP_MAX_SIZE = 200;
+
+    private static final Integer COOLDOWN_MINUTES = 2;
+
+    private static final String FQDN_BASE = "fqdn-";
+
+    private static final String POLLING_USER_CRN = "pollingUserCrn";
+
+    private static final String HOSTGROUP = "compute";
+
+    @Mock
+    private YarnMetricsClient yarnMetricsClient;
+
+    @Mock
+    private YarnResponseUtils yarnResponseUtils;
+
+    @Mock
+    private StackResponseUtils stackResponseUtils;
+
+    @Mock
+    private ScalingEventSender scalingEventSender;
+
+    @Mock
+    private EventPublisher eventPublisher;
+
+    @Captor
+    private ArgumentCaptor<ScalingEvent> eventCaptor;
+
+    @InjectMocks
+    private YarnBasedScalingAdjustmentService underTest;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(scalingEventSender, "eventPublisher", eventPublisher);
+    }
+
+    public static Stream<Arguments> dataUpScaling() {
+        return Stream.of(
+                //TestCase,CurrentHostGroupCount,yarnRecommendedScaleUpCount,DesiredAbsoluteHostGroupNodeCount
+                Arguments.of("SCALE_UP_ALLOWED_1", 3, 5, 8),
+                Arguments.of("SCALE_UP_ALLOWED_2", 6, 35, 41),
+                Arguments.of("SCALE_UP_ALLOWED_AT_LIMIT", HOSTGROUP_MAX_SIZE - 10, 10, HOSTGROUP_MAX_SIZE),
+                Arguments.of("SCALE_UP_BEYOND_MAX_LIMIT", HOSTGROUP_MAX_SIZE - 10, 20, HOSTGROUP_MAX_SIZE),
+                Arguments.of("SCALE_UP_BEYOND_STEP_LIMIT_1", 10, 500, 10 + DEFAULT_MAX_SCALE_UP_STEP_SIZE),
+                Arguments.of("SCALE_UP_BEYOND_STEP_LIMIT_2", 13, 150, 13 + DEFAULT_MAX_SCALE_UP_STEP_SIZE),
+                Arguments.of("SCALE_UP_NOT_ALLOWED_1", HOSTGROUP_MAX_SIZE + 2, 10, 0),
+                Arguments.of("SCALE_UP_NOT_ALLOWED_2", HOSTGROUP_MAX_SIZE, 10, 0)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("dataUpScaling")
+    void testLoadBasedUpscaling(String testCase, int currentHostGroupCount, int yarnRecommendedScaleUpCount, int desiredAbsoluteHostGroupNodeCount)
+            throws Exception {
+        Cluster cluster = getCluster();
+        StackV4Response stackResponse = MockStackResponseGenerator.getMockStackV4Response(STACK_CRN, HOSTGROUP, FQDN_BASE, currentHostGroupCount, 0);
+        YarnScalingServiceV1Response yarnResponse = getMockYarnScalingResponse(HOSTGROUP, yarnRecommendedScaleUpCount, 0);
+
+        setupBasicMocks(stackResponse, yarnResponse);
+
+        underTest.pollYarnMetricsAndScaleCluster(cluster, POLLING_USER_CRN, Boolean.TRUE.equals(cluster.isStopStartScalingEnabled()), stackResponse);
+
+        if (desiredAbsoluteHostGroupNodeCount - Math.min(yarnRecommendedScaleUpCount, DEFAULT_MAX_SCALE_UP_STEP_SIZE) > 0) {
+            verify(eventPublisher, times(1)).publishEvent(eventCaptor.capture());
+            ScalingEvent result = eventCaptor.getValue();
+            assertThat(result.getAlert()).isInstanceOf(LoadAlert.class);
+            assertThat(result.getScalingAdjustmentType()).isEqualTo(REGULAR);
+            assertThat(result.getExistingHostGroupNodeCount()).isEqualTo(currentHostGroupCount);
+            // Including 1 master and 2 worker nodes from MockStackResponseGenerator
+            assertThat(result.getExistingClusterNodeCount()).isEqualTo(currentHostGroupCount + 3);
+            assertThat(result.getDesiredAbsoluteHostGroupNodeCount()).isEqualTo(desiredAbsoluteHostGroupNodeCount);
+            assertThat(result.getExistingServiceHealthyHostGroupNodeCount()).isEqualTo(currentHostGroupCount);
+        } else {
+            verify(eventPublisher, never()).publishEvent(any(ScalingEvent.class));
+        }
+    }
+
+    public static Stream<Arguments> dataUpScalingWithUnhealthyInstances() {
+        return Stream.of(
+                // TestCase,healthyHostGroupNodeCount,unhealthyHostGroupNodeCount,yarnRecommendedUpScaleUpCount,desiredAbsoluteHostGroupNodeCount
+                Arguments.of("SCALE_UP_ALLOWED_1", 3, 2, 2, 7),
+                Arguments.of("SCALE_UP_ALLOWED_2", 38, 35, 77, 150),
+                Arguments.of("SCALE_UP_ALLOWED_3", 1, 2, 3, 6),
+                Arguments.of("SCALE_UP_ALLOWED_BEYOND_STEP_LIMIT_1", 35, 47, 123, 35 + 47 + DEFAULT_MAX_SCALE_UP_STEP_SIZE),
+                Arguments.of("SCALE_UP_ALLOWED_BEYOND_STEP_LIMIT_2", 40, 3, 257, 40 + 3 + DEFAULT_MAX_SCALE_UP_STEP_SIZE),
+                Arguments.of("SCALE_UP_ALLOWED_AT_LIMIT_1", HOSTGROUP_MAX_SIZE - 15, 10, 5, HOSTGROUP_MAX_SIZE),
+                Arguments.of("SCALE_UP_ALLOWED_AT_LIMIT_2", HOSTGROUP_MAX_SIZE - 25, 10, 15, HOSTGROUP_MAX_SIZE),
+                Arguments.of("SCALE_UP_BEYOND_MAX_LIMIT", HOSTGROUP_MAX_SIZE - 20, 15, 10, HOSTGROUP_MAX_SIZE),
+                Arguments.of("SCALE_UP_WHEN_SIZE_BELOW_MIN", 2, 1, 3, 6),
+                Arguments.of("SCALE_UP_NOT_ALLOWED_1", HOSTGROUP_MAX_SIZE - 10, 10, 13, 0),
+                Arguments.of("SCALE_UP_NOT_ALLOWED_2", HOSTGROUP_MAX_SIZE - 10, 10, 10, 0)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("dataUpScalingWithUnhealthyInstances")
+    void testLoadBasedUpscalingWithUnhealthyInstances(String testCase, int healthyHostGroupNodeCount, int unhealthyHostGroupNodeCount,
+            int yarnRecommendedScaleUpCount, int desiredAbsoluteHostGroupNodeCount) throws Exception {
+        Cluster cluster = getCluster();
+        StackV4Response stackResponse = MockStackResponseGenerator.getMockStackV4Response(STACK_CRN, HOSTGROUP, FQDN_BASE,
+                healthyHostGroupNodeCount + unhealthyHostGroupNodeCount, unhealthyHostGroupNodeCount);
+        YarnScalingServiceV1Response yarnResponse = getMockYarnScalingResponse(HOSTGROUP, yarnRecommendedScaleUpCount, 0);
+
+        setupBasicMocks(stackResponse, yarnResponse);
+
+        underTest.pollYarnMetricsAndScaleCluster(cluster, POLLING_USER_CRN, Boolean.TRUE.equals(cluster.isStopStartScalingEnabled()), stackResponse);
+
+        if (desiredAbsoluteHostGroupNodeCount - Math.min(yarnRecommendedScaleUpCount, DEFAULT_MAX_SCALE_UP_STEP_SIZE) > 0) {
+            verify(eventPublisher, times(1)).publishEvent(eventCaptor.capture());
+            ScalingEvent result = eventCaptor.getValue();
+            assertThat(result.getAlert()).isInstanceOf(LoadAlert.class);
+            assertThat(result.getScalingAdjustmentType()).isEqualTo(REGULAR);
+            assertThat(result.getExistingHostGroupNodeCount()).isEqualTo(healthyHostGroupNodeCount + unhealthyHostGroupNodeCount);
+            assertThat(result.getExistingClusterNodeCount()).isEqualTo(healthyHostGroupNodeCount + unhealthyHostGroupNodeCount + 3);
+            assertThat(result.getDesiredAbsoluteHostGroupNodeCount()).isEqualTo(desiredAbsoluteHostGroupNodeCount);
+            assertThat(result.getExistingServiceHealthyHostGroupNodeCount()).isEqualTo(healthyHostGroupNodeCount);
+        } else {
+            verify(eventPublisher, never()).publishEvent(any(ScalingEvent.class));
+        }
+
+    }
+
+    public static Stream<Arguments> dataUpScalingForStopStart() {
+        return Stream.of(
+                //TestCase,runningHostGroupNodeCount,stoppedHostGroupNodeCount,yarnRecommendedUpScaleUpCount,desiredAbsoluteHostGroupNodeCount
+                Arguments.of("STOP_START_SCALE_UP_ALLOWED_1", 3, HOSTGROUP_MAX_SIZE - 3, 2, 5),
+                Arguments.of("STOP_START_SCALE_UP_ALLOWED_2", 17, HOSTGROUP_MAX_SIZE - 17, 77, 94),
+                Arguments.of("STOP_START_SCALE_UP_ALLOWED_AT_LIMIT_1", HOSTGROUP_MAX_SIZE - 10, 10, 10, HOSTGROUP_MAX_SIZE),
+                Arguments.of("STOP_START_SCALE_UP_ALLOWED_AT_LIMIT_2", HOSTGROUP_MAX_SIZE - 43, 43, 43, HOSTGROUP_MAX_SIZE),
+                Arguments.of("STOP_START_SCALE_UP_BEYOND_STEP_LIMIT_1", 24, HOSTGROUP_MAX_SIZE - 24, 146, 24 + DEFAULT_MAX_SCALE_UP_STEP_SIZE),
+                Arguments.of("STOP_START_SCALE_UP_BEYOND_STEP_LIMIT_2", 3, HOSTGROUP_MAX_SIZE - 3, 157, 3 + DEFAULT_MAX_SCALE_UP_STEP_SIZE),
+                Arguments.of("STOP_START_SCALE_UP_BEYOND_MAX_LIMIT", HOSTGROUP_MAX_SIZE - 10, 10, 20, HOSTGROUP_MAX_SIZE),
+                Arguments.of("STOP_START_SCALE_UP_NOT_ALLOWED_1", HOSTGROUP_MAX_SIZE, 0, 43, 0),
+                Arguments.of("STOP_START_SCALE_UP_NOT_ALLOWED_2", HOSTGROUP_MAX_SIZE, 0, 64, 0)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("dataUpScalingForStopStart")
+    void testLoadBasedUpscalingWithStopStart(String testCase, int runningHostGroupNodeCount, int stoppedHostGroupNodeCount, int yarnRecommendedScaleUpCount,
+            int desiredAbsoluteHostGroupNodeCount) throws Exception {
+        Cluster cluster = getCluster();
+        cluster.setStopStartScalingEnabled(Boolean.TRUE);
+        StackV4Response stackResponse = MockStackResponseGenerator.getMockStackV4ResponseWithStoppedAndRunningNodes(STACK_CRN, HOSTGROUP, FQDN_BASE,
+                runningHostGroupNodeCount, stoppedHostGroupNodeCount);
+        YarnScalingServiceV1Response yarnResponse = getMockYarnScalingResponse(HOSTGROUP, yarnRecommendedScaleUpCount, 0);
+
+        setupBasicMocks(stackResponse, yarnResponse);
+
+        underTest.pollYarnMetricsAndScaleCluster(cluster, POLLING_USER_CRN, Boolean.TRUE.equals(cluster.isStopStartScalingEnabled()), stackResponse);
+
+        if (desiredAbsoluteHostGroupNodeCount - Math.min(yarnRecommendedScaleUpCount, DEFAULT_MAX_SCALE_UP_STEP_SIZE) > 0) {
+            verify(eventPublisher, times(1)).publishEvent(eventCaptor.capture());
+            ScalingEvent result = eventCaptor.getValue();
+            assertThat(result.getAlert()).isInstanceOf(LoadAlert.class);
+            assertThat(result.getScalingAdjustmentType()).isEqualTo(STOPSTART);
+            assertThat(result.getExistingHostGroupNodeCount()).isEqualTo(runningHostGroupNodeCount);
+            assertThat(result.getExistingClusterNodeCount()).isEqualTo(runningHostGroupNodeCount + 3);
+            assertThat(result.getDesiredAbsoluteHostGroupNodeCount()).isEqualTo(desiredAbsoluteHostGroupNodeCount);
+            assertThat(result.getExistingServiceHealthyHostGroupNodeCount()).isEqualTo(runningHostGroupNodeCount);
+        } else {
+            verify(eventPublisher, never()).publishEvent(any(ScalingEvent.class));
+        }
+    }
+
+    public static Stream<Arguments> dataDownScaling() {
+        return Stream.of(
+                //TestCase,CurrentHostGroupCount,YarnRecommendedDecommissionCount,ExpectedDecommissionCount
+                Arguments.of("SCALE_DOWN_ALLOWED_1", 7, 5, 7 - HOSTGROUP_MIN_SIZE),
+                Arguments.of("SCALE_DOWN_ALLOWED_2", 18, 7, 7),
+                Arguments.of("SCALE_DOWN_RECOMMENDED", HOSTGROUP_MAX_SIZE, 100, 100),
+                Arguments.of("SCALE_DOWN_BEYOND_STEP_LIMIT", 200, 150, 100),
+                Arguments.of("SCALE_DOWN_ALLOWED_MIN_LIMIT", 10, 10, 10 - HOSTGROUP_MIN_SIZE),
+                Arguments.of("SCALE_DOWN_ALLOWED_AT_MIN_LIMIT", 20, 20 - HOSTGROUP_MIN_SIZE, 20 - HOSTGROUP_MIN_SIZE),
+                Arguments.of("SCALE_DOWN_BEYOND_MIN_LIMIT", 10, 52, 10 - HOSTGROUP_MIN_SIZE),
+                Arguments.of("SCALE_DOWN_NOT_ALLOWED", 0, 5, 0)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("dataDownScaling")
+    void testLoadBasedDownscaling(String testCase, int currentHostGroupNodeCount, int yarnRecommendedDecommissionCount, int expectedDecommissionCount)
+            throws Exception {
+        Cluster cluster = getCluster();
+        StackV4Response stackResponse = MockStackResponseGenerator.getMockStackV4Response(STACK_CRN, HOSTGROUP, FQDN_BASE, currentHostGroupNodeCount, 0);
+        YarnScalingServiceV1Response yarnResponse = getMockYarnScalingResponse(HOSTGROUP, 0, yarnRecommendedDecommissionCount);
+
+        setupBasicMocks(stackResponse, yarnResponse);
+
+        underTest.pollYarnMetricsAndScaleCluster(cluster, POLLING_USER_CRN, Boolean.TRUE.equals(cluster.isStopStartScalingEnabled()), stackResponse);
+
+        if (expectedDecommissionCount > 0) {
+            verify(eventPublisher, times(1)).publishEvent(eventCaptor.capture());
+            ScalingEvent result = eventCaptor.getValue();
+            assertThat(result.getAlert()).isInstanceOf(LoadAlert.class);
+            assertThat(result.getScalingAdjustmentType()).isEqualTo(REGULAR);
+            assertThat(result.getExistingHostGroupNodeCount()).isEqualTo(currentHostGroupNodeCount);
+            assertThat(result.getDesiredAbsoluteHostGroupNodeCount()).isEqualTo(currentHostGroupNodeCount - expectedDecommissionCount);
+            assertThat(result.getExistingServiceHealthyHostGroupNodeCount()).isEqualTo(currentHostGroupNodeCount);
+            assertThat(result.getDecommissionNodeIds()).hasSize(expectedDecommissionCount);
+        } else {
+            verify(eventPublisher, never()).publishEvent(any(ScalingEvent.class));
+        }
+    }
+
+    public static Stream<Arguments> dataDownScalingWithUnhealthyInstances() {
+        return Stream.of(
+                //TestCase,HealthyHostGroupCount,UnhealthyHostGroupCount,YarnRecommendedDecommissionCount,ExpectedDecommissionCount
+                Arguments.of("SCALE_DOWN_ALLOWED_1", 15, 6, 18, 15 - HOSTGROUP_MIN_SIZE),
+                Arguments.of("SCALE_DOWN_ALLOWED_2", 34, 41, 47, 34 - HOSTGROUP_MIN_SIZE),
+                Arguments.of("SCALE_DOWN_ALLOWED_3", 113, 12, 78, 78),
+                Arguments.of("SCALE_DOWN_ALLOWED_4", 27, 4, 16, 16),
+                Arguments.of("SCALE_DOWN_BEYOND_STEP_LIMIT_1", 134, 17, 150, DEFAULT_MAX_SCALE_DOWN_STEP_SIZE),
+                Arguments.of("SCALE_DOWN_BEYOND_STEP_LIMIT_2", HOSTGROUP_MAX_SIZE - 65, 65, 108, DEFAULT_MAX_SCALE_DOWN_STEP_SIZE),
+                Arguments.of("SCALE_DOWN_ALLOWED_BEYOND_MIN_LIMIT_1", 16, 5, 23, 16 - HOSTGROUP_MIN_SIZE),
+                Arguments.of("SCALE_DOWN_ALLOWED_BEYOND_MIN_LIMIT_2", 47, 12, 83, 47 - HOSTGROUP_MIN_SIZE),
+                Arguments.of("SCALE_DOWN_NOT_ALLOWED", 0, 5, 3, 0)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("dataDownScalingWithUnhealthyInstances")
+    void testLoadBasedDownscalingWithUnhealthyInstances(String testCase, int healthyHostGroupNodeCount, int unhealthyHostGroupNodeCount,
+            int yarnRecommendedDecommissionNodeCount, int expectedDecommissionNodeCount) throws Exception {
+        Cluster cluster = getCluster();
+        StackV4Response stackResponse = MockStackResponseGenerator.getMockStackV4Response(STACK_CRN, HOSTGROUP, FQDN_BASE,
+                healthyHostGroupNodeCount + unhealthyHostGroupNodeCount, unhealthyHostGroupNodeCount);
+        YarnScalingServiceV1Response yarnResponse = getMockYarnScalingResponse(HOSTGROUP, 0, yarnRecommendedDecommissionNodeCount);
+
+        setupBasicMocks(stackResponse, yarnResponse);
+
+        underTest.pollYarnMetricsAndScaleCluster(cluster, POLLING_USER_CRN, Boolean.TRUE.equals(cluster.isStopStartScalingEnabled()), stackResponse);
+
+        if (expectedDecommissionNodeCount > 0) {
+            verify(eventPublisher, times(1)).publishEvent(eventCaptor.capture());
+            ScalingEvent result = eventCaptor.getValue();
+            assertThat(result.getAlert()).isInstanceOf(LoadAlert.class);
+            assertThat(result.getScalingAdjustmentType()).isEqualTo(REGULAR);
+            assertThat(result.getExistingHostGroupNodeCount()).isEqualTo(healthyHostGroupNodeCount);
+            assertThat(result.getDesiredAbsoluteHostGroupNodeCount()).isEqualTo(healthyHostGroupNodeCount - expectedDecommissionNodeCount);
+            assertThat(result.getExistingServiceHealthyHostGroupNodeCount()).isEqualTo(healthyHostGroupNodeCount);
+            assertThat(result.getDecommissionNodeIds()).hasSize(expectedDecommissionNodeCount);
+        } else {
+            verify(eventPublisher, never()).publishEvent(any(ScalingEvent.class));
+        }
+    }
+
+    public static Stream<Arguments> dataDownScalingForStopStart() {
+        return Stream.of(
+                //Testcase,runningHostGroupNodeCount,stoppedHostGroupNodeCount,yarnRecommendedDecommissionCount,expectedDecommissionCount
+                Arguments.of("STOP_START_SCALE_DOWN_ALLOWED_1", 27, HOSTGROUP_MAX_SIZE - 27, 16, 16),
+                Arguments.of("STOP_START_SCALE_DOWN_ALLOWED_2", HOSTGROUP_MAX_SIZE, 0, 78, 78),
+                Arguments.of("STOP_START_SCALE_DOWN_BEYOND_STEP_LIMIT_1", 117, HOSTGROUP_MAX_SIZE - 117, 103, DEFAULT_MAX_SCALE_DOWN_STEP_SIZE),
+                Arguments.of("STOP_START_SCALE_DOWN_BEYOND_STEP_LIMIT_2", HOSTGROUP_MAX_SIZE, 0, 153, DEFAULT_MAX_SCALE_DOWN_STEP_SIZE),
+                Arguments.of("STOP_START_SCALE_DOWN_BEYOND_LIMIT_1", 23, HOSTGROUP_MAX_SIZE - 23, 30, 23 - HOSTGROUP_MIN_SIZE),
+                Arguments.of("STOP_START_SCALE_DOWN_BEYOND_LIMIT_2", 47, HOSTGROUP_MAX_SIZE - 47, 83, 47 - HOSTGROUP_MIN_SIZE),
+                Arguments.of("STOP_START_SCALE_DOWN_NOT_ALLOWED_1", HOSTGROUP_MIN_SIZE, HOSTGROUP_MAX_SIZE - HOSTGROUP_MIN_SIZE, 35, 0),
+                Arguments.of("STOP_START_SCALE_DOWN_NOT_ALLOWED_2", 0, HOSTGROUP_MAX_SIZE, 3, 0)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("dataDownScalingForStopStart")
+    void testLoadBasedDownscalingWithStopStart(String testCase, int runningHostGroupNodeCount, int stoppedHostGroupNodeCount,
+            int yarnRecommendedDecommissionNodeCount, int expectedDecommissionNodeCount) throws Exception {
+        Cluster cluster = getCluster();
+        cluster.setStopStartScalingEnabled(Boolean.TRUE);
+        StackV4Response stackResponse = MockStackResponseGenerator.getMockStackV4ResponseWithStoppedAndRunningNodes(STACK_CRN, HOSTGROUP, FQDN_BASE,
+                runningHostGroupNodeCount, stoppedHostGroupNodeCount);
+        YarnScalingServiceV1Response yarnResponse = getMockYarnScalingResponse(HOSTGROUP, 0, yarnRecommendedDecommissionNodeCount);
+
+        setupBasicMocks(stackResponse, yarnResponse);
+
+        underTest.pollYarnMetricsAndScaleCluster(cluster, POLLING_USER_CRN, Boolean.TRUE.equals(cluster.isStopStartScalingEnabled()), stackResponse);
+
+        if (expectedDecommissionNodeCount > 0) {
+            verify(eventPublisher, times(1)).publishEvent(eventCaptor.capture());
+            ScalingEvent result = eventCaptor.getValue();
+            assertThat(result.getAlert()).isInstanceOf(LoadAlert.class);
+            assertThat(result.getScalingAdjustmentType()).isEqualTo(STOPSTART);
+            assertThat(result.getExistingHostGroupNodeCount()).isEqualTo(runningHostGroupNodeCount);
+            assertThat(result.getDesiredAbsoluteHostGroupNodeCount()).isEqualTo(runningHostGroupNodeCount - expectedDecommissionNodeCount);
+            assertThat(result.getExistingServiceHealthyHostGroupNodeCount()).isEqualTo(runningHostGroupNodeCount);
+            assertThat(result.getDecommissionNodeIds()).hasSize(expectedDecommissionNodeCount);
+        } else {
+            verify(eventPublisher, never()).publishEvent(any(ScalingEvent.class));
+        }
+    }
+
+    private YarnScalingServiceV1Response getMockYarnScalingResponse(String hostGroup, int upScaleCount, int downScaleCount) {
+        YarnScalingServiceV1Response.NewNodeManagerCandidates.Candidate candidate = new YarnScalingServiceV1Response.NewNodeManagerCandidates.Candidate();
+        candidate.setCount(upScaleCount);
+        candidate.setModelName(hostGroup);
+        YarnScalingServiceV1Response.NewNodeManagerCandidates candidates = new YarnScalingServiceV1Response.NewNodeManagerCandidates();
+        candidates.setCandidates(List.of(candidate));
+
+        YarnScalingServiceV1Response yarnScalingReponse = new YarnScalingServiceV1Response();
+        if (upScaleCount > 0) {
+            yarnScalingReponse.setNewNMCandidates(candidates);
+        }
+
+        List<YarnScalingServiceV1Response.DecommissionCandidate> decommissionCandidates = new ArrayList<>();
+        IntStream.range(1, downScaleCount + 1).forEach(i -> {
+            YarnScalingServiceV1Response.DecommissionCandidate decommissionCandidate = new YarnScalingServiceV1Response.DecommissionCandidate();
+            decommissionCandidate.setAmCount(2);
+            decommissionCandidate.setNodeId(FQDN_BASE + i + ":8042");
+            decommissionCandidates.add(decommissionCandidate);
+        });
+        yarnScalingReponse.setDecommissionCandidates(Map.of("candidates", decommissionCandidates));
+
+        return yarnScalingReponse;
+    }
+
+    private Cluster getCluster() {
+        Cluster cluster = new Cluster();
+        cluster.setId(CLUSTER_ID);
+        cluster.setStackCrn(STACK_CRN);
+        cluster.setAutoscalingEnabled(Boolean.TRUE);
+        cluster.setStopStartScalingEnabled(Boolean.FALSE);
+        cluster.setState(ClusterState.RUNNING);
+        cluster.setLastScalingActivity(Instant.now().minus(45, ChronoUnit.MINUTES).toEpochMilli());
+
+        ScalingPolicy scalingPolicy = new ScalingPolicy();
+        scalingPolicy.setAdjustmentType(AdjustmentType.LOAD_BASED);
+        scalingPolicy.setHostGroup(HOSTGROUP);
+
+        LoadAlert loadAlert = new LoadAlert();
+        loadAlert.setScalingPolicy(scalingPolicy);
+        loadAlert.setCluster(cluster);
+
+        LoadAlertConfiguration loadAlertConfiguration = new LoadAlertConfiguration();
+        loadAlertConfiguration.setMinResourceValue(HOSTGROUP_MIN_SIZE);
+        loadAlertConfiguration.setMaxResourceValue(HOSTGROUP_MAX_SIZE);
+        loadAlertConfiguration.setCoolDownMinutes(COOLDOWN_MINUTES);
+        loadAlert.setLoadAlertConfiguration(loadAlertConfiguration);
+
+        cluster.setLoadAlerts(Set.of(loadAlert));
+        return cluster;
+    }
+
+    private void setupBasicMocks(StackV4Response stackResponse, YarnScalingServiceV1Response yarnResponse) throws Exception {
+        doCallRealMethod().when(stackResponseUtils).getCloudInstanceIdsForHostGroup(any(StackV4Response.class), anyString());
+        doCallRealMethod().when(stackResponseUtils).getCloudInstanceIdsWithServicesHealthyForHostGroup(any(StackV4Response.class), anyString());
+        doCallRealMethod().when(stackResponseUtils).getStoppedCloudInstanceIdsInHostGroup(any(StackV4Response.class), anyString());
+        doReturn(yarnResponse).when(yarnMetricsClient).getYarnMetricsForCluster(any(Cluster.class), eq(stackResponse), eq(HOSTGROUP), eq(POLLING_USER_CRN),
+                any(Optional.class));
+        lenient().doCallRealMethod().when(scalingEventSender).sendScaleUpEvent(any(BaseAlert.class), anyInt(), anyInt(), anyInt(), anyInt());
+        lenient().doCallRealMethod().when(scalingEventSender).sendStopStartScaleUpEvent(any(BaseAlert.class), anyInt(), anyInt(), anyInt());
+        lenient().doCallRealMethod().when(scalingEventSender).sendScaleDownEvent(any(BaseAlert.class), anyInt(), anyList(), anyInt(),
+                any(ScalingAdjustmentType.class));
+        lenient().doNothing().when(eventPublisher).publishEvent(any(ScalingEvent.class));
+        doCallRealMethod().when(yarnResponseUtils).getYarnRecommendedScaleUpCount(any(YarnScalingServiceV1Response.class), anyString());
+        doCallRealMethod().when(yarnResponseUtils).getYarnRecommendedDecommissionHostsForHostGroup(any(YarnScalingServiceV1Response.class), anyMap());
+    }
+}

--- a/autoscale/src/test/java/com/sequenceiq/periscope/utils/MockStackResponseGenerator.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/utils/MockStackResponseGenerator.java
@@ -57,6 +57,7 @@ public class MockStackResponseGenerator {
         StackV4Response mockReponse = new StackV4Response();
         mockReponse.setCrn(clusterCrn);
         mockReponse.setInstanceGroups(instanceGroupV4Responses);
+        mockReponse.setNodeCount(instanceGroupV4Responses.stream().flatMap(ig -> ig.getMetadata().stream()).collect(Collectors.toSet()).size());
         mockReponse.setCloudPlatform(CloudPlatform.AWS);
         return mockReponse;
     }
@@ -101,7 +102,7 @@ public class MockStackResponseGenerator {
         StackV4Response mockResponse = new StackV4Response();
         mockResponse.setCrn(clusterCrn);
         mockResponse.setInstanceGroups(instanceGroupV4Responses);
-        mockResponse.setNodeCount(instanceGroupV4Responses.stream().flatMap(ig -> ig.getMetadata().stream()).collect(Collectors.counting()).intValue());
+        mockResponse.setNodeCount(instanceGroupV4Responses.stream().flatMap(ig -> ig.getMetadata().stream()).collect(Collectors.toSet()).size());
         mockResponse.setCloudPlatform(CloudPlatform.AWS);
         return mockResponse;
     }

--- a/autoscale/src/test/java/com/sequenceiq/periscope/utils/StackResponseUtilsTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/utils/StackResponseUtilsTest.java
@@ -41,7 +41,7 @@ public class StackResponseUtilsTest {
         String hostGroup = "compute";
 
         int servicesHealthyHostGroupSize = underTest.
-                getCloudInstanceIdsWithServicesHealthyForHostGroup(getMockStackV4Response(hostGroup, 2), hostGroup);
+                getCloudInstanceIdsWithServicesHealthyForHostGroup(getMockStackV4Response(hostGroup, 2), hostGroup).size();
 
         assertEquals("Retrieved healthy host group size should match", 1, servicesHealthyHostGroupSize);
     }
@@ -52,8 +52,8 @@ public class StackResponseUtilsTest {
         Integer runningHostGroupCount = 1;
         Integer stoppedHostGroupCount = 3;
 
-        Integer stoppedInstanceCount = underTest.getStoppedInstanceCountInHostGroup(getMockStackV4ResponseForStopStart(hostGroup,
-                runningHostGroupCount, stoppedHostGroupCount), hostGroup);
+        Integer stoppedInstanceCount = underTest.getStoppedCloudInstanceIdsInHostGroup(getMockStackV4ResponseForStopStart(hostGroup,
+                runningHostGroupCount, stoppedHostGroupCount), hostGroup).size();
         assertEquals("Stopped instance count should match", Integer.valueOf(3), stoppedInstanceCount);
     }
 


### PR DESCRIPTION
… load based autoscaling is enabled with the stop / start scaling mechanism

TODO

- [x] Improved unit testing, especially to ensure that node count stays within upper and lower bounds specified in the policy
- [x] ~Changes to ensure STOPPED nodes are deleted when a policy is deleted~ -> #13461 

See detailed description in the commit message.