### PR TITLE
CB-18332 Handle missing httpd Server-Cert

### DIFF
--- a/freeipa/src/main/resources/defaults/vm-logs.json
+++ b/freeipa/src/main/resources/defaults/vm-logs.json
@@ -102,5 +102,17 @@
   {
     "path": "/cdp/ipahealthagent/ipahealthagent.log",
     "label": "ipahealthagent"
+  },
+  {
+    "path": "/var/log/freeipa-healthagent-getcert.log",
+    "label": "freeipa-healthagent-getcert"
+  },
+  {
+    "path": "/var/log/freeipa-healthagent-setup.log",
+    "label": "freeipa-healthagent-setup"
+  },
+  {
+    "path": "/var/log/httpd-crt-tracking.log",
+    "label": "httpd-crt-tracking"
   }
 ]

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/healthagent.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/healthagent.sls
@@ -16,6 +16,25 @@
     - mode: 700
     - source: salt://freeipa/scripts/freeipa_healthagent_getcerts.sh
 
+/cdp/ipahealthagent/httpd-crt-tracking.sh:
+  file.managed:
+    - makedirs: True
+    - user: root
+    - group: root
+    - mode: 700
+    - source: salt://freeipa/scripts/httpd-crt-tracking.sh
+    - onlyif: test -f /var/lib/ipa/certs/httpd.crt
+
+/lib/systemd/system/httpd-crt-change-tracker.service:
+  file.managed:
+    - makedirs: True
+    - user: root
+    - group: root
+    - source: salt://freeipa/services/httpd-crt-change-tracker.service
+    - onlyif: test -f /var/lib/ipa/certs/httpd.crt
+    - require:
+      - file: /cdp/ipahealthagent/httpd-crt-tracking.sh
+
 setup-healthagent:
   cmd.run:
     - name: /opt/salt/scripts/freeipa_healthagent_setup.sh

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_healthagent_getcerts.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_healthagent_getcerts.sh
@@ -1,12 +1,60 @@
 #!/usr/bin/env bash
 
-BASE_PATH=/cdp/ipahealthagent
-CERT_FILE=$BASE_PATH/cert.p12
+set -x
+set -e
 
-pk12util -o $CERT_FILE -n 'Server-Cert' -d /etc/httpd/alias -k /etc/httpd/alias/pwdfile.txt -W ""
-openssl pkcs12 -in $CERT_FILE -nocerts -out $BASE_PATH/privateKey.pem -nodes -passout pass: -passin pass:
-openssl pkcs12 -in $CERT_FILE -clcerts -nokeys -out $BASE_PATH/publicCert.pem -passin pass:
-rm -f $CERT_FILE
-chmod 600 $BASE_PATH/privateKey.pem $BASE_PATH/publicCert.pem
+BASE_PATH=/cdp/ipahealthagent
+LOG_FILE=/var/log/freeipa-healthagent-getcert.log
+PUBLIC_CERT_PEM_FILE=$BASE_PATH/publicCert.pem
+PRIVATE_CERT_PEM_FILE=$BASE_PATH/privateKey.pem
+
+log() {
+    echo $(date) $* >> $LOG_FILE
+}
+
+log "Generate pems for freeipa health agent"
+
+if [ -f "/etc/httpd/alias/cert8.db" ]; then
+  log "Generate privateKey.pem and publicCert.pem by Server-Cert in /etc/httpd/alias/cert8.db"
+  CERT_FILE=$BASE_PATH/cert.p12
+
+  pk12util -o $CERT_FILE -n 'Server-Cert' -d /etc/httpd/alias -k /etc/httpd/alias/pwdfile.txt -W ""
+  openssl pkcs12 -in $CERT_FILE -nocerts -out $PRIVATE_CERT_PEM_FILE -nodes -passout pass: -passin pass:
+  openssl pkcs12 -in $CERT_FILE -clcerts -nokeys -out $PUBLIC_CERT_PEM_FILE -passin pass:
+  rm -f $CERT_FILE
+else
+  log "/etc/httpd/alias/cert8.db is missing"
+
+  PASSWORD_FILE=/var/lib/ipa/passwds/$(hostname)-443-RSA
+  KEY_FILE=/var/lib/ipa/private/httpd.key
+
+  if [ ! -f "$KEY_FILE" ]; then
+    log "$KEY_FILE is missing, unable to generate privateKey.pem"
+  elif [ ! -f "$PASSWORD_FILE" ]; then
+    log "$PASSWORD_FILE is missing, unable to generate privateKey.pem"
+  else
+    log "Generate privateKey.pem by $KEY_FILE and $PASSWORD_FILE"
+    openssl rsa -in $KEY_FILE -passin file:$PASSWORD_FILE -text > $$PRIVATE_CERT_PEM_FILE
+  fi
+
+  CRT_FILE=/var/lib/ipa/certs/httpd.crt
+  if [ ! -f "$CRT_FILE" ]; then
+    log "$CRT_FILE is missing, unable to generate publicCert.pem"
+  else
+    log "Generate publicCert.pem by $CRT_FILE"
+    openssl x509 -in $CRT_FILE -out $PUBLIC_CERT_PEM_FILE -outform PEM
+  fi
+fi
+
+if [ ! -f "$PUBLIC_CERT_PEM_FILE" ]; then
+  log "$PUBLIC_CERT_PEM_FILE is missing"
+  exit 1
+fi
+if [ ! -f "$PRIVATE_CERT_PEM_FILE" ]; then
+  log "$PRIVATE_CERT_PEM_FILE is missing"
+  exit 1
+fi
+
+chmod 600 $PRIVATE_CERT_PEM_FILE $PUBLIC_CERT_PEM_FILE
 
 systemctl restart cdp-freeipa-healthagent

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_healthagent_setup.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_healthagent_setup.sh
@@ -5,7 +5,24 @@
 set -x
 set -e
 
+LOG_FILE=/var/log/freeipa-healthagent-setup.log
+
+log() {
+    echo $(date) $* >> $LOG_FILE
+}
+
 #
-# Setup cert copy and service refstart on cert update
+# Setup cert copy and service restart on cert update
 #
-ipa-getcert start-tracking -n Server-Cert -d /etc/httpd/alias -C "/usr/libexec/ipa/certmonger/restart_httpd;/cdp/ipahealthagent/freeipa_healthagent_getcerts.sh"
+if [ -f "/etc/httpd/alias/cert8.db" ]; then
+  log "Start Server-Cert tracking by ipa-getcert"
+  ipa-getcert start-tracking -n Server-Cert -d /etc/httpd/alias -C "/usr/libexec/ipa/certmonger/restart_httpd;/cdp/ipahealthagent/freeipa_healthagent_getcerts.sh"
+elif [ -f "/var/lib/ipa/certs/httpd.crt" ]; then
+  log "Start httpd.crt tracking by systemd"
+  systemctl daemon-reload
+  systemctl enable httpd-crt-change-tracker
+  systemctl start httpd-crt-change-tracker
+else
+  log "Unable to track any kind of httpd certificate."
+  exit 1
+fi

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/httpd-crt-tracking.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/httpd-crt-tracking.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+LOG_FILE=/var/log/httpd-crt-tracking.log
+
+log() {
+    echo $(date) $* >> $LOG_FILE
+}
+
+log "Start /var/lib/ipa/certs/httpd.crt tracking by inotifywait"
+inotifywait -q -m -e close_write /var/lib/ipa/certs/httpd.crt |
+    while read -r filename event; do
+        log "Change has been detected by inotifywait in $filename. Execute /cdp/ipahealthagent/freeipa_healthagent_getcerts.sh"
+        /cdp/ipahealthagent/freeipa_healthagent_getcerts.sh;
+    done

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/update_cnames.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/update_cnames.sh
@@ -136,7 +136,11 @@ addHostToService "HTTP/kdc.$DOMAIN" "$FQDN"
 addHost "kerberos.$DOMAIN"
 addService "HTTP/kerberos.$DOMAIN"
 addHostToService "HTTP/kerberos.$DOMAIN" "$FQDN"
-HTTP_CERT_REQUEST_ID=$(getCertRequestIdFromDir /etc/httpd/alias Server-Cert)
-setDomainsForCert "$HTTP_CERT_REQUEST_ID" "freeipa.$DOMAIN kdc.$DOMAIN kerberos.$DOMAIN"
+
+# httpd Server-Cert (re)submit is needed when the legacy cert db does exist
+if [ -f "/etc/httpd/alias/cert8.db" ]; then
+  HTTP_CERT_REQUEST_ID=$(getCertRequestIdFromDir /etc/httpd/alias Server-Cert)
+  setDomainsForCert "$HTTP_CERT_REQUEST_ID" "freeipa.$DOMAIN kdc.$DOMAIN kerberos.$DOMAIN"
+fi
 
 set +e

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/services/httpd-crt-change-tracker.service
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/services/httpd-crt-change-tracker.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Track httpd crt changes in the background by inotifywait
+
+[Service]
+Type=simple
+User=root
+Group=root
+ExecStart=/cdp/ipahealthagent/httpd-crt-tracking.sh
+Restart=always
+RestartSec=3
+PIDFile=/var/run/httpd-crt-change-tracker.pid
+SyslogIdentifier=httpd-crt-change-tracker
+
+[Install]
+WantedBy=multi-user.target

--- a/freeipa/src/main/resources/freeipa-salt/salt/logrotate/conf/freeipa-healthagent-getcert
+++ b/freeipa/src/main/resources/freeipa-salt/salt/logrotate/conf/freeipa-healthagent-getcert
@@ -1,0 +1,6 @@
+/var/log/freeipa-healthagent-getcert.log {
+    missingok
+    notifempty
+    size 1M
+    rotate 6
+}

--- a/freeipa/src/main/resources/freeipa-salt/salt/logrotate/conf/freeipa-healthagent-setup
+++ b/freeipa/src/main/resources/freeipa-salt/salt/logrotate/conf/freeipa-healthagent-setup
@@ -1,0 +1,6 @@
+/var/log/freeipa-healthagent-setup.log {
+    missingok
+    notifempty
+    size 1M
+    rotate 6
+}

--- a/freeipa/src/main/resources/freeipa-salt/salt/logrotate/conf/httpd-crt-tracking
+++ b/freeipa/src/main/resources/freeipa-salt/salt/logrotate/conf/httpd-crt-tracking
@@ -1,0 +1,6 @@
+/var/log/httpd-crt-tracking.log {
+    missingok
+    notifempty
+    size 1M
+    rotate 6
+}

--- a/freeipa/src/main/resources/freeipa-salt/salt/logrotate/init.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/logrotate/init.sls
@@ -1,3 +1,27 @@
+logrotate-freeipa-healthagent-getcert:
+  file.managed:
+    - name: /etc/logrotate.d/freeipa-healthagent-getcert
+    - source: salt://logrotate/conf/freeipa-healthagent-getcert
+    - user: root
+    - group: root
+    - mode: 644
+
+logrotate-freeipa-healthagent-setup:
+  file.managed:
+    - name: /etc/logrotate.d/freeipa-healthagent-setup
+    - source: salt://logrotate/conf/freeipa-healthagent-setup
+    - user: root
+    - group: root
+    - mode: 644
+
+logrotate-httpd-crt-tracking:
+  file.managed:
+    - name: /etc/logrotate.d/freeipa-healthagent-setup
+    - source: salt://logrotate/conf/freeipa-healthagent-setup
+    - user: root
+    - group: root
+    - mode: 644
+
 logrotate-krb5kdc:
   file.managed:
     - name: /etc/logrotate.d/krb5kdc


### PR DESCRIPTION
On RHEL8, httpd is not using cert dbs by mod_nss anymore but uses crt files directly by mod_ssl. We should support pem generation for freeipa health agent directly from httpd crt file instead of using Server-Cert from cert db. We should track crt file changes similarly as Server-Cert was tracked in the cert db. We are using inotifywait 3rd party tool to track file changes, it triggers pem generation and freeipa healt agent restart.