### PR TITLE
CDPD-44553: remove STORAGEOPERATIONS role from Search Analytics template

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.16/cdp-search-analytics.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.16/cdp-search-analytics.bp
@@ -8,19 +8,13 @@
       {
         "refName": "core_settings",
         "serviceType": "CORE_SETTINGS",
-        "roleConfigGroups": [
+        "serviceConfigs": [
           {
-            "refName": "core_settings-STORAGEOPERATIONS-BASE",
-            "roleType": "STORAGEOPERATIONS",
-            "configs": [
-              {
-                "name": "core_defaultfs",
-                "value": ""
-              }
-            ],
-            "base": true
+            "name": "core_defaultfs",
+            "value": ""
           }
-        ]
+        ],
+        "roleConfigGroups": [ ]
       },
       {
         "refName": "zookeeper",
@@ -107,7 +101,6 @@
         "refName": "manager",
         "cardinality": 1,
         "roleConfigGroupsRefNames": [
-          "core_settings-STORAGEOPERATIONS-BASE",
           "solr-GATEWAY-BASE"
         ]
       },


### PR DESCRIPTION
The Search Analytics cluster template provides a minimal Solr cluster configuration using local file system. To use local filesystem instead of S3, Solr needs the core_defaultfs configuration to be set to empty string and have proper core-site.xml to be generated.

The core_defaultfs config used to be located inside the STORAGEOPERATIONS role, which was moved in 7.2.16 to the STUB_DFS service. In 7.2.16 the core_defaultfs config is a service level configuration in the CORE_SETTINGS service.

In this commit I moved the core_defaultfs config to service level and removed the STORAGEOPERATIONS from the template.