### PR TITLE
CB-18421: Introduce a new flag to enable the Data Lake upgrade with running Data Hub clusters

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/tags/upgrade/UpgradeV4Request.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/tags/upgrade/UpgradeV4Request.java
@@ -31,6 +31,9 @@ public class UpgradeV4Request {
 
     private Boolean replaceVms = Boolean.TRUE;
 
+    @ApiModelProperty(UpgradeModelDescription.SKIP_DATAHUB_VALIDATION)
+    private Boolean skipDataHubValidation;
+
     @ApiModelProperty(UpgradeModelDescription.SHOW_AVAILABLE_IMAGES)
     private UpgradeShowAvailableImages showAvailableImages = UpgradeShowAvailableImages.DO_NOT_SHOW;
 
@@ -97,6 +100,14 @@ public class UpgradeV4Request {
         this.replaceVms = replaceVms;
     }
 
+    public Boolean isSkipDataHubValidation() {
+        return skipDataHubValidation;
+    }
+
+    public void setSkipDataHubValidation(Boolean skipDataHubValidation) {
+        this.skipDataHubValidation = skipDataHubValidation;
+    }
+
     public boolean isEmpty() {
         return isUnspecifiedUpgradeType() &&
                 !Boolean.TRUE.equals(dryRun) &&
@@ -134,6 +145,7 @@ public class UpgradeV4Request {
                 .add("lockComponents=" + lockComponents)
                 .add("dryRun=" + dryRun)
                 .add("replaceVms=" + replaceVms)
+                .add("skipDataHubValidation=" + skipDataHubValidation)
                 .add("showAvailableImages=" + showAvailableImages)
                 .add("internalUpgradeSettings=" + internalUpgradeSettings)
                 .toString();

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
@@ -824,6 +824,8 @@ public class ModelDescriptions {
         public static final String LOCK_COMPONENTS = "Upgrades to image with the same version of stack and clustermanager, if available";
         public static final String DRY_RUN = "Checks the eligibility of an image to upgrade";
         public static final String SHOW_AVAILABLE_IMAGES = "Returns the list of images that are eligible for the upgrade";
+        public static final String SKIP_DATAHUB_VALIDATION = "With this option, the Data Lake upgrade can be performed with running Data Hub clusters. " +
+                "The usage of this option can cause problems on the running Data Hub clusters during the Data Lake upgrade.";
     }
 
     public static class CmSyncRequest {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/UpgradePreconditionService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/UpgradePreconditionService.java
@@ -32,9 +32,9 @@ public class UpgradePreconditionService {
     @Inject
     private StackStopRestrictionService stackStopRestrictionService;
 
-    public String checkForRunningAttachedClusters(StackViewV4Responses stackViewV4Responses, Stack stack) {
+    public String checkForRunningAttachedClusters(StackViewV4Responses stackViewV4Responses, Stack stack, Boolean skipDataHubValidation) {
         String notStoppedAttachedClusters = getNotStoppedAttachedClusters(stackViewV4Responses, stack);
-        if (!notStoppedAttachedClusters.isEmpty()) {
+        if (!Boolean.TRUE.equals(skipDataHubValidation) && !notStoppedAttachedClusters.isEmpty()) {
             return String.format("There are attached Data Hub clusters in incorrect state: %s. "
                     + "Please stop those to be able to perform the upgrade.", notStoppedAttachedClusters);
         }

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackUpgradeOperations.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackUpgradeOperations.java
@@ -124,13 +124,14 @@ public class StackUpgradeOperations {
         if (CollectionUtils.isNotEmpty(upgradeResponse.getUpgradeCandidates())) {
             clusterUpgradeAvailabilityService.filterUpgradeOptions(accountId, upgradeResponse, request, stack.isDatalake());
         }
-        validateAttachedDataHubsForDataLake(accountId, workspaceId, stack, upgradeResponse, request.getInternalUpgradeSettings());
+        validateAttachedDataHubsForDataLake(accountId, workspaceId, stack, upgradeResponse, request);
         LOGGER.debug("Upgrade response after validations: {}", upgradeResponse);
         return upgradeResponse;
     }
 
     private void validateAttachedDataHubsForDataLake(String accountId, Long workspaceId, Stack stack, UpgradeV4Response upgradeResponse,
-            InternalUpgradeSettings internalUpgradeSettings) {
+            UpgradeV4Request request) {
+        InternalUpgradeSettings internalUpgradeSettings = request.getInternalUpgradeSettings();
         if (entitlementService.runtimeUpgradeEnabled(accountId) && StackType.DATALAKE == stack.getType()
                 && (internalUpgradeSettings == null || !internalUpgradeSettings.isUpgradePreparation())) {
             LOGGER.info("Checking that the attached DataHubs of the Data lake are both in stopped state and upgradeable only in case if "
@@ -140,7 +141,8 @@ public class StackUpgradeOperations {
             if (!entitlementService.datahubRuntimeUpgradeEnabled(accountId)) {
                 upgradeResponse.appendReason(upgradePreconditionService.checkForNonUpgradeableAttachedClusters(stackViewV4Responses));
             }
-            upgradeResponse.appendReason(upgradePreconditionService.checkForRunningAttachedClusters(stackViewV4Responses, stack));
+            upgradeResponse.appendReason(upgradePreconditionService.checkForRunningAttachedClusters(stackViewV4Responses, stack, request.
+                    isSkipDataHubValidation()));
         }
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/UpgradePreconditionServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/UpgradePreconditionServiceTest.java
@@ -48,7 +48,7 @@ public class UpgradePreconditionServiceTest {
         StackViewV4Responses stackViewV4Responses = new StackViewV4Responses(Set.of(dataHubStack1, dataHubStack2, dataHubStack3));
         Stack stack = new Stack();
 
-        String actualRunning = underTest.checkForRunningAttachedClusters(stackViewV4Responses, stack);
+        String actualRunning = underTest.checkForRunningAttachedClusters(stackViewV4Responses, stack, null);
         String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(stackViewV4Responses);
 
         assertEquals("There are attached Data Hub clusters in incorrect state: stack-1. Please stop those to be able to perform the upgrade.",
@@ -56,6 +56,22 @@ public class UpgradePreconditionServiceTest {
         assertEquals("", actualNonUpgradeable);
 
         verify(spotInstanceUsageCondition).isStackRunsOnSpotInstances(stack);
+    }
+
+    @Test
+    public void testCheckForRunningAttachedClustersShouldNotReturnErrorMessageWhenThereAreClustersInNotProperStateAndTheSkipValidationFlagIsTrue() {
+        StackViewV4Response dataHubStack1 = createStackResponse(Status.AVAILABLE, "stack-1", "stack-crn-1");
+        dataHubStack1.setCluster(createClusterResponse(Status.AVAILABLE, BlueprintBasedUpgradeOption.UPGRADE_ENABLED));
+        StackViewV4Response dataHubStack2 = createStackResponse(Status.DELETE_COMPLETED, "stack-2", "stack-crn-2");
+        dataHubStack2.setCluster(createClusterResponse(Status.DELETE_COMPLETED, BlueprintBasedUpgradeOption.UPGRADE_ENABLED));
+        StackViewV4Response dataHubStack3 = createStackResponse(Status.STOPPED, "stack-3", "stack-crn-2");
+        dataHubStack3.setCluster(createClusterResponse(Status.DELETE_COMPLETED, BlueprintBasedUpgradeOption.UPGRADE_ENABLED));
+        StackViewV4Responses stackViewV4Responses = new StackViewV4Responses(Set.of(dataHubStack1, dataHubStack2, dataHubStack3));
+        Stack stack = new Stack();
+
+        String actualRunning = underTest.checkForRunningAttachedClusters(stackViewV4Responses, stack, Boolean.TRUE);
+
+        assertEquals("", actualRunning);
     }
 
     @Test
@@ -69,7 +85,7 @@ public class UpgradePreconditionServiceTest {
 
         StackViewV4Responses stackViewV4Responses = new StackViewV4Responses(Set.of(dataHubStack1, dataHubStack2, dataHubStack3));
 
-        String actualRunning = underTest.checkForRunningAttachedClusters(stackViewV4Responses, new Stack());
+        String actualRunning = underTest.checkForRunningAttachedClusters(stackViewV4Responses, new Stack(), null);
         String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(stackViewV4Responses);
 
         assertEquals("", actualRunning);
@@ -90,7 +106,7 @@ public class UpgradePreconditionServiceTest {
         StackViewV4Responses stackViewV4Responses = new StackViewV4Responses(Set.of(dataHubStack1, dataHubStack2, dataHubStack3));
         when(stackStopRestrictionService.isInfrastructureStoppable(any())).thenReturn(StopRestrictionReason.EPHEMERAL_VOLUMES);
 
-        String actual = underTest.checkForRunningAttachedClusters(stackViewV4Responses, new Stack());
+        String actual = underTest.checkForRunningAttachedClusters(stackViewV4Responses, new Stack(), Boolean.FALSE);
         String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(stackViewV4Responses);
 
         assertEquals("", actual);
@@ -112,7 +128,7 @@ public class UpgradePreconditionServiceTest {
         when(stackStopRestrictionService.isInfrastructureStoppable(any())).thenReturn(StopRestrictionReason.NONE);
         when(spotInstanceUsageCondition.isStackRunsOnSpotInstances(stack)).thenReturn(true);
 
-        String actualRunning = underTest.checkForRunningAttachedClusters(stackViewV4Responses, stack);
+        String actualRunning = underTest.checkForRunningAttachedClusters(stackViewV4Responses, stack, Boolean.FALSE);
         String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(stackViewV4Responses);
 
         assertEquals("", actualRunning);
@@ -130,7 +146,7 @@ public class UpgradePreconditionServiceTest {
         StackViewV4Responses stackViewV4Responses = new StackViewV4Responses(Set.of(dataHubStack1, dataHubStack2));
         Stack stack = new Stack();
 
-        String actualRunning = underTest.checkForRunningAttachedClusters(stackViewV4Responses, stack);
+        String actualRunning = underTest.checkForRunningAttachedClusters(stackViewV4Responses, stack, Boolean.FALSE);
         String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(stackViewV4Responses);
 
         assertEquals("There are attached Data Hub clusters that are non-upgradeable: stack-2. Please delete those to be able to perform the upgrade.",
@@ -148,7 +164,7 @@ public class UpgradePreconditionServiceTest {
         dataHubStack3.setCluster(createClusterResponse(Status.STOPPED, BlueprintBasedUpgradeOption.UPGRADE_ENABLED));
         StackViewV4Responses stackViewV4Responses = new StackViewV4Responses(Set.of(dataHubStack1, dataHubStack2, dataHubStack3));
 
-        String actual = underTest.checkForRunningAttachedClusters(stackViewV4Responses, new Stack());
+        String actual = underTest.checkForRunningAttachedClusters(stackViewV4Responses, new Stack(), Boolean.FALSE);
         String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(stackViewV4Responses);
 
         assertEquals("", actual);
@@ -167,7 +183,7 @@ public class UpgradePreconditionServiceTest {
         StackViewV4Responses stackViewV4Responses = new StackViewV4Responses(Set.of(dataHubStack1, dataHubStack2, dataHubStack3));
         Stack stack = new Stack();
 
-        String actualRunning = underTest.checkForRunningAttachedClusters(stackViewV4Responses, stack);
+        String actualRunning = underTest.checkForRunningAttachedClusters(stackViewV4Responses, stack, Boolean.FALSE);
         String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(stackViewV4Responses);
 
         assertEquals("There are attached Data Hub clusters in incorrect state: stack-1. Please stop those to be able to perform the upgrade.",
@@ -182,7 +198,7 @@ public class UpgradePreconditionServiceTest {
     public void testDataHubsNotAttached() {
         StackViewV4Responses stackViewV4Responses = new StackViewV4Responses(Set.of());
 
-        String actual = underTest.checkForRunningAttachedClusters(stackViewV4Responses, new Stack());
+        String actual = underTest.checkForRunningAttachedClusters(stackViewV4Responses, new Stack(), Boolean.FALSE);
         String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(stackViewV4Responses);
 
         assertEquals("", actual);

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/ModelDescriptions.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/ModelDescriptions.java
@@ -96,6 +96,9 @@ public class ModelDescriptions {
 
     public static final String DRY_RUN = "Doesn't perform the actual operation just validates if all preconditions are met.";
 
+    public static final String SKIP_DATAHUB_VALIDATION = "With this option, the Data Lake upgrade can be performed with running Data Hub clusters. " +
+            "The usage of this option can cause problems on the running Data Hub clusters during the Data Lake upgrade.";
+
     public static final String SKIP_BACKUP = "Option to skip the backup before the upgrade.";
 
     public static final String SKIP_ATLAS = "Option to skip the backup/restore of Atlas data.";

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxUpgradeRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxUpgradeRequest.java
@@ -30,6 +30,9 @@ public class SdxUpgradeRequest {
     @ApiModelProperty(ModelDescriptions.SKIP_BACKUP)
     private Boolean skipBackup;
 
+    @ApiModelProperty(ModelDescriptions.SKIP_DATAHUB_VALIDATION)
+    private Boolean skipDataHubValidation;
+
     @ApiModelProperty(ModelDescriptions.SKIP_ATLAS)
     private boolean skipAtlasMetadata;
 
@@ -87,6 +90,14 @@ public class SdxUpgradeRequest {
 
     public void setSkipBackup(Boolean skipBackup) {
         this.skipBackup = skipBackup;
+    }
+
+    public Boolean getSkipDataHubValidation() {
+        return skipDataHubValidation;
+    }
+
+    public void setSkipDataHubValidation(Boolean skipDataHubValidation) {
+        this.skipDataHubValidation = skipDataHubValidation;
     }
 
     public SdxUpgradeShowAvailableImages getShowAvailableImages() {
@@ -168,6 +179,7 @@ public class SdxUpgradeRequest {
                 ", dryRun=" + dryRun +
                 ", skipBackup=" + skipBackup +
                 ", replaceVms=" + replaceVms +
+                ", skipDataHubValidation=" + skipDataHubValidation +
                 '}';
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxUpgradeClusterConverter.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxUpgradeClusterConverter.java
@@ -33,6 +33,7 @@ public class SdxUpgradeClusterConverter {
             upgradeV4Request.setShowAvailableImages(UpgradeShowAvailableImages.valueOf(sdxUpgradeRequest.getShowAvailableImages().name()));
         }
         upgradeV4Request.setReplaceVms(Optional.ofNullable(sdxUpgradeRequest.getReplaceVms()).orElse(SdxUpgradeReplaceVms.ENABLED).getBooleanValue());
+        upgradeV4Request.setSkipDataHubValidation(sdxUpgradeRequest.getSkipDataHubValidation());
         return upgradeV4Request;
     }
 }


### PR DESCRIPTION
In some cases we can't stop the Data Hub clusters, therefore we introduced a new option to enable the Data Hub to upgrade with running Data Hub clusters. The new option is called skipDataHubValidation.