### PR TITLE
CB-16693 Last time timeouts have been increased to 5 minutes under CB…

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/clouderamanager-ssl-user-facing.conf
+++ b/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/clouderamanager-ssl-user-facing.conf
@@ -68,9 +68,9 @@ server {
     location ~ .*/ {
         proxy_pass         https://knox;
         proxy_connect_timeout       300;
-        proxy_send_timeout          300;
-        proxy_read_timeout          300;
-        send_timeout                300;
+        proxy_send_timeout          900;
+        proxy_read_timeout          900;
+        send_timeout                900;
         proxy_buffer_size  32k;
         proxy_buffers      8 32k;
         proxy_redirect     off;


### PR DESCRIPTION
…-12550. This time we were asked to set it to 15m. I am going to set only the socket timeout since the connection timeout has impact only when build up the connection, and it is very unlikely that connection cannot be built up in 5 mins.

Anyway, I will set it to 15 mins, but I consider such large timeouts as a workaround for the shortcomings of Atlas and Hue socket handling: CDPD-40768.

See detailed description in the commit message.