### PR TITLE
CB-18447 Distrox AWS external db is not ssl enforced after creation but will be after DB upgrade

### DIFF
--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/AwsRdsUpgradeSteps.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/AwsRdsUpgradeSteps.java
@@ -58,7 +58,12 @@ public class AwsRdsUpgradeSteps {
     public void upgradeRds(AmazonRdsClient rdsClient, DatabaseServer databaseServer, RdsInfo rdsInfo, Version targetMajorVersion) {
         RdsEngineVersion currentRdsVersion = rdsInfo.getRdsEngineVersion();
         RdsEngineVersion upgradeTargetVersion = awsRdsUpgradeOperations.getHighestUpgradeTargetVersion(rdsClient, targetMajorVersion, currentRdsVersion);
-        String dbParameterGroupName = awsRdsUpgradeOperations.createParameterGroupWithCustomSettings(rdsClient, databaseServer, upgradeTargetVersion);
+        String dbParameterGroupName;
+        if (isCustomParameterGroupNeeded(databaseServer)) {
+            dbParameterGroupName = awsRdsUpgradeOperations.createParameterGroupWithCustomSettings(rdsClient, databaseServer, upgradeTargetVersion);
+        } else {
+            dbParameterGroupName = null;
+        }
         awsRdsUpgradeOperations.upgradeRds(rdsClient, upgradeTargetVersion, databaseServer.getServerId(), dbParameterGroupName);
     }
 
@@ -66,4 +71,7 @@ public class AwsRdsUpgradeSteps {
         awsRdsUpgradeOperations.waitForRdsUpgrade(ac, rdsClient, databaseServer.getServerId());
     }
 
+    private boolean isCustomParameterGroupNeeded(DatabaseServer databaseServer) {
+        return databaseServer.isUseSslEnforcement();
+    }
 }

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsUpgradeOperations.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsUpgradeOperations.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -59,8 +60,10 @@ public class AwsRdsUpgradeOperations {
                 .withDBInstanceIdentifier(dbInstanceIdentifier)
                 .withEngineVersion(targetVersion.getVersion())
                 .withAllowMajorVersionUpgrade(true)
-                .withApplyImmediately(true)
-                .withDBParameterGroupName(dbParameterGroupName);
+                .withApplyImmediately(true);
+        if (StringUtils.isNotEmpty(dbParameterGroupName)) {
+            modifyDBInstanceRequest.withDBParameterGroupName(dbParameterGroupName);
+        }
 
         LOGGER.debug("RDS modify request to upgrade engine version to {} for DB {}, request: {}", targetVersion, dbInstanceIdentifier, modifyDBInstanceRequest);
         try {

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/AwsRdsUpgradeStepsTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/AwsRdsUpgradeStepsTest.java
@@ -102,12 +102,27 @@ public class AwsRdsUpgradeStepsTest {
         RdsEngineVersion targetVersion = new RdsEngineVersion(TARGET_VERSION);
         RdsInfo rdsInfo = new RdsInfo(RdsState.AVAILABLE, null, currentVersion);
         when(databaseServer.getServerId()).thenReturn(DB_INSTANCE_IDENTIFIER);
+        when(databaseServer.isUseSslEnforcement()).thenReturn(true);
         when(awsRdsUpgradeOperations.getHighestUpgradeTargetVersion(rdsClient, targetMajorVersion, currentVersion)).thenReturn(targetVersion);
         when(awsRdsUpgradeOperations.createParameterGroupWithCustomSettings(rdsClient, databaseServer, targetVersion)).thenReturn(DB_PARAMETER_GROUP_NAME);
 
         underTest.upgradeRds(rdsClient, databaseServer, rdsInfo, targetMajorVersion);
 
         verify(awsRdsUpgradeOperations).upgradeRds(rdsClient, targetVersion, DB_INSTANCE_IDENTIFIER, DB_PARAMETER_GROUP_NAME);
+    }
+
+    @Test
+    void testUpgradeRdsWithoutEnforceSsl() {
+        RdsEngineVersion currentVersion = new RdsEngineVersion(CURRENT_VERSION);
+        RdsEngineVersion targetVersion = new RdsEngineVersion(TARGET_VERSION);
+        RdsInfo rdsInfo = new RdsInfo(RdsState.AVAILABLE, null, currentVersion);
+        when(databaseServer.getServerId()).thenReturn(DB_INSTANCE_IDENTIFIER);
+        when(awsRdsUpgradeOperations.getHighestUpgradeTargetVersion(rdsClient, targetMajorVersion, currentVersion)).thenReturn(targetVersion);
+
+        underTest.upgradeRds(rdsClient, databaseServer, rdsInfo, targetMajorVersion);
+
+        verify(awsRdsUpgradeOperations, never()).createParameterGroupWithCustomSettings(rdsClient, databaseServer, targetVersion);
+        verify(awsRdsUpgradeOperations).upgradeRds(rdsClient, targetVersion, DB_INSTANCE_IDENTIFIER, null);
     }
 
     @Test
@@ -129,6 +144,7 @@ public class AwsRdsUpgradeStepsTest {
         RdsEngineVersion currentVersion = new RdsEngineVersion(CURRENT_VERSION);
         RdsEngineVersion targetVersion = new RdsEngineVersion(TARGET_VERSION);
         RdsInfo rdsInfo = new RdsInfo(RdsState.AVAILABLE, null, currentVersion);
+        when(databaseServer.isUseSslEnforcement()).thenReturn(true);
         when(awsRdsUpgradeOperations.getHighestUpgradeTargetVersion(rdsClient, targetMajorVersion, currentVersion)).thenReturn(targetVersion);
         when(awsRdsUpgradeOperations.createParameterGroupWithCustomSettings(rdsClient, databaseServer, targetVersion)).thenThrow(RuntimeException.class);
 

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsUpgradeOperationsTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsUpgradeOperationsTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -130,6 +131,23 @@ public class AwsRdsUpgradeOperationsTest {
         assertEquals(TARGET_VERSION, firedRequest.getEngineVersion());
         assertTrue(firedRequest.getAllowMajorVersionUpgrade());
         assertTrue(firedRequest.getApplyImmediately());
+        assertEquals(DB_PARAMETER_GROUP_NAME, firedRequest.getDBParameterGroupName());
+    }
+
+    @Test
+    void testUpgradeRdsWithoutDbParameterGroupName() {
+        RdsEngineVersion targetVersion = new RdsEngineVersion(TARGET_VERSION);
+
+        underTest.upgradeRds(rdsClient, targetVersion, DB_INSTANCE_IDENTIFIER, null);
+
+        ArgumentCaptor<ModifyDBInstanceRequest> modifyRequestCaptor = ArgumentCaptor.forClass(ModifyDBInstanceRequest.class);
+        verify(rdsClient).modifyDBInstance(modifyRequestCaptor.capture());
+        ModifyDBInstanceRequest firedRequest = modifyRequestCaptor.getValue();
+        assertEquals(DB_INSTANCE_IDENTIFIER, firedRequest.getDBInstanceIdentifier());
+        assertEquals(TARGET_VERSION, firedRequest.getEngineVersion());
+        assertTrue(firedRequest.getAllowMajorVersionUpgrade());
+        assertTrue(firedRequest.getApplyImmediately());
+        assertNull(firedRequest.getDBParameterGroupName());
     }
 
     @Test


### PR DESCRIPTION
CB-18447 Distrox AWS external db is not ssl enforced after creation but will be after DB upgrade

RDS with enforced ssl only set for Datalake clusters. In case of Datahub clusters the 'enforced ssl' parameter is currently not set. The fix is that during DB upgrade the 'enforced ssl' parameter is only set for Datalake clusters.
