### PR TITLE
CB-19260 pre stopstart scaling checks - validate health of dependent services in downscale flow

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
@@ -178,6 +178,8 @@ public class StackOperationService {
             throw new BadRequestException("Downscale via Instance Stop cannot process more than one host group");
         }
         updateNodeCountValidator.validateInstanceGroup(stackDto, instanceIdsByHostgroupMap.keySet().iterator().next());
+        updateNodeCountValidator.validateStackStatusForStopStartHostGroup(stackDto, instanceIdsByHostgroupMap.keySet().iterator().next(),
+                -instanceIdsByHostgroupMap.size());
         LOGGER.info("InstanceIds without metadata: [{}]", instanceIdsWithoutMetadata);
         updateNodeCountValidator.validateServiceRoles(stackDto, instanceIdsByHostgroupMap.entrySet()
                 .stream()
@@ -309,7 +311,8 @@ public class StackOperationService {
         try {
             return transactionService.required(() -> {
                 updateNodeCountValidator.validateServiceRoles(stackDto, instanceGroupAdjustmentJson);
-                updateNodeCountValidator.validateStackStatusForStartHostGroup(stackDto, instanceGroupAdjustmentJson);
+                updateNodeCountValidator.validateStackStatusForStopStartHostGroup(stackDto, instanceGroupAdjustmentJson.getInstanceGroup(),
+                        instanceGroupAdjustmentJson.getScalingAdjustment());
                 updateNodeCountValidator.validateInstanceGroup(stackDto, instanceGroupAdjustmentJson.getInstanceGroup());
                 updateNodeCountValidator.validateInstanceGroupForStopStart(stackDto,
                         instanceGroupAdjustmentJson.getInstanceGroup(), instanceGroupAdjustmentJson.getScalingAdjustment());

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationServiceTest.java
@@ -342,7 +342,7 @@ public class StackOperationServiceTest {
         when(transactionService.required(any(Supplier.class))).thenAnswer(ans -> ((Supplier) ans.getArgument(0)).get());
         doNothing().when(updateNodeCountValidator).validateServiceRoles(any(), any(InstanceGroupAdjustmentV4Request.class));
         if (stackStatus != CLUSTER_UPGRADE_FAILED) {
-            doNothing().when(updateNodeCountValidator).validateStackStatusForStartHostGroup(any(), any());
+            doNothing().when(updateNodeCountValidator).validateStackStatusForStopStartHostGroup(any(), any(), any());
             doNothing().when(updateNodeCountValidator).validateInstanceGroup(any(), any());
             doNothing().when(updateNodeCountValidator).validateScalabilityOfInstanceGroup(any(), any(InstanceGroupAdjustmentV4Request.class));
             doNothing().when(updateNodeCountValidator).validateScalingAdjustment(any(InstanceGroupAdjustmentV4Request.class), any());


### PR DESCRIPTION

- Here we will be checking the health of the hosts on which the services will be dependent before the downscale operation

See detailed description in the commit message.