### PR TITLE
CB-19094 Credential HTTP 500 responses are not visible in the logs,…

### DIFF
--- a/common/src/test/java/com/sequenceiq/cloudbreak/logger/RestLoggerFilterTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/logger/RestLoggerFilterTest.java
@@ -1,0 +1,78 @@
+package com.sequenceiq.cloudbreak.logger;
+
+import static org.mockito.AdditionalMatchers.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+
+import com.sequenceiq.cloudbreak.util.StaticFieldManipulationTestHelper;
+
+@ExtendWith(MockitoExtension.class)
+class RestLoggerFilterTest {
+
+    private RestLoggerFilter underTest;
+
+    @Mock
+    private Logger logger;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @BeforeEach
+    public void init() throws Exception {
+        StaticFieldManipulationTestHelper.setFinalStatic(RestLoggerFilter.class.getDeclaredField("LOGGER"), logger);
+        underTest = new RestLoggerFilter(true);
+    }
+
+    @Test
+    void doFilterCredential() throws ServletException, IOException {
+        when(request.getRequestURI()).thenReturn("env/credential");
+        when(request.getCharacterEncoding()).thenReturn("UTF8");
+        underTest.doFilterInternal(request, response, filterChain);
+
+        verify(logger, times(1)).debug(any());
+        verify(logger).debug(contains("REDACTED COMPLETELY"));
+    }
+
+    @Test
+    void doFilterOther() throws ServletException, IOException {
+        when(request.getRequestURI()).thenReturn("env/something");
+        when(request.getCharacterEncoding()).thenReturn("UTF8");
+        underTest.doFilterInternal(request, response, filterChain);
+
+        verify(logger, times(1)).debug(any());
+        verify(logger).debug(not(contains("REDACTED COMPLETELY")));
+    }
+
+    @Test
+    void doFilterUnsupportedEncoding() throws ServletException, IOException {
+        when(request.getRequestURI()).thenReturn("env/something");
+        when(request.getCharacterEncoding()).thenReturn("WRONG");
+        underTest.doFilterInternal(request, response, filterChain);
+
+        verify(logger, times(1)).debug(any());
+        verify(logger).debug(contains("We were not able to encode the content"));
+    }
+}

--- a/common/src/test/java/com/sequenceiq/cloudbreak/util/StaticFieldManipulationTestHelper.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/util/StaticFieldManipulationTestHelper.java
@@ -1,0 +1,18 @@
+package com.sequenceiq.cloudbreak.util;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+public class StaticFieldManipulationTestHelper {
+
+    private StaticFieldManipulationTestHelper() {
+    }
+
+    public static void setFinalStatic(Field field, Object newValue) throws Exception {
+        field.setAccessible(true);
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+        field.set(null, newValue);
+    }
+}


### PR DESCRIPTION
…with this change we ensure:

- HTTP responses are still logged by rest logger
- but also keep the functionality that if a credential word is present in the URL then we just redact the entire message due to its sensitive nature.
