### PR TITLE
CB-18548 Trigger distrox runtime upgrade with rolling upgrade option

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
@@ -63,9 +63,9 @@ public interface ClusterApi {
         return clusterModificationService().upscaleCluster(instanceMetaDatasByHostGroup);
     }
 
-    default void upgradeClusterRuntime(Set<ClusterComponentView> components, boolean patchUpgrade, Optional<String> remoteDataContext)
-            throws CloudbreakException {
-        clusterModificationService().upgradeClusterRuntime(components, patchUpgrade, remoteDataContext);
+    default void upgradeClusterRuntime(Set<ClusterComponentView> components, boolean patchUpgrade, Optional<String> remoteDataContext,
+            boolean rollingUpgradeEnabled) throws CloudbreakException {
+        clusterModificationService().upgradeClusterRuntime(components, patchUpgrade, remoteDataContext, rollingUpgradeEnabled);
     }
 
     default void updateServiceConfig(String serviceType, Map<String, String> config) throws CloudbreakException {

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterModificationService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterModificationService.java
@@ -34,7 +34,8 @@ public interface ClusterModificationService {
 
     void cleanupCluster(Telemetry telemetry) throws CloudbreakException;
 
-    void upgradeClusterRuntime(Set<ClusterComponentView> components, boolean patchUpgrade, Optional<String> remoteDataContext) throws CloudbreakException;
+    void upgradeClusterRuntime(Set<ClusterComponentView> components, boolean patchUpgrade, Optional<String> remoteDataContext, boolean rollingUpgradeEnabled)
+            throws CloudbreakException;
 
     Set<ParcelInfo> gatherInstalledParcels(String stackName);
 

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationServiceTest.java
@@ -693,7 +693,7 @@ class ClouderaManagerModificationServiceTest {
                 .collect(Collectors.toSet());
 
         NotFoundException exception = assertThrows(NotFoundException.class, () -> underTest.upgradeClusterRuntime(clusterComponentsNoCDH, false,
-                Optional.empty()));
+                Optional.empty(), false));
         Assertions.assertEquals("Runtime component not found!", exception.getMessage());
     }
 
@@ -738,7 +738,7 @@ class ClouderaManagerModificationServiceTest {
         when(clusterComponentProvider.getClouderaManagerRepoDetails(CLUSTER_ID)).thenReturn(clouderaManagerRepo);
         when(clouderaManagerRepo.getVersion()).thenReturn(CLOUDERAMANAGER_VERSION_7_4_3.getVersion());
 
-        underTest.upgradeClusterRuntime(clusterComponentViews, true, Optional.empty());
+        underTest.upgradeClusterRuntime(clusterComponentViews, true, Optional.empty(), false);
 
         verify(clouderaManagerPollingServiceProvider, times(1)).startPollingCmStartup(stack, apiClientMock);
         verify(clouderaManagerPollingServiceProvider, times(1)).startPollingCmHostStatus(stack, apiClientMock);
@@ -824,7 +824,7 @@ class ClouderaManagerModificationServiceTest {
 
         when(clouderaManagerApiClientProvider.getV45Client(any(), any(), any(), any())).thenReturn(apiClientMock);
 
-        underTest.upgradeClusterRuntime(clusterComponentViews, true, Optional.empty());
+        underTest.upgradeClusterRuntime(clusterComponentViews, true, Optional.empty(), false);
 
         verify(clouderaManagerPollingServiceProvider, times(1)).startPollingCmStartup(stack, apiClientMock);
         verify(clouderaManagerPollingServiceProvider, times(1)).startPollingCmHostStatus(stack, apiClientMock);
@@ -909,7 +909,7 @@ class ClouderaManagerModificationServiceTest {
 
         when(clouderaManagerApiClientProvider.getV45Client(any(), any(), any(), any())).thenReturn(apiClientMock);
 
-        underTest.upgradeClusterRuntime(clusterComponentViews, true, Optional.empty());
+        underTest.upgradeClusterRuntime(clusterComponentViews, true, Optional.empty(), false);
 
         verify(clouderaManagerPollingServiceProvider, times(1)).startPollingCmStartup(stack, apiClientMock);
         verify(clouderaManagerPollingServiceProvider, times(1)).startPollingCmHostStatus(stack, apiClientMock);
@@ -986,7 +986,7 @@ class ClouderaManagerModificationServiceTest {
         when(clusterComponentProvider.getClouderaManagerRepoDetails(CLUSTER_ID)).thenReturn(clouderaManagerRepo);
         when(clouderaManagerRepo.getVersion()).thenReturn(CLOUDERAMANAGER_VERSION_7_5_1.getVersion());
 
-        underTest.upgradeClusterRuntime(clusterComponentViews, false, Optional.empty());
+        underTest.upgradeClusterRuntime(clusterComponentViews, false, Optional.empty(), true);
 
         verify(clouderaManagerPollingServiceProvider, times(1)).startPollingCmStartup(stack, apiClientMock);
         verify(clouderaManagerPollingServiceProvider, times(1)).startPollingCmHostStatus(stack, apiClientMock);
@@ -995,7 +995,7 @@ class ClouderaManagerModificationServiceTest {
         verify(clouderaManagerParcelManagementService, times(1)).refreshParcelRepos(clouderaManagerResourceApi, stack, apiClientMock);
         verify(clouderaManagerParcelManagementService, times(2)).downloadParcels(any(), eq(parcelResourceApi), eq(stack), eq(apiClientMock));
         verify(clouderaManagerParcelManagementService, times(2)).distributeParcels(any(), eq(parcelResourceApi), eq(stack), eq(apiClientMock));
-        verify(clouderaManagerUpgradeService, times(1)).callUpgradeCdhCommand(TestUtil.CDH_VERSION, clustersResourceApi, stack, apiClientMock);
+        verify(clouderaManagerUpgradeService, times(1)).callUpgradeCdhCommand(TestUtil.CDH_VERSION, clustersResourceApi, stack, apiClientMock, true);
         verify(clouderaManagerParcelManagementService).activateParcels(any(), eq(parcelResourceApi), eq(stack), eq(apiClientMock));
         verify(clouderaManagerCommonCommandService, times(1)).getDeployClientConfigCommandId(any(), any(), any());
         verify(clouderaManagerCommonCommandService, times(1)).getApiCommand(any(), any(), any(), any());
@@ -1010,7 +1010,7 @@ class ClouderaManagerModificationServiceTest {
         inOrder.verify(clouderaManagerParcelManagementService).downloadParcels(any(), eq(parcelResourceApi), eq(stack), eq(apiClientMock));
         inOrder.verify(clouderaManagerParcelManagementService).distributeParcels(any(), eq(parcelResourceApi), eq(stack), eq(apiClientMock));
         inOrder.verify(clouderaManagerParcelManagementService).activateParcels(any(), eq(parcelResourceApi), eq(stack), eq(apiClientMock));
-        inOrder.verify(clouderaManagerUpgradeService).callUpgradeCdhCommand(TestUtil.CDH_VERSION, clustersResourceApi, stack, apiClientMock);
+        inOrder.verify(clouderaManagerUpgradeService).callUpgradeCdhCommand(TestUtil.CDH_VERSION, clustersResourceApi, stack, apiClientMock, true);
         inOrder.verify(servicesResourceApi).readServices(stack.getName(), "SUMMARY");
         inOrder.verify(clouderaManagerCommonCommandService).getDeployClientConfigCommandId(stack, clustersResourceApi, apiCommandList.getItems());
         inOrder.verify(clouderaManagerCommonCommandService).getApiCommand(any(), any(), any(), any());

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/InternalUpgradeSettings.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/InternalUpgradeSettings.java
@@ -17,10 +17,22 @@ public class InternalUpgradeSettings {
 
     private final boolean upgradePreparation;
 
+    private final boolean rollingUpgradeEnabled;
+
     public InternalUpgradeSettings(boolean skipValidations, boolean dataHubRuntimeUpgradeEntitled, boolean dataHubOsUpgradeEntitled) {
         this.skipValidations = skipValidations;
         this.dataHubRuntimeUpgradeEntitled = dataHubRuntimeUpgradeEntitled;
         this.dataHubOsUpgradeEntitled = dataHubOsUpgradeEntitled;
+        this.rollingUpgradeEnabled = false;
+        this.upgradePreparation = false;
+    }
+
+    public InternalUpgradeSettings(boolean skipValidations, boolean dataHubRuntimeUpgradeEntitled, boolean dataHubOsUpgradeEntitled,
+            boolean rollingUpgradeEnabled) {
+        this.skipValidations = skipValidations;
+        this.dataHubRuntimeUpgradeEntitled = dataHubRuntimeUpgradeEntitled;
+        this.dataHubOsUpgradeEntitled = dataHubOsUpgradeEntitled;
+        this.rollingUpgradeEnabled = rollingUpgradeEnabled;
         upgradePreparation = false;
     }
 
@@ -28,11 +40,13 @@ public class InternalUpgradeSettings {
     public InternalUpgradeSettings(@JsonProperty("skipValidations") boolean skipValidations,
             @JsonProperty("dataHubRuntimeUpgradeEntitled") boolean dataHubRuntimeUpgradeEntitled,
             @JsonProperty("dataHubOsUpgradeEntitled") boolean dataHubOsUpgradeEntitled,
-            @JsonProperty("upgradePreparation") boolean upgradePreparation) {
+            @JsonProperty("upgradePreparation") boolean upgradePreparation,
+            @JsonProperty("rollingUpgradeEnabled") boolean rollingUpgradeEnabled) {
         this.skipValidations = skipValidations;
         this.dataHubRuntimeUpgradeEntitled = dataHubRuntimeUpgradeEntitled;
         this.dataHubOsUpgradeEntitled = dataHubOsUpgradeEntitled;
         this.upgradePreparation = upgradePreparation;
+        this.rollingUpgradeEnabled = rollingUpgradeEnabled;
     }
 
     public boolean isSkipValidations() {
@@ -49,6 +63,10 @@ public class InternalUpgradeSettings {
 
     public boolean isUpgradePreparation() {
         return upgradePreparation;
+    }
+
+    public boolean isRollingUpgradeEnabled() {
+        return rollingUpgradeEnabled;
     }
 
     @Override

--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/endpoint/DistroXUpgradeV1Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/endpoint/DistroXUpgradeV1Endpoint.java
@@ -76,7 +76,7 @@ public interface DistroXUpgradeV1Endpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Upgrades the distrox cluster internal", nickname = "upgradeDistroxClusterInternal")
     DistroXUpgradeV1Response upgradeClusterByNameInternal(@PathParam("name") String name, @Valid DistroXUpgradeV1Request distroxUpgradeRequest,
-            @QueryParam("initiatorUserCrn") String initiatorUserCrn);
+            @QueryParam("initiatorUserCrn") String initiatorUserCrn, @QueryParam("rollingUpgradeEnabled") Boolean rollingUpgradeEnabled);
 
     @POST
     @Path("internal/crn/{crn}/upgrade")
@@ -84,7 +84,7 @@ public interface DistroXUpgradeV1Endpoint {
     @ApiOperation(value = "Upgrades the distrox cluster internal", nickname = "upgradeDistroxClusterByCrnInternal")
     DistroXUpgradeV1Response upgradeClusterByCrnInternal(@ValidCrn(resource = CrnResourceDescriptor.DATAHUB) @PathParam("crn") String crn,
             @Valid DistroXUpgradeV1Request distroxUpgradeRequest,
-            @QueryParam("initiatorUserCrn") String initiatorUserCrn);
+            @QueryParam("initiatorUserCrn") String initiatorUserCrn, @QueryParam("rollingUpgradeEnabled") Boolean rollingUpgradeEnabled);
 
     @PUT
     @Path("internal/crn/{crn}/upgrade_ccm")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeManagementService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeManagementService.java
@@ -1,0 +1,103 @@
+package com.sequenceiq.cloudbreak.core.cluster;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
+import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.ClusterUpgradeService;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
+import com.sequenceiq.cloudbreak.service.CloudbreakException;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
+import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
+import com.sequenceiq.cloudbreak.service.upgrade.sync.component.CmServerQueryService;
+
+@Service
+public class ClusterManagerUpgradeManagementService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterManagerUpgradeManagementService.class);
+
+    @Inject
+    private StackDtoService stackDtoService;
+
+    @Inject
+    private ClusterComponentConfigProvider clusterComponentConfigProvider;
+
+    @Inject
+    private ClusterApiConnectors clusterApiConnectors;
+
+    @Inject
+    private CmServerQueryService cmServerQueryService;
+
+    @Inject
+    private ClusterUpgradeService clusterUpgradeService;
+
+    @Inject
+    private ClusterManagerUpgradeService clusterManagerUpgradeService;
+
+    public void upgradeClusterManager(Long stackId, boolean runtimeServicesStartNeeded, boolean rollingUpgradeEnabled)
+            throws CloudbreakOrchestratorException, CloudbreakException {
+        StackDto stackDto = stackDtoService.getById(stackId);
+        ClouderaManagerRepo clouderaManagerRepo = clusterComponentConfigProvider.getClouderaManagerRepoDetails(stackDto.getCluster().getId());
+        stopClusterServicesIfNecessary(rollingUpgradeEnabled, stackDto);
+        if (isClusterManagerUpgradeNecessary(clouderaManagerRepo.getFullVersion(), stackDto)) {
+            clusterUpgradeService.upgradeClusterManager(stackDto.getId());
+            clusterManagerUpgradeService.upgradeClouderaManager(stackDto, clouderaManagerRepo);
+            validateCmVersionAfterUpgrade(stackDto, clouderaManagerRepo);
+        } else {
+            LOGGER.debug("Skipping Cloudera Manager upgrade because the version {} is already installed.", clouderaManagerRepo.getFullVersion());
+        }
+        startClusterServicesIfNecessary(rollingUpgradeEnabled, runtimeServicesStartNeeded, stackDto);
+    }
+
+    private boolean isClusterManagerUpgradeNecessary(String targetVersion, StackDto stackDto) {
+        Optional<String> installedCmVersion = cmServerQueryService.queryCmVersion(stackDto);
+        LOGGER.debug("Comparing installed CM version: {} with the target: {}", installedCmVersion, targetVersion);
+        return installedCmVersion.isEmpty() || !targetVersion.equals(installedCmVersion.get());
+    }
+
+    private void validateCmVersionAfterUpgrade(StackDto stack, ClouderaManagerRepo clouderaManagerRepo) {
+        Optional<String> cmVersion = cmServerQueryService.queryCmVersion(stack);
+        if (cmVersion.isPresent()) {
+            String cmVersionInRepoStripped = stripEndingMagicP(clouderaManagerRepo.getFullVersion());
+            String cmVersionOnHostStripped = stripEndingMagicP(cmVersion.get());
+            if (!cmVersionInRepoStripped.equals(cmVersionOnHostStripped)) {
+                throw new CloudbreakServiceException(String.format("Cloudera manager version on host is [%s], while the expected is [%s]",
+                        cmVersionOnHostStripped, cmVersionInRepoStripped));
+            }
+        } else {
+            LOGGER.warn("Couldn't get CM version after upgrade");
+        }
+    }
+
+    private String stripEndingMagicP(String version) {
+        return StringUtils.removeEnd(version, "p");
+    }
+
+    private void stopClusterServicesIfNecessary(boolean rollingUpgradeEnabled, StackDto stackDto) throws CloudbreakException {
+        if (rollingUpgradeEnabled) {
+            LOGGER.debug("Not necessary to stop services because the rolling upgrade option is enabled");
+        } else {
+            LOGGER.debug("Stopping cluster services.");
+            clusterApiConnectors.getConnector(stackDto).stopCluster(true);
+        }
+    }
+
+    private void startClusterServicesIfNecessary(boolean rollingUpgradeEnabled, boolean runtimeServicesStartNeeded, StackDto stackDto)
+            throws CloudbreakException {
+        if (!rollingUpgradeEnabled && runtimeServicesStartNeeded) {
+            LOGGER.debug("Starting cluster runtime services after CM upgrade, it's needed if cluster runtime version hasn't been changed");
+            clusterApiConnectors.getConnector(stackDto).startCluster();
+        } else {
+            LOGGER.debug("Runtime services won't be started after CM upgrade, it's not needed if cluster runtime version has been changed");
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeService.java
@@ -11,14 +11,11 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
-import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
-import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.orchestration.Node;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.ClusterHostServiceRunner;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.decorator.CsdParcelDecorator;
@@ -29,15 +26,10 @@ import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.orchestrator.model.SaltConfig;
 import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
 import com.sequenceiq.cloudbreak.orchestrator.state.ExitCriteriaModel;
-import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.cloudbreak.service.CloudbreakRuntimeException;
 import com.sequenceiq.cloudbreak.service.GatewayConfigService;
-import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
-import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
-import com.sequenceiq.cloudbreak.service.upgrade.sync.component.CmServerQueryService;
 import com.sequenceiq.cloudbreak.util.NodesUnreachableException;
 import com.sequenceiq.cloudbreak.util.StackUtil;
-import com.sequenceiq.cloudbreak.view.ClusterView;
 import com.sequenceiq.cloudbreak.view.InstanceMetadataView;
 import com.sequenceiq.cloudbreak.view.StackView;
 
@@ -53,84 +45,33 @@ public class ClusterManagerUpgradeService {
     private HostOrchestrator hostOrchestrator;
 
     @Inject
-    private StackDtoService stackDtoService;
-
-    @Inject
-    private ClusterComponentConfigProvider clusterComponentConfigProvider;
-
-    @Inject
-    private StackUtil stackUtil;
-
-    @Inject
-    private ClusterApiConnectors clusterApiConnectors;
-
-    @Inject
     private ClusterHostServiceRunner clusterHostServiceRunner;
 
     @Inject
     private CsdParcelDecorator csdParcelDecorator;
 
     @Inject
-    private CmServerQueryService cmServerQueryService;
+    private StackUtil stackUtil;
 
-    public void upgradeClusterManager(Long stackId, boolean runtimeServicesStartNeeded) throws CloudbreakOrchestratorException, CloudbreakException {
-        StackDto stackDto = stackDtoService.getById(stackId);
-        stopClusterServices(stackDto);
-        ClouderaManagerRepo clouderaManagerRepo = clusterComponentConfigProvider.getClouderaManagerRepoDetails(stackDto.getCluster().getId());
-        upgradeClusterManager(stackDto, clouderaManagerRepo);
-        if (runtimeServicesStartNeeded) {
-            LOGGER.info("Starting cluster runtime services after CM upgrade, it's needed if cluster runtime version hasn't been changed");
-            startClusterServices(stackDto);
-        } else {
-            LOGGER.info("Runtime services won't be started after CM upgrade, it's not needed if cluster runtime version has been changed");
-        }
-        validateCmVersionAfterUpgrade(stackDto, clouderaManagerRepo);
-    }
-
-    private void validateCmVersionAfterUpgrade(StackDto stack, ClouderaManagerRepo clouderaManagerRepo) {
-        Optional<String> cmVersion = cmServerQueryService.queryCmVersion(stack);
-        if (cmVersion.isPresent()) {
-            String cmVersionInRepoStripped = stripEndingMagicP(clouderaManagerRepo.getFullVersion());
-            String cmVersionOnHostStripped = stripEndingMagicP(cmVersion.get());
-            if (!cmVersionInRepoStripped.equals(cmVersionOnHostStripped)) {
-                throw new CloudbreakServiceException(String.format("Cloudera manager version on host is [%s], while the expected is [%s]",
-                        cmVersionOnHostStripped, cmVersionInRepoStripped));
-            }
-        } else {
-            LOGGER.warn("Couldn't get CM version after upgrade");
-        }
-    }
-
-    private String stripEndingMagicP(String version) {
-        return StringUtils.removeEnd(version, "p");
-    }
-
-    private void upgradeClusterManager(StackDto stackDto, ClouderaManagerRepo clouderaManagerRepo) throws CloudbreakOrchestratorException {
+    void upgradeClouderaManager(StackDto stackDto, ClouderaManagerRepo clouderaManagerRepo) throws CloudbreakOrchestratorException {
         StackView stack = stackDto.getStack();
-        ClusterView cluster = stackDto.getCluster();
         InstanceMetadataView gatewayInstance = stackDto.getPrimaryGatewayInstance();
         GatewayConfig primaryGatewayConfig = gatewayConfigService.getGatewayConfig(stack, stackDto.getSecurityConfig(), gatewayInstance, stackDto.hasGateway());
         Set<String> gatewayFQDN = Collections.singleton(gatewayInstance.getDiscoveryFQDN());
-        ExitCriteriaModel exitCriteriaModel = clusterDeletionBasedModel(stack.getId(), cluster.getId());
+        ExitCriteriaModel exitCriteriaModel = clusterDeletionBasedModel(stack.getId(), stack.getClusterId());
         SaltConfig pillar = createSaltConfig(stackDto, primaryGatewayConfig, clouderaManagerRepo);
         Set<String> allNode = stackUtil.collectNodes(stackDto).stream().map(Node::getHostname).collect(Collectors.toSet());
         try {
             Set<Node> reachableNodes = stackUtil.collectAndCheckReachableNodes(stackDto, allNode);
+            LOGGER.debug("Starting to upgrade cluster manager.");
             hostOrchestrator.upgradeClusterManager(primaryGatewayConfig, gatewayFQDN, reachableNodes, pillar, exitCriteriaModel);
+            LOGGER.debug("Cluster manager upgrade finished.");
         } catch (NodesUnreachableException e) {
             String errorMessage = "Can not upgrade cluster manager because the configuration management service is not responding on these nodes: "
                     + e.getUnreachableNodes();
             LOGGER.error(errorMessage);
             throw new CloudbreakRuntimeException(errorMessage, e);
         }
-    }
-
-    private void stopClusterServices(StackDto stackDto) throws CloudbreakException {
-        clusterApiConnectors.getConnector(stackDto).stopCluster(true);
-    }
-
-    private void startClusterServices(StackDto stackDto) throws CloudbreakException {
-        clusterApiConnectors.getConnector(stackDto).startCluster();
     }
 
     private SaltConfig createSaltConfig(StackDto stackDto, GatewayConfig primaryGatewayConfig, ClouderaManagerRepo clouderaManagerRepo) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpgradeDatalakeFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpgradeDatalakeFlowEventChainFactory.java
@@ -44,7 +44,7 @@ public class UpgradeDatalakeFlowEventChainFactory implements FlowEventChainFacto
         addUpgradeValidationToChain(event, flowEventChain);
         flowEventChain.add(new StackEvent(SaltUpdateEvent.SALT_UPDATE_EVENT.event(), event.getResourceId(), event.accepted()));
         flowEventChain.add(new ClusterUpgradeTriggerEvent(CLUSTER_UPGRADE_INIT_EVENT.event(), event.getResourceId(),
-                event.accepted(), event.getImageId()));
+                event.accepted(), event.getImageId(), event.isRollingUpgradeEnabled()));
         return new FlowTriggerEventQueue(getName(), event, flowEventChain);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpgradeDistroxFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpgradeDistroxFlowEventChainFactory.java
@@ -60,7 +60,7 @@ public class UpgradeDistroxFlowEventChainFactory implements FlowEventChainFactor
         flowEventChain.add(createClusterUpgradePreparationTriggerEvent(event));
         flowEventChain.add(new StackEvent(SaltUpdateEvent.SALT_UPDATE_EVENT.event(), event.getResourceId(), event.accepted()));
         flowEventChain.add(new ClusterUpgradeTriggerEvent(CLUSTER_UPGRADE_INIT_EVENT.event(), event.getResourceId(), event.accepted(),
-                event.getImageChangeDto().getImageId()));
+                event.getImageChangeDto().getImageId(), event.isRollingUpgradeEnabled()));
         flowEventChain.add(new StackImageUpdateTriggerEvent(FlowChainTriggers.STACK_IMAGE_UPDATE_TRIGGER_EVENT, event.getImageChangeDto()));
         if (event.isReplaceVms()) {
             Map<String, List<String>> nodeMap = getReplaceableInstancesByHostgroup(event);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/AbstractClusterUpgradeAction.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/AbstractClusterUpgradeAction.java
@@ -15,6 +15,8 @@ public abstract class AbstractClusterUpgradeAction<P extends Payload>
 
     protected static final String TARGET_IMAGE = "TARGET_IMAGE";
 
+    protected static final String ROLLING_UPGRADE_ENABLED = "ROLLING_UPGRADE_ENABLED";
+
     protected AbstractClusterUpgradeAction(Class<P> payloadClass) {
         super(payloadClass);
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterUpgradeTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterUpgradeTriggerEvent.java
@@ -14,9 +14,12 @@ public class ClusterUpgradeTriggerEvent extends StackEvent {
 
     private final String imageId;
 
-    public ClusterUpgradeTriggerEvent(String selector, Long stackId, String imageId) {
+    private final boolean rollingUpgradeEnabled;
+
+    public ClusterUpgradeTriggerEvent(String selector, Long stackId, String imageId, boolean rollingUpgradeEnabled) {
         super(selector, stackId);
         this.imageId = imageId;
+        this.rollingUpgradeEnabled = rollingUpgradeEnabled;
     }
 
     @JsonCreator
@@ -24,18 +27,24 @@ public class ClusterUpgradeTriggerEvent extends StackEvent {
             @JsonProperty("selector") String event,
             @JsonProperty("resourceId") Long resourceId,
             @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted,
-            @JsonProperty("imageId") String imageId) {
+            @JsonProperty("imageId") String imageId,
+            @JsonProperty("rollingUpgradeEnabled") boolean rollingUpgradeEnabled) {
         super(event, resourceId, accepted);
         this.imageId = imageId;
+        this.rollingUpgradeEnabled = rollingUpgradeEnabled;
     }
 
     public String getImageId() {
         return imageId;
     }
 
+    public boolean isRollingUpgradeEnabled() {
+        return rollingUpgradeEnabled;
+    }
+
     @Override
     public boolean equalsEvent(StackEvent other) {
         return isClassAndEqualsEvent(ClusterUpgradeTriggerEvent.class, other,
-                event -> Objects.equals(imageId, event.imageId));
+                event -> Objects.equals(imageId, event.imageId) && Objects.equals(rollingUpgradeEnabled, event.rollingUpgradeEnabled));
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/DistroXUpgradeTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/DistroXUpgradeTriggerEvent.java
@@ -17,6 +17,8 @@ public class DistroXUpgradeTriggerEvent extends StackEvent {
 
     private final String triggeredStackVariant;
 
+    private final boolean rollingUpgradeEnabled;
+
     @JsonCreator
     public DistroXUpgradeTriggerEvent(
             @JsonProperty("selector") String selector,
@@ -24,12 +26,14 @@ public class DistroXUpgradeTriggerEvent extends StackEvent {
             @JsonProperty("imageChangeDto") ImageChangeDto imageChangeDto,
             @JsonProperty("replaceVms") boolean replaceVms,
             @JsonProperty("lockComponents") boolean lockComponents,
-            @JsonProperty("triggeredStackVariant") String triggeredStackVariant) {
+            @JsonProperty("triggeredStackVariant") String triggeredStackVariant,
+            @JsonProperty("rollingUpgradeEnabled") boolean rollingUpgradeEnabled) {
         super(selector, stackId);
         this.imageChangeDto = imageChangeDto;
         this.replaceVms = replaceVms;
         this.lockComponents = lockComponents;
         this.triggeredStackVariant = triggeredStackVariant;
+        this.rollingUpgradeEnabled = rollingUpgradeEnabled;
     }
 
     public ImageChangeDto getImageChangeDto() {
@@ -48,12 +52,17 @@ public class DistroXUpgradeTriggerEvent extends StackEvent {
         return triggeredStackVariant;
     }
 
+    public boolean isRollingUpgradeEnabled() {
+        return rollingUpgradeEnabled;
+    }
+
     @Override
     public String toString() {
         return new StringJoiner(", ", DistroXUpgradeTriggerEvent.class.getSimpleName() + "[", "]")
                 .add("imageChangeDto=" + imageChangeDto)
                 .add("replaceVms=" + replaceVms)
                 .add("lockComponents=" + lockComponents)
+                .add("rollingUpgradeEnabled=" + rollingUpgradeEnabled)
                 .toString();
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
@@ -233,13 +233,14 @@ public class ReactorFlowManager {
 
     public FlowIdentifier triggerDatalakeClusterUpgrade(Long stackId, String imageId) {
         String selector = FlowChainTriggers.DATALAKE_CLUSTER_UPGRADE_CHAIN_TRIGGER_EVENT;
-        return reactorNotifier.notify(stackId, selector, new ClusterUpgradeTriggerEvent(selector, stackId, imageId));
+        return reactorNotifier.notify(stackId, selector, new ClusterUpgradeTriggerEvent(selector, stackId, imageId, false));
     }
 
-    public FlowIdentifier triggerDistroXUpgrade(Long stackId, ImageChangeDto imageChangeDto, boolean replaceVms, boolean lockComponents, String variant) {
+    public FlowIdentifier triggerDistroXUpgrade(Long stackId, ImageChangeDto imageChangeDto, boolean replaceVms, boolean lockComponents, String variant,
+            boolean rollingUpgradeEnabled) {
         String selector = FlowChainTriggers.DISTROX_CLUSTER_UPGRADE_CHAIN_TRIGGER_EVENT;
         return reactorNotifier.notify(stackId, selector, new DistroXUpgradeTriggerEvent(selector, stackId, imageChangeDto, replaceVms, lockComponents,
-                variant));
+                variant, rollingUpgradeEnabled));
     }
 
     public FlowIdentifier triggerClusterUpgradePreparation(Long stackId, ImageChangeDto imageChangeDto, boolean lockComponents) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ClusterManagerUpgradeRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ClusterManagerUpgradeRequest.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade;
 
+import java.util.StringJoiner;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
@@ -8,20 +10,36 @@ public class ClusterManagerUpgradeRequest extends StackEvent {
 
     private final boolean runtimeServicesStartNeeded;
 
+    private final boolean rollingUpgradeEnabled;
+
     @JsonCreator
     public ClusterManagerUpgradeRequest(
             @JsonProperty("resourceId") Long stackId,
-            @JsonProperty("runtimeServicesStartNeeded") boolean runtimeServicesStartNeeded) {
+            @JsonProperty("runtimeServicesStartNeeded") boolean runtimeServicesStartNeeded,
+            @JsonProperty("rollingUpgradeEnabled") boolean rollingUpgradeEnabled) {
         super(stackId);
         this.runtimeServicesStartNeeded = runtimeServicesStartNeeded;
+        this.rollingUpgradeEnabled = rollingUpgradeEnabled;
     }
 
     public boolean isRuntimeServicesStartNeeded() {
         return runtimeServicesStartNeeded;
     }
 
+    public boolean isRollingUpgradeEnabled() {
+        return rollingUpgradeEnabled;
+    }
+
     @Override
     public String selector() {
         return "ClusterManagerUpgradeRequest";
+    }
+
+    @Override public String toString() {
+        return new StringJoiner(", ", ClusterManagerUpgradeRequest.class.getSimpleName() + "[", "]")
+                .add("runtimeServicesStartNeeded=" + runtimeServicesStartNeeded)
+                .add("rollingUpgradeEnabled=" + rollingUpgradeEnabled)
+                .add(super.toString())
+                .toString();
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ClusterUpgradeRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ClusterUpgradeRequest.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade;
 
+import java.util.StringJoiner;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
@@ -8,15 +10,31 @@ public class ClusterUpgradeRequest extends StackEvent {
 
     private final boolean patchUpgrade;
 
+    private final boolean rollingUpgradeEnabled;
+
     @JsonCreator
     public ClusterUpgradeRequest(
             @JsonProperty("resourceId") Long stackId,
-            @JsonProperty("patchUpgrade") boolean patchUpgrade) {
+            @JsonProperty("patchUpgrade") boolean patchUpgrade,
+            @JsonProperty("rollingUpgradeEnabled") boolean rollingUpgradeEnabled) {
         super(stackId);
         this.patchUpgrade = patchUpgrade;
+        this.rollingUpgradeEnabled = rollingUpgradeEnabled;
     }
 
     public boolean isPatchUpgrade() {
         return patchUpgrade;
+    }
+
+    public boolean isRollingUpgradeEnabled() {
+        return rollingUpgradeEnabled;
+    }
+
+    @Override public String toString() {
+        return new StringJoiner(", ", ClusterUpgradeRequest.class.getSimpleName() + "[", "]")
+                .add("patchUpgrade=" + patchUpgrade)
+                .add("rollingUpgradeEnabled=" + rollingUpgradeEnabled)
+                .add(super.toString())
+                .toString();
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ClusterManagerUpgradeHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ClusterManagerUpgradeHandler.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
-import com.sequenceiq.cloudbreak.core.cluster.ClusterManagerUpgradeService;
+import com.sequenceiq.cloudbreak.core.cluster.ClusterManagerUpgradeManagementService;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ClusterManagerUpgradeRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ClusterManagerUpgradeSuccess;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ClusterUpgradeFailedEvent;
@@ -23,7 +23,7 @@ public class ClusterManagerUpgradeHandler extends ExceptionCatcherEventHandler<C
     private static final Logger LOGGER = LoggerFactory.getLogger(ClusterManagerUpgradeHandler.class);
 
     @Inject
-    private ClusterManagerUpgradeService clusterManagerUpgradeService;
+    private ClusterManagerUpgradeManagementService clusterManagerUpgradeManagementService;
 
     @Override
     public String selector() {
@@ -40,7 +40,8 @@ public class ClusterManagerUpgradeHandler extends ExceptionCatcherEventHandler<C
         LOGGER.debug("Accepting Cluster Manager upgrade event..");
         ClusterManagerUpgradeRequest request = event.getData();
         try {
-            clusterManagerUpgradeService.upgradeClusterManager(request.getResourceId(), request.isRuntimeServicesStartNeeded());
+            clusterManagerUpgradeManagementService.upgradeClusterManager(request.getResourceId(), request.isRuntimeServicesStartNeeded(),
+                    request.isRollingUpgradeEnabled());
             return new ClusterManagerUpgradeSuccess(request.getResourceId());
         } catch (Exception e) {
             LOGGER.info("Cluster Manager upgrade event failed", e);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ClusterUpgradeHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ClusterUpgradeHandler.java
@@ -72,7 +72,7 @@ public class ClusterUpgradeHandler extends ExceptionCatcherEventHandler<ClusterU
             Optional<String> remoteDataContext = getRemoteDataContext(stack);
             ClusterApi connector = clusterApiConnectors.getConnector(stackDto);
             Set<ClusterComponentView> components = parcelService.getParcelComponentsByBlueprint(stackDto);
-            connector.upgradeClusterRuntime(components, request.isPatchUpgrade(), remoteDataContext);
+            connector.upgradeClusterRuntime(components, request.isPatchUpgrade(), remoteDataContext, request.isRollingUpgradeEnabled());
             ParcelOperationStatus parcelOperationStatus = parcelService.removeUnusedParcelComponents(stackDto, components);
             if (parcelOperationStatus.getFailed().isEmpty()) {
                 result = new ClusterUpgradeSuccess(request.getResourceId());

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeManagementServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeManagementServiceTest.java
@@ -1,0 +1,145 @@
+package com.sequenceiq.cloudbreak.core.cluster;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.TestUtil;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
+import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
+import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.ClusterUpgradeService;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
+import com.sequenceiq.cloudbreak.service.CloudbreakException;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
+import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
+import com.sequenceiq.cloudbreak.service.upgrade.sync.component.CmServerQueryService;
+
+@ExtendWith(MockitoExtension.class)
+public class ClusterManagerUpgradeManagementServiceTest {
+
+    private static final Long STACK_ID = 1L;
+
+    private static final String OLD_CM_VERSION = "7.2.2-12345";
+
+    private static final String CM_VERSION = "7.2.6-12345";
+
+    private static final String CM_VERSION_WITH_P = "7.2.6-12345p";
+
+    @Mock
+    private StackDtoService stackDtoService;
+
+    @Mock
+    private ClusterComponentConfigProvider clusterComponentConfigProvider;
+
+    @Mock
+    private ClusterApiConnectors clusterApiConnectors;
+
+    @Mock
+    private ClusterApi clusterApi;
+
+    @Mock
+    private CmServerQueryService cmServerQueryService;
+
+    @Mock
+    private ClusterUpgradeService clusterUpgradeService;
+
+    @Mock
+    private ClusterManagerUpgradeService clusterManagerUpgradeService;
+
+    @InjectMocks
+    private ClusterManagerUpgradeManagementService underTest;
+
+    @Spy
+    private StackDto stackDto;
+
+    private Stack stack;
+
+    private Cluster cluster;
+
+    private static Stream<Arguments> cmVersions() {
+        return Stream.of(
+                Arguments.of(CM_VERSION, CM_VERSION),
+                Arguments.of(CM_VERSION_WITH_P, CM_VERSION),
+                Arguments.of(CM_VERSION, CM_VERSION_WITH_P),
+                Arguments.of(CM_VERSION_WITH_P, CM_VERSION_WITH_P)
+        );
+    }
+
+    @BeforeEach
+    public void setUp() {
+        stack = TestUtil.stack(Status.AVAILABLE, TestUtil.awsCredential());
+        cluster = TestUtil.cluster();
+        when(stackDtoService.getById(STACK_ID)).thenReturn(stackDto);
+        when(stackDto.getCluster()).thenReturn(cluster);
+        when(cmServerQueryService.queryCmVersion(stackDto)).thenReturn(Optional.empty());
+    }
+
+    @ParameterizedTest
+    @MethodSource("cmVersions")
+    public void testUpgradeClusterManager(String versionOnHost, String versionInRepo) throws CloudbreakOrchestratorException, CloudbreakException {
+        ClouderaManagerRepo clouderaManagerRepo = mock(ClouderaManagerRepo.class);
+        when(stackDto.getStack()).thenReturn(stack);
+        when(clouderaManagerRepo.getFullVersion()).thenReturn(versionInRepo);
+        when(clusterComponentConfigProvider.getClouderaManagerRepoDetails(cluster.getId())).thenReturn(clouderaManagerRepo);
+        when(cmServerQueryService.queryCmVersion(stackDto)).thenReturn(Optional.of(OLD_CM_VERSION)).thenReturn(Optional.of(versionOnHost));
+
+        underTest.upgradeClusterManager(STACK_ID, true, true);
+
+        verify(cmServerQueryService, times(2)).queryCmVersion(stackDto);
+        verify(clusterUpgradeService).upgradeClusterManager(STACK_ID);
+        verify(clusterManagerUpgradeService).upgradeClouderaManager(stackDto, clouderaManagerRepo);
+    }
+
+    @Test
+    public void testUpgradeClusterManagerVersionIsDifferent() throws CloudbreakOrchestratorException {
+        ClouderaManagerRepo clouderaManagerRepo = mock(ClouderaManagerRepo.class);
+        when(clouderaManagerRepo.getFullVersion()).thenReturn(CM_VERSION);
+        when(stackDto.getStack()).thenReturn(stack);
+        when(clusterComponentConfigProvider.getClouderaManagerRepoDetails(cluster.getId())).thenReturn(clouderaManagerRepo);
+        when(cmServerQueryService.queryCmVersion(stackDto)).thenReturn(Optional.of(OLD_CM_VERSION)).thenReturn(Optional.of("wrong"));
+
+        assertThrows(CloudbreakServiceException.class, () -> underTest.upgradeClusterManager(STACK_ID, true, true));
+
+        verify(cmServerQueryService, times(2)).queryCmVersion(stackDto);
+        verify(clusterUpgradeService).upgradeClusterManager(STACK_ID);
+        verify(clusterManagerUpgradeService).upgradeClouderaManager(stackDto, clouderaManagerRepo);
+    }
+
+    @Test
+    public void testUpgradeClusterManagerShouldSkipUpgradeWhenTheRequiredCmVersionIsAlreadyInstalled()
+            throws CloudbreakOrchestratorException, CloudbreakException {
+        ClouderaManagerRepo clouderaManagerRepo = mock(ClouderaManagerRepo.class);
+        when(clouderaManagerRepo.getFullVersion()).thenReturn(CM_VERSION);
+        when(clusterComponentConfigProvider.getClouderaManagerRepoDetails(cluster.getId())).thenReturn(clouderaManagerRepo);
+        when(cmServerQueryService.queryCmVersion(stackDto)).thenReturn(Optional.of(CM_VERSION));
+
+        underTest.upgradeClusterManager(STACK_ID, true, true);
+
+        verify(clusterComponentConfigProvider).getClouderaManagerRepoDetails(cluster.getId());
+        verify(cmServerQueryService).queryCmVersion(stackDto);
+        verifyNoInteractions(clusterApiConnectors, clusterUpgradeService, clusterManagerUpgradeService);
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeServiceTest.java
@@ -1,22 +1,13 @@
 package com.sequenceiq.cloudbreak.core.cluster;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-
-import java.util.Optional;
-import java.util.stream.Stream;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -26,9 +17,6 @@ import com.sequenceiq.cloudbreak.TestUtil;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
-import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
-import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
-import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.ClusterHostServiceRunner;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.decorator.CsdParcelDecorator;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
@@ -38,37 +26,13 @@ import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorEx
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.cloudbreak.service.GatewayConfigService;
-import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
-import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
-import com.sequenceiq.cloudbreak.service.upgrade.sync.component.CmServerQueryService;
 import com.sequenceiq.cloudbreak.util.StackUtil;
 
 @ExtendWith(MockitoExtension.class)
-public class ClusterManagerUpgradeServiceTest {
-
-    private static final Long STACK_ID = 1L;
-
-    private static final String CM_VERSION = "7.2.6-12345";
-
-    private static final String CM_VERSION_WITH_P = "7.2.6-12345p";
+class ClusterManagerUpgradeServiceTest {
 
     @Mock
     private GatewayConfigService gatewayConfigService;
-
-    @Mock
-    private StackDtoService stackDtoService;
-
-    @Mock
-    private ClusterComponentConfigProvider clusterComponentConfigProvider;
-
-    @Mock
-    private StackUtil stackUtil;
-
-    @Mock
-    private ClusterApiConnectors clusterApiConnectors;
-
-    @Mock
-    private ClusterApi clusterApi;
 
     @Mock
     private HostOrchestrator hostOrchestrator;
@@ -80,7 +44,10 @@ public class ClusterManagerUpgradeServiceTest {
     private CsdParcelDecorator csdParcelDecorator;
 
     @Mock
-    private CmServerQueryService cmServerQueryService;
+    private StackUtil stackUtil;
+
+    @Mock
+    private ClouderaManagerRepo clouderaManagerRepo;
 
     @InjectMocks
     private ClusterManagerUpgradeService underTest;
@@ -96,90 +63,34 @@ public class ClusterManagerUpgradeServiceTest {
     public void setUp() {
         stack = TestUtil.stack(Status.AVAILABLE, TestUtil.awsCredential());
         cluster = TestUtil.cluster();
-        when(stackDtoService.getById(STACK_ID)).thenReturn(stackDto);
-        when(clusterApiConnectors.getConnector(stackDto)).thenReturn(clusterApi);
         when(stackDto.hasGateway()).thenReturn(cluster.getGateway() != null);
         when(stackDto.getPrimaryGatewayInstance()).thenReturn(stack.getPrimaryGatewayInstance());
         when(stackDto.getStack()).thenReturn(stack);
-        when(stackDto.getCluster()).thenReturn(cluster);
         when(stackDto.getSecurityConfig()).thenReturn(stack.getSecurityConfig());
-        when(cmServerQueryService.queryCmVersion(stackDto)).thenReturn(Optional.empty());
-    }
-
-    private static Stream<Arguments> cmVersions() {
-        return Stream.of(
-                Arguments.of(CM_VERSION, CM_VERSION),
-                Arguments.of(CM_VERSION_WITH_P, CM_VERSION),
-                Arguments.of(CM_VERSION, CM_VERSION_WITH_P),
-                Arguments.of(CM_VERSION_WITH_P, CM_VERSION_WITH_P)
-        );
-    }
-
-    @ParameterizedTest
-    @MethodSource("cmVersions")
-    public void testUpgradeClusterManager(String versionOnHost, String versionInRepo) throws CloudbreakOrchestratorException, CloudbreakException {
-        ClouderaManagerRepo clouderaManagerRepo = mock(ClouderaManagerRepo.class);
-        when(clouderaManagerRepo.getFullVersion()).thenReturn(versionInRepo);
-        when(clusterComponentConfigProvider.getClouderaManagerRepoDetails(cluster.getId())).thenReturn(clouderaManagerRepo);
-        when(cmServerQueryService.queryCmVersion(stackDto)).thenReturn(Optional.of(versionOnHost));
-
-        underTest.upgradeClusterManager(STACK_ID, true);
-
-        verify(gatewayConfigService, times(1)).getGatewayConfig(stack, stack.getSecurityConfig(), stack.getPrimaryGatewayInstance(),
-                cluster.getGateway() != null);
-        verify(hostOrchestrator, times(1)).upgradeClusterManager(any(), any(), any(), any(), any());
-        verify(clusterApi).stopCluster(true);
-        verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerRepo(any(), any(), any());
-        verify(clusterHostServiceRunner, times(1)).createPillarWithClouderaManagerSettings(any(), any(), any());
-        verify(clusterApi).startCluster();
     }
 
     @Test
-    public void testUpgradeClusterManagerVersionIsDifferent() throws CloudbreakOrchestratorException, CloudbreakException {
-        ClouderaManagerRepo clouderaManagerRepo = mock(ClouderaManagerRepo.class);
-        when(clouderaManagerRepo.getFullVersion()).thenReturn(CM_VERSION);
-        when(clusterComponentConfigProvider.getClouderaManagerRepoDetails(cluster.getId())).thenReturn(clouderaManagerRepo);
-        when(cmServerQueryService.queryCmVersion(stackDto)).thenReturn(Optional.of("wrong"));
-
-        assertThrows(CloudbreakServiceException.class, () -> underTest.upgradeClusterManager(STACK_ID, true));
+    void testUpgradeClouderaManagerShouldCallTheUpgradeCommand() throws CloudbreakOrchestratorException {
+        underTest.upgradeClouderaManager(stackDto, clouderaManagerRepo);
 
         verify(gatewayConfigService, times(1)).getGatewayConfig(stack, stack.getSecurityConfig(), stack.getPrimaryGatewayInstance(),
                 cluster.getGateway() != null);
         verify(hostOrchestrator, times(1)).upgradeClusterManager(any(), any(), any(), any(), any());
-        verify(clusterApi).stopCluster(true);
         verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerRepo(any(), any(), any());
         verify(clusterHostServiceRunner, times(1)).createPillarWithClouderaManagerSettings(any(), any(), any());
-        verify(clusterApi).startCluster();
-    }
-
-    @Test
-    public void testUpgradeClusterManagerWithoutStartServices() throws CloudbreakOrchestratorException, CloudbreakException {
-        underTest.upgradeClusterManager(STACK_ID, false);
-
-        verify(gatewayConfigService, times(1)).getGatewayConfig(stack, stack.getSecurityConfig(), stack.getPrimaryGatewayInstance(),
-                cluster.getGateway() != null);
-        verify(clusterComponentConfigProvider, times(1)).getClouderaManagerRepoDetails(cluster.getId());
-        verify(hostOrchestrator, times(1)).upgradeClusterManager(any(), any(), any(), any(), any());
-        verify(clusterApi).stopCluster(true);
-        verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerRepo(any(), any(), any());
-        verify(clusterHostServiceRunner, times(1)).createPillarWithClouderaManagerSettings(any(), any(), any());
-        verify(clusterApi, never()).startCluster();
     }
 
     @Test
     public void testUpgradeClusterManagerShouldNotAddCsdToPillarWhenTheClusterTypeIsDataLake() throws CloudbreakOrchestratorException, CloudbreakException {
         stack.setType(StackType.DATALAKE);
 
-        underTest.upgradeClusterManager(STACK_ID, true);
+        underTest.upgradeClouderaManager(stackDto, clouderaManagerRepo);
 
         verify(gatewayConfigService, times(1)).getGatewayConfig(stack, stack.getSecurityConfig(), stack.getPrimaryGatewayInstance(),
                 cluster.getGateway() != null);
-        verify(clusterComponentConfigProvider, times(1)).getClouderaManagerRepoDetails(cluster.getId());
         verify(hostOrchestrator, times(1)).upgradeClusterManager(any(), any(), any(), any(), any());
-        verify(clusterApi).stopCluster(true);
         verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerRepo(any(), any(), any());
         verify(clusterHostServiceRunner, times(1)).createPillarWithClouderaManagerSettings(any(), any(), any());
-        verify(clusterApi).startCluster();
         verify(csdParcelDecorator, times(1)).decoratePillarWithCsdParcels(any(), any());
     }
 
@@ -187,16 +98,14 @@ public class ClusterManagerUpgradeServiceTest {
     public void testUpgradeClusterManagerShouldAddCsdToPillarWhenTheClusterTypeIsWorkload() throws CloudbreakOrchestratorException, CloudbreakException {
         stack.setType(StackType.WORKLOAD);
 
-        underTest.upgradeClusterManager(STACK_ID, true);
+        underTest.upgradeClouderaManager(stackDto, clouderaManagerRepo);
 
         verify(gatewayConfigService, times(1)).getGatewayConfig(stack, stack.getSecurityConfig(), stack.getPrimaryGatewayInstance(),
                 cluster.getGateway() != null);
-        verify(clusterComponentConfigProvider, times(1)).getClouderaManagerRepoDetails(cluster.getId());
         verify(hostOrchestrator, times(1)).upgradeClusterManager(any(), any(), any(), any(), any());
-        verify(clusterApi).stopCluster(true);
         verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerRepo(any(), any(), any());
         verify(clusterHostServiceRunner, times(1)).createPillarWithClouderaManagerSettings(any(), any(), any());
-        verify(clusterApi).startCluster();
         verify(csdParcelDecorator, times(1)).decoratePillarWithCsdParcels(any(), any());
     }
+
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
@@ -148,7 +148,7 @@ public class ReactorFlowManagerTest {
         underTest.triggerMaintenanceModeValidationFlow(STACK_ID);
         underTest.triggerClusterCertificationRenewal(STACK_ID);
         underTest.triggerDatalakeClusterUpgrade(STACK_ID, "asdf");
-        underTest.triggerDistroXUpgrade(STACK_ID, imageChangeDto, false, false, "variant");
+        underTest.triggerDistroXUpgrade(STACK_ID, imageChangeDto, false, false, "variant", false);
         underTest.triggerClusterUpgradePreparation(STACK_ID, imageChangeDto, false);
         underTest.triggerSaltUpdate(STACK_ID);
         underTest.triggerPillarConfigurationUpdate(STACK_ID);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpgradeDistroxFlowEventChainFactoryTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpgradeDistroxFlowEventChainFactoryTest.java
@@ -63,7 +63,7 @@ class UpgradeDistroxFlowEventChainFactoryTest {
     public void testChainQueueForNonReplaceVms() {
         ReflectionTestUtils.setField(underTest, "upgradeValidationEnabled", true);
         DistroXUpgradeTriggerEvent event = new DistroXUpgradeTriggerEvent(FlowChainTriggers.DISTROX_CLUSTER_UPGRADE_CHAIN_TRIGGER_EVENT, STACK_ID,
-                imageChangeDto, false, false, "variant");
+                imageChangeDto, false, false, "variant", true);
         FlowTriggerEventQueue flowChainQueue = underTest.createFlowTriggerEventQueue(event);
         assertEquals(5, flowChainQueue.getQueue().size());
         assertUpdateValidationEvent(flowChainQueue);
@@ -80,7 +80,7 @@ class UpgradeDistroxFlowEventChainFactoryTest {
         when(clusterRepairService.validateRepair(any(), anyLong(), any(), eq(false))).thenReturn(repairStartResult);
 
         DistroXUpgradeTriggerEvent event = new DistroXUpgradeTriggerEvent(FlowChainTriggers.DISTROX_CLUSTER_UPGRADE_CHAIN_TRIGGER_EVENT, STACK_ID,
-                imageChangeDto, true, true, "variant");
+                imageChangeDto, true, true, "variant", true);
         FlowTriggerEventQueue flowChainQueue = underTest.createFlowTriggerEventQueue(event);
         assertEquals(6, flowChainQueue.getQueue().size());
         assertUpdateValidationEvent(flowChainQueue);

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/StackUpgradeOperationsTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/StackUpgradeOperationsTest.java
@@ -53,8 +53,6 @@ class StackUpgradeOperationsTest {
 
     private static final long STACK_ID = 1L;
 
-    private static final long WORKSPACE_ID = 2L;
-
     private static final String ACCOUNT_ID = "account-id";
 
     private static final String STACK_NAME = "stack-name";
@@ -244,7 +242,7 @@ class StackUpgradeOperationsTest {
     void testCheckForClusterUpgradeShouldReturnUpgradeCandidatesWhenTheUpgradeIsRuntimeUpgradeAndTheStackTypeIsDataLakeAndReplaceVmEnabledAndPrepare() {
         Stack stack = createStack(StackType.DATALAKE);
         UpgradeV4Request request = createUpgradeRequest(null, null);
-        request.setInternalUpgradeSettings(new InternalUpgradeSettings(false, false, false, true));
+        request.setInternalUpgradeSettings(new InternalUpgradeSettings(false, false, false, true, false));
         UpgradeV4Response upgradeResponse = createUpgradeResponse();
         when(instanceGroupService.getByStackAndFetchTemplates(STACK_ID)).thenReturn(Collections.emptySet());
         when(upgradeService.isOsUpgrade(request)).thenReturn(false);

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/SdxRuntimeUpgradeService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/SdxRuntimeUpgradeService.java
@@ -131,7 +131,7 @@ public class SdxRuntimeUpgradeService {
             String clusterName, String accountId, boolean upgradePreparation) {
         UpgradeV4Request request = sdxUpgradeClusterConverter.sdxUpgradeRequestToUpgradeV4Request(upgradeSdxClusterRequest);
         if (upgradePreparation) {
-            InternalUpgradeSettings internalUpgradeSettings = new InternalUpgradeSettings(false, false, false, true);
+            InternalUpgradeSettings internalUpgradeSettings = new InternalUpgradeSettings(false, false, false, true, false);
             request.setInternalUpgradeSettings(internalUpgradeSettings);
         }
         UpgradeV4Response upgradeV4Response = ThreadBasedUserCrnProvider


### PR DESCRIPTION
In this commit I've extended the internal endpoint of the distrox upgrade with an additional rollingUpgradeEnabled request parameter. The effect of the rollingUpgradeEnabled parameter:
 - We're not stopping the cluster services before the Cloudera Manager upgrade.
 - Adding ApiCdhUpgradeArgs for the CDH upgrade command to indicate the rolling upgrade in cm

 Small improvements:
 - Skip Cloudera Manager upgrade when the target version is already installed.
 - Minor logging improvements.