### PR TITLE
CB-18635 Add short-term fallback for selecting postgres upgrade targe…

### DIFF
--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/AwsLaunchTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/AwsLaunchTest.java
@@ -96,7 +96,9 @@ import com.sequenceiq.common.api.type.ResourceType;
         "cb.gcp.create.batch.size=2",
         "cb.aws.hostkey.verify=true",
         "cb.aws.spotinstances.enabled=true",
-        "cb.aws.credential.cache.ttl=1"
+        "cb.aws.credential.cache.ttl=1",
+        "cb.db.override.aws.fallback.enabled=true",
+        "cb.db.override.aws.fallback.targetversion=11.16"
 })
 @ActiveProfiles("component")
 public class AwsLaunchTest {

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/AwsRepairTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/AwsRepairTest.java
@@ -113,7 +113,9 @@ import com.sequenceiq.common.api.type.ResourceType;
         "cb.gcp.create.batch.size=2",
         "cb.aws.hostkey.verify=true",
         "cb.aws.spotinstances.enabled=true",
-        "cb.aws.credential.cache.ttl=1"
+        "cb.aws.credential.cache.ttl=1",
+        "cb.db.override.aws.fallback.enabled=true",
+        "cb.db.override.aws.fallback.targetversion=11.16"
 })
 @ActiveProfiles("component")
 public class AwsRepairTest {

--- a/common/src/main/resources/common-config.yml
+++ b/common/src/main/resources/common-config.yml
@@ -137,3 +137,6 @@ cb:
   db.override:
     minRuntimeVersion: 7.2.7
     engineVersion: 11
+    aws.fallback:
+      enabled: true
+      targetversion: "11.16"


### PR DESCRIPTION
…t version on AWS if necessary permission is missing.

Selecting the target version for RDS postgres upgrade on AWS requies an extra permission, rds:DescribeDBEngineVersions. If this permission is missing, getting the target versions fail with access denied error. In such cases a short-term fallback is added, returning 11.16 as the target version. Currently this version is the hights available upgrade target version. The fallback can be turned on or off in config and the version could be also changed from config.

See detailed description in the commit message.