### PR TITLE
CB-18858 Additional validation for fallback salt password rotation

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/RotateSaltPasswordService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/RotateSaltPasswordService.java
@@ -72,7 +72,11 @@ public class RotateSaltPasswordService {
             throw new BadRequestException("Rotating SaltStack user password is not supported in your account");
         }
         if (stack.getNotTerminatedAndNotZombieGatewayInstanceMetadata().isEmpty()) {
-            throw new IllegalStateException("There are no available gateway instances");
+            throw new IllegalStateException("Rotating SaltStack user password is not supported when there are no available gateway instances");
+        }
+        if (!isChangeSaltuserPasswordSupported(stack) && stack.getNotTerminatedInstanceMetaData().stream().anyMatch(im -> !im.isRunning())) {
+            // fallback implementation re-bootstraps all nodes, so they have to be running
+            throw new IllegalStateException("Rotating SaltStack user password is only supported when all instances are running");
         }
     }
 


### PR DESCRIPTION
Fallback implementation includes re-bootstrapping all nodes, so they have to be running. The lack of this validation caused start-stop autoscale enabled cluster failures.

See detailed description in the commit message.