### PR TITLE
CB-18151 `README` & build fixes for consumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,47 +3,48 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/566493a63aaaf0c61bd4/maintainability)](https://codeclimate.com/github/hortonworks/cloudbreak/maintainability)
 [![Build Automated](https://img.shields.io/docker/automated/hortonworks/cloudbreak.svg)](https://hub.docker.com/r/hortonworks/cloudbreak/)
 [![Build Pulls](https://img.shields.io/docker/pulls/hortonworks/cloudbreak.svg)](https://hub.docker.com/r/hortonworks/cloudbreak/)
-[![Licence](https://img.shields.io/github/license/hortonworks/cloudbreak.svg)](https://github.com/hortonworks/cloudbreak/blob/fix-readme/LICENSE)
+[![Licence](https://img.shields.io/github/license/hortonworks/cloudbreak.svg)](https://github.com/hortonworks/cloudbreak/blob/master/LICENSE)
 
 - [Local Development Setup](#local-development-setup)
     * [Cloudbreak Deployer](#cloudbreak-deployer)
-        + [Cloudbreak service ports](#cloudbreak-service-ports)
-        + [Linux difference](#linux-difference)
+        + [Cloudbreak Service Ports](#cloudbreak-service-ports)
+        + [Linux Difference](#linux-difference)
     * [IDEA](#idea)
-        + [Check out the Cloudbreak repository](#check-out-the-cloudbreak-repository)
-        + [Project settings in IDEA](#project-settings-in-idea)
-        + [Import project](#import-project)
+        + [Check Out the Cloudbreak Repository](#check-out-the-cloudbreak-repository)
+        + [Project Settings in IDEA](#project-settings-in-idea)
+        + [Import Project](#import-project)
         + [Running Cloudbreak in IDEA](#running-cloudbreak-in-idea)
         + [Configure Before launch task](#configure-before-launch-task)
         + [Running Periscope in IDEA](#running-periscope-in-idea)
         + [Running Datalake in IDEA](#running-datalake-in-idea)
         + [Running FreeIPA in IDEA](#running-freeipa-in-idea)
         + [Running Redbeams in IDEA](#running-redbeams-in-idea)
-        + [Running the Environment service in IDEA](#running-the-environment-service-in-idea)
-        + [Running the Consumption service in IDEA](#running-the-consumption-service-in-idea)
+        + [Running the Environment Service in IDEA](#running-the-environment-service-in-idea)
+        + [Running the Consumption Service in IDEA](#running-the-consumption-service-in-idea)
         + [Running Thunderhead Mock in IDEA](#running-thunderhead-mock-in-idea)
         + [Running Mock-Infrastructure in IDEA](#running-mock-infrastructure-in-idea)
-    * [Command line](#command-line)
+    * [Command Line](#command-line)
         + [Running Cloudbreak from the Command Line](#running-cloudbreak-from-the-command-line)
         + [Running Periscope from the Command Line](#running-periscope-from-the-command-line)
         + [Running Datalake from the Command Line](#running-datalake-from-the-command-line)
         + [Running FreeIPA from the Command Line](#running-freeipa-from-the-command-line)
         + [Running Redbeams from the Command Line](#running-redbeams-from-the-command-line)
-        + [Running the Environment service from the Command Line](#running-the-environment-service-from-the-command-line)
+        + [Running the Environment Service from the Command Line](#running-the-environment-service-from-the-command-line)
+        + [Running the Consumption Service from the Command Line](#running-the-consumption-service-from-the-command-line)
         + [Running Thunderhead Mock from the Command Line](#running-thunderhead-mock-from-the-command-line)
-    * [Database development](#database-development)
+        + [Running Mock-Infrastructure from the Command Line](#running-mock-infrastructure-from-the-command-line)
+    * [Database Development](#database-development)
     * [Building](#building)
-    * [How to reach CM UI directly(not through Knox)](#how-to-reach-cm-ui-directly-not-through-knox-)
-- [How to contribute](#how-to-contribute)
+    * [How to Reach CM UI Directly (Not Through Knox)](#how-to-reach-cm-ui-directly-not-through-knox)
+- [How to Contribute](#how-to-contribute)
     * [Appearance](#appearance)
-    * [Coding guidelines](#coding-guidelines)
-    * [Catching up](#catching-up)
-    * [Additional info](#additional-info)
-
-* Documentation: https://docs.cloudera.com/management-console/cloud/index.html
+    * [Coding Guidelines](#coding-guidelines)
+    * [Catching Up](#catching-up)
+    * [Additional Info](#additional-info)
+- Documentation: https://docs.cloudera.com/management-console/cloud/index.html
 
 # Local Development Setup
-As of now this document focuses on setting up your development environment on macOS. You'll need Homebrew to install certain components in case you don't have them already. To get Homebrew please follow the install instructions on the Homebrew homepage: https://brew.sh
+As of now this document focuses on setting up your development environment on macOS. You'll need Homebrew to install certain components in case you don't have them already. To get Homebrew please follow the installation instructions on the Homebrew homepage: https://brew.sh
 
 As a prerequisite, you need to have Java 11 installed. You can choose from many options, including the Oracle JDK, Oracle OpenJDK, or an OpenJDK from any of several providers. For help in choosing your JDK, consult [Java is Still Free](https://medium.com/@javachampions/java-is-still-free-2-0-0-6b9aa8d6d244).
 
@@ -51,9 +52,9 @@ You'll need Docker. For Mac, use [Docker Desktop for Mac](https://docs.docker.co
 
 ## Cloudbreak Deployer
 
-The simplest way to setup the working environment to be able to start Cloudbreak on your local machine is to use the [Cloudbreak Deployer](https://github.com/hortonworks/cloudbreak-deployer).
+The simplest way to set up the working environment to be able to start Cloudbreak on your local machine is to use the [Cloudbreak Deployer](https://github.com/hortonworks/cloudbreak-deployer).
 
-First you need to create a sandbox directory which will store the necessary configuration files and dependencies of [Cloudbreak Deployer](https://github.com/hortonworks/cloudbreak-deployer). This directory must be created outside of the cloned Cloudbreak git repository:
+First you need to create a sandbox directory which will store the necessary configuration files and dependencies of [Cloudbreak Deployer](https://github.com/hortonworks/cloudbreak-deployer). This directory must be created outside the cloned Cloudbreak git repository:
 ```
 mkdir cbd-local
 cd cbd-local
@@ -65,6 +66,7 @@ curl -s https://raw.githubusercontent.com/hortonworks/cloudbreak-deployer/master
 ```
 
 Add the following to the file named `Profile` under the `cbd-local` directory you have just created. Please note, when a `cbd` command is executed you should go to the deployment's directory where your `Profile` file is found (`cbd-local` in our example). The `CB_SCHEMA_SCRIPTS_LOCATION` environment variable configures the location of SQL scripts that are in the `core/src/main/resources/schema` directory in the cloned Cloudbreak git repository.
+In a similar fashion, the rest of the other `*_SCHEMA_SCRIPTS_LOCATION` environment variables configure the locations of SQL scripts that are associated with those respective services.
 
 Please note that the full path needs to be configured and env variables like `$USER` cannot be used. You also have to set a password for your local Cloudbreak in `UAA_DEFAULT_USER_PW`:
 
@@ -72,7 +74,12 @@ Please note that the full path needs to be configured and env variables like `$U
 export CB_LOCAL_DEV_LIST=
 export UAA_DEFAULT_SECRET=cbsecret2015
 export CB_SCHEMA_SCRIPTS_LOCATION=/Users/YOUR_USERNAME/YOUR_PROJECT_DIR/cloudbreak/core/src/main/resources/schema
-export ENVIRONMENT_SCHEMA_SCRIPTS_LOCATION=/Users/YOUR_USERNAME/YOUR_PROJECT_DIR/environment/src/main/resources/schema
+export CONSUMPTION_SCHEMA_SCRIPTS_LOCATION=/Users/YOUR_USERNAME/YOUR_PROJECT_DIR/cloudbreak/cloud-consumption/src/main/resources/schema
+export DATALAKE_SCHEMA_SCRIPTS_LOCATION=/Users/YOUR_USERNAME/YOUR_PROJECT_DIR/cloudbreak/datalake/src/main/resources/schema
+export ENVIRONMENT_SCHEMA_SCRIPTS_LOCATION=/Users/YOUR_USERNAME/YOUR_PROJECT_DIR/cloudbreak/environment/src/main/resources/schema
+export FREEIPA_SCHEMA_SCRIPTS_LOCATION=/Users/YOUR_USERNAME/YOUR_PROJECT_DIR/cloudbreak/freeipa/src/main/resources/schema
+export PERISCOPE_SCHEMA_SCRIPTS_LOCATION=/Users/YOUR_USERNAME/YOUR_PROJECT_DIR/cloudbreak/autoscale/src/main/resources/schema
+export REDBEAMS_SCHEMA_SCRIPTS_LOCATION=/Users/YOUR_USERNAME/YOUR_PROJECT_DIR/cloudbreak/redbeams/src/main/resources/schema
 export ULU_SUBSCRIBE_TO_NOTIFICATIONS=true
 export CB_INSTANCE_UUID=$(uuidgen | tr '[:upper:]' '[:lower:]')
 export CB_INSTANCE_NODE_ID=5743e6ed-3409-420b-b08b-f688f2fc5db1
@@ -86,18 +93,25 @@ If you want to use the `mock-infrastructure`, you need to add to the `Profile` t
 export MOCK_INFRASTRUCTURE_HOST=localhost
 ```
 
-If you want to save some memory then some of the service can be skipped in local runs like:
+If you want to save some memory then one or more services can be skipped in local runs like (see complete list of supported service names below):
 ```
-export CB_LOCAL_DEV_LIST=periscope,distrox-api,jaeger,environments2-api,datalake-api
+export CB_LOCAL_DEV_LIST=periscope,distrox-api,environments2-api,datalake-api
 ```
 
-If you are using AWS, then also add the following lines, substituting your control plane AWS account id, and the AWS credentials that you have created for the CB role.
+If you are using AWS (commercial regions), then also add the following lines, substituting your control plane AWS account ID, and the AWS credentials that you have created for the CB role.
 
 ```
 export CB_AWS_ACCOUNT_ID="YOUR_AWS_ACCOUNT_ID"
 export AWS_ACCESS_KEY_ID="YOUR_ACCESS_KEY"
 export AWS_SECRET_ACCESS_KEY="YOUR_SECRET_KEY"
+```
 
+Furthermore, in order to use AWS GovCloud, also add the following lines, again substituting your control plane AWS GovCloud account ID, and the AWS GovCloud credentials that you have created for the CB role.
+
+```
+export CB_AWS_GOV_ACCOUNT_ID="YOUR_AWS_GOVCLOUD_ACCOUNT_ID"
+export AWS_GOV_ACCESS_KEY_ID="YOUR_ACCESS_KEY"
+export AWS_GOV_SECRET_ACCESS_KEY="YOUR_SECRET_KEY"
 ```
 
 At first, you should start every service from cbd to check that your cloud environment is set up correctly.
@@ -111,9 +125,31 @@ export CB_LOCAL_DEV_LIST=cloudbreak,periscope,datalake,freeipa,redbeams,environm
 ```
 
 Containers for these applications won't be started and Uluwatu (or the `cdp` & `dp` CLI tools) will connect to Java processes running on your host.
-You don't have to put all of the applications into local-dev mode; the value of the variable could be any combination.
+You don't have to put all the applications into local-dev mode; the value of the variable could be any combination. The following service names are supported in `CB_LOCAL_DEV_LIST`:
 
-You need to login to DockerHub:
+- `audit`
+- `audit-api`
+- `cadence`
+- `cloudbreak`
+- `cluster-proxy`
+- `consumption`
+- `core-gateway`
+- `datalake`
+- `datalake-api`
+- `datalake-dr`
+- `distrox-api`
+- `environment`
+- `environments2-api`
+- `freeipa`
+- `idbmms`
+- `mock-infrastructure`
+- `periscope`
+- `redbeams`
+- `thunderhead-api`
+- `thunderhead-mock`
+- `workloadiam`
+
+You need to log in to DockerHub:
 ```
 docker login
 ```
@@ -131,7 +167,7 @@ cbd migrate cbdb up
 cbd migrate cbdb pending
 ```
 
-For some reason if you encounter a similar problem with Periscope, Datalake, FreeIPA, Redbeams, or Environment, then run the following commands and you can restart the Cloudbreak Deployer:
+For some reason if you encounter a similar problem with Periscope, Datalake, FreeIPA, Redbeams, Environment, or Consumption, then run the following commands, and you can restart the Cloudbreak Deployer:
 ```
 cbd migrate periscopedb up
 cbd migrate periscopedb pending
@@ -147,10 +183,13 @@ cbd migrate redbeamsdb pending
 
 cbd migrate environmentdb up
 cbd migrate environmentdb pending
+
+cbd migrate consumptiondb up
+cbd migrate consumptiondb pending
 ```
 You can track any other application's logs to check the results by executing the following command:
 ```
-cbd logs periscope # or datalake, freeipa, redbeams, environment, thunderhead-mock, idbmms, environments2-api
+cbd logs periscope # or any other service name supported in CB_LOCAL_DEV_LIST
 ```
 
 If everything went well then Cloudbreak will be available on https://localhost. For more details and config parameters please check the documentation of [Cloudbreak Deployer](https://github.com/hortonworks/cloudbreak-deployer).
@@ -159,11 +198,11 @@ The deployer has generated a `certs` directory under `cbd-local` directory which
 
 If not already present, you shall create an `etc` directory under `cbd-local` directory and place your Cloudera Manager license file `license.txt` there. This is essential for Thunderhead Mock to start successfully. (Request a licence from us)
 
-### Cloudbreak service ports
+### Cloudbreak Service Ports
 
-When cloudbreak is started in a container, the port it listens on is 8080.  If "cloudbreak" is added to the CB_LOCAL_DEV_LIST variable, all services expect the cloudbreak port to be 9091.
+When `cloudbreak` is started in a container, the port it listens on is 8080.  If `cloudbreak` is added to the `CB_LOCAL_DEV_LIST` variable, all services expect the `cloudbreak` port to be 9091.
 
-### Linux difference
+### Linux Difference
 
 Cloudbreak Deployer is unable to determine the IP address on a Linux machine. Therefore, you must add in the public IP address manually to your `Profile`.
 
@@ -173,7 +212,7 @@ export PUBLIC_IP=127.0.0.1
 
 ## IDEA
 
-### Check out the Cloudbreak repository
+### Check Out the Cloudbreak Repository
 
 Go to https://github.com/hortonworks/cloudbreak, either clone or download the repository, use SSH which is described here: https://help.github.com/articles/connecting-to-github-with-ssh/
 
@@ -181,7 +220,7 @@ Go to https://github.com/hortonworks/cloudbreak, either clone or download the re
 - `defaultCmPrivateRepoUser`
 - `defaultCmPrivateRepoPassword`
 
-### Project settings in IDEA
+### Project Settings in IDEA
 
 In IDEA set your SDK to your Java version under:
 
@@ -200,16 +239,16 @@ Set Gradle JVM
 IntelliJ IDEA -> Preferences -> Build, Execution, Deployment -> Gradle -> Gradle JVM -> 11
 ```
 
-### Import project
+### Import Project
 
 Cloudbreak can be imported into IDEA as a Gradle project by specifying the `cloudbreak` repo root under Import Project. Once it is done, you need to import the proper code formatter by using the `File -> Import Settings...` menu and selecting the `idea_settings.jar` located in the `config/idea` directory in the Cloudbreak git repository.
 
-Also you need to import inspection settings called `inpsections.xml` located in `config/idea`:
+Also, you need to import inspection settings called `inpsections.xml` located in `config/idea`:
 ```
 IntelliJ IDEA -> Preferences -> Editor -> Inspections -> Settings icon -> Import Profile
 ```
 
-Cloudbreak integrates with GRPC components. This results in generated files inside the project with big file sizes. By default IDEA ignores anything that is more than 8MB, resulting in unknown classes inside the IDEA context. To circumvent this, you need to add this property to your IDEA properties.
+Cloudbreak integrates with GRPC components. This results in generated files inside the project with big file sizes. By default, IDEA ignores anything that is more than 8MB, resulting in unknown classes inside the IDEA context. To circumvent this, you need to add this property to your IDEA properties.
 
 Go to `Help -> Edit Custom Properties...`, then insert
 ```
@@ -252,11 +291,14 @@ SET cloudbreaknodeid = 'YOUR_NODE_ID_VALUE';
 ``` 
 Where the `YOUR_NODE_ID_VALUE` value must be the same what you provide in the cloudbreak run configuration mentioned above.
 
-Afterward add these entries to the environment variables (the same values the you set in Profile):
+Afterward add these entries to the environment variables (the same values that you set in `Profile`):
 ```
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 CB_AWS_ACCOUNT_ID=
+AWS_GOV_ACCESS_KEY_ID=
+AWS_GOV_SECRET_ACCESS_KEY=
+CB_AWS_GOV_ACCOUNT_ID=
 ```
 
 The database migration scripts are run automatically by Cloudbreak, but this migration can be turned off with the `-Dcb.schema.migration.auto=false` JVM option.
@@ -276,8 +318,8 @@ In order to be able to determine the local `Cloudbreak` and `FreeIPA` version au
 ### Running Periscope in IDEA
 
 After importing the `cloudbreak` repo root, launch the Periscope application by executing the `com.sequenceiq.periscope.PeriscopeApplication` class (set `Use classpath of module` to `cloudbreak.autoscale.main`) with the following JVM options:
-* Note: If cloudbreak is in the CB_LOCAL_DEV_LIST variable, the periscope.cloudbreak.url should be http://localhost:9091
-````
+* Note: If `cloudbreak` is in the `CB_LOCAL_DEV_LIST` variable, the `periscope.cloudbreak.url` should be http://localhost:9091
+```
 -Dperiscope.db.port.5432.tcp.addr=localhost
 -Dperiscope.db.port.5432.tcp.port=5432
 -Dperiscope.cloudbreak.url=http://localhost:8080
@@ -285,22 +327,22 @@ After importing the `cloudbreak` repo root, launch the Periscope application by 
 -Daltus.ums.host=localhost
 -Dvault.root.token=<VAULT_ROOT_TOKEN>
 -Dinstance.node.id=<NODE_ID>
-````
+```
 
 Replace `<VAULT_ROOT_TOKEN>` and `<NODE_ID>` with the value of `VAULT_ROOT_TOKEN` and `CB_INSTANCE_NODE_ID` respectively from the `Profile` file.
 
 ### Running Datalake in IDEA
 
 After importing the `cloudbreak` repo root, launch the Datalake application by executing the `com.sequenceiq.datalake.DatalakeApplication` class (set `Use classpath of module` to `cloudbreak.datalake.main`) with the following JVM options:
-* Note: If cloudbreak is in the CB_LOCAL_DEV_LIST variable, the datalake.cloudbreak.url should be http://localhost:9091
-````
+* Note: If `cloudbreak` is in the `CB_LOCAL_DEV_LIST` variable, the `datalake.cloudbreak.url` should be http://localhost:9091
+```
 -Dserver.port=8086
 -Dcb.enabledplatforms=AWS,AZURE,MOCK
 -Ddatalake.cloudbreak.url=http://localhost:8080
 -Dvault.root.token=<VAULT_ROOT_TOKEN>
 -Dvault.addr=localhost
 -Dinstance.node.id=<NODE_ID>
-````
+```
 
 Replace `<VAULT_ROOT_TOKEN>` and `<NODE_ID>` with the value of `VAULT_ROOT_TOKEN` and `CB_INSTANCE_NODE_ID` respectively from the `Profile` file.
 
@@ -308,26 +350,29 @@ Replace `<VAULT_ROOT_TOKEN>` and `<NODE_ID>` with the value of `VAULT_ROOT_TOKEN
 
 After importing the `cloudbreak` repo root, launch the FreeIPA application by executing the `com.sequenceiq.freeipa.FreeIpaApplication` class (set `Use classpath of module` to `cloudbreak.freeipa.main`) with the following JVM options:
 
-````
+```
 -Dfreeipa.db.addr=localhost
 -Dserver.port=8090
 -Dvault.root.token=<VAULT_ROOT_TOKEN>
 -Dinstance.node.id=<NODE_ID>
-````
+```
 
 Replace `<VAULT_ROOT_TOKEN>` and `<NODE_ID>` with the value of `VAULT_ROOT_TOKEN` and `CB_INSTANCE_NODE_ID` respectively from the `Profile` file.
 
-then add these entries to the environment variables (the same values the you set in Profile):
+Then add these entries to the environment variables (the same values that you set in `Profile`):
 ```
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 CB_AWS_ACCOUNT_ID=
+AWS_GOV_ACCESS_KEY_ID=
+AWS_GOV_SECRET_ACCESS_KEY=
+CB_AWS_GOV_ACCOUNT_ID=
 ```
 
 ### Running Redbeams in IDEA
 
 After importing the `cloudbreak` repo root, launch the Redbeams application by executing the `com.sequenceiq.redbeams.RedbeamsApplication` class (set `Use classpath of module` to `cloudbreak.redbeams.main`) with the following JVM options:
-* Note: If cloudbreak is in the CB_LOCAL_DEV_LIST variable, the redbeams.cloudbreak.url should be http://localhost:9091
+* Note: If `cloudbreak` is in the `CB_LOCAL_DEV_LIST` variable, the `redbeams.cloudbreak.url` should be http://localhost:9091
 ```
 -Dredbeams.db.port.5432.tcp.addr=localhost
 -Dredbeams.db.port.5432.tcp.port=5432
@@ -337,56 +382,62 @@ After importing the `cloudbreak` repo root, launch the Redbeams application by e
 -Dvault.root.token=<VAULT_ROOT_TOKEN>
 -Dcb.enabledplatforms=AWS,AZURE,MOCK
 -Dinstance.node.id=<NODE_ID>
-````
+```
 
 Replace `<VAULT_ROOT_TOKEN>` and `<NODE_ID>` with the value of `VAULT_ROOT_TOKEN` and `CB_INSTANCE_NODE_ID` respectively from the `Profile` file.
 
-then add these entries to the environment variables (the same values the you set in Profile):
+Then add these entries to the environment variables (the same values that you set in `Profile`):
 ```
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 CB_AWS_ACCOUNT_ID=
+AWS_GOV_ACCESS_KEY_ID=
+AWS_GOV_SECRET_ACCESS_KEY=
+CB_AWS_GOV_ACCOUNT_ID=
 ```
 
-### Running the Environment service in IDEA
+### Running the Environment Service in IDEA
 
 After importing the `cloudbreak` repo root, launch the Environment application by executing the `com.sequenceiq.environment.EnvironmentApplication` class (set `Use classpath of module` to `cloudbreak.environment.main`) with the following JVM options:
-* Note: If cloudbreak is in the CB_LOCAL_DEV_LIST variable, the environment.cloudbreak.url should be http://localhost:9091
+* Note: If `cloudbreak` is in the `CB_LOCAL_DEV_LIST` variable, the `environment.cloudbreak.url` should be http://localhost:9091
 ```
 -Dvault.root.token=<VAULT_ROOT_TOKEN>
 -Denvironment.cloudbreak.url=http://localhost:8080
 -Denvironment.enabledplatforms="YARN,YCLOUD,AWS,AZURE,MOCK"
 -Dinstance.node.id=<NODE_ID>
-````
+```
 
 Replace `<VAULT_ROOT_TOKEN>` and `<NODE_ID>` with the value of `VAULT_ROOT_TOKEN` and `CB_INSTANCE_NODE_ID` respectively from the `Profile` file.
 
-then add these entries to the environment variables (the same values the you set in Profile):
+Then add these entries to the environment variables (the same values that you set in `Profile`):
 ```
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 CB_AWS_ACCOUNT_ID=
+AWS_GOV_ACCESS_KEY_ID=
+AWS_GOV_SECRET_ACCESS_KEY=
+CB_AWS_GOV_ACCOUNT_ID=
 ```
 
-### Running the Consumption service in IDEA
+### Running the Consumption Service in IDEA
 
 After importing the `cloudbreak` repo root, launch the Consumption application by executing the `com.sequenceiq.consumption.ConsumptionApplication` class (set `Use classpath of module` to `cloudbreak.cloud-consumption.main`) with the following JVM options:
-* Note: If cloudbreak is in the CB_LOCAL_DEV_LIST variable, the environment.cloudbreak.url should be http://localhost:9091
 ```
 -Dvault.root.token=<VAULT_ROOT_TOKEN>
--Denvironment.cloudbreak.url=http://localhost:8080
 -Dserver.port=8099
--Denvironment.enabledplatforms="YARN,YCLOUD,AWS,AZURE,MOCK"
 -Dinstance.node.id=<NODE_ID>
-````
+```
 
 Replace `<VAULT_ROOT_TOKEN>` and `<NODE_ID>` with the value of `VAULT_ROOT_TOKEN` and `CB_INSTANCE_NODE_ID` respectively from the `Profile` file.
 
-then add these entries to the environment variables (the same values the you set in Profile):
+Then add these entries to the environment variables (the same values that you set in `Profile`):
 ```
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 CB_AWS_ACCOUNT_ID=
+AWS_GOV_ACCESS_KEY_ID=
+AWS_GOV_SECRET_ACCESS_KEY=
+CB_AWS_GOV_ACCOUNT_ID=
 ```
 
 ### Running Thunderhead Mock in IDEA
@@ -413,15 +464,18 @@ In the `Profile` file make sure to also add:
 export MOCK_INFRASTRUCTURE_HOST=localhost
 ```
 
-## Command line
+## Command Line
 
 ### Running Cloudbreak from the Command Line
-To run Cloudbreak from the command line first set the the AWS environment variables (use the same values as in Profile)
+To run Cloudbreak from the command line first set the AWS environment variables (use the same values as in `Profile`)
 
 ```
 export AWS_ACCESS_KEY_ID=...
 export AWS_SECRET_ACCESS_KEY=...
 export CB_AWS_ACCOUNT_ID=...
+export AWS_GOV_ACCESS_KEY_ID=...
+export AWS_GOV_SECRET_ACCESS_KEY=...
+export CB_AWS_GOV_ACCOUNT_ID=...
 ```
 
 Set the CM repository credentials in order to download artifacts from the internal repository. Ask us for details in the [#eng_cb_dev_internal](https://cloudera.slack.com/archives/CF66M7WP6) Slack channel. 
@@ -449,7 +503,7 @@ The database migration scripts are run automatically by Cloudbreak, this migrati
 
 ### Running Periscope from the Command Line
 To run Periscope from the command line, run the following Gradle command:
-* Note: If cloudbreak is in the CB_LOCAL_DEV_LIST variable, the periscope.cloudbreak.url should be http://localhost:9091
+* Note: If `cloudbreak` is in the `CB_LOCAL_DEV_LIST` variable, the `periscope.cloudbreak.url` should be http://localhost:9091
 ````
 ./gradlew :autoscale:bootRun -PjvmArgs="-Dperiscope.db.port.5432.tcp.addr=localhost \
 -Dperiscope.db.port.5432.tcp.port=5432 \
@@ -465,7 +519,7 @@ Replace `<VAULT_ROOT_TOKEN>` with the value of `VAULT_ROOT_TOKEN` from the `Prof
 
 ### Running Datalake from the Command Line
 To run Datalake from the command line, run the following Gradle command:
-* Note: If cloudbreak is in the CB_LOCAL_DEV_LIST variable, the datalake.cloudbreak.url should be http://localhost:9091
+* Note: If `cloudbreak` is in the `CB_LOCAL_DEV_LIST` variable, the `datalake.cloudbreak.url` should be http://localhost:9091
 ````
 ./gradlew :datalake:bootRun -PjvmArgs="-Dvault.root.token=<VAULT_ROOT_TOKEN> \
 -Dserver.port=8086 \
@@ -476,12 +530,15 @@ To run Datalake from the command line, run the following Gradle command:
 Replace `<VAULT_ROOT_TOKEN>` with the value of `VAULT_ROOT_TOKEN` from the `Profile` file.
 
 ### Running FreeIPA from the Command Line
-To run the FreeIPA management service from the command line first set the the AWS environment variables (use the same values as in Profile)
+To run the FreeIPA management service from the command line first set the AWS environment variables (use the same values as in `Profile`)
 
 ```
 export AWS_ACCESS_KEY_ID=...
 export AWS_SECRET_ACCESS_KEY=...
 export CB_AWS_ACCOUNT_ID=...
+export AWS_GOV_ACCESS_KEY_ID=...
+export AWS_GOV_SECRET_ACCESS_KEY=...
+export CB_AWS_GOV_ACCOUNT_ID=...
 ```
 
 then run the following Gradle command:
@@ -496,16 +553,19 @@ then run the following Gradle command:
 Replace `<VAULT_ROOT_TOKEN>` with the value of `VAULT_ROOT_TOKEN` from the `Profile` file.
 
 ### Running Redbeams from the Command Line
-To run the Redbeams from the command line first set the the AWS environment variables (use the same values as in Profile)
+To run the Redbeams from the command line first set the AWS environment variables (use the same values as in `Profile`)
 
 ```
 export AWS_ACCESS_KEY_ID=...
 export AWS_SECRET_ACCESS_KEY=...
 export CB_AWS_ACCOUNT_ID=...
+export AWS_GOV_ACCESS_KEY_ID=...
+export AWS_GOV_SECRET_ACCESS_KEY=...
+export CB_AWS_GOV_ACCOUNT_ID=...
 ```
 
 then run the following Gradle command:
-* Note: If cloudbreak is in the CB_LOCAL_DEV_LIST variable, the redbeams.cloudbreak.url should be http://localhost:9091
+* Note: If `cloudbreak` is in the `CB_LOCAL_DEV_LIST` variable, the `redbeams.cloudbreak.url` should be http://localhost:9091
 ```
 ./gradlew :redbeams:bootRun --no-daemon -PjvmArgs="-Dredbeams.db.port.5432.tcp.addr=localhost \
 -Dredbeams.db.port.5432.tcp.port=5432 \
@@ -519,22 +579,47 @@ then run the following Gradle command:
 
 Replace `<VAULT_ROOT_TOKEN>` with the value of `VAULT_ROOT_TOKEN` from the `Profile` file.
 
-### Running the Environment service from the Command Line
-To run the Environment service from the command line first set the the AWS environment variables (use the same values as in Profile)
+### Running the Environment Service from the Command Line
+To run the Environment service from the command line first set the AWS environment variables (use the same values as in `Profile`)
 
 ```
 export AWS_ACCESS_KEY_ID=...
 export AWS_SECRET_ACCESS_KEY=...
 export CB_AWS_ACCOUNT_ID=...
+export AWS_GOV_ACCESS_KEY_ID=...
+export AWS_GOV_SECRET_ACCESS_KEY=...
+export CB_AWS_GOV_ACCOUNT_ID=...
 ```
 
 then run the following Gradle command:
-* Note: If cloudbreak is in the CB_LOCAL_DEV_LIST variable, the environment.cloudbreak.url should be http://localhost:9091
+* Note: If `cloudbreak` is in the `CB_LOCAL_DEV_LIST` variable, the `environment.cloudbreak.url` should be http://localhost:9091
 ```
 ./gradlew :environment:bootRun -PjvmArgs="\
 -Denvironment.cloudbreak.url=http://localhost:8080 \
 -Dvault.root.token=<VAULT_ROOT_TOKEN> \
 -Dspring.config.location=$(pwd)/environment/src/main/resources/application.yml,$(pwd)/environment/build/resources/main/application.properties"
+```
+
+Replace `<VAULT_ROOT_TOKEN>` with the value of `VAULT_ROOT_TOKEN` from the `Profile` file.
+
+### Running the Consumption Service from the Command Line
+To run the Consumption service from the command line first set the AWS environment variables (use the same values as in `Profile`)
+
+```
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+export CB_AWS_ACCOUNT_ID=...
+export AWS_GOV_ACCESS_KEY_ID=...
+export AWS_GOV_SECRET_ACCESS_KEY=...
+export CB_AWS_GOV_ACCOUNT_ID=...
+```
+
+then run the following Gradle command:
+```
+./gradlew :cloud-consumption:bootRun -PjvmArgs="\
+-Dserver.port=8099 \
+-Dvault.root.token=<VAULT_ROOT_TOKEN> \
+-Dspring.config.location=$(pwd)/cloud-consumption/src/main/resources/application.yml,$(pwd)/cloud-consumption/build/resources/main/application.properties"
 ```
 
 Replace `<VAULT_ROOT_TOKEN>` with the value of `VAULT_ROOT_TOKEN` from the `Profile` file.
@@ -553,15 +638,30 @@ Replace `<CBD_LOCAL_ETC>` with the full path of your `cbd-local/etc` directory t
 
 Please make sure that `thunderhead-api` has also been added to `CB_LOCAL_DEV_LIST` list in `Profile` file of cbd (besides `thunderhead-mock`).
 
-## Database development
+### Running Mock-Infrastructure from the Command Line
+To run Mock-Infrastructure from the command line first set the following environment variable
 
-If any schema change is required in Cloudbreak services databases (`cbdb` / `periscopedb` / `datalakedb` / `redbeamsdb` / `environmentdb` / `freeipadb`), then the developer needs to write SQL scripts
+```
+export MOCK_INFRASTRUCTURE_HOST=localhost
+```
+
+then run the following Gradle command:
+```
+./gradlew :mock-infrastructure:bootRun -PjvmArgs="\
+-Dspring.config.location=$(pwd)/mock-infrastructure/src/main/resources/application.yml"
+```
+
+Please make sure that `mock-infrastructure` has been added to `CB_LOCAL_DEV_LIST` list in the `Profile` file of cbd.
+
+## Database Development
+
+If any schema change is required in Cloudbreak services databases (`cbdb` / `periscopedb` / `datalakedb` / `redbeamsdb` / `environmentdb` / `freeipadb` / `consumptiondb`), then the developer needs to write SQL scripts
  to migrate the database accordingly. The schema migration is managed by [MyBatis Migrations](https://github.com/mybatis/migrations) in Cloudbreak and the cbd tool provides an easy-to-use wrapper for it. The syntax for using the migration commands is `cbd migrate <database name> <command> [parameters]` e.g. `cbd migrate cbdb status`.
 Create a SQL template for schema changes:
 ```
 cbd migrate cbdb new "CLOUD-123 schema change for new feature"
 ```
-As as result of the above command an SQL file template is generated under the path specified in `CB_SCHEMA_SCRIPTS_LOCATION` environment variable, which is defined in `Profile`. The structure of the generated SQL template looks like the following:
+As result of the above command an SQL file template is generated under the path specified in `CB_SCHEMA_SCRIPTS_LOCATION` environment variable, which is defined in `Profile`. The structure of the generated SQL template looks like the following:
 ```
 -- // CLOUD-123 schema change for new feature
 -- Migration SQL that makes the change goes here.
@@ -579,11 +679,11 @@ Make sure pending SQLs to run as well:
 ```
 cbd migrate <database-name> pending
 ```
-If you would like to rollback the last SQL file, then just use the down command:
+If you would like to roll back the last SQL file, then just use the down command:
 ```
 cbd migrate <database-name> down
 ```
-On order to check the status of database
+In order to check the status of database
 ```
 cbd migrate <database-name> status
 
@@ -609,7 +709,9 @@ Gradle is used for build and dependency management. The Gradle wrapper is added 
 ./gradlew clean build
 ```
 
-## How to reach CM UI directly(not through Knox)
+Before running the above command, however, be sure to make the changes mentioned in [Check Out the Cloudbreak Repository](#check-out-the-cloudbreak-repository) to your `~/.gradle/gradle.properties`.
+
+## How to Reach CM UI Directly (Not Through Knox)
 With the current design on the cluster's gateway node there is an NGiNX which is responsible for routing requests through Knox by default. 
 But there are cases when the CM UI needs to be reached directly. It is possible on the same port by the same NGiNX on the `clouderamanager/` path of the provisioned cluster.
 Please note that the trailing slash is significant for the routing to work.
@@ -619,7 +721,7 @@ For example: `https://tb-nt-local.tb-local.xcu2-8y8x.workload-dev.cloudera.com/c
 > Be aware of that this routing mechanism is based on cookies, so if you have problems to reach the CM UI directly especially when you reached any service through Knox previously then the deletion of cookies could solve your issues.
 
 
-# How to contribute
+# How to Contribute
 
 I would like to start by the warm welcome if you would like to contribute to our project, making our - and from the point of contribution, it's yours also - goals closer. 
 
@@ -640,20 +742,20 @@ At the time of this writing, we don't enforce any formal requirements to the pul
 
 We were talking about what we should avoid, but let's see a few good examples, which helps the reviewer to understand the purpose of that commit:
 
-[https://github.com/hortonworks/cloudbreak/commit/56fdde5c6f48f48a378b505a170b3e3d83225c85](url)
+https://github.com/hortonworks/cloudbreak/commit/56fdde5c6f48f48a378b505a170b3e3d83225c85
 
-[https://github.com/hortonworks/cloudbreak/commit/d09b0074c45af209ccf34855dcf4c1f34c3ccebb](url)
+https://github.com/hortonworks/cloudbreak/commit/d09b0074c45af209ccf34855dcf4c1f34c3ccebb
 
-[https://github.com/hortonworks/cloudbreak/commit/c93b91fd6a08de7516ab763098f2dcd3abc149f0](url)
+https://github.com/hortonworks/cloudbreak/commit/c93b91fd6a08de7516ab763098f2dcd3abc149f0
 
-[https://github.com/hortonworks/cloudbreak/commit/f50f5c8f38941db958eac27c663ae00ecba7b0f5](url)
+https://github.com/hortonworks/cloudbreak/commit/f50f5c8f38941db958eac27c663ae00ecba7b0f5
 
 
-## Coding guidelines
+## Coding Guidelines
 
 - If you introduce a new Cloud SDK or API for a feature, please ensure that the newly introduced API calls **are supported in every region** and if not then search for an alternative solution. It is often the case that the cloud providers gradually introduce their new services.
 
-## Catching up
+## Catching Up
 
 When you're working on your precious change on your beloved branch and all of a sudden you face the issue of getting your branch drop behind from the desired/initial branch where you would like to open your future pull request, our way of catching up is [rebasing](https://git-scm.com/docs/git-rebase).
 
@@ -662,6 +764,5 @@ If you're experiencing this quite common then the good practice would be fetchin
 In addition, please do not merge branches together if you can solve your problem with rebasing, and even if you think that your change would have no impact on the codebase, or the actual collection of functionalities **- if you're not from our team or don't have written permission from one of our team members - please never ever push directly anything to the master branch normally and especially not by force.** 
 
 
-
-## Additional info
+## Additional Info
 > * [Cloudbreak Service Provider Interface (SPI)](https://github.com/hortonworks/cloudbreak/blob/master/docs/spi.md)

--- a/build.gradle
+++ b/build.gradle
@@ -254,7 +254,7 @@ subprojects {
   task('buildInfo', type: BuildInfoTask, dependsOn: processResources)
 
   afterEvaluate { Project project ->
-    if (project.name in ['core', 'autoscale', 'freeipa', 'redbeams', 'environment', 'datalake', 'integration-test'] && project.plugins.hasPlugin('org.springframework.boot')) {
+    if (project.name in ['core', 'autoscale', 'freeipa', 'redbeams', 'environment', 'datalake', 'integration-test', 'cloud-consumption'] && project.plugins.hasPlugin('org.springframework.boot')) {
       buildInfo.configure {
         destination = file("$project.buildDir")
         basename = project.bootJar.baseName

--- a/cloud-consumption/build.gradle
+++ b/cloud-consumption/build.gradle
@@ -10,6 +10,7 @@ buildscript {
         classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:${sonarVersion}"
     }
 }
+
 plugins {
     id "java"
     id "checkstyle"
@@ -148,7 +149,10 @@ bootRun {
     environment "AWS_ACCESS_KEY_ID", System.getenv('AWS_ACCESS_KEY_ID')
     environment "AWS_SECRET_ACCESS_KEY", System.getenv('AWS_SECRET_ACCESS_KEY')
     environment "CB_AWS_ACCOUNT_ID", System.getenv('CB_AWS_ACCOUNT_ID')
-    //Probably will need to add more for AZURE, GOV_CLOUD, GCE, etc
+    environment "AWS_GOV_ACCESS_KEY_ID", System.getenv('AWS_GOV_ACCESS_KEY_ID')
+    environment "AWS_GOV_SECRET_ACCESS_KEY", System.getenv('AWS_GOV_SECRET_ACCESS_KEY')
+    environment "CB_AWS_GOV_ACCOUNT_ID", System.getenv('CB_AWS_GOV_ACCOUNT_ID')
+    //Probably will need to add more for AZURE, GCE, etc
 
     if (project.hasProperty("jvmArgs")) {
         jvmArgs += project.jvmArgs.split("\\s+").toList()
@@ -185,4 +189,3 @@ publishing {
         }
     }
 }
-


### PR DESCRIPTION
* `build.gradle` (root): Enable `application.properties` generation for `cloud-consumption` as well.
* `cloud-consumption/build.gradle`: Import AWS GovCloud environment variables when executing `bootRun`.
* `README.md` (root):
  * Fix & add cloud-consumption details: DB, running in IDEA, running in CLI.
  * Add Mock-Infrastructure running in CLI.
  * Fix `LICENSE` file link.
  * Document the various `*_SCHEMA_SCRIPTS_LOCATION` environment variables supported in `Profile`.
  * Document AWS GovCloud environment variables.
  * Document the complete list of service names supported in `CB_LOCAL_DEV_LIST`.
  * Various spelling / wording / casing / formatting fixes.
