### PR TITLE
CB-16314 Reorder Core Start/Stop flowchains for clean RDS start/stop

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/StartFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/StartFlowEventChainFactory.java
@@ -25,8 +25,8 @@ public class StartFlowEventChainFactory implements FlowEventChainFactory<StackEv
     @Override
     public FlowTriggerEventQueue createFlowTriggerEventQueue(StackEvent event) {
         Queue<Selectable> flowEventChain = new ConcurrentLinkedQueue<>();
-        flowEventChain.add(new StackEvent(STACK_START_EVENT.event(), event.getResourceId(), event.accepted()));
-        flowEventChain.add(new StackEvent(EXTERNAL_DATABASE_COMMENCE_START_EVENT.event(), event.getResourceId()));
+        flowEventChain.add(new StackEvent(EXTERNAL_DATABASE_COMMENCE_START_EVENT.event(), event.getResourceId(), event.accepted()));
+        flowEventChain.add(new StackEvent(STACK_START_EVENT.event(), event.getResourceId()));
         flowEventChain.add(new StackEvent(CLUSTER_START_EVENT.event(), event.getResourceId()));
         return new FlowTriggerEventQueue(getName(), event, flowEventChain);
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/StopFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/StopFlowEventChainFactory.java
@@ -25,8 +25,8 @@ public class StopFlowEventChainFactory implements FlowEventChainFactory<StackEve
     public FlowTriggerEventQueue createFlowTriggerEventQueue(StackEvent event) {
         Queue<Selectable> flowEventChain = new ConcurrentLinkedQueue<>();
         flowEventChain.add(new StackEvent(CLUSTER_STOP_EVENT.event(), event.getResourceId(), event.accepted()));
-        flowEventChain.add(new StackEvent(EXTERNAL_DATABASE_COMMENCE_STOP_EVENT.event(), event.getResourceId()));
         flowEventChain.add(new StackEvent(STACK_STOP_EVENT.event(), event.getResourceId()));
+        flowEventChain.add(new StackEvent(EXTERNAL_DATABASE_COMMENCE_STOP_EVENT.event(), event.getResourceId()));
         return new FlowTriggerEventQueue(getName(), event, flowEventChain);
     }
 }


### PR DESCRIPTION
External DB starts first and stops last.
Fixing this for customer issues.