### PR TITLE
CB-18681 E2E tests cannot introduce multiple recipes to SDX

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
@@ -302,13 +302,13 @@ public class SdxTestDto extends AbstractSdxTestDto<SdxClusterRequest, SdxCluster
     public SdxTestDto withRecipes(Set<String> recipeNames, String hostGroup) {
         Set<SdxRecipe> sdxRecipes = getRequest().getRecipes();
         Set<SdxRecipe> newRecipes = new HashSet<>();
-        SdxRecipe sdxRecipe = new SdxRecipe();
 
-        recipeNames.forEach(recipeName -> {
+        for (String recipeName : recipeNames) {
+            SdxRecipe sdxRecipe = new SdxRecipe();
             sdxRecipe.setName(recipeName);
             sdxRecipe.setHostGroup(hostGroup);
             newRecipes.add(sdxRecipe);
-        });
+        }
 
         if (CollectionUtils.isEmpty(sdxRecipes)) {
             getRequest().setRecipes(newRecipes);


### PR DESCRIPTION
Our latest AWS API E2E [Build #4638--2.63.0-b58-AWS (23-Sep-2022 11:52:18)](http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-aws/4638/) is failing, because of [testSDXPreClouderaManagerStartRecipe](http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-aws/4638/testngreports/com.sequenceiq.it.cloudbreak.testcase.e2e.sdx/SdxRecipeTests/testSDXPreClouderaManagerStartRecipe/) test `verifyPreTerminationRecipe` is failing.

The pre-termination recipe has not been added to the SDX POST request, as it should be the second recipe in a set.