### PR TITLE
CB-18883 DatalakeDatahubCreateAuthTest needs to be refactored because the current logic may hide the actual failure cause

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/DatalakeDatahubCreateAuthTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/DatalakeDatahubCreateAuthTest.java
@@ -80,17 +80,17 @@ public class DatalakeDatahubCreateAuthTest extends AbstractIntegrationTest {
                 .when(environmentTestClient.create())
                 .await(EnvironmentStatus.AVAILABLE)
                 .given(UmsTestDto.class)
-                .assignTarget(EnvironmentTestDto.class.getSimpleName())
-                .withDatahubCreator()
+                    .assignTarget(EnvironmentTestDto.class.getSimpleName())
+                    .withDatahubCreator()
                 .when(umsTestClient.assignResourceRole(AuthUserKeys.ENV_CREATOR_B, regionAwareInternalCrnGeneratorFactory))
-                .withEnvironmentUser()
+                    .withEnvironmentUser()
                 .when(umsTestClient.assignResourceRole(AuthUserKeys.ENV_CREATOR_B, regionAwareInternalCrnGeneratorFactory))
                 .given(clouderaManager, ClouderaManagerTestDto.class)
                 .given(cluster, ClusterTestDto.class)
-                .withClouderaManager(clouderaManager)
+                    .withClouderaManager(clouderaManager)
                 .given(stack, StackTestDto.class).withCluster(cluster)
                 .given(sdxInternal, SdxInternalTestDto.class)
-                .withStackRequest(key(cluster), key(stack))
+                    .withStackRequest(key(cluster), key(stack))
                 .when(sdxTestClient.createInternal(), key(sdxInternal))
                 .await(SdxClusterStatusResponse.RUNNING)
                 .when(sdxTestClient.detailedDescribeInternal(), RunningParameter.who(cloudbreakActor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_A)))
@@ -99,11 +99,15 @@ public class DatalakeDatahubCreateAuthTest extends AbstractIntegrationTest {
                         "'datalake/describeDetailedDatalake' right on any of the environment[(]s[)] " + environmentDatalakePattern(testContext) +
                         " or on " + datalakePattern(testContext.get(sdxInternal).getName()))
                         .withWho(cloudbreakActor.useRealUmsUser(AuthUserKeys.ZERO_RIGHTS)))
+                .validate();
+
+        testContext
                 .given(RenewDatalakeCertificateTestDto.class)
-                .withStackCrn(testContext.get(sdxInternal).getCrn())
+                    .withStackCrn(testContext.get(sdxInternal).getCrn())
                 .whenException(sdxTestClient.renewDatalakeCertificateV4(), ForbiddenException.class, expectedMessage("Doesn't have 'datalake/repairDatalake'" +
                         " right on any of the environment[(]s[)] " + environmentDatalakePattern(testContext) + " or on " +
-                        datalakePattern(testContext.get(sdxInternal).getName())).withWho(cloudbreakActor.useRealUmsUser(AuthUserKeys.ZERO_RIGHTS)))
+                        datalakePattern(testContext.get(sdxInternal).getName()))
+                        .withWho(cloudbreakActor.useRealUmsUser(AuthUserKeys.ZERO_RIGHTS)))
                 .validate();
     }
 


### PR DESCRIPTION
In a recent E2E run, `DatalakeDatahubCreateAuthTest.testCreateEnvironment()` failed with: `You have tried to assign to SdxInternalTestDto, that hasn't been created and therefore has no Response object` cryptic error in the TestNG report. Upon closer inspection and digging up test logs, the root cause could be found much earlier: `Default error handler: Authorization failed due to user management service call timed out.` So basically the `SdxInternalEndpoint.create()` call failed due to an UMS timeout. The test case, however, kept running further.

Here need to break up the logic into multiple resource validation sections (e.g. one for `SdxInternalTestDto` followed by another one for `RenewDatalakeCertificateTestDto`). Each such section should conclude with an explicit `validate()` invocation, so that any errors or assertion failures can be reported at the right time.