### PR TITLE
CB-18384 CB-18642 After CM upgrade CmVersionQueryService fails to det…

### DIFF
--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/common/model/PackageInfo.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/common/model/PackageInfo.java
@@ -52,6 +52,14 @@ public class PackageInfo {
         if (Objects.isNull(buildNumber)) {
             return this.version;
         } else {
+            return String.format("%s.%s", this.version, this.buildNumber);
+        }
+    }
+
+    public String getFullVersionPrettyPrinted() {
+        if (Objects.isNull(buildNumber)) {
+            return this.version;
+        } else {
             return String.format("%s-%s", this.version, this.buildNumber);
         }
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmServerQueryService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmServerQueryService.java
@@ -60,7 +60,7 @@ public class CmServerQueryService {
         try {
             Map<String, List<PackageInfo>> packageVersions = cmVersionQueryService.queryCmPackageInfo(stack);
             PackageInfo cmPackageInfo = cmVersionQueryService.checkCmPackageInfoConsistency(packageVersions);
-            String version = cmPackageInfo.getFullVersion();
+            String version = cmPackageInfo.getFullVersionPrettyPrinted();
             LOGGER.debug("Reading CM version info, found version: {}", version);
             return Optional.of(version);
         } catch (CloudbreakOrchestratorFailedException e) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmVersionQueryService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmVersionQueryService.java
@@ -83,7 +83,7 @@ public class CmVersionQueryService {
 
     private PackageInfo getPackageInfoWithLatestVersion(Set<PackageInfo> distinctPackageInfos) {
         return distinctPackageInfos.stream()
-                .max((p1, p2) -> new VersionComparator().compare(p1::getVersion, p2::getVersion))
+                .max((p1, p2) -> new VersionComparator().compare(p1::getFullVersion, p2::getFullVersion))
                 .get();
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmVersionQueryServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmVersionQueryServiceTest.java
@@ -56,6 +56,12 @@ class CmVersionQueryServiceTest {
 
     private static final String OTHER_BUILD_NUMBER = "2000";
 
+    private static final String LOWER_BUILD_NUMBER = "26761258";
+
+    private static final String HIGHER_BUILD_NUMBER = "32005272";
+
+    private static final String C_VERSION = "7.4.1";
+
     @Mock
     private HostOrchestrator hostOrchestrator;
 
@@ -105,7 +111,7 @@ class CmVersionQueryServiceTest {
 
         Assertions.assertEquals("1", packageInfo.getVersion());
         Assertions.assertEquals("1000", packageInfo.getBuildNumber());
-        Assertions.assertEquals("1-1000", packageInfo.getFullVersion());
+        Assertions.assertEquals("1-1000", packageInfo.getFullVersionPrettyPrinted());
     }
 
     @Test
@@ -135,6 +141,22 @@ class CmVersionQueryServiceTest {
 
         Assertions.assertEquals(packageInfo.getVersion(), OTHER_VERSION);
         Assertions.assertEquals(packageInfo.getBuildNumber(), OTHER_BUILD_NUMBER);
+    }
+
+    @Test
+    void testWhenServerHasMultiplePackageVersionsDifferingInBuildOnlyThenValidateConsistencyShouldPassAndChooseLatestVersion() {
+        Map<String, List<PackageInfo>> hostPackageMap = Maps.newHashMap();
+        hostPackageMap.put(HOST_2, List.of(
+                getPackageInfo(CLOUDERA_MANAGER_SERVER, C_VERSION, LOWER_BUILD_NUMBER),
+                getPackageInfo(CLOUDERA_MANAGER_AGENT, C_VERSION, HIGHER_BUILD_NUMBER)));
+        hostPackageMap.put(HOST_1, List.of(
+                getPackageInfo(CLOUDERA_MANAGER_SERVER, C_VERSION, HIGHER_BUILD_NUMBER),
+                getPackageInfo(CLOUDERA_MANAGER_AGENT, C_VERSION, HIGHER_BUILD_NUMBER)));
+
+        PackageInfo packageInfo = underTest.checkCmPackageInfoConsistency(hostPackageMap);
+
+        Assertions.assertEquals(C_VERSION, packageInfo.getVersion());
+        Assertions.assertEquals(HIGHER_BUILD_NUMBER, packageInfo.getBuildNumber());
     }
 
     @Test


### PR DESCRIPTION
…ermine the correct CM server version

After the CM is upgraded, there is a check to see that the server version in yum really changed on the CM node. This check, however, failed. The reason was that only the version was compared but not the build number, so upgrades where only the CM build number changed failed.

Since the ordering of CM server version from nodes depended on the hash of the componentname:version:buildnumber, the failure comes only with certain version and build number values.

See detailed description in the commit message.