### PR TITLE
CB-18601 Fixing multiple Jackson serialization issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,11 @@ allprojects {
     maven { url = "$cdpRepoUrl" }
     maven { url = "$repoUrl" }
   }
+
   apply plugin: 'idea'
   apply plugin: 'eclipse'
+  apply plugin: 'nebula.blacklist'
+
   group = 'com.sequenceiq'
 
   configurations {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -38,6 +38,8 @@ dependencies {
   implementation group: 'org.mybatis',                           name: 'mybatis-migrations',             version: mybatisMigrationVersion
   implementation group: 'com.fasterxml.jackson.core',            name: 'jackson-databind',               version: jacksonVersion
   implementation group: 'com.fasterxml.jackson.datatype',        name: 'jackson-datatype-jdk8',          version: jacksonVersion
+  implementation group: 'com.fasterxml.jackson.datatype',        name: 'jackson-datatype-jsr310',        version: jacksonVersion
+  implementation group: 'com.fasterxml.jackson.datatype',        name: 'jackson-datatype-hibernate5',    version: jacksonVersion
   implementation group: 'net.sf.json-lib',                       name: 'json-lib',                       version: '2.4',  classifier: 'jdk15'
   api group: 'net.jcip',                              name: 'jcip-annotations',               version: '1.0'
   api group: 'com.github.spotbugs',                   name: 'spotbugs-annotations',           version: '4.4.2'

--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/json/JsonUtil.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/json/JsonUtil.java
@@ -23,7 +23,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.datatype.hibernate5.Hibernate5Module;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import net.sf.json.JSONObject;
 
@@ -41,7 +43,10 @@ public class JsonUtil {
         MAPPER.enable(DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY);
         MAPPER.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, false);
         MAPPER.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        MAPPER.enable(SerializationFeature.WRITE_SELF_REFERENCES_AS_NULL);
         MAPPER.registerModule(new Jdk8Module());
+        MAPPER.registerModule(new JavaTimeModule());
+        MAPPER.registerModule(new Hibernate5Module());
     }
 
     private JsonUtil() {
@@ -115,7 +120,8 @@ public class JsonUtil {
                 }
                 return MAPPER.writeValueAsString(object);
             } catch (JsonProcessingException e) {
-                LOGGER.warn("JSON serialization went wrong in silent mode: {}", e.getMessage());
+                LOGGER.warn("JSON serialization went wrong in silent mode:", e);
+                logObject(object);
             }
         }
         return null;
@@ -191,6 +197,14 @@ public class JsonUtil {
             } catch (IOException e) {
                 LOGGER.error("Failed to deserialize with Jackson: {}", jackson, e);
             }
+        }
+    }
+
+    private static void logObject(Object object) {
+        try {
+            LOGGER.debug("Original object: {}", object);
+        } catch (Exception e) {
+            LOGGER.debug("{}.toString() has thrown an error.", object.getClass().getName(), e);
         }
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/json/TypedJsonUtil.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/json/TypedJsonUtil.java
@@ -15,7 +15,9 @@ import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.datatype.hibernate5.Hibernate5Module;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 public class TypedJsonUtil {
 
@@ -27,8 +29,11 @@ public class TypedJsonUtil {
             .enable(DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY)
             .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, false)
             .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+            .enable(SerializationFeature.WRITE_SELF_REFERENCES_AS_NULL)
             .activateDefaultTypingAsProperty(LaissezFaireSubTypeValidator.instance, DefaultTyping.JAVA_LANG_OBJECT, "@type")
             .addModule(new Jdk8Module())
+            .addModule(new JavaTimeModule())
+            .addModule(new Hibernate5Module())
             .build();
 
     private TypedJsonUtil() {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/InstanceGroup.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/InstanceGroup.java
@@ -21,6 +21,8 @@ import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.SequenceGenerator;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.json.JsonToString;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupType;
@@ -57,9 +59,11 @@ public class InstanceGroup implements Comparable<InstanceGroup> {
     private InstanceGroupType instanceGroupType = InstanceGroupType.MASTER;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JsonBackReference
     private Stack stack;
 
     @OneToMany(mappedBy = "instanceGroup", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonManagedReference
     private Set<InstanceMetaData> instanceMetaData = new HashSet<>();
 
     @Convert(converter = JsonToString.class)

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/InstanceMetaData.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/InstanceMetaData.java
@@ -11,6 +11,7 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.sequenceiq.cloudbreak.common.orchestration.Node;
 import com.sequenceiq.cloudbreak.common.orchestration.OrchestrationNode;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceLifeCycle;
@@ -61,6 +62,7 @@ public class InstanceMetaData implements OrchestrationNode {
     private String instanceName;
 
     @ManyToOne
+    @JsonBackReference
     private InstanceGroup instanceGroup;
 
     @Convert(converter = InstanceLifeCycleConverter.class)

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/SecurityGroup.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/SecurityGroup.java
@@ -15,6 +15,8 @@ import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.SequenceGenerator;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+
 @Entity
 public class SecurityGroup {
 
@@ -26,6 +28,7 @@ public class SecurityGroup {
     private String name;
 
     @OneToMany(mappedBy = "securityGroup", cascade = {CascadeType.REMOVE, CascadeType.PERSIST}, orphanRemoval = true, fetch = FetchType.EAGER)
+    @JsonManagedReference
     private Set<SecurityRule> securityRules = new HashSet<>();
 
     @ElementCollection(fetch = FetchType.EAGER)

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/SecurityRule.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/SecurityRule.java
@@ -9,6 +9,8 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+
 @Entity
 public class SecurityRule {
 
@@ -24,6 +26,7 @@ public class SecurityRule {
     private Long id;
 
     @ManyToOne
+    @JsonBackReference
     private SecurityGroup securityGroup;
 
     private String cidr;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/Stack.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/Stack.java
@@ -31,6 +31,7 @@ import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 import javax.persistence.Version;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.sequenceiq.cloudbreak.ccm.cloudinit.CcmConnectivityParameters;
 import com.sequenceiq.cloudbreak.common.dal.model.AccountAwareResource;
 import com.sequenceiq.cloudbreak.common.domain.IdAware;
@@ -91,6 +92,7 @@ public class Stack implements AccountAwareResource, OrchestratorAware, IdAware {
     private Boolean clusterProxyRegistered = Boolean.FALSE;
 
     @OneToMany(mappedBy = "stack", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonManagedReference
     private Set<InstanceGroup> instanceGroups = new HashSet<>();
 
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
@@ -117,6 +119,7 @@ public class Stack implements AccountAwareResource, OrchestratorAware, IdAware {
     private Network network;
 
     @OneToOne(cascade = CascadeType.ALL)
+    @JsonManagedReference
     private StackStatus stackStatus;
 
     @OneToOne(fetch = FetchType.LAZY, mappedBy = "stack")

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/StackStatus.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/StackStatus.java
@@ -13,6 +13,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.entity.util.DetailsStackStatusConverter;
@@ -27,6 +28,7 @@ public class StackStatus {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JsonBackReference
     private Stack stack;
 
     private Long created;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/FreeIpaCleanupActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/FreeIpaCleanupActions.java
@@ -53,7 +53,7 @@ public class FreeIpaCleanupActions {
                             new RevokeCertsResponse(payload, Collections.emptySet(), Collections.emptyMap());
                     sendEvent(context, response);
                 } else {
-                    RevokeCertsRequest request = new RevokeCertsRequest(payload, context.getStack());
+                    RevokeCertsRequest request = new RevokeCertsRequest(payload);
                     sendEvent(context, request);
                 }
             }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/cert/RevokeCertsRequest.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/cert/RevokeCertsRequest.java
@@ -2,7 +2,6 @@ package com.sequenceiq.freeipa.flow.freeipa.cleanup.event.cert;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.CleanupEvent;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.AbstractCleanupEvent;
 
@@ -12,7 +11,7 @@ public class RevokeCertsRequest extends AbstractCleanupEvent {
         super(stackId);
     }
 
-    public RevokeCertsRequest(CleanupEvent cleanupEvent, Stack stack) {
+    public RevokeCertsRequest(CleanupEvent cleanupEvent) {
         super(cleanupEvent);
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/action/FreeIpaDownscaleActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/action/FreeIpaDownscaleActions.java
@@ -276,7 +276,7 @@ public class FreeIpaDownscaleActions {
             protected void doExecute(StackContext context, StackEvent payload, Map<Object, Object> variables) {
                 stackUpdater.updateStackStatus(context.getStack().getId(), getInProgressStatus(variables), "Revoking certificates");
                 CleanupEvent cleanupEvent = buildCleanupEvent(context, getDownscaleHosts(variables));
-                RevokeCertsRequest request = new RevokeCertsRequest(cleanupEvent, context.getStack());
+                RevokeCertsRequest request = new RevokeCertsRequest(cleanupEvent);
                 sendEvent(context, request);
             }
         };


### PR DESCRIPTION
Annotating for Hibernate's circular references, also extend unit test with this. Adding Hibernate5 Jackson Module to skip lazy-loaded entities. Adding Time module to properly serialize Durations. Changing ObjectMapper configuration to prevent failure in case of self references (occuring mostly in exceptions).
Cleaning up RevokeCertsRequest.