### PR TITLE
CB-18599 - Some Azure resources types are not tagged - fix arm templates

### DIFF
--- a/cloud-azure/src/main/resources/templates/arm-v2-freeipa.ftl
+++ b/cloud-azure/src/main/resources/templates/arm-v2-freeipa.ftl
@@ -74,6 +74,13 @@
                 "name": "[variables('${group.compressedName}AsName')]",
                 "apiVersion": "2018-04-01",
                 "location": "[parameters('region')]",
+                "tags": {
+                    <#if userDefinedTags?? && userDefinedTags?has_content>
+                        <#list userDefinedTags?keys as key>
+                        "${key}": "${userDefinedTags[key]}"<#if key_has_next>,</#if>
+                        </#list>
+                    </#if>
+                },
                 <#if group.managedDisk == true>
                 "sku": {
                     "name": "Aligned"

--- a/cloud-azure/src/main/resources/templates/arm-v2.ftl
+++ b/cloud-azure/src/main/resources/templates/arm-v2.ftl
@@ -99,6 +99,13 @@
                 "name": "[variables('${group.compressedName}AsName')]",
                 "apiVersion": "2018-04-01",
                 "location": "[parameters('region')]",
+                "tags": {
+                    <#if userDefinedTags?? && userDefinedTags?has_content>
+                        <#list userDefinedTags?keys as key>
+                        "${key}": "${userDefinedTags[key]}"<#if key_has_next>,</#if>
+                        </#list>
+                    </#if>
+                },
                 "sku": {
                     "name": "Aligned"
                 },
@@ -563,6 +570,13 @@
                     "apiVersion": "2020-06-01",
                     "name": "${loadBalancer.name}-publicIp",
                     "location": "[parameters('region')]",
+                    "tags": {
+                        <#if userDefinedTags?? && userDefinedTags?has_content>
+                            <#list userDefinedTags?keys as key>
+                            "${key}": "${userDefinedTags[key]}"<#if key_has_next>,</#if>
+                            </#list>
+                        </#if>
+                    },
                     "sku": {
                         "name": "${loadBalancer.sku.templateName}"
                     },

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/AzureMarketplaceImageTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/AzureMarketplaceImageTest.java
@@ -21,6 +21,7 @@ import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.credential.CredentialTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.telemetry.TelemetryTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
 import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
 import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
 
@@ -81,6 +82,9 @@ public class AzureMarketplaceImageTest extends AbstractE2ETest {
             }
             if (!image.getId().equals(imageUuid)) {
                 throw new IllegalArgumentException("Image uuid does not match the Marketplace image uuid!");
+            }
+            if (environment.getTags().getUserDefined().isEmpty()) {
+                throw new TestFailException("User defined tags aren't being set in the environment!");
             }
             return testDto;
         };


### PR DESCRIPTION
Jira - https://jira.cloudera.com/browse/CB-18599

Added tags to availabilitySets and PublicIPAddresses for load balancer, the only way that I could test if the resource has tags on it is to check if tags exist on the environment itself. I couldn't get the resources from the current way the environment is defined and changing that will take a lot more effort.