### PR TITLE
CB-18504: Made FreeIpa status result message more UI friendly, by not returning JSON strings

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/FreeipaChecker.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/FreeipaChecker.java
@@ -80,7 +80,8 @@ public class FreeipaChecker {
                 status = DetailedStackStatus.UNHEALTHY;
             }
 
-            return new SyncResult("FreeIpa is " + status + ", " + statusCheckPair.getSecond(), status, statusCheckPair.getFirst());
+            LOGGER.info("FreeIpa is {}, node health cheks: {}", status, statusCheckPair.getSecond());
+            return new SyncResult("FreeIpa is " + status, status, statusCheckPair.getFirst());
         } catch (Exception e) {
             LOGGER.info("Error occurred during status fetch: " + e.getMessage(), e);
             return new SyncResult("FreeIpa is unreachable, because error occurred: " + e.getMessage(), DetailedStackStatus.UNREACHABLE, null);


### PR DESCRIPTION
The node check results are logged instead of being sent as the result string.