### PR TITLE
CB-18959 Configurable audit for Consumption and Redbeams services

### DIFF
--- a/cloud-consumption/build.gradle
+++ b/cloud-consumption/build.gradle
@@ -115,7 +115,7 @@ dependencies {
         implementation     group: 'org.springframework.boot',  name: 'spring-boot-starter-data-jpa',   version: springBootVersion
         testImplementation group: 'org.springframework.boot',  name: 'spring-boot-starter-test',       version: springBootVersion
     }
-    implementation project(":structuredevent-service-cdp")
+    implementation project(':structuredevent-service-cdp')
     implementation project(':audit-connector')
     implementation project(':authorization-common')
     implementation project(':cloud-reactor-api')

--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/configuration/api/EndpointConfig.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/configuration/api/EndpointConfig.java
@@ -14,6 +14,7 @@ import com.sequenceiq.authorization.controller.AuthorizationInfoController;
 import com.sequenceiq.authorization.info.AuthorizationUtilEndpoint;
 import com.sequenceiq.cloudbreak.exception.mapper.DefaultExceptionMapper;
 import com.sequenceiq.cloudbreak.structuredevent.rest.controller.CDPStructuredEventV1Controller;
+import com.sequenceiq.cloudbreak.structuredevent.rest.filter.CDPRestAuditFilter;
 import com.sequenceiq.cloudbreak.structuredevent.rest.filter.CDPStructuredEventFilter;
 import com.sequenceiq.consumption.api.v1.ConsumptionApi;
 import com.sequenceiq.consumption.endpoint.ConsumptionInternalV1Controller;
@@ -94,6 +95,7 @@ public class EndpointConfig extends ResourceConfig {
     }
 
     private void registerFilters() {
+        register(CDPRestAuditFilter.class);
         if (auditEnabled) {
             register(CDPStructuredEventFilter.class);
         }

--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/configuration/api/EndpointConfig.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/configuration/api/EndpointConfig.java
@@ -53,6 +53,7 @@ public class EndpointConfig extends ResourceConfig {
         this.applicationVersion = applicationVersion;
         this.auditEnabled = auditEnabled;
         this.exceptionMappers = exceptionMappers;
+        registerFilters();
         registerEndpoints();
         registerExceptionMappers();
         registerSwagger();
@@ -85,14 +86,16 @@ public class EndpointConfig extends ResourceConfig {
     }
 
     private void registerEndpoints() {
-        if (auditEnabled) {
-            register(CDPStructuredEventFilter.class);
-        }
-
         CONTROLLERS.forEach(this::register);
 
         register(io.swagger.jaxrs.listing.ApiListingResource.class);
         register(io.swagger.jaxrs.listing.SwaggerSerializers.class);
         register(io.swagger.jaxrs.listing.AcceptHeaderApiListingResource.class);
+    }
+
+    private void registerFilters() {
+        if (auditEnabled) {
+            register(CDPStructuredEventFilter.class);
+        }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/EndpointConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/EndpointConfig.java
@@ -40,8 +40,8 @@ import com.sequenceiq.cloudbreak.controller.v4.UserProfileV4Controller;
 import com.sequenceiq.cloudbreak.controller.v4.UtilV4Controller;
 import com.sequenceiq.cloudbreak.controller.v4.WorkspaceAwareUtilV4Controller;
 import com.sequenceiq.cloudbreak.exception.mapper.DefaultExceptionMapper;
+import com.sequenceiq.cloudbreak.structuredevent.rest.LegacyStructuredEventFilter;
 import com.sequenceiq.cloudbreak.structuredevent.rest.filter.CDPRestAuditFilter;
-import com.sequenceiq.cloudbreak.structuredevent.rest.filter.CDPStructuredEventFilter;
 import com.sequenceiq.cloudbreak.util.FileReaderUtils;
 import com.sequenceiq.distrox.v1.distrox.controller.DistroXDatabaseServerV1Controller;
 import com.sequenceiq.distrox.v1.distrox.controller.DistroXInternalV1Controller;
@@ -154,7 +154,7 @@ public class EndpointConfig extends ResourceConfig {
     private void registerFilters() {
         register(CDPRestAuditFilter.class);
         if (auditEnabled) {
-            register(CDPStructuredEventFilter.class);
+            register(LegacyStructuredEventFilter.class);
         }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/EndpointConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/EndpointConfig.java
@@ -40,8 +40,8 @@ import com.sequenceiq.cloudbreak.controller.v4.UserProfileV4Controller;
 import com.sequenceiq.cloudbreak.controller.v4.UtilV4Controller;
 import com.sequenceiq.cloudbreak.controller.v4.WorkspaceAwareUtilV4Controller;
 import com.sequenceiq.cloudbreak.exception.mapper.DefaultExceptionMapper;
-import com.sequenceiq.cloudbreak.structuredevent.rest.LegacyStructuredEventFilter;
 import com.sequenceiq.cloudbreak.structuredevent.rest.filter.CDPRestAuditFilter;
+import com.sequenceiq.cloudbreak.structuredevent.rest.filter.CDPStructuredEventFilter;
 import com.sequenceiq.cloudbreak.util.FileReaderUtils;
 import com.sequenceiq.distrox.v1.distrox.controller.DistroXDatabaseServerV1Controller;
 import com.sequenceiq.distrox.v1.distrox.controller.DistroXInternalV1Controller;
@@ -113,6 +113,7 @@ public class EndpointConfig extends ResourceConfig {
 
     @PostConstruct
     private void init() {
+        registerFilters();
         registerEndpoints();
         registerExceptionMappers();
         register(serverTracingDynamicFeature);
@@ -143,15 +144,17 @@ public class EndpointConfig extends ResourceConfig {
     }
 
     private void registerEndpoints() {
-        register(CDPRestAuditFilter.class);
-        if (auditEnabled) {
-            register(LegacyStructuredEventFilter.class);
-        }
-
         CONTROLLERS.forEach(this::register);
 
         register(io.swagger.jaxrs.listing.ApiListingResource.class);
         register(io.swagger.jaxrs.listing.SwaggerSerializers.class);
         register(io.swagger.jaxrs.listing.AcceptHeaderApiListingResource.class);
+    }
+
+    private void registerFilters() {
+        register(CDPRestAuditFilter.class);
+        if (auditEnabled) {
+            register(CDPStructuredEventFilter.class);
+        }
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/structuredevent/rest/StructuredEventFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/structuredevent/rest/StructuredEventFilterTest.java
@@ -39,6 +39,7 @@ import com.sequenceiq.cloudbreak.structuredevent.CloudbreakRestRequestThreadLoca
 import com.sequenceiq.cloudbreak.structuredevent.LegacyDefaultStructuredEventClient;
 import com.sequenceiq.cloudbreak.structuredevent.event.StructuredRestCallEvent;
 import com.sequenceiq.cloudbreak.structuredevent.event.rest.RestRequestDetails;
+import com.sequenceiq.cloudbreak.structuredevent.filter.CDPJaxRsFilterPropertyKeys;
 import com.sequenceiq.flow.ha.NodeConfig;
 
 @ExtendWith(MockitoExtension.class)
@@ -75,9 +76,9 @@ class StructuredEventFilterTest {
 
         underTest.filter(requestContext);
 
-        RestRequestDetails requestDetais = (RestRequestDetails) requestContext.getProperty("REQUEST_DETAIS");
+        RestRequestDetails requestDetails = (RestRequestDetails) requestContext.getProperty(CDPJaxRsFilterPropertyKeys.REQUEST_DETAILS);
 
-        headersMap.forEach((key, value) -> assertEquals(value.get(0), requestDetais.getHeaders().get(key)));
+        headersMap.forEach((key, value) -> assertEquals(value.get(0), requestDetails.getHeaders().get(key)));
     }
 
     private ContainerRequest createRequestContext(MultivaluedMap<String, String> headersMap) {

--- a/datalake/src/main/java/com/sequenceiq/datalake/configuration/EndpointConfig.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/configuration/EndpointConfig.java
@@ -85,6 +85,7 @@ public class EndpointConfig extends ResourceConfig {
 
     @PostConstruct
     private void init() {
+        register(CDPRestAuditFilter.class);
         registerEndpoints();
         registerExceptionMappers();
         register(serverTracingDynamicFeature);
@@ -116,8 +117,6 @@ public class EndpointConfig extends ResourceConfig {
     }
 
     private void registerEndpoints() {
-        register(CDPRestAuditFilter.class);
-
         CONTROLLERS.forEach(this::register);
 
         register(io.swagger.jaxrs.listing.ApiListingResource.class);

--- a/environment/src/main/java/com/sequenceiq/environment/configuration/api/EndpointConfig.java
+++ b/environment/src/main/java/com/sequenceiq/environment/configuration/api/EndpointConfig.java
@@ -73,6 +73,7 @@ public class EndpointConfig extends ResourceConfig {
         this.applicationVersion = applicationVersion;
         this.auditEnabled = auditEnabled;
         this.exceptionMappers = exceptionMappers;
+        registerFilters();
         registerEndpoints();
         registerExceptionMappers();
         registerSwagger();
@@ -103,16 +104,16 @@ public class EndpointConfig extends ResourceConfig {
     }
 
     private void registerEndpoints() {
-        register(CDPRestAuditFilter.class);
-
         CONTROLLERS.forEach(this::register);
-
-        if (auditEnabled) {
-            register(CDPStructuredEventFilter.class);
-        }
-
         register(io.swagger.jaxrs.listing.ApiListingResource.class);
         register(io.swagger.jaxrs.listing.SwaggerSerializers.class);
         register(io.swagger.jaxrs.listing.AcceptHeaderApiListingResource.class);
+    }
+
+    private void registerFilters() {
+        register(CDPRestAuditFilter.class);
+        if (auditEnabled) {
+            register(CDPStructuredEventFilter.class);
+        }
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/EndpointConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/EndpointConfig.java
@@ -83,6 +83,7 @@ public class EndpointConfig extends ResourceConfig {
 
     @PostConstruct
     private void init() {
+        registerFilters();
         registerEndpoints();
         registerExceptionMappers();
         register(serverTracingDynamicFeature);
@@ -115,15 +116,18 @@ public class EndpointConfig extends ResourceConfig {
     }
 
     private void registerEndpoints() {
-        register(CDPRestAuditFilter.class);
-        if (auditEnabled) {
-            register(CDPStructuredEventFilter.class);
-        }
         CONTROLLERS.forEach(this::register);
 
         register(io.swagger.jaxrs.listing.ApiListingResource.class);
         register(io.swagger.jaxrs.listing.SwaggerSerializers.class);
         register(io.swagger.jaxrs.listing.AcceptHeaderApiListingResource.class);
+    }
+
+    private void registerFilters() {
+        register(CDPRestAuditFilter.class);
+        if (auditEnabled) {
+            register(CDPStructuredEventFilter.class);
+        }
     }
 }
 

--- a/redbeams/build.gradle
+++ b/redbeams/build.gradle
@@ -111,15 +111,14 @@ dependencies {
     implementation     group: 'org.springframework.boot',  name: 'spring-boot-starter-data-jpa',   version: springBootVersion
     testImplementation group: 'org.springframework.boot',  name: 'spring-boot-starter-test',       version: springBootVersion
   }
-  implementation project(':authorization-common')
 
+  implementation project(':authorization-common')
   implementation project(':flow')
   implementation project(':cloud-reactor')
   implementation project(':cloud-reactor-api')
   implementation project(':environment-api')
   implementation project(':datalake-api')
   implementation project(':status-checker')
-
   implementation project(':cloud-common')
   implementation project(':secret-engine')
   implementation project(':common')
@@ -127,6 +126,8 @@ dependencies {
   implementation project(':core-api')
   implementation project(':redbeams-api')
   implementation project(':template-manager-tag')
+  implementation project(':structuredevent-service-cdp')
+
   runtimeOnly project(':cloud-gcp')
   runtimeOnly project(':cloud-aws-cloudformation')
   runtimeOnly project(':cloud-mock')

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/DatabaseConfig.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/DatabaseConfig.java
@@ -119,7 +119,8 @@ public class DatabaseConfig {
     public EntityManagerFactory entityManagerFactory() throws SQLException {
         LocalContainerEntityManagerFactoryBean entityManagerFactory = new LocalContainerEntityManagerFactoryBean();
 
-        entityManagerFactory.setPackagesToScan("com.sequenceiq.redbeams", "com.sequenceiq.flow", "com.sequenceiq.cloudbreak.ha");
+        entityManagerFactory.setPackagesToScan("com.sequenceiq.redbeams", "com.sequenceiq.flow", "com.sequenceiq.cloudbreak.ha",
+                "com.sequenceiq.cloudbreak.structuredevent.domain");
         entityManagerFactory.setDataSource(dataSource());
 
         entityManagerFactory.setJpaVendorAdapter(jpaVendorAdapter());

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/EndpointConfig.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/EndpointConfig.java
@@ -8,10 +8,12 @@ import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.ext.ExceptionMapper;
 
 import org.glassfish.jersey.server.ResourceConfig;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
 import com.sequenceiq.authorization.controller.AuthorizationInfoController;
 import com.sequenceiq.cloudbreak.exception.mapper.DefaultExceptionMapper;
+import com.sequenceiq.cloudbreak.structuredevent.rest.filter.CDPRestAuditFilter;
 import com.sequenceiq.flow.controller.FlowController;
 import com.sequenceiq.flow.controller.FlowPublicController;
 import com.sequenceiq.redbeams.api.RedbeamsApi;
@@ -38,8 +40,8 @@ public class EndpointConfig extends ResourceConfig {
             AuthorizationInfoController.class
     );
 
-    // @Value("${redbeams.structuredevent.rest.enabled:false}")
-    // private Boolean auditEnabled;
+    @Value("${redbeams.structuredevent.rest.enabled:false}")
+    private Boolean auditEnabled;
 
     @Inject
     private List<ExceptionMapper<?>> exceptionMappers;
@@ -52,11 +54,7 @@ public class EndpointConfig extends ResourceConfig {
 
     @PostConstruct
     private void init() {
-        /* TODO Add StructuredEventFilter, preferably as a library
-            if (auditEnabled) {
-                register(StructuredEventFilter.class);
-            }
-         */
+        registerFilters();
         registerEndpoints();
         registerExceptionMappers();
         register(serverTracingDynamicFeature);
@@ -77,5 +75,9 @@ public class EndpointConfig extends ResourceConfig {
         register(io.swagger.jaxrs.listing.ApiListingResource.class);
         register(io.swagger.jaxrs.listing.SwaggerSerializers.class);
         register(io.swagger.jaxrs.listing.AcceptHeaderApiListingResource.class);
+    }
+
+    private void registerFilters() {
+        register(CDPRestAuditFilter.class);
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/event/RedbeamsStructuredFlowEventFactory.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/event/RedbeamsStructuredFlowEventFactory.java
@@ -1,0 +1,76 @@
+package com.sequenceiq.redbeams.event;
+
+import static com.sequenceiq.cloudbreak.structuredevent.event.StructuredEventType.FLOW;
+
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.common.service.Clock;
+import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
+import com.sequenceiq.cloudbreak.structuredevent.event.FlowDetails;
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPOperationDetails;
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPStructuredFlowEvent;
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.redbeams.CDPRedbeamsStructuredFlowEvent;
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.redbeams.RedbeamsDetails;
+import com.sequenceiq.cloudbreak.structuredevent.service.CDPStructuredFlowEventFactory;
+import com.sequenceiq.flow.ha.NodeConfig;
+import com.sequenceiq.redbeams.domain.stack.DBStack;
+import com.sequenceiq.redbeams.service.stack.DBStackService;
+
+@Component
+public class RedbeamsStructuredFlowEventFactory implements CDPStructuredFlowEventFactory {
+
+    @Inject
+    private Clock clock;
+
+    @Inject
+    private DBStackService dbStackService;
+
+    @Inject
+    private NodeConfig nodeConfig;
+
+    @Value("${info.app.version:}")
+    private String serviceVersion;
+
+    @Override
+    public CDPStructuredFlowEvent createStructuredFlowEvent(Long resourceId, FlowDetails flowDetails) {
+        return createStructuredFlowEvent(resourceId, flowDetails, null);
+    }
+
+    @Override
+    public CDPStructuredFlowEvent createStructuredFlowEvent(Long resourceId, FlowDetails flowDetails, Exception exception) {
+        DBStack dbStack = dbStackService.getById(resourceId);
+        CDPOperationDetails operationDetails = new CDPOperationDetails(
+                clock.getCurrentTimeMillis(),
+                FLOW,
+                CloudbreakEventService.REDBEAMS_RESOURCE_TYPE,
+                dbStack.getId(),
+                dbStack.getName(),
+                nodeConfig.getId(),
+                serviceVersion,
+                dbStack.getAccountId(),
+                dbStack.getResourceCrn(),
+                ThreadBasedUserCrnProvider.getUserCrn(),
+                dbStack.getEnvironmentId(),
+                null);
+
+        RedbeamsDetails redbeamsDetails = new RedbeamsDetails(
+                dbStack.getId(),
+                dbStack.getName(),
+                dbStack.getResourceCrn(),
+                dbStack.getAccountId(),
+                dbStack.getEnvironmentId(),
+                dbStack.getRegion(),
+                dbStack.getAvailabilityZone());
+        CDPRedbeamsStructuredFlowEvent event = new CDPRedbeamsStructuredFlowEvent(operationDetails, flowDetails, redbeamsDetails,
+                null, null);
+        if (exception != null) {
+            event.setException(ExceptionUtils.getStackTrace(exception));
+        }
+        return event;
+    }
+}

--- a/redbeams/src/main/resources/application.yml
+++ b/redbeams/src/main/resources/application.yml
@@ -42,9 +42,7 @@ redbeams:
   cloudbreak.url: http://localhost:9091
   cert.dir: /certs/
   client.id: redbeams
-  structuredevent:
-    rest:
-      enabled: false
+  structuredevent.rest.enabled: false
   db:
     port.5432.tcp.port: 5432
     port.5432.tcp.addr: 127.0.0.1
@@ -74,6 +72,7 @@ redbeams:
     core.size: 40
     capacity.size: 4000
   etc.config.dir: /etc/cloudbreak
+
   ssl:
     enabled: true
     certs:
@@ -331,7 +330,6 @@ vault:
       login.role: "cloudbreak.default"
 
 cb:
-  uaa.startup.timeout.sec: 300
   enabledplatforms: AZURE,AWS,GCP
   platform.default.rootVolumeSize:
     AWS: 100
@@ -373,65 +371,9 @@ cb:
     host.name.prefix.length: 255
     database.template.batchSize: 1
 
-  os:
-    enable.autoimport: true
-    import:
-      root.url.pattern: http://public-repo-1.hortonworks.com/HDP/cloudbreak/%s.img
-      from.format: qcow2
-      disk.format: qcow2
-      container.format: bare
-
-  yarn:
-    domain: default.com
-    defaultQueue: "default"
-    defaultLifeTime: 604800
-
-  clusterdefinition:
-    cm:
-      defaults: >
-        CDH 6.1 - Data Science: Apache Spark, Apache Hive, Impala=cdh6-data-science;
-        CDH 6.1 - Data Lake: Hive Metastore=cdh6-shared-services
-    ambari:
-      defaults: >
-        EDW-ETL: Apache Hive, Apache Spark 2=hdp26-etl-edw-spark2;
-        EDW-Analytics: Apache Hive 2 LLAP, Apache Zeppelin=hdp26-edw-analytics;
-        Data Science: Apache Spark 2, Apache Zeppelin=hdp26-data-science-spark2;
-        Flow Management: Apache NiFi, Apache NiFi Registry=hdf33-flow-management;
-        HDF-3.3 Messaging Management: Apache Kafka=hdf33-messaging-kafka;
-        Messaging Management: Apache Kafka, Schema Registry=hdf33-messaging-kafka-registry;
-        Data Lake: Apache Ranger, Apache Atlas, Apache Hive Metastore=hdp26-shared-services;
-        Data Lake: Apache Ranger, Apache Hive Metastore HA=hdp26-shared-services-ha;
-        HDP 3.1 - Data Science: Apache Spark 2, Apache Zeppelin=hdp31-data-science-spark2;
-        HDP 3.1 - EDW-Analytics: Apache Hive 2 LLAP, Apache Zeppelin=hdp31-edw-analytics;
-        HDP 3.1 - Data Lake: Apache Ranger, Apache Hive Metastore=hdp31-shared-services
-      internal: >
-        HDP 3.0 - Data Science: Apache Spark 2, Apache Zeppelin=hdp30-data-science-spark2;
-        HDP 3.0 - EDW-Analytics: Apache Hive 2 LLAP, Apache Zeppelin=hdp30-edw-analytics;
-        HDP 3.0 - Data Lake: Apache Ranger, Apache Hive Metastore=hdp30-shared-services;
-        HDP 3.0 - Data Lake: Apache Ranger, Apache Atlas, Infrastructure Services=hdp30-shared-services-v2;
-        HDP 3.0 - Data Science Attached: Apache Spark 2, Apache Zeppelin=hdp30-data-science-spark2-attached-v2;
-        HDP 3.0 - Data Science Standalone: Apache Spark 2, Apache Zeppelin=hdp30-data-science-spark2-standalone-v2;
-        HDP 3.0 - EDW-Analytics Attached: Apache Hive 3 LLAP=hdp30-edw-analytics-attached-v2;
-        HDP 3.0 - EDW-Analytics Standalone: Apache Hive 3 LLAP=hdp30-edw-analytics-standalone-v2
-  clustertemplate.defaults:
-  template.defaults: minviable-gcp,minviable-azure-managed-disks,minviable-aws
   custom.user.data: |
     touch /tmp/custom-user-data
     date >> /tmp/custom-user-data
-
-  mail:
-    smtp:
-      auth: true
-      type: smtp
-      starttls.enable: true
-  success.cluster.installer.mail.template.path: templates/cluster-installer-mail-success.ftl
-  failed.cluster.installer.mail.template.path: templates/cluster-installer-mail-fail.ftl
-
-  docker:
-    container:
-      yarn.ambari.server: hortonworks/yarn-cloudbreak-ambari-server:2.5.0-v1
-      yarn.ambari.agent: hortonworks/yarn-cloudbreak-ambari-agent:2.5.0-v1
-      yarn.ambari.db: hortonworks/yarn-cloudbreak-postgres:9.4.1
 
   arm:
     template.path: templates/arm-v2.ftl
@@ -490,271 +432,10 @@ cb:
     db: ranger
     port: 5432
 
-  ambari:
-    entries:
-      2.6:
-        version: 2.6.2.2
-        repo:
-          redhat6:
-            baseurl: http://public-repo-1.hortonworks.com/ambari/centos6/2.x/updates/2.6.2.2
-            gpgkey: http://public-repo-1.hortonworks.com/ambari/centos6/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
-          redhat7:
-            baseurl: http://public-repo-1.hortonworks.com/ambari/centos7/2.x/updates/2.6.2.2
-            gpgkey: http://public-repo-1.hortonworks.com/ambari/centos7/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
-          debian9:
-            baseurl: http://public-repo-1.hortonworks.com/ambari/debian9/2.x/updates/2.6.2.2
-          ubuntu16:
-            baseurl: http://public-repo-1.hortonworks.com/ambari/ubuntu16/2.x/updates/2.6.2.2
-          sles12:
-            baseurl: http://public-repo-1.hortonworks.com/ambari/sles12/2.x/updates/2.6.2.2
-            gpgkey: http://public-repo-1.hortonworks.com/ambari/sles12/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
-      2.7:
-        version: 2.7.3.0
-        repo:
-          redhat7:
-            baseurl: http://public-repo-1.hortonworks.com/ambari/centos7/2.x/updates/2.7.3.0
-            gpgkey: http://public-repo-1.hortonworks.com/ambari/centos7/2.x/updates/2.7.3.0/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
-          debian9:
-            baseurl: http://public-repo-1.hortonworks.com/ambari/debian9/2.x/updates/2.7.3.0
-          ubuntu16:
-            baseurl: http://public-repo-1.hortonworks.com/ambari/ubuntu16/2.x/updates/2.7.3.0
-          ubuntu18:
-            baseurl: http://public-repo-1.hortonworks.com/ambari/ubuntu18/2.x/updates/2.7.3.0
-          sles12:
-            baseurl: http://public-repo-1.hortonworks.com/ambari/sles12/2.x/updates/2.7.3.0
-            gpgkey: http://public-repo-1.hortonworks.com/ambari/sles12/2.x/updates/2.7.3.0/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
-          amazonlinux2:
-            baseurl: http://public-repo-1.hortonworks.com/ambari/amazonlinux2/2.x/updates/2.7.3.0
-            gpgkey: http://public-repo-1.hortonworks.com/ambari/amazonlinux2/2.x/updates/2.7.3.0/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
-    database:
-      port: 5432
-      user: ambari
-      db: ambari
-    ldaps:
-      certPath: /etc/ambari-server/cert
-      keystorePath: /var/lib/ambari-server/keys
-      keystorePassword: mypass
-
-  hdp:
-    entries:
-      2.5:
-        version: 2.5.5.0
-        minAmbari: 2.6
-        repo:
-          stack:
-            repoid: HDP-2.5
-            redhat6: http://public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.5.5.0
-            redhat7: http://public-repo-1.hortonworks.com/HDP/centos7/2.x/updates/2.5.5.0
-            debian9: http://public-repo-1.hortonworks.com/HDP/debian9/2.x/updates/2.5.5.0
-            ubuntu16: http://public-repo-1.hortonworks.com/HDP/ubuntu16/2.x/updates/2.5.5.0
-            repository-version: 2.5.3.0-37
-            vdf-redhat6: http://public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.5.3.0/HDP-2.5.3.0-37.xml
-            vdf-redhat7: http://public-repo-1.hortonworks.com/HDP/centos7/2.x/updates/2.5.3.0/HDP-2.5.3.0-37.xml
-            vdf-debian9: http://public-repo-1.hortonworks.com/HDP/debian9/2.x/updates/2.5.3.0/HDP-2.5.3.0-37.xml
-            vdf-ubuntu16: http://public-repo-1.hortonworks.com/HDP/ubuntu16/2.x/updates/2.5.3.0/HDP-2.5.3.0-37.xml
-          util:
-            repoid: HDP-UTILS-1.1.0.21
-            redhat6: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.21/repos/centos6
-            redhat7: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.21/repos/centos7
-            debian9: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.21/repos/debian9
-            ubuntu16: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.21/repos/ubuntu16
-      2.6:
-        version: 2.6.5.0
-        minAmbari: 2.6
-        repo:
-          stack:
-            repoid: HDP-2.6
-            redhat6: http://public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.6.5.0
-            redhat7: http://public-repo-1.hortonworks.com/HDP/centos7/2.x/updates/2.6.5.0
-            debian9: http://public-repo-1.hortonworks.com/HDP/debian9/2.x/updates/2.6.5.0
-            ubuntu16: http://public-repo-1.hortonworks.com/HDP/ubuntu16/2.x/updates/2.6.5.0
-            sles12: http://public-repo-1.hortonworks.com/HDP/sles12/2.x/updates/2.6.5.0
-            repository-version: 2.6.5.0-292
-            vdf-redhat6: http://public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.6.5.0/HDP-2.6.5.0-292.xml
-            vdf-redhat7: http://public-repo-1.hortonworks.com/HDP/centos7/2.x/updates/2.6.5.0/HDP-2.6.5.0-292.xml
-            vdf-debian9: http://public-repo-1.hortonworks.com/HDP/debian9/2.x/updates/2.6.5.0/HDP-2.6.5.0-292.xml
-            vdf-ubuntu16: http://public-repo-1.hortonworks.com/HDP/ubuntu16/2.x/updates/2.6.5.0/HDP-2.6.5.0-292.xml
-            vdf-sles12: http://public-repo-1.hortonworks.com/HDP/sles12/2.x/updates/2.6.5.0/HDP-2.6.5.0-292.xml
-          util:
-            repoid: HDP-UTILS-1.1.0.22
-            redhat6: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/centos6
-            redhat7: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/centos7
-            debian9: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/debian9
-            ubuntu16: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/ubuntu16
-            sles12: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/sles12
-      3.1:
-        version: 3.1.0.0
-        minAmbari: 2.7
-        repo:
-          stack:
-            repoid: HDP-3.1
-            redhat7: http://public-repo-1.hortonworks.com/HDP/centos7/3.x/updates/3.1.0.0
-            debian9: http://public-repo-1.hortonworks.com/HDP/debian9/3.x/updates/3.1.0.0
-            ubuntu16: http://public-repo-1.hortonworks.com/HDP/ubuntu16/3.x/updates/3.1.0.0
-            ubuntu18: http://public-repo-1.hortonworks.com/HDP/ubuntu18/3.x/updates/3.1.0.0
-            sles12: http://public-repo-1.hortonworks.com/HDP/sles12/3.x/updates/3.1.0.0
-            amazonlinux2: http://public-repo-1.hortonworks.com/HDP/amazonlinux2/3.x/updates/3.1.0.0
-            repository-version: 3.1.0.0-78
-            vdf-redhat7: http://public-repo-1.hortonworks.com/HDP/centos7/3.x/updates/3.1.0.0/HDP-3.1.0.0-78.xml
-            vdf-debian9: http://public-repo-1.hortonworks.com/HDP/debian9/3.x/updates/3.1.0.0/HDP-3.1.0.0-78.xml
-            vdf-ubuntu16: http://public-repo-1.hortonworks.com/HDP/ubuntu16/3.x/updates/3.1.0.0/HDP-3.1.0.0-78.xml
-            vdf-ubuntu18: http://public-repo-1.hortonworks.com/HDP/ubuntu18/3.x/updates/3.1.0.0/HDP-3.1.0.0-78.xml
-            vdf-sles12: http://public-repo-1.hortonworks.com/HDP/sles12/3.x/updates/3.1.0.0/HDP-3.1.0.0-78.xml
-            vdf-amazonlinux2: http://public-repo-1.hortonworks.com/HDP/amazonlinux2/3.x/updates/3.1.0.0/HDP-3.1.0.0-78.xml
-          util:
-            repoid: HDP-UTILS-1.1.0.22
-            redhat7: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/centos7
-            debian9: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/debian9
-            ubuntu16: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/ubuntu16
-            ubuntu18: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/ubuntu18
-            sles12: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/sles12
-            amazonlinux2: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/amazonlinux2
-  hdf:
-    entries:
-      3.1:
-        version: 3.1.2.0-7
-        min-ambari: 2.6
-        repo:
-          stack:
-            repoid: HDF-3.1
-            redhat6: http://public-repo-1.hortonworks.com/HDF/centos6/3.x/updates/3.1.2.0
-            redhat7: http://public-repo-1.hortonworks.com/HDF/centos7/3.x/updates/3.1.2.0
-            debian9: http://public-repo-1.hortonworks.com/HDF/debian9/3.x/updates/3.1.2.0
-            ubuntu16: http://public-repo-1.hortonworks.com/HDF/ubuntu16/3.x/updates/3.1.2.0
-            sles12: http://public-repo-1.hortonworks.com/HDF/sles12/3.x/updates/3.1.2.0
-            repository-version: 3.1.2.0-7
-            vdf-redhat6: http://public-repo-1.hortonworks.com/HDF/centos6/3.x/updates/3.1.2.0/HDF-3.1.2.0-7.xml
-            vdf-redhat7: http://public-repo-1.hortonworks.com/HDF/centos7/3.x/updates/3.1.2.0/HDF-3.1.2.0-7.xml
-            vdf-debian9: http://public-repo-1.hortonworks.com/HDF/debian9/3.x/updates/3.1.2.0/HDF-3.1.2.0-7.xml
-            vdf-ubuntu16: http://public-repo-1.hortonworks.com/HDF/ubuntu16/3.x/updates/3.1.2.0/HDF-3.1.2.0-7.xml
-            vdf-sles12: http://public-repo-1.hortonworks.com/HDF/sles12/3.x/updates/3.1.2.0/HDF-3.1.2.0-7.xml
-          util:
-            repoid: HDP-UTILS-1.1.0.22
-            redhat6: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/centos6
-            redhat7: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/centos7
-            debian9: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/debian9
-            ubuntu16: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/ubuntu16
-            sles12: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/sles12
-          mpacks:
-            redhat6:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/centos6/3.x/updates/3.1.2.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.1.2.0-7.tar.gz
-                stackDefault: true
-            redhat7:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/centos7/3.x/updates/3.1.2.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.1.2.0-7.tar.gz
-                stackDefault: true
-            debian9:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/debian9/3.x/updates/3.1.2.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.1.2.0-7.tar.gz
-                stackDefault: true
-            ubuntu16:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/ubuntu16/3.x/updates/3.1.2.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.1.2.0-7.tar.gz
-                stackDefault: true
-            sles12:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/sles12/3.x/updates/3.1.2.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.1.2.0-7.tar.gz
-                stackDefault: true
-      3.2:
-        version: 3.2.0.0-520
-        min-ambari: 2.7
-        repo:
-          stack:
-            repoid: HDF-3.2
-            redhat7: http://public-repo-1.hortonworks.com/HDF/centos7/3.x/updates/3.2.0.0
-            debian9: http://public-repo-1.hortonworks.com/HDF/debian9/3.x/updates/3.2.0.0
-            ubuntu16: http://public-repo-1.hortonworks.com/HDF/ubuntu16/3.x/updates/3.2.0.0
-            sles12: http://public-repo-1.hortonworks.com/HDF/sles12/3.x/updates/3.2.0.0
-            amazonlinux2: http://public-repo-1.hortonworks.com/HDF/amazonlinux2/3.x/updates/3.2.0.0
-            repository-version: 3.2.0.0-520
-            vdf-redhat7: http://public-repo-1.hortonworks.com/HDF/centos7/3.x/updates/3.2.0.0/HDF-3.2.0.0-520.xml
-            vdf-debian9: http://public-repo-1.hortonworks.com/HDF/debian9/3.x/updates/3.2.0.0/HDF-3.2.0.0-520.xml
-            vdf-ubuntu16: http://public-repo-1.hortonworks.com/HDF/ubuntu16/3.x/updates/3.2.0.0/HDF-3.2.0.0-520.xml
-            vdf-sles12: http://public-repo-1.hortonworks.com/HDF/sles12/3.x/updates/3.2.0.0/HDF-3.2.0.0-520.xml
-            vdf-amazonlinux2: http://public-repo-1.hortonworks.com/HDF/amazonlinux2/3.x/updates/3.2.0.0/HDF-3.2.0.0-520.xml
-          util:
-            repoid: HDP-UTILS-1.1.0.22
-            redhat7: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/centos7
-            debian9: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/debian9
-            ubuntu16: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/ubuntu16
-            sles12: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/sles12
-            amazonlinux2: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/amazonlinux2
-          mpacks:
-            redhat7:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/centos7/3.x/updates/3.2.0.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.2.0.0-520.tar.gz
-                stackDefault: true
-            debian9:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/debian9/3.x/updates/3.2.0.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.2.0.0-520.tar.gz
-                stackDefault: true
-            ubuntu16:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/ubuntu16/3.x/updates/3.2.0.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.2.0.0-520.tar.gz
-                stackDefault: true
-            sles12:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/sles12/3.x/updates/3.2.0.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.2.0.0-520.tar.gz
-                stackDefault: true
-            amazonlinux2:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/amazonlinux2/3.x/updates/3.2.0.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.2.0.0-520.tar.gz
-                stackDefault: true
-      3.3:
-        version: 3.3.1.0-10
-        min-ambari: 2.7
-        repo:
-          stack:
-            repoid: HDF-3.3
-            redhat7: http://public-repo-1.hortonworks.com/HDF/centos7/3.x/updates/3.3.1.0
-            debian9: http://public-repo-1.hortonworks.com/HDF/debian9/3.x/updates/3.3.1.0
-            ubuntu16: http://public-repo-1.hortonworks.com/HDF/ubuntu16/3.x/updates/3.3.1.0
-            sles12: http://public-repo-1.hortonworks.com/HDF/sles12/3.x/updates/3.3.1.0
-            amazonlinux2: http://public-repo-1.hortonworks.com/HDF/amazonlinux2/3.x/updates/3.3.1.0
-            repository-version: 3.3.1.0-10
-            vdf-redhat7: http://public-repo-1.hortonworks.com/HDF/centos7/3.x/updates/3.3.1.0/HDF-3.3.1.0-10.xml
-            vdf-debian9: http://public-repo-1.hortonworks.com/HDF/debian9/3.x/updates/3.3.1.0/HDF-3.3.1.0-10.xml
-            vdf-ubuntu16: http://public-repo-1.hortonworks.com/HDF/ubuntu16/3.x/updates/3.3.1.0/HDF-3.3.1.0-10.xml
-            vdf-sles12: http://public-repo-1.hortonworks.com/HDF/sles12/3.x/updates/3.3.1.0/HDF-3.3.1.0-10.xml
-            vdf-amazonlinux2: http://public-repo-1.hortonworks.com/HDF/amazonlinux2/3.x/updates/3.3.1.0/HDF-3.3.1.0-10.xml
-          util:
-            repoid: HDP-UTILS-1.1.0.22
-            redhat7: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/centos7
-            debian9: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/debian9
-            ubuntu16: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/ubuntu16
-            sles12: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/sles12
-            amazonlinux2: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/amazonlinux2
-          mpacks:
-            redhat7:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/centos7/3.x/updates/3.3.1.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.3.1.0-10.tar.gz
-                stackDefault: true
-            debian9:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/debian9/3.x/updates/3.3.1.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.3.1.0-10.tar.gz
-                stackDefault: true
-            ubuntu16:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/ubuntu16/3.x/updates/3.3.1.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.3.1.0-10.tar.gz
-                stackDefault: true
-            sles12:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/sles12/3.x/updates/3.3.1.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.3.1.0-10.tar.gz
-                stackDefault: true
-            amazonlinux2:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/amazonlinux2/3.x/updates/3.3.1.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.3.1.0-10.tar.gz
-                stackDefault: true
-
-  structuredevent:
-    rest:
-      enabled: true
-      contentlogging: true
-
-  instance:
-    packages:
-      - name: salt
-        prewarmed: false
-        grain: saltversion
-      - name: salt-bootstrap
-        prewarmed: false
-        command: "salt-bootstrap version"
-      - name: stack
-        pkgName: hdp-select,hdf-select
-        prewarmed: true
-      - name: ambari
-        pkgName: ambari-agent
-        prewarmed: true
-
 altus:
   audit:
-    enabled: false
+    enabled: true
+    endpoint: localhost:8982
   ums:
     host: localhost
     caller: redbeams
@@ -762,3 +443,7 @@ altus:
 crn:
   partition: cdp
   region: us-west-1
+
+cdp.structuredevent:
+  rest:
+    contentlogging: true

--- a/redbeams/src/main/resources/schema/app/20221013125607_CB-18959_include_structuredeven-service-cdp_in_the_redbeams_service.sql
+++ b/redbeams/src/main/resources/schema/app/20221013125607_CB-18959_include_structuredeven-service-cdp_in_the_redbeams_service.sql
@@ -1,0 +1,27 @@
+-- // CB-18959 include structuredeven-service-cdp in the redbeams service
+-- Migration SQL that makes the change goes here.
+
+CREATE TABLE IF NOT EXISTS cdp_structured_event (
+    id                      bigserial NOT NULL,
+    eventtype               VARCHAR (255) NOT NULL,
+    resourcetype            VARCHAR (255) NOT NULL,
+    resourcecrn             VARCHAR (255) NOT NULL,
+    accountid               VARCHAR (255) NOT NULL,
+    timestamp               BIGINT NOT NULL DEFAULT (date_part('epoch'::text, now()) * 1000::double precision),
+    structuredeventjson     TEXT NOT NULL,
+
+    CONSTRAINT              pk_cdp_structured_event_id              PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_cdp_structured_event_resourcecrn_eventtype ON cdp_structured_event (resourcecrn, eventtype);
+CREATE INDEX idx_cdp_structured_event_resourcecrn_eventtype_timestamp ON cdp_structured_event (resourcecrn, eventtype, timestamp);
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+DROP INDEX IF EXISTS idx_cdp_structured_event_resourcecrn_eventtype;
+DROP INDEX IF EXISTS idx_cdp_structured_event_resourcecrn_eventtype_timestamp;
+DROP TABLE IF EXISTS cdp_structured_event;
+
+

--- a/structuredevent-model/src/main/java/com/sequenceiq/cloudbreak/structuredevent/event/CloudbreakEventService.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/cloudbreak/structuredevent/event/CloudbreakEventService.java
@@ -28,6 +28,8 @@ public interface CloudbreakEventService {
 
     String CONSUMPTION_RESOURCE_TYPE = "consumption";
 
+    String REDBEAMS_RESOURCE_TYPE = "redbeams";
+
     void fireCloudbreakEvent(Long entityId, String eventType, ResourceEvent resourceEvent);
 
     void fireCloudbreakEvent(Long entityId, String eventType, ResourceEvent resourceEvent, Collection<String> eventMessageArgs);

--- a/structuredevent-model/src/main/java/com/sequenceiq/cloudbreak/structuredevent/event/cdp/redbeams/CDPRedbeamsStructuredFlowEvent.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/cloudbreak/structuredevent/event/cdp/redbeams/CDPRedbeamsStructuredFlowEvent.java
@@ -1,0 +1,16 @@
+package com.sequenceiq.cloudbreak.structuredevent.event.cdp.redbeams;
+
+import com.sequenceiq.cloudbreak.structuredevent.event.FlowDetails;
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPOperationDetails;
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPStructuredFlowEvent;
+
+public class CDPRedbeamsStructuredFlowEvent extends CDPStructuredFlowEvent<RedbeamsDetails> {
+
+    public CDPRedbeamsStructuredFlowEvent() {
+    }
+
+    public CDPRedbeamsStructuredFlowEvent(CDPOperationDetails operation, FlowDetails flow,
+            RedbeamsDetails payload, String status, String statusReason) {
+        super(operation, flow, payload, status, statusReason);
+    }
+}

--- a/structuredevent-model/src/main/java/com/sequenceiq/cloudbreak/structuredevent/event/cdp/redbeams/RedbeamsDetails.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/cloudbreak/structuredevent/event/cdp/redbeams/RedbeamsDetails.java
@@ -1,0 +1,94 @@
+package com.sequenceiq.cloudbreak.structuredevent.event.cdp.redbeams;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RedbeamsDetails implements Serializable {
+
+    private Long resourceId;
+
+    private String name;
+
+    private String resourceCrn;
+
+    private String accountId;
+
+    private String environmentCrn;
+
+    private String region;
+
+    private String availabilityZone;
+
+    public RedbeamsDetails() {
+    }
+
+    public RedbeamsDetails(Long resourceId, String name, String resourceCrn, String accountId, String environmentCrn, String region, String availabilityZone) {
+        this.resourceId = resourceId;
+        this.name = name;
+        this.resourceCrn = resourceCrn;
+        this.accountId = accountId;
+        this.environmentCrn = environmentCrn;
+        this.region = region;
+        this.availabilityZone = availabilityZone;
+    }
+
+    public Long getResourceId() {
+        return resourceId;
+    }
+
+    public void setResourceId(Long resourceId) {
+        this.resourceId = resourceId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getResourceCrn() {
+        return resourceCrn;
+    }
+
+    public void setResourceCrn(String resourceCrn) {
+        this.resourceCrn = resourceCrn;
+    }
+
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
+    }
+
+    public String getEnvironmentCrn() {
+        return environmentCrn;
+    }
+
+    public void setEnvironmentCrn(String environmentCrn) {
+        this.environmentCrn = environmentCrn;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public void setRegion(String region) {
+        this.region = region;
+    }
+
+    public String getAvailabilityZone() {
+        return availabilityZone;
+    }
+
+    public void setAvailabilityZone(String availabilityZone) {
+        this.availabilityZone = availabilityZone;
+    }
+}

--- a/structuredevent-model/src/main/java/com/sequenceiq/cloudbreak/structuredevent/filter/CDPJaxRsFilterPropertyKeys.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/cloudbreak/structuredevent/filter/CDPJaxRsFilterPropertyKeys.java
@@ -5,9 +5,9 @@ public class CDPJaxRsFilterPropertyKeys {
 
     public static final String REQUEST_TIME = "REQUEST_TIME";
 
-    public static final String REQUEST_DETAILS = "REQUEST_DETAIS";
+    public static final String REQUEST_DETAILS = "REQUEST_DETAILS";
 
-    public static final String RESPONSE_DETAILS = "RESPONSE_DETAIS";
+    public static final String RESPONSE_DETAILS = "RESPONSE_DETAILS";
 
     private CDPJaxRsFilterPropertyKeys() {
     }


### PR DESCRIPTION
**Changes:**
 - CB-18959 enable strict audit filter in Consumption and Redbeams services
 - CB-18426 register filters in an individual private method in endpoint configs - some cosmetics of filter registration that just verbally mentioned as a review item for the original PR