### PR TITLE
CB-18563 Datalake failed to start but Environment had run to timeout

### DIFF
--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxFlowEndpoint.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxFlowEndpoint.java
@@ -1,0 +1,18 @@
+package com.sequenceiq.sdx.api.endpoint;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.MediaType;
+
+import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
+import com.sequenceiq.flow.api.FlowEndpoint;
+
+import io.swagger.annotations.Api;
+
+@Path("/flow")
+@RetryAndMetrics
+@Consumes(MediaType.APPLICATION_JSON)
+@Api(value = "/flow", description = "Operations on flow logs", protocols = "http,https",
+        consumes = MediaType.APPLICATION_JSON)
+public interface SdxFlowEndpoint extends FlowEndpoint {
+}

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/client/internal/SdxApiClientConfig.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/client/internal/SdxApiClientConfig.java
@@ -15,6 +15,7 @@ import com.sequenceiq.sdx.api.endpoint.OperationEndpoint;
 import com.sequenceiq.sdx.api.endpoint.ProgressEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxBackupEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxEndpoint;
+import com.sequenceiq.sdx.api.endpoint.SdxFlowEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxInternalEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxRestoreEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxUpgradeEndpoint;
@@ -83,5 +84,11 @@ public class SdxApiClientConfig {
     @ConditionalOnBean(name = "sdxApiClientWebTarget")
     OperationEndpoint createSdxV1OperationEndpoint(WebTarget sdxApiClientWebTarget) {
         return new WebTargetEndpointFactory().createEndpoint(sdxApiClientWebTarget, OperationEndpoint.class);
+    }
+
+    @Bean
+    @ConditionalOnBean(name = "sdxApiClientWebTarget")
+    SdxFlowEndpoint createSdxV1FlowEndpoint(WebTarget sdxApiClientWebTarget) {
+        return new WebTargetEndpointFactory().createEndpoint(sdxApiClientWebTarget, SdxFlowEndpoint.class);
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/configuration/EndpointConfig.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/configuration/EndpointConfig.java
@@ -26,13 +26,13 @@ import com.sequenceiq.datalake.controller.sdx.DatabaseConfigController;
 import com.sequenceiq.datalake.controller.sdx.DatabaseServerController;
 import com.sequenceiq.datalake.controller.sdx.SdxBackupController;
 import com.sequenceiq.datalake.controller.sdx.SdxController;
+import com.sequenceiq.datalake.controller.sdx.SdxFlowController;
 import com.sequenceiq.datalake.controller.sdx.SdxInternalController;
 import com.sequenceiq.datalake.controller.sdx.SdxRecipeController;
 import com.sequenceiq.datalake.controller.sdx.SdxRecoveryController;
 import com.sequenceiq.datalake.controller.sdx.SdxRestoreController;
 import com.sequenceiq.datalake.controller.sdx.SdxUpgradeController;
 import com.sequenceiq.datalake.controller.util.UtilController;
-import com.sequenceiq.flow.controller.FlowController;
 import com.sequenceiq.flow.controller.FlowPublicController;
 import com.sequenceiq.sdx.api.SdxApi;
 
@@ -52,7 +52,7 @@ public class EndpointConfig extends ResourceConfig {
             SdxInternalController.class,
             DatabaseConfigController.class,
             UtilController.class,
-            FlowController.class,
+            SdxFlowController.class,
             FlowPublicController.class,
             AuthorizationInfoController.class,
             DiagnosticsController.class,

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxFlowController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxFlowController.java
@@ -1,0 +1,12 @@
+package com.sequenceiq.datalake.controller.sdx;
+
+import org.springframework.stereotype.Controller;
+
+import com.sequenceiq.authorization.annotation.InternalOnly;
+import com.sequenceiq.flow.controller.FlowController;
+import com.sequenceiq.sdx.api.endpoint.SdxFlowEndpoint;
+
+@Controller
+@InternalOnly
+public class SdxFlowController extends FlowController implements SdxFlowEndpoint {
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/DatalakeMultipleFlowsResultEvaluator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/DatalakeMultipleFlowsResultEvaluator.java
@@ -1,0 +1,81 @@
+package com.sequenceiq.environment.environment.flow;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
+import com.sequenceiq.flow.api.model.FlowCheckResponse;
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+import com.sequenceiq.sdx.api.endpoint.SdxFlowEndpoint;
+
+@Service
+public class DatalakeMultipleFlowsResultEvaluator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DatalakeMultipleFlowsResultEvaluator.class);
+
+    private final SdxFlowEndpoint sdxFlowEndpoint;
+
+    private final RegionAwareInternalCrnGeneratorFactory regionAwareInternalCrnGeneratorFactory;
+
+    public DatalakeMultipleFlowsResultEvaluator(SdxFlowEndpoint sdxFlowEndpoint,
+            RegionAwareInternalCrnGeneratorFactory regionAwareInternalCrnGeneratorFactory) {
+
+        this.sdxFlowEndpoint = sdxFlowEndpoint;
+        this.regionAwareInternalCrnGeneratorFactory = regionAwareInternalCrnGeneratorFactory;
+    }
+
+    public boolean allFinished(List<FlowIdentifier> flowIds) {
+        return !flowIds.stream().anyMatch(this::isFlowRunning);
+    }
+
+    public boolean anyFailed(List<FlowIdentifier> flowIds) {
+        return flowIds.stream().anyMatch(this::isFlowFailed);
+    }
+
+    private Optional<FlowCheckResponse> getFlowCheckResponse(FlowIdentifier flowId) {
+        Optional<FlowCheckResponse> flowCheckResponse = Optional.empty();
+        switch (flowId.getType()) {
+            case FLOW:
+                flowCheckResponse = Optional.of(ThreadBasedUserCrnProvider.doAsInternalActor(
+                        regionAwareInternalCrnGeneratorFactory.iam().getInternalCrnForServiceAsString(),
+                        () -> sdxFlowEndpoint.hasFlowRunningByFlowId(flowId.getPollableId())));
+                break;
+            case FLOW_CHAIN:
+                flowCheckResponse = Optional.of(ThreadBasedUserCrnProvider.doAsInternalActor(
+                        regionAwareInternalCrnGeneratorFactory.iam().getInternalCrnForServiceAsString(),
+                        () -> sdxFlowEndpoint.hasFlowRunningByChainId(flowId.getPollableId())));
+                break;
+            case NOT_TRIGGERED:
+                LOGGER.debug("Flow {} is not triggered.", flowId);
+                break;
+            default:
+                throw new IllegalStateException("Unexpected Flow type: " + flowId.getType());
+        }
+        return flowCheckResponse;
+    }
+
+    private Boolean isFlowFailed(FlowIdentifier flowId) {
+        Optional<FlowCheckResponse> flowCheckResponse = getFlowCheckResponse(flowId);
+        if (flowCheckResponse.isPresent()) {
+            return flowCheckResponse.get().getLatestFlowFinalizedAndFailed();
+        } else {
+            return Boolean.FALSE;
+        }
+    }
+
+    private Boolean isFlowRunning(FlowIdentifier flowId) {
+        Optional<FlowCheckResponse> flowCheckResponse = getFlowCheckResponse(flowId);
+        if (flowCheckResponse.isPresent()) {
+            return flowCheckResponse.get().getHasActiveFlow();
+        } else {
+            return Boolean.FALSE;
+        }
+    }
+
+}
+

--- a/environment/src/main/java/com/sequenceiq/environment/environment/poller/SdxPollerProvider.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/poller/SdxPollerProvider.java
@@ -1,8 +1,6 @@
 package com.sequenceiq.environment.environment.poller;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,12 +11,12 @@ import com.dyngr.core.AttemptResult;
 import com.dyngr.core.AttemptResults;
 import com.dyngr.exception.PollerStoppedException;
 import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
+import com.sequenceiq.environment.environment.flow.DatalakeMultipleFlowsResultEvaluator;
 import com.sequenceiq.environment.environment.service.sdx.SdxService;
 import com.sequenceiq.environment.store.EnvironmentInMemoryStateStore;
+import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.flow.api.model.operation.OperationProgressStatus;
 import com.sequenceiq.flow.api.model.operation.OperationView;
-import com.sequenceiq.sdx.api.model.SdxClusterResponse;
-import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 
 @Component
 public class SdxPollerProvider {
@@ -27,52 +25,29 @@ public class SdxPollerProvider {
 
     private final SdxService sdxService;
 
-    private final ClusterPollerResultEvaluator clusterPollerResultEvaluator;
+    private final DatalakeMultipleFlowsResultEvaluator multipleFlowsResultEvaluator;
 
-    public SdxPollerProvider(SdxService sdxService, ClusterPollerResultEvaluator clusterPollerResultEvaluator) {
+    public SdxPollerProvider(SdxService sdxService,
+            DatalakeMultipleFlowsResultEvaluator multipleFlowsResultEvaluator) {
         this.sdxService = sdxService;
-        this.clusterPollerResultEvaluator = clusterPollerResultEvaluator;
+        this.multipleFlowsResultEvaluator = multipleFlowsResultEvaluator;
     }
 
-    public AttemptMaker<Void> startSdxClustersPoller(Long envId, List<String> pollingCrns) {
-        List<String> mutableCrnList = new ArrayList<>(pollingCrns);
-        return () -> {
-            List<String> remaining = new ArrayList<>();
-            List<AttemptResult<Void>> results = collectSdxStartResults(mutableCrnList, remaining, envId);
-            mutableCrnList.retainAll(remaining);
-            return clusterPollerResultEvaluator.evaluateResult(results);
-        };
+    public AttemptMaker<Void> startStopSdxClustersPoller(Long envId, List<FlowIdentifier> flowIdentifiers) {
+        return () -> collectSdxResults(flowIdentifiers, envId);
     }
 
-    private List<AttemptResult<Void>> collectSdxStartResults(List<String> pollingCrns, List<String> remainingCrns, Long envId) {
+    private AttemptResult<Void> collectSdxResults(List<FlowIdentifier> flowIdentifiers, Long envId) {
         if (PollGroup.CANCELLED.equals(EnvironmentInMemoryStateStore.get(envId))) {
             String message = "Sdx polling cancelled in inmemory store, id: " + envId;
             LOGGER.info(message);
             throw new PollerStoppedException(message);
         }
-        return pollingCrns.stream()
-                .map(crn -> fetchStartSdxClustersResult(crn, remainingCrns))
-                .collect(Collectors.toList());
-    }
-
-    private AttemptResult<Void> fetchStartSdxClustersResult(String sdxCrn, List<String> remainingCrns) {
-        SdxClusterResponse sdx = sdxService.getByCrn(sdxCrn);
-        if (sdxStarted(sdx)) {
-            return AttemptResults.finishWith(null);
+        if (multipleFlowsResultEvaluator.allFinished(flowIdentifiers)) {
+            return AttemptResults.justFinish();
         } else {
-            remainingCrns.add(sdxCrn);
-            return checkSdxStartStatus(sdx);
+            return AttemptResults.justContinue();
         }
-    }
-
-    public AttemptMaker<Void> stopSdxClustersPoller(Long envId, List<String> pollingCrns) {
-        List<String> mutableCrnList = new ArrayList<>(pollingCrns);
-        return () -> {
-            List<String> remaining = new ArrayList<>();
-            List<AttemptResult<Void>> results = collectSdxStopResults(mutableCrnList, remaining, envId);
-            mutableCrnList.retainAll(remaining);
-            return clusterPollerResultEvaluator.evaluateResult(results);
-        };
     }
 
     public AttemptResult<Void> upgradeCcmPoller(Long envId, String datalakeCrn) {
@@ -95,53 +70,6 @@ public class SdxPollerProvider {
             default:
                 return AttemptResults.breakFor("SDX Upgrade CCM is in ambiguous state " + progressStatus + " for environment CRN " + datalakeCrn);
         }
-    }
-
-    private List<AttemptResult<Void>> collectSdxStopResults(List<String> pollingCrns, List<String> remainingCrns, Long envId) {
-        if (PollGroup.CANCELLED.equals(EnvironmentInMemoryStateStore.get(envId))) {
-            String message = "Sdx polling cancelled in inmemory store, id: " + envId;
-            LOGGER.info(message);
-            throw new PollerStoppedException(message);
-        }
-        return pollingCrns.stream()
-                .map(crn -> fetchStopSdxClustersResult(remainingCrns, crn))
-                .collect(Collectors.toList());
-    }
-
-    private AttemptResult<Void> fetchStopSdxClustersResult(List<String> remainingCrns, String crn) {
-        SdxClusterResponse sdx = sdxService.getByCrn(crn);
-        if (sdxStopped(sdx)) {
-            return AttemptResults.finishWith(null);
-        } else {
-            remainingCrns.add(crn);
-            return checkSdxStopStatus(sdx);
-        }
-    }
-
-    private AttemptResult<Void> checkSdxStopStatus(SdxClusterResponse sdx) {
-        if (SdxClusterStatusResponse.STOP_FAILED.equals(sdx.getStatus())) {
-            LOGGER.error("SDX stop failed for '{}' with status {}, reason: {}", sdx.getName(), sdx.getStatus(), sdx.getStatusReason());
-            return AttemptResults.breakFor("SDX stop failed '" + sdx.getName() + "', " + sdx.getStatusReason());
-        } else {
-            return AttemptResults.justContinue();
-        }
-    }
-
-    private AttemptResult<Void> checkSdxStartStatus(SdxClusterResponse sdx) {
-        if (SdxClusterStatusResponse.START_FAILED.equals(sdx.getStatus())) {
-            LOGGER.error("SDX start failed for '{}' with status {}, reason: {}", sdx.getName(), sdx.getStatus(), sdx.getStatusReason());
-            return AttemptResults.breakFor("SDX start failed '" + sdx.getName() + "', " + sdx.getStatusReason());
-        } else {
-            return AttemptResults.justContinue();
-        }
-    }
-
-    private boolean sdxStopped(SdxClusterResponse sdx) {
-        return SdxClusterStatusResponse.STOPPED.equals(sdx.getStatus());
-    }
-
-    private boolean sdxStarted(SdxClusterResponse sdx) {
-        return SdxClusterStatusResponse.RUNNING.equals(sdx.getStatus());
     }
 
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/sdx/SdxService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/sdx/SdxService.java
@@ -14,6 +14,7 @@ import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory
 import com.sequenceiq.cloudbreak.common.exception.WebApplicationExceptionMessageExtractor;
 import com.sequenceiq.cloudbreak.saas.sdx.PaasRemoteDataContextSupplier;
 import com.sequenceiq.environment.exception.SdxOperationFailedException;
+import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.flow.api.model.operation.OperationView;
 import com.sequenceiq.sdx.api.endpoint.OperationEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxEndpoint;
@@ -68,9 +69,9 @@ public class SdxService implements PaasRemoteDataContextSupplier {
         }
     }
 
-    public void startByCrn(String crn) {
+    public FlowIdentifier startByCrn(String crn) {
         try {
-            sdxEndpoint.startByCrn(crn);
+            return sdxEndpoint.startByCrn(crn);
         } catch (WebApplicationException e) {
             String errorMessage = webApplicationExceptionMessageExtractor.getErrorMessage(e);
             LOGGER.error(String.format("Failed to start SDX cluster by crn '%s' due to '%s'.", crn, errorMessage), e);
@@ -78,9 +79,9 @@ public class SdxService implements PaasRemoteDataContextSupplier {
         }
     }
 
-    public void stopByCrn(String crn) {
+    public FlowIdentifier stopByCrn(String crn) {
         try {
-            sdxEndpoint.stopByCrn(crn);
+            return sdxEndpoint.stopByCrn(crn);
         } catch (WebApplicationException e) {
             String errorMessage = webApplicationExceptionMessageExtractor.getErrorMessage(e);
             LOGGER.error(String.format("Failed to stop SDX cluster by crn '%s' due to '%s'.", crn, errorMessage), e);

--- a/environment/src/test/java/com/sequenceiq/environment/environment/flow/DatalakeMultipleFlowsResultEvaluatorTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/flow/DatalakeMultipleFlowsResultEvaluatorTest.java
@@ -1,0 +1,114 @@
+package com.sequenceiq.environment.environment.flow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGenerator;
+import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
+import com.sequenceiq.flow.api.model.FlowCheckResponse;
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+import com.sequenceiq.flow.api.model.FlowType;
+import com.sequenceiq.sdx.api.endpoint.SdxFlowEndpoint;
+
+@ExtendWith(MockitoExtension.class)
+public class DatalakeMultipleFlowsResultEvaluatorTest {
+
+    @Mock
+    private SdxFlowEndpoint flowEndpoint;
+
+    @Mock
+    private RegionAwareInternalCrnGeneratorFactory regionAwareInternalCrnGeneratorFactory;
+
+    @Mock
+    private RegionAwareInternalCrnGenerator regionAwareInternalCrnGenerator;
+
+    @InjectMocks
+    private DatalakeMultipleFlowsResultEvaluator underTest;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(regionAwareInternalCrnGenerator.getInternalCrnForServiceAsString()).thenReturn("crn");
+        lenient().when(regionAwareInternalCrnGeneratorFactory.iam()).thenReturn(regionAwareInternalCrnGenerator);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("scenariosAllFinished")
+    void testAllFinished(String testName, boolean flow1Active, boolean flow1Failed, boolean flow2Active, boolean flow2Failed, boolean expectedResult) {
+        FlowIdentifier flowId1 = createFlowIdentifier();
+        FlowIdentifier flowId2 = createFlowIdentifier();
+        FlowCheckResponse checkResponse1 = createFlowCheckResponse(flowId1, flow1Active, flow1Failed);
+        FlowCheckResponse checkResponse2 = createFlowCheckResponse(flowId2, flow2Active, flow2Failed);
+        lenient().when(flowEndpoint.hasFlowRunningByFlowId(flowId1.getPollableId())).thenReturn(checkResponse1);
+        lenient().when(flowEndpoint.hasFlowRunningByFlowId(flowId2.getPollableId())).thenReturn(checkResponse2);
+
+        boolean result = underTest.allFinished(List.of(flowId1, flowId2));
+        assertThat(result).isEqualTo(expectedResult);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("scenariosAnyFailed")
+    void testAnyFailed(String testName, boolean flow1Active, boolean flow1Failed, boolean flow2Active, boolean flow2Failed, boolean expectedResult) {
+        FlowIdentifier flowId1 = createFlowIdentifier();
+        FlowIdentifier flowId2 = createFlowIdentifier();
+        FlowCheckResponse checkResponse1 = createFlowCheckResponse(flowId1, flow1Active, flow1Failed);
+        FlowCheckResponse checkResponse2 = createFlowCheckResponse(flowId2, flow2Active, flow2Failed);
+        lenient().when(flowEndpoint.hasFlowRunningByFlowId(flowId1.getPollableId())).thenReturn(checkResponse1);
+        lenient().when(flowEndpoint.hasFlowRunningByFlowId(flowId2.getPollableId())).thenReturn(checkResponse2);
+
+        boolean result = underTest.anyFailed(List.of(flowId1, flowId2));
+        assertThat(result).isEqualTo(expectedResult);
+    }
+
+    private FlowIdentifier createFlowIdentifier() {
+        return new FlowIdentifier(FlowType.FLOW, UUID.randomUUID().toString());
+    }
+
+    private FlowCheckResponse createFlowCheckResponse(FlowIdentifier flowId, boolean flowActive, boolean flowFailed) {
+        FlowCheckResponse checkResponse = new FlowCheckResponse();
+        checkResponse.setFlowId(flowId.getPollableId());
+        checkResponse.setHasActiveFlow(flowActive);
+        checkResponse.setLatestFlowFinalizedAndFailed(flowFailed);
+        return checkResponse;
+    }
+
+    // @formatter:off
+    // CHECKSTYLE:OFF
+    public static Object[][] scenariosAllFinished() {
+        return new Object[][] {
+                // testName                     flow1Active flow1Failed flow2Active flow2Failed allFinished
+                { "Flow1 and Flow2 finished",   false,      false,      false,      false,      true  },
+                { "Flow1 active",               true,       false,      false,      false,      false },
+                { "Flow1 failed",               false,      true,       false,      false,      true  },
+                { "Flow2 active",               false,      false,      true,       false,      false },
+                { "Flow2 failed",               false,      false,      false,      true,       true  },
+                { "Flow1 and Flow2 active",     true,       false,      true,       false,      false },
+                { "Flow1 and Flow2 failed",     false,      true,       false,      true,       true  },
+        };
+    }
+
+    public static Object[][] scenariosAnyFailed() {
+        return new Object[][] {
+                // testName                     flow1Active flow1Failed flow2Active flow2Failed allFinished
+                { "Flow1 and Flow2 finished",   false,      false,      false,      false,      false },
+                { "Flow1 active",               true,       false,      false,      false,      false },
+                { "Flow1 failed",               false,      true,       false,      false,      true  },
+                { "Flow2 active",               false,      false,      true,       false,      false },
+                { "Flow2 failed",               false,      false,      false,      true,       true  },
+                { "Flow1 and Flow2 active",     true,       false,      true,       false,      false },
+                { "Flow1 and Flow2 failed",     false,      true,       false,      true,       true  },
+        };
+    }
+    // CHECKSTYLE:ON
+    // @formatter:on
+}

--- a/environment/src/test/java/com/sequenceiq/environment/environment/poller/SdxPollerProviderTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/poller/SdxPollerProviderTest.java
@@ -1,11 +1,10 @@
 package com.sequenceiq.environment.environment.poller;
 
-import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -16,7 +15,9 @@ import org.mockito.Mockito;
 
 import com.dyngr.core.AttemptResult;
 import com.dyngr.core.AttemptState;
+import com.sequenceiq.environment.environment.flow.DatalakeMultipleFlowsResultEvaluator;
 import com.sequenceiq.environment.environment.service.sdx.SdxService;
+import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.flow.api.model.operation.OperationProgressStatus;
 import com.sequenceiq.flow.api.model.operation.OperationView;
 import com.sequenceiq.sdx.api.model.SdxClusterResponse;
@@ -28,42 +29,30 @@ class SdxPollerProviderTest {
 
     private final SdxService sdxService = Mockito.mock(SdxService.class);
 
-    private final ClusterPollerResultEvaluator clusterPollerResultEvaluator = new ClusterPollerResultEvaluator();
+    private final FlowIdentifier flowIdentifier1 = Mockito.mock(FlowIdentifier.class);
 
-    private SdxPollerProvider underTest = new SdxPollerProvider(sdxService, clusterPollerResultEvaluator);
+    private final FlowIdentifier flowIdentifier2 = Mockito.mock(FlowIdentifier.class);
+
+    private final DatalakeMultipleFlowsResultEvaluator multipleFlowsResultEvaluator = Mockito.mock(DatalakeMultipleFlowsResultEvaluator.class);
+
+    private SdxPollerProvider underTest = new SdxPollerProvider(sdxService, multipleFlowsResultEvaluator);
 
     @ParameterizedTest
     @MethodSource("datalakeStopStatuses")
-    void testStopDatalakePoller(SdxClusterStatusResponse s1Status, SdxClusterStatusResponse s2Status,
-            AttemptState attemptState, String message, List<String> remaining) throws Exception {
-        List<String> pollingCrn = new ArrayList<>();
-        pollingCrn.add("crn1");
-        pollingCrn.add("crn2");
-        SdxClusterResponse sdx1 = getSdxResponse(s1Status, "crn1");
-        SdxClusterResponse sdx2 = getSdxResponse(s2Status, "crn2");
+    void testStopDatalakePoller(AttemptState attemptState, Boolean allFinished) throws Exception {
+        when(multipleFlowsResultEvaluator.allFinished(anyList())).thenReturn(allFinished);
 
-        when(sdxService.getByCrn("crn1")).thenReturn(sdx1);
-        when(sdxService.getByCrn("crn2")).thenReturn(sdx2);
-
-        AttemptResult<Void> result = underTest.stopSdxClustersPoller(ENV_ID, pollingCrn).process();
+        AttemptResult<Void> result = underTest.startStopSdxClustersPoller(ENV_ID, List.of(flowIdentifier1, flowIdentifier2)).process();
 
         assertEquals(attemptState, result.getState());
     }
 
     @ParameterizedTest
     @MethodSource("datalakeStartStatuses")
-    void testStartDatalakePoller(SdxClusterStatusResponse s1Status, SdxClusterStatusResponse s2Status, AttemptState attemptState, String message,
-            List<String> remaining) throws Exception {
-        List<String> pollingCrn = new ArrayList<>();
-        pollingCrn.add("crn1");
-        pollingCrn.add("crn2");
-        SdxClusterResponse sdx1 = getSdxResponse(s1Status, "crn1");
-        SdxClusterResponse sdx2 = getSdxResponse(s2Status, "crn2");
+    void testStartDatalakePoller(AttemptState attemptState, Boolean allFinished) throws Exception {
+        when(multipleFlowsResultEvaluator.allFinished(anyList())).thenReturn(allFinished);
 
-        when(sdxService.getByCrn("crn1")).thenReturn(sdx1);
-        when(sdxService.getByCrn("crn2")).thenReturn(sdx2);
-
-        AttemptResult<Void> result = underTest.startSdxClustersPoller(ENV_ID, pollingCrn).process();
+        AttemptResult<Void> result = underTest.startStopSdxClustersPoller(ENV_ID, List.of(flowIdentifier1, flowIdentifier2)).process();
 
         assertEquals(attemptState, result.getState());
     }
@@ -78,19 +67,15 @@ class SdxPollerProviderTest {
 
     private static Stream<Arguments> datalakeStopStatuses() {
         return Stream.of(
-                Arguments.of(SdxClusterStatusResponse.STOPPED, SdxClusterStatusResponse.STOPPED, AttemptState.FINISH, "", emptyList()),
-                Arguments.of(SdxClusterStatusResponse.STOP_IN_PROGRESS, SdxClusterStatusResponse.STOPPED, AttemptState.CONTINUE, "", List.of("crn1")),
-                Arguments.of(SdxClusterStatusResponse.STOP_FAILED, SdxClusterStatusResponse.STOPPED, AttemptState.BREAK, "SDX stop failed 'crn1', reason",
-                        List.of("crn1"))
+                Arguments.of(AttemptState.FINISH, Boolean.TRUE),
+                Arguments.of(AttemptState.CONTINUE, Boolean.FALSE)
         );
     }
 
     private static Stream<Arguments> datalakeStartStatuses() {
         return Stream.of(
-                Arguments.of(SdxClusterStatusResponse.RUNNING, SdxClusterStatusResponse.RUNNING, AttemptState.FINISH, "", emptyList()),
-                Arguments.of(SdxClusterStatusResponse.START_IN_PROGRESS, SdxClusterStatusResponse.RUNNING, AttemptState.CONTINUE, "", List.of("crn1")),
-                Arguments.of(SdxClusterStatusResponse.START_FAILED, SdxClusterStatusResponse.RUNNING, AttemptState.BREAK, "SDX start failed 'crn1', reason",
-                        List.of("crn1"))
+                Arguments.of(AttemptState.FINISH, Boolean.TRUE),
+                Arguments.of(AttemptState.CONTINUE, Boolean.FALSE)
         );
     }
 

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/sdx/SdxPollerServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/sdx/SdxPollerServiceTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Set;
-import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -16,6 +16,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.sdx.api.model.SdxClusterResponse;
 import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 
@@ -31,7 +32,7 @@ public class SdxPollerServiceTest {
     private SdxService sdxService;
 
     @Mock
-    private Consumer<String> consumer;
+    private Function<String, FlowIdentifier> consumer;
 
     @Test
     public void testGetExecuteSdxOperationsAndGetCrnsWhenShouldSkipTheConsumer() {
@@ -40,23 +41,22 @@ public class SdxPollerServiceTest {
         sdxClusterResponse.setStatus(SdxClusterStatusResponse.STOPPED);
         when(sdxService.list(ENV_NAME)).thenReturn(List.of(sdxClusterResponse));
 
-        List<String> actual = underTest.getExecuteSdxOperationsAndGetCrns(ENV_NAME, consumer, Set.of(SdxClusterStatusResponse.STOPPED));
+        List<FlowIdentifier> actual = underTest.getExecuteSdxOperationsAndGetCrns(ENV_NAME, consumer, Set.of(SdxClusterStatusResponse.STOPPED));
 
-        verify(consumer, never()).accept(any());
+        verify(consumer, never()).apply(any());
         Assertions.assertEquals(1, actual.size());
     }
 
     @Test
     public void testGetExecuteSdxOperationsAndGetCrnsWhenShouldNotSkipTheConsumer() {
-
         SdxClusterResponse sdxClusterResponse = new SdxClusterResponse();
         sdxClusterResponse.setStatus(SdxClusterStatusResponse.RUNNING);
         sdxClusterResponse.setCrn("crn");
         when(sdxService.list(ENV_NAME)).thenReturn(List.of(sdxClusterResponse));
 
-        List<String> actual = underTest.getExecuteSdxOperationsAndGetCrns(ENV_NAME, consumer, Set.of(SdxClusterStatusResponse.STOPPED));
+        List<FlowIdentifier> actual = underTest.getExecuteSdxOperationsAndGetCrns(ENV_NAME, consumer, Set.of(SdxClusterStatusResponse.STOPPED));
 
-        verify(consumer).accept(any());
+        verify(consumer).apply(any());
         Assertions.assertEquals(1, actual.size());
     }
 
@@ -71,10 +71,10 @@ public class SdxPollerServiceTest {
         sdxClusterResponse1.setCrn("crn1");
         when(sdxService.list(ENV_NAME)).thenReturn(List.of(sdxClusterResponse, sdxClusterResponse1));
 
-        List<String> actual = underTest.getExecuteSdxOperationsAndGetCrns(ENV_NAME, consumer, Set.of(SdxClusterStatusResponse.STOPPED));
+        List<FlowIdentifier> actual = underTest.getExecuteSdxOperationsAndGetCrns(ENV_NAME, consumer, Set.of(SdxClusterStatusResponse.STOPPED));
 
-        verify(consumer).accept("crn");
-        verify(consumer, never()).accept("crn1");
+        verify(consumer).apply("crn");
+        verify(consumer, never()).apply("crn1");
         Assertions.assertEquals(2, actual.size());
     }
 


### PR DESCRIPTION
The environment poller shouldn't stop in case of exception, because the flow is still running on the datalake side.