### PR TITLE
CB-18817 RTM Prod DL does not have monitoring enabled but entitlement…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
@@ -438,7 +438,9 @@ public class TelemetryConverter {
     }
 
     private void setMonitoring(TelemetryRequest request, Features features) {
-        if (monitoringEnabled) {
+        // second condition is a temporary workaround, later we should check an entitlement instead to simplify logic
+        // now if monitoring and url is not null, it means env/freeipa has monitoring enabled, based on conditions in those services
+        if (monitoringEnabled || (request.getMonitoring() != null && request.getMonitoring().getRemoteWriteUrl() != null)) {
             if (request.getFeatures() != null && request.getFeatures().getMonitoring() != null) {
                 LOGGER.debug("Fill cluster monitoring setting from telemetry feature request");
                 features.setMonitoring(request.getFeatures().getMonitoring());

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
@@ -27,6 +27,7 @@ import com.sequenceiq.common.api.telemetry.model.Telemetry;
 import com.sequenceiq.common.api.telemetry.model.WorkloadAnalytics;
 import com.sequenceiq.common.api.telemetry.request.FeaturesRequest;
 import com.sequenceiq.common.api.telemetry.request.LoggingRequest;
+import com.sequenceiq.common.api.telemetry.request.MonitoringRequest;
 import com.sequenceiq.common.api.telemetry.request.TelemetryRequest;
 import com.sequenceiq.common.api.telemetry.request.WorkloadAnalyticsRequest;
 import com.sequenceiq.common.api.telemetry.response.FeaturesResponse;
@@ -162,6 +163,20 @@ public class TelemetryConverterTest {
 
         assertNotNull(result);
         assertFalse(result.getFeatures().getMonitoring().getEnabled());
+    }
+
+    @Test
+    public void testConvertWhenMonitoringIsDisabledButUrlIsInRequest() {
+        ReflectionTestUtils.setField(underTest, "monitoringEnabled", false);
+        TelemetryRequest input = new TelemetryRequest();
+        MonitoringRequest monitoring = new MonitoringRequest();
+        monitoring.setRemoteWriteUrl("anurl");
+        input.setMonitoring(monitoring);
+
+        Telemetry result = underTest.convert(input, StackType.WORKLOAD);
+
+        assertNotNull(result);
+        assertTrue(result.getFeatures().getMonitoring().getEnabled());
     }
 
     @Test


### PR DESCRIPTION
… is added for PAAS

- if telemetry request contains url, it means env/freeipa has monitoring enabled, based on entitlement/config, thus we enable it for DL/DH too

See detailed description in the commit message.