### PR TITLE
CB-18648 - HA cluster's db upgrade fails

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeOrchestratorService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeOrchestratorService.java
@@ -82,21 +82,21 @@ public class RdsUpgradeOrchestratorService {
     private double backupValidationRatio;
 
     public void backupRdsData(Long stackId) throws CloudbreakOrchestratorException {
-        OrchestratorStateParams stateParams = createStateParams(stackId, BACKUP_STATE);
+        OrchestratorStateParams stateParams = createStateParams(stackId, BACKUP_STATE, true);
         stateParams.setStateParams(backupRestoreEmbeddedDBStateParamsProvider.createParamsForBackupRestore());
         LOGGER.debug("Calling backupRdsData with state params '{}'", stateParams);
         hostOrchestrator.runOrchestratorState(stateParams);
     }
 
     public void restoreRdsData(Long stackId) throws CloudbreakOrchestratorException {
-        OrchestratorStateParams stateParams = createStateParams(stackId, RESTORE_STATE);
+        OrchestratorStateParams stateParams = createStateParams(stackId, RESTORE_STATE, true);
         stateParams.setStateParams(backupRestoreEmbeddedDBStateParamsProvider.createParamsForBackupRestore());
         LOGGER.debug("Calling restoreRdsData with state params '{}'", stateParams);
         hostOrchestrator.runOrchestratorState(stateParams);
     }
 
     public void installPostgresPackages(Long stackId) throws CloudbreakOrchestratorException {
-        OrchestratorStateParams stateParams = createStateParams(stackId, PG11_INSTALL_STATE);
+        OrchestratorStateParams stateParams = createStateParams(stackId, PG11_INSTALL_STATE, false);
         LOGGER.debug("Calling installPostgresPackages with state params '{}'", stateParams);
         hostOrchestrator.runOrchestratorState(stateParams);
     }
@@ -200,10 +200,6 @@ public class RdsUpgradeOrchestratorService {
             LOGGER.warn(msg);
             throw new CloudbreakOrchestratorFailedException(msg);
         }
-    }
-
-    private OrchestratorStateParams createStateParams(Long stackId, String saltState) {
-        return createStateParams(stackId, saltState, false);
     }
 
     private OrchestratorStateParams createStateParams(Long stackId, String saltState, boolean onlyOnPrimary) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeOrchestratorServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeOrchestratorServiceTest.java
@@ -90,6 +90,7 @@ class RdsUpgradeOrchestratorServiceTest {
         lenient().when(stack.getId()).thenReturn(STACK_ID);
         lenient().when(stack.getCluster()).thenReturn(cluster);
         lenient().when(stackDtoService.getById(STACK_ID)).thenReturn(stack);
+        lenient().when(gatewayConfig.getHostname()).thenReturn("fqdn1");
         lenient().when(gatewayConfigService.getPrimaryGatewayConfig(any())).thenReturn(gatewayConfig);
         lenient().when(stackUtil.collectGatewayNodes(any())).thenReturn(Set.of(node1, node2));
     }
@@ -100,7 +101,7 @@ class RdsUpgradeOrchestratorServiceTest {
         verify(hostOrchestrator).runOrchestratorState(paramCaptor.capture());
         OrchestratorStateParams params = paramCaptor.getValue();
         assertThat(params.getState()).isEqualTo("postgresql/upgrade/backup");
-        assertThat(params.getTargetHostNames()).hasSameElementsAs(Set.of("fqdn1", "fqdn2"));
+        assertThat(params.getTargetHostNames()).hasSameElementsAs(Set.of("fqdn1"));
         assertOtherStateParams(params);
     }
 
@@ -110,7 +111,7 @@ class RdsUpgradeOrchestratorServiceTest {
         verify(hostOrchestrator).runOrchestratorState(paramCaptor.capture());
         OrchestratorStateParams params = paramCaptor.getValue();
         assertThat(params.getState()).isEqualTo("postgresql/upgrade/restore");
-        assertThat(params.getTargetHostNames()).hasSameElementsAs(Set.of("fqdn1", "fqdn2"));
+        assertThat(params.getTargetHostNames()).hasSameElementsAs(Set.of("fqdn1"));
         assertOtherStateParams(params);
     }
 


### PR DESCRIPTION
This commit introduces a fix to only perform `backup` and `restore` salt states on the primary gateway node.

