### PR TITLE
CB-18466 Add `fromrepo` directive to postgres 11 install state

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/pg11-install.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/pg11-install.sls
@@ -9,3 +9,4 @@ install-postgres11:
         - postgresql11
         - postgresql11-contrib
         - postgresql11-docs
+    - fromrepo: pgdg11


### PR DESCRIPTION
To avoid yum reaching out to other repositories, `fromrepo` is added like it's done for upgrading CM.

See detailed description in the commit message.