### PR TITLE
CB-18629 - Data Lake Postgres upgrade fails due to flow restart

### DIFF
--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/RedbeamsUpgradeService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/RedbeamsUpgradeService.java
@@ -6,8 +6,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.common.database.MajorVersion;
+import com.sequenceiq.cloudbreak.common.database.TargetMajorVersion;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.cloudbreak.util.MajorVersionComparator;
 import com.sequenceiq.redbeams.api.model.common.DetailedDBStackStatus;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
 import com.sequenceiq.redbeams.domain.upgrade.UpgradeDatabaseRequest;
@@ -32,20 +34,33 @@ public class RedbeamsUpgradeService {
         DBStack dbStack = dbStackService.getByCrn(crn);
         MDCBuilder.addEnvironmentCrn(dbStack.getEnvironmentId());
 
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Upgrade called for: {}, with target version: {}", dbStack, upgradeDatabaseRequest.getTargetMajorVersion());
-        }
+        MajorVersion currentVersion = dbStack.getMajorVersion();
+        TargetMajorVersion targetVersion = upgradeDatabaseRequest.getTargetMajorVersion();
 
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Upgrade called for: {}, with target version: {}, current version is: {}", dbStack, targetVersion, currentVersion);
+        }
         if (dbStack.getStatus().isUpgradeInProgress()) {
-            String message = String.format("DatabaseServer with crn %s is already being upgraded", dbStack.getResourceCrn());
-            LOGGER.debug(message);
-            throw new BadRequestException(message);
+            LOGGER.debug(String.format("DatabaseServer with crn %s is already being upgraded", crn));
+            return;
+        } else if (!isUpgradeNeeded(currentVersion, targetVersion)) {
+            LOGGER.debug(String.format("DatabaseServer with crn %s is already on version %s, upgrade is not necessary.",
+                    crn, currentVersion.getVersion()));
+            return;
         }
 
         dbStackStatusUpdater.updateStatus(dbStack.getId(), DetailedDBStackStatus.UPGRADE_REQUESTED);
         RedbeamsStartUpgradeRequest redbeamsStartUpgradeRequest = new RedbeamsStartUpgradeRequest(dbStack.getId(),
                 upgradeDatabaseRequest.getTargetMajorVersion());
         flowManager.notify(RedbeamsUpgradeEvent.REDBEAMS_START_UPGRADE_EVENT.selector(), redbeamsStartUpgradeRequest);
+    }
+
+    private boolean isUpgradeNeeded(MajorVersion currentVersion, TargetMajorVersion targetMajorVersion) {
+        MajorVersionComparator majorVersionComparator = new MajorVersionComparator();
+        boolean upgradeNeeded = majorVersionComparator.compare(currentVersion, targetMajorVersion.convertToMajorVersion()) < 0;
+        LOGGER.debug("Comparing current and target versions. Current version is {}, and target version is {}, isUpgradeNeeded: {}", currentVersion,
+                targetMajorVersion, upgradeNeeded);
+        return upgradeNeeded;
     }
 
 }


### PR DESCRIPTION
This commit does the following:
  - if the upgrarde is triggered again when the upgrade is in progress, no exception is thrown, redbeams returns without triggering the upgrade flow
  - if the DB is already at the target version, then upgrade flow is not be triggered

See detailed description in the commit message.