### PR TITLE
CB-19054 Fix Stack repository function "getNotUpgradedStackCount"

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
@@ -459,11 +459,12 @@ public interface StackRepository extends WorkspaceResourceRepository<Stack, Long
     int setTunnelByStackId(@Param("id") Long id, @Param("tunnel") Tunnel tunnel);
 
     @Query("SELECT COUNT(*) " +
-            "FROM Stack s " +
-            "WHERE s.environmentCrn = :envCrn " +
-            "AND s.terminated IS NULL " +
-            "AND tunnel <> :latestTunnel")
-    int getNotUpgradedStackCount(@Param("envCrn") String envCrn, @Param("latestTunnel") Tunnel latestTunnel);
+            "FROM Stack " +
+            "WHERE environmentCrn = :envCrn " +
+            "AND terminated IS NULL " +
+            "AND type IN ('DATALAKE', 'WORKLOAD') " +
+            "AND tunnel IN (:upgradableTunnels)")
+    int getNotUpgradedStackCount(@Param("envCrn") String envCrn, @Param("upgradableTunnels") Collection<Tunnel> upgradableTunnels);
 
     @Modifying
     @Query("UPDATE Stack s SET s.securityConfig = :securityConfig WHERE s.id = :stackId")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
@@ -1034,8 +1034,8 @@ public class StackService implements ResourceIdProvider, AuthorizationResourceNa
         return stackRepository.findById(stackId).orElse(null);
     }
 
-    public int getNotUpgradedStackCount(String envCrn, Tunnel latestTunnel) {
-        return stackRepository.getNotUpgradedStackCount(envCrn, latestTunnel);
+    public int getNotUpgradedStackCount(String envCrn, Collection<Tunnel> upgradableTunnels) {
+        return stackRepository.getNotUpgradedStackCount(envCrn, upgradableTunnels);
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ccm/StackCcmUpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ccm/StackCcmUpgradeService.java
@@ -120,6 +120,6 @@ public class StackCcmUpgradeService {
     }
 
     public int getNotUpgradedStackCount(String envCrn) {
-        return stackService.getNotUpgradedStackCount(envCrn, Tunnel.latestUpgradeTarget());
+        return stackService.getNotUpgradedStackCount(envCrn, Tunnel.getUpgradables());
     }
 }


### PR DESCRIPTION
Before it did not filter out TEMPLATEs
Also changed the logic to filter the inclusive upgradable tunnel types instead of the exclusive target tunnel type.