### PR TITLE
CB-19389: Extend salt timeout for database upgrade backup

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeOrchestratorService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/rds/RdsUpgradeOrchestratorService.java
@@ -59,7 +59,7 @@ public class RdsUpgradeOrchestratorService {
 
     private static final int MAX_RETRY_ON_ERROR = 3;
 
-    private static final int MAX_RETRY = 500;
+    private static final int MAX_RETRY = 2000;
 
     @Inject
     private StackDtoService stackDtoService;

--- a/datalake/src/main/resources/application.yml
+++ b/datalake/src/main/resources/application.yml
@@ -76,7 +76,7 @@ sdx:
     ssotype: SSO_PROVIDER
   upgrade.database:
     sleeptime-sec: 20
-    duration-min: 180
+    duration-min: 330
 
   paywall.url: "https://archive.cloudera.com/p/cdp-public/"
 


### PR DESCRIPTION
In this commit, I updated the salt retry count from 500 to 2000 and the upgrade timeout from ~1h 23min to ~5h 30min

