### PR TITLE
CB-18989 Fix provisioning of multiple LB per stack with native

### DIFF
--- a/cloud-aws-native/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/metadata/AwsNativeLbMetadataCollector.java
+++ b/cloud-aws-native/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/metadata/AwsNativeLbMetadataCollector.java
@@ -49,7 +49,7 @@ public class AwsNativeLbMetadataCollector {
                     .map(CloudResource::getReference)
                     .findFirst().orElse(null);
 
-                LOGGER.debug("Found target group ARN {} and listern ARN {} associated with load balancer {}, port {}",
+                LOGGER.debug("Found target group ARN {} and listener ARN {} associated with load balancer {}, port {}",
                     targetGroupArn, listenerArn, loadBalancerArn, port);
                 targetGroupParameters.put(AwsLoadBalancerMetadataView.getTargetGroupParam(port.get()), targetGroupArn);
                 targetGroupParameters.put(AwsLoadBalancerMetadataView.getListenerParam(port.get()), listenerArn);

--- a/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/resource/loadbalancer/AwsNativeLoadBalancerLaunchServiceTest.java
+++ b/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/resource/loadbalancer/AwsNativeLoadBalancerLaunchServiceTest.java
@@ -7,7 +7,6 @@ import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -17,12 +16,13 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
@@ -49,6 +49,7 @@ import com.sequenceiq.cloudbreak.cloud.aws.common.loadbalancer.AwsLoadBalancer;
 import com.sequenceiq.cloudbreak.cloud.aws.common.loadbalancer.AwsLoadBalancerScheme;
 import com.sequenceiq.cloudbreak.cloud.aws.common.service.AwsResourceNameService;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
@@ -58,6 +59,7 @@ import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.Subnet;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceRetriever;
+import com.sequenceiq.cloudbreak.cloud.service.ResourceRetriever;
 import com.sequenceiq.cloudbreak.common.network.NetworkConstants;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.ResourceType;
@@ -69,6 +71,40 @@ class AwsNativeLoadBalancerLaunchServiceTest {
 
     private static final int HEALTH_CHECK_PORT = 8443;
 
+    private static final String STACK_NAME = "stackName";
+
+    private static final String STACK_CRN = "stackCrn";
+
+    private static final Long STACK_ID = 123L;
+
+    private static final String LB_NAME_INTERNAL = "stackn-LBInternal-20221028001020";
+
+    private static final String LB_NAME_INTERNAL_NEW = "stackn-LBInternal-20221028102030";
+
+    private static final String LB_NAME_INTERNAL_NO_HASH = "stackn-LBInternal";
+
+    private static final String TG_NAME_INTERNAL = "sta-TG443Internal-20221028001020";
+
+    private static final String TG_NAME_INTERNAL_NEW = "sta-TG443Internal-20221028102030";
+
+    private static final String TG_NAME_INTERNAL_NO_HASH = "sta-TG443Internal";
+
+    private static final String LB_NAME_EXTERNAL = "stackn-LBExternal-20221028001020";
+
+    private static final String LB_NAME_EXTERNAL_NEW = "stackn-LBExternal-20221028102030";
+
+    private static final String LB_NAME_EXTERNAL_NO_HASH = "stackn-LBExternal";
+
+    private static final String TG_NAME_EXTERNAL = "sta-TG443External-20221028001020";
+
+    private static final String TG_NAME_EXTERNAL_NEW = "sta-TG443External-20221028102030";
+
+    private static final String TG_NAME_EXTERNAL_NO_HASH = "sta-TG443External";
+
+    private static final String INTERNAL = "Internal";
+
+    private static final String EXTERNAL = "External";
+
     @Mock
     private AwsLoadBalancerCommonService loadBalancerCommonService;
 
@@ -77,6 +113,9 @@ class AwsNativeLoadBalancerLaunchServiceTest {
 
     @Mock
     private PersistenceRetriever persistenceRetriever;
+
+    @Mock
+    private ResourceRetriever resourceRetriever;
 
     @Mock
     private PersistenceNotifier persistenceNotifier;
@@ -91,31 +130,39 @@ class AwsNativeLoadBalancerLaunchServiceTest {
     private AwsResourceNameService resourceNameService;
 
     @InjectMocks
-    private AwsNativeLoadBalancerLaunchService undertTest;
+    private AwsNativeLoadBalancerLaunchService underTest;
 
     @BeforeEach
     void setUp() {
         when(awsTaggingService.prepareElasticLoadBalancingTags(any())).thenReturn(List.of(new Tag().withKey("aTag").withValue("aValue")));
+        CloudContext cloudContext = authenticatedContext.getCloudContext();
+        when(cloudContext.getCrn()).thenReturn(STACK_CRN);
+        when(cloudContext.getName()).thenReturn(STACK_NAME);
+        when(cloudContext.getId()).thenReturn(STACK_ID);
     }
 
     @Test
     void testLaunchLoadBalancerResourcesWhenNoNeedToRegisterTargetGroup() {
         CloudStack stack = mock(CloudStack.class);
         AwsLoadBalancer loadBalancer = mock(AwsLoadBalancer.class);
+        when(loadBalancer.getScheme()).thenReturn(AwsLoadBalancerScheme.INTERNAL);
 
+        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER, STACK_NAME, INTERNAL)).thenReturn(LB_NAME_INTERNAL_NEW);
+        when(resourceNameService.trimHash(LB_NAME_INTERNAL)).thenReturn(LB_NAME_INTERNAL_NO_HASH);
+        when(resourceNameService.trimHash(LB_NAME_INTERNAL_NEW)).thenReturn(LB_NAME_INTERNAL_NO_HASH);
         CloudResource loadBalancerResource = CloudResource.builder()
-                .withName("aLoadBalancerName")
+                .withName(LB_NAME_INTERNAL)
                 .withReference("aLoadBalancerArn")
                 .withType(ResourceType.ELASTIC_LOAD_BALANCER)
                 .build();
-        when(persistenceRetriever.retrieveFirstByTypeAndStatusForStack(eq(ResourceType.ELASTIC_LOAD_BALANCER), eq(CommonStatus.CREATED), any()))
-                .thenReturn(Optional.of(loadBalancerResource));
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER, STACK_ID)).thenReturn(List.of(loadBalancerResource));
 
         when(stack.getGroups()).thenReturn(emptyList());
         when(stack.getLoadBalancers()).thenReturn(emptyList());
         when(loadBalancerCommonService.getAwsLoadBalancers(any(), any(), any())).thenReturn(List.of(loadBalancer));
 
-        undertTest.launchLoadBalancerResources(authenticatedContext, stack, persistenceNotifier, loadBalancingClient, false);
+        underTest.launchLoadBalancerResources(authenticatedContext, stack, persistenceNotifier, loadBalancingClient, false);
 
         verify(loadBalancer, never()).getListeners();
     }
@@ -125,7 +172,7 @@ class AwsNativeLoadBalancerLaunchServiceTest {
         CloudStack stack = getCloudStack();
         when(loadBalancerCommonService.getAwsLoadBalancers(any(), any(), any())).thenReturn(new ArrayList<>());
 
-        List<CloudResourceStatus> result = undertTest.launchLoadBalancerResources(authenticatedContext, stack, persistenceNotifier, loadBalancingClient, true);
+        List<CloudResourceStatus> result = underTest.launchLoadBalancerResources(authenticatedContext, stack, persistenceNotifier, loadBalancingClient, true);
 
         assertTrue(result.isEmpty());
     }
@@ -134,32 +181,38 @@ class AwsNativeLoadBalancerLaunchServiceTest {
     void testLaunchLoadBalancerResourcesWhenLoadBalancerCouldNotBeCreated() {
         CloudStack stack = getCloudStack();
         when(loadBalancerCommonService.getAwsLoadBalancers(any(), any(), any())).thenReturn(List.of(getAwsLoadBalancer()));
-        when(persistenceRetriever.retrieveFirstByTypeAndStatusForStack(eq(ResourceType.ELASTIC_LOAD_BALANCER), eq(CommonStatus.CREATED), any()))
-                .thenReturn(Optional.empty());
+        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER, STACK_NAME, INTERNAL)).thenReturn(LB_NAME_INTERNAL_NEW);
+        when(resourceNameService.trimHash(LB_NAME_INTERNAL_NEW)).thenReturn(LB_NAME_INTERNAL_NO_HASH);
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER, STACK_ID)).thenReturn(List.of());
         when(loadBalancingClient.registerLoadBalancer(any())).thenThrow(new AmazonElasticLoadBalancingException("something went wrong"));
 
         Assertions.assertThrows(CloudConnectorException.class,
-                () -> undertTest.launchLoadBalancerResources(authenticatedContext, stack, persistenceNotifier, loadBalancingClient, true));
+                () -> underTest.launchLoadBalancerResources(authenticatedContext, stack, persistenceNotifier, loadBalancingClient, true));
     }
 
     @Test
     void testLaunchLoadBalancerResourcesWhenLoadBalancerAlreadyExistsWithNameAndTargetGroupCouldNotBeCreated() {
         CloudStack stack = getCloudStack();
         when(loadBalancerCommonService.getAwsLoadBalancers(any(), any(), any())).thenReturn(List.of(getAwsLoadBalancer()));
-        when(resourceNameService.resourceName(eq(ResourceType.ELASTIC_LOAD_BALANCER), any(), any())).thenReturn("aLoadBalancerName");
+        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER, STACK_NAME, INTERNAL)).thenReturn(LB_NAME_INTERNAL_NEW);
+        when(resourceNameService.trimHash(LB_NAME_INTERNAL_NEW)).thenReturn(LB_NAME_INTERNAL_NO_HASH);
         AmazonServiceException loadBalancerDuplicatedExc = new AmazonServiceException(DUPLICATE_LOAD_BALANCER_NAME_ERROR_CODE);
         loadBalancerDuplicatedExc.setErrorCode(DUPLICATE_LOAD_BALANCER_NAME_ERROR_CODE);
-        when(persistenceRetriever.retrieveFirstByTypeAndStatusForStack(eq(ResourceType.ELASTIC_LOAD_BALANCER), eq(CommonStatus.CREATED), any()))
-                .thenReturn(Optional.empty());
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER, STACK_ID)).thenReturn(List.of());
         when(loadBalancingClient.registerLoadBalancer(any())).thenThrow(loadBalancerDuplicatedExc);
         LoadBalancer loadBalancer = new LoadBalancer()
                 .withLoadBalancerArn("anARN");
         DescribeLoadBalancersResult loadBalancerResult = new DescribeLoadBalancersResult().withLoadBalancers(loadBalancer);
         when(loadBalancingClient.describeLoadBalancers(any())).thenReturn(loadBalancerResult);
+        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, STACK_NAME, INTERNAL, USER_FACING_PORT))
+                .thenReturn(TG_NAME_INTERNAL_NEW);
+        when(resourceNameService.trimHash(TG_NAME_INTERNAL_NEW)).thenReturn(TG_NAME_INTERNAL_NO_HASH);
         when(loadBalancingClient.createTargetGroup(any())).thenThrow(new AmazonElasticLoadBalancingException("something went wrong"));
 
         Assertions.assertThrows(CloudConnectorException.class,
-                () -> undertTest.launchLoadBalancerResources(authenticatedContext, stack, persistenceNotifier, loadBalancingClient, true));
+                () -> underTest.launchLoadBalancerResources(authenticatedContext, stack, persistenceNotifier, loadBalancingClient, true));
 
         ArgumentCaptor<CloudResource> cloudResourceArgumentCaptor = ArgumentCaptor.forClass(CloudResource.class);
         verify(persistenceNotifier, times(1)).notifyAllocation(cloudResourceArgumentCaptor.capture(), any());
@@ -170,18 +223,22 @@ class AwsNativeLoadBalancerLaunchServiceTest {
     void testLaunchLoadBalancerResourcesWhenLoadBalancerTargetGroupCouldNotBeCreated() {
         CloudStack stack = getCloudStack();
         when(loadBalancerCommonService.getAwsLoadBalancers(any(), any(), any())).thenReturn(List.of(getAwsLoadBalancer()));
-        when(resourceNameService.resourceName(eq(ResourceType.ELASTIC_LOAD_BALANCER), any(), any())).thenReturn("aLoadBalancerName");
-        when(persistenceRetriever.retrieveFirstByTypeAndStatusForStack(eq(ResourceType.ELASTIC_LOAD_BALANCER), eq(CommonStatus.CREATED), any()))
-                .thenReturn(Optional.empty());
+        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER, STACK_NAME, INTERNAL)).thenReturn(LB_NAME_INTERNAL_NEW);
+        when(resourceNameService.trimHash(LB_NAME_INTERNAL_NEW)).thenReturn(LB_NAME_INTERNAL_NO_HASH);
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER, STACK_ID)).thenReturn(List.of());
         LoadBalancer loadBalancer = new LoadBalancer()
                 .withLoadBalancerArn("anARN");
         CreateLoadBalancerResult loadBalancerResult = new CreateLoadBalancerResult()
                 .withLoadBalancers(loadBalancer);
         when(loadBalancingClient.registerLoadBalancer(any())).thenReturn(loadBalancerResult);
+        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, STACK_NAME, INTERNAL, USER_FACING_PORT))
+                .thenReturn(TG_NAME_INTERNAL_NEW);
+        when(resourceNameService.trimHash(TG_NAME_INTERNAL_NEW)).thenReturn(TG_NAME_INTERNAL_NO_HASH);
         when(loadBalancingClient.createTargetGroup(any())).thenThrow(new AmazonElasticLoadBalancingException("something went wrong"));
 
         Assertions.assertThrows(CloudConnectorException.class,
-                () -> undertTest.launchLoadBalancerResources(authenticatedContext, stack, persistenceNotifier, loadBalancingClient, true));
+                () -> underTest.launchLoadBalancerResources(authenticatedContext, stack, persistenceNotifier, loadBalancingClient, true));
 
         ArgumentCaptor<CloudResource> cloudResourceArgumentCaptor = ArgumentCaptor.forClass(CloudResource.class);
         verify(persistenceNotifier, times(1)).notifyAllocation(cloudResourceArgumentCaptor.capture(), any());
@@ -192,27 +249,30 @@ class AwsNativeLoadBalancerLaunchServiceTest {
     void testLaunchLoadBalancerResourcesWhenLoadBalancerListenerCouldNotBeCreated() {
         CloudStack stack = getCloudStack();
         when(loadBalancerCommonService.getAwsLoadBalancers(any(), any(), any())).thenReturn(List.of(getAwsLoadBalancer()));
-        when(resourceNameService.resourceName(eq(ResourceType.ELASTIC_LOAD_BALANCER), any(), any())).thenReturn("aLoadBalancerName");
-        when(persistenceRetriever.retrieveFirstByTypeAndStatusForStack(eq(ResourceType.ELASTIC_LOAD_BALANCER), eq(CommonStatus.CREATED), any()))
-                .thenReturn(Optional.empty());
+        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER, STACK_NAME, INTERNAL)).thenReturn(LB_NAME_INTERNAL_NEW);
+        when(resourceNameService.trimHash(LB_NAME_INTERNAL_NEW)).thenReturn(LB_NAME_INTERNAL_NO_HASH);
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER, STACK_ID)).thenReturn(List.of());
         LoadBalancer loadBalancer = new LoadBalancer()
                 .withLoadBalancerArn("anARN");
         CreateLoadBalancerResult loadBalancerResult = new CreateLoadBalancerResult().withLoadBalancers(loadBalancer);
         when(loadBalancingClient.registerLoadBalancer(any())).thenReturn(loadBalancerResult);
-        when(resourceNameService.resourceName(eq(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP), any(), any(), any())).thenReturn("aLoadBalancerTGName");
-        when(persistenceRetriever.retrieveFirstByTypeAndStatusForStack(eq(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP), eq(CommonStatus.CREATED), any()))
-                .thenReturn(Optional.empty());
+        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, STACK_NAME, INTERNAL, USER_FACING_PORT))
+                .thenReturn(TG_NAME_INTERNAL_NEW);
+        when(resourceNameService.trimHash(TG_NAME_INTERNAL_NEW)).thenReturn(TG_NAME_INTERNAL_NO_HASH);
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, STACK_ID)).thenReturn(List.of());
         TargetGroup targetGroup = new TargetGroup()
                 .withTargetGroupArn("aTargetGroupArn");
         CreateTargetGroupResult createTargetGroupResult = new CreateTargetGroupResult()
                 .withTargetGroups(List.of(targetGroup));
         when(loadBalancingClient.createTargetGroup(any())).thenReturn(createTargetGroupResult);
-        when(persistenceRetriever.retrieveFirstByTypeAndStatusForStack(eq(ResourceType.ELASTIC_LOAD_BALANCER_LISTENER), eq(CommonStatus.CREATED), any()))
-                .thenReturn(Optional.empty());
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER_LISTENER, STACK_ID)).thenReturn(List.of());
         when(loadBalancingClient.registerListener(any())).thenThrow(new AmazonElasticLoadBalancingException("something went wrong"));
 
         Assertions.assertThrows(CloudConnectorException.class,
-                () -> undertTest.launchLoadBalancerResources(authenticatedContext, stack, persistenceNotifier, loadBalancingClient, true));
+                () -> underTest.launchLoadBalancerResources(authenticatedContext, stack, persistenceNotifier, loadBalancingClient, true));
 
         ArgumentCaptor<CloudResource> cloudResourceArgumentCaptor = ArgumentCaptor.forClass(CloudResource.class);
         verify(persistenceNotifier, times(2)).notifyAllocation(cloudResourceArgumentCaptor.capture(), any());
@@ -226,16 +286,19 @@ class AwsNativeLoadBalancerLaunchServiceTest {
     void testLaunchLoadBalancerResourcesWhenTargetGroupAlreadyExistsWithNameAndLoadBalancerListenerCouldNotBeCreated() {
         CloudStack stack = getCloudStack();
         when(loadBalancerCommonService.getAwsLoadBalancers(any(), any(), any())).thenReturn(List.of(getAwsLoadBalancer()));
-        when(resourceNameService.resourceName(eq(ResourceType.ELASTIC_LOAD_BALANCER), any(), any())).thenReturn("aLoadBalancerName");
-        when(persistenceRetriever.retrieveFirstByTypeAndStatusForStack(eq(ResourceType.ELASTIC_LOAD_BALANCER), eq(CommonStatus.CREATED), any()))
-                .thenReturn(Optional.empty());
+        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER, STACK_NAME, INTERNAL)).thenReturn(LB_NAME_INTERNAL_NEW);
+        when(resourceNameService.trimHash(LB_NAME_INTERNAL_NEW)).thenReturn(LB_NAME_INTERNAL_NO_HASH);
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER, STACK_ID)).thenReturn(List.of());
         LoadBalancer loadBalancer = new LoadBalancer()
                 .withLoadBalancerArn("anARN");
         CreateLoadBalancerResult loadBalancerResult = new CreateLoadBalancerResult().withLoadBalancers(loadBalancer);
         when(loadBalancingClient.registerLoadBalancer(any())).thenReturn(loadBalancerResult);
-        when(resourceNameService.resourceName(eq(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP), any(), any(), any())).thenReturn("aLoadBalancerTGName");
-        when(persistenceRetriever.retrieveFirstByTypeAndStatusForStack(eq(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP), eq(CommonStatus.CREATED), any()))
-                .thenReturn(Optional.empty());
+        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, STACK_NAME, INTERNAL, USER_FACING_PORT))
+                .thenReturn(TG_NAME_INTERNAL_NEW);
+        when(resourceNameService.trimHash(TG_NAME_INTERNAL_NEW)).thenReturn(TG_NAME_INTERNAL_NO_HASH);
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, STACK_ID)).thenReturn(List.of());
         AmazonServiceException amazonServiceException = new AmazonServiceException(DUPLICATE_TARGET_GROUP_NAME_ERROR_CODE);
         amazonServiceException.setErrorCode(DUPLICATE_TARGET_GROUP_NAME_ERROR_CODE);
         when(loadBalancingClient.createTargetGroup(any())).thenThrow(amazonServiceException);
@@ -244,12 +307,12 @@ class AwsNativeLoadBalancerLaunchServiceTest {
         DescribeTargetGroupsResult describeTargetGroupsResult = new DescribeTargetGroupsResult()
                 .withTargetGroups(targetGroup);
         when(loadBalancingClient.describeTargetGroup(any())).thenReturn(describeTargetGroupsResult);
-        when(persistenceRetriever.retrieveFirstByTypeAndStatusForStack(eq(ResourceType.ELASTIC_LOAD_BALANCER_LISTENER), eq(CommonStatus.CREATED), any()))
-                .thenReturn(Optional.empty());
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER_LISTENER, STACK_ID)).thenReturn(List.of());
         when(loadBalancingClient.registerListener(any())).thenThrow(new AmazonElasticLoadBalancingException("something went wrong"));
 
         Assertions.assertThrows(CloudConnectorException.class,
-                () -> undertTest.launchLoadBalancerResources(authenticatedContext, stack, persistenceNotifier, loadBalancingClient, true));
+                () -> underTest.launchLoadBalancerResources(authenticatedContext, stack, persistenceNotifier, loadBalancingClient, true));
 
         ArgumentCaptor<CloudResource> cloudResourceArgumentCaptor = ArgumentCaptor.forClass(CloudResource.class);
         verify(persistenceNotifier, times(2)).notifyAllocation(cloudResourceArgumentCaptor.capture(), any());
@@ -263,23 +326,26 @@ class AwsNativeLoadBalancerLaunchServiceTest {
     void testLaunchLoadBalancerResourcesWhenLoadBalancerTargetsCouldNotBeRegistered() {
         CloudStack stack = getCloudStack();
         when(loadBalancerCommonService.getAwsLoadBalancers(any(), any(), any())).thenReturn(List.of(getAwsLoadBalancer()));
-        when(resourceNameService.resourceName(eq(ResourceType.ELASTIC_LOAD_BALANCER), any(), any())).thenReturn("aLoadBalancerName");
-        when(persistenceRetriever.retrieveFirstByTypeAndStatusForStack(eq(ResourceType.ELASTIC_LOAD_BALANCER), eq(CommonStatus.CREATED), any()))
-                .thenReturn(Optional.empty());
+        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER, STACK_NAME, INTERNAL)).thenReturn(LB_NAME_INTERNAL_NEW);
+        when(resourceNameService.trimHash(LB_NAME_INTERNAL_NEW)).thenReturn(LB_NAME_INTERNAL_NO_HASH);
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER, STACK_ID)).thenReturn(List.of());
         LoadBalancer loadBalancer = new LoadBalancer()
                 .withLoadBalancerArn("anARN");
         CreateLoadBalancerResult loadBalancerResult = new CreateLoadBalancerResult().withLoadBalancers(loadBalancer);
         when(loadBalancingClient.registerLoadBalancer(any())).thenReturn(loadBalancerResult);
-        when(resourceNameService.resourceName(eq(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP), any(), any(), any())).thenReturn("aLoadBalancerTGName");
-        when(persistenceRetriever.retrieveFirstByTypeAndStatusForStack(eq(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP), eq(CommonStatus.CREATED), any()))
-                .thenReturn(Optional.empty());
+        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, STACK_NAME, INTERNAL, USER_FACING_PORT))
+                .thenReturn(TG_NAME_INTERNAL_NEW);
+        when(resourceNameService.trimHash(TG_NAME_INTERNAL_NEW)).thenReturn(TG_NAME_INTERNAL_NO_HASH);
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, STACK_ID)).thenReturn(List.of());
         TargetGroup targetGroup = new TargetGroup()
                 .withTargetGroupArn("aTargetGroupArn");
         CreateTargetGroupResult createTargetGroupResult = new CreateTargetGroupResult()
                 .withTargetGroups(List.of(targetGroup));
         when(loadBalancingClient.createTargetGroup(any())).thenReturn(createTargetGroupResult);
-        when(persistenceRetriever.retrieveFirstByTypeAndStatusForStack(eq(ResourceType.ELASTIC_LOAD_BALANCER_LISTENER), eq(CommonStatus.CREATED), any()))
-                .thenReturn(Optional.empty());
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER_LISTENER, STACK_ID)).thenReturn(List.of());
         Listener listener = new Listener()
                 .withListenerArn("aListenerArn");
         CreateListenerResult createListenerResult = new CreateListenerResult()
@@ -288,7 +354,7 @@ class AwsNativeLoadBalancerLaunchServiceTest {
         when(loadBalancingClient.registerTargets(any())).thenThrow(new AmazonElasticLoadBalancingException("something went wrong"));
 
         Assertions.assertThrows(CloudConnectorException.class,
-                () -> undertTest.launchLoadBalancerResources(authenticatedContext, stack, persistenceNotifier, loadBalancingClient, true));
+                () -> underTest.launchLoadBalancerResources(authenticatedContext, stack, persistenceNotifier, loadBalancingClient, true));
 
         ArgumentCaptor<CloudResource> cloudResourceArgumentCaptor = ArgumentCaptor.forClass(CloudResource.class);
         verify(loadBalancingClient, times(1)).registerTargets(any());
@@ -305,23 +371,26 @@ class AwsNativeLoadBalancerLaunchServiceTest {
     void testLaunchLoadBalancerResourcesWhenListenerAlreadyExistsAndLoadBalancerTargetsCouldNotBeRegistered() {
         CloudStack stack = getCloudStack();
         when(loadBalancerCommonService.getAwsLoadBalancers(any(), any(), any())).thenReturn(List.of(getAwsLoadBalancer()));
-        when(resourceNameService.resourceName(eq(ResourceType.ELASTIC_LOAD_BALANCER), any(), any())).thenReturn("aLoadBalancerName");
-        when(persistenceRetriever.retrieveFirstByTypeAndStatusForStack(eq(ResourceType.ELASTIC_LOAD_BALANCER), eq(CommonStatus.CREATED), any()))
-                .thenReturn(Optional.empty());
+        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER, STACK_NAME, INTERNAL)).thenReturn(LB_NAME_INTERNAL_NEW);
+        when(resourceNameService.trimHash(LB_NAME_INTERNAL_NEW)).thenReturn(LB_NAME_INTERNAL_NO_HASH);
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER, STACK_ID)).thenReturn(List.of());
         LoadBalancer loadBalancer = new LoadBalancer()
                 .withLoadBalancerArn("anARN");
         CreateLoadBalancerResult loadBalancerResult = new CreateLoadBalancerResult().withLoadBalancers(loadBalancer);
         when(loadBalancingClient.registerLoadBalancer(any())).thenReturn(loadBalancerResult);
-        when(resourceNameService.resourceName(eq(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP), any(), any(), any())).thenReturn("aLoadBalancerTGName");
-        when(persistenceRetriever.retrieveFirstByTypeAndStatusForStack(eq(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP), eq(CommonStatus.CREATED), any()))
-                .thenReturn(Optional.empty());
+        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, STACK_NAME, INTERNAL, USER_FACING_PORT))
+                .thenReturn(TG_NAME_INTERNAL_NEW);
+        when(resourceNameService.trimHash(TG_NAME_INTERNAL_NEW)).thenReturn(TG_NAME_INTERNAL_NO_HASH);
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, STACK_ID)).thenReturn(List.of());
         TargetGroup targetGroup = new TargetGroup()
                 .withTargetGroupArn("aTargetGroupArn");
         CreateTargetGroupResult createTargetGroupResult = new CreateTargetGroupResult()
                 .withTargetGroups(List.of(targetGroup));
         when(loadBalancingClient.createTargetGroup(any())).thenReturn(createTargetGroupResult);
-        when(persistenceRetriever.retrieveFirstByTypeAndStatusForStack(eq(ResourceType.ELASTIC_LOAD_BALANCER_LISTENER), eq(CommonStatus.CREATED), any()))
-                .thenReturn(Optional.empty());
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER_LISTENER, STACK_ID)).thenReturn(List.of());
         AmazonServiceException amazonServiceException = new AmazonServiceException(DUPLICATE_LISTENER_ERROR_CODE);
         amazonServiceException.setErrorCode(DUPLICATE_LISTENER_ERROR_CODE);
         when(loadBalancingClient.registerListener(any())).thenThrow(amazonServiceException);
@@ -333,7 +402,7 @@ class AwsNativeLoadBalancerLaunchServiceTest {
         when(loadBalancingClient.registerTargets(any())).thenThrow(new AmazonElasticLoadBalancingException("something went wrong"));
 
         Assertions.assertThrows(CloudConnectorException.class,
-                () -> undertTest.launchLoadBalancerResources(authenticatedContext, stack, persistenceNotifier, loadBalancingClient, true));
+                () -> underTest.launchLoadBalancerResources(authenticatedContext, stack, persistenceNotifier, loadBalancingClient, true));
 
         ArgumentCaptor<CloudResource> cloudResourceArgumentCaptor = ArgumentCaptor.forClass(CloudResource.class);
         verify(loadBalancingClient, times(1)).registerTargets(any());
@@ -346,27 +415,35 @@ class AwsNativeLoadBalancerLaunchServiceTest {
                 .anyMatch(cloudResource -> ResourceType.ELASTIC_LOAD_BALANCER_LISTENER.equals(cloudResource.getType())));
     }
 
-    @Test
-    void testLaunchLoadBalancerResourcesWhenAllResourcesCouldBeCreated() {
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(booleans = {false, true})
+    void testLaunchLoadBalancerResourcesWhenAllResourcesCouldBeCreated(boolean internal) {
         CloudStack stack = getCloudStack();
-        when(loadBalancerCommonService.getAwsLoadBalancers(any(), any(), any())).thenReturn(List.of(getAwsLoadBalancer()));
-        when(resourceNameService.resourceName(eq(ResourceType.ELASTIC_LOAD_BALANCER), any(), any())).thenReturn("aLoadBalancerName");
-        when(persistenceRetriever.retrieveFirstByTypeAndStatusForStack(eq(ResourceType.ELASTIC_LOAD_BALANCER), eq(CommonStatus.CREATED), any()))
-                .thenReturn(Optional.empty());
+        when(loadBalancerCommonService.getAwsLoadBalancers(any(), any(), any())).thenReturn(List.of(
+                getAwsLoadBalancer(internal ? AwsLoadBalancerScheme.INTERNAL : AwsLoadBalancerScheme.INTERNET_FACING)));
+        String scheme = internal ? INTERNAL : EXTERNAL;
+        String lbNameNew = internal ? LB_NAME_INTERNAL_NEW : LB_NAME_EXTERNAL_NEW;
+        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER, STACK_NAME, scheme)).thenReturn(lbNameNew);
+        when(resourceNameService.trimHash(lbNameNew)).thenReturn(internal ? LB_NAME_INTERNAL_NO_HASH : LB_NAME_EXTERNAL_NO_HASH);
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER, STACK_ID)).thenReturn(List.of());
         LoadBalancer loadBalancer = new LoadBalancer()
                 .withLoadBalancerArn("anARN");
         CreateLoadBalancerResult loadBalancerResult = new CreateLoadBalancerResult().withLoadBalancers(loadBalancer);
         when(loadBalancingClient.registerLoadBalancer(any())).thenReturn(loadBalancerResult);
-        when(resourceNameService.resourceName(eq(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP), any(), any(), any())).thenReturn("aLoadBalancerTGName");
-        when(persistenceRetriever.retrieveFirstByTypeAndStatusForStack(eq(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP), eq(CommonStatus.CREATED), any()))
-                .thenReturn(Optional.empty());
+        String tgNameNew = internal ? TG_NAME_INTERNAL_NEW : TG_NAME_EXTERNAL_NEW;
+        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, STACK_NAME, scheme, USER_FACING_PORT))
+                .thenReturn(tgNameNew);
+        when(resourceNameService.trimHash(tgNameNew)).thenReturn(internal ? TG_NAME_INTERNAL_NO_HASH : TG_NAME_EXTERNAL_NO_HASH);
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, STACK_ID)).thenReturn(List.of());
         TargetGroup targetGroup = new TargetGroup()
                 .withTargetGroupArn("aTargetGroupArn");
         CreateTargetGroupResult createTargetGroupResult = new CreateTargetGroupResult()
                 .withTargetGroups(List.of(targetGroup));
         when(loadBalancingClient.createTargetGroup(any())).thenReturn(createTargetGroupResult);
-        when(persistenceRetriever.retrieveFirstByTypeAndStatusForStack(eq(ResourceType.ELASTIC_LOAD_BALANCER_LISTENER), eq(CommonStatus.CREATED), any()))
-                .thenReturn(Optional.empty());
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER_LISTENER, STACK_ID)).thenReturn(List.of());
         Listener listener = new Listener()
                 .withListenerArn("aListenerArn");
         CreateListenerResult createListenerResult = new CreateListenerResult()
@@ -374,7 +451,7 @@ class AwsNativeLoadBalancerLaunchServiceTest {
         when(loadBalancingClient.registerListener(any())).thenReturn(createListenerResult);
         when(loadBalancingClient.registerTargets(any())).thenReturn(new RegisterTargetsResult());
 
-        List<CloudResourceStatus> statuses = undertTest.launchLoadBalancerResources(authenticatedContext, stack, persistenceNotifier, loadBalancingClient,
+        List<CloudResourceStatus> statuses = underTest.launchLoadBalancerResources(authenticatedContext, stack, persistenceNotifier, loadBalancingClient,
                 true);
 
         ArgumentCaptor<CloudResource> cloudResourceArgumentCaptor = ArgumentCaptor.forClass(CloudResource.class);
@@ -391,28 +468,39 @@ class AwsNativeLoadBalancerLaunchServiceTest {
         assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER_LISTENER, ResourceStatus.CREATED));
     }
 
-    @Test
-    void testLaunchLoadBalancerResourcesWhenLoadBalancerResourceExistsAlready() {
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(booleans = {false, true})
+    void testLaunchLoadBalancerResourcesWhenLoadBalancerResourceExistsAlreadyWithSameSchemeAndTargetGroupAndListener(boolean internal) {
         CloudStack stack = getCloudStack();
-        when(loadBalancerCommonService.getAwsLoadBalancers(any(), any(), any())).thenReturn(List.of(getAwsLoadBalancer()));
-        String aLoadBalancerName = "aLoadBalancerName";
+        when(loadBalancerCommonService.getAwsLoadBalancers(any(), any(), any())).thenReturn(List.of(
+                getAwsLoadBalancer(internal ? AwsLoadBalancerScheme.INTERNAL : AwsLoadBalancerScheme.INTERNET_FACING)));
+        String scheme = internal ? INTERNAL : EXTERNAL;
+        String lbNameNew = internal ? LB_NAME_INTERNAL_NEW : LB_NAME_EXTERNAL_NEW;
+        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER, STACK_NAME, scheme)).thenReturn(lbNameNew);
+        String lbName = internal ? LB_NAME_INTERNAL : LB_NAME_EXTERNAL;
+        String lbNameNoHash = internal ? LB_NAME_INTERNAL_NO_HASH : LB_NAME_EXTERNAL_NO_HASH;
+        when(resourceNameService.trimHash(lbName)).thenReturn(lbNameNoHash);
+        when(resourceNameService.trimHash(lbNameNew)).thenReturn(lbNameNoHash);
         CloudResource loadBalancerResource = CloudResource.builder()
-                .withName(aLoadBalancerName)
+                .withName(lbName)
                 .withReference("aLoadBalancerArn")
                 .withType(ResourceType.ELASTIC_LOAD_BALANCER)
                 .build();
-        when(persistenceRetriever.retrieveFirstByTypeAndStatusForStack(eq(ResourceType.ELASTIC_LOAD_BALANCER), eq(CommonStatus.CREATED), any()))
-                .thenReturn(Optional.of(loadBalancerResource));
-        when(resourceNameService.resourceName(eq(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP), any(), any(), any())).thenReturn("aLoadBalancerTGName");
-        when(persistenceRetriever.retrieveFirstByTypeAndStatusForStack(eq(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP), eq(CommonStatus.CREATED), any()))
-                .thenReturn(Optional.empty());
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER, STACK_ID)).thenReturn(List.of(loadBalancerResource));
+        String tgNameNew = internal ? TG_NAME_INTERNAL_NEW : TG_NAME_EXTERNAL_NEW;
+        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, STACK_NAME, scheme, USER_FACING_PORT))
+                .thenReturn(tgNameNew);
+        when(resourceNameService.trimHash(tgNameNew)).thenReturn(internal ? TG_NAME_INTERNAL_NO_HASH : TG_NAME_EXTERNAL_NO_HASH);
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, STACK_ID)).thenReturn(List.of());
         TargetGroup targetGroup = new TargetGroup()
                 .withTargetGroupArn("aTargetGroupArn");
         CreateTargetGroupResult createTargetGroupResult = new CreateTargetGroupResult()
                 .withTargetGroups(List.of(targetGroup));
         when(loadBalancingClient.createTargetGroup(any())).thenReturn(createTargetGroupResult);
-        when(persistenceRetriever.retrieveFirstByTypeAndStatusForStack(eq(ResourceType.ELASTIC_LOAD_BALANCER_LISTENER), eq(CommonStatus.CREATED), any()))
-                .thenReturn(Optional.empty());
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER_LISTENER, STACK_ID)).thenReturn(List.of());
         Listener listener = new Listener()
                 .withListenerArn("aListenerArn");
         CreateListenerResult createListenerResult = new CreateListenerResult()
@@ -420,7 +508,7 @@ class AwsNativeLoadBalancerLaunchServiceTest {
         when(loadBalancingClient.registerListener(any())).thenReturn(createListenerResult);
         when(loadBalancingClient.registerTargets(any())).thenReturn(new RegisterTargetsResult());
 
-        List<CloudResourceStatus> statuses = undertTest.launchLoadBalancerResources(authenticatedContext, stack, persistenceNotifier, loadBalancingClient,
+        List<CloudResourceStatus> statuses = underTest.launchLoadBalancerResources(authenticatedContext, stack, persistenceNotifier, loadBalancingClient,
                 true);
 
         ArgumentCaptor<CloudResource> cloudResourceArgumentCaptor = ArgumentCaptor.forClass(CloudResource.class);
@@ -436,27 +524,42 @@ class AwsNativeLoadBalancerLaunchServiceTest {
         assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER_LISTENER, ResourceStatus.CREATED));
     }
 
-    @Test
-    void testLaunchLoadBalancerResourcesWhenTargetGroupResourcesExistAlready() {
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(booleans = {false, true})
+    void testLaunchLoadBalancerResourcesWhenLoadBalancerResourceExistsAlreadyButDifferentSchemeAndTargetGroupAndListener(boolean existingInternal) {
         CloudStack stack = getCloudStack();
-        when(loadBalancerCommonService.getAwsLoadBalancers(any(), any(), any())).thenReturn(List.of(getAwsLoadBalancer()));
-        when(resourceNameService.resourceName(eq(ResourceType.ELASTIC_LOAD_BALANCER), any(), any())).thenReturn("aLoadBalancerName");
-        when(persistenceRetriever.retrieveFirstByTypeAndStatusForStack(eq(ResourceType.ELASTIC_LOAD_BALANCER), eq(CommonStatus.CREATED), any()))
-                .thenReturn(Optional.empty());
+        when(loadBalancerCommonService.getAwsLoadBalancers(any(), any(), any())).thenReturn(List.of(
+                getAwsLoadBalancer(existingInternal ? AwsLoadBalancerScheme.INTERNET_FACING : AwsLoadBalancerScheme.INTERNAL)));
+        String schemeNew = existingInternal ? EXTERNAL : INTERNAL;
+        String lbNameNew = existingInternal ? LB_NAME_EXTERNAL_NEW : LB_NAME_INTERNAL_NEW;
+        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER, STACK_NAME, schemeNew)).thenReturn(lbNameNew);
+        String lbName = existingInternal ? LB_NAME_INTERNAL : LB_NAME_EXTERNAL;
+        when(resourceNameService.trimHash(lbName)).thenReturn(existingInternal ? LB_NAME_INTERNAL_NO_HASH : LB_NAME_EXTERNAL_NO_HASH);
+        when(resourceNameService.trimHash(lbNameNew)).thenReturn(existingInternal ? LB_NAME_EXTERNAL_NO_HASH : LB_NAME_INTERNAL_NO_HASH);
+        CloudResource loadBalancerResource = CloudResource.builder()
+                .withName(lbName)
+                .withReference("aLoadBalancerArn")
+                .withType(ResourceType.ELASTIC_LOAD_BALANCER)
+                .build();
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER, STACK_ID)).thenReturn(List.of(loadBalancerResource));
         LoadBalancer loadBalancer = new LoadBalancer()
                 .withLoadBalancerArn("anARN");
         CreateLoadBalancerResult loadBalancerResult = new CreateLoadBalancerResult().withLoadBalancers(loadBalancer);
         when(loadBalancingClient.registerLoadBalancer(any())).thenReturn(loadBalancerResult);
-        CloudResource targetGroupResource = CloudResource.builder()
-                .withName("aTargetTG443Master")
-                .withType(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP)
-                .withReference("aTargetGroupArn")
-                .build();
-        when(persistenceRetriever.retrieveFirstByTypeAndStatusForStack(eq(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP), eq(CommonStatus.CREATED), any()))
-                .thenReturn(Optional.of(targetGroupResource));
-        when(resourceNameService.resourceName(eq(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP), any(), any(), any())).thenReturn("aLoadBalancerTGName");
-        when(persistenceRetriever.retrieveFirstByTypeAndStatusForStack(eq(ResourceType.ELASTIC_LOAD_BALANCER_LISTENER), eq(CommonStatus.CREATED), any()))
-                .thenReturn(Optional.empty());
+        String tgNameNew = existingInternal ? TG_NAME_EXTERNAL_NEW : TG_NAME_INTERNAL_NEW;
+        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, STACK_NAME, schemeNew, USER_FACING_PORT))
+                .thenReturn(tgNameNew);
+        when(resourceNameService.trimHash(tgNameNew)).thenReturn(existingInternal ? TG_NAME_EXTERNAL_NO_HASH : TG_NAME_INTERNAL_NO_HASH);
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, STACK_ID)).thenReturn(List.of());
+        TargetGroup targetGroup = new TargetGroup()
+                .withTargetGroupArn("aTargetGroupArn");
+        CreateTargetGroupResult createTargetGroupResult = new CreateTargetGroupResult()
+                .withTargetGroups(List.of(targetGroup));
+        when(loadBalancingClient.createTargetGroup(any())).thenReturn(createTargetGroupResult);
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER_LISTENER, STACK_ID)).thenReturn(List.of());
         Listener listener = new Listener()
                 .withListenerArn("aListenerArn");
         CreateListenerResult createListenerResult = new CreateListenerResult()
@@ -464,7 +567,64 @@ class AwsNativeLoadBalancerLaunchServiceTest {
         when(loadBalancingClient.registerListener(any())).thenReturn(createListenerResult);
         when(loadBalancingClient.registerTargets(any())).thenReturn(new RegisterTargetsResult());
 
-        List<CloudResourceStatus> statuses = undertTest.launchLoadBalancerResources(authenticatedContext, stack, persistenceNotifier, loadBalancingClient,
+        List<CloudResourceStatus> statuses = underTest.launchLoadBalancerResources(authenticatedContext, stack, persistenceNotifier, loadBalancingClient,
+                true);
+
+        ArgumentCaptor<CloudResource> cloudResourceArgumentCaptor = ArgumentCaptor.forClass(CloudResource.class);
+        verify(persistenceNotifier, times(3)).notifyAllocation(cloudResourceArgumentCaptor.capture(), any());
+        verify(loadBalancingClient, times(1)).registerTargets(any());
+        assertTrue(cloudResourceArgumentCaptor.getAllValues().stream()
+                .anyMatch(cloudResource -> ResourceType.ELASTIC_LOAD_BALANCER.equals(cloudResource.getType())));
+        assertTrue(cloudResourceArgumentCaptor.getAllValues().stream()
+                .anyMatch(cloudResource -> ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP.equals(cloudResource.getType())));
+        assertTrue(cloudResourceArgumentCaptor.getAllValues().stream()
+                .anyMatch(cloudResource -> ResourceType.ELASTIC_LOAD_BALANCER_LISTENER.equals(cloudResource.getType())));
+        assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER, ResourceStatus.CREATED));
+        assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, ResourceStatus.CREATED));
+        assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER_LISTENER, ResourceStatus.CREATED));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(booleans = {false, true})
+    void testLaunchLoadBalancerResourcesWhenTargetGroupResourceExistsAlreadyWithSameSchemeAndLoadBalancerAndListener(boolean internal) {
+        CloudStack stack = getCloudStack();
+        when(loadBalancerCommonService.getAwsLoadBalancers(any(), any(), any())).thenReturn(List.of(
+                getAwsLoadBalancer(internal ? AwsLoadBalancerScheme.INTERNAL : AwsLoadBalancerScheme.INTERNET_FACING)));
+        String scheme = internal ? INTERNAL : EXTERNAL;
+        String lbNameNew = internal ? LB_NAME_INTERNAL_NEW : LB_NAME_EXTERNAL_NEW;
+        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER, STACK_NAME, scheme)).thenReturn(lbNameNew);
+        when(resourceNameService.trimHash(lbNameNew)).thenReturn(internal ? LB_NAME_INTERNAL_NO_HASH : LB_NAME_EXTERNAL_NO_HASH);
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER, STACK_ID)).thenReturn(List.of());
+        LoadBalancer loadBalancer = new LoadBalancer()
+                .withLoadBalancerArn("anARN");
+        CreateLoadBalancerResult loadBalancerResult = new CreateLoadBalancerResult().withLoadBalancers(loadBalancer);
+        when(loadBalancingClient.registerLoadBalancer(any())).thenReturn(loadBalancerResult);
+        String tgName = internal ? TG_NAME_INTERNAL : TG_NAME_EXTERNAL;
+        CloudResource targetGroupResource = CloudResource.builder()
+                .withName(tgName)
+                .withType(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP)
+                .withReference("aTargetGroupArn")
+                .build();
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, STACK_ID))
+                .thenReturn(List.of(targetGroupResource));
+        String tgNameNew = internal ? TG_NAME_INTERNAL_NEW : TG_NAME_EXTERNAL_NEW;
+        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, STACK_NAME, scheme, USER_FACING_PORT))
+                .thenReturn(tgNameNew);
+        String tgNameNoHash = internal ? TG_NAME_INTERNAL_NO_HASH : TG_NAME_EXTERNAL_NO_HASH;
+        when(resourceNameService.trimHash(tgName)).thenReturn(tgNameNoHash);
+        when(resourceNameService.trimHash(tgNameNew)).thenReturn(tgNameNoHash);
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER_LISTENER, STACK_ID)).thenReturn(List.of());
+        Listener listener = new Listener()
+                .withListenerArn("aListenerArn");
+        CreateListenerResult createListenerResult = new CreateListenerResult()
+                .withListeners(listener);
+        when(loadBalancingClient.registerListener(any())).thenReturn(createListenerResult);
+        when(loadBalancingClient.registerTargets(any())).thenReturn(new RegisterTargetsResult());
+
+        List<CloudResourceStatus> statuses = underTest.launchLoadBalancerResources(authenticatedContext, stack, persistenceNotifier, loadBalancingClient,
                 true);
 
         ArgumentCaptor<CloudResource> cloudResourceArgumentCaptor = ArgumentCaptor.forClass(CloudResource.class);
@@ -480,36 +640,108 @@ class AwsNativeLoadBalancerLaunchServiceTest {
         assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER_LISTENER, ResourceStatus.CREATED));
     }
 
-    @Test
-    void testLaunchLoadBalancerResourcesWhenLoadBalancerAndTargetGroupAndListenerResourcesExistAlready() {
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(booleans = {false, true})
+    void testLaunchLoadBalancerResourcesWhenTargetGroupResourceExistsAlreadyButDifferentSchemeAndLoadBalancerAndListener(boolean existingInternal) {
         CloudStack stack = getCloudStack();
-        when(loadBalancerCommonService.getAwsLoadBalancers(any(), any(), any())).thenReturn(List.of(getAwsLoadBalancer()));
-        when(resourceNameService.resourceName(eq(ResourceType.ELASTIC_LOAD_BALANCER), any(), any())).thenReturn("aLoadBalancerName");
-        when(persistenceRetriever.retrieveFirstByTypeAndStatusForStack(eq(ResourceType.ELASTIC_LOAD_BALANCER), eq(CommonStatus.CREATED), any()))
-                .thenReturn(Optional.empty());
+        when(loadBalancerCommonService.getAwsLoadBalancers(any(), any(), any())).thenReturn(List.of(
+                getAwsLoadBalancer(existingInternal ? AwsLoadBalancerScheme.INTERNET_FACING : AwsLoadBalancerScheme.INTERNAL)));
+        String schemeNew = existingInternal ? EXTERNAL : INTERNAL;
+        String lbNameNew = existingInternal ? LB_NAME_EXTERNAL_NEW : LB_NAME_INTERNAL_NEW;
+        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER, STACK_NAME, schemeNew)).thenReturn(lbNameNew);
+        when(resourceNameService.trimHash(lbNameNew)).thenReturn(existingInternal ? LB_NAME_EXTERNAL_NO_HASH : LB_NAME_INTERNAL_NO_HASH);
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER, STACK_ID)).thenReturn(List.of());
         LoadBalancer loadBalancer = new LoadBalancer()
                 .withLoadBalancerArn("anARN");
         CreateLoadBalancerResult loadBalancerResult = new CreateLoadBalancerResult().withLoadBalancers(loadBalancer);
         when(loadBalancingClient.registerLoadBalancer(any())).thenReturn(loadBalancerResult);
-        String aLoadBalancerTGName = "aLoadBalancerTGName";
-        when(resourceNameService.resourceName(eq(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP), any(), any(), any())).thenReturn(aLoadBalancerTGName);
-        when(persistenceRetriever.retrieveFirstByTypeAndStatusForStack(eq(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP), eq(CommonStatus.CREATED), any()))
-                .thenReturn(Optional.empty());
+        String tgName = existingInternal ? TG_NAME_INTERNAL : TG_NAME_EXTERNAL;
+        CloudResource targetGroupResource = CloudResource.builder()
+                .withName(tgName)
+                .withType(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP)
+                .withReference("aTargetGroupArn")
+                .build();
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, STACK_ID))
+                .thenReturn(List.of(targetGroupResource));
+        String tgNameNew = existingInternal ? TG_NAME_EXTERNAL_NEW : TG_NAME_INTERNAL_NEW;
+        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, STACK_NAME, schemeNew, USER_FACING_PORT))
+                .thenReturn(tgNameNew);
+        when(resourceNameService.trimHash(tgName)).thenReturn(existingInternal ? TG_NAME_INTERNAL_NO_HASH : TG_NAME_EXTERNAL_NO_HASH);
+        when(resourceNameService.trimHash(tgNameNew)).thenReturn(existingInternal ? TG_NAME_EXTERNAL_NO_HASH : TG_NAME_INTERNAL_NO_HASH);
         TargetGroup targetGroup = new TargetGroup()
                 .withTargetGroupArn("aTargetGroupArn");
         CreateTargetGroupResult createTargetGroupResult = new CreateTargetGroupResult()
                 .withTargetGroups(List.of(targetGroup));
         when(loadBalancingClient.createTargetGroup(any())).thenReturn(createTargetGroupResult);
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER_LISTENER, STACK_ID)).thenReturn(List.of());
+        Listener listener = new Listener()
+                .withListenerArn("aListenerArn");
+        CreateListenerResult createListenerResult = new CreateListenerResult()
+                .withListeners(listener);
+        when(loadBalancingClient.registerListener(any())).thenReturn(createListenerResult);
+        when(loadBalancingClient.registerTargets(any())).thenReturn(new RegisterTargetsResult());
+
+        List<CloudResourceStatus> statuses = underTest.launchLoadBalancerResources(authenticatedContext, stack, persistenceNotifier, loadBalancingClient,
+                true);
+
+        ArgumentCaptor<CloudResource> cloudResourceArgumentCaptor = ArgumentCaptor.forClass(CloudResource.class);
+        verify(persistenceNotifier, times(3)).notifyAllocation(cloudResourceArgumentCaptor.capture(), any());
+        verify(loadBalancingClient, times(1)).registerTargets(any());
+        assertTrue(cloudResourceArgumentCaptor.getAllValues().stream()
+                .anyMatch(cloudResource -> ResourceType.ELASTIC_LOAD_BALANCER.equals(cloudResource.getType())));
+        assertTrue(cloudResourceArgumentCaptor.getAllValues().stream()
+                .anyMatch(cloudResource -> ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP.equals(cloudResource.getType())));
+        assertTrue(cloudResourceArgumentCaptor.getAllValues().stream()
+                .anyMatch(cloudResource -> ResourceType.ELASTIC_LOAD_BALANCER_LISTENER.equals(cloudResource.getType())));
+        assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER, ResourceStatus.CREATED));
+        assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, ResourceStatus.CREATED));
+        assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER_LISTENER, ResourceStatus.CREATED));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(booleans = {false, true})
+    void testLaunchLoadBalancerResourcesWhenListenerResourceExistsAlreadyWithSameSchemeAndLoadBalancerAndTargetGroup(boolean internal) {
+        CloudStack stack = getCloudStack();
+        when(loadBalancerCommonService.getAwsLoadBalancers(any(), any(), any())).thenReturn(List.of(
+                getAwsLoadBalancer(internal ? AwsLoadBalancerScheme.INTERNAL : AwsLoadBalancerScheme.INTERNET_FACING)));
+        String scheme = internal ? INTERNAL : EXTERNAL;
+        String lbNameNew = internal ? LB_NAME_INTERNAL_NEW : LB_NAME_EXTERNAL_NEW;
+        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER, STACK_NAME, scheme)).thenReturn(lbNameNew);
+        when(resourceNameService.trimHash(lbNameNew)).thenReturn(internal ? LB_NAME_INTERNAL_NO_HASH : LB_NAME_EXTERNAL_NO_HASH);
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER, STACK_ID)).thenReturn(List.of());
+        LoadBalancer loadBalancer = new LoadBalancer()
+                .withLoadBalancerArn("anARN");
+        CreateLoadBalancerResult loadBalancerResult = new CreateLoadBalancerResult().withLoadBalancers(loadBalancer);
+        when(loadBalancingClient.registerLoadBalancer(any())).thenReturn(loadBalancerResult);
+        String tgNameNew = internal ? TG_NAME_INTERNAL_NEW : TG_NAME_EXTERNAL_NEW;
+        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, STACK_NAME, scheme, USER_FACING_PORT))
+                .thenReturn(tgNameNew);
+        String tgNameNoHash = internal ? TG_NAME_INTERNAL_NO_HASH : TG_NAME_EXTERNAL_NO_HASH;
+        when(resourceNameService.trimHash(tgNameNew)).thenReturn(tgNameNoHash);
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, STACK_ID)).thenReturn(List.of());
+        TargetGroup targetGroup = new TargetGroup()
+                .withTargetGroupArn("aTargetGroupArn");
+        CreateTargetGroupResult createTargetGroupResult = new CreateTargetGroupResult()
+                .withTargetGroups(List.of(targetGroup));
+        when(loadBalancingClient.createTargetGroup(any())).thenReturn(createTargetGroupResult);
+        String listenerName = internal ? TG_NAME_INTERNAL : TG_NAME_EXTERNAL;
         CloudResource listenerResource = CloudResource.builder()
-                .withName(aLoadBalancerTGName)
+                .withName(listenerName)
                 .withType(ResourceType.ELASTIC_LOAD_BALANCER_LISTENER)
                 .withReference("aListenerArn")
                 .build();
-        when(persistenceRetriever.retrieveFirstByTypeAndStatusForStack(eq(ResourceType.ELASTIC_LOAD_BALANCER_LISTENER), eq(CommonStatus.CREATED), any()))
-                .thenReturn(Optional.of(listenerResource));
+        when(resourceNameService.trimHash(listenerName)).thenReturn(tgNameNoHash);
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER_LISTENER, STACK_ID))
+                .thenReturn(List.of(listenerResource));
         when(loadBalancingClient.registerTargets(any())).thenReturn(new RegisterTargetsResult());
 
-        List<CloudResourceStatus> statuses = undertTest.launchLoadBalancerResources(authenticatedContext, stack, persistenceNotifier, loadBalancingClient,
+        List<CloudResourceStatus> statuses = underTest.launchLoadBalancerResources(authenticatedContext, stack, persistenceNotifier, loadBalancingClient,
                 true);
 
         ArgumentCaptor<CloudResource> cloudResourceArgumentCaptor = ArgumentCaptor.forClass(CloudResource.class);
@@ -525,13 +757,79 @@ class AwsNativeLoadBalancerLaunchServiceTest {
         assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER_LISTENER, ResourceStatus.CREATED));
     }
 
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(booleans = {false, true})
+    void testLaunchLoadBalancerResourcesWhenListenerResourceExistsAlreadyButDifferentSchemeAndLoadBalancerAndTargetGroup(boolean existingInternal) {
+        CloudStack stack = getCloudStack();
+        when(loadBalancerCommonService.getAwsLoadBalancers(any(), any(), any())).thenReturn(List.of(
+                getAwsLoadBalancer(existingInternal ? AwsLoadBalancerScheme.INTERNET_FACING : AwsLoadBalancerScheme.INTERNAL)));
+        String schemeNew = existingInternal ? EXTERNAL : INTERNAL;
+        String lbNameNew = existingInternal ? LB_NAME_EXTERNAL_NEW : LB_NAME_INTERNAL_NEW;
+        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER, STACK_NAME, schemeNew)).thenReturn(lbNameNew);
+        when(resourceNameService.trimHash(lbNameNew)).thenReturn(existingInternal ? LB_NAME_EXTERNAL_NO_HASH : LB_NAME_INTERNAL_NO_HASH);
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER, STACK_ID)).thenReturn(List.of());
+        LoadBalancer loadBalancer = new LoadBalancer()
+                .withLoadBalancerArn("anARN");
+        CreateLoadBalancerResult loadBalancerResult = new CreateLoadBalancerResult().withLoadBalancers(loadBalancer);
+        when(loadBalancingClient.registerLoadBalancer(any())).thenReturn(loadBalancerResult);
+        String tgNameNew = existingInternal ? TG_NAME_EXTERNAL_NEW : TG_NAME_INTERNAL_NEW;
+        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, STACK_NAME, schemeNew, USER_FACING_PORT))
+                .thenReturn(tgNameNew);
+        String tgNameNoHash = existingInternal ? TG_NAME_EXTERNAL_NO_HASH : TG_NAME_INTERNAL_NO_HASH;
+        when(resourceNameService.trimHash(tgNameNew)).thenReturn(tgNameNoHash);
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, STACK_ID)).thenReturn(List.of());
+        TargetGroup targetGroup = new TargetGroup()
+                .withTargetGroupArn("aTargetGroupArn");
+        CreateTargetGroupResult createTargetGroupResult = new CreateTargetGroupResult()
+                .withTargetGroups(List.of(targetGroup));
+        when(loadBalancingClient.createTargetGroup(any())).thenReturn(createTargetGroupResult);
+        String listenerName = existingInternal ? TG_NAME_INTERNAL : TG_NAME_EXTERNAL;
+        CloudResource listenerResource = CloudResource.builder()
+                .withName(listenerName)
+                .withType(ResourceType.ELASTIC_LOAD_BALANCER_LISTENER)
+                .withReference("aListenerArn")
+                .build();
+        when(resourceNameService.trimHash(listenerName)).thenReturn(existingInternal ? TG_NAME_INTERNAL_NO_HASH : TG_NAME_EXTERNAL_NO_HASH);
+        when(resourceRetriever
+                .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER_LISTENER, STACK_ID))
+                .thenReturn(List.of(listenerResource));
+        Listener listener = new Listener()
+                .withListenerArn("aListenerArn");
+        CreateListenerResult createListenerResult = new CreateListenerResult()
+                .withListeners(listener);
+        when(loadBalancingClient.registerListener(any())).thenReturn(createListenerResult);
+        when(loadBalancingClient.registerTargets(any())).thenReturn(new RegisterTargetsResult());
+
+        List<CloudResourceStatus> statuses = underTest.launchLoadBalancerResources(authenticatedContext, stack, persistenceNotifier, loadBalancingClient,
+                true);
+
+        ArgumentCaptor<CloudResource> cloudResourceArgumentCaptor = ArgumentCaptor.forClass(CloudResource.class);
+        verify(persistenceNotifier, times(3)).notifyAllocation(cloudResourceArgumentCaptor.capture(), any());
+        verify(loadBalancingClient, times(1)).registerTargets(any());
+        assertTrue(cloudResourceArgumentCaptor.getAllValues().stream()
+                .anyMatch(cloudResource -> ResourceType.ELASTIC_LOAD_BALANCER.equals(cloudResource.getType())));
+        assertTrue(cloudResourceArgumentCaptor.getAllValues().stream()
+                .anyMatch(cloudResource -> ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP.equals(cloudResource.getType())));
+        assertTrue(cloudResourceArgumentCaptor.getAllValues().stream()
+                .anyMatch(cloudResource -> ResourceType.ELASTIC_LOAD_BALANCER_LISTENER.equals(cloudResource.getType())));
+        assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER, ResourceStatus.CREATED));
+        assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, ResourceStatus.CREATED));
+        assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER_LISTENER, ResourceStatus.CREATED));
+    }
+
     private CloudStack getCloudStack() {
         Network network = new Network(new Subnet("10.0.0.0/16"), Map.of(NetworkConstants.VPC_ID, "vpc-avpcarn"));
         return new CloudStack(List.of(), network, null, Map.of(), Map.of(), null, null, null, null, null, null);
     }
 
     private AwsLoadBalancer getAwsLoadBalancer() {
-        AwsLoadBalancer awsLoadBalancer = new AwsLoadBalancer(AwsLoadBalancerScheme.INTERNAL);
+        return getAwsLoadBalancer(AwsLoadBalancerScheme.INTERNAL);
+    }
+
+    private AwsLoadBalancer getAwsLoadBalancer(AwsLoadBalancerScheme scheme) {
+        AwsLoadBalancer awsLoadBalancer = new AwsLoadBalancer(scheme);
         awsLoadBalancer.getOrCreateListener(USER_FACING_PORT, HEALTH_CHECK_PORT);
         return awsLoadBalancer;
     }
@@ -541,4 +839,5 @@ class AwsNativeLoadBalancerLaunchServiceTest {
                 .stream()
                 .anyMatch(status -> resourceType.equals(status.getCloudResource().getType()) && resourceStatus.equals(status.getStatus()));
     }
+
 }


### PR DESCRIPTION
* Platform variant: `AWS_NATIVE`
  * Handle the case when the stack has both an external and internal LB.
  * Just like for the CF-based AWS variant, separate `loadbalancer`, `targetgroup` and `listener` ELB resources will be provisioned, depending on the scheme requested.
  * The LB provisioning logic remains idempotent.
* Some code cleanup.
* Testing:
  * Manual testing in local CB: Data Engineering HA, `AWS` and `AWS_NATIVE` variants.
  * Added new UT and updated existing ones.
