### PR TITLE
CB-18938: Data Lake rolling runtime upgrade

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
@@ -439,7 +439,8 @@ public interface StackV4Endpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = STACK_UPGRADE_INTERNAL, nickname = "upgradeClusterByNameInternal")
     FlowIdentifier upgradeClusterByNameInternal(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name,
-            @QueryParam("imageId") String imageId, @QueryParam("initiatorUserCrn") String initiatorUserCrn);
+            @QueryParam("imageId") String imageId, @QueryParam("initiatorUserCrn") String initiatorUserCrn,
+            @QueryParam("rollingUpgradeEnabled") Boolean rollingUpgradeEnabled);
 
     @POST
     @Path("internal/{crn}/prepare_cluster_upgrade")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
@@ -362,13 +362,14 @@ public class StackV4Controller extends NotificationController implements StackV4
     @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.POWERUSER_ONLY)
     public FlowIdentifier upgradeClusterByName(Long workspaceId, String name, String imageId, @AccountId String accountId) {
-        return stackUpgradeOperations.upgradeCluster(NameOrCrn.ofName(name), restRequestThreadLocalService.getAccountId(), imageId);
+        return stackUpgradeOperations.upgradeCluster(NameOrCrn.ofName(name), restRequestThreadLocalService.getAccountId(), imageId, Boolean.FALSE);
     }
 
     @Override
     @InternalOnly
-    public FlowIdentifier upgradeClusterByNameInternal(Long workspaceId, String name, String imageId, @InitiatorUserCrn String initiatorUserCrn) {
-        return stackUpgradeOperations.upgradeCluster(NameOrCrn.ofName(name), restRequestThreadLocalService.getAccountId(), imageId);
+    public FlowIdentifier upgradeClusterByNameInternal(Long workspaceId, String name, String imageId, @InitiatorUserCrn String initiatorUserCrn,
+            Boolean rollingUpgradeEnabled) {
+        return stackUpgradeOperations.upgradeCluster(NameOrCrn.ofName(name), restRequestThreadLocalService.getAccountId(), imageId, rollingUpgradeEnabled);
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
@@ -231,9 +231,9 @@ public class ReactorFlowManager {
         return reactorNotifier.notify(stackId, selector, new StackEvent(selector, stackId));
     }
 
-    public FlowIdentifier triggerDatalakeClusterUpgrade(Long stackId, String imageId) {
+    public FlowIdentifier triggerDatalakeClusterUpgrade(Long stackId, String imageId, boolean rollingUpgradeEnabled) {
         String selector = FlowChainTriggers.DATALAKE_CLUSTER_UPGRADE_CHAIN_TRIGGER_EVENT;
-        return reactorNotifier.notify(stackId, selector, new ClusterUpgradeTriggerEvent(selector, stackId, imageId, false));
+        return reactorNotifier.notify(stackId, selector, new ClusterUpgradeTriggerEvent(selector, stackId, imageId, rollingUpgradeEnabled));
     }
 
     public FlowIdentifier triggerDistroXUpgrade(Long stackId, ImageChangeDto imageChangeDto, boolean replaceVms, boolean lockComponents, String variant,

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/UpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/UpgradeService.java
@@ -133,10 +133,10 @@ public class UpgradeService {
         }
     }
 
-    public FlowIdentifier upgradeCluster(String accountId, NameOrCrn stackNameOrCrn, String imageId) {
+    public FlowIdentifier upgradeCluster(String accountId, NameOrCrn stackNameOrCrn, String imageId, Boolean rollingUpgradeEnabled) {
         StackView stack = stackDtoService.getStackViewByNameOrCrn(stackNameOrCrn, accountId);
         MDCBuilder.buildMdcContext(stack);
-        return flowManager.triggerDatalakeClusterUpgrade(stack.getId(), imageId);
+        return flowManager.triggerDatalakeClusterUpgrade(stack.getId(), imageId, Boolean.TRUE.equals(rollingUpgradeEnabled));
     }
 
     public FlowIdentifier prepareClusterUpgrade(String accountId, NameOrCrn stackNameOrCrn, String imageId) {

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackUpgradeOperations.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackUpgradeOperations.java
@@ -80,9 +80,9 @@ public class StackUpgradeOperations {
         return upgradeService.upgradeOs(accountId, nameOrCrn);
     }
 
-    public FlowIdentifier upgradeCluster(@NotNull NameOrCrn nameOrCrn, String accountId, String imageId) {
+    public FlowIdentifier upgradeCluster(@NotNull NameOrCrn nameOrCrn, String accountId, String imageId, Boolean rollingUpgradeEnabled) {
         LOGGER.debug("Starting to upgrade cluster: " + nameOrCrn);
-        return upgradeService.upgradeCluster(accountId, nameOrCrn, imageId);
+        return upgradeService.upgradeCluster(accountId, nameOrCrn, imageId, rollingUpgradeEnabled);
     }
 
     public FlowIdentifier prepareClusterUpgrade(@NotNull NameOrCrn nameOrCrn, String accountId, String imageId) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
@@ -147,7 +147,7 @@ public class ReactorFlowManagerTest {
         underTest.triggerStackImageUpdate(new ImageChangeDto(STACK_ID, "asdf"));
         underTest.triggerMaintenanceModeValidationFlow(STACK_ID);
         underTest.triggerClusterCertificationRenewal(STACK_ID);
-        underTest.triggerDatalakeClusterUpgrade(STACK_ID, "asdf");
+        underTest.triggerDatalakeClusterUpgrade(STACK_ID, "asdf", true);
         underTest.triggerDistroXUpgrade(STACK_ID, imageChangeDto, false, false, "variant", false);
         underTest.triggerClusterUpgradePreparation(STACK_ID, imageChangeDto, false);
         underTest.triggerSaltUpdate(STACK_ID);

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/StackUpgradeOperationsTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/StackUpgradeOperationsTest.java
@@ -59,6 +59,8 @@ class StackUpgradeOperationsTest {
 
     private static final String IMAGE_ID = "image-id";
 
+    private static final boolean ROLLING_UPGRADE_ENABLED = true;
+
     private static final int INSTANCE_COUNT = 10;
 
     private static final int NODE_LIMIT = 15;
@@ -116,8 +118,8 @@ class StackUpgradeOperationsTest {
 
     @Test
     void testUpgradeClusterShouldCallUpgradeService() {
-        underTest.upgradeCluster(nameOrCrn, ACCOUNT_ID, IMAGE_ID);
-        verify(upgradeService).upgradeCluster(ACCOUNT_ID, nameOrCrn, IMAGE_ID);
+        underTest.upgradeCluster(nameOrCrn, ACCOUNT_ID, IMAGE_ID, ROLLING_UPGRADE_ENABLED);
+        verify(upgradeService).upgradeCluster(ACCOUNT_ID, nameOrCrn, IMAGE_ID, ROLLING_UPGRADE_ENABLED);
     }
 
     @Test

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/ModelDescriptions.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/ModelDescriptions.java
@@ -101,6 +101,8 @@ public class ModelDescriptions {
     public static final String SKIP_DATAHUB_VALIDATION = "With this option, the Data Lake upgrade can be performed with running Data Hub clusters. " +
             "The usage of this option can cause problems on the running Data Hub clusters during the Data Lake upgrade.";
 
+    public static final String ROLLING_UPGRADE_ENABLED = "Doesn't perform the actual operation just validates if all preconditions are met.";
+
     public static final String SKIP_BACKUP = "Option to skip the backup before the upgrade.";
 
     public static final String SKIP_ATLAS = "Option to skip the backup/restore of Atlas data.";

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxUpgradeRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxUpgradeRequest.java
@@ -33,6 +33,9 @@ public class SdxUpgradeRequest {
     @ApiModelProperty(ModelDescriptions.SKIP_DATAHUB_VALIDATION)
     private Boolean skipDataHubValidation;
 
+    @ApiModelProperty(ModelDescriptions.ROLLING_UPGRADE_ENABLED)
+    private Boolean rollingUpgradeEnabled;
+
     @ApiModelProperty(ModelDescriptions.SKIP_ATLAS)
     private boolean skipAtlasMetadata;
 
@@ -98,6 +101,14 @@ public class SdxUpgradeRequest {
 
     public void setSkipDataHubValidation(Boolean skipDataHubValidation) {
         this.skipDataHubValidation = skipDataHubValidation;
+    }
+
+    public Boolean getRollingUpgradeEnabled() {
+        return rollingUpgradeEnabled;
+    }
+
+    public void setRollingUpgradeEnabled(Boolean rollingUpgradeEnabled) {
+        this.rollingUpgradeEnabled = rollingUpgradeEnabled;
     }
 
     public SdxUpgradeShowAvailableImages getShowAvailableImages() {

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxReactorFlowManager.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxReactorFlowManager.java
@@ -162,7 +162,7 @@ public class SdxReactorFlowManager {
     }
 
     public FlowIdentifier triggerDatalakeRuntimeUpgradeFlow(SdxCluster cluster, String imageId, SdxUpgradeReplaceVms replaceVms, boolean skipBackup,
-            DatalakeDrSkipOptions skipOptions) {
+            DatalakeDrSkipOptions skipOptions, boolean rollingUpgradeEnabled) {
         LOGGER.info("Trigger Datalake runtime upgrade for: {} with imageId: {} and replace vm param: {}", cluster, imageId, replaceVms);
         String userId = ThreadBasedUserCrnProvider.getUserCrn();
         if (!skipBackup && sdxBackupRestoreService.shouldSdxBackupBePerformed(
@@ -172,11 +172,11 @@ public class SdxReactorFlowManager {
             return notify(DatalakeUpgradeFlowChainStartEvent.DATALAKE_UPGRADE_FLOW_CHAIN_EVENT,
                     new DatalakeUpgradeFlowChainStartEvent(DatalakeUpgradeFlowChainStartEvent.DATALAKE_UPGRADE_FLOW_CHAIN_EVENT, cluster.getId(),
                             userId, imageId, replaceVms.getBooleanValue(), environmentClientService.getBackupLocation(cluster.getEnvCrn()),
-                            skipOptions),
+                            skipOptions, rollingUpgradeEnabled),
                     cluster.getClusterName());
         } else {
             return notify(DATALAKE_UPGRADE_EVENT.event(), new DatalakeUpgradeStartEvent(DATALAKE_UPGRADE_EVENT.event(), cluster.getId(),
-                    userId, imageId, replaceVms.getBooleanValue()), cluster.getClusterName());
+                    userId, imageId, replaceVms.getBooleanValue(), rollingUpgradeEnabled), cluster.getClusterName());
         }
     }
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/chain/DatalakeUpgradeFlowEventChainFactory.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/chain/DatalakeUpgradeFlowEventChainFactory.java
@@ -33,7 +33,7 @@ public class DatalakeUpgradeFlowEventChainFactory implements FlowEventChainFacto
                 event.getSkipOptions(),
                 DatalakeBackupFailureReason.BACKUP_ON_UPGRADE, List.of(DatabaseType.HIVE.toString().toLowerCase()), event.accepted()));
         chain.add(new DatalakeUpgradeStartEvent(DATALAKE_UPGRADE_EVENT.event(), event.getResourceId(), event.getUserId(),
-                event.getImageId(), event.isReplaceVms()));
+                event.getImageId(), event.isReplaceVms(), event.isRollingUpgradeEnabled()));
         return new FlowTriggerEventQueue(getName(), event, chain);
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/DatalakeUpgradeActions.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/DatalakeUpgradeActions.java
@@ -76,7 +76,7 @@ public class DatalakeUpgradeActions {
             @Override
             protected void doExecute(SdxContext context, DatalakeUpgradeStartEvent payload, Map<Object, Object> variables) {
                 LOGGER.info("Datalake upgrade has been started for {}", payload.getResourceId());
-                sdxUpgradeService.upgradeRuntime(payload.getResourceId(), payload.getImageId());
+                sdxUpgradeService.upgradeRuntime(payload.getResourceId(), payload.getImageId(), payload.isRollingUpgradeEnabled());
                 sendEvent(context, DATALAKE_UPGRADE_IN_PROGRESS_EVENT.event(), payload);
             }
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/event/DatalakeUpgradeFlowChainStartEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/event/DatalakeUpgradeFlowChainStartEvent.java
@@ -19,6 +19,8 @@ public class DatalakeUpgradeFlowChainStartEvent extends SdxEvent {
 
     private final DatalakeDrSkipOptions skipOptions;
 
+    private final boolean rollingUpgradeEnabled;
+
     @JsonCreator
     public DatalakeUpgradeFlowChainStartEvent(
             @JsonProperty("selector") String selector,
@@ -27,12 +29,14 @@ public class DatalakeUpgradeFlowChainStartEvent extends SdxEvent {
             @JsonProperty("imageId") String imageId,
             @JsonProperty("replaceVms") boolean replaceVms,
             @JsonProperty("backupLocation") String backupLocation,
-            @JsonProperty("skipOptions") DatalakeDrSkipOptions skipOptions) {
+            @JsonProperty("skipOptions") DatalakeDrSkipOptions skipOptions,
+            @JsonProperty("rollingUpgradeEnabled") boolean rollingUpgradeEnabled) {
         super(selector, sdxId, userId);
         this.imageId = imageId;
         this.replaceVms = replaceVms;
         this.backupLocation = backupLocation;
         this.skipOptions = skipOptions;
+        this.rollingUpgradeEnabled = rollingUpgradeEnabled;
     }
 
     public String getImageId() {
@@ -49,6 +53,10 @@ public class DatalakeUpgradeFlowChainStartEvent extends SdxEvent {
 
     public DatalakeDrSkipOptions getSkipOptions() {
         return skipOptions;
+    }
+
+    public boolean isRollingUpgradeEnabled() {
+        return rollingUpgradeEnabled;
     }
 
     @Override
@@ -70,6 +78,7 @@ public class DatalakeUpgradeFlowChainStartEvent extends SdxEvent {
                 "imageId='" + imageId + '\'' +
                 ", replaceVms=" + replaceVms +
                 ", backupLocation='" + backupLocation + '\'' +
+                ", rollingUpgradeEnabled='" + rollingUpgradeEnabled + '\'' +
                 "} " + super.toString();
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/event/DatalakeUpgradeStartEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/event/DatalakeUpgradeStartEvent.java
@@ -12,16 +12,20 @@ public class DatalakeUpgradeStartEvent extends SdxEvent {
 
     private final boolean replaceVms;
 
+    private final boolean rollingUpgradeEnabled;
+
     @JsonCreator
     public DatalakeUpgradeStartEvent(
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long sdxId,
             @JsonProperty("userId") String userId,
             @JsonProperty("imageId") String imageId,
-            @JsonProperty("replaceVms") boolean replaceVms) {
+            @JsonProperty("replaceVms") boolean replaceVms,
+            @JsonProperty("rollingUpgradeEnabled") boolean rollingUpgradeEnabled) {
         super(selector, sdxId, userId);
         this.imageId = imageId;
         this.replaceVms = replaceVms;
+        this.rollingUpgradeEnabled = rollingUpgradeEnabled;
     }
 
     public String getImageId() {
@@ -32,11 +36,16 @@ public class DatalakeUpgradeStartEvent extends SdxEvent {
         return replaceVms;
     }
 
+    public boolean isRollingUpgradeEnabled() {
+        return rollingUpgradeEnabled;
+    }
+
     @Override
     public boolean equalsEvent(SdxEvent other) {
         return isClassAndEqualsEvent(DatalakeUpgradeStartEvent.class, other,
                 event -> Objects.equals(imageId, event.imageId)
-                        && replaceVms == event.replaceVms);
+                        && replaceVms == event.replaceVms
+                        && rollingUpgradeEnabled == event.rollingUpgradeEnabled);
     }
 
     @Override
@@ -44,6 +53,7 @@ public class DatalakeUpgradeStartEvent extends SdxEvent {
         return "DatalakeUpgradeStartEvent{" +
                 "imageId='" + imageId + '\'' +
                 ", replaceVms=" + replaceVms +
+                ", rollingUpgradeEnabled=" + rollingUpgradeEnabled +
                 "} " + super.toString();
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxUpgradeService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxUpgradeService.java
@@ -77,7 +77,7 @@ public class SdxUpgradeService {
         }
     }
 
-    public void upgradeRuntime(Long id, String imageId) {
+    public void upgradeRuntime(Long id, String imageId, boolean rollingUpgradeEnabled) {
         SdxCluster sdxCluster = sdxService.getById(id);
         sdxStatusService.setStatusForDatalakeAndNotify(DatalakeStatusEnum.DATALAKE_UPGRADE_IN_PROGRESS, "Upgrading datalake stack", sdxCluster);
         try {
@@ -85,7 +85,7 @@ public class SdxUpgradeService {
             FlowIdentifier flowIdentifier = ThreadBasedUserCrnProvider.doAsInternalActor(
                     regionAwareInternalCrnGeneratorFactory.iam().getInternalCrnForServiceAsString(),
                     () ->
-                    stackV4Endpoint.upgradeClusterByNameInternal(0L, sdxCluster.getClusterName(), imageId, initiatorUserCrn));
+                    stackV4Endpoint.upgradeClusterByNameInternal(0L, sdxCluster.getClusterName(), imageId, initiatorUserCrn, rollingUpgradeEnabled));
             cloudbreakFlowService.saveLastCloudbreakFlowChainId(sdxCluster, flowIdentifier);
         } catch (WebApplicationException e) {
             String exceptionMessage = exceptionMessageExtractor.getErrorMessage(e);

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/SdxRuntimeUpgradeService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/SdxRuntimeUpgradeService.java
@@ -151,8 +151,10 @@ public class SdxRuntimeUpgradeService {
         boolean skipAtlasMetadata = request != null && Boolean.TRUE.equals(request.isSkipAtlasMetadata());
         boolean skipRangerAudits = request != null && Boolean.TRUE.equals(request.isSkipRangerAudits());
         boolean skipRangerMetadata = request != null && Boolean.TRUE.equals(request.isSkipRangerMetadata());
+        boolean rollingUpgradeEnabled = request != null && Boolean.TRUE.equals(request.getRollingUpgradeEnabled());
         DatalakeDrSkipOptions skipOptions = new DatalakeDrSkipOptions(skipAtlasMetadata, skipRangerAudits, skipRangerMetadata);
-        FlowIdentifier flowIdentifier = triggerDatalakeUpgradeFlow(imageId, cluster, shouldReplaceVmsAfterUpgrade(request), skipBackup, skipOptions);
+        FlowIdentifier flowIdentifier = triggerDatalakeUpgradeFlow(imageId, cluster, shouldReplaceVmsAfterUpgrade(request), skipBackup, skipOptions,
+                rollingUpgradeEnabled);
         String message = messagesService.getMessage(ResourceEvent.DATALAKE_UPGRADE.getMessage(), Collections.singletonList(imageId));
         return new SdxUpgradeResponse(message, flowIdentifier);
     }
@@ -186,8 +188,8 @@ public class SdxRuntimeUpgradeService {
     }
 
     private FlowIdentifier triggerDatalakeUpgradeFlow(String imageId, SdxCluster cluster, SdxUpgradeReplaceVms replaceVms,
-            boolean skipBackup, DatalakeDrSkipOptions skipOptions) {
-        return sdxReactorFlowManager.triggerDatalakeRuntimeUpgradeFlow(cluster, imageId, replaceVms, skipBackup, skipOptions);
+            boolean skipBackup, DatalakeDrSkipOptions skipOptions, boolean rollingUpgradeEnabled) {
+        return sdxReactorFlowManager.triggerDatalakeRuntimeUpgradeFlow(cluster, imageId, replaceVms, skipBackup, skipOptions, rollingUpgradeEnabled);
     }
 
     private String determineImageId(SdxUpgradeRequest upgradeRequest, List<ImageInfoV4Response> upgradeCandidates) {

--- a/datalake/src/test/java/com/sequenceiq/datalake/flow/SdxReactorFlowManagerTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/flow/SdxReactorFlowManagerTest.java
@@ -53,11 +53,11 @@ class SdxReactorFlowManagerTest {
 
     private static final String ENV_CRN = "crn:cdp:environments:us-west-1:460c0d8f-ae8e-4dce-9cd7-2351762eb9ac:environment:6b2b1600-8ac6-4c26-aa34-dab36f4bd243";
 
-    private static final String BACKUP_LOCATION = "s3a://path/to/backup";
-
     private static final String IMAGE_ID = "image-id-first";
 
     private static final boolean SKIP_BACKUP = false;
+
+    private static final boolean ROLLING_UPGRADE_ENABLED = true;
 
     private static final DatalakeDrSkipOptions SKIP_OPTIONS = new DatalakeDrSkipOptions(false, false, false);
 
@@ -105,7 +105,7 @@ class SdxReactorFlowManagerTest {
         when(sdxBackupRestoreService.shouldSdxBackupBePerformed(any(), eq(true))).thenReturn(true);
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
                 underTest.triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, SdxUpgradeReplaceVms.DISABLED, SKIP_BACKUP,
-                        SKIP_OPTIONS));
+                        SKIP_OPTIONS, ROLLING_UPGRADE_ENABLED));
         verify(reactor, times(1)).notify(eq(DatalakeUpgradeFlowChainStartEvent.DATALAKE_UPGRADE_FLOW_CHAIN_EVENT), any(Event.class));
     }
 
@@ -115,13 +115,13 @@ class SdxReactorFlowManagerTest {
         when(sdxBackupRestoreService.shouldSdxBackupBePerformed(any(), eq(true))).thenReturn(false);
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
                 underTest.triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, SdxUpgradeReplaceVms.DISABLED, SKIP_BACKUP,
-                        SKIP_OPTIONS));
+                        SKIP_OPTIONS, ROLLING_UPGRADE_ENABLED));
         verify(reactor, times(0)).notify(eq(DatalakeUpgradeFlowChainStartEvent.DATALAKE_UPGRADE_FLOW_CHAIN_EVENT), any(Event.class));
 
         when(sdxBackupRestoreService.shouldSdxBackupBePerformed(any(), eq(true))).thenReturn(false);
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
                 underTest.triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, SdxUpgradeReplaceVms.DISABLED, SKIP_BACKUP,
-                        SKIP_OPTIONS));
+                        SKIP_OPTIONS, ROLLING_UPGRADE_ENABLED));
         verify(reactor, times(0)).notify(eq(DatalakeUpgradeFlowChainStartEvent.DATALAKE_UPGRADE_FLOW_CHAIN_EVENT), any(Event.class));
     }
 
@@ -132,7 +132,7 @@ class SdxReactorFlowManagerTest {
         sdxCluster.setCloudStorageFileSystemType(FileSystemType.S3);
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
                 underTest.triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, SdxUpgradeReplaceVms.DISABLED, SKIP_BACKUP,
-                        SKIP_OPTIONS));
+                        SKIP_OPTIONS, ROLLING_UPGRADE_ENABLED));
         verify(reactor, times(0)).notify(eq(DatalakeUpgradeFlowChainStartEvent.DATALAKE_UPGRADE_FLOW_CHAIN_EVENT), any(Event.class));
     }
 
@@ -144,7 +144,7 @@ class SdxReactorFlowManagerTest {
         when(entitlementService.isDatalakeBackupOnUpgradeEnabled(any())).thenReturn(false);
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
                 underTest.triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, SdxUpgradeReplaceVms.DISABLED, SKIP_BACKUP,
-                        SKIP_OPTIONS));
+                        SKIP_OPTIONS, ROLLING_UPGRADE_ENABLED));
         verify(reactor, times(1)).notify(eq(DATALAKE_UPGRADE_EVENT.event()), any(Event.class));
     }
 
@@ -155,7 +155,7 @@ class SdxReactorFlowManagerTest {
         sdxCluster.setCloudStorageFileSystemType(FileSystemType.S3);
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
                 underTest.triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, SdxUpgradeReplaceVms.DISABLED, true,
-                        SKIP_OPTIONS));
+                        SKIP_OPTIONS, ROLLING_UPGRADE_ENABLED));
         verify(reactor, times(1)).notify(eq(DATALAKE_UPGRADE_EVENT.event()), any(Event.class));
     }
 

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/upgrade/SdxRuntimeUpgradeServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/upgrade/SdxRuntimeUpgradeServiceTest.java
@@ -83,6 +83,8 @@ public class SdxRuntimeUpgradeServiceTest {
 
     private static final boolean SKIP_BACKUP = false;
 
+    private static final boolean ROLLING_UPGRADE_ENABLED = true;
+
     private static final DatalakeDrSkipOptions SKIP_OPTIONS = new DatalakeDrSkipOptions(false, false, false);
 
     @Mock
@@ -265,14 +267,15 @@ public class SdxRuntimeUpgradeServiceTest {
         sdxUpgradeRequest.setLockComponents(false);
         sdxUpgradeRequest.setImageId(null);
         sdxUpgradeRequest.setReplaceVms(REPAIR_AFTER_UPGRADE);
+        sdxUpgradeRequest.setRollingUpgradeEnabled(ROLLING_UPGRADE_ENABLED);
 
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
                 underTest.triggerUpgradeByCrn(USER_CRN, STACK_CRN, sdxUpgradeRequest, ACCOUNT_ID, false));
 
         verify(sdxReactorFlowManager, times(1)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID_LAST, REPAIR_AFTER_UPGRADE, SKIP_BACKUP,
-                SKIP_OPTIONS);
+                SKIP_OPTIONS, ROLLING_UPGRADE_ENABLED);
         verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, REPAIR_AFTER_UPGRADE, SKIP_BACKUP,
-                SKIP_OPTIONS);
+                SKIP_OPTIONS, ROLLING_UPGRADE_ENABLED);
         assertNull(upgradeV4RequestCaptor.getValue().getInternalUpgradeSettings());
     }
 
@@ -282,6 +285,7 @@ public class SdxRuntimeUpgradeServiceTest {
         sdxUpgradeRequest.setSkipAtlasMetadata(true);
         sdxUpgradeRequest.setSkipRangerAudits(true);
         sdxUpgradeRequest.setSkipRangerMetadata(true);
+        sdxUpgradeRequest.setRollingUpgradeEnabled(ROLLING_UPGRADE_ENABLED);
 
         when(sdxService.getByCrn(anyString(), anyString())).thenReturn(sdxCluster);
         ArgumentCaptor<UpgradeV4Request> upgradeV4RequestCaptor = ArgumentCaptor.forClass(UpgradeV4Request.class);
@@ -298,7 +302,7 @@ public class SdxRuntimeUpgradeServiceTest {
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
                 underTest.triggerUpgradeByCrn(USER_CRN, STACK_CRN, sdxUpgradeRequest, ACCOUNT_ID, false));
         verify(sdxReactorFlowManager, times(1)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, REPAIR_AFTER_UPGRADE, SKIP_BACKUP,
-                skipOptions);
+                skipOptions, ROLLING_UPGRADE_ENABLED);
         assertNull(upgradeV4RequestCaptor.getValue().getInternalUpgradeSettings());
     }
 
@@ -370,13 +374,14 @@ public class SdxRuntimeUpgradeServiceTest {
         sdxUpgradeRequest.setLockComponents(false);
         sdxUpgradeRequest.setImageId(null);
         sdxUpgradeRequest.setReplaceVms(REPAIR_AFTER_UPGRADE);
+        sdxUpgradeRequest.setRollingUpgradeEnabled(ROLLING_UPGRADE_ENABLED);
 
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
                 underTest.triggerUpgradeByCrn(USER_CRN, STACK_CRN, sdxUpgradeRequest, ACCOUNT_ID, false));
         verify(sdxReactorFlowManager, times(1)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID_LAST, REPAIR_AFTER_UPGRADE,
-                SKIP_BACKUP, SKIP_OPTIONS);
+                SKIP_BACKUP, SKIP_OPTIONS, ROLLING_UPGRADE_ENABLED);
         verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, REPAIR_AFTER_UPGRADE,
-                SKIP_BACKUP, SKIP_OPTIONS);
+                SKIP_BACKUP, SKIP_OPTIONS, ROLLING_UPGRADE_ENABLED);
         assertNull(upgradeV4RequestCaptor.getValue().getInternalUpgradeSettings());
     }
 
@@ -421,9 +426,9 @@ public class SdxRuntimeUpgradeServiceTest {
 
 
         verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID_LAST, REPAIR_AFTER_UPGRADE,
-                SKIP_BACKUP, SKIP_OPTIONS);
+                SKIP_BACKUP, SKIP_OPTIONS, ROLLING_UPGRADE_ENABLED);
         verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, REPAIR_AFTER_UPGRADE,
-                SKIP_BACKUP, SKIP_OPTIONS);
+                SKIP_BACKUP, SKIP_OPTIONS, ROLLING_UPGRADE_ENABLED);
         assertNull(upgradeV4RequestCaptor.getValue().getInternalUpgradeSettings());
     }
 
@@ -466,9 +471,9 @@ public class SdxRuntimeUpgradeServiceTest {
         }
 
         verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID_LAST, REPAIR_AFTER_UPGRADE,
-                SKIP_BACKUP, SKIP_OPTIONS);
+                SKIP_BACKUP, SKIP_OPTIONS, ROLLING_UPGRADE_ENABLED);
         verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, REPAIR_AFTER_UPGRADE,
-                SKIP_BACKUP, SKIP_OPTIONS);
+                SKIP_BACKUP, SKIP_OPTIONS, ROLLING_UPGRADE_ENABLED);
         assertNull(upgradeV4RequestCaptor.getValue().getInternalUpgradeSettings());
     }
 


### PR DESCRIPTION
The core of the rolling upgrade logic is implemented in the CB. In this commit I extended the Data Lake upgrade API with the rolling upgrade option and I extend the internal upgrade Cloudbreak API with the rolling upgrade parameter