### PR TITLE
CB-19042 improve logging and sent parameters around Autoscale audit event sending

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/AuditService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/AuditService.java
@@ -18,7 +18,10 @@ import com.sequenceiq.cloudbreak.audit.model.ApiRequestData;
 import com.sequenceiq.cloudbreak.audit.model.AuditEvent;
 import com.sequenceiq.cloudbreak.audit.model.AuditEventName;
 import com.sequenceiq.cloudbreak.audit.model.ServiceEventData;
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
+import com.sequenceiq.cloudbreak.common.user.CloudbreakUser;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.periscope.api.model.ScalingStatus;
 import com.sequenceiq.periscope.model.json.Json;
 
@@ -43,27 +46,34 @@ public class AuditService {
 
     @Async
     public void auditRestApi(Map<String, Object> requestParameters, boolean mutating,
-            String userAgent, String userCrn, String accountId, String sourceIp) {
-        AuditEvent event = null;
-        try {
-            ApiRequestData apiRequestData = ApiRequestData.builder()
-                    .withApiVersion(periscopeVersion)
-                    .withMutating(mutating)
-                    .withRequestParameters(new Json(requestParameters).getValue())
-                    .withUserAgent(userAgent)
-                    .build();
-            event = AuditEvent.builder()
-                    .withAccountId(accountId)
-                    .withActor(ActorCrn.builder().withActorCrn(userCrn).build())
-                    .withEventData(apiRequestData)
-                    .withEventName(AuditEventName.MANAGE_AUTOSCALE_DATAHUB_CLUSTER)
-                    .withEventSource(Crn.Service.DATAHUB)
-                    .withSourceIp(sourceIp)
-                    .build();
-            auditClient.createAuditEvent(event);
-        } catch (Exception ex) {
-            LOGGER.warn("API Audit event creation failed, error : '{}', event : '{}'", ex.getMessage(), event, ex);
-        }
+            String userAgent, CloudbreakUser user, String requestId, String sourceIp) {
+        String userCrn = user.getUserCrn();
+        ThreadBasedUserCrnProvider.doAs(userCrn, () -> {
+            String tenant = user.getTenant();
+            MDCBuilder.addRequestId(requestId);
+            AuditEvent event = null;
+            try {
+                ApiRequestData apiRequestData = ApiRequestData.builder()
+                        .withApiVersion(periscopeVersion)
+                        .withMutating(mutating)
+                        .withRequestParameters(new Json(requestParameters).getValue())
+                        .withUserAgent(userAgent)
+                        .build();
+                event = AuditEvent.builder()
+                        .withAccountId(tenant)
+                        .withActor(ActorCrn.builder().withActorCrn(userCrn).build())
+                        .withEventData(apiRequestData)
+                        .withEventName(AuditEventName.MANAGE_AUTOSCALE_DATAHUB_CLUSTER)
+                        .withEventSource(Crn.Service.AUTOSCALE)
+                        .withSourceIp(sourceIp)
+                        .withRequestId(requestId)
+                        .build();
+                auditClient.createAuditEvent(event);
+                LOGGER.info("Audit event has been sent with request id: {}", requestId);
+            } catch (Exception ex) {
+                LOGGER.warn("API Audit event creation failed, error : '{}', event : '{}'", ex.getMessage(), event, ex);
+            }
+        });
     }
 
     @Async
@@ -86,7 +96,7 @@ public class AuditService {
                     .withAccountId(accountId)
                     .withEventData(serviceEventData)
                     .withEventName(AuditEventName.AUTOSCALE_DATAHUB_CLUSTER)
-                    .withEventSource(Crn.Service.DATAHUB)
+                    .withEventSource(Crn.Service.AUTOSCALE)
                     .withActor(ActorService.builder().withActorServiceName(Crn.Service.DATAHUB.getName()).build())
                     .build();
             auditClient.createAuditEvent(event);

--- a/autoscale/src/test/java/com/sequenceiq/periscope/service/AuditServiceTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/service/AuditServiceTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.Map;
 
@@ -25,6 +26,7 @@ import com.sequenceiq.cloudbreak.audit.model.ApiRequestData;
 import com.sequenceiq.cloudbreak.audit.model.AuditEvent;
 import com.sequenceiq.cloudbreak.audit.model.ServiceEventData;
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
+import com.sequenceiq.cloudbreak.common.user.CloudbreakUser;
 import com.sequenceiq.periscope.api.model.ScalingStatus;
 
 public class AuditServiceTest {
@@ -35,6 +37,9 @@ public class AuditServiceTest {
     @Mock
     AuditClient auditClient;
 
+    @Mock
+    CloudbreakUser cloudbreakUser;
+
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
@@ -44,16 +49,19 @@ public class AuditServiceTest {
     public void testAuditRestEvent() {
         Map requestParams = Map.of("param1", "param2");
         String userCrn = "crn:altus:iam:us-west-1:05681f13-41fc-4b2a-9588-a78d640f3c23:user:5f03bc0d-83d5-40c3-8624-f7b21481c1f7";
-        underTest.auditRestApi(requestParams, true, "user-agent", userCrn, "user-account", "127.0.0.1");
+        when(cloudbreakUser.getUserCrn()).thenReturn(userCrn);
+        when(cloudbreakUser.getTenant()).thenReturn("05681f13-41fc-4b2a-9588-a78d640f3c23");
+        underTest.auditRestApi(requestParams, true, "user-agent", cloudbreakUser, "requestId", "127.0.0.1");
 
         ArgumentCaptor<AuditEvent> captor = ArgumentCaptor.forClass(AuditEvent.class);
         verify(auditClient, times(1)).createAuditEvent(captor.capture());
         AuditEvent auditEvent = captor.getValue();
 
-        assertEquals("user-account", auditEvent.getAccountId());
+        assertEquals("requestId", auditEvent.getRequestId());
+        assertEquals("05681f13-41fc-4b2a-9588-a78d640f3c23", auditEvent.getAccountId());
         assertEquals("127.0.0.1", auditEvent.getSourceIp());
         assertEquals(MANAGE_AUTOSCALE_DATAHUB_CLUSTER, auditEvent.getEventName());
-        assertEquals(Crn.Service.DATAHUB, auditEvent.getEventSource());
+        assertEquals(Crn.Service.AUTOSCALE, auditEvent.getEventSource());
         assertEquals(userCrn, ((ActorCrn) auditEvent.getActor()).getActorCrn());
 
         ApiRequestData apiRequestData = (ApiRequestData) auditEvent.getEventData();
@@ -74,7 +82,7 @@ public class AuditServiceTest {
 
         assertEquals("user-account", auditEvent.getAccountId());
         assertEquals(AUTOSCALE_DATAHUB_CLUSTER, auditEvent.getEventName());
-        assertEquals(Crn.Service.DATAHUB, auditEvent.getEventSource());
+        assertEquals(Crn.Service.AUTOSCALE, auditEvent.getEventSource());
         assertEquals(Crn.Service.DATAHUB.getName(), ((ActorService) auditEvent.getActor()).getActorServiceName());
 
         ServiceEventData serviceEventData = (ServiceEventData) auditEvent.getEventData();

--- a/ccm-connector/src/test/java/com/sequenceiq/cloudbreak/ccmimpl/ccmv2/CcmV2ManagementClientTest.java
+++ b/ccm-connector/src/test/java/com/sequenceiq/cloudbreak/ccmimpl/ccmv2/CcmV2ManagementClientTest.java
@@ -30,7 +30,7 @@ class CcmV2ManagementClientTest {
 
     private static final String TEST_ENVIRONMENT_CRN = "environmentCrn";
 
-    private static final String TEST_USER_CRN = "testUserCrn";
+    private static final String TEST_USER_CRN = "crn:cdp:iam:us-west-1:cloudera:user:ausername";
 
     private static final String TEST_AGENT_CRN = "testAgentCrn";
 

--- a/cloud-consumption/src/test/java/com/sequenceiq/consumption/service/DatahubServiceTest.java
+++ b/cloud-consumption/src/test/java/com/sequenceiq/consumption/service/DatahubServiceTest.java
@@ -24,6 +24,7 @@ import com.sequenceiq.distrox.api.v1.distrox.endpoint.DistroXInternalV1Endpoint;
 
 @ExtendWith(MockitoExtension.class)
 public class DatahubServiceTest {
+    private static final String INTERNAL_ACTOR_CRN = "crn:cdp:iam:us-west-1:altus:user:__internal__actor__";
 
     @Mock
     private CloudbreakInternalCrnClient cloudbreakInternalCrnClient;
@@ -51,7 +52,7 @@ public class DatahubServiceTest {
         String datahubCrn = "crn";
         StackInstancesV4Responses stackInstancesV4Responses = new StackInstancesV4Responses();
 
-        when(regionAwareInternalCrnGenerator.getInternalCrnForServiceAsString()).thenReturn("iam");
+        when(regionAwareInternalCrnGenerator.getInternalCrnForServiceAsString()).thenReturn(INTERNAL_ACTOR_CRN);
         when(regionAwareInternalCrnGeneratorFactory.iam()).thenReturn(regionAwareInternalCrnGenerator);
         when(cloudbreakInternalCrnClient.withInternalCrn()).thenReturn(cloudbreakServiceCrnEndpoints);
         when(cloudbreakServiceCrnEndpoints.distroXInternalV1Endpoint()).thenReturn(distroXInternalV1Endpoint);
@@ -66,7 +67,7 @@ public class DatahubServiceTest {
         String datahubCrn = "crn";
         WebApplicationException webApplicationException = new WebApplicationException("test");
 
-        when(regionAwareInternalCrnGenerator.getInternalCrnForServiceAsString()).thenReturn("iam");
+        when(regionAwareInternalCrnGenerator.getInternalCrnForServiceAsString()).thenReturn(INTERNAL_ACTOR_CRN);
         when(regionAwareInternalCrnGeneratorFactory.iam()).thenReturn(regionAwareInternalCrnGenerator);
         when(cloudbreakInternalCrnClient.withInternalCrn()).thenReturn(cloudbreakServiceCrnEndpoints);
         when(cloudbreakServiceCrnEndpoints.distroXInternalV1Endpoint()).thenReturn(distroXInternalV1Endpoint);

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerDatabusServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerDatabusServiceTest.java
@@ -26,6 +26,8 @@ public class ClouderaManagerDatabusServiceTest {
 
     private static final String SDX_STACK_CRN = "crn:cdp:sdx:us-west-1:1234:sdxcluster:mystack";
 
+    private static final String INTERNAL_ACTOR_CRN = "crn:cdp:iam:us-west-1:altus:user:__internal__actor__";
+
     @InjectMocks
     private ClouderaManagerDatabusService underTest;
 
@@ -64,7 +66,7 @@ public class ClouderaManagerDatabusServiceTest {
         // GIVEN
         AltusCredential credential = new AltusCredential("accessKey", "secretKey".toCharArray());
         when(iamService.generateMachineUserWithAccessKeyForLegacyCm(any(), any(), any(), any())).thenReturn(credential);
-        when(regionAwareInternalCrnGenerator.getInternalCrnForServiceAsString()).thenReturn("crn");
+        when(regionAwareInternalCrnGenerator.getInternalCrnForServiceAsString()).thenReturn(INTERNAL_ACTOR_CRN);
         when(regionAwareInternalCrnGeneratorFactory.iam()).thenReturn(regionAwareInternalCrnGenerator);
         when(roleCrnGenerator.getBuiltInWXMClusterAdminResourceRoleCrn(any())).thenReturn("resourceRoleCrn");
         when(regionAwareCrnGenerator.generateCrnString(any(), any(), any())).thenReturn("resourceCrn");

--- a/common/src/main/java/com/sequenceiq/cloudbreak/auth/ThreadBasedUserCrnProvider.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/auth/ThreadBasedUserCrnProvider.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.auth;
 
+import static com.sequenceiq.cloudbreak.util.NullUtil.doIfNotNull;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Optional;
@@ -16,6 +18,7 @@ import org.slf4j.LoggerFactory;
 
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorUtil;
+import com.sequenceiq.cloudbreak.logger.MdcContext;
 
 public class ThreadBasedUserCrnProvider {
 
@@ -49,6 +52,7 @@ public class ThreadBasedUserCrnProvider {
             throw new IllegalStateException(errorMessage);
         } else {
             USER_CRN.set(userCrn);
+            addUserCrnAndTenantToMdcContext(userCrn);
         }
     }
 
@@ -67,6 +71,7 @@ public class ThreadBasedUserCrnProvider {
     }
 
     // CHECKSTYLE:OFF
+
     public static <T, W extends Throwable> T doAsAndThrow(String userCrn, ThrowableCallable<T, W> callable) throws Throwable {
         // CHECKSTYLE:ON
         String previousUserCrn = getUserCrn();
@@ -134,5 +139,11 @@ public class ThreadBasedUserCrnProvider {
         } else {
             return doAs(internalCrn, () -> originalUserCrnConsumer.apply(originalUserCrn));
         }
+    }
+
+    private static void addUserCrnAndTenantToMdcContext(String userCrn) {
+        MdcContext.Builder builder = MdcContext.builder();
+        doIfNotNull(userCrn, builder::userCrn);
+        builder.buildMdc();
     }
 }

--- a/flow/src/test/java/com/sequenceiq/flow/core/AbstractActionTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/core/AbstractActionTest.java
@@ -47,7 +47,7 @@ public class AbstractActionTest {
 
     public static final String FLOW_ID = "flowId";
 
-    public static final String FLOW_TRIGGER_USERCRN = "flowTriggerUserCrn";
+    public static final String FLOW_TRIGGER_USERCRN = "crn:cdp:iam:us-west-1:cloudera:user:ausername";
 
     public static final FlowParameters FLOW_PARAMETERS = new FlowParameters(FLOW_ID, FLOW_TRIGGER_USERCRN, null);
 


### PR DESCRIPTION
CB-19042 improve logging and sent parameters around Autoscale audit event sending

**Improvements:**
 - send request method and request id with audit events
 - proper log context setup for Autoscale's async audit event sender with request id, user crn, tenant to make the investigations easier
 - modify ThreadBasedUserCrnProvider to update the MDC context too when user crn is updated on the thread local level