### PR TITLE
CB-18682 Freeipa upgrade consistently fails with could not prepare st…

### DIFF
--- a/cluster-api/build.gradle
+++ b/cluster-api/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 
   implementation     group: 'org.hibernate',           name: 'hibernate-envers',      version: hibernateCoreVersion
 
-  testImplementation(group: 'org.mockito',             name: 'mockito-core',          version: mockitoVersion) {
+  testImplementation(group: 'org.mockito',             name: 'mockito-inline',          version: mockitoVersion) {
     exclude group: 'org.hamcrest'
   }
   testImplementation group: 'org.hamcrest',            name: 'hamcrest',              version: hamcrestVersion

--- a/cluster-api/src/test/java/com/sequenceiq/cloudbreak/cluster/service/ClusterComponentConfigProviderTest.java
+++ b/cluster-api/src/test/java/com/sequenceiq/cloudbreak/cluster/service/ClusterComponentConfigProviderTest.java
@@ -2,21 +2,37 @@ package com.sequenceiq.cloudbreak.cluster.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
+import javax.persistence.EntityManager;
+
+import org.hibernate.envers.AuditReader;
+import org.hibernate.envers.AuditReaderFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
 import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.common.service.TransactionService;
 import com.sequenceiq.cloudbreak.common.type.ComponentType;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterComponent;
 import com.sequenceiq.cloudbreak.domain.view.ClusterComponentView;
+import com.sequenceiq.cloudbreak.repository.ClusterComponentRepository;
 import com.sequenceiq.cloudbreak.repository.ClusterComponentViewRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -24,11 +40,29 @@ class ClusterComponentConfigProviderTest {
 
     private static final Long CLUSTER_ID = 1L;
 
+    private static final long CLUSTER_COMPONENT_ID = 10L;
+
+    private static final long CLUSTER_COMPONENT_REV_1 = 1L;
+
+    private static final long CLUSTER_COMPONENT_REV_2 = 2L;
+
     @Mock
     private ClusterComponentViewRepository componentViewRepository;
 
+    @Mock
+    private EntityManager entityManager;
+
+    @Mock
+    private TransactionService transactionService;
+
+    @Mock
+    private ClusterComponentRepository componentRepository;
+
     @InjectMocks
     private ClusterComponentConfigProvider underTest;
+
+    @Mock
+    private AuditReader auditReader;
 
     private String json = "{\"name\":\"CDH\",\"version\":\"7.2.15-1.cdh7.2.15.p1.26792553\"," +
             "\"parcel\":\"http://build-cache.vpc.cloudera.com/s3/build/26792553/cdh/7.x/parcels/\"}";
@@ -45,4 +79,51 @@ class ClusterComponentConfigProviderTest {
         ClouderaManagerProduct product = underTest.getNormalizedCdhProductWithNormalizedVersion(CLUSTER_ID).get();
         assertEquals(product.getVersion(), "7.2.15");
     }
+
+    @Test
+    void testRestorePreviousVersionWhenMultipleOlderVersionsThenHighestIsSelected() throws TransactionService.TransactionExecutionException {
+        try (MockedStatic<AuditReaderFactory> auditReaderFactory = Mockito.mockStatic(AuditReaderFactory.class)) {
+            ClusterComponent clusterComponent = createClusterComponent(CLUSTER_COMPONENT_ID);
+            setupInvokeAuditReaderInTransaction(auditReaderFactory);
+            when(auditReader.getRevisions(ClusterComponent.class, CLUSTER_COMPONENT_ID))
+                    .thenReturn(List.of(CLUSTER_COMPONENT_REV_1, CLUSTER_COMPONENT_REV_2));
+            ClusterComponent previousClusterComponent = createClusterComponent(CLUSTER_COMPONENT_ID);
+            when(auditReader.find(ClusterComponent.class, CLUSTER_COMPONENT_ID, CLUSTER_COMPONENT_REV_2)).thenReturn(previousClusterComponent);
+
+            underTest.restorePreviousVersion(clusterComponent);
+
+            verify(componentRepository).save(previousClusterComponent);
+        }
+    }
+
+    @Test
+    void testRestorePreviousVersionWhenNoRevisionInfoThenNothingSaved() throws TransactionService.TransactionExecutionException {
+        try (MockedStatic<AuditReaderFactory> auditReaderFactory = Mockito.mockStatic(AuditReaderFactory.class)) {
+            ClusterComponent clusterComponent = createClusterComponent(CLUSTER_COMPONENT_ID);
+            setupInvokeAuditReaderInTransaction(auditReaderFactory);
+            when(auditReader.getRevisions(ClusterComponent.class, CLUSTER_COMPONENT_ID)).thenReturn(List.of());
+
+            underTest.restorePreviousVersion(clusterComponent);
+
+            verify(auditReader, never()).find(any(), anyLong(), anyLong());
+            verify(componentRepository, never()).save(any());
+        }
+    }
+
+    private ClusterComponent createClusterComponent(Long id) {
+        ClusterComponent cc = new ClusterComponent();
+        cc.setId(id);
+        return cc;
+    }
+
+    private void setupInvokeAuditReaderInTransaction(MockedStatic<AuditReaderFactory> auditReaderFactory)
+            throws TransactionService.TransactionExecutionException {
+        auditReaderFactory.when(() -> AuditReaderFactory.get(entityManager)).thenReturn(auditReader);
+        doAnswer((Answer<Void>) invocation -> {
+            Runnable runnable = invocation.getArgument(0);
+            runnable.run();
+            return null;
+        }).when(transactionService).required(any(Runnable.class));
+    }
+
 }

--- a/cluster-api/src/test/java/com/sequenceiq/cloudbreak/cluster/service/clustercomponent/ClusterComponentConfigProviderTestBase.java
+++ b/cluster-api/src/test/java/com/sequenceiq/cloudbreak/cluster/service/clustercomponent/ClusterComponentConfigProviderTestBase.java
@@ -5,7 +5,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-import org.hibernate.envers.AuditReader;
+import javax.persistence.EntityManager;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -14,6 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
 import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.common.service.TransactionService;
 import com.sequenceiq.cloudbreak.repository.ClusterComponentHistoryRepository;
 import com.sequenceiq.cloudbreak.repository.ClusterComponentRepository;
 import com.sequenceiq.cloudbreak.repository.ClusterComponentViewRepository;
@@ -33,7 +35,10 @@ public class ClusterComponentConfigProviderTestBase {
     private ClusterComponentHistoryRepository mockClusterComponentHistoryRepository;
 
     @Mock
-    private AuditReader mockAuditReader;
+    private EntityManager entityManager;
+
+    @Mock
+    private TransactionService transactionService;
 
     @InjectMocks
     private ClusterComponentConfigProvider underTest;
@@ -59,8 +64,12 @@ public class ClusterComponentConfigProviderTestBase {
         return mockClusterComponentHistoryRepository;
     }
 
-    public AuditReader getMockAuditReader() {
-        return mockAuditReader;
+    public EntityManager getEntityManager() {
+        return entityManager;
+    }
+
+    public TransactionService getTransactionService() {
+        return transactionService;
     }
 
     public ClusterComponentConfigProvider getUnderTest() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/conf/DatabaseConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/conf/DatabaseConfig.java
@@ -7,11 +7,8 @@ import java.sql.SQLException;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
 
-import org.hibernate.envers.AuditReader;
-import org.hibernate.envers.AuditReaderFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -130,11 +127,6 @@ public class DatabaseConfig {
         jpaTransactionManager.setEntityManagerFactory(entityManagerFactory().getObject());
         jpaTransactionManager.afterPropertiesSet();
         return jpaTransactionManager;
-    }
-
-    @Bean
-    public AuditReader auditReader(EntityManagerFactory entityManagerFactory) {
-        return AuditReaderFactory.get(entityManagerFactory.createEntityManager());
     }
 
     @Bean

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -402,7 +402,7 @@ public class SdxService implements ResourceIdProvider, PayloadContextProvider, H
     }
 
     private Pair<SdxCluster, FlowIdentifier> createSdx(final String userCrn, final String name, final SdxClusterRequest sdxClusterRequest,
-            final StackV4Request internalStackV4Request, final ImageSettingsV4Request imageSettingsV4Request) {
+            final StackV4Request internalStackV4Request, ImageSettingsV4Request imageSettingsV4Request) {
         LOGGER.info("Creating SDX cluster with name {}", name);
         String accountId = getAccountIdFromCrn(userCrn);
         validateSdxRequest(name, sdxClusterRequest.getEnvironment(), accountId);

--- a/freeipa/build.gradle
+++ b/freeipa/build.gradle
@@ -77,6 +77,7 @@ dependencies {
   implementation     group: 'com.github.briandilley.jsonrpc4j', name: 'jsonrpc4j',                     version: '1.6'
   implementation     group: 'com.dyngr',                        name: 'polling',                       version: dyngrPollingVersion
   implementation     group: 'org.freemarker',                   name: 'freemarker',                    version: freemarkerVersion
+  testImplementation group: 'org.mockito',               name: 'mockito-inline',                   version: mockitoVersion
   testImplementation ('org.springframework.boot:spring-boot-starter-test') {
     exclude group: 'junit'
   }
@@ -113,7 +114,7 @@ dependencies {
     implementation     group: 'org.springframework.boot',  name: 'spring-boot-starter-data-jpa',   version: springBootVersion
     implementation     group: 'org.hibernate',             name: 'hibernate-envers',               version: hibernateCoreVersion
     testImplementation group: 'org.springframework.boot',  name: 'spring-boot-starter-test',       version: springBootVersion
-    testImplementation group: 'org.mockito',               name: 'mockito-core',                   version: mockitoVersion
+    testImplementation group: 'org.mockito',               name: 'mockito-inline',                   version: mockitoVersion
   }
 
   implementation project(":structuredevent-service-cdp")

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/DatabaseConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/DatabaseConfig.java
@@ -10,8 +10,6 @@ import javax.inject.Named;
 import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
 
-import org.hibernate.envers.AuditReader;
-import org.hibernate.envers.AuditReaderFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -136,11 +134,6 @@ public class DatabaseConfig {
         hibernateJpaVendorAdapter.setShowSql(true);
         hibernateJpaVendorAdapter.setDatabase(Database.POSTGRESQL);
         return hibernateJpaVendorAdapter;
-    }
-
-    @Bean
-    public AuditReader auditReader(EntityManagerFactory entityManagerFactory) {
-        return AuditReaderFactory.get(entityManagerFactory.createEntityManager());
     }
 
     private BatchProperties createBatchProperties() {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/image/change/action/ImageChangeAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/image/change/action/ImageChangeAction.java
@@ -10,7 +10,6 @@ import java.util.Optional;
 
 import javax.inject.Inject;
 
-import org.hibernate.envers.AuditReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,7 +27,7 @@ public class ImageChangeAction extends AbstractImageChangeAction<ImageChangeEven
     private ImageService imageService;
 
     @Inject
-    private AuditReader auditReader;
+    private ImageRevisionReaderService imageRevisionReaderService;
 
     public ImageChangeAction() {
         super(ImageChangeEvent.class);
@@ -51,7 +50,8 @@ public class ImageChangeAction extends AbstractImageChangeAction<ImageChangeEven
     private ImageEntity storeOriginalImageRevision(ImageChangeEvent payload, Map<Object, Object> variables) {
         ImageEntity imageEntity = imageService.getByStackId(payload.getResourceId());
         Long imageEntityId = imageEntity.getId();
-        List<Number> revisions = auditReader.getRevisions(ImageEntity.class, imageEntityId);
+        List<Number> revisions = imageRevisionReaderService.getRevisions(imageEntityId);
+        LOGGER.debug("Revisions found for current image with id {} are: {}", imageEntityId, revisions);
         if (!revisions.isEmpty()) {
             storeRevisionInfo(variables, imageEntityId, revisions);
         } else {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/image/change/action/ImageRevisionReaderService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/image/change/action/ImageRevisionReaderService.java
@@ -1,0 +1,56 @@
+package com.sequenceiq.freeipa.flow.stack.image.change.action;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.hibernate.envers.AuditReader;
+import org.hibernate.envers.AuditReaderFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.common.service.TransactionService;
+import com.sequenceiq.cloudbreak.service.OperationException;
+import com.sequenceiq.freeipa.entity.ImageEntity;
+
+@Service
+public class ImageRevisionReaderService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ImageRevisionReaderService.class);
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Inject
+    private TransactionService transactionService;
+
+    public List<Number> getRevisions(Long imageEntityId) {
+        try {
+            return transactionService.required(() -> {
+                AuditReader auditReader = AuditReaderFactory.get(entityManager);
+                return auditReader.getRevisions(ImageEntity.class, imageEntityId);
+            });
+        } catch (TransactionService.TransactionExecutionException e) {
+            String message = String.format("Could not retrieve revisions for Freeipa Image: %s", e);
+            LOGGER.error(message);
+            throw new OperationException(message);
+        }
+    }
+
+    public ImageEntity find(Long imageEntityId, Number revision) {
+        try {
+            return transactionService.required(() -> {
+                AuditReader auditReader = AuditReaderFactory.get(entityManager);
+                return auditReader.find(ImageEntity.class, imageEntityId, revision);
+            });
+        } catch (TransactionService.TransactionExecutionException e) {
+            String message = String.format("Could not retrieve Freeipa image of revision %s: %s", revision, e);
+            LOGGER.error(message);
+            throw new OperationException(message);
+        }
+    }
+
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/ImageService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/ImageService.java
@@ -9,7 +9,6 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.hibernate.envers.AuditReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -25,6 +24,7 @@ import com.sequenceiq.freeipa.converter.image.ImageToImageEntityConverter;
 import com.sequenceiq.freeipa.dto.ImageWrapper;
 import com.sequenceiq.freeipa.entity.ImageEntity;
 import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.flow.stack.image.change.action.ImageRevisionReaderService;
 import com.sequenceiq.freeipa.repository.ImageRepository;
 
 @Service
@@ -46,7 +46,7 @@ public class ImageService {
     private ImageProviderFactory imageProviderFactory;
 
     @Inject
-    private AuditReader auditReader;
+    private ImageRevisionReaderService imageRevisionReaderService;
 
     @Value("${freeipa.image.catalog.default.os}")
     private String defaultOs;
@@ -121,8 +121,7 @@ public class ImageService {
     }
 
     public void revertImageToRevision(Long imageEntityId, Number revision) {
-        ImageEntity originalImageEntity =
-                auditReader.find(ImageEntity.class, imageEntityId, revision);
+        ImageEntity originalImageEntity = imageRevisionReaderService.find(imageEntityId, revision);
         LOGGER.info("Reverting to revision [{}] using {}", revision, originalImageEntity);
         ImageEntity imageEntity = imageRepository.findById(imageEntityId).get();
         imageEntity.setImageName(originalImageEntity.getImageName());

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/image/change/action/ImageRevisionReaderServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/image/change/action/ImageRevisionReaderServiceTest.java
@@ -1,0 +1,92 @@
+package com.sequenceiq.freeipa.flow.stack.image.change.action;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import javax.persistence.EntityManager;
+
+import org.hibernate.envers.AuditReader;
+import org.hibernate.envers.AuditReaderFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+
+import com.sequenceiq.cloudbreak.common.service.TransactionService;
+import com.sequenceiq.freeipa.entity.ImageEntity;
+
+@ExtendWith(MockitoExtension.class)
+public class ImageRevisionReaderServiceTest {
+
+    private static final long IMAGE_ENTITY_ID = 3L;
+
+    private static final long REVISION = 5L;
+
+    @Mock
+    private EntityManager entityManager;
+
+    @Mock
+    private TransactionService transactionService;
+
+    @Mock
+    private AuditReader auditReader;
+
+    @InjectMocks
+    private ImageRevisionReaderService underTest;
+
+    @Test
+    void testGetRevisions() throws TransactionService.TransactionExecutionException {
+        try (MockedStatic<AuditReaderFactory> auditReaderFactory = Mockito.mockStatic(AuditReaderFactory.class)) {
+            setupInvokeAuditReaderGetRevisionsInTransaction(auditReaderFactory);
+            when(auditReader.getRevisions(ImageEntity.class, IMAGE_ENTITY_ID)).thenReturn(List.of(1, 2, 3));
+
+            List<Number> revisions = underTest.getRevisions(IMAGE_ENTITY_ID);
+
+            assertThat(revisions).hasSameElementsAs(List.of(1, 2, 3));
+        }
+    }
+
+    @Test
+    void testFind() throws TransactionService.TransactionExecutionException {
+        try (MockedStatic<AuditReaderFactory> auditReaderFactory = Mockito.mockStatic(AuditReaderFactory.class)) {
+            ImageEntity imageEntity = new ImageEntity();
+            imageEntity.setId(IMAGE_ENTITY_ID);
+            setupInvokeAuditReaderFindInTransaction(auditReaderFactory);
+            when(auditReader.find(ImageEntity.class, IMAGE_ENTITY_ID, REVISION)).thenReturn(imageEntity);
+
+            ImageEntity returnedEntity = underTest.find(IMAGE_ENTITY_ID, REVISION);
+
+            assertEquals(imageEntity, returnedEntity);
+        }
+    }
+
+    private void setupInvokeAuditReaderGetRevisionsInTransaction(MockedStatic<AuditReaderFactory> auditReaderFactory)
+            throws TransactionService.TransactionExecutionException {
+        auditReaderFactory.when(() -> AuditReaderFactory.get(entityManager)).thenReturn(auditReader);
+        when(transactionService.required(any(Supplier.class)))
+                .thenAnswer((Answer<List<Number>>) invocation -> {
+                    Supplier<List<Number>> listSupplier = invocation.getArgument(0);
+                    return listSupplier.get();
+                });
+    }
+
+    private void setupInvokeAuditReaderFindInTransaction(MockedStatic<AuditReaderFactory> auditReaderFactory)
+            throws TransactionService.TransactionExecutionException {
+        auditReaderFactory.when(() -> AuditReaderFactory.get(entityManager)).thenReturn(auditReader);
+        when(transactionService.required(any(Supplier.class)))
+                .thenAnswer((Answer<ImageEntity>) invocation -> {
+                    Supplier<ImageEntity> listSupplier = invocation.getArgument(0);
+                    return listSupplier.get();
+                });
+    }
+
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/ImageServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/ImageServiceTest.java
@@ -14,7 +14,6 @@ import java.util.Optional;
 
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.hibernate.envers.AuditReader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -31,6 +30,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.ImageCatalog;
 import com.sequenceiq.freeipa.dto.ImageWrapper;
 import com.sequenceiq.freeipa.entity.ImageEntity;
 import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.flow.stack.image.change.action.ImageRevisionReaderService;
 import com.sequenceiq.freeipa.repository.ImageRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -64,7 +64,7 @@ public class ImageServiceTest {
     private ImageRepository imageRepository;
 
     @Mock
-    private AuditReader auditReader;
+    private ImageRevisionReaderService imageRevisionReaderService;
 
     @InjectMocks
     private ImageService underTest;
@@ -138,7 +138,7 @@ public class ImageServiceTest {
         originalImage.setImageId(IMAGE_UUID);
         originalImage.setImageCatalogName(IMAGE_CATALOG);
         originalImage.setImageCatalogUrl(IMAGE_CATALOG_URL);
-        when(auditReader.find(ImageEntity.class, 2L, 3L)).thenReturn(originalImage);
+        when(imageRevisionReaderService.find(2L, 3L)).thenReturn(originalImage);
         ImageEntity currentImage = new ImageEntity();
         currentImage.setId(2L);
         when(imageRepository.findById(2L)).thenReturn(Optional.of(currentImage));


### PR DESCRIPTION
…atement - connection is closed

After a DB restart some DB queries from cloudbreak towards control plane did not work. It turned out this only affects queries related to AuditReader. After code inspection we found that the AuditReader setup was wrong in freeipa and in cloudbreak as well, as it was using a new EntityManager, instead of the exissting one.

The present commit fixes the AuditReader configuration and introduces a litle refactor.

See detailed description in the commit message.