### PR TITLE
CB-18482 Create flow in environment service for proxy edit

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
@@ -180,6 +180,10 @@ public enum ResourceEvent {
     ENVIRONMENT_VERTICAL_SCALE_FINISHED("environment.vertical.scale.finished"),
     ENVIRONMENT_VERTICAL_SCALE_FAILED("environment.vertical.scale.failed"),
 
+    ENVIRONMENT_PROXY_CONFIG_MODIFICATION_STARTED("environment.proxy.modification.started"),
+    ENVIRONMENT_PROXY_CONFIG_MODIFICATION_FAILED("environment.proxy.modification.failed"),
+    ENVIRONMENT_PROXY_CONFIG_MODIFICATION_FINISHED("environment.proxy.modification.finished"),
+
     CREDENTIAL_AZURE_INTERACTIVE_CREATED("credential.azure.interactive.created"),
     CREDENTIAL_AZURE_INTERACTIVE_STATUS("credential.azure.interactive.status"),
     CREDENTIAL_AZURE_INTERACTIVE_FAILED("credential.azure.interactive.failed"),

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -577,6 +577,10 @@ environment.vertical.scale.freeipa.failed=Vertical scaling FreeIPA failed to {0}
 environment.vertical.scale.finished=Vertical scaling FreeIPA finished to {0} instance type
 environment.vertical.scale.failed=Vertical scaling FreeIPA was not successful to {0} instance type, please retry
 
+environment.proxy.modification.started=Proxy config modification started for environment
+environment.proxy.modification.failed=Proxy config modification failed for environment. Details: {0}
+environment.proxy.modification.finished=Proxy config modification finished for environment
+
 credential.azure.interactive.created=Azure interactive credential app successfully created
 credential.azure.interactive.failed=Azure interactive credential app creation failed
 credential.azure.interactive.status=Azure interactive credential status

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentStatus.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentStatus.java
@@ -99,7 +99,10 @@ public enum EnvironmentStatus {
     VERTICAL_SCALE_VALIDATION_FAILED("Validation for Vertical Scale failed"),
     VERTICAL_SCALE_ON_FREEIPA_IN_PROGRESS("Vertical Scale on FreeIPA"),
     VERTICAL_SCALE_ON_FREEIPA_FAILED("Vertical Scale on FreeIPA failed"),
-    VERTICAL_SCALE_FAILED("Vertical Scale failed");
+    VERTICAL_SCALE_FAILED("Vertical Scale failed"),
+
+    PROXY_CONFIG_MODIFICATION_IN_PROGRESS("Starting proxy configuration modification"),
+    PROXY_CONFIG_MODIFICATION_FAILED("Proxy configuration modification failed");
 
     private static final Set<EnvironmentStatus> STARTABLE_STATUSES = Set.of(
             AVAILABLE,

--- a/environment/src/main/java/com/sequenceiq/environment/environment/EnvironmentStatus.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/EnvironmentStatus.java
@@ -149,7 +149,10 @@ public enum EnvironmentStatus {
     VERTICAL_SCALE_VALIDATION_FAILED(com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus.VERTICAL_SCALE_VALIDATION_FAILED),
     VERTICAL_SCALE_ON_FREEIPA_IN_PROGRESS(com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus.VERTICAL_SCALE_ON_FREEIPA_IN_PROGRESS),
     VERTICAL_SCALE_ON_FREEIPA_FAILED(com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus.VERTICAL_SCALE_ON_FREEIPA_FAILED),
-    VERTICAL_SCALE_FAILED(com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus.VERTICAL_SCALE_FAILED);
+    VERTICAL_SCALE_FAILED(com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus.VERTICAL_SCALE_FAILED),
+
+    PROXY_CONFIG_MODIFICATION_IN_PROGRESS(com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus.PROXY_CONFIG_MODIFICATION_IN_PROGRESS),
+    PROXY_CONFIG_MODIFICATION_FAILED(com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus.PROXY_CONFIG_MODIFICATION_FAILED);
 
     public static final Set<EnvironmentStatus> AVAILABLE_STATUSES = Set.of(
             CREATION_INITIATED,

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/EnvironmentEvent.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/EnvironmentEvent.java
@@ -1,0 +1,10 @@
+package com.sequenceiq.environment.environment.flow;
+
+import com.sequenceiq.cloudbreak.common.event.IdempotentEvent;
+import com.sequenceiq.cloudbreak.common.event.ResourceCrnPayload;
+import com.sequenceiq.environment.environment.dto.EnvironmentDto;
+import com.sequenceiq.flow.reactor.api.event.BaseFlowEvent;
+
+public interface EnvironmentEvent extends IdempotentEvent<BaseFlowEvent>, ResourceCrnPayload {
+    EnvironmentDto getEnvironmentDto();
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/EnvironmentReactorFlowManager.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/EnvironmentReactorFlowManager.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.common.api.type.DataHubStartAction;
 import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
 import com.sequenceiq.environment.environment.domain.EnvironmentView;
@@ -22,6 +23,8 @@ import com.sequenceiq.environment.environment.flow.creation.event.EnvCreationEve
 import com.sequenceiq.environment.environment.flow.deletion.event.EnvDeleteEvent;
 import com.sequenceiq.environment.environment.flow.loadbalancer.event.LoadBalancerUpdateEvent;
 import com.sequenceiq.environment.environment.flow.loadbalancer.event.LoadBalancerUpdateStateSelectors;
+import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationDefaultEvent;
+import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationStateSelectors;
 import com.sequenceiq.environment.environment.flow.start.event.EnvStartEvent;
 import com.sequenceiq.environment.environment.flow.start.event.EnvStartStateSelectors;
 import com.sequenceiq.environment.environment.flow.stop.event.EnvStopEvent;
@@ -31,6 +34,7 @@ import com.sequenceiq.environment.environment.flow.upgrade.ccm.event.UpgradeCcmS
 import com.sequenceiq.environment.environment.flow.verticalscale.freeipa.event.EnvironmentVerticalScaleEvent;
 import com.sequenceiq.environment.environment.flow.verticalscale.freeipa.event.EnvironmentVerticalScaleStateSelectors;
 import com.sequenceiq.environment.environment.service.stack.StackService;
+import com.sequenceiq.environment.proxy.domain.ProxyConfig;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.flow.core.FlowConstants;
 import com.sequenceiq.flow.reactor.api.event.EventSender;
@@ -144,6 +148,13 @@ public class EnvironmentReactorFlowManager {
 
         return eventSender.sendEvent(envStackConfigUpdatesEvent,
                 new Event.Headers(getFlowTriggerUsercrn(userCrn)));
+    }
+
+    public FlowIdentifier triggerEnvironmentProxyConfigModification(EnvironmentDto environment, ProxyConfig proxyConfig) {
+        LOGGER.info("Environment proxy config modification flow triggered.");
+        EnvProxyModificationDefaultEvent envProxyModificationEvent =
+                new EnvProxyModificationDefaultEvent(EnvProxyModificationStateSelectors.MODIFY_PROXY_START_EVENT.selector(), environment, proxyConfig);
+        return eventSender.sendEvent(envProxyModificationEvent, new Event.Headers(getFlowTriggerUsercrn(ThreadBasedUserCrnProvider.getUserCrn())));
     }
 
     public FlowIdentifier triggerLoadBalancerUpdateFlow(EnvironmentDto environmentDto, Long envId, String envName, String envCrn,

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/EnvProxyModificationContext.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/EnvProxyModificationContext.java
@@ -1,0 +1,19 @@
+package com.sequenceiq.environment.environment.flow.modify.proxy;
+
+import com.sequenceiq.environment.proxy.domain.ProxyConfig;
+import com.sequenceiq.flow.core.CommonContext;
+import com.sequenceiq.flow.core.FlowParameters;
+
+public class EnvProxyModificationContext extends CommonContext {
+
+    private final ProxyConfig previousProxyConfig;
+
+    public EnvProxyModificationContext(FlowParameters flowParameters, ProxyConfig previousProxyConfig) {
+        super(flowParameters);
+        this.previousProxyConfig = previousProxyConfig;
+    }
+
+    public ProxyConfig getPreviousProxyConfig() {
+        return previousProxyConfig;
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/EnvProxyModificationState.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/EnvProxyModificationState.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.environment.environment.flow.modify.proxy;
+
+import com.sequenceiq.environment.environment.flow.EnvironmentFillInMemoryStateStoreRestartAction;
+import com.sequenceiq.environment.environment.flow.modify.proxy.action.AbstractEnvProxyModificationAction;
+import com.sequenceiq.environment.environment.flow.modify.proxy.action.ProxyConfigModificationFailedStateAction;
+import com.sequenceiq.environment.environment.flow.modify.proxy.action.ProxyConfigModificationFinishedStateAction;
+import com.sequenceiq.environment.environment.flow.modify.proxy.action.ProxyConfigModificationStartStateAction;
+import com.sequenceiq.flow.core.AbstractAction;
+import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
+
+public enum EnvProxyModificationState implements FlowState {
+    INIT_STATE,
+    PROXY_CONFIG_MODIFICATION_START_STATE(ProxyConfigModificationStartStateAction.class),
+    PROXY_CONFIG_MODIFICATION_FINISHED_STATE(ProxyConfigModificationFinishedStateAction.class),
+    PROXY_CONFIG_MODIFICATION_FAILED_STATE(ProxyConfigModificationFailedStateAction.class),
+    FINAL_STATE;
+
+    private Class<? extends AbstractEnvProxyModificationAction<?>> action;
+
+    EnvProxyModificationState() {
+    }
+
+    EnvProxyModificationState(Class<? extends AbstractEnvProxyModificationAction<?>> action) {
+        this.action = action;
+    }
+
+    @Override
+    public Class<? extends AbstractAction<?, ?, ?, ?>> action() {
+        return action;
+    }
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return EnvironmentFillInMemoryStateStoreRestartAction.class;
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/AbstractEnvProxyModificationAction.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/AbstractEnvProxyModificationAction.java
@@ -1,0 +1,53 @@
+package com.sequenceiq.environment.environment.flow.modify.proxy.action;
+
+import java.util.Map;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.springframework.statemachine.StateContext;
+
+import com.sequenceiq.environment.environment.EnvironmentStatus;
+import com.sequenceiq.environment.environment.flow.EnvironmentEvent;
+import com.sequenceiq.environment.environment.flow.modify.proxy.EnvProxyModificationContext;
+import com.sequenceiq.environment.environment.flow.modify.proxy.EnvProxyModificationState;
+import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationFailedEvent;
+import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationStateSelectors;
+import com.sequenceiq.environment.environment.service.EnvironmentService;
+import com.sequenceiq.environment.proxy.domain.ProxyConfig;
+import com.sequenceiq.flow.core.AbstractAction;
+import com.sequenceiq.flow.core.FlowParameters;
+
+public abstract class AbstractEnvProxyModificationAction<P extends EnvironmentEvent>
+        extends AbstractAction<EnvProxyModificationState, EnvProxyModificationStateSelectors, EnvProxyModificationContext, P> {
+
+    public static final String PREVIOUS_PROXY_CONFIG = "previousProxyConfig";
+
+    @Inject
+    private EnvironmentService environmentService;
+
+    protected AbstractEnvProxyModificationAction(Class<P> clazz) {
+        super(clazz);
+    }
+
+    @Override
+    protected EnvProxyModificationContext createFlowContext(FlowParameters flowParameters,
+            StateContext<EnvProxyModificationState, EnvProxyModificationStateSelectors> stateContext, P payload) {
+        Map<Object, Object> variables = stateContext.getExtendedState().getVariables();
+        ProxyConfig previousProxyConfig = (ProxyConfig) variables.computeIfAbsent(PREVIOUS_PROXY_CONFIG, k -> getPreviousProxyConfig(payload));
+        return new EnvProxyModificationContext(flowParameters, previousProxyConfig);
+    }
+
+    private ProxyConfig getPreviousProxyConfig(P payload) {
+        return environmentService.findEnvironmentByIdOrThrow(payload.getResourceId()).getProxyConfig();
+    }
+
+    @Override
+    protected Object getFailurePayload(P payload, Optional<EnvProxyModificationContext> flowContext, Exception ex) {
+        return new EnvProxyModificationFailedEvent(payload.getEnvironmentDto(), getFailureEnvironmentStatus(), ex);
+    }
+
+    protected EnvironmentStatus getFailureEnvironmentStatus() {
+        return EnvironmentStatus.PROXY_CONFIG_MODIFICATION_FAILED;
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/ProxyConfigModificationFailedStateAction.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/ProxyConfigModificationFailedStateAction.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.environment.environment.flow.modify.proxy.action;
+
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.event.ResourceEvent;
+import com.sequenceiq.environment.environment.flow.modify.proxy.EnvProxyModificationContext;
+import com.sequenceiq.environment.environment.flow.modify.proxy.EnvProxyModificationState;
+import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationFailedEvent;
+import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationStateSelectors;
+import com.sequenceiq.environment.environment.service.EnvironmentStatusUpdateService;
+
+@Component("ProxyConfigModificationFailedStateAction")
+public class ProxyConfigModificationFailedStateAction extends AbstractEnvProxyModificationAction<EnvProxyModificationFailedEvent> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProxyConfigModificationFailedStateAction.class);
+
+    private final EnvironmentStatusUpdateService environmentStatusUpdateService;
+
+    public ProxyConfigModificationFailedStateAction(EnvironmentStatusUpdateService environmentStatusUpdateService) {
+        super(EnvProxyModificationFailedEvent.class);
+        this.environmentStatusUpdateService = environmentStatusUpdateService;
+    }
+
+    @Override
+    protected void doExecute(EnvProxyModificationContext context, EnvProxyModificationFailedEvent payload, Map<Object, Object> variables) {
+        LOGGER.warn("Env proxy modification flow finished with an error", payload.getException());
+
+        environmentStatusUpdateService.updateFailedEnvironmentStatusAndNotify(context, payload, payload.getEnvironmentStatus(),
+                ResourceEvent.ENVIRONMENT_PROXY_CONFIG_MODIFICATION_FAILED, List.of(payload.getException().getMessage()),
+                EnvProxyModificationState.PROXY_CONFIG_MODIFICATION_FAILED_STATE);
+        sendEvent(context, EnvProxyModificationStateSelectors.HANDLE_FAILED_MODIFY_PROXY_EVENT.event(), payload);
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/ProxyConfigModificationFinishedStateAction.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/ProxyConfigModificationFinishedStateAction.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.environment.environment.flow.modify.proxy.action;
+
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.event.ResourceEvent;
+import com.sequenceiq.environment.environment.EnvironmentStatus;
+import com.sequenceiq.environment.environment.flow.modify.proxy.EnvProxyModificationContext;
+import com.sequenceiq.environment.environment.flow.modify.proxy.EnvProxyModificationState;
+import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationDefaultEvent;
+import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationStateSelectors;
+import com.sequenceiq.environment.environment.service.EnvironmentStatusUpdateService;
+
+@Component("ProxyConfigModificationFinishedStateAction")
+public class ProxyConfigModificationFinishedStateAction extends AbstractEnvProxyModificationAction<EnvProxyModificationDefaultEvent> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProxyConfigModificationFinishedStateAction.class);
+
+    private final EnvironmentStatusUpdateService environmentStatusUpdateService;
+
+    public ProxyConfigModificationFinishedStateAction(EnvironmentStatusUpdateService environmentStatusUpdateService) {
+        super(EnvProxyModificationDefaultEvent.class);
+        this.environmentStatusUpdateService = environmentStatusUpdateService;
+    }
+
+    @Override
+    protected void doExecute(EnvProxyModificationContext context, EnvProxyModificationDefaultEvent payload, Map<Object, Object> variables) {
+        LOGGER.info("Env proxy modification flow finished successfully");
+
+        environmentStatusUpdateService.updateEnvironmentStatusAndNotify(context, payload, EnvironmentStatus.AVAILABLE,
+                ResourceEvent.ENVIRONMENT_PROXY_CONFIG_MODIFICATION_FINISHED, EnvProxyModificationState.PROXY_CONFIG_MODIFICATION_FINISHED_STATE);
+        sendEvent(context, EnvProxyModificationStateSelectors.FINALIZE_MODIFY_PROXY_EVENT.selector(), payload);
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/ProxyConfigModificationStartStateAction.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/ProxyConfigModificationStartStateAction.java
@@ -1,0 +1,43 @@
+package com.sequenceiq.environment.environment.flow.modify.proxy.action;
+
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.event.ResourceEvent;
+import com.sequenceiq.environment.environment.EnvironmentStatus;
+import com.sequenceiq.environment.environment.dto.EnvironmentDto;
+import com.sequenceiq.environment.environment.flow.EnvironmentEvent;
+import com.sequenceiq.environment.environment.flow.modify.proxy.EnvProxyModificationContext;
+import com.sequenceiq.environment.environment.flow.modify.proxy.EnvProxyModificationState;
+import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationDefaultEvent;
+import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationHandlerSelectors;
+import com.sequenceiq.environment.environment.service.EnvironmentStatusUpdateService;
+
+@Component("ProxyConfigModificationStartStateAction")
+public class ProxyConfigModificationStartStateAction extends AbstractEnvProxyModificationAction<EnvProxyModificationDefaultEvent> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProxyConfigModificationStartStateAction.class);
+
+    private final EnvironmentStatusUpdateService environmentStatusUpdateService;
+
+    public ProxyConfigModificationStartStateAction(EnvironmentStatusUpdateService environmentStatusUpdateService) {
+        super(EnvProxyModificationDefaultEvent.class);
+        this.environmentStatusUpdateService = environmentStatusUpdateService;
+    }
+
+    @Override
+    protected void doExecute(EnvProxyModificationContext context, EnvProxyModificationDefaultEvent payload, Map<Object, Object> variables) {
+        LOGGER.info("Env proxy modification flow started");
+
+        EnvironmentDto environmentDto = environmentStatusUpdateService.updateEnvironmentStatusAndNotify(context, payload,
+                EnvironmentStatus.PROXY_CONFIG_MODIFICATION_IN_PROGRESS, ResourceEvent.ENVIRONMENT_PROXY_CONFIG_MODIFICATION_STARTED,
+                EnvProxyModificationState.PROXY_CONFIG_MODIFICATION_START_STATE);
+
+        String selector = EnvProxyModificationHandlerSelectors.SAVE_NEW_PROXY_ASSOCIATION_HANDLER_EVENT.selector();
+        EnvironmentEvent event = new EnvProxyModificationDefaultEvent(selector, environmentDto, payload.getProxyConfig());
+        sendEvent(context, selector, event);
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/config/EnvProxyModificationFlowConfig.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/config/EnvProxyModificationFlowConfig.java
@@ -1,0 +1,76 @@
+package com.sequenceiq.environment.environment.flow.modify.proxy.config;
+
+import static com.sequenceiq.environment.environment.flow.modify.proxy.EnvProxyModificationState.FINAL_STATE;
+import static com.sequenceiq.environment.environment.flow.modify.proxy.EnvProxyModificationState.INIT_STATE;
+import static com.sequenceiq.environment.environment.flow.modify.proxy.EnvProxyModificationState.PROXY_CONFIG_MODIFICATION_FAILED_STATE;
+import static com.sequenceiq.environment.environment.flow.modify.proxy.EnvProxyModificationState.PROXY_CONFIG_MODIFICATION_FINISHED_STATE;
+import static com.sequenceiq.environment.environment.flow.modify.proxy.EnvProxyModificationState.PROXY_CONFIG_MODIFICATION_START_STATE;
+import static com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationStateSelectors.FAILED_MODIFY_PROXY_EVENT;
+import static com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationStateSelectors.FINALIZE_MODIFY_PROXY_EVENT;
+import static com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationStateSelectors.FINISH_MODIFY_PROXY_EVENT;
+import static com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationStateSelectors.HANDLE_FAILED_MODIFY_PROXY_EVENT;
+import static com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationStateSelectors.MODIFY_PROXY_START_EVENT;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.environment.environment.flow.modify.proxy.EnvProxyModificationState;
+import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationStateSelectors;
+import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
+import com.sequenceiq.flow.core.config.RetryableFlowConfiguration;
+
+@Component
+public class EnvProxyModificationFlowConfig extends
+        AbstractFlowConfiguration<EnvProxyModificationState, EnvProxyModificationStateSelectors>
+        implements RetryableFlowConfiguration<EnvProxyModificationStateSelectors> {
+
+    private static final List<Transition<EnvProxyModificationState, EnvProxyModificationStateSelectors>> TRANSITIONS =
+            new Transition.Builder<EnvProxyModificationState, EnvProxyModificationStateSelectors>()
+                    .defaultFailureEvent(FAILED_MODIFY_PROXY_EVENT)
+
+                    .from(INIT_STATE).to(PROXY_CONFIG_MODIFICATION_START_STATE)
+                    .event(MODIFY_PROXY_START_EVENT).defaultFailureEvent()
+
+                    .from(PROXY_CONFIG_MODIFICATION_START_STATE).to(PROXY_CONFIG_MODIFICATION_FINISHED_STATE)
+                    .event(FINISH_MODIFY_PROXY_EVENT).defaultFailureEvent()
+
+                    .from(PROXY_CONFIG_MODIFICATION_FINISHED_STATE).to(FINAL_STATE)
+                    .event(FINALIZE_MODIFY_PROXY_EVENT).defaultFailureEvent()
+
+                    .build();
+
+    protected EnvProxyModificationFlowConfig() {
+        super(EnvProxyModificationState.class, EnvProxyModificationStateSelectors.class);
+    }
+
+    @Override
+    protected List<Transition<EnvProxyModificationState, EnvProxyModificationStateSelectors>> getTransitions() {
+        return TRANSITIONS;
+    }
+
+    @Override
+    protected FlowEdgeConfig<EnvProxyModificationState, EnvProxyModificationStateSelectors> getEdgeConfig() {
+        return new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, PROXY_CONFIG_MODIFICATION_FAILED_STATE, HANDLE_FAILED_MODIFY_PROXY_EVENT);
+    }
+
+    @Override
+    public EnvProxyModificationStateSelectors[] getEvents() {
+        return EnvProxyModificationStateSelectors.values();
+    }
+
+    @Override
+    public EnvProxyModificationStateSelectors[] getInitEvents() {
+        return new EnvProxyModificationStateSelectors[]{MODIFY_PROXY_START_EVENT};
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Modify environment proxy configuration";
+    }
+
+    @Override
+    public EnvProxyModificationStateSelectors getRetryableEvent() {
+        return HANDLE_FAILED_MODIFY_PROXY_EVENT;
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/event/EnvProxyModificationDefaultEvent.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/event/EnvProxyModificationDefaultEvent.java
@@ -1,0 +1,53 @@
+package com.sequenceiq.environment.environment.flow.modify.proxy.event;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.environment.environment.dto.EnvironmentDto;
+import com.sequenceiq.environment.environment.flow.EnvironmentEvent;
+import com.sequenceiq.environment.proxy.domain.ProxyConfig;
+import com.sequenceiq.flow.reactor.api.event.BaseFlowEvent;
+
+public class EnvProxyModificationDefaultEvent extends BaseFlowEvent implements EnvironmentEvent {
+
+    private final EnvironmentDto environmentDto;
+
+    private final ProxyConfig proxyConfig;
+
+    @JsonCreator
+    public EnvProxyModificationDefaultEvent(
+            @JsonProperty("selector") String selector,
+            @JsonProperty("environmentDto") EnvironmentDto environmentDto,
+            @JsonProperty("proxyConfig") ProxyConfig proxyConfig) {
+        super(selector, environmentDto.getId(), environmentDto.getResourceCrn());
+        this.environmentDto = environmentDto;
+        this.proxyConfig = proxyConfig;
+    }
+
+    @Override
+    public EnvironmentDto getEnvironmentDto() {
+        return environmentDto;
+    }
+
+    public ProxyConfig getProxyConfig() {
+        return proxyConfig;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof EnvProxyModificationDefaultEvent)) {
+            return false;
+        }
+        EnvProxyModificationDefaultEvent that = (EnvProxyModificationDefaultEvent) o;
+        return Objects.equals(environmentDto, that.environmentDto) && Objects.equals(proxyConfig, that.proxyConfig);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(environmentDto, proxyConfig);
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/event/EnvProxyModificationFailedEvent.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/event/EnvProxyModificationFailedEvent.java
@@ -1,0 +1,54 @@
+package com.sequenceiq.environment.environment.flow.modify.proxy.event;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.environment.environment.EnvironmentStatus;
+import com.sequenceiq.environment.environment.dto.EnvironmentDto;
+import com.sequenceiq.environment.environment.flow.EnvironmentEvent;
+import com.sequenceiq.flow.reactor.api.event.BaseFailedFlowEvent;
+
+public class EnvProxyModificationFailedEvent extends BaseFailedFlowEvent implements EnvironmentEvent {
+
+    private final EnvironmentDto environmentDto;
+
+    private final EnvironmentStatus environmentStatus;
+
+    @JsonCreator
+    public EnvProxyModificationFailedEvent(
+            @JsonProperty("environmentDto") EnvironmentDto environmentDto,
+            @JsonProperty("environmentStatus") EnvironmentStatus environmentStatus,
+            @JsonProperty("exception") Exception exception) {
+        super(EnvProxyModificationStateSelectors.FAILED_MODIFY_PROXY_EVENT.selector(),
+                environmentDto.getResourceId(), environmentDto.getName(), environmentDto.getResourceCrn(), exception);
+        this.environmentDto = environmentDto;
+        this.environmentStatus = environmentStatus;
+    }
+
+    @Override
+    public EnvironmentDto getEnvironmentDto() {
+        return environmentDto;
+    }
+
+    public EnvironmentStatus getEnvironmentStatus() {
+        return environmentStatus;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof EnvProxyModificationFailedEvent)) {
+            return false;
+        }
+        EnvProxyModificationFailedEvent that = (EnvProxyModificationFailedEvent) o;
+        return Objects.equals(environmentDto, that.environmentDto) && environmentStatus == that.environmentStatus;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(environmentDto, environmentStatus);
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/event/EnvProxyModificationHandlerSelectors.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/event/EnvProxyModificationHandlerSelectors.java
@@ -1,0 +1,12 @@
+package com.sequenceiq.environment.environment.flow.modify.proxy.event;
+
+import com.sequenceiq.flow.core.FlowEvent;
+
+public enum EnvProxyModificationHandlerSelectors implements FlowEvent {
+    SAVE_NEW_PROXY_ASSOCIATION_HANDLER_EVENT;
+
+    @Override
+    public String event() {
+        return name();
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/event/EnvProxyModificationStateSelectors.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/event/EnvProxyModificationStateSelectors.java
@@ -1,0 +1,18 @@
+package com.sequenceiq.environment.environment.flow.modify.proxy.event;
+
+import com.sequenceiq.flow.core.FlowEvent;
+
+public enum EnvProxyModificationStateSelectors implements FlowEvent {
+
+    MODIFY_PROXY_START_EVENT,
+    FINISH_MODIFY_PROXY_EVENT,
+    FINALIZE_MODIFY_PROXY_EVENT,
+    HANDLE_MODIFY_PROXY_EVENT,
+    HANDLE_FAILED_MODIFY_PROXY_EVENT,
+    FAILED_MODIFY_PROXY_EVENT;
+
+    @Override
+    public String event() {
+        return name();
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/handler/EnvProxyModificationSaveAssociationHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/handler/EnvProxyModificationSaveAssociationHandler.java
@@ -1,0 +1,49 @@
+package com.sequenceiq.environment.environment.flow.modify.proxy.handler;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.environment.environment.EnvironmentStatus;
+import com.sequenceiq.environment.environment.dto.EnvironmentDto;
+import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationDefaultEvent;
+import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationFailedEvent;
+import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationHandlerSelectors;
+import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationStateSelectors;
+import com.sequenceiq.environment.environment.service.EnvironmentService;
+import com.sequenceiq.flow.reactor.api.event.EventSender;
+import com.sequenceiq.flow.reactor.api.handler.EventSenderAwareHandler;
+
+import reactor.bus.Event;
+
+@Component
+public class EnvProxyModificationSaveAssociationHandler extends EventSenderAwareHandler<EnvProxyModificationDefaultEvent> {
+
+    private final EnvironmentService environmentService;
+
+    public EnvProxyModificationSaveAssociationHandler(EventSender eventSender, EnvironmentService environmentService) {
+        super(eventSender);
+        this.environmentService = environmentService;
+    }
+
+    @Override
+    public String selector() {
+        return EnvProxyModificationHandlerSelectors.SAVE_NEW_PROXY_ASSOCIATION_HANDLER_EVENT.selector();
+    }
+
+    @Override
+    public void accept(Event<EnvProxyModificationDefaultEvent> event) {
+        EnvProxyModificationDefaultEvent eventData = event.getData();
+        try {
+            EnvironmentDto environmentDto = environmentService.updateProxyConfig(eventData.getEnvironmentDto().getId(), eventData.getProxyConfig());
+
+            EnvProxyModificationDefaultEvent envProxyModificationEvent = new EnvProxyModificationDefaultEvent(
+                    EnvProxyModificationStateSelectors.FINISH_MODIFY_PROXY_EVENT.selector(), environmentDto, eventData.getProxyConfig());
+            eventSender().sendEvent(envProxyModificationEvent, event.getHeaders());
+        } catch (Exception e) {
+            // we can not reach this without knowing that an environment exists with the given id, therefore the orElseThrow() should be safe
+            EnvironmentDto environmentDto = environmentService.findById(eventData.getEnvironmentDto().getId()).orElseThrow();
+            EnvProxyModificationFailedEvent envProxyModificationFailedEvent = new EnvProxyModificationFailedEvent(
+                    environmentDto, EnvironmentStatus.PROXY_CONFIG_MODIFICATION_FAILED, e);
+            eventSender().sendEvent(envProxyModificationFailedEvent, event.getHeaders());
+        }
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentService.java
@@ -19,9 +19,6 @@ import java.util.stream.Collectors;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.InternalServerErrorException;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
-import com.sequenceiq.environment.experience.ExperienceCluster;
-import com.sequenceiq.environment.experience.ExperienceConnectorService;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,6 +30,7 @@ import com.sequenceiq.authorization.service.CompositeAuthResourcePropertyProvide
 import com.sequenceiq.authorization.service.EnvironmentPropertyProvider;
 import com.sequenceiq.authorization.service.OwnerAssignmentService;
 import com.sequenceiq.authorization.service.list.ResourceWithId;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
 import com.sequenceiq.cloudbreak.auth.altus.service.RoleCrnGenerator;
@@ -58,8 +56,11 @@ import com.sequenceiq.environment.environment.dto.EnvironmentDtoConverter;
 import com.sequenceiq.environment.environment.dto.SecurityAccessDto;
 import com.sequenceiq.environment.environment.repository.EnvironmentRepository;
 import com.sequenceiq.environment.environment.validation.EnvironmentValidatorService;
+import com.sequenceiq.environment.experience.ExperienceCluster;
+import com.sequenceiq.environment.experience.ExperienceConnectorService;
 import com.sequenceiq.environment.platformresource.PlatformParameterService;
 import com.sequenceiq.environment.platformresource.PlatformResourceRequest;
+import com.sequenceiq.environment.proxy.domain.ProxyConfig;
 import com.sequenceiq.flow.core.PayloadContextProvider;
 import com.sequenceiq.flow.core.ResourceIdProvider;
 
@@ -491,6 +492,13 @@ public class EnvironmentService extends AbstractAccountAwareResourceService<Envi
         } else {
             throw notFoundException("Environment with ID: ", environmentId.toString());
         }
+    }
+
+    public EnvironmentDto updateProxyConfig(Long environmentId, ProxyConfig proxyConfig) {
+        Environment environment = findEnvironmentByIdOrThrow(environmentId);
+        environment.setProxyConfig(proxyConfig);
+        Environment savedEnvironment = save(environment);
+        return environmentDtoConverter.environmentToDto(savedEnvironment);
     }
 
 }

--- a/environment/src/main/java/com/sequenceiq/environment/proxy/service/ProxyConfigModificationService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/proxy/service/ProxyConfigModificationService.java
@@ -1,15 +1,16 @@
 package com.sequenceiq.environment.proxy.service;
 
 import java.util.List;
+import java.util.Objects;
 
 import javax.ws.rs.BadRequestException;
 
-import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Responses;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.environment.environment.domain.Environment;
+import com.sequenceiq.environment.environment.dto.EnvironmentDto;
 import com.sequenceiq.environment.environment.service.datahub.DatahubService;
 import com.sequenceiq.environment.environment.service.freeipa.FreeIpaService;
 import com.sequenceiq.environment.environment.service.sdx.SdxService;
@@ -39,12 +40,15 @@ public class ProxyConfigModificationService {
         this.datahubService = datahubService;
     }
 
-    public void modify(Environment environment, ProxyConfig proxyConfig) {
-        validateModify(environment);
-        throw new NotImplementedException("Editing the proxy configuration is not supported yet");
+    public boolean shouldModify(Environment environment, ProxyConfig newProxyConfig) {
+        ProxyConfig currentProxyConfig = environment.getProxyConfig();
+        boolean addProxy = newProxyConfig.getName() != null && currentProxyConfig == null;
+        boolean removeProxy = newProxyConfig.getName() == null && currentProxyConfig != null;
+        boolean changeProxy = currentProxyConfig != null && !Objects.equals(newProxyConfig.getName(), currentProxyConfig.getName());
+        return addProxy || removeProxy || changeProxy;
     }
 
-    private void validateModify(Environment environment) {
+    public void validateModify(EnvironmentDto environment) {
         if (!entitlementService.isEditProxyConfigEnabled(environment.getAccountId())) {
             throw new BadRequestException("Proxy config editing is not enabled in your account");
         }

--- a/environment/src/main/java/com/sequenceiq/environment/proxy/service/ProxyConfigService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/proxy/service/ProxyConfigService.java
@@ -27,7 +27,6 @@ import com.sequenceiq.cloudbreak.auth.crn.RegionAwareCrnGenerator;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
-import com.sequenceiq.environment.environment.domain.Environment;
 import com.sequenceiq.environment.proxy.domain.ProxyConfig;
 import com.sequenceiq.environment.proxy.repository.ProxyConfigRepository;
 
@@ -135,10 +134,6 @@ public class ProxyConfigService implements CompositeAuthResourcePropertyProvider
         } catch (TransactionService.TransactionExecutionException e) {
             throw e.getCause();
         }
-    }
-
-    public void modify(Environment environment, ProxyConfig proxyConfig) {
-        proxyConfigModificationService.modify(environment, proxyConfig);
     }
 
     public List<ResourceWithId> getProxyResources() {

--- a/environment/src/test/java/com/sequenceiq/environment/environment/flow/EnvironmentReactorFlowManagerTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/flow/EnvironmentReactorFlowManagerTest.java
@@ -2,11 +2,13 @@ package com.sequenceiq.environment.environment.flow;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Map;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -16,11 +18,17 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.environment.environment.domain.EnvironmentView;
+import com.sequenceiq.environment.environment.dto.EnvironmentDto;
 import com.sequenceiq.environment.environment.flow.deletion.event.EnvDeleteEvent;
+import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationDefaultEvent;
+import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationStateSelectors;
 import com.sequenceiq.environment.environment.service.stack.StackService;
+import com.sequenceiq.environment.proxy.domain.ProxyConfig;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.flow.core.FlowConstants;
+import com.sequenceiq.flow.reactor.api.event.BaseFlowEvent;
 import com.sequenceiq.flow.reactor.api.event.BaseNamedFlowEvent;
 import com.sequenceiq.flow.reactor.api.event.EventSender;
 import com.sequenceiq.flow.service.FlowCancelService;
@@ -55,6 +63,9 @@ class EnvironmentReactorFlowManagerTest {
     private ArgumentCaptor<EnvDeleteEvent> envDeleteEventCaptor;
 
     @Captor
+    private ArgumentCaptor<EnvProxyModificationDefaultEvent> envProxyModificationDefaultEventCaptor;
+
+    @Captor
     private ArgumentCaptor<Event.Headers> headersCaptor;
 
     @ParameterizedTest(name = "forced={0}")
@@ -84,6 +95,25 @@ class EnvironmentReactorFlowManagerTest {
         verify(flowCancelService).cancelRunningFlows(ENVIRONMENT_ID);
         verify(eventSender).sendEvent(envDeleteEventCaptor.capture(), headersCaptor.capture());
         verifyEnvDeleteEvent(forced, "ENV_DELETE_CLUSTERS_TRIGGER_EVENT");
+        verifyHeaders();
+    }
+
+    @Test
+    void triggerEnvironmentProxyConfigModification() {
+        EnvironmentDto environmentDto = mock(EnvironmentDto.class);
+        ProxyConfig proxyConfig = mock(ProxyConfig.class);
+        when(eventSender.sendEvent(any(EnvProxyModificationDefaultEvent.class), any(Event.Headers.class))).thenReturn(flowIdentifier);
+
+        FlowIdentifier result = ThreadBasedUserCrnProvider.doAs(USER_CRN,
+                () -> underTest.triggerEnvironmentProxyConfigModification(environmentDto, proxyConfig));
+
+        assertThat(result).isSameAs(flowIdentifier);
+        verify(eventSender).sendEvent(envProxyModificationDefaultEventCaptor.capture(), headersCaptor.capture());
+        EnvProxyModificationDefaultEvent event = envProxyModificationDefaultEventCaptor.getValue();
+        assertThat(event)
+                .returns(EnvProxyModificationStateSelectors.MODIFY_PROXY_START_EVENT.selector(), BaseFlowEvent::selector)
+                .returns(environmentDto, EnvProxyModificationDefaultEvent::getEnvironmentDto)
+                .returns(proxyConfig, EnvProxyModificationDefaultEvent::getProxyConfig);
         verifyHeaders();
     }
 

--- a/environment/src/test/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/AbstractEnvProxyModificationActionTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/AbstractEnvProxyModificationActionTest.java
@@ -1,0 +1,122 @@
+package com.sequenceiq.environment.environment.flow.modify.proxy.action;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.statemachine.ExtendedState;
+import org.springframework.statemachine.StateContext;
+
+import com.sequenceiq.environment.environment.EnvironmentStatus;
+import com.sequenceiq.environment.environment.domain.Environment;
+import com.sequenceiq.environment.environment.dto.EnvironmentDto;
+import com.sequenceiq.environment.environment.flow.modify.proxy.EnvProxyModificationContext;
+import com.sequenceiq.environment.environment.flow.modify.proxy.EnvProxyModificationState;
+import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationDefaultEvent;
+import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationFailedEvent;
+import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationStateSelectors;
+import com.sequenceiq.environment.environment.service.EnvironmentService;
+import com.sequenceiq.environment.proxy.domain.ProxyConfig;
+import com.sequenceiq.flow.core.CommonContext;
+import com.sequenceiq.flow.core.FlowParameters;
+
+@ExtendWith(MockitoExtension.class)
+class AbstractEnvProxyModificationActionTest {
+
+    private static final Long RESOURCE_ID = 1L;
+
+    @Mock
+    private EnvironmentService environmentService;
+
+    @InjectMocks
+    private DummyEnvProxyModificationAction underTest;
+
+    @Mock
+    private FlowParameters flowParameters;
+
+    @Mock
+    private StateContext<EnvProxyModificationState, EnvProxyModificationStateSelectors> stateContext;
+
+    @Mock
+    private ExtendedState extendedState;
+
+    @Mock
+    private EnvProxyModificationDefaultEvent payload;
+
+    @Mock
+    private Environment environment;
+
+    @Mock
+    private EnvironmentDto environmentDto;
+
+    @Mock
+    private ProxyConfig proxyConfig;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(stateContext.getExtendedState()).thenReturn(extendedState);
+        lenient().when(payload.getResourceId()).thenReturn(RESOURCE_ID);
+        lenient().when(payload.getEnvironmentDto()).thenReturn(environmentDto);
+        lenient().when(environment.getId()).thenReturn(RESOURCE_ID);
+        lenient().when(environment.getProxyConfig()).thenReturn(proxyConfig);
+        lenient().when(environmentService.findEnvironmentByIdOrThrow(RESOURCE_ID)).thenReturn(environment);
+    }
+
+    @Test
+    void createFlowContextWithoutVariable() {
+        EnvProxyModificationContext result = underTest.createFlowContext(flowParameters, stateContext, payload);
+
+        assertThat(result)
+                .returns(flowParameters, CommonContext::getFlowParameters)
+                .returns(proxyConfig, EnvProxyModificationContext::getPreviousProxyConfig);
+    }
+
+    @Test
+    void createFlowContextWithVariable() {
+        ProxyConfig proxyConfig1 = mock(ProxyConfig.class);
+        when(extendedState.getVariables()).thenReturn(new HashMap<>(Map.of(AbstractEnvProxyModificationAction.PREVIOUS_PROXY_CONFIG, proxyConfig1)));
+
+        EnvProxyModificationContext result = underTest.createFlowContext(flowParameters, stateContext, payload);
+
+        assertThat(result)
+                .returns(flowParameters, CommonContext::getFlowParameters)
+                .returns(proxyConfig1, EnvProxyModificationContext::getPreviousProxyConfig);
+    }
+
+    @Test
+    void getFailurePayload() {
+        RuntimeException exception = new RuntimeException("message");
+
+        Object result = underTest.getFailurePayload(payload, Optional.empty(), exception);
+
+        assertThat(result)
+                .isInstanceOf(EnvProxyModificationFailedEvent.class)
+                .extracting(EnvProxyModificationFailedEvent.class::cast)
+                .returns(environmentDto, EnvProxyModificationFailedEvent::getEnvironmentDto)
+                .returns(EnvironmentStatus.PROXY_CONFIG_MODIFICATION_FAILED, EnvProxyModificationFailedEvent::getEnvironmentStatus)
+                .returns(exception, EnvProxyModificationFailedEvent::getException);
+    }
+
+    private static class DummyEnvProxyModificationAction extends AbstractEnvProxyModificationAction<EnvProxyModificationDefaultEvent> {
+
+        protected DummyEnvProxyModificationAction() {
+            super(EnvProxyModificationDefaultEvent.class);
+        }
+
+        @Override
+        protected void doExecute(EnvProxyModificationContext context, EnvProxyModificationDefaultEvent payload, Map<Object, Object> variables) {
+            // do nothing
+        }
+    }
+}

--- a/environment/src/test/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/ProxyConfigModificationFailedStateActionTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/ProxyConfigModificationFailedStateActionTest.java
@@ -1,0 +1,58 @@
+package com.sequenceiq.environment.environment.flow.modify.proxy.action;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.sequenceiq.cloudbreak.event.ResourceEvent;
+import com.sequenceiq.environment.environment.EnvironmentStatus;
+import com.sequenceiq.environment.environment.flow.modify.proxy.EnvProxyModificationContext;
+import com.sequenceiq.environment.environment.flow.modify.proxy.EnvProxyModificationState;
+import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationFailedEvent;
+import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationStateSelectors;
+import com.sequenceiq.environment.environment.service.EnvironmentStatusUpdateService;
+import com.sequenceiq.flow.core.ActionTest;
+
+class ProxyConfigModificationFailedStateActionTest extends ActionTest {
+
+    private static final EnvironmentStatus STATUS = EnvironmentStatus.PROXY_CONFIG_MODIFICATION_FAILED;
+
+    private static final String EXCEPTION_MESSAGE = "exception-message";
+
+    @Mock
+    private EnvironmentStatusUpdateService environmentStatusUpdateService;
+
+    @InjectMocks
+    private ProxyConfigModificationFailedStateAction underTest;
+
+    @Mock
+    private EnvProxyModificationContext context;
+
+    @Mock
+    private EnvProxyModificationFailedEvent payload;
+
+    @BeforeEach
+    void setUp() {
+        super.setUp(context);
+        when(payload.getEnvironmentStatus()).thenReturn(STATUS);
+        when(payload.getException()).thenReturn(new RuntimeException(EXCEPTION_MESSAGE));
+    }
+
+    @Test
+    void doExecute() {
+        underTest.doExecute(context, payload, Map.of());
+
+        verify(environmentStatusUpdateService).updateFailedEnvironmentStatusAndNotify(context, payload, STATUS,
+                ResourceEvent.ENVIRONMENT_PROXY_CONFIG_MODIFICATION_FAILED, List.of(EXCEPTION_MESSAGE),
+                EnvProxyModificationState.PROXY_CONFIG_MODIFICATION_FAILED_STATE);
+        verifySendEvent(context, EnvProxyModificationStateSelectors.HANDLE_FAILED_MODIFY_PROXY_EVENT.event(), payload);
+    }
+
+}

--- a/environment/src/test/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/ProxyConfigModificationFinishedStateActionTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/ProxyConfigModificationFinishedStateActionTest.java
@@ -1,0 +1,49 @@
+package com.sequenceiq.environment.environment.flow.modify.proxy.action;
+
+import static org.mockito.Mockito.verify;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.sequenceiq.cloudbreak.event.ResourceEvent;
+import com.sequenceiq.environment.environment.EnvironmentStatus;
+import com.sequenceiq.environment.environment.flow.modify.proxy.EnvProxyModificationContext;
+import com.sequenceiq.environment.environment.flow.modify.proxy.EnvProxyModificationState;
+import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationDefaultEvent;
+import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationStateSelectors;
+import com.sequenceiq.environment.environment.service.EnvironmentStatusUpdateService;
+import com.sequenceiq.flow.core.ActionTest;
+
+class ProxyConfigModificationFinishedStateActionTest extends ActionTest {
+
+    @Mock
+    private EnvironmentStatusUpdateService environmentStatusUpdateService;
+
+    @InjectMocks
+    private ProxyConfigModificationFinishedStateAction underTest;
+
+    @Mock
+    private EnvProxyModificationContext context;
+
+    @Mock
+    private EnvProxyModificationDefaultEvent payload;
+
+    @BeforeEach
+    void setUp() {
+        super.setUp(context);
+    }
+
+    @Test
+    void doExecute() {
+        underTest.doExecute(context, payload, Map.of());
+
+        verifySendEvent(context, EnvProxyModificationStateSelectors.FINALIZE_MODIFY_PROXY_EVENT.selector(), payload);
+        verify(environmentStatusUpdateService).updateEnvironmentStatusAndNotify(context, payload, EnvironmentStatus.AVAILABLE,
+                ResourceEvent.ENVIRONMENT_PROXY_CONFIG_MODIFICATION_FINISHED, EnvProxyModificationState.PROXY_CONFIG_MODIFICATION_FINISHED_STATE);
+    }
+
+}

--- a/environment/src/test/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/ProxyConfigModificationStartStateActionTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/ProxyConfigModificationStartStateActionTest.java
@@ -1,0 +1,65 @@
+package com.sequenceiq.environment.environment.flow.modify.proxy.action;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.sequenceiq.cloudbreak.event.ResourceEvent;
+import com.sequenceiq.environment.environment.EnvironmentStatus;
+import com.sequenceiq.environment.environment.dto.EnvironmentDto;
+import com.sequenceiq.environment.environment.flow.modify.proxy.EnvProxyModificationContext;
+import com.sequenceiq.environment.environment.flow.modify.proxy.EnvProxyModificationState;
+import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationDefaultEvent;
+import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationHandlerSelectors;
+import com.sequenceiq.environment.environment.service.EnvironmentStatusUpdateService;
+import com.sequenceiq.environment.proxy.domain.ProxyConfig;
+import com.sequenceiq.flow.core.ActionTest;
+
+class ProxyConfigModificationStartStateActionTest extends ActionTest {
+
+    @Mock
+    private EnvironmentStatusUpdateService environmentStatusUpdateService;
+
+    @InjectMocks
+    private ProxyConfigModificationStartStateAction underTest;
+
+    @Mock
+    private EnvProxyModificationContext context;
+
+    @Mock
+    private EnvProxyModificationDefaultEvent payload;
+
+    @Mock
+    private ProxyConfig proxyConfig;
+
+    @Mock
+    private EnvironmentDto environmentDto;
+
+    @BeforeEach
+    void setUp() {
+        super.setUp(context);
+        when(payload.getProxyConfig()).thenReturn(proxyConfig);
+        when(environmentStatusUpdateService.updateEnvironmentStatusAndNotify(any(), any(), any(), any(), any())).thenReturn(environmentDto);
+    }
+
+    @Test
+    void doExecute() {
+        underTest.doExecute(context, payload, Map.of());
+
+        verify(environmentStatusUpdateService).updateEnvironmentStatusAndNotify(context, payload,
+                EnvironmentStatus.PROXY_CONFIG_MODIFICATION_IN_PROGRESS, ResourceEvent.ENVIRONMENT_PROXY_CONFIG_MODIFICATION_STARTED,
+                EnvProxyModificationState.PROXY_CONFIG_MODIFICATION_START_STATE);
+
+        String selector = EnvProxyModificationHandlerSelectors.SAVE_NEW_PROXY_ASSOCIATION_HANDLER_EVENT.selector();
+        EnvProxyModificationDefaultEvent event = new EnvProxyModificationDefaultEvent(selector, environmentDto, proxyConfig);
+        verifySendEvent(context, selector, event);
+    }
+
+}

--- a/environment/src/test/java/com/sequenceiq/environment/environment/flow/modify/proxy/handler/EnvProxyModificationSaveAssociationHandlerTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/flow/modify/proxy/handler/EnvProxyModificationSaveAssociationHandlerTest.java
@@ -1,0 +1,85 @@
+package com.sequenceiq.environment.environment.flow.modify.proxy.handler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.environment.environment.EnvironmentStatus;
+import com.sequenceiq.environment.environment.dto.EnvironmentDto;
+import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationDefaultEvent;
+import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationFailedEvent;
+import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationStateSelectors;
+import com.sequenceiq.environment.environment.service.EnvironmentService;
+import com.sequenceiq.environment.proxy.domain.ProxyConfig;
+import com.sequenceiq.flow.reactor.api.event.EventSender;
+
+import reactor.bus.Event;
+
+@ExtendWith(MockitoExtension.class)
+class EnvProxyModificationSaveAssociationHandlerTest {
+
+    private static final String SELECTOR = "selector";
+
+    private static final long ENV_ID = 1L;
+
+    @Mock
+    private EnvironmentService environmentService;
+
+    @Mock
+    private EventSender eventSender;
+
+    @InjectMocks
+    private EnvProxyModificationSaveAssociationHandler underTest;
+
+    @Mock
+    private EnvironmentDto environmentDto;
+
+    @Mock
+    private ProxyConfig proxyConfig;
+
+    private EnvProxyModificationDefaultEvent event;
+
+    @BeforeEach
+    void setUp() {
+        event = new EnvProxyModificationDefaultEvent(SELECTOR, environmentDto, proxyConfig);
+        lenient().when(environmentDto.getId()).thenReturn(ENV_ID);
+        lenient().when(environmentService.findById(ENV_ID)).thenReturn(Optional.of(environmentDto));
+    }
+
+    @Test
+    void acceptSuccess() {
+        when(environmentService.updateProxyConfig(any(), any())).thenReturn(environmentDto);
+        Event<EnvProxyModificationDefaultEvent> wrappedEvent = Event.wrap(event);
+        underTest.accept(wrappedEvent);
+
+        EnvProxyModificationDefaultEvent envProxyModificationEvent = new EnvProxyModificationDefaultEvent(
+                EnvProxyModificationStateSelectors.FINISH_MODIFY_PROXY_EVENT.selector(), environmentDto, proxyConfig);
+        verify(environmentService).updateProxyConfig(ENV_ID, proxyConfig);
+        verify(eventSender).sendEvent(envProxyModificationEvent, wrappedEvent.getHeaders());
+    }
+
+    @Test
+    void acceptFailure() {
+        RuntimeException cause = new RuntimeException("cause");
+        when(environmentService.updateProxyConfig(any(), any())).thenThrow(cause);
+        Event<EnvProxyModificationDefaultEvent> wrappedEvent = Event.wrap(event);
+        underTest.accept(wrappedEvent);
+
+        EnvProxyModificationFailedEvent envProxyModificationFailedEvent = new EnvProxyModificationFailedEvent(
+                environmentDto, EnvironmentStatus.PROXY_CONFIG_MODIFICATION_FAILED, cause);
+        verify(environmentService).updateProxyConfig(ENV_ID, proxyConfig);
+        verify(environmentService).findById(ENV_ID);
+        verify(eventSender).sendEvent(envProxyModificationFailedEvent, wrappedEvent.getHeaders());
+    }
+
+}

--- a/environment/src/test/java/com/sequenceiq/environment/proxy/v1/service/ProxyConfigServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/proxy/v1/service/ProxyConfigServiceTest.java
@@ -27,6 +27,7 @@ import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
 import com.sequenceiq.environment.proxy.domain.ProxyConfig;
 import com.sequenceiq.environment.proxy.repository.ProxyConfigRepository;
+import com.sequenceiq.environment.proxy.service.ProxyConfigModificationService;
 import com.sequenceiq.environment.proxy.service.ProxyConfigService;
 import com.sequenceiq.environment.proxy.v1.ProxyTestSource;
 
@@ -57,6 +58,9 @@ public class ProxyConfigServiceTest {
 
     @Mock
     private EntitlementService entitlementService;
+
+    @Mock
+    private ProxyConfigModificationService proxyConfigModificationService;
 
     @InjectMocks
     private ProxyConfigService underTestProxyConfigService;

--- a/flow/src/test/java/com/sequenceiq/flow/core/ActionTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/core/ActionTest.java
@@ -1,0 +1,71 @@
+package com.sequenceiq.flow.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.metrics.MetricService;
+import com.sequenceiq.flow.reactor.ErrorHandlerAwareReactorEventFactory;
+
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import reactor.bus.Event;
+import reactor.bus.EventBus;
+
+@ExtendWith(MockitoExtension.class)
+public abstract class ActionTest {
+
+    @Mock
+    protected MetricService metricService;
+
+    @Mock
+    protected EventBus eventBus;
+
+    @Mock
+    protected FlowRegister runningFlows;
+
+    @Mock
+    protected ErrorHandlerAwareReactorEventFactory reactorEventFactory;
+
+    @Mock
+    protected Tracer tracer;
+
+    @Mock
+    protected FlowParameters flowParameters;
+
+    @Captor
+    private ArgumentCaptor<Event<?>> eventCaptor;
+
+    protected void setUp(CommonContext context) {
+        when(context.getFlowParameters()).thenReturn(flowParameters);
+        when(flowParameters.getFlowId()).thenReturn("flow-id");
+        when(flowParameters.getFlowTriggerUserCrn()).thenReturn("trigger-user-crn");
+        when(flowParameters.getSpanContext()).thenReturn(mock(SpanContext.class));
+        when(flowParameters.getFlowOperationType()).thenReturn("flow-operation-type");
+
+        when(reactorEventFactory.createEvent(any(), any())).then(input -> {
+            Map<String, Object> headers = input.getArgument(0);
+            Object payload = input.getArgument(1);
+            return new Event<>(new Event.Headers(headers), payload);
+        });
+    }
+
+    protected <C, E> void verifySendEvent(C context, String selector, E event) {
+        verify(eventBus).notify(eq(selector), eventCaptor.capture());
+        Event<?> capturedEvent = eventCaptor.getValue();
+        assertThat(capturedEvent)
+                .returns(event, Event::getData);
+    }
+
+}


### PR DESCRIPTION
Currently the only meaningful step is to save the new proxy association to the db, additional steps will be added in subsequent tickets.

See detailed description in the commit message.