### PR TITLE
CB-11835 Remove Mock IDBroker Mappings from API test project and E2E tests

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
@@ -339,9 +339,8 @@ public class StackRequestManifester {
                 MappingsConfig mappingsConfig;
                 try {
                     // Must pass the internal actor here as this operation is internal-use only; requests with other actors will be always rejected.
-                    mappingsConfig = idbmmsClient.getMappingsConfig(
-                            regionAwareInternalCrnGeneratorFactory.iam().getInternalCrnForServiceAsString(),
-                            environmentCrn, Optional.empty());
+                    mappingsConfig = idbmmsClient.getMappingsConfig(regionAwareInternalCrnGeneratorFactory.iam().getInternalCrnForServiceAsString(),
+                            environmentCrn);
                     validateMappingsConfig(mappingsConfig, stackRequest);
                 } catch (IdbmmsOperationException e) {
                     throw new BadRequestException(String.format("Unable to get mappings: %s", e.getMessage()), e);

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/StackRequestManifesterTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/StackRequestManifesterTest.java
@@ -13,7 +13,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Assertions;
@@ -293,7 +292,7 @@ public class StackRequestManifesterTest {
         when(stackV4Request.getName()).thenReturn(STACK_NAME);
         when(regionAwareInternalCrnGenerator.getInternalCrnForServiceAsString()).thenReturn("crn");
         when(regionAwareInternalCrnGeneratorFactory.iam()).thenReturn(regionAwareInternalCrnGenerator);
-        when(idbmmsClient.getMappingsConfig("crn", ENVIRONMENT_CRN, Optional.empty())).thenReturn(mappingsConfig);
+        when(idbmmsClient.getMappingsConfig("crn", ENVIRONMENT_CRN)).thenReturn(mappingsConfig);
         when(mappingsConfig.getGroupMappings()).thenReturn(Map.ofEntries(Map.entry(GROUP_2, GROUP_ROLE_2)));
         when(mappingsConfig.getActorMappings()).thenReturn(Map.ofEntries(Map.entry(USER_2, USER_ROLE_2)));
 
@@ -314,7 +313,7 @@ public class StackRequestManifesterTest {
         when(stackV4Request.getName()).thenReturn(STACK_NAME);
         when(regionAwareInternalCrnGenerator.getInternalCrnForServiceAsString()).thenReturn("crn");
         when(regionAwareInternalCrnGeneratorFactory.iam()).thenReturn(regionAwareInternalCrnGenerator);
-        when(idbmmsClient.getMappingsConfig("crn", BAD_ENVIRONMENT_CRN, Optional.empty()))
+        when(idbmmsClient.getMappingsConfig("crn", BAD_ENVIRONMENT_CRN))
                 .thenThrow(new IdbmmsOperationException("Houston, we have a problem."));
 
         clusterV4Request.setCloudStorage(cloudStorage);
@@ -367,7 +366,7 @@ public class StackRequestManifesterTest {
         when(regionAwareInternalCrnGenerator.getInternalCrnForServiceAsString()).thenReturn("crn");
         when(regionAwareInternalCrnGeneratorFactory.iam()).thenReturn(regionAwareInternalCrnGenerator);
         clusterV4Request.setCloudStorage(cloudStorage);
-        when(idbmmsClient.getMappingsConfig("crn", ENVIRONMENT_CRN, Optional.empty())).thenReturn(mappingsConfig);
+        when(idbmmsClient.getMappingsConfig("crn", ENVIRONMENT_CRN)).thenReturn(mappingsConfig);
 
         // Enable RAZ for this test and make sure role is checked for.
         clusterV4Request.setRangerRazEnabled(true);
@@ -384,7 +383,7 @@ public class StackRequestManifesterTest {
         when(regionAwareInternalCrnGenerator.getInternalCrnForServiceAsString()).thenReturn("crn");
         when(regionAwareInternalCrnGeneratorFactory.iam()).thenReturn(regionAwareInternalCrnGenerator);
         clusterV4Request.setCloudStorage(cloudStorage);
-        when(idbmmsClient.getMappingsConfig("crn", ENVIRONMENT_CRN, Optional.empty())).thenReturn(mappingsConfig);
+        when(idbmmsClient.getMappingsConfig("crn", ENVIRONMENT_CRN)).thenReturn(mappingsConfig);
 
         // Enable RAZ without mapping which should throw an error.
         clusterV4Request.setRangerRazEnabled(true);

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/deletion/handler/IdBrokerMappingsDeleteHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/deletion/handler/IdBrokerMappingsDeleteHandler.java
@@ -3,8 +3,6 @@ package com.sequenceiq.environment.environment.flow.deletion.handler;
 import static com.sequenceiq.environment.environment.flow.deletion.event.EnvDeleteHandlerSelectors.DELETE_IDBROKER_MAPPINGS_EVENT;
 import static com.sequenceiq.environment.environment.flow.deletion.event.EnvDeleteStateSelectors.START_S3GUARD_TABLE_DELETE_EVENT;
 
-import java.util.Optional;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -81,7 +79,7 @@ public class IdBrokerMappingsDeleteHandler extends EventSenderAwareHandler<Envir
     private void deleteIdBrokerMappings(String environmentCrn) {
         try {
             // Must pass the internal actor here as this operation is internal-use only; requests with other actors will be always rejected.
-            idbmmsClient.deleteMappings(regionAwareInternalCrnGeneratorFactory.iam().getInternalCrnForServiceAsString(), environmentCrn, Optional.empty());
+            idbmmsClient.deleteMappings(regionAwareInternalCrnGeneratorFactory.iam().getInternalCrnForServiceAsString(), environmentCrn);
         } catch (IdbmmsOperationException e) {
             if (e.getErrorStatus() == IdbmmsOperationErrorStatus.NOT_FOUND) {
                 // This is a non-fatal situation when deleting the environment.

--- a/idbmms-connector/src/main/java/com/sequenceiq/cloudbreak/idbmms/GrpcIdbmmsClient.java
+++ b/idbmms-connector/src/main/java/com/sequenceiq/cloudbreak/idbmms/GrpcIdbmmsClient.java
@@ -2,9 +2,6 @@ package com.sequenceiq.cloudbreak.idbmms;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.Optional;
-import java.util.UUID;
-
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
@@ -12,11 +9,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
+import com.cloudera.thunderhead.service.idbrokermappingmanagement.IdBrokerMappingManagementProto.DeleteMappingsResponse;
+import com.cloudera.thunderhead.service.idbrokermappingmanagement.IdBrokerMappingManagementProto.GetMappingsResponse;
+import com.cloudera.thunderhead.service.idbrokermappingmanagement.IdBrokerMappingManagementProto.SetMappingsResponse;
 import com.sequenceiq.cloudbreak.grpc.ManagedChannelWrapper;
+import com.sequenceiq.cloudbreak.idbmms.config.IdbmmsClientConfig;
 import com.sequenceiq.cloudbreak.idbmms.exception.IdbmmsOperationException;
 import com.sequenceiq.cloudbreak.idbmms.model.MappingsConfig;
-
-import io.grpc.ManagedChannel;
 
 /**
  * A GRPC-based client for the IDBroker Mapping Management Service (IDBMMS).
@@ -30,29 +29,36 @@ public class GrpcIdbmmsClient {
     @Inject
     private ManagedChannelWrapper channelWrapper;
 
+    @Inject
+    private IdbmmsClientConfig idbmmsClientConfig;
+
+    public static GrpcIdbmmsClient createClient(ManagedChannelWrapper channelWrapper, IdbmmsClientConfig idbmmsClientConfig) {
+        GrpcIdbmmsClient client = new GrpcIdbmmsClient();
+        client.channelWrapper = checkNotNull(channelWrapper, "channelWrapper should not be null.");
+        client.idbmmsClientConfig = checkNotNull(idbmmsClientConfig, "clientConfig should not be null.");
+        return client;
+    }
+
     /**
      * Retrieves IDBroker mappings from IDBMMS for a particular environment.
      *
      * @param actorCrn       the actor CRN; must not be {@code null}
      * @param environmentCrn the environment CRN to get mappings for; must not be {@code null}
-     * @param requestId      an optional request ID; must not be {@code null}
      * @return the mappings config associated with environment {@code environmentCrn}; never {@code null}
      * @throws NullPointerException     if either argument is {@code null}
      * @throws IdbmmsOperationException if any problem is encountered during the IDBMMS call processing
      */
-    public MappingsConfig getMappingsConfig(String actorCrn, String environmentCrn, Optional<String> requestId) {
-        checkNotNull(actorCrn, "actorCrn should not be null.");
-        checkNotNull(environmentCrn);
-        checkNotNull(requestId, "requestId should not be null.");
+    public MappingsConfig getMappingsConfig(String actorCrn, String environmentCrn) {
+        checkNotNull(actorCrn, "actor Crn should not be null.");
+        checkNotNull(environmentCrn, "environment Crn should not be null.");
         try {
-            IdbmmsClient client = makeClient(channelWrapper.getChannel(), actorCrn);
-            String effectiveRequestId = requestId.orElse(UUID.randomUUID().toString());
-            LOGGER.debug("Fetching IDBroker mappings for environment {} using request ID {}", environmentCrn, effectiveRequestId);
-            MappingsConfig mappingsConfig = client.getMappingsConfig(effectiveRequestId, environmentCrn);
-            LOGGER.debug("Retrieved IDBroker mappings of version {} for environment {}", mappingsConfig.getMappingsVersion(), environmentCrn);
+            IdbmmsClient client = makeClient(actorCrn);
+            LOGGER.debug("Fetching IDBroker mappings for environment {} with user {}.", environmentCrn, actorCrn);
+            MappingsConfig mappingsConfig = client.getMappingsConfig(environmentCrn);
+            LOGGER.debug("Retrieved IDBroker mappings with version {} for environment {}.", mappingsConfig.getMappingsVersion(), environmentCrn);
             return mappingsConfig;
         } catch (RuntimeException e) {
-            throw new IdbmmsOperationException(String.format("Error during IDBMMS operation: %s", e.getMessage()), e);
+            throw new IdbmmsOperationException(String.format("Error during getting IDBroker mappings configuration: %s", e.getMessage()), e);
         }
     }
 
@@ -61,27 +67,80 @@ public class GrpcIdbmmsClient {
      *
      * @param actorCrn       the actor CRN; must not be {@code null}
      * @param environmentCrn the environment CRN to delete mappings for; must not be {@code null}
-     * @param requestId      an optional request ID; must not be {@code null}
+     * @return delete mappings response
      * @throws NullPointerException     if either argument is {@code null}
      * @throws IdbmmsOperationException if any problem is encountered during the IDBMMS call processing
      */
-    public void deleteMappings(String actorCrn, String environmentCrn, Optional<String> requestId) {
-        checkNotNull(actorCrn, "actorCrn should not be null.");
-        checkNotNull(environmentCrn);
-        checkNotNull(requestId, "requestId should not be null.");
+    public DeleteMappingsResponse deleteMappings(String actorCrn, String environmentCrn) {
+        checkNotNull(actorCrn, "actor Crn should not be null.");
+        checkNotNull(environmentCrn, "environment Crn should not be null.");
         try {
-            IdbmmsClient client = makeClient(channelWrapper.getChannel(), actorCrn);
-            String effectiveRequestId = requestId.orElse(UUID.randomUUID().toString());
-            LOGGER.debug("Deleting IDBroker mappings for environment {} using request ID {}", environmentCrn, effectiveRequestId);
-            client.deleteMappings(effectiveRequestId, environmentCrn);
-            LOGGER.debug("Deleted IDBroker mappings for environment {}", environmentCrn);
+            IdbmmsClient client = makeClient(actorCrn);
+            LOGGER.debug("Deleting IDBroker mappings from environment {} with user {}.", environmentCrn, actorCrn);
+            DeleteMappingsResponse deleteResponse = client.deleteMappings(environmentCrn);
+            LOGGER.debug("Deleted IDBroker mappings from environment {} with {}.", environmentCrn, deleteResponse);
+            return deleteResponse;
         } catch (RuntimeException e) {
-            throw new IdbmmsOperationException(String.format("Error during IDBMMS operation: %s", e.getMessage()), e);
+            throw new IdbmmsOperationException(String.format("Error during deleting IDBroker mappings: %s", e.getMessage()), e);
         }
     }
 
-    private IdbmmsClient makeClient(ManagedChannel channel, String actorCrn) {
-        return new IdbmmsClient(channel, actorCrn);
+    /**
+     * Sets IDBroker mappings in IDBMMS for a particular environment.
+     *
+     * @param actorCrn                   the actor CRN; must not be {@code null}
+     * @param environmentCrn             the environment CRN to delete mappings for; must not be {@code null}
+     * @param dataAccessRole             the cloud provider role to which data access services will be mapped; must not be {@code null}
+     * @param baselineRole               the cloud provider role associated with the baseline instance identity,
+     *                                   that write to cloud storage will be mapped to this role; must not be {@code null}
+     * @param rangerAccessAuthorizerRole the cloud provider role to which the Ranger RAZ service will be mapped
+     * @return set mappings response associated with environment {@code environmentCrn}; never {@code null}
+     * @throws NullPointerException if either argument is {@code null}
+     * @throws IdbmmsOperationException if any problem is encountered during the IDBMMS call processing
+     */
+    public SetMappingsResponse setMappings(String actorCrn, String environmentCrn, String dataAccessRole,
+            String baselineRole, String rangerAccessAuthorizerRole) {
+        checkNotNull(actorCrn, "actor Crn should not be null.");
+        checkNotNull(environmentCrn, "environment Crn should not be null.");
+        checkNotNull(dataAccessRole, "data access role should not be null.");
+        checkNotNull(baselineRole, "baseline role should not be null.");
+
+        try {
+            IdbmmsClient client = makeClient(actorCrn);
+            LOGGER.debug("Setting IDBroker mappings for environment {} with user {}.", environmentCrn, actorCrn);
+            SetMappingsResponse mappings = client.setMappings(environmentCrn, dataAccessRole, baselineRole, rangerAccessAuthorizerRole);
+            LOGGER.debug("IDBroker mappings {} for environment {} has been set.", mappings, environmentCrn);
+            return mappings;
+        } catch (RuntimeException e) {
+            throw new IdbmmsOperationException(String.format("Error during setting new IDBroker mappings for environment: %s", e.getMessage()), e);
+        }
     }
 
+    /**
+     * Retrieves IDBroker mappings from IDBMMS for a particular environment.
+     *
+     * @param actorCrn       the actor CRN; must not be {@code null}
+     * @param environmentCrn the environment CRN to get mappings for; must not be {@code null}
+     * @return get mappings response associated with environment {@code environmentCrn}; never {@code null}
+     * @throws NullPointerException if either argument is {@code null}
+     * @throws IdbmmsOperationException if any problem is encountered during the IDBMMS call processing
+     */
+    public GetMappingsResponse getMappings(String actorCrn, String environmentCrn) {
+        checkNotNull(actorCrn, "actor Crn should not be null.");
+        checkNotNull(environmentCrn, "actorCrn should not be null.");
+
+        try {
+            IdbmmsClient client = makeClient(actorCrn);
+            LOGGER.debug("Fetching IDBroker mappings for environment {} with user {}.", environmentCrn, actorCrn);
+            GetMappingsResponse mappings = client.getMappings(environmentCrn);
+            LOGGER.debug("Retrieved IDBroker mappings {} for environment {}.", mappings, environmentCrn);
+            return mappings;
+        } catch (RuntimeException e) {
+            throw new IdbmmsOperationException(String.format("Error during getting IDBroker mappings: %s", e.getMessage()), e);
+        }
+    }
+
+    IdbmmsClient makeClient(String actorCrn) {
+        return new IdbmmsClient(channelWrapper.getChannel(), idbmmsClientConfig, actorCrn);
+    }
 }

--- a/idbmms-connector/src/main/java/com/sequenceiq/cloudbreak/idbmms/IdbmmsClient.java
+++ b/idbmms-connector/src/main/java/com/sequenceiq/cloudbreak/idbmms/IdbmmsClient.java
@@ -2,12 +2,28 @@ package com.sequenceiq.cloudbreak.idbmms;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.Map;
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
 
 import com.cloudera.thunderhead.service.idbrokermappingmanagement.IdBrokerMappingManagementGrpc;
-import com.cloudera.thunderhead.service.idbrokermappingmanagement.IdBrokerMappingManagementProto;
+import com.cloudera.thunderhead.service.idbrokermappingmanagement.IdBrokerMappingManagementGrpc.IdBrokerMappingManagementBlockingStub;
+import com.cloudera.thunderhead.service.idbrokermappingmanagement.IdBrokerMappingManagementProto.DeleteMappingsRequest;
+import com.cloudera.thunderhead.service.idbrokermappingmanagement.IdBrokerMappingManagementProto.DeleteMappingsResponse;
+import com.cloudera.thunderhead.service.idbrokermappingmanagement.IdBrokerMappingManagementProto.GetMappingsConfigRequest;
+import com.cloudera.thunderhead.service.idbrokermappingmanagement.IdBrokerMappingManagementProto.GetMappingsConfigResponse;
+import com.cloudera.thunderhead.service.idbrokermappingmanagement.IdBrokerMappingManagementProto.GetMappingsRequest;
+import com.cloudera.thunderhead.service.idbrokermappingmanagement.IdBrokerMappingManagementProto.GetMappingsResponse;
+import com.cloudera.thunderhead.service.idbrokermappingmanagement.IdBrokerMappingManagementProto.SetMappingsRequest;
+import com.cloudera.thunderhead.service.idbrokermappingmanagement.IdBrokerMappingManagementProto.SetMappingsRequest.Builder;
+import com.cloudera.thunderhead.service.idbrokermappingmanagement.IdBrokerMappingManagementProto.SetMappingsResponse;
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.grpc.altus.AltusMetadataInterceptor;
+import com.sequenceiq.cloudbreak.grpc.altus.CallingServiceNameInterceptor;
+import com.sequenceiq.cloudbreak.idbmms.config.IdbmmsClientConfig;
 import com.sequenceiq.cloudbreak.idbmms.model.MappingsConfig;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.cloudbreak.logger.MDCUtils;
 
 import io.grpc.ManagedChannel;
 
@@ -27,60 +43,100 @@ class IdbmmsClient {
 
     private final String actorCrn;
 
-    IdbmmsClient(ManagedChannel channel, String actorCrn) {
+    private final IdbmmsClientConfig idbmmsClientConfig;
+
+    IdbmmsClient(ManagedChannel channel, IdbmmsClientConfig idbmmsClientConfig, String actorCrn) {
         this.channel = checkNotNull(channel, "channel should not be null.");
+        this.idbmmsClientConfig = checkNotNull(idbmmsClientConfig, "clientConfig should not be null.");
         this.actorCrn = checkNotNull(actorCrn, "actorCrn should not be null.");
+    }
+
+    private static String getOrGenerate(Optional<String> requestId) {
+        return requestId.orElse(MDCBuilder.getOrGenerateRequestId());
+    }
+
+    private IdBrokerMappingManagementBlockingStub newStub() {
+        String requestId = getOrGenerate(MDCUtils.getRequestId());
+        return IdBrokerMappingManagementGrpc.newBlockingStub(channel)
+                .withInterceptors(
+                        new AltusMetadataInterceptor(requestId, actorCrn),
+                        new CallingServiceNameInterceptor(idbmmsClientConfig.getCallingServiceName()));
     }
 
     /**
      * Wraps a call to {@code GetMappingsConfig}.
      *
-     * @param requestId      the request ID for the request; must not be {@code null}
      * @param environmentCrn the environment CRN; must not be {@code null}
      * @return the mappings config; never {@code null}
      * @throws NullPointerException if either argument is {@code null}
      */
-    MappingsConfig getMappingsConfig(String requestId, String environmentCrn) {
-        checkNotNull(requestId, "requestId should not be null.");
-        checkNotNull(environmentCrn);
-        IdBrokerMappingManagementProto.GetMappingsConfigResponse mappingsConfig = newStub(requestId).getMappingsConfig(
-                IdBrokerMappingManagementProto.GetMappingsConfigRequest.newBuilder()
-                        .setEnvironmentCrn(environmentCrn)
-                        .build()
-        );
-        long mappingsVersion = mappingsConfig.getMappingsVersion();
-        Map<String, String> actorMappings = mappingsConfig.getActorMappingsMap();
-        Map<String, String> groupMappings = mappingsConfig.getGroupMappingsMap();
-        return new MappingsConfig(mappingsVersion, actorMappings, groupMappings);
+    MappingsConfig getMappingsConfig(String environmentCrn) {
+        checkNotNull(environmentCrn, "environment Crn should not be null.");
+        GetMappingsConfigRequest request = GetMappingsConfigRequest.newBuilder()
+                .setEnvironmentCrn(environmentCrn)
+                .build();
+        GetMappingsConfigResponse mappingsConfigResponse = newStub().getMappingsConfig(request);
+        return new MappingsConfig(mappingsConfigResponse.getMappingsVersion(), mappingsConfigResponse.getActorMappingsMap(),
+                mappingsConfigResponse.getGroupMappingsMap());
     }
 
     /**
      * Wraps a call to {@code DeleteMappings}.
      *
-     * @param requestId      the request ID for the request; must not be {@code null}
      * @param environmentCrn the environment CRN; must not be {@code null}
      * @throws NullPointerException if either argument is {@code null}
+     * @return delete mappings response
      */
-    void deleteMappings(String requestId, String environmentCrn) {
-        checkNotNull(requestId, "requestId should not be null.");
-        checkNotNull(environmentCrn);
-        newStub(requestId).deleteMappings(
-                IdBrokerMappingManagementProto.DeleteMappingsRequest.newBuilder()
+    DeleteMappingsResponse deleteMappings(String environmentCrn) {
+        checkNotNull(environmentCrn, "environment Crn should not be null.");
+        DeleteMappingsRequest request = DeleteMappingsRequest.newBuilder()
                         .setEnvironmentCrn(environmentCrn)
-                        .build()
-        );
+                        .build();
+        return newStub().deleteMappings(request);
     }
 
     /**
-     * Creates a new stub with the appropriate metadata injecting interceptors.
+     * Wraps a call to {@code CreateMappings}.
      *
-     * @param requestId the request ID
-     * @return the stub
+     * @param environmentCrn             the environment CRN; must not be {@code null}
+     * @param dataAccessRole             the cloud provider role to which data access services will be mapped; must not be {@code null}
+     * @param baselineRole               the cloud provider role associated with the baseline instance identity,
+     *                                   that write to cloud storage will be mapped to this role; must not be {@code null}
+     * @param rangerAccessAuthorizerRole the cloud provider role to which the Ranger RAZ service will be mapped
+     * @return the set mappings response; never {@code null}
+     * @throws NullPointerException if either argument is {@code null}
      */
-    private IdBrokerMappingManagementGrpc.IdBrokerMappingManagementBlockingStub newStub(String requestId) {
-        checkNotNull(requestId, "requestId should not be null.");
-        return IdBrokerMappingManagementGrpc.newBlockingStub(channel)
-                .withInterceptors(new AltusMetadataInterceptor(requestId, actorCrn));
+    SetMappingsResponse setMappings(String environmentCrn, String dataAccessRole, String baselineRole, String rangerAccessAuthorizerRole) {
+        checkNotNull(environmentCrn, "environment Crn should not be null.");
+        checkNotNull(dataAccessRole, "data access role should not be null.");
+        checkNotNull(baselineRole, "baseline role should not be null.");
+
+        Builder setMappingsRequestBuilder = SetMappingsRequest.newBuilder()
+                .setBaselineRole(baselineRole)
+                .setDataAccessRole(dataAccessRole)
+                .setEnvironmentNameOrCrn(environmentCrn)
+                .setAccountId(Crn.safeFromString(environmentCrn).getAccountId());
+        if (StringUtils.isNotBlank(rangerAccessAuthorizerRole)) {
+            setMappingsRequestBuilder.setRangerCloudAccessAuthorizerRole(rangerAccessAuthorizerRole);
+        }
+        SetMappingsRequest request = setMappingsRequestBuilder.build();
+        return newStub().setMappings(request);
     }
 
+    /**
+     * Wraps a call to {@code GetMappings}.
+     *
+     * @param environmentCrn the environment CRN; must not be {@code null}
+     * @return the get mappings response; never {@code null}
+     * @throws NullPointerException if either argument is {@code null}
+     */
+    GetMappingsResponse getMappings(String environmentCrn) {
+        checkNotNull(environmentCrn, "environment Crn should not be null.");
+
+        GetMappingsRequest request = GetMappingsRequest.newBuilder()
+                .setEnvironmentNameOrCrn(environmentCrn)
+                .setAccountId(Crn.safeFromString(environmentCrn).getAccountId())
+                .build();
+        return newStub().getMappings(request);
+    }
 }

--- a/idbmms-connector/src/main/java/com/sequenceiq/cloudbreak/idbmms/config/IdbmmsChannelConfig.java
+++ b/idbmms-connector/src/main/java/com/sequenceiq/cloudbreak/idbmms/config/IdbmmsChannelConfig.java
@@ -15,7 +15,7 @@ import io.netty.util.internal.StringUtil;
  * Configuration settings for the IDBroker Mapping Management Service endpoint.
  */
 @Configuration
-public class IdbmmsConfig {
+public class IdbmmsChannelConfig {
 
     @Value("${altus.idbmms.host:}")
     private String host;
@@ -25,6 +25,10 @@ public class IdbmmsConfig {
 
     @Bean
     public ManagedChannelWrapper idbmmsManagedChannelWrapper() {
+        return newManagedChannelWrapper(host, port);
+    }
+
+    public static ManagedChannelWrapper newManagedChannelWrapper(String host, int port) {
         return new ManagedChannelWrapper(
                 ManagedChannelBuilder.forAddress(host, port)
                         .usePlaintext()
@@ -43,5 +47,4 @@ public class IdbmmsConfig {
     public boolean isConfigured() {
         return !StringUtil.isNullOrEmpty(host);
     }
-
 }

--- a/idbmms-connector/src/main/java/com/sequenceiq/cloudbreak/idbmms/config/IdbmmsClientConfig.java
+++ b/idbmms-connector/src/main/java/com/sequenceiq/cloudbreak/idbmms/config/IdbmmsClientConfig.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.cloudbreak.idbmms.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+import io.netty.util.internal.StringUtil;
+
+@Configuration
+public class IdbmmsClientConfig {
+
+    private final String callingServiceName;
+
+    @Autowired
+    public IdbmmsClientConfig(@Value("${altus.idbmms.caller:cloudbreak}") String callingServiceName) {
+        this.callingServiceName = callingServiceName;
+    }
+
+    public String getCallingServiceName() {
+        return callingServiceName;
+    }
+
+    public boolean isConfigured() {
+        return !StringUtil.isNullOrEmpty(callingServiceName);
+    }
+}

--- a/idbmms-connector/src/test/java/com/sequenceiq/cloudbreak/idbmms/config/IdbmmsChannelConfigTest.java
+++ b/idbmms-connector/src/test/java/com/sequenceiq/cloudbreak/idbmms/config/IdbmmsChannelConfigTest.java
@@ -9,10 +9,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
-class IdbmmsConfigTest {
+class IdbmmsChannelConfigTest {
 
     @InjectMocks
-    private IdbmmsConfig underTest;
+    private IdbmmsChannelConfig underTest;
 
     @Test
     void isConfiguredTestNullEndpoint() {

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -113,6 +113,9 @@ dependencies {
   implementation (project(':auth-distributor-connector')) {
     transitive = false;
   }
+  implementation (project(':idbmms-connector')) {
+    transitive = false;
+  }
 
   implementation project(':common')
   implementation project(':cloud-gcp')

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/idbmms/IdbmmsDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/idbmms/IdbmmsDeleteAction.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.it.cloudbreak.action.idbmms;
+
+import static java.lang.String.format;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.cloudera.thunderhead.service.idbrokermappingmanagement.IdBrokerMappingManagementProto.DeleteMappingsResponse;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.idbmms.IdbmmsTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+import com.sequenceiq.it.cloudbreak.microservice.IdbmmsClient;
+
+public class IdbmmsDeleteAction implements Action<IdbmmsTestDto, IdbmmsClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(IdbmmsDeleteAction.class);
+
+    @Override
+    public IdbmmsTestDto action(TestContext testContext, IdbmmsTestDto testDto, IdbmmsClient client) throws Exception {
+        String environmentCrn = testContext.get(EnvironmentTestDto.class).getCrn();
+        String actingUserCrn = testContext.getActingUser().getCrn();
+        Log.when(LOGGER, format(" Deleting IDBroker mappings from environment: %s", environmentCrn));
+        DeleteMappingsResponse deleteMappingsResponse = client.getDefaultClient()
+                .deleteMappings(actingUserCrn, environmentCrn);
+        testDto.setDeleteMappingsDetails(deleteMappingsResponse);
+        Log.when(LOGGER, format(" IDBroker mappings has been deleted with details %s! ", deleteMappingsResponse));
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/idbmms/IdbmmsGetAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/idbmms/IdbmmsGetAction.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.it.cloudbreak.action.idbmms;
+
+import static java.lang.String.format;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.cloudera.thunderhead.service.idbrokermappingmanagement.IdBrokerMappingManagementProto.GetMappingsResponse;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.idbmms.IdbmmsTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+import com.sequenceiq.it.cloudbreak.microservice.IdbmmsClient;
+
+public class IdbmmsGetAction implements Action<IdbmmsTestDto, IdbmmsClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(IdbmmsGetAction.class);
+
+    @Override
+    public IdbmmsTestDto action(TestContext testContext, IdbmmsTestDto testDto, IdbmmsClient client) throws Exception {
+        String environmentCrn = testContext.get(EnvironmentTestDto.class).getCrn();
+        String actingUserCrn = testContext.getActingUser().getCrn();
+        Log.when(LOGGER, format(" Getting IDBroker mappings from environment '%s'. ", environmentCrn));
+        GetMappingsResponse getMappingsResponse = client.getDefaultClient()
+                .getMappings(actingUserCrn, environmentCrn);
+        testDto.setMappingsDetails(getMappingsResponse);
+        LOGGER.info(format(" IDBroker mappings has been set with Ranger Audit: '%s', Data Access: '%s' " +
+                        "and Ranger Cloud Access Authorizer: '%s' roles at environment '%s'. ", getMappingsResponse.getBaselineRole(),
+                getMappingsResponse.getDataAccessRole(), getMappingsResponse.getRangerCloudAccessAuthorizerRole(),
+                environmentCrn));
+        Log.when(LOGGER, format(" IDBroker mappings has been set with Ranger Audit: '%s', Data Access: '%s' " +
+                        "and Ranger Cloud Access Authorizer: '%s' roles at environment '%s'. ", getMappingsResponse.getBaselineRole(),
+                getMappingsResponse.getDataAccessRole(), getMappingsResponse.getRangerCloudAccessAuthorizerRole(),
+                environmentCrn));
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/idbmms/IdbmmsSetAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/idbmms/IdbmmsSetAction.java
@@ -1,0 +1,49 @@
+package com.sequenceiq.it.cloudbreak.action.idbmms;
+
+import static java.lang.String.format;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.cloudera.thunderhead.service.idbrokermappingmanagement.IdBrokerMappingManagementProto.SetMappingsResponse;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.idbmms.IdbmmsTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+import com.sequenceiq.it.cloudbreak.microservice.IdbmmsClient;
+
+public class IdbmmsSetAction implements Action<IdbmmsTestDto, IdbmmsClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(IdbmmsSetAction.class);
+
+    private final String dataAccessRole;
+
+    private final String baselineRole;
+
+    private final String rangerAccessAuthorizerRole;
+
+    public IdbmmsSetAction(String dataAccessRole, String baselineRole, String rangerAccessAuthorizerRole) {
+        this.dataAccessRole = dataAccessRole;
+        this.baselineRole = baselineRole;
+        this.rangerAccessAuthorizerRole = rangerAccessAuthorizerRole;
+    }
+
+    @Override
+    public IdbmmsTestDto action(TestContext testContext, IdbmmsTestDto testDto, IdbmmsClient client) throws Exception {
+        String environmentCrn = testContext.get(EnvironmentTestDto.class).getCrn();
+        String actingUserCrn = testContext.getActingUser().getCrn();
+        Log.when(LOGGER, format(" Setting IDBroker mappings to environment '%s' with Data Access Role '%s', Baseline Role '%s' " +
+                        "and Ranger Cloud Access Authorizer Role '%s'. ", environmentCrn, dataAccessRole, baselineRole, rangerAccessAuthorizerRole));
+        SetMappingsResponse setMappingsResponse = client.getDefaultClient()
+                .setMappings(actingUserCrn, environmentCrn, dataAccessRole, baselineRole, rangerAccessAuthorizerRole);
+        testDto.setResponse(setMappingsResponse);
+        LOGGER.info(format(" IDBroker mappings has been set with Ranger Audit: '%s', Data Access: '%s' roles " +
+                        "and Ranger Cloud Access Authorizer Role '%s'. ", testDto.getResponse().getBaselineRole(), testDto.getResponse().getDataAccessRole(),
+                testDto.getResponse().getRangerCloudAccessAuthorizerRole()));
+        Log.when(LOGGER, format(" IDBroker mappings has been set with Ranger Audit: '%s', Data Access: '%s' roles " +
+                        "and Ranger Cloud Access Authorizer Role '%s'. ", testDto.getResponse().getBaselineRole(), testDto.getResponse().getDataAccessRole(),
+                testDto.getResponse().getRangerCloudAccessAuthorizerRole()));
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/IdbmmsTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/IdbmmsTestClient.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.it.cloudbreak.client;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.action.idbmms.IdbmmsDeleteAction;
+import com.sequenceiq.it.cloudbreak.action.idbmms.IdbmmsGetAction;
+import com.sequenceiq.it.cloudbreak.action.idbmms.IdbmmsSetAction;
+import com.sequenceiq.it.cloudbreak.dto.idbmms.IdbmmsTestDto;
+import com.sequenceiq.it.cloudbreak.microservice.IdbmmsClient;
+
+@Service
+public class IdbmmsTestClient {
+
+    public Action<IdbmmsTestDto, IdbmmsClient> set(String dataAccessRole, String baselineRole, String rangerAccessAuthorizerRole) {
+        return new IdbmmsSetAction(dataAccessRole, baselineRole, rangerAccessAuthorizerRole);
+    }
+
+    public Action<IdbmmsTestDto, IdbmmsClient> delete() {
+        return new IdbmmsDeleteAction();
+    }
+
+    public Action<IdbmmsTestDto, IdbmmsClient> get() {
+        return new IdbmmsGetAction();
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProvider.java
@@ -124,6 +124,12 @@ public interface CloudProvider {
 
     SdxCloudStorageTestDto cloudStorage(SdxCloudStorageTestDto cloudStorage);
 
+    String getDataAccessRole();
+
+    String getRangerAuditRole();
+
+    String rangerAccessAuthorizerRole();
+
     FileSystemType getFileSystemType();
 
     String getBaseLocation();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProviderProxy.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProviderProxy.java
@@ -184,6 +184,21 @@ public class CloudProviderProxy implements CloudProvider {
     }
 
     @Override
+    public String getRangerAuditRole() {
+        return delegate.getRangerAuditRole();
+    }
+
+    @Override
+    public String getDataAccessRole() {
+        return delegate.getDataAccessRole();
+    }
+
+    @Override
+    public String rangerAccessAuthorizerRole() {
+        return delegate.rangerAccessAuthorizerRole();
+    }
+
+    @Override
     public FileSystemType getFileSystemType() {
         return delegate.getFileSystemType();
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProvider.java
@@ -395,6 +395,21 @@ public class AwsCloudProvider extends AbstractCloudProvider {
     }
 
     @Override
+    public String getRangerAuditRole() {
+        return awsProperties.getCloudStorage().getRangerAuditRole();
+    }
+
+    @Override
+    public String getDataAccessRole() {
+        return awsProperties.getCloudStorage().getDataAccessRole();
+    }
+
+    @Override
+    public String rangerAccessAuthorizerRole() {
+        return awsProperties.getCloudStorage().getRangerAccessAuthorizerRole();
+    }
+
+    @Override
     public ImageSettingsTestDto imageSettings(ImageSettingsTestDto imageSettings) {
         return imageSettings
                 .withImageId(awsProperties.getBaseimage().getImageId())

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsProperties.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsProperties.java
@@ -283,6 +283,12 @@ public class AwsProperties {
 
         private String fileSystemType;
 
+        private String dataAccessRole;
+
+        private String rangerAuditRole;
+
+        private String rangerAccessAuthorizerRole;
+
         public S3 getS3() {
             return s3;
         }
@@ -301,6 +307,30 @@ public class AwsProperties {
 
         public void setFileSystemType(String fileSystemType) {
             this.fileSystemType = fileSystemType;
+        }
+
+        public String getDataAccessRole() {
+            return dataAccessRole;
+        }
+
+        public void setDataAccessRole(String dataAccessRole) {
+            this.dataAccessRole = dataAccessRole;
+        }
+
+        public String getRangerAuditRole() {
+            return rangerAuditRole;
+        }
+
+        public void setRangerAuditRole(String rangerAuditRole) {
+            this.rangerAuditRole = rangerAuditRole;
+        }
+
+        public String getRangerAccessAuthorizerRole() {
+            return rangerAccessAuthorizerRole;
+        }
+
+        public void setRangerAccessAuthorizerRole(String rangerAccessAuthorizerRole) {
+            this.rangerAccessAuthorizerRole = rangerAccessAuthorizerRole;
         }
 
         public static class S3 {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
@@ -411,6 +411,21 @@ public class AzureCloudProvider extends AbstractCloudProvider {
     }
 
     @Override
+    public String getRangerAuditRole() {
+        return azureProperties.getCloudStorage().getRangerAuditRole();
+    }
+
+    @Override
+    public String getDataAccessRole() {
+        return azureProperties.getCloudStorage().getDataAccessRole();
+    }
+
+    @Override
+    public String rangerAccessAuthorizerRole() {
+        return azureProperties.getCloudStorage().getRangerAccessAuthorizerRole();
+    }
+
+    @Override
     public ImageSettingsTestDto imageSettings(ImageSettingsTestDto imageSettings) {
         return imageSettings
                 .withImageId(azureProperties.getBaseimage().getImageId())

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureProperties.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureProperties.java
@@ -242,6 +242,12 @@ public class AzureProperties {
 
         private Integer zeroBlobLengthToleration = 5;
 
+        private String dataAccessRole;
+
+        private String rangerAuditRole;
+
+        private String rangerAccessAuthorizerRole;
+
         public String getAccountKey() {
             return accountKey;
         }
@@ -292,6 +298,30 @@ public class AzureProperties {
 
         public void setZeroBlobLengthToleration(Integer zeroBlobLengthToleration) {
             this.zeroBlobLengthToleration = zeroBlobLengthToleration;
+        }
+
+        public String getDataAccessRole() {
+            return dataAccessRole;
+        }
+
+        public void setDataAccessRole(String dataAccessRole) {
+            this.dataAccessRole = dataAccessRole;
+        }
+
+        public String getRangerAuditRole() {
+            return rangerAuditRole;
+        }
+
+        public void setRangerAuditRole(String rangerAuditRole) {
+            this.rangerAuditRole = rangerAuditRole;
+        }
+
+        public String getRangerAccessAuthorizerRole() {
+            return rangerAccessAuthorizerRole;
+        }
+
+        public void setRangerAccessAuthorizerRole(String rangerAccessAuthorizerRole) {
+            this.rangerAccessAuthorizerRole = rangerAccessAuthorizerRole;
         }
 
         public static class AdlsGen2 {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpCloudProvider.java
@@ -445,6 +445,21 @@ public class GcpCloudProvider extends AbstractCloudProvider {
     }
 
     @Override
+    public String getRangerAuditRole() {
+        return gcpProperties.getCloudStorage().getRangerAuditRole();
+    }
+
+    @Override
+    public String getDataAccessRole() {
+        return gcpProperties.getCloudStorage().getDataAccessRole();
+    }
+
+    @Override
+    public String rangerAccessAuthorizerRole() {
+        return gcpProperties.getCloudStorage().getRangerAccessAuthorizerRole();
+    }
+
+    @Override
     public ImageSettingsTestDto imageSettings(ImageSettingsTestDto imageSettings) {
         return imageSettings
                 .withImageId(gcpProperties.getBaseimage().getImageId())

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpProperties.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpProperties.java
@@ -367,6 +367,12 @@ public class GcpProperties {
 
         private String fileSystemType;
 
+        private String dataAccessRole;
+
+        private String rangerAuditRole;
+
+        private String rangerAccessAuthorizerRole;
+
         public Gcs getGcs() {
             return gcs;
         }
@@ -385,6 +391,30 @@ public class GcpProperties {
 
         public void setFileSystemType(String fileSystemType) {
             this.fileSystemType = fileSystemType;
+        }
+
+        public String getDataAccessRole() {
+            return dataAccessRole;
+        }
+
+        public void setDataAccessRole(String dataAccessRole) {
+            this.dataAccessRole = dataAccessRole;
+        }
+
+        public String getRangerAuditRole() {
+            return rangerAuditRole;
+        }
+
+        public void setRangerAuditRole(String rangerAuditRole) {
+            this.rangerAuditRole = rangerAuditRole;
+        }
+
+        public String getRangerAccessAuthorizerRole() {
+            return rangerAccessAuthorizerRole;
+        }
+
+        public void setRangerAccessAuthorizerRole(String rangerAccessAuthorizerRole) {
+            this.rangerAccessAuthorizerRole = rangerAccessAuthorizerRole;
         }
 
         public static class Gcs {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/mock/MockCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/mock/MockCloudProvider.java
@@ -440,6 +440,21 @@ public class MockCloudProvider extends AbstractCloudProvider {
         return mockProperties.getCloudStorage().getS3().getInstanceProfile();
     }
 
+    @Override
+    public String getRangerAuditRole() {
+        return mockProperties.getCloudStorage().getRangerAuditRole();
+    }
+
+    @Override
+    public String getDataAccessRole() {
+        return mockProperties.getCloudStorage().getDataAccessRole();
+    }
+
+    @Override
+    public String rangerAccessAuthorizerRole() {
+        return mockProperties.getCloudStorage().getRangerAccessAuthorizerRole();
+    }
+
     private MockNetworkV1Parameters distroXNetworkParameters() {
         MockNetworkV1Parameters params = new MockNetworkV1Parameters();
         params.setSubnetId(getSubnetId());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/mock/MockProperties.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/mock/MockProperties.java
@@ -311,6 +311,12 @@ public class MockProperties {
 
         private String fileSystemType;
 
+        private String dataAccessRole;
+
+        private String rangerAuditRole;
+
+        private String rangerAccessAuthorizerRole;
+
         public S3 getS3() {
             return s3;
         }
@@ -329,6 +335,30 @@ public class MockProperties {
 
         public void setFileSystemType(String fileSystemType) {
             this.fileSystemType = fileSystemType;
+        }
+
+        public String getDataAccessRole() {
+            return dataAccessRole;
+        }
+
+        public void setDataAccessRole(String dataAccessRole) {
+            this.dataAccessRole = dataAccessRole;
+        }
+
+        public String getRangerAuditRole() {
+            return rangerAuditRole;
+        }
+
+        public void setRangerAuditRole(String rangerAuditRole) {
+            this.rangerAuditRole = rangerAuditRole;
+        }
+
+        public String getRangerAccessAuthorizerRole() {
+            return rangerAccessAuthorizerRole;
+        }
+
+        public void setRangerAccessAuthorizerRole(String rangerAccessAuthorizerRole) {
+            this.rangerAccessAuthorizerRole = rangerAccessAuthorizerRole;
         }
 
         public static class S3 {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/yarn/YarnCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/yarn/YarnCloudProvider.java
@@ -348,6 +348,21 @@ public class YarnCloudProvider extends AbstractCloudProvider {
     }
 
     @Override
+    public String getRangerAuditRole() {
+        return null;
+    }
+
+    @Override
+    public String getDataAccessRole() {
+        return null;
+    }
+
+    @Override
+    public String rangerAccessAuthorizerRole() {
+        return null;
+    }
+
+    @Override
     public EnvironmentTestDto withResourceEncryption(EnvironmentTestDto environmentTestDto) {
         return environmentTestDto;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
@@ -96,13 +96,15 @@ public class EnvironmentTestDto
 
     @Override
     public EnvironmentTestDto valid() {
+        IdBrokerMappingSource idBrokerMappingSource =
+                getCloudPlatform().equalsIgnoreCase("MOCK") ? IdBrokerMappingSource.MOCK : IdBrokerMappingSource.IDBMMS;
         return getCloudProvider()
                 .environment(withName(getResourcePropertyProvider().getEnvironmentName(getCloudPlatform()))
                         .withDescription(getResourcePropertyProvider().getDescription("environment")))
                 .withCredentialName(getTestContext().get(CredentialTestDto.class).getName())
                 .withAuthentication(getTestContext().given(EnvironmentAuthenticationTestDto.class))
                 .withCloudplatform(getCloudPlatform().toString())
-                .withIdBrokerMappingSource(IdBrokerMappingSource.MOCK)
+                .withIdBrokerMappingSource(idBrokerMappingSource)
                 .withResourceGroup(getResourceGroupUsage(), getResourceGroupName())
                 .withNetwork()
                 .withCloudStorageValidation(CloudStorageValidation.ENABLED)
@@ -153,8 +155,13 @@ public class EnvironmentTestDto
         return this;
     }
 
-    public EnvironmentTestDto withMockIDBMS() {
+    public EnvironmentTestDto withMockIdBrokerMappingSource() {
         getRequest().setIdBrokerMappingSource(IdBrokerMappingSource.MOCK);
+        return this;
+    }
+
+    public EnvironmentTestDto withIdBrokerMappingSource() {
+        getRequest().setIdBrokerMappingSource(IdBrokerMappingSource.IDBMMS);
         return this;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/idbmms/IdbmmsTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/idbmms/IdbmmsTestDto.java
@@ -1,0 +1,107 @@
+package com.sequenceiq.it.cloudbreak.dto.idbmms;
+
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.emptyRunningParameter;
+
+import javax.ws.rs.NotFoundException;
+
+import com.cloudera.thunderhead.service.idbrokermappingmanagement.IdBrokerMappingManagementProto.DeleteMappingsResponse;
+import com.cloudera.thunderhead.service.idbrokermappingmanagement.IdBrokerMappingManagementProto.GetMappingsResponse;
+import com.cloudera.thunderhead.service.idbrokermappingmanagement.IdBrokerMappingManagementProto.SetMappingsRequest;
+import com.cloudera.thunderhead.service.idbrokermappingmanagement.IdBrokerMappingManagementProto.SetMappingsResponse;
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
+import com.sequenceiq.it.cloudbreak.Prototype;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.assertion.Assertion;
+import com.sequenceiq.it.cloudbreak.context.RunningParameter;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractTestDto;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.microservice.IdbmmsClient;
+
+@Prototype
+public class IdbmmsTestDto extends AbstractTestDto<SetMappingsRequest, SetMappingsResponse,
+        IdbmmsTestDto, IdbmmsClient> {
+
+    private String crn;
+
+    private GetMappingsResponse getMappingsResponse;
+
+    private DeleteMappingsResponse deleteMappingsResponse;
+
+    public IdbmmsTestDto(SetMappingsRequest request, TestContext testContext) {
+        super(request, testContext);
+    }
+
+    public IdbmmsTestDto(TestContext testContext) {
+        super(SetMappingsRequest.newBuilder().build(), testContext);
+    }
+
+    @Override
+    public IdbmmsTestDto valid() {
+        String environmentCrn = getTestContext().get(EnvironmentTestDto.class).getCrn();
+        SetMappingsRequest request = defaultRequest(environmentCrn);
+        setRequest(request);
+        return this;
+    }
+
+    private SetMappingsRequest defaultRequest(String environmentCrn) {
+        SetMappingsRequest request = SetMappingsRequest.newBuilder()
+                .setAccountId(Crn.safeFromString(environmentCrn).getAccountId())
+                .setEnvironmentNameOrCrn(environmentCrn)
+                .setDataAccessRole(getCloudProvider().getDataAccessRole())
+                .setBaselineRole(getCloudProvider().getRangerAuditRole())
+                .build();
+        return request;
+    }
+
+    @Override
+    public String getCrn() {
+        return crn;
+    }
+
+    public IdbmmsTestDto withCrn(String crn) {
+        this.crn = crn;
+        return this;
+    }
+
+    public void setDeleteMappingsDetails(DeleteMappingsResponse deleteMappingsResponse) {
+        this.deleteMappingsResponse = deleteMappingsResponse;
+    }
+
+    public DeleteMappingsResponse getDeleteMappingsDetails() {
+        return deleteMappingsResponse;
+    }
+
+    public void setMappingsDetails(GetMappingsResponse getMappingsResponse) {
+        this.getMappingsResponse = getMappingsResponse;
+    }
+
+    public GetMappingsResponse getMappingsDetails() {
+        return getMappingsResponse;
+    }
+
+    @Override
+    public IdbmmsTestDto when(Action<IdbmmsTestDto, IdbmmsClient> action) {
+        return getTestContext().when(this, IdbmmsClient.class, action, emptyRunningParameter());
+    }
+
+    @Override
+    public IdbmmsTestDto then(Assertion<IdbmmsTestDto, IdbmmsClient> assertion) {
+        return then(assertion, emptyRunningParameter());
+    }
+
+    @Override
+    public IdbmmsTestDto then(Assertion<IdbmmsTestDto, IdbmmsClient> assertion, RunningParameter runningParameter) {
+        return getTestContext().then(this, IdbmmsClient.class, assertion, runningParameter);
+    }
+
+    @Override
+    public void deleteForCleanup() {
+        try {
+            String environmentCrn = getTestContext().get(EnvironmentTestDto.class).getCrn();
+            getClientForCleanup().getDefaultClient().deleteMappings(getTestContext().getActingUser().getCrn(), environmentCrn);
+        } catch (NotFoundException nfe) {
+            LOGGER.info("IDBMMS resource not found, thus cleanup not needed.");
+        }
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/microservice/IdbmmsClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/microservice/IdbmmsClient.java
@@ -1,0 +1,51 @@
+package com.sequenceiq.it.cloudbreak.microservice;
+
+import java.util.Set;
+
+import com.sequenceiq.cloudbreak.idbmms.GrpcIdbmmsClient;
+import com.sequenceiq.cloudbreak.idbmms.config.IdbmmsChannelConfig;
+import com.sequenceiq.cloudbreak.idbmms.config.IdbmmsClientConfig;
+import com.sequenceiq.flow.api.FlowPublicEndpoint;
+import com.sequenceiq.it.cloudbreak.dto.idbmms.IdbmmsTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.it.cloudbreak.util.wait.service.WaitObject;
+import com.sequenceiq.it.cloudbreak.util.wait.service.WaitService;
+
+public class IdbmmsClient<E extends Enum<E>, W extends WaitObject> extends MicroserviceClient<GrpcIdbmmsClient, Void, E, W> {
+
+    private GrpcIdbmmsClient idbmmsClient;
+
+    @Override
+    public FlowPublicEndpoint flowPublicEndpoint() {
+        throw new TestFailException("Flow does not support by idbmms client");
+    }
+
+    @Override
+    public <T extends WaitObject> WaitService<T> waiterService() {
+        throw new TestFailException("Wait service does not support by idbmms client");
+    }
+
+    @Override
+    public GrpcIdbmmsClient getDefaultClient() {
+        return idbmmsClient;
+    }
+
+    /**
+     * Creates the IDBroker mapping client for test project.
+     *
+     * @param idbmmsHost    IDBroker Mapping service host
+     * @param idbmmsPort    IDBroker Mapping service port
+     * @return a connected IdbmmsClient
+     */
+    public static synchronized IdbmmsClient createIdbmmsClient(String idbmmsHost, int idbmmsPort) {
+        IdbmmsClient clientEntity = new IdbmmsClient();
+        clientEntity.idbmmsClient = GrpcIdbmmsClient.createClient(
+                IdbmmsChannelConfig.newManagedChannelWrapper(idbmmsHost, idbmmsPort), new IdbmmsClientConfig("cloudbreak"));
+        return clientEntity;
+    }
+
+    @Override
+    public Set<String> supportedTestDtos() {
+        return Set.of(IdbmmsTestDto.class.getSimpleName());
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXEncryptedVolumeTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXEncryptedVolumeTest.java
@@ -178,6 +178,11 @@ public class DistroXEncryptedVolumeTest extends AbstractE2ETest {
                 .then(this::verifyEnvironmentResponseDiskEncryptionKey)
                 .given(FreeIpaTestDto.class)
                 .then(this::verifyFreeIpaVolumeEncryptionKey)
+                .validate();
+
+        createIDBrokerMappings(testContext);
+
+        testContext
                 .given(SdxTestDto.class)
                     .withCloudStorage()
                     .withEnableMultiAz()
@@ -256,6 +261,11 @@ public class DistroXEncryptedVolumeTest extends AbstractE2ETest {
                 .then(this::verifyEnvironmentResponseDiskEncryptionKey)
                 .given(FreeIpaTestDto.class)
                 .then(this::verifyFreeIpaVolumeEncryptionKey)
+                .validate();
+
+        createIDBrokerMappings(testContext);
+
+        testContext
                 .given(SdxTestDto.class)
                     .withCloudStorage()
                 .when(sdxTestClient.create())

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/EnvironmentStopStartTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/EnvironmentStopStartTests.java
@@ -155,6 +155,11 @@ public class EnvironmentStopStartTests extends AbstractE2ETest {
                     .addTags(ENV_TAGS)
                 .when(environmentTestClient.create())
                 .then(this::getTelemetryStorageLocation)
+                .validate();
+
+        createIDBrokerMappings(testContext);
+
+        testContext
                 .given(SdxInternalTestDto.class)
                     .withTelemetry("telemetry")
                 .addTags(SDX_TAGS)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/NewNetworkWithNoInternetEnvironmentTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/NewNetworkWithNoInternetEnvironmentTests.java
@@ -85,11 +85,14 @@ public class NewNetworkWithNoInternetEnvironmentTests extends AbstractE2ETest {
                 .await(EnvironmentStatus.AVAILABLE)
                 .then((tc, testDto, cc) -> environmentTestClient.describe().action(tc, testDto, cc))
                 .then(EnvironmentNetworkTestAssertion.environmentContainsNeccessaryConfigs())
-
                 .init(FreeIpaTestDto.class)
                 .when(freeIpaTestClient.describe())
                 .then((tc, testDto, client) -> sshJClientActions.checkNoOutboundInternetTraffic(testDto, client))
+                .validate();
 
+        createIDBrokerMappings(testContext);
+
+        testContext
                 .given(sdx, SdxTestDto.class)
                 .withExternalDatabase(database)
                 .withCloudStorage()

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/MonitoringTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/MonitoringTests.java
@@ -6,6 +6,8 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.testng.annotations.Test;
 
@@ -17,6 +19,7 @@ import com.sequenceiq.freeipa.api.v1.operation.model.OperationState;
 import com.sequenceiq.it.cloudbreak.client.DistroXTestClient;
 import com.sequenceiq.it.cloudbreak.client.EnvironmentTestClient;
 import com.sequenceiq.it.cloudbreak.client.FreeIpaTestClient;
+import com.sequenceiq.it.cloudbreak.client.IdbmmsTestClient;
 import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
@@ -25,6 +28,7 @@ import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentNetworkTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaUserSyncTestDto;
+import com.sequenceiq.it.cloudbreak.dto.idbmms.IdbmmsTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.dto.telemetry.TelemetryTestDto;
 import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
@@ -36,8 +40,13 @@ import com.sequenceiq.sdx.api.model.SdxDatabaseRequest;
 
 public class MonitoringTests extends AbstractE2ETest {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(MonitoringTests.class);
+
     @Inject
     private EnvironmentTestClient environmentTestClient;
+
+    @Inject
+    private IdbmmsTestClient idbmmsTestClient;
 
     @Inject
     private SdxTestClient sdxTestClient;
@@ -99,6 +108,19 @@ public class MonitoringTests extends AbstractE2ETest {
                 .given(EnvironmentTestDto.class)
                 .when(environmentTestClient.describe())
                 .validate();
+
+        testContext
+                .given("idbmms-mapping", IdbmmsTestDto.class)
+                .when(idbmmsTestClient.set(testContext.getCloudProvider().getDataAccessRole(), testContext.getCloudProvider().getRangerAuditRole(), null))
+                .when(idbmmsTestClient.get())
+                .then((tc, testDto, client) -> {
+                    LOGGER.info("IDBMMS version: {}", testDto.getMappingsDetails().getMappingsVersion());
+                    LOGGER.info("IDBMMS actor and group mappings: {}", testDto.getMappingsDetails().getMappingsMap());
+                    LOGGER.info("IDBMMS Data Access role: {}", testDto.getMappingsDetails().getDataAccessRole());
+                    LOGGER.info("IDBMMS Data Access role: {}", testDto.getMappingsDetails().getBaselineRole());
+                    return testDto;
+                })
+                .validate();
     }
 
     @Test(dataProvider = TEST_CONTEXT)
@@ -147,6 +169,11 @@ public class MonitoringTests extends AbstractE2ETest {
                 })
                 .given(EnvironmentTestDto.class)
                 .when(environmentTestClient.describe())
+                .validate();
+
+        createIDBrokerMappings(testContext);
+
+        testContext
                 .given(SdxInternalTestDto.class)
                     .withEnvironment()
                     .withDatabase(sdxDatabaseRequest)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/PreconditionSdxE2ETest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/PreconditionSdxE2ETest.java
@@ -30,6 +30,14 @@ public class PreconditionSdxE2ETest extends AbstractE2ETest {
         createEnvironmentWithFreeIpa(testContext);
     }
 
+    protected void createEnvironmentForRAZEnabledSdx(TestContext testContext) {
+        createResourceGroup(testContext);
+        initiateEnvironmentCreation(testContext);
+        waitForEnvironmentCreation(testContext);
+        waitForUserSync(testContext);
+        createIDBrokerMappingsWithRAZ(testContext);
+    }
+
     protected SdxTestClient sdxTestClient() {
         return sdxTestClient;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxRangerRazEnabledTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxRangerRazEnabledTests.java
@@ -22,6 +22,14 @@ public class SdxRangerRazEnabledTests extends PreconditionSdxE2ETest {
     @Inject
     private SdxTestClient sdxTestClient;
 
+    @Override
+    protected void setupTest(TestContext testContext) {
+        testContext.getCloudProvider().getCloudFunctionality().cloudStorageInitialize();
+        createDefaultUser(testContext);
+        initializeDefaultBlueprints(testContext);
+        createDefaultCredential(testContext);
+    }
+
     @Test(dataProvider = TEST_CONTEXT)
     @Description(
             given = "there is a running Cloudbreak",
@@ -32,6 +40,8 @@ public class SdxRangerRazEnabledTests extends PreconditionSdxE2ETest {
         String sdx = resourcePropertyProvider().getName();
         SdxDatabaseRequest sdxDatabaseRequest = new SdxDatabaseRequest();
         sdxDatabaseRequest.setAvailabilityType(SdxDatabaseAvailabilityType.NONE);
+
+        createEnvironmentWithFreeIpa(testContext);
 
         testContext
                 .given(SdxTestDto.class)
@@ -54,6 +64,8 @@ public class SdxRangerRazEnabledTests extends PreconditionSdxE2ETest {
         String sdx = resourcePropertyProvider().getName();
         SdxDatabaseRequest sdxDatabaseRequest = new SdxDatabaseRequest();
         sdxDatabaseRequest.setAvailabilityType(SdxDatabaseAvailabilityType.NONE);
+
+        createEnvironmentForRAZEnabledSdx(testContext);
 
         testContext
                 .given(SdxTestDto.class)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXClusterCreationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXClusterCreationTest.java
@@ -208,7 +208,7 @@ public class DistroXClusterCreationTest extends AbstractClouderaManagerTest {
                 .withNetwork()
                 .withTelemetry(telemetry())
                 .withCreateFreeIpa(Boolean.FALSE)
-                .withMockIDBMS()
+                .withMockIdBrokerMappingSource()
                 .when(getEnvironmentTestClient().create(), key(storageEnvKey))
                 .await(EnvironmentStatus.AVAILABLE)
                 .when(getEnvironmentTestClient().describe(), key(storageEnvKey))

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentDatalakeClusterTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentDatalakeClusterTest.java
@@ -140,6 +140,7 @@ public class EnvironmentDatalakeClusterTest extends AbstractMockTest {
         String rangerdb = resourcePropertyProvider().getName();
         Set<String> rdsList = createDatalakeResources(testContext, hivedb, rangerdb);
         testContext.given(EnvironmentTestDto.class)
+                .withMockIdBrokerMappingSource()
                 .when(environmentTestClient.create())
                 .given("placement", PlacementSettingsTestDto.class)
                 .given(StackTestDto.class)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentStartStopTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentStartStopTest.java
@@ -83,7 +83,9 @@ public class EnvironmentStartStopTest extends AbstractMockTest {
     public void testCreateEnvironment(MockedTestContext testContext) {
         testContext
                 .given(EnvironmentNetworkTestDto.class)
-                .given(EnvironmentTestDto.class).withNetwork().withCreateFreeIpa(false)
+                .given(EnvironmentTestDto.class)
+                .withNetwork()
+                .withCreateFreeIpa(false)
                 .when(environmentTestClient.create())
                 .await(EnvironmentStatus.AVAILABLE)
                 .given(FreeIpaTestDto.class)
@@ -111,7 +113,9 @@ public class EnvironmentStartStopTest extends AbstractMockTest {
     public void testCreateStopStartEnvironment(MockedTestContext testContext) {
         testContext
                 .given(EnvironmentNetworkTestDto.class)
-                .given(EnvironmentTestDto.class).withNetwork().withCreateFreeIpa(false)
+                .given(EnvironmentTestDto.class)
+                .withNetwork()
+                .withCreateFreeIpa(false)
                 .when(environmentTestClient.create())
                 .await(EnvironmentStatus.AVAILABLE)
                 .given(FreeIpaTestDto.class)
@@ -180,7 +184,9 @@ public class EnvironmentStartStopTest extends AbstractMockTest {
     public void testStopStartEnvironmentWithStopFailed(MockedTestContext testContext) {
         testContext
                 .given(EnvironmentNetworkTestDto.class)
-                .given(EnvironmentTestDto.class).withNetwork().withCreateFreeIpa(false)
+                .given(EnvironmentTestDto.class)
+                .withNetwork()
+                .withCreateFreeIpa(false)
                 .when(environmentTestClient.create())
                 .await(EnvironmentStatus.AVAILABLE)
                 .given(FreeIpaTestDto.class)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/UsedImagesTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/UsedImagesTest.java
@@ -89,7 +89,6 @@ public class UsedImagesTest extends AbstractMockTest {
                 .when(environmentTestClient.create())
                 .await(EnvironmentStatus.AVAILABLE)
                 .when(environmentTestClient.describe())
-
                 .given(FreeIpaTestDto.class)
                     .withCatalog(getImageCatalogMockServerSetup().getFreeIpaImageCatalogUrlWitdDefaultImageUuid(freeipaImageUuid))
                 .when(freeIpaTestClient.create())

--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -37,6 +37,11 @@ integrationtest:
     server: http://localhost
   redbeams:
     server: http://localhost
+
+  idbmms:
+    host: localhost
+    port: 8990
+
   ums:
     host: ums.thunderhead-dev.cloudera.com
     port: 8982
@@ -158,6 +163,9 @@ integrationtest:
         instanceProfile:
       baseLocation:
       fileSystemType: S3
+      dataAccessRole:
+      rangerAuditRole:
+      rangerAccessAuthorizerRole:
     hybridCloudSecurityGroupID: sg-0c73a7f815c452e9d
     freeipa:
       upgrade:
@@ -220,6 +228,9 @@ integrationtest:
         assumerIdentity:
         loggerIdentity:
       secure: false
+      dataAccessRole:
+      rangerAuditRole:
+      rangerAccessAuthorizerRole:
     resourcegroup:
       usage: SINGLE_WITH_DEDICATED_STORAGE_ACCOUNT
       name: cb-e2e-westus2-tmp
@@ -285,6 +296,9 @@ integrationtest:
       fileSystemType: GCS
       gcs:
         serviceAccountEmail:
+      dataAccessRole:
+      rangerAuditRole:
+      rangerAccessAuthorizerRole:
     freeipa:
       upgrade:
         imageId: bbc059cd-d7c7-4938-bb34-5c7fc09f1204
@@ -351,6 +365,9 @@ integrationtest:
         instanceProfile: "arn:aws:iam::1234567890:instance-profile/mock.testing.instance.profile"
       baseLocation: "s3a://mock-test"
       fileSystemType: S3
+      dataAccessRole:
+      rangerAuditRole:
+      rangerAccessAuthorizerRole:
     diskEncryption:
       environmentKey:
       datahubKey:


### PR DESCRIPTION
This is a tech debt task. Mock IDBroker has caused multiple production down issues. We shall remove it from CB, based on the [EPIC CB-11728](https://jira.cloudera.com/browse/CB-11728)