### PR TITLE
CB-17744 Integration consumption service with EFS. Adding the cloudpr…

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/ConsumptionCalculator.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/ConsumptionCalculator.java
@@ -22,6 +22,9 @@ public interface ConsumptionCalculator {
 
     StorageType storageType();
 
-    CloudPlatform cloudPlatform();
+    MeteringEventsProto.ServiceType.Value getMeteringServiceType();
 
+    MeteringEventsProto.ServiceFeature.Value getServiceFeature();
+
+    CloudPlatform cloudPlatform();
 }

--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/connector/resource/AwsEfsCommonService.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/connector/resource/AwsEfsCommonService.java
@@ -1,0 +1,45 @@
+package com.sequenceiq.cloudbreak.cloud.aws.common.connector.resource;
+
+import java.util.Date;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.amazonaws.services.elasticfilesystem.model.AmazonElasticFileSystemException;
+import com.amazonaws.services.elasticfilesystem.model.DescribeFileSystemsRequest;
+import com.amazonaws.services.elasticfilesystem.model.DescribeFileSystemsResult;
+import com.sequenceiq.cloudbreak.cloud.aws.common.CommonAwsClient;
+import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonEfsClient;
+import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsCredentialView;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+
+@Service
+public class AwsEfsCommonService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsEfsCommonService.class);
+
+    @Inject
+    private CommonAwsClient awsClient;
+
+    public DescribeFileSystemsResult getEfsSize(CloudCredential cloudCredential, String region, Date startTime, Date endTime, String efsId) {
+        try {
+            AwsCredentialView credentialView = new AwsCredentialView(cloudCredential);
+            AmazonEfsClient elasticFileSystemClient = awsClient.createElasticFileSystemClient(credentialView, region);
+            DescribeFileSystemsRequest describeFileSystemsRequest = new DescribeFileSystemsRequest();
+            describeFileSystemsRequest.setFileSystemId(efsId);
+            DescribeFileSystemsResult describeFileSystemsResult = elasticFileSystemClient.describeFileSystems(describeFileSystemsRequest);
+            LOGGER.info("Successfully queried efs for {} and timeframe from {} to {}. Returned number of datapoints: {}",
+                    efsId, startTime, endTime, describeFileSystemsResult.getFileSystems().stream().findFirst().get().getSizeInBytes());
+            return describeFileSystemsResult;
+        } catch (AmazonElasticFileSystemException e) {
+            String message = String.format("Cannot get size for efs %s and timeframe from %s to %s. Reason: %s",
+                    efsId, startTime, endTime, e.getMessage());
+            LOGGER.error(message, e);
+            throw new CloudConnectorException(message, e);
+        }
+    }
+}

--- a/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/consumption/AwsEFSConsumptionCalculatorTest.java
+++ b/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/consumption/AwsEFSConsumptionCalculatorTest.java
@@ -1,0 +1,127 @@
+package com.sequenceiq.cloudbreak.cloud.aws.common.consumption;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.List;
+
+import javax.validation.ValidationException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.amazonaws.services.elasticfilesystem.model.DescribeFileSystemsResult;
+import com.amazonaws.services.elasticfilesystem.model.FileSystemDescription;
+import com.amazonaws.services.elasticfilesystem.model.FileSystemSize;
+import com.sequenceiq.cloudbreak.cloud.aws.common.connector.resource.AwsEfsCommonService;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.model.CloudConsumption;
+import com.sequenceiq.cloudbreak.cloud.model.Region;
+import com.sequenceiq.cloudbreak.cloud.model.StorageSizeRequest;
+import com.sequenceiq.cloudbreak.cloud.model.StorageSizeResponse;
+import com.sequenceiq.common.model.FileSystemType;
+
+@ExtendWith(MockitoExtension.class)
+class AwsEFSConsumptionCalculatorTest {
+
+    private static final String BUCKET_NAME = "fs-123345";
+
+    private static final String REGION_NAME = "bucket-location";
+
+    private static final String ERROR_MESSAGE = "errormessage";
+
+    private static final double DOUBLE_ASSERT_EPSILON = 0.001;
+
+    private static final String EFS_OBJECT_PATH = "fs-12312";
+
+    private static final String ABFS_OBJECT_PATH = "abfs://FILESYSTEM@STORAGEACCOUNT.dfs.core.windows.net/PATH";
+
+    @Mock
+    private AwsEfsCommonService awsEfsCommonService;
+
+    @InjectMocks
+    private AwsEFSConsumptionCalculator underTest;
+
+    @Test
+    public void getEfsDoesNotExistThrowsException() {
+        Date startTime = Date.from(Instant.now().minus(42, ChronoUnit.MINUTES));
+        Date endTime = Date.from(Instant.now());
+        Region region = Region.region(REGION_NAME);
+        StorageSizeRequest request = StorageSizeRequest.builder()
+                .withObjectStoragePath(BUCKET_NAME)
+                .withStartTime(startTime)
+                .withEndTime(endTime)
+                .withRegion(region)
+                .build();
+
+        DescribeFileSystemsResult statisticsResult = new DescribeFileSystemsResult()
+                .withFileSystems(List.of());
+        when(awsEfsCommonService.getEfsSize(null, REGION_NAME, startTime, endTime, BUCKET_NAME)).thenReturn(statisticsResult);
+
+        CloudConnectorException ex = assertThrows(CloudConnectorException.class, () -> underTest.calculate(request));
+
+        verify(awsEfsCommonService).getEfsSize(null, REGION_NAME, startTime, endTime, BUCKET_NAME);
+        assertEquals(String.format("No Efs were returned by efs id %s and timeframe from %s to %s",
+                BUCKET_NAME, startTime, endTime), ex.getMessage());
+    }
+
+    @Test
+    public void getObjectStorageSizeOneDatapoint() {
+        Date startTime = Date.from(Instant.now().minus(42, ChronoUnit.MINUTES));
+        Date endTime = Date.from(Instant.now());
+        Region region = Region.region(REGION_NAME);
+        StorageSizeRequest request = StorageSizeRequest.builder()
+                .withObjectStoragePath(BUCKET_NAME)
+                .withStartTime(startTime)
+                .withEndTime(endTime)
+                .withRegion(region)
+                .build();
+
+        FileSystemDescription description = new FileSystemDescription()
+                .withCreationTime(Date.from(Instant.now()))
+                .withSizeInBytes(new FileSystemSize().withValue(42L));
+        DescribeFileSystemsResult statisticsResult = new DescribeFileSystemsResult()
+                .withFileSystems(List.of(description));
+        when(awsEfsCommonService.getEfsSize(null, REGION_NAME, startTime, endTime, BUCKET_NAME)).thenReturn(statisticsResult);
+
+        StorageSizeResponse result = underTest.calculate(request);
+
+        verify(awsEfsCommonService).getEfsSize(null, REGION_NAME, startTime, endTime, BUCKET_NAME);
+        assertEquals(42.0, result.getStorageInBytes(), DOUBLE_ASSERT_EPSILON);
+    }
+
+    @Test
+    public void testEfsName() {
+        assertEquals("fs-12312", underTest.getObjectId(EFS_OBJECT_PATH));
+    }
+
+    @ParameterizedTest(name = "With requiredType={0} and storageLocation={1}, validation should succeed: {2}")
+    @MethodSource("scenarios")
+    public void testValidateCloudStorageType(FileSystemType requiredType, String storageLocation, boolean valid) {
+        CloudConsumption cloudConsumption = CloudConsumption.builder().withStorageLocation(storageLocation).build();
+        if (valid) {
+            underTest.validate(cloudConsumption);
+        } else {
+            assertThrows(ValidationException.class, () -> underTest.validate(cloudConsumption));
+        }
+    }
+
+    static Object[][] scenarios() {
+        return new Object[][]{
+                {FileSystemType.EFS,     EFS_OBJECT_PATH,     true},
+                {FileSystemType.EFS,     ABFS_OBJECT_PATH,   false},
+                {FileSystemType.EFS,     "",                 false},
+                {FileSystemType.EFS,     null,               false},
+        };
+    }
+}

--- a/cloud-consumption-api/src/main/java/com/sequenceiq/consumption/api/v1/consumption/model/common/ConsumptionType.java
+++ b/cloud-consumption-api/src/main/java/com/sequenceiq/consumption/api/v1/consumption/model/common/ConsumptionType.java
@@ -6,6 +6,7 @@ public enum ConsumptionType {
 
     UNKNOWN(StorageType.UNKNOWN),
     STORAGE(StorageType.S3),
+    ELASTIC_FILESYSTEM(StorageType.EFS),
     EBS(StorageType.EBS);
 
     private final StorageType storageType;

--- a/cloud-consumption-api/src/main/java/com/sequenceiq/consumption/api/v1/consumption/model/request/CloudResourceConsumptionRequest.java
+++ b/cloud-consumption-api/src/main/java/com/sequenceiq/consumption/api/v1/consumption/model/request/CloudResourceConsumptionRequest.java
@@ -19,7 +19,7 @@ public class CloudResourceConsumptionRequest extends ConsumptionBaseRequest {
     private String cloudResourceId;
 
     @NotNull
-    @ApiModelProperty(value = ConsumptionModelDescription.CONSUMPTION_TYPE, allowableValues = "UNKNOWN,STORAGE,EBS", required = true)
+    @ApiModelProperty(value = ConsumptionModelDescription.CONSUMPTION_TYPE, allowableValues = "UNKNOWN,STORAGE,EBS,ELASTIC_FILESYSTEM", required = true)
     private ConsumptionType consumptionType;
 
     public ConsumptionType getConsumptionType() {

--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/endpoint/ConsumptionInternalV1Controller.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/endpoint/ConsumptionInternalV1Controller.java
@@ -81,7 +81,7 @@ public class ConsumptionInternalV1Controller implements ConsumptionInternalEndpo
     @InternalOnly
     public void scheduleConsumptionCollection(@AccountId String accountId,
             @Valid @NotNull CloudResourceConsumptionRequest request,
-            @ValidCrn(resource = {CrnResourceDescriptor.USER, CrnResourceDescriptor.MACHINE_USER}) @NotEmpty String initiatorUserCrn) {
+            @ValidCrn(resource = {CrnResourceDescriptor.USER, CrnResourceDescriptor.MACHINE_USER}) @InitiatorUserCrn @NotEmpty String initiatorUserCrn) {
         LOGGER.info("Registering consumption collection for resource with CRN [{}] and location [{}]",
                 request.getMonitoredResourceCrn(), request.getCloudResourceId());
         scheduleCloudResourceConsumption(request, request.getConsumptionType());

--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/flow/consumption/storage/handler/SendConsumptionEventHandler.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/flow/consumption/storage/handler/SendConsumptionEventHandler.java
@@ -56,7 +56,10 @@ public class SendConsumptionEventHandler  extends AbstractStorageOperationHandle
         if (storage != null && consumptionCalculator.isPresent()) {
             MeteringEventsProto.StorageHeartbeat heartbeat = consumptionCalculator.get()
                     .convertToStorageHeartbeat(cloudConsumption, storage.getStorageInBytes());
-            meteringEventProcessor.storageHeartbeat(heartbeat, MeteringEventsProto.ServiceType.Value.ENVIRONMENT);
+            meteringEventProcessor.storageHeartbeat(heartbeat,
+                    consumptionCalculator.get().getMeteringServiceType(),
+                    consumptionCalculator.get().getServiceFeature()
+            );
             LOGGER.debug("StorageHeartbeat event was successfully sent for Consumption with CRN [{}]", resourceCrn);
 
             return StorageConsumptionCollectionEvent.builder()

--- a/cloud-consumption/src/test/java/com/sequenceiq/consumption/flow/consumption/storage/handler/SendConsumptionEventHandlerTest.java
+++ b/cloud-consumption/src/test/java/com/sequenceiq/consumption/flow/consumption/storage/handler/SendConsumptionEventHandlerTest.java
@@ -95,11 +95,16 @@ public class SendConsumptionEventHandlerTest {
         MeteringEventsProto.StorageHeartbeat heartbeat = MeteringEventsProto.StorageHeartbeat.newBuilder().build();
 
         when(awsS3ConsumptionCalculator.convertToStorageHeartbeat(any(CloudConsumption.class), eq(storageResult.getStorageInBytes()))).thenReturn(heartbeat);
-        doNothing().when(meteringEventProcessor).storageHeartbeat(heartbeat, MeteringEventsProto.ServiceType.Value.ENVIRONMENT);
+        when(awsS3ConsumptionCalculator.getMeteringServiceType()).thenReturn(MeteringEventsProto.ServiceType.Value.ENVIRONMENT);
+        when(awsS3ConsumptionCalculator.getServiceFeature()).thenReturn(MeteringEventsProto.ServiceFeature.Value.OBJECT_STORAGE);
+        doNothing().when(meteringEventProcessor).storageHeartbeat(heartbeat,
+                MeteringEventsProto.ServiceType.Value.ENVIRONMENT,
+                MeteringEventsProto.ServiceFeature.Value.OBJECT_STORAGE);
         StorageConsumptionCollectionEvent result = (StorageConsumptionCollectionEvent) underTest.doAccept(new HandlerEvent<>(new Event<>(event)));
 
         verify(awsS3ConsumptionCalculator).convertToStorageHeartbeat(any(CloudConsumption.class), eq(storageResult.getStorageInBytes()));
-        verify(meteringEventProcessor).storageHeartbeat(heartbeat, MeteringEventsProto.ServiceType.Value.ENVIRONMENT);
+        verify(meteringEventProcessor).storageHeartbeat(heartbeat, MeteringEventsProto.ServiceType.Value.ENVIRONMENT,
+                MeteringEventsProto.ServiceFeature.Value.OBJECT_STORAGE);
         assertEquals(CRN, result.getResourceCrn());
         assertEquals(ID, result.getResourceId());
         assertEquals(STORAGE_CONSUMPTION_COLLECTION_FINISH_EVENT.selector(), result.selector());

--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/mappable/StorageType.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/mappable/StorageType.java
@@ -4,6 +4,7 @@ public enum StorageType {
 
     UNKNOWN(CloudPlatform.MOCK),
     S3(CloudPlatform.AWS),
+    EFS(CloudPlatform.AWS),
     EBS(CloudPlatform.AWS);
 
     private final CloudPlatform cloudPlatform;

--- a/usage-collection/src/main/java/com/sequenceiq/cloudbreak/usage/MeteringEventProcessor.java
+++ b/usage-collection/src/main/java/com/sequenceiq/cloudbreak/usage/MeteringEventProcessor.java
@@ -44,7 +44,9 @@ public class MeteringEventProcessor {
         meteringDatabusRecordProcessor.processRecord(databusRequest);
     }
 
-    public void storageHeartbeat(MeteringEventsProto.StorageHeartbeat details, MeteringEventsProto.ServiceType.Value serviceType) {
+    public void storageHeartbeat(MeteringEventsProto.StorageHeartbeat details,
+        MeteringEventsProto.ServiceType.Value serviceType,
+        MeteringEventsProto.ServiceFeature.Value serviceFeature) {
         try {
             checkNotNull(details);
             checkNotNull(serviceType);
@@ -52,7 +54,7 @@ public class MeteringEventProcessor {
                     .setStorageHeartbeat(details)
                     .setServiceType(serviceType)
                     .setServiceConfiguration(MeteringEventsProto.ServiceConfiguration.newBuilder()
-                            .setServiceFeature(MeteringEventsProto.ServiceFeature.Value.OBJECT_STORAGE).build())
+                            .setServiceFeature(serviceFeature).build())
                     .build();
             processEvent(event);
             LOGGER.info("Sent binary format for the following metering event: {}", details);

--- a/usage-collection/src/test/java/com/sequenceiq/cloudbreak/usage/MeteringEventProcessorTest.java
+++ b/usage-collection/src/test/java/com/sequenceiq/cloudbreak/usage/MeteringEventProcessorTest.java
@@ -35,8 +35,10 @@ public class MeteringEventProcessorTest {
 
     @Test
     public void testStorageHeartbeatWithNull() {
-        assertThrows(NullPointerException.class, () -> underTest.storageHeartbeat(null, MeteringEventsProto.ServiceType.Value.ENVIRONMENT));
-        assertThrows(NullPointerException.class, () -> underTest.storageHeartbeat(MeteringEventsProto.StorageHeartbeat.newBuilder().build(), null));
+        assertThrows(NullPointerException.class, () -> underTest.storageHeartbeat(null,
+                MeteringEventsProto.ServiceType.Value.ENVIRONMENT,
+                MeteringEventsProto.ServiceFeature.Value.OBJECT_STORAGE));
+        assertThrows(NullPointerException.class, () -> underTest.storageHeartbeat(MeteringEventsProto.StorageHeartbeat.newBuilder().build(), null, null));
     }
 
     @Test
@@ -46,7 +48,7 @@ public class MeteringEventProcessorTest {
 
         MeteringEventsProto.StorageHeartbeat storageHeartbeat = MeteringEventsProto.StorageHeartbeat.newBuilder().build();
 
-        underTest.storageHeartbeat(storageHeartbeat, MeteringEventsProto.ServiceType.Value.ENVIRONMENT);
+        underTest.storageHeartbeat(storageHeartbeat, MeteringEventsProto.ServiceType.Value.ENVIRONMENT, MeteringEventsProto.ServiceFeature.Value.OBJECT_STORAGE);
 
         ArgumentCaptor<DatabusRequest> captor = ArgumentCaptor.forClass(DatabusRequest.class);
         verify(meteringDatabusRecordProcessor).processRecord(captor.capture());


### PR DESCRIPTION
…ovider interaction. Tested with curl -X POST 'http://localhost:8099/consumption/api/v1/internal/consumption/schedule?accountId=default&initiatorUserCrn=crn:cdp:iam:us-west-1:hortonworks:user:rdoktorics@hortonworks.com' \

 -H 'Content-Type: application/json' \
 -H 'x-cdp-actor-crn: crn:cdp:iam:us-west-1:altus:user:__internal__actor__' \
 -d '{"environmentCrn":"crn:cdp:environments:us-west-1:hortonworks:environment:5302bdc9-9231-424a-9973-603ccc326bb7","monitoredResourceType":"ENVIRONMENT","monitoredResourceCrn":"crn:cdp:environments:us-west-1:hortonworks:environment:5302bdc9-9231-424a-9973-603ccc326bb7","cloudResourceId":"fs-03fb582194c0b190f","consumptionType":"ELASTIC_FILESYSTEM","monitoredResourceName":"rdoktorics-310"}'

See detailed description in the commit message.