### PR TITLE
Fixed mapping error when tag is not well formatted. Now it throws 400…

### DIFF
--- a/redbeams/src/main/java/com/sequenceiq/redbeams/controller/mapper/IllegalArgumentExceptionMapper.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/controller/mapper/IllegalArgumentExceptionMapper.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.redbeams.controller.mapper;
+
+import javax.ws.rs.core.Response.Status;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.exception.mapper.BaseExceptionMapper;
+
+@Component
+public class IllegalArgumentExceptionMapper extends BaseExceptionMapper<IllegalArgumentException> {
+
+    @Override
+    public Status getResponseStatus(IllegalArgumentException exception) {
+        return Status.BAD_REQUEST;
+    }
+
+    @Override
+    public Class<IllegalArgumentException> getExceptionType() {
+        return IllegalArgumentException.class;
+    }
+}


### PR DESCRIPTION
… instead of 500 internal server error.

See detailed description in the commit message.