### PR TITLE
CB-18269: Remove the CORE_SETTINGS service in the datamart blueprints

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.16/cdp-data-mart.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.16/cdp-data-mart.bp
@@ -6,22 +6,6 @@
     "blueprintUpgradeOption": "GA",
     "services": [
       {
-        "refName": "core_settings",
-        "serviceType": "CORE_SETTINGS",
-        "roleConfigGroups": [
-          {
-            "refName": "core_settings-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "base": true
-          },
-          {
-            "refName": "core_settings-STORAGEOPERATIONS-BASE",
-            "roleType": "STORAGEOPERATIONS",
-            "base": true
-          }
-        ]
-      },
-      {
         "refName": "hue",
         "serviceType": "HUE",
         "roleConfigGroups": [
@@ -93,8 +77,6 @@
         "refName": "master",
         "cardinality": "1",
         "roleConfigGroupsRefNames": [
-          "core_settings-GATEWAY-BASE",
-          "core_settings-STORAGEOPERATIONS-BASE",
           "hue-HUE_LOAD_BALANCER-BASE",
           "hue-HUE_SERVER-BASE",
           "impala-CATALOGSERVER-BASE",


### PR DESCRIPTION
As I saw in #13253, StubDFS will be added by CB automatically, so no need to rename this service in the bp.

This change has been tested on the pcqe mow-int tenant with a custom template and the deployment passed: https://quanta.infra.cloudera.com/#/runDetails?gtn=31503675
https://console.cdp.mow-int.cloudera.com/cloud/shared-resources/cluster-templates/details/7.2.16%20-%20Data%20Mart:%20Apache%20Impala,%20Hue%20No%20StorageOps
```
{
  "cdhVersion": "7.2.16",
  "displayName": "datamart",
  "blueprintUpgradeOption": "GA",
  "services": [
    {
      "refName": "hue",
      "serviceType": "HUE",
      "roleConfigGroups": [
        {
          "refName": "hue-HUE_SERVER-BASE",
          "roleType": "HUE_SERVER",
          "base": true
        },
        {
          "refName": "hue-HUE_LOAD_BALANCER-BASE",
          "roleType": "HUE_LOAD_BALANCER",
          "base": true
        }
      ]
    },
    {
      "refName": "impala",
      "serviceType": "IMPALA",
      "serviceConfigs": [
        {
          "name": "impala_cmd_args_safety_valve",
          "value": "--cache_s3_file_handles=true"
        }
      ],
      "roleConfigGroups": [
        {
          "refName": "impala-IMPALAD-COORDINATOR",
          "roleType": "IMPALAD",
          "configs": [
            {
              "name": "impalad_specialization",
              "value": "COORDINATOR_ONLY"
            },
            {
              "name": "impalad_core_site_safety_valve",
              "value": "<property><name>fs.s3a.experimental.input.fadvise</name><value>RANDOM</value></property><property><name>fs.s3a.fast.upload</name><value>true</value></property>"
            },
            {
              "name": "impala_graceful_shutdown_deadline",
              "value": "60"
            }
          ],
          "base": false
        },
        {
          "refName": "impala-IMPALAD-EXECUTOR",
          "roleType": "IMPALAD",
          "configs": [
            {
              "name": "impalad_specialization",
              "value": "EXECUTOR_ONLY"
            },
            {
              "name": "impalad_core_site_safety_valve",
              "value": "<property><name>fs.s3a.experimental.input.fadvise</name><value>RANDOM</value></property><property><name>fs.s3a.fast.upload</name><value>true</value></property>"
            },
            {
              "name": "impala_graceful_shutdown_deadline",
              "value": "60"
            }
          ],
          "base": false
        },
        {
          "refName": "impala-STATESTORE-BASE",
          "roleType": "STATESTORE",
          "base": true
        },
        {
          "refName": "impala-CATALOGSERVER-BASE",
          "roleType": "CATALOGSERVER",
          "base": true
        }
      ]
    }
  ],
  "hostTemplates": [
    {
      "refName": "master",
      "cardinality": "1",
      "roleConfigGroupsRefNames": [
        "hue-HUE_LOAD_BALANCER-BASE",
        "hue-HUE_SERVER-BASE",
        "impala-CATALOGSERVER-BASE",
        "impala-STATESTORE-BASE"
      ]
    },
    {
      "refName": "coordinator",
      "cardinality": "1",
      "roleConfigGroupsRefNames": [
        "impala-IMPALAD-COORDINATOR"
      ]
    },
    {
      "refName": "executor",
      "cardinality": "2",
      "roleConfigGroupsRefNames": [
        "impala-IMPALAD-EXECUTOR"
      ]
    }
  ]
}
```