### PR TITLE
CB-18800 [API E2E] Unrecognized field at SaltFunctionReport exception

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/salt/SaltFunctionReport.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/salt/SaltFunctionReport.java
@@ -3,8 +3,10 @@ package com.sequenceiq.it.cloudbreak.salt;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SaltFunctionReport {
     private Map<String, Object> changes;
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/salt/SaltHighstateReport.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/salt/SaltHighstateReport.java
@@ -3,6 +3,9 @@ package com.sequenceiq.it.cloudbreak.salt;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SaltHighstateReport {
     private String jid;
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/salt/SaltStateReport.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/salt/SaltStateReport.java
@@ -2,6 +2,9 @@ package com.sequenceiq.it.cloudbreak.salt;
 
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SaltStateReport {
     private String state;
 


### PR DESCRIPTION
API E2E GCP [#1787--2.63.0-b91-GCP (04-Oct-2022 09:20:24)](http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-gcp/1787/) build is failing, because of [testCreateDistroXWithEncryptedVolumes](http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-gcp/1787/testngreports/com.sequenceiq.it.cloudbreak.testcase.e2e.distrox/DistroXEncryptedVolumeTest/testCreateDistroXWithEncryptedVolumes/) generating Salt report step throws `UnrecognizedPropertyException: Unrecognized field "_stamp"`.

So we should introduce a `@JsonIgnoreProperties(ignoreUnknown = true)` annotation at the related Salt util classes. Furthermore should manage the `getSaltExecutionMetrics` exceptions with warning and the case when the `List<SaltHighstateReport>` is empty.