### PR TITLE
CB-18459 Create FreeIPA E2E test for pre-termination recipe

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProvider.java
@@ -125,6 +125,8 @@ public interface CloudProvider {
 
     String getBaseLocation();
 
+    String getBaseLocationForPreTermination();
+
     String getSubnetCIDR();
 
     String getAccessCIDR();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProviderProxy.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProviderProxy.java
@@ -193,6 +193,11 @@ public class CloudProviderProxy implements CloudProvider {
     }
 
     @Override
+    public String getBaseLocationForPreTermination() {
+        return delegate.getBaseLocationForPreTermination();
+    }
+
+    @Override
     public VolumeV4TestDto attachedVolume(VolumeV4TestDto volume) {
         return getDelegate(volume).attachedVolume(volume);
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProvider.java
@@ -383,6 +383,11 @@ public class AwsCloudProvider extends AbstractCloudProvider {
         return String.join("/", awsProperties.getCloudStorage().getBaseLocation(), DEFAULT_STORAGE_NAME);
     }
 
+    @Override
+    public String getBaseLocationForPreTermination() {
+        return String.join("/", awsProperties.getCloudStorage().getBaseLocation(), "pre-termination");
+    }
+
     public String getInstanceProfile() {
         return awsProperties.getCloudStorage().getS3().getInstanceProfile();
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
@@ -359,6 +359,12 @@ public class AzureCloudProvider extends AbstractCloudProvider {
         return String.join("/", azureProperties.getCloudStorage().getBaseLocation(), DEFAULT_STORAGE_NAME);
     }
 
+    @Override
+    public String getBaseLocationForPreTermination() {
+        return String.join("/", azureProperties.getCloudStorage().getBaseLocation(),
+                "pre-termination");
+    }
+
     public String getAssumerIdentity() {
         return azureProperties.getCloudStorage().getAdlsGen2().getAssumerIdentity();
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpCloudProvider.java
@@ -409,6 +409,12 @@ public class GcpCloudProvider extends AbstractCloudProvider {
         return String.join("/", gcpProperties.getCloudStorage().getBaseLocation(), DEFAULT_STORAGE_NAME);
     }
 
+    @Override
+    public String getBaseLocationForPreTermination() {
+        return String.join("/", gcpProperties.getCloudStorage().getBaseLocation(),
+                "pre-termination");
+    }
+
     public String getServiceAccountEmail() {
         return gcpProperties.getCloudStorage().getGcs().getServiceAccountEmail();
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/mock/MockCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/mock/MockCloudProvider.java
@@ -391,6 +391,12 @@ public class MockCloudProvider extends AbstractCloudProvider {
         return String.join("/", mockProperties.getCloudStorage().getBaseLocation(), DEFAULT_STORAGE_NAME);
     }
 
+    @Override
+    public String getBaseLocationForPreTermination() {
+        return String.join("/", mockProperties.getCloudStorage().getBaseLocation(),
+                "pre-termination");
+    }
+
     public String getInstanceProfile() {
         return mockProperties.getCloudStorage().getS3().getInstanceProfile();
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/yarn/YarnCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/yarn/YarnCloudProvider.java
@@ -316,6 +316,11 @@ public class YarnCloudProvider extends AbstractCloudProvider {
         return null;
     }
 
+    @Override
+    public String getBaseLocationForPreTermination() {
+        return null;
+    }
+
     public String getInstanceProfile() {
         return null;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDto.java
@@ -3,6 +3,7 @@ package com.sequenceiq.it.cloudbreak.dto.distrox;
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.emptyRunningParameter;
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
 import static com.sequenceiq.it.cloudbreak.testcase.AbstractIntegrationTest.STACK_DELETED;
+import static java.lang.String.format;
 
 import java.util.Collections;
 import java.util.List;
@@ -194,13 +195,13 @@ public class DistroXTestDto extends DistroXTestDtoBase<DistroXTestDto> implement
         if (!getInstanceIdsForAction().isEmpty()) {
             return awaitForInstance(Map.of(getInstanceIdsForAction(), instanceStatus));
         } else {
-            throw new IllegalStateException(String.format("There is no '%s' instance to wait!", instanceStatus));
+            throw new IllegalStateException(format("There is no '%s' instance to wait!", instanceStatus));
         }
     }
 
     public DistroXTestDto awaitForHostGroup(String hostGroup, InstanceStatus instanceStatus) {
         if (!getTestContext().getExceptionMap().isEmpty()) {
-            Log.await(LOGGER, String.format("Await for host group should be skipped because of previous error. awaitForHostGroup [%s] - [%s]",
+            Log.await(LOGGER, format("Await for host group should be skipped because of previous error. awaitForHostGroup [%s] - [%s]",
                     hostGroup, instanceStatus));
             return this;
         }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/instancegroup/DistroXInstanceGroupTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/instancegroup/DistroXInstanceGroupTestDto.java
@@ -6,9 +6,13 @@ import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.GATEWAY;
 import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.MASTER;
 import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.WORKER;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.apache.commons.collections4.CollectionUtils;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.RecoveryMode;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
@@ -76,6 +80,7 @@ public class DistroXInstanceGroupTestDto extends AbstractCloudbreakTestDto<Insta
                 .withType(hostGroupType.getInstanceGroupType())
                 .withName(hostGroupType.getName())
                 .withNetwork(SubnetId.all())
+                .withRecipes(entity.getRequest().getRecipeNames())
                 .withTemplate(testContext.given(DistroXInstanceTemplateTestDto.class));
     }
 
@@ -85,8 +90,24 @@ public class DistroXInstanceGroupTestDto extends AbstractCloudbreakTestDto<Insta
     }
 
     public DistroXInstanceGroupTestDto withRecipes(String... recipeNames) {
+        Set<String> recipes = new HashSet<String>();
         for (String recipeName : recipeNames) {
-            getRequest().getRecipeNames().add(recipeName);
+            recipes = getRequest().getRecipeNames();
+            recipes.add(recipeName);
+        }
+        getRequest().setRecipeNames(recipes);
+        return this;
+    }
+
+    public DistroXInstanceGroupTestDto withRecipes(Set<String> recipeNames) {
+        if (CollectionUtils.isNotEmpty(recipeNames)) {
+            Set<String> recipes = getRequest().getRecipeNames();
+            if (CollectionUtils.isNotEmpty(recipes)) {
+                recipes.addAll(recipeNames);
+                getRequest().setRecipeNames(recipes);
+            } else {
+                getRequest().setRecipeNames(recipeNames);
+            }
         }
         return this;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/instancegroup/DistroXInstanceGroupsBuilder.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/instancegroup/DistroXInstanceGroupsBuilder.java
@@ -7,9 +7,11 @@ import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.WORKER;
 import static com.sequenceiq.it.cloudbreak.dto.distrox.instancegroup.DistroXInstanceGroupTestDto.withHostGroup;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
+import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.InstanceGroupV1Request;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.InstanceTemplateV1Request;
 import com.sequenceiq.it.cloudbreak.cloud.v4.CloudProvider;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
@@ -51,6 +53,11 @@ public class DistroXInstanceGroupsBuilder {
         return this;
     }
 
+    public DistroXInstanceGroupsBuilder withRecipes(Set<String> recipeNames) {
+        getInstanceGroupRequests().forEach(instanceGroupRequest -> instanceGroupRequest.setRecipeNames(recipeNames));
+        return this;
+    }
+
     public List<DistroXInstanceGroupTestDto> build() {
         return distroXInstanceGroupTestDtoList;
     }
@@ -63,5 +70,15 @@ public class DistroXInstanceGroupsBuilder {
 
     private InstanceTemplateV1Request getInstanceTemplate(DistroXInstanceGroupTestDto distroXInstanceGroupTestDto) {
         return distroXInstanceGroupTestDto.getRequest().getTemplate();
+    }
+
+    private List<InstanceGroupV1Request> getInstanceGroupRequests() {
+        return distroXInstanceGroupTestDtoList.stream()
+                .map(this::getInstanceGroupRequest)
+                .collect(Collectors.toList());
+    }
+
+    private InstanceGroupV1Request getInstanceGroupRequest(DistroXInstanceGroupTestDto distroXInstanceGroupTestDto) {
+        return distroXInstanceGroupTestDto.getRequest();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaTestDto.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.ws.rs.NotFoundException;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.testng.util.Strings;
 
@@ -414,8 +415,27 @@ public class FreeIpaTestDto extends AbstractFreeIpaTestDto<CreateFreeIpaRequest,
         return this;
     }
 
-    public FreeIpaTestDto withRecipe(Set<String> recipes) {
-        getRequest().setRecipes(recipes);
+    public FreeIpaTestDto withRecipes(Set<String> recipeNames) {
+        Set<String> existingRecipes = getRequest().getRecipes();
+
+        if (CollectionUtils.isEmpty(existingRecipes)) {
+            getRequest().setRecipes(recipeNames);
+        } else {
+            existingRecipes.addAll(recipeNames);
+            getRequest().setRecipes(existingRecipes);
+        }
+        return this;
+    }
+
+    public FreeIpaTestDto withRecipe(String recipeName) {
+        Set<String> existingRecipes = getRequest().getRecipes();
+
+        if (CollectionUtils.isEmpty(existingRecipes)) {
+            getRequest().setRecipes(Set.of(recipeName));
+        } else {
+            existingRecipes.add(recipeName);
+            getRequest().setRecipes(existingRecipes);
+        }
         return this;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.ws.rs.NotFoundException;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -293,6 +293,26 @@ public class SdxTestDto extends AbstractSdxTestDto<SdxClusterRequest, SdxCluster
         sdxRecipe.setName(recipeName);
         sdxRecipe.setHostGroup(hostGroup);
         recipes.add(sdxRecipe);
+        return this;
+    }
+
+    public SdxTestDto withRecipes(Set<String> recipeNames, String hostGroup) {
+        Set<SdxRecipe> sdxRecipes = getRequest().getRecipes();
+        Set<SdxRecipe> newRecipes = new HashSet<>();
+        SdxRecipe sdxRecipe = new SdxRecipe();
+
+        recipeNames.forEach(recipeName -> {
+            sdxRecipe.setName(recipeName);
+            sdxRecipe.setHostGroup(hostGroup);
+            newRecipes.add(sdxRecipe);
+        });
+
+        if (CollectionUtils.isEmpty(sdxRecipes)) {
+            getRequest().setRecipes(newRecipes);
+        } else {
+            sdxRecipes.addAll(newRecipes);
+            getRequest().setRecipes(sdxRecipes);
+        }
         return this;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/AbstractE2ETest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/AbstractE2ETest.java
@@ -90,4 +90,8 @@ public abstract class AbstractE2ETest extends AbstractIntegrationTest {
                 cloudProvider,
                 not(equalToIgnoringCase(cloudPlatform.name())));
     }
+
+    protected String getBaseLocationForPreTermination(TestContext testContext) {
+        return testContext.getCloudProvider().getBaseLocationForPreTermination();
+    }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXAwsMigrationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXAwsMigrationTest.java
@@ -4,6 +4,7 @@ import javax.inject.Inject;
 
 import org.testng.annotations.Test;
 
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.distrox.api.v1.distrox.model.upgrade.DistroXUpgradeReplaceVms;
 import com.sequenceiq.it.cloudbreak.client.DistroXTestClient;
 import com.sequenceiq.it.cloudbreak.client.ImageCatalogTestClient;
@@ -30,6 +31,7 @@ public class DistroXAwsMigrationTest extends AbstractE2ETest {
 
     @Override
     protected void setupTest(TestContext testContext) {
+        assertSupportedCloudPlatform(CloudPlatform.AWS);
         createDefaultUser(testContext);
         initializeDefaultBlueprints(testContext);
         createDefaultCredential(testContext);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/freeipa/FreeIpaRecipeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/freeipa/FreeIpaRecipeTests.java
@@ -122,7 +122,7 @@ public class FreeIpaRecipeTests extends AbstractE2ETest {
                     .withReportClusterLogs()
                 .given(FreeIpaTestDto.class)
                     .withTelemetry("telemetry")
-                    .withRecipe(Set.of(preRecipeName, postInstallRecipeName))
+                    .withRecipes(Set.of(preRecipeName, postInstallRecipeName))
                 .when(freeIpaTestClient.create())
                 .await(Status.AVAILABLE)
                 .awaitForHealthyInstances()

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxCloudStorageTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxCloudStorageTest.java
@@ -13,7 +13,6 @@ import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
-import com.sequenceiq.it.cloudbreak.util.aws.amazons3.AmazonS3Util;
 import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
 import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 import com.sequenceiq.sdx.api.model.SdxDatabaseAvailabilityType;
@@ -26,9 +25,6 @@ public class SdxCloudStorageTest extends PreconditionSdxE2ETest {
 
     @Inject
     private FreeIpaTestClient freeIpaTestClient;
-
-    @Inject
-    private AmazonS3Util amazonS3Util;
 
     @Test(dataProvider = TEST_CONTEXT)
     @UseSpotInstances

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentChildTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentChildTest.java
@@ -164,6 +164,7 @@ public class EnvironmentChildTest extends AbstractMockTest {
                 .when(environmentTestClient.deleteMultipleByNames(parentEnvName, testContext.get(CHILD_ENVIRONMENT).getName()))
                 .await(EnvironmentStatus.ARCHIVED, RunningParameter.key(CHILD_ENVIRONMENT))
                 .given(EnvironmentTestDto.class)
+                .when(environmentTestClient.describe())
                 .await(EnvironmentStatus.ARCHIVED)
                 .when(environmentTestClient.list())
                 .then(checkEnvsAreNotListedByName(List.of(parentEnvName, testContext.get(CHILD_ENVIRONMENT).getName())))

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/FreeIpaCreationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/FreeIpaCreationTest.java
@@ -70,7 +70,7 @@ public class FreeIpaCreationTest extends AbstractMockTest {
                     .withRecipeType(PRE_TERMINATION)
                 .when(recipeTestClient.createV4())
                 .given(FreeIpaTestDto.class)
-                .withRecipe(Set.of(preRecipeName, postInstallRecipeName, preTerminationRecipeName))
+                .withRecipes(Set.of(preRecipeName, postInstallRecipeName, preTerminationRecipeName))
                 .when(freeIpaTestClient.create())
                 .enableVerification()
                 .await(Status.AVAILABLE)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/FreeIpaRecipeDetachTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/FreeIpaRecipeDetachTest.java
@@ -72,7 +72,7 @@ public class FreeIpaRecipeDetachTest extends AbstractMockTest {
                 .withRecipeType(POST_SERVICE_DEPLOYMENT)
                 .when(recipeTestClient.createV4())
                 .given(FreeIpaTestDto.class)
-                .withRecipe(Set.of(preRecipeName, postInstallRecipeName))
+                .withRecipes(Set.of(preRecipeName, postInstallRecipeName))
                 .withFreeIpaHa(1, 2)
                 .when(freeIpaTestClient.create())
                 .enableVerification()

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazons3/action/S3ClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazons3/action/S3ClientActions.java
@@ -16,6 +16,7 @@ import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3URI;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest.KeyVersion;
 import com.amazonaws.services.s3.model.ListObjectsRequest;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.S3Object;
@@ -43,9 +44,9 @@ public class S3ClientActions extends S3Client {
                 ObjectListing objectListing = s3Client.listObjects(listObjectsRequest);
 
                 do {
-                    List<DeleteObjectsRequest.KeyVersion> deletableObjects = Lists.newArrayList();
+                    List<KeyVersion> deletableObjects = Lists.newArrayList();
                     for (S3ObjectSummary objectSummary : objectListing.getObjectSummaries()) {
-                        deletableObjects.add(new DeleteObjectsRequest.KeyVersion(objectSummary.getKey()));
+                        deletableObjects.add(new KeyVersion(objectSummary.getKey()));
                     }
                     DeleteObjectsRequest deleteObjectsRequest = new DeleteObjectsRequest(bucketName);
                     deleteObjectsRequest.setKeys(deletableObjects);
@@ -103,9 +104,9 @@ public class S3ClientActions extends S3Client {
                     }
                 } while (filteredObjectSummaries.isEmpty() && objectListing.isTruncated());
 
-                if (filteredObjectSummaries.size() == 0) {
+                if (filteredObjectSummaries.isEmpty()) {
                     LOGGER.error("Amazon S3 object: {} has 0 sub-objects!", selectedObject);
-                    throw new TestFailException(String.format("Amazon S3 object: %s has 0 sub-objects!", selectedObject));
+                    throw new TestFailException(format("Amazon S3 object: %s has 0 sub-objects!", selectedObject));
                 } else {
                     Log.log(LOGGER, format(" Amazon S3 object: %s contains %d sub-objects.",
                             selectedObject, filteredObjectSummaries.size()));
@@ -117,7 +118,7 @@ public class S3ClientActions extends S3Client {
 
                     if (!zeroContent && object.getObjectMetadata().getContentLength() == 0) {
                         LOGGER.error("Amazon S3 path: {} has 0 bytes of content!", object.getKey());
-                        throw new TestFailException(String.format("Amazon S3 path: %s has 0 bytes of content!", object.getKey()));
+                        throw new TestFailException(format("Amazon S3 path: %s has 0 bytes of content!", object.getKey()));
                     }
                     try {
                         inputStream.abort();

--- a/integration-test/src/main/resources/recipes/e2e-pre-termination.sh
+++ b/integration-test/src/main/resources/recipes/e2e-pre-termination.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+touch /e2e-pre-termination
+echo "Hello Pre-Termination" >> /e2e-pre-termination
+
+COPY_TO_OBJECT


### PR DESCRIPTION
PRE-Termination recipes are very hard to assert, because of the cluster is deleted after the recipes are executed. So we need to upload the result of recipe execution, for example: put a file into S3.

Furthermore this commit contains fixes:
- for the recently observed cascading delete mock test issue at [testDeleteChildAndParentEnvironment](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentChildTest.java#L164-L167) highlighted by @topolyai5 
- code style issues at changed classes