### PR TITLE
CB-18847 [API E2E] GCP Storage and Compute client need to be updated based on latest changes

### DIFF
--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -129,12 +129,13 @@ dependencies {
   implementation group: 'org.kohsuke', name: 'wordnet-random-name', version: '1.3'
   implementation group: 'com.google.code.gson',          name: 'gson',                           version: gsonVersion
   implementation (group: 'com.microsoft.azure',          name: 'azure',                          version: azureSdkVersion) { exclude group: 'org.slf4j' }
-  implementation (group:  'com.google.apis',              name: 'google-api-services-compute',    version: 'v1-rev20211019-1.32.1'){
+  implementation (group: 'com.google.apis',              name: 'google-api-services-compute',    version: 'v1-rev20220918-2.0.0'){
     exclude group: 'com.google.guava',  module: 'guava'
   }
-  implementation group: 'com.google.apis',               name: 'google-api-services-storage',    version: 'v1-rev20211018-1.32.1'
-  implementation group: 'com.google.auth',               name: 'google-auth-library-oauth2-http',            version: '1.2.2'
-  implementation group: 'com.google.http-client',        name: 'google-http-client-jackson2',                version: '1.40.1'
+  implementation group: 'com.google.apis',               name: 'google-api-services-storage',    version: 'v1-rev20220705-2.0.0'
+  implementation group: 'com.google.auth',               name: 'google-auth-library-oauth2-http',            version: '1.11.0'
+  implementation group: 'com.google.http-client',        name: 'google-http-client-jackson2',                version: '1.42.2'
+  implementation group: 'com.google.cloud',              name: 'google-cloud-storage',           version: '2.13.0'
   implementation group: 'com.microsoft.azure',           name: 'azure-storage',                  version: azureStorageSdkVersion
   implementation group: 'com.microsoft.azure',           name: 'azure-data-lake-store-sdk',      version: '2.1.5'
 


### PR DESCRIPTION
We got several intermittent GCP list/query storage object, list/delete/stop instances ([CB-18678](https://jira.cloudera.com/browse/CB-18678), [CB-18788](https://jira.cloudera.com/browse/CB-18788)) issues during our E2E builds. Furthermore we had some deprecated components (JacksonFactory, GoogleCredential) on these GCP clients. So we should update the related libs and methods.