### PR TITLE
CB-15170 pre stopstart scaling checks - ensure CM, relevant services are in a functional state

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterHealthService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterHealthService.java
@@ -11,5 +11,7 @@ public interface ClusterHealthService {
 
     boolean isClusterManagerRunning();
 
+    boolean checkRMhealth(Optional<String> runtimeVersion);
+
     DetailedHostStatuses getDetailedHostStatuses(Optional<String> runtimeVersion);
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stopstart/RecoveryCandidateCollectionService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stopstart/RecoveryCandidateCollectionService.java
@@ -48,7 +48,8 @@ public class RecoveryCandidateCollectionService {
             Set<String> startedInstanceIdsOnCloudProvider) {
         ClusterHealthService clusterHealthService = clusterApiConnectors.getConnector(stack).clusterHealthService();
 
-        if (clusterHealthService.isClusterManagerRunning()) {
+        if (clusterHealthService.isClusterManagerRunning() &&
+                clusterHealthService.checkRMhealth(runtimeVersionService.getRuntimeVersion(stack.getCluster().getId()))) {
             List<InstanceMetadataView> startedInstancesMetadata = cloudInstanceIdToInstanceMetaDataConverter.getNotDeletedAndNotZombieInstances(
                     stack.getAllAvailableInstances(),
                     hostGroupName,

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stopstart/RecoveryCandidateCollectionServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stopstart/RecoveryCandidateCollectionServiceTest.java
@@ -188,6 +188,7 @@ class RecoveryCandidateCollectionServiceTest {
         doReturn(Boolean.TRUE).when(clusterHealthService).isClusterManagerRunning();
         doReturn(detailedHostStatuses).when(clusterHealthService).getDetailedHostStatuses(any(Optional.class));
         doReturn(allInstancesInHg).when(stack).getAllAvailableInstances();
+        doReturn(Boolean.TRUE).when(clusterHealthService).checkRMhealth(any(Optional.class));
         doReturn(runningInstances).when(cloudInstanceIdToInstanceMetaDataConverter).getNotDeletedAndNotZombieInstances(
                 anyList(), anyString(), anySet());
     }


### PR DESCRIPTION

- Checking the Resource Manager health during the collection of recovery Candidates.

See detailed description in the commit message.