### PR TITLE
CB-19142 testsuites/e2e/gcp-longrunning-e2e-tests.yaml was introduced

### DIFF
--- a/integration-test/src/main/resources/testsuites/e2e/gcp-longrunning-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/gcp-longrunning-e2e-tests.yaml
@@ -3,8 +3,4 @@ tests:
   - name: "gcp_longrunning_e2e_tests"
     classes:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.EnvironmentStopStartTests
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxUpgradeRecoveryTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.freeipa.FreeIpaUpgradeTests
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRepairTests
-        excludedMethods:
-          - testSDXMediumDutyCreation


### PR DESCRIPTION
some test are not workig properly on gcp. disabling those and fixing them on master