### PR TITLE
CB-19087 Azure storage validation should support management group

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/Scope.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/Scope.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.cloudbreak.cloud.azure.validator;
+
+class Scope {
+
+    public static final String MANAGEMENT_GROUP_SCOPE = "/providers/Microsoft.Management/managementGroups/";
+
+    private final ScopeType scopeType;
+
+    private final String scope;
+
+    private enum ScopeType {
+        RESOURCE,
+        MANAGEMENT_GROUP
+    }
+
+    private Scope(ScopeType scopeType, String scope) {
+        this.scopeType = scopeType;
+        this.scope = scope;
+    }
+
+    public static Scope resource(String resource) {
+        return new Scope(ScopeType.RESOURCE, resource);
+    }
+
+    public static Scope managementGroup() {
+        return new Scope(ScopeType.MANAGEMENT_GROUP, MANAGEMENT_GROUP_SCOPE);
+    }
+
+    public boolean match(String roleAssignmentScope) {
+        switch (this.scopeType) {
+            case RESOURCE:
+                return roleAssignmentScope.endsWith(this.scope);
+            case MANAGEMENT_GROUP:
+                return roleAssignmentScope.startsWith(this.scope);
+            default:
+                throw new IllegalStateException("Unexpected value: " + this.scopeType);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return scope;
+    }
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/ScopeTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/ScopeTest.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.cloudbreak.cloud.azure.validator;
+
+import static com.sequenceiq.cloudbreak.cloud.azure.validator.Scope.MANAGEMENT_GROUP_SCOPE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ScopeTest {
+
+    @Test
+    public void testResourceScope() {
+        Scope scope = Scope.resource("resourceId");
+        assertEquals("resourceId", scope.toString());
+        assertTrue(scope.match("resourceId"));
+        assertTrue(scope.match("prefix/resourceId"));
+        assertFalse(scope.match("resourceId/postfix"));
+    }
+
+    @Test
+    public void testManagementGroupScope() {
+        Scope scope = Scope.managementGroup();
+        assertEquals(MANAGEMENT_GROUP_SCOPE, scope.toString());
+        assertTrue(scope.match(MANAGEMENT_GROUP_SCOPE));
+        assertTrue(scope.match(MANAGEMENT_GROUP_SCOPE + "/managementGroupName"));
+        assertFalse(scope.match("prefix/" + MANAGEMENT_GROUP_SCOPE));
+    }
+}


### PR DESCRIPTION
Add /providers/Microsoft.Management/managementGroups/ scope prefix for management group support. Management group related scopes are not hierarchical, thus they can be matched on the static string above.

See detailed description in the commit message.