### PR TITLE
CB-11832 [Breaking API change] Rename internal method because of swag…

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
@@ -665,7 +665,7 @@ public interface StackV4Endpoint {
     @Path("internal/{name}/vertical_scaling")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = VERTICAL_SCALE_BY_NAME, produces = MediaType.APPLICATION_JSON, notes = Notes.STACK_NOTES,
-            nickname = "verticalScalingByName")
+            nickname = "verticalScalingInternalByName")
     FlowIdentifier verticalScalingByName(
             @PathParam("workspaceId") Long workspaceId,
             @PathParam("name") String name,


### PR DESCRIPTION
…ger name collision.

See detailed description in the commit message.