### PR TITLE
CB-17129 Ensure FreeIPA instances are in different AZ after upgrade.

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/RepairFlowEventChainFactory.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/RepairFlowEventChainFactory.java
@@ -39,7 +39,7 @@ public class RepairFlowEventChainFactory implements FlowEventChainFactory<Repair
         flowEventChain.add(new DownscaleEvent(DownscaleFlowEvent.DOWNSCALE_EVENT.event(),
                 event.getResourceId(), terminatedOrRemovedInstanceIds, event.getInstanceCountByGroup(), true, true, false, event.getOperationId()));
         flowEventChain.add(new UpscaleEvent(UpscaleFlowEvent.UPSCALE_EVENT.event(),
-                event.getResourceId(), event.getInstanceCountByGroup(), true, true, false, event.getOperationId(), null));
+                event.getResourceId(), new ArrayList<>(), event.getInstanceCountByGroup(), true, true, false, event.getOperationId(), null));
         flowEventChain.add(new ChangePrimaryGatewayEvent(ChangePrimaryGatewayFlowEvent.CHANGE_PRIMARY_GATEWAY_EVENT.event(), event.getResourceId(),
                 terminatedOrRemovedInstanceIds, true, event.getOperationId()));
         return new FlowTriggerEventQueue(getName(), event, flowEventChain);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/event/UpscaleEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/event/UpscaleEvent.java
@@ -1,12 +1,17 @@
 package com.sequenceiq.freeipa.flow.freeipa.upscale.event;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.freeipa.flow.stack.StackEvent;
 
-public class UpscaleEvent extends StackEvent {
+public class
+UpscaleEvent extends StackEvent {
+
+    private final ArrayList<String> instanceIds;
 
     private final Integer instanceCountByGroup;
 
@@ -24,6 +29,7 @@ public class UpscaleEvent extends StackEvent {
     public UpscaleEvent(
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long stackId,
+            @JsonProperty("instanceIds") ArrayList<String> instanceIds,
             @JsonProperty("instanceCountByGroup") Integer instanceCountByGroup,
             @JsonProperty("repair") Boolean repair,
             @JsonProperty("chained") boolean chained,
@@ -31,12 +37,17 @@ public class UpscaleEvent extends StackEvent {
             @JsonProperty("operationId") String operationId,
             @JsonProperty("triggeredVariant") String triggeredVariant) {
         super(selector, stackId);
+        this.instanceIds = instanceIds;
         this.instanceCountByGroup = instanceCountByGroup;
         this.repair = repair;
         this.chained = chained;
         this.finalChain = finalChain;
         this.operationId = operationId;
         this.triggeredVariant = triggeredVariant;
+    }
+
+    public List<String> getInstanceIds() {
+        return instanceIds;
     }
 
     public Integer getInstanceCountByGroup() {
@@ -76,7 +87,8 @@ public class UpscaleEvent extends StackEvent {
     @Override
     public String toString() {
         return "UpscaleEvent{" +
-                "instanceCountByGroup=" + instanceCountByGroup +
+                "instanceIds=" + instanceIds +
+                ", instanceCountByGroup=" + instanceCountByGroup +
                 ", repair=" + repair +
                 ", operationId='" + operationId + '\'' +
                 ", chained=" + chained +

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaScalingService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaScalingService.java
@@ -86,8 +86,8 @@ public class FreeIpaScalingService {
 
     private UpscaleResponse triggerUpscale(UpscaleRequest request, Stack stack, AvailabilityType originalAvailabilityType) {
         Operation operation = startScalingOperation(stack.getAccountId(), request.getEnvironmentCrn(), OperationType.UPSCALE);
-        UpscaleEvent upscaleEvent = new UpscaleEvent(UpscaleFlowEvent.UPSCALE_EVENT.event(),
-                stack.getId(), request.getTargetAvailabilityType().getInstanceCount(), false, false, false, operation.getOperationId(), null);
+        UpscaleEvent upscaleEvent = new UpscaleEvent(UpscaleFlowEvent.UPSCALE_EVENT.event(), stack.getId(), new ArrayList<>(),
+                request.getTargetAvailabilityType().getInstanceCount(), false, false, false, operation.getOperationId(), null);
         try {
             LOGGER.info("Trigger upscale flow with event: {}", upscaleEvent);
             FlowIdentifier flowIdentifier = flowManager.notify(UpscaleFlowEvent.UPSCALE_EVENT.event(), upscaleEvent);

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/InstanceMetadataServiceComponentTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/InstanceMetadataServiceComponentTest.java
@@ -95,7 +95,7 @@ public class InstanceMetadataServiceComponentTest {
         freeIpa.setDomain("domain");
         when(freeIpaService.findByStack(stack)).thenReturn(freeIpa);
 
-        instanceMetaDataService.saveInstanceAndGetUpdatedStack(stack, cloudInstances(42, "worker"));
+        instanceMetaDataService.saveInstanceAndGetUpdatedStack(stack, cloudInstances(42, "worker"), Collections.emptyList());
         Map<String, List<InstanceMetaData>> groupBySub = workerInstanceGroup.getInstanceMetaDataSet().stream()
                 .collect(Collectors.groupingBy(
                         InstanceMetaData::getSubnetId,
@@ -153,7 +153,7 @@ public class InstanceMetadataServiceComponentTest {
         freeIpa.setDomain("domain");
         when(freeIpaService.findByStack(stack)).thenReturn(freeIpa);
 
-        instanceMetaDataService.saveInstanceAndGetUpdatedStack(stack, cloudInstances(1, "master"));
+        instanceMetaDataService.saveInstanceAndGetUpdatedStack(stack, cloudInstances(1, "master"), Collections.emptyList());
         Map<String, List<InstanceMetaData>> groupBySub = masterInstanceGroup.getInstanceMetaDataSet().stream()
                 .collect(Collectors.groupingBy(
                         InstanceMetaData::getSubnetId,


### PR DESCRIPTION
The subnet and AZ will be saved to the new instance metadata. The instances are grouped by the same group type and we create the same amount of instances with the same amount of AZs