### PR TITLE
CB-18649 Datalake postgres upgrade timeout to 2 hours

### DIFF
--- a/datalake/src/main/resources/application.yml
+++ b/datalake/src/main/resources/application.yml
@@ -76,7 +76,7 @@ sdx:
     ssotype: SSO_PROVIDER
   upgrade.database:
     sleeptime-sec: 20
-    duration-min: 40
+    duration-min: 120
 
   paywall.url: "https://archive.cloudera.com/p/cdp-public/"
 


### PR DESCRIPTION
Sdx current timeout is 40 minutes, but there is anecdotal evidence that this might be too short (AWS HA upgrade). The upgrade timeout is thus increased to 120 min in this commit.

See detailed description in the commit message.