### PR TITLE
CB-18416, CB-18417, CB-18418: E2E tests for Postgres Upgrade on AWS, Azure, GCP

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxUpgradeDatabaseServerAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxUpgradeDatabaseServerAction.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.it.cloudbreak.action.sdx;
+
+import java.util.Collections;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.SdxClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
+import com.sequenceiq.sdx.api.model.SdxUpgradeDatabaseServerRequest;
+import com.sequenceiq.sdx.api.model.SdxUpgradeDatabaseServerResponse;
+
+public class SdxUpgradeDatabaseServerAction implements Action<SdxTestDto, SdxClient> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxUpgradeDatabaseServerAction.class);
+
+    @Override
+    public SdxTestDto action(TestContext testContext, SdxTestDto testDto, SdxClient client) throws Exception {
+        SdxUpgradeDatabaseServerRequest upgradeDatabaseServerRequest = testDto.getSdxUpgradeDatabaseServerRequest();
+
+        Log.when(LOGGER, " SDX endpoint: %s" + client.getDefaultClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
+        Log.whenJson(LOGGER, " SDX upgrade database server request: ", upgradeDatabaseServerRequest);
+        SdxUpgradeDatabaseServerResponse upgradeDatabaseServerResponse = client.getDefaultClient()
+                .sdxUpgradeEndpoint()
+                .upgradeDatabaseServerByName(testDto.getName(), upgradeDatabaseServerRequest);
+        testDto.setFlow("SDX upgrade database server", upgradeDatabaseServerResponse.getFlowIdentifier());
+        SdxClusterDetailResponse detailedResponse = client.getDefaultClient()
+                .sdxEndpoint()
+                .getDetail(testDto.getName(), Collections.emptySet());
+        testDto.setResponse(detailedResponse);
+        Log.whenJson(LOGGER, " SDX upgrade database server response: ", detailedResponse);
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/SdxTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/SdxTestClient.java
@@ -44,6 +44,7 @@ import com.sequenceiq.it.cloudbreak.action.sdx.SdxStopAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxSyncAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxSyncInternalAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxUpgradeAction;
+import com.sequenceiq.it.cloudbreak.action.sdx.SdxUpgradeDatabaseServerAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxUpgradeRecoveryAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxVerticalScaleAction;
 import com.sequenceiq.it.cloudbreak.action.v4.util.RenewDatalakeCertificateAction;
@@ -146,6 +147,10 @@ public class SdxTestClient {
 
     public Action<SdxInternalTestDto, SdxClient> upgradeInternal() {
         return new SdxInternalUpgradeAction();
+    }
+
+    public Action<SdxTestDto, SdxClient> upgradeDatabaseServer() {
+        return new SdxUpgradeDatabaseServerAction();
     }
 
     public Action<SdxTestDto, SdxClient> recoverFromUpgrade() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/AbstractCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/AbstractCloudProvider.java
@@ -364,6 +364,11 @@ public abstract class AbstractCloudProvider implements CloudProvider {
     }
 
     @Override
+    public boolean isExternalDatabaseSslEnforcementSupported() {
+        return false;
+    }
+
+    @Override
     public EnvironmentNetworkTestDto newNetwork(EnvironmentNetworkTestDto network) {
         return network;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProvider.java
@@ -201,4 +201,6 @@ public interface CloudProvider {
     boolean isMultiAZ();
 
     boolean verticalScalingSupported();
+
+    boolean isExternalDatabaseSslEnforcementSupported();
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProviderProxy.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProviderProxy.java
@@ -470,4 +470,8 @@ public class CloudProviderProxy implements CloudProvider {
     public boolean verticalScalingSupported() {
         return delegate.verticalScalingSupported();
     }
+
+    public boolean isExternalDatabaseSslEnforcementSupported() {
+        return delegate.isExternalDatabaseSslEnforcementSupported();
+    }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CommonClusterManagerProperties.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CommonClusterManagerProperties.java
@@ -23,6 +23,8 @@ public class CommonClusterManagerProperties {
 
     private UpgradeProperties upgrade = new UpgradeProperties();
 
+    private UpgradeDatabaseServerProperties upgradeDatabaseServer = new UpgradeDatabaseServerProperties();
+
     public String getRuntimeVersion() {
         return runtimeVersion;
     }
@@ -72,6 +74,10 @@ public class CommonClusterManagerProperties {
 
     public UpgradeProperties getUpgrade() {
         return upgrade;
+    }
+
+    public UpgradeDatabaseServerProperties getUpgradeDatabaseServer() {
+        return upgradeDatabaseServer;
     }
 
     public static class ClouderaManager {
@@ -188,5 +194,27 @@ public class CommonClusterManagerProperties {
             this.distroXUpgrade3rdPartyTargetVersion = distroXUpgrade3rdPartyTargetVersion;
         }
 
+    }
+
+    public static class UpgradeDatabaseServerProperties {
+        private String originalDatabaseMajorVersion;
+
+        private String targetDatabaseMajorVersion;
+
+        public String getOriginalDatabaseMajorVersion() {
+            return originalDatabaseMajorVersion;
+        }
+
+        public void setOriginalDatabaseMajorVersion(String originalDatabaseMajorVersion) {
+            this.originalDatabaseMajorVersion = originalDatabaseMajorVersion;
+        }
+
+        public String getTargetDatabaseMajorVersion() {
+            return targetDatabaseMajorVersion;
+        }
+
+        public void setTargetDatabaseMajorVersion(String targetDatabaseMajorVersion) {
+            this.targetDatabaseMajorVersion = targetDatabaseMajorVersion;
+        }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProvider.java
@@ -572,4 +572,9 @@ public class AwsCloudProvider extends AbstractCloudProvider {
     public boolean isMultiAZ() {
         return awsProperties.getMultiaz();
     }
+
+    @Override
+    public boolean isExternalDatabaseSslEnforcementSupported() {
+        return awsProperties.getExternalDatabaseSslEnforcementSupported();
+    }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsProperties.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsProperties.java
@@ -30,6 +30,8 @@ public class AwsProperties {
 
     private Boolean govCloud;
 
+    private Boolean externalDatabaseSslEnforcementSupported;
+
     private final Instance instance = new Instance();
 
     private final Instance storageOptimizedInstance = new Instance();
@@ -84,6 +86,14 @@ public class AwsProperties {
 
     public void setGovCloud(Boolean govCloud) {
         this.govCloud = govCloud;
+    }
+
+    public Boolean getExternalDatabaseSslEnforcementSupported() {
+        return Boolean.TRUE.equals(externalDatabaseSslEnforcementSupported);
+    }
+
+    public void setExternalDatabaseSslEnforcementSupported(Boolean externalDatabaseSslEnforcementSupported) {
+        this.externalDatabaseSslEnforcementSupported = externalDatabaseSslEnforcementSupported;
     }
 
     public String getLocation() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
@@ -509,4 +509,9 @@ public class AzureCloudProvider extends AbstractCloudProvider {
             Log.then(LOGGER, format(" Volume has been encrypted with '%s' DES key. ", desKeyUrl));
         }
     }
+
+    @Override
+    public boolean isExternalDatabaseSslEnforcementSupported() {
+        return azureProperties.getExternalDatabaseSslEnforcementSupported();
+    }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureProperties.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureProperties.java
@@ -38,6 +38,8 @@ public class AzureProperties {
 
     private VerticalScaleProperties verticalScale = new VerticalScaleProperties();
 
+    private Boolean externalDatabaseSslEnforcementSupported;
+
     public VerticalScaleProperties getVerticalScale() {
         return verticalScale;
     }
@@ -108,6 +110,14 @@ public class AzureProperties {
 
     public Resourcegroup getResourcegroup() {
         return resourcegroup;
+    }
+
+    public Boolean getExternalDatabaseSslEnforcementSupported() {
+        return Boolean.TRUE.equals(externalDatabaseSslEnforcementSupported);
+    }
+
+    public void setExternalDatabaseSslEnforcementSupported(Boolean externalDatabaseSslEnforcementSupported) {
+        this.externalDatabaseSslEnforcementSupported = externalDatabaseSslEnforcementSupported;
     }
 
     public static class Credential {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpCloudProvider.java
@@ -545,4 +545,9 @@ public class GcpCloudProvider extends AbstractCloudProvider {
     public boolean isMultiAZ() {
         return gcpProperties.getMultiaz();
     }
+
+    @Override
+    public boolean isExternalDatabaseSslEnforcementSupported() {
+        return gcpProperties.getExternalDatabaseSslEnforcementSupported();
+    }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpProperties.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpProperties.java
@@ -20,6 +20,8 @@ public class GcpProperties {
 
     private Boolean multiaz;
 
+    private Boolean externalDatabaseSslEnforcementSupported;
+
     private final Credential credential = new Credential();
 
     private final Instance instance = new Instance();
@@ -63,6 +65,14 @@ public class GcpProperties {
 
     public void setMultiaz(Boolean multiaz) {
         this.multiaz = multiaz;
+    }
+
+    public Boolean getExternalDatabaseSslEnforcementSupported() {
+        return Boolean.TRUE.equals(externalDatabaseSslEnforcementSupported);
+    }
+
+    public void setExternalDatabaseSslEnforcementSupported(Boolean externalDatabaseSslEnforcementSupported) {
+        this.externalDatabaseSslEnforcementSupported = externalDatabaseSslEnforcementSupported;
     }
 
     public Baseimage getBaseimage() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
@@ -62,6 +62,7 @@ import com.sequenceiq.sdx.api.model.SdxInstanceGroupRequest;
 import com.sequenceiq.sdx.api.model.SdxRecipe;
 import com.sequenceiq.sdx.api.model.SdxRecoveryRequest;
 import com.sequenceiq.sdx.api.model.SdxRepairRequest;
+import com.sequenceiq.sdx.api.model.SdxUpgradeDatabaseServerRequest;
 import com.sequenceiq.sdx.api.model.SdxUpgradeRequest;
 
 @Prototype
@@ -364,6 +365,14 @@ public class SdxTestDto extends AbstractSdxTestDto<SdxClusterRequest, SdxCluster
             throw new IllegalArgumentException("SDX Upgrade does not exist!");
         }
         return upgrade.getRequest();
+    }
+
+    public SdxUpgradeDatabaseServerRequest getSdxUpgradeDatabaseServerRequest() {
+        SdxUpgradeDatabaseServerTestDto upgradeDatabaseServer = given(SdxUpgradeDatabaseServerTestDto.class);
+        if (upgradeDatabaseServer == null) {
+            throw new IllegalArgumentException("SDX Upgrade Database Server does not exist!");
+        }
+        return upgradeDatabaseServer.getRequest();
     }
 
     public SdxRecoveryRequest getSdxRecoveryRequest() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxUpgradeDatabaseServerTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxUpgradeDatabaseServerTestDto.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.it.cloudbreak.dto.sdx;
+
+import com.sequenceiq.cloudbreak.common.database.TargetMajorVersion;
+import com.sequenceiq.it.cloudbreak.Prototype;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractSdxTestDto;
+import com.sequenceiq.sdx.api.model.SdxUpgradeDatabaseServerRequest;
+import com.sequenceiq.sdx.api.model.SdxUpgradeDatabaseServerResponse;
+
+@Prototype
+public class SdxUpgradeDatabaseServerTestDto extends AbstractSdxTestDto<SdxUpgradeDatabaseServerRequest, SdxUpgradeDatabaseServerResponse,
+        SdxUpgradeDatabaseServerTestDto> {
+    public SdxUpgradeDatabaseServerTestDto(SdxUpgradeDatabaseServerRequest request, TestContext testContext) {
+        super(request, testContext);
+    }
+
+    public SdxUpgradeDatabaseServerTestDto(TestContext testContext) {
+        super(new SdxUpgradeDatabaseServerRequest(), testContext);
+    }
+
+    public SdxUpgradeDatabaseServerTestDto() {
+        super(SdxUpgradeDatabaseServerTestDto.class.getSimpleName().toUpperCase());
+    }
+
+    @Override
+    public SdxUpgradeDatabaseServerTestDto valid() {
+        return this;
+    }
+
+    public SdxUpgradeDatabaseServerTestDto withTargetMajorVersion(TargetMajorVersion targetMajorVersion) {
+        getRequest().setTargetMajorVersion(targetMajorVersion);
+        return this;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxUpgradeDatabaseServerTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxUpgradeDatabaseServerTests.java
@@ -1,0 +1,127 @@
+package com.sequenceiq.it.cloudbreak.testcase.e2e.sdx;
+
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import com.sequenceiq.cloudbreak.common.database.TargetMajorVersion;
+import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
+import com.sequenceiq.it.cloudbreak.cloud.v4.CommonClusterManagerProperties;
+import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxUpgradeDatabaseServerTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
+import com.sequenceiq.it.cloudbreak.util.ssh.action.SshJClientActions;
+import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
+import com.sequenceiq.sdx.api.model.SdxDatabaseAvailabilityType;
+import com.sequenceiq.sdx.api.model.SdxDatabaseRequest;
+
+public class SdxUpgradeDatabaseServerTests extends PreconditionSdxE2ETest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxUpgradeDatabaseServerTests.class);
+
+    private static final String DBSERVER_VERSION_CMD_SSL = "sudo sh -c '. activate_salt_env; \\\n" +
+            "DBUSER=$(salt-call pillar.get \"postgres:clouderamanager:remote_admin\" --output json 2>/dev/null | jq -r .local); \\\n" +
+            "DBHOST=$(salt-call pillar.get \"postgres:clouderamanager:remote_db_url\" --output json 2>/dev/null | jq -r .local); \\\n" +
+            "DBPORT=$(salt-call pillar.get \"postgres:clouderamanager:remote_db_port\" --output json 2>/dev/null | jq -r .local); \\\n" +
+            "export PGPASSWORD=$(salt-call pillar.get \"postgres:clouderamanager:remote_admin_pw\" --output json 2>/dev/null | jq -r .local); \\\n" +
+            "export PGSSLROOTCERT=$(salt-call pillar.get \"postgres_root_certs:ssl_certs_file_path\" --output json 2>/dev/null | jq -r .local); \\\n" +
+            "export PGSSLMODE=verify-full; \\\n" +
+            "psql -h \"$DBHOST\" -p \"$DBPORT\" -U \"$DBUSER\" -d postgres -c \"show server_version\" | grep -o \"[0-9]*\\.\"'";
+
+    private static final String DBSERVER_VERSION_CMD = "sudo sh -c '. activate_salt_env; \\\n" +
+            "DBUSER=$(salt-call pillar.get \"postgres:clouderamanager:remote_admin\" --output json 2>/dev/null | jq -r .local); \\\n" +
+            "DBHOST=$(salt-call pillar.get \"postgres:clouderamanager:remote_db_url\" --output json 2>/dev/null | jq -r .local); \\\n" +
+            "DBPORT=$(salt-call pillar.get \"postgres:clouderamanager:remote_db_port\" --output json 2>/dev/null | jq -r .local); \\\n" +
+            "export PGPASSWORD=$(salt-call pillar.get \"postgres:clouderamanager:remote_admin_pw\" --output json 2>/dev/null | jq -r .local); \\\n" +
+            "psql -h \"$DBHOST\" -p \"$DBPORT\" -U \"$DBUSER\" -d postgres -c \"show server_version\" | grep -o \"[0-9]*\\.\"'";
+
+    @Inject
+    private SdxTestClient sdxTestClient;
+
+    @Inject
+    private CommonClusterManagerProperties commonClusterManagerProperties;
+
+    @Inject
+    private SshJClientActions sshJClientActions;
+
+    @Test(dataProvider = TEST_CONTEXT)
+    @UseSpotInstances
+    @Description(
+            given = "there is a running Cloudbreak, and an SDX cluster in available state",
+            when = "upgrade called on the SDX cluster",
+            then = "SDX upgrade database server should be successful, the cluster should be up and running"
+    )
+    public void testSDXDatabaseUpgrade(TestContext testContext) {
+        String sdx = resourcePropertyProvider().getName();
+
+        String originalDatabaseMajorVersion = commonClusterManagerProperties.getUpgradeDatabaseServer().getOriginalDatabaseMajorVersion();
+        String targetDatabaseMajorVersion = commonClusterManagerProperties.getUpgradeDatabaseServer().getTargetDatabaseMajorVersion();
+        SdxDatabaseRequest sdxDatabaseRequest = new SdxDatabaseRequest();
+        sdxDatabaseRequest.setAvailabilityType(SdxDatabaseAvailabilityType.NON_HA);
+        sdxDatabaseRequest.setDatabaseEngineVersion(originalDatabaseMajorVersion);
+
+        testContext
+                .given(sdx, SdxTestDto.class)
+                .withCloudStorage()
+                .withExternalDatabase(sdxDatabaseRequest)
+                .when(sdxTestClient.create(), key(sdx))
+                .await(SdxClusterStatusResponse.RUNNING, key(sdx))
+                .awaitForHealthyInstances()
+                .given(SdxUpgradeDatabaseServerTestDto.class)
+                .withTargetMajorVersion(fromVersionString(targetDatabaseMajorVersion))
+                .given(sdx, SdxTestDto.class)
+                .when(sdxTestClient.upgradeDatabaseServer(), key(sdx))
+                .await(SdxClusterStatusResponse.DATALAKE_UPGRADE_DATABASE_SERVER_IN_PROGRESS, key(sdx).withWaitForFlow(Boolean.FALSE))
+                .await(SdxClusterStatusResponse.RUNNING, key(sdx))
+                .awaitForHealthyInstances()
+                .then((tc, testDto, client) -> checkDbEngineVersionIsUpdated(targetDatabaseMajorVersion, testDto))
+                .then((tc, testDto, client) -> checkCloudProviderDatabaseVersionFromMasterNode(targetDatabaseMajorVersion, tc, testDto))
+                .validate();
+    }
+
+    private TargetMajorVersion fromVersionString(String versionString) {
+        try {
+            return TargetMajorVersion.valueOf("VERSION_" + versionString);
+        } catch (Exception exception) {
+            return TargetMajorVersion.VERSION_11;
+        }
+    }
+
+    private SdxTestDto checkDbEngineVersionIsUpdated(String targetDatabaseMajorVersion, SdxTestDto testDto) {
+        String actualDatabaseMajorVersion = testDto.getResponse().getDatabaseEngineVersion();
+        if (!targetDatabaseMajorVersion.equals(actualDatabaseMajorVersion)) {
+            String errorMsg = String.format("Datalake's database engine version is wrong: %s, expected: %s",
+                    actualDatabaseMajorVersion, targetDatabaseMajorVersion);
+            LOGGER.error(errorMsg);
+            throw new TestFailException(errorMsg);
+        }
+        return testDto;
+    }
+
+    private SdxTestDto checkCloudProviderDatabaseVersionFromMasterNode(String targetDatabaseMajorVersion, TestContext tc, SdxTestDto testDto) {
+        String command = tc.getCloudProvider().isExternalDatabaseSslEnforcementSupported() ? DBSERVER_VERSION_CMD_SSL : DBSERVER_VERSION_CMD;
+        Map<String, Pair<Integer, String>> dbVersions = sshJClientActions.executeSshCommandOnPrimaryGateways(
+                testDto.getResponse().getStackV4Response().getInstanceGroups(), command, false);
+        List<Pair<Integer, String>> wrongVersions = dbVersions.values().stream()
+                .filter(ssh -> !ssh.getValue().startsWith(targetDatabaseMajorVersion))
+                .collect(Collectors.toList());
+        if (!wrongVersions.isEmpty()) {
+            String errorMsg = String.format("Datalake's database engine version check is wrong on primary gateways: %s, expected: %s",
+                    dbVersions, targetDatabaseMajorVersion);
+            LOGGER.error(errorMsg);
+            throw new TestFailException(errorMsg);
+        }
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/action/SshJClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/action/SshJClientActions.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.it.cloudbreak.util.ssh.action;
 
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceMetadataType.GATEWAY_PRIMARY;
 import static java.lang.String.format;
 
 import java.io.IOException;
@@ -63,6 +64,18 @@ public class SshJClientActions extends SshJClient {
                             publicIp ? "Public" : "Private");
                     return publicIp ? instanceMetaData.getPublicIp() : instanceMetaData.getPrivateIp();
                 })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    private List<String> getPrimaryGatewayIps(List<InstanceGroupV4Response> instanceGroups, boolean publicIp) {
+        return instanceGroups.stream()
+                .filter(ig -> com.sequenceiq.common.api.type.InstanceGroupType.GATEWAY == ig.getType())
+                .map(InstanceGroupV4Response::getMetadata)
+                .filter(Objects::nonNull)
+                .flatMap(Collection::stream)
+                .filter(imd -> GATEWAY_PRIMARY == imd.getInstanceType())
+                .map(imd -> publicIp && StringUtils.isNotEmpty(imd.getPublicIp()) ? imd.getPublicIp() : imd.getPrivateIp())
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
     }
@@ -209,6 +222,12 @@ public class SshJClientActions extends SshJClient {
     public Map<String, Pair<Integer, String>> executeSshCommandOnHost(List<InstanceGroupV4Response> instanceGroups, List<String> hostGroupNames,
             String sshCommand, boolean publicIp) {
         return getInstanceGroupIps(instanceGroups, hostGroupNames, publicIp).stream()
+                .collect(Collectors.toMap(ip -> ip, ip -> executeSshCommand(ip, sshCommand)));
+    }
+
+    public Map<String, Pair<Integer, String>> executeSshCommandOnPrimaryGateways(List<InstanceGroupV4Response> instanceGroups, String sshCommand,
+            boolean publicIp) {
+        return getPrimaryGatewayIps(instanceGroups, publicIp).stream()
                 .collect(Collectors.toMap(ip -> ip, ip -> executeSshCommand(ip, sshCommand)));
     }
 

--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -94,6 +94,9 @@ integrationtest:
     distroXUpgrade3rdPartyCurrentVersion: 7.2.7
     distroXUpgrade3rdPartyTargetVersion: 7.2.12
     imageCatalogUrl3rdParty: https://cloudbreak-imagecatalog.s3.amazonaws.com/v3-prod-cb-image-catalog.json
+  upgradeDatabaseServer:
+    originalDatabaseMajorVersion: 10
+    targetDatabaseMajorVersion: 11
   privateEndpointEnabled: false
 
   spot:
@@ -108,6 +111,7 @@ integrationtest:
   aws:
     govCloud: false
     multiaz: false
+    externalDatabaseSslEnforcementSupported: true
     region: eu-central-1
     location: eu-central-1
     availabilityZone: eu-central-1a
@@ -165,6 +169,7 @@ integrationtest:
   # azure parameters
   azure:
     availabilityZone:
+    externalDatabaseSslEnforcementSupported: true
     region: West US 2
     location: West US 2
     verticalScale:
@@ -227,6 +232,7 @@ integrationtest:
     baseimage:
       imageId:
     availabilityZone: europe-west2-a
+    externalDatabaseSslEnforcementSupported: false
     region: europe-west2
     location: europe-west2
     verticalScale:

--- a/integration-test/src/main/resources/testsuites/e2e/aws-longrunning-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/aws-longrunning-e2e-tests.yaml
@@ -13,3 +13,4 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.freeipa.FreeIpaUpgradeTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxResizeTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxResizeRecoveryTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxUpgradeDatabaseServerTests

--- a/integration-test/src/main/resources/testsuites/e2e/azure-longrunning-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/azure-longrunning-e2e-tests.yaml
@@ -10,3 +10,4 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.freeipa.FreeIpaUpgradeTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxResizeTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxResizeRecoveryTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxUpgradeDatabaseServerTests

--- a/integration-test/src/main/resources/testsuites/e2e/gcp-longrunning-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/gcp-longrunning-e2e-tests.yaml
@@ -5,6 +5,7 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.EnvironmentStopStartTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxUpgradeRecoveryTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.freeipa.FreeIpaUpgradeTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxUpgradeDatabaseServerTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRepairTests
           excludedMethods:
             - testSDXMediumDutyCreation


### PR DESCRIPTION
CB-18416, CB-18417, CB-18418: E2E tests for Postgres Upgrade on AWS, Azure, GCP

E2E test steps:
- Create Datalake cluster with Postgres10 external database
- Upgrade the database to Postgres11
- Check the database version is updated to 11 in CB services
- Check the database server version is upgraded to 11 using psql "show server_version" command on the primary gateway node
