### PR TITLE
CB-19031 Postgres backup timed out because of large DB

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeOrchestratorService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeOrchestratorService.java
@@ -54,7 +54,7 @@ public class RdsUpgradeOrchestratorService {
 
     private static final int MAX_RETRY_ON_ERROR = 3;
 
-    private static final int MAX_RETRY = 200;
+    private static final int MAX_RETRY = 500;
 
     @Inject
     private StackDtoService stackDtoService;

--- a/datalake/src/main/resources/application.yml
+++ b/datalake/src/main/resources/application.yml
@@ -76,7 +76,7 @@ sdx:
     ssotype: SSO_PROVIDER
   upgrade.database:
     sleeptime-sec: 20
-    duration-min: 120
+    duration-min: 180
 
   paywall.url: "https://archive.cloudera.com/p/cdp-public/"
 


### PR DESCRIPTION
A customer had a ~300GB, the backup and upload would have lasted more than the allotted 30 minutes of time. In the present commits we increase timeouts:
- backup and restore to ~1h 23min
- the whole upgrade process to 3h

As a side effect, if anything in PG upgrade would hang, the total timeout would be 3h.

See detailed description in the commit message.