### PR TITLE
CB-19072 New DistroX endpoint for initiating Salt Update

### DIFF
--- a/authorization-common-api/src/main/java/com/sequenceiq/authorization/resource/AuthorizationResourceAction.java
+++ b/authorization-common-api/src/main/java/com/sequenceiq/authorization/resource/AuthorizationResourceAction.java
@@ -98,6 +98,8 @@ public enum AuthorizationResourceAction {
     ROTATE_SALTUSER_PASSWORD_ENVIRONMENT("environments/rotateSaltuserPassword", AuthorizationResourceType.ENVIRONMENT),
     ROTATE_SALTUSER_PASSWORD_DATALAKE("environments/rotateSaltuserPassword", AuthorizationResourceType.DATALAKE),
     ROTATE_SALTUSER_PASSWORD_DATAHUB("environments/rotateSaltuserPassword", AuthorizationResourceType.DATAHUB),
+    UPDATE_SALT_DATALAKE("environments/updateSalt", AuthorizationResourceType.DATALAKE),
+    UPDATE_SALT_DATAHUB("environments/updateSalt", AuthorizationResourceType.DATAHUB),
     MODIFY_AUDIT_CREDENTIAL("environments/modifyAuditCredential", AuthorizationResourceType.AUDIT_CREDENTIAL),
     POWERUSER_ONLY("cloudbreak/allowPowerUserOnly", null),
     LIST_ASSIGNED_ROLES("iam/listAssignedResourceRoles", null),

--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/endpoint/DistroXV1Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/endpoint/DistroXV1Endpoint.java
@@ -2,6 +2,7 @@ package com.sequenceiq.distrox.api.v1.distrox.endpoint;
 
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.ClusterOpDescription.SET_MAINTENANCE_MODE_BY_CRN;
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.ClusterOpDescription.SET_MAINTENANCE_MODE_BY_NAME;
+import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.ClusterOpDescription.UPDATE_SALT;
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescription.ATTACH_RECIPE_BY_CRN;
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescription.ATTACH_RECIPE_BY_NAME;
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescription.CHANGE_IMAGE_CATALOG;
@@ -261,6 +262,12 @@ public interface DistroXV1Endpoint {
     @ApiOperation(value = ROTATE_SALT_PASSWORD_BY_CRN, produces = MediaType.APPLICATION_JSON, notes = Notes.STACK_NOTES,
             nickname = "rotateSaltPasswordDistroXV1ByCrn")
     FlowIdentifier rotateSaltPasswordByCrn(@PathParam("crn") String crn);
+
+    @PUT
+    @Path("crn/{crn}/salt_update")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = UPDATE_SALT, nickname = "updateSaltDistroxV1ByCrn")
+    FlowIdentifier updateSaltByCrn(@ValidCrn(resource = CrnResourceDescriptor.DATAHUB) @PathParam("crn") String crn);
 
     @PUT
     @Path("name/{name}/scaling")

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXV1Controller.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXV1Controller.java
@@ -345,6 +345,12 @@ public class DistroXV1Controller implements DistroXV1Endpoint {
     }
 
     @Override
+    @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.UPDATE_SALT_DATAHUB)
+    public FlowIdentifier updateSaltByCrn(@ValidCrn(resource = CrnResourceDescriptor.DATAHUB) @ResourceCrn String crn) {
+        return stackOperations.updateSalt(NameOrCrn.ofCrn(crn), restRequestThreadLocalService.getAccountId());
+    }
+
+    @Override
     @CheckPermissionByResourceNameList(action = AuthorizationResourceAction.START_DATAHUB)
     public void putStartByNames(@ResourceNameList List<String> names) {
         names.forEach(this::putStartByName);

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXV1ControllerTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXV1ControllerTest.java
@@ -127,4 +127,13 @@ class DistroXV1ControllerTest {
 
         verify(stackOperations).rotateSaltPassword(NameOrCrn.ofCrn(CRN), ACCOUNT_ID, RotateSaltPasswordReason.MANUAL);
     }
+
+    @Test
+    void testUpdateSaltByCrn() {
+        when(restRequestThreadLocalService.getAccountId()).thenReturn(ACCOUNT_ID);
+
+        distroXV1Controller.updateSaltByCrn(CRN);
+
+        verify(stackOperations).updateSalt(NameOrCrn.ofCrn(CRN), ACCOUNT_ID);
+    }
 }

--- a/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/mapper/ClusterUseCaseMapper.java
+++ b/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/mapper/ClusterUseCaseMapper.java
@@ -64,6 +64,8 @@ public class ClusterUseCaseMapper {
                 UsageProto.CDPClusterStatus.Value.VERTICAL_SCALE_STARTED);
         firstStepUseCaseMap.put(Pair.of("UpgradeRdsFlowEventChainFactory", "SaltUpdateFlowConfig"),
                 UsageProto.CDPClusterStatus.Value.DATABASE_UPGRADE_STARTED);
+        firstStepUseCaseMap.put(Pair.of("", "SaltUpdateFlowConfig"),
+                UsageProto.CDPClusterStatus.Value.SALT_UPDATE_STARTED);
     }
 
     // At the moment we need to introduce a complex logic to figure out the use case
@@ -181,6 +183,10 @@ public class ClusterUseCaseMapper {
                 case "UpgradeRdsFlowEventChainFactory":
                     useCase = getClusterStatus(nextFlowState, "UPGRADE_RDS_FINISHED_STATE",
                             UsageProto.CDPClusterStatus.Value.DATABASE_UPGRADE_FINISHED, UsageProto.CDPClusterStatus.Value.DATABASE_UPGRADE_FAILED);
+                    break;
+                case "SaltUpdateFlowConfig":
+                    useCase = getClusterStatus(nextFlowState, "SALT_UPDATE_FINISHED_STATE",
+                            UsageProto.CDPClusterStatus.Value.SALT_UPDATE_FINISHED, UsageProto.CDPClusterStatus.Value.SALT_UPDATE_FAILED);
                     break;
                 default:
                     LOGGER.debug("Next flow state: {}", nextFlowState);

--- a/usage-collection/src/main/proto/usage.proto
+++ b/usage-collection/src/main/proto/usage.proto
@@ -222,6 +222,8 @@ message Event {
     CDPDFFlowDesignLifecycle cdpDFFlowDesignLifecycle = 106;
     // A CDP environment's proxy config is edited.
     CDPEnvironmentProxyConfigEditEvent cdpEnvironmentProxyConfigEditEvent = 107;
+    // A CDP CDW Usage Event.
+    CDPCDWUsageEvent cdpCDWUsageEvent = 108;
   }
 }
 
@@ -1570,6 +1572,13 @@ message CDPClusterStatus {
     DATABASE_UPGRADE_FINISHED = 56;
     // The status when the database server upgrade fails for a DL / DH
     DATABASE_UPGRADE_FAILED = 57;
+
+    // The status when a salt update operation on the cluster is started
+    SALT_UPDATE_STARTED = 58;
+    // The status when a salt update operation on the cluster is finished
+    SALT_UPDATE_FINISHED = 59;
+    // The status when a salt update operation on the cluster is failed
+    SALT_UPDATE_FAILED = 60;
   }
 }
 
@@ -2151,6 +2160,14 @@ message CDPDFServiceStatus {
     ROLLBACK_IN_PROGRESS = 25;
     // The status of a df service that has deployments upgrade in progress
     UPGRADE_DEPLOYMENTS_IN_PROGRESS = 26;
+    // The status of a df service that indicates that the PEM certificate renewal was requested
+    PEM_CERTIFICATE_RENEWAL_REQUESTED = 27;
+    // The status of a df service that indicates that the PEM certificate renewal is in progress
+    PEM_CERTIFICATE_RENEWAL_IN_PROGRESS = 28;
+    // The status of a df service that indicates that the PEM certificate renewal failed
+    PEM_CERTIFICATE_RENEWAL_FAILED = 29;
+    // The status of a df service that indicates that the PEM certificate renewal succeeded
+    PEM_CERTIFICATE_RENEWAL_SUCCEEDED = 30;
   }
 }
 
@@ -2824,6 +2841,44 @@ message CDPCDWResourceStatus {
   }
 }
 
+// Generic CDW Usage Event generated for different cases.
+message CDPCDWUsageEvent {
+  // The CDP account ID.
+  string accountId = 1;
+  // The CDP environment name.
+  string environmentName = 2;
+  // The CDP CDW environment type.
+  CDPEnvironmentsEnvironmentType.Value environmentType = 3;
+  // The CDP CDW cluster ID.
+  string clusterId = 4;
+  // The type of CDW resource.
+  CDPCDWResourceType.Value resourceType = 5;
+  // The id of CDW resource.
+  string resourceId = 6;
+  // The component sending the event.
+  string component = 7;
+  // The type of CDW usage event.
+  string eventType = 8;
+  // The data of CDW usage event.
+  string eventData = 9;
+}
+
+// The type of a CDW Resource.
+message CDPCDWResourceType {
+  enum Value {
+    // A value indicating the enum is unset.
+    UNSET = 0;
+    // Environment.
+    ENVIRONMENT = 1;
+    // Database Catalog.
+    DATABASE_CATALOG = 2;
+    // Virtual Warehouse.
+    VIRTUAL_WAREHOUSE = 3;
+    // Data Visualization.
+    DATA_VISUALIZATION = 4;
+  }
+}
+
 // Generated when a CDP CDW environment create, update or upgrade has been requested.
 message CDPCDWEnvironmentRequested {
   // The ID of the CDW environment.
@@ -2840,6 +2895,8 @@ message CDPCDWEnvironmentRequested {
   string actorCrn = 6;
   // The status of the CDW environment.
   CDPCDWResourceStatus.Value status = 7;
+  // Track Enable Das Link
+  bool enableDas = 8;
 }
 
 // Generated when a CDP CDW environment's status has changed.
@@ -3160,10 +3217,18 @@ message CDPCDEJobRunStatusChanged {
   string vcId = 2;
   // ID if the job run.
   string runId = 3;
+  // Name of the user running the job(hashed)
+  string user = 8;
   // New status of the job run.
   string status = 4;
   // Details of the job run.
   CDPCDEJobDetails jobDetails = 5;
+  // Indicates when the job was started
+  uint64 started = 6;
+  // Indicates when the job run ended
+  uint64 ended = 7;
+  // Indicates the duration of the job run
+  int32 duration = 9;
 }
 
 // Generated when a CDP CDE job is created or is modified.


### PR DESCRIPTION
This commit adds a new endpoint to the DistroXV1 API that initiates Salt Update on a Datahub. This operation previously was only available on the StackV4 internal endpoint. EDH tracking for separate Salt Update operation is also added.

See detailed description in the commit message.