### PR TITLE
CB-18780 COLLECT_DB_ENGINE_VERSION is failing where crn is different … 

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/datalake/SdxClientService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/datalake/SdxClientService.java
@@ -40,6 +40,16 @@ public class SdxClientService {
         }
     }
 
+    public List<SdxClusterResponse> getByEnvironmentCrnInernal(String environmentCrn) {
+        try {
+            return ThreadBasedUserCrnProvider.doAsInternalActor(regionAwareInternalCrnGeneratorFactory.iam().getInternalCrnForServiceAsString(),
+                    () -> sdxEndpoint.getByEnvCrn(environmentCrn));
+        } catch (WebApplicationException | ProcessingException | IllegalStateException e) {
+            LOGGER.error(String.format("Failed to get datalake clusters for environment %s", environmentCrn), e);
+            return new ArrayList<>();
+        }
+    }
+
     public SdxClusterResponse getByCrn(String crn) {
         return sdxEndpoint.getByCrn(crn);
     }


### PR DESCRIPTION
…in DL and core service

For old clusters it's possible the crn in the core and datalake service is different. In this case DL service returns with 404.
The solution is in this case, we list all datalakes for the environment and filter by name, and use it's crn for updating DB engine version.