### PR TITLE
CB-19594 Migrate common and auth-connector modules from junit4 to junit5

### DIFF
--- a/audit-connector/src/test/java/com/sequenceiq/cloudbreak/audit/converter/AttemptAuditEventResultToGrpcAttemptAuditEventResultConverterTest.java
+++ b/audit-connector/src/test/java/com/sequenceiq/cloudbreak/audit/converter/AttemptAuditEventResultToGrpcAttemptAuditEventResultConverterTest.java
@@ -2,7 +2,7 @@ package com.sequenceiq.cloudbreak.audit.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;

--- a/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/PaywallCredentialPopulatorTest.java
+++ b/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/PaywallCredentialPopulatorTest.java
@@ -1,7 +1,7 @@
 package com.sequenceiq.cloudbreak.auth;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -11,15 +11,15 @@ import static org.mockito.Mockito.when;
 import javax.ws.rs.client.WebTarget;
 
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.client.RestClientUtil;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PaywallCredentialPopulatorTest {
 
     @Mock

--- a/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/altus/VirtualGroupServiceTest.java
+++ b/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/altus/VirtualGroupServiceTest.java
@@ -1,7 +1,7 @@
 package com.sequenceiq.cloudbreak.auth.altus;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;

--- a/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/altus/service/RoleCrnGeneratorTest.java
+++ b/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/altus/service/RoleCrnGeneratorTest.java
@@ -1,7 +1,7 @@
 package com.sequenceiq.cloudbreak.auth.altus.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;

--- a/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/security/CrnUserDetailsServiceTest.java
+++ b/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/security/CrnUserDetailsServiceTest.java
@@ -1,22 +1,22 @@
 package com.sequenceiq.cloudbreak.auth.security;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.User;
 import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
 import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class CrnUserDetailsServiceTest {
 
     private String userCrn = "crn:cdp:iam:us-west-1:9d74eee4-1cad-45d7-b645-7ccf9edbb73d:user:f3b8ed82-e712-4f89-bda7-be07183720d3";
@@ -29,7 +29,7 @@ public class CrnUserDetailsServiceTest {
 
     private CrnUserDetailsService underTest;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         underTest = new CrnUserDetailsService(mockedUmsClient, regionAwareInternalCrnGeneratorFactory);
     }

--- a/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/security/InternalCrnBuilderTest.java
+++ b/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/security/InternalCrnBuilderTest.java
@@ -1,11 +1,11 @@
 package com.sequenceiq.cloudbreak.auth.security;
 
 import static com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGenerator.regionalAwareInternalCrnGenerator;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGenerator;

--- a/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/security/authentication/UmsAuthenticationServiceTest.java
+++ b/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/security/authentication/UmsAuthenticationServiceTest.java
@@ -1,17 +1,16 @@
 package com.sequenceiq.cloudbreak.auth.security.authentication;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
 import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
@@ -19,11 +18,8 @@ import com.sequenceiq.cloudbreak.auth.altus.exception.UmsAuthenticationException
 import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
 import com.sequenceiq.cloudbreak.common.user.CloudbreakUser;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class UmsAuthenticationServiceTest {
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @Mock
     private GrpcUmsClient grpcUmsClient;
@@ -33,60 +29,51 @@ public class UmsAuthenticationServiceTest {
 
     private UmsAuthenticationService underTest;
 
-    @Before
+    @BeforeEach
     public void before() {
         underTest = new UmsAuthenticationService(grpcUmsClient, regionAwareInternalCrnGeneratorFactory);
     }
 
     @Test
     public void testInvalidCrnNull() {
-        thrown.expect(UmsAuthenticationException.class);
-
-        try {
+        UmsAuthenticationException exception = assertThrows(UmsAuthenticationException.class, () -> {
             underTest.getCloudbreakUser(null, "principal");
-        } catch (UmsAuthenticationException e) {
-            assertEquals("Invalid CRN has been provided: null", e.getMessage());
-            throw e;
-        }
+        });
+
+        assertEquals("Invalid CRN has been provided: null", exception.getMessage());
     }
 
     @Test
     public void testInvalidCrnDueToPattern() {
-        thrown.expect(UmsAuthenticationException.class);
-
         String crn = "crsdfadsfdsf sadasf3-df81ae585e10";
-        try {
+
+        UmsAuthenticationException exception = assertThrows(UmsAuthenticationException.class, () -> {
             underTest.getCloudbreakUser(crn, "principal");
-        } catch (UmsAuthenticationException e) {
-            assertEquals("Invalid CRN has been provided: " + crn, e.getMessage());
-            throw e;
-        }
+        });
+
+        assertEquals("Invalid CRN has been provided: " + crn, exception.getMessage());
     }
 
     @Test
     public void testInvalidCrnDueToParse() {
-        thrown.expect(UmsAuthenticationException.class);
-
         String crn = "crn:cdp:cookie:us-west-1:9d74eee4-1cad-45d7-b645-7ccf9edbb73d:user:qaas/b8a64902-7765-4ddd-a4f3-df81ae585e10";
-        try {
+
+        UmsAuthenticationException exception = assertThrows(UmsAuthenticationException.class, () -> {
             underTest.getCloudbreakUser(crn, "principal");
-        } catch (UmsAuthenticationException e) {
-            assertEquals("Invalid CRN has been provided: " + crn, e.getMessage());
-            throw e;
-        }
+        });
+
+        assertEquals("Invalid CRN has been provided: " + crn, exception.getMessage());
     }
 
     @Test
     public void testInvalidTypeCrn() {
-        thrown.expect(UmsAuthenticationException.class);
-
         String crn = "crn:cdp:iam:us-west-1:9d74eee4-1cad-45d7-b645-7ccf9edbb73d:cluster:qaas/b8a64902-7765-4ddd-a4f3-df81ae585e10";
-        try {
+
+        UmsAuthenticationException exception = assertThrows(UmsAuthenticationException.class, () -> {
             underTest.getCloudbreakUser(crn, "principal");
-        } catch (UmsAuthenticationException e) {
-            assertEquals("Authentication is supported only with User and MachineUser CRN: " + crn, e.getMessage());
-            throw e;
-        }
+        });
+
+        assertEquals("Authentication is supported only with User and MachineUser CRN: " + crn, exception.getMessage());
     }
 
     @Test

--- a/common/src/test/java/com/sequenceiq/cloudbreak/auth/crn/CrnTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/auth/crn/CrnTest.java
@@ -1,18 +1,14 @@
 package com.sequenceiq.cloudbreak.auth.crn;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 public class CrnTest {
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     private String exampleCrn = "crn:cdp:iam:us-west-1:9d74eee4-1cad-45d7-b645-7ccf9edbb73d:user:f3b8ed82-e712-4f89-bda7-be07183720d3";
 
@@ -38,10 +34,7 @@ public class CrnTest {
 
     @Test
     public void testBuilder() {
-        Crn crn = CrnTestUtil.getUserCrnBuilder()
-                .setAccountId("accountId")
-                .setResource("userId")
-                .build();
+        Crn crn = CrnTestUtil.getUserCrnBuilder().setAccountId("accountId").setResource("userId").build();
 
         assertEquals(Crn.Service.IAM, crn.getService());
         assertEquals("accountId", crn.getAccountId());
@@ -81,40 +74,46 @@ public class CrnTest {
 
     @Test
     public void testInvalidCrnDueToPartition() {
-        thrown.expect(CrnParseException.class);
-        Crn.fromString(invalidCrnPartition);
+        CrnParseException exception = assertThrows(CrnParseException.class, () -> {
+            Crn.fromString(invalidCrnPartition);
+        });
+
+        assertEquals("cookie is not a valid partition value", exception.getMessage());
     }
 
     @Test
     public void testInvalidCrnDueToRegion() {
-        thrown.expect(CrnParseException.class);
-        Crn.fromString(invalidCrnRegion);
+        CrnParseException exception = assertThrows(CrnParseException.class, () -> {
+            Crn.fromString(invalidCrnRegion);
+        });
+
+        assertEquals("eu-north-1 is not a valid region value", exception.getMessage());
     }
 
     @Test
     public void testInvalidCrnDueToService() {
-        thrown.expect(CrnParseException.class);
-        Crn.fromString(invalidCrnService);
+        CrnParseException exception = assertThrows(CrnParseException.class, () -> {
+            Crn.fromString(invalidCrnService);
+        });
+
+        assertEquals("cookie is not a valid service value", exception.getMessage());
     }
 
     @Test
     public void testInvalidCrnDueToResourceType() {
-        thrown.expect(CrnParseException.class);
-        Crn.fromString(invalidCrnResourceType);
+        CrnParseException exception = assertThrows(CrnParseException.class, () -> {
+            Crn.fromString(invalidCrnResourceType);
+        });
+
+        assertEquals("cookie is not a valid resource type value", exception.getMessage());
     }
 
     @Test
     public void testGetUserId() {
-        Crn crn = CrnTestUtil.getUserCrnBuilder()
-                .setAccountId("accountId")
-                .setResource("userId")
-                .build();
+        Crn crn = CrnTestUtil.getUserCrnBuilder().setAccountId("accountId").setResource("userId").build();
         assertEquals("userId", crn.getUserId());
 
-        crn = CrnTestUtil.getUserCrnBuilder()
-                .setAccountId("accountId")
-                .setResource("externalId/userId")
-                .build();
+        crn = CrnTestUtil.getUserCrnBuilder().setAccountId("accountId").setResource("externalId/userId").build();
         assertEquals("userId", crn.getUserId());
     }
 

--- a/common/src/test/java/com/sequenceiq/cloudbreak/auth/crn/InternalCrnBuilderTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/auth/crn/InternalCrnBuilderTest.java
@@ -1,10 +1,10 @@
 package com.sequenceiq.cloudbreak.auth.crn;
 
 import static com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGenerator.regionalAwareInternalCrnGenerator;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class InternalCrnBuilderTest {
 
@@ -12,14 +12,14 @@ public class InternalCrnBuilderTest {
     public void testIsInternalCrnForServiceWhenServiceMatch() {
         RegionAwareInternalCrnGenerator autoscale = regionalAwareInternalCrnGenerator(Crn.Service.AUTOSCALE, "partition", "region");
         boolean autoscaleService = autoscale.isInternalCrnForService("crn:cdp:autoscale:us-west-1:altus:user:__internal__actor__");
-        assertTrue("Internal Crn For Service should match.", autoscaleService);
+        assertTrue(autoscaleService, "Internal Crn For Service should match.");
     }
 
     @Test
     public void testIsInternalCrnForServiceWhenServiceNotMatching() {
         RegionAwareInternalCrnGenerator autoscale = regionalAwareInternalCrnGenerator(Crn.Service.AUTOSCALE, "partition", "region");
         boolean autoscaleService = autoscale.isInternalCrnForService("crn:cdp:datahub:us-west-1:altus:user:__internal__actor__");
-        assertFalse("Internal Crn For Service should not match.", autoscaleService);
+        assertFalse(autoscaleService, "Internal Crn For Service should not match.");
     }
 
     @Test
@@ -27,6 +27,6 @@ public class InternalCrnBuilderTest {
         RegionAwareInternalCrnGenerator autoscale = regionalAwareInternalCrnGenerator(Crn.Service.AUTOSCALE, "partition", "region");
         String testCrn = "crn:cdp:iam:us-west-1:9d74eee4-1cad-45d7-b645-7ccf9edbb73d:user:f3b8ed82-e712-4f89-bda7-be07183720d3";
         boolean autoscaleService = autoscale.isInternalCrnForService(testCrn);
-        assertFalse("External Crn For Service should not match.", autoscaleService);
+        assertFalse(autoscaleService, "External Crn For Service should not match.");
     }
 }

--- a/common/src/test/java/com/sequenceiq/cloudbreak/ccm/cloudinit/CcmConnectivityParametersTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/ccm/cloudinit/CcmConnectivityParametersTest.java
@@ -3,7 +3,7 @@ package com.sequenceiq.cloudbreak.ccm.cloudinit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CcmConnectivityParametersTest {
 

--- a/common/src/test/java/com/sequenceiq/cloudbreak/ccm/cloudinit/DefaultCcmV2ParametersTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/ccm/cloudinit/DefaultCcmV2ParametersTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DefaultCcmV2ParametersTest {
 

--- a/common/src/test/java/com/sequenceiq/cloudbreak/ccm/endpoint/DirectServiceEndpointFinderTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/ccm/endpoint/DirectServiceEndpointFinderTest.java
@@ -1,7 +1,7 @@
 package com.sequenceiq.cloudbreak.ccm.endpoint;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -9,7 +9,7 @@ import java.util.Optional;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests {@link DirectServiceEndpointFinder}

--- a/common/src/test/java/com/sequenceiq/cloudbreak/common/anonymizer/AnonymizerUtilTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/common/anonymizer/AnonymizerUtilTest.java
@@ -1,9 +1,10 @@
 package com.sequenceiq.cloudbreak.common.anonymizer;
 
 import static com.sequenceiq.cloudbreak.common.anonymizer.AnonymizerUtil.anonymize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AnonymizerUtilTest {
 
@@ -11,20 +12,20 @@ public class AnonymizerUtilTest {
 
     @Test
     public void testNullInput() {
-        Assert.assertNull(anonymize(null));
+        assertNull(anonymize(null));
     }
 
     @Test
     public void testHidePasswordSingleQuote() {
         String testData = " DC=hortonworks,DC=com '--ldap-manager-password=2#KQ01DLbUdljJ!AVs' --ldap-sync-usern' sd dsds '";
-        Assert.assertEquals(" DC=hortonworks,DC=com '--ldap-manager-password=" + REPLACEMENT + "' --ldap-sync-usern' sd dsds '",
+        assertEquals(" DC=hortonworks,DC=com '--ldap-manager-password=" + REPLACEMENT + "' --ldap-sync-usern' sd dsds '",
                 anonymize(testData));
     }
 
     @Test
     public void testCapitalHidePasswordSingleQuote() {
         String testData = " DC=hortonworks,DC=com '--ldap-manager-PASSWORD=2#KQ01DLbUdljJ!AVs' --ldap-sync-usern' sd dsds '";
-        Assert.assertEquals(" DC=hortonworks,DC=com '--ldap-manager-PASSWORD=" + REPLACEMENT + "' --ldap-sync-usern' sd dsds '",
+        assertEquals(" DC=hortonworks,DC=com '--ldap-manager-PASSWORD=" + REPLACEMENT + "' --ldap-sync-usern' sd dsds '",
                 anonymize(testData));
     }
 
@@ -103,41 +104,41 @@ public class AnonymizerUtilTest {
                 + "export \"test6_secret\":\"****\"\n"
                 + "export \"test6_key\":\"****\"\n"
                 + "export \"test6_credential\":\"****\"\n";
-        Assert.assertEquals(expected, anonymize(testData));
+        assertEquals(expected, anonymize(testData));
     }
 
     @Test
     public void testHidePasswordDoubleQuote() {
         String testData = " DC=hortonworks,DC=com \"--ldap-manager-password=2#KQ01DLbUdljJ!AVs\" --ldap-sync-usern\" sd dsds \"";
-        Assert.assertEquals(" DC=hortonworks,DC=com \"--ldap-manager-password=" + REPLACEMENT + "\" --ldap-sync-usern\" sd dsds \"",
+        assertEquals(" DC=hortonworks,DC=com \"--ldap-manager-password=" + REPLACEMENT + "\" --ldap-sync-usern\" sd dsds \"",
                 anonymize(testData));
     }
 
     @Test
     public void testCapitalHidePasswordDoubleQuote() {
         String testData = " DC=hortonworks,DC=com \"--ldap-manager-PASSWORD=2#KQ01DLbUdljJ!AVs\" --ldap-sync-usern\" sd dsds \"";
-        Assert.assertEquals(" DC=hortonworks,DC=com \"--ldap-manager-PASSWORD=" + REPLACEMENT + "\" --ldap-sync-usern\" sd dsds \"",
+        assertEquals(" DC=hortonworks,DC=com \"--ldap-manager-PASSWORD=" + REPLACEMENT + "\" --ldap-sync-usern\" sd dsds \"",
                 anonymize(testData));
     }
 
     @Test
     public void testHidePasswordNoQuotes() {
         String testData = " DC=hortonworks,DC=com --ldap-manager-password=2#KQ01DLbUdljJ!AVs --ldap-sync-usern' sd dsds '";
-        Assert.assertEquals(" DC=hortonworks,DC=com --ldap-manager-password=" + REPLACEMENT + " --ldap-sync-usern' sd dsds '",
+        assertEquals(" DC=hortonworks,DC=com --ldap-manager-password=" + REPLACEMENT + " --ldap-sync-usern' sd dsds '",
                 anonymize(testData));
     }
 
     @Test
     public void testCapitalHidePasswordNoQuotes() {
         String testData = " DC=hortonworks,DC=com --ldap-manager-PASSWORD=2#KQ01DLbUdljJ!AVs --ldap-sync-usern' sd dsds '";
-        Assert.assertEquals(" DC=hortonworks,DC=com --ldap-manager-PASSWORD=" + REPLACEMENT + " --ldap-sync-usern' sd dsds '",
+        assertEquals(" DC=hortonworks,DC=com --ldap-manager-PASSWORD=" + REPLACEMENT + " --ldap-sync-usern' sd dsds '",
                 anonymize(testData));
     }
 
     @Test
     public void testCapitalHidePasswordEqualsSingleQuotes() {
         String testData = " DC=hortonworks,DC=com --ldap-manager-PASSWORD='2#KQ01DLbUdljJ!AVs' --ldap-sync-usern' sd dsds '";
-        Assert.assertEquals(" DC=hortonworks,DC=com --ldap-manager-PASSWORD='" + REPLACEMENT + "' --ldap-sync-usern' sd dsds '",
+        assertEquals(" DC=hortonworks,DC=com --ldap-manager-PASSWORD='" + REPLACEMENT + "' --ldap-sync-usern' sd dsds '",
                 anonymize(testData));
     }
 
@@ -145,7 +146,7 @@ public class AnonymizerUtilTest {
     public void testHideInJson() {
         String testData = "username\":\"admin\",\"external_ranger_admin_password\":\"rangerpassword123\"}}},"
                 + "{\"admin-properties\":{\"properties\":{\"db_root_user\":\"rangerroot\",\"db_root_password\":\"rangerpass\",\"db_host\":\"localhost\"}}}";
-        Assert.assertEquals("username\":\"admin\",\"external_ranger_admin_password\":\"" + REPLACEMENT + "\"}}},"
+        assertEquals("username\":\"admin\",\"external_ranger_admin_password\":\"" + REPLACEMENT + "\"}}},"
                         + "{\"admin-properties\":{\"properties\":{\"db_root_user\":\"rangerroot\",\"db_root_password\":\""
                         + REPLACEMENT + "\",\"db_host\":\"localhost\"}}}",
                 anonymize(testData));
@@ -155,7 +156,7 @@ public class AnonymizerUtilTest {
     public void testAwsKeybasedJson() {
         String testData = "{\"cloudPlatform\":\"AWS\",\"description\":\"\",\"name\":\"anyad\",\"parameters\":{\"selector\":\"key-based\","
                 + "\"secretKey\":\"dontshowup\",\"accessKey\":\"dontshowup\"}}";
-        Assert.assertEquals("{\"cloudPlatform\":\"AWS\",\"description\":\"\",\"name\":\"anyad\",\"parameters\":{\"selector\":\"key-based\","
+        assertEquals("{\"cloudPlatform\":\"AWS\",\"description\":\"\",\"name\":\"anyad\",\"parameters\":{\"selector\":\"key-based\","
                         + "\"secretKey\":\"" + REPLACEMENT + "\",\"accessKey\":\"" + REPLACEMENT + "\"}}",
                 anonymize(testData));
     }
@@ -166,7 +167,7 @@ public class AnonymizerUtilTest {
                 + "\"core-site\":{\"fs.AbstractFileSystem.wasbs.impl\":\"org.apache.hadoop.fs.azure.Wasbs\",\"fs.AbstractFileSystem.wasb.impl\""
                 + ":\"org.apache.hadoop.fs.azure.Wasbs\",\"fs.azure.account.key.mmolnar.blob.core.windows.net\":\"dontshowup\","
                 + "\"fs.azure.selfthrottling.read.factor\":\"1.0\",\"fs.azure.selfthrottling.write.factor\":\"1.0\"}}";
-        Assert.assertEquals("{\"hive-site\":{\"hive.metastore.warehouse.dir\":\"wasb://asdf/mmolnar-v/apps/hive/warehouse\"},"
+        assertEquals("{\"hive-site\":{\"hive.metastore.warehouse.dir\":\"wasb://asdf/mmolnar-v/apps/hive/warehouse\"},"
                         + "\"core-site\":{\"fs.AbstractFileSystem.wasbs.impl\":\"org.apache.hadoop.fs.azure.Wasbs\",\"fs.AbstractFileSystem.wasb.impl\""
                         + ":\"org.apache.hadoop.fs.azure.Wasbs\",\"fs.azure.account.key.mmolnar.blob.core.windows.net\":\"" + REPLACEMENT + "\","
                         + "\"fs.azure.selfthrottling.read.factor\":\"1.0\",\"fs.azure.selfthrottling.write.factor\":\"1.0\"}}",
@@ -176,7 +177,7 @@ public class AnonymizerUtilTest {
     @Test
     public void testLdapPassword() {
         String testData = "ambari-server sync-ldap --all --ldap-sync-admin-name cloudbreak --ldap-sync-admin-password thisismypassword";
-        Assert.assertEquals("ambari-server sync-ldap --all --ldap-sync-admin-name cloudbreak --ldap-sync-admin-password " + REPLACEMENT,
+        assertEquals("ambari-server sync-ldap --all --ldap-sync-admin-name cloudbreak --ldap-sync-admin-password " + REPLACEMENT,
                 anonymize(testData));
     }
 
@@ -190,70 +191,70 @@ public class AnonymizerUtilTest {
                 + "        \"name\": \"hive-hive_metastore_database_password\",\n"
                 + "        \"value\": \"" + REPLACEMENT + "\"\n"
                 + "      },";
-        Assert.assertEquals(expectedData, anonymize(testData));
+        assertEquals(expectedData, anonymize(testData));
     }
 
     @Test
     public void testCmTemplatePasswordOneLine() {
         String testData = "{\"name\": \"hive-hive_metastore_database_password\",\"value\": \"Horton01\"},";
         String expectedData = "{\"name\": \"hive-hive_metastore_database_password\",\"value\": \"" + REPLACEMENT + "\"},";
-        Assert.assertEquals(expectedData, anonymize(testData));
+        assertEquals(expectedData, anonymize(testData));
 
     }
 
     @Test
     public void testHideSecretInJson() {
         String testData = "{\"name\":\"gateway_master_secret\",\"value\":\"7hiihnuqtlthgp57o6otvf04im\",\"ref\":null,\"variable\":null,\"autoConfig\":null}";
-        Assert.assertEquals("{\"name\":\"gateway_master_secret\",\"value\":\"" + REPLACEMENT + "\",\"ref\":null,\"variable\":null,\"autoConfig\":null}",
+        assertEquals("{\"name\":\"gateway_master_secret\",\"value\":\"" + REPLACEMENT + "\",\"ref\":null,\"variable\":null,\"autoConfig\":null}",
                 anonymize(testData));
     }
 
     @Test
     public void testHideAzureDbArmTemplateSecretsInJson() {
         String testData = "{\"type\": \"securestring\",\"defaultValue\" : \"7hiihnuqtlthgp57o6otvf04im\",\"minLength\"1}";
-        Assert.assertEquals("{\"type\": \"securestring\",\"defaultValue\" : \"" + REPLACEMENT + "\",\"minLength\"1}",
+        assertEquals("{\"type\": \"securestring\",\"defaultValue\" : \"" + REPLACEMENT + "\",\"minLength\"1}",
                 anonymize(testData));
     }
 
     @Test
     public void testHideSecretSingleQuote() {
         String testData = " DC=hortonworks,DC=com '--ldap-manager-secret=2#KQ01DLbUdljJ!AVs' --ldap-sync-usern' sd dsds '";
-        Assert.assertEquals(" DC=hortonworks,DC=com '--ldap-manager-secret=" + REPLACEMENT + "' --ldap-sync-usern' sd dsds '",
+        assertEquals(" DC=hortonworks,DC=com '--ldap-manager-secret=" + REPLACEMENT + "' --ldap-sync-usern' sd dsds '",
                 anonymize(testData));
     }
 
     @Test
     public void testCapitalHideSecretSingleQuote() {
         String testData = " DC=hortonworks,DC=com '--ldap-manager-SECRET=2#KQ01DLbUdljJ!AVs' --ldap-sync-usern' sd dsds '";
-        Assert.assertEquals(" DC=hortonworks,DC=com '--ldap-manager-SECRET=" + REPLACEMENT + "' --ldap-sync-usern' sd dsds '",
+        assertEquals(" DC=hortonworks,DC=com '--ldap-manager-SECRET=" + REPLACEMENT + "' --ldap-sync-usern' sd dsds '",
                 anonymize(testData));
     }
 
     @Test
     public void testHideSecretDoubleQuote() {
         String testData = " DC=hortonworks,DC=com \"--ldap-manager-secret=2#KQ01DLbUdljJ!AVs\" --ldap-sync-usern\" sd dsds \"";
-        Assert.assertEquals(" DC=hortonworks,DC=com \"--ldap-manager-secret=" + REPLACEMENT + "\" --ldap-sync-usern\" sd dsds \"",
+        assertEquals(" DC=hortonworks,DC=com \"--ldap-manager-secret=" + REPLACEMENT + "\" --ldap-sync-usern\" sd dsds \"",
                 anonymize(testData));
     }
 
     @Test
     public void testCapitalHideSecretDoubleQuote() {
         String testData = " DC=hortonworks,DC=com \"--ldap-manager-SECRET=2#KQ01DLbUdljJ!AVs\" --ldap-sync-usern\" sd dsds \"";
-        Assert.assertEquals(" DC=hortonworks,DC=com \"--ldap-manager-SECRET=" + REPLACEMENT + "\" --ldap-sync-usern\" sd dsds \"",
+        assertEquals(" DC=hortonworks,DC=com \"--ldap-manager-SECRET=" + REPLACEMENT + "\" --ldap-sync-usern\" sd dsds \"",
                 anonymize(testData));
     }
 
     @Test
     public void testHideSecretNoQuotes() {
         String testData = " DC=hortonworks,DC=com --ldap-manager-secret=2#KQ01DLbUdljJ!AVs --ldap-sync-usern' sd dsds '";
-        Assert.assertEquals(" DC=hortonworks,DC=com --ldap-manager-secret=" + REPLACEMENT + " --ldap-sync-usern' sd dsds '",
+        assertEquals(" DC=hortonworks,DC=com --ldap-manager-secret=" + REPLACEMENT + " --ldap-sync-usern' sd dsds '",
                 anonymize(testData));
     }
 
     @Test
     public void testCapitalHideSecretNoQuotes() {
         String testData = " DC=hortonworks,DC=com --ldap-manager-SECRET=2#KQ01DLbUdljJ!AVs --ldap-sync-usern' sd dsds '";
-        Assert.assertEquals(" DC=hortonworks,DC=com --ldap-manager-SECRET=" + REPLACEMENT + " --ldap-sync-usern' sd dsds '",
+        assertEquals(" DC=hortonworks,DC=com --ldap-manager-SECRET=" + REPLACEMENT + " --ldap-sync-usern' sd dsds '",
                 anonymize(testData));
     }
 
@@ -261,7 +262,7 @@ public class AnonymizerUtilTest {
     public void testFreeIpaLdapModifyPassword() {
         String testData = "ldapmodify x -D 'cn=directory manager' -w 'Cloudera01' -h localhost";
         String expectedData = "ldapmodify x -D 'cn=directory manager' -w '" + REPLACEMENT + "' -h localhost";
-        Assert.assertEquals(expectedData, anonymize(testData));
+        assertEquals(expectedData, anonymize(testData));
     }
 
     @Test
@@ -271,7 +272,7 @@ public class AnonymizerUtilTest {
                 "X-Frame-Options: DENY, Content-Security-Policy: frame-ancestors 'none', Cache-Control: no-cache]";
         String expectedData = "IPASESSION: MagBearerToken=" + REPLACEMENT + ", Set-Cookie: ipa_session=MagBearerToken=" + REPLACEMENT +
                 ";path=/ipa;httponly;secure;, X-Frame-Options: DENY, Content-Security-Policy: frame-ancestors 'none', Cache-Control: no-cache]";
-        Assert.assertEquals(expectedData, anonymize(testData));
+        assertEquals(expectedData, anonymize(testData));
     }
 
     @Test
@@ -288,6 +289,6 @@ public class AnonymizerUtilTest {
                 "\\\"alma\\\",\\\"tenantId\\\":\\\"tenant\\\"," +
                 "\\\"appBased\\\":{\\\"accessKey\\\":\\\"alma\\\",\\\"secretKey\\\":\\\"****\"}}," +
                 "\\\"gcp\\\":null,\\\"yarn\\\":null,\\\"mock\\\":null,\\\"govCloud\\\":false}\"}}";
-        Assert.assertEquals(expectedData, anonymize(testData));
+        assertEquals(expectedData, anonymize(testData));
     }
 }

--- a/common/src/test/java/com/sequenceiq/cloudbreak/common/archive/AbstractArchivistServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/common/archive/AbstractArchivistServiceTest.java
@@ -1,13 +1,13 @@
 package com.sequenceiq.cloudbreak.common.archive;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -24,7 +24,7 @@ public class AbstractArchivistServiceTest {
     @InjectMocks
     private ArchivistServiceImplementation underTest;
 
-    @Before
+    @BeforeEach
     public void init() {
         MockitoAnnotations.initMocks(this);
     }

--- a/common/src/test/java/com/sequenceiq/cloudbreak/common/json/JsonTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/common/json/JsonTest.java
@@ -1,11 +1,11 @@
 package com.sequenceiq.cloudbreak.common.json;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JsonTest {
 

--- a/common/src/test/java/com/sequenceiq/cloudbreak/common/tx/HibernateNPlusOneCircuitBreakerTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/common/tx/HibernateNPlusOneCircuitBreakerTest.java
@@ -1,8 +1,8 @@
 package com.sequenceiq.cloudbreak.common.tx;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/src/test/java/com/sequenceiq/cloudbreak/common/tx/HibernateNPlusOneLoggerTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/common/tx/HibernateNPlusOneLoggerTest.java
@@ -1,7 +1,7 @@
 package com.sequenceiq.cloudbreak.common.tx;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/src/test/java/com/sequenceiq/cloudbreak/common/tx/HibernateStatementStatisticsTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/common/tx/HibernateStatementStatisticsTest.java
@@ -1,8 +1,8 @@
 package com.sequenceiq.cloudbreak.common.tx;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,7 +28,7 @@ public class HibernateStatementStatisticsTest {
 
         String log = underTest.constructLogline();
 
-        assertEquals("Number of executed queries does not match", 2, underTest.getQueryCount());
+        assertEquals(2, underTest.getQueryCount(), "Number of executed queries does not match");
         assertThat(log, containsString("preparing 1 JDBC statements"));
         assertThat(log, containsString("executing 2 JDBC statements"));
     }

--- a/common/src/test/java/com/sequenceiq/cloudbreak/converter/DefaultEnumConverterTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/converter/DefaultEnumConverterTest.java
@@ -1,6 +1,6 @@
 package com.sequenceiq.cloudbreak.converter;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Optional;
 

--- a/common/src/test/java/com/sequenceiq/cloudbreak/converter/ServiceEndpointCreationToEndpointTypeConverterTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/converter/ServiceEndpointCreationToEndpointTypeConverterTest.java
@@ -2,7 +2,7 @@ package com.sequenceiq.cloudbreak.converter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 

--- a/common/src/test/java/com/sequenceiq/cloudbreak/logger/format/CustomJsonLayoutTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/logger/format/CustomJsonLayoutTest.java
@@ -1,10 +1,10 @@
 package com.sequenceiq.cloudbreak.logger.format;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import ch.qos.logback.classic.spi.LoggingEvent;
 
@@ -12,7 +12,7 @@ public class CustomJsonLayoutTest {
 
     private CustomJsonLayout underTest;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         underTest = new CustomJsonLayout("context", 10);
     }

--- a/common/src/test/java/com/sequenceiq/cloudbreak/quartz/EnforceStatusCheckerAnnotationUtil.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/quartz/EnforceStatusCheckerAnnotationUtil.java
@@ -1,6 +1,6 @@
 package com.sequenceiq.cloudbreak.quartz;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -32,7 +32,7 @@ public class EnforceStatusCheckerAnnotationUtil {
         Set<Class<? extends StatusCheckerJob>> statusCheckers = REFLECTIONS.getSubTypesOf(StatusCheckerJob.class);
         Set<Class<? extends StatusCheckerJob>> statusCheckersWithMissingAnnotation =
                 Sets.difference(statusCheckers, annotatedStatusCheckers);
-        assertTrue("These classes are missing @DisallowConcurrentExecution annotation: " + Joiner.on(",").join(statusCheckersWithMissingAnnotation),
-                statusCheckersWithMissingAnnotation.isEmpty());
+        assertTrue(statusCheckersWithMissingAnnotation.isEmpty(),
+                "These classes are missing @DisallowConcurrentExecution annotation: " + Joiner.on(",").join(statusCheckersWithMissingAnnotation));
     }
 }

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/common/AnonymizationRuleResolverTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/common/AnonymizationRuleResolverTest.java
@@ -1,13 +1,13 @@
 package com.sequenceiq.cloudbreak.telemetry.common;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.sequenceiq.common.api.telemetry.model.AnonymizationRule;
 
@@ -15,7 +15,7 @@ public class AnonymizationRuleResolverTest {
 
     private AnonymizationRuleResolver underTest;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         underTest = new AnonymizationRuleResolver();
     }

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/common/TelemetryCommonConfigServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/common/TelemetryCommonConfigServiceTest.java
@@ -3,9 +3,9 @@ package com.sequenceiq.cloudbreak.telemetry.common;
 import static com.sequenceiq.cloudbreak.telemetry.common.TelemetryCommonConfigService.AGENT_LOG_FOLDER_PREFIX;
 import static com.sequenceiq.cloudbreak.telemetry.common.TelemetryCommonConfigService.SERVER_LOG_FOLDER_PREFIX;
 import static com.sequenceiq.cloudbreak.telemetry.common.TelemetryCommonConfigService.SERVICE_LOG_FOLDER_PREFIX;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
 import java.util.ArrayList;
@@ -13,8 +13,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -47,7 +47,7 @@ public class TelemetryCommonConfigServiceTest {
     @Mock
     private AltusDatabusConnectionConfiguration altusDatabusConnectionConfiguration;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
         underTest = new TelemetryCommonConfigService(anonymizationRuleResolver, telemetryUpgradeConfiguration,

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/databus/DatabusConfigServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/databus/DatabusConfigServiceTest.java
@@ -1,13 +1,13 @@
 package com.sequenceiq.cloudbreak.telemetry.databus;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.sequenceiq.cloudbreak.telemetry.context.DatabusContext;
 import com.sequenceiq.cloudbreak.telemetry.context.TelemetryContext;
@@ -17,7 +17,7 @@ public class DatabusConfigServiceTest {
 
     private DatabusConfigService underTest;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         underTest = new DatabusConfigService();
     }

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigServiceTest.java
@@ -1,14 +1,14 @@
 package com.sequenceiq.cloudbreak.telemetry.fluent;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.sequenceiq.cloudbreak.telemetry.TelemetryClusterDetails;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryConfiguration;
@@ -42,7 +42,7 @@ public class FluentConfigServiceTest {
 
     private FluentConfigService underTest;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         MeteringConfiguration meteringConfiguration =
                 new MeteringConfiguration(false, "dbusApp", "dbusStream", false);

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/cloud/CloudStorageFolderResolverServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/cloud/CloudStorageFolderResolverServiceTest.java
@@ -1,10 +1,11 @@
 package com.sequenceiq.cloudbreak.telemetry.fluent.cloud;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.sequenceiq.cloudbreak.auth.crn.CrnParseException;
 import com.sequenceiq.cloudbreak.telemetry.fluent.FluentClusterType;
@@ -17,7 +18,7 @@ public class CloudStorageFolderResolverServiceTest {
 
     private CloudStorageFolderResolverService underTest;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         underTest = new CloudStorageFolderResolverService(new S3ConfigGenerator(),
                 new AdlsGen2ConfigGenerator(), new GcsConfigGenerator());
@@ -110,13 +111,16 @@ public class CloudStorageFolderResolverServiceTest {
         assertNull(telemetry);
     }
 
-    @Test(expected = CrnParseException.class)
+    @Test
     public void testUpdateStorageLocationWithInvalidCrn() {
         // GIVEN
         Telemetry telemetry = createTelemetry();
         // WHEN
-        underTest.updateStorageLocation(telemetry, FluentClusterType.DATAHUB.value(), "mycluster",
-                "crn:cdp:cloudbreak:us-west:someone:stack:12345");
+        CrnParseException exception = assertThrows(CrnParseException.class, () -> {
+            underTest.updateStorageLocation(telemetry, FluentClusterType.DATAHUB.value(), "mycluster",
+                    "crn:cdp:cloudbreak:us-west:someone:stack:12345");
+        });
+        assertEquals("us-west is not a valid region value", exception.getMessage());
     }
 
     private Telemetry createTelemetry() {

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/metering/MeteringConfigServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/metering/MeteringConfigServiceTest.java
@@ -1,13 +1,13 @@
 package com.sequenceiq.cloudbreak.telemetry.metering;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.sequenceiq.cloudbreak.telemetry.TelemetryClusterDetails;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryComponentUpgradeConfiguration;
@@ -22,7 +22,7 @@ public class MeteringConfigServiceTest {
 
     private MeteringConfigService underTest;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         MeteringConfiguration meteringConfiguration = new MeteringConfiguration(true, "app", "stream", false);
         TelemetryComponentUpgradeConfiguration meteringAgentConfig = new TelemetryComponentUpgradeConfiguration();

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfigServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfigServiceTest.java
@@ -1,14 +1,14 @@
 package com.sequenceiq.cloudbreak.telemetry.monitoring;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -51,7 +51,7 @@ public class MonitoringConfigServiceTest {
     @Mock
     private RequestSignerConfiguration requestSignerConfiguration;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
         underTest = new MonitoringConfigService(monitoringConfiguration, monitoringGlobalAuthConfig);

--- a/common/src/test/java/com/sequenceiq/cloudbreak/util/DatabaseCommonTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/util/DatabaseCommonTest.java
@@ -1,9 +1,10 @@
 package com.sequenceiq.cloudbreak.util;
 
 import static com.sequenceiq.cloudbreak.common.database.DatabaseCommon.POSTGRES_VERSION_REGEX;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -18,10 +19,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 
 import com.sequenceiq.cloudbreak.common.database.DatabaseCommon;
@@ -52,12 +51,9 @@ public class DatabaseCommonTest {
 
     private static final String POSTGRES_URL_WITH_HYPHENATED_DATABASE_NAME = POSTGRES_URL_WITHOUT_DATABASE + "hive-db-";
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     private DatabaseCommon databaseCommon;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         databaseCommon = new DatabaseCommon();
     }
@@ -65,130 +61,135 @@ public class DatabaseCommonTest {
     @Test
     public void testMariadbParsing() {
         JdbcConnectionUrlFields fields = databaseCommon.parseJdbcConnectionUrl(MARIADB_URL);
-        assertThat(fields.getVendorDriverId()).isEqualTo("mariadb");
-        assertThat(fields.getHost()).isEqualTo("test.eu-west-1.rds.amazonaws.com");
-        assertThat(fields.getPort()).isEqualTo(3306);
-        assertThat(fields.getHostAndPort()).isEqualTo("test.eu-west-1.rds.amazonaws.com:3306");
-        assertThat(fields.getDatabase()).isEqualTo(Optional.of("hivedb"));
+        assertEquals(fields.getVendorDriverId(), "mariadb");
+        assertEquals(fields.getHost(), "test.eu-west-1.rds.amazonaws.com");
+        assertEquals(fields.getPort(), 3306);
+        assertEquals(fields.getHostAndPort(), "test.eu-west-1.rds.amazonaws.com:3306");
+        assertEquals(fields.getDatabase(), Optional.of("hivedb"));
     }
 
     @Test
     public void testMysqlParsing() {
         JdbcConnectionUrlFields fields = databaseCommon.parseJdbcConnectionUrl(MYSQL_URL);
-        assertThat(fields.getVendorDriverId()).isEqualTo("mysql");
-        assertThat(fields.getHost()).isEqualTo("test.eu-west-1.rds.amazonaws.com");
-        assertThat(fields.getPort()).isEqualTo(3306);
-        assertThat(fields.getHostAndPort()).isEqualTo("test.eu-west-1.rds.amazonaws.com:3306");
-        assertThat(fields.getDatabase()).isEqualTo(Optional.of("hivedb"));
+        assertEquals(fields.getVendorDriverId(), "mysql");
+        assertEquals(fields.getHost(), "test.eu-west-1.rds.amazonaws.com");
+        assertEquals(fields.getPort(), 3306);
+        assertEquals(fields.getHostAndPort(), "test.eu-west-1.rds.amazonaws.com:3306");
+        assertEquals(fields.getDatabase(), Optional.of("hivedb"));
     }
 
     @Test
     public void testMysqlNoDatabaseParsing() {
         JdbcConnectionUrlFields fields = databaseCommon.parseJdbcConnectionUrl(MYSQL_URL_WITHOUT_DATABASE_AND_SSL);
-        assertThat(fields.getVendorDriverId()).isEqualTo("mysql");
-        assertThat(fields.getHost()).isEqualTo("test.eu-west-1.rds.amazonaws.com");
-        assertThat(fields.getPort()).isEqualTo(3306);
-        assertThat(fields.getHostAndPort()).isEqualTo("test.eu-west-1.rds.amazonaws.com:3306");
-        assertThat(fields.getDatabase().isPresent()).isFalse();
+        assertEquals(fields.getVendorDriverId(), "mysql");
+        assertEquals(fields.getHost(), "test.eu-west-1.rds.amazonaws.com");
+        assertEquals(fields.getPort(), 3306);
+        assertEquals(fields.getHostAndPort(), "test.eu-west-1.rds.amazonaws.com:3306");
+        assertFalse(fields.getDatabase().isPresent());
     }
 
     @Test
     public void testOracleParsing() {
         JdbcConnectionUrlFields fields = databaseCommon.parseJdbcConnectionUrl(ORACLE_URL);
-        assertThat(fields.getVendorDriverId()).isEqualTo("oracle");
-        assertThat(fields.getHost()).isEqualTo("test.eu-west-1.rds.amazonaws.com");
-        assertThat(fields.getPort()).isEqualTo(1521);
-        assertThat(fields.getHostAndPort()).isEqualTo("test.eu-west-1.rds.amazonaws.com:1521");
-        assertThat(fields.getDatabase()).isEqualTo(Optional.of("hivedb"));
+        assertEquals(fields.getVendorDriverId(), "oracle");
+        assertEquals(fields.getHost(), "test.eu-west-1.rds.amazonaws.com");
+        assertEquals(fields.getPort(), 1521);
+        assertEquals(fields.getHostAndPort(), "test.eu-west-1.rds.amazonaws.com:1521");
+        assertEquals(fields.getDatabase(), Optional.of("hivedb"));
     }
 
     @Test
     public void testOracleThinParsing() {
         JdbcConnectionUrlFields fields = databaseCommon.parseJdbcConnectionUrl(ORACLE_THIN_URL);
-        assertThat(fields.getVendorDriverId()).isEqualTo("oracle");
-        assertThat(fields.getHost()).isEqualTo("test.eu-west-1.rds.amazonaws.com");
-        assertThat(fields.getPort()).isEqualTo(1521);
-        assertThat(fields.getHostAndPort()).isEqualTo("test.eu-west-1.rds.amazonaws.com:1521");
-        assertThat(fields.getDatabase()).isEqualTo(Optional.of("hivedb"));
+        assertEquals(fields.getVendorDriverId(), "oracle");
+        assertEquals(fields.getHost(), "test.eu-west-1.rds.amazonaws.com");
+        assertEquals(fields.getPort(), 1521);
+        assertEquals(fields.getHostAndPort(), "test.eu-west-1.rds.amazonaws.com:1521");
+        assertEquals(fields.getDatabase(), Optional.of("hivedb"));
     }
 
     @Test
     public void testOracleThinNoDatabaseParsing() {
         JdbcConnectionUrlFields fields = databaseCommon.parseJdbcConnectionUrl(ORACLE_THIN_URL_WITHOUT_DATABASE);
-        assertThat(fields.getVendorDriverId()).isEqualTo("oracle");
-        assertThat(fields.getHost()).isEqualTo("test.eu-west-1.rds.amazonaws.com");
-        assertThat(fields.getPort()).isEqualTo(1521);
-        assertThat(fields.getHostAndPort()).isEqualTo("test.eu-west-1.rds.amazonaws.com:1521");
-        assertThat(fields.getDatabase().isPresent()).isFalse();
+        assertEquals(fields.getVendorDriverId(), "oracle");
+        assertEquals(fields.getHost(), "test.eu-west-1.rds.amazonaws.com");
+        assertEquals(fields.getPort(), 1521);
+        assertEquals(fields.getHostAndPort(), "test.eu-west-1.rds.amazonaws.com:1521");
+        assertFalse(fields.getDatabase().isPresent());
     }
 
     @Test
     public void testPostgresParsing() {
         JdbcConnectionUrlFields fields = databaseCommon.parseJdbcConnectionUrl(POSTGRES_URL);
-        assertThat(fields.getVendorDriverId()).isEqualTo("postgresql");
-        assertThat(fields.getHost()).isEqualTo("test.eu-west-1.rds.amazonaws.com");
-        assertThat(fields.getPort()).isEqualTo(5432);
-        assertThat(fields.getHostAndPort()).isEqualTo("test.eu-west-1.rds.amazonaws.com:5432");
-        assertThat(fields.getDatabase()).isEqualTo(Optional.of("hivedb"));
+        assertEquals(fields.getVendorDriverId(), "postgresql");
+        assertEquals(fields.getHost(), "test.eu-west-1.rds.amazonaws.com");
+        assertEquals(fields.getPort(), 5432);
+        assertEquals(fields.getHostAndPort(), "test.eu-west-1.rds.amazonaws.com:5432");
+        assertEquals(fields.getDatabase(), Optional.of("hivedb"));
     }
 
     @Test
     public void testPostgresNoDatabaseParsing() {
-        thrown.expect(IllegalArgumentException.class);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            databaseCommon.parseJdbcConnectionUrl(POSTGRES_URL_WITHOUT_DATABASE);
+        });
 
-        databaseCommon.parseJdbcConnectionUrl(POSTGRES_URL_WITHOUT_DATABASE);
+        assertEquals("PostgreSQL connection URLs require a database", exception.getMessage());
     }
 
     @Test
     public void testPostgresHyphenatedDatabaseParsing() {
         JdbcConnectionUrlFields fields = databaseCommon.parseJdbcConnectionUrl(POSTGRES_URL_WITH_HYPHENATED_DATABASE_NAME);
-        assertThat(fields.getVendorDriverId()).isEqualTo("postgresql");
-        assertThat(fields.getHost()).isEqualTo("test.eu-west-1.rds.amazonaws.com");
-        assertThat(fields.getPort()).isEqualTo(5432);
-        assertThat(fields.getHostAndPort()).isEqualTo("test.eu-west-1.rds.amazonaws.com:5432");
-        assertThat(fields.getDatabase()).isEqualTo(Optional.of("hive-db-"));
+        assertEquals(fields.getVendorDriverId(), "postgresql");
+        assertEquals(fields.getHost(), "test.eu-west-1.rds.amazonaws.com");
+        assertEquals(fields.getPort(), 5432);
+        assertEquals(fields.getHostAndPort(), "test.eu-west-1.rds.amazonaws.com:5432");
+        assertEquals(fields.getDatabase(), Optional.of("hive-db-"));
     }
 
     @Test
     public void testPostgresConnectionUrlWithoutDatabase() {
         String url = databaseCommon.getJdbcConnectionUrl("postgresql", "test.eu-west-1.rds.amazonaws.com", 5432, Optional.empty());
-        assertThat(url).isEqualTo(POSTGRES_URL_WITH_POSTGRES_DATABASE);
+        assertEquals(url, POSTGRES_URL_WITH_POSTGRES_DATABASE);
     }
 
     @Test
     public void testPostgresConnectionUrlWithDatabase() {
         String url = databaseCommon.getJdbcConnectionUrl("postgresql", "test.eu-west-1.rds.amazonaws.com", 5432, Optional.of("hivedb"));
-        assertThat(url).isEqualTo(POSTGRES_URL);
+        assertEquals(url, POSTGRES_URL);
     }
 
     @Test
     public void testMySQLConnectionUrlWithoutDatabase() {
         String url = databaseCommon.getJdbcConnectionUrl("mysql", "test.eu-west-1.rds.amazonaws.com", 3306, Optional.empty());
-        assertThat(url).isEqualTo(MYSQL_URL_WITHOUT_DATABASE_AND_SSL);
+        assertEquals(url, MYSQL_URL_WITHOUT_DATABASE_AND_SSL);
     }
 
     @Test
     public void testMySQLConnectionUrlWithDatabase() {
         String url = databaseCommon.getJdbcConnectionUrl("mysql", "test.eu-west-1.rds.amazonaws.com", 3306, Optional.of("hivedb"));
-        assertThat(url).isEqualTo(MYSQL_URL_WITHOUT_SSL);
+        assertEquals(url, MYSQL_URL_WITHOUT_SSL);
     }
 
     @Test
     public void testOracleConnectionUrlWithoutDatabase() {
         String url = databaseCommon.getJdbcConnectionUrl("oracle", "test.eu-west-1.rds.amazonaws.com", 1521, Optional.empty());
-        assertThat(url).isEqualTo(ORACLE_THIN_URL_WITHOUT_DATABASE);
+        assertEquals(url, ORACLE_THIN_URL_WITHOUT_DATABASE);
     }
 
     @Test
     public void testOracleConnectionUrlWithDatabase() {
         String url = databaseCommon.getJdbcConnectionUrl("oracle", "test.eu-west-1.rds.amazonaws.com", 1521, Optional.of("hivedb"));
-        assertThat(url).isEqualTo(ORACLE_THIN_URL);
+        assertEquals(url, ORACLE_THIN_URL);
     }
 
     @Test
     public void testPortCheck() {
-        thrown.expect(IllegalArgumentException.class);
-        new JdbcConnectionUrlFields("postgresql", "test.eu-west-1.rds.amazonaws.com", -1, Optional.empty());
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            new JdbcConnectionUrlFields("postgresql", "test.eu-west-1.rds.amazonaws.com", -1, Optional.empty());
+        });
+
+        assertEquals("invalid port -1", exception.getMessage());
     }
 
     @Test
@@ -201,7 +202,7 @@ public class DatabaseCommonTest {
 
         List<Integer> rowCounts = databaseCommon.executeUpdates(conn, sqlStrings, false);
 
-        assertThat(rowCounts).isEqualTo(List.of(1, 1));
+        assertEquals(rowCounts, List.of(1, 1));
         verify(statement).executeUpdate("sql1");
         verify(statement).executeUpdate("sql2");
         verify(conn, never()).setAutoCommit(false);
@@ -218,7 +219,7 @@ public class DatabaseCommonTest {
 
         List<Integer> rowCounts = databaseCommon.executeUpdates(conn, sqlStrings, true);
 
-        assertThat(rowCounts).isEqualTo(List.of(1, 1));
+        assertEquals(rowCounts, List.of(1, 1));
         verify(statement).executeUpdate("sql1");
         verify(statement).executeUpdate("sql2");
 
@@ -231,57 +232,64 @@ public class DatabaseCommonTest {
 
     @Test
     public void testExecuteUpdatesFailNoTransaction() throws SQLException {
-        thrown.expect(SQLException.class);
         Connection conn = mock(Connection.class);
         Statement statement = mock(Statement.class);
         when(conn.createStatement()).thenReturn(statement);
         when(statement.executeUpdate("sql1")).thenThrow(new SQLException("fail"));
         List<String> sqlStrings = List.of("sql1", "sql2");
 
-        try {
-            databaseCommon.executeUpdates(conn, sqlStrings, false);
-        } finally {
-            verify(statement).executeUpdate("sql1");
-            verify(statement, never()).executeUpdate("sql2");
-            verify(conn, never()).rollback();
-        }
+
+        SQLException exception = assertThrows(SQLException.class, () -> {
+            try {
+                databaseCommon.executeUpdates(conn, sqlStrings, false);
+            } finally {
+                verify(statement).executeUpdate("sql1");
+                verify(statement, never()).executeUpdate("sql2");
+                verify(conn, never()).rollback();
+            }
+        });
+
+        assertEquals("fail", exception.getMessage());
     }
 
     @Test
     public void testExecuteUpdatesFailTransaction() throws SQLException {
-        thrown.expect(SQLException.class);
         Connection conn = mock(Connection.class);
         Statement statement = mock(Statement.class);
         when(conn.createStatement()).thenReturn(statement);
         when(statement.executeUpdate("sql1")).thenThrow(new SQLException("fail"));
         List<String> sqlStrings = List.of("sql1", "sql2");
 
-        try {
-            databaseCommon.executeUpdates(conn, sqlStrings, true);
-        } finally {
-            verify(statement).executeUpdate("sql1");
-            verify(statement, never()).executeUpdate("sql2");
+        SQLException exception = assertThrows(SQLException.class, () -> {
+            try {
+                databaseCommon.executeUpdates(conn, sqlStrings, true);
+            } finally {
+                verify(statement).executeUpdate("sql1");
+                verify(statement, never()).executeUpdate("sql2");
 
-            InOrder inOrder = inOrder(conn);
-            inOrder.verify(conn).setAutoCommit(false);
-            inOrder.verify(conn).rollback();
-            inOrder.verify(conn, never()).commit();
-            inOrder.verify(conn).setAutoCommit(true);
-        }
+                InOrder inOrder = inOrder(conn);
+                inOrder.verify(conn).setAutoCommit(false);
+                inOrder.verify(conn).rollback();
+                inOrder.verify(conn, never()).commit();
+                inOrder.verify(conn).setAutoCommit(true);
+            }
+        });
+
+        assertEquals("fail", exception.getMessage());
     }
 
     @Test
     public void testDbMajorVersionRegexp() {
         Pattern dbVersionPattern = Pattern.compile(POSTGRES_VERSION_REGEX);
-        assertFalse("empty string", dbVersionPattern.matcher("").matches());
-        assertFalse("not a version", dbVersionPattern.matcher("null").matches());
-        assertTrue("valid version: 9.6", dbVersionPattern.matcher("9.6").matches());
-        assertTrue("valid version: 10", dbVersionPattern.matcher("10").matches());
-        assertTrue("valid version: 11", dbVersionPattern.matcher("11").matches());
-        assertTrue("valid version: 12", dbVersionPattern.matcher("12").matches());
-        assertTrue("valid version: 13", dbVersionPattern.matcher("13").matches());
-        assertTrue("valid version: 14", dbVersionPattern.matcher("14").matches());
-        assertFalse("not a valid version", dbVersionPattern.matcher("141").matches());
-        assertFalse("valid version twice", dbVersionPattern.matcher("1111").matches());
+        assertFalse(dbVersionPattern.matcher("").matches(), "empty string");
+        assertFalse(dbVersionPattern.matcher("null").matches(), "not a version");
+        assertTrue(dbVersionPattern.matcher("9.6").matches(), "valid version: 9.6");
+        assertTrue(dbVersionPattern.matcher("10").matches(), "valid version: 10");
+        assertTrue(dbVersionPattern.matcher("11").matches(), "valid version: 11");
+        assertTrue(dbVersionPattern.matcher("12").matches(), "valid version: 12");
+        assertTrue(dbVersionPattern.matcher("13").matches(), "valid version: 13");
+        assertTrue(dbVersionPattern.matcher("14").matches(), "valid version: 14");
+        assertFalse(dbVersionPattern.matcher("141").matches(), "not a valid version");
+        assertFalse(dbVersionPattern.matcher("1111").matches(), "valid version twice");
     }
 }

--- a/common/src/test/java/com/sequenceiq/cloudbreak/util/FreeIpaPasswordUtilTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/util/FreeIpaPasswordUtilTest.java
@@ -1,9 +1,10 @@
 package com.sequenceiq.cloudbreak.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.Set;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FreeIpaPasswordUtilTest {
 
@@ -12,7 +13,7 @@ public class FreeIpaPasswordUtilTest {
     @Test
     public void testGeneratePasswordShouldCreatePwdWithCorrectSize() {
         String actual = FreeIpaPasswordUtil.generatePassword();
-        Assert.assertEquals(32, actual.length());
+        assertEquals(32, actual.length());
     }
 
     @Test
@@ -20,7 +21,7 @@ public class FreeIpaPasswordUtilTest {
         String actual = FreeIpaPasswordUtil.generatePassword();
         long characterClasses = PATTERNS.stream().filter(actual::matches).count();
 
-        Assert.assertEquals(4, characterClasses);
+        assertEquals(4, characterClasses);
     }
 
 }

--- a/common/src/test/java/com/sequenceiq/cloudbreak/util/TimeUtilTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/util/TimeUtilTest.java
@@ -1,6 +1,6 @@
 package com.sequenceiq.cloudbreak.util;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.time.Instant;

--- a/common/src/test/java/com/sequenceiq/cloudbreak/util/VersionComparatorTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/util/VersionComparatorTest.java
@@ -1,99 +1,98 @@
 package com.sequenceiq.cloudbreak.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class VersionComparatorTest {
 
     private VersionComparator underTest;
 
-    @Before
+    @BeforeEach
     public void setup() {
         underTest = new VersionComparator();
     }
 
     @Test
     public void testEquals() {
-        Assert.assertEquals(0L, underTest.compare(() -> "2.4.0.0-770", () -> "2.4.0.0-770"));
+        assertEquals(0L, underTest.compare(() -> "2.4.0.0-770", () -> "2.4.0.0-770"));
     }
 
     @Test
     public void testGreater() {
-        Assert.assertEquals(1L, underTest.compare(() -> "2.4.0.0-880", () -> "2.4.0.0-770"));
-        Assert.assertEquals(1L, underTest.compare(() -> "2.4.0.0-1000", () -> "2.4.0.0-770"));
-        Assert.assertEquals(1L, underTest.compare(() -> "2.5.0.0-1000", () -> "2.4.0.0-1000"));
-        Assert.assertEquals(1L, underTest.compare(() -> "2.15.0.0-1000", () -> "2.5.0.0-1000"));
+        assertEquals(1L, underTest.compare(() -> "2.4.0.0-880", () -> "2.4.0.0-770"));
+        assertEquals(1L, underTest.compare(() -> "2.4.0.0-1000", () -> "2.4.0.0-770"));
+        assertEquals(1L, underTest.compare(() -> "2.5.0.0-1000", () -> "2.4.0.0-1000"));
+        assertEquals(1L, underTest.compare(() -> "2.15.0.0-1000", () -> "2.5.0.0-1000"));
     }
 
     @Test
     public void testGreaterNonEqualLength() {
-        Assert.assertEquals(1L, underTest.compare(() -> "2.4.0.0", () -> "2.4.0.0-770"));
-        Assert.assertEquals(1L, underTest.compare(() -> "2.5.0.0", () -> "2.5.0.0-770"));
-        Assert.assertEquals(1L, underTest.compare(() -> "7.2.9.1", () -> "7.2.9-1000"));
+        assertEquals(1L, underTest.compare(() -> "2.4.0.0", () -> "2.4.0.0-770"));
+        assertEquals(1L, underTest.compare(() -> "2.5.0.0", () -> "2.5.0.0-770"));
+        assertEquals(1L, underTest.compare(() -> "7.2.9.1", () -> "7.2.9-1000"));
     }
 
     @Test
     public void testSmaller() {
-        Assert.assertEquals(-1L, underTest.compare(() -> "2.4.0.0-770", () -> "2.4.0.0-880"));
-        Assert.assertEquals(-1L, underTest.compare(() -> "2.4.0.0-770", () -> "2.4.0.0-1000"));
-        Assert.assertEquals(-1L, underTest.compare(() -> "2.4.0.0-1000", () -> "2.5.0.0-1000"));
-        Assert.assertEquals(-1L, underTest.compare(() -> "2.5.0.0-1000", () -> "2.15.0.0-1000"));
-        Assert.assertEquals(-1L, underTest.compare(() -> "7.2.9", () -> "7.2.9.1"));
-        Assert.assertEquals(-1L, underTest.compare(() -> "7.2.9-1000", () -> "7.2.9.1"));
-        Assert.assertEquals(-1L, underTest.compare(() -> "7.2.9-1", () -> "7.2.9.1-200"));
-        Assert.assertEquals(-1L, underTest.compare(() -> "7.2.9", () -> "7.2.9.1-1000"));
+        assertEquals(-1L, underTest.compare(() -> "2.4.0.0-770", () -> "2.4.0.0-880"));
+        assertEquals(-1L, underTest.compare(() -> "2.4.0.0-770", () -> "2.4.0.0-1000"));
+        assertEquals(-1L, underTest.compare(() -> "2.4.0.0-1000", () -> "2.5.0.0-1000"));
+        assertEquals(-1L, underTest.compare(() -> "2.5.0.0-1000", () -> "2.15.0.0-1000"));
+        assertEquals(-1L, underTest.compare(() -> "7.2.9", () -> "7.2.9.1"));
+        assertEquals(-1L, underTest.compare(() -> "7.2.9-1000", () -> "7.2.9.1"));
+        assertEquals(-1L, underTest.compare(() -> "7.2.9-1", () -> "7.2.9.1-200"));
+        assertEquals(-1L, underTest.compare(() -> "7.2.9", () -> "7.2.9.1-1000"));
     }
 
     @Test
     public void compareCloudbreakVersions() {
         VersionComparator comparator = new VersionComparator();
 
-        assertEquals("dev major desc", 1L, comparator.compare(() -> "2.0.0-rc.1", () -> "2.0.0-dev.1"));
-        assertEquals("major desc", 1L, comparator.compare(() -> "2.0.0", () -> "1.0.0"));
-        assertEquals("minor desc", 1L, comparator.compare(() -> "2.1.0", () -> "2.0.0"));
-        assertEquals("patch desc", 1L, comparator.compare(() -> "2.1.1", () -> "2.1.0"));
-        assertEquals("equals", 0L, comparator.compare(() -> "2.0.0", () -> "2.0.0"));
-        assertEquals("major asc", -1L, comparator.compare(() -> "1.0.0", () -> "2.0.0"));
-        assertEquals("minor asc", -1L, comparator.compare(() -> "2.0.0", () -> "2.1.0"));
-        assertEquals("patch asc", -1L, comparator.compare(() -> "2.1.0", () -> "2.1.1"));
+        assertEquals(1L, comparator.compare(() -> "2.0.0-rc.1", () -> "2.0.0-dev.1"), "dev major desc");
+        assertEquals(1L, comparator.compare(() -> "2.0.0", () -> "1.0.0"), "major desc");
+        assertEquals(1L, comparator.compare(() -> "2.1.0", () -> "2.0.0"), "minor desc");
+        assertEquals(1L, comparator.compare(() -> "2.1.1", () -> "2.1.0"), "patch desc");
+        assertEquals(0L, comparator.compare(() -> "2.0.0", () -> "2.0.0"), "equals");
+        assertEquals(-1L, comparator.compare(() -> "1.0.0", () -> "2.0.0"), "major asc");
+        assertEquals(-1L, comparator.compare(() -> "2.0.0", () -> "2.1.0"), "minor asc");
+        assertEquals(-1L, comparator.compare(() -> "2.1.0", () -> "2.1.1"), "patch asc");
 
-        assertEquals("dev major desc", 1L, comparator.compare(() -> "2.0.0-dev.1", () -> "1.0.0-dev.1"));
-        assertEquals("dev minor desc", 1L, comparator.compare(() -> "2.1.0-dev.1", () -> "2.0.0-dev.1"));
-        assertEquals("dev patch desc", 1L, comparator.compare(() -> "2.1.1-dev.1", () -> "2.1.0-dev.1"));
-        assertEquals("dev desc", 1L, comparator.compare(() -> "2.1.1-dev.2", () -> "2.1.1-dev.1"));
-        assertEquals("dev equals", 0L, comparator.compare(() -> "2.0.0-dev.1", () -> "2.0.0-dev.1"));
-        assertEquals("dev major asc", -1L, comparator.compare(() -> "1.0.0-dev.1", () -> "2.0.0-dev.1"));
-        assertEquals("dev minor asc", -1L, comparator.compare(() -> "2.0.0-dev.1", () -> "2.1.0-dev.1"));
-        assertEquals("dev patch asc", -1L, comparator.compare(() -> "2.1.0-dev.1", () -> "2.1.1-dev.1"));
-        assertEquals("dev asc", -1L, comparator.compare(() -> "2.1.1-dev.1", () -> "2.1.1-dev.2"));
+        assertEquals(1L, comparator.compare(() -> "2.0.0-dev.1", () -> "1.0.0-dev.1"), "dev major desc");
+        assertEquals(1L, comparator.compare(() -> "2.1.0-dev.1", () -> "2.0.0-dev.1"), "dev minor desc");
+        assertEquals(1L, comparator.compare(() -> "2.1.1-dev.1", () -> "2.1.0-dev.1"), "dev patch desc");
+        assertEquals(1L, comparator.compare(() -> "2.1.1-dev.2", () -> "2.1.1-dev.1"), "dev desc");
+        assertEquals(0L, comparator.compare(() -> "2.0.0-dev.1", () -> "2.0.0-dev.1"), "dev equals");
+        assertEquals(-1L, comparator.compare(() -> "1.0.0-dev.1", () -> "2.0.0-dev.1"), "dev major asc");
+        assertEquals(-1L, comparator.compare(() -> "2.0.0-dev.1", () -> "2.1.0-dev.1"), "dev minor asc");
+        assertEquals(-1L, comparator.compare(() -> "2.1.0-dev.1", () -> "2.1.1-dev.1"), "dev patch asc");
+        assertEquals(-1L, comparator.compare(() -> "2.1.1-dev.1", () -> "2.1.1-dev.2"), "dev asc");
     }
 
     @Test
     public void testSmallerNonEqualLength() {
-        Assert.assertEquals(-1, underTest.compare(() -> "2.4.0.0", () -> "2.5.0.0-770"));
+        assertEquals(-1, underTest.compare(() -> "2.4.0.0", () -> "2.5.0.0-770"));
     }
 
     @Test
     public void testComparingNewREVersioning() {
-        assertEquals("dev vs new re versioning asc", -1L, underTest.compare(() -> "2.1.1-dev.1", () -> "2.1.1-b3"));
-        assertEquals("dev vs new re versioning desc", 1L, underTest.compare(() -> "2.1.2-dev.13", () -> "2.1.1-b3"));
-        assertEquals("dev vs new re versioning desc build number", -1L, underTest.compare(() -> "2.1.1-dev.13", () -> "2.1.1-b3"));
-        assertEquals("dev vs new re versioning equals", -1L, underTest.compare(() -> "2.1.1-dev.3", () -> "2.1.1-b3"));
-        assertEquals("rc vs new re versioning asc", -1L, underTest.compare(() -> "2.1.1-rc.1", () -> "2.1.1-b3"));
-        assertEquals("rc vs new re versioning desc", 1L, underTest.compare(() -> "2.1.2-rc.13", () -> "2.1.1-b3"));
-        assertEquals("rc vs new re versioning desc build number", -1L, underTest.compare(() -> "2.1.1-rc.13", () -> "2.1.1-b3"));
-        assertEquals("rc vs new re versioning equals", -1L, underTest.compare(() -> "2.1.1-rc.3", () -> "2.1.1-b3"));
-        assertEquals("released vs new re versioning asc", -1L, underTest.compare(() -> "2.1.1-rc.1", () -> "2.3.1"));
-        assertEquals("released vs new re versioning desc", 1L, underTest.compare(() -> "2.1.2-b13", () -> "2.1.1"));
-        assertEquals("re versioning asc", -1L, underTest.compare(() -> "2.1.1-b2", () -> "2.1.1-b3"));
-        assertEquals("re versioning desc", 1L, underTest.compare(() -> "2.1.1-b12", () -> "2.1.1-b3"));
-        assertEquals("unspecified vs new re versioning", -1L, underTest.compare(() -> "2.1.2-b13", () -> "unspecified"));
+        assertEquals(-1L, underTest.compare(() -> "2.1.1-dev.1", () -> "2.1.1-b3"), "dev vs new re versioning asc");
+        assertEquals(1L, underTest.compare(() -> "2.1.2-dev.13", () -> "2.1.1-b3"), "dev vs new re versioning desc");
+        assertEquals(-1L, underTest.compare(() -> "2.1.1-dev.13", () -> "2.1.1-b3"), "dev vs new re versioning desc build number");
+        assertEquals(-1L, underTest.compare(() -> "2.1.1-dev.3", () -> "2.1.1-b3"), "dev vs new re versioning equals");
+        assertEquals(-1L, underTest.compare(() -> "2.1.1-rc.1", () -> "2.1.1-b3"), "rc vs new re versioning asc");
+        assertEquals(1L, underTest.compare(() -> "2.1.2-rc.13", () -> "2.1.1-b3"), "rc vs new re versioning desc");
+        assertEquals(-1L, underTest.compare(() -> "2.1.1-rc.13", () -> "2.1.1-b3"), "rc vs new re versioning desc build number");
+        assertEquals(-1L, underTest.compare(() -> "2.1.1-rc.3", () -> "2.1.1-b3"), "rc vs new re versioning equals");
+        assertEquals(-1L, underTest.compare(() -> "2.1.1-rc.1", () -> "2.3.1"), "released vs new re versioning asc");
+        assertEquals(1L, underTest.compare(() -> "2.1.2-b13", () -> "2.1.1"), "released vs new re versioning desc");
+        assertEquals(-1L, underTest.compare(() -> "2.1.1-b2", () -> "2.1.1-b3"), "re versioning asc");
+        assertEquals(1L, underTest.compare(() -> "2.1.1-b12", () -> "2.1.1-b3"), "re versioning desc");
+        assertEquals(-1L, underTest.compare(() -> "2.1.2-b13", () -> "unspecified"), "unspecified vs new re versioning");
 
-        assertEquals("dev vs new re versioning asc", -1L, underTest.compare(() -> "2.1.1-dev.1", () -> "2.2.1-b3"));
-        assertEquals("rc vs new re versioning asc", -1L, underTest.compare(() -> "2.1.1-rc.1", () -> "2.2.1-b3"));
+        assertEquals(-1L, underTest.compare(() -> "2.1.1-dev.1", () -> "2.2.1-b3"), "dev vs new re versioning asc");
+        assertEquals(-1L, underTest.compare(() -> "2.1.1-rc.1", () -> "2.2.1-b3"), "rc vs new re versioning asc");
     }
 
 }

--- a/common/src/test/java/com/sequenceiq/cloudbreak/validation/ChoiceValidatorTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/validation/ChoiceValidatorTest.java
@@ -1,5 +1,8 @@
 package com.sequenceiq.cloudbreak.validation;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Set;
 
 import javax.validation.ConstraintViolation;
@@ -7,9 +10,8 @@ import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -17,7 +19,7 @@ public class ChoiceValidatorTest {
 
     private static Validator validator;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass() {
         ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
         validator = factory.getValidator();
@@ -27,21 +29,21 @@ public class ChoiceValidatorTest {
     public void passSimple1() {
         DummyClass dummyObject = new DummyClass(1);
         Set<ConstraintViolation<DummyClass>> violations = validator.validate(dummyObject);
-        Assert.assertTrue(violations.isEmpty());
+        assertTrue(violations.isEmpty());
     }
 
     @Test
     public void passSimple2() {
         DummyClass dummyObject = new DummyClass(2);
         Set<ConstraintViolation<DummyClass>> violations = validator.validate(dummyObject);
-        Assert.assertTrue(violations.isEmpty());
+        assertTrue(violations.isEmpty());
     }
 
     @Test
     public void failSimple3() {
         DummyClass dummyObject = new DummyClass(3);
         Set<ConstraintViolation<DummyClass>> violations = validator.validate(dummyObject);
-        Assert.assertFalse(violations.isEmpty());
+        assertFalse(violations.isEmpty());
     }
 
     static class DummyClass {

--- a/common/src/test/java/com/sequenceiq/cloudbreak/validation/HueWorkaroundValidatorServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/validation/HueWorkaroundValidatorServiceTest.java
@@ -1,24 +1,24 @@
 package com.sequenceiq.cloudbreak.validation;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Set;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class HueWorkaroundValidatorServiceTest {
 
     private HueWorkaroundValidatorService underTest;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         underTest = new HueWorkaroundValidatorService();
     }
@@ -32,7 +32,7 @@ public class HueWorkaroundValidatorServiceTest {
     public void validateBlueprintRequestWhenHueIsPresentedAndHueHostgroupIsTooLongMustThrowException() {
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
                 () -> underTest.validateForBlueprintRequest(Set.of("master123456")));
-        Assert.assertEquals("Hue does not support CDP Data Hubs where hostgroup name is longer than 7 characters. "
+        assertEquals("Hue does not support CDP Data Hubs where hostgroup name is longer than 7 characters. "
                         + "Please retry creating the template by shortening the hostgroup name: master123456  under 7 characters.",
                 badRequestException.getMessage());
     }
@@ -42,7 +42,7 @@ public class HueWorkaroundValidatorServiceTest {
         String stackName = "iamveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong";
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
                 () -> underTest.validateForStackRequest(Set.of("master"), stackName));
-        Assert.assertEquals("Your Data Hub contains Hue. Hue does not support CDP Data Hubs where Data Hub name is longer than 20 characters. "
+        assertEquals("Your Data Hub contains Hue. Hue does not support CDP Data Hubs where Data Hub name is longer than 20 characters. "
                         + "Please retry creating Data Hub using a Data Hub name that is shorter than 20 characters.",
                 badRequestException.getMessage());
     }
@@ -53,7 +53,7 @@ public class HueWorkaroundValidatorServiceTest {
 
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
                 () -> underTest.validateForStackRequest(Set.of("master123456"), stackName));
-        Assert.assertEquals("Hue does not support CDP Data Hubs where hostgroup name is longer than 7 characters. "
+        assertEquals("Hue does not support CDP Data Hubs where hostgroup name is longer than 7 characters. "
                         + "Please retry creating the template by shortening the hostgroup name: master123456  under 7 characters.",
                 badRequestException.getMessage());
     }
@@ -71,7 +71,7 @@ public class HueWorkaroundValidatorServiceTest {
 
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
                 () -> underTest.validateForEnvironmentDomainName(Set.of("master"), endpointName));
-        Assert.assertEquals("Your Data Hub contains Hue. Hue does not support CDP Data Hubs where the fully qualified domain name of a "
+        assertEquals("Your Data Hub contains Hue. Hue does not support CDP Data Hubs where the fully qualified domain name of a "
                         + "VM is longer than 63 characters. Generated hostname: "
                         + "thisisfine.thisisfinethisisfinethisisfinethisisfinethisisfinethisisfinethisisfinethisisfine. "
                         + "Please retry creating Data Hub using a Data Hub name that is shorter than 20 characters and a"

--- a/common/src/test/java/com/sequenceiq/cloudbreak/validation/MutuallyExclusiveNotNullValidatorTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/validation/MutuallyExclusiveNotNullValidatorTest.java
@@ -1,5 +1,8 @@
 package com.sequenceiq.cloudbreak.validation;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Set;
 
 import javax.validation.ConstraintViolation;
@@ -7,9 +10,8 @@ import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -17,7 +19,7 @@ public class MutuallyExclusiveNotNullValidatorTest {
 
     private static Validator validator;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass() {
         ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
         validator = factory.getValidator();
@@ -27,196 +29,196 @@ public class MutuallyExclusiveNotNullValidatorTest {
     public void passSimple1() {
         DummySimpleClass dummyObject = new DummySimpleClass("a", null);
         Set<ConstraintViolation<DummySimpleClass>> violations = validator.validate(dummyObject);
-        Assert.assertTrue(violations.isEmpty());
+        assertTrue(violations.isEmpty());
     }
 
     @Test
     public void passSimple2() {
         DummySimpleClass dummyObject = new DummySimpleClass(null, "b");
         Set<ConstraintViolation<DummySimpleClass>> violations = validator.validate(dummyObject);
-        Assert.assertTrue(violations.isEmpty());
+        assertTrue(violations.isEmpty());
     }
 
     @Test
     public void failSimpleBothNull() {
         DummySimpleClass dummyObject = new DummySimpleClass(null, null);
         Set<ConstraintViolation<DummySimpleClass>> violations = validator.validate(dummyObject);
-        Assert.assertFalse(violations.isEmpty());
+        assertFalse(violations.isEmpty());
     }
 
     @Test
     public void failSimpleBothNonNull() {
         DummySimpleClass dummyObject = new DummySimpleClass("a", "b");
         Set<ConstraintViolation<DummySimpleClass>> violations = validator.validate(dummyObject);
-        Assert.assertFalse(violations.isEmpty());
+        assertFalse(violations.isEmpty());
     }
 
     @Test
     public void passComplex1() {
         DummyComplexClass dummyObject = new DummyComplexClass("a", "b", null, null);
         Set<ConstraintViolation<DummyComplexClass>> violations = validator.validate(dummyObject);
-        Assert.assertTrue(violations.isEmpty());
+        assertTrue(violations.isEmpty());
     }
 
     @Test
     public void passComplex2() {
         DummyComplexClass dummyObject = new DummyComplexClass(null, null, "c", "d");
         Set<ConstraintViolation<DummyComplexClass>> violations = validator.validate(dummyObject);
-        Assert.assertTrue(violations.isEmpty());
+        assertTrue(violations.isEmpty());
     }
 
     @Test
     public void failComplexAllNull() {
         DummyComplexClass dummyObject = new DummyComplexClass(null, null, null, null);
         Set<ConstraintViolation<DummyComplexClass>> violations = validator.validate(dummyObject);
-        Assert.assertFalse(violations.isEmpty());
+        assertFalse(violations.isEmpty());
     }
 
     @Test
     public void failComplexAllNonNull() {
         DummyComplexClass dummyObject = new DummyComplexClass("a", "b", "c", "d");
         Set<ConstraintViolation<DummyComplexClass>> violations = validator.validate(dummyObject);
-        Assert.assertFalse(violations.isEmpty());
+        assertFalse(violations.isEmpty());
     }
 
     @Test
     public void failFirstMixed1SecondNullGroup() {
         DummyComplexClass dummyObject = new DummyComplexClass(null, "b", null, null);
         Set<ConstraintViolation<DummyComplexClass>> violations = validator.validate(dummyObject);
-        Assert.assertFalse(violations.isEmpty());
+        assertFalse(violations.isEmpty());
     }
 
     @Test
     public void failFirstMixed2SecondNullGroup() {
         DummyComplexClass dummyObject = new DummyComplexClass("a", null, null, null);
         Set<ConstraintViolation<DummyComplexClass>> violations = validator.validate(dummyObject);
-        Assert.assertFalse(violations.isEmpty());
+        assertFalse(violations.isEmpty());
     }
 
     @Test
     public void failFirstMixed1SecondNonNullGroup() {
         DummyComplexClass dummyObject = new DummyComplexClass(null, "b", "c", "d");
         Set<ConstraintViolation<DummyComplexClass>> violations = validator.validate(dummyObject);
-        Assert.assertFalse(violations.isEmpty());
+        assertFalse(violations.isEmpty());
     }
 
     @Test
     public void failFirstMixed1SecondMixed1Group() {
         DummyComplexClass dummyObject = new DummyComplexClass(null, "b", null, "d");
         Set<ConstraintViolation<DummyComplexClass>> violations = validator.validate(dummyObject);
-        Assert.assertFalse(violations.isEmpty());
+        assertFalse(violations.isEmpty());
     }
 
     @Test
     public void failFirstMixed1SecondMixed2Group() {
         DummyComplexClass dummyObject = new DummyComplexClass(null, "b", "c", null);
         Set<ConstraintViolation<DummyComplexClass>> violations = validator.validate(dummyObject);
-        Assert.assertFalse(violations.isEmpty());
+        assertFalse(violations.isEmpty());
     }
 
     @Test
     public void failFirstMixed2SecondNonNullGroup() {
         DummyComplexClass dummyObject = new DummyComplexClass("a", null, "c", "d");
         Set<ConstraintViolation<DummyComplexClass>> violations = validator.validate(dummyObject);
-        Assert.assertFalse(violations.isEmpty());
+        assertFalse(violations.isEmpty());
     }
 
     @Test
     public void failFirstMixed2SecondMixed1Group() {
         DummyComplexClass dummyObject = new DummyComplexClass("a", null, null, "d");
         Set<ConstraintViolation<DummyComplexClass>> violations = validator.validate(dummyObject);
-        Assert.assertFalse(violations.isEmpty());
+        assertFalse(violations.isEmpty());
     }
 
     @Test
     public void failFirstMixed2SecondMixed2Group() {
         DummyComplexClass dummyObject = new DummyComplexClass("a", null, "c", null);
         Set<ConstraintViolation<DummyComplexClass>> violations = validator.validate(dummyObject);
-        Assert.assertFalse(violations.isEmpty());
+        assertFalse(violations.isEmpty());
     }
 
     @Test
     public void failFirstNullSecondMixed1Group() {
         DummyComplexClass dummyObject = new DummyComplexClass(null, null, "c", null);
         Set<ConstraintViolation<DummyComplexClass>> violations = validator.validate(dummyObject);
-        Assert.assertFalse(violations.isEmpty());
+        assertFalse(violations.isEmpty());
     }
 
     @Test
     public void failFirstNullSecondMixed2Group() {
         DummyComplexClass dummyObject = new DummyComplexClass(null, null, null, "d");
         Set<ConstraintViolation<DummyComplexClass>> violations = validator.validate(dummyObject);
-        Assert.assertFalse(violations.isEmpty());
+        assertFalse(violations.isEmpty());
     }
 
     @Test
     public void failFirstNonNullSecondMixed1Group() {
         DummyComplexClass dummyObject = new DummyComplexClass("a", "b", null, "d");
         Set<ConstraintViolation<DummyComplexClass>> violations = validator.validate(dummyObject);
-        Assert.assertFalse(violations.isEmpty());
+        assertFalse(violations.isEmpty());
     }
 
     @Test
     public void failFirstNonNullSecondMixed2Group() {
         DummyComplexClass dummyObject = new DummyComplexClass("a", "b", "c", null);
         Set<ConstraintViolation<DummyComplexClass>> violations = validator.validate(dummyObject);
-        Assert.assertFalse(violations.isEmpty());
+        assertFalse(violations.isEmpty());
     }
 
     @Test
     public void passSemi() {
         DummySemiClass dummyObject = new DummySemiClass("a", "b");
         Set<ConstraintViolation<DummySemiClass>> violations = validator.validate(dummyObject);
-        Assert.assertTrue(violations.isEmpty());
+        assertTrue(violations.isEmpty());
     }
 
     @Test
     public void failNullSemi() {
         DummySemiClass dummyObject = new DummySemiClass(null, null);
         Set<ConstraintViolation<DummySemiClass>> violations = validator.validate(dummyObject);
-        Assert.assertFalse(violations.isEmpty());
+        assertFalse(violations.isEmpty());
     }
 
     @Test
     public void fail1Semi() {
         DummySemiClass dummyObject = new DummySemiClass("a", null);
         Set<ConstraintViolation<DummySemiClass>> violations = validator.validate(dummyObject);
-        Assert.assertFalse(violations.isEmpty());
+        assertFalse(violations.isEmpty());
     }
 
     @Test
     public void fail2Semi() {
         DummySemiClass dummyObject = new DummySemiClass(null, "b");
         Set<ConstraintViolation<DummySemiClass>> violations = validator.validate(dummyObject);
-        Assert.assertFalse(violations.isEmpty());
+        assertFalse(violations.isEmpty());
     }
 
     @Test
     public void passComplexAllowNullWhenAllGroupsNull() {
         DummyClassWithComplexValidationAllowAllGroupsNull dummyObject = new DummyClassWithComplexValidationAllowAllGroupsNull(null, null, null, null);
         Set<ConstraintViolation<DummyClassWithComplexValidationAllowAllGroupsNull>> violations = validator.validate(dummyObject);
-        Assert.assertTrue(violations.isEmpty());
+        assertTrue(violations.isEmpty());
     }
 
     @Test
     public void failComplexAllowNullWhenAllGroupsFilled() {
         DummyClassWithComplexValidationAllowAllGroupsNull dummyObject = new DummyClassWithComplexValidationAllowAllGroupsNull("a", "b", "c", "d");
         Set<ConstraintViolation<DummyClassWithComplexValidationAllowAllGroupsNull>> violations = validator.validate(dummyObject);
-        Assert.assertFalse(violations.isEmpty());
+        assertFalse(violations.isEmpty());
     }
 
     @Test
     public void passComplexAllowNullWhenOneGroupIsFilled() {
         DummyClassWithComplexValidationAllowAllGroupsNull dummyObject = new DummyClassWithComplexValidationAllowAllGroupsNull(null, null, "c", "d");
         Set<ConstraintViolation<DummyClassWithComplexValidationAllowAllGroupsNull>> violations = validator.validate(dummyObject);
-        Assert.assertTrue(violations.isEmpty());
+        assertTrue(violations.isEmpty());
     }
 
     @Test
     public void failComplexAllowNullWhenOneGroupPartiallyFilled() {
         DummyClassWithComplexValidationAllowAllGroupsNull dummyObject = new DummyClassWithComplexValidationAllowAllGroupsNull("a", null, "c", "d");
         Set<ConstraintViolation<DummyClassWithComplexValidationAllowAllGroupsNull>> violations = validator.validate(dummyObject);
-        Assert.assertFalse(violations.isEmpty());
+        assertFalse(violations.isEmpty());
     }
 
     @MutuallyExclusiveNotNull(fieldGroups = {"a", "b"})


### PR DESCRIPTION
unfortunately,  the IllegalImport checkstyle rule can't be enforced on the common module only.

See detailed description in the commit message.