### PR TITLE
CB-19045: Support rolling patch upgrade

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerRestartService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerRestartService.java
@@ -1,0 +1,123 @@
+package com.sequenceiq.cloudbreak.cm;
+
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.UPDATE_IN_PROGRESS;
+import static com.sequenceiq.cloudbreak.cm.DataView.SUMMARY;
+import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_CM_CLUSTER_SERVICES_RESTARTING;
+
+import java.math.BigDecimal;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.cloudera.api.swagger.ClustersResourceApi;
+import com.cloudera.api.swagger.ServicesResourceApi;
+import com.cloudera.api.swagger.client.ApiClient;
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.model.ApiCommand;
+import com.cloudera.api.swagger.model.ApiCommandList;
+import com.cloudera.api.swagger.model.ApiRestartClusterArgs;
+import com.cloudera.api.swagger.model.ApiRolesToInclude;
+import com.cloudera.api.swagger.model.ApiRollingRestartClusterArgs;
+import com.cloudera.api.swagger.model.ApiService;
+import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollingServiceProvider;
+import com.sequenceiq.cloudbreak.cm.polling.PollingResultErrorHandler;
+import com.sequenceiq.cloudbreak.dto.StackDtoDelegate;
+import com.sequenceiq.cloudbreak.polling.ExtendedPollingResult;
+import com.sequenceiq.cloudbreak.service.CloudbreakException;
+import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
+
+@Component
+public class ClouderaManagerRestartService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerRestartService.class);
+
+    @Inject
+    private ClouderaManagerPollingServiceProvider clouderaManagerPollingServiceProvider;
+
+    @Inject
+    private PollingResultErrorHandler pollingResultErrorHandler;
+
+    @Inject
+    private CloudbreakEventService eventService;
+
+    @Inject
+    private ClouderaManagerApiFactory clouderaManagerApiFactory;
+
+    public int doRestartServicesIfNeeded(ApiClient apiClient, StackDtoDelegate stack, boolean rollingRestartEnabled) throws ApiException, CloudbreakException {
+        LOGGER.debug("Restarting Cloudera Manager services, rollingRestartEnabled: {}", rollingRestartEnabled);
+        ClustersResourceApi clustersResourceApi = clouderaManagerApiFactory.getClustersResourceApi(apiClient);
+        Optional<ApiCommand> optionalActiveRestartCommand = findActiveRestartCommand(stack, clustersResourceApi, rollingRestartEnabled);
+        if (optionalActiveRestartCommand.isPresent()) {
+            LOGGER.debug("Restart for Cluster services is already running with id: [{}]", optionalActiveRestartCommand.get().getId());
+            return waitForRestartExecution(apiClient, stack, optionalActiveRestartCommand.get());
+        } else {
+            LOGGER.info("Calling restart command. rollingRestartEnabled {}", rollingRestartEnabled);
+            ApiCommand restartCommand = rollingRestartEnabled ?
+                    executeRollingRestartCommand(apiClient, stack, clustersResourceApi) :
+                    executeRestartCommand(stack, clustersResourceApi);
+            eventService.fireCloudbreakEvent(stack.getId(), UPDATE_IN_PROGRESS.name(), CLUSTER_CM_CLUSTER_SERVICES_RESTARTING);
+            return waitForRestartExecution(apiClient, stack, restartCommand);
+        }
+    }
+
+    public void waitForRestartExecutionIfPresent(ApiClient apiClient, StackDtoDelegate stack, boolean rollingRestartEnabled)
+            throws ApiException, CloudbreakException {
+        ClustersResourceApi clustersResourceApi = clouderaManagerApiFactory.getClustersResourceApi(apiClient);
+        Optional<ApiCommand> optionalRestartCommand = findActiveRestartCommand(stack, clustersResourceApi, rollingRestartEnabled);
+        waitForRestartExecution(apiClient, stack, optionalRestartCommand.orElse(null));
+    }
+
+    private int waitForRestartExecution(ApiClient apiClient, StackDtoDelegate stack, ApiCommand restartCommand) throws CloudbreakException {
+        if (Objects.isNull(restartCommand)) {
+            LOGGER.debug("There is no running restart command.");
+            return 0;
+        } else {
+            LOGGER.debug("Start polling restart command. The command ID is: {}", restartCommand.getId());
+            ExtendedPollingResult pollingResult = clouderaManagerPollingServiceProvider.startPollingCmServicesRestart(stack, apiClient, restartCommand.getId());
+            pollingResultErrorHandler.handlePollingResult(pollingResult, "Cluster was terminated while restarting services.",
+                    "Timeout happened while restarting services.");
+            return restartCommand.getId().intValue();
+        }
+    }
+
+    private ApiCommand executeRollingRestartCommand(ApiClient apiClient, StackDtoDelegate stack, ClustersResourceApi clustersResourceApi) throws ApiException {
+        List<String> serviceNamesToRollingRestart = readServices(stack, apiClient).stream().map(ApiService::getName).collect(Collectors.toList());
+        ApiRollingRestartClusterArgs rollingRestartClusterArgs = new ApiRollingRestartClusterArgs();
+        rollingRestartClusterArgs.setSlaveBatchSize(BigDecimal.ONE);
+        rollingRestartClusterArgs.setRolesToInclude(ApiRolesToInclude.ALL_ROLES);
+        rollingRestartClusterArgs.setRestartServiceNames(serviceNamesToRollingRestart);
+        return clustersResourceApi.rollingRestart(stack.getName(), rollingRestartClusterArgs);
+    }
+
+    private ApiCommand executeRestartCommand(StackDtoDelegate stack, ClustersResourceApi clustersResourceApi) throws ApiException {
+        ApiRestartClusterArgs restartClusterArgs = new ApiRestartClusterArgs();
+        restartClusterArgs.setRedeployClientConfiguration(true);
+        return clustersResourceApi.restartCommand(stack.getName(), restartClusterArgs);
+    }
+
+    private Optional<ApiCommand> findActiveRestartCommand(StackDtoDelegate stack, ClustersResourceApi clustersResourceApi, boolean rollingRestartEnabled)
+            throws ApiException {
+        String restartCommandName = determineRestartCommandName(rollingRestartEnabled);
+        ApiCommandList apiCommandList = clustersResourceApi.listActiveCommands(stack.getName(), SUMMARY.name(), null);
+        return apiCommandList.getItems().stream()
+                .filter(cmd -> restartCommandName.equals(cmd.getName())).findFirst();
+    }
+
+    private String determineRestartCommandName(boolean rollingRestartEnabled) {
+        return rollingRestartEnabled ? "RollingRestart" : "Restart";
+    }
+
+    private Collection<ApiService> readServices(StackDtoDelegate stack, ApiClient apiClient) throws ApiException {
+        ServicesResourceApi servicesResourceApi = clouderaManagerApiFactory.getServicesResourceApi(apiClient);
+        return servicesResourceApi.readServices(stack.getName(), SUMMARY.name()).getItems();
+    }
+}

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerRestartServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerRestartServiceTest.java
@@ -1,0 +1,166 @@
+package com.sequenceiq.cloudbreak.cm;
+
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.UPDATE_IN_PROGRESS;
+import static com.sequenceiq.cloudbreak.cm.DataView.SUMMARY;
+import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_CM_CLUSTER_SERVICES_RESTARTING;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.cloudera.api.swagger.ClustersResourceApi;
+import com.cloudera.api.swagger.ServicesResourceApi;
+import com.cloudera.api.swagger.client.ApiClient;
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.model.ApiCommand;
+import com.cloudera.api.swagger.model.ApiCommandList;
+import com.cloudera.api.swagger.model.ApiRestartClusterArgs;
+import com.cloudera.api.swagger.model.ApiRollingRestartClusterArgs;
+import com.cloudera.api.swagger.model.ApiService;
+import com.cloudera.api.swagger.model.ApiServiceList;
+import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollingServiceProvider;
+import com.sequenceiq.cloudbreak.cm.polling.PollingResultErrorHandler;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.polling.ExtendedPollingResult;
+import com.sequenceiq.cloudbreak.service.CloudbreakException;
+import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
+
+@ExtendWith(MockitoExtension.class)
+class ClouderaManagerRestartServiceTest {
+
+    private static final BigDecimal COMMAND_ID = BigDecimal.ONE;
+
+    @InjectMocks
+    private ClouderaManagerRestartService underTest;
+
+    @Mock
+    private ClouderaManagerPollingServiceProvider clouderaManagerPollingServiceProvider;
+
+    @Mock
+    private PollingResultErrorHandler pollingResultErrorHandler;
+
+    @Mock
+    private CloudbreakEventService eventService;
+
+    @Mock
+    private ClouderaManagerApiFactory clouderaManagerApiFactory;
+
+    @Mock
+    private ApiClient apiClient;
+
+    @Mock
+    private ClustersResourceApi clustersResourceApi;
+
+    @Mock
+    private ServicesResourceApi servicesResourceApi;
+
+    @Mock
+    private ExtendedPollingResult pollingResult;
+
+    private final Stack stack = createStack();
+
+    @Test
+    void testRestartWhenExistingRestartCommandIsPresent() throws CloudbreakException, ApiException {
+        ApiCommandList activeCommands = new ApiCommandList().items(Collections.singletonList(new ApiCommand().name("Restart").id(COMMAND_ID)));
+        when(clouderaManagerApiFactory.getClustersResourceApi(apiClient)).thenReturn(clustersResourceApi);
+        when(clustersResourceApi.listActiveCommands(stack.getName(), SUMMARY.name(), null)).thenReturn(activeCommands);
+        when(clouderaManagerPollingServiceProvider.startPollingCmServicesRestart(stack, apiClient, COMMAND_ID)).thenReturn(pollingResult);
+
+        int actual = underTest.doRestartServicesIfNeeded(apiClient, stack, false);
+
+        assertEquals(COMMAND_ID.intValue(), actual);
+        verify(pollingResultErrorHandler).handlePollingResult(eq(pollingResult), anyString(), anyString());
+        verifyNoInteractions(eventService);
+    }
+
+    @Test
+    void testRestartWhenWaitForCommandExecutionOnly() throws CloudbreakException, ApiException {
+        when(clouderaManagerApiFactory.getClustersResourceApi(apiClient)).thenReturn(clustersResourceApi);
+        when(clustersResourceApi.listActiveCommands(stack.getName(), SUMMARY.name(), null)).thenReturn(new ApiCommandList().items(Collections.emptyList()));
+
+        underTest.waitForRestartExecutionIfPresent(apiClient, stack, true);
+
+        verify(clouderaManagerApiFactory).getClustersResourceApi(apiClient);
+        verify(clustersResourceApi).listActiveCommands(stack.getName(), SUMMARY.name(), null);
+        verifyNoInteractions(eventService, clouderaManagerPollingServiceProvider);
+    }
+
+    @Test
+    void testRestartWhenTriggerRestartCommand() throws CloudbreakException, ApiException {
+        when(clouderaManagerApiFactory.getClustersResourceApi(apiClient)).thenReturn(clustersResourceApi);
+        when(clustersResourceApi.listActiveCommands(stack.getName(), SUMMARY.name(), null)).thenReturn(new ApiCommandList().items(Collections.emptyList()));
+        when(clouderaManagerPollingServiceProvider.startPollingCmServicesRestart(stack, apiClient, COMMAND_ID)).thenReturn(pollingResult);
+        when(clustersResourceApi.restartCommand(eq(stack.getName()), any(ApiRestartClusterArgs.class))).thenReturn(new ApiCommand().id(COMMAND_ID));
+
+        int actual = underTest.doRestartServicesIfNeeded(apiClient, stack, false);
+
+        assertEquals(COMMAND_ID.intValue(), actual);
+        verify(pollingResultErrorHandler).handlePollingResult(eq(pollingResult), anyString(), anyString());
+        verify(eventService).fireCloudbreakEvent(stack.getId(), UPDATE_IN_PROGRESS.name(), CLUSTER_CM_CLUSTER_SERVICES_RESTARTING);
+    }
+
+    @Test
+    void testRestartWhenTriggeredRestartCommandIsNull() throws CloudbreakException, ApiException {
+        when(clouderaManagerApiFactory.getClustersResourceApi(apiClient)).thenReturn(clustersResourceApi);
+        when(clustersResourceApi.listActiveCommands(stack.getName(), SUMMARY.name(), null)).thenReturn(new ApiCommandList().items(Collections.emptyList()));
+        when(clustersResourceApi.restartCommand(eq(stack.getName()), any(ApiRestartClusterArgs.class))).thenReturn(null);
+
+        int actual = underTest.doRestartServicesIfNeeded(apiClient, stack, false);
+
+        assertEquals(0, actual);
+        verify(eventService).fireCloudbreakEvent(stack.getId(), UPDATE_IN_PROGRESS.name(), CLUSTER_CM_CLUSTER_SERVICES_RESTARTING);
+        verifyNoInteractions(pollingResultErrorHandler);
+    }
+
+    @Test
+    void testRestartWhenTriggerRollingRestartCommand() throws CloudbreakException, ApiException {
+        List<String> serviceNames = List.of("hive, spark, flink");
+        when(clouderaManagerApiFactory.getClustersResourceApi(apiClient)).thenReturn(clustersResourceApi);
+        when(clustersResourceApi.listActiveCommands(stack.getName(), SUMMARY.name(), null)).thenReturn(new ApiCommandList().items(Collections.emptyList()));
+        when(clouderaManagerApiFactory.getServicesResourceApi(apiClient)).thenReturn(servicesResourceApi);
+        when(servicesResourceApi.readServices(stack.getName(), SUMMARY.name())).thenReturn(createApiServiceList(serviceNames));
+        when(clustersResourceApi.rollingRestart(eq(stack.getName()), any(ApiRollingRestartClusterArgs.class))).thenReturn(new ApiCommand().id(COMMAND_ID));
+        when(clouderaManagerPollingServiceProvider.startPollingCmServicesRestart(stack, apiClient, COMMAND_ID)).thenReturn(pollingResult);
+
+        int actual = underTest.doRestartServicesIfNeeded(apiClient, stack, true);
+
+        assertEquals(COMMAND_ID.intValue(), actual);
+        ArgumentCaptor<ApiRollingRestartClusterArgs> argumentCaptor = ArgumentCaptor.forClass(ApiRollingRestartClusterArgs.class);
+        verify(clustersResourceApi).rollingRestart(eq(stack.getName()), argumentCaptor.capture());
+        assertTrue(CollectionUtils.isEqualCollection(serviceNames, argumentCaptor.getValue().getRestartServiceNames()));
+        verify(pollingResultErrorHandler).handlePollingResult(eq(pollingResult), anyString(), anyString());
+        verify(eventService).fireCloudbreakEvent(stack.getId(), UPDATE_IN_PROGRESS.name(), CLUSTER_CM_CLUSTER_SERVICES_RESTARTING);
+    }
+
+    private ApiServiceList createApiServiceList(List<String> serviceNames) {
+        return new ApiServiceList().items(serviceNames.stream()
+                .map(serviceName -> new ApiService().name(serviceName))
+                .collect(Collectors.toList()));
+    }
+
+    private Stack createStack() {
+        Stack stack = new Stack();
+        stack.setName("stack-name");
+        stack.setId(1L);
+        return stack;
+    }
+
+}


### PR DESCRIPTION
In this commit, I've added support for performing rolling patch upgrades.

- Extract CM service restart logic into a separate class.
- Call rolling restart instead of rolling upgrade instead of the regular restart command
