### PR TITLE
ENGESC-17409 Change the AWS Instance name to the CF template's format on AWS_NATIVE variant

### DIFF
--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/util/AwsStackNameCommonUtil.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/util/AwsStackNameCommonUtil.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.cloudbreak.cloud.aws.common.util;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+
+@Component
+public class AwsStackNameCommonUtil {
+
+    private static final Logger LOGGER = getLogger(AwsStackNameCommonUtil.class);
+
+    private static final String INSTANCE_NAME_PATTERN = "%s-%s%d";
+
+    @Value("${cb.max.aws.resource.name.length:}")
+    private int maxResourceNameLength;
+
+    public String getInstanceName(AuthenticatedContext ac, String groupName, Long privateId) {
+        if (StringUtils.isBlank(groupName)) {
+            throw new IllegalArgumentException("Group name cannot be empty, instance name cannot be generated");
+        }
+        int lengthOfPostFix = String.valueOf(privateId).length() + groupName.length();
+        int maxLengthOfName = maxResourceNameLength - lengthOfPostFix;
+        String stackName = ac.getCloudContext().getName();
+        if (stackName.length() > maxLengthOfName) {
+            stackName = stackName.substring(0, maxLengthOfName - 1);
+        }
+
+        String instanceName = String.format(INSTANCE_NAME_PATTERN, stackName, groupName, privateId);
+        LOGGER.debug("Generated instance name: {}", instanceName);
+        return instanceName;
+    }
+}

--- a/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/util/AwsStackNameCommonUtilTest.java
+++ b/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/util/AwsStackNameCommonUtilTest.java
@@ -1,0 +1,66 @@
+package com.sequenceiq.cloudbreak.cloud.aws.common.util;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+
+@ExtendWith(MockitoExtension.class)
+public class AwsStackNameCommonUtilTest {
+
+    private static final int MAX_RESOURCE_NAME_LENGTH = 50;
+
+    private static final long PRIVATE_ID = 233L;
+
+    @InjectMocks
+    private AwsStackNameCommonUtil underTest;
+
+    @BeforeEach
+    public void setup() {
+        ReflectionTestUtils.setField(underTest, "maxResourceNameLength", MAX_RESOURCE_NAME_LENGTH);
+    }
+
+    @Test
+    public void testGetInstanceNameWhenHasGroup() {
+        AuthenticatedContext ac = mock(AuthenticatedContext.class);
+        CloudContext cloudContext = mock(CloudContext.class);
+        when(ac.getCloudContext()).thenReturn(cloudContext);
+        when(cloudContext.getName()).thenReturn("stack-name");
+        String actual = underTest.getInstanceName(ac, "group-name", 1L);
+        Assertions.assertEquals("stack-name-group-name1", actual);
+    }
+
+    @Test
+    public void testGetInstanceNameWhenEmptyGroup() {
+        AuthenticatedContext ac = mock(AuthenticatedContext.class);
+        IllegalArgumentException actual = Assertions.assertThrows(IllegalArgumentException.class, () -> underTest.getInstanceName(ac, "", 1L));
+        Assertions.assertEquals("Group name cannot be empty, instance name cannot be generated", actual.getMessage());
+    }
+
+    @Test
+    public void testGetInstanceNameWhenNullGroup() {
+        AuthenticatedContext ac = mock(AuthenticatedContext.class);
+        IllegalArgumentException actual = Assertions.assertThrows(IllegalArgumentException.class, () -> underTest.getInstanceName(ac, null, 1L));
+        Assertions.assertEquals("Group name cannot be empty, instance name cannot be generated", actual.getMessage());
+    }
+
+    @Test
+    public void testGetInstanceNameWhenNameTooLong() {
+        AuthenticatedContext ac = mock(AuthenticatedContext.class);
+        CloudContext cloudContext = mock(CloudContext.class);
+        when(ac.getCloudContext()).thenReturn(cloudContext);
+        when(cloudContext.getName()).thenReturn("very-very-very-long-stack-name-for-cutting");
+        String actual = underTest.getInstanceName(ac, "group-name", PRIVATE_ID);
+        Assertions.assertEquals("very-very-very-long-stack-name-for-c-group-name233", actual);
+        Assertions.assertEquals(MAX_RESOURCE_NAME_LENGTH, actual.length());
+    }
+}

--- a/cloud-aws-native/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/resource/instance/AwsNativeInstanceResourceBuilder.java
+++ b/cloud-aws-native/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/resource/instance/AwsNativeInstanceResourceBuilder.java
@@ -40,6 +40,7 @@ import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonEc2Client;
 import com.sequenceiq.cloudbreak.cloud.aws.common.context.AwsContext;
 import com.sequenceiq.cloudbreak.cloud.aws.common.resource.VolumeBuilderUtil;
 import com.sequenceiq.cloudbreak.cloud.aws.common.util.AwsMethodExecutor;
+import com.sequenceiq.cloudbreak.cloud.aws.common.util.AwsStackNameCommonUtil;
 import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsInstanceView;
 import com.sequenceiq.cloudbreak.cloud.aws.resource.instance.util.SecurityGroupBuilderUtil;
 import com.sequenceiq.cloudbreak.cloud.aws.view.AwsCloudStackView;
@@ -80,6 +81,9 @@ public class AwsNativeInstanceResourceBuilder extends AbstractAwsNativeComputeBu
 
     @Inject
     private VolumeBuilderUtil volumeBuilderUtil;
+
+    @Inject
+    private AwsStackNameCommonUtil awsStackNameCommonUtil;
 
     @Inject
     private SecurityGroupBuilderUtil securityGroupBuilderUtil;
@@ -124,7 +128,7 @@ public class AwsNativeInstanceResourceBuilder extends AbstractAwsNativeComputeBu
             TagSpecification tagSpecification = awsTaggingService.prepareEc2TagSpecification(awsCloudStackView.getTags(),
                     com.amazonaws.services.ec2.model.ResourceType.Instance);
             tagSpecification.withTags(
-                    new Tag().withKey("Name").withValue(cloudResource.getName()),
+                    new Tag().withKey("Name").withValue(awsStackNameCommonUtil.getInstanceName(ac, group.getName(), privateId)),
                     new Tag().withKey("instanceGroup").withValue(group.getName())
             );
             RunInstancesRequest request = new RunInstancesRequest()

--- a/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/resource/instance/AwsNativeInstanceResourceBuilderTest.java
+++ b/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/resource/instance/AwsNativeInstanceResourceBuilderTest.java
@@ -37,6 +37,7 @@ import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonEc2Client;
 import com.sequenceiq.cloudbreak.cloud.aws.common.context.AwsContext;
 import com.sequenceiq.cloudbreak.cloud.aws.common.resource.VolumeBuilderUtil;
 import com.sequenceiq.cloudbreak.cloud.aws.common.util.AwsMethodExecutor;
+import com.sequenceiq.cloudbreak.cloud.aws.common.util.AwsStackNameCommonUtil;
 import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsInstanceView;
 import com.sequenceiq.cloudbreak.cloud.aws.resource.instance.util.SecurityGroupBuilderUtil;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
@@ -101,6 +102,9 @@ class AwsNativeInstanceResourceBuilderTest {
     @Mock
     private InstanceTemplate instanceTemplate;
 
+    @Mock
+    private AwsStackNameCommonUtil awsStackNameCommonUtil;
+
     @Test
     void testBuildWhenBuildableResorucesAreEmpty() throws Exception {
         long privateId = 0;
@@ -137,6 +141,7 @@ class AwsNativeInstanceResourceBuilderTest {
         when(cloudStack.getInstanceAuthentication()).thenReturn(authentication);
         when(awsContext.getAmazonEc2Client()).thenReturn(amazonEc2Client);
         when(securityGroupBuilderUtil.getSecurityGroupIds(awsContext, group)).thenReturn(List.of("sg-id"));
+        when(awsStackNameCommonUtil.getInstanceName(ac, "groupName", privateId)).thenReturn("stackname");
 
         ArgumentCaptor<RunInstancesRequest> runInstancesRequestArgumentCaptor = ArgumentCaptor.forClass(RunInstancesRequest.class);
         List<CloudResource> actual = underTest.build(awsContext, cloudInstance, privateId, ac, group, Collections.singletonList(cloudResource), cloudStack);
@@ -213,6 +218,7 @@ class AwsNativeInstanceResourceBuilderTest {
         when(cloudStack.getInstanceAuthentication()).thenReturn(authentication);
         when(awsContext.getAmazonEc2Client()).thenReturn(amazonEc2Client);
         when(group.getName()).thenReturn("groupName");
+        when(awsStackNameCommonUtil.getInstanceName(ac, "groupName", privateId)).thenReturn("stackname");
 
         List<CloudResource> actual = underTest.build(awsContext, cloudInstance, privateId, ac, group, Collections.singletonList(cloudResource), cloudStack);
         Assertions.assertEquals(actual.get(0).getInstanceId(), "instanceId");


### PR DESCRIPTION
The pattern will be stack-name-stackid-group-name. The created instances won't be affected but after a repair or OS Upgrade, the name will change