### PR TITLE
CB-18471: Remove response type and reason fields from RDS upgrade response

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
@@ -460,9 +460,6 @@ public enum ResourceEvent {
     CLUSTER_RDS_UPGRADE_FINISHED("cluster.externaldatabase.upgrade.finished"),
     CLUSTER_RDS_UPGRADE_FAILED("cluster.externaldatabase.upgrade.failed"),
 
-    CLUSTER_RDS_UPGRADE_NOT_AVAILABLE("cluster.externaldatabase.upgrade.not.available"),
-    CLUSTER_RDS_UPGRADE_ALREADY_UPGRADED("cluster.externaldatabase.upgrade.already.upgraded"),
-
     CLUSTER_CCM_UPGRADE_TUNNEL_UPDATE("cluster.ccm.upgrade.tunnel.update"),
     CLUSTER_CCM_UPGRADE_PUSH_SALT_STATES("cluster.ccm.upgrade.push.salt.states"),
     CLUSTER_CCM_UPGRADE_RECONFIGURE_NGINX("cluster.ccm.upgrade.reconfigure.nginx"),

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -211,8 +211,6 @@ cluster.externaldatabase.upgrade.restore.data=Restoring data from the backup, it
 cluster.externaldatabase.upgrade.start.services=Starting back Cloudera Manager and Runtime Services.
 cluster.externaldatabase.upgrade.finished=Upgrading database server finished.
 cluster.externaldatabase.upgrade.failed=Upgrading database server failed.
-cluster.externaldatabase.upgrade.already.upgraded=Upgrading database server is not needed as it is already on the latest version ({0}).
-cluster.externaldatabase.upgrade.not.available=Upgrading database server is not possible as stack is not available.
 
 cluster.ccm.upgrade.tunnel.update=Cluster Connectivity Manager tunnel type update.
 cluster.ccm.upgrade.push.salt.states=Cluster Connectivity Manager upgrade pushing Salt states.

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/upgrade/RdsUpgradeV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/upgrade/RdsUpgradeV4Response.java
@@ -1,28 +1,19 @@
 package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.upgrade;
 
-import org.apache.commons.lang3.StringUtils;
-
-import com.sequenceiq.cloudbreak.api.model.RdsUpgradeResponseType;
 import com.sequenceiq.cloudbreak.common.database.TargetMajorVersion;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 
 public class RdsUpgradeV4Response {
 
-    private RdsUpgradeResponseType responseType;
-
     private TargetMajorVersion targetVersion;
-
-    private String reason;
 
     private FlowIdentifier flowIdentifier;
 
     public RdsUpgradeV4Response() {
     }
 
-    public RdsUpgradeV4Response(RdsUpgradeResponseType responseType, FlowIdentifier flowIdentifier, String reason, TargetMajorVersion targetVersion) {
-        this.responseType = responseType;
+    public RdsUpgradeV4Response(FlowIdentifier flowIdentifier, TargetMajorVersion targetVersion) {
         this.flowIdentifier = flowIdentifier;
-        this.reason = reason;
         this.targetVersion = targetVersion;
     }
 
@@ -32,30 +23,6 @@ public class RdsUpgradeV4Response {
 
     public void setTargetVersion(TargetMajorVersion targetVersion) {
         this.targetVersion = targetVersion;
-    }
-
-    public String getReason() {
-        return reason;
-    }
-
-    public void setReason(String reason) {
-        this.reason = reason;
-    }
-
-    public void appendReason(String reason) {
-        if (StringUtils.isNotEmpty(this.reason)) {
-            this.reason += " " + reason;
-        } else {
-            setReason(reason);
-        }
-    }
-
-    public RdsUpgradeResponseType getResponseType() {
-        return responseType;
-    }
-
-    public void setResponseType(RdsUpgradeResponseType responseType) {
-        this.responseType = responseType;
     }
 
     public FlowIdentifier getFlowIdentifier() {
@@ -69,9 +36,7 @@ public class RdsUpgradeV4Response {
     @Override
     public String toString() {
         return "RdsUpgradeV4Response{" +
-                "responseType=" + responseType +
                 ", targetVersion=" + targetVersion +
-                ", reason='" + reason + '\'' +
                 ", flowIdentifier=" + flowIdentifier +
                 '}';
     }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/RdsUpgradeResponseType.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/RdsUpgradeResponseType.java
@@ -1,7 +1,0 @@
-package com.sequenceiq.cloudbreak.api.model;
-
-public enum RdsUpgradeResponseType {
-    TRIGGERED,
-    SKIP,
-    ERROR
-}

--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/model/upgrade/rds/DistroXRdsUpgradeV1Response.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/model/upgrade/rds/DistroXRdsUpgradeV1Response.java
@@ -1,28 +1,19 @@
 package com.sequenceiq.distrox.api.v1.distrox.model.upgrade.rds;
 
-import org.apache.commons.lang3.StringUtils;
-
-import com.sequenceiq.cloudbreak.api.model.RdsUpgradeResponseType;
 import com.sequenceiq.cloudbreak.common.database.TargetMajorVersion;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 
 public class DistroXRdsUpgradeV1Response {
 
-    private RdsUpgradeResponseType responseType;
-
     private TargetMajorVersion targetVersion;
-
-    private String reason;
 
     private FlowIdentifier flowIdentifier;
 
     public DistroXRdsUpgradeV1Response() {
     }
 
-    public DistroXRdsUpgradeV1Response(RdsUpgradeResponseType responseType, FlowIdentifier flowIdentifier, String reason, TargetMajorVersion targetVersion) {
-        this.responseType = responseType;
+    public DistroXRdsUpgradeV1Response(FlowIdentifier flowIdentifier, TargetMajorVersion targetVersion) {
         this.flowIdentifier = flowIdentifier;
-        this.reason = reason;
         this.targetVersion = targetVersion;
     }
 
@@ -32,22 +23,6 @@ public class DistroXRdsUpgradeV1Response {
 
     public void setTargetVersion(TargetMajorVersion targetVersion) {
         this.targetVersion = targetVersion;
-    }
-
-    public String getReason() {
-        return reason;
-    }
-
-    public void setReason(String reason) {
-        this.reason = reason;
-    }
-
-    public void appendReason(String reason) {
-        if (StringUtils.isNotEmpty(this.reason)) {
-            this.reason += " " + reason;
-        } else {
-            setReason(reason);
-        }
     }
 
     public FlowIdentifier getFlowIdentifier() {
@@ -61,9 +36,7 @@ public class DistroXRdsUpgradeV1Response {
     @Override
     public String toString() {
         return "DistroXRdsUpgradeV1Response{" +
-                "responseType=" + responseType +
                 ", targetVersion=" + targetVersion +
-                ", reason='" + reason + '\'' +
                 ", flowIdentifier=" + flowIdentifier +
                 '}';
     }

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/service/upgrade/rds/DistroXRdsUpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/service/upgrade/rds/DistroXRdsUpgradeService.java
@@ -24,11 +24,7 @@ public class DistroXRdsUpgradeService {
     public DistroXRdsUpgradeV1Response triggerUpgrade(NameOrCrn cluster, DistroXRdsUpgradeV1Request request) {
         TargetMajorVersion targetVersion = request.getTargetVersion();
         RdsUpgradeV4Response rdsUpgradeV4Response = rdsUpgradeService.upgradeRds(cluster, targetVersion);
-        DistroXRdsUpgradeV1Response response = new DistroXRdsUpgradeV1Response(
-                rdsUpgradeV4Response.getResponseType(),
-                rdsUpgradeV4Response.getFlowIdentifier(),
-                rdsUpgradeV4Response.getReason(),
-                targetVersion);
+        DistroXRdsUpgradeV1Response response = new DistroXRdsUpgradeV1Response(rdsUpgradeV4Response.getFlowIdentifier(), targetVersion);
         LOGGER.debug("Rds upgrade requested, response {}", response);
         return response;
     }


### PR DESCRIPTION
These fields are not used anymore because:
- successful responses do not have a reason
- error responses are returned via throwing an exception and are mapped as an exception mapper