### PR TITLE
CB-18789 Fixing unit problem in the memory of an instance type. Memor…

### DIFF
--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/AwsPlatformResources.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/AwsPlatformResources.java
@@ -183,7 +183,7 @@ public class AwsPlatformResources implements PlatformResources {
 
     private static final int MAX_RESULTS = 1000;
 
-    private static final int ONE_THOUSAND = 1000;
+    private static final int ONE_THOUSAND_TWENTY_FOUR = 1024;
 
     @Inject
     private CommonAwsClient awsClient;
@@ -770,7 +770,7 @@ public class AwsPlatformResources implements PlatformResources {
     }
 
     private float getMemory(InstanceTypeInfo instanceType) {
-        return (float) instanceType.getMemoryInfo().getSizeInMiB() / ONE_THOUSAND;
+        return (float) instanceType.getMemoryInfo().getSizeInMiB() / ONE_THOUSAND_TWENTY_FOUR;
     }
 
     private List<String> getInstanceTypes(List<String> instanceTypes, int i) {


### PR DESCRIPTION
…y of the instance type was in decimal fraction because AWS returning it in MiB and it was divided by 1000 instead of 1024 which caused the issue.

See detailed description in the commit message.