### PR TITLE
CB-18853 Fix MDC context of quartz jobs

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/quartz/TracedQuartzJob.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/quartz/TracedQuartzJob.java
@@ -63,7 +63,11 @@ public abstract class TracedQuartzJob extends QuartzJobBean {
         context.put(LoggerContextKey.REQUEST_ID.toString(), requestId);
     }
 
+    /**
+     * @deprecated use {@link TracedQuartzJob#getMdcContextConfigProvider()} instead for type-safety
+     */
     @Nullable
+    @Deprecated
     protected Optional<Object> getMdcContextObject() {
         return null;
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/instancemetadata/ArchiveInstanceMetaDataJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/instancemetadata/ArchiveInstanceMetaDataJob.java
@@ -14,7 +14,9 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.domain.view.StackView;
+import com.sequenceiq.cloudbreak.logger.MdcContextInfoProvider;
 import com.sequenceiq.cloudbreak.quartz.statuschecker.job.StatusCheckerJob;
+import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 import com.sequenceiq.cloudbreak.service.stack.StackViewService;
 import com.sequenceiq.cloudbreak.service.stack.archive.ArchiveInstanceMetaDataException;
 import com.sequenceiq.cloudbreak.service.stack.archive.ArchiveInstanceMetaDataService;
@@ -32,6 +34,9 @@ public class ArchiveInstanceMetaDataJob extends StatusCheckerJob {
     private StackViewService stackViewService;
 
     @Inject
+    private StackDtoService stackDtoService;
+
+    @Inject
     private ArchiveInstanceMetaDataJobService jobService;
 
     @Inject
@@ -42,8 +47,8 @@ public class ArchiveInstanceMetaDataJob extends StatusCheckerJob {
     }
 
     @Override
-    protected Optional<Object> getMdcContextObject() {
-        return Optional.ofNullable(stackViewService.findById(getStackId()));
+    protected Optional<MdcContextInfoProvider> getMdcContextConfigProvider() {
+        return Optional.ofNullable(stackDtoService.getStackViewById(getLocalIdAsLong()));
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/nodestatus/NodeStatusCheckerJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/nodestatus/NodeStatusCheckerJob.java
@@ -17,7 +17,6 @@ import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import com.cloudera.thunderhead.telemetry.nodestatus.NodeStatusProto;
@@ -28,11 +27,12 @@ import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.client.RPCResponse;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.logger.MdcContextInfoProvider;
 import com.sequenceiq.cloudbreak.node.status.NodeStatusService;
 import com.sequenceiq.cloudbreak.quartz.statuschecker.job.StatusCheckerJob;
 import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
+import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
-import com.sequenceiq.cloudbreak.service.stack.StackViewService;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
 import com.sequenceiq.node.health.client.model.CdpNodeStatusRequest;
 import com.sequenceiq.node.health.client.model.CdpNodeStatuses;
@@ -55,8 +55,7 @@ public class NodeStatusCheckerJob extends StatusCheckerJob {
     private StackService stackService;
 
     @Inject
-    @Qualifier("stackViewServiceDeprecated")
-    private StackViewService stackViewService;
+    private StackDtoService stackDtoService;
 
     @Inject
     private NodeStatusCheckerJobService jobService;
@@ -69,8 +68,8 @@ public class NodeStatusCheckerJob extends StatusCheckerJob {
     }
 
     @Override
-    protected Optional<Object> getMdcContextObject() {
-        return Optional.ofNullable(stackViewService.findById(getStackId()));
+    protected Optional<MdcContextInfoProvider> getMdcContextConfigProvider() {
+        return Optional.ofNullable(stackDtoService.getStackViewById(getStackId()));
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/salt/StackSaltStatusCheckerJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/salt/StackSaltStatusCheckerJob.java
@@ -22,6 +22,7 @@ import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGenerator;
 import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.logger.MdcContextInfoProvider;
 import com.sequenceiq.cloudbreak.quartz.statuschecker.job.StatusCheckerJob;
 import com.sequenceiq.cloudbreak.service.RotateSaltPasswordService;
 import com.sequenceiq.cloudbreak.service.SaltPasswordStatusService;
@@ -99,7 +100,7 @@ public class StackSaltStatusCheckerJob extends StatusCheckerJob {
     }
 
     @Override
-    protected Optional<Object> getMdcContextObject() {
+    protected Optional<MdcContextInfoProvider> getMdcContextConfigProvider() {
         return Optional.ofNullable(stackDtoService.getStackViewById(getStackId()));
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJob.java
@@ -11,7 +11,6 @@ import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
@@ -19,9 +18,10 @@ import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.StackPatch;
 import com.sequenceiq.cloudbreak.domain.stack.StackPatchStatus;
 import com.sequenceiq.cloudbreak.domain.stack.StackPatchType;
+import com.sequenceiq.cloudbreak.logger.MdcContextInfoProvider;
 import com.sequenceiq.cloudbreak.quartz.statuschecker.job.StatusCheckerJob;
+import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
-import com.sequenceiq.cloudbreak.service.stack.StackViewService;
 import com.sequenceiq.cloudbreak.service.stackpatch.ExistingStackPatchApplyException;
 import com.sequenceiq.cloudbreak.service.stackpatch.ExistingStackPatchService;
 import com.sequenceiq.cloudbreak.service.stackpatch.StackPatchService;
@@ -35,8 +35,7 @@ public class ExistingStackPatcherJob extends StatusCheckerJob {
     private static final Logger LOGGER = LoggerFactory.getLogger(ExistingStackPatcherJob.class);
 
     @Inject
-    @Qualifier("stackViewServiceDeprecated")
-    private StackViewService stackViewService;
+    private StackDtoService stackDtoService;
 
     @Inject
     private StackService stackService;
@@ -55,8 +54,8 @@ public class ExistingStackPatcherJob extends StatusCheckerJob {
     }
 
     @Override
-    protected Optional<Object> getMdcContextObject() {
-        return Optional.ofNullable(stackViewService.findById(getStackId()));
+    protected Optional<MdcContextInfoProvider> getMdcContextConfigProvider() {
+        return Optional.ofNullable(stackDtoService.getStackViewById(getStackId()));
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/job/StructuredSynchronizerJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/job/StructuredSynchronizerJob.java
@@ -16,7 +16,9 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.logger.MdcContextInfoProvider;
 import com.sequenceiq.cloudbreak.quartz.statuschecker.job.StatusCheckerJob;
+import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.structuredevent.LegacyDefaultStructuredEventClient;
 import com.sequenceiq.cloudbreak.structuredevent.StructuredSyncEventFactory;
@@ -34,6 +36,9 @@ public class StructuredSynchronizerJob extends StatusCheckerJob {
     private StackService stackService;
 
     @Inject
+    private StackDtoService stackDtoService;
+
+    @Inject
     private StructuredSynchronizerJobService syncJobService;
 
     @Inject
@@ -47,8 +52,8 @@ public class StructuredSynchronizerJob extends StatusCheckerJob {
     }
 
     @Override
-    protected Optional<Object> getMdcContextObject() {
-        return Optional.ofNullable(stackService.getById(getLocalIdAsLong()));
+    protected Optional<MdcContextInfoProvider> getMdcContextConfigProvider() {
+        return Optional.ofNullable(stackDtoService.getStackViewById(getLocalIdAsLong()));
     }
 
     @Override


### PR DESCRIPTION
Some quartz jobs still used the deprecated non typer-safe getMdcContextObject() instead of the type-safe getMdcContextConfigProvider() implementation. The legacy one could not resolve fields from Hibernate generated proxy view objects, so these were replaced in this commit. There are still some jobs using the legacy method, but those use types that can be resolved by MDCBuilder.buildMdcContext().

See detailed description in the commit message.