### PR TITLE
[API E2E] Rewind the GCP Longrunning test suite for Master

### DIFF
--- a/integration-test/src/main/resources/testsuites/e2e/gcp-longrunning-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/gcp-longrunning-e2e-tests.yaml
@@ -3,4 +3,9 @@ tests:
   - name: "gcp_longrunning_e2e_tests"
     classes:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.EnvironmentStopStartTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxUpgradeRecoveryTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.freeipa.FreeIpaUpgradeTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxUpgradeDatabaseServerTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRepairTests
+        excludedMethods:
+          - testSDXMediumDutyCreation


### PR DESCRIPTION
Previously we've removed following test suites from the GCP Longrunning YAML:
- com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxUpgradeRecoveryTests
- com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRepairTests
- com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxUpgradeDatabaseServerTests 

We have done on the default `currentRuntimeVersion` to `7.2.7` task ([CB-19522](https://jira.cloudera.com/browse/CB-19522)) for 2.65.0-b33+. So we can set the above test suites back.