### PR TITLE
CB-18570 Add more investigation steps to the integration test module

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/Clue.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/Clue.java
@@ -1,20 +1,34 @@
 package com.sequenceiq.it.cloudbreak.context;
 
+import java.util.List;
+
 import com.sequenceiq.cloudbreak.api.endpoint.v4.audits.responses.AuditEventV4Responses;
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPStructuredEvent;
 
 public class Clue {
 
     private final String name;
 
+    private final String crn;
+
     private final AuditEventV4Responses auditEvents;
+
+    private final List<CDPStructuredEvent> cdpStructuredEvents;
 
     private final Object response;
 
     private final boolean hasSpotTermination;
 
-    public Clue(String name, AuditEventV4Responses auditEvents, Object response, boolean hasSpotTermination) {
+    public Clue(String name,
+            String crn,
+            AuditEventV4Responses auditEvents,
+            List<CDPStructuredEvent> cdpStructuredEvents,
+            Object response,
+            boolean hasSpotTermination) {
         this.name = name;
+        this.crn = crn;
         this.auditEvents = auditEvents;
+        this.cdpStructuredEvents = cdpStructuredEvents;
         this.response = response;
         this.hasSpotTermination = hasSpotTermination;
     }
@@ -23,8 +37,16 @@ public class Clue {
         return name;
     }
 
+    public String getCrn() {
+        return crn;
+    }
+
     public AuditEventV4Responses getAuditEvents() {
         return auditEvents;
+    }
+
+    public List<CDPStructuredEvent> getCdpStructuredEvents() {
+        return cdpStructuredEvents;
     }
 
     public Object getResponse() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDto.java
@@ -336,7 +336,13 @@ public class DistroXTestDto extends DistroXTestDtoBase<DistroXTestDto> implement
         boolean hasSpotTermination = (getResponse().getInstanceGroups() == null) ? false : getResponse().getInstanceGroups().stream()
                 .flatMap(ig -> ig.getMetadata().stream())
                 .anyMatch(metadata -> InstanceStatus.DELETED_BY_PROVIDER == metadata.getInstanceStatus());
-        return new Clue("DistroX", auditEvents, getResponse(), hasSpotTermination);
+        return new Clue(
+                getResponse().getName(),
+                getResponse().getCrn(),
+                auditEvents,
+                List.of(),
+                getResponse(),
+                hasSpotTermination);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/stack/StackTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/stack/StackTestDto.java
@@ -161,7 +161,13 @@ public class StackTestDto extends StackTestDtoBase<StackTestDto> implements Purg
         boolean hasSpotTermination = (getResponse().getInstanceGroups() == null) ? false : getResponse().getInstanceGroups().stream()
                 .flatMap(ig -> ig.getMetadata().stream())
                 .anyMatch(metadata -> InstanceStatus.DELETED_BY_PROVIDER == metadata.getInstanceStatus());
-        return new Clue("DistroX", auditEvents, getResponse(), hasSpotTermination);
+        return new Clue(
+                getResponse().getName(),
+                getResponse().getCrn(),
+                auditEvents,
+                List.of(),
+                getResponse(),
+                hasSpotTermination);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/AuditUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/AuditUtil.java
@@ -1,15 +1,10 @@
 package com.sequenceiq.it.cloudbreak.util;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.sequenceiq.cloudbreak.api.endpoint.v4.audits.AuditEventV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.audits.responses.AuditEventV4Responses;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 
 public class AuditUtil {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(AuditUtil.class);
 
     private AuditUtil() {
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ErrorLogMessageProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ErrorLogMessageProvider.java
@@ -2,10 +2,15 @@ package com.sequenceiq.it.cloudbreak.util;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -13,6 +18,12 @@ import org.springframework.stereotype.Component;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.audits.responses.AuditEventV4Response;
+import com.sequenceiq.cloudbreak.structuredevent.event.NotificationDetails;
+import com.sequenceiq.cloudbreak.structuredevent.event.StructuredNotificationEvent;
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPStructuredEvent;
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPStructuredFlowEvent;
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPStructuredNotificationEvent;
 import com.sequenceiq.it.cloudbreak.context.Clue;
 import com.sequenceiq.it.cloudbreak.exception.TestFailException;
 
@@ -31,7 +42,7 @@ public class ErrorLogMessageProvider {
     }
 
     public String getMessage(Map<String, Exception> exceptionsDuringTest, List<Clue> clues) {
-        StringBuilder messageBuilder = new StringBuilder("All Exceptions that occurred during the test are logged after this message")
+        StringBuilder messageBuilder = new StringBuilder("All Exceptions that occurred during the test are logged after this message.")
                 .append(System.lineSeparator());
         exceptionsDuringTest.forEach((msg, ex) -> {
             LOGGER.error("Exception during test: " + msg, ex);
@@ -64,6 +75,38 @@ public class ErrorLogMessageProvider {
                         .append(spotTerminatedNames)
                         .append(System.lineSeparator());
             }
+
+            List<Clue> failureOrderedClues = clues.stream()
+                    .sorted((clue1, clue2) -> {
+                        boolean clue1HasFailed = hashFailedStructuredEvent(clue1);
+                        boolean clue2HasFiled = hashFailedStructuredEvent(clue2);
+                        if (clue1HasFailed == clue2HasFiled) {
+                            return 0;
+                        } else if (clue1HasFailed) {
+                            return -1;
+                        } else {
+                            return 1;
+                        }
+                    })
+                    .collect(Collectors.toList());
+            clues = failureOrderedClues;
+
+            builder.append("You can see structured events and audit events about the resources created during test.").append(System.lineSeparator());
+            clues.forEach(clue -> {
+                appendLine(builder, "");
+                appendLine(builder, clue.getName() + " - " + clue.getCrn());
+
+                if (clue.getAuditEvents() != null && CollectionUtils.isNotEmpty(clue.getAuditEvents().getResponses())) {
+                    appendLine(builder, "Audit events:");
+                    appendLine(builder, formatAuditEvents(clue.getAuditEvents().getResponses()));
+                }
+
+                if (CollectionUtils.isNotEmpty(clue.getCdpStructuredEvents())) {
+                    appendLine(builder, "Structured events:");
+                    appendLine(builder, formatStructuredEvents(clue.getCdpStructuredEvents()));
+                }
+            });
+
             builder.append("Responses:")
                     .append(System.lineSeparator());
             clues.forEach(clue -> builder.append(clue.getName())
@@ -72,7 +115,7 @@ public class ErrorLogMessageProvider {
                     .append(System.lineSeparator()));
             builder.append("All audit events:")
                     .append(System.lineSeparator());
-            clues.forEach(clue -> builder.append(clue.getName())
+            clues.forEach(clue -> builder.append(clue.getName() + " - " + clue.getCrn())
                     .append(" audit events: ")
                     .append(convertToString(clue.getAuditEvents()))
                     .append(System.lineSeparator()));
@@ -81,11 +124,79 @@ public class ErrorLogMessageProvider {
         }
     }
 
+    private String formatStructuredEvents(List<CDPStructuredEvent> events) {
+        return events
+                .stream()
+                .map(event -> {
+                    if (event instanceof CDPStructuredFlowEvent) {
+                        CDPStructuredFlowEvent<?> flowEvent = (CDPStructuredFlowEvent<?>) event;
+                        return String.format("- [FlowEvent(flowId=%s)] %s - %s %s",
+                                flowEvent.getFlow().getFlowId(),
+                                flowEvent.getStatus(),
+                                flowEvent.getStatusReason(),
+                                doubleDecodeBase64(flowEvent.getException()));
+                    } else if (event instanceof CDPStructuredNotificationEvent) {
+                        return String.format("- [Notification] %s - %s",
+                                event.getStatus(),
+                                event.getStatusReason());
+                    } else {
+                        return String.format("- %s - %s",
+                                event.getStatus(),
+                                event.getStatusReason());
+                    }
+                })
+                .collect(Collectors.joining(System.lineSeparator()));
+    }
+
+    private String formatAuditEvents(Collection<AuditEventV4Response> events) {
+        return events
+                .stream()
+                .filter(auditEventV4Response -> auditEventV4Response.getStructuredEvent() instanceof StructuredNotificationEvent)
+                .map(auditEventV4Response -> (StructuredNotificationEvent) auditEventV4Response.getStructuredEvent())
+                .map(structuredNotificationEvent -> {
+                    NotificationDetails notificationDetails = structuredNotificationEvent.getNotificationDetails();
+                    return "- " + notificationDetails.getNotificationType() + " - " + notificationDetails.getNotification();
+                })
+                .collect(Collectors.joining(System.lineSeparator()));
+    }
+
+    private void appendLine(StringBuilder builder, String content) {
+        builder.append(content).append(System.lineSeparator());
+    }
+
     private String convertToString(Object o) {
         try {
             return OBJECT_WRITER.writeValueAsString(o);
         } catch (JsonProcessingException e) {
             return "[ERROR] Failed to process json from " + o;
         }
+    }
+
+    private static String doubleDecodeBase64(String value) {
+        if (value == null) {
+            return "";
+        }
+        try {
+            return " Exception: " + decode(decode(value));
+        } catch (Exception e) {
+            return " WARN: Couldn't decode base64 encoded exception.";
+        }
+    }
+
+    private boolean hashFailedStructuredEvent(Clue clue) {
+        if (CollectionUtils.isEmpty(clue.getCdpStructuredEvents())) {
+            return false;
+        }
+        return clue.getCdpStructuredEvents().stream().anyMatch(event -> {
+            if (event instanceof CDPStructuredFlowEvent) {
+                CDPStructuredFlowEvent flowEvent = (CDPStructuredFlowEvent<?>) event;
+                return StringUtils.isNotBlank(flowEvent.getException());
+            }
+            return false;
+        });
+    }
+
+    private static String decode(String value) {
+        return new String(Base64.getDecoder().decode(value), StandardCharsets.UTF_8);
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/StructuredEventUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/StructuredEventUtil.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.it.cloudbreak.util;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPStructuredEvent;
+import com.sequenceiq.cloudbreak.structuredevent.rest.endpoint.CDPStructuredEventV1Endpoint;
+
+public class StructuredEventUtil {
+
+    private static final int MAX_EVENT_NUMBER = 1000;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StructuredEventUtil.class);
+
+    private StructuredEventUtil() {
+    }
+
+    public static List<CDPStructuredEvent> getStructuredEvents(CDPStructuredEventV1Endpoint endpoint, String resourceCrn) {
+        try {
+            return endpoint.getAuditEvents(resourceCrn, List.of(), 0, MAX_EVENT_NUMBER);
+        } catch (Exception e) {
+            LOGGER.error("Failed to load structured events. {}", e.getMessage(), e);
+            return List.of();
+        }
+    }
+}


### PR DESCRIPTION
Add more investigation steps to the integration test module. After a failed test the framework:

- collects structured events for environment, freeipa, datalake resources,
- sorts the clues by checking if it contains issues so that developers don't need to scroll a lot to find the resource where the problem happened,
- presents the events in a nicely formatted human readable way.

The goal is to minimize the developer effort to find the root cause of the issue.

__Example output:__

Notice that now we don't just log huge jsons. We collect additional information and sort them by relevance. We can even see the exact stack trace from services which is present in structured events.

```
com.sequenceiq.it.cloudbreak.exception.TestFailException: All Exceptions that occurred during the test are logged after this message.
Cloudbreak await for flow SdxInternalTestDto[name: mock-test-564a57cfd]:  Flow has been finalized with failed status. Crn=crn:cdp:datalake:us-west-1:cloudera:datalake:fe24f840-df87-46ad-9c78-98c94c9809ae, FlowId=442a07b5-9973-4cfa-8319-95508b746e66 , FlowChainId=null 
com.sequenceiq.it.cloudbreak.exception.TestFailException:  Flow has been finalized with failed status. Crn=crn:cdp:datalake:us-west-1:cloudera:datalake:fe24f840-df87-46ad-9c78-98c94c9809ae, FlowId=442a07b5-9973-4cfa-8319-95508b746e66 , FlowChainId=null 
	at com.sequenceiq.it.cloudbreak.util.wait.FlowUtil.waitForFlow(FlowUtil.java:130)
	at com.sequenceiq.it.cloudbreak.util.wait.FlowUtil.waitBasedOnLastKnownFlow(FlowUtil.java:75)
	at com.sequenceiq.it.cloudbreak.context.TestContext.awaitForFlow(TestContext.java:1097)
	at com.sequenceiq.it.cloudbreak.context.TestContext.awaitWithClient(TestContext.java:1028)
	at com.sequenceiq.it.cloudbreak.context.TestContext.await(TestContext.java:1016)
	at com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto.await(SdxInternalTestDto.java:332)
	at com.sequenceiq.it.cloudbreak.testcase.mock.MockSdxTests.testSdxStopStart(MockSdxTests.java:216)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:132)
	at org.testng.internal.MethodInvocationHelper$1.runTestMethod(MethodInvocationHelper.java:238)
	at org.springframework.test.context.testng.AbstractTestNGSpringContextTests.run(AbstractTestNGSpringContextTests.java:184)
	at org.testng.internal.MethodInvocationHelper.invokeHookable(MethodInvocationHelper.java:252)
	at org.testng.internal.TestInvoker.invokeMethod(TestInvoker.java:595)
	at org.testng.internal.TestInvoker.invokeTestMethod(TestInvoker.java:174)
	at org.testng.internal.MethodRunner.runInSequence(MethodRunner.java:46)
	at org.testng.internal.TestInvoker$MethodInvocationAgent.invoke(TestInvoker.java:822)
	at org.testng.internal.TestInvoker.invokeTestMethods(TestInvoker.java:147)
	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:146)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:128)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at org.testng.TestRunner.privateRun(TestRunner.java:764)
	at org.testng.TestRunner.run(TestRunner.java:585)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:384)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:378)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:337)
	at org.testng.SuiteRunner.run(SuiteRunner.java:286)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:53)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:96)
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1218)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1140)
	at org.testng.TestNG.runSuites(TestNG.java:1069)
	at org.testng.TestNG.run(TestNG.java:1037)
	at com.intellij.rt.testng.IDEARemoteTestNG.run(IDEARemoteTestNG.java:66)
	at com.intellij.rt.testng.RemoteTestNGStarter.main(RemoteTestNGStarter.java:109)

You can see structured events and audit events about the resources created during test.

mock-test-564a57cfd - crn:cdp:datalake:us-west-1:cloudera:datalake:fe24f840-df87-46ad-9c78-98c94c9809ae
Audit events:
- CREATE_FAILED - Infrastructure creation failed. Reason: Ooops
- CREATE_IN_PROGRESS - Creating infrastructure
- CREATE_IN_PROGRESS - Setting up CDP image
Structured events:
- [FlowEvent(flowId=442a07b5-9973-4cfa-8319-95508b746e66)] SDX_CREATION_FAILED_STATE - Datalake creation failed. Data Lake creation failed on 'mock-test-564a57cfd' cluster. Reason: Stack status: CREATE_FAILED, cluster status: CREATE_FAILED, reason: Ooops 
- [FlowEvent(flowId=442a07b5-9973-4cfa-8319-95508b746e66)] SDX_STACK_CREATION_IN_PROGRESS_STATE - Datalake creation failed. Data Lake creation failed on 'mock-test-564a57cfd' cluster. Reason: Stack status: CREATE_FAILED, cluster status: CREATE_FAILED, reason: Ooops  Exception: com.dyngr.exception.UserBreakException: Data Lake creation failed on 'mock-test-564a57cfd' cluster. Reason: Stack status: CREATE_FAILED, cluster status: CREATE_FAILED, reason: Ooops
	at com.dyngr.core.DefaultPoller$PollerCallable.call(DefaultPoller.java:86)
	at java.base/java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:264)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java)
	at com.dyngr.concurrent.DirectExecutorService.execute(DirectExecutorService.java:55)
	at java.base/java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:140)
	at com.dyngr.core.DefaultPoller.start(DefaultPoller.java:54)
	at com.dyngr.Polling$PollingOptions.run(Polling.java:155)
	at com.sequenceiq.datalake.service.sdx.CloudbreakPoller.waitForState(CloudbreakPoller.java:103)
	at com.sequenceiq.datalake.service.sdx.CloudbreakPoller.pollCreateUntilAvailable(CloudbreakPoller.java:52)
	at com.sequenceiq.datalake.service.sdx.ProvisionerService.waitCloudbreakClusterCreation(ProvisionerService.java:201)
	at com.sequenceiq.datalake.flow.create.handler.StackCreationHandler.doAccept(StackCreationHandler.java:65)
	at com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler.accept(ExceptionCatcherEventHandler.java:32)
	at com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler.accept(ExceptionCatcherEventHandler.java:15)
	at com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler$$FastClassBySpringCGLIB$$d666e3b5.invoke(<generated>)
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:783)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:753)
	at org.springframework.aop.aspectj.MethodInvocationProceedingJoinPoint.proceed(MethodInvocationProceedingJoinPoint.java:89)
	at com.sequenceiq.flow.reactor.FlowParametersAspects.doProceed(FlowParametersAspects.java:72)
	at com.sequenceiq.flow.reactor.FlowParametersAspects.lambda$setFlowTriggerUserCrnForReactorHandler$0(FlowParametersAspects.java:53)
	at com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider.doAsAndThrow(ThreadBasedUserCrnProvider.java:76)
	at com.sequenceiq.flow.reactor.FlowParametersAspects.setFlowTriggerUserCrnForReactorHandler(FlowParametersAspects.java:41)
	at jdk.internal.reflect.GeneratedMethodAccessor214.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethodWithGivenArgs(AbstractAspectJAdvice.java:634)
	at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethod(AbstractAspectJAdvice.java:624)
	at org.springframework.aop.aspectj.AspectJAroundAdvice.invoke(AspectJAroundAdvice.java:72)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:753)
	at org.springframework.aop.framework.adapter.MethodBeforeAdviceInterceptor.invoke(MethodBeforeAdviceInterceptor.java:58)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:753)
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:753)
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:698)
	at com.sequenceiq.datalake.flow.create.handler.StackCreationHandler$$EnhancerBySpringCGLIB$$ee78eb10.accept(<generated>)
	at reactor.bus.EventBus$3.accept(EventBus.java:317)
	at reactor.bus.EventBus$3.accept(EventBus.java:310)
	at reactor.bus.routing.ConsumerFilteringRouter.route(ConsumerFilteringRouter.java:72)
	at reactor.bus.routing.TraceableDelegatingRouter.route(TraceableDelegatingRouter.java:51)
	at reactor.bus.EventBus.accept(EventBus.java:591)
	at com.sequenceiq.flow.reactor.eventbus.ConsumerCheckerEventBus.accept(ConsumerCheckerEventBus.java:28)
	at com.sequenceiq.flow.reactor.eventbus.ConsumerCheckerEventBus.accept(ConsumerCheckerEventBus.java:11)
	at reactor.core.dispatch.AbstractLifecycleDispatcher.route(AbstractLifecycleDispatcher.java:160)
	at reactor.core.dispatch.MultiThreadDispatcher$MultiThreadTask.run(MultiThreadDispatcher.java:74)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)

- [Notification] SENT - Datalake cluster creation failed.
- [Notification] SENT - Datalake cluster stack provision in progress.
- [FlowEvent(flowId=442a07b5-9973-4cfa-8319-95508b746e66)] SDX_CREATION_START_STATE - Environment created 
- [FlowEvent(flowId=442a07b5-9973-4cfa-8319-95508b746e66)] SDX_CREATION_STORAGE_CONSUMPTION_COLLECTION_SCHEDULING_STATE - Environment created 
- [FlowEvent(flowId=442a07b5-9973-4cfa-8319-95508b746e66)] SDX_CREATION_WAIT_ENV_STATE - Environment created 
- [Notification] SENT - Storage consumption collection scheduling started for datalake cluster.
- [Notification] SENT - Environment for datalake has been created.
- [Notification] SENT - Datalake cluster is waiting for the environment.
- [FlowEvent(flowId=442a07b5-9973-4cfa-8319-95508b746e66)] SDX_CREATION_WAIT_RDS_STATE - Waiting for environment creation 
- [Notification] SENT - Datalake cluster is waiting for the environment.
- [FlowEvent(flowId=442a07b5-9973-4cfa-8319-95508b746e66)] SDX_CREATION_STORAGE_VALIDATION_STATE - Waiting for environment creation 
- [FlowEvent(flowId=442a07b5-9973-4cfa-8319-95508b746e66)] SDX_CREATION_VALIDATION_STATE - Waiting for environment creation 
- [Notification] SENT - Datalake cluster is waiting for the environment.
- [FlowEvent(flowId=442a07b5-9973-4cfa-8319-95508b746e66)] INIT_STATE - Datalake requested 
- [Notification] SENT - Datalake cluster provision started.
- [FlowEvent(flowId=442a07b5-9973-4cfa-8319-95508b746e66)] unknown - Datalake requested 
- [Notification] SENT - Datalake requested.

mock-test-9f403cdf2 - crn:cdp:freeipa:us-west-1:cloudera:freeipa:b16c5fc5-82e8-4c4e-a520-19d5681830bb
Structured events:
- [FlowEvent(flowId=329e20ff-7e9a-4023-9d95-dd980c634ebf)] CREATE_BIND_USER_FINISHED_STATE - FreeIPA installation finished 
- [FlowEvent(flowId=329e20ff-7e9a-4023-9d95-dd980c634ebf)] CREATE_LDAP_BIND_USER_STATE - FreeIPA installation finished 
- [FlowEvent(flowId=329e20ff-7e9a-4023-9d95-dd980c634ebf)] CREATE_KERBEROS_BIND_USER_STATE - FreeIPA installation finished 
- [FlowEvent(flowId=329e20ff-7e9a-4023-9d95-dd980c634ebf)] INIT_STATE - FreeIPA installation finished 
- [FlowEvent(flowId=329e20ff-7e9a-4023-9d95-dd980c634ebf)] unknown - FreeIPA installation finished 
- [FlowEvent(flowId=3786da4c-3066-4f61-b2e3-a8609b4e4bd2)] FREEIPA_PROVISION_FINISHED_STATE - FreeIPA installation finished 
- [FlowEvent(flowId=3786da4c-3066-4f61-b2e3-a8609b4e4bd2)] FREEIPA_POST_INSTALL_STATE - FreeIPA installation finished 
- [FlowEvent(flowId=3786da4c-3066-4f61-b2e3-a8609b4e4bd2)] CLUSTERPROXY_UPDATE_REGISTRATION_STATE - Performing FreeIPA post-install configuration 
- [FlowEvent(flowId=3786da4c-3066-4f61-b2e3-a8609b4e4bd2)] FREEIPA_INSTALL_STATE - Updating cluster proxy registration. 
- [FlowEvent(flowId=3786da4c-3066-4f61-b2e3-a8609b4e4bd2)] VALIDATING_CLOUD_STORAGE_STATE - Starting FreeIPA services 
- [FlowEvent(flowId=3786da4c-3066-4f61-b2e3-a8609b4e4bd2)] ORCHESTRATOR_CONFIG_STATE - Validating cloud storage 
- [FlowEvent(flowId=3786da4c-3066-4f61-b2e3-a8609b4e4bd2)] COLLECTING_HOST_METADATA_STATE - Configuring the orchestrator 
- [FlowEvent(flowId=3786da4c-3066-4f61-b2e3-a8609b4e4bd2)] BOOTSTRAPPING_MACHINES_STATE - Collecting host metadata 
- [FlowEvent(flowId=3786da4c-3066-4f61-b2e3-a8609b4e4bd2)] INIT_STATE - Bootstrapping machines 
- [FlowEvent(flowId=3786da4c-3066-4f61-b2e3-a8609b4e4bd2)] unknown - Stack provisioned. 
- [FlowEvent(flowId=238610b7-07cf-42ff-8068-0c65f8c16254)] STACK_CREATION_FINISHED_STATE - Stack provisioned. 
- [FlowEvent(flowId=238610b7-07cf-42ff-8068-0c65f8c16254)] CLUSTERPROXY_REGISTRATION_STATE - Stack provisioned. 
- [FlowEvent(flowId=238610b7-07cf-42ff-8068-0c65f8c16254)] TLS_SETUP_STATE - Registering stack with cluster proxy. 
- [FlowEvent(flowId=238610b7-07cf-42ff-8068-0c65f8c16254)] GET_TLS_INFO_STATE - TLS setup 
- [FlowEvent(flowId=238610b7-07cf-42ff-8068-0c65f8c16254)] COLLECTMETADATA_STATE - TLS setup 
- [FlowEvent(flowId=238610b7-07cf-42ff-8068-0c65f8c16254)] PROVISIONING_FINISHED_STATE - TLS setup 
- [FlowEvent(flowId=238610b7-07cf-42ff-8068-0c65f8c16254)] START_PROVISIONING_STATE - Metadata collection 
- [FlowEvent(flowId=238610b7-07cf-42ff-8068-0c65f8c16254)] CREATE_CREDENTIAL_STATE - Creating infrastructure 
- [FlowEvent(flowId=238610b7-07cf-42ff-8068-0c65f8c16254)] IMAGE_CHECK_STATE - Creating infrastructure 
- [FlowEvent(flowId=238610b7-07cf-42ff-8068-0c65f8c16254)] IMAGESETUP_STATE - Image setup 
- [FlowEvent(flowId=238610b7-07cf-42ff-8068-0c65f8c16254)] SETUP_STATE - Image setup 
- [FlowEvent(flowId=238610b7-07cf-42ff-8068-0c65f8c16254)] CREATE_USER_DATA_STATE - Provisioning setup 
- [FlowEvent(flowId=238610b7-07cf-42ff-8068-0c65f8c16254)] VALIDATION_STATE - Stack provision requested. 
- [FlowEvent(flowId=238610b7-07cf-42ff-8068-0c65f8c16254)] INIT_STATE - Stack provision requested. 
- [FlowEvent(flowId=238610b7-07cf-42ff-8068-0c65f8c16254)] unknown - Stack provision requested. 
- OK - 200 - null

mock-test-d727e208d8f347f9af - crn:cdp:environments:us-west-1:cloudera:environment:df6ef385-9281-40a2-923f-88496eadf8f2
Structured events:
- [FlowEvent(flowId=f82d7e8a-dbc2-4c1a-900e-c39b288de10e)] ENV_CREATION_FINISHED_STATE - Available 
- [FlowEvent(flowId=f82d7e8a-dbc2-4c1a-900e-c39b288de10e)] FREEIPA_CREATION_STARTED_STATE - Available 
- [Notification] SENT - Environment creation successfully finished
- [FlowEvent(flowId=f82d7e8a-dbc2-4c1a-900e-c39b288de10e)] ENVIRONMENT_RESOURCE_ENCRYPTION_INITIALIZATION_STARTED_STATE - FreeIPA creation in progress 
- [Notification] SENT - FreeIPA creation/registration started for environment
- [FlowEvent(flowId=f82d7e8a-dbc2-4c1a-900e-c39b288de10e)] PUBLICKEY_CREATION_STARTED_STATE - Initializing Resource Encryption settings for environment 
- [Notification] SENT - Resource Encryption initialization started for environment
- [FlowEvent(flowId=f82d7e8a-dbc2-4c1a-900e-c39b288de10e)] NETWORK_CREATION_STARTED_STATE - Creating SSH Public key 
- [Notification] SENT - Public Key creation/registration started for environment
- [FlowEvent(flowId=f82d7e8a-dbc2-4c1a-900e-c39b288de10e)] STORAGE_CONSUMPTION_COLLECTION_SCHEDULING_STARTED_STATE - Network creation in progress 
- [Notification] SENT - Network creation/registration started for environment
- [FlowEvent(flowId=f82d7e8a-dbc2-4c1a-900e-c39b288de10e)] ENVIRONMENT_CREATION_VALIDATION_STATE - Storage consumption collection scheduling in progress 
- [Notification] SENT - Storage consumption collection scheduling started for environment
- [FlowEvent(flowId=f82d7e8a-dbc2-4c1a-900e-c39b288de10e)] ENVIRONMENT_INITIALIZATION_STATE - Validation in progress 
- [Notification] SENT - Environment creation request validation started
- [FlowEvent(flowId=f82d7e8a-dbc2-4c1a-900e-c39b288de10e)] INIT_STATE - Initialization in progress 
- [Notification] SENT - Environment initialization started
- [FlowEvent(flowId=f82d7e8a-dbc2-4c1a-900e-c39b288de10e)] unknown - Creation Initiated 
- OK - 200 - null
```