### PR TITLE
CB-19023: Fix failure reason display in events generated by backup failures.

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/DatalakeBackupActions.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/DatalakeBackupActions.java
@@ -6,6 +6,7 @@ import static com.sequenceiq.datalake.flow.dr.backup.DatalakeBackupEvent.DATALAK
 import static com.sequenceiq.datalake.flow.dr.backup.DatalakeBackupEvent.DATALAKE_DATABASE_BACKUP_FINALIZED_EVENT;
 import static com.sequenceiq.datalake.flow.dr.backup.DatalakeBackupEvent.DATALAKE_DATABASE_BACKUP_IN_PROGRESS_EVENT;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
@@ -310,9 +311,10 @@ public class DatalakeBackupActions {
             protected void doExecute(SdxContext context, DatalakeBackupFailedEvent payload, Map<Object, Object> variables) {
                 Exception exception = payload.getException();
                 LOGGER.error("Datalake backup failed for datalake with id: {}", payload.getResourceId(), exception);
+                String failureReason = getFailureReason(variables, exception);
                 SdxCluster sdxCluster = sdxStatusService.setStatusForDatalakeAndNotify(DatalakeStatusEnum.RUNNING,
-                        ResourceEvent.DATALAKE_BACKUP_FAILED,
-                        getFailureReason(variables, exception), payload.getResourceId());
+                        ResourceEvent.DATALAKE_BACKUP_FAILED, Collections.singleton(failureReason),
+                        failureReason, payload.getResourceId());
 
                 metricService.incrementMetricCounter(MetricType.SDX_BACKUP_FAILED, sdxCluster);
                 Flow flow = getFlow(context.getFlowParameters().getFlowId());

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/validation/DatalakeBackupValidationActions.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/validation/DatalakeBackupValidationActions.java
@@ -4,6 +4,7 @@ import static com.sequenceiq.datalake.flow.dr.validation.DatalakeBackupValidatio
 import static com.sequenceiq.datalake.flow.dr.validation.DatalakeBackupValidationEvent.DATALAKE_BACKUP_VALIDATION_FINALIZED_EVENT;
 import static com.sequenceiq.datalake.flow.dr.validation.DatalakeBackupValidationEvent.DATALAKE_BACKUP_VALIDATION_IN_PROGRESS_EVENT;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
@@ -139,7 +140,7 @@ public class DatalakeBackupValidationActions {
                         failureReason, exception
                 );
                 SdxCluster sdxCluster = sdxStatusService.setStatusForDatalakeAndNotify(DatalakeStatusEnum.RUNNING,
-                        ResourceEvent.DATALAKE_BACKUP_VALIDATION_FAILED,
+                        ResourceEvent.DATALAKE_BACKUP_VALIDATION_FAILED, Collections.singleton(failureReason),
                         failureReason, payload.getResourceId());
                 metricService.incrementMetricCounter(MetricType.SDX_BACKUP_VALIDATION_FAILED, sdxCluster);
                 Flow flow = getFlow(context.getFlowParameters().getFlowId());

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/status/SdxStatusService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/status/SdxStatusService.java
@@ -119,6 +119,14 @@ public class SdxStatusService {
         }).orElseThrow(() -> new NotFoundException("SdxCluster was not found with ID: " + datalakeId));
     }
 
+    public SdxCluster setStatusForDatalakeAndNotify(DatalakeStatusEnum status, ResourceEvent event,  Collection<?> messageArgs, String statusReason,
+            Long datalakeId) {
+        return sdxClusterRepository.findById(datalakeId).map(cluster -> {
+            setStatusForDatalakeAndNotify(status, event, messageArgs, statusReason, cluster);
+            return cluster;
+        }).orElseThrow(() -> new NotFoundException("SdxCluster was not found with ID: " + datalakeId));
+    }
+
     public void setStatusForDatalake(DatalakeStatusEnum status, String statusReason, SdxCluster sdxCluster) {
         try {
             transactionService.required(() -> {

--- a/datalake/src/test/java/com/sequenceiq/datalake/job/SdxClusterStatusCheckerJobTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/job/SdxClusterStatusCheckerJobTest.java
@@ -202,7 +202,7 @@ class SdxClusterStatusCheckerJobTest {
 
         underTest.executeTracedJob(jobExecutionContext);
 
-        verify(sdxStatusService, times(0)).setStatusForDatalakeAndNotify(any(), any(), any(), any(), any());
+        verify(sdxStatusService, times(0)).setStatusForDatalakeAndNotify(any(), any(), any(), any(), eq(sdxCluster));
         verify(jobService, times(0)).schedule(any());
         verify(jobService, times(0)).scheduleLongIntervalCheck(any());
     }


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-19023

Simply added a new method to the status service for accepting a message argument for the event sent with the other parameters.