### PR TITLE
CB-18775: Added Salt script for determining the sizes of the DL data to be backed up.

### DIFF
--- a/core/src/main/resources/defaults/vm-logs.json
+++ b/core/src/main/resources/defaults/vm-logs.json
@@ -338,5 +338,9 @@
   {
     "path": "/var/log/dl_postgres_backup.log",
     "label": "dl_backup"
+  },
+  {
+    "path": "/var/log/get_backup_data_sizes.log",
+    "label": "get_backup_data_sizes"
   }
 ]

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/get_backup_data_sizes.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/get_backup_data_sizes.sls
@@ -1,0 +1,23 @@
+{% set configure_remote_db = salt['pillar.get']('postgres:configure_remote_db', 'None') %}
+
+include:
+  - postgresql.disaster_recovery
+
+{% if 'None' != configure_remote_db %}
+get_backup_data_sizes:
+  cmd.run:
+    - name: /opt/salt/scripts/get_backup_data_sizes.sh {{salt['pillar.get']('postgres:clouderamanager:remote_db_url')}} {{salt['pillar.get']('postgres:clouderamanager:remote_db_port')}} {{salt['pillar.get']('postgres:clouderamanager:remote_admin')}}
+{%- else %}
+add_root_role_to_database:
+  cmd.run:
+    - name: createuser root --superuser --login
+    - runas: postgres
+    # counting failure as a success because if `root` is already there, this command will fail.
+    - success_retcodes: 1
+
+get_backup_data_sizes:
+  cmd.run:
+    - name: /opt/salt/scripts/get_backup_data_sizes.sh "" "" ""
+    - require:
+          - cmd: add_root_role_to_database
+{% endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/init.sls
@@ -26,6 +26,13 @@
     - source: salt://postgresql/disaster_recovery/scripts/backup_and_restore_dh.sh
     - template: jinja
 
+/opt/salt/scripts/get_backup_data_sizes.sh:
+  file.managed:
+    - makedirs: True
+    - mode: 750
+    - source: salt://postgresql/disaster_recovery/scripts/get_backup_data_sizes.sh
+    - template: jinja
+
 /opt/salt/postgresql/.pgpass:
   file.managed:
     - makedirs: True

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
@@ -136,7 +136,7 @@ backup_database_for_service() {
   SERVICE="$1"
   is_database_exists $SERVICE
   if [ "$?" -eq 1 ];then
-    doLog "WARN database for $SERVICE doesn't exists"
+    doLog "WARN database for $SERVICE doesn't exist"
     return 0
   fi
 

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/get_backup_data_sizes.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/get_backup_data_sizes.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+
+set -o nounset
+set -o pipefail
+
+# Import validation.
+if [[ $# -lt 3 ]]; then
+  echo "Invalid inputs provided"
+  echo "Script requires the following inputs:"
+  echo "  1. PostgreSQL host name."
+  echo "  2. PostgreSQL port."
+  echo "  3. PostgreSQL user name."
+  exit 1
+fi
+
+# Global variables for the script.
+PSQL_HOST="$1"
+PSQL_PORT="$2"
+PSQL_USERNAME="$3"
+LOG_FILE=/var/log/get_backup_data_sizes.log
+
+# PSQL SSL configuration.
+{%- from 'postgresql/settings.sls' import postgresql with context %}
+{% if postgresql.ssl_enabled == True %}
+export PGSSLROOTCERT="{{ postgresql.root_certs_file }}"
+export PGSSLMODE=verify-full
+{%- endif %}
+
+doLog() {
+  if [ -n "${1-}" ]; then
+    echo "$(date "+%Y-%m-%dT%H:%M:%S") $1" >>$LOG_FILE
+  fi
+}
+
+errorExit() {
+  doLog "Getting backup data sizes failed due to: $1"
+  exit 1
+}
+
+runPSQLCommand() {
+  CMD=$1
+  echo $(psql --host="$PSQL_HOST" --port="$PSQL_PORT" --dbname="postgres" \
+    --username="$PSQL_USERNAME" -c "$CMD" -At 2> >(doLog))
+}
+
+doesDatabaseExist() {
+  DESIRED_DB=$1
+  doLog "Checking the existence of database ${DESIRED_DB}"
+  FOUND_DB=$(runPSQLCommand "SELECT datname FROM pg_catalog.pg_database WHERE datname = '${DESIRED_DB}';")
+  if [[ "$FOUND_DB" != "$DESIRED_DB" ]]; then
+    doLog "Database ${DESIRED_DB} does not exist! Skipping it for this process."
+    return 1
+  fi
+  return 0
+}
+
+getDataSizesForDatabases() {
+  doLog "Getting the data sizes for the local databases."
+
+  DATABASES='"hive" "ranger" "profiler_agent" "profiler_metric"'
+  RESULT=""
+
+  CUR_DB_SIZE=0
+  TRIMMED_DB=""
+  for DB in $DATABASES; do
+    TRIMMED_DB=$(echo "$DB" | tr -d '"')
+    if doesDatabaseExist "$TRIMMED_DB" ; then
+      CUR_DB_SIZE=$(runPSQLCommand "SELECT pg_database_size('${TRIMMED_DB}');")
+      RESULT="${RESULT}${DB}:${CUR_DB_SIZE},"
+      doLog "Size of database ${DB} is ${CUR_DB_SIZE} bytes."
+    fi
+  done
+
+  doLog "Finished getting the data sizes for the local databases."
+  echo "{${RESULT%?}}"
+}
+
+kinit_as() {
+  doLog "Attempting kinit as $1 using Keytab: $2"
+  kinit -kt "$2" "$1/$(hostname -f)"
+  if [[ $? -ne 0 ]]; then
+    errorExit "Couldn't kinit as $1."
+  fi
+}
+
+getDataSizesForHBase() {
+    doLog "Getting data sizes for HBase tables."
+
+    HBASE_KEYTAB=$(find /run/cloudera-scm-agent/process/ \
+      -name "*.keytab" -a \( -path "*hbase-REGIONSERVER*" -o -path "*hbase-MASTER*" \) \
+      -a -type f | head -n 1)
+    kinit_as "hbase" "$HBASE_KEYTAB"
+
+    # Get sizes of each table along with the name of the table. (Sizes are duplicated which is why we skip the second field)
+    SIZES=($(hdfs --loglevel ERROR  dfs -du -x /hbase/data/default/ 2> >(doLog) | awk '{print $1" "$3}'))
+
+    # Construct final output from response.
+    RESULT=""
+    TABLE_NAME=""
+    CUR_SIZE=""
+    IDX=0
+    {% raw %}
+    while [[ ${IDX} -lt ${#SIZES[@]} ]]; do
+    {% endraw %}
+      CUR_SIZE="${SIZES[$IDX]}"
+      TABLE_NAME="${SIZES[$((IDX+1))]##*/}" # Remove preceding directories in path to table.
+      TABLE_NAME=$(echo ${TABLE_NAME} | awk '{print tolower($0)}')
+      doLog "Size of HBase table \"${TABLE_NAME}\" is ${CUR_SIZE} bytes."
+
+      RESULT="${RESULT}\"${TABLE_NAME}\":${CUR_SIZE},"
+      IDX=$((IDX+2))
+    done
+
+    doLog "Finished getting data sizes for HBase tables."
+    echo "{${RESULT%?}}"
+}
+
+getDataSizesForSolr() {
+  doLog "Getting data sizes for Solr collections."
+
+  SOLR_KEYTAB=$(find /run/cloudera-scm-agent/process/ -name "*.keytab" -path "*solr-SOLR_SERVER*" | head -n 1)
+  kinit_as "solr" "$SOLR_KEYTAB"
+
+  # Obtain sizes for all Solr shards. Below query simply obtains the sizes of each shard for each collection, ensuring to ignore replicas by taking
+  # the maximum size replica, and then summing the sizes of the shards for each collection.
+  SIZES=$(curl -k -s --negotiate -u : "https://$(hostname -f):8985/solr/admin/cores?action=STATUS&wt=json&indent=true" | \
+    jq -c 'reduce .status[] as $x (null; .[$x.cloud.collection][$x.cloud.shard] = ([.[$x.cloud.collection][$x.cloud.shard], $x.index.sizeInBytes] | max))
+    | reduce to_entries[] as $x (null; .[$x.key] += ([$x.value[]] | add))')
+  doLog "Solr collection sizes result: ${SIZES}"
+
+  doLog "Finished getting data sizes for Solr collections."
+  echo "$SIZES"
+}
+
+outputDataSizes() {
+  printf '{"database":%s,"hbase":%s,"solr":%s}\n' "$1" "$2" "$3"
+}
+
+# Empty/create log file.
+>$LOG_FILE
+
+# Perform main process.
+doLog "Starting process for getting backup data sizes."
+DB_DATA_SIZES=$(getDataSizesForDatabases)
+HBASE_DATA_SIZES=$(getDataSizesForHBase)
+SOLR_DATA_SIZES=$(getDataSizesForSolr)
+doLog "Finished process for getting backup data sizes."
+outputDataSizes "$DB_DATA_SIZES" "$HBASE_DATA_SIZES" "$SOLR_DATA_SIZES"

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/restore_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/restore_db.sh
@@ -124,7 +124,7 @@ restore_db_from_local() {
 
   is_database_exists $SERVICE
   if [ "$?" -eq 1 ];then
-    doLog "WARN database for $SERVICE doesn't exists"
+    doLog "WARN database for $SERVICE doesn't exist"
     return 0
   fi
 


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-18775

Please look at this [section in my design document](https://docs.google.com/document/d/17cNhj9gz-qoB_lnAXGMMwXIcA8jRYb0TuYhUq9v3s1s/edit#heading=h.5k4lj3wyor3) to understand what's happening in the script.

Overall the objective of this is just to enable functionality via Salt to obtain the sizes of all of the data in the DL to be backed up by the backup operation. This results in a flat JSON string like this:

```
{"database":{"hive":12153503,"ranger":18854559},"hbase":{"atlas_entity_audit_events":408,"atlas_janus":954200},"solr":{"edge_index":69,"fulltext_index":69,"ranger_audits":1663331,"vertex_index":496952}}
```

Tested this by creating a local DL, and running the Salt state using generic Salt commands from within the DL's primary gateway node.