### PR TITLE
CB-18436 During upscale we can count the number of upscaled nodes inc…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleService.java
@@ -131,9 +131,10 @@ public class StackUpscaleService {
     public Set<String> finishExtendMetadata(StackView stackView, Integer scalingAdjustment, CollectMetadataResult payload) throws TransactionExecutionException {
         return transactionService.required(() -> {
             List<CloudVmMetaDataStatus> coreInstanceMetaData = payload.getResults();
-            int newInstances = metadataSetupService.saveInstanceMetaData(stackView, coreInstanceMetaData, CREATED);
+            metadataSetupService.saveInstanceMetaData(stackView, coreInstanceMetaData, CREATED);
             Set<String> upscaleCandidateAddresses = coreInstanceMetaData.stream().filter(im -> im.getMetaData().getPrivateIp() != null)
                     .map(im -> im.getMetaData().getPrivateIp()).collect(Collectors.toSet());
+            int newInstances = upscaleCandidateAddresses.size();
             try {
                 clusterService.updateClusterStatusByStackIdOutOfTransaction(stackView.getId(), DetailedStackStatus.EXTENDING_METADATA_FINISHED);
             } catch (TransactionExecutionException e) {


### PR DESCRIPTION
…orrectly. This changes fixes it by using the upscale candidates list which contains the correct number of nodes.

See detailed description in the commit message.