### PR TITLE
CB-18110: Don't stop services before CM upgrade

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import com.cloudera.api.swagger.BatchResourceApi;
 import com.cloudera.api.swagger.ClouderaManagerResourceApi;
@@ -827,7 +828,6 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
         ClustersResourceApi clustersResourceApi = clouderaManagerApiFactory.getClustersResourceApi(apiClient);
         try {
             LOGGER.debug("Stopping all Cloudera Runtime services");
-
             ExtendedPollingResult extendedPollingResult = clouderaManagerPollingServiceProvider.checkCmStatus(stack, apiClient);
             if (extendedPollingResult.isSuccess()) {
                 stopWithRunningCm(disableKnoxAutorestart, cluster, clustersResourceApi);
@@ -971,15 +971,19 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
         String clusterName = cluster.getName();
         LOGGER.debug("Starting all services for cluster.");
         configService.enableKnoxAutorestartIfCmVersionAtLeast(CLOUDERAMANAGER_VERSION_7_1_0, apiClient, stack.getName());
-        eventService
-                .fireCloudbreakEvent(stack.getId(), UPDATE_IN_PROGRESS.name(), CLUSTER_CM_CLUSTER_SERVICES_STARTING);
+        eventService.fireCloudbreakEvent(stack.getId(), UPDATE_IN_PROGRESS.name(), CLUSTER_CM_CLUSTER_SERVICES_STARTING);
         Collection<ApiService> apiServices = readServices(stack);
-        boolean anyServiceNotStarted = apiServices.stream()
-                .anyMatch(service -> !ApiServiceState.STARTED.equals(service.getServiceState())
+        Set<ApiService> notStartedServices = apiServices.stream()
+                .filter(service -> !ApiServiceState.STARTED.equals(service.getServiceState())
                         && !ApiServiceState.STARTING.equals(service.getServiceState())
-                        && !ApiServiceState.NA.equals(service.getServiceState()));
+                        && !ApiServiceState.NA.equals(service.getServiceState()))
+                .collect(Collectors.toSet());
         ApiCommand apiCommand = null;
-        if (anyServiceNotStarted) {
+        if (!notStartedServices.isEmpty()) {
+            LOGGER.debug("Starting cluster because the following services are not running: {}", notStartedServices.stream()
+                    .map(ApiService::getName)
+                    .filter(StringUtils::hasText)
+                    .collect(Collectors.toSet()));
             apiCommand = apiInstance.startCommand(clusterName);
             ExtendedPollingResult pollingResult = clouderaManagerPollingServiceProvider.startPollingCmStartup(stack, apiClient, apiCommand.getId());
             handlePollingResult(pollingResult, "Cluster was terminated while waiting for Cloudera Runtime services to start",

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeManagementService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeManagementService.java
@@ -1,0 +1,99 @@
+package com.sequenceiq.cloudbreak.core.cluster;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
+import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.ClusterUpgradeService;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
+import com.sequenceiq.cloudbreak.service.CloudbreakException;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
+import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
+import com.sequenceiq.cloudbreak.service.upgrade.sync.component.CmServerQueryService;
+import com.sequenceiq.cloudbreak.util.VersionComparator;
+
+@Service
+public class ClusterManagerUpgradeManagementService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterManagerUpgradeManagementService.class);
+
+    private static final String RUNTIME_VERSION_7_2_2 = "7.2.2";
+
+    @Inject
+    private StackDtoService stackDtoService;
+
+    @Inject
+    private ClusterComponentConfigProvider clusterComponentConfigProvider;
+
+    @Inject
+    private ClusterApiConnectors clusterApiConnectors;
+
+    @Inject
+    private CmServerQueryService cmServerQueryService;
+
+    @Inject
+    private ClusterUpgradeService clusterUpgradeService;
+
+    @Inject
+    private ClusterManagerUpgradeService clusterManagerUpgradeService;
+
+    public void upgradeClusterManager(Long stackId) throws CloudbreakOrchestratorException, CloudbreakException {
+        StackDto stackDto = stackDtoService.getById(stackId);
+        ClouderaManagerRepo clouderaManagerRepo = clusterComponentConfigProvider.getClouderaManagerRepoDetails(stackDto.getCluster().getId());
+        if (isClusterManagerUpgradeNecessary(clouderaManagerRepo.getFullVersion(), stackDto)) {
+            stopClusterServicesIfNecessary(stackDto);
+            clusterUpgradeService.upgradeClusterManager(stackDto.getId());
+            clusterManagerUpgradeService.upgradeClouderaManager(stackDto, clouderaManagerRepo);
+            validateCmVersionAfterUpgrade(stackDto, clouderaManagerRepo);
+        } else {
+            LOGGER.debug("Skipping Cloudera Manager upgrade because the version {} is already installed.", clouderaManagerRepo.getFullVersion());
+        }
+    }
+
+    private boolean isClusterManagerUpgradeNecessary(String targetVersion, StackDto stackDto) {
+        Optional<String> installedCmVersion = cmServerQueryService.queryCmVersion(stackDto);
+        LOGGER.debug("Comparing installed CM version: {} with the target: {}", installedCmVersion, targetVersion);
+        return installedCmVersion.isEmpty() || !targetVersion.equals(installedCmVersion.get());
+    }
+
+    private void validateCmVersionAfterUpgrade(StackDto stack, ClouderaManagerRepo clouderaManagerRepo) {
+        Optional<String> cmVersion = cmServerQueryService.queryCmVersion(stack);
+        if (cmVersion.isPresent()) {
+            String cmVersionInRepoStripped = stripEndingMagicP(clouderaManagerRepo.getFullVersion());
+            String cmVersionOnHostStripped = stripEndingMagicP(cmVersion.get());
+            if (!cmVersionInRepoStripped.equals(cmVersionOnHostStripped)) {
+                throw new CloudbreakServiceException(String.format("Cloudera manager version on host is [%s], while the expected is [%s]",
+                        cmVersionOnHostStripped, cmVersionInRepoStripped));
+            }
+        } else {
+            LOGGER.warn("Couldn't get CM version after upgrade");
+        }
+    }
+
+    private String stripEndingMagicP(String version) {
+        return StringUtils.removeEnd(version, "p");
+    }
+
+    private void stopClusterServicesIfNecessary(StackDto stackDto) throws CloudbreakException {
+        if (isServiceStopNecessaryBasedOnRuntimeVersion(stackDto)) {
+            LOGGER.debug("Stopping cluster services because the runtime version is lower or equals than {}"
+                    + " and the upgrade is not supported with running services on this version.", RUNTIME_VERSION_7_2_2);
+            clusterApiConnectors.getConnector(stackDto).stopCluster(true);
+        } else {
+            LOGGER.debug("Not necessary to stop services because the runtime version is higher than {}", RUNTIME_VERSION_7_2_2);
+        }
+    }
+
+    private boolean isServiceStopNecessaryBasedOnRuntimeVersion(StackDto stackDto) {
+        return new VersionComparator().compare(stackDto::getStackVersion, () -> RUNTIME_VERSION_7_2_2) < 1;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeService.java
@@ -11,14 +11,11 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
-import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
-import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.orchestration.Node;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.ClusterHostServiceRunner;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.decorator.CsdParcelDecorator;
@@ -29,15 +26,10 @@ import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.orchestrator.model.SaltConfig;
 import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
 import com.sequenceiq.cloudbreak.orchestrator.state.ExitCriteriaModel;
-import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.cloudbreak.service.CloudbreakRuntimeException;
 import com.sequenceiq.cloudbreak.service.GatewayConfigService;
-import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
-import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
-import com.sequenceiq.cloudbreak.service.upgrade.sync.component.CmServerQueryService;
 import com.sequenceiq.cloudbreak.util.NodesUnreachableException;
 import com.sequenceiq.cloudbreak.util.StackUtil;
-import com.sequenceiq.cloudbreak.view.ClusterView;
 import com.sequenceiq.cloudbreak.view.InstanceMetadataView;
 import com.sequenceiq.cloudbreak.view.StackView;
 
@@ -53,84 +45,33 @@ public class ClusterManagerUpgradeService {
     private HostOrchestrator hostOrchestrator;
 
     @Inject
-    private StackDtoService stackDtoService;
-
-    @Inject
-    private ClusterComponentConfigProvider clusterComponentConfigProvider;
-
-    @Inject
-    private StackUtil stackUtil;
-
-    @Inject
-    private ClusterApiConnectors clusterApiConnectors;
-
-    @Inject
     private ClusterHostServiceRunner clusterHostServiceRunner;
 
     @Inject
     private CsdParcelDecorator csdParcelDecorator;
 
     @Inject
-    private CmServerQueryService cmServerQueryService;
+    private StackUtil stackUtil;
 
-    public void upgradeClusterManager(Long stackId, boolean runtimeServicesStartNeeded) throws CloudbreakOrchestratorException, CloudbreakException {
-        StackDto stackDto = stackDtoService.getById(stackId);
-        stopClusterServices(stackDto);
-        ClouderaManagerRepo clouderaManagerRepo = clusterComponentConfigProvider.getClouderaManagerRepoDetails(stackDto.getCluster().getId());
-        upgradeClusterManager(stackDto, clouderaManagerRepo);
-        if (runtimeServicesStartNeeded) {
-            LOGGER.info("Starting cluster runtime services after CM upgrade, it's needed if cluster runtime version hasn't been changed");
-            startClusterServices(stackDto);
-        } else {
-            LOGGER.info("Runtime services won't be started after CM upgrade, it's not needed if cluster runtime version has been changed");
-        }
-        validateCmVersionAfterUpgrade(stackDto, clouderaManagerRepo);
-    }
-
-    private void validateCmVersionAfterUpgrade(StackDto stack, ClouderaManagerRepo clouderaManagerRepo) {
-        Optional<String> cmVersion = cmServerQueryService.queryCmVersion(stack);
-        if (cmVersion.isPresent()) {
-            String cmVersionInRepoStripped = stripEndingMagicP(clouderaManagerRepo.getFullVersion());
-            String cmVersionOnHostStripped = stripEndingMagicP(cmVersion.get());
-            if (!cmVersionInRepoStripped.equals(cmVersionOnHostStripped)) {
-                throw new CloudbreakServiceException(String.format("Cloudera manager version on host is [%s], while the expected is [%s]",
-                        cmVersionOnHostStripped, cmVersionInRepoStripped));
-            }
-        } else {
-            LOGGER.warn("Couldn't get CM version after upgrade");
-        }
-    }
-
-    private String stripEndingMagicP(String version) {
-        return StringUtils.removeEnd(version, "p");
-    }
-
-    private void upgradeClusterManager(StackDto stackDto, ClouderaManagerRepo clouderaManagerRepo) throws CloudbreakOrchestratorException {
+    void upgradeClouderaManager(StackDto stackDto, ClouderaManagerRepo clouderaManagerRepo) throws CloudbreakOrchestratorException {
         StackView stack = stackDto.getStack();
-        ClusterView cluster = stackDto.getCluster();
         InstanceMetadataView gatewayInstance = stackDto.getPrimaryGatewayInstance();
         GatewayConfig primaryGatewayConfig = gatewayConfigService.getGatewayConfig(stack, stackDto.getSecurityConfig(), gatewayInstance, stackDto.hasGateway());
         Set<String> gatewayFQDN = Collections.singleton(gatewayInstance.getDiscoveryFQDN());
-        ExitCriteriaModel exitCriteriaModel = clusterDeletionBasedModel(stack.getId(), cluster.getId());
+        ExitCriteriaModel exitCriteriaModel = clusterDeletionBasedModel(stack.getId(), stack.getClusterId());
         SaltConfig pillar = createSaltConfig(stackDto, primaryGatewayConfig, clouderaManagerRepo);
         Set<String> allNode = stackUtil.collectNodes(stackDto).stream().map(Node::getHostname).collect(Collectors.toSet());
         try {
             Set<Node> reachableNodes = stackUtil.collectAndCheckReachableNodes(stackDto, allNode);
+            LOGGER.debug("Starting to upgrade cluster manager.");
             hostOrchestrator.upgradeClusterManager(primaryGatewayConfig, gatewayFQDN, reachableNodes, pillar, exitCriteriaModel);
+            LOGGER.debug("Cluster manager upgrade finished.");
         } catch (NodesUnreachableException e) {
             String errorMessage = "Can not upgrade cluster manager because the configuration management service is not responding on these nodes: "
                     + e.getUnreachableNodes();
             LOGGER.error(errorMessage);
             throw new CloudbreakRuntimeException(errorMessage, e);
         }
-    }
-
-    private void stopClusterServices(StackDto stackDto) throws CloudbreakException {
-        clusterApiConnectors.getConnector(stackDto).stopCluster(true);
-    }
-
-    private void startClusterServices(StackDto stackDto) throws CloudbreakException {
-        clusterApiConnectors.getConnector(stackDto).startCluster();
     }
 
     private SaltConfig createSaltConfig(StackDto stackDto, GatewayConfig primaryGatewayConfig, ClouderaManagerRepo clouderaManagerRepo) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/ClusterUpgradeActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/ClusterUpgradeActions.java
@@ -106,13 +106,10 @@ public class ClusterUpgradeActions {
 
             @Override
             protected void doExecute(ClusterUpgradeContext context, ClusterUpgradeInitSuccess payload, Map<Object, Object> variables) {
-                Image currentImage = getCurrentImage(variables).getImage();
                 StatedImage targetStatedImage = getTargetImage(variables);
-                Image targetImage = targetStatedImage.getImage();
                 imageComponentUpdaterService.updateComponentsForUpgrade(targetStatedImage, payload.getResourceId());
                 clusterUpgradeService.upgradeClusterManager(context.getStackId());
-                Selectable event = new ClusterManagerUpgradeRequest(context.getStackId(),
-                        !clusterUpgradeService.isClusterRuntimeUpgradeNeeded(currentImage, targetImage));
+                Selectable event = new ClusterManagerUpgradeRequest(context.getStackId());
                 sendEvent(context, event.selector(), event);
             }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/ClusterUpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/ClusterUpgradeService.java
@@ -109,11 +109,6 @@ public class ClusterUpgradeService {
         }
     }
 
-    public boolean isClusterRuntimeUpgradeNeeded(Image currentImage, Image targetImage) {
-        return isUpdateNeeded(NullUtil.getIfNotNull(currentImage.getStackDetails(), ImageStackDetails::getStackBuildNumber),
-                NullUtil.getIfNotNull(targetImage.getStackDetails(), ImageStackDetails::getStackBuildNumber));
-    }
-
     private boolean isUpdateNeeded(String currentBuildNumber, String targetBuildNumber) {
         if (StringUtils.isEmpty(currentBuildNumber) || StringUtils.isEmpty(targetBuildNumber)) {
             return true;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ClusterManagerUpgradeRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ClusterManagerUpgradeRequest.java
@@ -6,18 +6,9 @@ import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 
 public class ClusterManagerUpgradeRequest extends StackEvent {
 
-    private final boolean runtimeServicesStartNeeded;
-
     @JsonCreator
-    public ClusterManagerUpgradeRequest(
-            @JsonProperty("resourceId") Long stackId,
-            @JsonProperty("runtimeServicesStartNeeded") boolean runtimeServicesStartNeeded) {
+    public ClusterManagerUpgradeRequest(@JsonProperty("resourceId") Long stackId) {
         super(stackId);
-        this.runtimeServicesStartNeeded = runtimeServicesStartNeeded;
-    }
-
-    public boolean isRuntimeServicesStartNeeded() {
-        return runtimeServicesStartNeeded;
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ClusterManagerUpgradeHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ClusterManagerUpgradeHandler.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
-import com.sequenceiq.cloudbreak.core.cluster.ClusterManagerUpgradeService;
+import com.sequenceiq.cloudbreak.core.cluster.ClusterManagerUpgradeManagementService;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ClusterManagerUpgradeRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ClusterManagerUpgradeSuccess;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ClusterUpgradeFailedEvent;
@@ -23,7 +23,7 @@ public class ClusterManagerUpgradeHandler extends ExceptionCatcherEventHandler<C
     private static final Logger LOGGER = LoggerFactory.getLogger(ClusterManagerUpgradeHandler.class);
 
     @Inject
-    private ClusterManagerUpgradeService clusterManagerUpgradeService;
+    private ClusterManagerUpgradeManagementService clusterManagerUpgradeManagementService;
 
     @Override
     public String selector() {
@@ -40,7 +40,7 @@ public class ClusterManagerUpgradeHandler extends ExceptionCatcherEventHandler<C
         LOGGER.debug("Accepting Cluster Manager upgrade event..");
         ClusterManagerUpgradeRequest request = event.getData();
         try {
-            clusterManagerUpgradeService.upgradeClusterManager(request.getResourceId(), request.isRuntimeServicesStartNeeded());
+            clusterManagerUpgradeManagementService.upgradeClusterManager(request.getResourceId());
             return new ClusterManagerUpgradeSuccess(request.getResourceId());
         } catch (Exception e) {
             LOGGER.info("Cluster Manager upgrade event failed", e);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeManagementServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeManagementServiceTest.java
@@ -1,0 +1,169 @@
+package com.sequenceiq.cloudbreak.core.cluster;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.TestUtil;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
+import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
+import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.ClusterUpgradeService;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
+import com.sequenceiq.cloudbreak.service.CloudbreakException;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
+import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
+import com.sequenceiq.cloudbreak.service.upgrade.sync.component.CmServerQueryService;
+
+@ExtendWith(MockitoExtension.class)
+public class ClusterManagerUpgradeManagementServiceTest {
+
+    private static final Long STACK_ID = 1L;
+
+    private static final String OLD_CM_VERSION = "7.2.2-12345";
+
+    private static final String CM_VERSION = "7.2.6-12345";
+
+    private static final String CM_VERSION_WITH_P = "7.2.6-12345p";
+
+    private static final String STACK_VERSION = "7.2.7";
+
+    @Mock
+    private StackDtoService stackDtoService;
+
+    @Mock
+    private ClusterComponentConfigProvider clusterComponentConfigProvider;
+
+    @Mock
+    private ClusterApiConnectors clusterApiConnectors;
+
+    @Mock
+    private ClusterApi clusterApi;
+
+    @Mock
+    private CmServerQueryService cmServerQueryService;
+
+    @Mock
+    private ClusterUpgradeService clusterUpgradeService;
+
+    @Mock
+    private ClusterManagerUpgradeService clusterManagerUpgradeService;
+
+    @InjectMocks
+    private ClusterManagerUpgradeManagementService underTest;
+
+    @Spy
+    private StackDto stackDto;
+
+    private Stack stack;
+
+    private Cluster cluster;
+
+    private static Stream<Arguments> cmVersions() {
+        return Stream.of(
+                Arguments.of(CM_VERSION, CM_VERSION),
+                Arguments.of(CM_VERSION_WITH_P, CM_VERSION),
+                Arguments.of(CM_VERSION, CM_VERSION_WITH_P),
+                Arguments.of(CM_VERSION_WITH_P, CM_VERSION_WITH_P)
+        );
+    }
+
+    @BeforeEach
+    public void setUp() {
+        stack = TestUtil.stack(Status.AVAILABLE, TestUtil.awsCredential());
+        cluster = TestUtil.cluster();
+        when(stackDtoService.getById(STACK_ID)).thenReturn(stackDto);
+        when(stackDto.getCluster()).thenReturn(cluster);
+        when(cmServerQueryService.queryCmVersion(stackDto)).thenReturn(Optional.empty());
+    }
+
+    @ParameterizedTest
+    @MethodSource("cmVersions")
+    public void testUpgradeClusterManager(String versionOnHost, String versionInRepo) throws CloudbreakOrchestratorException, CloudbreakException {
+        ClouderaManagerRepo clouderaManagerRepo = mock(ClouderaManagerRepo.class);
+        when(stackDto.getStack()).thenReturn(stack);
+        when(clouderaManagerRepo.getFullVersion()).thenReturn(versionInRepo);
+        when(clusterComponentConfigProvider.getClouderaManagerRepoDetails(cluster.getId())).thenReturn(clouderaManagerRepo);
+        when(cmServerQueryService.queryCmVersion(stackDto)).thenReturn(Optional.of(OLD_CM_VERSION)).thenReturn(Optional.of(versionOnHost));
+        when(stackDto.getStackVersion()).thenReturn(STACK_VERSION);
+
+        underTest.upgradeClusterManager(STACK_ID);
+
+        verify(cmServerQueryService, times(2)).queryCmVersion(stackDto);
+        verify(clusterUpgradeService).upgradeClusterManager(STACK_ID);
+        verify(clusterManagerUpgradeService).upgradeClouderaManager(stackDto, clouderaManagerRepo);
+    }
+
+    @Test
+    public void testUpgradeClusterManagerVersionIsDifferent() throws CloudbreakOrchestratorException {
+        ClouderaManagerRepo clouderaManagerRepo = mock(ClouderaManagerRepo.class);
+        when(clouderaManagerRepo.getFullVersion()).thenReturn(CM_VERSION);
+        when(stackDto.getStack()).thenReturn(stack);
+        when(clusterComponentConfigProvider.getClouderaManagerRepoDetails(cluster.getId())).thenReturn(clouderaManagerRepo);
+        when(cmServerQueryService.queryCmVersion(stackDto)).thenReturn(Optional.of(OLD_CM_VERSION)).thenReturn(Optional.of("wrong"));
+        when(stackDto.getStackVersion()).thenReturn(STACK_VERSION);
+
+        assertThrows(CloudbreakServiceException.class, () -> underTest.upgradeClusterManager(STACK_ID));
+
+        verify(cmServerQueryService, times(2)).queryCmVersion(stackDto);
+        verify(clusterUpgradeService).upgradeClusterManager(STACK_ID);
+        verify(clusterManagerUpgradeService).upgradeClouderaManager(stackDto, clouderaManagerRepo);
+    }
+
+    @Test
+    public void testUpgradeClusterManagerShouldSkipUpgradeWhenTheRequiredCmVersionIsAlreadyInstalled()
+            throws CloudbreakOrchestratorException, CloudbreakException {
+        ClouderaManagerRepo clouderaManagerRepo = mock(ClouderaManagerRepo.class);
+        when(clouderaManagerRepo.getFullVersion()).thenReturn(CM_VERSION);
+        when(clusterComponentConfigProvider.getClouderaManagerRepoDetails(cluster.getId())).thenReturn(clouderaManagerRepo);
+        when(cmServerQueryService.queryCmVersion(stackDto)).thenReturn(Optional.of(CM_VERSION));
+
+        underTest.upgradeClusterManager(STACK_ID);
+
+        verify(clusterComponentConfigProvider).getClouderaManagerRepoDetails(cluster.getId());
+        verify(cmServerQueryService).queryCmVersion(stackDto);
+        verifyNoInteractions(clusterApiConnectors, clusterUpgradeService, clusterManagerUpgradeService);
+    }
+
+    @Test
+    public void testUpgradeClusterManagerShouldCallClusterStopWhenTheRuntimeVersionIsTooLow()
+            throws CloudbreakOrchestratorException, CloudbreakException {
+        ClouderaManagerRepo clouderaManagerRepo = mock(ClouderaManagerRepo.class);
+        when(stackDto.getStack()).thenReturn(stack);
+        when(clouderaManagerRepo.getFullVersion()).thenReturn(CM_VERSION);
+        when(clusterComponentConfigProvider.getClouderaManagerRepoDetails(cluster.getId())).thenReturn(clouderaManagerRepo);
+        when(cmServerQueryService.queryCmVersion(stackDto)).thenReturn(Optional.of(OLD_CM_VERSION)).thenReturn(Optional.of(CM_VERSION));
+        when(stackDto.getStackVersion()).thenReturn("7.2.2");
+        when(clusterApiConnectors.getConnector(stackDto)).thenReturn(clusterApi);
+
+
+        underTest.upgradeClusterManager(STACK_ID);
+
+        verify(clusterComponentConfigProvider).getClouderaManagerRepoDetails(cluster.getId());
+        verify(cmServerQueryService, times(2)).queryCmVersion(stackDto);
+        verify(clusterApiConnectors).getConnector(stackDto);
+        verify(clusterApi).stopCluster(true);
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeServiceTest.java
@@ -1,22 +1,13 @@
 package com.sequenceiq.cloudbreak.core.cluster;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-
-import java.util.Optional;
-import java.util.stream.Stream;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -26,9 +17,6 @@ import com.sequenceiq.cloudbreak.TestUtil;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
-import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
-import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
-import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.ClusterHostServiceRunner;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.decorator.CsdParcelDecorator;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
@@ -38,37 +26,13 @@ import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorEx
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.cloudbreak.service.GatewayConfigService;
-import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
-import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
-import com.sequenceiq.cloudbreak.service.upgrade.sync.component.CmServerQueryService;
 import com.sequenceiq.cloudbreak.util.StackUtil;
 
 @ExtendWith(MockitoExtension.class)
-public class ClusterManagerUpgradeServiceTest {
-
-    private static final Long STACK_ID = 1L;
-
-    private static final String CM_VERSION = "7.2.6-12345";
-
-    private static final String CM_VERSION_WITH_P = "7.2.6-12345p";
+class ClusterManagerUpgradeServiceTest {
 
     @Mock
     private GatewayConfigService gatewayConfigService;
-
-    @Mock
-    private StackDtoService stackDtoService;
-
-    @Mock
-    private ClusterComponentConfigProvider clusterComponentConfigProvider;
-
-    @Mock
-    private StackUtil stackUtil;
-
-    @Mock
-    private ClusterApiConnectors clusterApiConnectors;
-
-    @Mock
-    private ClusterApi clusterApi;
 
     @Mock
     private HostOrchestrator hostOrchestrator;
@@ -80,7 +44,10 @@ public class ClusterManagerUpgradeServiceTest {
     private CsdParcelDecorator csdParcelDecorator;
 
     @Mock
-    private CmServerQueryService cmServerQueryService;
+    private StackUtil stackUtil;
+
+    @Mock
+    private ClouderaManagerRepo clouderaManagerRepo;
 
     @InjectMocks
     private ClusterManagerUpgradeService underTest;
@@ -96,90 +63,34 @@ public class ClusterManagerUpgradeServiceTest {
     public void setUp() {
         stack = TestUtil.stack(Status.AVAILABLE, TestUtil.awsCredential());
         cluster = TestUtil.cluster();
-        when(stackDtoService.getById(STACK_ID)).thenReturn(stackDto);
-        when(clusterApiConnectors.getConnector(stackDto)).thenReturn(clusterApi);
         when(stackDto.hasGateway()).thenReturn(cluster.getGateway() != null);
         when(stackDto.getPrimaryGatewayInstance()).thenReturn(stack.getPrimaryGatewayInstance());
         when(stackDto.getStack()).thenReturn(stack);
-        when(stackDto.getCluster()).thenReturn(cluster);
         when(stackDto.getSecurityConfig()).thenReturn(stack.getSecurityConfig());
-        when(cmServerQueryService.queryCmVersion(stackDto)).thenReturn(Optional.empty());
-    }
-
-    private static Stream<Arguments> cmVersions() {
-        return Stream.of(
-                Arguments.of(CM_VERSION, CM_VERSION),
-                Arguments.of(CM_VERSION_WITH_P, CM_VERSION),
-                Arguments.of(CM_VERSION, CM_VERSION_WITH_P),
-                Arguments.of(CM_VERSION_WITH_P, CM_VERSION_WITH_P)
-        );
-    }
-
-    @ParameterizedTest
-    @MethodSource("cmVersions")
-    public void testUpgradeClusterManager(String versionOnHost, String versionInRepo) throws CloudbreakOrchestratorException, CloudbreakException {
-        ClouderaManagerRepo clouderaManagerRepo = mock(ClouderaManagerRepo.class);
-        when(clouderaManagerRepo.getFullVersion()).thenReturn(versionInRepo);
-        when(clusterComponentConfigProvider.getClouderaManagerRepoDetails(cluster.getId())).thenReturn(clouderaManagerRepo);
-        when(cmServerQueryService.queryCmVersion(stackDto)).thenReturn(Optional.of(versionOnHost));
-
-        underTest.upgradeClusterManager(STACK_ID, true);
-
-        verify(gatewayConfigService, times(1)).getGatewayConfig(stack, stack.getSecurityConfig(), stack.getPrimaryGatewayInstance(),
-                cluster.getGateway() != null);
-        verify(hostOrchestrator, times(1)).upgradeClusterManager(any(), any(), any(), any(), any());
-        verify(clusterApi).stopCluster(true);
-        verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerRepo(any(), any(), any());
-        verify(clusterHostServiceRunner, times(1)).createPillarWithClouderaManagerSettings(any(), any(), any());
-        verify(clusterApi).startCluster();
     }
 
     @Test
-    public void testUpgradeClusterManagerVersionIsDifferent() throws CloudbreakOrchestratorException, CloudbreakException {
-        ClouderaManagerRepo clouderaManagerRepo = mock(ClouderaManagerRepo.class);
-        when(clouderaManagerRepo.getFullVersion()).thenReturn(CM_VERSION);
-        when(clusterComponentConfigProvider.getClouderaManagerRepoDetails(cluster.getId())).thenReturn(clouderaManagerRepo);
-        when(cmServerQueryService.queryCmVersion(stackDto)).thenReturn(Optional.of("wrong"));
-
-        assertThrows(CloudbreakServiceException.class, () -> underTest.upgradeClusterManager(STACK_ID, true));
+    void testUpgradeClouderaManagerShouldCallTheUpgradeCommand() throws CloudbreakOrchestratorException {
+        underTest.upgradeClouderaManager(stackDto, clouderaManagerRepo);
 
         verify(gatewayConfigService, times(1)).getGatewayConfig(stack, stack.getSecurityConfig(), stack.getPrimaryGatewayInstance(),
                 cluster.getGateway() != null);
         verify(hostOrchestrator, times(1)).upgradeClusterManager(any(), any(), any(), any(), any());
-        verify(clusterApi).stopCluster(true);
         verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerRepo(any(), any(), any());
         verify(clusterHostServiceRunner, times(1)).createPillarWithClouderaManagerSettings(any(), any(), any());
-        verify(clusterApi).startCluster();
-    }
-
-    @Test
-    public void testUpgradeClusterManagerWithoutStartServices() throws CloudbreakOrchestratorException, CloudbreakException {
-        underTest.upgradeClusterManager(STACK_ID, false);
-
-        verify(gatewayConfigService, times(1)).getGatewayConfig(stack, stack.getSecurityConfig(), stack.getPrimaryGatewayInstance(),
-                cluster.getGateway() != null);
-        verify(clusterComponentConfigProvider, times(1)).getClouderaManagerRepoDetails(cluster.getId());
-        verify(hostOrchestrator, times(1)).upgradeClusterManager(any(), any(), any(), any(), any());
-        verify(clusterApi).stopCluster(true);
-        verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerRepo(any(), any(), any());
-        verify(clusterHostServiceRunner, times(1)).createPillarWithClouderaManagerSettings(any(), any(), any());
-        verify(clusterApi, never()).startCluster();
     }
 
     @Test
     public void testUpgradeClusterManagerShouldNotAddCsdToPillarWhenTheClusterTypeIsDataLake() throws CloudbreakOrchestratorException, CloudbreakException {
         stack.setType(StackType.DATALAKE);
 
-        underTest.upgradeClusterManager(STACK_ID, true);
+        underTest.upgradeClouderaManager(stackDto, clouderaManagerRepo);
 
         verify(gatewayConfigService, times(1)).getGatewayConfig(stack, stack.getSecurityConfig(), stack.getPrimaryGatewayInstance(),
                 cluster.getGateway() != null);
-        verify(clusterComponentConfigProvider, times(1)).getClouderaManagerRepoDetails(cluster.getId());
         verify(hostOrchestrator, times(1)).upgradeClusterManager(any(), any(), any(), any(), any());
-        verify(clusterApi).stopCluster(true);
         verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerRepo(any(), any(), any());
         verify(clusterHostServiceRunner, times(1)).createPillarWithClouderaManagerSettings(any(), any(), any());
-        verify(clusterApi).startCluster();
         verify(csdParcelDecorator, times(1)).decoratePillarWithCsdParcels(any(), any());
     }
 
@@ -187,16 +98,14 @@ public class ClusterManagerUpgradeServiceTest {
     public void testUpgradeClusterManagerShouldAddCsdToPillarWhenTheClusterTypeIsWorkload() throws CloudbreakOrchestratorException, CloudbreakException {
         stack.setType(StackType.WORKLOAD);
 
-        underTest.upgradeClusterManager(STACK_ID, true);
+        underTest.upgradeClouderaManager(stackDto, clouderaManagerRepo);
 
         verify(gatewayConfigService, times(1)).getGatewayConfig(stack, stack.getSecurityConfig(), stack.getPrimaryGatewayInstance(),
                 cluster.getGateway() != null);
-        verify(clusterComponentConfigProvider, times(1)).getClouderaManagerRepoDetails(cluster.getId());
         verify(hostOrchestrator, times(1)).upgradeClusterManager(any(), any(), any(), any(), any());
-        verify(clusterApi).stopCluster(true);
         verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerRepo(any(), any(), any());
         verify(clusterHostServiceRunner, times(1)).createPillarWithClouderaManagerSettings(any(), any(), any());
-        verify(clusterApi).startCluster();
         verify(csdParcelDecorator, times(1)).decoratePillarWithCsdParcels(any(), any());
     }
+
 }


### PR DESCRIPTION
This commit contains the following improvements over the Cloudera Manager upgrade:

- Skip service stop if the runtime version is above 7.2.2.
- Skip the whole cluster manager upgrade if the target version is already installed
- Some improvements in the logging