### PR TITLE
CB-18486 Modify proxy config on existing FreeIpa instances

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
@@ -182,6 +182,7 @@ public enum ResourceEvent {
     ENVIRONMENT_VERTICAL_SCALE_FAILED("environment.vertical.scale.failed"),
 
     ENVIRONMENT_PROXY_CONFIG_MODIFICATION_STARTED("environment.proxy.modification.started"),
+    ENVIRONMENT_PROXY_CONFIG_MODIFICATION_ON_FREEIPA_STARTED("environment.proxy.modification.freeipa.started"),
     ENVIRONMENT_PROXY_CONFIG_MODIFICATION_FAILED("environment.proxy.modification.failed"),
     ENVIRONMENT_PROXY_CONFIG_MODIFICATION_FINISHED("environment.proxy.modification.finished"),
 

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -584,6 +584,7 @@ environment.vertical.scale.finished=Vertical scaling FreeIPA finished to {0} ins
 environment.vertical.scale.failed=Vertical scaling FreeIPA was not successful to {0} instance type, please retry
 
 environment.proxy.modification.started=Proxy config modification started for environment
+environment.proxy.modification.freeipa.started=Proxy config modification started for FreeIPA instances
 environment.proxy.modification.failed=Proxy config modification failed for environment. Details: {0}
 environment.proxy.modification.finished=Proxy config modification finished for environment
 

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/ProxyConfigModificationFreeipaStateAction.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/ProxyConfigModificationFreeipaStateAction.java
@@ -33,7 +33,7 @@ public class ProxyConfigModificationFreeipaStateAction extends AbstractEnvProxyM
         LOGGER.info("Env proxy modification freeipa step started");
 
         EnvironmentDto environmentDto = environmentStatusUpdateService.updateEnvironmentStatusAndNotify(context, payload,
-                EnvironmentStatus.PROXY_CONFIG_MODIFICATION_IN_PROGRESS, ResourceEvent.ENVIRONMENT_PROXY_CONFIG_MODIFICATION_STARTED,
+                EnvironmentStatus.PROXY_CONFIG_MODIFICATION_ON_FREEIPA_IN_PROGRESS, ResourceEvent.ENVIRONMENT_PROXY_CONFIG_MODIFICATION_ON_FREEIPA_STARTED,
                 EnvProxyModificationState.PROXY_CONFIG_MODIFICATION_START_STATE);
 
         String selector = EnvProxyModificationHandlerSelectors.TRACK_FREEIPA_PROXY_MODIFICATION_EVENT.selector();

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/freeipa/FreeIpaService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/freeipa/FreeIpaService.java
@@ -8,6 +8,8 @@ import javax.ws.rs.WebApplicationException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
@@ -178,6 +180,7 @@ public class FreeIpaService {
         }
     }
 
+    @Retryable(value = FreeIpaOperationFailedException.class, maxAttempts = 3, backoff = @Backoff(delay = 2000))
     public OperationStatus getOperationStatus(String operationId) {
         String accountId = ThreadBasedUserCrnProvider.getAccountId();
         try {

--- a/environment/src/test/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/ProxyConfigModificationFreeipaStateActionTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/ProxyConfigModificationFreeipaStateActionTest.java
@@ -44,7 +44,7 @@ class ProxyConfigModificationFreeipaStateActionTest extends ActionTest {
     void setUp() {
         super.setUp(context);
         when(environmentStatusUpdateService.updateEnvironmentStatusAndNotify(context, payload,
-                EnvironmentStatus.PROXY_CONFIG_MODIFICATION_IN_PROGRESS, ResourceEvent.ENVIRONMENT_PROXY_CONFIG_MODIFICATION_STARTED,
+                EnvironmentStatus.PROXY_CONFIG_MODIFICATION_ON_FREEIPA_IN_PROGRESS, ResourceEvent.ENVIRONMENT_PROXY_CONFIG_MODIFICATION_ON_FREEIPA_STARTED,
                 EnvProxyModificationState.PROXY_CONFIG_MODIFICATION_START_STATE)).thenReturn(environmentDto);
     }
 
@@ -53,7 +53,7 @@ class ProxyConfigModificationFreeipaStateActionTest extends ActionTest {
         underTest.doExecute(context, payload, Map.of());
 
         verify(environmentStatusUpdateService).updateEnvironmentStatusAndNotify(context, payload,
-                EnvironmentStatus.PROXY_CONFIG_MODIFICATION_IN_PROGRESS, ResourceEvent.ENVIRONMENT_PROXY_CONFIG_MODIFICATION_STARTED,
+                EnvironmentStatus.PROXY_CONFIG_MODIFICATION_ON_FREEIPA_IN_PROGRESS, ResourceEvent.ENVIRONMENT_PROXY_CONFIG_MODIFICATION_ON_FREEIPA_STARTED,
                 EnvProxyModificationState.PROXY_CONFIG_MODIFICATION_START_STATE);
         String selector = EnvProxyModificationHandlerSelectors.TRACK_FREEIPA_PROXY_MODIFICATION_EVENT.selector();
         verifySendEvent(context, selector, new EnvProxyModificationDefaultEvent(selector, environmentDto, payload.getProxyConfig()));

--- a/flow/src/test/java/com/sequenceiq/flow/core/ActionTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/core/ActionTest.java
@@ -2,10 +2,11 @@ package com.sequenceiq.flow.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import java.util.Map;
 
@@ -26,6 +27,8 @@ import io.opentracing.Tracer;
 @ExtendWith(MockitoExtension.class)
 public abstract class ActionTest {
 
+    private static final String FLOW_ID = "flow-id";
+
     @Mock
     protected MetricService metricService;
 
@@ -44,24 +47,33 @@ public abstract class ActionTest {
     @Mock
     protected FlowParameters flowParameters;
 
+    @Mock
+    protected Flow flow;
+
     @Captor
     private ArgumentCaptor<Event<?>> eventCaptor;
 
     protected void setUp(CommonContext context) {
-        when(context.getFlowParameters()).thenReturn(flowParameters);
-        when(flowParameters.getFlowId()).thenReturn("flow-id");
-        when(flowParameters.getFlowTriggerUserCrn()).thenReturn("trigger-user-crn");
-        when(flowParameters.getSpanContext()).thenReturn(mock(SpanContext.class));
-        when(flowParameters.getFlowOperationType()).thenReturn("flow-operation-type");
+        lenient().when(context.getFlowParameters()).thenReturn(flowParameters);
+        lenient().when(flowParameters.getFlowId()).thenReturn(FLOW_ID);
+        lenient().when(flowParameters.getFlowTriggerUserCrn()).thenReturn("trigger-user-crn");
+        lenient().when(flowParameters.getSpanContext()).thenReturn(mock(SpanContext.class));
+        lenient().when(flowParameters.getFlowOperationType()).thenReturn("flow-operation-type");
 
-        when(reactorEventFactory.createEvent(any(), any())).then(input -> {
+        lenient().when(runningFlows.get(FLOW_ID)).thenReturn(flow);
+
+        lenient().when(reactorEventFactory.createEvent(any(), any())).then(input -> {
             Map<String, Object> headers = input.getArgument(0);
             Object payload = input.getArgument(1);
             return new Event<>(new Event.Headers(headers), payload);
         });
     }
 
-    protected <C, E> void verifySendEvent(C context, String selector, E event) {
+    protected <C extends CommonContext> void verifySendEvent() {
+        verify(eventBus).notify(anyString(), any(Event.class));
+    }
+
+    protected <C extends CommonContext, E> void verifySendEvent(C context, String selector, E event) {
         verify(eventBus).notify(eq(selector), eventCaptor.capture());
         Event<?> capturedEvent = eventCaptor.getValue();
         assertThat(capturedEvent)

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/FreeIpaFlowInformation.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/FreeIpaFlowInformation.java
@@ -26,6 +26,7 @@ import com.sequenceiq.freeipa.flow.freeipa.verticalscale.event.FreeIpaVerticalSc
 import com.sequenceiq.freeipa.flow.instance.reboot.RebootEvent;
 import com.sequenceiq.freeipa.flow.stack.image.change.event.ImageChangeEvents;
 import com.sequenceiq.freeipa.flow.stack.migration.AwsVariantMigrationEvent;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.selector.ModifyProxyConfigEvent;
 import com.sequenceiq.freeipa.flow.stack.termination.StackTerminationEvent;
 import com.sequenceiq.freeipa.flow.stack.termination.StackTerminationFlowConfig;
 import com.sequenceiq.freeipa.flow.stack.update.UpdateUserDataEvents;
@@ -51,7 +52,8 @@ public class FreeIpaFlowInformation implements ApplicationFlowInformation {
             AwsVariantMigrationEvent.CREATE_RESOURCES_EVENT.event(),
             UpdateUserDataEvents.UPDATE_USERDATA_TRIGGER_EVENT.event(),
             UpgradeCcmStateSelector.UPGRADE_CCM_TRIGGER_EVENT.event(),
-            RotateSaltPasswordEvent.ROTATE_SALT_PASSWORD_EVENT.event());
+            RotateSaltPasswordEvent.ROTATE_SALT_PASSWORD_EVENT.event(),
+            ModifyProxyConfigEvent.MODIFY_PROXY_TRIGGER_EVENT.event());
 
     private static final List<Class<? extends FlowConfiguration<?>>> TERMINATION_FLOWS = List.of(StackTerminationFlowConfig.class);
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/ModifyProxyConfigFlowEventChainFactory.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/ModifyProxyConfigFlowEventChainFactory.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
 import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
+import com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateTriggerEvent;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.event.ModifyProxyConfigTriggerEvent;
 import com.sequenceiq.freeipa.flow.stack.modify.proxy.event.ModifyProxyFlowChainTriggerEvent;
 import com.sequenceiq.freeipa.flow.stack.update.UpdateUserDataEvents;
 import com.sequenceiq.freeipa.flow.stack.update.event.UserDataUpdateRequest;
@@ -23,10 +25,13 @@ public class ModifyProxyConfigFlowEventChainFactory implements FlowEventChainFac
     @Override
     public FlowTriggerEventQueue createFlowTriggerEventQueue(ModifyProxyFlowChainTriggerEvent event) {
         Queue<Selectable> flowEventChain = new ConcurrentLinkedQueue<>();
-        flowEventChain.add(new UserDataUpdateRequest(UpdateUserDataEvents.UPDATE_USERDATA_TRIGGER_EVENT.event(), event.getResourceId(), event.accepted())
-                .withOperationId(event.getOperationId())
-                .withIsChained(true)
-                .withIsFinal(true));
+        flowEventChain.add(new SaltUpdateTriggerEvent(event.getResourceId(), event.accepted(), true, false, event.getOperationId()));
+        flowEventChain.add(new ModifyProxyConfigTriggerEvent(event.getResourceId(), event.accepted(), event.getOperationId()));
+        flowEventChain.add(
+                new UserDataUpdateRequest(UpdateUserDataEvents.UPDATE_USERDATA_TRIGGER_EVENT.event(), event.getResourceId(), event.accepted())
+                        .withOperationId(event.getOperationId())
+                        .withIsChained(true)
+                        .withIsFinal(true));
         return new FlowTriggerEventQueue(getName(), event, flowEventChain);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/UpgradeFlowEventChainFactory.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/UpgradeFlowEventChainFactory.java
@@ -22,7 +22,6 @@ import com.sequenceiq.freeipa.flow.freeipa.downscale.DownscaleFlowEvent;
 import com.sequenceiq.freeipa.flow.freeipa.downscale.event.DownscaleEvent;
 import com.sequenceiq.freeipa.flow.freeipa.repair.changeprimarygw.ChangePrimaryGatewayFlowEvent;
 import com.sequenceiq.freeipa.flow.freeipa.repair.changeprimarygw.event.ChangePrimaryGatewayEvent;
-import com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateEvent;
 import com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateTriggerEvent;
 import com.sequenceiq.freeipa.flow.freeipa.upgrade.UpgradeEvent;
 import com.sequenceiq.freeipa.flow.freeipa.upscale.UpscaleFlowEvent;
@@ -52,8 +51,7 @@ public class UpgradeFlowEventChainFactory implements FlowEventChainFactory<Upgra
     @Override
     public FlowTriggerEventQueue createFlowTriggerEventQueue(UpgradeEvent event) {
         Queue<Selectable> flowEventChain = new ConcurrentLinkedQueue<>();
-        flowEventChain.add(new SaltUpdateTriggerEvent(SaltUpdateEvent.SALT_UPDATE_EVENT.event(), event.getResourceId(), event.accepted(), true, false)
-                .withOperationId(event.getOperationId()));
+        flowEventChain.add(new SaltUpdateTriggerEvent(event.getResourceId(), event.accepted(), true, false, event.getOperationId()));
         flowEventChain.add(new ImageChangeEvent(IMAGE_CHANGE_EVENT.event(), event.getResourceId(), event.getImageSettingsRequest())
                 .withOperationId(event.getOperationId()));
 
@@ -63,8 +61,7 @@ public class UpgradeFlowEventChainFactory implements FlowEventChainFactory<Upgra
         Set<String> groupNames = instanceGroupService.findGroupNamesByStackId(event.getResourceId());
         flowEventChain.addAll(createScaleEventsForNonPgwInstances(event, instanceCountForUpscale, instanceCountForDownscale, groupNames));
         flowEventChain.addAll(createScaleEventsAndChangePgw(event, instanceCountForUpscale, instanceCountForDownscale, groupNames));
-        flowEventChain.add(new SaltUpdateTriggerEvent(SaltUpdateEvent.SALT_UPDATE_EVENT.event(), event.getResourceId(), event.accepted(), true, true)
-                .withOperationId(event.getOperationId()));
+        flowEventChain.add(new SaltUpdateTriggerEvent(event.getResourceId(), event.accepted(), true, true, event.getOperationId()));
         return new FlowTriggerEventQueue(getName(), event, flowEventChain);
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/update/SaltUpdateTriggerEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/update/SaltUpdateTriggerEvent.java
@@ -11,41 +11,34 @@ import com.sequenceiq.freeipa.flow.stack.StackEvent;
 
 public class SaltUpdateTriggerEvent extends StackEvent {
 
-    private String operationId;
+    private final String operationId;
 
     private final boolean chained;
 
     private final boolean finalChain;
 
-    public SaltUpdateTriggerEvent(String selector, Long stackId) {
-        super(selector, stackId);
+    public SaltUpdateTriggerEvent(Long stackId) {
+        super(SaltUpdateEvent.SALT_UPDATE_EVENT.event(), stackId);
         chained = false;
         finalChain = false;
+        operationId = null;
     }
 
     @JsonCreator
     public SaltUpdateTriggerEvent(
-            @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long stackId,
             @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted,
             @JsonProperty("chained") boolean chained,
-            @JsonProperty("finalChain") boolean finalChain) {
-        super(selector, stackId, accepted);
+            @JsonProperty("finalChain") boolean finalChain,
+            @JsonProperty("operationId") String operationId) {
+        super(SaltUpdateEvent.SALT_UPDATE_EVENT.event(), stackId, accepted);
         this.chained = chained;
         this.finalChain = finalChain;
-    }
-
-    public SaltUpdateTriggerEvent withOperationId(String operationId) {
         this.operationId = operationId;
-        return this;
     }
 
     public String getOperationId() {
         return operationId;
-    }
-
-    public void setOperationId(String operationId) {
-        this.operationId = operationId;
     }
 
     public boolean isChained() {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/ModifyProxyConfigContext.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/ModifyProxyConfigContext.java
@@ -1,0 +1,19 @@
+package com.sequenceiq.freeipa.flow.stack.modify.proxy;
+
+import com.sequenceiq.flow.core.CommonContext;
+import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.freeipa.entity.Stack;
+
+public class ModifyProxyConfigContext extends CommonContext {
+
+    private final Stack stack;
+
+    public ModifyProxyConfigContext(FlowParameters flowParameters, Stack stack) {
+        super(flowParameters);
+        this.stack = stack;
+    }
+
+    public Stack getStack() {
+        return stack;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/ModifyProxyConfigFlowConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/ModifyProxyConfigFlowConfig.java
@@ -1,0 +1,83 @@
+package com.sequenceiq.freeipa.flow.stack.modify.proxy;
+
+
+import static com.sequenceiq.freeipa.flow.stack.modify.proxy.ModifyProxyConfigState.FINAL_STATE;
+import static com.sequenceiq.freeipa.flow.stack.modify.proxy.ModifyProxyConfigState.INIT_STATE;
+import static com.sequenceiq.freeipa.flow.stack.modify.proxy.ModifyProxyConfigState.MODIFY_PROXY_FAILED_STATE;
+import static com.sequenceiq.freeipa.flow.stack.modify.proxy.ModifyProxyConfigState.MODIFY_PROXY_FINISHED_STATE;
+import static com.sequenceiq.freeipa.flow.stack.modify.proxy.ModifyProxyConfigState.MODIFY_PROXY_SALT_STATE_APPLY_STATE;
+import static com.sequenceiq.freeipa.flow.stack.modify.proxy.selector.ModifyProxyConfigEvent.MODIFY_PROXY_FAILED_EVENT;
+import static com.sequenceiq.freeipa.flow.stack.modify.proxy.selector.ModifyProxyConfigEvent.MODIFY_PROXY_FAILURE_HANDLED_EVENT;
+import static com.sequenceiq.freeipa.flow.stack.modify.proxy.selector.ModifyProxyConfigEvent.MODIFY_PROXY_FINISHED_EVENT;
+import static com.sequenceiq.freeipa.flow.stack.modify.proxy.selector.ModifyProxyConfigEvent.MODIFY_PROXY_SUCCESS_EVENT;
+import static com.sequenceiq.freeipa.flow.stack.modify.proxy.selector.ModifyProxyConfigEvent.MODIFY_PROXY_TRIGGER_EVENT;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
+import com.sequenceiq.flow.core.config.RetryableFlowConfiguration;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.selector.ModifyProxyConfigEvent;
+
+@Component
+public class ModifyProxyConfigFlowConfig extends AbstractFlowConfiguration<ModifyProxyConfigState, ModifyProxyConfigEvent>
+        implements RetryableFlowConfiguration<ModifyProxyConfigEvent> {
+
+    private static final FlowEdgeConfig<ModifyProxyConfigState, ModifyProxyConfigEvent> EDGE_CONFIG =
+            new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, MODIFY_PROXY_FAILED_STATE, MODIFY_PROXY_FAILURE_HANDLED_EVENT);
+
+    private static final List<Transition<ModifyProxyConfigState, ModifyProxyConfigEvent>> TRANSITIONS =
+            new Transition.Builder<ModifyProxyConfigState, ModifyProxyConfigEvent>().defaultFailureEvent(MODIFY_PROXY_FAILED_EVENT)
+
+                    .from(INIT_STATE)
+                    .to(MODIFY_PROXY_SALT_STATE_APPLY_STATE)
+                    .event(MODIFY_PROXY_TRIGGER_EVENT)
+                    .defaultFailureEvent()
+
+                    .from(MODIFY_PROXY_SALT_STATE_APPLY_STATE)
+                    .to(MODIFY_PROXY_FINISHED_STATE)
+                    .event(MODIFY_PROXY_SUCCESS_EVENT)
+                    .defaultFailureEvent()
+
+                    .from(MODIFY_PROXY_FINISHED_STATE)
+                    .to(FINAL_STATE)
+                    .event(MODIFY_PROXY_FINISHED_EVENT)
+                    .defaultFailureEvent()
+
+                    .build();
+
+    protected ModifyProxyConfigFlowConfig() {
+        super(ModifyProxyConfigState.class, ModifyProxyConfigEvent.class);
+    }
+
+    @Override
+    protected List<Transition<ModifyProxyConfigState, ModifyProxyConfigEvent>> getTransitions() {
+        return TRANSITIONS;
+    }
+
+    @Override
+    protected FlowEdgeConfig<ModifyProxyConfigState, ModifyProxyConfigEvent> getEdgeConfig() {
+        return EDGE_CONFIG;
+    }
+
+    @Override
+    public ModifyProxyConfigEvent[] getEvents() {
+        return ModifyProxyConfigEvent.values();
+    }
+
+    @Override
+    public ModifyProxyConfigEvent[] getInitEvents() {
+        return new ModifyProxyConfigEvent[]{ModifyProxyConfigEvent.MODIFY_PROXY_TRIGGER_EVENT};
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Modify proxy config";
+    }
+
+    @Override
+    public ModifyProxyConfigEvent getRetryableEvent() {
+        return EDGE_CONFIG.getFailureHandled();
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/ModifyProxyConfigState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/ModifyProxyConfigState.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.freeipa.flow.stack.modify.proxy;
+
+import com.sequenceiq.flow.core.AbstractAction;
+import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
+import com.sequenceiq.freeipa.flow.FillInMemoryStateStoreRestartAction;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.action.ModifyProxyConfigAction;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.action.ModifyProxyConfigFailedAction;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.action.ModifyProxyConfigFinishedAction;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.action.ModifyProxyConfigSaltStateApplyAction;
+
+public enum ModifyProxyConfigState implements FlowState  {
+
+    INIT_STATE,
+    MODIFY_PROXY_SALT_STATE_APPLY_STATE(ModifyProxyConfigSaltStateApplyAction.class),
+    MODIFY_PROXY_FINISHED_STATE(ModifyProxyConfigFinishedAction.class),
+    MODIFY_PROXY_FAILED_STATE(ModifyProxyConfigFailedAction.class),
+    FINAL_STATE;
+
+    private Class<? extends ModifyProxyConfigAction<?>> action;
+
+    ModifyProxyConfigState() {
+    }
+
+    ModifyProxyConfigState(Class<? extends ModifyProxyConfigAction<?>> action) {
+        this.action = action;
+    }
+
+    @Override
+    public Class<? extends AbstractAction<?, ?, ?, ?>> action() {
+        return action;
+    }
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return FillInMemoryStateStoreRestartAction.class;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/action/ModifyProxyConfigAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/action/ModifyProxyConfigAction.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.freeipa.flow.stack.modify.proxy.action;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.springframework.statemachine.StateContext;
+
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.flow.OperationAwareAction;
+import com.sequenceiq.freeipa.flow.stack.AbstractStackAction;
+import com.sequenceiq.freeipa.flow.stack.StackEvent;
+import com.sequenceiq.freeipa.flow.stack.StackFailureEvent;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.ModifyProxyConfigContext;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.ModifyProxyConfigState;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.selector.ModifyProxyConfigEvent;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+public abstract class ModifyProxyConfigAction<P extends StackEvent>
+        extends AbstractStackAction<ModifyProxyConfigState, ModifyProxyConfigEvent, ModifyProxyConfigContext, P>
+        implements OperationAwareAction {
+
+    @Inject
+    private StackService stackService;
+
+    protected ModifyProxyConfigAction(Class<P> payloadClass) {
+        super(payloadClass);
+    }
+
+    @Override
+    protected ModifyProxyConfigContext createFlowContext(FlowParameters flowParameters, StateContext<ModifyProxyConfigState,
+            ModifyProxyConfigEvent> stateContext, P payload) {
+        Stack stack = stackService.getStackById(payload.getResourceId());
+        MDCBuilder.buildMdcContext(stack);
+        return new ModifyProxyConfigContext(flowParameters, stack);
+    }
+
+    @Override
+    protected Object getFailurePayload(P payload, Optional<ModifyProxyConfigContext> flowContext, Exception ex) {
+        return new StackFailureEvent(ModifyProxyConfigEvent.MODIFY_PROXY_FAILED_EVENT.selector(), payload.getResourceId(), ex);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/action/ModifyProxyConfigFailedAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/action/ModifyProxyConfigFailedAction.java
@@ -1,0 +1,60 @@
+package com.sequenceiq.freeipa.flow.stack.modify.proxy.action;
+
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.statemachine.StateContext;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.flow.core.Flow;
+import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
+import com.sequenceiq.freeipa.flow.stack.StackEvent;
+import com.sequenceiq.freeipa.flow.stack.StackFailureEvent;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.ModifyProxyConfigContext;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.ModifyProxyConfigState;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.selector.ModifyProxyConfigEvent;
+import com.sequenceiq.freeipa.service.operation.OperationService;
+import com.sequenceiq.freeipa.service.stack.StackUpdater;
+
+@Component("ModifyProxyConfigFailedAction")
+public class ModifyProxyConfigFailedAction extends ModifyProxyConfigAction<StackFailureEvent> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ModifyProxyConfigFailedAction.class);
+
+    @Inject
+    private StackUpdater stackUpdater;
+
+    @Inject
+    private OperationService operationService;
+
+    public ModifyProxyConfigFailedAction() {
+        super(StackFailureEvent.class);
+    }
+
+    @Override
+    protected ModifyProxyConfigContext createFlowContext(FlowParameters flowParameters, StateContext<ModifyProxyConfigState,
+            ModifyProxyConfigEvent> stateContext, StackFailureEvent payload) {
+        Flow flow = getFlow(flowParameters.getFlowId());
+        flow.setFlowFailed(payload.getException());
+        return super.createFlowContext(flowParameters, stateContext, payload);
+    }
+
+    @Override
+    protected void doExecute(ModifyProxyConfigContext context, StackFailureEvent payload, Map<Object, Object> variables) throws Exception {
+        LOGGER.info("Failed modify proxy config state", payload.getException());
+        stackUpdater.updateStackStatus(payload.getResourceId(), DetailedStackStatus.MODIFY_PROXY_CONFIG_FAILED, getErrorReason(payload.getException()));
+        LOGGER.debug("Failing operation with id: [{}]", getOperationId(variables));
+        operationService.failOperation(context.getStack().getAccountId(), getOperationId(variables), payload.getException().getMessage());
+        sendEvent(context);
+    }
+
+    @Override
+    protected Selectable createRequest(ModifyProxyConfigContext context) {
+        return new StackEvent(ModifyProxyConfigEvent.MODIFY_PROXY_FAILURE_HANDLED_EVENT.event(), context.getStack().getId());
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/action/ModifyProxyConfigFinishedAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/action/ModifyProxyConfigFinishedAction.java
@@ -1,0 +1,51 @@
+package com.sequenceiq.freeipa.flow.stack.modify.proxy.action;
+
+import java.util.Map;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SuccessDetails;
+import com.sequenceiq.freeipa.flow.stack.StackEvent;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.ModifyProxyConfigContext;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.selector.ModifyProxyConfigEvent;
+import com.sequenceiq.freeipa.service.operation.OperationService;
+import com.sequenceiq.freeipa.service.stack.StackUpdater;
+
+@Component("ModifyProxyConfigFinishedAction")
+public class ModifyProxyConfigFinishedAction extends ModifyProxyConfigAction<StackEvent> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ModifyProxyConfigFinishedAction.class);
+
+    @Inject
+    private StackUpdater stackUpdater;
+
+    @Inject
+    private OperationService operationService;
+
+    public ModifyProxyConfigFinishedAction() {
+        super(StackEvent.class);
+    }
+
+    @Override
+    protected void doExecute(ModifyProxyConfigContext context, StackEvent payload, Map<Object, Object> variables) throws Exception {
+        LOGGER.info("Finished modify proxy config state");
+        stackUpdater.updateStackStatus(payload.getResourceId(), DetailedStackStatus.AVAILABLE,
+                "Successfully updated proxy config settings on all instances");
+        LOGGER.debug("Complete operation with id: [{}]", getOperationId(variables));
+        SuccessDetails successDetails = new SuccessDetails(context.getStack().getEnvironmentCrn());
+        operationService.completeOperation(context.getStack().getAccountId(), getOperationId(variables), Set.of(successDetails), Set.of());
+        sendEvent(context);
+    }
+
+    @Override
+    protected Selectable createRequest(ModifyProxyConfigContext context) {
+        return new StackEvent(ModifyProxyConfigEvent.MODIFY_PROXY_FINISHED_EVENT.selector(), context.getStack().getId());
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/action/ModifyProxyConfigSaltStateApplyAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/action/ModifyProxyConfigSaltStateApplyAction.java
@@ -1,0 +1,43 @@
+package com.sequenceiq.freeipa.flow.stack.modify.proxy.action;
+
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.ModifyProxyConfigContext;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.event.ModifyProxyConfigSaltStateApplyRequest;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.event.ModifyProxyConfigTriggerEvent;
+import com.sequenceiq.freeipa.service.stack.StackUpdater;
+
+@Component("ModifyProxyConfigSaltStateApplyAction")
+public class ModifyProxyConfigSaltStateApplyAction extends ModifyProxyConfigAction<ModifyProxyConfigTriggerEvent> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ModifyProxyConfigSaltStateApplyAction.class);
+
+    @Inject
+    private StackUpdater stackUpdater;
+
+    public ModifyProxyConfigSaltStateApplyAction() {
+        super(ModifyProxyConfigTriggerEvent.class);
+    }
+
+    @Override
+    protected void doExecute(ModifyProxyConfigContext context, ModifyProxyConfigTriggerEvent payload, Map<Object, Object> variables) throws Exception {
+        LOGGER.info("Start modify proxy config salt state apply");
+        setOperationId(variables, payload.getOperationId());
+        stackUpdater.updateStackStatus(payload.getResourceId(), DetailedStackStatus.MODIFY_PROXY_CONFIG_IN_PROGRESS,
+                "Applying modified proxy config salt state");
+        sendEvent(context);
+    }
+
+    @Override
+    protected Selectable createRequest(ModifyProxyConfigContext context) {
+        return new ModifyProxyConfigSaltStateApplyRequest(context.getStack().getId());
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/event/ModifyProxyConfigSaltStateApplyRequest.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/event/ModifyProxyConfigSaltStateApplyRequest.java
@@ -1,0 +1,14 @@
+package com.sequenceiq.freeipa.flow.stack.modify.proxy.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.freeipa.flow.stack.StackEvent;
+
+public class ModifyProxyConfigSaltStateApplyRequest extends StackEvent {
+
+    @JsonCreator
+    public ModifyProxyConfigSaltStateApplyRequest(
+            @JsonProperty("resourceId") Long stackId) {
+        super(stackId);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/event/ModifyProxyConfigTriggerEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/event/ModifyProxyConfigTriggerEvent.java
@@ -1,0 +1,42 @@
+package com.sequenceiq.freeipa.flow.stack.modify.proxy.event;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.AcceptResult;
+import com.sequenceiq.cloudbreak.common.json.JsonIgnoreDeserialization;
+import com.sequenceiq.cloudbreak.eventbus.Promise;
+import com.sequenceiq.freeipa.flow.stack.StackEvent;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.selector.ModifyProxyConfigEvent;
+
+public class ModifyProxyConfigTriggerEvent extends StackEvent {
+
+    private final String operationId;
+
+    @JsonCreator
+    public ModifyProxyConfigTriggerEvent(
+            @JsonProperty("resourceId") Long stackId,
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted,
+            @JsonProperty("operationId") String operationId) {
+        super(ModifyProxyConfigEvent.MODIFY_PROXY_TRIGGER_EVENT.event(), stackId, accepted);
+        this.operationId = operationId;
+    }
+
+    @Override
+    public boolean equalsEvent(StackEvent other) {
+        return isClassAndEqualsEvent(ModifyProxyConfigTriggerEvent.class, other,
+                event -> Objects.equals(operationId, event.operationId));
+    }
+
+    public String getOperationId() {
+        return operationId;
+    }
+
+    @Override
+    public String toString() {
+        return "ModifyProxyConfigTriggerEvent{" +
+                "operationId='" + operationId + '\'' +
+                "} " + super.toString();
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/handler/ModifyProxyConfigSaltStateApplyHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/handler/ModifyProxyConfigSaltStateApplyHandler.java
@@ -1,0 +1,52 @@
+package com.sequenceiq.freeipa.flow.stack.modify.proxy.handler;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.eventbus.Event;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
+import com.sequenceiq.cloudbreak.service.CloudbreakRuntimeException;
+import com.sequenceiq.flow.event.EventSelectorUtil;
+import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
+import com.sequenceiq.freeipa.flow.stack.StackEvent;
+import com.sequenceiq.freeipa.flow.stack.StackFailureEvent;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.event.ModifyProxyConfigSaltStateApplyRequest;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.selector.ModifyProxyConfigEvent;
+import com.sequenceiq.freeipa.service.proxy.ModifyProxyConfigOrchestratorService;
+
+@Component
+public class ModifyProxyConfigSaltStateApplyHandler extends ExceptionCatcherEventHandler<ModifyProxyConfigSaltStateApplyRequest> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ModifyProxyConfigSaltStateApplyHandler.class);
+
+    @Inject
+    private ModifyProxyConfigOrchestratorService modifyProxyConfigOrchestratorService;
+
+    @Override
+    public String selector() {
+        return EventSelectorUtil.selector(ModifyProxyConfigSaltStateApplyRequest.class);
+    }
+
+    @Override
+    protected Selectable defaultFailureEvent(Long resourceId, Exception e, Event<ModifyProxyConfigSaltStateApplyRequest> event) {
+        LOGGER.warn("Fallback to default failure event for exception", e);
+        return new StackFailureEvent(ModifyProxyConfigEvent.MODIFY_PROXY_FAILED_EVENT.selector(), resourceId, e);
+    }
+
+    @Override
+    protected Selectable doAccept(HandlerEvent<ModifyProxyConfigSaltStateApplyRequest> event) {
+        Long resourceId = event.getData().getResourceId();
+        try {
+            LOGGER.info("Applying salt state for proxy config modification on stack {}", resourceId);
+            modifyProxyConfigOrchestratorService.applyModifyProxyState(resourceId);
+            return new StackEvent(ModifyProxyConfigEvent.MODIFY_PROXY_SUCCESS_EVENT.selector(), resourceId);
+        } catch (CloudbreakOrchestratorException e) {
+            throw new CloudbreakRuntimeException("Failed to apply modify proxy orchestrator state: " + e.getMessage(), e);
+        }
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/selector/ModifyProxyConfigEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/selector/ModifyProxyConfigEvent.java
@@ -1,0 +1,17 @@
+package com.sequenceiq.freeipa.flow.stack.modify.proxy.selector;
+
+import com.sequenceiq.flow.core.FlowEvent;
+
+public enum ModifyProxyConfigEvent implements FlowEvent {
+
+    MODIFY_PROXY_TRIGGER_EVENT,
+    MODIFY_PROXY_SUCCESS_EVENT,
+    MODIFY_PROXY_FAILED_EVENT,
+    MODIFY_PROXY_FAILURE_HANDLED_EVENT,
+    MODIFY_PROXY_FINISHED_EVENT;
+
+    @Override
+    public String event() {
+        return name();
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/orchestrator/SaltUpdateService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/orchestrator/SaltUpdateService.java
@@ -1,7 +1,5 @@
 package com.sequenceiq.freeipa.orchestrator;
 
-import static com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateEvent.SALT_UPDATE_EVENT;
-
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
@@ -29,7 +27,7 @@ public class SaltUpdateService {
     public FlowIdentifier updateSaltStates(String environmentCrn, String accountId) {
         Stack stack = stackService.getByEnvironmentCrnAndAccountId(environmentCrn, accountId);
         MDCBuilder.buildMdcContext(stack);
-        StackEvent event = new SaltUpdateTriggerEvent(SALT_UPDATE_EVENT.event(), stack.getId());
+        StackEvent event = new SaltUpdateTriggerEvent(stack.getId());
         LOGGER.info("Triggering salt update flow with event: {}", event);
         return flowManager.notify(event.selector(), event);
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/SaltConfigProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/SaltConfigProvider.java
@@ -50,7 +50,7 @@ public class SaltConfigProvider {
         servicePillarConfig.put("freeipa", new SaltPillarProperties("/freeipa/init.sls", singletonMap("freeipa", freeIpaConfigView.toMap())));
         servicePillarConfig.put("discovery", new SaltPillarProperties("/discovery/init.sls", singletonMap("platform", stack.getCloudPlatform())));
         servicePillarConfig.putAll(telemetryConfigService.createTelemetryPillarConfig(stack));
-        servicePillarConfig.putAll(proxyConfigService.createProxyPillarConfig(stack.getEnvironmentCrn()));
+        servicePillarConfig.putAll(proxyConfigService.createProxyPillarConfig(stack));
         servicePillarConfig.putAll(tagConfigService.createTagsPillarConfig(stack));
         servicePillarConfig.putAll(getCcmPillarProperties(stack));
         servicePillarConfig.putAll(ldapAgentConfigProvider.generateConfig(freeIpaConfigView.getDomain()));

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/orchestrator/OrchestratorStateParamsProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/orchestrator/OrchestratorStateParamsProvider.java
@@ -1,0 +1,52 @@
+package com.sequenceiq.freeipa.service.orchestrator;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.common.orchestration.Node;
+import com.sequenceiq.cloudbreak.orchestrator.host.OrchestratorStateParams;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.orchestrator.StackBasedExitCriteriaModel;
+import com.sequenceiq.freeipa.service.GatewayConfigService;
+import com.sequenceiq.freeipa.service.freeipa.flow.FreeIpaNodeUtilService;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+@Service
+public class OrchestratorStateParamsProvider {
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private GatewayConfigService gatewayConfigService;
+
+    @Inject
+    private FreeIpaNodeUtilService freeIpaNodeUtilService;
+
+    public OrchestratorStateParams createStateParams(Long stackId, String saltState) {
+        Stack stack = stackService.getByIdWithListsInTransaction(stackId);
+        Set<Node> allNodes = freeIpaNodeUtilService.mapInstancesToNodes(stack.getNotDeletedInstanceMetaDataSet());
+
+        OrchestratorStateParams stateParams = getOrchestratorStateParamsWithoutTarget(stack, saltState);
+        stateParams.setTargetHostNames(allNodes.stream().map(Node::getHostname).collect(Collectors.toSet()));
+        return stateParams;
+    }
+
+    public OrchestratorStateParams createStateParamsForSingleTarget(Stack stack, String hostName, String saltState) {
+        OrchestratorStateParams stateParams = getOrchestratorStateParamsWithoutTarget(stack, saltState);
+        stateParams.setTargetHostNames(Set.of(hostName));
+        return stateParams;
+    }
+
+    private OrchestratorStateParams getOrchestratorStateParamsWithoutTarget(Stack stack, String saltState) {
+        OrchestratorStateParams stateParams = new OrchestratorStateParams();
+        stateParams.setState(saltState);
+        stateParams.setPrimaryGatewayConfig(gatewayConfigService.getPrimaryGatewayConfig(stack));
+        stateParams.setExitCriteriaModel(new StackBasedExitCriteriaModel(stack.getId()));
+        return stateParams;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/proxy/ModifyProxyConfigOrchestratorService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/proxy/ModifyProxyConfigOrchestratorService.java
@@ -1,0 +1,83 @@
+package com.sequenceiq.freeipa.service.proxy;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.orchestrator.host.OrchestratorStateParams;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceMetadataType;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.NodeHealthDetails;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.orchestrator.OrchestratorStateParamsProvider;
+import com.sequenceiq.freeipa.service.stack.FreeIpaSafeInstanceHealthDetailsService;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+@Service
+public class ModifyProxyConfigOrchestratorService {
+
+    static final String MODIFY_PROXY_STATE = "modifyproxy";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ModifyProxyConfigOrchestratorService.class);
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private OrchestratorStateParamsProvider orchestratorStateParamsProvider;
+
+    @Inject
+    private HostOrchestrator hostOrchestrator;
+
+    @Inject
+    private FreeIpaSafeInstanceHealthDetailsService healthDetailsService;
+
+    public void applyModifyProxyState(Long stackId) throws CloudbreakOrchestratorException {
+        Stack stack = stackService.getByIdWithListsInTransaction(stackId);
+        List<InstanceMetaData> sortedInstances = getSortedInstances(stack);
+
+        for (InstanceMetaData instance : sortedInstances) {
+            String hostName = instance.getDiscoveryFQDN();
+            OrchestratorStateParams stateParams = orchestratorStateParamsProvider.createStateParamsForSingleTarget(stack, hostName, MODIFY_PROXY_STATE);
+            LOGGER.debug("Calling applyModifyProxyState for instance {} with state params '{}'", hostName, stateParams);
+            hostOrchestrator.runOrchestratorState(stateParams);
+            runHealthCheck(stack, instance);
+        }
+    }
+
+    /**
+     * Instances have to be sorted to make sure that we are applying the state on the instances in the same order in a flow retry.
+     */
+    private List<InstanceMetaData> getSortedInstances(Stack stack) {
+        return stack.getNotDeletedInstanceMetaDataList().stream()
+                .sorted(getInstanceMetaDataComparator())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * The order is determined by leaving the primary gateway last, other gateways are sorted by their private id.
+     */
+    private Comparator<InstanceMetaData> getInstanceMetaDataComparator() {
+        return Comparator.comparing((InstanceMetaData i) -> InstanceMetadataType.GATEWAY_PRIMARY.equals(i.getInstanceMetadataType()))
+                .thenComparing(InstanceMetaData::getPrivateId);
+    }
+
+    private void runHealthCheck(Stack stack, InstanceMetaData instance) throws CloudbreakOrchestratorException {
+        NodeHealthDetails nodeHealthDetails = healthDetailsService.getInstanceHealthDetails(stack, instance);
+        if (!nodeHealthDetails.getStatus().isAvailable()) {
+            String issues = String.join("; ", nodeHealthDetails.getIssues());
+            String message = String.format("Health check failed after proxy config modification for instance %s: %s", instance.getDiscoveryFQDN(), issues);
+            LOGGER.warn(message);
+            throw new CloudbreakOrchestratorFailedException(message);
+        }
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/proxy/ProxyConfigService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/proxy/ProxyConfigService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import com.sequenceiq.cloudbreak.dto.ProxyConfig;
 import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
 import com.sequenceiq.cloudbreak.service.proxy.ProxyConfigDtoService;
+import com.sequenceiq.freeipa.entity.Stack;
 
 @Service
 public class ProxyConfigService {
@@ -24,8 +25,8 @@ public class ProxyConfigService {
     @Inject
     private ProxyConfigDtoService proxyConfigDtoService;
 
-    public Map<String, SaltPillarProperties> createProxyPillarConfig(String environmentCrn) {
-        Optional<ProxyConfig> proxyConfig = proxyConfigDtoService.getByEnvironmentCrn(environmentCrn);
+    public Map<String, SaltPillarProperties> createProxyPillarConfig(Stack stack) {
+        Optional<ProxyConfig> proxyConfig = proxyConfigDtoService.getByEnvironmentCrn(stack.getEnvironmentCrn());
         if (proxyConfig.isPresent()) {
             ProxyConfig config = proxyConfig.get();
             Map<String, Object> proxy = new HashMap<>();
@@ -37,6 +38,7 @@ public class ProxyConfigService {
                 proxy.put("password", auth.getPassword());
             });
             proxy.put("noProxyHosts", config.getNoProxyHosts());
+            proxy.put("tunnel", stack.getTunnel());
             return Map.of(PROXY_KEY, new SaltPillarProperties(PROXY_SLS_PATH, singletonMap(PROXY_KEY, proxy)));
         } else {
             return Map.of();

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaSafeInstanceHealthDetailsService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaSafeInstanceHealthDetailsService.java
@@ -1,0 +1,41 @@
+package com.sequenceiq.freeipa.service.stack;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceStatus;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.NodeHealthDetails;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
+import com.sequenceiq.freeipa.entity.Stack;
+
+@Service
+public class FreeIpaSafeInstanceHealthDetailsService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FreeIpaSafeInstanceHealthDetailsService.class);
+
+    @Inject
+    private FreeIpaInstanceHealthDetailsService healthDetailsService;
+
+    public NodeHealthDetails getInstanceHealthDetails(Stack stack, InstanceMetaData instance) {
+        NodeHealthDetails nodeHealthDetails;
+        try {
+            nodeHealthDetails = healthDetailsService.getInstanceHealthDetails(stack, instance);
+        } catch (Exception e) {
+            LOGGER.error(String.format("Unable to check the health of FreeIPA instance: %s", instance.getInstanceId()), e);
+            nodeHealthDetails = createNodeResponseWithStatusAndIssue(instance, InstanceStatus.UNREACHABLE, e.getLocalizedMessage());
+        }
+        return nodeHealthDetails;
+    }
+
+    public NodeHealthDetails createNodeResponseWithStatusAndIssue(InstanceMetaData instance, InstanceStatus status, String issue) {
+        NodeHealthDetails nodeResponse = new NodeHealthDetails();
+        nodeResponse.setName(instance.getDiscoveryFQDN());
+        nodeResponse.setStatus(status);
+        nodeResponse.setInstanceId(instance.getInstanceId());
+        nodeResponse.addIssue(issue);
+        return nodeResponse;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaStackHealthDetailsService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaStackHealthDetailsService.java
@@ -33,30 +33,22 @@ public class FreeIpaStackHealthDetailsService {
     private StackService stackService;
 
     @Inject
-    private FreeIpaInstanceHealthDetailsService freeIpaInstanceHealthDetailsService;
+    private FreeIpaSafeInstanceHealthDetailsService healthDetailsService;
 
     public HealthDetailsFreeIpaResponse getHealthDetails(String environmentCrn, String accountId) {
         Stack stack = stackService.getByEnvironmentCrnAndAccountIdWithListsAndMdcContext(environmentCrn, accountId);
         List<InstanceMetaData> instances = stack.getAllInstanceMetaDataList();
-        HealthDetailsFreeIpaResponse response = new HealthDetailsFreeIpaResponse();
 
+        HealthDetailsFreeIpaResponse response = new HealthDetailsFreeIpaResponse();
         for (InstanceMetaData instance: instances) {
+            NodeHealthDetails nodeResponse;
             if (shouldRunHealthCheck(instance)) {
-                try {
-                    NodeHealthDetails nodeHealthDetails = freeIpaInstanceHealthDetailsService.getInstanceHealthDetails(stack, instance);
-                    response.addNodeHealthDetailsFreeIpaResponses(nodeHealthDetails);
-                } catch (Exception e) {
-                    addUnreachableResponse(instance, response, e.getLocalizedMessage());
-                    LOGGER.error(String.format("Unable to check the health of FreeIPA instance: %s", instance.getInstanceId()), e);
-                }
+                nodeResponse = healthDetailsService.getInstanceHealthDetails(stack, instance);
             } else {
-                NodeHealthDetails nodeResponse = new NodeHealthDetails();
-                response.addNodeHealthDetailsFreeIpaResponses(nodeResponse);
-                nodeResponse.setName(instance.getDiscoveryFQDN());
-                nodeResponse.setStatus(instance.getInstanceStatus());
-                nodeResponse.setInstanceId(instance.getInstanceId());
-                nodeResponse.addIssue("Unable to check health as instance is " + instance.getInstanceStatus().name());
+                String issue = "Unable to check health as instance is " + instance.getInstanceStatus().name();
+                nodeResponse = healthDetailsService.createNodeResponseWithStatusAndIssue(instance, instance.getInstanceStatus(), issue);
             }
+            response.addNodeHealthDetailsFreeIpaResponses(nodeResponse);
         }
         return updateResponse(stack, response);
     }
@@ -65,15 +57,6 @@ public class FreeIpaStackHealthDetailsService {
         return !(instance.isTerminated() ||
                 instance.isDeletedOnProvider() ||
                 CACHEABLE_INSTANCE_STATUS.contains(instance.getInstanceStatus()));
-    }
-
-    private void addUnreachableResponse(InstanceMetaData instance, HealthDetailsFreeIpaResponse response, String issue) {
-        NodeHealthDetails nodeResponse = new NodeHealthDetails();
-        response.addNodeHealthDetailsFreeIpaResponses(nodeResponse);
-        nodeResponse.setName(instance.getDiscoveryFQDN());
-        nodeResponse.setStatus(InstanceStatus.UNREACHABLE);
-        nodeResponse.setInstanceId(instance.getInstanceId());
-        nodeResponse.addIssue(issue);
     }
 
     private HealthDetailsFreeIpaResponse updateResponse(Stack stack, HealthDetailsFreeIpaResponse response) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/upgrade/ccm/UpgradeCcmOrchestratorService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/upgrade/ccm/UpgradeCcmOrchestratorService.java
@@ -1,24 +1,15 @@
 package com.sequenceiq.freeipa.service.upgrade.ccm;
 
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-import com.sequenceiq.cloudbreak.common.orchestration.Node;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.host.OrchestratorStateParams;
-import com.sequenceiq.freeipa.entity.InstanceMetaData;
-import com.sequenceiq.freeipa.entity.Stack;
-import com.sequenceiq.freeipa.orchestrator.StackBasedExitCriteriaModel;
-import com.sequenceiq.freeipa.service.GatewayConfigService;
-import com.sequenceiq.freeipa.service.freeipa.flow.FreeIpaNodeUtilService;
-import com.sequenceiq.freeipa.service.stack.StackService;
+import com.sequenceiq.freeipa.service.orchestrator.OrchestratorStateParamsProvider;
 
 @Service
 public class UpgradeCcmOrchestratorService {
@@ -34,51 +25,32 @@ public class UpgradeCcmOrchestratorService {
     private static final String FINALIZE = "upgradeccm/finalize";
 
     @Inject
-    private StackService stackService;
-
-    @Inject
-    private GatewayConfigService gatewayConfigService;
-
-    @Inject
-    private FreeIpaNodeUtilService freeIpaNodeUtilService;
+    private OrchestratorStateParamsProvider orchestratorStateParamsProvider;
 
     @Inject
     private HostOrchestrator hostOrchestrator;
 
     public void applyUpgradeState(Long stackId) throws CloudbreakOrchestratorException {
-        OrchestratorStateParams stateParams = createStateParams(stackId, UPGRADE_CCM_STATE);
+        OrchestratorStateParams stateParams = orchestratorStateParamsProvider.createStateParams(stackId, UPGRADE_CCM_STATE);
         LOGGER.debug("Calling applyUpgradeState with state params '{}'", stateParams);
         hostOrchestrator.runOrchestratorState(stateParams);
     }
 
     public void reconfigureNginx(Long stackId) throws CloudbreakOrchestratorException {
-        OrchestratorStateParams stateParams = createStateParams(stackId, NGINX_STATE);
+        OrchestratorStateParams stateParams = orchestratorStateParamsProvider.createStateParams(stackId, NGINX_STATE);
         LOGGER.debug("Calling reconfigureNginx with state params '{}'", stateParams);
         hostOrchestrator.runOrchestratorState(stateParams);
     }
 
     public void finalizeConfiguration(Long stackId) throws CloudbreakOrchestratorException {
-        OrchestratorStateParams stateParams = createStateParams(stackId, FINALIZE);
+        OrchestratorStateParams stateParams = orchestratorStateParamsProvider.createStateParams(stackId, FINALIZE);
         LOGGER.debug("Calling finalize with state params '{}'", stateParams);
         hostOrchestrator.runOrchestratorState(stateParams);
     }
 
     public void disableMina(Long stackId) throws CloudbreakOrchestratorException {
-        OrchestratorStateParams stateParams = createStateParams(stackId, DISABLE_MINA_STATE);
+        OrchestratorStateParams stateParams = orchestratorStateParamsProvider.createStateParams(stackId, DISABLE_MINA_STATE);
         LOGGER.debug("Calling disableMina with state params '{}'", stateParams);
         hostOrchestrator.runOrchestratorState(stateParams);
-    }
-
-    private OrchestratorStateParams createStateParams(Long stackId, String saltState) {
-        Stack stack = stackService.getByIdWithListsInTransaction(stackId);
-        Set<InstanceMetaData> instanceMetaDatas = stack.getNotDeletedInstanceMetaDataSet();
-        Set<Node> allNodes = freeIpaNodeUtilService.mapInstancesToNodes(instanceMetaDatas);
-
-        OrchestratorStateParams stateParams = new OrchestratorStateParams();
-        stateParams.setState(saltState);
-        stateParams.setPrimaryGatewayConfig(gatewayConfigService.getPrimaryGatewayConfig(stack));
-        stateParams.setTargetHostNames(allNodes.stream().map(Node::getHostname).collect(Collectors.toSet()));
-        stateParams.setExitCriteriaModel(new StackBasedExitCriteriaModel(stack.getId()));
-        return stateParams;
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/freeipa/upscale/handler/ValidateInstancesHealthHandlerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/freeipa/upscale/handler/ValidateInstancesHealthHandlerTest.java
@@ -25,7 +25,7 @@ import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.flow.freeipa.upscale.event.UpscaleFailureEvent;
 import com.sequenceiq.freeipa.flow.freeipa.upscale.event.ValidateInstancesHealthEvent;
 import com.sequenceiq.freeipa.flow.stack.StackEvent;
-import com.sequenceiq.freeipa.service.stack.FreeIpaInstanceHealthDetailsService;
+import com.sequenceiq.freeipa.service.stack.FreeIpaSafeInstanceHealthDetailsService;
 import com.sequenceiq.freeipa.service.stack.StackService;
 import com.sequenceiq.freeipa.service.stack.instance.InstanceMetaDataService;
 
@@ -38,7 +38,7 @@ class ValidateInstancesHealthHandlerTest {
     private InstanceMetaDataService instanceMetaDataService;
 
     @Mock
-    private FreeIpaInstanceHealthDetailsService healthService;
+    private FreeIpaSafeInstanceHealthDetailsService healthService;
 
     @Mock
     private StackService stackService;
@@ -112,33 +112,6 @@ class ValidateInstancesHealthHandlerTest {
         assertTrue(result.getSuccess().contains("im1"));
         assertEquals(1, result.getFailureDetails().size());
         assertEquals("bad", result.getFailureDetails().get("im2"));
-        assertEquals("Unhealthy instances found: [im2]", result.getException().getMessage());
-    }
-
-    @Test
-    public void testExceptionDuringHealthCheck() throws FreeIpaClientException {
-        Stack stack = new Stack();
-        stack.setId(1L);
-        when(stackService.getStackById(1L)).thenReturn(stack);
-        List<String> instanceIds = List.of("im1", "im2");
-        InstanceMetaData im1 = new InstanceMetaData();
-        im1.setInstanceId("im1");
-        im1.setDiscoveryFQDN("im1Fqdn");
-        InstanceMetaData im2 = new InstanceMetaData();
-        im2.setInstanceId("im2");
-        im2.setDiscoveryFQDN("im2Fqdn");
-        when(instanceMetaDataService.getNotTerminatedByInstanceIds(1L, instanceIds)).thenReturn(Set.of(im1, im2));
-        when(healthService.getInstanceHealthDetails(stack, im1)).thenReturn(createHealthyNodeDetail(im1));
-        when(healthService.getInstanceHealthDetails(stack, im2)).thenThrow(new FreeIpaClientException("nono"));
-
-        ValidateInstancesHealthEvent validateInstancesHealthEvent = new ValidateInstancesHealthEvent(1L, instanceIds);
-        UpscaleFailureEvent result = (UpscaleFailureEvent) underTest.doAccept(new HandlerEvent<>(new Event<>(validateInstancesHealthEvent)));
-
-        assertEquals(1L, result.getResourceId());
-        assertEquals(PHASE, result.getFailedPhase());
-        assertTrue(result.getSuccess().contains("im1"));
-        assertEquals(1, result.getFailureDetails().size());
-        assertEquals("nono", result.getFailureDetails().get("im2"));
         assertEquals("Unhealthy instances found: [im2]", result.getException().getMessage());
     }
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/action/ModifyProxyConfigActionTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/action/ModifyProxyConfigActionTest.java
@@ -1,0 +1,91 @@
+package com.sequenceiq.freeipa.flow.stack.modify.proxy.action;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.statemachine.StateContext;
+
+import com.sequenceiq.flow.core.CommonContext;
+import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.flow.stack.StackEvent;
+import com.sequenceiq.freeipa.flow.stack.StackFailureEvent;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.ModifyProxyConfigContext;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.ModifyProxyConfigState;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.selector.ModifyProxyConfigEvent;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+@ExtendWith(MockitoExtension.class)
+class ModifyProxyConfigActionTest {
+
+    private static final long STACK_ID = 1L;
+
+    @InjectMocks
+    private DummyModifyProxyConfigAction underTest;
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private Stack stack;
+
+    @Mock
+    private FlowParameters flowParameters;
+
+    @Mock
+    private StateContext<ModifyProxyConfigState, ModifyProxyConfigEvent> stateContext;
+
+    private StackEvent event;
+
+    @BeforeEach
+    void setUp() {
+        event = new StackEvent(STACK_ID);
+        lenient().when(stackService.getStackById(STACK_ID)).thenReturn(stack);
+    }
+
+    @Test
+    void createFlowContext() {
+        ModifyProxyConfigContext result = underTest.createFlowContext(flowParameters, stateContext, event);
+
+        verify(stackService).getStackById(STACK_ID);
+        assertThat(result)
+                .returns(flowParameters, CommonContext::getFlowParameters)
+                .returns(stack, ModifyProxyConfigContext::getStack);
+    }
+
+    @Test
+    void getFailurePayload() {
+        Exception cause = new Exception("cause");
+        Object failurePayload = underTest.getFailurePayload(event, Optional.empty(), cause);
+
+        assertThat(failurePayload)
+                .isInstanceOf(StackFailureEvent.class)
+                .extracting(StackFailureEvent.class::cast)
+                .returns(ModifyProxyConfigEvent.MODIFY_PROXY_FAILED_EVENT.selector(), StackFailureEvent::selector)
+                .returns(STACK_ID, StackFailureEvent::getResourceId)
+                .returns(cause, StackFailureEvent::getException);
+    }
+
+    static class DummyModifyProxyConfigAction extends ModifyProxyConfigAction<StackEvent> {
+
+        protected DummyModifyProxyConfigAction() {
+            super(StackEvent.class);
+        }
+
+        @Override
+        protected void doExecute(ModifyProxyConfigContext context, StackEvent payload, Map<Object, Object> variables) throws Exception {
+            // do nothing
+        }
+    }
+
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/action/ModifyProxyConfigFailedActionTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/action/ModifyProxyConfigFailedActionTest.java
@@ -1,0 +1,104 @@
+package com.sequenceiq.freeipa.flow.stack.modify.proxy.action;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.statemachine.StateContext;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.flow.core.ActionTest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.flow.OperationAwareAction;
+import com.sequenceiq.freeipa.flow.stack.StackEvent;
+import com.sequenceiq.freeipa.flow.stack.StackFailureEvent;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.ModifyProxyConfigContext;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.selector.ModifyProxyConfigEvent;
+import com.sequenceiq.freeipa.service.operation.OperationService;
+import com.sequenceiq.freeipa.service.stack.StackService;
+import com.sequenceiq.freeipa.service.stack.StackUpdater;
+
+@ExtendWith(MockitoExtension.class)
+class ModifyProxyConfigFailedActionTest extends ActionTest {
+
+    private static final String OPERATION_ID = "operationId";
+
+    private static final Map<Object, Object> VARIABLES = Map.of(OperationAwareAction.OPERATION_ID, OPERATION_ID);
+
+    private static final String ACCOUNT_ID = "accountId";
+
+    private static final long STACK_ID = 1L;
+
+    @InjectMocks
+    private ModifyProxyConfigFailedAction underTest;
+
+    @Mock
+    private StackUpdater stackUpdater;
+
+    @Mock
+    private OperationService operationService;
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private ModifyProxyConfigContext context;
+
+    @Mock
+    private Stack stack;
+
+    @BeforeEach
+    void setUp() {
+        super.setUp(context);
+        lenient().when(context.getStack()).thenReturn(stack);
+        lenient().when(stack.getAccountId()).thenReturn(ACCOUNT_ID);
+        lenient().when(stack.getId()).thenReturn(STACK_ID);
+    }
+
+    @Test
+    void createFlowContext() {
+        Exception cause = new Exception("cause");
+        StackFailureEvent payload = mock(StackFailureEvent.class);
+        when(payload.getException()).thenReturn(cause);
+
+        underTest.createFlowContext(flowParameters, mock(StateContext.class), payload);
+
+        verify(flow).setFlowFailed(cause);
+    }
+
+    @Test
+    void doExecute() throws Exception {
+        Exception exception = new Exception("cause");
+        StackFailureEvent stackFailureEvent = new StackFailureEvent(STACK_ID, exception);
+
+        underTest.doExecute(context, stackFailureEvent, VARIABLES);
+
+        verify(stackUpdater)
+                .updateStackStatus(stackFailureEvent.getResourceId(), DetailedStackStatus.MODIFY_PROXY_CONFIG_FAILED, exception.getMessage());
+        verify(operationService).failOperation(ACCOUNT_ID, OPERATION_ID, exception.getMessage());
+        verifySendEvent();
+    }
+
+    @Test
+    void createRequest() {
+        Selectable result = underTest.createRequest(context);
+
+        assertThat(result)
+                .isInstanceOf(StackEvent.class)
+                .extracting(StackEvent.class::cast)
+                .returns(ModifyProxyConfigEvent.MODIFY_PROXY_FAILURE_HANDLED_EVENT.event(), StackEvent::selector)
+                .returns(STACK_ID, StackEvent::getResourceId);
+    }
+
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/action/ModifyProxyConfigFinishedActionTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/action/ModifyProxyConfigFinishedActionTest.java
@@ -1,0 +1,84 @@
+package com.sequenceiq.freeipa.flow.stack.modify.proxy.action;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.flow.core.ActionTest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SuccessDetails;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.flow.OperationAwareAction;
+import com.sequenceiq.freeipa.flow.stack.StackEvent;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.ModifyProxyConfigContext;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.selector.ModifyProxyConfigEvent;
+import com.sequenceiq.freeipa.service.operation.OperationService;
+import com.sequenceiq.freeipa.service.stack.StackUpdater;
+
+class ModifyProxyConfigFinishedActionTest extends ActionTest {
+
+    private static final String OPERATION_ID = "operationId";
+
+    private static final Map<Object, Object> VARIABLES = Map.of(OperationAwareAction.OPERATION_ID, OPERATION_ID);
+
+    private static final String ACCOUNT_ID = "accountId";
+
+    private static final long STACK_ID = 1L;
+
+    @InjectMocks
+    private ModifyProxyConfigFinishedAction underTest;
+
+    @Mock
+    private StackUpdater stackUpdater;
+
+    @Mock
+    private OperationService operationService;
+
+    @Mock
+    private ModifyProxyConfigContext context;
+
+    @Mock
+    private Stack stack;
+
+    @BeforeEach
+    void setUp() {
+        super.setUp(context);
+        lenient().when(context.getStack()).thenReturn(stack);
+        lenient().when(stack.getAccountId()).thenReturn(ACCOUNT_ID);
+        lenient().when(stack.getId()).thenReturn(STACK_ID);
+    }
+
+    @Test
+    void doExecute() throws Exception {
+        StackEvent stackEvent = new StackEvent(STACK_ID);
+
+        underTest.doExecute(context, stackEvent, VARIABLES);
+
+        verify(stackUpdater).updateStackStatus(stackEvent.getResourceId(), DetailedStackStatus.AVAILABLE,
+                "Successfully updated proxy config settings on all instances");
+        SuccessDetails successDetails = new SuccessDetails(context.getStack().getEnvironmentCrn());
+        verify(operationService).completeOperation(ACCOUNT_ID, OPERATION_ID, Set.of(successDetails), Set.of());
+        verifySendEvent();
+    }
+
+    @Test
+    void createRequest() {
+        Selectable result = underTest.createRequest(context);
+
+        assertThat(result)
+                .isInstanceOf(StackEvent.class)
+                .extracting(StackEvent.class::cast)
+                .returns(ModifyProxyConfigEvent.MODIFY_PROXY_FINISHED_EVENT.event(), StackEvent::selector)
+                .returns(STACK_ID, StackEvent::getResourceId);
+    }
+
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/action/ModifyProxyConfigSaltStateApplyActionTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/action/ModifyProxyConfigSaltStateApplyActionTest.java
@@ -1,0 +1,80 @@
+package com.sequenceiq.freeipa.flow.stack.modify.proxy.action;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.eventbus.Promise;
+import com.sequenceiq.flow.core.ActionTest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.flow.OperationAwareAction;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.ModifyProxyConfigContext;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.event.ModifyProxyConfigSaltStateApplyRequest;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.event.ModifyProxyConfigTriggerEvent;
+import com.sequenceiq.freeipa.service.stack.StackUpdater;
+
+@ExtendWith(MockitoExtension.class)
+class ModifyProxyConfigSaltStateApplyActionTest extends ActionTest {
+
+    private static final String OPERATION_ID = "operationId";
+
+    private static final long STACK_ID = 1L;
+
+    @InjectMocks
+    private ModifyProxyConfigSaltStateApplyAction underTest;
+
+    @Mock
+    private StackUpdater stackUpdater;
+
+    @Mock
+    private ModifyProxyConfigContext context;
+
+    @Mock
+    private Stack stack;
+
+    private ModifyProxyConfigTriggerEvent payload;
+
+    @BeforeEach
+    void setUp() {
+        super.setUp(context);
+        lenient().when(context.getStack()).thenReturn(stack);
+        lenient().when(stack.getId()).thenReturn(STACK_ID);
+        payload = new ModifyProxyConfigTriggerEvent(STACK_ID, mock(Promise.class), OPERATION_ID);
+    }
+
+    @Test
+    void doExecute() throws Exception {
+        Map<Object, Object> variables = new HashMap<>();
+
+        underTest.doExecute(context, payload, variables);
+
+        verify(stackUpdater).updateStackStatus(STACK_ID, DetailedStackStatus.MODIFY_PROXY_CONFIG_IN_PROGRESS,
+                "Applying modified proxy config salt state");
+        assertThat(variables).containsEntry(OperationAwareAction.OPERATION_ID, OPERATION_ID);
+        verifySendEvent();
+    }
+
+    @Test
+    void createRequest() {
+        Selectable result = underTest.createRequest(context);
+
+        assertThat(result)
+                .isInstanceOf(ModifyProxyConfigSaltStateApplyRequest.class)
+                .extracting(ModifyProxyConfigSaltStateApplyRequest.class::cast)
+                .returns(STACK_ID, ModifyProxyConfigSaltStateApplyRequest::getResourceId);
+    }
+
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/handler/ModifyProxyConfigSaltStateApplyHandlerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/handler/ModifyProxyConfigSaltStateApplyHandlerTest.java
@@ -1,0 +1,77 @@
+package com.sequenceiq.freeipa.flow.stack.modify.proxy.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.eventbus.Event;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.service.CloudbreakRuntimeException;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
+import com.sequenceiq.freeipa.flow.stack.StackEvent;
+import com.sequenceiq.freeipa.flow.stack.StackFailureEvent;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.event.ModifyProxyConfigSaltStateApplyRequest;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.selector.ModifyProxyConfigEvent;
+import com.sequenceiq.freeipa.service.proxy.ModifyProxyConfigOrchestratorService;
+
+@ExtendWith(MockitoExtension.class)
+class ModifyProxyConfigSaltStateApplyHandlerTest {
+
+    private static final long STACK_ID = 1L;
+
+    private static final HandlerEvent<ModifyProxyConfigSaltStateApplyRequest> EVENT =
+            new HandlerEvent<>(Event.wrap(new ModifyProxyConfigSaltStateApplyRequest(STACK_ID)));
+
+    @InjectMocks
+    private ModifyProxyConfigSaltStateApplyHandler underTest;
+
+    @Mock
+    private ModifyProxyConfigOrchestratorService modifyProxyConfigOrchestratorService;
+
+    @Test
+    void defaultFailureEvent() {
+        Exception cause = new Exception("cause");
+
+        Selectable result = underTest.defaultFailureEvent(STACK_ID, cause, mock(Event.class));
+
+        assertThat(result)
+                .isInstanceOf(StackFailureEvent.class)
+                .extracting(StackFailureEvent.class::cast)
+                .returns(STACK_ID, StackFailureEvent::getResourceId)
+                .returns(cause, StackFailureEvent::getException);
+    }
+
+    @Test
+    void doAccept() throws CloudbreakOrchestratorException {
+        Selectable result = underTest.doAccept(EVENT);
+
+        verify(modifyProxyConfigOrchestratorService).applyModifyProxyState(STACK_ID);
+        assertThat(result)
+                .isInstanceOf(StackEvent.class)
+                .extracting(StackEvent.class::cast)
+                .returns(ModifyProxyConfigEvent.MODIFY_PROXY_SUCCESS_EVENT.selector(), StackEvent::selector)
+                .returns(STACK_ID, StackEvent::getResourceId);
+    }
+
+    @Test
+    void doAcceptFailure() throws CloudbreakOrchestratorException {
+        CloudbreakOrchestratorFailedException cause = new CloudbreakOrchestratorFailedException("cause");
+        doThrow(cause).when(modifyProxyConfigOrchestratorService).applyModifyProxyState(STACK_ID);
+
+        assertThatThrownBy(() -> underTest.doAccept(EVENT))
+                .isInstanceOf(CloudbreakRuntimeException.class)
+                .hasMessage("Failed to apply modify proxy orchestrator state: " + cause.getMessage())
+                .hasCause(cause);
+    }
+
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaParallelFlowValidatorTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaParallelFlowValidatorTest.java
@@ -50,6 +50,7 @@ import com.sequenceiq.freeipa.flow.freeipa.verticalscale.event.FreeIpaVerticalSc
 import com.sequenceiq.freeipa.flow.instance.reboot.RebootEvent;
 import com.sequenceiq.freeipa.flow.stack.image.change.event.ImageChangeEvents;
 import com.sequenceiq.freeipa.flow.stack.migration.AwsVariantMigrationEvent;
+import com.sequenceiq.freeipa.flow.stack.modify.proxy.selector.ModifyProxyConfigEvent;
 import com.sequenceiq.freeipa.flow.stack.termination.StackTerminationEvent;
 import com.sequenceiq.freeipa.flow.stack.update.UpdateUserDataEvents;
 import com.sequenceiq.freeipa.flow.stack.upgrade.ccm.selector.UpgradeCcmStateSelector;
@@ -140,7 +141,7 @@ class FreeIpaParallelFlowValidatorTest {
     @Test
     public void testNewParallelFlows() {
         List<String> allowedParallelFlows = new FreeIpaFlowInformation().getAllowedParallelFlows();
-        assertEquals(16, allowedParallelFlows.size(),
+        assertEquals(17, allowedParallelFlows.size(),
                 "You have changed parallel flows for FreeIPA. Please make sure 'FreeIpaParallelFlowValidator' is adjusted if necessary");
         assertTrue(Set.of(
                         FreeIpaCleanupEvent.CLEANUP_EVENT.event(),
@@ -158,7 +159,8 @@ class FreeIpaParallelFlowValidatorTest {
                         AwsVariantMigrationEvent.CREATE_RESOURCES_EVENT.event(),
                         UpdateUserDataEvents.UPDATE_USERDATA_TRIGGER_EVENT.event(),
                         UpgradeCcmStateSelector.UPGRADE_CCM_TRIGGER_EVENT.event(),
-                        RotateSaltPasswordEvent.ROTATE_SALT_PASSWORD_EVENT.event()).containsAll(allowedParallelFlows),
+                        RotateSaltPasswordEvent.ROTATE_SALT_PASSWORD_EVENT.event(),
+                        ModifyProxyConfigEvent.MODIFY_PROXY_TRIGGER_EVENT.event()).containsAll(allowedParallelFlows),
                 "You have changed parallel flows for FreeIPA. Please make sure 'FreeIpaParallelFlowValidator' is adjusted if necessary");
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/orchestrator/OrchestratorStateParamsProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/orchestrator/OrchestratorStateParamsProviderTest.java
@@ -1,0 +1,86 @@
+package com.sequenceiq.freeipa.service.orchestrator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.orchestration.Node;
+import com.sequenceiq.cloudbreak.orchestrator.host.OrchestratorStateParams;
+import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.orchestrator.StackBasedExitCriteriaModel;
+import com.sequenceiq.freeipa.service.GatewayConfigService;
+import com.sequenceiq.freeipa.service.freeipa.flow.FreeIpaNodeUtilService;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+@ExtendWith(MockitoExtension.class)
+class OrchestratorStateParamsProviderTest {
+
+    private static final long STACK_ID = 123L;
+
+    private static final String STATE = "state";
+
+    @InjectMocks
+    private OrchestratorStateParamsProvider underTest;
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private GatewayConfigService gatewayConfigService;
+
+    @Mock
+    private FreeIpaNodeUtilService freeIpaNodeUtilService;
+
+    @Mock
+    private Stack stack;
+
+    @Mock
+    private GatewayConfig gatewayConfig;
+
+    private Node node1;
+
+    private Node node2;
+
+    @BeforeEach
+    void setUp() {
+        node1 = new Node("privateIP1", "publicIP1", "instance1", "instanceType1", "fqdn1", "hostgroup");
+        node2 = new Node("privateIP2", "publicIP2", "instance2", "instanceType2", "fqdn2", "hostgroup");
+        lenient().when(stack.getId()).thenReturn(STACK_ID);
+        lenient().when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
+        lenient().when(gatewayConfigService.getPrimaryGatewayConfig(any())).thenReturn(gatewayConfig);
+        lenient().when(freeIpaNodeUtilService.mapInstancesToNodes(any())).thenReturn(Set.of(node1, node2));
+    }
+
+    @Test
+    void createStateParams() {
+        OrchestratorStateParams params = underTest.createStateParams(STACK_ID, STATE);
+
+        assertThat(params.getState()).isEqualTo(STATE);
+        assertThat(params.getPrimaryGatewayConfig()).isEqualTo(gatewayConfig);
+        assertThat(params.getTargetHostNames()).hasSameElementsAs(Set.of("fqdn1", "fqdn2"));
+        assertThat(params.getExitCriteriaModel()).isInstanceOf(StackBasedExitCriteriaModel.class);
+        assertThat(((StackBasedExitCriteriaModel) params.getExitCriteriaModel()).getStackId().get()).isEqualTo(STACK_ID);
+    }
+
+    @Test
+    void createStateParamsForSingleTarget() {
+        OrchestratorStateParams params = underTest.createStateParamsForSingleTarget(stack, "fqdn1", STATE);
+
+        assertThat(params.getState()).isEqualTo(STATE);
+        assertThat(params.getPrimaryGatewayConfig()).isEqualTo(gatewayConfig);
+        assertThat(params.getTargetHostNames()).containsOnly("fqdn1");
+        assertThat(params.getExitCriteriaModel()).isInstanceOf(StackBasedExitCriteriaModel.class);
+        assertThat(((StackBasedExitCriteriaModel) params.getExitCriteriaModel()).getStackId().get()).isEqualTo(STACK_ID);
+    }
+
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/proxy/ModifyProxyConfigOrchestratorServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/proxy/ModifyProxyConfigOrchestratorServiceTest.java
@@ -1,0 +1,139 @@
+package com.sequenceiq.freeipa.service.proxy;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.orchestrator.host.OrchestratorStateParams;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceMetadataType;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceStatus;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.NodeHealthDetails;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.orchestrator.OrchestratorStateParamsProvider;
+import com.sequenceiq.freeipa.service.stack.FreeIpaSafeInstanceHealthDetailsService;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+@ExtendWith(MockitoExtension.class)
+class ModifyProxyConfigOrchestratorServiceTest {
+
+    private static final long STACK_ID = 123L;
+
+    private static final InstanceMetaData I_1 = createInstance(1L, true);
+
+    private static final InstanceMetaData I_2 = createInstance(2L, false);
+
+    private static final InstanceMetaData I_3 = createInstance(3L, false);
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private OrchestratorStateParamsProvider orchestratorStateParamsProvider;
+
+    @Mock
+    private HostOrchestrator hostOrchestrator;
+
+    @Mock
+    private FreeIpaSafeInstanceHealthDetailsService healthDetailsService;
+
+    @InjectMocks
+    private ModifyProxyConfigOrchestratorService underTest;
+
+    @Mock
+    private OrchestratorStateParams stateParams1;
+
+    @Mock
+    private OrchestratorStateParams stateParams2;
+
+    @Mock
+    private OrchestratorStateParams stateParams3;
+
+    @Mock
+    private Stack stack;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
+        lenient().when(stack.getNotDeletedInstanceMetaDataList()).thenReturn(List.of(I_2, I_1, I_3));
+        lenient().when(orchestratorStateParamsProvider.createStateParamsForSingleTarget(eq(stack), eq(I_1.getDiscoveryFQDN()), any())).thenReturn(stateParams1);
+        lenient().when(orchestratorStateParamsProvider.createStateParamsForSingleTarget(eq(stack), eq(I_2.getDiscoveryFQDN()), any())).thenReturn(stateParams2);
+        lenient().when(orchestratorStateParamsProvider.createStateParamsForSingleTarget(eq(stack), eq(I_3.getDiscoveryFQDN()), any())).thenReturn(stateParams3);
+        NodeHealthDetails nodeHealthDetails = new NodeHealthDetails();
+        nodeHealthDetails.setStatus(InstanceStatus.CREATED);
+        lenient().when(healthDetailsService.getInstanceHealthDetails(eq(stack), any())).thenReturn(nodeHealthDetails);
+    }
+
+    private static InstanceMetaData createInstance(long privateId, boolean primaryGateway) {
+        InstanceMetaData instance = new InstanceMetaData();
+        instance.setPrivateId(privateId);
+        instance.setDiscoveryFQDN("i-" + privateId);
+        instance.setInstanceMetadataType(primaryGateway ? InstanceMetadataType.GATEWAY_PRIMARY : InstanceMetadataType.GATEWAY);
+        return instance;
+    }
+
+    @Test
+    void applyModifyProxyState() throws Exception {
+        underTest.applyModifyProxyState(STACK_ID);
+
+        InOrder inOrder = inOrder(orchestratorStateParamsProvider, hostOrchestrator, healthDetailsService);
+        inOrder.verify(orchestratorStateParamsProvider)
+                .createStateParamsForSingleTarget(stack, I_2.getDiscoveryFQDN(), ModifyProxyConfigOrchestratorService.MODIFY_PROXY_STATE);
+        inOrder.verify(hostOrchestrator).runOrchestratorState(stateParams2);
+        inOrder.verify(healthDetailsService).getInstanceHealthDetails(stack, I_2);
+        inOrder.verify(orchestratorStateParamsProvider)
+                .createStateParamsForSingleTarget(stack, I_3.getDiscoveryFQDN(), ModifyProxyConfigOrchestratorService.MODIFY_PROXY_STATE);
+        inOrder.verify(hostOrchestrator).runOrchestratorState(stateParams3);
+        inOrder.verify(healthDetailsService).getInstanceHealthDetails(stack, I_3);
+        inOrder.verify(orchestratorStateParamsProvider)
+                .createStateParamsForSingleTarget(stack, I_1.getDiscoveryFQDN(), ModifyProxyConfigOrchestratorService.MODIFY_PROXY_STATE);
+        inOrder.verify(hostOrchestrator).runOrchestratorState(stateParams1);
+        inOrder.verify(healthDetailsService).getInstanceHealthDetails(stack, I_1);
+    }
+
+    @Test
+    void applyModifyProxyStateHealthCheckFails() throws Exception {
+        NodeHealthDetails nodeHealthDetails = mock(NodeHealthDetails.class);
+        String issue = "cause";
+        when(nodeHealthDetails.getIssues()).thenReturn(List.of(issue));
+        when(nodeHealthDetails.getStatus()).thenReturn(InstanceStatus.FAILED);
+        when(healthDetailsService.getInstanceHealthDetails(stack, I_2)).thenReturn(nodeHealthDetails);
+
+        Assertions.assertThatThrownBy(() -> underTest.applyModifyProxyState(STACK_ID))
+                .isInstanceOf(CloudbreakOrchestratorFailedException.class)
+                .hasMessage("Health check failed after proxy config modification for instance %s: %s", I_2.getDiscoveryFQDN(), issue);
+
+        verify(orchestratorStateParamsProvider)
+                .createStateParamsForSingleTarget(stack, I_2.getDiscoveryFQDN(), ModifyProxyConfigOrchestratorService.MODIFY_PROXY_STATE);
+        verify(hostOrchestrator).runOrchestratorState(stateParams2);
+        verify(healthDetailsService).getInstanceHealthDetails(stack, I_2);
+
+        verify(orchestratorStateParamsProvider, never())
+                .createStateParamsForSingleTarget(stack, I_3.getDiscoveryFQDN(), ModifyProxyConfigOrchestratorService.MODIFY_PROXY_STATE);
+        verify(hostOrchestrator, never()).runOrchestratorState(stateParams3);
+        verify(healthDetailsService, never()).getInstanceHealthDetails(stack, I_3);
+        verify(orchestratorStateParamsProvider, never())
+                .createStateParamsForSingleTarget(stack, I_1.getDiscoveryFQDN(), ModifyProxyConfigOrchestratorService.MODIFY_PROXY_STATE);
+        verify(hostOrchestrator, never()).runOrchestratorState(stateParams1);
+        verify(healthDetailsService, never()).getInstanceHealthDetails(stack, I_1);
+    }
+
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaInstanceHealthDetailsServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaInstanceHealthDetailsServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -59,6 +60,9 @@ public class FreeIpaInstanceHealthDetailsServiceTest {
 
     @InjectMocks
     private FreeIpaInstanceHealthDetailsService underTest;
+
+    @Mock
+    private FreeIpaInstanceHealthDetailsService mockFreeIpaInstanceHealthDetailsService;
 
     private List<RPCMessage> getLegacyBaseMessages(String host) {
         List<RPCMessage> messages = new ArrayList<>();
@@ -192,7 +196,7 @@ public class FreeIpaInstanceHealthDetailsServiceTest {
 
     @Test
     public void testGetInstanceHealthDetailsLegacyHealthyNode() throws Exception {
-        FreeIpaClient mockIpaClient = Mockito.mock(FreeIpaClient.class);
+        FreeIpaClient mockIpaClient = mock(FreeIpaClient.class);
         Mockito.when(healthCheckAvailabilityChecker.isCdpFreeIpaHeathAgentAvailable(any())).thenReturn(false);
         Mockito.when(mockIpaClient.getHostname()).thenReturn("test.host");
         Mockito.when(freeIpaClientFactory.getFreeIpaClientForStackForLegacyHealthCheck(any(), any())).thenReturn(mockIpaClient);
@@ -210,7 +214,7 @@ public class FreeIpaInstanceHealthDetailsServiceTest {
 
     @Test
     public void testGetInstanceHealthDetailsLegacyUnhealthyNode() throws Exception {
-        FreeIpaClient mockIpaClient = Mockito.mock(FreeIpaClient.class);
+        FreeIpaClient mockIpaClient = mock(FreeIpaClient.class);
         Mockito.when(healthCheckAvailabilityChecker.isCdpFreeIpaHeathAgentAvailable(any())).thenReturn(false);
         Mockito.when(mockIpaClient.getHostname()).thenReturn(HOST);
         Mockito.when(freeIpaClientFactory.getFreeIpaClientForStackForLegacyHealthCheck(any(), any())).thenReturn(mockIpaClient);
@@ -228,7 +232,7 @@ public class FreeIpaInstanceHealthDetailsServiceTest {
 
     @Test
     public void testGetInstanceHealthDetailsLegacyUnresponsiveNodeThrows() throws Exception {
-        FreeIpaClient mockIpaClient = Mockito.mock(FreeIpaClient.class);
+        FreeIpaClient mockIpaClient = mock(FreeIpaClient.class);
         Mockito.when(healthCheckAvailabilityChecker.isCdpFreeIpaHeathAgentAvailable(any())).thenReturn(false);
         Mockito.when(mockIpaClient.getHostname()).thenReturn(HOST);
         Mockito.when(freeIpaClientFactory.getFreeIpaClientForStackForLegacyHealthCheck(any(), any())).thenReturn(mockIpaClient);
@@ -242,7 +246,7 @@ public class FreeIpaInstanceHealthDetailsServiceTest {
 
     @Test
     public void testGetInstanceHealthDetailsHealthyNode() throws Exception {
-        FreeIpaHealthCheckClient mockIpaHealthClient = Mockito.mock(FreeIpaHealthCheckClient.class);
+        FreeIpaHealthCheckClient mockIpaHealthClient = mock(FreeIpaHealthCheckClient.class);
         Mockito.when(healthCheckAvailabilityChecker.isCdpFreeIpaHeathAgentAvailable(any())).thenReturn(true);
         Mockito.when(freeIpaHealthCheckClientFactory.getClient(any(), any())).thenReturn(mockIpaHealthClient);
         Mockito.when(mockIpaHealthClient.nodeHealth()).thenReturn(getGoodPayload(HOST));
@@ -259,7 +263,7 @@ public class FreeIpaInstanceHealthDetailsServiceTest {
 
     @Test
     public void testGetInstanceHealthDetailsUnhealthyNode() throws Exception {
-        FreeIpaHealthCheckClient mockIpaHealthClient = Mockito.mock(FreeIpaHealthCheckClient.class);
+        FreeIpaHealthCheckClient mockIpaHealthClient = mock(FreeIpaHealthCheckClient.class);
         Mockito.when(healthCheckAvailabilityChecker.isCdpFreeIpaHeathAgentAvailable(any())).thenReturn(true);
         Mockito.when(freeIpaHealthCheckClientFactory.getClient(any(), any())).thenReturn(mockIpaHealthClient);
         Mockito.when(mockIpaHealthClient.nodeHealth()).thenReturn(getErrorPayload(HOST));
@@ -276,7 +280,7 @@ public class FreeIpaInstanceHealthDetailsServiceTest {
 
     @Test
     public void testGetInstanceHealthDetailsUnresponsiveNodeThrows() throws Exception {
-        FreeIpaHealthCheckClient mockIpaHealthClient = Mockito.mock(FreeIpaHealthCheckClient.class);
+        FreeIpaHealthCheckClient mockIpaHealthClient = mock(FreeIpaHealthCheckClient.class);
         Mockito.when(healthCheckAvailabilityChecker.isCdpFreeIpaHeathAgentAvailable(any())).thenReturn(true);
         Mockito.when(freeIpaHealthCheckClientFactory.getClient(any(), any())).thenReturn(mockIpaHealthClient);
         Mockito.when(mockIpaHealthClient.nodeHealth()).thenThrow(ipaClientException);
@@ -289,7 +293,7 @@ public class FreeIpaInstanceHealthDetailsServiceTest {
 
     @Test
     public void testCheckFreeIpaHealthLegacyHealthyNode() throws Exception {
-        FreeIpaClient mockIpaClient = Mockito.mock(FreeIpaClient.class);
+        FreeIpaClient mockIpaClient = mock(FreeIpaClient.class);
         Mockito.when(healthCheckAvailabilityChecker.isCdpFreeIpaHeathAgentAvailable(any())).thenReturn(false);
         Mockito.when(mockIpaClient.getHostname()).thenReturn("test.host");
         Mockito.when(freeIpaClientFactory.getFreeIpaClientForStackForLegacyHealthCheck(any(), any())).thenReturn(mockIpaClient);
@@ -304,7 +308,7 @@ public class FreeIpaInstanceHealthDetailsServiceTest {
 
     @Test
     public void testCheckFreeIpaHealthLegacyUnhealthyNode() throws Exception {
-        FreeIpaClient mockIpaClient = Mockito.mock(FreeIpaClient.class);
+        FreeIpaClient mockIpaClient = mock(FreeIpaClient.class);
         Mockito.when(healthCheckAvailabilityChecker.isCdpFreeIpaHeathAgentAvailable(any())).thenReturn(false);
         Mockito.when(mockIpaClient.getHostname()).thenReturn(HOST);
         Mockito.when(freeIpaClientFactory.getFreeIpaClientForStackForLegacyHealthCheck(any(), any())).thenReturn(mockIpaClient);
@@ -319,7 +323,7 @@ public class FreeIpaInstanceHealthDetailsServiceTest {
 
     @Test
     public void testCheckFreeIpaHealthLegacyUnresponsiveNodeThrows() throws Exception {
-        FreeIpaClient mockIpaClient = Mockito.mock(FreeIpaClient.class);
+        FreeIpaClient mockIpaClient = mock(FreeIpaClient.class);
         Mockito.when(healthCheckAvailabilityChecker.isCdpFreeIpaHeathAgentAvailable(any())).thenReturn(false);
         Mockito.when(mockIpaClient.getHostname()).thenReturn(HOST);
         Mockito.when(freeIpaClientFactory.getFreeIpaClientForStackForLegacyHealthCheck(any(), any())).thenReturn(mockIpaClient);
@@ -333,7 +337,7 @@ public class FreeIpaInstanceHealthDetailsServiceTest {
 
     @Test
     public void testCheckFreeIpaHealthHealthyNode() throws Exception {
-        FreeIpaHealthCheckClient mockIpaHealthClient = Mockito.mock(FreeIpaHealthCheckClient.class);
+        FreeIpaHealthCheckClient mockIpaHealthClient = mock(FreeIpaHealthCheckClient.class);
         Mockito.when(healthCheckAvailabilityChecker.isCdpFreeIpaHeathAgentAvailable(any())).thenReturn(true);
         Mockito.when(freeIpaHealthCheckClientFactory.getClient(any(), any())).thenReturn(mockIpaHealthClient);
         Mockito.when(mockIpaHealthClient.nodeHealth()).thenReturn(getGoodPayload(HOST));
@@ -347,7 +351,7 @@ public class FreeIpaInstanceHealthDetailsServiceTest {
 
     @Test
     public void testCheckFreeIpaHealthUnhealthyNode() throws Exception {
-        FreeIpaHealthCheckClient mockIpaHealthClient = Mockito.mock(FreeIpaHealthCheckClient.class);
+        FreeIpaHealthCheckClient mockIpaHealthClient = mock(FreeIpaHealthCheckClient.class);
         Mockito.when(healthCheckAvailabilityChecker.isCdpFreeIpaHeathAgentAvailable(any())).thenReturn(true);
         Mockito.when(freeIpaHealthCheckClientFactory.getClient(any(), any())).thenReturn(mockIpaHealthClient);
         Mockito.when(mockIpaHealthClient.nodeHealth()).thenReturn(getErrorPayload(HOST));
@@ -361,7 +365,7 @@ public class FreeIpaInstanceHealthDetailsServiceTest {
 
     @Test
     public void testCheckFreeIpaHealthUnhealthyNodeWithFiltering() throws Exception {
-        FreeIpaHealthCheckClient mockIpaHealthClient = Mockito.mock(FreeIpaHealthCheckClient.class);
+        FreeIpaHealthCheckClient mockIpaHealthClient = mock(FreeIpaHealthCheckClient.class);
         Mockito.when(healthCheckAvailabilityChecker.isCdpFreeIpaHeathAgentAvailable(any())).thenReturn(true);
         Mockito.when(freeIpaHealthCheckClientFactory.getClient(any(), any())).thenReturn(mockIpaHealthClient);
         Mockito.when(mockIpaHealthClient.nodeHealth()).thenReturn(getErrorPayloadWithMixedResults(HOST));
@@ -384,7 +388,7 @@ public class FreeIpaInstanceHealthDetailsServiceTest {
 
     @Test
     public void testCheckFreeIpaHealthUnresponsiveNodeThrows() throws Exception {
-        FreeIpaHealthCheckClient mockIpaHealthClient = Mockito.mock(FreeIpaHealthCheckClient.class);
+        FreeIpaHealthCheckClient mockIpaHealthClient = mock(FreeIpaHealthCheckClient.class);
         Mockito.when(healthCheckAvailabilityChecker.isCdpFreeIpaHeathAgentAvailable(any())).thenReturn(true);
         Mockito.when(freeIpaHealthCheckClientFactory.getClient(any(), any())).thenReturn(mockIpaHealthClient);
         Mockito.when(mockIpaHealthClient.nodeHealth()).thenThrow(ipaClientException);

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaSafeInstanceHealthDetailsServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaSafeInstanceHealthDetailsServiceTest.java
@@ -1,0 +1,79 @@
+package com.sequenceiq.freeipa.service.stack;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupType;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceStatus;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.NodeHealthDetails;
+import com.sequenceiq.freeipa.client.FreeIpaClientException;
+import com.sequenceiq.freeipa.entity.InstanceGroup;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
+import com.sequenceiq.freeipa.entity.Stack;
+
+@ExtendWith(MockitoExtension.class)
+class FreeIpaSafeInstanceHealthDetailsServiceTest {
+
+    @Mock
+    private FreeIpaInstanceHealthDetailsService healthDetailsService;
+
+    @InjectMocks
+    private FreeIpaSafeInstanceHealthDetailsService underTest;
+
+    @Test
+    void safeGetInstanceHealthDetailsSuccess() throws Exception {
+        InstanceMetaData instance = getInstance();
+        Stack stack = getStack(Set.of(instance));
+        NodeHealthDetails nodeHealthDetails = new NodeHealthDetails();
+        when(healthDetailsService.getInstanceHealthDetails(stack, instance)).thenReturn(nodeHealthDetails);
+
+        NodeHealthDetails result = underTest.getInstanceHealthDetails(stack, instance);
+
+        assertEquals(nodeHealthDetails, result);
+        verify(healthDetailsService).getInstanceHealthDetails(stack, instance);
+    }
+
+    @Test
+    void safeGetInstanceHealthDetailsFailure() throws Exception {
+        InstanceMetaData instance = getInstance();
+        Stack stack = getStack(Set.of(instance));
+        FreeIpaClientException cause = new FreeIpaClientException("cause");
+        doThrow(cause).when(healthDetailsService).getInstanceHealthDetails(stack, instance);
+
+        NodeHealthDetails result = underTest.getInstanceHealthDetails(stack, instance);
+
+        assertEquals(InstanceStatus.UNREACHABLE, result.getStatus());
+        assertEquals(List.of(cause.getMessage()), result.getIssues());
+        verify(healthDetailsService).getInstanceHealthDetails(stack, instance);
+    }
+
+    private InstanceMetaData getInstance() {
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+        instanceMetaData.setInstanceId("i-1");
+        instanceMetaData.setDiscoveryFQDN("host-1");
+        instanceMetaData.setInstanceStatus(InstanceStatus.CREATED);
+        return instanceMetaData;
+    }
+
+    private Stack getStack(Set<InstanceMetaData> instanceMetaData) {
+        Stack stack = new Stack();
+        stack.setResourceCrn("crn");
+        InstanceGroup instanceGroup = new InstanceGroup();
+        stack.getInstanceGroups().add(instanceGroup);
+        instanceGroup.setInstanceGroupType(InstanceGroupType.MASTER);
+        instanceGroup.setInstanceMetaData(instanceMetaData);
+        return stack;
+    }
+
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaStackHealthDetailsServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaStackHealthDetailsServiceTest.java
@@ -1,5 +1,9 @@
 package com.sequenceiq.freeipa.service.stack;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -7,8 +11,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.Assert;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -22,7 +25,6 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.Instanc
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.HealthDetailsFreeIpaResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.NodeHealthDetails;
-import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.entity.InstanceGroup;
 import com.sequenceiq.freeipa.entity.InstanceMetaData;
 import com.sequenceiq.freeipa.entity.Stack;
@@ -30,12 +32,10 @@ import com.sequenceiq.freeipa.entity.Stack;
 import io.opentracing.Tracer;
 
 @ExtendWith(MockitoExtension.class)
-public class FreeIpaStackHealthDetailsServiceTest {
+class FreeIpaStackHealthDetailsServiceTest {
     private static final String ENVIRONMENT_ID = "crn:cdp:environments:us-west-1:f39af961-e0ce-4f79-826c-45502efb9ca3:environment:12345-6789";
 
     private static final String ACCOUNT_ID = "accountId";
-
-    private static FreeIpaClientException ipaClientException;
 
     private static final String HOST1 = "host1.domain";
 
@@ -52,7 +52,7 @@ public class FreeIpaStackHealthDetailsServiceTest {
     private StackService stackService;
 
     @Mock
-    private FreeIpaInstanceHealthDetailsService freeIpaInstanceHealthDetailsService;
+    private FreeIpaSafeInstanceHealthDetailsService freeIpaInstanceHealthDetailsService;
 
     @InjectMocks
     private FreeIpaStackHealthDetailsService underTest;
@@ -145,169 +145,116 @@ public class FreeIpaStackHealthDetailsServiceTest {
         return instanceMetaData;
     }
 
-    @BeforeAll
-    public static void init() {
-        ipaClientException = new FreeIpaClientException("Error during healthcheck");
+    @BeforeEach
+    void setUp() {
+        Mockito.lenient().when(freeIpaInstanceHealthDetailsService.createNodeResponseWithStatusAndIssue(any(), any(), anyString())).thenCallRealMethod();
     }
 
     @Test
-    public void testNodeDeletedOnProvider() throws Exception {
+    void testNodeDeletedOnProvider() throws Exception {
         Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithListsAndMdcContext(anyString(), anyString())).thenReturn(getDeletedStack());
         HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
-        Assert.assertEquals(Status.UNHEALTHY, response.getStatus());
-        Assert.assertFalse(response.getNodeHealthDetails().isEmpty());
-        Assert.assertTrue(response.getNodeHealthDetails().stream().findFirst().get().getStatus() == InstanceStatus.TERMINATED);
+        assertEquals(Status.UNHEALTHY, response.getStatus());
+        assertFalse(response.getNodeHealthDetails().isEmpty());
+        assertSame(response.getNodeHealthDetails().stream().findFirst().get().getStatus(), InstanceStatus.TERMINATED);
     }
 
     @Test
-    public void testHealthySingleNode() throws Exception {
+    void testHealthySingleNode() throws Exception {
         Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithListsAndMdcContext(anyString(), anyString())).thenReturn(getStack());
         Mockito.when(freeIpaInstanceHealthDetailsService.getInstanceHealthDetails(any(), any())).thenReturn(getGoodDetails1());
         HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
-        Assert.assertEquals(Status.AVAILABLE, response.getStatus());
-        Assert.assertFalse(response.getNodeHealthDetails().isEmpty());
+        assertEquals(Status.AVAILABLE, response.getStatus());
+        assertFalse(response.getNodeHealthDetails().isEmpty());
         for (NodeHealthDetails nodeHealth:response.getNodeHealthDetails()) {
-            Assert.assertTrue(nodeHealth.getIssues().isEmpty());
-            Assert.assertEquals(InstanceStatus.CREATED, nodeHealth.getStatus());
+            assertTrue(nodeHealth.getIssues().isEmpty());
+            assertEquals(InstanceStatus.CREATED, nodeHealth.getStatus());
         }
     }
 
     @Test
-    public void testUnhealthySingleNode() throws Exception {
+    void testUnhealthySingleNode() throws Exception {
         Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithListsAndMdcContext(anyString(), anyString())).thenReturn(getStack());
         Mockito.when(freeIpaInstanceHealthDetailsService.getInstanceHealthDetails(any(), any())).thenReturn(getUnhealthyDetails1());
         HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
-        Assert.assertEquals(Status.UNHEALTHY, response.getStatus());
-        Assert.assertFalse(response.getNodeHealthDetails().isEmpty());
+        assertEquals(Status.UNHEALTHY, response.getStatus());
+        assertFalse(response.getNodeHealthDetails().isEmpty());
         for (NodeHealthDetails nodeHealth:response.getNodeHealthDetails()) {
-            Assert.assertFalse(nodeHealth.getIssues().isEmpty());
-            Assert.assertEquals(InstanceStatus.UNHEALTHY, nodeHealth.getStatus());
+            assertFalse(nodeHealth.getIssues().isEmpty());
+            assertEquals(InstanceStatus.UNHEALTHY, nodeHealth.getStatus());
         }
     }
 
     @Test
-    public void testUnresponsiveSingleNode() throws Exception {
-        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithListsAndMdcContext(anyString(), anyString())).thenReturn(getStack());
-        Mockito.when(freeIpaInstanceHealthDetailsService.getInstanceHealthDetails(any(), any())).thenThrow(ipaClientException);
-        HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
-        Assert.assertEquals(Status.UNREACHABLE, response.getStatus());
-        Assert.assertTrue(response.getNodeHealthDetails().size() == 1);
-        for (NodeHealthDetails nodeHealth:response.getNodeHealthDetails()) {
-            Assert.assertTrue(!nodeHealth.getIssues().isEmpty());
-            Assert.assertEquals(InstanceStatus.UNREACHABLE, nodeHealth.getStatus());
-            Assert.assertTrue(nodeHealth.getIssues().size() == 1);
-            Assert.assertTrue(nodeHealth.getIssues().get(0).equals("Error during healthcheck"));
-        }
-    }
-
-    @Test
-    public void testUnresponsiveSingleNodeThatThrowsRuntimeException() throws Exception {
-        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithListsAndMdcContext(anyString(), anyString())).thenReturn(getStack());
-        Mockito.when(freeIpaInstanceHealthDetailsService.getInstanceHealthDetails(any(), any())).thenThrow(new RuntimeException("Expected"));
-        HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
-        Assert.assertEquals(Status.UNREACHABLE, response.getStatus());
-        Assert.assertTrue(response.getNodeHealthDetails().size() == 1);
-        for (NodeHealthDetails nodeHealth:response.getNodeHealthDetails()) {
-            Assert.assertTrue(!nodeHealth.getIssues().isEmpty());
-            Assert.assertEquals(InstanceStatus.UNREACHABLE, nodeHealth.getStatus());
-            Assert.assertTrue(nodeHealth.getIssues().size() == 1);
-            Assert.assertTrue(nodeHealth.getIssues().get(0).equals("Expected"));
-        }
-    }
-
-    @Test
-    public void testUnresponsiveSecondaryNode() throws Exception {
-        InstanceMetaData im1 = getInstance1();
-        InstanceMetaData im2 = getInstance2();
-        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithListsAndMdcContext(anyString(), anyString())).thenReturn(getStackTwoInstances(im1, im2));
-        Mockito.when(freeIpaInstanceHealthDetailsService.getInstanceHealthDetails(any(), eq(im1))).thenReturn(getGoodDetails1());
-        Mockito.when(freeIpaInstanceHealthDetailsService.getInstanceHealthDetails(any(), eq(im2))).thenThrow(ipaClientException);
-        HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
-        Assert.assertEquals(Status.UNHEALTHY, response.getStatus());
-        Assert.assertTrue(response.getNodeHealthDetails().size() == 2);
-    }
-
-    @Test
-    public void testTwoGoodNodes() throws Exception {
+    void testTwoGoodNodes() throws Exception {
         InstanceMetaData im1 = getInstance1();
         InstanceMetaData im2 = getInstance2();
         Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithListsAndMdcContext(anyString(), anyString())).thenReturn(getStackTwoInstances(im1, im2));
         Mockito.when(freeIpaInstanceHealthDetailsService.getInstanceHealthDetails(any(), eq(im1))).thenReturn(getGoodDetails1());
         Mockito.when(freeIpaInstanceHealthDetailsService.getInstanceHealthDetails(any(), eq(im2))).thenReturn(getGoodDetails2());
         HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
-        Assert.assertEquals(Status.AVAILABLE, response.getStatus());
-        Assert.assertTrue(response.getNodeHealthDetails().size() == 2);
+        assertEquals(Status.AVAILABLE, response.getStatus());
+        assertEquals(2, response.getNodeHealthDetails().size());
     }
 
     @Test
-    public void testOneGoodOneUnhealthyNode() throws Exception {
+    void testOneGoodOneUnhealthyNode() throws Exception {
         InstanceMetaData im1 = getInstance1();
         InstanceMetaData im2 = getInstance2();
         Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithListsAndMdcContext(anyString(), anyString())).thenReturn(getStackTwoInstances(im1, im2));
         Mockito.when(freeIpaInstanceHealthDetailsService.getInstanceHealthDetails(any(), eq(im1))).thenReturn(getGoodDetails1());
         Mockito.when(freeIpaInstanceHealthDetailsService.getInstanceHealthDetails(any(), eq(im2))).thenReturn(getUnhealthyDetails2());
         HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
-        Assert.assertEquals(Status.UNHEALTHY, response.getStatus());
-        Assert.assertTrue(response.getNodeHealthDetails().size() == 2);
+        assertEquals(Status.UNHEALTHY, response.getStatus());
+        assertEquals(2, response.getNodeHealthDetails().size());
     }
 
     @Test
-    public void testTwoUnhealthyNodes() throws Exception {
+    void testTwoUnhealthyNodes() throws Exception {
         InstanceMetaData im1 = getInstance1();
         InstanceMetaData im2 = getInstance2();
         Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithListsAndMdcContext(anyString(), anyString())).thenReturn(getStackTwoInstances(im1, im2));
         Mockito.when(freeIpaInstanceHealthDetailsService.getInstanceHealthDetails(any(), eq(im1))).thenReturn(getUnhealthyDetails1());
         Mockito.when(freeIpaInstanceHealthDetailsService.getInstanceHealthDetails(any(), eq(im2))).thenReturn(getUnhealthyDetails2());
         HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
-        Assert.assertEquals(Status.UNHEALTHY, response.getStatus());
-        Assert.assertTrue(response.getNodeHealthDetails().size() == 2);
+        assertEquals(Status.UNHEALTHY, response.getStatus());
+        assertEquals(2, response.getNodeHealthDetails().size());
     }
 
     @Test
-    public void testOneStoppedOneGoodNode() throws Exception {
+    void testOneStoppedOneGoodNode() throws Exception {
         InstanceMetaData im1 = getInstance1();
         im1.setInstanceStatus(InstanceStatus.STOPPED);
         InstanceMetaData im2 = getInstance2();
         Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithListsAndMdcContext(anyString(), anyString())).thenReturn(getStackTwoInstances(im1, im2));
         Mockito.when(freeIpaInstanceHealthDetailsService.getInstanceHealthDetails(any(), eq(im2))).thenReturn(getUnhealthyDetails2());
         HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
-        Assert.assertEquals(Status.UNHEALTHY, response.getStatus());
-        Assert.assertTrue(response.getNodeHealthDetails().size() == 2);
+        assertEquals(Status.UNHEALTHY, response.getStatus());
+        assertEquals(2, response.getNodeHealthDetails().size());
     }
 
     @Test
-    public void testTwoStoppedNodes() throws Exception {
+    void testTwoStoppedNodes() throws Exception {
         InstanceMetaData im1 = getInstance1();
         im1.setInstanceStatus(InstanceStatus.STOPPED);
         InstanceMetaData im2 = getInstance2();
         im2.setInstanceStatus(InstanceStatus.STOPPED);
         Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithListsAndMdcContext(anyString(), anyString())).thenReturn(getStackTwoInstances(im1, im2));
         HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
-        Assert.assertEquals(Status.STOPPED, response.getStatus());
-        Assert.assertTrue(response.getNodeHealthDetails().size() == 2);
+        assertEquals(Status.STOPPED, response.getStatus());
+        assertEquals(2, response.getNodeHealthDetails().size());
     }
 
     @Test
-    public void testTwoFailedNodes() throws Exception {
+    void testTwoFailedNodes() throws Exception {
         InstanceMetaData im1 = getInstance1();
         im1.setInstanceStatus(InstanceStatus.FAILED);
         InstanceMetaData im2 = getInstance2();
         im2.setInstanceStatus(InstanceStatus.FAILED);
         Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithListsAndMdcContext(anyString(), anyString())).thenReturn(getStackTwoInstances(im1, im2));
         HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
-        Assert.assertEquals(Status.UNHEALTHY, response.getStatus());
-        Assert.assertTrue(response.getNodeHealthDetails().size() == 2);
-    }
-
-    @Test
-    public void testTwoUnresponsiveNodes() throws Exception {
-        InstanceMetaData im1 = getInstance1();
-        InstanceMetaData im2 = getInstance2();
-        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithListsAndMdcContext(anyString(), anyString())).thenReturn(getStackTwoInstances(im1, im2));
-        Mockito.when(freeIpaInstanceHealthDetailsService.getInstanceHealthDetails(any(), any())).thenThrow(ipaClientException);
-        HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
-        Assert.assertEquals(Status.UNREACHABLE, response.getStatus());
-        Assert.assertTrue(response.getNodeHealthDetails().size() == 2);
+        assertEquals(Status.UNHEALTHY, response.getStatus());
+        assertEquals(2, response.getNodeHealthDetails().size());
     }
 
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/upgrade/ccm/UpgradeCcmOrchestratorServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/upgrade/ccm/UpgradeCcmOrchestratorServiceTest.java
@@ -1,31 +1,22 @@
 package com.sequenceiq.freeipa.service.upgrade.ccm;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.sequenceiq.cloudbreak.common.orchestration.Node;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.host.OrchestratorStateParams;
-import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.freeipa.entity.Stack;
-import com.sequenceiq.freeipa.orchestrator.StackBasedExitCriteriaModel;
-import com.sequenceiq.freeipa.service.GatewayConfigService;
-import com.sequenceiq.freeipa.service.freeipa.flow.FreeIpaNodeUtilService;
-import com.sequenceiq.freeipa.service.stack.StackService;
+import com.sequenceiq.freeipa.service.orchestrator.OrchestratorStateParamsProvider;
 
 @ExtendWith(MockitoExtension.class)
 class UpgradeCcmOrchestratorServiceTest {
@@ -33,13 +24,7 @@ class UpgradeCcmOrchestratorServiceTest {
     private static final long STACK_ID = 123L;
 
     @Mock
-    private StackService stackService;
-
-    @Mock
-    private GatewayConfigService gatewayConfigService;
-
-    @Mock
-    private FreeIpaNodeUtilService freeIpaNodeUtilService;
+    private OrchestratorStateParamsProvider orchestratorStateParamsProvider;
 
     @Mock
     private HostOrchestrator hostOrchestrator;
@@ -47,61 +32,44 @@ class UpgradeCcmOrchestratorServiceTest {
     @Mock
     private Stack stack;
 
-    @Captor
-    private ArgumentCaptor<OrchestratorStateParams> paramCaptor;
-
     @InjectMocks
     private UpgradeCcmOrchestratorService underTest;
 
     @Mock
-    private GatewayConfig gatewayConfig;
-
-    private Node node1;
-
-    private Node node2;
+    private OrchestratorStateParams stateParams;
 
     @BeforeEach
     void setUp() {
-        node1 = new Node("privateIP1", "publicIP1", "instance1", "instanceType1", "fqdn1", "hostgroup");
-        node2 = new Node("privateIP2", "publicIP2", "instance2", "instanceType2", "fqdn2", "hostgroup");
-        when(stack.getId()).thenReturn(STACK_ID);
-        when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
-        when(gatewayConfigService.getPrimaryGatewayConfig(any())).thenReturn(gatewayConfig);
-        when(freeIpaNodeUtilService.mapInstancesToNodes(any())).thenReturn(Set.of(node1, node2));
+        when(orchestratorStateParamsProvider.createStateParams(eq(STACK_ID), any())).thenReturn(stateParams);
     }
 
     @Test
     void testApplyUpgradeState() throws CloudbreakOrchestratorException {
         underTest.applyUpgradeState(STACK_ID);
-        verify(hostOrchestrator).runOrchestratorState(paramCaptor.capture());
-        OrchestratorStateParams params = paramCaptor.getValue();
-        assertThat(params.getState()).isEqualTo("upgradeccm");
-        assertOtherStateParams(params);
+        verifyState("upgradeccm");
     }
 
     @Test
     void testReconfigureNginx() throws CloudbreakOrchestratorException {
         underTest.reconfigureNginx(STACK_ID);
-        verify(hostOrchestrator).runOrchestratorState(paramCaptor.capture());
-        OrchestratorStateParams params = paramCaptor.getValue();
-        assertThat(params.getState()).isEqualTo("nginx");
-        assertOtherStateParams(params);
+        verifyState("nginx");
+    }
+
+    @Test
+    void testFinalize() throws CloudbreakOrchestratorException {
+        underTest.finalizeConfiguration(STACK_ID);
+        verifyState("upgradeccm/finalize");
     }
 
     @Test
     void testDisableMina() throws CloudbreakOrchestratorException {
         underTest.disableMina(STACK_ID);
-        verify(hostOrchestrator).runOrchestratorState(paramCaptor.capture());
-        OrchestratorStateParams params = paramCaptor.getValue();
-        assertThat(params.getState()).isEqualTo("upgradeccm/disable-ccmv1");
-        assertOtherStateParams(params);
+        verifyState("upgradeccm/disable-ccmv1");
     }
 
-    private void assertOtherStateParams(OrchestratorStateParams params) {
-        assertThat(params.getPrimaryGatewayConfig()).isEqualTo(gatewayConfig);
-        assertThat(params.getTargetHostNames()).hasSameElementsAs(Set.of("fqdn1", "fqdn2"));
-        assertThat(params.getExitCriteriaModel()).isInstanceOf(StackBasedExitCriteriaModel.class);
-        assertThat(((StackBasedExitCriteriaModel) params.getExitCriteriaModel()).getStackId().get()).isEqualTo(STACK_ID);
+    private void verifyState(String state) throws CloudbreakOrchestratorException {
+        verify(orchestratorStateParamsProvider).createStateParams(STACK_ID, state);
+        verify(hostOrchestrator).runOrchestratorState(stateParams);
     }
 
 }

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/SaltJobIdTracker.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/SaltJobIdTracker.java
@@ -18,6 +18,7 @@ import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorTe
 import com.sequenceiq.cloudbreak.orchestrator.salt.client.SaltConnector;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.JobState;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.RunningJobsResponse;
+import com.sequenceiq.cloudbreak.orchestrator.salt.poller.checker.SaltJobFailedException;
 import com.sequenceiq.cloudbreak.orchestrator.salt.states.SaltStateService;
 
 public class SaltJobIdTracker implements OrchestratorBootstrap {
@@ -48,7 +49,7 @@ public class SaltJobIdTracker implements OrchestratorBootstrap {
         if (JobState.NOT_STARTED.equals(saltJobRunner.getJobState())) {
             LOGGER.debug("Job has not started in the cluster. Starting for first time.");
             checkIsOtherJobRunning();
-            saltJobRunner.setJid(jobId(saltJobRunner.submit(saltConnector)));
+            submitJob();
             checkIsFinished(saltJobRunner.getJid().getJobId());
         } else if (JobState.IN_PROGRESS.equals(saltJobRunner.getJobState())) {
             String jobId = saltJobRunner.getJid().getJobId();
@@ -61,8 +62,7 @@ public class SaltJobIdTracker implements OrchestratorBootstrap {
         } else if (JobState.FAILED == saltJobRunner.getJobState() || JobState.AMBIGUOUS == saltJobRunner.getJobState()) {
             String jobId = saltJobRunner.getJid().getJobId();
             LOGGER.debug("Job: {} failed in the previous time. Trigger again with these targets: {}", jobId, saltJobRunner.getTargetHostnames());
-            saltJobRunner.setJid(jobId(saltJobRunner.submit(saltConnector)));
-            saltJobRunner.setJobState(JobState.IN_PROGRESS);
+            submitJob();
             return call();
         }
         if (JobState.IN_PROGRESS.equals(saltJobRunner.getJobState())) {
@@ -84,6 +84,11 @@ public class SaltJobIdTracker implements OrchestratorBootstrap {
             LOGGER.warn("There are running job(s) with id: {}. Postpone starting the new job until these are finished.", runningJobIds);
             throw new CloudbreakOrchestratorInProgressException("There are running job(s) with id: " + runningJobIds, saltJobRunner.getNodesWithError());
         }
+    }
+
+    private void submitJob() throws SaltJobFailedException {
+        saltJobRunner.setJid(jobId(saltJobRunner.submit(saltConnector)));
+        saltJobRunner.setJobState(JobState.IN_PROGRESS);
     }
 
     private List<String> mapToRunningJobIds(RunningJobsResponse runningJobs) {

--- a/orchestrator-salt/src/main/resources/salt-common/salt/modifyproxy/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/modifyproxy/init.sls
@@ -1,0 +1,86 @@
+{% if salt['pillar.get']('proxy') != None %}
+# Proxy added or modified
+
+{%- from 'modifyproxy/settings.sls' import proxy with context %}
+
+{% if proxy.tunnel == 'CCM' %}
+
+{% if proxy.user %}
+
+ccm_ssh_proxy_auth:
+  file.managed:
+    - name: /root/.ssh/proxy_auth
+    - create: True
+    - mode: 600
+    - contents:
+      - "{{ proxy.user }}:{{ proxy.password }}"
+
+{% endif %} # proxy_user
+
+ccm_setup_ssh_proxy:
+  file.managed:
+    - name: /root/.ssh/config
+    - create: True
+    - contents:
+      - "{{ proxy.proxy_command }}"
+
+{% elif proxy.tunnel == 'CCMV2' or proxy.tunnel == 'CCMV2_JUMPGATE' %}
+
+ccmv2_setup_jumpgate_proxy:
+  file.replace:
+    - name: /etc/jumpgate/config.toml
+    - pattern: "^http_proxy.*"
+    - repl: 'http_proxy = "{{ proxy.proxy_url }}"'
+    - append_if_not_found: True
+
+{% endif %} # tunnel
+
+proxy_env:
+  file.managed:
+    - name: /etc/cdp/proxy.env
+    - mode: 640
+    - makedirs: True
+    - contents:
+      - "https_proxy={{ proxy.proxy_url }}"
+{% if proxy.no_proxy_hosts %}
+      - "no_proxy={{ proxy.no_proxy_hosts }}"
+{% endif %}
+
+{% else %}
+# The proxy is removed
+
+ccm_remove_ssh_proxy_auth:
+  file.absent:
+    - name: /root/.ssh/proxy_auth
+
+ccm_remove_ssh_proxy:
+  file.absent:
+    - name: /root/.ssh/config
+
+ccmv2_remove_jumpgate_proxy:
+  file.replace:
+    - name: /etc/jumpgate/config.toml
+    - pattern: "^http_proxy.*"
+    - repl: 'http_proxy = ""'
+    - ignore_if_missing: True
+
+remove_proxy_env:
+  file.absent:
+    - name: /etc/cdp/proxy.env
+
+{% endif %} # proxy added/modified/removed
+
+restart_ccm_gateway_tunnel_service:
+  cmd.run:
+    - name: systemctl restart ccm-tunnel@GATEWAY
+    - onlyif: systemctl is-active ccm-tunnel@GATEWAY
+
+restart_ccm_knox_tunnel_service:
+  cmd.run:
+    - name: systemctl restart ccm-tunnel@KNOX
+    - onlyif: systemctl is-active ccm-tunnel@KNOX
+
+restart_ccmv2_jumpgate_service:
+  cmd.run:
+    - name: systemctl restart jumpgate-agent
+    - onlyif: systemctl is-active jumpgate-agent

--- a/orchestrator-salt/src/main/resources/salt-common/salt/modifyproxy/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/modifyproxy/settings.sls
@@ -1,0 +1,28 @@
+{% set proxy_protocol = salt['pillar.get']('proxy:protocol') %}
+{% set proxy_host = salt['pillar.get']('proxy:host') %}
+{% set proxy_port = salt['pillar.get']('proxy:port') %}
+{% set proxy_user = salt['pillar.get']('proxy:user') %}
+{% set proxy_password = salt['pillar.get']('proxy:password') %}
+{% set proxy_no_proxy_hosts = salt['pillar.get']('proxy:noProxyHosts') %}
+{% set tunnel = salt['pillar.get']('proxy:tunnel') %}
+
+{% set proxy_url = proxy_protocol ~ '://' ~ proxy_host ~ ':' ~ proxy_port %}
+{% set proxy_command = 'ProxyCommand /usr/bin/corkscrew ' ~ proxy_host ~ ' ' ~ proxy_port ~ ' %h %p' %}
+
+{% if proxy_user %}
+  {% set proxy_url = proxy_protocol ~ '://' ~ proxy_user ~ ':' ~ proxy_password ~ '@' ~ proxy_host ~ ':' ~ proxy_port %}
+  {% set proxy_command = proxy_command ~ ' /root/.ssh/proxy_auth' %}
+{% endif %}
+
+{% set proxy = {} %}
+{% do proxy.update({
+  'protocol': proxy_protocol,
+  'host': proxy_host,
+  'port': proxy_port,
+  'user': proxy_user,
+  'password': proxy_password,
+  'no_proxy_hosts': proxy_no_proxy_hosts,
+  'tunnel': tunnel,
+  'proxy_url': proxy_url,
+  'proxy_command': proxy_command,
+}) %}

--- a/orchestrator-salt/src/main/resources/salt/salt/top.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/top.sls
@@ -14,6 +14,7 @@ base:
     - ntp
     - postgresql.root-certs
     - sshd
+    - modifyproxy
 
   'G@roles:ad_member and G@os_family:RedHat':
     - match: compound

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/SaltJobIdTrackerTest.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/SaltJobIdTrackerTest.java
@@ -81,6 +81,27 @@ class SaltJobIdTrackerTest {
         verify(saltStateService).jobIsRunning(any(), eq(jobId));
         checkTargets(targets, targetCaptor.getAllValues());
         verify(saltJobRunner, times(2)).getJobState();
+        verify(saltJobRunner, times(2)).setJobState(JobState.IN_PROGRESS);
+    }
+
+    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
+    @Test
+    void callWithNotStartedAndJobIsRunningFailsThenJobStateIsSet() throws Exception {
+        String jobId = "1";
+        SaltJobRunner saltJobRunner = Mockito.mock(SaltJobRunner.class);
+        when(saltStateService.jobIsRunning(any(), any())).thenThrow(new RuntimeException());
+        RunningJobsResponse jobsResponse = new RunningJobsResponse();
+        jobsResponse.setResult(List.of());
+        when(saltStateService.getRunningJobs(saltConnector)).thenReturn(jobsResponse);
+
+        when(saltJobRunner.getJid()).thenReturn(JobId.jobId(jobId));
+        when(saltJobRunner.getJobState()).thenReturn(JobState.NOT_STARTED, JobState.IN_PROGRESS);
+        when(saltJobRunner.submit(any(SaltConnector.class))).thenReturn(jobId);
+        SaltJobIdTracker saltJobIdTracker = new SaltJobIdTracker(saltStateService, saltConnector, saltJobRunner);
+
+        assertThatThrownBy(saltJobIdTracker::call)
+                .isInstanceOf(RuntimeException.class);
+        verify(saltJobRunner).setJobState(JobState.IN_PROGRESS);
     }
 
     @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")


### PR DESCRIPTION
Run salt update on the FreeIpa cluster, then apply a new salt state called 'modifyproxy' that will change the proxy configurations originally generated by user-data-helper.sh that is burned on the images.
The salt state is applied to instances in order by id, leaving the primary gateway last. After each state apply a health check is ran to ensure the instance is still reachable.

Some small improvements were also made:
1) FreeIpaService.getOperationStatus retry mechanism was introduced to improve stability (in testing some failed UMS calls failed the polling of the operation status, but the underlying operation finished successfully)
2) SaltJobIdTracker now also sets the job state to IN_PROGRESS when submitting a new job (not just when resubmitting a failed job). This was needed because the checkIsFinished may fail after the job submit (the node can not answer while the CCM services are restarted), and when the call() method is executed again, it will submit the job again.
