### PR TITLE
CB-18418 fix gcp-longrunning-e2e-tests.yaml indentation

### DIFF
--- a/integration-test/src/main/resources/testsuites/e2e/gcp-longrunning-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/gcp-longrunning-e2e-tests.yaml
@@ -6,5 +6,5 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxUpgradeRecoveryTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.freeipa.FreeIpaUpgradeTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRepairTests
-          excludedMethods:
-            - testSDXMediumDutyCreation
+        excludedMethods:
+          - testSDXMediumDutyCreation


### PR DESCRIPTION
CB-18418 fix gcp-longrunning-e2e-tests.yaml indentation
