### PR TITLE
CB-18667 Save the Salt HighState Total Duration report as test artifact on Jenkins

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/salt/SaltHighStateDurationAssertions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/salt/SaltHighStateDurationAssertions.java
@@ -46,7 +46,8 @@ public class SaltHighStateDurationAssertions {
         Map<String, Double> fetchedFreeIpaSaltDurations = fetchSaltDurations("freeipa");
         List<SaltHighstateReport> freeIpaSaltHighstateReports = saltMetrics.getSaltExecutionMetrics(freeIpaTestDto.getEnvironmentCrn(),
                 freeIpaTestDto.getName(), freeIpaClient, "freeipa");
-        validateSaltStatesTotalDurations(freeIpaSaltHighstateReports, fetchedFreeIpaSaltDurations);
+        Table<String, String, Double> saltStatesTotalDurations = validateSaltStatesTotalDurations(freeIpaSaltHighstateReports, fetchedFreeIpaSaltDurations);
+        saltMetrics.writeSaltStatesTotalDurationsReportsToFiles(testContext, "freeipa", saltStatesTotalDurations);
         return freeIpaTestDto;
     }
 
@@ -54,7 +55,8 @@ public class SaltHighStateDurationAssertions {
         Map<String, Double> fetchedSdxSaltDurations = fetchSaltDurations("sdx");
         List<SaltHighstateReport> sdxSaltHighstateReports = saltMetrics.getSaltExecutionMetrics(sdxTestDto.getResponse().getEnvironmentCrn(),
                 sdxTestDto.getName(), sdxClient, "sdx");
-        validateSaltStatesTotalDurations(sdxSaltHighstateReports, fetchedSdxSaltDurations);
+        Table<String, String, Double> saltStatesTotalDurations = validateSaltStatesTotalDurations(sdxSaltHighstateReports, fetchedSdxSaltDurations);
+        saltMetrics.writeSaltStatesTotalDurationsReportsToFiles(testContext, "sdx", saltStatesTotalDurations);
         return sdxTestDto;
     }
 
@@ -62,7 +64,8 @@ public class SaltHighStateDurationAssertions {
         Map<String, Double> fetchedDistroxSaltDurations = fetchSaltDurations("distrox");
         List<SaltHighstateReport> distroxSaltHighstateReports = saltMetrics.getSaltExecutionMetrics(distroXTestDto.getResponse().getEnvironmentCrn(),
                 distroXTestDto.getName(), cloudbreakClient, "distrox");
-        validateSaltStatesTotalDurations(distroxSaltHighstateReports, fetchedDistroxSaltDurations);
+        Table<String, String, Double> saltStatesTotalDurations = validateSaltStatesTotalDurations(distroxSaltHighstateReports, fetchedDistroxSaltDurations);
+        saltMetrics.writeSaltStatesTotalDurationsReportsToFiles(testContext, "distrox", saltStatesTotalDurations);
         return distroXTestDto;
     }
 
@@ -92,7 +95,8 @@ public class SaltHighStateDurationAssertions {
         }
     }
 
-    private void validateSaltStatesTotalDurations(List<SaltHighstateReport> saltHighstateReports, Map<String, Double> fetchedSaltDurations) {
+    private Table<String, String, Double> validateSaltStatesTotalDurations(List<SaltHighstateReport> saltHighstateReports,
+            Map<String, Double> fetchedSaltDurations) {
         Table<String, String, Double> saltStatesTotalDurations = Tables.synchronizedTable(HashBasedTable.create());
         LOGGER.info("Number of Salt High State reports: {}", saltHighstateReports.size());
         for (SaltHighstateReport saltHighstateReport : saltHighstateReports) {
@@ -120,5 +124,6 @@ public class SaltHighStateDurationAssertions {
             }
         }
         LOGGER.info("Total durations for Salt states by job: {}", saltStatesTotalDurations);
+        return saltStatesTotalDurations;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/action/SshSaltExecutionMetricsActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/action/SshSaltExecutionMetricsActions.java
@@ -3,9 +3,11 @@ package com.sequenceiq.it.cloudbreak.util.ssh.action;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceMetadataType.GATEWAY_PRIMARY;
 import static com.sequenceiq.common.api.type.InstanceGroupType.GATEWAY;
 
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -33,6 +35,7 @@ import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Table;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupResponse;
@@ -83,6 +86,20 @@ public class SshSaltExecutionMetricsActions extends SshJClientActions {
             LOGGER.info("Error occurred while trying to retrieve Salt execution metrics and generating report on instance [{}]: {}",
                     saltMasterIp, e.getMessage());
             throw new RuntimeException(e);
+        }
+    }
+
+    public void writeSaltStatesTotalDurationsReportsToFiles(TestContext testContext, String serviceName,
+            Table<String, String, Double> saltStatesTotalDurations) {
+        String fileName = String.format("salt_states_totalduration_report_%s_%s.log", serviceName,
+                testContext.getTestMethodName().orElse(DEFAULT_TEST_METHOD_NAME));
+        File outputDirectory = new File(saltMetricsWorkingDirectory);
+        String filePath = outputDirectory.getPath() + System.getProperty("file.separator") + fileName;
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(filePath))) {
+            writer.write(saltStatesTotalDurations.toString());
+            LOGGER.info("Log file for Salt States Totalduration report has been created successfully at: {}", filePath);
+        } catch (IOException e) {
+            LOGGER.error("Cannot create log file for Salt States Totalduration report!", e);
         }
     }
 


### PR DESCRIPTION
We should save the generated `Salt HighStates TotalDuration` report to disk. Major goal of this to keep the new report at Jenkins as test artifact along with others Salt reportsCB-18667 Save the Salt HighState Total Duration report as test artifact on Jenkins.
