### PR TITLE
CB-18795 Create pre and post usersync endpoint

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/UserV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/UserV1Endpoint.java
@@ -10,8 +10,10 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import com.sequenceiq.cloudbreak.auth.crn.CrnResourceDescriptor;
 import com.sequenceiq.cloudbreak.auth.security.internal.AccountId;
 import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
+import com.sequenceiq.cloudbreak.validation.ValidCrn;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.doc.UserNotes;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.doc.UserOperationDescriptions;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.EnvironmentUserSyncState;
@@ -77,4 +79,18 @@ public interface UserV1Endpoint {
     @ApiOperation(value = UserOperationDescriptions.ENVIRONMENT_USERSYNC_STATE, notes = UserNotes.USER_NOTES, produces = MediaType.APPLICATION_JSON,
             nickname = "getEnvironmentUserSyncStateV1")
     EnvironmentUserSyncState getUserSyncState(@QueryParam("environmentCrn") @NotEmpty String environmentCrn);
+
+    @POST
+    @Path("presync")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = UserOperationDescriptions.PRE_SYNC, notes = UserNotes.USER_NOTES, produces = MediaType.APPLICATION_JSON,
+            nickname = "preSynchronizeV1")
+    SyncOperationStatus preSynchronize(@QueryParam("environmentCrn") @ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT) @NotEmpty String environmentCrn);
+
+    @POST
+    @Path("postsync")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = UserOperationDescriptions.POST_SYNC, notes = UserNotes.USER_NOTES, produces = MediaType.APPLICATION_JSON,
+            nickname = "postSynchronizeV1")
+    SyncOperationStatus postSynchronize(@QueryParam("environmentCrn") @ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT) @NotEmpty String environmentCrn);
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/doc/UserOperationDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/doc/UserOperationDescriptions.java
@@ -2,6 +2,8 @@ package com.sequenceiq.freeipa.api.v1.freeipa.user.doc;
 
 public final class UserOperationDescriptions {
     public static final String SYNC_SINGLE = "Synchronizes a User to the FreeIPA servers";
+    public static final String PRE_SYNC = "Start pre usersync related tasks";
+    public static final String POST_SYNC = "Start post usersync related tasks";
     public static final String SYNC_ALL = "Synchronizes Groups and Users to the FreeIPA servers";
     public static final String SET_PASSWORD = "Sets the user's password in the FreeIPA servers";
     public static final String SYNC_OPERATION_STATUS = "Gets the status of a sync operation";

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/AbstractUserSyncTaskRunner.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/AbstractUserSyncTaskRunner.java
@@ -1,0 +1,60 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationState;
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationType;
+import com.sequenceiq.freeipa.entity.Operation;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.operation.OperationService;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+public abstract class AbstractUserSyncTaskRunner {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractUserSyncTaskRunner.class);
+
+    @Value("#{${freeipa.operation.cleanup.timeout-millis} * 0.1 }")
+    private Long operationTimeout;
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private OperationService operationService;
+
+    @Inject
+    private RegionAwareInternalCrnGeneratorFactory regionAwareInternalCrnGeneratorFactory;
+
+    public Operation runUserSyncTasks(String environmentCrn, String accountId) {
+        Operation operation = operationService.startOperation(accountId, OperationType.USER_SYNC, List.of(environmentCrn), List.of());
+        MDCBuilder.addOperationId(operation.getOperationId());
+        if (operation.getStatus() == OperationState.RUNNING) {
+            operationService.tryWithOperationCleanup(operation.getOperationId(), accountId, () -> {
+                Stack stack = stackService.getByEnvironmentCrnAndAccountId(environmentCrn, accountId);
+                MDCBuilder.buildMdcContext(stack);
+                LOGGER.info("Starting usersync task");
+                ThreadBasedUserCrnProvider.doAs(
+                        regionAwareInternalCrnGeneratorFactory.iam().getInternalCrnForServiceAsString(),
+                        () -> asyncRunTask(operation.getOperationId(), accountId, stack));
+            });
+        } else {
+            LOGGER.warn("Operation is not RUNNING, usrsync task won't start. {}", operation);
+        }
+        return operation;
+    }
+
+    protected abstract void asyncRunTask(String operationId, String accountId, Stack stack);
+
+    protected Long getOperationTimeout() {
+        return operationTimeout;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/PostUserSyncService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/PostUserSyncService.java
@@ -1,0 +1,69 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import static com.sequenceiq.freeipa.service.freeipa.user.UserSyncLogEvent.ADD_SUDO_RULES;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SuccessDetails;
+import com.sequenceiq.freeipa.client.FreeIpaClient;
+import com.sequenceiq.freeipa.configuration.UsersyncConfig;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
+import com.sequenceiq.freeipa.service.operation.OperationService;
+
+@Service
+public class PostUserSyncService extends AbstractUserSyncTaskRunner {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PostUserSyncService.class);
+
+    @Inject
+    private TimeoutTaskScheduler timeoutTaskScheduler;
+
+    @Inject
+    @Qualifier(UsersyncConfig.USERSYNC_EXTERNAL_TASK_EXECUTOR)
+    private ExecutorService usersyncExternalTaskExecutor;
+
+    @Inject
+    private OperationService operationService;
+
+    @Inject
+    private EntitlementService entitlementService;
+
+    @Inject
+    private SudoRuleService sudoRuleService;
+
+    @Inject
+    private FreeIpaClientFactory freeIpaClientFactory;
+
+    protected void asyncRunTask(String operationId, String accountId, Stack stack) {
+        Future<?> task = usersyncExternalTaskExecutor.submit(() -> {
+            if (entitlementService.isEnvironmentPrivilegedUserEnabled(stack.getAccountId())) {
+                LOGGER.debug("Starting {} ...", ADD_SUDO_RULES);
+                try {
+                    FreeIpaClient freeIpaClient = freeIpaClientFactory.getFreeIpaClientForStack(stack);
+                    sudoRuleService.setupSudoRule(stack, freeIpaClient);
+                    operationService.completeOperation(accountId, operationId, List.of(new SuccessDetails(stack.getEnvironmentCrn())), List.of());
+                } catch (Exception e) {
+                    LOGGER.error("{} failed for environment '{}'.", ADD_SUDO_RULES, stack.getEnvironmentCrn(), e);
+                    operationService.failOperation(accountId, operationId, ADD_SUDO_RULES + " failed for environment with " + e.getMessage());
+                }
+                LOGGER.debug("Finished {}.", ADD_SUDO_RULES);
+            } else {
+                LOGGER.debug("Nothing to do for environment {}", stack.getEnvironmentCrn());
+                operationService.completeOperation(accountId, operationId, List.of(new SuccessDetails(stack.getEnvironmentCrn())), List.of());
+            }
+
+        });
+        timeoutTaskScheduler.scheduleTimeoutTask(operationId, accountId, task, getOperationTimeout());
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/PreUserSyncService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/PreUserSyncService.java
@@ -1,0 +1,46 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SuccessDetails;
+import com.sequenceiq.freeipa.configuration.UsersyncConfig;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.operation.OperationService;
+
+@Service
+public class PreUserSyncService extends AbstractUserSyncTaskRunner {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PreUserSyncService.class);
+
+    @Inject
+    private TimeoutTaskScheduler timeoutTaskScheduler;
+
+    @Inject
+    private UmsVirtualGroupCreateService umsVirtualGroupCreateService;
+
+    @Inject
+    @Qualifier(UsersyncConfig.USERSYNC_EXTERNAL_TASK_EXECUTOR)
+    private ExecutorService usersyncExternalTaskExecutor;
+
+    @Inject
+    private OperationService operationService;
+
+    protected void asyncRunTask(String operationId, String accountId, Stack stack) {
+        LOGGER.debug("Scheduling pre usersync task with [{}] operation id", operationId);
+        Future<?> task = usersyncExternalTaskExecutor.submit(() -> {
+            LOGGER.info("Starting pre usersync task with [{}] operation id", operationId);
+            umsVirtualGroupCreateService.createVirtualGroups(accountId, List.of(stack));
+            operationService.completeOperation(accountId, operationId, List.of(new SuccessDetails(stack.getEnvironmentCrn())), List.of());
+        });
+        timeoutTaskScheduler.scheduleTimeoutTask(operationId, accountId, task, getOperationTimeout());
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/TimeoutTaskScheduler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/TimeoutTaskScheduler.java
@@ -1,0 +1,46 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import java.util.Map;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.freeipa.configuration.UsersyncConfig;
+import com.sequenceiq.freeipa.service.operation.OperationService;
+
+@Component
+public class TimeoutTaskScheduler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TimeoutTaskScheduler.class);
+
+    @Inject
+    @Qualifier(UsersyncConfig.USERSYNC_TIMEOUT_TASK_EXECUTOR)
+    private ScheduledExecutorService timeoutTaskExecutor;
+
+    @Inject
+    private OperationService operationService;
+
+    public void scheduleTimeoutTask(String operationId, String accountId, Future<?> task, Long operationTimeout) {
+        LOGGER.info("Scheduling timeout task for {} with {}ms timeout", operationId, operationTimeout);
+        Map<String, String> mdcContextMap = MDCBuilder.getMdcContextMap();
+        timeoutTaskExecutor.schedule(() -> {
+            MDCBuilder.buildMdcContextFromMap(mdcContextMap);
+            if (task.isCancelled() || task.isDone()) {
+                LOGGER.debug("Nothing to do for operation id: [{}]", operationId);
+            } else {
+                LOGGER.debug("Terminating usersync task with operation id: [{}]", operationId);
+                task.cancel(true);
+                operationService.timeout(operationId, accountId);
+            }
+            MDCBuilder.cleanupMdc();
+        }, operationTimeout, TimeUnit.MILLISECONDS);
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/AbstractUserSyncTaskRunnerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/AbstractUserSyncTaskRunnerTest.java
@@ -1,0 +1,91 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGenerator;
+import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationState;
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationType;
+import com.sequenceiq.freeipa.entity.Operation;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.operation.OperationService;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+@ExtendWith(MockitoExtension.class)
+class AbstractUserSyncTaskRunnerTest {
+
+    private static final String ACCOUNT_ID = "accid";
+
+    private static final String ENVIRONMENT_CRN = "envcrn";
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private OperationService operationService;
+
+    @Mock
+    private RegionAwareInternalCrnGeneratorFactory regionAwareInternalCrnGeneratorFactory;
+
+    @Mock
+    private RegionAwareInternalCrnGenerator regionAwareInternalCrnGenerator;
+
+    @InjectMocks
+    private AbstractUserSyncTaskRunner underTest = spy(create());
+
+    @Test
+    public void testOperationRunning() {
+        Operation operation = new Operation();
+        operation.setOperationId(UUID.randomUUID().toString());
+        operation.setStatus(OperationState.RUNNING);
+        when(operationService.startOperation(ACCOUNT_ID, OperationType.USER_SYNC, List.of(ENVIRONMENT_CRN), List.of())).thenReturn(operation);
+        Stack stack = new Stack();
+        when(stackService.getByEnvironmentCrnAndAccountId(ENVIRONMENT_CRN, ACCOUNT_ID)).thenReturn(stack);
+        doAnswer(inv -> {
+            inv.getArgument(2, Runnable.class).run();
+            return null;
+        }).when(operationService).tryWithOperationCleanup(eq(operation.getOperationId()), eq(ACCOUNT_ID), any(Runnable.class));
+        when(regionAwareInternalCrnGeneratorFactory.iam()).thenReturn(regionAwareInternalCrnGenerator);
+        when(regionAwareInternalCrnGenerator.getInternalCrnForServiceAsString()).thenReturn("crn:cdp:freeipa:us-west-1:altus:user:__internal__actor__");
+
+        underTest.runUserSyncTasks(ENVIRONMENT_CRN, ACCOUNT_ID);
+
+        verify(underTest).asyncRunTask(operation.getOperationId(), ACCOUNT_ID, stack);
+    }
+
+    @Test
+    public void testOperationRejected() {
+        Operation operation = new Operation();
+        operation.setOperationId(UUID.randomUUID().toString());
+        operation.setStatus(OperationState.REJECTED);
+        when(operationService.startOperation(ACCOUNT_ID, OperationType.USER_SYNC, List.of(ENVIRONMENT_CRN), List.of())).thenReturn(operation);
+
+        underTest.runUserSyncTasks(ENVIRONMENT_CRN, ACCOUNT_ID);
+
+        verify(underTest, never()).asyncRunTask(any(), any(), any());
+    }
+
+    private AbstractUserSyncTaskRunner create() {
+        return new AbstractUserSyncTaskRunner() {
+            @Override
+            protected void asyncRunTask(String operationId, String accountId, Stack stack) {
+            }
+        };
+    }
+
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/PostUserSyncServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/PostUserSyncServiceTest.java
@@ -1,0 +1,129 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SuccessDetails;
+import com.sequenceiq.freeipa.client.FreeIpaClient;
+import com.sequenceiq.freeipa.client.FreeIpaClientException;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
+import com.sequenceiq.freeipa.service.operation.OperationService;
+
+@ExtendWith(MockitoExtension.class)
+class PostUserSyncServiceTest {
+
+    private static final String OPERATION_ID = "opId";
+
+    private static final String ACCOUNT_ID = "accId";
+
+    private static final Long TIMEOUT = 6L;
+
+    @Mock
+    private TimeoutTaskScheduler timeoutTaskScheduler;
+
+    @Mock
+    private ExecutorService usersyncExternalTaskExecutor;
+
+    @Mock
+    private OperationService operationService;
+
+    @Mock
+    private EntitlementService entitlementService;
+
+    @Mock
+    private SudoRuleService sudoRuleService;
+
+    @Mock
+    private FreeIpaClientFactory freeIpaClientFactory;
+
+    @InjectMocks
+    private PostUserSyncService underTest;
+
+    @Test
+    public void testSchedulingEntitlementPresent() throws Exception {
+        Stack stack = new Stack();
+        stack.setEnvironmentCrn("ENV_CRN");
+        stack.setAccountId(ACCOUNT_ID);
+        Future<Void> task = mock(Future.class);
+        doAnswer(inv -> {
+            Runnable runnable = inv.getArgument(0, Runnable.class);
+            runnable.run();
+            return task;
+        }).when(usersyncExternalTaskExecutor).submit(any(Runnable.class));
+        when(entitlementService.isEnvironmentPrivilegedUserEnabled(ACCOUNT_ID)).thenReturn(true);
+        FreeIpaClient freeIpaClient = mock(FreeIpaClient.class);
+        when(freeIpaClientFactory.getFreeIpaClientForStack(stack)).thenReturn(freeIpaClient);
+        ReflectionTestUtils.setField(underTest, "operationTimeout", TIMEOUT);
+
+        underTest.asyncRunTask(OPERATION_ID, ACCOUNT_ID, stack);
+
+        verify(sudoRuleService).setupSudoRule(stack, freeIpaClient);
+        verify(operationService).completeOperation(ACCOUNT_ID, OPERATION_ID, List.of(new SuccessDetails(stack.getEnvironmentCrn())), List.of());
+        verify(timeoutTaskScheduler).scheduleTimeoutTask(OPERATION_ID, ACCOUNT_ID, task, TIMEOUT);
+    }
+
+    @Test
+    public void testSchedulingEntitlementPresentSudoFails() throws Exception {
+        Stack stack = new Stack();
+        stack.setEnvironmentCrn("ENV_CRN");
+        stack.setAccountId(ACCOUNT_ID);
+        Future<Void> task = mock(Future.class);
+        doAnswer(inv -> {
+            Runnable runnable = inv.getArgument(0, Runnable.class);
+            runnable.run();
+            return task;
+        }).when(usersyncExternalTaskExecutor).submit(any(Runnable.class));
+        when(entitlementService.isEnvironmentPrivilegedUserEnabled(ACCOUNT_ID)).thenReturn(true);
+        FreeIpaClient freeIpaClient = mock(FreeIpaClient.class);
+        when(freeIpaClientFactory.getFreeIpaClientForStack(stack)).thenReturn(freeIpaClient);
+        doThrow(FreeIpaClientException.class).when(sudoRuleService).setupSudoRule(stack, freeIpaClient);
+        ReflectionTestUtils.setField(underTest, "operationTimeout", TIMEOUT);
+
+        underTest.asyncRunTask(OPERATION_ID, ACCOUNT_ID, stack);
+
+        verify(operationService).failOperation(eq(ACCOUNT_ID), eq(OPERATION_ID), anyString());
+        verify(timeoutTaskScheduler).scheduleTimeoutTask(OPERATION_ID, ACCOUNT_ID, task, TIMEOUT);
+    }
+
+    @Test
+    public void testSchedulingEntitlementMissing() {
+        Stack stack = new Stack();
+        stack.setEnvironmentCrn("ENV_CRN");
+        stack.setAccountId(ACCOUNT_ID);
+        Future<Void> task = mock(Future.class);
+        doAnswer(inv -> {
+            Runnable runnable = inv.getArgument(0, Runnable.class);
+            runnable.run();
+            return task;
+        }).when(usersyncExternalTaskExecutor).submit(any(Runnable.class));
+        when(entitlementService.isEnvironmentPrivilegedUserEnabled(ACCOUNT_ID)).thenReturn(false);
+        ReflectionTestUtils.setField(underTest, "operationTimeout", TIMEOUT);
+
+        underTest.asyncRunTask(OPERATION_ID, ACCOUNT_ID, stack);
+
+        verify(operationService).completeOperation(ACCOUNT_ID, OPERATION_ID, List.of(new SuccessDetails(stack.getEnvironmentCrn())), List.of());
+        verify(timeoutTaskScheduler).scheduleTimeoutTask(OPERATION_ID, ACCOUNT_ID, task, TIMEOUT);
+        verifyNoInteractions(sudoRuleService);
+    }
+
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/PreUserSyncServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/PreUserSyncServiceTest.java
@@ -1,0 +1,65 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SuccessDetails;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.operation.OperationService;
+
+@ExtendWith(MockitoExtension.class)
+class PreUserSyncServiceTest {
+
+    private static final String OPERATION_ID = "opId";
+
+    private static final String ACCOUNT_ID = "accId";
+
+    private static final Long TIMEOUT = 6L;
+
+    @Mock
+    private TimeoutTaskScheduler timeoutTaskScheduler;
+
+    @Mock
+    private UmsVirtualGroupCreateService umsVirtualGroupCreateService;
+
+    @Mock
+    private ExecutorService usersyncExternalTaskExecutor;
+
+    @Mock
+    private OperationService operationService;
+
+    @InjectMocks
+    private PreUserSyncService underTest;
+
+    @Test
+    public void testScheduling() {
+        Stack stack = new Stack();
+        stack.setEnvironmentCrn("ENV_CRN");
+        Future<Void> task = mock(Future.class);
+        doAnswer(inv -> {
+            Runnable runnable = inv.getArgument(0, Runnable.class);
+            runnable.run();
+            return task;
+        }).when(usersyncExternalTaskExecutor).submit(any(Runnable.class));
+        ReflectionTestUtils.setField(underTest, "operationTimeout", TIMEOUT);
+
+        underTest.asyncRunTask(OPERATION_ID, ACCOUNT_ID, stack);
+
+        verify(umsVirtualGroupCreateService).createVirtualGroups(ACCOUNT_ID, List.of(stack));
+        verify(operationService).completeOperation(ACCOUNT_ID, OPERATION_ID, List.of(new SuccessDetails(stack.getEnvironmentCrn())), List.of());
+        verify(timeoutTaskScheduler).scheduleTimeoutTask(OPERATION_ID, ACCOUNT_ID, task, TIMEOUT);
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/TimeoutTaskSchedulerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/TimeoutTaskSchedulerTest.java
@@ -1,0 +1,91 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.freeipa.service.operation.OperationService;
+
+@ExtendWith(MockitoExtension.class)
+class TimeoutTaskSchedulerTest {
+
+    private static final String OPERATION_ID = "opId";
+
+    private static final String ACCOUNT_ID = "accId";
+
+    private static final Long TIMEOUT = 6L;
+
+    @Mock
+    private ScheduledExecutorService timeoutTaskExecutor;
+
+    @Mock
+    private OperationService operationService;
+
+    @InjectMocks
+    private TimeoutTaskScheduler underTest;
+
+    @Test
+    public void taskCancelled() {
+                Future<Void> task = mock(Future.class);
+        when(task.isCancelled()).thenReturn(false);
+        when(task.isDone()).thenReturn(false);
+        doAnswer(inv -> {
+            Runnable runnable = inv.getArgument(0, Runnable.class);
+            runnable.run();
+            return null;
+        }).when(timeoutTaskExecutor).schedule(any(Runnable.class), eq(TIMEOUT), eq(TimeUnit.MILLISECONDS));
+
+        underTest.scheduleTimeoutTask(OPERATION_ID, ACCOUNT_ID, task, TIMEOUT);
+
+        verify(operationService).timeout(OPERATION_ID, ACCOUNT_ID);
+        verify(task).cancel(true);
+    }
+
+    @Test
+    public void taskAlreadyCancelled() {
+        Future<Void> task = mock(Future.class);
+        when(task.isCancelled()).thenReturn(true);
+        doAnswer(inv -> {
+            Runnable runnable = inv.getArgument(0, Runnable.class);
+            runnable.run();
+            return null;
+        }).when(timeoutTaskExecutor).schedule(any(Runnable.class), eq(TIMEOUT), eq(TimeUnit.MILLISECONDS));
+
+        underTest.scheduleTimeoutTask(OPERATION_ID, ACCOUNT_ID, task, TIMEOUT);
+
+        verifyNoInteractions(operationService);
+        verifyNoMoreInteractions(task);
+    }
+
+    @Test
+    public void taskIsDone() {
+        Future<Void> task = mock(Future.class);
+        when(task.isCancelled()).thenReturn(false);
+        when(task.isDone()).thenReturn(true);
+        doAnswer(inv -> {
+            Runnable runnable = inv.getArgument(0, Runnable.class);
+            runnable.run();
+            return null;
+        }).when(timeoutTaskExecutor).schedule(any(Runnable.class), eq(TIMEOUT), eq(TimeUnit.MILLISECONDS));
+
+        underTest.scheduleTimeoutTask(OPERATION_ID, ACCOUNT_ID, task, TIMEOUT);
+
+        verifyNoInteractions(operationService);
+        verifyNoMoreInteractions(task);
+    }
+}

--- a/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
+++ b/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
@@ -53,6 +53,7 @@ import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.CDP_DATA_LA
 import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.CDP_ENABLE_DISTROX_INSTANCE_TYPES;
 import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.CDP_ENDPOINT_GATEWAY_SKIP_VALIDATION;
 import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.CDP_ENVIRONMENT_EDIT_PROXY_CONFIG;
+import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.CDP_ENVIRONMENT_PRIVILEGED_USER;
 import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.CDP_EXPERIENCE_DELETION_BY_ENVIRONMENT;
 import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.CDP_FMS_DELAYED_STOP_START;
 import static com.sequenceiq.cloudbreak.auth.altus.model.Entitlement.CDP_FMS_RECIPE;
@@ -476,6 +477,9 @@ public class MockUserManagementService extends UserManagementImplBase {
 
     @Value("${auth.mock.datalake.zdu.osupgrade.enable}")
     private boolean enableDatalakeZduOSUpgrade;
+
+    @Value("${auth.mock.freeipa.privileged.user.enable}")
+    private boolean enablePrivilegedUser;
 
     @Value("${auth.mock.workloadiam.sync.enable}")
     private boolean enableWorkloadIamSync;
@@ -1024,6 +1028,9 @@ public class MockUserManagementService extends UserManagementImplBase {
         }
         if (enableDatalakeZduOSUpgrade) {
             builder.addEntitlements(createEntitlement(CDP_DATALAKE_ZDU_OS_UPGRADE));
+        }
+        if (enablePrivilegedUser) {
+            builder.addEntitlements(createEntitlement(CDP_ENVIRONMENT_PRIVILEGED_USER));
         }
         if (enableWorkloadIamSync) {
             builder.addEntitlements(createEntitlement(WORKLOAD_IAM_SYNC));

--- a/mock-thunderhead/src/main/resources/application.yml
+++ b/mock-thunderhead/src/main/resources/application.yml
@@ -24,6 +24,7 @@ auth:
       usersync.thread.timeout.enable: true
       delayedstopstart.enable: true
       recipes.enable: true
+      privileged.user.enable: true
     cloudstoragevalidation.enable:
       global: true
       aws: true


### PR DESCRIPTION
Exposing WAG creation with pre usersync API, and sudo rule creation as post usersync API  for WIAM. The new endpoint are internal only.
The actual logic is running async, so WIAM should check the operation to see if it's finished. Same operation type (USER_SYNC) is used during the new endpoints, so there shouldn't be conflicting usersyncs.

`CDP_ENVIRONMENT_PRIVILEGED_USER` is enabled in mock-thunderhead to enable testing.

See detailed description in the commit message.