### PR TITLE
CB-18503 Knox is not accessible after upgrade and stop-start

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
@@ -899,6 +899,7 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
     public int deployConfigAndStartClusterServices() throws CloudbreakException {
         try {
             LOGGER.info("Deploying configuration and restarting services");
+            configService.enableKnoxAutorestartIfCmVersionAtLeast(CLOUDERAMANAGER_VERSION_7_1_0, apiClient, stack.getName());
             deployConfig();
             return restartServices();
         } catch (ApiException e) {

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationServiceTest.java
@@ -1151,6 +1151,21 @@ class ClouderaManagerModificationServiceTest {
     }
 
     @Test
+    public void testDeployConfigAndStartClusterServices() throws Exception {
+        // GIVEN
+        BigDecimal apiCommandId = new BigDecimal(200);
+        when(clustersResourceApi.deployClientConfig(stack.getName())).thenReturn(new ApiCommand().id(new BigDecimal(100)));
+        when(clouderaManagerApiFactory.getClustersResourceApi(eq(apiClientMock))).thenReturn(clustersResourceApi);
+        when(clustersResourceApi.listActiveCommands(stack.getName(), "SUMMARY", null)).thenReturn(new ApiCommandList().items(
+                List.of(new ApiCommand().id(apiCommandId).name("Restart"))));
+        when(clouderaManagerPollingServiceProvider.startPollingCmServicesRestart(stack, apiClientMock, apiCommandId)).thenReturn(success);
+        // WHEN
+        underTest.deployConfigAndStartClusterServices();
+        // THEN
+        verify(configService, times(1)).enableKnoxAutorestartIfCmVersionAtLeast(CLOUDERAMANAGER_VERSION_7_1_0, apiClientMock, stack.getName());
+    }
+
+    @Test
     void removeUnusedParcels() {
         // GIVEN
         Set<String> parcelNamesFromImage = new HashSet<>();


### PR DESCRIPTION
CB-18503 Knox is not accessible after upgrade and stop-start

Set knox autorestart config parameter to true in all case of cluster start.
