### PR TITLE
CB-18702 Fix cdp-freeipa-healthagent IndexError by creating the missing file on RHEL8

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_healthagent_setup.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_healthagent_setup.sh
@@ -26,3 +26,12 @@ else
   log "Unable to track any kind of httpd certificate."
   exit 1
 fi
+
+#
+# Create dirsrv- file if does not exist. It happens in case of RHEL8
+#
+DIRSRV_FILE=/etc/sysconfig/dirsrv-$(cat /srv/pillar/freeipa/init.sls | grep -v json | jq -r '.freeipa.realm' | tr . -)
+if [ ! -f "$DIRSRV_FILE" ]; then
+  log "$DIRSRV_FILE is missing. Create it with empty content as freeipa-healthagent depends on the file name to check dirsrv service instance."
+  echo > $DIRSRV_FILE
+fi


### PR DESCRIPTION
It is a workaround as cdp-freeipa-healthagent should not depend on a file what might missing (and it is missing on RHEL8). Final solution should be a fix in the healthagen. Instead of a string magic on top of the filename it should consume the service name form a different source in a failsafe way.
