### PR TITLE
CB-17695 Disable dnssec validation by default on freeipa in named.conf

### DIFF
--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -70,7 +70,7 @@ freeipa:
     GCP: n1-standard-2
     MOCK: large
   platform.dnssec.validation:
-    AWS: true
+    AWS: false
     AZURE: false
     GCP: false
   environment:


### PR DESCRIPTION
Right now it's disabled  on Azure and GCP, but customers can have their own dnssec enabled nameservers which could cause failures.

See detailed description in the commit message.