### PR TITLE
CB-18809 Enable DH upgrades for Streaming Analytics clusters

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.11/cdp-flink-heavy.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.11/cdp-flink-heavy.bp
@@ -3,6 +3,7 @@
   "blueprint": {
     "cdhVersion": "7.2.11",
     "displayName": "streaming-analytics",
+    "blueprintUpgradeOption": "GA",
     "hostTemplates": [
       {
         "refName": "manager",

--- a/core/src/main/resources/defaults/blueprints/7.2.11/cdp-flink-light.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.11/cdp-flink-light.bp
@@ -3,6 +3,7 @@
   "blueprint": {
     "cdhVersion": "7.2.11",
     "displayName": "streaming-analytics",
+    "blueprintUpgradeOption": "GA",
     "hostTemplates": [
       {
         "refName": "manager",

--- a/core/src/main/resources/defaults/blueprints/7.2.12/cdp-flink-heavy.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.12/cdp-flink-heavy.bp
@@ -3,6 +3,7 @@
   "blueprint": {
     "cdhVersion": "7.2.12",
     "displayName": "streaming-analytics",
+    "blueprintUpgradeOption": "GA",
     "hostTemplates": [
       {
         "refName": "manager",

--- a/core/src/main/resources/defaults/blueprints/7.2.12/cdp-flink-light.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.12/cdp-flink-light.bp
@@ -3,6 +3,7 @@
   "blueprint": {
     "cdhVersion": "7.2.12",
     "displayName": "streaming-analytics",
+    "blueprintUpgradeOption": "GA",
     "hostTemplates": [
       {
         "refName": "manager",

--- a/core/src/main/resources/defaults/blueprints/7.2.14/cdp-flink-heavy.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.14/cdp-flink-heavy.bp
@@ -3,6 +3,7 @@
   "blueprint": {
     "cdhVersion": "7.2.14",
     "displayName": "streaming-analytics",
+    "blueprintUpgradeOption": "GA",
     "hostTemplates": [
       {
         "refName": "manager",

--- a/core/src/main/resources/defaults/blueprints/7.2.14/cdp-flink-light.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.14/cdp-flink-light.bp
@@ -3,6 +3,7 @@
   "blueprint": {
     "cdhVersion": "7.2.14",
     "displayName": "streaming-analytics",
+    "blueprintUpgradeOption": "GA",
     "hostTemplates": [
       {
         "refName": "manager",

--- a/core/src/main/resources/defaults/blueprints/7.2.15/cdp-flink-heavy.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.15/cdp-flink-heavy.bp
@@ -3,6 +3,7 @@
   "blueprint": {
     "cdhVersion": "7.2.15",
     "displayName": "streaming-analytics",
+    "blueprintUpgradeOption": "GA",
     "hostTemplates": [
       {
         "refName": "manager",

--- a/core/src/main/resources/defaults/blueprints/7.2.15/cdp-flink-light.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.15/cdp-flink-light.bp
@@ -3,6 +3,7 @@
   "blueprint": {
     "cdhVersion": "7.2.15",
     "displayName": "streaming-analytics",
+    "blueprintUpgradeOption": "GA",
     "hostTemplates": [
       {
         "refName": "manager",

--- a/core/src/main/resources/defaults/blueprints/7.2.16/cdp-flink-heavy.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.16/cdp-flink-heavy.bp
@@ -3,6 +3,7 @@
   "blueprint": {
     "cdhVersion": "7.2.16",
     "displayName": "streaming-analytics",
+    "blueprintUpgradeOption": "GA",
     "hostTemplates": [
       {
         "refName": "manager",

--- a/core/src/main/resources/defaults/blueprints/7.2.16/cdp-flink-light.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.16/cdp-flink-light.bp
@@ -3,6 +3,7 @@
   "blueprint": {
     "cdhVersion": "7.2.16",
     "displayName": "streaming-analytics",
+    "blueprintUpgradeOption": "GA",
     "hostTemplates": [
       {
         "refName": "manager",


### PR DESCRIPTION
Set the "blueprintUpgradeOption" member to GA in all cdp-flink-* blueprints

See detailed description in the commit message.