### PR TITLE
CB-19522 [API E2E] Set the Upgrade/Recovery tests default "currentRuntimeVersion" to 7.2.7

### DIFF
--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -88,7 +88,7 @@ integrationtest:
   runtimeVersion: 7.2.15
   upgrade:
     currentHARuntimeVersion: 7.2.7
-    currentRuntimeVersion: 7.2.0
+    currentRuntimeVersion: 7.2.7
     targetRuntimeVersion: 7.2.15
     distroXUpgradeCurrentVersion: 7.2.7
     distroXUpgradeTargetVersion: 7.2.15


### PR DESCRIPTION
We have `currentRuntimeVersion: 7.2.0` [test parameter](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/src/main/resources/application.yml#L91) at `cloudbreak/integration-test/src/main/resources/application.yml`.

The GCP provider is not supported at `Runtime: 7.2.0`. Furthermore we should update to `7.2.7`.

**So the `currentRuntimeVersion` should be updated to `7.2.7` where the GCP provider is also supported.**