### PR TITLE
CB-18344: Add validation for nameserver settings during service pillar setup

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
@@ -31,7 +31,6 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -40,7 +39,6 @@ import org.springframework.util.CollectionUtils;
 
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.Account;
 import com.google.common.base.Joiner;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.net.InetAddresses;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
@@ -72,8 +70,8 @@ import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterDeletionBasedExit
 import com.sequenceiq.cloudbreak.core.bootstrap.service.container.postgres.PostgresConfigService;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.decorator.CsdParcelDecorator;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.decorator.HostAttributeDecorator;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.host.decorator.NameserverPillarDecorator;
 import com.sequenceiq.cloudbreak.domain.stack.DnsResolverType;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.IdBroker;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.gateway.ExposedServices;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.gateway.GatewayTopology;
@@ -110,13 +108,11 @@ import com.sequenceiq.cloudbreak.service.hostgroup.HostGroupService;
 import com.sequenceiq.cloudbreak.service.idbroker.IdBrokerService;
 import com.sequenceiq.cloudbreak.service.proxy.ProxyConfigProvider;
 import com.sequenceiq.cloudbreak.service.rdsconfig.RdsConfigWithoutClusterService;
-import com.sequenceiq.cloudbreak.service.sharedservice.DatalakeService;
 import com.sequenceiq.cloudbreak.service.stack.TargetedUpscaleSupportService;
 import com.sequenceiq.cloudbreak.service.stack.flow.MountDisks;
 import com.sequenceiq.cloudbreak.telemetry.orchestrator.TelemetrySaltPillarDecorator;
 import com.sequenceiq.cloudbreak.template.kerberos.KerberosDetailService;
 import com.sequenceiq.cloudbreak.template.views.RdsView;
-import com.sequenceiq.cloudbreak.type.KerberosType;
 import com.sequenceiq.cloudbreak.util.NodesUnreachableException;
 import com.sequenceiq.cloudbreak.util.StackUtil;
 import com.sequenceiq.cloudbreak.view.ClusterView;
@@ -232,9 +228,6 @@ public class ClusterHostServiceRunner {
     private EntitlementService entitlementService;
 
     @Inject
-    private DatalakeService datalakeService;
-
-    @Inject
     private TargetedUpscaleSupportService targetedUpscaleSupportService;
 
     @Inject
@@ -245,6 +238,9 @@ public class ClusterHostServiceRunner {
 
     @Inject
     private SssdConfigProvider sssdConfigProvider;
+
+    @Inject
+    private NameserverPillarDecorator nameserverPillarDecorator;
 
     public NodeReachabilityResult runClusterServices(@Nonnull StackDto stackDto, Map<String, String> candidateAddresses) {
         try {
@@ -427,7 +423,7 @@ public class ClusterHostServiceRunner {
         ClouderaManagerRepo clouderaManagerRepo = clusterComponentConfigProvider.getClouderaManagerRepoDetails(cluster.getId());
         Map<String, SaltPillarProperties> servicePillar = new HashMap<>();
         KerberosConfig kerberosConfig = kerberosConfigService.get(stack.getEnvironmentCrn(), stack.getName()).orElse(null);
-        saveCustomNameservers(stackDto, kerberosConfig, servicePillar);
+        nameserverPillarDecorator.decorateServicePillarWithNameservers(stackDto, kerberosConfig, servicePillar);
         servicePillar.putAll(createUnboundEliminationPillar(stack.getDomainDnsResolver()));
         addKerberosConfig(servicePillar, kerberosConfig);
         servicePillar.putAll(hostAttributeDecorator.createHostAttributePillars(stackDto));
@@ -669,28 +665,6 @@ public class ClusterHostServiceRunner {
     private Map<String, SaltPillarProperties> createUnboundEliminationPillar(DnsResolverType dnsResolverType) {
         return Map.of("unbound-elimination", new SaltPillarProperties("/unbound/elimination.sls", singletonMap("unbound_elimination_supported",
                 DnsResolverType.FREEIPA_FOR_ENV.equals(dnsResolverType))));
-    }
-
-    private void saveCustomNameservers(StackDto stackDto, KerberosConfig kerberosConfig, Map<String, SaltPillarProperties> servicePillar) {
-        if (kerberosConfig != null && StringUtils.isNotBlank(kerberosConfig.getDomain()) && StringUtils.isNotBlank(kerberosConfig.getNameServers())) {
-            List<String> ipList = Lists.newArrayList(kerberosConfig.getNameServers().split(","));
-            servicePillar.put("forwarder-zones", new SaltPillarProperties("/unbound/forwarders.sls",
-                    singletonMap("forwarder-zones", singletonMap(kerberosConfig.getDomain(), singletonMap("nameservers", ipList)))));
-        } else if (kerberosConfig == null || (kerberosConfig.getType() != KerberosType.FREEIPA && kerberosConfig.getType() != KerberosType.ACTIVE_DIRECTORY)) {
-            saveDatalakeNameservers(stackDto, servicePillar);
-        }
-    }
-
-    private void saveDatalakeNameservers(StackDto stackDto, Map<String, SaltPillarProperties> servicePillar) {
-        Optional<Stack> datalakeStackOptional = datalakeService.getDatalakeStackByDatahubStack(stackDto.getStack());
-        if (datalakeStackOptional.isPresent()) {
-            Stack dataLakeStack = datalakeStackOptional.get();
-            String datalakeDomain = dataLakeStack.getNotTerminatedAndNotZombieGatewayInstanceMetadata().get(0).getDomain();
-            List<String> ipList = dataLakeStack.getNotTerminatedAndNotZombieGatewayInstanceMetadata().stream().map(InstanceMetadataView::getPrivateIp)
-                    .collect(Collectors.toList());
-            servicePillar.put("forwarder-zones", new SaltPillarProperties("/unbound/forwarders.sls",
-                    singletonMap("forwarder-zones", singletonMap(datalakeDomain, singletonMap("nameservers", ipList)))));
-        }
     }
 
     @SuppressWarnings("ParameterNumber")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/NameserverPillarDecorator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/NameserverPillarDecorator.java
@@ -1,0 +1,74 @@
+package com.sequenceiq.cloudbreak.core.bootstrap.service.host.decorator;
+
+import static java.util.Collections.singletonMap;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import com.google.common.collect.Lists;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.dto.KerberosConfig;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
+import com.sequenceiq.cloudbreak.service.sharedservice.DatalakeService;
+import com.sequenceiq.cloudbreak.type.KerberosType;
+import com.sequenceiq.cloudbreak.view.InstanceMetadataView;
+
+@Component
+public class NameserverPillarDecorator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NameserverPillarDecorator.class);
+
+    @Inject
+    private DatalakeService datalakeService;
+
+    private static List<InstanceMetadataView> getGatewayInstanceMetadata(Stack dataLakeStack) {
+        return dataLakeStack.getNotTerminatedAndNotZombieGatewayInstanceMetadata();
+    }
+
+    public void decorateServicePillarWithNameservers(StackDto stackDto, KerberosConfig kerberosConfig, Map<String, SaltPillarProperties> servicePillar) {
+        if (kerberosConfig != null && StringUtils.hasText(kerberosConfig.getDomain()) && StringUtils.hasText(kerberosConfig.getNameServers())) {
+            LOGGER.debug("Add nameserver config to pillar based on kerberos config.");
+            List<String> ipList = Lists.newArrayList(kerberosConfig.getNameServers().split(","));
+            servicePillar.put("forwarder-zones", new SaltPillarProperties("/unbound/forwarders.sls",
+                    singletonMap("forwarder-zones", singletonMap(kerberosConfig.getDomain(), singletonMap("nameservers", ipList)))));
+        } else if (kerberosConfig == null || kerberosConfig.getType() != KerberosType.FREEIPA && kerberosConfig.getType() != KerberosType.ACTIVE_DIRECTORY) {
+            decorateServicePillarWithDatalakeNameservers(stackDto, servicePillar);
+        } else {
+            LOGGER.debug("Skip to add nameserver config for pillar because kerberos config type is {}", kerberosConfig.getType());
+        }
+    }
+
+    private void decorateServicePillarWithDatalakeNameservers(StackDto stackDto, Map<String, SaltPillarProperties> servicePillar) {
+        Optional<Stack> datalakeStackOptional = datalakeService.getDatalakeStackByDatahubStack(stackDto.getStack());
+        if (datalakeStackOptional.isPresent()) {
+            LOGGER.debug("Add nameserver config to pillar based on datalake gateway addresses.");
+            List<InstanceMetadataView> gatewayInstanceMetadata = getGatewayInstanceMetadata(datalakeStackOptional.get());
+            String datalakeDomain = gatewayInstanceMetadata.get(0).getDomain();
+            List<String> ipList = getDatalakeGatewayPrivateIps(gatewayInstanceMetadata);
+            servicePillar.put("forwarder-zones", new SaltPillarProperties("/unbound/forwarders.sls",
+                    singletonMap("forwarder-zones", singletonMap(datalakeDomain, singletonMap("nameservers", ipList)))));
+        } else {
+            LOGGER.debug("Skip to add nameserver config for pillar because Datalake stack is not present.");
+        }
+    }
+
+    private List<String> getDatalakeGatewayPrivateIps(List<InstanceMetadataView> gatewayInstanceMetadata) {
+        return gatewayInstanceMetadata.stream()
+                .map(InstanceMetadataView::getPrivateIp)
+                .filter(StringUtils::hasText)
+                .collect(Collectors.collectingAndThen(Collectors.toList(), Optional::of))
+                .filter(ipList -> !ipList.isEmpty())
+                .orElseThrow(() -> new CloudbreakServiceException("Unable to setup nameservers because there is no IP address present."));
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunnerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunnerTest.java
@@ -62,6 +62,7 @@ import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.container.postgres.PostgresConfigService;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.decorator.CsdParcelDecorator;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.decorator.HostAttributeDecorator;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.host.decorator.NameserverPillarDecorator;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.domain.Template;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
@@ -234,6 +235,9 @@ class ClusterHostServiceRunnerTest {
 
     @Mock
     private KerberosDetailService kerberosDetailService;
+
+    @Mock
+    private NameserverPillarDecorator nameserverPillarDecorator;
 
     @BeforeEach
     void setUp() {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/NameserverPillarDecoratorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/NameserverPillarDecoratorTest.java
@@ -1,0 +1,147 @@
+package com.sequenceiq.cloudbreak.core.bootstrap.service.host.decorator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.dto.KerberosConfig;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
+import com.sequenceiq.cloudbreak.service.sharedservice.DatalakeService;
+import com.sequenceiq.cloudbreak.type.KerberosType;
+import com.sequenceiq.cloudbreak.view.StackView;
+
+@ExtendWith(MockitoExtension.class)
+class NameserverPillarDecoratorTest {
+
+    private static final String SERVICE_KEY = "forwarder-zones";
+
+    private static final String SERVICE_PATH = "/unbound/forwarders.sls";
+
+    private static final String KERBEROS_NAMESERVER_1 = "1.1.1.1";
+
+    private static final String KERBEROS_NAMESERVER_2 = "2.2.2.2";
+
+    private static final String DL_PRIVATE_IP = "3.3.3.3";
+
+    private static final String NAMESERVERS_KEY = "nameservers";
+
+    private static final String DOMAIN = "cloudera.com";
+
+    @InjectMocks
+    private NameserverPillarDecorator underTest;
+
+    @Mock
+    private DatalakeService datalakeService;
+
+    @Mock
+    private StackDto stackDto;
+
+    @Mock
+    private StackView stack;
+
+    @Mock
+    private Stack datalakeStack;
+
+    @Test
+    void testShouldPopulateThePillarWhenKerberosConfigIsAvailable() {
+        Map<String, SaltPillarProperties> servicePillar = new HashMap<>();
+        KerberosConfig kerberosConfig = KerberosConfig.KerberosConfigBuilder.aKerberosConfig()
+                .withDomain(DOMAIN)
+                .withNameServers(KERBEROS_NAMESERVER_1 + "," + KERBEROS_NAMESERVER_2)
+                .build();
+        underTest.decorateServicePillarWithNameservers(stackDto, kerberosConfig, servicePillar);
+
+        SaltPillarProperties pillarProperties = servicePillar.get(SERVICE_KEY);
+        Map<String, Map<String, List<String>>> nameservers = (Map<String, Map<String, List<String>>>) pillarProperties.getProperties().get(SERVICE_KEY);
+        assertNotNull(pillarProperties);
+        assertEquals(SERVICE_PATH, pillarProperties.getPath());
+        assertTrue(nameservers.get(kerberosConfig.getDomain()).get(NAMESERVERS_KEY).contains(KERBEROS_NAMESERVER_1));
+        assertTrue(nameservers.get(kerberosConfig.getDomain()).get(NAMESERVERS_KEY).contains(KERBEROS_NAMESERVER_2));
+        verifyNoInteractions(datalakeService);
+    }
+
+    @Test
+    void testShouldPopulateThePillarWithDatalakeNameserverWhenKerberosConfigIsNotPresent() {
+        Map<String, SaltPillarProperties> servicePillar = new HashMap<>();
+
+        when(stackDto.getStack()).thenReturn(stack);
+        when(datalakeService.getDatalakeStackByDatahubStack(stack)).thenReturn(Optional.of(datalakeStack));
+        when(datalakeStack.getNotTerminatedAndNotZombieGatewayInstanceMetadata()).thenReturn(Collections.singletonList(createInstanceMetaData(DL_PRIVATE_IP)));
+
+        underTest.decorateServicePillarWithNameservers(stackDto, null, servicePillar);
+
+        SaltPillarProperties pillarProperties = servicePillar.get(SERVICE_KEY);
+        Map<String, Map<String, List<String>>> nameservers = (Map<String, Map<String, List<String>>>) pillarProperties.getProperties().get(SERVICE_KEY);
+        assertNotNull(pillarProperties);
+        assertEquals(SERVICE_PATH, pillarProperties.getPath());
+        assertTrue(nameservers.get(DOMAIN).get(NAMESERVERS_KEY).contains(DL_PRIVATE_IP));
+        verify(datalakeService).getDatalakeStackByDatahubStack(stack);
+    }
+
+    @Test
+    void testShouldPopulateThePillarShouldThrowExceptionWhenDatalakeNameserverAddressIsNull() {
+        Map<String, SaltPillarProperties> servicePillar = new HashMap<>();
+
+        when(stackDto.getStack()).thenReturn(stack);
+        when(datalakeService.getDatalakeStackByDatahubStack(stack)).thenReturn(Optional.of(datalakeStack));
+        when(datalakeStack.getNotTerminatedAndNotZombieGatewayInstanceMetadata()).thenReturn(Collections.singletonList(createInstanceMetaData(null)));
+
+        Exception exception = assertThrows(CloudbreakServiceException.class,
+                () -> underTest.decorateServicePillarWithNameservers(stackDto, null, servicePillar));
+
+        assertEquals("Unable to setup nameservers because there is no IP address present.", exception.getMessage());
+        assertTrue(servicePillar.isEmpty());
+        verify(datalakeService).getDatalakeStackByDatahubStack(stack);
+    }
+
+    @Test
+    void testShouldPopulateThePillarShouldNotPopulateServicePillarWhenKerberosTypeIsFreeipaAndKerberosNameserverIsMissing() {
+        Map<String, SaltPillarProperties> servicePillar = new HashMap<>();
+        KerberosConfig kerberosConfig = KerberosConfig.KerberosConfigBuilder.aKerberosConfig().withType(KerberosType.FREEIPA).build();
+
+        underTest.decorateServicePillarWithNameservers(stackDto, kerberosConfig, servicePillar);
+
+        assertTrue(servicePillar.isEmpty());
+        verifyNoInteractions(datalakeService);
+    }
+
+    @Test
+    void testShouldPopulateThePillarShouldNotPopulateServicePillarWhenKerberosSettingsAreMissingAndDatalakeIsNotPresent() {
+        Map<String, SaltPillarProperties> servicePillar = new HashMap<>();
+        when(stackDto.getStack()).thenReturn(stack);
+        when(datalakeService.getDatalakeStackByDatahubStack(stack)).thenReturn(Optional.empty());
+
+        underTest.decorateServicePillarWithNameservers(stackDto, null, servicePillar);
+
+        assertTrue(servicePillar.isEmpty());
+        verify(datalakeService).getDatalakeStackByDatahubStack(stack);
+    }
+
+    private InstanceMetaData createInstanceMetaData(String privateIp) {
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+        instanceMetaData.setDiscoveryFQDN("test." + DOMAIN);
+        instanceMetaData.setPrivateIp(privateIp);
+        return instanceMetaData;
+    }
+
+}


### PR DESCRIPTION
In this commit I added validation to prevent the nameserver settings in the service pillar from null values. Sometimes we set the nameserver address in the unbound config to null and this causes cluster creation failures. From now we're breaking the cluster install with a proper error message when the nameserver address is not present.