### PR TITLE
CB-18422 Postgres upgrade: on AWS upgrade fails if DB is already upgr…

### DIFF
--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsUpgradeValidatorServiceTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/operation/AwsRdsUpgradeValidatorServiceTest.java
@@ -8,44 +8,29 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
-import com.sequenceiq.cloudbreak.common.database.Version;
 
 public class AwsRdsUpgradeValidatorServiceTest {
 
     private final AwsRdsUpgradeValidatorService underTest = new AwsRdsUpgradeValidatorService();
 
     @Test
-    void testValidateRdsCanBeUpgraded() {
+    void testValidateRdsIsAvailableOrUpgrading() {
         RdsInfo rdsInfo = new RdsInfo(RdsState.AVAILABLE, Map.of(), new RdsEngineVersion("10"));
-        Version targetMajorVersion = () -> "11";
 
         Assertions.assertDoesNotThrow(() ->
-                underTest.validateRdsCanBeUpgraded(rdsInfo, targetMajorVersion)
+                underTest.validateRdsIsAvailableOrUpgrading(rdsInfo)
         );
     }
 
     @ParameterizedTest
     @EnumSource(value = RdsState.class, names = {"AVAILABLE", "UPGRADING"}, mode = EnumSource.Mode.EXCLUDE)
-    void testValidateRdsCanBeUpgradedWhenStateNotOk(RdsState rdsState) {
+    void testValidateRdsIsAvailableOrUpgradingWhenStateNotOk(RdsState rdsState) {
         RdsInfo rdsInfo = new RdsInfo(rdsState, Map.of(), new RdsEngineVersion("10"));
-        Version targetMajorVersion = () -> "11";
 
         Assertions.assertThrows(CloudConnectorException.class, () ->
-                underTest.validateRdsCanBeUpgraded(rdsInfo, targetMajorVersion)
-        );
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"11", "12"})
-    void testValidateRdsCanBeUpgradedWhenVersionGreaterOrEqualToTarget(String currentEngineVersion) {
-        RdsInfo rdsInfo = new RdsInfo(RdsState.AVAILABLE, Map.of(), new RdsEngineVersion(currentEngineVersion));
-        Version targetMajorVersion = () -> "11";
-
-        Assertions.assertThrows(CloudConnectorException.class, () ->
-                underTest.validateRdsCanBeUpgraded(rdsInfo, targetMajorVersion)
+                underTest.validateRdsIsAvailableOrUpgrading(rdsInfo)
         );
     }
 


### PR DESCRIPTION
…aded

On AWS, if the DB was already upgraded by say, the customer, the code threw an exception. This killed the flow in core. Now there is no exception, just nothing is done with the RDS.

See detailed description in the commit message.