### PR TITLE
CB-18726 Fix environment status syncer

### DIFF
--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentStatus.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentStatus.java
@@ -76,6 +76,8 @@ public enum EnvironmentStatus {
     START_SYNCHRONIZE_USERS_FAILED("Failed to synchronize users"),
 
     FREEIPA_DELETED_ON_PROVIDER_SIDE("FreeIPA deleted on cloud provider side"),
+    FREEIPA_UNHEALTHY("FreeIPA is unhealthy"),
+    FREEIPA_UNREACHABLE("FreeIPA is unreachable"),
 
     LOAD_BALANCER_ENV_UPDATE_STARTED("Starting load balancer update for environment"),
     LOAD_BALANCER_ENV_UPDATE_FAILED("Failed to update environment with load balancer"),
@@ -146,6 +148,8 @@ public enum EnvironmentStatus {
             STOP_DATALAKE_FAILED,
             STOP_FREEIPA_FAILED,
             FREEIPA_DELETED_ON_PROVIDER_SIDE,
+            FREEIPA_UNHEALTHY,
+            FREEIPA_UNREACHABLE,
             UPGRADE_CCM_VALIDATION_FAILED,
             UPGRADE_CCM_ON_FREEIPA_FAILED,
             UPGRADE_CCM_ON_DATALAKE_FAILED,

--- a/environment/src/main/java/com/sequenceiq/environment/environment/EnvironmentStatus.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/EnvironmentStatus.java
@@ -121,6 +121,12 @@ public enum EnvironmentStatus {
     // The FreeIPA instance deleted on provider side
     FREEIPA_DELETED_ON_PROVIDER_SIDE(com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus.FREEIPA_DELETED_ON_PROVIDER_SIDE),
 
+    // FreeIPA is unhealthy
+    FREEIPA_UNHEALTHY(com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus.FREEIPA_UNHEALTHY),
+
+    // FreeIPA is unreachable
+    FREEIPA_UNREACHABLE(com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus.FREEIPA_UNREACHABLE),
+
     // Start updating the LoadBalancer on Data Lake in an Environment
     LOAD_BALANCER_ENV_UPDATE_STARTED(com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus.LOAD_BALANCER_ENV_UPDATE_STARTED),
     // Failed to updating the LoadBalancer on Data Lake in an Environment (Detailed message in the statusReason)

--- a/environment/src/main/java/com/sequenceiq/environment/environment/sync/EnvironmentSyncService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/sync/EnvironmentSyncService.java
@@ -1,23 +1,100 @@
 package com.sequenceiq.environment.environment.sync;
 
 import static com.sequenceiq.environment.environment.EnvironmentStatus.ENV_STOPPED;
+import static com.sequenceiq.environment.environment.EnvironmentStatus.FREEIPA_CREATION_IN_PROGRESS;
 import static com.sequenceiq.environment.environment.EnvironmentStatus.FREEIPA_DELETED_ON_PROVIDER_SIDE;
+import static com.sequenceiq.environment.environment.EnvironmentStatus.FREEIPA_DELETE_IN_PROGRESS;
+import static com.sequenceiq.environment.environment.EnvironmentStatus.FREEIPA_UNHEALTHY;
+import static com.sequenceiq.environment.environment.EnvironmentStatus.FREEIPA_UNREACHABLE;
 import static com.sequenceiq.environment.environment.EnvironmentStatus.START_FREEIPA_FAILED;
 import static com.sequenceiq.environment.environment.EnvironmentStatus.START_FREEIPA_STARTED;
+import static com.sequenceiq.environment.environment.EnvironmentStatus.START_SYNCHRONIZE_USERS_STARTED;
 import static com.sequenceiq.environment.environment.EnvironmentStatus.STOP_FREEIPA_FAILED;
 import static com.sequenceiq.environment.environment.EnvironmentStatus.STOP_FREEIPA_STARTED;
+import static com.sequenceiq.environment.environment.EnvironmentStatus.UPDATE_INITIATED;
+import static com.sequenceiq.environment.environment.EnvironmentStatus.UPGRADE_CCM_ON_FREEIPA_IN_PROGRESS;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.CREATE_FAILED;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.CREATE_IN_PROGRESS;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.DELETED_ON_PROVIDER_SIDE;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.DELETE_COMPLETED;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.DELETE_FAILED;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.DELETE_IN_PROGRESS;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.DIAGNOSTICS_COLLECTION_IN_PROGRESS;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.DOWNSCALE_FAILED;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.MAINTENANCE_MODE_ENABLED;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.REPAIR_FAILED;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.REQUESTED;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.STACK_AVAILABLE;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.START_FAILED;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.START_IN_PROGRESS;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.START_REQUESTED;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.STOPPED;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.STOP_FAILED;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.STOP_IN_PROGRESS;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.STOP_REQUESTED;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.UNHEALTHY;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.UNKNOWN;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.UNREACHABLE;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.UPDATE_FAILED;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.UPDATE_IN_PROGRESS;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.UPDATE_REQUESTED;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.UPGRADE_CCM_FAILED;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.UPGRADE_CCM_IN_PROGRESS;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.UPGRADE_CCM_REQUESTED;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.UPSCALE_FAILED;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.VERTICAL_SCALE_FAILED;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.WAIT_FOR_SYNC;
 
+import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.environment.environment.EnvironmentStatus;
 import com.sequenceiq.environment.environment.domain.Environment;
 import com.sequenceiq.environment.environment.service.freeipa.FreeIpaService;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.describe.DescribeFreeIpaResponse;
 
 @Component
 public class EnvironmentSyncService {
+
+    private static final Map<Status, EnvironmentStatus> FREEIPA_STATUS_TO_ENV_STATUS_MAP = Map.ofEntries(
+            Map.entry(REQUESTED, FREEIPA_CREATION_IN_PROGRESS),
+            Map.entry(CREATE_IN_PROGRESS, FREEIPA_CREATION_IN_PROGRESS),
+            Map.entry(AVAILABLE, EnvironmentStatus.AVAILABLE),
+            Map.entry(STACK_AVAILABLE, FREEIPA_CREATION_IN_PROGRESS),
+            Map.entry(DIAGNOSTICS_COLLECTION_IN_PROGRESS, EnvironmentStatus.AVAILABLE),
+            Map.entry(UPDATE_IN_PROGRESS, UPDATE_INITIATED),
+            Map.entry(UPDATE_REQUESTED, UPDATE_INITIATED),
+            Map.entry(UPDATE_FAILED, EnvironmentStatus.UPDATE_FAILED),
+            Map.entry(UPSCALE_FAILED, EnvironmentStatus.AVAILABLE),
+            Map.entry(DOWNSCALE_FAILED, EnvironmentStatus.AVAILABLE),
+            Map.entry(VERTICAL_SCALE_FAILED, EnvironmentStatus.AVAILABLE),
+            Map.entry(REPAIR_FAILED, FREEIPA_UNHEALTHY),
+            Map.entry(CREATE_FAILED, EnvironmentStatus.CREATE_FAILED),
+            Map.entry(DELETE_IN_PROGRESS, FREEIPA_DELETE_IN_PROGRESS),
+            Map.entry(DELETE_FAILED, EnvironmentStatus.DELETE_FAILED),
+            Map.entry(DELETE_COMPLETED, FREEIPA_DELETE_IN_PROGRESS),
+            Map.entry(STOPPED, ENV_STOPPED),
+            Map.entry(STOP_REQUESTED, STOP_FREEIPA_STARTED),
+            Map.entry(START_REQUESTED, START_FREEIPA_STARTED),
+            Map.entry(STOP_IN_PROGRESS, STOP_FREEIPA_STARTED),
+            Map.entry(START_IN_PROGRESS, START_FREEIPA_STARTED),
+            Map.entry(START_FAILED, START_FREEIPA_FAILED),
+            Map.entry(STOP_FAILED, STOP_FREEIPA_FAILED),
+            Map.entry(WAIT_FOR_SYNC, START_SYNCHRONIZE_USERS_STARTED),
+            Map.entry(MAINTENANCE_MODE_ENABLED, EnvironmentStatus.AVAILABLE),
+            Map.entry(DELETED_ON_PROVIDER_SIDE, FREEIPA_DELETED_ON_PROVIDER_SIDE),
+            Map.entry(UPGRADE_CCM_REQUESTED, UPGRADE_CCM_ON_FREEIPA_IN_PROGRESS),
+            Map.entry(UPGRADE_CCM_IN_PROGRESS, UPGRADE_CCM_ON_FREEIPA_IN_PROGRESS),
+            Map.entry(UPGRADE_CCM_FAILED, EnvironmentStatus.AVAILABLE),
+            Map.entry(UNREACHABLE, FREEIPA_UNREACHABLE),
+            Map.entry(UNHEALTHY, FREEIPA_UNHEALTHY),
+            Map.entry(UNKNOWN, FREEIPA_UNHEALTHY)
+    );
 
     private final FreeIpaService freeIpaService;
 
@@ -28,27 +105,15 @@ public class EnvironmentSyncService {
     public EnvironmentStatus getStatusByFreeipa(Environment environment) {
         Optional<DescribeFreeIpaResponse> freeIpaResponseOpt = freeIpaService.internalDescribe(environment.getResourceCrn(), environment.getAccountId());
         if (freeIpaResponseOpt.isPresent()) {
-            DescribeFreeIpaResponse freeIpaResponse = freeIpaResponseOpt.get();
-            switch (freeIpaResponse.getStatus()) {
-                case STOPPED:
-                    return ENV_STOPPED;
-                case DELETED_ON_PROVIDER_SIDE:
-                    return FREEIPA_DELETED_ON_PROVIDER_SIDE;
-                case STOP_FAILED:
-                    return STOP_FREEIPA_FAILED;
-                case START_FAILED:
-                    return START_FREEIPA_FAILED;
-                case START_IN_PROGRESS:
-                    return START_FREEIPA_STARTED;
-                case STOP_IN_PROGRESS:
-                    return STOP_FREEIPA_STARTED;
-                // TODO: add CCM upgrade statuses here
-                default:
-                    break;
-            }
+            return FREEIPA_STATUS_TO_ENV_STATUS_MAP.get(freeIpaResponseOpt.get().getStatus());
         } else if (environment.isCreateFreeIpa()) {
             return FREEIPA_DELETED_ON_PROVIDER_SIDE;
         }
         return EnvironmentStatus.AVAILABLE;
+    }
+
+    @VisibleForTesting
+    Map<Status, EnvironmentStatus> getStatusMap() {
+        return FREEIPA_STATUS_TO_ENV_STATUS_MAP;
     }
 }

--- a/environment/src/test/java/com/sequenceiq/environment/environment/sync/EnvironmentSyncServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/sync/EnvironmentSyncServiceTest.java
@@ -1,9 +1,12 @@
 package com.sequenceiq.environment.environment.sync;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
 import java.util.Optional;
+import java.util.Set;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -61,6 +64,12 @@ public class EnvironmentSyncServiceTest {
 
         EnvironmentStatus actual = underTest.getStatusByFreeipa(environment);
         Assertions.assertEquals(EnvironmentStatus.AVAILABLE, actual);
+    }
+
+    @Test
+    void allFreeIpaStatusesMapped() {
+        Set<Status> testedSet = underTest.getStatusMap().keySet();
+        assertThat(testedSet).hasSameElementsAs(Arrays.asList(Status.values()));
     }
 
     // @formatter:off


### PR DESCRIPTION
Add missing FreeIPA statuses as many cases the syncer function was returning AVAILABLE even if the FreeIPA was in failed/unreachable/unhealthy etc. state. New EnvironmentStatuses were needed too.
