### PR TITLE
CB-18838 Check readbeams server availablity in request time during DL…

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/database/DatabaseServerStatus.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/database/DatabaseServerStatus.java
@@ -27,5 +27,10 @@ public enum DatabaseServerStatus {
     UPGRADE_REQUESTED,
     UPGRADE_IN_PROGRESS,
     UPGRADE_FAILED,
-    UNKNOWN
+    UNKNOWN;
+
+    public boolean isAvailableForUpgrade() {
+        return AVAILABLE.equals(this)
+                || UPGRADE_FAILED.equals(this);
+    }
 }

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/service/upgrade/rds/DistroXRdsUpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/service/upgrade/rds/DistroXRdsUpgradeService.java
@@ -24,7 +24,8 @@ public class DistroXRdsUpgradeService {
     public DistroXRdsUpgradeV1Response triggerUpgrade(NameOrCrn cluster, DistroXRdsUpgradeV1Request request) {
         TargetMajorVersion targetVersion = request.getTargetVersion();
         RdsUpgradeV4Response rdsUpgradeV4Response = rdsUpgradeService.upgradeRds(cluster, targetVersion);
-        DistroXRdsUpgradeV1Response response = new DistroXRdsUpgradeV1Response(rdsUpgradeV4Response.getFlowIdentifier(), targetVersion);
+        DistroXRdsUpgradeV1Response response = new DistroXRdsUpgradeV1Response(
+                rdsUpgradeV4Response.getFlowIdentifier(), rdsUpgradeV4Response.getTargetVersion());
         LOGGER.debug("Rds upgrade requested, response {}", response);
         return response;
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeServiceTest.java
@@ -34,6 +34,7 @@ import org.springframework.util.ReflectionUtils;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.database.DatabaseServerStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.database.StackDatabaseServerResponse;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.upgrade.RdsUpgradeV4Response;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
@@ -296,12 +297,6 @@ class RdsUpgradeServiceTest {
         verify(stackService, never()).getByWorkspaceId(1L, stack.getEnvironmentCrn(), List.of(StackType.WORKLOAD));
     }
 
-    private StackDatabaseServerResponse createDatabaseServerResponse(MajorVersion majorVersion) {
-        StackDatabaseServerResponse stackDatabaseServerResponse = new StackDatabaseServerResponse();
-        stackDatabaseServerResponse.setMajorVersion(majorVersion);
-        return stackDatabaseServerResponse;
-    }
-
     @ParameterizedTest
     @EnumSource(value = Status.class, names = {"AVAILABLE", "MAINTENANCE_MODE_ENABLED", "EXTERNAL_DATABASE_UPGRADE_FAILED"}, mode = EnumSource.Mode.EXCLUDE)
     void testWhenStackUnavailableThenError(Status status) {
@@ -315,6 +310,69 @@ class RdsUpgradeServiceTest {
                 .hasMessage(ERROR_REASON);
 
         verifyNoInteractions(reactorFlowManager);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = DatabaseServerStatus.class, names = {"AVAILABLE", "UPGRADE_FAILED"})
+    void testUpgradeRdsWithValidDatabaseStuatusThenSuccess(DatabaseServerStatus status) {
+        Stack stack = createStack(Status.AVAILABLE);
+        when(restRequestThreadLocalService.getAccountId()).thenReturn(ACCOUNT_ID);
+        when(databaseService.getDatabaseServer(eq(STACK_NAME_OR_CRN))).thenReturn(createDatabaseServerResponse(MajorVersion.VERSION_10, status));
+        when(stackDtoService.getStackViewByNameOrCrn(eq(NameOrCrn.ofCrn(STACK_CRN)), any())).thenReturn(stack);
+        FlowIdentifier flowId = new FlowIdentifier(FlowType.FLOW_CHAIN, FLOW_ID);
+        when(databaseUpgradeRuntimeValidator.validateRuntimeVersionForUpgrade(STACK_VERSION, ACCOUNT_ID)).thenReturn(Optional.empty());
+        when(reactorFlowManager.triggerRdsUpgrade(eq(STACK_ID), eq(TARGET_VERSION), eq(BACKUP_LOCATION))).thenReturn(flowId);
+        when(entitlementService.isPostgresUpgradeAttachedDatahubsCheckSkipped(ACCOUNT_ID)).thenReturn(false);
+
+        RdsUpgradeV4Response response = underTest.upgradeRds(NameOrCrn.ofCrn(STACK_CRN), TARGET_VERSION);
+
+        verify(reactorFlowManager).triggerRdsUpgrade(eq(STACK_ID), eq(TARGET_VERSION), eq(BACKUP_LOCATION));
+        assertThat(response.getFlowIdentifier().getType()).isEqualTo(FlowType.FLOW_CHAIN);
+        assertThat(response.getFlowIdentifier().getPollableId()).isEqualTo(FLOW_ID);
+    }
+
+    @Test
+    void testUpgradeRdsWithDatabaseNullStatusThenError() {
+        Stack stack = createStack(Status.AVAILABLE);
+        when(restRequestThreadLocalService.getAccountId()).thenReturn(ACCOUNT_ID);
+        when(databaseService.getDatabaseServer(eq(STACK_NAME_OR_CRN))).thenReturn(createDatabaseServerResponse(MajorVersion.VERSION_10, null));
+        when(stackDtoService.getStackViewByNameOrCrn(eq(NameOrCrn.ofCrn(STACK_CRN)), any())).thenReturn(stack);
+        when(databaseUpgradeRuntimeValidator.validateRuntimeVersionForUpgrade(STACK_VERSION, ACCOUNT_ID)).thenReturn(Optional.empty());
+        when(entitlementService.isPostgresUpgradeAttachedDatahubsCheckSkipped(ACCOUNT_ID)).thenReturn(false);
+
+        Assertions.assertThatCode(() -> underTest.upgradeRds(NameOrCrn.ofCrn(STACK_CRN), TARGET_VERSION))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("Upgrading database server is not possible as database server is not available.");
+
+        verifyNoInteractions(reactorFlowManager);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = DatabaseServerStatus.class, names = {"AVAILABLE", "UPGRADE_FAILED"}, mode = EnumSource.Mode.EXCLUDE)
+    void testUpgradeRdsWithDatabaseNotAvailableThenError(DatabaseServerStatus status) {
+        Stack stack = createStack(Status.AVAILABLE);
+        when(restRequestThreadLocalService.getAccountId()).thenReturn(ACCOUNT_ID);
+        when(databaseService.getDatabaseServer(eq(STACK_NAME_OR_CRN))).thenReturn(createDatabaseServerResponse(MajorVersion.VERSION_10, status));
+        when(stackDtoService.getStackViewByNameOrCrn(eq(NameOrCrn.ofCrn(STACK_CRN)), any())).thenReturn(stack);
+        when(databaseUpgradeRuntimeValidator.validateRuntimeVersionForUpgrade(STACK_VERSION, ACCOUNT_ID)).thenReturn(Optional.empty());
+        when(entitlementService.isPostgresUpgradeAttachedDatahubsCheckSkipped(ACCOUNT_ID)).thenReturn(false);
+
+        Assertions.assertThatCode(() -> underTest.upgradeRds(NameOrCrn.ofCrn(STACK_CRN), TARGET_VERSION))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(String.format("Upgrading database server is not possible as database server is not available, it is in %s state.", status));
+
+        verifyNoInteractions(reactorFlowManager);
+    }
+
+    private StackDatabaseServerResponse createDatabaseServerResponse(MajorVersion majorVersion) {
+        return createDatabaseServerResponse(majorVersion, DatabaseServerStatus.AVAILABLE);
+    }
+
+    private StackDatabaseServerResponse createDatabaseServerResponse(MajorVersion majorVersion, DatabaseServerStatus status) {
+        StackDatabaseServerResponse stackDatabaseServerResponse = new StackDatabaseServerResponse();
+        stackDatabaseServerResponse.setMajorVersion(majorVersion);
+        stackDatabaseServerResponse.setStatus(status);
+        return stackDatabaseServerResponse;
     }
 
     private Stack createStack(Status status) {

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/database/DatabaseEngineVersionReaderService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/database/DatabaseEngineVersionReaderService.java
@@ -8,12 +8,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.DatabaseBase;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.database.StackDatabaseServerResponse;
 import com.sequenceiq.cloudbreak.common.database.MajorVersion;
 import com.sequenceiq.datalake.entity.SdxCluster;
-import com.sequenceiq.datalake.service.sdx.CloudbreakStackService;
 import com.sequenceiq.datalake.service.sdx.database.DatabaseService;
 
 @Service
@@ -24,31 +21,10 @@ public class DatabaseEngineVersionReaderService {
     @Inject
     private DatabaseService databaseService;
 
-    @Inject
-    private CloudbreakStackService cloudbreakStackService;
-
     public Optional<MajorVersion> getDatabaseServerMajorVersion(SdxCluster sdxCluster) {
-        Optional<MajorVersion> databaseServerMajorVersion = sdxCluster.hasExternalDatabase()
-                ? getExternalDbMajorVersion(sdxCluster)
-                : getEmbeddedDatabaseVersion(sdxCluster);
+        StackDatabaseServerResponse stackDatabaseServerResponse = databaseService.getDatabaseServer(sdxCluster.getDatabaseCrn());
+        Optional<MajorVersion> databaseServerMajorVersion = Optional.ofNullable(stackDatabaseServerResponse.getMajorVersion());
         LOGGER.debug("Database server major version is now {} for SDX {}", databaseServerMajorVersion, sdxCluster);
         return databaseServerMajorVersion;
     }
-
-    private Optional<MajorVersion> getExternalDbMajorVersion(SdxCluster cluster) {
-        StackDatabaseServerResponse stackDatabaseServerResponse = databaseService.getDatabaseServer(cluster.getDatabaseCrn());
-        Optional<MajorVersion> currentVersionFromRedbeams = Optional.ofNullable(stackDatabaseServerResponse.getMajorVersion());
-        LOGGER.debug("Queried external database server major version from redbeams for external DB: {}", currentVersionFromRedbeams);
-        return currentVersionFromRedbeams;
-    }
-
-    private Optional<MajorVersion> getEmbeddedDatabaseVersion(SdxCluster sdxCluster) {
-        StackV4Response stackV4Response = cloudbreakStackService.getStack(sdxCluster);
-        Optional<MajorVersion> currentMajorVersionInStackOptional = MajorVersion.get(
-                Optional.ofNullable(stackV4Response.getExternalDatabase())
-                        .map(DatabaseBase::getDatabaseEngineVersion).orElse(null));
-        LOGGER.debug("Queried embedded database server major version from stack, found {}", currentMajorVersionInStackOptional);
-        return currentMajorVersionInStackOptional;
-    }
-
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/database/SdxDatabaseServerUpgradeAvailabilityChecker.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/database/SdxDatabaseServerUpgradeAvailabilityChecker.java
@@ -2,32 +2,23 @@ package com.sequenceiq.datalake.service.upgrade.database;
 
 import java.util.Optional;
 
-import javax.inject.Inject;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.database.StackDatabaseServerResponse;
 import com.sequenceiq.cloudbreak.common.database.MajorVersion;
 import com.sequenceiq.cloudbreak.common.database.TargetMajorVersion;
 import com.sequenceiq.cloudbreak.util.MajorVersionComparator;
-import com.sequenceiq.datalake.entity.SdxCluster;
 
 @Component
 public class SdxDatabaseServerUpgradeAvailabilityChecker {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SdxDatabaseServerUpgradeAvailabilityChecker.class);
 
-    @Inject
-    private DatabaseEngineVersionReaderService databaseEngineVersionReaderService;
-
-    public boolean isUpgradeNeeded(SdxCluster cluster, TargetMajorVersion targetMajorVersion) {
-        Optional<MajorVersion> currentVersionOptional = MajorVersion.get(cluster.getDatabaseEngineVersion());
-        LOGGER.debug("Checking if upgrade is needed for sdx cluster. Registered database engine version: {}", currentVersionOptional);
-        if (currentVersionOptional.isEmpty()) {
-            currentVersionOptional =  databaseEngineVersionReaderService.getDatabaseServerMajorVersion(cluster);
-            LOGGER.debug("Database server engine version was not present in SDX, tried to query it, result: {}", currentVersionOptional);
-        }
+    public boolean isUpgradeNeeded(StackDatabaseServerResponse stackDatabaseServerResponse, TargetMajorVersion targetMajorVersion) {
+        Optional<MajorVersion> currentVersionOptional = Optional.ofNullable(stackDatabaseServerResponse.getMajorVersion());
+        LOGGER.debug("Checking if database upgrade is needed for sdx cluster. Registered database engine version: {}", currentVersionOptional);
         return currentVersionOptional
                 .map(majorVersion -> isUpgradeNeeded(majorVersion, targetMajorVersion))
                 .orElse(true);

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/database/SdxDatabaseServerUpgradeService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/database/SdxDatabaseServerUpgradeService.java
@@ -16,6 +16,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.database.DatabaseServerStatus;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.database.StackDatabaseServerResponse;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.common.database.TargetMajorVersion;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
@@ -30,6 +32,7 @@ import com.sequenceiq.datalake.service.sdx.CloudbreakPoller;
 import com.sequenceiq.datalake.service.sdx.CloudbreakStackService;
 import com.sequenceiq.datalake.service.sdx.PollingConfig;
 import com.sequenceiq.datalake.service.sdx.SdxService;
+import com.sequenceiq.datalake.service.sdx.database.DatabaseService;
 import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
 import com.sequenceiq.datalake.service.validation.database.DatabaseUpgradeRuntimeValidator;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
@@ -68,6 +71,9 @@ public class SdxDatabaseServerUpgradeService {
     private DatabaseUpgradeRuntimeValidator databaseUpgradeRuntimeValidator;
 
     @Inject
+    private DatabaseService databaseService;
+
+    @Inject
     private CloudbreakMessagesService cloudbreakMessagesService;
 
     public SdxUpgradeDatabaseServerResponse upgrade(NameOrCrn sdxNameOrCrn, TargetMajorVersion requestedTargetMajorVersion) {
@@ -82,7 +88,7 @@ public class SdxDatabaseServerUpgradeService {
             throwUpgradeInProgressError(cluster, targetMajorVersion);
         }
 
-        if (isDatabaseAvailableForUpgade(status)) {
+        if (!isDatalakeAvailableForUpgade(status)) {
             throwDatalakeNotAvailableForUpgradeError(cluster, targetMajorVersion);
         }
 
@@ -90,15 +96,21 @@ public class SdxDatabaseServerUpgradeService {
             throwDatalakeRuntimeTooLowError(targetMajorVersion, cluster);
         }
 
-        if (!isUpgradeNeeded(targetMajorVersion, cluster)) {
-            throwAlreadyOnLatestError(cluster, targetMajorVersion);
+        StackDatabaseServerResponse databaseResponse = databaseService.getDatabaseServer(cluster.getDatabaseCrn());
+        if (!isUpgradeNeeded(targetMajorVersion, databaseResponse)) {
+            throwAlreadyOnLatestError(cluster);
         }
+
+        if (!isDatabaseAvailableForUpgade(databaseResponse)) {
+            throwDatabaseNotAvailableForUpgradeError(cluster, databaseResponse);
+        }
+
         cloudbreakStackService.checkUpgradeRdsByClusterNameInternal(cluster, targetMajorVersion);
         return triggerDatabaseUpgrade(cluster, targetMajorVersion);
     }
 
-    private boolean isUpgradeNeeded(TargetMajorVersion targetMajorVersion, SdxCluster cluster) {
-        return sdxDatabaseServerUpgradeAvailabilityService.isUpgradeNeeded(cluster, targetMajorVersion);
+    private boolean isUpgradeNeeded(TargetMajorVersion targetMajorVersion, StackDatabaseServerResponse databaseResponse) {
+        return sdxDatabaseServerUpgradeAvailabilityService.isUpgradeNeeded(databaseResponse, targetMajorVersion);
     }
 
     private boolean isDatabaseServerUpgradeInProgress(DatalakeStatusEnum status) {
@@ -109,8 +121,13 @@ public class SdxDatabaseServerUpgradeService {
         return databaseUpgradeRuntimeValidator.isRuntimeVersionAllowedForUpgrade(cluster.getRuntime());
     }
 
-    private boolean isDatabaseAvailableForUpgade(DatalakeStatusEnum status) {
-        return RUNNING != status && DATALAKE_UPGRADE_DATABASE_SERVER_FAILED != status;
+    private boolean isDatalakeAvailableForUpgade(DatalakeStatusEnum status) {
+        return RUNNING == status || DATALAKE_UPGRADE_DATABASE_SERVER_FAILED == status;
+    }
+
+    private boolean isDatabaseAvailableForUpgade(StackDatabaseServerResponse databaseResponse) {
+        DatabaseServerStatus status = databaseResponse.getStatus();
+        return status != null && status.isAvailableForUpgrade();
     }
 
     public void initUpgradeInCb(SdxCluster sdxCluster, TargetMajorVersion targetMajorVersion) {
@@ -128,7 +145,7 @@ public class SdxDatabaseServerUpgradeService {
                 List.of(targetMajorVersion.getMajorVersion()));
         if (message.contains(alreadyUpgradedMessage)) {
             updateDatabaseServerEngineVersion(sdxCluster);
-            throwAlreadyOnLatestError(sdxCluster, targetMajorVersion);
+            throwAlreadyOnLatestError(sdxCluster);
         } else {
             throw exception;
         }
@@ -149,11 +166,18 @@ public class SdxDatabaseServerUpgradeService {
         throwBadRequestException(String.format("Data Lake %s is not available for database server upgrade", cluster.getName()));
     }
 
+    private void throwDatabaseNotAvailableForUpgradeError(SdxCluster cluster, StackDatabaseServerResponse databaseResponse) {
+        DatabaseServerStatus status = databaseResponse.getStatus();
+        String msg = String.format("Upgrading database server of Data Lake %s is not possible as database server is not available", cluster.getName());
+        msg += status == null ? "." : String.format(", it is in %s state.", status);
+        throwBadRequestException(msg);
+    }
+
     private void throwUpgradeInProgressError(SdxCluster cluster, TargetMajorVersion targetMajorVersion) {
         throwBadRequestException(String.format("Database server upgrade for Data Lake %s is already in progress", cluster.getName()));
     }
 
-    private void throwAlreadyOnLatestError(SdxCluster cluster, TargetMajorVersion targetMajorVersion) {
+    private void throwAlreadyOnLatestError(SdxCluster cluster) {
         throwBadRequestException(String.format("Database server is already on the latest version for data lake %s", cluster.getName()));
     }
 

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/upgrade/database/DatabaseEngineVersionReaderServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/upgrade/database/DatabaseEngineVersionReaderServiceTest.java
@@ -13,12 +13,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.database.DatabaseResponse;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.database.StackDatabaseServerResponse;
 import com.sequenceiq.cloudbreak.common.database.MajorVersion;
 import com.sequenceiq.datalake.entity.SdxCluster;
-import com.sequenceiq.datalake.service.sdx.CloudbreakStackService;
 import com.sequenceiq.datalake.service.sdx.database.DatabaseService;
 
 @ExtendWith(MockitoExtension.class)
@@ -28,9 +25,6 @@ public class DatabaseEngineVersionReaderServiceTest {
 
     @Mock
     private DatabaseService databaseService;
-
-    @Mock
-    private CloudbreakStackService cloudbreakStackService;
 
     @InjectMocks
     private DatabaseEngineVersionReaderService underTest;
@@ -59,37 +53,9 @@ public class DatabaseEngineVersionReaderServiceTest {
         assertTrue(result.isEmpty());
     }
 
-    @Test
-    void testGetEmbeddedDbMajorVersionWhenMajorVersionPresent() {
-        SdxCluster sdxCluster = new SdxCluster();
-        StackV4Response stackV4Response = new StackV4Response();
-        DatabaseResponse databaseResponse = new DatabaseResponse();
-        databaseResponse.setDatabaseEngineVersion("10.4");
-        stackV4Response.setExternalDatabase(databaseResponse);
-        when(cloudbreakStackService.getStack(sdxCluster)).thenReturn(stackV4Response);
-
-        Optional<MajorVersion> result = underTest.getDatabaseServerMajorVersion(sdxCluster);
-
-        assertTrue(result.isPresent());
-        Assertions.assertEquals(MajorVersion.VERSION_10, result.get());
-    }
-
-    @Test
-    void testGetEmbeddedDbMajorVersionWhenMajorVersionEmpty() {
-        SdxCluster sdxCluster = new SdxCluster();
-        StackV4Response stackV4Response = new StackV4Response();
-        when(cloudbreakStackService.getStack(sdxCluster)).thenReturn(stackV4Response);
-
-        Optional<MajorVersion> result = underTest.getDatabaseServerMajorVersion(sdxCluster);
-
-        assertTrue(result.isEmpty());
-    }
-
     private SdxCluster setupSdxClusterWithExternalDb() {
         SdxCluster sdxCluster = mock(SdxCluster.class);
-        when(sdxCluster.hasExternalDatabase()).thenReturn(true);
         when(sdxCluster.getDatabaseCrn()).thenReturn(DATABASE_CRN);
         return sdxCluster;
     }
-
 }

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/upgrade/database/SdxDatabaseServerUpgradeAvailabilityCheckerTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/upgrade/database/SdxDatabaseServerUpgradeAvailabilityCheckerTest.java
@@ -4,23 +4,21 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
-import java.util.Optional;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.database.StackDatabaseServerResponse;
 import com.sequenceiq.cloudbreak.common.database.MajorVersion;
 import com.sequenceiq.cloudbreak.common.database.TargetMajorVersion;
-import com.sequenceiq.datalake.entity.SdxCluster;
 
 @ExtendWith(MockitoExtension.class)
 public class SdxDatabaseServerUpgradeAvailabilityCheckerTest {
 
     @Mock
-    private DatabaseEngineVersionReaderService databaseEngineVersionReaderService;
+    private StackDatabaseServerResponse stackDatabaseServerResponse;
 
     @InjectMocks
     private SdxDatabaseServerUpgradeAvailabilityChecker underTest;
@@ -28,10 +26,9 @@ public class SdxDatabaseServerUpgradeAvailabilityCheckerTest {
     @Test
     void testUpgradeNeededWhenDatabaseEngineVersionSmallerThanTargetVersion() {
         TargetMajorVersion targetMajorVersion = TargetMajorVersion.VERSION_11;
-        SdxCluster sdxCluster = new SdxCluster();
-        sdxCluster.setDatabaseEngineVersion("10.6");
+        when(stackDatabaseServerResponse.getMajorVersion()).thenReturn(MajorVersion.VERSION_10);
 
-        boolean upgradeNeeded = underTest.isUpgradeNeeded(sdxCluster, targetMajorVersion);
+        boolean upgradeNeeded = underTest.isUpgradeNeeded(stackDatabaseServerResponse, targetMajorVersion);
 
         assertTrue(upgradeNeeded);
     }
@@ -39,53 +36,9 @@ public class SdxDatabaseServerUpgradeAvailabilityCheckerTest {
     @Test
     void testUpgradeNeededWhenDatabaseEngineVersionEqualsTargetVersion() {
         TargetMajorVersion targetMajorVersion = TargetMajorVersion.VERSION_11;
-        SdxCluster sdxCluster = new SdxCluster();
-        sdxCluster.setDatabaseEngineVersion("11.0");
+        when(stackDatabaseServerResponse.getMajorVersion()).thenReturn(MajorVersion.VERSION_11);
 
-        boolean upgradeNeeded = underTest.isUpgradeNeeded(sdxCluster, targetMajorVersion);
-
-        assertFalse(upgradeNeeded);
-    }
-
-    @Test
-    void testUpgradeNeededWhenExternalDbAndVersionSmallerThanTarget() {
-        TargetMajorVersion targetMajorVersion = TargetMajorVersion.VERSION_11;
-        SdxCluster sdxCluster = new SdxCluster();
-
-        boolean upgradeNeeded = underTest.isUpgradeNeeded(sdxCluster, targetMajorVersion);
-
-        assertTrue(upgradeNeeded);
-    }
-
-    @Test
-    void testUpgradeNeededWhenExternalDbAndVersionEqualsTarget() {
-        TargetMajorVersion targetMajorVersion = TargetMajorVersion.VERSION_11;
-        SdxCluster sdxCluster = new SdxCluster();
-        when(databaseEngineVersionReaderService.getDatabaseServerMajorVersion(sdxCluster)).thenReturn(Optional.of(MajorVersion.VERSION_11));
-
-        boolean upgradeNeeded = underTest.isUpgradeNeeded(sdxCluster, targetMajorVersion);
-
-        assertFalse(upgradeNeeded);
-    }
-
-    @Test
-    void testUpgradeNeededWhenEmbeddedDbAndVersionSmallerThanTarget() {
-        TargetMajorVersion targetMajorVersion = TargetMajorVersion.VERSION_11;
-        SdxCluster sdxCluster = new SdxCluster();
-        when(databaseEngineVersionReaderService.getDatabaseServerMajorVersion(sdxCluster)).thenReturn(Optional.of(MajorVersion.VERSION_10));
-
-        boolean upgradeNeeded = underTest.isUpgradeNeeded(sdxCluster, targetMajorVersion);
-
-        assertTrue(upgradeNeeded);
-    }
-
-    @Test
-    void testUpgradeNeededWhenEmbeddedDbAndVersionEqualsTarget() {
-        TargetMajorVersion targetMajorVersion = TargetMajorVersion.VERSION_11;
-        SdxCluster sdxCluster = new SdxCluster();
-        when(databaseEngineVersionReaderService.getDatabaseServerMajorVersion(sdxCluster)).thenReturn(Optional.of(MajorVersion.VERSION_11));
-
-        boolean upgradeNeeded = underTest.isUpgradeNeeded(sdxCluster, targetMajorVersion);
+        boolean upgradeNeeded = underTest.isUpgradeNeeded(stackDatabaseServerResponse, targetMajorVersion);
 
         assertFalse(upgradeNeeded);
     }
@@ -93,21 +46,9 @@ public class SdxDatabaseServerUpgradeAvailabilityCheckerTest {
     @Test
     void testIsUpgradeNeededWhenExternalDbAndVersionUnknown() {
         TargetMajorVersion targetMajorVersion = TargetMajorVersion.VERSION_11;
-        SdxCluster sdxCluster = new SdxCluster();
-        when(databaseEngineVersionReaderService.getDatabaseServerMajorVersion(sdxCluster)).thenReturn(Optional.empty());
+        when(stackDatabaseServerResponse.getMajorVersion()).thenReturn(null);
 
-        boolean upgradeNeeded = underTest.isUpgradeNeeded(sdxCluster, targetMajorVersion);
-
-        assertTrue(upgradeNeeded);
-    }
-
-    @Test
-    void testIsUpgradeNeededWhenEmbeddedDbAndVersionUnknown() {
-        TargetMajorVersion targetMajorVersion = TargetMajorVersion.VERSION_11;
-        SdxCluster sdxCluster = new SdxCluster();
-        when(databaseEngineVersionReaderService.getDatabaseServerMajorVersion(sdxCluster)).thenReturn(Optional.empty());
-
-        boolean upgradeNeeded = underTest.isUpgradeNeeded(sdxCluster, targetMajorVersion);
+        boolean upgradeNeeded = underTest.isUpgradeNeeded(stackDatabaseServerResponse, targetMajorVersion);
 
         assertTrue(upgradeNeeded);
     }

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/upgrade/database/SdxDatabaseServerUpgradeServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/upgrade/database/SdxDatabaseServerUpgradeServiceTest.java
@@ -26,6 +26,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.database.DatabaseServerStatus;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.database.StackDatabaseServerResponse;
 import com.sequenceiq.cloudbreak.common.database.MajorVersion;
 import com.sequenceiq.cloudbreak.common.database.TargetMajorVersion;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
@@ -40,6 +42,7 @@ import com.sequenceiq.datalake.service.sdx.CloudbreakPoller;
 import com.sequenceiq.datalake.service.sdx.CloudbreakStackService;
 import com.sequenceiq.datalake.service.sdx.PollingConfig;
 import com.sequenceiq.datalake.service.sdx.SdxService;
+import com.sequenceiq.datalake.service.sdx.database.DatabaseService;
 import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
 import com.sequenceiq.datalake.service.validation.database.DatabaseUpgradeRuntimeValidator;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
@@ -50,6 +53,8 @@ import com.sequenceiq.sdx.api.model.SdxUpgradeDatabaseServerResponse;
 public class SdxDatabaseServerUpgradeServiceTest {
 
     private static final String SDX_CRN = "sdxCrn";
+
+    private static final String DB_CRN = "dbCrn";
 
     private static final NameOrCrn NAME_OR_CRN = NameOrCrn.ofCrn(SDX_CRN);
 
@@ -84,6 +89,12 @@ public class SdxDatabaseServerUpgradeServiceTest {
     @Mock
     private DatabaseEngineVersionReaderService databaseEngineVersionReaderService;
 
+    @Mock
+    private DatabaseService databaseService;
+
+    @Mock
+    private StackDatabaseServerResponse databaseResponse;
+
     @InjectMocks
     private SdxDatabaseServerUpgradeService underTest;
 
@@ -94,10 +105,13 @@ public class SdxDatabaseServerUpgradeServiceTest {
         when(sdxService.getByNameOrCrn(any(), eq(NAME_OR_CRN))).thenReturn(sdxCluster);
         SdxStatusEntity status = getDatalakeStatus(DatalakeStatusEnum.RUNNING);
         when(sdxStatusService.getActualStatusForSdx(sdxCluster)).thenReturn(status);
-        when(sdxDatabaseServerUpgradeAvailabilityService.isUpgradeNeeded(sdxCluster, targetMajorVersion)).thenReturn(true);
+        sdxCluster.setDatabaseCrn(DB_CRN);
+        when(databaseService.getDatabaseServer(DB_CRN)).thenReturn(databaseResponse);
+        when(sdxDatabaseServerUpgradeAvailabilityService.isUpgradeNeeded(databaseResponse, targetMajorVersion)).thenReturn(true);
         FlowIdentifier flowIdentifier = new FlowIdentifier(FlowType.FLOW, POLLABLE_ID);
         when(reactorFlowManager.triggerDatabaseServerUpgradeFlow(sdxCluster, targetMajorVersion)).thenReturn(flowIdentifier);
         when(databaseUpgradeRuntimeValidator.isRuntimeVersionAllowedForUpgrade(any())).thenReturn(true);
+        when(databaseResponse.getStatus()).thenReturn(DatabaseServerStatus.AVAILABLE);
 
         SdxUpgradeDatabaseServerResponse response = underTest.upgrade(NAME_OR_CRN, targetMajorVersion);
 
@@ -112,10 +126,13 @@ public class SdxDatabaseServerUpgradeServiceTest {
         when(sdxService.getByNameOrCrn(any(), eq(NAME_OR_CRN))).thenReturn(sdxCluster);
         SdxStatusEntity status = getDatalakeStatus(DatalakeStatusEnum.RUNNING);
         when(sdxStatusService.getActualStatusForSdx(sdxCluster)).thenReturn(status);
-        when(sdxDatabaseServerUpgradeAvailabilityService.isUpgradeNeeded(sdxCluster, TargetMajorVersion.VERSION_11)).thenReturn(true);
+        sdxCluster.setDatabaseCrn(DB_CRN);
+        when(databaseService.getDatabaseServer(DB_CRN)).thenReturn(databaseResponse);
+        when(sdxDatabaseServerUpgradeAvailabilityService.isUpgradeNeeded(databaseResponse, TargetMajorVersion.VERSION_11)).thenReturn(true);
         FlowIdentifier flowIdentifier = new FlowIdentifier(FlowType.FLOW, POLLABLE_ID);
         when(reactorFlowManager.triggerDatabaseServerUpgradeFlow(sdxCluster, TargetMajorVersion.VERSION_11)).thenReturn(flowIdentifier);
         when(databaseUpgradeRuntimeValidator.isRuntimeVersionAllowedForUpgrade(any())).thenReturn(true);
+        when(databaseResponse.getStatus()).thenReturn(DatabaseServerStatus.AVAILABLE);
 
         SdxUpgradeDatabaseServerResponse response = underTest.upgrade(NAME_OR_CRN, null);
 
@@ -130,10 +147,13 @@ public class SdxDatabaseServerUpgradeServiceTest {
         when(sdxService.getByNameOrCrn(any(), eq(NAME_OR_CRN))).thenReturn(sdxCluster);
         SdxStatusEntity status = getDatalakeStatus(DatalakeStatusEnum.DATALAKE_UPGRADE_DATABASE_SERVER_FAILED);
         when(sdxStatusService.getActualStatusForSdx(sdxCluster)).thenReturn(status);
-        when(sdxDatabaseServerUpgradeAvailabilityService.isUpgradeNeeded(sdxCluster, targetMajorVersion)).thenReturn(true);
+        sdxCluster.setDatabaseCrn(DB_CRN);
+        when(databaseService.getDatabaseServer(DB_CRN)).thenReturn(databaseResponse);
+        when(sdxDatabaseServerUpgradeAvailabilityService.isUpgradeNeeded(databaseResponse, targetMajorVersion)).thenReturn(true);
         FlowIdentifier flowIdentifier = new FlowIdentifier(FlowType.FLOW, POLLABLE_ID);
         when(reactorFlowManager.triggerDatabaseServerUpgradeFlow(sdxCluster, targetMajorVersion)).thenReturn(flowIdentifier);
         when(databaseUpgradeRuntimeValidator.isRuntimeVersionAllowedForUpgrade(any())).thenReturn(true);
+        when(databaseResponse.getStatus()).thenReturn(DatabaseServerStatus.AVAILABLE);
 
         SdxUpgradeDatabaseServerResponse response = underTest.upgrade(NAME_OR_CRN, targetMajorVersion);
 
@@ -160,6 +180,7 @@ public class SdxDatabaseServerUpgradeServiceTest {
                 .hasMessage(String.format("Data Lake %s is not available for database server upgrade", SDX_CLUSTER_NAME));
 
         verify(sdxDatabaseServerUpgradeAvailabilityService, never()).isUpgradeNeeded(any(), any());
+        verify(databaseService, never()).getDatabaseServer(any());
         verify(reactorFlowManager, never()).triggerDatabaseServerUpgradeFlow(any(), any());
     }
 
@@ -177,6 +198,7 @@ public class SdxDatabaseServerUpgradeServiceTest {
                 .hasMessage(String.format("Database server upgrade for Data Lake %s is already in progress", SDX_CLUSTER_NAME));
 
         verify(sdxDatabaseServerUpgradeAvailabilityService, never()).isUpgradeNeeded(any(), any());
+        verify(databaseService, never()).getDatabaseServer(any());
         verify(reactorFlowManager, never()).triggerDatabaseServerUpgradeFlow(any(), any());
     }
 
@@ -203,8 +225,11 @@ public class SdxDatabaseServerUpgradeServiceTest {
         when(sdxService.getByNameOrCrn(any(), eq(NAME_OR_CRN))).thenReturn(sdxCluster);
         SdxStatusEntity status = getDatalakeStatus(DatalakeStatusEnum.RUNNING);
         when(sdxStatusService.getActualStatusForSdx(sdxCluster)).thenReturn(status);
-        when(sdxDatabaseServerUpgradeAvailabilityService.isUpgradeNeeded(sdxCluster, targetMajorVersion)).thenReturn(true);
+        sdxCluster.setDatabaseCrn(DB_CRN);
+        when(databaseService.getDatabaseServer(DB_CRN)).thenReturn(databaseResponse);
+        when(sdxDatabaseServerUpgradeAvailabilityService.isUpgradeNeeded(databaseResponse, targetMajorVersion)).thenReturn(true);
         when(databaseUpgradeRuntimeValidator.isRuntimeVersionAllowedForUpgrade(any())).thenReturn(true);
+        when(databaseResponse.getStatus()).thenReturn(DatabaseServerStatus.AVAILABLE);
         doThrow(new BadRequestException("badrequest")).when(cloudbreakStackService).checkUpgradeRdsByClusterNameInternal(sdxCluster, targetMajorVersion);
 
         Assertions.assertThatCode(() -> underTest.upgrade(NAME_OR_CRN, targetMajorVersion))
@@ -268,6 +293,70 @@ public class SdxDatabaseServerUpgradeServiceTest {
                 eq(List.of(targetMajorVersion.getMajorVersion())));
         verify(databaseEngineVersionReaderService, times(1)).getDatabaseServerMajorVersion(sdxCluster);
         verify(sdxService, times(1)).updateDatabaseEngineVersion(eq(sdxCluster.getCrn()), eq(targetMajorVersion.getMajorVersion()));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = DatabaseServerStatus.class, names = {"AVAILABLE", "UPGRADE_FAILED"})
+    void testUpgradeWhenDatabaseIsAvailableForUpgradeThenUpgradeTriggered(DatabaseServerStatus dbStatus) {
+        TargetMajorVersion targetMajorVersion = TargetMajorVersion.VERSION_11;
+        SdxCluster sdxCluster = getSdxCluster();
+        when(sdxService.getByNameOrCrn(any(), eq(NAME_OR_CRN))).thenReturn(sdxCluster);
+        SdxStatusEntity status = getDatalakeStatus(DatalakeStatusEnum.RUNNING);
+        when(sdxStatusService.getActualStatusForSdx(sdxCluster)).thenReturn(status);
+        sdxCluster.setDatabaseCrn(DB_CRN);
+        when(databaseService.getDatabaseServer(DB_CRN)).thenReturn(databaseResponse);
+        when(sdxDatabaseServerUpgradeAvailabilityService.isUpgradeNeeded(databaseResponse, targetMajorVersion)).thenReturn(true);
+        FlowIdentifier flowIdentifier = new FlowIdentifier(FlowType.FLOW, POLLABLE_ID);
+        when(reactorFlowManager.triggerDatabaseServerUpgradeFlow(sdxCluster, targetMajorVersion)).thenReturn(flowIdentifier);
+        when(databaseUpgradeRuntimeValidator.isRuntimeVersionAllowedForUpgrade(any())).thenReturn(true);
+        when(databaseResponse.getStatus()).thenReturn(dbStatus);
+
+        SdxUpgradeDatabaseServerResponse response = underTest.upgrade(NAME_OR_CRN, targetMajorVersion);
+
+        assertEquals(flowIdentifier, response.getFlowIdentifier());
+        assertEquals(targetMajorVersion, response.getTargetMajorVersion());
+    }
+
+    @Test
+    void testUpgradeWhenDatabaseStatusIsNullThenUpgradeNotTriggered() {
+        TargetMajorVersion targetMajorVersion = TargetMajorVersion.VERSION_11;
+        SdxCluster sdxCluster = getSdxCluster();
+        when(sdxService.getByNameOrCrn(any(), eq(NAME_OR_CRN))).thenReturn(sdxCluster);
+        SdxStatusEntity status = getDatalakeStatus(DatalakeStatusEnum.RUNNING);
+        when(sdxStatusService.getActualStatusForSdx(sdxCluster)).thenReturn(status);
+        sdxCluster.setDatabaseCrn(DB_CRN);
+        when(databaseService.getDatabaseServer(DB_CRN)).thenReturn(databaseResponse);
+        when(sdxDatabaseServerUpgradeAvailabilityService.isUpgradeNeeded(databaseResponse, targetMajorVersion)).thenReturn(true);
+        when(databaseUpgradeRuntimeValidator.isRuntimeVersionAllowedForUpgrade(any())).thenReturn(true);
+        when(databaseResponse.getStatus()).thenReturn(null);
+
+        Assertions.assertThatCode(() -> underTest.upgrade(NAME_OR_CRN, targetMajorVersion))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(String.format("Upgrading database server of Data Lake %s is not possible as database server is not available.", SDX_CLUSTER_NAME));
+
+        verify(reactorFlowManager, never()).triggerDatabaseServerUpgradeFlow(any(), any());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = DatabaseServerStatus.class, names = {"AVAILABLE", "UPGRADE_FAILED"}, mode = EnumSource.Mode.EXCLUDE)
+    void testUpgradeWhenDatabaseNotAvailableThenUpgradeNotTriggered(DatabaseServerStatus dbStatus) {
+        TargetMajorVersion targetMajorVersion = TargetMajorVersion.VERSION_11;
+        SdxCluster sdxCluster = getSdxCluster();
+        when(sdxService.getByNameOrCrn(any(), eq(NAME_OR_CRN))).thenReturn(sdxCluster);
+        SdxStatusEntity status = getDatalakeStatus(DatalakeStatusEnum.RUNNING);
+        when(sdxStatusService.getActualStatusForSdx(sdxCluster)).thenReturn(status);
+        sdxCluster.setDatabaseCrn(DB_CRN);
+        when(databaseService.getDatabaseServer(DB_CRN)).thenReturn(databaseResponse);
+        when(sdxDatabaseServerUpgradeAvailabilityService.isUpgradeNeeded(databaseResponse, targetMajorVersion)).thenReturn(true);
+        when(databaseUpgradeRuntimeValidator.isRuntimeVersionAllowedForUpgrade(any())).thenReturn(true);
+        when(databaseResponse.getStatus()).thenReturn(dbStatus);
+
+        Assertions.assertThatCode(() -> underTest.upgrade(NAME_OR_CRN, targetMajorVersion))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(String.format("Upgrading database server of Data Lake %s is not possible as database server is not available, it is in %s state.",
+                        SDX_CLUSTER_NAME, dbStatus));
+
+        verify(reactorFlowManager, never()).triggerDatabaseServerUpgradeFlow(any(), any());
     }
 
     @Test

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/model/common/Status.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/model/common/Status.java
@@ -110,8 +110,8 @@ public enum Status {
     }
 
     public boolean isUpgradeInProgress() {
-        return UPGRADE_REQUESTED.equals(this) ||
-                UPGRADE_IN_PROGRESS.equals(this);
+        return UPGRADE_REQUESTED.equals(this)
+                || UPGRADE_IN_PROGRESS.equals(this);
     }
 
     public static Set<Status> getAutoSyncStatuses() {


### PR DESCRIPTION
…/DH database upgrade

This change adds an extra validation to the DL/DH database upgrade operation that checks in request time if the database that is being upgraded is either in AVAILABLE or UPGRADE_FAILED state.

A small additional change makes sure that when the DH database upgrade endpoint is called without a specified target version the response contains the default target version that will be used for the upgrade, similarly to the behaviour for the DL database upgrade.

See detailed description in the commit message.