### PR TITLE
CB-17686 The flowchain could get stuck between flows after pod restart/deployment.

### DIFF
--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/flow/ConsumptionFillInMemoryStateStoreRestartAction.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/flow/ConsumptionFillInMemoryStateStoreRestartAction.java
@@ -6,12 +6,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.common.event.Payload;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.consumption.domain.Consumption;
 import com.sequenceiq.consumption.service.ConsumptionService;
-import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.flow.core.RestartContext;
 import com.sequenceiq.flow.core.restart.DefaultRestartAction;
 
 @Component("ConsumptionFillInMemoryStateStoreRestartAction")
@@ -22,19 +21,15 @@ public class ConsumptionFillInMemoryStateStoreRestartAction extends DefaultResta
     private ConsumptionService consumptionService;
 
     @Override
-    public void restart(FlowParameters flowParameters, String flowChainId, String event, Object payload) {
-        LOGGER.debug("Restoring MDC context and InMemoryStateStore entry for flow: '{}', flow chain: '{}', event: '{}'", flowParameters.getFlowId(),
-                flowChainId, event);
-        Payload consumptionPayload = (Payload) payload;
+    public void doBeforeRestart(RestartContext restartContext, Object payload) {
+        LOGGER.debug("Restoring MDC context and InMemoryStateStore entry for flow: '{}', flow chain: '{}', event: '{}'",
+                restartContext.getFlowId(), restartContext.getFlowChainId(), restartContext.getEvent());
         try {
-            Consumption consumption = consumptionService.findConsumptionById(consumptionPayload.getResourceId());
+            Consumption consumption = consumptionService.findConsumptionById(restartContext.getResourceId());
             MDCBuilder.buildMdcContext(consumption);
-            MDCBuilder.addFlowId(flowParameters.getFlowId());
-            LOGGER.debug("MDC context and InMemoryStateStore entry have been restored for flow: '{}', flow chain: '{}', event: '{}'", flowParameters.getFlowId(),
-                    flowChainId, event);
-            super.restart(flowParameters, flowChainId, event, payload);
+            MDCBuilder.addFlowId(restartContext.getFlowId());
         } catch (NotFoundException e) {
-            LOGGER.error("Consumption not found with id [{}], error: {}", consumptionPayload.getResourceId(), e.getMessage());
+            LOGGER.error("Consumption not found with id [{}], error: {}", restartContext.getResourceId(), e.getMessage());
         }
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/logger/MDCBuilder.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/logger/MDCBuilder.java
@@ -41,7 +41,9 @@ public class MDCBuilder {
     }
 
     public static void addFlowId(String flowId) {
-        MDC.put(LoggerContextKey.FLOW_ID.toString(), flowId);
+        if (flowId != null) {
+            MDC.put(LoggerContextKey.FLOW_ID.toString(), flowId);
+        }
     }
 
     public static void addRequestId(String requestId) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/restart/FillInMemoryStateStoreRestartAction.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/restart/FillInMemoryStateStoreRestartAction.java
@@ -5,12 +5,11 @@ import javax.inject.Inject;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.cloud.store.InMemoryStateStore;
-import com.sequenceiq.cloudbreak.common.event.Payload;
 import com.sequenceiq.cloudbreak.converter.scheduler.StatusToPollGroupConverter;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 import com.sequenceiq.cloudbreak.view.StackView;
-import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.flow.core.RestartContext;
 import com.sequenceiq.flow.core.restart.DefaultRestartAction;
 
 @Component("FillInMemoryStateStoreRestartAction")
@@ -23,18 +22,12 @@ public class FillInMemoryStateStoreRestartAction extends DefaultRestartAction {
     private StatusToPollGroupConverter statusToPollGroupConverter;
 
     @Override
-    public void restart(FlowParameters flowParameters, String flowChainId, String event, Object payload) {
-        Payload stackPayload = (Payload) payload;
-        StackView stack = stackDtoService.getStackViewById(stackPayload.getResourceId());
-        restart(flowParameters, flowChainId, event, payload, stack);
-    }
-
-    protected void restart(FlowParameters flowParameters, String flowChainId, String event, Object payload, StackView stack) {
+    public void doBeforeRestart(RestartContext restartContext, Object payload) {
+        StackView stack = stackDtoService.getStackViewById(restartContext.getResourceId());
         InMemoryStateStore.putStack(stack.getId(), statusToPollGroupConverter.convert(stack.getStatus()));
         if (stack.getClusterId() != null) {
             InMemoryStateStore.putCluster(stack.getClusterId(), statusToPollGroupConverter.convert(stack.getStatus()));
         }
         MDCBuilder.buildMdcContext(stack);
-        super.restart(flowParameters, flowChainId, event, payload);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/restart/InitializeMDCContextRestartAction.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/restart/InitializeMDCContextRestartAction.java
@@ -4,11 +4,10 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.common.event.Payload;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
-import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.flow.core.RestartContext;
 import com.sequenceiq.flow.core.restart.DefaultRestartAction;
 
 @Component("InitializeMDCContextRestartAction")
@@ -18,10 +17,8 @@ public class InitializeMDCContextRestartAction extends DefaultRestartAction {
     private StackService stackService;
 
     @Override
-    public void restart(FlowParameters flowParameters, String flowChainId, String event, Object payload) {
-        Payload stackPayload = (Payload) payload;
-        Stack stack = stackService.getById(stackPayload.getResourceId());
+    public void doBeforeRestart(RestartContext restartContext, Object payload) {
+        Stack stack = stackService.getById(restartContext.getResourceId());
         MDCBuilder.buildMdcContext(stack);
-        super.restart(flowParameters, flowChainId, event, payload);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/stop/StackStopRestartAction.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/stop/StackStopRestartAction.java
@@ -4,11 +4,10 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.common.event.Payload;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
-import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.flow.core.RestartContext;
 import com.sequenceiq.flow.core.restart.DefaultRestartAction;
 
 @Component("StackStopRestartAction")
@@ -18,10 +17,8 @@ public class StackStopRestartAction extends DefaultRestartAction {
     private StackService stackService;
 
     @Override
-    public void restart(FlowParameters flowParameters, String flowChainId, String event, Object payload) {
-        Payload stackPayload = (Payload) payload;
-        Stack stack = stackService.getById(stackPayload.getResourceId());
+    public void doBeforeRestart(RestartContext restartContext, Object payload) {
+        Stack stack = stackService.getById(restartContext.getResourceId());
         MDCBuilder.buildMdcContext(stack);
-        super.restart(flowParameters, flowChainId, event, payload);
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/FillInMemoryStateStoreRestartAction.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/FillInMemoryStateStoreRestartAction.java
@@ -6,12 +6,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.common.event.Payload;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.service.sdx.SdxService;
 import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
-import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.flow.core.RestartContext;
 import com.sequenceiq.flow.core.restart.DefaultRestartAction;
 
 @Component("FillInMemoryStateStoreRestartAction")
@@ -26,14 +25,12 @@ public class FillInMemoryStateStoreRestartAction extends DefaultRestartAction {
     private SdxService sdxService;
 
     @Override
-    public void restart(FlowParameters flowParameters, String flowChainId, String event, Object payload) {
-        Payload datalakePayload = (Payload) payload;
-        SdxCluster sdxCluster = sdxService.getById(datalakePayload.getResourceId());
+    public void doBeforeRestart(RestartContext restartContext, Object payload) {
+        SdxCluster sdxCluster = sdxService.getById(restartContext.getResourceId());
         sdxStatusService.updateInMemoryStateStore(sdxCluster);
         MDCBuilder.buildMdcContext(sdxCluster);
-        MDCBuilder.addFlowId(flowParameters.getFlowId());
-        LOGGER.debug("MDC context and InMemoryStateStore entry have been restored for flow: '{}', flow chain: '{}', event: '{}'", flowParameters.getFlowId(),
-                flowChainId, event);
-        super.restart(flowParameters, flowChainId, event, payload);
+        MDCBuilder.addFlowId(restartContext.getFlowId());
+        LOGGER.debug("MDC context and InMemoryStateStore entry have been restored for flow: '{}', flow chain: '{}', event: '{}'", restartContext.getFlowId(),
+                restartContext.getFlowChainId(), restartContext.getEvent());
     }
 }

--- a/flow/src/main/java/com/sequenceiq/flow/core/RestartAction.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/RestartAction.java
@@ -2,5 +2,5 @@ package com.sequenceiq.flow.core;
 
 public interface RestartAction {
 
-    void restart(FlowParameters flowParameters, String flowChainId, String event, Object payload);
+    void restart(RestartContext restartContext, Object payload);
 }

--- a/flow/src/main/java/com/sequenceiq/flow/core/RestartContext.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/RestartContext.java
@@ -1,0 +1,96 @@
+package com.sequenceiq.flow.core;
+
+import java.util.Map;
+
+public class RestartContext {
+
+    private final Long resourceId;
+
+    private final String flowId;
+
+    private final String flowChainId;
+
+    private final String flowTriggerUserCrn;
+
+    private final String flowOperationType;
+
+    private final String event;
+
+    private final Map<Object, Object> contextParams;
+
+    private RestartContext(
+            Long resourceId,
+            String flowId,
+            String flowChainId,
+            String flowTriggerUserCrn,
+            String flowOperationType,
+            String event,
+            Map<Object, Object> contextParams) {
+        this.resourceId = resourceId;
+        this.flowId = flowId;
+        this.flowChainId = flowChainId;
+        this.flowTriggerUserCrn = flowTriggerUserCrn;
+        this.flowOperationType = flowOperationType;
+        this.event = event;
+        this.contextParams = contextParams;
+    }
+
+    public static RestartContext flowRestart(
+            Long resourceId,
+            String flowId,
+            String flowChainId,
+            String flowTriggerUserCrn,
+            String flowOperationType,
+            String event) {
+        return new RestartContext(resourceId, flowId, flowChainId, flowTriggerUserCrn, flowOperationType, event, Map.of());
+    }
+
+    public static RestartContext flowChainRestart(
+            Long resourceId,
+            String flowChainId,
+            String flowTriggerUserCrn,
+            String flowOperationType,
+            Map<Object, Object> contextParams) {
+        return new RestartContext(resourceId, null, flowChainId, flowTriggerUserCrn, flowOperationType, null, contextParams);
+    }
+
+    public Long getResourceId() {
+        return resourceId;
+    }
+
+    public String getFlowId() {
+        return flowId;
+    }
+
+    public String getFlowChainId() {
+        return flowChainId;
+    }
+
+    public String getFlowTriggerUserCrn() {
+        return flowTriggerUserCrn;
+    }
+
+    public String getFlowOperationType() {
+        return flowOperationType;
+    }
+
+    public String getEvent() {
+        return event;
+    }
+
+    public Map<Object, Object> getContextParams() {
+        return contextParams;
+    }
+
+    @Override
+    public String toString() {
+        return "RestartContext{" +
+                "resourceId=" + resourceId +
+                ", flowId='" + flowId + '\'' +
+                ", flowChainId='" + flowChainId + '\'' +
+                ", flowTriggerUserCrn='" + flowTriggerUserCrn + '\'' +
+                ", flowOperationType='" + flowOperationType + '\'' +
+                ", event='" + event + '\'' +
+                '}';
+    }
+}

--- a/flow/src/main/java/com/sequenceiq/flow/core/config/AbstractFlowConfiguration.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/config/AbstractFlowConfiguration.java
@@ -176,12 +176,17 @@ public abstract class AbstractFlowConfiguration<S extends FlowState, E extends F
 
     @Override
     public RestartAction getRestartAction(String event) {
-        Optional<Transition<S, E>> transaction = getTransitions().stream().filter(t -> t.event.event().equals(event)).findFirst();
-        if (transaction.isPresent() && transaction.get().target.restartAction() != null) {
-            Class<? extends RestartAction> restartAction = transaction.get().target.restartAction();
+        if (event == null) {
+            Class<? extends RestartAction> restartAction = getTransitions().get(getTransitions().size() - 1).target.restartAction();
             return applicationContext.getBean(restartAction.getSimpleName(), restartAction);
+        } else {
+            Optional<Transition<S, E>> transition = getTransitions().stream().filter(t -> t.event.event().equals(event)).findFirst();
+            if (transition.isPresent() && transition.get().target.restartAction() != null) {
+                Class<? extends RestartAction> restartAction = transition.get().target.restartAction();
+                return applicationContext.getBean(restartAction.getSimpleName(), restartAction);
+            }
+            return defaultRestartAction;
         }
-        return defaultRestartAction;
     }
 
     static class MachineConfiguration<S, E> {

--- a/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowLogDBService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowLogDBService.java
@@ -160,6 +160,11 @@ public class FlowLogDBService implements FlowLogService {
                 flowLog.setVariables(variablesJson);
                 flowLog.setVariablesJackson(variablesJackson);
             }
+            lastFlowLogOpt.ifPresent(lastFlowLog -> {
+                flowLog.setFlowType(lastFlowLog.getFlowType());
+                flowLog.setFlowChainId(lastFlowLog.getFlowChainId());
+                flowLog.setFlowTriggerUserCrn(lastFlowLog.getFlowTriggerUserCrn());
+            });
             flowLog.setCloudbreakNodeId(nodeConfig.getId());
             LOGGER.info("Persisting final FlowLog: {}", flowLog);
             return flowLogRepository.save(flowLog);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/FillInMemoryStateStoreRestartAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/FillInMemoryStateStoreRestartAction.java
@@ -6,9 +6,8 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
 import com.sequenceiq.cloudbreak.cloud.store.InMemoryStateStore;
-import com.sequenceiq.cloudbreak.common.event.Payload;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
-import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.flow.core.RestartContext;
 import com.sequenceiq.flow.core.restart.DefaultRestartAction;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.entity.Stack;
@@ -21,16 +20,10 @@ public class FillInMemoryStateStoreRestartAction extends DefaultRestartAction {
     private StackService stackService;
 
     @Override
-    public void restart(FlowParameters flowParameters, String flowChainId, String event, Object payload) {
-        Payload stackPayload = (Payload) payload;
-        Stack stack = stackService.getByIdWithListsInTransaction(stackPayload.getResourceId());
-        restart(flowParameters, flowChainId, event, payload, stack);
-    }
-
-    protected void restart(FlowParameters flowParameters, String flowChainId, String event, Object payload, Stack stack) {
+    public void doBeforeRestart(RestartContext restartContext, Object payload) {
+        Stack stack = stackService.getByIdWithListsInTransaction(restartContext.getResourceId());
         PollGroup pollGroup = Status.DELETE_COMPLETED == stack.getStackStatus().getStatus() ? PollGroup.CANCELLED : PollGroup.POLLABLE;
         InMemoryStateStore.putStack(stack.getId(), pollGroup);
         MDCBuilder.buildMdcContext(stack);
-        super.restart(flowParameters, flowChainId, event, payload);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/InitializeMDCContextRestartAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/InitializeMDCContextRestartAction.java
@@ -4,9 +4,8 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.common.event.Payload;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
-import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.flow.core.RestartContext;
 import com.sequenceiq.flow.core.restart.DefaultRestartAction;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.service.stack.StackService;
@@ -18,10 +17,8 @@ public class InitializeMDCContextRestartAction extends DefaultRestartAction {
     private StackService stackService;
 
     @Override
-    public void restart(FlowParameters flowParameters, String flowChainId, String event, Object payload) {
-        Payload stackPayload = (Payload) payload;
-        Stack stack = stackService.getStackById(stackPayload.getResourceId());
+    public void doBeforeRestart(RestartContext restartContext, Object payload) {
+        Stack stack = stackService.getStackById(restartContext.getResourceId());
         MDCBuilder.buildMdcContext(stack);
-        super.restart(flowParameters, flowChainId, event, payload);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/stop/StackStopRestartAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/stop/StackStopRestartAction.java
@@ -4,9 +4,8 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.common.event.Payload;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
-import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.flow.core.RestartContext;
 import com.sequenceiq.flow.core.restart.DefaultRestartAction;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
 import com.sequenceiq.freeipa.entity.Stack;
@@ -23,11 +22,9 @@ public class StackStopRestartAction extends DefaultRestartAction {
     private StackUpdater stackUpdater;
 
     @Override
-    public void restart(FlowParameters flowParameters, String flowChainId, String event, Object payload) {
-        Payload stackPayload = (Payload) payload;
-        stackUpdater.updateStackStatus(stackPayload.getResourceId(), DetailedStackStatus.STOP_REQUESTED, "Stop/restart");
-        Stack stack = stackService.getByIdWithListsInTransaction(stackPayload.getResourceId());
+    public void doBeforeRestart(RestartContext restartContext, Object payload) {
+        stackUpdater.updateStackStatus(restartContext.getResourceId(), DetailedStackStatus.STOP_REQUESTED, "Stop/restart");
+        Stack stack = stackService.getByIdWithListsInTransaction(restartContext.getResourceId());
         MDCBuilder.buildMdcContext(stack);
-        super.restart(flowParameters, flowChainId, event, payload);
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/common/FillInMemoryStateStoreRestartAction.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/common/FillInMemoryStateStoreRestartAction.java
@@ -6,9 +6,8 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.common.event.Payload;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
-import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.flow.core.RestartContext;
 import com.sequenceiq.flow.core.restart.DefaultRestartAction;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
 import com.sequenceiq.redbeams.domain.stack.DatabaseServer;
@@ -25,16 +24,15 @@ public class FillInMemoryStateStoreRestartAction extends DefaultRestartAction {
     private RedbeamsInMemoryStateStoreUpdaterService redbeamsInMemoryStateStoreUpdaterService;
 
     @Override
-    public void restart(FlowParameters flowParameters, String flowChainId, String event, Object payload) {
-        Payload redbeamsPayload = (Payload) payload;
-        DBStack dbStack = dbStackService.getById(redbeamsPayload.getResourceId());
+    public void restart(RestartContext restartContext, Object payload) {
+        DBStack dbStack = dbStackService.getById(restartContext.getResourceId());
         if (dbStack != null) {
             redbeamsInMemoryStateStoreUpdaterService.update(dbStack.getId(), dbStack.getStatus());
             MDCBuilder.buildMdcContext(dbStack);
             MDCBuilder.addEnvironmentCrn(dbStack.getEnvironmentId());
             MDCBuilder.addAccountId(getAccountId(dbStack));
         }
-        super.restart(flowParameters, flowChainId, event, payload);
+        super.restart(restartContext, payload);
     }
 
     private String getAccountId(DBStack dbStack) {


### PR DESCRIPTION
Flow engine can't restart flow chain if the application stops right after the a flow is finished. This change fixes it be checking not only the last flow but the overall state of the flow chain as well.