### PR TITLE
CB-18514 Improve the E2E Stack Authentication for request parameters

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProvider.java
@@ -18,6 +18,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.network.A
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.stack.AwsStackV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AwsInstanceTemplateV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AwsInstanceTemplateV4SpotParameters;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.authentication.StackAuthenticationV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.network.InstanceGroupNetworkV4Request;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
@@ -318,7 +319,13 @@ public class AwsCloudProvider extends AbstractCloudProvider {
 
     @Override
     public StackAuthenticationTestDto stackAuthentication(StackAuthenticationTestDto stackAuthenticationEntity) {
-        return stackAuthenticationEntity.withPublicKeyId(awsProperties.getPublicKeyId());
+        StackAuthenticationV4Request request = stackAuthenticationEntity.getRequest();
+        stackAuthenticationEntity.withPublicKeyId(StringUtils.isBlank(request.getPublicKeyId())
+                ? awsProperties.getPublicKeyId()
+                : request.getPublicKeyId());
+        stackAuthenticationEntity.withPublicKey(request.getPublicKey());
+        stackAuthenticationEntity.withLoginUserName(request.getLoginUserName());
+        return stackAuthenticationEntity;
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpCloudProvider.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.network.GcpNetworkV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.stack.GcpStackV4Parameters;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.authentication.StackAuthenticationV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.network.InstanceGroupNetworkV4Request;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.common.api.cloudstorage.old.GcsCloudStorageV1Parameters;
@@ -142,8 +143,8 @@ public class GcpCloudProvider extends AbstractCloudProvider {
     }
 
     @Override
-    public EnvironmentSecurityAccessTestDto environmentSecurityAccess(EnvironmentSecurityAccessTestDto environmentSecurityAccessTestDto) {
-        EnvironmentSecurityAccessTestDto envSecAcc = super.environmentSecurityAccess(environmentSecurityAccessTestDto);
+    public EnvironmentSecurityAccessTestDto environmentSecurityAccess(EnvironmentSecurityAccessTestDto environmentSecurityAccess) {
+        EnvironmentSecurityAccessTestDto envSecAcc = super.environmentSecurityAccess(environmentSecurityAccess);
         return envSecAcc.withDefaultSecurityGroupId(gcpProperties.getSecurityAccess().getDefaultSecurityGroup())
                 .withSecurityGroupIdForKnox(gcpProperties.getSecurityAccess().getKnoxSecurityGroup());
     }
@@ -364,7 +365,13 @@ public class GcpCloudProvider extends AbstractCloudProvider {
 
     @Override
     public StackAuthenticationTestDto stackAuthentication(StackAuthenticationTestDto stackAuthenticationEntity) {
-        return stackAuthenticationEntity.withPublicKey(commonCloudProperties().getSshPublicKey());
+        StackAuthenticationV4Request request = stackAuthenticationEntity.getRequest();
+        stackAuthenticationEntity.withPublicKeyId(request.getPublicKeyId());
+        stackAuthenticationEntity.withPublicKey(StringUtils.isBlank(request.getPublicKey())
+                ? commonCloudProperties().getSshPublicKey()
+                : request.getPublicKey());
+        stackAuthenticationEntity.withLoginUserName(request.getLoginUserName());
+        return stackAuthenticationEntity;
     }
 
     @Override
@@ -447,7 +454,7 @@ public class GcpCloudProvider extends AbstractCloudProvider {
     }
 
     private <T> T notImplementedException() {
-        throw new NotImplementedException(String.format("Not implemented on %s", getCloudPlatform()));
+        throw new NotImplementedException(format("Not implemented on %s", getCloudPlatform()));
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/yarn/YarnCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/yarn/YarnCloudProvider.java
@@ -5,6 +5,7 @@ import static java.lang.String.format;
 import javax.inject.Inject;
 
 import org.apache.commons.lang3.NotImplementedException;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.network.YarnNetworkV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.stack.YarnStackV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.YarnInstanceTemplateV4Parameters;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.authentication.StackAuthenticationV4Request;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.common.model.FileSystemType;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.InstanceTemplateV1Request;
@@ -69,7 +71,7 @@ public class YarnCloudProvider extends AbstractCloudProvider {
 
     @Override
     public EnvironmentTestDto environment(EnvironmentTestDto environment) {
-        final AttachedFreeIpaRequest attachedFreeIpaRequest = new AttachedFreeIpaRequest();
+        AttachedFreeIpaRequest attachedFreeIpaRequest = new AttachedFreeIpaRequest();
         attachedFreeIpaRequest.setCreate(Boolean.FALSE);
 
         return environment
@@ -232,7 +234,7 @@ public class YarnCloudProvider extends AbstractCloudProvider {
     }
 
     private <T> T throwNotImplementedException() {
-        throw new NotImplementedException(String.format("Not implemented on %s", getCloudPlatform()));
+        throw new NotImplementedException(format("Not implemented on %s", getCloudPlatform()));
     }
 
     @Override
@@ -242,7 +244,13 @@ public class YarnCloudProvider extends AbstractCloudProvider {
 
     @Override
     public StackAuthenticationTestDto stackAuthentication(StackAuthenticationTestDto stackAuthenticationEntity) {
-        return stackAuthenticationEntity.withPublicKey(commonCloudProperties().getSshPublicKey());
+        StackAuthenticationV4Request request = stackAuthenticationEntity.getRequest();
+        stackAuthenticationEntity.withPublicKeyId(request.getPublicKeyId());
+        stackAuthenticationEntity.withPublicKey(StringUtils.isBlank(request.getPublicKey())
+                ? commonCloudProperties().getSshPublicKey()
+                : request.getPublicKey());
+        stackAuthenticationEntity.withLoginUserName(request.getLoginUserName());
+        return stackAuthenticationEntity;
     }
 
     @Override


### PR DESCRIPTION
Right now we have `stackAuthentication` method for every each cloud provider with different implementation to setting up SSH Public Key ID (AWS and MOCK) or Public Key (AZURE, GCP, YARN).
However these right now support only one stack authentication parameter set up.

Beyond these we have partially implemented solution for get Stack Authentication from SDX template. Right now this is only support setting up `publicKeyId` from template. So we need to improve this solution for the other two parameters as well.