### PR TITLE
CB-19063 tracing should be configurable in ums clients in order to avoid tracing to block ums related requests in tests

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/config/UmsClientConfig.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/config/UmsClientConfig.java
@@ -37,6 +37,9 @@ public class UmsClientConfig {
     @Value("${altus.ums.client.grpc.short.timeout.sec:5}")
     private long grpcShortTimeoutSec;
 
+    @Value("${altus.ums.tracing.enabled:false}")
+    private boolean tracingEnabled;
+
     @PostConstruct
     public void init() {
         checkNotNull(callingServiceName, "callingServiceName must not be null.");
@@ -79,4 +82,7 @@ public class UmsClientConfig {
         return grpcShortTimeoutSec;
     }
 
+    public boolean isTracingEnabled() {
+        return tracingEnabled;
+    }
 }


### PR DESCRIPTION
See detailed description in the commit message.