### PR TITLE
CB-18774 - Backup/restore retry counter should be increased

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeOrchestratorService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeOrchestratorService.java
@@ -54,7 +54,7 @@ public class RdsUpgradeOrchestratorService {
 
     private static final int MAX_RETRY_ON_ERROR = 3;
 
-    private static final int MAX_RETRY = 20;
+    private static final int MAX_RETRY = 200;
 
     @Inject
     private StackDtoService stackDtoService;


### PR DESCRIPTION
The current retry counter of 20 is turned out to be not enough for some customers, as it takes ~4 minutes.

200 sounds like a better alternative.

