### PR TITLE
CB-19079: Data Hub rolling OS upgrade is using zero downtime upgrade

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpgradeDistroxFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpgradeDistroxFlowEventChainFactory.java
@@ -64,8 +64,8 @@ public class UpgradeDistroxFlowEventChainFactory implements FlowEventChainFactor
         flowEventChain.add(new StackImageUpdateTriggerEvent(FlowChainTriggers.STACK_IMAGE_UPDATE_TRIGGER_EVENT, event.getImageChangeDto()));
         if (event.isReplaceVms()) {
             Map<String, List<String>> nodeMap = getReplaceableInstancesByHostgroup(event);
-            flowEventChain.add(new ClusterRepairTriggerEvent(FlowChainTriggers.CLUSTER_REPAIR_TRIGGER_EVENT, event.getResourceId(), nodeMap, true,
-                    event.getTriggeredStackVariant()));
+            flowEventChain.add(new ClusterRepairTriggerEvent(FlowChainTriggers.CLUSTER_REPAIR_TRIGGER_EVENT, event.getResourceId(),
+                    event.isRollingUpgradeEnabled(), nodeMap, true, event.getTriggeredStackVariant()));
         }
         return new FlowTriggerEventQueue(getName(), event, flowEventChain);
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/ClusterRepairTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/ClusterRepairTriggerEvent.java
@@ -61,13 +61,14 @@ public class ClusterRepairTriggerEvent extends StackEvent {
     public ClusterRepairTriggerEvent(
             @JsonProperty("selector") String event,
             @JsonProperty("resourceId") Long stackId,
+            @JsonProperty("oneNodeFromEachHostGroupAtOnce") boolean oneNodeFromEachHostGroupAtOnce,
             @JsonProperty("failedNodesMap") Map<String, List<String>> failedNodesMap,
             @JsonProperty("restartServices") boolean restartServices,
             @JsonProperty("triggeredStackVariant") String triggeredStackVariant) {
         super(event, stackId);
         this.failedNodesMap = copyToSerializableMap(failedNodesMap);
         this.stackId = stackId;
-        this.oneNodeFromEachHostGroupAtOnce = false;
+        this.oneNodeFromEachHostGroupAtOnce = oneNodeFromEachHostGroupAtOnce;
         this.restartServices = restartServices;
         this.upgrade = triggeredStackVariant != null;
         this.triggeredStackVariant = triggeredStackVariant;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterRepairFlowEventChainFactoryTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterRepairFlowEventChainFactoryTest.java
@@ -402,7 +402,7 @@ public class ClusterRepairFlowEventChainFactoryTest {
         String groupName = "groupName";
         String triggeredVariant = "triggeredVariant";
         when(stackView.getPlatformVariant()).thenReturn(AwsConstants.AwsVariant.AWS_VARIANT.variant().value());
-        ClusterRepairTriggerEvent triggerEvent = new ClusterRepairTriggerEvent("eventname", stackView.getId(), Map.of(), false, triggeredVariant);
+        ClusterRepairTriggerEvent triggerEvent = new ClusterRepairTriggerEvent("eventname", stackView.getId(), false, Map.of(), false, triggeredVariant);
 
         underTest.addAwsNativeEventMigrationIfNeeded(flowTriggers, triggerEvent, groupName, stackView);
 
@@ -415,7 +415,7 @@ public class ClusterRepairFlowEventChainFactoryTest {
         String groupName = "groupName";
         String triggeredVariant = AwsConstants.AwsVariant.AWS_NATIVE_VARIANT.variant().value();
         when(stackView.getPlatformVariant()).thenReturn(AwsConstants.AwsVariant.AWS_NATIVE_VARIANT.variant().value());
-        ClusterRepairTriggerEvent triggerEvent = new ClusterRepairTriggerEvent("eventname", stackView.getId(), Map.of(), false, triggeredVariant);
+        ClusterRepairTriggerEvent triggerEvent = new ClusterRepairTriggerEvent("eventname", stackView.getId(), false, Map.of(), false, triggeredVariant);
 
         underTest.addAwsNativeEventMigrationIfNeeded(flowTriggers, triggerEvent, groupName, stackView);
 
@@ -429,7 +429,7 @@ public class ClusterRepairFlowEventChainFactoryTest {
         String groupName = "groupName";
         String triggeredVariant = AwsConstants.AwsVariant.AWS_NATIVE_VARIANT.variant().value();
         when(stackView.getPlatformVariant()).thenReturn(AwsConstants.AwsVariant.AWS_VARIANT.variant().value());
-        ClusterRepairTriggerEvent triggerEvent = new ClusterRepairTriggerEvent("eventname", stackView.getId(), Map.of(), false, triggeredVariant);
+        ClusterRepairTriggerEvent triggerEvent = new ClusterRepairTriggerEvent("eventname", stackView.getId(), false, Map.of(), false, triggeredVariant);
 
         underTest.addAwsNativeEventMigrationIfNeeded(flowTriggers, triggerEvent, groupName, stackView);
 
@@ -443,7 +443,7 @@ public class ClusterRepairFlowEventChainFactoryTest {
         String groupName = "groupName";
         String triggeredVariant = "AWS_NATIVE";
         when(stackUpgradeService.awsVariantMigrationIsFeasible(stackView, triggeredVariant)).thenReturn(true);
-        ClusterRepairTriggerEvent triggerEvent = new ClusterRepairTriggerEvent("eventname", stackView.getId(), Map.of(), false, triggeredVariant);
+        ClusterRepairTriggerEvent triggerEvent = new ClusterRepairTriggerEvent("eventname", stackView.getId(), false, Map.of(), false, triggeredVariant);
 
         underTest.addAwsNativeEventMigrationIfNeeded(flowTriggers, triggerEvent, groupName, stackView);
 


### PR DESCRIPTION
When we call rolling OS upgrade on Data Hub clusters is using the regular VM replacement but it should call the zero downtime upgrade to replace the VMs one by one. In this commit I modified the UpgradeDistroxFlowEventChainFactory to create a new ClusterRepairTriggerEvent with oneNodeFromEachHostGroupAtOnce flag based on the rolling upgrade option.