### PR TITLE
CB-18968 Do not allow database upgrade via API for datahubs with embedded DB

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeService.java
@@ -91,6 +91,13 @@ public class RdsUpgradeService {
         TargetMajorVersion calculatedVersion = ObjectUtils.defaultIfNull(targetMajorVersion, defaultTargetMajorVersion);
         String accountId = restRequestThreadLocalService.getAccountId();
         StackView stack = stackDtoService.getStackViewByNameOrCrn(nameOrCrn, accountId);
+
+        boolean dataHubWithEmbeddedDatabase = !stack.isDatalake() && stack.getExternalDatabaseCreationType().isEmbedded();
+        if (dataHubWithEmbeddedDatabase) {
+            LOGGER.warn("Database upgrade is not allowed for DataHubs with embedded database ");
+            throw new BadRequestException("Database upgrade is not allowed for DataHubs with embedded database");
+        }
+
         MDCBuilder.buildMdcContext(stack);
         LOGGER.info("RDS upgrade has been initiated for stack {} to version {}, request version was {}",
                 nameOrCrn.getNameOrCrn(), calculatedVersion, targetMajorVersion);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeServiceTest.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.service.upgrade.rds;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_RDS_UPGRADE_ALREADY_UPGRADED;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_RDS_UPGRADE_NOT_AVAILABLE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -34,6 +35,7 @@ import org.springframework.util.ReflectionUtils;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseAvailabilityType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.database.DatabaseServerStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.database.StackDatabaseServerResponse;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.upgrade.RdsUpgradeV4Response;
@@ -143,6 +145,20 @@ class RdsUpgradeServiceTest {
         verify(reactorFlowManager).triggerRdsUpgrade(eq(STACK_ID), eq(TARGET_VERSION), eq(BACKUP_LOCATION));
         assertThat(response.getFlowIdentifier().getType()).isEqualTo(FlowType.FLOW_CHAIN);
         assertThat(response.getFlowIdentifier().getPollableId()).isEqualTo(FLOW_ID);
+    }
+
+    @Test
+    void testUpgradeRdsRejectedOnDataHubWithEmbeddedDB() {
+        Stack stack = createStack(Status.AVAILABLE);
+        stack.setType(StackType.WORKLOAD);
+        stack.setExternalDatabaseCreationType(DatabaseAvailabilityType.ON_ROOT_VOLUME);
+
+        when(restRequestThreadLocalService.getAccountId()).thenReturn(ACCOUNT_ID);
+        when(stackDtoService.getStackViewByNameOrCrn(eq(NameOrCrn.ofCrn(STACK_CRN)), any())).thenReturn(stack);
+
+        BadRequestException exception = assertThrows(BadRequestException.class, () -> underTest.upgradeRds(NameOrCrn.ofCrn(STACK_CRN), TARGET_VERSION));
+
+        assertThat(exception.getMessage()).isEqualTo("Database upgrade is not allowed for DataHubs with embedded database");
     }
 
     @Test
@@ -388,6 +404,7 @@ class RdsUpgradeServiceTest {
         workspace.setTenant(tenant);
         stack.setWorkspace(workspace);
         stack.setStackStatus(new StackStatus(stack, status, null, null));
+        stack.setExternalDatabaseCreationType(DatabaseAvailabilityType.HA);
         Cluster cluster = new Cluster();
         cluster.setId(CLUSTER_ID);
         stack.setCluster(cluster);


### PR DESCRIPTION
Embedded DB upgrade is executed via the pg_upgrade utility, and needs both pg 10 and 11 installed on the same image. To make sure that the customer has both, an OS upgrade is required as well. 

As a result embedded DB upgrade should not be allowed via the Database server upgrade API of distrox, it will not work. 