### PR TITLE
CB-18035 NPE in datalakeWaitObject

### DIFF
--- a/datalake/src/test/java/com/sequenceiq/datalake/controller/sdx/SdxClusterConverterTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/controller/sdx/SdxClusterConverterTest.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.datalake.controller.sdx;
+
+import static org.junit.Assert.assertThrows;
+import static org.springframework.util.Assert.notNull;
+
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.datalake.entity.DatalakeStatusEnum;
+import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
+
+class SdxClusterConverterTest {
+
+    @Test
+    void sdxClusterStatusConverter() {
+        for (SdxClusterStatusResponse s : SdxClusterStatusResponse.values()) {
+            notNull(DatalakeStatusEnum.valueOf(s.name()), s.name());
+        }
+        for (DatalakeStatusEnum value : DatalakeStatusEnum.values()) {
+            notNull(SdxClusterStatusResponse.valueOf(value.name()), value.name());
+        }
+        assertThrows("null Response conversion", NullPointerException.class, () -> SdxClusterStatusResponse.valueOf(null));
+        assertThrows("null Status conversion", NullPointerException.class, () -> DatalakeStatusEnum.valueOf(null));
+
+    }
+}


### PR DESCRIPTION
added test to ensure that name translation doesn't introduce any potential NPE for conversion.

See detailed description in the commit message.