### PR TITLE
[CB-18319] skip Hive database backup on upgrade

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
@@ -522,6 +522,7 @@ public interface StackV4Endpoint {
     @ApiOperation(value = DATABASE_BACKUP, nickname = "databaseBackup")
     BackupV4Response backupDatabaseByName(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name,
             @QueryParam("backupLocation") String backupLocation, @QueryParam("backupId") String backupId,
+            @QueryParam("skipDatabaseNames") List<String> skipDatabaseNames,
             @AccountId @QueryParam("accountId") String accountId);
 
     @POST
@@ -530,7 +531,8 @@ public interface StackV4Endpoint {
     @ApiOperation(value = DATABASE_BACKUP_INTERNAL, nickname = "databaseBackupInternal")
     BackupV4Response backupDatabaseByNameInternal(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name,
             @QueryParam("backupId") String backupId, @QueryParam("backupLocation") String backupLocation,
-            @QueryParam("closeConnections") boolean closeConnections, @QueryParam("initiatorUserCrn") String initiatorUserCrn);
+            @QueryParam("closeConnections") boolean closeConnections,
+            @QueryParam("skipDatabaseNames") List<String> skipDatabaseNames, @QueryParam("initiatorUserCrn") String initiatorUserCrn);
 
     @POST
     @Path("{name}/database_restore")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
@@ -439,19 +439,19 @@ public class StackV4Controller extends NotificationController implements StackV4
 
     @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.POWERUSER_ONLY)
-    public BackupV4Response backupDatabaseByName(Long workspaceId, String name, String backupLocation, String backupId,
+    public BackupV4Response backupDatabaseByName(Long workspaceId, String name, String backupLocation, String backupId, List<String> skipDatabaseNames,
             @AccountId String accountId) {
         FlowIdentifier flowIdentifier = stackOperations.backupClusterDatabase(NameOrCrn.ofName(name),
-                restRequestThreadLocalService.getRequestedWorkspaceId(), backupLocation, backupId, true);
+                restRequestThreadLocalService.getRequestedWorkspaceId(), backupLocation, backupId, true, skipDatabaseNames);
         return new BackupV4Response(flowIdentifier);
     }
 
     @Override
     @InternalOnly
     public BackupV4Response backupDatabaseByNameInternal(Long workspaceId, String name, String backupId, String backupLocation,
-            boolean closeConnections, @InitiatorUserCrn String initiatorUserCrn) {
+            boolean closeConnections, List<String> skipDatabaseNames, @InitiatorUserCrn String initiatorUserCrn) {
         FlowIdentifier flowIdentifier = stackOperations.backupClusterDatabase(NameOrCrn.ofName(name),
-                restRequestThreadLocalService.getRequestedWorkspaceId(), backupLocation, backupId, closeConnections);
+                restRequestThreadLocalService.getRequestedWorkspaceId(), backupLocation, backupId, closeConnections, skipDatabaseNames);
         return new BackupV4Response(flowIdentifier);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/BackupDatalakeDatabaseFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/BackupDatalakeDatabaseFlowEventChainFactory.java
@@ -26,7 +26,7 @@ public class BackupDatalakeDatabaseFlowEventChainFactory implements FlowEventCha
         Queue<Selectable> flowEventChain = new ConcurrentLinkedQueue<>();
         flowEventChain.add(new StackEvent(SaltUpdateEvent.SALT_UPDATE_EVENT.event(), event.getResourceId(), event.accepted()));
         flowEventChain.add(new DatabaseBackupTriggerEvent(DATABASE_BACKUP_EVENT.event(), event.getResourceId(),
-                event.getBackupLocation(), event.getBackupId(), event.isCloseConnections()));
+                event.getBackupLocation(), event.getBackupId(), event.isCloseConnections(), event.getSkipDatabaseNames()));
         return new FlowTriggerEventQueue(getName(), event, flowEventChain);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/AbstractBackupRestoreActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/AbstractBackupRestoreActions.java
@@ -21,7 +21,8 @@ public abstract class AbstractBackupRestoreActions<P extends BackupRestoreEvent>
     @Override
     protected BackupRestoreContext createFlowContext(FlowParameters flowParameters, StateContext<FlowState, FlowEvent> stateContext,
             P payload) {
-        return BackupRestoreContext.from(flowParameters, payload, payload.getBackupLocation(), payload.getBackupId(), payload.isCloseConnections());
+        return BackupRestoreContext.from(flowParameters, payload, payload.getBackupLocation(), payload.getBackupId(),
+                payload.isCloseConnections(), payload.getSkipDatabaseNames());
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/BackupRestoreContext.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/BackupRestoreContext.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.dr;
 
+import java.util.List;
+
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.flow.core.CommonContext;
 import com.sequenceiq.flow.core.FlowParameters;
@@ -14,24 +16,21 @@ public class BackupRestoreContext extends CommonContext {
 
     private final boolean closeConnections;
 
-    public BackupRestoreContext(FlowParameters flowParameters, StackEvent event, String backupLocation, String backupId, boolean closeConnections) {
+    private final List<String> skipDatabaseNames;
+
+    public BackupRestoreContext(FlowParameters flowParameters, StackEvent event, String backupLocation, String backupId,
+            boolean closeConnections, List<String> skipDatabaseNames) {
         super(flowParameters);
         this.stackId = event.getResourceId();
         this.backupLocation = backupLocation;
         this.backupId = backupId;
         this.closeConnections = closeConnections;
+        this.skipDatabaseNames = skipDatabaseNames;
     }
 
-    public BackupRestoreContext(FlowParameters flowParameters, Long stackId, String backupLocation, String backupId) {
-        super(flowParameters);
-        this.stackId = stackId;
-        this.backupLocation = backupLocation;
-        this.backupId = backupId;
-        this.closeConnections = true;
-    }
-
-    public static BackupRestoreContext from(FlowParameters flowParameters, StackEvent event, String backupLocation, String backupId, boolean closeConnections) {
-        return new BackupRestoreContext(flowParameters, event, backupLocation, backupId, closeConnections);
+    public static BackupRestoreContext from(FlowParameters flowParameters, StackEvent event, String backupLocation, String backupId,
+            boolean closeConnections, List<String> skipDatabaseNames) {
+        return new BackupRestoreContext(flowParameters, event, backupLocation, backupId, closeConnections, skipDatabaseNames);
     }
 
     public Long getStackId() {
@@ -48,5 +47,9 @@ public class BackupRestoreContext extends CommonContext {
 
     public boolean getCloseConnections() {
         return closeConnections;
+    }
+
+    public List<String> getSkipDatabaseNames() {
+        return skipDatabaseNames;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/backup/DatabaseBackupActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/backup/DatabaseBackupActions.java
@@ -2,6 +2,16 @@ package com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.dr.backup;
 
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.dr.backup.DatabaseBackupEvent.DATABASE_BACKUP_FAIL_HANDLED_EVENT;
 
+import java.util.Map;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.statemachine.StateContext;
+import org.springframework.statemachine.action.Action;
+
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.dr.AbstractBackupRestoreActions;
@@ -16,16 +26,6 @@ import com.sequenceiq.flow.core.Flow;
 import com.sequenceiq.flow.core.FlowEvent;
 import com.sequenceiq.flow.core.FlowParameters;
 import com.sequenceiq.flow.core.FlowState;
-
-import java.util.Map;
-import java.util.Optional;
-
-import javax.inject.Inject;
-
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.statemachine.StateContext;
-import org.springframework.statemachine.action.Action;
 
 @Configuration
 public class DatabaseBackupActions {
@@ -45,7 +45,8 @@ public class DatabaseBackupActions {
 
             @Override
             protected Selectable createRequest(BackupRestoreContext context) {
-                return new DatabaseBackupRequest(context.getStackId(), context.getBackupLocation(), context.getBackupId(), context.getCloseConnections());
+                return new DatabaseBackupRequest(context.getStackId(), context.getBackupLocation(), context.getBackupId(),
+                        context.getCloseConnections(), context.getSkipDatabaseNames());
             }
 
             @Override
@@ -81,7 +82,7 @@ public class DatabaseBackupActions {
                     DatabaseBackupFailedEvent payload) {
                 Flow flow = getFlow(flowParameters.getFlowId());
                 flow.setFlowFailed(payload.getException());
-                return BackupRestoreContext.from(flowParameters, payload, null, null, true);
+                return BackupRestoreContext.from(flowParameters, payload, null, null, true, payload.getSkipDatabaseNames());
             }
 
             @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/restore/DatabaseRestoreActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/restore/DatabaseRestoreActions.java
@@ -2,6 +2,16 @@ package com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.dr.restore;
 
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.dr.restore.DatabaseRestoreEvent.DATABASE_RESTORE_FAIL_HANDLED_EVENT;
 
+import java.util.Map;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.statemachine.StateContext;
+import org.springframework.statemachine.action.Action;
+
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.dr.AbstractBackupRestoreActions;
@@ -16,16 +26,6 @@ import com.sequenceiq.flow.core.Flow;
 import com.sequenceiq.flow.core.FlowEvent;
 import com.sequenceiq.flow.core.FlowParameters;
 import com.sequenceiq.flow.core.FlowState;
-
-import java.util.Map;
-import java.util.Optional;
-
-import javax.inject.Inject;
-
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.statemachine.StateContext;
-import org.springframework.statemachine.action.Action;
 
 @Configuration
 public class DatabaseRestoreActions {
@@ -81,7 +81,7 @@ public class DatabaseRestoreActions {
                     DatabaseRestoreFailedEvent payload) {
                 Flow flow = getFlow(flowParameters.getFlowId());
                 flow.setFlowFailed(payload.getException());
-                return BackupRestoreContext.from(flowParameters, payload, null, null, true);
+                return BackupRestoreContext.from(flowParameters, payload, null, null, true, payload.getSkipDatabaseNames());
             }
 
             @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/DatabaseBackupTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/DatabaseBackupTriggerEvent.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.core.flow2.event;
 
+import java.util.List;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -13,12 +14,9 @@ import reactor.rx.Promise;
 
 public class DatabaseBackupTriggerEvent extends BackupRestoreEvent {
 
-    public DatabaseBackupTriggerEvent(String selector, Long stackId, String backupLocation, String backupId, boolean closeConnections) {
-        super(selector, stackId, backupLocation, backupId, closeConnections);
-    }
-
-    public DatabaseBackupTriggerEvent(String selector, Long stackId, String backupLocation, String backupId) {
-        super(selector, stackId, backupLocation, backupId);
+    public DatabaseBackupTriggerEvent(String selector, Long stackId, String backupLocation, String backupId,
+            boolean closeConnections, List<String> skipDatabaseNames) {
+        super(selector, stackId, backupLocation, backupId, closeConnections, skipDatabaseNames);
     }
 
     @JsonCreator
@@ -28,8 +26,9 @@ public class DatabaseBackupTriggerEvent extends BackupRestoreEvent {
             @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted,
             @JsonProperty("backupLocation") String backupLocation,
             @JsonProperty("backupId") String backupId,
-            @JsonProperty("closeConnections") boolean closeConnections) {
-        super(event, resourceId, accepted, backupLocation, backupId, closeConnections);
+            @JsonProperty("closeConnections") boolean closeConnections,
+            @JsonProperty("skipDatabaseNames") List<String> skipDatabaseNames) {
+        super(event, resourceId, accepted, backupLocation, backupId, closeConnections, skipDatabaseNames);
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/DatabaseRestoreTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/DatabaseRestoreTriggerEvent.java
@@ -24,7 +24,7 @@ public class DatabaseRestoreTriggerEvent extends BackupRestoreEvent {
             @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted,
             @JsonProperty("backupLocation") String backupLocation,
             @JsonProperty("backupId") String backupId) {
-        super(event, resourceId, accepted, backupLocation, backupId);
+        super(event, resourceId, accepted, backupLocation, backupId, true);
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
@@ -396,9 +396,11 @@ public class ReactorFlowManager {
         return reactorNotifier.notify(stackId, selector, new StackEvent(selector, stackId));
     }
 
-    public FlowIdentifier triggerDatalakeDatabaseBackup(Long stackId, String location, String backupId, boolean closeConnections) {
+    public FlowIdentifier triggerDatalakeDatabaseBackup(Long stackId, String location, String backupId,
+            boolean closeConnections, List<String> skipDatabaseNames) {
         String selector = FlowChainTriggers.DATALAKE_DATABASE_BACKUP_CHAIN_TRIGGER_EVENT;
-        return reactorNotifier.notify(stackId, selector, new DatabaseBackupTriggerEvent(selector, stackId, location, backupId, closeConnections));
+        return reactorNotifier.notify(stackId, selector, new DatabaseBackupTriggerEvent(selector, stackId,
+                location, backupId, closeConnections, skipDatabaseNames));
     }
 
     public FlowIdentifier triggerDatalakeDatabaseRestore(Long stackId, String location, String backupId) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/dr/BackupRestoreEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/dr/BackupRestoreEvent.java
@@ -1,5 +1,8 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.dr;
 
+import java.util.Collections;
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.common.event.AcceptResult;
@@ -16,12 +19,10 @@ public class BackupRestoreEvent extends StackEvent {
 
     private final boolean closeConnections;
 
+    private final List<String> skipDatabaseNames;
+
     public BackupRestoreEvent(Long stackId, String backupLocation, String backupId) {
         this (null, stackId, backupLocation, backupId);
-    }
-
-    public BackupRestoreEvent(Long stackId, String backupLocation, String backupId, boolean closeConnections) {
-        this(null, stackId, backupLocation, backupId, closeConnections);
     }
 
     public BackupRestoreEvent(String selector, Long stackId, String backupLocation, String backupId) {
@@ -29,20 +30,23 @@ public class BackupRestoreEvent extends StackEvent {
         this.backupLocation = backupLocation;
         this.backupId = backupId;
         this.closeConnections = true;
+        this.skipDatabaseNames = Collections.emptyList();
     }
 
-    public BackupRestoreEvent(String selector, Long stackId, String backupLocation, String backupId, boolean closeConnections) {
+    public BackupRestoreEvent(String selector, Long stackId, String backupLocation, String backupId, boolean closeConnections, List<String> skipDatabaseNames) {
         super(selector, stackId);
         this.backupLocation = backupLocation;
         this.backupId = backupId;
         this.closeConnections = closeConnections;
+        this.skipDatabaseNames = skipDatabaseNames;
     }
 
-    public BackupRestoreEvent(String selector, Long stackId, Promise<AcceptResult> accepted, String backupLocation, String backupId) {
+    public BackupRestoreEvent(String selector, Long stackId, Promise<AcceptResult> accepted, String backupLocation, String backupId, boolean closeConnections) {
         super(selector, stackId, accepted);
         this.backupLocation = backupLocation;
         this.backupId = backupId;
-        this.closeConnections = true;
+        this.closeConnections = closeConnections;
+        this.skipDatabaseNames = Collections.emptyList();
     }
 
     @JsonCreator
@@ -52,11 +56,13 @@ public class BackupRestoreEvent extends StackEvent {
             @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted,
             @JsonProperty("backupLocation") String backupLocation,
             @JsonProperty("backupId") String backupId,
-            @JsonProperty("closeConnections") boolean closeConnections) {
+            @JsonProperty("closeConnections") boolean closeConnections,
+            @JsonProperty("skipDatabaseNames") List<String> skipDatabaseNames) {
         super(selector, stackId, accepted);
         this.backupLocation = backupLocation;
         this.backupId = backupId;
         this.closeConnections = closeConnections;
+        this.skipDatabaseNames = skipDatabaseNames;
     }
 
     public String getBackupLocation() {
@@ -69,5 +75,9 @@ public class BackupRestoreEvent extends StackEvent {
 
     public boolean isCloseConnections() {
         return closeConnections;
+    }
+
+    public List<String> getSkipDatabaseNames() {
+        return skipDatabaseNames;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/dr/backup/DatabaseBackupRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/dr/backup/DatabaseBackupRequest.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.dr.backup;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.dr.BackupRestoreEvent;
@@ -11,7 +13,8 @@ public class DatabaseBackupRequest extends BackupRestoreEvent {
             @JsonProperty("resourceId") Long stackId,
             @JsonProperty("backupLocation") String backupLocation,
             @JsonProperty("backupId") String backupId,
-            @JsonProperty("closeConnections") boolean closeConnections) {
-        super(stackId, backupLocation, backupId, closeConnections);
+            @JsonProperty("closeConnections") boolean closeConnections,
+            @JsonProperty("skipDatabaseNames") List<String> skipDatabaseNames) {
+        super(null, stackId, backupLocation, backupId, closeConnections, skipDatabaseNames);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/BackupRestoreSaltConfigGenerator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/BackupRestoreSaltConfigGenerator.java
@@ -9,11 +9,17 @@ import static java.util.Collections.singletonMap;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.google.common.base.Strings;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.orchestrator.model.SaltConfig;
 import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
 import com.sequenceiq.cloudbreak.view.StackView;
@@ -33,7 +39,15 @@ public class BackupRestoreSaltConfigGenerator {
 
     public static final String CLOSE_CONNECTIONS = "close_connections";
 
-    public SaltConfig createSaltConfig(String location, String backupId, String rangerAdminGroup, boolean closeConnections, StackView stack)
+    public static final String DATABASE_NAMES_KEY = "database_name";
+
+    public static final List<DatabaseType> DEFAULT_BACKUP_DATABASE =
+            List.of(DatabaseType.HIVE, DatabaseType.RANGER, DatabaseType.PROFILER_AGENT, DatabaseType.PROFILER_METRIC);
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BackupRestoreSaltConfigGenerator.class);
+
+    public SaltConfig createSaltConfig(String location, String backupId, String rangerAdminGroup,
+            boolean closeConnections, List<String> skipDatabaseNames, StackView stack)
             throws URISyntaxException {
         String fullLocation = buildFullLocation(location, backupId, stack.getCloudPlatform());
 
@@ -43,7 +57,18 @@ public class BackupRestoreSaltConfigGenerator {
         disasterRecoveryValues.put(OBJECT_STORAGE_URL_KEY, fullLocation);
         disasterRecoveryValues.put(RANGER_ADMIN_GROUP_KEY, rangerAdminGroup);
         disasterRecoveryValues.put(CLOSE_CONNECTIONS, String.valueOf(closeConnections));
+        if (!skipDatabaseNames.isEmpty()) {
+            List<String> names = DEFAULT_BACKUP_DATABASE.stream()
+                    .map(DatabaseType::toString)
+                    .map(String::toLowerCase)
+                    .collect(Collectors.toList());
 
+            skipDatabaseNames.stream()
+                    .filter(((Predicate<String>) names::remove).negate())
+                    .map(db -> "Tried to skip unknown database " + db)
+                    .forEach(LOGGER::warn);
+            disasterRecoveryValues.put(DATABASE_NAMES_KEY, String.join(" ", names));
+        }
         servicePillar.put("disaster-recovery", new SaltPillarProperties(POSTGRESQL_DISASTER_RECOVERY_PILLAR_PATH,
                 singletonMap(DISASTER_RECOVERY_KEY, disasterRecoveryValues)));
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/backup/DatabaseBackupHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/backup/DatabaseBackupHandler.java
@@ -78,7 +78,7 @@ public class DatabaseBackupHandler extends ExceptionCatcherEventHandler<Database
             ExitCriteriaModel exitModel = ClusterDeletionBasedExitCriteriaModel.clusterDeletionBasedModel(stackId, cluster.getId());
             String rangerAdminGroup = rangerVirtualGroupService.getRangerVirtualGroup(stack);
             SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(request.getBackupLocation(), request.getBackupId(), rangerAdminGroup,
-                    request.isCloseConnections(), stack);
+                    request.isCloseConnections(), request.getSkipDatabaseNames(), stack);
             hostOrchestrator.backupDatabase(gatewayConfig, gatewayFQDN, saltConfig, exitModel);
 
             result = new DatabaseBackupSuccess(stackId);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/restore/DatabaseRestoreHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/restore/DatabaseRestoreHandler.java
@@ -77,7 +77,8 @@ public class DatabaseRestoreHandler extends ExceptionCatcherEventHandler<Databas
             Set<String> gatewayFQDN = Collections.singleton(gatewayInstance.getDiscoveryFQDN());
             ExitCriteriaModel exitModel = ClusterDeletionBasedExitCriteriaModel.clusterDeletionBasedModel(stackId, cluster.getId());
             String rangerAdminGroup = rangerVirtualGroupService.getRangerVirtualGroup(stack);
-            SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(request.getBackupLocation(), request.getBackupId(), rangerAdminGroup, true, stack);
+            SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(request.getBackupLocation(), request.getBackupId(), rangerAdminGroup,
+                    true, Collections.emptyList(), stack);
             hostOrchestrator.restoreDatabase(gatewayConfig, gatewayFQDN, saltConfig, exitModel);
 
             result = new DatabaseRestoreSuccess(stackId);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/DatabaseBackupRestoreService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/DatabaseBackupRestoreService.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.service;
 
+import java.util.List;
+
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
@@ -42,11 +44,12 @@ public class DatabaseBackupRestoreService {
         }
     }
 
-    public FlowIdentifier backupDatabase(Long workspaceId, NameOrCrn nameOrCrn, String location, String backupId, boolean closeConnections) {
+    public FlowIdentifier backupDatabase(Long workspaceId, NameOrCrn nameOrCrn, String location, String backupId,
+            boolean closeConnections, List<String> skipDatabaseNames) {
         Stack stack = stackService.getByNameOrCrnInWorkspace(nameOrCrn, workspaceId);
         MDCBuilder.buildMdcContext(stack);
         LOGGER.info("Initiating database backup flow for stack {}", stack.getId());
-        return flowManager.triggerDatalakeDatabaseBackup(stack.getId(), location, backupId, closeConnections);
+        return flowManager.triggerDatalakeDatabaseBackup(stack.getId(), location, backupId, closeConnections, skipDatabaseNames);
     }
 
     public FlowIdentifier restoreDatabase(Long workspaceId, NameOrCrn nameOrCrn, String location, String backupId) {

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
@@ -381,10 +381,11 @@ public class StackOperations implements HierarchyAuthResourcePropertyProvider {
         return stackCommonService.getRetryableFlows(name, workspaceId);
     }
 
-    public FlowIdentifier backupClusterDatabase(@NotNull NameOrCrn nameOrCrn, Long workspaceId, String location, String backupId, boolean closeConnections) {
+    public FlowIdentifier backupClusterDatabase(@NotNull NameOrCrn nameOrCrn, Long workspaceId, String location, String backupId,
+            boolean closeConnections, List<String> skipDatabaseNames) {
         databaseBackupRestoreService.validate(workspaceId, nameOrCrn, location, backupId);
         LOGGER.debug("Starting cluster database backup: " + nameOrCrn);
-        return databaseBackupRestoreService.backupDatabase(workspaceId, nameOrCrn, location, backupId, closeConnections);
+        return databaseBackupRestoreService.backupDatabase(workspaceId, nameOrCrn, location, backupId, closeConnections, skipDatabaseNames);
     }
 
     public FlowIdentifier restoreClusterDatabase(@NotNull NameOrCrn nameOrCrn, Long workspaceId, String location, String backupId) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
@@ -152,7 +152,7 @@ public class ReactorFlowManagerTest {
         underTest.triggerClusterUpgradePreparation(STACK_ID, imageChangeDto, false);
         underTest.triggerSaltUpdate(STACK_ID);
         underTest.triggerPillarConfigurationUpdate(STACK_ID);
-        underTest.triggerDatalakeDatabaseBackup(STACK_ID, null, null, true);
+        underTest.triggerDatalakeDatabaseBackup(STACK_ID, null, null, true, Collections.emptyList());
         underTest.triggerDatalakeDatabaseRestore(STACK_ID, null, null);
         underTest.triggerAutoTlsCertificatesRotation(STACK_ID, new CertificatesRotationV4Request());
         underTest.triggerStackLoadBalancerUpdate(STACK_ID);
@@ -267,7 +267,7 @@ public class ReactorFlowManagerTest {
     public void testTriggerDatabaseBackupFlowchain() {
         long stackId = 1L;
         String backupId = UUID.randomUUID().toString();
-        underTest.triggerDatalakeDatabaseBackup(stackId, BACKUP_LOCATION, backupId, true);
+        underTest.triggerDatalakeDatabaseBackup(stackId, BACKUP_LOCATION, backupId, true, Collections.emptyList());
         ArgumentCaptor<Acceptable> captor = ArgumentCaptor.forClass(Acceptable.class);
         verify(reactorNotifier).notify(eq(stackId), eq(FlowChainTriggers.DATALAKE_DATABASE_BACKUP_CHAIN_TRIGGER_EVENT), captor.capture());
         DatabaseBackupTriggerEvent event = (DatabaseBackupTriggerEvent) captor.getValue();

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/BackupRestoreSaltConfigGeneratorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/BackupRestoreSaltConfigGeneratorTest.java
@@ -1,12 +1,16 @@
 package com.sequenceiq.cloudbreak.reactor.handler.cluster.dr;
 
 import static com.sequenceiq.cloudbreak.reactor.handler.cluster.dr.BackupRestoreSaltConfigGenerator.DATABASE_BACKUP_POSTFIX;
+import static com.sequenceiq.cloudbreak.reactor.handler.cluster.dr.BackupRestoreSaltConfigGenerator.DATABASE_NAMES_KEY;
 import static com.sequenceiq.cloudbreak.reactor.handler.cluster.dr.BackupRestoreSaltConfigGenerator.DISASTER_RECOVERY_KEY;
 import static com.sequenceiq.cloudbreak.reactor.handler.cluster.dr.BackupRestoreSaltConfigGenerator.OBJECT_STORAGE_URL_KEY;
 import static com.sequenceiq.cloudbreak.reactor.handler.cluster.dr.BackupRestoreSaltConfigGenerator.RANGER_ADMIN_GROUP_KEY;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -37,13 +41,14 @@ public class BackupRestoreSaltConfigGeneratorTest {
         Stack placeholderStack = new Stack();
         placeholderStack.setCloudPlatform(cloudPlatform);
 
-        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, true, placeholderStack);
+        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, true, Collections.emptyList(), placeholderStack);
 
         Map<String, Object> disasterRecoveryProperties = saltConfig.getServicePillarConfig().get("disaster-recovery").getProperties();
         Map<String, String> disasterRecoveryKeyValuePairs = (Map<String, String>) disasterRecoveryProperties.get(DISASTER_RECOVERY_KEY);
 
         assertEquals("s3a://test/backups/backupId_database_backup", disasterRecoveryKeyValuePairs.get(OBJECT_STORAGE_URL_KEY));
         assertEquals(RANGER_ADMIN_GROUP, disasterRecoveryKeyValuePairs.get(RANGER_ADMIN_GROUP_KEY));
+        assertNull(disasterRecoveryKeyValuePairs.get(DATABASE_NAMES_KEY));
     }
 
     @Test
@@ -54,7 +59,7 @@ public class BackupRestoreSaltConfigGeneratorTest {
         Stack placeholderStack = new Stack();
         placeholderStack.setCloudPlatform(cloudPlatform);
 
-        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, true, placeholderStack);
+        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, true, Collections.emptyList(), placeholderStack);
 
         Map<String, Object> disasterRecoveryProperties = saltConfig.getServicePillarConfig().get("disaster-recovery").getProperties();
         Map<String, String> disasterRecoveryKeyValuePairs = (Map<String, String>) disasterRecoveryProperties.get(DISASTER_RECOVERY_KEY);
@@ -67,12 +72,30 @@ public class BackupRestoreSaltConfigGeneratorTest {
         placeholderStack = new Stack();
         placeholderStack.setCloudPlatform(cloudPlatform);
 
-        saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, true, placeholderStack);
+        saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, true, Collections.emptyList(), placeholderStack);
 
         disasterRecoveryProperties = saltConfig.getServicePillarConfig().get("disaster-recovery").getProperties();
         disasterRecoveryKeyValuePairs = (Map<String, String>) disasterRecoveryProperties.get(DISASTER_RECOVERY_KEY);
 
         assertEquals("hdfs://test/backups/backupId_database_backup", disasterRecoveryKeyValuePairs.get(OBJECT_STORAGE_URL_KEY));
+    }
+
+    @Test
+    public void testCreateSaltConfigWithSkipDatabaseNames() throws URISyntaxException {
+        String cloudPlatform = "aws";
+        String location = "/test/backups";
+        Stack placeholderStack = new Stack();
+        placeholderStack.setCloudPlatform(cloudPlatform);
+
+        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, true, List.of("hive"), placeholderStack);
+
+        Map<String, Object> disasterRecoveryProperties = saltConfig.getServicePillarConfig().get("disaster-recovery").getProperties();
+        Map<String, String> disasterRecoveryKeyValuePairs = (Map<String, String>) disasterRecoveryProperties.get(DISASTER_RECOVERY_KEY);
+
+        assertEquals("s3a://test/backups/backupId_database_backup", disasterRecoveryKeyValuePairs.get(OBJECT_STORAGE_URL_KEY));
+        assertEquals(RANGER_ADMIN_GROUP, disasterRecoveryKeyValuePairs.get(RANGER_ADMIN_GROUP_KEY));
+        assertEquals("ranger profiler_agent profiler_metric", disasterRecoveryKeyValuePairs.get(DATABASE_NAMES_KEY));
+
     }
 
     @Test
@@ -82,7 +105,7 @@ public class BackupRestoreSaltConfigGeneratorTest {
         Stack placeholderStack = new Stack();
         placeholderStack.setCloudPlatform(cloudPlatform);
 
-        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, true, placeholderStack);
+        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, true, Collections.emptyList(), placeholderStack);
 
         Map<String, Object> disasterRecoveryProperties = saltConfig.getServicePillarConfig().get("disaster-recovery").getProperties();
         Map<String, String> disasterRecoveryKeyValuePairs = (Map<String, String>) disasterRecoveryProperties.get(DISASTER_RECOVERY_KEY);
@@ -97,7 +120,7 @@ public class BackupRestoreSaltConfigGeneratorTest {
         Stack placeholderStack = new Stack();
         placeholderStack.setCloudPlatform(cloudPlatform);
 
-        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, true, placeholderStack);
+        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, true, Collections.emptyList(), placeholderStack);
 
         Map<String, Object> disasterRecoveryProperties = saltConfig.getServicePillarConfig().get("disaster-recovery").getProperties();
         Map<String, String> disasterRecoveryKeyValuePairs = (Map<String, String>) disasterRecoveryProperties.get(DISASTER_RECOVERY_KEY);
@@ -112,7 +135,7 @@ public class BackupRestoreSaltConfigGeneratorTest {
         Stack placeholderStack = new Stack();
         placeholderStack.setCloudPlatform(cloudPlatform);
 
-        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, true, placeholderStack);
+        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, true, Collections.emptyList(), placeholderStack);
 
         Map<String, Object> disasterRecoveryProperties = saltConfig.getServicePillarConfig().get("disaster-recovery").getProperties();
         Map<String, String> disasterRecoveryKeyValuePairs = (Map<String, String>) disasterRecoveryProperties.get(DISASTER_RECOVERY_KEY);
@@ -127,7 +150,7 @@ public class BackupRestoreSaltConfigGeneratorTest {
         Stack placeholderStack = new Stack();
         placeholderStack.setCloudPlatform(cloudPlatform);
 
-        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, true, placeholderStack);
+        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, true, Collections.emptyList(),  placeholderStack);
 
         Map<String, Object> disasterRecoveryProperties = saltConfig.getServicePillarConfig().get("disaster-recovery").getProperties();
         Map<String, String> disasterRecoveryKeyValuePairs = (Map<String, String>) disasterRecoveryProperties.get(DISASTER_RECOVERY_KEY);
@@ -142,7 +165,7 @@ public class BackupRestoreSaltConfigGeneratorTest {
         Stack placeholderStack = new Stack();
         placeholderStack.setCloudPlatform(cloudPlatform);
 
-        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, true, placeholderStack);
+        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, true, Collections.emptyList(), placeholderStack);
 
         Map<String, Object> disasterRecoveryProperties = saltConfig.getServicePillarConfig().get("disaster-recovery").getProperties();
         Map<String, String> disasterRecoveryKeyValuePairs = (Map<String, String>) disasterRecoveryProperties.get(DISASTER_RECOVERY_KEY);
@@ -157,7 +180,7 @@ public class BackupRestoreSaltConfigGeneratorTest {
         Stack placeholderStack = new Stack();
         placeholderStack.setCloudPlatform(cloudPlatform);
 
-        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, true, placeholderStack);
+        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, true, Collections.emptyList(), placeholderStack);
 
         Map<String, Object> disasterRecoveryProperties = saltConfig.getServicePillarConfig().get("disaster-recovery").getProperties();
         Map<String, String> disasterRecoveryKeyValuePairs = (Map<String, String>) disasterRecoveryProperties.get(DISASTER_RECOVERY_KEY);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/DatabaseBackupRestoreServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/DatabaseBackupRestoreServiceTest.java
@@ -91,9 +91,9 @@ public class DatabaseBackupRestoreServiceTest {
         when(stackService.findStackByNameAndWorkspaceId(any(), anyLong())).thenReturn(Optional.of(stack));
         when(stackService.getByNameOrCrnInWorkspace(any(), anyLong())).thenReturn(stack);
         when(flowLogService.findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(1L)).thenReturn(Collections.EMPTY_LIST);
-        when(flowManager.triggerDatalakeDatabaseBackup(anyLong(), any(), any(), anyBoolean())).thenReturn(FlowIdentifier.notTriggered());
+        when(flowManager.triggerDatalakeDatabaseBackup(anyLong(), any(), any(), anyBoolean(), any())).thenReturn(FlowIdentifier.notTriggered());
 
-        service.backupDatabase(WORKSPACE_ID, ofName, null, null, true);
+        service.backupDatabase(WORKSPACE_ID, ofName, null, null, true, Collections.emptyList());
     }
 
     @Test

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/ModelDescriptions.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/ModelDescriptions.java
@@ -12,6 +12,8 @@ public class ModelDescriptions {
 
     public static final String CLOSE_CONNECTIONS = "The conditional parameter for whether connections to the database will be closed during backup or not.";
 
+    public static final String SKIP_DATABASE_NAMES = "The names of the Databases not to be backed up, or blank for all";
+
     public static final String ENVIRONMENT_CRN = "Environment crn.";
 
     public static final String ENVIRONMENT_NAME = "The name of the environment.";

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxDatabaseBackupRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxDatabaseBackupRequest.java
@@ -1,5 +1,8 @@
 package com.sequenceiq.sdx.api.model;
 
+import java.util.Collections;
+import java.util.List;
+
 import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -23,6 +26,9 @@ public class SdxDatabaseBackupRequest {
     @NotNull
     @ApiModelProperty(value = ModelDescriptions.CLOSE_CONNECTIONS, required = true)
     private boolean closeConnections;
+
+    @ApiModelProperty(value = ModelDescriptions.SKIP_DATABASE_NAMES, required = false)
+    private List<String> skipDatabaseNames;
 
     public String getBackupId() {
         return backupId;
@@ -48,12 +54,21 @@ public class SdxDatabaseBackupRequest {
         this.closeConnections = closeConnections;
     }
 
+    public List<String> getSkipDatabaseNames() {
+        return skipDatabaseNames == null ? Collections.emptyList() : skipDatabaseNames;
+    }
+
+    public void setSkipDatabaseNames(List<String> skipDatabaseNames) {
+        this.skipDatabaseNames = skipDatabaseNames;
+    }
+
     @Override
     public String toString() {
         return "SdxDatabaseBackupRequest{" +
                 "backupId='" + backupId + '\'' +
                 ", backupLocation='" + backupLocation + '\'' +
                 ", closeConnections=" + closeConnections +
+                ", skipDatabaseNames='" + skipDatabaseNames + '\'' +
                 '}';
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxBackupController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxBackupController.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.datalake.controller.sdx;
 
+import java.util.Collections;
+
 import javax.inject.Inject;
 
 import org.springframework.stereotype.Controller;
@@ -44,6 +46,7 @@ public class SdxBackupController implements SdxBackupEndpoint {
             backupRequest.setBackupId(backupId);
             backupRequest.setBackupLocation(backupLocation);
             backupRequest.setCloseConnections(true);
+            backupRequest.setSkipDatabaseNames(Collections.emptyList());
             return sdxBackupRestoreService.triggerDatabaseBackup(sdxCluster, backupRequest);
         }
     }

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/chain/DatalakeResizeFlowEventChainFactory.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/chain/DatalakeResizeFlowEventChainFactory.java
@@ -8,6 +8,7 @@ import static com.sequenceiq.datalake.flow.dr.backup.DatalakeBackupEvent.DATALAK
 import static com.sequenceiq.datalake.flow.dr.restore.DatalakeRestoreEvent.DATALAKE_TRIGGER_RESTORE_EVENT;
 import static com.sequenceiq.datalake.flow.stop.SdxStopEvent.SDX_STOP_EVENT;
 
+import java.util.Collections;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
@@ -46,7 +47,7 @@ public class DatalakeResizeFlowEventChainFactory implements FlowEventChainFactor
             chain.add(new DatalakeTriggerBackupEvent(DATALAKE_TRIGGER_BACKUP_EVENT.event(),
                     event.getResourceId(), event.getUserId(), event.getBackupLocation(), "resize" + System.currentTimeMillis(),
                     event.getSkipOptions(),
-                    DatalakeBackupFailureReason.BACKUP_ON_RESIZE, event.accepted()));
+                    DatalakeBackupFailureReason.BACKUP_ON_RESIZE, Collections.emptyList(), event.accepted()));
             // Stop datalake
             chain.add(new SdxStartStopEvent(SDX_STOP_EVENT.event(), event.getResourceId(), event.getUserId(), STOP_DATAHUBS));
         } else {

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/chain/DatalakeUpgradeFlowEventChainFactory.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/chain/DatalakeUpgradeFlowEventChainFactory.java
@@ -3,11 +3,13 @@ package com.sequenceiq.datalake.flow.chain;
 import static com.sequenceiq.datalake.flow.datalake.upgrade.DatalakeUpgradeEvent.DATALAKE_UPGRADE_EVENT;
 import static com.sequenceiq.datalake.flow.dr.backup.DatalakeBackupEvent.DATALAKE_TRIGGER_BACKUP_EVENT;
 
+import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.datalake.flow.datalake.upgrade.event.DatalakeUpgradeFlowChainStartEvent;
 import com.sequenceiq.datalake.flow.datalake.upgrade.event.DatalakeUpgradeStartEvent;
@@ -29,7 +31,7 @@ public class DatalakeUpgradeFlowEventChainFactory implements FlowEventChainFacto
         chain.add(new DatalakeTriggerBackupEvent(DATALAKE_TRIGGER_BACKUP_EVENT.event(),
                 event.getResourceId(), event.getUserId(), event.getBackupLocation(), "",
                 event.getSkipOptions(),
-                DatalakeBackupFailureReason.BACKUP_ON_UPGRADE, event.accepted()));
+                DatalakeBackupFailureReason.BACKUP_ON_UPGRADE, List.of(DatabaseType.HIVE.toString().toLowerCase()), event.accepted()));
         chain.add(new DatalakeUpgradeStartEvent(DATALAKE_UPGRADE_EVENT.event(), event.getResourceId(), event.getUserId(),
                 event.getImageId(), event.isReplaceVms()));
         return new FlowTriggerEventQueue(getName(), event, chain);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeDatabaseBackupStartEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeDatabaseBackupStartEvent.java
@@ -2,6 +2,7 @@ package com.sequenceiq.datalake.flow.dr.backup.event;
 
 import static com.sequenceiq.datalake.flow.dr.backup.DatalakeBackupEvent.DATALAKE_DATABASE_BACKUP_EVENT;
 
+import java.util.List;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -23,17 +24,18 @@ public class DatalakeDatabaseBackupStartEvent extends DatalakeDatabaseDrStartBas
             @JsonProperty("userId") String userId,
             @JsonProperty("backupRequest") SdxDatabaseBackupRequest backupRequest) {
 
-        super(selector, sdxId, userId, SdxOperationType.BACKUP);
+        super(selector, sdxId, userId, SdxOperationType.BACKUP, backupRequest.getSkipDatabaseNames());
         this.backupRequest = backupRequest;
     }
 
     public DatalakeDatabaseBackupStartEvent(String selector, SdxOperation drStatus, String userId,
-                                            String backupId, String backupLocation) {
-        super(selector, drStatus.getSdxClusterId(), userId, drStatus);
+                                            String backupId, String backupLocation, List<String> skipDatabaseNames) {
+        super(selector, drStatus.getSdxClusterId(), userId, drStatus, skipDatabaseNames);
         backupRequest = new SdxDatabaseBackupRequest();
         backupRequest.setBackupId(backupId);
         backupRequest.setBackupLocation(backupLocation);
         backupRequest.setCloseConnections(true);
+        backupRequest.setSkipDatabaseNames(skipDatabaseNames);
     }
 
     public static DatalakeDatabaseBackupStartEvent from(DatalakeTriggerBackupEvent trigggerBackupEvent,
@@ -42,7 +44,8 @@ public class DatalakeDatabaseBackupStartEvent extends DatalakeDatabaseDrStartBas
                 trigggerBackupEvent.getDrStatus(),
                 trigggerBackupEvent.getUserId(),
                 backupId,
-                trigggerBackupEvent.getBackupLocation());
+                trigggerBackupEvent.getBackupLocation(),
+                trigggerBackupEvent.getSkipDatabaseNames());
     }
 
     public SdxDatabaseBackupRequest getBackupRequest() {

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeTriggerBackupEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeTriggerBackupEvent.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.datalake.flow.dr.backup.event;
 
+import java.util.List;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -33,8 +34,9 @@ public class DatalakeTriggerBackupEvent extends DatalakeDatabaseDrStartBaseEvent
             @JsonProperty("backupName") String backupName,
             @JsonProperty("skipOptions") DatalakeDrSkipOptions skipOptions,
             @JsonProperty("reason") DatalakeBackupFailureReason reason,
+            @JsonProperty("skipDatabaseNames") List<String> skipDatabaseNames,
             @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
-        super(selector, sdxId, userId, SdxOperationType.BACKUP, accepted);
+        super(selector, sdxId, userId, SdxOperationType.BACKUP, skipDatabaseNames, accepted);
         this.backupLocation = backupLocation;
         this.backupName = backupName;
         this.skipOptions = skipOptions;
@@ -42,8 +44,8 @@ public class DatalakeTriggerBackupEvent extends DatalakeDatabaseDrStartBaseEvent
     }
 
     public DatalakeTriggerBackupEvent(String selector, Long sdxId, String userId, String backupLocation, String backupName,
-            DatalakeBackupFailureReason reason, DatalakeDrSkipOptions skipOptions) {
-        super(selector, sdxId, userId, SdxOperationType.BACKUP);
+            DatalakeBackupFailureReason reason, DatalakeDrSkipOptions skipOptions, List<String> skipDatabaseNames) {
+        super(selector, sdxId, userId, SdxOperationType.BACKUP, skipDatabaseNames);
         this.backupLocation = backupLocation;
         this.backupName = backupName;
         this.reason = reason;

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/event/DatalakeDatabaseDrStartBaseEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/event/DatalakeDatabaseDrStartBaseEvent.java
@@ -1,5 +1,8 @@
 package com.sequenceiq.datalake.flow.dr.event;
 
+import java.util.Collections;
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.common.event.AcceptResult;
@@ -14,33 +17,40 @@ public class DatalakeDatabaseDrStartBaseEvent extends SdxEvent  {
 
     private final SdxOperation drStatus;
 
+    private final List<String> skipDatabaseNames;
+
     @JsonCreator
     public DatalakeDatabaseDrStartBaseEvent(
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long sdxId,
             @JsonProperty("userId") String userId,
             @JsonProperty("operationType") SdxOperationType operationType,
+            @JsonProperty("skipDatabaseNames") List<String> skipDatabaseNames,
             @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, sdxId, userId, accepted);
         drStatus = new SdxOperation(operationType, sdxId);
+        this.skipDatabaseNames = skipDatabaseNames;
     }
 
     public DatalakeDatabaseDrStartBaseEvent(String selector, Long sdxId, String userId,
-                                            SdxOperationType operationType) {
+                                            SdxOperationType operationType, List<String> skipDatabaseNames) {
         super(selector, sdxId, userId);
         drStatus = new SdxOperation(operationType, sdxId);
+        this.skipDatabaseNames = skipDatabaseNames;
     }
 
     public DatalakeDatabaseDrStartBaseEvent(String selector, Long sdxId, String sdxName, String userId,
             SdxOperationType operationType) {
         super(selector, sdxId, sdxName, userId);
         drStatus = new SdxOperation(operationType, sdxId);
+        this.skipDatabaseNames = Collections.emptyList();
     }
 
     public DatalakeDatabaseDrStartBaseEvent(String selector, Long sdxId, String userId,
-                                            SdxOperation drStatus) {
+                                            SdxOperation drStatus, List<String> skipDatabaseNames) {
         super(selector, sdxId, userId);
         this.drStatus = drStatus;
+        this.skipDatabaseNames = skipDatabaseNames;
     }
 
     public SdxOperation getDrStatus() {
@@ -49,5 +59,9 @@ public class DatalakeDatabaseDrStartBaseEvent extends SdxEvent  {
 
     public SdxOperationType getOperationType() {
         return drStatus.getOperationType();
+    }
+
+    public List<String> getSkipDatabaseNames() {
+        return skipDatabaseNames;
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/event/DatalakeDatabaseRestoreStartEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/event/DatalakeDatabaseRestoreStartEvent.java
@@ -2,6 +2,7 @@ package com.sequenceiq.datalake.flow.dr.restore.event;
 
 import static com.sequenceiq.datalake.flow.dr.restore.DatalakeRestoreEvent.DATALAKE_DATABASE_RESTORE_EVENT;
 
+import java.util.Collections;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -20,7 +21,7 @@ public class DatalakeDatabaseRestoreStartEvent extends DatalakeDatabaseDrStartBa
 
     public DatalakeDatabaseRestoreStartEvent(String selector, Long sdxId, String userId,
             String backupId, String restoreId, String backupLocation) {
-        super(selector, sdxId, userId, SdxOperationType.RESTORE);
+        super(selector, sdxId, userId, SdxOperationType.RESTORE, Collections.emptyList());
         this.backupId = backupId;
         this.restoreId = restoreId;
         this.backupLocation = backupLocation;
@@ -35,7 +36,7 @@ public class DatalakeDatabaseRestoreStartEvent extends DatalakeDatabaseDrStartBa
             @JsonProperty("backupId") String backupId,
             @JsonProperty("restoreId") String restoreId,
             @JsonProperty("backupLocation") String backupLocation) {
-        super(selector, sdxId, userId, drStatus);
+        super(selector, sdxId, userId, drStatus, Collections.emptyList());
         this.backupId = backupId;
         this.restoreId = restoreId;
         this.backupLocation = backupLocation;

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/validation/event/DatalakeTriggerBackupValidationEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/validation/event/DatalakeTriggerBackupValidationEvent.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.datalake.flow.dr.validation.event;
 
+import java.util.Collections;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -27,14 +28,14 @@ public class DatalakeTriggerBackupValidationEvent extends DatalakeDatabaseDrStar
             @JsonProperty("backupLocation") String backupLocation,
             @JsonProperty("reason") DatalakeBackupFailureReason reason,
             @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
-        super(selector, sdxId, userId, SdxOperationType.BACKUP, accepted);
+        super(selector, sdxId, userId, SdxOperationType.BACKUP, Collections.emptyList(), accepted);
         this.backupLocation = backupLocation;
         this.reason = reason;
     }
 
     public DatalakeTriggerBackupValidationEvent(String selector, Long sdxId, String userId, String backupLocation,
             DatalakeBackupFailureReason reason) {
-        super(selector, sdxId, userId, SdxOperationType.BACKUP);
+        super(selector, sdxId, userId, SdxOperationType.BACKUP, Collections.emptyList());
         this.backupLocation = backupLocation;
         this.reason = reason;
     }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/dr/SdxBackupRestoreService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/dr/SdxBackupRestoreService.java
@@ -210,7 +210,7 @@ public class SdxBackupRestoreService {
         String selector = DATALAKE_TRIGGER_BACKUP_EVENT.event();
         String userId = ThreadBasedUserCrnProvider.getUserCrn();
         DatalakeTriggerBackupEvent startEvent = new DatalakeTriggerBackupEvent(selector, cluster.getId(), userId,
-            backupLocation, backupName, DatalakeBackupFailureReason.USER_TRIGGERED, skipOptions);
+            backupLocation, backupName, DatalakeBackupFailureReason.USER_TRIGGERED, skipOptions, Collections.emptyList());
         FlowIdentifier flowIdentifier = sdxReactorFlowManager.triggerDatalakeBackupFlow(startEvent, cluster.getClusterName());
         return new SdxBackupResponse(startEvent.getDrStatus().getOperationId(), flowIdentifier);
     }
@@ -242,7 +242,8 @@ public class SdxBackupRestoreService {
                 BackupV4Response backupV4Response = ThreadBasedUserCrnProvider.doAsInternalActor(
                         regionAwareInternalCrnGeneratorFactory.iam().getInternalCrnForServiceAsString(),
                         () -> stackV4Endpoint.backupDatabaseByNameInternal(0L, sdxCluster.getClusterName(),
-                        backupRequest.getBackupId(), backupRequest.getBackupLocation(), backupRequest.isCloseConnections(), initiatorUserCrn));
+                        backupRequest.getBackupId(), backupRequest.getBackupLocation(), backupRequest.isCloseConnections(),
+                                backupRequest.getSkipDatabaseNames(),  initiatorUserCrn));
                 updateSuccessStatus(drStatus.getOperationId(), sdxCluster, backupV4Response.getFlowIdentifier(),
                         SdxOperationStatus.TRIGGERRED);
             }, () -> {


### PR DESCRIPTION
script changes run on local dev datalake with manually set params logs show only the 3 backed up
(salt_3000.8) [root@drutl-dl-salt-9-13-1-master0 srv]# cat /var/log/dl_postgres_backup.log 2022-09-13T20:06:20Z INFO  Starting backup to s3a://drutledge-sdx-daily-datalake/drutledge-cloudbreak/ 2022-09-13T20:06:20Z INFO  Conditional variable for closing connections to database during backup is set to True 2022-09-13T20:06:20Z INFO  Backing up ranger.
2022-09-13T20:06:20Z INFO  Checking the existence of database ranger ranger
2022-09-13T20:06:20Z INFO  Dumping ranger
2022-09-13T20:06:20Z Ranger admin group is None
2022-09-13T20:06:20Z INFO  Replacing None with _RANGER_WAG_2f0264fa-0a04-462b-af85-7c09891568ef in the dump before export 2022-09-13T20:06:20Z attempting kinit as hdfs using Keytab: /run/cloudera-scm-agent/process/1546335542-dfs-create-dir/hdfs.keytab 2022-09-13T20:06:20Z Successful kinit using hdfs principal 2022-09-13T20:06:20Z INFO  Uploading to s3a://drutledge-sdx-daily-datalake/drutledge-cloudbreak/ Sep 13, 2022 8:06:22 PM org.apache.knox.gateway.shell.KnoxSession createClient INFO: Using default JAAS configuration
Sep 13, 2022 8:06:25 PM org.apache.knox.gateway.shell.KnoxSession createClient INFO: Using default JAAS configuration
Sep 13, 2022 8:06:25 PM org.apache.knox.gateway.shell.KnoxSession createClient INFO: Using default JAAS configuration
2022-09-13T20:06:27Z INFO  Completed upload to s3a://drutledge-sdx-daily-datalake/drutledge-cloudbreak/ 2022-09-13T20:06:27Z INFO  Completed upload to s3a://drutledge-sdx-daily-datalake/drutledge-cloudbreak/ 2022-09-13T20:06:27Z INFO  ranger dumped to s3a://drutledge-sdx-daily-datalake/drutledge-cloudbreak//ranger_backup 2022-09-13T20:06:27Z INFO  Backing up profiler_agent. 2022-09-13T20:06:27Z INFO  Checking the existence of database profiler_agent 2022-09-13T20:06:27Z WARN  database for profiler_agent doesn't exists 2022-09-13T20:06:27Z INFO  Backing up profiler_metric. 2022-09-13T20:06:27Z INFO  Checking the existence of database profiler_metric 2022-09-13T20:06:27Z WARN  database for profiler_metric doesn't exists rmdir: removing directory, '/var/tmp//2022-09-13T20:06:20Z' rmdir: removing directory, '/var/tmp//2022-09-13T20:06:20Z' 2022-09-13T20:06:27Z INFO  Completed backup s3a://drutledge-sdx-daily-datalake/drutledge-cloudbreak/

See detailed description in the commit message.