### PR TITLE
CB-18556 Verifying Stacks by name for datahub. DistroXUpgradeV1Endpoi…

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/endpoint/DistroXUpgradeV1Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/endpoint/DistroXUpgradeV1Endpoint.java
@@ -42,7 +42,8 @@ public interface DistroXUpgradeV1Endpoint {
     @Path("/crn/{crn}/rds_upgrade")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Upgrades the external database of the distrox cluster", nickname = "upgradeDistroXRdsByCrn")
-    DistroXRdsUpgradeV1Response upgradeRdsByCrn(@PathParam("crn") String clusterCrn, @Valid DistroXRdsUpgradeV1Request distroxRdsUpgradeRequest);
+    DistroXRdsUpgradeV1Response upgradeRdsByCrn(@ValidCrn(resource = CrnResourceDescriptor.DATAHUB) @PathParam("crn") String clusterCrn,
+            @Valid DistroXRdsUpgradeV1Request distroxRdsUpgradeRequest);
 
     @POST
     @Path("{name}/upgrade")
@@ -54,7 +55,8 @@ public interface DistroXUpgradeV1Endpoint {
     @Path("/crn/{crn}/upgrade")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Upgrades the distrox cluster", nickname = "upgradeDistroxClusterByCrn")
-    DistroXUpgradeV1Response upgradeClusterByCrn(@PathParam("crn") String crn, @Valid DistroXUpgradeV1Request distroxUpgradeRequest);
+    DistroXUpgradeV1Response upgradeClusterByCrn(@ValidCrn(resource = CrnResourceDescriptor.DATAHUB) @PathParam("crn") String crn,
+            @Valid DistroXUpgradeV1Request distroxUpgradeRequest);
 
     @POST
     @Path("{name}/prepare_upgrade")
@@ -66,7 +68,8 @@ public interface DistroXUpgradeV1Endpoint {
     @Path("/crn/{crn}/prepare_upgrade")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "prepares the distrox cluster for upgrade", nickname = "prepareDistroxClusterUpgradeByCrn")
-    DistroXUpgradeV1Response prepareClusterUpgradeByCrn(@PathParam("crn") String crn, @Valid DistroXUpgradeV1Request distroxUpgradeRequest);
+    DistroXUpgradeV1Response prepareClusterUpgradeByCrn(@ValidCrn(resource = CrnResourceDescriptor.DATAHUB) @PathParam("crn") String crn,
+            @Valid DistroXUpgradeV1Request distroxUpgradeRequest);
 
     @POST
     @Path("internal/{name}/upgrade")
@@ -79,7 +82,8 @@ public interface DistroXUpgradeV1Endpoint {
     @Path("internal/crn/{crn}/upgrade")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Upgrades the distrox cluster internal", nickname = "upgradeDistroxClusterByCrnInternal")
-    DistroXUpgradeV1Response upgradeClusterByCrnInternal(@PathParam("crn") String crn, @Valid DistroXUpgradeV1Request distroxUpgradeRequest,
+    DistroXUpgradeV1Response upgradeClusterByCrnInternal(@ValidCrn(resource = CrnResourceDescriptor.DATAHUB) @PathParam("crn") String crn,
+            @Valid DistroXUpgradeV1Request distroxUpgradeRequest,
             @QueryParam("initiatorUserCrn") String initiatorUserCrn);
 
     @PUT

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/ShowTerminatedClusterConfigService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/ShowTerminatedClusterConfigService.java
@@ -21,6 +21,9 @@ public class ShowTerminatedClusterConfigService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ShowTerminatedClusterConfigService.class);
 
+    private static final ShowTerminatedClustersAfterConfig HIDE_TERMINATED =
+            new ShowTerminatedClustersAfterConfig(false, 0L);
+
     private ShowTerminatedClustersConfig defaultShowTerminatedClustersConfig;
 
     @Inject
@@ -60,6 +63,10 @@ public class ShowTerminatedClusterConfigService {
                 config.isActive(),
                 computeShowAfterTimestampMillisecs(config.getTimeout())
         );
+    }
+
+    public ShowTerminatedClustersAfterConfig getHideTerminated() {
+        return HIDE_TERMINATED;
     }
 
     public ShowTerminatedClustersConfig getConfig() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
@@ -717,6 +717,14 @@ public class StackService implements ResourceIdProvider, AuthorizationResourceNa
         }
     }
 
+    public void checkLiveStackExistenceByName(String name, String accountId, StackType stackType) {
+        ShowTerminatedClustersAfterConfig showTerminatedClustersAfterConfig = showTerminatedClusterConfigService.getHideTerminated();
+        Optional<StackDto> stack = findByNameAndWorkspaceId(name, accountId, stackType, showTerminatedClustersAfterConfig);
+        if (stack.isEmpty()) {
+            throw new NotFoundException(format(STACK_NOT_FOUND_BY_NAME_EXCEPTION_MESSAGE, name));
+        }
+    }
+
     public Stack save(Stack stack) {
         return stackRepository.save(stack);
     }

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXUpgradeV1ControllerTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXUpgradeV1ControllerTest.java
@@ -13,6 +13,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.InternalUpgradeSettings;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.tags.upgrade.UpgradeV4Request;
@@ -20,6 +21,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.upgrade.StackCc
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.upgrade.UpgradeV4Response;
 import com.sequenceiq.cloudbreak.api.model.CcmUpgradeResponseType;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.service.upgrade.ccm.StackCcmUpgradeService;
 import com.sequenceiq.cloudbreak.structuredevent.CloudbreakRestRequestThreadLocalService;
 import com.sequenceiq.common.model.UpgradeShowAvailableImages;
@@ -60,12 +62,16 @@ class DistroXUpgradeV1ControllerTest {
     @Mock
     private StackCcmUpgradeService stackCcmUpgradeService;
 
+    @Mock
+    private StackService stackService;
+
     @InjectMocks
     private DistroXUpgradeV1Controller underTest;
 
     @BeforeEach
     public void init() {
         lenient().when(restRequestThreadLocalService.getRequestedWorkspaceId()).thenReturn(WORKSPACE_ID);
+        lenient().when(restRequestThreadLocalService.getAccountId()).thenReturn(ACCOUNT_ID);
     }
 
     @Test
@@ -83,6 +89,7 @@ class DistroXUpgradeV1ControllerTest {
 
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.upgradeClusterByName(CLUSTER_NAME, distroxUpgradeRequest));
 
+        verify(stackService).checkLiveStackExistenceByName(CLUSTER_NAME, ACCOUNT_ID, StackType.WORKLOAD);
         verify(upgradeAvailabilityService).checkForUpgrade(NameOrCrn.ofName(CLUSTER_NAME), WORKSPACE_ID, upgradeV4Request, USER_CRN);
         verifyNoInteractions(upgradeService);
     }
@@ -102,6 +109,7 @@ class DistroXUpgradeV1ControllerTest {
 
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.upgradeClusterByName(CLUSTER_NAME, distroxUpgradeRequest));
 
+        verify(stackService).checkLiveStackExistenceByName(CLUSTER_NAME, ACCOUNT_ID, StackType.WORKLOAD);
         verify(upgradeAvailabilityService).checkForUpgrade(NameOrCrn.ofName(CLUSTER_NAME), WORKSPACE_ID, upgradeV4Request, USER_CRN);
         verifyNoInteractions(upgradeService);
     }
@@ -120,6 +128,7 @@ class DistroXUpgradeV1ControllerTest {
 
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.upgradeClusterByName(CLUSTER_NAME, distroxUpgradeRequest));
 
+        verify(stackService).checkLiveStackExistenceByName(CLUSTER_NAME, ACCOUNT_ID, StackType.WORKLOAD);
         verify(upgradeService).triggerUpgrade(NameOrCrn.ofName(CLUSTER_NAME), WORKSPACE_ID, USER_CRN, upgradeV4Request, false);
     }
 
@@ -154,6 +163,7 @@ class DistroXUpgradeV1ControllerTest {
 
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.prepareClusterUpgradeByName(CLUSTER_NAME, distroxUpgradeRequest));
 
+        verify(stackService).checkLiveStackExistenceByName(CLUSTER_NAME, ACCOUNT_ID, StackType.WORKLOAD);
         verify(upgradeService).triggerUpgrade(NameOrCrn.ofName(CLUSTER_NAME), WORKSPACE_ID, USER_CRN, upgradeV4Request, true);
     }
 


### PR DESCRIPTION
…nt didn't have method for verifying if the stack belongs to DH or DL. For Endpoints which take crn  `@ValidCrn` annotations are added and for endpoints which take name(rds or cluster name) as parameter new `validateClusterName` method have been created. Method will verify the type of stack by searching the name in the repository.
