### PR TITLE
CB-18534 UpgradePreconditionService.getNotStoppedAttachedClusters() m…

### DIFF
--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/dto/StackDto.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/dto/StackDto.java
@@ -17,7 +17,6 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.StringUtils;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceMetadataType;
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.common.domain.IdAware;
@@ -97,9 +96,7 @@ public class StackDto implements OrchestratorAware, StackDtoDelegate, MdcContext
         this.tenant = tenant;
     }
 
-    @VisibleForTesting
     public StackDto() {
-
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJob.java
@@ -129,7 +129,7 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
 
     @Override
     protected Optional<MdcContextInfoProvider> getMdcContextConfigProvider() {
-        return Optional.ofNullable(stackDtoService.getStackViewByIdOpt(getStackId()).orElse(null));
+        return Optional.ofNullable(stackDtoService.getStackViewById(getStackId()));
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackDtoRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackDtoRepository.java
@@ -152,6 +152,13 @@ public interface StackDtoRepository extends Repository<Stack, Long> {
     )
     Optional<StackViewDelegate> findByNameAndAccountId(@Param("names") String resourceName, @Param("accountId") String accountId);
 
+    @Query(BASE_QUERY
+            + "WHERE s.environmentCrn = :environmentCrn "
+            + "AND s.type in :stackTypes"
+    )
+    List<StackViewDelegate> findAllByEnvironmentCrnAndStackType(@Param("environmentCrn") String environmentCrn,
+            @Param("stackTypes") List<StackType> stackTypes);
+
     @Query("SELECT sc FROM SecurityConfig sc " +
             "LEFT JOIN sc.stack s " +
             "WHERE s.id = :stackId")

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/service/upgrade/DistroXUpgradeAvailabilityService.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/service/upgrade/DistroXUpgradeAvailabilityService.java
@@ -89,7 +89,7 @@ public class DistroXUpgradeAvailabilityService {
     public UpgradeV4Response checkForUpgrade(NameOrCrn nameOrCrn, Long workspaceId, UpgradeV4Request request, String userCrn) {
         Stack stack = stackService.getByNameOrCrnInWorkspace(nameOrCrn, workspaceId);
         String accountId = Crn.safeFromString(userCrn).getAccountId();
-        UpgradeV4Response response = stackUpgradeOperations.checkForClusterUpgrade(accountId, stack, workspaceId, request);
+        UpgradeV4Response response = stackUpgradeOperations.checkForClusterUpgrade(accountId, stack, request);
         List<ImageInfoV4Response> filteredCandidates = filterCandidates(accountId, stack, request, response);
         List<ImageInfoV4Response> razValidatedCandidates = validateRangerRazCandidates(accountId, stack, filteredCandidates);
         response.setUpgradeCandidates(razValidatedCandidates);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/UpgradePreconditionServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/UpgradePreconditionServiceTest.java
@@ -2,11 +2,13 @@ package com.sequenceiq.cloudbreak.service.upgrade;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import java.util.Set;
+import java.util.List;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,14 +16,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.blueprint.responses.BlueprintV4ViewResponse;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.common.BlueprintBasedUpgradeOption;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Response;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Responses;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.views.ClusterViewV4Response;
+import com.sequenceiq.cloudbreak.domain.Blueprint;
+import com.sequenceiq.cloudbreak.domain.BlueprintUpgradeOption;
 import com.sequenceiq.cloudbreak.domain.StopRestrictionReason;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.dto.StackDtoDelegate;
 import com.sequenceiq.cloudbreak.service.spot.SpotInstanceUsageCondition;
 import com.sequenceiq.cloudbreak.service.stack.StackStopRestrictionService;
 
@@ -39,75 +38,32 @@ public class UpgradePreconditionServiceTest {
 
     @Test
     public void testCheckForRunningAttachedClustersShouldReturnErrorMessageWhenThereAreClustersInNotProperState() {
-        StackViewV4Response dataHubStack1 = createStackResponse(Status.AVAILABLE, "stack-1", "stack-crn-1");
-        dataHubStack1.setCluster(createClusterResponse(Status.AVAILABLE, BlueprintBasedUpgradeOption.UPGRADE_ENABLED));
-        StackViewV4Response dataHubStack2 = createStackResponse(Status.DELETE_COMPLETED, "stack-2", "stack-crn-2");
-        dataHubStack2.setCluster(createClusterResponse(Status.DELETE_COMPLETED, BlueprintBasedUpgradeOption.UPGRADE_ENABLED));
-        StackViewV4Response dataHubStack3 = createStackResponse(Status.STOPPED, "stack-3", "stack-crn-2");
-        dataHubStack3.setCluster(createClusterResponse(Status.DELETE_COMPLETED, BlueprintBasedUpgradeOption.UPGRADE_ENABLED));
-        StackViewV4Responses stackViewV4Responses = new StackViewV4Responses(Set.of(dataHubStack1, dataHubStack2, dataHubStack3));
-        Stack stack = new Stack();
+        StackDtoDelegate dataHubStack1 = createStackDtoDelegate(Status.AVAILABLE, "stack-1", "stack-crn-1", BlueprintUpgradeOption.GA);
+        StackDtoDelegate dataHubStack2 = createStackDtoDelegate(Status.DELETE_COMPLETED, "stack-2", "stack-crn-2", BlueprintUpgradeOption.GA);
+        StackDtoDelegate dataHubStack3 = createStackDtoDelegate(Status.STOPPED, "stack-3", "stack-crn-2", BlueprintUpgradeOption.GA);
+        List<StackDtoDelegate> datahubs = List.of(dataHubStack1, dataHubStack2, dataHubStack3);
 
-        String actualRunning = underTest.checkForRunningAttachedClusters(stackViewV4Responses, stack, null);
-        String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(stackViewV4Responses);
+        String actualRunning = underTest.checkForRunningAttachedClusters(datahubs, null);
+        String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(datahubs);
 
         assertEquals("There are attached Data Hub clusters in incorrect state: stack-1. Please stop those to be able to perform the upgrade.",
                 actualRunning);
         assertEquals("", actualNonUpgradeable);
 
-        verify(spotInstanceUsageCondition).isStackRunsOnSpotInstances(stack);
-    }
-
-    @Test
-    public void testCheckForRunningAttachedClustersShouldNotReturnErrorMessageWhenThereAreClustersInNotProperStateAndTheSkipValidationFlagIsTrue() {
-        StackViewV4Response dataHubStack1 = createStackResponse(Status.AVAILABLE, "stack-1", "stack-crn-1");
-        dataHubStack1.setCluster(createClusterResponse(Status.AVAILABLE, BlueprintBasedUpgradeOption.UPGRADE_ENABLED));
-        StackViewV4Response dataHubStack2 = createStackResponse(Status.DELETE_COMPLETED, "stack-2", "stack-crn-2");
-        dataHubStack2.setCluster(createClusterResponse(Status.DELETE_COMPLETED, BlueprintBasedUpgradeOption.UPGRADE_ENABLED));
-        StackViewV4Response dataHubStack3 = createStackResponse(Status.STOPPED, "stack-3", "stack-crn-2");
-        dataHubStack3.setCluster(createClusterResponse(Status.DELETE_COMPLETED, BlueprintBasedUpgradeOption.UPGRADE_ENABLED));
-        StackViewV4Responses stackViewV4Responses = new StackViewV4Responses(Set.of(dataHubStack1, dataHubStack2, dataHubStack3));
-        Stack stack = new Stack();
-
-        String actualRunning = underTest.checkForRunningAttachedClusters(stackViewV4Responses, stack, Boolean.TRUE);
-
-        assertEquals("", actualRunning);
-    }
-
-    @Test
-    public void testCheckForRunningAttachedClustersShouldNotReturnErrorMessageWhenThereAreNoClustersInNotProperState() {
-        StackViewV4Response dataHubStack1 = createStackResponse(Status.STOPPED, "stack-1", "stack-crn-1");
-        dataHubStack1.setCluster(createClusterResponse(Status.STOPPED, BlueprintBasedUpgradeOption.UPGRADE_ENABLED));
-        StackViewV4Response dataHubStack2 = createStackResponse(Status.DELETE_COMPLETED, "stack-2", "stack-crn-2");
-        dataHubStack2.setCluster(createClusterResponse(Status.DELETE_COMPLETED, BlueprintBasedUpgradeOption.UPGRADE_ENABLED));
-        StackViewV4Response dataHubStack3 = createStackResponse(Status.STOPPED, "stack-3", "stack-crn-3");
-        dataHubStack3.setCluster(createClusterResponse(Status.DELETE_COMPLETED, BlueprintBasedUpgradeOption.UPGRADE_ENABLED));
-
-        StackViewV4Responses stackViewV4Responses = new StackViewV4Responses(Set.of(dataHubStack1, dataHubStack2, dataHubStack3));
-
-        String actualRunning = underTest.checkForRunningAttachedClusters(stackViewV4Responses, new Stack(), null);
-        String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(stackViewV4Responses);
-
-        assertEquals("", actualRunning);
-        assertEquals("", actualNonUpgradeable);
-
-        verifyNoInteractions(spotInstanceUsageCondition);
+        verify(spotInstanceUsageCondition).isStackRunsOnSpotInstances(dataHubStack1);
     }
 
     @Test
     public void testCheckForRunningAttachedClustersShouldNotReturnErrorMessageWhenThereAreOnlyOneClusterIsRunningWithEphemeralVolume() {
-        StackViewV4Response dataHubStack1 = createStackResponse(Status.AVAILABLE, "stack-1", "stack-crn-1");
-        dataHubStack1.setCluster(createClusterResponse(Status.AVAILABLE, BlueprintBasedUpgradeOption.UPGRADE_ENABLED));
-        StackViewV4Response dataHubStack2 = createStackResponse(Status.DELETE_COMPLETED, "stack-2", "stack-crn-2");
-        dataHubStack2.setCluster(createClusterResponse(Status.DELETE_COMPLETED, BlueprintBasedUpgradeOption.UPGRADE_ENABLED));
-        StackViewV4Response dataHubStack3 = createStackResponse(Status.STOPPED, "stack-3", "stack-crn-3");
-        dataHubStack3.setCluster(createClusterResponse(Status.DELETE_COMPLETED, BlueprintBasedUpgradeOption.UPGRADE_ENABLED));
+        StackDtoDelegate dataHubStack1 = createStackDtoDelegate(Status.AVAILABLE, "stack-1", "stack-crn-1", BlueprintUpgradeOption.GA);
+        StackDtoDelegate dataHubStack2 = createStackDtoDelegate(Status.DELETE_COMPLETED, "stack-2", "stack-crn-2", BlueprintUpgradeOption.GA);
+        StackDtoDelegate dataHubStack3 = createStackDtoDelegate(Status.STOPPED, "stack-3", "stack-crn-3", BlueprintUpgradeOption.GA);
 
-        StackViewV4Responses stackViewV4Responses = new StackViewV4Responses(Set.of(dataHubStack1, dataHubStack2, dataHubStack3));
+        List<StackDtoDelegate> datahubs = List.of(dataHubStack1, dataHubStack2, dataHubStack3);
         when(stackStopRestrictionService.isInfrastructureStoppable(any())).thenReturn(StopRestrictionReason.EPHEMERAL_VOLUMES);
 
-        String actual = underTest.checkForRunningAttachedClusters(stackViewV4Responses, new Stack(), Boolean.FALSE);
-        String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(stackViewV4Responses);
+        String actual = underTest.checkForRunningAttachedClusters(datahubs, Boolean.FALSE);
+        String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(datahubs);
 
         assertEquals("", actual);
         assertEquals("", actualNonUpgradeable);
@@ -117,37 +73,30 @@ public class UpgradePreconditionServiceTest {
 
     @Test
     public void testCheckForRunningAttachedClustersShouldNotReturnErrorMessageWhenThereAreOnlyOneClusterIsRunningWithSpotInstance() {
-        StackViewV4Response dataHubStack1 = createStackResponse(Status.AVAILABLE, "stack-1", "stack-crn-1");
-        dataHubStack1.setCluster(createClusterResponse(Status.AVAILABLE, BlueprintBasedUpgradeOption.UPGRADE_ENABLED));
-        StackViewV4Response dataHubStack2 = createStackResponse(Status.DELETE_COMPLETED, "stack-2", "stack-crn-2");
-        dataHubStack2.setCluster(createClusterResponse(Status.DELETE_COMPLETED, BlueprintBasedUpgradeOption.UPGRADE_ENABLED));
-        StackViewV4Response dataHubStack3 = createStackResponse(Status.STOPPED, "stack-3", "stack-crn-3");
-        dataHubStack3.setCluster(createClusterResponse(Status.DELETE_COMPLETED, BlueprintBasedUpgradeOption.UPGRADE_ENABLED));
-        StackViewV4Responses stackViewV4Responses = new StackViewV4Responses(Set.of(dataHubStack1, dataHubStack2, dataHubStack3));
-        Stack stack = new Stack();
+        StackDtoDelegate dataHubStack1 = createStackDtoDelegate(Status.AVAILABLE, "stack-1", "stack-crn-1", BlueprintUpgradeOption.GA);
+        StackDtoDelegate dataHubStack2 = createStackDtoDelegate(Status.DELETE_COMPLETED, "stack-2", "stack-crn-2", BlueprintUpgradeOption.GA);
+        StackDtoDelegate dataHubStack3 = createStackDtoDelegate(Status.STOPPED, "stack-3", "stack-crn-3", BlueprintUpgradeOption.GA);
+        List<StackDtoDelegate> datahubs = List.of(dataHubStack1, dataHubStack2, dataHubStack3);
         when(stackStopRestrictionService.isInfrastructureStoppable(any())).thenReturn(StopRestrictionReason.NONE);
-        when(spotInstanceUsageCondition.isStackRunsOnSpotInstances(stack)).thenReturn(true);
+        when(spotInstanceUsageCondition.isStackRunsOnSpotInstances(dataHubStack1)).thenReturn(true);
 
-        String actualRunning = underTest.checkForRunningAttachedClusters(stackViewV4Responses, stack, Boolean.FALSE);
-        String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(stackViewV4Responses);
+        String actualRunning = underTest.checkForRunningAttachedClusters(datahubs, Boolean.FALSE);
+        String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(datahubs);
 
         assertEquals("", actualRunning);
         assertEquals("", actualNonUpgradeable);
 
-        verify(spotInstanceUsageCondition).isStackRunsOnSpotInstances(stack);
+        verify(spotInstanceUsageCondition).isStackRunsOnSpotInstances(dataHubStack1);
     }
 
     @Test
     public void testCheckForUpgradeableAttachedClustersShouldReturnErrorMessageWhenThereIsNoNonUpgradeableCluster() {
-        StackViewV4Response dataHubStack1 = createStackResponse(Status.STOPPED, "stack-1", "stack-crn-1");
-        dataHubStack1.setCluster(createClusterResponse(Status.STOPPED, BlueprintBasedUpgradeOption.UPGRADE_ENABLED));
-        StackViewV4Response dataHubStack2 = createStackResponse(Status.DELETE_COMPLETED, "stack-2", "stack-crn-2");
-        dataHubStack2.setCluster(createClusterResponse(Status.DELETE_COMPLETED, BlueprintBasedUpgradeOption.UPGRADE_DISABLED));
-        StackViewV4Responses stackViewV4Responses = new StackViewV4Responses(Set.of(dataHubStack1, dataHubStack2));
-        Stack stack = new Stack();
+        StackDtoDelegate dataHubStack1 = createStackDtoDelegate(Status.STOPPED, "stack-1", "stack-crn-1", BlueprintUpgradeOption.GA);
+        StackDtoDelegate dataHubStack2 = createStackDtoDelegate(Status.DELETE_COMPLETED, "stack-2", "stack-crn-2", BlueprintUpgradeOption.DISABLED);
+        List<StackDtoDelegate> datahubs = List.of(dataHubStack1, dataHubStack2);
 
-        String actualRunning = underTest.checkForRunningAttachedClusters(stackViewV4Responses, stack, Boolean.FALSE);
-        String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(stackViewV4Responses);
+        String actualRunning = underTest.checkForRunningAttachedClusters(datahubs, Boolean.FALSE);
+        String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(datahubs);
 
         assertEquals("There are attached Data Hub clusters that are non-upgradeable: stack-2. Please delete those to be able to perform the upgrade.",
                 actualNonUpgradeable);
@@ -156,16 +105,13 @@ public class UpgradePreconditionServiceTest {
 
     @Test
     public void testCheckForUpgradeableAttachedClustersShouldNotReturnErrorMessageWhenThereIsNoNonUpgradeableCluster() {
-        StackViewV4Response dataHubStack1 = createStackResponse(Status.STOPPED, "stack-1", "stack-crn-1");
-        dataHubStack1.setCluster(createClusterResponse(Status.STOPPED, BlueprintBasedUpgradeOption.UPGRADE_ENABLED));
-        StackViewV4Response dataHubStack2 = createStackResponse(Status.DELETE_COMPLETED, "stack-2", "stack-crn-2");
-        dataHubStack2.setCluster(createClusterResponse(Status.DELETE_COMPLETED, BlueprintBasedUpgradeOption.UPGRADE_ENABLED));
-        StackViewV4Response dataHubStack3 = createStackResponse(Status.STOPPED, "stack-3", "stack-crn-3");
-        dataHubStack3.setCluster(createClusterResponse(Status.STOPPED, BlueprintBasedUpgradeOption.UPGRADE_ENABLED));
-        StackViewV4Responses stackViewV4Responses = new StackViewV4Responses(Set.of(dataHubStack1, dataHubStack2, dataHubStack3));
+        StackDtoDelegate dataHubStack1 = createStackDtoDelegate(Status.STOPPED, "stack-1", "stack-crn-1", BlueprintUpgradeOption.GA);
+        StackDtoDelegate dataHubStack2 = createStackDtoDelegate(Status.DELETE_COMPLETED, "stack-2", "stack-crn-2", BlueprintUpgradeOption.GA);
+        StackDtoDelegate dataHubStack3 = createStackDtoDelegate(Status.STOPPED, "stack-3", "stack-crn-3", BlueprintUpgradeOption.GA);
+        List<StackDtoDelegate> datahubs = List.of(dataHubStack1, dataHubStack2, dataHubStack3);
 
-        String actual = underTest.checkForRunningAttachedClusters(stackViewV4Responses, new Stack(), Boolean.FALSE);
-        String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(stackViewV4Responses);
+        String actual = underTest.checkForRunningAttachedClusters(datahubs, Boolean.FALSE);
+        String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(datahubs);
 
         assertEquals("", actual);
         assertEquals("", actualNonUpgradeable);
@@ -175,31 +121,28 @@ public class UpgradePreconditionServiceTest {
 
     @Test
     public void testCheckForAttachedClustersShouldReturnBothErrorMessagesWhenBothValidationsFail() {
-        StackViewV4Response dataHubStack1 = createStackResponse(Status.AVAILABLE, "stack-1", "stack-crn-1");
-        dataHubStack1.setCluster(createClusterResponse(Status.AVAILABLE, BlueprintBasedUpgradeOption.UPGRADE_ENABLED));
-        StackViewV4Response dataHubStack2 = createStackResponse(Status.DELETE_COMPLETED, "stack-2", "stack-crn-2");
-        dataHubStack2.setCluster(createClusterResponse(Status.DELETE_COMPLETED, BlueprintBasedUpgradeOption.UPGRADE_DISABLED));
-        StackViewV4Response dataHubStack3 = createStackResponse(Status.STOPPED, "stack-3", "stack-crn-2");
-        StackViewV4Responses stackViewV4Responses = new StackViewV4Responses(Set.of(dataHubStack1, dataHubStack2, dataHubStack3));
-        Stack stack = new Stack();
+        StackDtoDelegate dataHubStack1 = createStackDtoDelegate(Status.AVAILABLE, "stack-1", "stack-crn-1", BlueprintUpgradeOption.GA);
+        StackDtoDelegate dataHubStack2 = createStackDtoDelegate(Status.DELETE_COMPLETED, "stack-2", "stack-crn-2", BlueprintUpgradeOption.DISABLED);
+        StackDtoDelegate dataHubStack3 = createStackDtoDelegate(Status.STOPPED, "stack-3", "stack-crn-3", BlueprintUpgradeOption.GA);
+        List<StackDtoDelegate> datahubs = List.of(dataHubStack1, dataHubStack2, dataHubStack3);
 
-        String actualRunning = underTest.checkForRunningAttachedClusters(stackViewV4Responses, stack, Boolean.FALSE);
-        String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(stackViewV4Responses);
+        String actualRunning = underTest.checkForRunningAttachedClusters(datahubs, Boolean.FALSE);
+        String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(datahubs);
 
         assertEquals("There are attached Data Hub clusters in incorrect state: stack-1. Please stop those to be able to perform the upgrade.",
                 actualRunning);
-        assertEquals("There are attached Data Hub clusters that are non-upgradeable: stack-2,stack-3. Please delete those to be able to perform the upgrade.",
+        assertEquals("There are attached Data Hub clusters that are non-upgradeable: stack-2. Please delete those to be able to perform the upgrade.",
                 actualNonUpgradeable);
 
-        verify(spotInstanceUsageCondition).isStackRunsOnSpotInstances(stack);
+        verify(spotInstanceUsageCondition).isStackRunsOnSpotInstances(dataHubStack1);
     }
 
     @Test
     public void testDataHubsNotAttached() {
-        StackViewV4Responses stackViewV4Responses = new StackViewV4Responses(Set.of());
+        List<StackDtoDelegate> datahubs = List.of();
 
-        String actual = underTest.checkForRunningAttachedClusters(stackViewV4Responses, new Stack(), Boolean.FALSE);
-        String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(stackViewV4Responses);
+        String actual = underTest.checkForRunningAttachedClusters(datahubs, Boolean.FALSE);
+        String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(datahubs);
 
         assertEquals("", actual);
         assertEquals("", actualNonUpgradeable);
@@ -207,21 +150,14 @@ public class UpgradePreconditionServiceTest {
         verifyNoInteractions(spotInstanceUsageCondition);
     }
 
-    private ClusterViewV4Response createClusterResponse(Status clusterStatus, BlueprintBasedUpgradeOption upgradeable) {
-        ClusterViewV4Response dataHubCluster = new ClusterViewV4Response();
-        dataHubCluster.setStatus(clusterStatus);
-        BlueprintV4ViewResponse blueprint = new BlueprintV4ViewResponse();
-        blueprint.setUpgradeable(upgradeable);
-        dataHubCluster.setBlueprint(blueprint);
-
-        return dataHubCluster;
-    }
-
-    private StackViewV4Response createStackResponse(Status stackStatus, String stackName, String stackCrn) {
-        StackViewV4Response dataHubStack = new StackViewV4Response();
-        dataHubStack.setStatus(stackStatus);
-        dataHubStack.setName(stackName);
-        dataHubStack.setCrn(stackCrn);
+    private StackDtoDelegate createStackDtoDelegate(Status stackStatus, String stackName, String stackCrn, BlueprintUpgradeOption blueprintUpgradeOption) {
+        StackDtoDelegate dataHubStack = mock(StackDtoDelegate.class);
+        when(dataHubStack.getStatus()).thenReturn(stackStatus);
+        when(dataHubStack.getName()).thenReturn(stackName);
+        lenient().when(dataHubStack.getResourceCrn()).thenReturn(stackCrn);
+        Blueprint blueprint = mock(Blueprint.class);
+        when(blueprint.getBlueprintUpgradeOption()).thenReturn(blueprintUpgradeOption);
+        when(dataHubStack.getBlueprint()).thenReturn(blueprint);
         return dataHubStack;
     }
 }

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/service/upgrade/DistroXUpgradeAvailabilityServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/service/upgrade/DistroXUpgradeAvailabilityServiceTest.java
@@ -125,7 +125,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         UpgradeV4Response response = new UpgradeV4Response();
         response.setUpgradeCandidates(List.of(mock(ImageInfoV4Response.class), mock(ImageInfoV4Response.class)));
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(stack);
-        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, WORKSPACE_ID, request)).thenReturn(response);
+        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, request)).thenReturn(response);
 
         UpgradeV4Response result = underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN);
 
@@ -147,7 +147,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         response.setCurrent(currentImage);
         when(entitlementService.datahubRuntimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(false);
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(stack);
-        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, WORKSPACE_ID, request)).thenReturn(response);
+        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, request)).thenReturn(response);
         when(clusterService.getClusterByStackResourceCrn(DATALAKE_CRN)).thenReturn(datalakeCluster);
         when(runtimeVersionService.getRuntimeVersion(any())).thenReturn(Optional.of("7.2.0"));
 
@@ -173,7 +173,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         response.setCurrent(currentImage);
         when(entitlementService.datahubRuntimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(false);
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(stack);
-        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, WORKSPACE_ID, request)).thenReturn(response);
+        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, request)).thenReturn(response);
         when(clusterService.getClusterByStackResourceCrn(any())).thenReturn(datalakeCluster);
 
         assertDoesNotThrow(() -> underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN));
@@ -193,7 +193,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         response.setCurrent(currentImage);
         when(entitlementService.datahubRuntimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(true);
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(stack);
-        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, WORKSPACE_ID, request)).thenReturn(response);
+        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, request)).thenReturn(response);
 
         assertDoesNotThrow(() -> underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN));
 
@@ -213,7 +213,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         image3.setCreated(5L);
         response.setUpgradeCandidates(List.of(image1, image2, image3));
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(stack);
-        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, WORKSPACE_ID, request)).thenReturn(response);
+        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, request)).thenReturn(response);
 
         UpgradeV4Response result = underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN);
 
@@ -237,7 +237,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         ImageInfoV4Response image9 = createImageResponse(6L, "C");
         response.setUpgradeCandidates(List.of(image1, image2, image3, image4, image5, image6, image7, image8, image9));
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(stack);
-        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, WORKSPACE_ID, request)).thenReturn(response);
+        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, request)).thenReturn(response);
 
         UpgradeV4Response result = underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN);
 
@@ -267,7 +267,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         clusterView.setId(1L);
         ReflectionTestUtils.setField(stackView, "cluster", clusterView);
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(stack);
-        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, WORKSPACE_ID, request)).thenReturn(response);
+        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, request)).thenReturn(response);
         when(stackViewService.findDatalakeViewByEnvironmentCrn(stack.getEnvironmentCrn())).thenReturn(Optional.of(stackView));
         when(runtimeVersionService.getRuntimeVersion(eq(clusterView.getId()))).thenReturn(Optional.of("C"));
         when(entitlementService.datahubRuntimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(true);
@@ -286,7 +286,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         UpgradeV4Response response = new UpgradeV4Response();
         response.setUpgradeCandidates(List.of());
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(stack);
-        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, WORKSPACE_ID, request)).thenReturn(response);
+        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, request)).thenReturn(response);
 
         UpgradeV4Response result = underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN);
 
@@ -310,7 +310,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         clusterView.setId(1L);
         ReflectionTestUtils.setField(stackView, "cluster", clusterView);
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(stack);
-        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, WORKSPACE_ID, request)).thenReturn(response);
+        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, request)).thenReturn(response);
         when(stackViewService.findDatalakeViewByEnvironmentCrn(stack.getEnvironmentCrn())).thenReturn(Optional.of(stackView));
         when(runtimeVersionService.getRuntimeVersion(eq(clusterView.getId()))).thenReturn(Optional.of("7.1.0"));
         when(entitlementService.isDifferentDataHubAndDataLakeVersionAllowed(anyString())).thenReturn(false);
@@ -340,7 +340,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         clusterView.setId(1L);
         ReflectionTestUtils.setField(stackView, "cluster", clusterView);
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(stack);
-        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, WORKSPACE_ID, request)).thenReturn(response);
+        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, request)).thenReturn(response);
         when(entitlementService.isDifferentDataHubAndDataLakeVersionAllowed(anyString())).thenReturn(true);
 
         UpgradeV4Response result = underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN);
@@ -364,7 +364,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         response.setCurrent(current);
         when(clusterService.getClusterByStackResourceCrn(any())).thenReturn(datalakeCluster);
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(stack);
-        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, WORKSPACE_ID, request)).thenReturn(response);
+        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, request)).thenReturn(response);
         when(entitlementService.datahubRuntimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(false);
 
         UpgradeV4Response result = underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN);
@@ -390,7 +390,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         response.setCurrent(current);
         when(clusterService.getClusterByStackResourceCrn(any())).thenReturn(datalakeCluster);
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(stack);
-        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, WORKSPACE_ID, request)).thenReturn(response);
+        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, request)).thenReturn(response);
         when(entitlementService.datahubRuntimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(false);
 
         UpgradeV4Response result = underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN);
@@ -422,7 +422,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         when(runtimeVersionService.getRuntimeVersion(any())).thenReturn(Optional.of("C"));
         when(clusterService.getClusterByStackResourceCrn(any())).thenReturn(datalakeCluster);
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(stack);
-        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, WORKSPACE_ID, request)).thenReturn(response);
+        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, request)).thenReturn(response);
         when(entitlementService.datahubRuntimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(false);
         when(entitlementService.isDifferentDataHubAndDataLakeVersionAllowed(anyString())).thenReturn(false);
         when(stackViewService.findDatalakeViewByEnvironmentCrn(stack.getEnvironmentCrn())).thenReturn(Optional.of(stackView));
@@ -451,7 +451,7 @@ public class DistroXUpgradeAvailabilityServiceTest {
         response.setCurrent(current);
         stack.getCluster().getBlueprint().setBlueprintUpgradeOption(BlueprintUpgradeOption.GA);
         when(stackService.getByNameOrCrnInWorkspace(CLUSTER, WORKSPACE_ID)).thenReturn(stack);
-        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, WORKSPACE_ID, request)).thenReturn(response);
+        when(stackUpgradeOperations.checkForClusterUpgrade(ACCOUNT_ID, stack, request)).thenReturn(response);
 
         UpgradeV4Response result = underTest.checkForUpgrade(CLUSTER, WORKSPACE_ID, request, USER_CRN);
 


### PR DESCRIPTION
…ethod contains wrong condition: isStoppable(stack)

From now on instead of the Datalake stack, the datahub stacks are checked. Also switched from `StackViewV4Responses` and `StackView` to `StackDto`, as it was expected for checking stopability. Cluster status check has been also removed as:
- cluster status is depracated already
- it would required adding extra fields for StackDto

See detailed description in the commit message.