### PR TITLE
CB-18626 Enable dedicated storage account for azure E2E with SINGLE_WITH_DEDICATED_STORAGE_ACCOUNT resource group usage

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureProperties.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureProperties.java
@@ -31,6 +31,8 @@ public class AzureProperties {
 
     private final DiskEncription diskEncryption = new DiskEncription();
 
+    private final Resourcegroup resourcegroup = new Resourcegroup();
+
     private FreeIpaProperties freeipa = new FreeIpaProperties();
 
     public FreeIpaProperties getFreeipa() {
@@ -91,6 +93,10 @@ public class AzureProperties {
 
     public DiskEncription getDiskEncryption() {
         return diskEncryption;
+    }
+
+    public Resourcegroup getResourcegroup() {
+        return resourcegroup;
     }
 
     public static class Credential {
@@ -344,7 +350,6 @@ public class AzureProperties {
     }
 
     public static class DiskEncription {
-
         private String encryptionKeyUrl;
 
         private String resourceGroupName;
@@ -364,5 +369,27 @@ public class AzureProperties {
         public void setResourceGroupName(String resourceGroupName) {
                 this.resourceGroupName = resourceGroupName;
             }
+    }
+
+    public static class Resourcegroup {
+        private String usage;
+
+        private String name;
+
+        public String getUsage() {
+            return usage;
+        }
+
+        public void setUsage(String usage) {
+            this.usage = usage;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentNetworkTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentNetworkTestDto.java
@@ -4,6 +4,7 @@ import java.util.Set;
 
 import com.sequenceiq.common.api.type.OutboundInternetTraffic;
 import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
+import com.sequenceiq.common.api.type.ServiceEndpointCreation;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkAwsParams;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkAzureParams;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkGcpParams;
@@ -75,6 +76,11 @@ public class EnvironmentNetworkTestDto extends AbstractCloudbreakTestDto<Environ
 
     public EnvironmentNetworkTestDto withServiceEndpoints() {
         getRequest().setServiceEndpointCreation(getCloudProvider().serviceEndpoint());
+        return this;
+    }
+
+    public EnvironmentNetworkTestDto withServiceEndpoints(ServiceEndpointCreation serviceEndpointCreation) {
+        getRequest().setServiceEndpointCreation(serviceEndpointCreation);
         return this;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXEncryptedVolumeTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXEncryptedVolumeTest.java
@@ -17,6 +17,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 import com.microsoft.azure.management.resources.ResourceGroup;
+import com.sequenceiq.common.api.type.ServiceEndpointCreation;
 import com.sequenceiq.distrox.api.v1.distrox.model.database.DistroXDatabaseAvailabilityType;
 import com.sequenceiq.distrox.api.v1.distrox.model.database.DistroXDatabaseRequest;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
@@ -222,7 +223,7 @@ public class DistroXEncryptedVolumeTest extends AbstractE2ETest {
 
         testContext
                 .given(EnvironmentNetworkTestDto.class)
-                    .withServiceEndpoints()
+                    .withServiceEndpoints(ServiceEndpointCreation.DISABLED)
                 .given("telemetry", TelemetryTestDto.class)
                     .withLogging()
                     .withReportClusterLogs()

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/AzureMarketplaceImageTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/AzureMarketplaceImageTest.java
@@ -8,17 +8,20 @@ import javax.inject.Inject;
 import org.testng.annotations.Test;
 
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.common.api.type.ServiceEndpointCreation;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
 import com.sequenceiq.environment.api.v1.environment.model.response.FreeIpaImageResponse;
 import com.sequenceiq.it.TestParameter;
 import com.sequenceiq.it.cloudbreak.EnvironmentClient;
+import com.sequenceiq.it.cloudbreak.ResourceGroupTest;
 import com.sequenceiq.it.cloudbreak.assertion.Assertion;
 import com.sequenceiq.it.cloudbreak.client.CredentialTestClient;
 import com.sequenceiq.it.cloudbreak.client.EnvironmentTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.credential.CredentialTestDto;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentNetworkTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.telemetry.TelemetryTestDto;
 import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
@@ -50,14 +53,17 @@ public class AzureMarketplaceImageTest extends AbstractE2ETest {
                 .given(CredentialTestDto.class)
                 .when(credentialTestClient.create())
                 .given("telemetry", TelemetryTestDto.class)
-                .withLogging()
-                .withReportClusterLogs()
+                    .withLogging()
+                    .withReportClusterLogs()
+                .given(EnvironmentNetworkTestDto.class)
+                    .withServiceEndpoints(ServiceEndpointCreation.DISABLED)
                 .given(EnvironmentTestDto.class)
-                .withNetwork()
-                .withTelemetry("telemetry")
-                .withCreateFreeIpa(Boolean.TRUE)
-                .withOneFreeIpaNode()
-                .withMarketplaceFreeIpaImage()
+                    .withNetwork()
+                    .withTelemetry("telemetry")
+                    .withCreateFreeIpa(Boolean.TRUE)
+                    .withOneFreeIpaNode()
+                    .withMarketplaceFreeIpaImage()
+                    .withResourceGroup(ResourceGroupTest.AZURE_RESOURCE_GROUP_USAGE_MULTIPLE, "")
                 .when(environmentTestClient.create())
                 .await(EnvironmentStatus.AVAILABLE)
                 .then((tc, testDto, cc) -> environmentTestClient.describe().action(tc, testDto, cc))

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurevm/action/AzureClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurevm/action/AzureClientActions.java
@@ -121,9 +121,10 @@ public class AzureClientActions {
         return Optional.ofNullable(vm).map(VirtualMachine::provisioningState).orElse("no provisioning state");
     }
 
-    // We don't have resource group name, so we are guessing it from cluster name and instance name
+    // If we don't have resource group name, we are going to be guessing it from cluster name and instance name.
     private String getResourceGroupName(String clusterName, String id) {
-        return id.replaceAll("(" + clusterName + "[0-9]+).*", "$1");
+        String resourcegroupName = azureProperties.getResourcegroup().getName();
+        return StringUtils.isBlank(resourcegroupName) ? id.replaceAll("(" + clusterName + "[0-9]+).*", "$1") : resourcegroupName;
     }
 
     public void setAzure(Azure azure) {


### PR DESCRIPTION
We have implemented a special single resource group usage flag for AZURE: `SINGLE_WITH_DEDICATED_STORAGE_ACCOUNT`. This kind of single resource group usage will reduce the execution time of the tests and might add to stability.