### PR TITLE
CB-18993 Improve salt password rotation fallback implementation

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapper.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapper.java
@@ -144,6 +144,7 @@ public class ClusterBootstrapper {
 
     public void bootstrapMachines(Long stackId) throws CloudbreakException {
         StackDto stackDto = stackDtoService.getById(stackId);
+        LOGGER.info("BootstrapMachines for stack [{}] [{}]", stackDto.getName(), stackDto.getResourceCrn());
         bootstrapOnHost(stackDto);
     }
 
@@ -155,7 +156,28 @@ public class ClusterBootstrapper {
 
     @SuppressFBWarnings("REC_CATCH_EXCEPTION")
     public void bootstrapOnHost(StackDto stack) throws CloudbreakException {
+        LOGGER.info("BootstrapOnHost for stack [{}] [{}]", stack.getName(), stack.getResourceCrn());
         bootstrapOnHostInternal(stack, this::saveSaltComponent);
+    }
+
+    public void reBootstrapGateways(StackDto stack) throws CloudbreakException {
+        try {
+            List<GatewayConfig> allGatewayConfig = collectAndCheckGateways(stack);
+            Set<Node> gatewayNodes = transactionService.required(() -> collectNodesForBootstrap(stack)).stream()
+                    .filter(node -> allGatewayConfig.stream().anyMatch(gw -> gw.getPrivateAddress().equals(node.getPrivateIp())))
+                    .collect(Collectors.toSet());
+            Set<String> gatewayHostNames = gatewayNodes.stream().map(Node::getHostname).collect(Collectors.toSet());
+            LOGGER.info("ReBootstrapGateways for stack [{}] [{}] with gateways {}", stack.getName(), stack.getResourceCrn(), gatewayHostNames);
+
+            BootstrapParams params = createBootstrapParams(stack);
+            hostOrchestrator.reBootstrapExistingNodes(allGatewayConfig, gatewayNodes, params, clusterDeletionBasedModel(stack.getId(), null));
+
+            checkIfAllNodesAvailable(stack, gatewayNodes, stack.getPrimaryGatewayInstance());
+        } catch (TransactionExecutionException e) {
+            throw new CloudbreakException(e.getCause());
+        } catch (Exception e) {
+            throw new CloudbreakException(e);
+        }
     }
 
     private void bootstrapOnHostInternal(StackDto stack, Consumer<StackView> saveOrUpdateSaltComponent) throws CloudbreakException {
@@ -203,6 +225,7 @@ public class ClusterBootstrapper {
 
     private void checkIfAllNodesAvailable(StackDto stack, Set<Node> nodes, InstanceMetadataView primaryGateway)
             throws CloudbreakOrchestratorFailedException {
+        LOGGER.info("Checking availability of nodes {}", nodes.stream().map(Node::getHostname).collect(Collectors.toSet()));
         GatewayConfig gatewayConfig = gatewayConfigService.getGatewayConfig(stack.getStack(), stack.getSecurityConfig(), primaryGateway, isKnoxEnabled(stack));
         ExtendedPollingResult allNodesAvailabilityPolling = hostClusterAvailabilityPollingService.pollWithAbsoluteTimeout(
                 hostClusterAvailabilityCheckerTask, new HostOrchestratorClusterContext(stack, hostOrchestrator, gatewayConfig, nodes),
@@ -211,6 +234,7 @@ public class ClusterBootstrapper {
         if (allNodesAvailabilityPolling.isTimeout()) {
             clusterBootstrapperErrorHandler.terminateFailedNodes(hostOrchestrator, null, stack, gatewayConfig, nodes);
         }
+        LOGGER.info("All nodes are available");
     }
 
     private void saveSaltComponent(StackView stack) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/RotateSaltPasswordService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/RotateSaltPasswordService.java
@@ -115,7 +115,7 @@ public class RotateSaltPasswordService {
         SecurityConfig securityConfig = stack.getSecurityConfig();
         securityConfig.getSaltSecurityConfig().setSaltPassword(newPassword);
         try {
-            clusterBootstrapper.reBootstrapOnHost(stack);
+            clusterBootstrapper.reBootstrapGateways(stack);
             securityConfigService.changeSaltPassword(securityConfig, newPassword);
         } catch (CloudbreakException e) {
             Set<String> gatewayConfigAddresses = allGatewayConfig.stream()

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/RotateSaltPasswordServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/RotateSaltPasswordServiceTest.java
@@ -212,7 +212,7 @@ class RotateSaltPasswordServiceTest {
         String newPassword = stack.getSecurityConfig().getSaltSecurityConfig().getSaltPassword();
         assertThat(newPassword).isNotEqualTo(OLD_PASSWORD);
         verify(hostOrchestrator).runCommandOnHosts(gatewayConfigs, Set.of("fqdn"), "userdel saltuser");
-        verify(clusterBootstrapper).reBootstrapOnHost(stack);
+        verify(clusterBootstrapper).reBootstrapGateways(stack);
         verify(securityConfigService).changeSaltPassword(securityConfig, newPassword);
     }
 
@@ -229,7 +229,7 @@ class RotateSaltPasswordServiceTest {
         String newPassword = stack.getSecurityConfig().getSaltSecurityConfig().getSaltPassword();
         assertThat(newPassword).isNotEqualTo(OLD_PASSWORD);
         verify(hostOrchestrator).runCommandOnHosts(gatewayConfigs, Set.of("fqdn"), "userdel saltuser");
-        verify(clusterBootstrapper).reBootstrapOnHost(stack);
+        verify(clusterBootstrapper).reBootstrapGateways(stack);
         verify(securityConfigService).changeSaltPassword(securityConfig, newPassword);
     }
 
@@ -239,7 +239,7 @@ class RotateSaltPasswordServiceTest {
         when(node.getHostname()).thenReturn("fqdn");
         Set<Node> nodes = Set.of(node);
         when(stack.getAllPrimaryGatewayInstanceNodes()).thenReturn(nodes);
-        doThrow(CloudbreakException.class).when(clusterBootstrapper).reBootstrapOnHost(stack);
+        doThrow(CloudbreakException.class).when(clusterBootstrapper).reBootstrapGateways(stack);
 
         assertThatThrownBy(() -> underTest.rotateSaltPasswordFallback(stack))
                 .isInstanceOf(CloudbreakOrchestratorFailedException.class)

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/BootstrapService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/BootstrapService.java
@@ -69,10 +69,13 @@ public class BootstrapService {
         Set<InstanceMetaData> instanceMetaDatas = instanceMetaDataService.findNotTerminatedForStack(stack.getId()).stream()
                 .filter(instanceMetaData -> Objects.isNull(instanceIds) || instanceIds.contains(instanceMetaData.getInstanceId()))
                 .collect(Collectors.toSet());
+        Set<String> hostNames = instanceMetaDatas.stream().map(InstanceMetaData::getShortHostname).collect(Collectors.toSet());
+        LOGGER.info("Bootstrapping nodes {} of stack {}", hostNames, stack.getResourceCrn());
         bootstrap(stack, instanceMetaDatas, false);
     }
 
     public void reBootstrap(Stack stack) throws CloudbreakOrchestratorException {
+        LOGGER.info("Re-bootstrapping nodes of stack {}", stack.getResourceCrn());
         bootstrap(stack, stack.getNotDeletedInstanceMetaDataSet(), true);
     }
 
@@ -97,7 +100,7 @@ public class BootstrapService {
         StackBasedExitCriteriaModel exitCriteriaModel = new StackBasedExitCriteriaModel(stack.getId());
         try {
             if (reBootstrap) {
-                hostOrchestrator.bootstrap(gatewayConfigs, allNodes, params, exitCriteriaModel);
+                hostOrchestrator.reBootstrapExistingNodes(gatewayConfigs, allNodes, params, exitCriteriaModel);
             } else {
                 byte[] stateConfigZip = getStateConfigZip();
                 hostOrchestrator.bootstrapNewNodes(gatewayConfigs, allNodes, allNodes,

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/BootstrapServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/BootstrapServiceTest.java
@@ -252,7 +252,8 @@ class BootstrapServiceTest {
         ArgumentCaptor<Set<Node>> targetCaptor = ArgumentCaptor.forClass((Class) Set.class);
         ArgumentCaptor<BootstrapParams> bootstrapParamsCaptor = ArgumentCaptor.forClass(BootstrapParams.class);
         ArgumentCaptor<ExitCriteriaModel> exitCriteriaModelCaptor = ArgumentCaptor.forClass(ExitCriteriaModel.class);
-        verify(hostOrchestrator).bootstrap(eq(gatewayConfigs), targetCaptor.capture(), bootstrapParamsCaptor.capture(), exitCriteriaModelCaptor.capture());
+        verify(hostOrchestrator).reBootstrapExistingNodes(eq(gatewayConfigs), targetCaptor.capture(), bootstrapParamsCaptor.capture(),
+                exitCriteriaModelCaptor.capture());
         Set<Node> targetNodes = targetCaptor.getValue();
         assertEquals(1, targetNodes.size());
         assertTrue(targetNodes.stream().allMatch(node -> node.getPrivateIp().equals(instanceMetaData.getPrivateIp())));

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
@@ -31,6 +31,9 @@ public interface HostOrchestrator extends HostRecipeExecutor {
     void bootstrapNewNodes(List<GatewayConfig> allGatewayConfigs, Set<Node> nodes, Set<Node> allNodes, byte[] stateConfigZip,
             BootstrapParams params, ExitCriteriaModel exitCriteriaModel) throws CloudbreakOrchestratorException;
 
+    void reBootstrapExistingNodes(List<GatewayConfig> allGatewayConfigs, Set<Node> nodes, BootstrapParams params,
+            ExitCriteriaModel exitCriteriaModel) throws CloudbreakOrchestratorException;
+
     boolean isBootstrapApiAvailable(GatewayConfig gatewayConfig);
 
     void changePassword(List<GatewayConfig> allGatewayConfigs, String newPassword, String oldPassword) throws CloudbreakOrchestratorException;

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
@@ -207,7 +207,7 @@ public class SaltOrchestrator implements HostOrchestrator {
             uploadSaltConfig(sc, gatewayTargets, exitModel);
             Set<String> allTargets = targets.stream().map(Node::getPrivateIp).collect(Collectors.toSet());
             uploadSignKey(sc, primaryGateway, gatewayTargets, allTargets, exitModel);
-            OrchestratorBootstrap saltBootstrap = saltBootstrapFactory.of(saltStateService, sc, saltConnectors, allGatewayConfigs, targets, params);
+            OrchestratorBootstrap saltBootstrap = saltBootstrapFactory.of(sc, saltConnectors, allGatewayConfigs, targets, params);
             Callable<Boolean> saltBootstrapRunner = saltRunner.runner(saltBootstrap, exitCriteria, exitModel);
             saltBootstrapRunner.call();
         } catch (Exception e) {
@@ -421,9 +421,33 @@ public class SaltOrchestrator implements HostOrchestrator {
             uploadSignKey(sc, primaryGateway, gatewayTargets, targets.stream().map(Node::getPrivateIp).collect(Collectors.toSet()), exitModel);
             // if there is a new salt master then re-bootstrap all nodes
             Set<Node> nodes = gatewayTargets.isEmpty() ? targets : allNodes;
-            OrchestratorBootstrap saltBootstrap = saltBootstrapFactory.of(saltStateService, sc, saltConnectors, allGatewayConfigs, nodes, params);
+            OrchestratorBootstrap saltBootstrap = saltBootstrapFactory.of(sc, saltConnectors, allGatewayConfigs, nodes, params);
             Callable<Boolean> saltBootstrapRunner = saltRunner.runner(saltBootstrap, exitCriteria, exitModel);
             saltBootstrapRunner.call();
+        } catch (Exception e) {
+            LOGGER.info("Error occurred during salt upscale", e);
+            throw new CloudbreakOrchestratorFailedException(e.getMessage(), e);
+        } finally {
+            saltConnectors.forEach(SaltConnector::close);
+        }
+    }
+
+    @Override
+    public void reBootstrapExistingNodes(List<GatewayConfig> allGatewayConfigs, Set<Node> targets, BootstrapParams params,
+            ExitCriteriaModel exitModel) throws CloudbreakOrchestratorException {
+        LOGGER.info("Re-bootstrap existing nodes: {}", targets.stream().map(Node::getHostname).collect(Collectors.toSet()));
+        GatewayConfig primaryGateway = saltService.getPrimaryGatewayConfig(allGatewayConfigs);
+        List<SaltConnector> saltConnectors = saltService.createSaltConnector(allGatewayConfigs);
+        try (SaltConnector sc = saltService.createSaltConnector(primaryGateway)) {
+            GenericResponses genericResponses = saltStateService.bootstrap(sc, params, allGatewayConfigs, targets);
+            List<GenericResponse> errorResponses = genericResponses.getResponses().stream()
+                    .filter(response -> response.getStatusCode() != HttpStatus.OK.value())
+                    .collect(Collectors.toList());
+            if (!errorResponses.isEmpty()) {
+                Set<String> nodesWithErrors = errorResponses.stream().map(GenericResponse::getAddress).collect(Collectors.toSet());
+                LOGGER.error("Failed to rebootstrap existing nodes [{}/{}] {}", targets.size(), nodesWithErrors.size(), errorResponses);
+                throw new CloudbreakOrchestratorFailedException(String.format("Failed to rebootstrap existing nodes %s", nodesWithErrors));
+            }
         } catch (Exception e) {
             LOGGER.info("Error occurred during salt upscale", e);
             throw new CloudbreakOrchestratorFailedException(e.getMessage(), e);

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/client/SaltActionType.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/client/SaltActionType.java
@@ -18,4 +18,9 @@ public enum SaltActionType {
     public String getAction() {
         return action;
     }
+
+    @Override
+    public String toString() {
+        return action;
+    }
 }

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/client/SaltConnector.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/client/SaltConnector.java
@@ -152,6 +152,7 @@ public class SaltConnector implements Closeable {
     @Measure(SaltConnector.class)
     @Retryable(value = ClusterProxyWebApplicationException.class, backoff = @Backoff(delay = 1000))
     public GenericResponses action(SaltAction saltAction) {
+        LOGGER.debug("Executing salt action {}", saltAction);
         Response response = postSignedJsonSaltRequest(SaltEndpoint.BOOT_ACTION_DISTRIBUTE, saltAction);
         GenericResponses responseEntity = JaxRSUtil.response(response, GenericResponses.class);
         LOGGER.debug("SaltBoot. SaltAction response: {}", responseEntity);

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/domain/Cloud.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/domain/Cloud.java
@@ -18,4 +18,9 @@ public class Cloud {
     public void setName(String name) {
         this.name = name;
     }
+
+    @Override
+    public String toString() {
+        return name;
+    }
 }

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/domain/Os.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/domain/Os.java
@@ -18,4 +18,9 @@ public class Os {
     public void setName(String name) {
         this.name = name;
     }
+
+    @Override
+    public String toString() {
+        return name;
+    }
 }

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/domain/SaltAction.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/domain/SaltAction.java
@@ -118,4 +118,15 @@ public class SaltAction {
     public void setOs(Os os) {
         this.os = os;
     }
+
+    @Override
+    public String toString() {
+        return "SaltAction{" +
+                "action=" + action +
+                ", masters=" + masters +
+                ", minions=" + minions +
+                ", cloud=" + cloud +
+                ", os=" + os +
+                '}';
+    }
 }

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/domain/SaltMaster.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/domain/SaltMaster.java
@@ -41,4 +41,13 @@ public class SaltMaster {
     public void setHostName(String hostName) {
         this.hostName = hostName;
     }
+
+    @Override
+    public String toString() {
+        return "SaltMaster{" +
+                "address='" + address + '\'' +
+                ", domain='" + domain + '\'' +
+                ", hostName='" + hostName + '\'' +
+                '}';
+    }
 }

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/SaltBootstrap.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/SaltBootstrap.java
@@ -18,21 +18,16 @@ import com.sequenceiq.cloudbreak.orchestrator.model.BootstrapParams;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.orchestrator.model.GenericResponse;
 import com.sequenceiq.cloudbreak.orchestrator.model.GenericResponses;
-import com.sequenceiq.cloudbreak.orchestrator.salt.client.SaltActionType;
 import com.sequenceiq.cloudbreak.orchestrator.salt.client.SaltConnector;
-import com.sequenceiq.cloudbreak.orchestrator.salt.domain.Cloud;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.Minion;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.MinionIpAddressesResponse;
-import com.sequenceiq.cloudbreak.orchestrator.salt.domain.Os;
-import com.sequenceiq.cloudbreak.orchestrator.salt.domain.SaltAction;
-import com.sequenceiq.cloudbreak.orchestrator.salt.domain.SaltAuth;
-import com.sequenceiq.cloudbreak.orchestrator.salt.domain.SaltMaster;
 import com.sequenceiq.cloudbreak.orchestrator.salt.poller.join.AcceptAllFpMatcher;
 import com.sequenceiq.cloudbreak.orchestrator.salt.poller.join.DummyFingerprintCollector;
 import com.sequenceiq.cloudbreak.orchestrator.salt.poller.join.EqualMinionFpMatcher;
 import com.sequenceiq.cloudbreak.orchestrator.salt.poller.join.FingerprintFromSbCollector;
 import com.sequenceiq.cloudbreak.orchestrator.salt.poller.join.MinionAcceptor;
 import com.sequenceiq.cloudbreak.orchestrator.salt.states.SaltStateService;
+import com.sequenceiq.cloudbreak.orchestrator.salt.utils.MinionUtil;
 
 public class SaltBootstrap implements OrchestratorBootstrap {
 
@@ -50,6 +45,8 @@ public class SaltBootstrap implements OrchestratorBootstrap {
 
     private final SaltStateService saltStateService;
 
+    private final MinionUtil minionUtil;
+
     private Set<Node> targets;
 
     /*
@@ -57,8 +54,8 @@ public class SaltBootstrap implements OrchestratorBootstrap {
         PowerMockito checked for the creation of the SaltBootsrap class. On regular Mockito, verifying of constructor call is not possible.
         To work around this, a Factory class is introduced that instantiates SaltBootstrap and now the factory method can be verified.
      */
-    SaltBootstrap(SaltStateService saltStateService, SaltConnector sc, Collection<SaltConnector> saltConnectors, List<GatewayConfig> allGatewayConfigs,
-            Set<Node> targets, BootstrapParams params) {
+    SaltBootstrap(SaltStateService saltStateService, MinionUtil minionUtil, SaltConnector sc, Collection<SaltConnector> saltConnectors,
+            List<GatewayConfig> allGatewayConfigs, Set<Node> targets, BootstrapParams params) {
         this.sc = sc;
         this.saltConnectors = saltConnectors;
         this.allGatewayConfigs = allGatewayConfigs;
@@ -66,6 +63,7 @@ public class SaltBootstrap implements OrchestratorBootstrap {
         this.targets = targets;
         this.params = params;
         this.saltStateService = saltStateService;
+        this.minionUtil = minionUtil;
     }
 
     @Override
@@ -74,8 +72,7 @@ public class SaltBootstrap implements OrchestratorBootstrap {
         if (!targets.isEmpty()) {
             LOGGER.debug("Missing targets for SaltBootstrap: {}", targets);
 
-            SaltAction saltAction = createBootstrap(params.isRestartNeededFlagSupported(), params.isRestartNeeded());
-            GenericResponses responses = sc.action(saltAction);
+            GenericResponses responses = saltStateService.bootstrap(sc, params, allGatewayConfigs, targets);
 
             Set<Node> failedTargets = new HashSet<>();
 
@@ -127,87 +124,11 @@ public class SaltBootstrap implements OrchestratorBootstrap {
                 : new MinionAcceptor(saltConnectors, minions, new AcceptAllFpMatcher(), new DummyFingerprintCollector());
     }
 
-    private SaltAction createBootstrap(boolean restartNeededFlagSupported, boolean restartNeeded) {
-        SaltAction saltAction = new SaltAction(SaltActionType.RUN);
-        if (params.getCloud() != null) {
-            saltAction.setCloud(new Cloud(params.getCloud()));
-        }
-        if (params.getOs() != null) {
-            saltAction.setOs(new Os(params.getOs()));
-        }
-        SaltAuth auth = new SaltAuth(sc.getSaltPassword());
-        List<String> targetIps = targets.stream().map(Node::getPrivateIp).collect(Collectors.toList());
-        for (GatewayConfig gatewayConfig : allGatewayConfigs) {
-            String gatewayAddress = gatewayConfig.getPrivateAddress();
-            if (targetIps.contains(gatewayAddress)) {
-                Node saltMaster = targets.stream().filter(n -> n.getPrivateIp().equals(gatewayAddress)).findFirst().get();
-                SaltMaster master = new SaltMaster();
-                master.setAddress(gatewayAddress);
-                master.setAuth(auth);
-                master.setDomain(saltMaster.getDomain());
-                master.setHostName(saltMaster.getHostname());
-                // set due to compatibility reasons
-                saltAction.setServer(gatewayAddress);
-                saltAction.setMaster(master);
-                saltAction.addMinion(createMinion(saltMaster, restartNeededFlagSupported, restartNeeded));
-                saltAction.addMaster(master);
-            }
-        }
-        for (Node minion : targets.stream().filter(node -> !getGatewayPrivateIps().contains(node.getPrivateIp())).collect(Collectors.toList())) {
-            saltAction.addMinion(createMinion(minion, restartNeededFlagSupported, restartNeeded));
-        }
-        return saltAction;
-    }
-
-    private Minion createMinion(Node node, boolean restartNeededFlagSupported, boolean restartNeeded) {
-        Minion minion = new Minion();
-        minion.setAddress(node.getPrivateIp());
-        minion.setHostGroup(node.getHostGroup());
-        minion.setHostName(node.getHostname());
-        minion.setDomain(node.getDomain());
-        minion.setServers(calculateServerIps(restartNeededFlagSupported, restartNeeded));
-        minion.setRestartNeeded(restartNeeded);
-        // set due to compatibility reasons
-        minion.setServer(getGatewayPrivateIps().get(0));
-        return minion;
-    }
-
     private List<Minion> createMinionsFromOriginalTargets() {
+        List<String> gatewayPrivateIps = getGatewayPrivateIps();
         return originalTargets.stream()
-                .map(ot -> createMinion(ot, params.isRestartNeededFlagSupported(), params.isRestartNeeded()))
+                .map(ot -> minionUtil.createMinion(ot, gatewayPrivateIps, params.isRestartNeededFlagSupported(), params.isRestartNeeded()))
                 .collect(Collectors.toList());
-    }
-
-    /***
-     *  Restart needed flag was introduced for the following use case:
-     *
-     *     In a repair scenario where salt master has the same IP address as before, the minions on other instances are not restarted by salt-bootstrap.
-     *     Salt minion does not try to communicate with master by itself for a long time (30mins or sthg like this).
-     *     So when we are waiting for the minions' keys on salt-master then timeout can happen if all the minions haven't tried to communicate with
-     *     master during this time frame.
-     *
-     *     Timeout error message in this scenario: There are missing nodes from salt network response.
-     *     Solution was to introduce a restartNeeded flag in salt-bootstrap and we restart salt minions every time we do a salt-master replacement.
-     *     (it used to be restarted only in case when salt-master IP address changed)
-     *
-     *  In case of older salt-bootsrap ( pre 0.13.4 ) the restartNeeded flag is not interpreted. So in an upgrade scenario (it has a repair flow in
-     *  itself) where the upgrade starts from a 7.1.0 image, the minions are not restarted so the above mentioned timeout could happen.
-     *
-     *  It is a dirty fix but if the restartNeeded flag is set but salt-bootstrap does not support this flag, then we change the
-     *  salt master ip address to loopback address (127.0.0.1), so salt-minion will be restarted by older salt-bootstrap also.
-     *
-     *  The original IP will be set in the next iteration because restartNeeded flag will be false.
-     *
-     * @param restartNeededFlagSupported is restartNeeded flag supported by salt-bootstrap
-     * @param restartNeeded restart minions
-     * @return salt master(s) ip adress(es)
-     */
-    private List<String> calculateServerIps(boolean restartNeededFlagSupported, boolean restartNeeded) {
-        if (!restartNeededFlagSupported && restartNeeded) {
-            return Collections.singletonList("127.0.0.1");
-        } else {
-            return getGatewayPrivateIps();
-        }
     }
 
     private List<String> getGatewayPrivateIps() {

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/SaltBootstrapFactory.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/SaltBootstrapFactory.java
@@ -4,6 +4,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
+import javax.inject.Inject;
+
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.common.orchestration.Node;
@@ -11,12 +13,19 @@ import com.sequenceiq.cloudbreak.orchestrator.model.BootstrapParams;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.orchestrator.salt.client.SaltConnector;
 import com.sequenceiq.cloudbreak.orchestrator.salt.states.SaltStateService;
+import com.sequenceiq.cloudbreak.orchestrator.salt.utils.MinionUtil;
 
 @Component
 public class SaltBootstrapFactory {
 
-    public SaltBootstrap of(SaltStateService saltStateService, SaltConnector sc, Collection<SaltConnector> saltConnectors, List<GatewayConfig> allGatewayConfigs,
+    @Inject
+    private SaltStateService saltStateService;
+
+    @Inject
+    private MinionUtil minionUtil;
+
+    public SaltBootstrap of(SaltConnector sc, Collection<SaltConnector> saltConnectors, List<GatewayConfig> allGatewayConfigs,
             Set<Node> targets, BootstrapParams params) {
-        return new SaltBootstrap(saltStateService, sc, saltConnectors, allGatewayConfigs, targets, params);
+        return new SaltBootstrap(saltStateService, minionUtil, sc, saltConnectors, allGatewayConfigs, targets, params);
     }
 }

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStateService.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStateService.java
@@ -19,6 +19,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import javax.inject.Inject;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -32,6 +34,8 @@ import com.google.common.collect.Multimap;
 import com.sequenceiq.cloudbreak.common.model.PackageInfo;
 import com.sequenceiq.cloudbreak.common.orchestration.Node;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.orchestrator.model.BootstrapParams;
+import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.orchestrator.model.GenericResponses;
 import com.sequenceiq.cloudbreak.orchestrator.salt.client.SaltActionType;
 import com.sequenceiq.cloudbreak.orchestrator.salt.client.SaltConnector;
@@ -40,11 +44,13 @@ import com.sequenceiq.cloudbreak.orchestrator.salt.client.target.HostList;
 import com.sequenceiq.cloudbreak.orchestrator.salt.client.target.Target;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.ApplyFullResponse;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.ApplyResponse;
+import com.sequenceiq.cloudbreak.orchestrator.salt.domain.Cloud;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.CommandExecutionResponse;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.JidInfoResponse;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.Minion;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.MinionIpAddressesResponse;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.MinionStatusSaltResponse;
+import com.sequenceiq.cloudbreak.orchestrator.salt.domain.Os;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.PackageVersionResponse;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.PingResponse;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.RunnerInfo;
@@ -55,6 +61,7 @@ import com.sequenceiq.cloudbreak.orchestrator.salt.domain.SaltAuth;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.SaltMaster;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.SlsExistsSaltResponse;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.StateType;
+import com.sequenceiq.cloudbreak.orchestrator.salt.utils.MinionUtil;
 import com.sequenceiq.cloudbreak.service.Retry;
 
 @Service
@@ -65,6 +72,9 @@ public class SaltStateService {
     private static final long NETWORK_IPADDRS_TIMEOUT = 15L;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SaltStateService.class);
+
+    @Inject
+    private MinionUtil minionUtil;
 
     public Map<String, String> getUuidList(SaltConnector sc) {
         ApplyResponse applyResponse = applyStateAllSync(sc, "disks.get-uuid-list");
@@ -312,14 +322,47 @@ public class SaltStateService {
         return sc.action(saltAction);
     }
 
+    public GenericResponses bootstrap(SaltConnector sc, BootstrapParams params, List<GatewayConfig> allGatewayConfigs, Set<Node> targets) {
+        SaltAction saltAction = new SaltAction(SaltActionType.RUN);
+        if (params.getCloud() != null) {
+            saltAction.setCloud(new Cloud(params.getCloud()));
+        }
+        if (params.getOs() != null) {
+            saltAction.setOs(new Os(params.getOs()));
+        }
+        SaltAuth auth = new SaltAuth(sc.getSaltPassword());
+        List<String> targetIps = targets.stream().map(Node::getPrivateIp).collect(Collectors.toList());
+        List<String> gatewayPrivateIps = allGatewayConfigs.stream().map(GatewayConfig::getPrivateAddress).collect(Collectors.toList());
+        for (GatewayConfig gatewayConfig : allGatewayConfigs) {
+            String gatewayAddress = gatewayConfig.getPrivateAddress();
+            if (targetIps.contains(gatewayAddress)) {
+                Node saltMaster = targets.stream().filter(n -> n.getPrivateIp().equals(gatewayAddress)).findFirst().get();
+                SaltMaster master = new SaltMaster();
+                master.setAddress(gatewayAddress);
+                master.setAuth(auth);
+                master.setDomain(saltMaster.getDomain());
+                master.setHostName(saltMaster.getHostname());
+                // set due to compatibility reasons
+                saltAction.setServer(gatewayAddress);
+                saltAction.setMaster(master);
+                saltAction.addMinion(minionUtil.createMinion(saltMaster, gatewayPrivateIps, params.isRestartNeededFlagSupported(), params.isRestartNeeded()));
+                saltAction.addMaster(master);
+            }
+        }
+        for (Node minionNode : targets.stream().filter(node -> !gatewayPrivateIps.contains(node.getPrivateIp())).collect(Collectors.toList())) {
+            saltAction.addMinion(minionUtil.createMinion(minionNode, gatewayPrivateIps, params.isRestartNeededFlagSupported(), params.isRestartNeeded()));
+        }
+        return sc.action(saltAction);
+    }
+
     public Map<String, List<PackageInfo>> getPackageVersions(SaltConnector sc, Map<String, Optional<String>> packages) {
         Map<String, List<PackageInfo>> packageVersions = new HashMap<>();
-            packages.forEach((key, versionPattern) -> {
-                Map<String, PackageInfo> singlePackageVersion = getSinglePackageVersion(sc, key, versionPattern);
-                singlePackageVersion.entrySet().forEach(entry -> addToVersionList(packageVersions, entry));
-            });
-            return packageVersions;
-        }
+        packages.forEach((key, versionPattern) -> {
+            Map<String, PackageInfo> singlePackageVersion = getSinglePackageVersion(sc, key, versionPattern);
+            singlePackageVersion.entrySet().forEach(entry -> addToVersionList(packageVersions, entry));
+        });
+        return packageVersions;
+    }
 
     private void addToVersionList(Map<String, List<PackageInfo>> packageVersions, Entry<String, PackageInfo> entry) {
         String hostKey = entry.getKey();

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/utils/MinionUtil.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/utils/MinionUtil.java
@@ -1,0 +1,58 @@
+package com.sequenceiq.cloudbreak.orchestrator.salt.utils;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.orchestration.Node;
+import com.sequenceiq.cloudbreak.orchestrator.salt.domain.Minion;
+
+@Component
+public class MinionUtil {
+
+    public Minion createMinion(Node node, List<String> gatewayPrivateIps, boolean restartNeededFlagSupported, boolean restartNeeded) {
+        Minion minion = new Minion();
+        minion.setAddress(node.getPrivateIp());
+        minion.setHostGroup(node.getHostGroup());
+        minion.setHostName(node.getHostname());
+        minion.setDomain(node.getDomain());
+        minion.setServers(calculateServerIps(gatewayPrivateIps, restartNeededFlagSupported, restartNeeded));
+        minion.setRestartNeeded(restartNeeded);
+        // set due to compatibility reasons
+        minion.setServer(gatewayPrivateIps.get(0));
+        return minion;
+    }
+
+    /***
+     *  Restart needed flag was introduced for the following use case:
+     *
+     *     In a repair scenario where salt master has the same IP address as before, the minions on other instances are not restarted by salt-bootstrap.
+     *     Salt minion does not try to communicate with master by itself for a long time (30mins or sthg like this).
+     *     So when we are waiting for the minions' keys on salt-master then timeout can happen if all the minions haven't tried to communicate with
+     *     master during this time frame.
+     *
+     *     Timeout error message in this scenario: There are missing nodes from salt network response.
+     *     Solution was to introduce a restartNeeded flag in salt-bootstrap and we restart salt minions every time we do a salt-master replacement.
+     *     (it used to be restarted only in case when salt-master IP address changed)
+     *
+     *  In case of older salt-bootsrap ( pre 0.13.4 ) the restartNeeded flag is not interpreted. So in an upgrade scenario (it has a repair flow in
+     *  itself) where the upgrade starts from a 7.1.0 image, the minions are not restarted so the above mentioned timeout could happen.
+     *
+     *  It is a dirty fix but if the restartNeeded flag is set but salt-bootstrap does not support this flag, then we change the
+     *  salt master ip address to loopback address (127.0.0.1), so salt-minion will be restarted by older salt-bootstrap also.
+     *
+     *  The original IP will be set in the next iteration because restartNeeded flag will be false.
+     *
+     * @param restartNeededFlagSupported is restartNeeded flag supported by salt-bootstrap
+     * @param restartNeeded restart minions
+     * @return salt master(s) ip adress(es)
+     */
+    private static List<String> calculateServerIps(List<String> gatewayPrivateIps, boolean restartNeededFlagSupported, boolean restartNeeded) {
+        if (!restartNeededFlagSupported && restartNeeded) {
+            return Collections.singletonList("127.0.0.1");
+        } else {
+            return gatewayPrivateIps;
+        }
+    }
+}

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/SaltBootstrapTest.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/SaltBootstrapTest.java
@@ -1,9 +1,6 @@
 package com.sequenceiq.cloudbreak.orchestrator.salt.poller;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -25,7 +22,6 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
@@ -39,11 +35,10 @@ import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.orchestrator.model.GenericResponse;
 import com.sequenceiq.cloudbreak.orchestrator.model.GenericResponses;
 import com.sequenceiq.cloudbreak.orchestrator.salt.client.SaltConnector;
-import com.sequenceiq.cloudbreak.orchestrator.salt.domain.Minion;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.MinionIpAddressesResponse;
-import com.sequenceiq.cloudbreak.orchestrator.salt.domain.SaltAction;
 import com.sequenceiq.cloudbreak.orchestrator.salt.poller.join.MinionAcceptor;
 import com.sequenceiq.cloudbreak.orchestrator.salt.states.SaltStateService;
+import com.sequenceiq.cloudbreak.orchestrator.salt.utils.MinionUtil;
 
 @ExtendWith(MockitoExtension.class)
 class SaltBootstrapTest {
@@ -52,24 +47,28 @@ class SaltBootstrapTest {
     private SaltStateService saltStateService;
 
     @Mock
+    private MinionUtil minionUtil;
+
+    @Mock
     private SaltConnector saltConnector;
 
-    private GatewayConfig gatewayConfig;
+    private List<GatewayConfig> gatewayConfigs;
 
     private MinionIpAddressesResponse minionIpAddressesResponse;
 
     @BeforeEach
     void setUp() {
-        gatewayConfig = new GatewayConfig("1.1.1.1", "10.0.0.1", "172.16.252.43",
+        GatewayConfig gatewayConfig = new GatewayConfig("1.1.1.1", "10.0.0.1", "172.16.252.43",
                 "10-0-0-1.example.com", 9443, "instanceId", "serverCert", "clientCert", "clientKey",
                 "saltpasswd", "saltbootpassword", "signkey", false, true, null, null, null, null);
+        gatewayConfigs = List.of(gatewayConfig);
 
         GenericResponse response = new GenericResponse();
         response.setStatusCode(HttpStatus.OK.value());
         GenericResponses genericResponses = new GenericResponses();
         genericResponses.setResponses(Collections.singletonList(response));
 
-        when(saltConnector.action(any(SaltAction.class))).thenReturn(genericResponses);
+        when(saltStateService.bootstrap(eq(saltConnector), any(), any(), any())).thenReturn(genericResponses);
 
         minionIpAddressesResponse = new MinionIpAddressesResponse();
         when(saltStateService.collectMinionIpAddresses(eq(saltConnector))).thenReturn(minionIpAddressesResponse);
@@ -90,11 +89,14 @@ class SaltBootstrapTest {
         targets.add(new Node("10.0.0.2", null, null, "hg"));
         targets.add(new Node("10.0.0.3", null, null, "hg"));
 
-        SaltBootstrap saltBootstrap = spy(new SaltBootstrap(saltStateService, saltConnector, List.of(saltConnector),
-                Collections.singletonList(gatewayConfig), targets, new BootstrapParams()));
+        BootstrapParams params = new BootstrapParams();
+        SaltBootstrap saltBootstrap = spy(new SaltBootstrap(saltStateService, minionUtil, saltConnector, List.of(saltConnector), gatewayConfigs, targets,
+                params));
         doReturn(mock(MinionAcceptor.class)).when(saltBootstrap).createMinionAcceptor();
 
         saltBootstrap.call();
+
+        verify(saltStateService, times(1)).bootstrap(saltConnector, params, gatewayConfigs, targets);
     }
 
     @Test
@@ -112,8 +114,7 @@ class SaltBootstrapTest {
         String missingNodeIp = "10.0.0.3";
         targets.add(new Node(missingNodeIp, null, null, "hg"));
 
-        SaltBootstrap saltBootstrap = spy(new SaltBootstrap(saltStateService, saltConnector, List.of(saltConnector),
-                Collections.singletonList(gatewayConfig), targets,
+        SaltBootstrap saltBootstrap = spy(new SaltBootstrap(saltStateService, minionUtil, saltConnector, List.of(saltConnector), gatewayConfigs, targets,
                 new BootstrapParams()));
         doReturn(mock(MinionAcceptor.class)).when(saltBootstrap).createMinionAcceptor();
 
@@ -122,154 +123,6 @@ class SaltBootstrapTest {
                 .hasMessageNotContaining("10.0.0.1")
                 .hasMessageNotContaining("10.0.0.2")
                 .isInstanceOf(CloudbreakOrchestratorFailedException.class);
-    }
-
-    @Test
-    void restartNeededTrueButFlagNotSupportedBySaltBootstrap() throws Exception {
-        List<Map<String, JsonNode>> result = new ArrayList<>();
-        Map<String, JsonNode> ipAddressesForMinions = new HashMap<>();
-        ipAddressesForMinions.put("10-0-0-1.example.com", JsonUtil.readTree("[\"10.0.0.1\"]"));
-        ipAddressesForMinions.put("10-0-0-2.example.com", JsonUtil.readTree("[\"10.0.0.2\"]"));
-        ipAddressesForMinions.put("10-0-0-3.example.com", JsonUtil.readTree("[\"10.0.0.3\"]"));
-        result.add(ipAddressesForMinions);
-        minionIpAddressesResponse.setResult(result);
-
-        Set<Node> targets = new HashSet<>();
-        targets.add(new Node("10.0.0.1", null, null, "hg"));
-        targets.add(new Node("10.0.0.2", null, null, "hg"));
-        targets.add(new Node("10.0.0.3", null, null, "hg"));
-
-        BootstrapParams params = new BootstrapParams();
-        params.setRestartNeeded(true);
-        params.setRestartNeededFlagSupported(false);
-        SaltBootstrap saltBootstrap =
-                spy(new SaltBootstrap(saltStateService, saltConnector, List.of(saltConnector), Collections.singletonList(gatewayConfig), targets, params));
-        doReturn(mock(MinionAcceptor.class)).when(saltBootstrap).createMinionAcceptor();
-
-        saltBootstrap.call();
-
-        ArgumentCaptor<SaltAction> captor = ArgumentCaptor.forClass(SaltAction.class);
-        verify(saltConnector, times(1)).action(captor.capture());
-        SaltAction saltAction = captor.getValue();
-        List<Minion> minions = saltAction.getMinions();
-        assertEquals(3, minions.size());
-        assertEquals(Collections.singletonList("127.0.0.1"), minions.get(0).getServers());
-        assertEquals(Collections.singletonList("127.0.0.1"), minions.get(1).getServers());
-        assertEquals(Collections.singletonList("127.0.0.1"), minions.get(2).getServers());
-        assertTrue(minions.get(0).isRestartNeeded());
-        assertTrue(minions.get(1).isRestartNeeded());
-        assertTrue(minions.get(2).isRestartNeeded());
-    }
-
-    @Test
-    void restartNeededTrueAndFlagSupportedBySaltBootstrap() throws Exception {
-        List<Map<String, JsonNode>> result = new ArrayList<>();
-        Map<String, JsonNode> ipAddressesForMinions = new HashMap<>();
-        ipAddressesForMinions.put("10-0-0-1.example.com", JsonUtil.readTree("[\"10.0.0.1\"]"));
-        ipAddressesForMinions.put("10-0-0-2.example.com", JsonUtil.readTree("[\"10.0.0.2\"]"));
-        ipAddressesForMinions.put("10-0-0-3.example.com", JsonUtil.readTree("[\"10.0.0.3\"]"));
-        result.add(ipAddressesForMinions);
-        minionIpAddressesResponse.setResult(result);
-
-        Set<Node> targets = new HashSet<>();
-        targets.add(new Node("10.0.0.1", null, null, "hg"));
-        targets.add(new Node("10.0.0.2", null, null, "hg"));
-        targets.add(new Node("10.0.0.3", null, null, "hg"));
-
-        BootstrapParams params = new BootstrapParams();
-        params.setRestartNeeded(true);
-        params.setRestartNeededFlagSupported(true);
-        SaltBootstrap saltBootstrap =
-                spy(new SaltBootstrap(saltStateService, saltConnector, List.of(saltConnector), Collections.singletonList(gatewayConfig), targets, params));
-        doReturn(mock(MinionAcceptor.class)).when(saltBootstrap).createMinionAcceptor();
-
-        saltBootstrap.call();
-
-        ArgumentCaptor<SaltAction> captor = ArgumentCaptor.forClass(SaltAction.class);
-        verify(saltConnector, times(1)).action(captor.capture());
-        SaltAction saltAction = captor.getValue();
-        List<Minion> minions = saltAction.getMinions();
-        assertEquals(3, minions.size());
-        assertEquals(Collections.singletonList("172.16.252.43"), minions.get(0).getServers());
-        assertEquals(Collections.singletonList("172.16.252.43"), minions.get(1).getServers());
-        assertEquals(Collections.singletonList("172.16.252.43"), minions.get(2).getServers());
-        assertTrue(minions.get(0).isRestartNeeded());
-        assertTrue(minions.get(1).isRestartNeeded());
-        assertTrue(minions.get(2).isRestartNeeded());
-    }
-
-    @Test
-    void restartNeededFalseAndFlagSupportedBySaltBootstrap() throws Exception {
-        List<Map<String, JsonNode>> result = new ArrayList<>();
-        Map<String, JsonNode> ipAddressesForMinions = new HashMap<>();
-        ipAddressesForMinions.put("10-0-0-1.example.com", JsonUtil.readTree("[\"10.0.0.1\"]"));
-        ipAddressesForMinions.put("10-0-0-2.example.com", JsonUtil.readTree("[\"10.0.0.2\"]"));
-        ipAddressesForMinions.put("10-0-0-3.example.com", JsonUtil.readTree("[\"10.0.0.3\"]"));
-        result.add(ipAddressesForMinions);
-        minionIpAddressesResponse.setResult(result);
-
-        Set<Node> targets = new HashSet<>();
-        targets.add(new Node("10.0.0.1", null, null, "hg"));
-        targets.add(new Node("10.0.0.2", null, null, "hg"));
-        targets.add(new Node("10.0.0.3", null, null, "hg"));
-
-        BootstrapParams params = new BootstrapParams();
-        params.setRestartNeeded(false);
-        params.setRestartNeededFlagSupported(true);
-        SaltBootstrap saltBootstrap =
-                spy(new SaltBootstrap(saltStateService, saltConnector, List.of(saltConnector), Collections.singletonList(gatewayConfig), targets, params));
-        doReturn(mock(MinionAcceptor.class)).when(saltBootstrap).createMinionAcceptor();
-
-        saltBootstrap.call();
-
-        ArgumentCaptor<SaltAction> captor = ArgumentCaptor.forClass(SaltAction.class);
-        verify(saltConnector, times(1)).action(captor.capture());
-        SaltAction saltAction = captor.getValue();
-        List<Minion> minions = saltAction.getMinions();
-        assertEquals(3, minions.size());
-        assertEquals(Collections.singletonList("172.16.252.43"), minions.get(0).getServers());
-        assertEquals(Collections.singletonList("172.16.252.43"), minions.get(1).getServers());
-        assertEquals(Collections.singletonList("172.16.252.43"), minions.get(2).getServers());
-        assertFalse(minions.get(0).isRestartNeeded());
-        assertFalse(minions.get(1).isRestartNeeded());
-        assertFalse(minions.get(2).isRestartNeeded());
-    }
-
-    @Test
-    void restartNeededFalseAndFlagNotSupportedBySaltBootstrap() throws Exception {
-        List<Map<String, JsonNode>> result = new ArrayList<>();
-        Map<String, JsonNode> ipAddressesForMinions = new HashMap<>();
-        ipAddressesForMinions.put("10-0-0-1.example.com", JsonUtil.readTree("[\"10.0.0.1\"]"));
-        ipAddressesForMinions.put("10-0-0-2.example.com", JsonUtil.readTree("[\"10.0.0.2\"]"));
-        ipAddressesForMinions.put("10-0-0-3.example.com", JsonUtil.readTree("[\"10.0.0.3\"]"));
-        result.add(ipAddressesForMinions);
-        minionIpAddressesResponse.setResult(result);
-
-        Set<Node> targets = new HashSet<>();
-        targets.add(new Node("10.0.0.1", null, null, "hg"));
-        targets.add(new Node("10.0.0.2", null, null, "hg"));
-        targets.add(new Node("10.0.0.3", null, null, "hg"));
-
-        BootstrapParams params = new BootstrapParams();
-        params.setRestartNeeded(false);
-        params.setRestartNeededFlagSupported(false);
-        SaltBootstrap saltBootstrap =
-                spy(new SaltBootstrap(saltStateService, saltConnector, List.of(saltConnector), Collections.singletonList(gatewayConfig), targets, params));
-        doReturn(mock(MinionAcceptor.class)).when(saltBootstrap).createMinionAcceptor();
-
-        saltBootstrap.call();
-
-        ArgumentCaptor<SaltAction> captor = ArgumentCaptor.forClass(SaltAction.class);
-        verify(saltConnector, times(1)).action(captor.capture());
-        SaltAction saltAction = captor.getValue();
-        List<Minion> minions = saltAction.getMinions();
-        assertEquals(3, minions.size());
-        assertEquals(Collections.singletonList("172.16.252.43"), minions.get(0).getServers());
-        assertEquals(Collections.singletonList("172.16.252.43"), minions.get(1).getServers());
-        assertEquals(Collections.singletonList("172.16.252.43"), minions.get(2).getServers());
-        assertFalse(minions.get(0).isRestartNeeded());
-        assertFalse(minions.get(1).isRestartNeeded());
-        assertFalse(minions.get(2).isRestartNeeded());
     }
 
 }

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStateServiceTest.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStateServiceTest.java
@@ -10,7 +10,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -43,6 +45,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -50,7 +53,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.sequenceiq.cloudbreak.common.model.PackageInfo;
+import com.sequenceiq.cloudbreak.common.orchestration.Node;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.orchestrator.model.BootstrapParams;
+import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.cloudbreak.orchestrator.model.GenericResponses;
 import com.sequenceiq.cloudbreak.orchestrator.salt.client.SaltActionType;
 import com.sequenceiq.cloudbreak.orchestrator.salt.client.SaltConnector;
 import com.sequenceiq.cloudbreak.orchestrator.salt.client.target.Glob;
@@ -68,6 +75,7 @@ import com.sequenceiq.cloudbreak.orchestrator.salt.domain.RunningJobsResponse;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.SaltAction;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.SaltMaster;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.StateType;
+import com.sequenceiq.cloudbreak.orchestrator.salt.utils.MinionUtil;
 import com.sequenceiq.cloudbreak.service.Retry;
 import com.sequenceiq.cloudbreak.service.RetryService;
 
@@ -83,6 +91,9 @@ class SaltStateServiceTest {
     @Captor
     private ArgumentCaptor<Set<String>> minionIdsCaptor;
 
+    @Mock
+    private MinionUtil minionUtil;
+
     @InjectMocks
     private SaltStateService underTest;
 
@@ -94,6 +105,7 @@ class SaltStateServiceTest {
         targets.add("10-0-0-3.example.com");
         target = new HostList(targets);
         saltConnector = mock(SaltConnector.class);
+        lenient().when(minionUtil.createMinion(any(), any(), anyBoolean(), anyBoolean())).thenReturn(mock(Minion.class));
     }
 
     @Test
@@ -346,6 +358,35 @@ class SaltStateServiceTest {
         Set<String> minionAddresses = saltAction.getMasters().stream().map(SaltMaster::getAddress).collect(Collectors.toSet());
         assertThat(minionAddresses, containsInAnyOrder("10.0.0.1", "10.0.0.2", "10.0.0.3"));
         assertTrue(saltAction.getMasters().stream().allMatch(master -> master.getAuth().getPassword().equals(password)));
+    }
+
+    @Test
+    void bootstrapTest() {
+        Set<Node> targets = new HashSet<>();
+        targets.add(new Node("10.0.0.1", null, null, "hg"));
+        targets.add(new Node("10.0.0.2", null, null, "hg"));
+        targets.add(new Node("10.0.0.3", null, null, "hg"));
+
+        GenericResponses genericResponses = mock(GenericResponses.class);
+        when(saltConnector.action(any())).thenReturn(genericResponses);
+
+        BootstrapParams params = new BootstrapParams();
+        params.setRestartNeeded(true);
+        params.setRestartNeededFlagSupported(false);
+
+        GatewayConfig gatewayConfig = mock(GatewayConfig.class);
+        String gatewayIp = "8.8.8.8";
+        when(gatewayConfig.getPrivateAddress()).thenReturn(gatewayIp);
+
+        GenericResponses result = underTest.bootstrap(saltConnector, params, List.of(gatewayConfig), targets);
+
+        assertEquals(genericResponses, result);
+        targets.forEach(node -> verify(minionUtil).createMinion(node, List.of(gatewayIp), params.isSaltBootstrapFpSupported(), params.isRestartNeeded()));
+        ArgumentCaptor<SaltAction> captor = ArgumentCaptor.forClass(SaltAction.class);
+        verify(saltConnector).action(captor.capture());
+        SaltAction saltAction = captor.getValue();
+        List<Minion> minions = saltAction.getMinions();
+        assertEquals(3, minions.size());
     }
 
     @Test

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/utils/MinionUtilTest.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/utils/MinionUtilTest.java
@@ -1,0 +1,40 @@
+package com.sequenceiq.cloudbreak.orchestrator.salt.utils;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.sequenceiq.cloudbreak.common.orchestration.Node;
+import com.sequenceiq.cloudbreak.orchestrator.salt.domain.Minion;
+
+class MinionUtilTest {
+
+    private final Node node = new Node("10.0.0.1", null, null, "hg");
+
+    private final List<String> gatewayPrivateIps = List.of("172.16.252.43");
+
+    private final MinionUtil underTest = new MinionUtil();
+
+    @ParameterizedTest(name = "{index} Create minion with restartNeededFlagSupported={0} and restartNeeded={1}")
+    @MethodSource("createMinionSource")
+    void createMinionTest(boolean restartNeededFlagSupported, boolean restartNeeded, List<String> expectedServers, boolean expectedRestartNeededFlag) {
+        Minion minion = underTest.createMinion(node, gatewayPrivateIps, restartNeededFlagSupported, restartNeeded);
+
+        Assertions.assertThat(minion)
+                .returns(expectedServers, Minion::getServers)
+                .returns(expectedRestartNeededFlag, Minion::isRestartNeeded);
+    }
+
+    private static Stream<Arguments> createMinionSource() {
+        return Stream.of(
+                Arguments.of(false, false, List.of("172.16.252.43"), false),
+                Arguments.of(true, true, List.of("172.16.252.43"), true),
+                Arguments.of(true, false, List.of("172.16.252.43"), false),
+                Arguments.of(false, true, List.of("127.0.0.1"), true));
+    }
+
+}


### PR DESCRIPTION
Simplified the rebootstrap step by refactoring it out from the bootstrap step - this way the salt states will not be uploaded, and only the gateway nodes have to be rebootstrapped.

See detailed description in the commit message.