### PR TITLE
CB-19036: Fix DB server deletion when the FlowType is null

### DIFF
--- a/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowLogDBService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowLogDBService.java
@@ -316,7 +316,7 @@ public class FlowLogDBService implements FlowLogService {
         boolean running = false;
         if (lastFlowLog.isPresent()) {
             FlowLog flowLog = lastFlowLog.get();
-            running = flowLog.getFlowType().getClassValue().equals(flowConfigurationClass)
+            running = flowLog.getFlowType() != null && flowLog.getFlowType().getClassValue().equals(flowConfigurationClass)
                     && flowLog.getStateStatus() == StateStatus.PENDING;
         }
         return running;

--- a/flow/src/test/java/com/sequenceiq/flow/service/flowlog/FlowLogDBServiceTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/service/flowlog/FlowLogDBServiceTest.java
@@ -377,6 +377,15 @@ class FlowLogDBServiceTest {
     }
 
     @Test
+    void testIsTerminatedFlowAlreadyRunningWhenShouldReturnFalseWhenTheFlowTypeIsNotPresent() {
+        FlowLog flowLog = mock(FlowLog.class);
+        when(flowLogRepository.findFirstByResourceIdOrderByCreatedDesc(1L)).thenReturn(Optional.of(flowLog));
+        when(flowLog.getFlowType()).thenReturn(null);
+        boolean actual = underTest.isFlowConfigAlreadyRunning(1L, TerminationFlowConfig.class);
+        Assertions.assertFalse(actual);
+    }
+
+    @Test
     void testIsTerminatedFlowAlreadyRunningWhenNoLastFlow() {
         when(flowLogRepository.findFirstByResourceIdOrderByCreatedDesc(1L)).thenReturn(Optional.empty());
         boolean actual = underTest.isFlowConfigAlreadyRunning(1L, TerminationFlowConfig.class);


### PR DESCRIPTION
There are some cases when the FlowType is not set in the FlogLog table. In this commit, I added a null check to prevent the DB server deletion from NPE when the FlowType is null.