### PR TITLE
CB-19033 Use azcopy instead of cdp-telemetry to upload Azure DB backup

### DIFF
--- a/common-model/src/main/java/com/sequenceiq/common/api/backup/base/BackupBase.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/backup/base/BackupBase.java
@@ -1,17 +1,18 @@
 package com.sequenceiq.common.api.backup.base;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.sequenceiq.common.api.cloudstorage.old.GcsCloudStorageV1Parameters;
-import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
-import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
 import com.sequenceiq.common.api.backup.doc.BackupModelDescription;
 import com.sequenceiq.common.api.backup.model.BackupCloudwatchParams;
+import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
+import com.sequenceiq.common.api.cloudstorage.old.GcsCloudStorageV1Parameters;
+import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -74,6 +75,17 @@ public abstract class BackupBase implements Serializable {
 
     public BackupCloudwatchParams getCloudwatch() {
         return cloudwatch;
+    }
+
+    public String getInstanceProfile() {
+        if (Objects.nonNull(s3)) {
+            return s3.getInstanceProfile();
+        } else if (Objects.nonNull(adlsGen2)) {
+            return adlsGen2.getManagedIdentity();
+        } else if (Objects.nonNull(gcs)) {
+            return gcs.getServiceAccountEmail();
+        }
+        return null;
     }
 
     public void setCloudwatch(BackupCloudwatchParams cloudwatch) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterRepairFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterRepairFlowEventChainFactory.java
@@ -161,7 +161,7 @@ public class ClusterRepairFlowEventChainFactory implements FlowEventChainFactory
         addDownscaleAndUpscaleEvents(event, flowTriggers, repairableGroupsWithHostNames, singlePrimaryGW, stackView);
         if (embeddedDBUpgrade) {
             LOGGER.debug("Cluster repair flowchain is extended with upgrade rds flow as embedded db upgrade is needed");
-            flowTriggers.add(new UpgradeRdsTriggerRequest(UpgradeRdsEvent.UPGRADE_RDS_EVENT.event(), event.getResourceId(), targetMajorVersion, null));
+            flowTriggers.add(new UpgradeRdsTriggerRequest(UpgradeRdsEvent.UPGRADE_RDS_EVENT.event(), event.getResourceId(), targetMajorVersion, null, null));
         }
         flowTriggers.add(rescheduleStatusCheckEvent(event));
         flowTriggers.add(new FlowChainFinalizePayload(getName(), event.getResourceId(), event.accepted()));

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpgradeRdsFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpgradeRdsFlowEventChainFactory.java
@@ -36,7 +36,7 @@ public class UpgradeRdsFlowEventChainFactory implements FlowEventChainFactory<Rd
         flowEventChain.add(new ValidateRdsUpgradeTriggerRequest(ValidateRdsUpgradeEvent.VALIDATE_RDS_UPGRADE_EVENT.event(),
                 event.getResourceId(), event.getVersion(), event.accepted()));
         flowEventChain.add(new UpgradeRdsTriggerRequest(UpgradeRdsEvent.UPGRADE_RDS_EVENT.event(),
-                event.getResourceId(), event.getVersion(), event.getBackupLocation()));
+                event.getResourceId(), event.getVersion(), event.getBackupLocation(), event.getBackupInstanceProfile()));
         return new FlowTriggerEventQueue(getName(), event, flowEventChain);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/rds/upgrade/UpgradeRdsActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/rds/upgrade/UpgradeRdsActions.java
@@ -38,6 +38,8 @@ public class UpgradeRdsActions {
 
     private static final Object CLOUD_STORAGE_BACKUP_LOCATION = "cloud_storage_backup_location";
 
+    private static final Object CLOUD_STORAGE_INSTANCE_PROFILE = "cloud_storage_instance_profile";
+
     @Inject
     private UpgradeRdsService upgradeRdsService;
 
@@ -47,6 +49,7 @@ public class UpgradeRdsActions {
             @Override
             protected void doExecute(UpgradeRdsContext context, UpgradeRdsTriggerRequest payload, Map<Object, Object> variables) {
                 putIfPresent(variables, CLOUD_STORAGE_BACKUP_LOCATION, payload.getBackupLocation());
+                putIfPresent(variables, CLOUD_STORAGE_INSTANCE_PROFILE, payload.getBackupInstanceProfile());
                 upgradeRdsService.stopServicesState(payload.getResourceId());
                 sendEvent(context, new UpgradeRdsStopServicesRequest(context.getStackId(), context.getVersion()));
             }
@@ -60,8 +63,9 @@ public class UpgradeRdsActions {
             protected void doExecute(UpgradeRdsContext context, UpgradeRdsStopServicesResult payload, Map<Object, Object> variables) {
                 if (upgradeRdsService.shouldRunDataBackupRestore(context.getStack(), context.getCluster())) {
                     String backupLocation = Objects.toString(variables.get(CLOUD_STORAGE_BACKUP_LOCATION), null);
+                    String backupInstanceProfile = Objects.toString(variables.get(CLOUD_STORAGE_INSTANCE_PROFILE), null);
                     upgradeRdsService.backupRdsState(payload.getResourceId());
-                    sendEvent(context, new UpgradeRdsDataBackupRequest(context.getStackId(), context.getVersion(), backupLocation));
+                    sendEvent(context, new UpgradeRdsDataBackupRequest(context.getStackId(), context.getVersion(), backupLocation, backupInstanceProfile));
                 } else {
                     sendEvent(context, new UpgradeRdsDataBackupResult(context.getStackId(), context.getVersion()));
                 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/rds/upgrade/UpgradeRdsService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/rds/upgrade/UpgradeRdsService.java
@@ -90,8 +90,8 @@ public class UpgradeRdsService {
         stackUpdater.updateStackStatus(stackId, DetailedStackStatus.DATABASE_UPGRADE_IN_PROGRESS, statusReason);
     }
 
-    public void backupRds(Long stackId, String backupLocation) throws CloudbreakOrchestratorException {
-        rdsUpgradeOrchestratorService.backupRdsData(stackId, backupLocation);
+    public void backupRds(Long stackId, String backupLocation, String backupInstanceProfile) throws CloudbreakOrchestratorException {
+        rdsUpgradeOrchestratorService.backupRdsData(stackId, backupLocation, backupInstanceProfile);
     }
 
     public void restoreRds(Long stackId) throws CloudbreakOrchestratorException {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/RdsUpgradeChainTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/RdsUpgradeChainTriggerEvent.java
@@ -1,7 +1,5 @@
 package com.sequenceiq.cloudbreak.core.flow2.event;
 
-import java.util.StringJoiner;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.common.database.TargetMajorVersion;
@@ -13,14 +11,18 @@ public class RdsUpgradeChainTriggerEvent extends StackEvent {
 
     private final String backupLocation;
 
+    private final String backupInstanceProfile;
+
     @JsonCreator
     public RdsUpgradeChainTriggerEvent(
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long stackId,
             @JsonProperty("version") TargetMajorVersion version,
-            @JsonProperty("backupLocation") String backupLocation) {
+            @JsonProperty("backupLocation") String backupLocation,
+            @JsonProperty("backupInstanceProfile") String backupInstanceProfile) {
         super(selector, stackId);
         this.backupLocation = backupLocation;
+        this.backupInstanceProfile = backupInstanceProfile;
         this.version = version;
     }
 
@@ -32,11 +34,16 @@ public class RdsUpgradeChainTriggerEvent extends StackEvent {
         return backupLocation;
     }
 
+    public String getBackupInstanceProfile() {
+        return backupInstanceProfile;
+    }
+
     @Override
     public String toString() {
-        return new StringJoiner(", ", RdsUpgradeChainTriggerEvent.class.getSimpleName() + "[", "]")
-                .add("version=" + version)
-                .add("backupLocation='" + backupLocation + "'")
-                .toString();
+        return "RdsUpgradeChainTriggerEvent{" +
+                "version=" + version +
+                ", backupLocation='" + backupLocation + '\'' +
+                ", backupInstanceProfile='" + backupInstanceProfile + '\'' +
+                "} " + super.toString();
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
@@ -247,9 +247,10 @@ public class ReactorFlowManager {
         return reactorNotifier.notify(stackId, selector, new UpgradePreparationChainTriggerEvent(selector, stackId, imageChangeDto, lockComponents));
     }
 
-    public FlowIdentifier triggerRdsUpgrade(Long stackId, TargetMajorVersion targetVersion, String backupLocation) {
+    public FlowIdentifier triggerRdsUpgrade(Long stackId, TargetMajorVersion targetVersion, String backupLocation, String backupInstanceProfile) {
         String selector = FlowChainTriggers.UPGRADE_RDS_CHAIN_TRIGGER_EVENT;
-        return reactorNotifier.notify(stackId, selector, new RdsUpgradeChainTriggerEvent(selector, stackId, targetVersion, backupLocation));
+        return reactorNotifier.notify(stackId, selector,
+                new RdsUpgradeChainTriggerEvent(selector, stackId, targetVersion, backupLocation, backupInstanceProfile));
     }
 
     public FlowIdentifier triggerDatalakeClusterRecovery(Long stackId) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/rds/UpgradeRdsDataBackupRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/rds/UpgradeRdsDataBackupRequest.java
@@ -8,16 +8,34 @@ public class UpgradeRdsDataBackupRequest extends AbstractUpgradeRdsEvent {
 
     private final String backupLocation;
 
+    private final String backupInstanceProfile;
+
     @JsonCreator
     public UpgradeRdsDataBackupRequest(
             @JsonProperty("resourceId") Long stackId,
             @JsonProperty("version") TargetMajorVersion version,
-            @JsonProperty("backupLocation") String backupLocation) {
+            @JsonProperty("backupLocation") String backupLocation,
+            @JsonProperty("backupInstanceProfile") String backupInstanceProfile
+    ) {
         super(stackId, version);
         this.backupLocation = backupLocation;
+        this.backupInstanceProfile = backupInstanceProfile;
+
     }
 
     public String getBackupLocation() {
         return backupLocation;
+    }
+
+    public String getBackupInstanceProfile() {
+        return backupInstanceProfile;
+    }
+
+    @Override
+    public String toString() {
+        return "UpgradeRdsDataBackupRequest{" +
+                "backupLocation='" + backupLocation + '\'' +
+                ", backupInstanceProfile='" + backupInstanceProfile + '\'' +
+                "} " + super.toString();
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/rds/UpgradeRdsTriggerRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/rds/UpgradeRdsTriggerRequest.java
@@ -8,17 +8,33 @@ public class UpgradeRdsTriggerRequest extends AbstractUpgradeRdsEvent {
 
     private final String backupLocation;
 
+    private final String backupInstanceProfile;
+
     @JsonCreator
     public UpgradeRdsTriggerRequest(
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long stackId,
             @JsonProperty("version") TargetMajorVersion version,
-            @JsonProperty("backupLocation") String backupLocation) {
+            @JsonProperty("backupLocation") String backupLocation,
+            @JsonProperty("backupInstanceProfile") String backupInstanceProfile) {
         super(selector, stackId, version);
         this.backupLocation = backupLocation;
+        this.backupInstanceProfile = backupInstanceProfile;
     }
 
     public String getBackupLocation() {
         return backupLocation;
+    }
+
+    public String getBackupInstanceProfile() {
+        return backupInstanceProfile;
+    }
+
+    @Override
+    public String toString() {
+        return "UpgradeRdsTriggerRequest{" +
+                "backupLocation='" + backupLocation + '\'' +
+                ", backupInstanceProfile='" + backupInstanceProfile + '\'' +
+                "} " + super.toString();
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/rds/BackupRdsDataHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/rds/BackupRdsDataHandler.java
@@ -44,10 +44,13 @@ public class BackupRdsDataHandler extends ExceptionCatcherEventHandler<UpgradeRd
         UpgradeRdsDataBackupRequest request = event.getData();
         Long stackId = request.getResourceId();
         String backupLocation = request.getBackupLocation();
-        LOGGER.info("Starting backup for RDS upgrade {}...",
-                StringUtils.isNotBlank(backupLocation) ? "and uploading to storage location " + backupLocation :  "");
+        String backupInstanceProfile = request.getBackupInstanceProfile();
+        LOGGER.info("Starting backup for RDS upgrade {} {}...",
+                StringUtils.isNotBlank(backupLocation) ? "and uploading to storage location " + backupLocation :  "",
+                StringUtils.isNotBlank(backupInstanceProfile) ? "with using the backup instance profile " + backupInstanceProfile :  ""
+        );
         try {
-            upgradeRdsService.backupRds(stackId, backupLocation);
+            upgradeRdsService.backupRds(stackId, backupLocation, backupInstanceProfile);
         } catch (CloudbreakOrchestratorException e) {
             LOGGER.warn("RDS backup failed due to {}", e.getMessage());
             return new UpgradeRdsFailedEvent(stackId, e, DetailedStackStatus.AVAILABLE);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/BackupRestoreDBStateParamsProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/BackupRestoreDBStateParamsProvider.java
@@ -29,6 +29,8 @@ public class BackupRestoreDBStateParamsProvider {
 
     private static final String BACKUP_LOCATION_KEY = "backup_location";
 
+    private static final String BACKUP_INSTANCE_PROFILE = "backup_instance_profile";
+
     private static final String ABFS_ACCOUNT_NAME_KEY = "abfs_account_name";
 
     private static final String ABFS_FILE_SYSTEM_KEY = "abfs_file_system";
@@ -38,7 +40,7 @@ public class BackupRestoreDBStateParamsProvider {
     @Inject
     private AdlsGen2ConfigGenerator adlsGen2ConfigGenerator;
 
-    public Map<String, Object> createParamsForBackupRestore(String backupLocation) {
+    public Map<String, Object> createParamsForBackupRestore(String backupLocation, String backupInstanceProfile) {
         Map<String, Object> params = new HashMap<>();
         Map<String, Object> postgresParams = new HashMap<>();
         params.put("postgres", postgresParams);
@@ -48,17 +50,19 @@ public class BackupRestoreDBStateParamsProvider {
         upgradeParams.put(EMBEDDED_DB_PORT_KEY, "5432");
         upgradeParams.put(EMBEDDED_DB_USER_KEY, "postgres");
         upgradeParams.put(EMBEDDED_DB_PASSWORD_KEY, "postgres");
-        setCloudStorageBackupParameters(backupLocation, upgradeParams);
+        setCloudStorageBackupParameters(backupLocation, upgradeParams, backupInstanceProfile);
+        LOGGER.debug("Created parameters for RDS upgrade backup and restore: {}", upgradeParams);
         return params;
     }
 
-    private void setCloudStorageBackupParameters(String backupLocation, Map<String, String> upgradeParams) {
+    private void setCloudStorageBackupParameters(String backupLocation, Map<String, String> upgradeParams, String backupInstanceProfile) {
         if (StringUtils.isNotBlank(backupLocation) && backupLocation.startsWith(FileSystemType.ADLS_GEN_2.getProtocol())) {
             AdlsGen2Config adlsGen2Config = adlsGen2ConfigGenerator.generateStorageConfig(backupLocation);
             upgradeParams.put(BACKUP_LOCATION_KEY, backupLocation);
             upgradeParams.put(ABFS_ACCOUNT_NAME_KEY, adlsGen2Config.getAccount());
             upgradeParams.put(ABFS_FILE_SYSTEM_KEY, adlsGen2Config.getFileSystem());
             upgradeParams.put(ABFS_FILE_SYSTEM_FOLDER_KEY, adlsGen2Config.getFolderPrefix());
+            upgradeParams.put(BACKUP_INSTANCE_PROFILE, backupInstanceProfile);
             LOGGER.debug("Pillars for cloud storage location {} have been set", backupLocation);
         }
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeOrchestratorService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeOrchestratorService.java
@@ -80,16 +80,16 @@ public class RdsUpgradeOrchestratorService {
     @Value("${cb.db.env.upgrade.rds.backuprestore.validationratio}")
     private double backupValidationRatio;
 
-    public void backupRdsData(Long stackId, String backupLocation) throws CloudbreakOrchestratorException {
+    public void backupRdsData(Long stackId, String backupLocation, String backupInstanceProfile) throws CloudbreakOrchestratorException {
         OrchestratorStateParams stateParams = createStateParams(stackId, BACKUP_STATE, true);
-        stateParams.setStateParams(backupRestoreDBStateParamsProvider.createParamsForBackupRestore(backupLocation));
+        stateParams.setStateParams(backupRestoreDBStateParamsProvider.createParamsForBackupRestore(backupLocation, backupInstanceProfile));
         LOGGER.debug("Calling backupRdsData with state params '{}'", stateParams);
         hostOrchestrator.runOrchestratorState(stateParams);
     }
 
     public void restoreRdsData(Long stackId) throws CloudbreakOrchestratorException {
         OrchestratorStateParams stateParams = createStateParams(stackId, RESTORE_STATE, true);
-        stateParams.setStateParams(backupRestoreDBStateParamsProvider.createParamsForBackupRestore(null));
+        stateParams.setStateParams(backupRestoreDBStateParamsProvider.createParamsForBackupRestore(null, null));
         LOGGER.debug("Calling restoreRdsData with state params '{}'", stateParams);
         hostOrchestrator.runOrchestratorState(stateParams);
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
@@ -162,7 +162,7 @@ public class ReactorFlowManagerTest {
         underTest.triggerStopStartStackDownscale(STACK_ID, instanceIdsByHostgroup, false);
         underTest.triggerClusterServicesRestart(STACK_ID);
         underTest.triggerClusterProxyConfigReRegistration(STACK_ID);
-        underTest.triggerRdsUpgrade(STACK_ID, TargetMajorVersion.VERSION_11, null);
+        underTest.triggerRdsUpgrade(STACK_ID, TargetMajorVersion.VERSION_11, null, null);
         underTest.triggerRotateSaltPassword(STACK_ID, RotateSaltPasswordReason.MANUAL, RotateSaltPasswordType.FALLBACK);
         underTest.triggerVerticalScale(STACK_ID, new StackVerticalScaleV4Request());
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/rds/upgrade/UpgradeRdsActionsTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/rds/upgrade/UpgradeRdsActionsTest.java
@@ -69,7 +69,8 @@ class UpgradeRdsActionsTest {
     public void testShouldAddBackupLocationIfNotNull() throws Exception {
         AbstractAction action = (AbstractAction) upgradeRdsActions.stopServicesAndCm();
         UpgradeRdsTriggerRequest triggerEvent =
-                new UpgradeRdsTriggerRequest(UpgradeRdsEvent.UPGRADE_RDS_EVENT.event(), STACK_ID, TargetMajorVersion.VERSION_11, "aLocation");
+                new UpgradeRdsTriggerRequest(UpgradeRdsEvent.UPGRADE_RDS_EVENT.event(), STACK_ID, TargetMajorVersion.VERSION_11, "aLocation",
+                        "anInstanceProfile");
         Map<Object, Object> variables = mockAndTriggerRdsUpgradeAction(action, triggerEvent, true, true);
 
         verify(upgradeRdsService).stopServicesState(STACK_ID);
@@ -81,7 +82,7 @@ class UpgradeRdsActionsTest {
     public void testShouldNotAddBackupLocationIfItIsNull() throws Exception {
         AbstractAction action = (AbstractAction) upgradeRdsActions.stopServicesAndCm();
         UpgradeRdsTriggerRequest triggerEvent =
-                new UpgradeRdsTriggerRequest(UpgradeRdsEvent.UPGRADE_RDS_EVENT.event(), STACK_ID, TargetMajorVersion.VERSION_11, null);
+                new UpgradeRdsTriggerRequest(UpgradeRdsEvent.UPGRADE_RDS_EVENT.event(), STACK_ID, TargetMajorVersion.VERSION_11, null, null);
         Map<Object, Object> variables = mockAndTriggerRdsUpgradeAction(action, triggerEvent, true, true);
 
         verify(upgradeRdsService).stopServicesState(STACK_ID);
@@ -112,8 +113,8 @@ class UpgradeRdsActionsTest {
     @Test
     public void testShouldStopServicesAlways() throws Exception {
         AbstractAction action = (AbstractAction) upgradeRdsActions.stopServicesAndCm();
-        UpgradeRdsTriggerRequest triggerEvent =
-                new UpgradeRdsTriggerRequest(UpgradeRdsEvent.UPGRADE_RDS_EVENT.event(), STACK_ID, TargetMajorVersion.VERSION_11, "aLocation");
+        UpgradeRdsTriggerRequest triggerEvent = new UpgradeRdsTriggerRequest(UpgradeRdsEvent.UPGRADE_RDS_EVENT.event(), STACK_ID,
+                TargetMajorVersion.VERSION_11, "aLocation", "anInstanceProfile");
         mockAndTriggerRdsUpgradeAction(action, triggerEvent, true, true);
 
         verify(upgradeRdsService, times(1)).stopServicesState(STACK_ID);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/rds/upgrade/UpgradeRdsServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/rds/upgrade/UpgradeRdsServiceTest.java
@@ -49,6 +49,8 @@ class UpgradeRdsServiceTest {
 
     private static final String INSTALL_PG_STATE = "Installing Postgres packages if necessary.";
 
+    private static final String BACKUP_INSTANCE_PROFILE = "BACKUP_INSTANCE_PROFILE";
+
     @Mock
     private StackUpdater stackUpdater;
 
@@ -102,9 +104,9 @@ class UpgradeRdsServiceTest {
 
     @Test
     public void testBackupRds() throws CloudbreakOrchestratorException {
-        underTest.backupRds(STACK_ID, BACKUP_LOCATION);
+        underTest.backupRds(STACK_ID, BACKUP_LOCATION, BACKUP_INSTANCE_PROFILE);
 
-        verify(rdsUpgradeOrchestratorService).backupRdsData(eq(STACK_ID), eq(BACKUP_LOCATION));
+        verify(rdsUpgradeOrchestratorService).backupRdsData(eq(STACK_ID), eq(BACKUP_LOCATION), eq(BACKUP_INSTANCE_PROFILE));
     }
 
     @Test

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/rds/BackupRdsDataHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/rds/BackupRdsDataHandlerTest.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.cloudbreak.reactor.handler.cluster.upgrade.rds;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -30,6 +29,8 @@ class BackupRdsDataHandlerTest {
 
     private static final String BACKUP_LOCATION = "abfs://abcd@efgh.dfs.core.windows.net";
 
+    private static final String BACKUP_INSTANCE_PROFILE = "BACKUP_INSTANCE_PROFILE";
+
     @Mock
     private UpgradeRdsService upgradeRdsService;
 
@@ -46,22 +47,23 @@ class BackupRdsDataHandlerTest {
 
     @Test
     void doAccept() throws CloudbreakOrchestratorException {
-        UpgradeRdsDataBackupRequest request = new UpgradeRdsDataBackupRequest(STACK_ID, TARGET_MAJOR_VERSION, BACKUP_LOCATION);
+        UpgradeRdsDataBackupRequest request = new UpgradeRdsDataBackupRequest(STACK_ID, TARGET_MAJOR_VERSION, BACKUP_LOCATION, BACKUP_INSTANCE_PROFILE);
         when(event.getData()).thenReturn(request);
 
         Selectable result = underTest.doAccept(event);
-        verify(upgradeRdsService).backupRds(STACK_ID, BACKUP_LOCATION);
+        verify(upgradeRdsService).backupRds(STACK_ID, BACKUP_LOCATION, BACKUP_INSTANCE_PROFILE);
         assertThat(result.selector()).isEqualTo("UPGRADERDSDATABACKUPRESULT");
     }
 
     @Test
     void orchestrationException() throws CloudbreakOrchestratorException {
-        UpgradeRdsDataBackupRequest request = new UpgradeRdsDataBackupRequest(STACK_ID, TARGET_MAJOR_VERSION, BACKUP_LOCATION);
+        UpgradeRdsDataBackupRequest request = new UpgradeRdsDataBackupRequest(STACK_ID, TARGET_MAJOR_VERSION, BACKUP_LOCATION, BACKUP_INSTANCE_PROFILE);
         when(event.getData()).thenReturn(request);
-        doThrow(new CloudbreakOrchestratorFailedException("salt error")).when(upgradeRdsService).backupRds(eq(STACK_ID), eq(BACKUP_LOCATION));
+        doThrow(new CloudbreakOrchestratorFailedException("salt error"))
+                .when(upgradeRdsService).backupRds(STACK_ID, BACKUP_LOCATION, BACKUP_INSTANCE_PROFILE);
 
         Selectable result = underTest.doAccept(event);
-        verify(upgradeRdsService).backupRds(STACK_ID, BACKUP_LOCATION);
+        verify(upgradeRdsService).backupRds(STACK_ID, BACKUP_LOCATION, BACKUP_INSTANCE_PROFILE);
         assertThat(result.selector()).isEqualTo("UPGRADERDSFAILEDEVENT");
         assertThat(result).isInstanceOf(UpgradeRdsFailedEvent.class);
         UpgradeRdsFailedEvent failedEvent = (UpgradeRdsFailedEvent) result;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/rds/BackupRestoreDBStateParamsProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/rds/BackupRestoreDBStateParamsProviderTest.java
@@ -25,6 +25,8 @@ class BackupRestoreDBStateParamsProviderTest {
 
     private static final String ABFS_FOLDER = "aFolder";
 
+    private static final String BACKUP_INSTANCE_PROFILE = "BACKUP_INSTANCE_PROFILE";
+
     @Mock
     private AdlsGen2ConfigGenerator adlsGen2ConfigGenerator;
 
@@ -33,10 +35,11 @@ class BackupRestoreDBStateParamsProviderTest {
 
     @Test
     void testCreateBackupParamsWithoutLocation() {
-        Map<String, Object> actualResult = underTest.createParamsForBackupRestore(null);
+        Map<String, Object> actualResult = underTest.createParamsForBackupRestore(null, null);
         Map<String, String> upgradeParams = (Map<String, String>) ((Map<String, Object>) actualResult.get("postgres")).get("upgrade");
         assertEmbeddedParams(upgradeParams);
         Assertions.assertNull(upgradeParams.get("backup_location"));
+        Assertions.assertNull(upgradeParams.get("backup_instance_profile"));
     }
 
     @Test
@@ -44,10 +47,11 @@ class BackupRestoreDBStateParamsProviderTest {
         AdlsGen2Config adlsGen2Config = new AdlsGen2Config(ABFS_FOLDER, ABFS_FILESYSTEM_NAME, ABFS_STORAGE_ACCOUNT_NAME, false);
         when(adlsGen2ConfigGenerator.generateStorageConfig(BACKUP_LOCATION)).thenReturn(adlsGen2Config);
 
-        Map<String, Object> actualResult = underTest.createParamsForBackupRestore(BACKUP_LOCATION);
+        Map<String, Object> actualResult = underTest.createParamsForBackupRestore(BACKUP_LOCATION, BACKUP_INSTANCE_PROFILE);
         Map<String, String> upgradeParams = (Map<String, String>) ((Map<String, Object>) actualResult.get("postgres")).get("upgrade");
         assertEmbeddedParams(upgradeParams);
         Assertions.assertEquals(BACKUP_LOCATION, upgradeParams.get("backup_location"));
+        Assertions.assertEquals(BACKUP_INSTANCE_PROFILE, upgradeParams.get("backup_instance_profile"));
         Assertions.assertEquals(ABFS_STORAGE_ACCOUNT_NAME, upgradeParams.get("abfs_account_name"));
         Assertions.assertEquals(ABFS_FILESYSTEM_NAME, upgradeParams.get("abfs_file_system"));
         Assertions.assertEquals(ABFS_FOLDER, upgradeParams.get("abfs_file_system_folder"));

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeOrchestratorServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeOrchestratorServiceTest.java
@@ -47,6 +47,8 @@ class RdsUpgradeOrchestratorServiceTest {
 
     private static final String BACKUP_LOCATION = "location";
 
+    private static final String BACKUP_INSTANCE_PROFILE = "BACKUP_INSTANCE_PROFILE";
+
     @Mock
     private StackDtoService stackDtoService;
 
@@ -99,7 +101,7 @@ class RdsUpgradeOrchestratorServiceTest {
 
     @Test
     void testBackupRdsData() throws CloudbreakOrchestratorException {
-        underTest.backupRdsData(STACK_ID, BACKUP_LOCATION);
+        underTest.backupRdsData(STACK_ID, BACKUP_LOCATION, BACKUP_INSTANCE_PROFILE);
         verify(hostOrchestrator).runOrchestratorState(paramCaptor.capture());
         OrchestratorStateParams params = paramCaptor.getValue();
         assertThat(params.getState()).isEqualTo("postgresql/upgrade/backup");

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeServiceTest.java
@@ -54,6 +54,7 @@ import com.sequenceiq.cloudbreak.structuredevent.CloudbreakRestRequestThreadLoca
 import com.sequenceiq.cloudbreak.workspace.model.Tenant;
 import com.sequenceiq.cloudbreak.workspace.model.Workspace;
 import com.sequenceiq.common.api.backup.response.BackupResponse;
+import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.flow.api.model.FlowType;
@@ -86,6 +87,8 @@ class RdsUpgradeServiceTest {
     private static final String ACCOUNT_ID = "accountId";
 
     private static final String BACKUP_LOCATION = "location";
+
+    private static final String BACKUP_INSTANCE_PROFILE = "BACKUP_INSTANCE_PROFILE";
 
     @Mock
     private EnvironmentClientService environmentService;
@@ -122,6 +125,9 @@ class RdsUpgradeServiceTest {
         DetailedEnvironmentResponse environmentResponse = new DetailedEnvironmentResponse();
         BackupResponse backupResponse = new BackupResponse();
         backupResponse.setStorageLocation(BACKUP_LOCATION);
+        AdlsGen2CloudStorageV1Parameters adlsGen2CloudStorageV1Parameters = new AdlsGen2CloudStorageV1Parameters();
+        adlsGen2CloudStorageV1Parameters.setManagedIdentity(BACKUP_INSTANCE_PROFILE);
+        backupResponse.setAdlsGen2(adlsGen2CloudStorageV1Parameters);
         environmentResponse.setBackup(backupResponse);
         lenient().when(environmentService.getByCrn(anyString())).thenReturn(environmentResponse);
     }
@@ -134,12 +140,12 @@ class RdsUpgradeServiceTest {
         when(stackDtoService.getStackViewByNameOrCrn(eq(NameOrCrn.ofCrn(STACK_CRN)), any())).thenReturn(stack);
         FlowIdentifier flowId = new FlowIdentifier(FlowType.FLOW_CHAIN, FLOW_ID);
         when(databaseUpgradeRuntimeValidator.validateRuntimeVersionForUpgrade(STACK_VERSION, ACCOUNT_ID)).thenReturn(Optional.empty());
-        when(reactorFlowManager.triggerRdsUpgrade(eq(STACK_ID), eq(TARGET_VERSION), eq(BACKUP_LOCATION))).thenReturn(flowId);
+        when(reactorFlowManager.triggerRdsUpgrade(eq(STACK_ID), eq(TARGET_VERSION), eq(BACKUP_LOCATION), eq(BACKUP_INSTANCE_PROFILE))).thenReturn(flowId);
         when(entitlementService.isPostgresUpgradeAttachedDatahubsCheckSkipped(ACCOUNT_ID)).thenReturn(false);
 
         RdsUpgradeV4Response response = underTest.upgradeRds(NameOrCrn.ofCrn(STACK_CRN), TARGET_VERSION);
 
-        verify(reactorFlowManager).triggerRdsUpgrade(eq(STACK_ID), eq(TARGET_VERSION), eq(BACKUP_LOCATION));
+        verify(reactorFlowManager).triggerRdsUpgrade(eq(STACK_ID), eq(TARGET_VERSION), eq(BACKUP_LOCATION), eq(BACKUP_INSTANCE_PROFILE));
         assertThat(response.getFlowIdentifier().getType()).isEqualTo(FlowType.FLOW_CHAIN);
         assertThat(response.getFlowIdentifier().getPollableId()).isEqualTo(FLOW_ID);
     }
@@ -155,12 +161,12 @@ class RdsUpgradeServiceTest {
         when(stackDtoService.getStackViewByNameOrCrn(eq(NameOrCrn.ofCrn(STACK_CRN)), any())).thenReturn(stack);
         FlowIdentifier flowId = new FlowIdentifier(FlowType.FLOW_CHAIN, FLOW_ID);
         when(databaseUpgradeRuntimeValidator.validateRuntimeVersionForUpgrade(STACK_VERSION, ACCOUNT_ID)).thenReturn(Optional.empty());
-        when(reactorFlowManager.triggerRdsUpgrade(eq(STACK_ID), eq(TARGET_VERSION), eq(null))).thenReturn(flowId);
+        when(reactorFlowManager.triggerRdsUpgrade(eq(STACK_ID), eq(TARGET_VERSION), eq(null), eq(null))).thenReturn(flowId);
         when(entitlementService.isPostgresUpgradeAttachedDatahubsCheckSkipped(ACCOUNT_ID)).thenReturn(false);
 
         RdsUpgradeV4Response response = underTest.upgradeRds(NameOrCrn.ofCrn(STACK_CRN), TARGET_VERSION);
 
-        verify(reactorFlowManager).triggerRdsUpgrade(eq(STACK_ID), eq(TARGET_VERSION), eq(null));
+        verify(reactorFlowManager).triggerRdsUpgrade(eq(STACK_ID), eq(TARGET_VERSION), eq(null), eq(null));
         assertThat(response.getFlowIdentifier().getType()).isEqualTo(FlowType.FLOW_CHAIN);
         assertThat(response.getFlowIdentifier().getPollableId()).isEqualTo(FLOW_ID);
     }
@@ -177,12 +183,12 @@ class RdsUpgradeServiceTest {
         when(stackDtoService.getStackViewByNameOrCrn(eq(NameOrCrn.ofCrn(STACK_CRN)), any())).thenReturn(stack);
         when(databaseUpgradeRuntimeValidator.validateRuntimeVersionForUpgrade(STACK_VERSION, ACCOUNT_ID)).thenReturn(Optional.empty());
         FlowIdentifier flowId = new FlowIdentifier(FlowType.FLOW_CHAIN, FLOW_ID);
-        when(reactorFlowManager.triggerRdsUpgrade(eq(STACK_ID), eq(TARGET_VERSION), eq(BACKUP_LOCATION))).thenReturn(flowId);
+        when(reactorFlowManager.triggerRdsUpgrade(eq(STACK_ID), eq(TARGET_VERSION), eq(BACKUP_LOCATION), eq(BACKUP_INSTANCE_PROFILE))).thenReturn(flowId);
         when(entitlementService.isPostgresUpgradeAttachedDatahubsCheckSkipped(ACCOUNT_ID)).thenReturn(false);
 
         RdsUpgradeV4Response response = underTest.upgradeRds(NameOrCrn.ofCrn(STACK_CRN), null);
 
-        verify(reactorFlowManager).triggerRdsUpgrade(eq(STACK_ID), eq(TARGET_VERSION), eq(BACKUP_LOCATION));
+        verify(reactorFlowManager).triggerRdsUpgrade(eq(STACK_ID), eq(TARGET_VERSION), eq(BACKUP_LOCATION), eq(BACKUP_INSTANCE_PROFILE));
         assertThat(response.getFlowIdentifier().getType()).isEqualTo(FlowType.FLOW_CHAIN);
         assertThat(response.getFlowIdentifier().getPollableId()).isEqualTo(FLOW_ID);
     }
@@ -195,12 +201,12 @@ class RdsUpgradeServiceTest {
         when(stackDtoService.getStackViewByNameOrCrn(eq(NameOrCrn.ofCrn(STACK_CRN)), any())).thenReturn(stack);
         FlowIdentifier flowId = new FlowIdentifier(FlowType.FLOW_CHAIN, FLOW_ID);
         when(databaseUpgradeRuntimeValidator.validateRuntimeVersionForUpgrade(STACK_VERSION, ACCOUNT_ID)).thenReturn(Optional.empty());
-        when(reactorFlowManager.triggerRdsUpgrade(eq(STACK_ID), eq(TARGET_VERSION), eq(BACKUP_LOCATION))).thenReturn(flowId);
+        when(reactorFlowManager.triggerRdsUpgrade(eq(STACK_ID), eq(TARGET_VERSION), eq(BACKUP_LOCATION), eq(BACKUP_INSTANCE_PROFILE))).thenReturn(flowId);
         when(entitlementService.isPostgresUpgradeAttachedDatahubsCheckSkipped(ACCOUNT_ID)).thenReturn(false);
 
         RdsUpgradeV4Response response = underTest.upgradeRds(NameOrCrn.ofCrn(STACK_CRN), TARGET_VERSION);
 
-        verify(reactorFlowManager).triggerRdsUpgrade(eq(STACK_ID), eq(TARGET_VERSION), eq(BACKUP_LOCATION));
+        verify(reactorFlowManager).triggerRdsUpgrade(eq(STACK_ID), eq(TARGET_VERSION), eq(BACKUP_LOCATION), eq(BACKUP_INSTANCE_PROFILE));
         assertThat(response.getFlowIdentifier().getType()).isEqualTo(FlowType.FLOW_CHAIN);
         assertThat(response.getFlowIdentifier().getPollableId()).isEqualTo(FLOW_ID);
     }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentBaseResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentBaseResponse.java
@@ -210,6 +210,10 @@ public abstract class EnvironmentBaseResponse implements TaggedResponse {
         return backup != null ? backup.getStorageLocation() : null;
     }
 
+    public String getBackupInstanceProfile() {
+        return backup != null ? backup.getInstanceProfile() : null;
+    }
+
     public void setBackup(BackupResponse backup) {
         this.backup = backup;
     }


### PR DESCRIPTION
During postgres upgrade CDP creates a backup on Azure (on AWS and GCP the provider creates it automatically). The backup is then uploaded to cloud storage. The upload up to now used cdp-telemetry. At some customers, however, because of some unknown permission issue, the backup could not be uploaded. A PoC at these customers showed that with the attached msi azcopy is capable of copying the backup to the cloud storage without any issues. Also at the same customers freeipa backup also worked flawlessly with azcopy.

In the present commit thus cdp-telemetry is changed for azcopy.

See detailed description in the commit message.