### PR TITLE
CB-18613 FreeIPA permission polling should not stop on exception

### DIFF
--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/polling/Poller.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/polling/Poller.java
@@ -15,6 +15,12 @@ public class Poller<V> {
                 .stopIfException(true)
                 .stopAfterDelay(durationInMinutes, TimeUnit.MINUTES)
                 .run(attemptMaker);
+    }
 
+    public void runPollerDontStopOnException(long sleepTimeInSeconds, long durationInMinutes, AttemptMaker<V> attemptMaker) {
+        Polling.waitPeriodly(sleepTimeInSeconds, TimeUnit.SECONDS)
+                .stopIfException(false)
+                .stopAfterDelay(durationInMinutes, TimeUnit.MINUTES)
+                .run(attemptMaker);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaPermissionService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaPermissionService.java
@@ -62,7 +62,7 @@ public class FreeIpaPermissionService {
     private void waitForPermissionToReplicate(List<FreeIpaClient> clientForAllInstances, String permission) {
         if (!clientForAllInstances.isEmpty()) {
             LOGGER.info("Start polling if [{}] permission is replicated to all instances", permission);
-            poller.runPoller(pollingInterval, pollingDelay,
+            poller.runPollerDontStopOnException(pollingInterval, pollingDelay,
                     new FreeIpaPermissionReplicatedPoller(clientForAllInstances, HOST_ENROLLMENT_PRIVILEGE, permission));
         } else {
             LOGGER.info("Polling is skipped for non HA FreeIPA deployment");

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaPermissionServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaPermissionServiceTest.java
@@ -110,7 +110,7 @@ class FreeIpaPermissionServiceTest {
         underTest.setPermissions(stack, freeIpaClient);
 
         ArgumentCaptor<FreeIpaPermissionReplicatedPoller> replicatedPollerArgumentCaptor = ArgumentCaptor.forClass(FreeIpaPermissionReplicatedPoller.class);
-        verify(poller, times(3)).runPoller(eq(POLLING_INTERVAL), eq(POLLING_DELAY), replicatedPollerArgumentCaptor.capture());
+        verify(poller, times(3)).runPollerDontStopOnException(eq(POLLING_INTERVAL), eq(POLLING_DELAY), replicatedPollerArgumentCaptor.capture());
         verify(freeIpaClient).addPermissionsToPrivilege(HOST_ENROLLMENT_PRIVILEGE, List.of(ADD_HOSTS_PERMISSION));
         verify(freeIpaClient).addPermissionsToPrivilege(HOST_ENROLLMENT_PRIVILEGE, List.of(REMOVE_HOSTS_PERMISSION));
         verify(freeIpaClient).addPermissionsToPrivilege(HOST_ENROLLMENT_PRIVILEGE, List.of(REMOVE_SERVICES_PERMISSION));


### PR DESCRIPTION
To have a meaningful error message, `FreeIpaPermissionReplicatedPoller` is using `AttemptResults#continueFor` which expect an exception. If the poller is initialized with `stopIfException(true)`, this would cause a failure and stop polling. This prevents currently the polling after the first attempt. Poller adjusted to continue after an exception.

See detailed description in the commit message.