### PR TITLE
CB-19021 Set atlernatives if postgres 11 is installed during upgrade

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/rds/upgrade/UpgradeRdsService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/rds/upgrade/UpgradeRdsService.java
@@ -100,6 +100,7 @@ public class UpgradeRdsService {
 
     public void installPostgresPackages(Long stackId) throws CloudbreakOrchestratorException {
         rdsUpgradeOrchestratorService.installPostgresPackages(stackId);
+        rdsUpgradeOrchestratorService.updatePostgresAlternatives(stackId);
     }
 
     public void handleInstallPostgresPackagesError(Long stackId, String version, String exception) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeOrchestratorService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeOrchestratorService.java
@@ -40,6 +40,8 @@ public class RdsUpgradeOrchestratorService {
 
     private static final String PG11_INSTALL_STATE = "postgresql/pg11-install";
 
+    private static final String PG11_ALTERNATIVES_STATE = "postgresql/pg11-alternatives";
+
     private static final String UPGRADE_EMBEDDED_DATABASE = "postgresql/upgrade/embedded";
 
     private static final String PREPARE_UPGRADE_EMBEDDED_DATABASE = "postgresql/upgrade/prepare-embedded";
@@ -97,6 +99,12 @@ public class RdsUpgradeOrchestratorService {
     public void installPostgresPackages(Long stackId) throws CloudbreakOrchestratorException {
         OrchestratorStateParams stateParams = createStateParams(stackId, PG11_INSTALL_STATE, false);
         LOGGER.debug("Calling installPostgresPackages with state params '{}'", stateParams);
+        hostOrchestrator.runOrchestratorState(stateParams);
+    }
+
+    public void updatePostgresAlternatives(Long stackId) throws CloudbreakOrchestratorException {
+        OrchestratorStateParams stateParams = createStateParams(stackId, PG11_ALTERNATIVES_STATE, false);
+        LOGGER.debug("Calling updatePostgresAlternatives with state params '{}'", stateParams);
         hostOrchestrator.runOrchestratorState(stateParams);
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/rds/upgrade/UpgradeRdsServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/rds/upgrade/UpgradeRdsServiceTest.java
@@ -119,6 +119,7 @@ class UpgradeRdsServiceTest {
         underTest.installPostgresPackages(STACK_ID);
 
         verify(rdsUpgradeOrchestratorService).installPostgresPackages(eq(STACK_ID));
+        verify(rdsUpgradeOrchestratorService).updatePostgresAlternatives(eq(STACK_ID));
     }
 
     @Test

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/backup.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/backup.sls
@@ -2,6 +2,9 @@
 
 include:
   - postgresql.disaster_recovery
+{ %- if salt[ 'pillar.get' ]('postgres:postgres_version', '10') | int == 11 % }
+  - postgresql.pg11-alternatives
+{ %- endif % }
 
 {% if 'None' != configure_remote_db %}
 backup_postgresql_db:


### PR DESCRIPTION
When external DB is used, and postgres 11 is missing on the image, after successful upgrade the postgres 11 packages are installed. Unfortunately after the installation alternatives were not updated.

In this commit we update the alternatives to the new version after installing the packages. Also this update is added to backup to avoid issues for already upgraded clusters.

See detailed description in the commit message.