### PR TITLE
Cb 18506:  Null pointer exception is caused by getBackupOperationType.

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/BackupOperationType.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/BackupOperationType.java
@@ -4,4 +4,9 @@ public enum BackupOperationType {
     ANY,
     BACKUP,
     RESTORE,
+    NONE;
+
+    public static boolean isRestore(BackupOperationType operationType) {
+        return operationType == ANY || operationType == RESTORE;
+    }
 }

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/BackupOperationType.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/BackupOperationType.java
@@ -1,0 +1,7 @@
+package com.sequenceiq.cloudbreak.cloud.model;
+
+public enum BackupOperationType {
+    ANY,
+    BACKUP,
+    RESTORE,
+}

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/objectstorage/ObjectStorageValidateRequest.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/objectstorage/ObjectStorageValidateRequest.java
@@ -222,7 +222,11 @@ public class ObjectStorageValidateRequest implements CloudPlatformAware {
         }
 
         public Builder withBackupOperationType(BackupOperationType backupOperationType) {
-            this.backupOperationType = backupOperationType;
+            if (backupOperationType != null) {
+                this.backupOperationType = backupOperationType;
+            } else {
+                this.backupOperationType = BackupOperationType.ANY;
+            }
             return this;
         }
 

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/objectstorage/ObjectStorageValidateRequest.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/objectstorage/ObjectStorageValidateRequest.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import javax.validation.constraints.NotNull;
 
 import com.sequenceiq.cloudbreak.cloud.CloudPlatformAware;
+import com.sequenceiq.cloudbreak.cloud.model.BackupOperationType;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
 import com.sequenceiq.cloudbreak.cloud.model.SpiFileSystem;
@@ -26,6 +27,8 @@ public class ObjectStorageValidateRequest implements CloudPlatformAware {
 
     private String backupLocationBase;
 
+    private BackupOperationType backupOperationType;
+
     private AzureParameters azure;
 
     private MockAccountMappingSettings mockAccountMappingSettings;
@@ -40,6 +43,7 @@ public class ObjectStorageValidateRequest implements CloudPlatformAware {
         this.spiFileSystem = builder.spiFileSystem;
         this.logsLocationBase = builder.logsLocationBase;
         this.backupLocationBase = builder.backupLocationBase;
+        this.backupOperationType = builder.backupOperationType;
         this.mockAccountMappingSettings = builder.mockAccountMappingSettings;
         this.azure = builder.azure;
     }
@@ -96,6 +100,14 @@ public class ObjectStorageValidateRequest implements CloudPlatformAware {
         this.backupLocationBase = backupLocationBase;
     }
 
+    public BackupOperationType getBackupOperationType() {
+        return backupOperationType;
+    }
+
+    public void setBackupOperationType(BackupOperationType backupOperationType) {
+        this.backupOperationType = backupOperationType;
+    }
+
     public MockAccountMappingSettings getMockAccountMappingSettings() {
         return mockAccountMappingSettings;
     }
@@ -112,6 +124,7 @@ public class ObjectStorageValidateRequest implements CloudPlatformAware {
         this.azure = azure;
     }
 
+    @SuppressWarnings("checkstyle:CyclomaticComplexity")
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -126,6 +139,8 @@ public class ObjectStorageValidateRequest implements CloudPlatformAware {
                 Objects.equals(cloudStorageRequest, request.cloudStorageRequest) &&
                 Objects.equals(spiFileSystem, request.spiFileSystem) &&
                 Objects.equals(logsLocationBase, request.logsLocationBase) &&
+                Objects.equals(backupLocationBase, request.backupLocationBase) &&
+                Objects.equals(backupOperationType, request.backupOperationType) &&
                 Objects.equals(azure, request.azure);
     }
 
@@ -141,7 +156,8 @@ public class ObjectStorageValidateRequest implements CloudPlatformAware {
                 ", cloudStorageRequest='" + JsonUtil.writeValueAsStringSilent(cloudStorageRequest) + '\'' +
                 ", spiFileSystem='" + spiFileSystem + '\'' +
                 ", logsLocationBase='" + logsLocationBase + '\'' +
-                ", azureParameters='" + azure + '\'' +
+                ", backupLocationBase='" + backupLocationBase + '\'' +
+                ", backupOperationType='" + backupOperationType + '\'' +
                 '}';
     }
 
@@ -168,6 +184,8 @@ public class ObjectStorageValidateRequest implements CloudPlatformAware {
         private String logsLocationBase;
 
         private String backupLocationBase;
+
+        private BackupOperationType backupOperationType;
 
         private MockAccountMappingSettings mockAccountMappingSettings;
 
@@ -200,6 +218,11 @@ public class ObjectStorageValidateRequest implements CloudPlatformAware {
 
         public Builder withBackupLocationBase(String backupLocationBase) {
             this.backupLocationBase = backupLocationBase;
+            return this;
+        }
+
+        public Builder withBackupOperationType(BackupOperationType backupOperationType) {
+            this.backupOperationType = backupOperationType;
             return this;
         }
 

--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/AwsObjectStorageConnector.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/AwsObjectStorageConnector.java
@@ -87,9 +87,8 @@ public class AwsObjectStorageConnector implements ObjectStorageConnector {
         SpiFileSystem spiFileSystem = request.getSpiFileSystem();
         ValidationResultBuilder resultBuilder = new ValidationResultBuilder();
         resultBuilder.prefix("Cloud Storage validation failed");
-        ValidationResult validationResult = awsIDBrokerObjectStorageValidator.validateObjectStorage(
-                iam, spiFileSystem, request.getLogsLocationBase(), request.getBackupLocationBase(), accountId,
-                resultBuilder);
+        ValidationResult validationResult = awsIDBrokerObjectStorageValidator.validateObjectStorage(request, iam, spiFileSystem,
+                accountId, resultBuilder);
         ObjectStorageValidateResponse response;
         if (validationResult.hasError()) {
             response = ObjectStorageValidateResponse.builder()

--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/validator/AwsIDBrokerMappedRolePermissionValidator.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/validator/AwsIDBrokerMappedRolePermissionValidator.java
@@ -167,6 +167,9 @@ public abstract class AwsIDBrokerMappedRolePermissionValidator extends AbstractA
     }
 
     List<String> getPolicyFiles(BackupOperationType backupOperationType) {
+        if (backupOperationType == null) {
+            return Collections.EMPTY_LIST;
+        }
         switch (backupOperationType) {
             case ANY:
                 return Arrays.asList(getBackupPolicy(), getRestorePolicy());

--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/validator/AwsIDBrokerObjectStorageValidator.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/validator/AwsIDBrokerObjectStorageValidator.java
@@ -80,7 +80,8 @@ public class AwsIDBrokerObjectStorageValidator {
     private void validateIDBroker(ObjectStorageValidateRequest validationRequest,
             AmazonIdentityManagementClient iam, InstanceProfile instanceProfile,
             CloudS3View cloudFileSystem, String accountId, ValidationResultBuilder resultBuilder) {
-        LOGGER.info("Permission validation on IBBroker role: {}", instanceProfile.getInstanceProfileName());
+        LOGGER.info("Permission validation on IBBroker role: {} for operation: {}",
+                instanceProfile.getInstanceProfileName(), validationRequest.getBackupOperationType().name());
         awsInstanceProfileEC2TrustValidator.isTrusted(instanceProfile, cloudFileSystem.getCloudIdentityType(), resultBuilder);
         Set<Role> allMappedRoles = getAllMappedRoles(iam, cloudFileSystem, resultBuilder);
         awsIDBrokerAssumeRoleValidator.canAssumeRoles(iam, instanceProfile, allMappedRoles, resultBuilder);
@@ -93,11 +94,12 @@ public class AwsIDBrokerObjectStorageValidator {
     private void validateLocation(ObjectStorageValidateRequest validationRequest, AmazonIdentityManagementClient iam,
             InstanceProfile instanceProfile, CloudS3View cloudFileSystem,
             String accountId, ValidationResultBuilder resultBuilder) {
-        LOGGER.info("Permission validation on Role: {}", instanceProfile.getInstanceProfileName());
+        LOGGER.info("Permission validation on Role: {} for operation: {}",
+                instanceProfile.getInstanceProfileName(), validationRequest.getBackupOperationType().name());
         awsInstanceProfileEC2TrustValidator.isTrusted(instanceProfile, cloudFileSystem.getCloudIdentityType(), resultBuilder);
         awsLogRolePermissionValidator.validateLog(iam, instanceProfile, cloudFileSystem, validationRequest.getLogsLocationBase(), resultBuilder);
         if (entitlementService.isDatalakeBackupRestorePrechecksEnabled(accountId) &&
-                validationRequest.getBackupOperationType().equals(BackupOperationType.RESTORE)) {
+                BackupOperationType.isRestore(validationRequest.getBackupOperationType())) {
             LOGGER.info("Permission validation on backup location: {}", validationRequest.getBackupLocationBase());
             awsLogRolePermissionValidator.validateBackup(iam, instanceProfile, cloudFileSystem,
                     Strings.isNullOrEmpty(validationRequest.getBackupLocationBase()) ? validationRequest.getLogsLocationBase()

--- a/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/validator/AwsDataAccessRolePermissionValidatorTest.java
+++ b/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/validator/AwsDataAccessRolePermissionValidatorTest.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -20,6 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.amazonaws.auth.policy.Policy;
 import com.sequenceiq.cloudbreak.cloud.aws.common.util.AwsIamService;
+import com.sequenceiq.cloudbreak.cloud.model.BackupOperationType;
 import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudS3View;
 import com.sequenceiq.cloudbreak.cloud.storage.LocationHelper;
 import com.sequenceiq.cloudbreak.service.identitymapping.AccountMappingSubject;
@@ -202,12 +204,36 @@ public class AwsDataAccessRolePermissionValidatorTest extends AwsIDBrokerMappedR
         CloudS3View cloudFileSystem = new CloudS3View(CloudIdentityType.ID_BROKER);
         cloudFileSystem.setInstanceProfile("arn:aws:iam::11111111111:instance-profile/instanceprofile");
 
-        List<Policy> policies = getValidator().collectBackupRestorePolicies(cloudFileSystem, backupLocation);
+        List<Policy> policies = getValidator().collectBackupRestorePolicies(cloudFileSystem, BackupOperationType.ANY, backupLocation);
 
         assertEquals(2, policies.size());
         Map<String, String> replacements = replacementsCaptor.getValue();
         assertEquals("bucket", replacements.get("${BACKUP_BUCKET}"));
         assertEquals("bucket/cluster", replacements.get("${BACKUP_LOCATION_BASE}"));
         assertEquals("aws", replacements.get("${ARN_PARTITION}"));
+
+        policies = getValidator().collectBackupRestorePolicies(cloudFileSystem, BackupOperationType.BACKUP, backupLocation);
+        assertEquals(1, policies.size());
+
+        policies = getValidator().collectBackupRestorePolicies(cloudFileSystem, BackupOperationType.RESTORE, backupLocation);
+        assertEquals(1, policies.size());
+    }
+
+    @Test
+    public void testCollectBackupFiles() {
+
+        List<String> policies = getValidator().getPolicyFiles(BackupOperationType.ANY);
+
+        assertEquals(2, policies.size());
+        assertTrue(policies.contains(getValidator().getBackupPolicy()));
+        assertTrue(policies.contains(getValidator().getRestorePolicy()));
+
+        policies = getValidator().getPolicyFiles(BackupOperationType.BACKUP);
+        assertEquals(1, policies.size());
+        assertTrue(policies.contains(getValidator().getBackupPolicy()));
+
+        policies = getValidator().getPolicyFiles(BackupOperationType.RESTORE);
+        assertEquals(1, policies.size());
+        assertTrue(policies.contains(getValidator().getRestorePolicy()));
     }
 }

--- a/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/validator/AwsDataAccessRolePermissionValidatorTest.java
+++ b/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/validator/AwsDataAccessRolePermissionValidatorTest.java
@@ -11,7 +11,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;

--- a/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/validator/AwsRangerAuditRolePermissionValidatorTest.java
+++ b/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/validator/AwsRangerAuditRolePermissionValidatorTest.java
@@ -19,6 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.amazonaws.auth.policy.Policy;
 import com.sequenceiq.cloudbreak.cloud.aws.common.util.AwsIamService;
+import com.sequenceiq.cloudbreak.cloud.model.BackupOperationType;
 import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudS3View;
 import com.sequenceiq.cloudbreak.cloud.storage.LocationHelper;
 import com.sequenceiq.cloudbreak.service.identitymapping.AccountMappingSubject;
@@ -209,7 +210,7 @@ public class AwsRangerAuditRolePermissionValidatorTest extends AwsIDBrokerMapped
         CloudS3View cloudFileSystem = new CloudS3View(CloudIdentityType.ID_BROKER);
         cloudFileSystem.setInstanceProfile("arn:aws:iam::11111111111:instance-profile/instanceprofile");
 
-        List<Policy> policies = getValidator().collectBackupRestorePolicies(cloudFileSystem, backupLocation);
+        List<Policy> policies = getValidator().collectBackupRestorePolicies(cloudFileSystem, BackupOperationType.ANY, backupLocation);
 
         assertEquals(2, policies.size());
         Map<String, String> replacements = replacementsCaptor.getValue();

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureObjectStorageConnector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureObjectStorageConnector.java
@@ -82,7 +82,7 @@ public class AzureObjectStorageConnector implements ObjectStorageConnector {
         resultBuilder.prefix("Cloud Storage validation failed");
         try {
             ValidationResult validationResult = azureIDBrokerObjectStorageValidator.validateObjectStorage(
-                    client, spiFileSystem, request.getLogsLocationBase(), request.getBackupLocationBase(),
+                    client, accountId, spiFileSystem, request.getLogsLocationBase(), request.getBackupLocationBase(),
                     getSingleResourceGroupName(request), resultBuilder);
             ObjectStorageValidateResponse response;
             if (validationResult.hasError()) {

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureObjectStorageConnectorTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureObjectStorageConnectorTest.java
@@ -84,7 +84,7 @@ public class AzureObjectStorageConnectorTest {
 
     private void mockIDBrokerStorageValidationError(int code, CloudError cloudError) {
         Response<ResponseBody> response = Response.error(code, ResponseBody.create("body", MediaType.get("application/json")));
-        when(azureIDBrokerObjectStorageValidator.validateObjectStorage(any(), any(), any(), any(), any(), any())).thenThrow(
+        when(azureIDBrokerObjectStorageValidator.validateObjectStorage(any(), any(), any(), any(), any(), any(), any())).thenThrow(
                 new CloudException("error", response, cloudError));
     }
 }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/AzureIDBrokerObjectStorageValidatorTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/AzureIDBrokerObjectStorageValidatorTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -29,6 +30,7 @@ import com.microsoft.azure.management.msi.Identity;
 import com.microsoft.azure.management.resources.ResourceGroup;
 import com.microsoft.azure.management.resources.Subscription;
 import com.microsoft.azure.management.storage.StorageAccount;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureStorage;
 import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
 import com.sequenceiq.cloudbreak.cloud.model.SpiFileSystem;
@@ -48,6 +50,8 @@ import com.sequenceiq.common.model.FileSystemType;
 public class AzureIDBrokerObjectStorageValidatorTest {
 
     private static final CloudStorageCdpService SERVICE_1 = CloudStorageCdpService.ZEPPELIN_NOTEBOOK;
+
+    private static final String ACCOUNT_ID = UUID.randomUUID().toString();
 
     private static final String PATH_1 = "path1";
 
@@ -117,6 +121,9 @@ public class AzureIDBrokerObjectStorageValidatorTest {
     @Mock
     private StorageAccount storageAccount;
 
+    @Mock
+    private EntitlementService entitlementService;
+
     @InjectMocks
     private AzureIDBrokerObjectStorageValidator underTest;
 
@@ -143,13 +150,14 @@ public class AzureIDBrokerObjectStorageValidatorTest {
         when(assumer.id()).thenReturn(ASSUMER_IDENTITY);
         when(assumer.principalId()).thenReturn(ASSUMER_IDENTITY_PRINCIPAL_ID);
         when(azureStorage.findStorageAccountIdInVisibleSubscriptions(any(), anyString())).thenReturn(Optional.of(ABFS_STORAGE_ACCOUNT_ID));
+        when(entitlementService.isDatalakeBackupRestorePrechecksEnabled(any())).thenReturn(true);
     }
 
     @Test
     public void testValidateObjectStorageWithoutFileSystems() {
         SpiFileSystem fileSystem = new SpiFileSystem("test", FileSystemType.ADLS_GEN_2, null);
         ValidationResultBuilder resultBuilder = new ValidationResultBuilder();
-        underTest.validateObjectStorage(client, fileSystem, "", null, null, resultBuilder);
+        underTest.validateObjectStorage(client, ACCOUNT_ID, fileSystem, "", null, null, resultBuilder);
         assertFalse(resultBuilder.build().hasError());
     }
 
@@ -161,7 +169,7 @@ public class AzureIDBrokerObjectStorageValidatorTest {
                 .withAssignment(LOG_IDENTITY_PRINCIPAL_ID, ABFS_STORAGE_ACCOUNT_NAME);
         ValidationResultBuilder resultBuilder = new ValidationResultBuilder();
 
-        underTest.validateObjectStorage(client, fileSystem, "", null, null, resultBuilder);
+        underTest.validateObjectStorage(client, ACCOUNT_ID, fileSystem, "", null, null, resultBuilder);
 
         ValidationResult validationResult = resultBuilder.build();
         assertFalse(validationResult.hasError());
@@ -180,7 +188,7 @@ public class AzureIDBrokerObjectStorageValidatorTest {
                 .withAssignment(LOG_IDENTITY_PRINCIPAL_ID, STORAGE_RESOURCE_GROUP_NAME);
         ValidationResultBuilder resultBuilder = new ValidationResultBuilder();
 
-        underTest.validateObjectStorage(client, fileSystem, "", null, null, resultBuilder);
+        underTest.validateObjectStorage(client, ACCOUNT_ID, fileSystem, "", null, null, resultBuilder);
 
         ValidationResult validationResult = resultBuilder.build();
         assertFalse(validationResult.hasError());
@@ -194,7 +202,7 @@ public class AzureIDBrokerObjectStorageValidatorTest {
                 .withAssignment(LOG_IDENTITY_PRINCIPAL_ID, STORAGE_RESOURCE_GROUP_NAME);
         ValidationResultBuilder resultBuilder = new ValidationResultBuilder();
 
-        underTest.validateObjectStorage(client, fileSystem, "", null, null, resultBuilder);
+        underTest.validateObjectStorage(client, ACCOUNT_ID, fileSystem, "", null, null, resultBuilder);
 
         ValidationResult validationResult = resultBuilder.build();
         assertFalse(validationResult.hasError());
@@ -208,7 +216,7 @@ public class AzureIDBrokerObjectStorageValidatorTest {
         when(client.getIdentityById(ASSUMER_IDENTITY)).thenReturn(null);
         ValidationResultBuilder resultBuilder = new ValidationResultBuilder();
 
-        underTest.validateObjectStorage(client, fileSystem, "", null, null, resultBuilder);
+        underTest.validateObjectStorage(client, ACCOUNT_ID, fileSystem, "", null, null, resultBuilder);
 
         ValidationResult validationResult = resultBuilder.build();
         assertTrue(validationResult.hasError());
@@ -226,7 +234,7 @@ public class AzureIDBrokerObjectStorageValidatorTest {
         when(client.getIdentityById(LOG_IDENTITY)).thenReturn(null);
         ValidationResultBuilder resultBuilder = new ValidationResultBuilder();
 
-        underTest.validateObjectStorage(client, fileSystem, "", null, null, resultBuilder);
+        underTest.validateObjectStorage(client, ACCOUNT_ID, fileSystem, "", null, null, resultBuilder);
 
         ValidationResult validationResult = resultBuilder.build();
         assertTrue(validationResult.hasError());
@@ -249,7 +257,7 @@ public class AzureIDBrokerObjectStorageValidatorTest {
                 .withAssignment(LOG_IDENTITY_PRINCIPAL_ID, STORAGE_RESOURCE_GROUP_NAME);
         ValidationResultBuilder resultBuilder = new ValidationResultBuilder();
 
-        underTest.validateObjectStorage(client, fileSystem, STORAGE_LOCATION_RANGER, null, null, resultBuilder);
+        underTest.validateObjectStorage(client, ACCOUNT_ID, fileSystem, STORAGE_LOCATION_RANGER, null, null, resultBuilder);
 
         ValidationResult validationResult = resultBuilder.build();
         assertTrue(validationResult.hasError());
@@ -275,7 +283,7 @@ public class AzureIDBrokerObjectStorageValidatorTest {
                 .withAssignment(LOG_IDENTITY_PRINCIPAL_ID, STORAGE_RESOURCE_GROUP_NAME);
 
         ValidationResultBuilder resultBuilder = new ValidationResultBuilder();
-        underTest.validateObjectStorage(client, fileSystem, "", null, null, resultBuilder);
+        underTest.validateObjectStorage(client, ACCOUNT_ID, fileSystem, "", null, null, resultBuilder);
         ValidationResult validationResult = resultBuilder.build();
         assertFalse(validationResult.hasError());
     }
@@ -294,7 +302,7 @@ public class AzureIDBrokerObjectStorageValidatorTest {
                 .withAssignment(LOG_IDENTITY_PRINCIPAL_ID, STORAGE_RESOURCE_GROUP_NAME);
 
         ValidationResultBuilder resultBuilder = new ValidationResultBuilder();
-        underTest.validateObjectStorage(client, fileSystem, LOG_LOCATION, BACKUP_LOCATION, null, resultBuilder);
+        underTest.validateObjectStorage(client, ACCOUNT_ID, fileSystem, LOG_LOCATION, BACKUP_LOCATION, null, resultBuilder);
         ValidationResult validationResult = resultBuilder.build();
         assertFalse(validationResult.hasError());
     }
@@ -318,7 +326,7 @@ public class AzureIDBrokerObjectStorageValidatorTest {
 
         ValidationResultBuilder resultBuilder = new ValidationResultBuilder();
 
-        underTest.validateObjectStorage(client, fileSystem, STORAGE_LOCATION_RANGER, null, null, resultBuilder);
+        underTest.validateObjectStorage(client, ACCOUNT_ID, fileSystem, STORAGE_LOCATION_RANGER, null, null, resultBuilder);
 
         ValidationResult validationResult = resultBuilder.build();
         assertTrue(validationResult.hasError());
@@ -339,7 +347,7 @@ public class AzureIDBrokerObjectStorageValidatorTest {
         new RoleASsignmentBuilder(client);
         ValidationResultBuilder resultBuilder = new ValidationResultBuilder();
 
-        underTest.validateObjectStorage(client, fileSystem, "", null, null, resultBuilder);
+        underTest.validateObjectStorage(client, ACCOUNT_ID, fileSystem, "", null, null, resultBuilder);
 
         ValidationResult validationResult = resultBuilder.build();
         assertTrue(validationResult.hasError());
@@ -357,7 +365,7 @@ public class AzureIDBrokerObjectStorageValidatorTest {
                 .withAssignment(LOG_IDENTITY_PRINCIPAL_ID, STORAGE_RESOURCE_GROUP_NAME);
         ValidationResultBuilder resultBuilder = new ValidationResultBuilder();
 
-        underTest.validateObjectStorage(client, fileSystem, "", null, null, resultBuilder);
+        underTest.validateObjectStorage(client, ACCOUNT_ID, fileSystem, "", null, null, resultBuilder);
 
         ValidationResult validationResult = resultBuilder.build();
         assertTrue(validationResult.hasError());
@@ -375,7 +383,7 @@ public class AzureIDBrokerObjectStorageValidatorTest {
                 .withAssignment(LOG_IDENTITY_PRINCIPAL_ID, STORAGE_RESOURCE_GROUP_NAME);
         ValidationResultBuilder resultBuilder = new ValidationResultBuilder();
 
-        underTest.validateObjectStorage(client, fileSystem, "", null, RESOURCE_GROUP_NAME, resultBuilder);
+        underTest.validateObjectStorage(client, ACCOUNT_ID, fileSystem, "", null, RESOURCE_GROUP_NAME, resultBuilder);
 
         ValidationResult validationResult = resultBuilder.build();
         verify(client, times(0)).listRoleAssignments();
@@ -395,7 +403,7 @@ public class AzureIDBrokerObjectStorageValidatorTest {
                 .withAssignment(ASSUMER_IDENTITY_PRINCIPAL_ID, SUBSCRIPTION_FULL_ID);
         ValidationResultBuilder resultBuilder = new ValidationResultBuilder();
 
-        underTest.validateObjectStorage(client, fileSystem, STORAGE_LOCATION_RANGER, null, null, resultBuilder);
+        underTest.validateObjectStorage(client, ACCOUNT_ID, fileSystem, STORAGE_LOCATION_RANGER, null, null, resultBuilder);
 
         ValidationResult validationResult = resultBuilder.build();
         assertTrue(validationResult.hasError());
@@ -415,7 +423,7 @@ public class AzureIDBrokerObjectStorageValidatorTest {
         when(azureStorage.findStorageAccountIdInVisibleSubscriptions(any(), anyString())).thenReturn(Optional.empty());
         ValidationResultBuilder resultBuilder = new ValidationResultBuilder();
 
-        underTest.validateObjectStorage(client, fileSystem, "", null, null, resultBuilder);
+        underTest.validateObjectStorage(client, ACCOUNT_ID, fileSystem, "", null, null, resultBuilder);
 
         ValidationResult validationResult = resultBuilder.build();
         assertTrue(validationResult.hasError());

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/ModelDescriptions.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/ModelDescriptions.java
@@ -8,7 +8,7 @@ public class ModelDescriptions {
 
     public static final String BACKUP_LOCATION = "The location where the database backup will be stored.";
 
-    public static final String OPERATION_TYPE = "The type of operation.";
+    public static final String OPERATION_TYPE = "The type of disaster recovery operation.";
 
     public static final String CLOSE_CONNECTIONS = "The conditional parameter for whether connections to the database will be closed during backup or not.";
 

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/ModelDescriptions.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/ModelDescriptions.java
@@ -8,6 +8,8 @@ public class ModelDescriptions {
 
     public static final String BACKUP_LOCATION = "The location where the database backup will be stored.";
 
+    public static final String OPERATION_TYPE = "The type of operation.";
+
     public static final String CLOSE_CONNECTIONS = "The conditional parameter for whether connections to the database will be closed during backup or not.";
 
     public static final String ENVIRONMENT_CRN = "Environment crn.";

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxBackupLocationValidationRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxBackupLocationValidationRequest.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.cloudbreak.validation.ValidStackNameFormat;
 import com.sequenceiq.cloudbreak.validation.ValidStackNameLength;
 
+import com.sequenceiq.cloudbreak.cloud.model.BackupOperationType;
+
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -21,15 +23,20 @@ public class SdxBackupLocationValidationRequest {
     @ApiModelProperty(value = ModelDescriptions.BACKUP_LOCATION)
     private String backupLocation;
 
+    @ApiModelProperty(value = ModelDescriptions.OPERATION_TYPE)
+    private BackupOperationType operationType;
+
     public SdxBackupLocationValidationRequest() {
     }
 
-    public SdxBackupLocationValidationRequest(String clusterName) {
+    public SdxBackupLocationValidationRequest(String clusterName, BackupOperationType operationType) {
         this.clusterName = clusterName;
+        this.operationType = operationType;
     }
 
-    public SdxBackupLocationValidationRequest(String clusterName, String backupLocation) {
+    public SdxBackupLocationValidationRequest(String clusterName, BackupOperationType operationType, String backupLocation) {
         this.clusterName = clusterName;
+        this.operationType = operationType;
         this.backupLocation = backupLocation;
     }
 
@@ -41,10 +48,15 @@ public class SdxBackupLocationValidationRequest {
         return clusterName;
     }
 
+    public BackupOperationType getOperationType() {
+        return operationType;
+    }
+
     @Override
     public String toString() {
         return "SdxBackupLocationValidationRequest{" +
                 "ClusterName='" + clusterName + '\'' +
+                "Operation Type ='" + operationType + '\'' +
                 "BackupLocation='" + backupLocation + '\'' +
                 '}';
     }

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
@@ -197,7 +197,8 @@ public class SdxController implements SdxEndpoint {
     @CheckPermissionByRequestProperty(path = "clusterName", type = NAME, action = DESCRIBE_DATALAKE)
     public ValidationResult validateBackupStorage(@RequestObject @Valid SdxBackupLocationValidationRequest sdxBackupLocationValidationRequest) {
         SdxCluster sdxCluster = getSdxClusterByName(sdxBackupLocationValidationRequest.getClusterName());
-        return storageValidationService.validateBackupStorage(sdxCluster, sdxBackupLocationValidationRequest.getBackupLocation());
+        return storageValidationService.validateBackupStorage(sdxCluster, sdxBackupLocationValidationRequest.getOperationType(),
+                sdxBackupLocationValidationRequest.getBackupLocation());
     }
 
     @Override

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StorageValidationService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StorageValidationService.java
@@ -89,6 +89,7 @@ public class StorageValidationService {
                 .withCloudPlatform(credentialResponse.getCloudPlatform())
                 .withCredential(cloudCredential)
                 .withCloudStorageRequest(cloudStorageRequest)
+                .withBackupOperationType(BackupOperationType.NONE)
                 .build();
         return ThreadBasedUserCrnProvider.doAsInternalActor(
                 regionAwareInternalCrnGeneratorFactory.iam().getInternalCrnForServiceAsString(),

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StorageValidationService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StorageValidationService.java
@@ -20,6 +20,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackV4Request;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.BackupOperationType;
 import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageValidateRequest;
 import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageValidateResponse;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
@@ -94,7 +95,7 @@ public class StorageValidationService {
                 () -> cloudProviderServicesV4Endpoint.validateObjectStorage(objectStorageValidateRequest));
     }
 
-    public ValidationResult validateBackupStorage(SdxCluster sdxCluster, String backupLocation) {
+    public ValidationResult validateBackupStorage(SdxCluster sdxCluster, BackupOperationType backupOperationType, String backupLocation) {
         DetailedEnvironmentResponse environmentResponse = environmentService.getDetailedEnvironmentResponseByName(sdxCluster.getEnvName());
         CloudStorageRequest cloudStorageRequest = null;
         try {
@@ -112,7 +113,7 @@ public class StorageValidationService {
         }
         ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
         try {
-            cloudStorageValidator.validateBackupLocation(cloudStorageRequest, environmentResponse, backupLocation, validationResultBuilder);
+            cloudStorageValidator.validateBackupLocation(cloudStorageRequest, backupOperationType, environmentResponse, backupLocation, validationResultBuilder);
         } catch (Exception e) {
             String message = String.format("Error occured during object storage validation, validation skipped. Error: %s", e.getMessage());
             LOGGER.warn(message);

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/validation/cloudstorage/CloudStorageValidator.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/validation/cloudstorage/CloudStorageValidator.java
@@ -150,6 +150,7 @@ public class CloudStorageValidator {
                 .withCloudStorageRequest(cloudStorageRequest)
                 .withLogsLocationBase(getLogsLocationBase(environment))
                 .withBackupLocationBase(getBackupLocationBase(environment))
+                .withBackupOperationType(BackupOperationType.NONE)
                 .withAzureParameters(getSingleResourceGroupName(environment));
         if (environment.getIdBrokerMappingSource() == MOCK) {
             result.withMockSettings(environment.getLocation().getName(), environment.getAdminGroupName());

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/validation/cloudstorage/CloudStorageValidator.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/validation/cloudstorage/CloudStorageValidator.java
@@ -20,6 +20,7 @@ import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.BackupOperationType;
 import com.sequenceiq.cloudbreak.cloud.model.base.ResponseStatus;
 import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageValidateRequest;
 import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageValidateResponse;
@@ -106,14 +107,16 @@ public class CloudStorageValidator {
      * @param environment Details of the environment on which validation is performed.
      * @param validationResultBuilder Builder to gather the failures.
      */
-    public void validateBackupLocation(CloudStorageRequest cloudStorageRequest, DetailedEnvironmentResponse environment, String customBackupLocation,
+    public void validateBackupLocation(CloudStorageRequest cloudStorageRequest, BackupOperationType backupOperationType,
+            DetailedEnvironmentResponse environment, String customBackupLocation,
             ValidationResult.ValidationResultBuilder validationResultBuilder) {
         String backupLocation = !Strings.isNullOrEmpty(customBackupLocation) ? customBackupLocation : getBackupLocationBase(environment);
         LOGGER.info("Validating backup Location: {}", backupLocation);
         Credential credential = getCredential(environment);
         CloudCredential cloudCredential = credentialToCloudCredentialConverter.convert(credential);
         List<StorageLocationBase> locations = cloudStorageRequest.getLocations();
-        ObjectStorageValidateRequest request = createBackupLocationValidateRequest(cloudCredential, cloudStorageRequest, environment, backupLocation);
+        ObjectStorageValidateRequest request = createBackupLocationValidateRequest(cloudCredential, backupOperationType, cloudStorageRequest,
+                environment, backupLocation);
         ObjectStorageValidateResponse response = ThreadBasedUserCrnProvider.doAsInternalActor(
                 regionAwareInternalCrnGeneratorFactory.iam().getInternalCrnForServiceAsString(),
                 () -> cloudProviderServicesV4Endpoint.validateObjectStorage(request));
@@ -155,7 +158,8 @@ public class CloudStorageValidator {
     }
 
     private ObjectStorageValidateRequest createBackupLocationValidateRequest(
-            CloudCredential credential, CloudStorageRequest cloudStorageRequest,
+            CloudCredential credential, BackupOperationType backupOperationType,
+            CloudStorageRequest cloudStorageRequest,
             DetailedEnvironmentResponse environment, String backupLocation) {
         cloudStorageRequest.setLocations(Collections.emptyList());
         ObjectStorageValidateRequest.Builder result = ObjectStorageValidateRequest.builder()
@@ -163,6 +167,7 @@ public class CloudStorageValidator {
                 .withCredential(credential)
                 .withCloudStorageRequest(cloudStorageRequest)
                 .withBackupLocationBase(backupLocation)
+                .withBackupOperationType(backupOperationType)
                 .withAzureParameters(getSingleResourceGroupName(environment));
         if (environment.getIdBrokerMappingSource() == MOCK) {
             result.withMockSettings(environment.getLocation().getName(), environment.getAdminGroupName());

--- a/datalake/src/test/java/com/sequenceiq/datalake/controller/sdx/SdxControllerTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/controller/sdx/SdxControllerTest.java
@@ -27,6 +27,7 @@ import com.sequenceiq.cloudbreak.api.model.RotateSaltPasswordReason;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakImageCatalogV3;
+import com.sequenceiq.cloudbreak.cloud.model.BackupOperationType;
 import com.sequenceiq.cloudbreak.validation.ValidationResult;
 import com.sequenceiq.datalake.entity.DatalakeStatusEnum;
 import com.sequenceiq.datalake.entity.SdxCluster;
@@ -206,14 +207,15 @@ class SdxControllerTest {
 
         SdxCluster sdxCluster = getValidSdxCluster();
         sdxCluster.setClusterName(SDX_CLUSTER_NAME);
-        SdxBackupLocationValidationRequest sdxBackupLocationValidationRequest = new SdxBackupLocationValidationRequest(SDX_CLUSTER_NAME);
-        when(storageValidationService.validateBackupStorage(sdxCluster, null)).thenReturn(validationResult);
+        SdxBackupLocationValidationRequest sdxBackupLocationValidationRequest = new SdxBackupLocationValidationRequest(SDX_CLUSTER_NAME,
+                BackupOperationType.ANY);
+        when(storageValidationService.validateBackupStorage(sdxCluster, BackupOperationType.ANY, null)).thenReturn(validationResult);
         when(sdxService.getByNameInAccount(USER_CRN, SDX_CLUSTER_NAME)).thenReturn(sdxCluster);
 
         ValidationResult result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> sdxController.validateBackupStorage(sdxBackupLocationValidationRequest));
 
         verify(sdxService, times(1)).getByNameInAccount(USER_CRN, SDX_CLUSTER_NAME);
-        verify(storageValidationService, times(1)).validateBackupStorage(sdxCluster, null);
+        verify(storageValidationService, times(1)).validateBackupStorage(sdxCluster, BackupOperationType.ANY, null);
         assertEquals(ValidationResult.State.VALID, result.getState());
     }
 
@@ -224,14 +226,15 @@ class SdxControllerTest {
 
         SdxCluster sdxCluster = getValidSdxCluster();
         sdxCluster.setClusterName(SDX_CLUSTER_NAME);
-        SdxBackupLocationValidationRequest sdxBackupLocationValidationRequest = new SdxBackupLocationValidationRequest(SDX_CLUSTER_NAME, BACKUP_LOCATION);
-        when(storageValidationService.validateBackupStorage(sdxCluster, BACKUP_LOCATION)).thenReturn(validationResult);
+        SdxBackupLocationValidationRequest sdxBackupLocationValidationRequest = new SdxBackupLocationValidationRequest(SDX_CLUSTER_NAME,
+                BackupOperationType.ANY, BACKUP_LOCATION);
+        when(storageValidationService.validateBackupStorage(sdxCluster, BackupOperationType.ANY, BACKUP_LOCATION)).thenReturn(validationResult);
         when(sdxService.getByNameInAccount(USER_CRN, SDX_CLUSTER_NAME)).thenReturn(sdxCluster);
 
         ValidationResult result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> sdxController.validateBackupStorage(sdxBackupLocationValidationRequest));
 
         verify(sdxService, times(1)).getByNameInAccount(USER_CRN, SDX_CLUSTER_NAME);
-        verify(storageValidationService, times(1)).validateBackupStorage(sdxCluster, BACKUP_LOCATION);
+        verify(storageValidationService, times(1)).validateBackupStorage(sdxCluster, BackupOperationType.ANY, BACKUP_LOCATION);
         assertEquals(ValidationResult.State.VALID, result.getState());
     }
 

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/StorageValidationServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/StorageValidationServiceTest.java
@@ -20,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.cloud.model.BackupOperationType;
 import com.sequenceiq.cloudbreak.util.FileReaderUtils;
 import com.sequenceiq.cloudbreak.validation.ValidationResult;
 import com.sequenceiq.common.api.backup.response.BackupResponse;
@@ -202,7 +203,7 @@ class StorageValidationServiceTest {
         when(sdxCluster.getStackRequestToCloudbreak()).thenReturn("StackRequest");
 
         BadRequestException exception = Assertions.assertThrows(BadRequestException.class,
-                () -> underTest.validateBackupStorage(sdxCluster, null));
+                () -> underTest.validateBackupStorage(sdxCluster, BackupOperationType.ANY, null));
         assertEquals(exception.getMessage(), "Failed to validate backup storage");
     }
 
@@ -212,7 +213,7 @@ class StorageValidationServiceTest {
         when(sdxCluster.getEnvName()).thenReturn("test environment");
         when(environmentService.getDetailedEnvironmentResponseByName(anyString())).thenReturn(new DetailedEnvironmentResponse());
         BadRequestException exception = Assertions.assertThrows(BadRequestException.class,
-                () -> underTest.validateBackupStorage(sdxCluster, null));
+                () -> underTest.validateBackupStorage(sdxCluster, BackupOperationType.ANY,  null));
         assertEquals(exception.getMessage(), "Failed to validate backup storage");
     }
 
@@ -229,9 +230,9 @@ class StorageValidationServiceTest {
         when(sdxCluster.getStackRequestToCloudbreak()).thenReturn(stackRequest);
         when(sdxCluster.getEnvName()).thenReturn("test environment");
         when(environmentService.getDetailedEnvironmentResponseByName(anyString())).thenReturn(detailedEnvironmentResponse);
-        ValidationResult validationResult = underTest.validateBackupStorage(sdxCluster, null);
+        ValidationResult validationResult = underTest.validateBackupStorage(sdxCluster, BackupOperationType.ANY, null);
         verify(cloudStorageValidator, times(1)).validateBackupLocation(cloudStorageRequestArgumentCaptor.capture(),
-                detailedEnvironmentResponseArgumentCaptor.capture(), eq(null), any());
+                eq(BackupOperationType.ANY), detailedEnvironmentResponseArgumentCaptor.capture(), eq(null), any());
         Assertions.assertEquals(5, cloudStorageRequestArgumentCaptor.getValue().getLocations().size());
         Assertions.assertEquals(2, cloudStorageRequestArgumentCaptor.getValue().getIdentities().size());
         Assertions.assertNull(cloudStorageRequestArgumentCaptor.getValue().getAws());
@@ -250,9 +251,9 @@ class StorageValidationServiceTest {
         when(sdxCluster.getStackRequestToCloudbreak()).thenReturn(stackRequest);
         when(sdxCluster.getEnvName()).thenReturn("test environment");
         when(environmentService.getDetailedEnvironmentResponseByName(anyString())).thenReturn(detailedEnvironmentResponse);
-        ValidationResult validationResult = underTest.validateBackupStorage(sdxCluster, BACKUP_LOCATION);
+        ValidationResult validationResult = underTest.validateBackupStorage(sdxCluster, BackupOperationType.ANY, BACKUP_LOCATION);
         verify(cloudStorageValidator, times(1)).validateBackupLocation(cloudStorageRequestArgumentCaptor.capture(),
-                detailedEnvironmentResponseArgumentCaptor.capture(), eq(BACKUP_LOCATION), any());
+                eq(BackupOperationType.ANY), detailedEnvironmentResponseArgumentCaptor.capture(), eq(BACKUP_LOCATION), any());
         Assertions.assertEquals(5, cloudStorageRequestArgumentCaptor.getValue().getLocations().size());
         Assertions.assertEquals(2, cloudStorageRequestArgumentCaptor.getValue().getIdentities().size());
         Assertions.assertNull(cloudStorageRequestArgumentCaptor.getValue().getAws());

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/validation/cloudstorage/CloudStorageValidatorTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/validation/cloudstorage/CloudStorageValidatorTest.java
@@ -24,6 +24,7 @@ import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGenerator;
 import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.base.ResponseStatus;
+import com.sequenceiq.cloudbreak.cloud.model.BackupOperationType;
 import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageValidateRequest;
 import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageValidateResponse;
 import com.sequenceiq.cloudbreak.service.secret.service.SecretService;
@@ -121,7 +122,8 @@ public class CloudStorageValidatorTest {
 
         when(cloudProviderServicesV4Endpoint.validateObjectStorage(any())).thenReturn(new ObjectStorageValidateResponse());
         ValidationResultBuilder validationResultBuilder = new ValidationResultBuilder();
-        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.validateBackupLocation(new CloudStorageRequest(), environment, null, validationResultBuilder));
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.validateBackupLocation(new CloudStorageRequest(), BackupOperationType.ANY,
+                environment, null, validationResultBuilder));
         assertFalse(validationResultBuilder.build().hasError());
     }
 
@@ -137,8 +139,8 @@ public class CloudStorageValidatorTest {
 
         when(cloudProviderServicesV4Endpoint.validateObjectStorage(any())).thenReturn(new ObjectStorageValidateResponse());
         ValidationResultBuilder validationResultBuilder = new ValidationResultBuilder();
-        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.validateBackupLocation(new CloudStorageRequest(), environment, CUSTOM_BACKUP_LOCATION,
-                validationResultBuilder));
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.validateBackupLocation(new CloudStorageRequest(), BackupOperationType.ANY, environment,
+                CUSTOM_BACKUP_LOCATION, validationResultBuilder));
         verify(cloudProviderServicesV4Endpoint, times(1)).validateObjectStorage(captor.capture());
         assertEquals(CUSTOM_BACKUP_LOCATION, captor.getValue().getBackupLocationBase());
         assertFalse(validationResultBuilder.build().hasError());
@@ -160,7 +162,7 @@ public class CloudStorageValidatorTest {
         objectStorageValidateResponse.setError("dummy failure");
         when(cloudProviderServicesV4Endpoint.validateObjectStorage(any())).thenReturn(objectStorageValidateResponse);
         ValidationResultBuilder validationResultBuilderforFailure = new ValidationResultBuilder();
-        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.validateBackupLocation(new CloudStorageRequest(), environment, null,
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.validateBackupLocation(new CloudStorageRequest(), BackupOperationType.ANY, environment, null,
                 validationResultBuilderforFailure));
         verify(cloudProviderServicesV4Endpoint, times(1)).validateObjectStorage(captor.capture());
         assertTrue(captor.getValue().getCloudStorageRequest().getLocations().isEmpty());
@@ -187,9 +189,10 @@ public class CloudStorageValidatorTest {
         objectStorageValidateResponse.setError("dummy failure");
         when(cloudProviderServicesV4Endpoint.validateObjectStorage(any())).thenReturn(objectStorageValidateResponse);
         ValidationResultBuilder validationResultBuilderforFailure = new ValidationResultBuilder();
-        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.validateBackupLocation(new CloudStorageRequest(), environment, CUSTOM_BACKUP_LOCATION,
-                validationResultBuilderforFailure));
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.validateBackupLocation(new CloudStorageRequest(), BackupOperationType.ANY,
+                environment, CUSTOM_BACKUP_LOCATION, validationResultBuilderforFailure));
         verify(cloudProviderServicesV4Endpoint, times(1)).validateObjectStorage(captor.capture());
+        assertTrue(captor.getValue().getBackupOperationType().name().equals(BackupOperationType.ANY.name()));
         assertTrue(captor.getValue().getCloudStorageRequest().getLocations().isEmpty());
         assertEquals("id", captor.getValue().getCredential().getId());
         assertEquals("acc", captor.getValue().getCredential().getAccountId());

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/cloudstorage/CloudStorageValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/cloudstorage/CloudStorageValidator.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.providerservices.CloudProviderServicesV4Endopint;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
+import com.sequenceiq.cloudbreak.cloud.model.BackupOperationType;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageValidateRequest;
 import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageValidateResponse;
@@ -62,6 +63,7 @@ public class CloudStorageValidator {
         ObjectStorageValidateRequest.Builder objectStorageValidateBuilder = ObjectStorageValidateRequest.builder()
                 .withCloudPlatform(credential.getCloudPlatform())
                 .withCredential(cloudCredential)
+                .withBackupOperationType(BackupOperationType.NONE)
                 .withCloudStorageRequest(cloudStorageRequest);
         if (loggingConfigured) {
             objectStorageValidateBuilder.withLogsLocationBase(telemetryRequest.getLogging().getStorageLocation());


### PR DESCRIPTION
Changes for CB-18406 had a bug causing NPE when the environment/datalake is created. 
This PR brings back changes done for CB-18406 and the necessary changes to fix the BUG it had.

Testing performed:
1. Made sure unit tests were passed.
2. Made sure the upgrade pre-checks were run through well.
3. Made sure the environment/datalake creation is good.
4. Made sure that permission pre-checks are not executed on environment/datalake creation.

