### PR TITLE
CB-19095 Monitor Redbeams upgrade flow status instead of stack status

### DIFF
--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v1/RedBeamsFlowEndpoint.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v1/RedBeamsFlowEndpoint.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.redbeams.api.endpoint.v1;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
+import com.sequenceiq.flow.api.FlowEndpoint;
+
+import io.swagger.annotations.Api;
+
+@Path("/flow")
+@RetryAndMetrics
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+@Api(tags = {"flow"},
+        protocols = "http,https",
+        value = "/flow",
+        consumes = MediaType.APPLICATION_JSON,
+        produces = MediaType.APPLICATION_JSON)
+public interface RedBeamsFlowEndpoint extends FlowEndpoint {
+}

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/client/RedbeamsApiKeyEndpoints.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/client/RedbeamsApiKeyEndpoints.java
@@ -3,6 +3,7 @@ package com.sequenceiq.redbeams.client;
 import javax.ws.rs.client.WebTarget;
 
 import com.sequenceiq.cloudbreak.client.AbstractKeyBasedServiceEndpoint;
+import com.sequenceiq.flow.api.FlowEndpoint;
 import com.sequenceiq.redbeams.api.endpoint.v4.database.DatabaseV4Endpoint;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.DatabaseServerV4Endpoint;
 import com.sequenceiq.redbeams.api.endpoint.v4.operation.OperationV4Endpoint;
@@ -32,6 +33,11 @@ public class RedbeamsApiKeyEndpoints extends AbstractKeyBasedServiceEndpoint imp
     @Override
     public OperationV4Endpoint operationV4Endpoint() {
         return getEndpoint(OperationV4Endpoint.class);
+    }
+
+    @Override
+    public FlowEndpoint flowEndpoint() {
+        return getEndpoint(FlowEndpoint.class);
     }
 }
 

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/client/RedbeamsClient.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/client/RedbeamsClient.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.redbeams.client;
 
+import com.sequenceiq.flow.api.FlowEndpoint;
 import com.sequenceiq.redbeams.api.endpoint.v4.database.DatabaseV4Endpoint;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.DatabaseServerV4Endpoint;
 import com.sequenceiq.redbeams.api.endpoint.v4.operation.OperationV4Endpoint;
@@ -14,4 +15,6 @@ public interface RedbeamsClient {
     ProgressV4Endpoint progressV4Endpoint();
 
     OperationV4Endpoint operationV4Endpoint();
+
+    FlowEndpoint flowEndpoint();
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/client/RedbeamsServiceCrnEndpoints.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/client/RedbeamsServiceCrnEndpoints.java
@@ -3,6 +3,7 @@ package com.sequenceiq.redbeams.client;
 import javax.ws.rs.client.WebTarget;
 
 import com.sequenceiq.cloudbreak.client.AbstractUserCrnServiceEndpoint;
+import com.sequenceiq.flow.api.FlowEndpoint;
 import com.sequenceiq.redbeams.api.endpoint.v4.database.DatabaseV4Endpoint;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.DatabaseServerV4Endpoint;
 import com.sequenceiq.redbeams.api.endpoint.v4.operation.OperationV4Endpoint;
@@ -32,5 +33,10 @@ public class RedbeamsServiceCrnEndpoints extends AbstractUserCrnServiceEndpoint 
     @Override
     public OperationV4Endpoint operationV4Endpoint() {
         return getEndpoint(OperationV4Endpoint.class);
+    }
+
+    @Override
+    public FlowEndpoint flowEndpoint() {
+        return getEndpoint(FlowEndpoint.class);
     }
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/client/internal/RedbeamsApiClientConfig.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/client/internal/RedbeamsApiClientConfig.java
@@ -10,6 +10,7 @@ import com.sequenceiq.cloudbreak.client.ApiClientRequestFilter;
 import com.sequenceiq.cloudbreak.client.ThreadLocalUserCrnWebTargetBuilder;
 import com.sequenceiq.cloudbreak.client.WebTargetEndpointFactory;
 import com.sequenceiq.redbeams.api.RedbeamsApi;
+import com.sequenceiq.redbeams.api.endpoint.v1.RedBeamsFlowEndpoint;
 import com.sequenceiq.redbeams.api.endpoint.v4.database.DatabaseV4Endpoint;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.DatabaseServerV4Endpoint;
 import com.sequenceiq.redbeams.api.endpoint.v4.operation.OperationV4Endpoint;
@@ -64,5 +65,11 @@ public class RedbeamsApiClientConfig {
     @ConditionalOnBean(RedbeamsApiClientParams.class)
     OperationV4Endpoint operationDatabaseServerV4Endpoint(WebTarget redbeamsApiClientWebTarget) {
         return new WebTargetEndpointFactory().createEndpoint(redbeamsApiClientWebTarget, OperationV4Endpoint.class);
+    }
+
+    @Bean
+    @ConditionalOnBean(RedbeamsApiClientParams.class)
+    RedBeamsFlowEndpoint redBeamsV1FlowEndpoint(WebTarget redbeamsApiClientWebTarget) {
+        return new WebTargetEndpointFactory().createEndpoint(redbeamsApiClientWebTarget, RedBeamsFlowEndpoint.class);
     }
 }


### PR DESCRIPTION
When only monitoring the stack status, there was an issue, where the upgrade failed, but the syncer detected the server as available, and updated the status before the core service could check it.
Now the upgrade endpoint returns a flow id, which we us to poll the redbeams service about the upgrade flow status. If there is no flow id in the response, that means the upgrade has already finished.

