### PR TITLE
CB-19610 AKS private DNS zone - post, get and store

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureNetworkConnector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureNetworkConnector.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.cloud.azure;
 
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.RESOURCE_GROUP_NAME;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -286,7 +288,7 @@ public class AzureNetworkConnector implements NetworkConnector {
 
     private Map<String, Object> createProperties(String resourceGroupName, String stackName) {
         Map<String, Object> properties = new HashMap<>();
-        properties.put("resourceGroupName", resourceGroupName);
+        properties.put(RESOURCE_GROUP_NAME, resourceGroupName);
         properties.put("stackName", stackName);
         return properties;
     }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePlatformResources.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePlatformResources.java
@@ -3,6 +3,8 @@ package com.sequenceiq.cloudbreak.cloud.azure;
 import static com.sequenceiq.cloudbreak.cloud.model.VolumeParameterType.EPHEMERAL;
 import static com.sequenceiq.cloudbreak.cloud.model.VolumeParameterType.MAGNETIC;
 import static com.sequenceiq.cloudbreak.cloud.model.VolumeParameterType.SSD;
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.NETWORK_ID;
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.RESOURCE_GROUP_NAME;
 
 import java.security.InvalidParameterException;
 import java.util.ArrayList;
@@ -111,8 +113,8 @@ public class AzurePlatformResources implements PlatformResources {
     public CloudNetworks networks(ExtendedCloudCredential cloudCredential, Region region, Map<String, String> filters) {
         AzureClient client = azureClientService.getClient(cloudCredential);
         Map<String, Set<CloudNetwork>> result = new HashMap<>();
-        String networkId = filters.get("networkId");
-        String resourceGroupName = filters.get("resourceGroupName");
+        String networkId = filters.get(NETWORK_ID);
+        String resourceGroupName = filters.get(RESOURCE_GROUP_NAME);
         if (!StringUtils.isEmpty(networkId) && !StringUtils.isEmpty(resourceGroupName)) {
             LOGGER.info("Query network with id '{}' and resource group {}", networkId, resourceGroupName);
             Network network = client.getNetworkByResourceGroup(resourceGroupName, networkId);

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStackViewProvider.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStackViewProvider.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.cloudbreak.cloud.azure;
 
 import static com.sequenceiq.cloudbreak.cloud.azure.subnetstrategy.AzureSubnetStrategy.SubnetStratgyType.FILL;
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.NETWORK_ID;
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.RESOURCE_GROUP_NAME;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -78,8 +80,8 @@ class AzureStackViewProvider {
 
     private Map<String, Long> getNumberOfAvailableIPsInSubnets(AzureClient client, Network network) {
         Map<String, Long> result = new HashMap<>();
-        String resourceGroup = network.getStringParameter("resourceGroupName");
-        String networkId = network.getStringParameter("networkId");
+        String resourceGroup = network.getStringParameter(RESOURCE_GROUP_NAME);
+        String networkId = network.getStringParameter(NETWORK_ID);
         Collection<String> subnetIds = azureUtils.getCustomSubnetIds(network);
         for (String subnetId : subnetIds) {
             Subnet subnet = client.getSubnetProperties(resourceGroup, networkId, subnetId);

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtils.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtils.java
@@ -1,6 +1,10 @@
 package com.sequenceiq.cloudbreak.cloud.azure;
 
 import static com.sequenceiq.cloudbreak.common.network.NetworkConstants.SUBNET_ID;
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.DATABASE_PRIVATE_DNS_ZONE_ID;
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.NETWORK_ID;
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.NO_PUBLIC_IP;
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.RESOURCE_GROUP_NAME;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 import java.util.ArrayList;
@@ -69,15 +73,8 @@ import rx.schedulers.Schedulers;
 
 @Component
 public class AzureUtils {
-    public static final String RG_NAME = "resourceGroupName";
-
-    public static final String NETWORK_ID = "networkId";
-
-    public static final String DATABASE_PRIVATE_DS_ZONE_ID = "databasePrivateDsZoneId";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AzureUtils.class);
-
-    private static final String NO_PUBLIC_IP = "noPublicIp";
 
     private static final int HOST_GROUP_LENGTH = 3;
 
@@ -208,11 +205,11 @@ public class AzureUtils {
     }
 
     public String getPrivateDnsZoneId(Network network) {
-        return network.getStringParameter(DATABASE_PRIVATE_DS_ZONE_ID);
+        return network.getStringParameter(DATABASE_PRIVATE_DNS_ZONE_ID);
     }
 
     public String getCustomResourceGroupName(Network network) {
-        return network.getStringParameter(RG_NAME);
+        return network.getStringParameter(RESOURCE_GROUP_NAME);
     }
 
     public List<String> getCustomSubnetIds(Network network) {

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureNetworkConnectorTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureNetworkConnectorTest.java
@@ -94,6 +94,8 @@ public class AzureNetworkConnectorTest {
 
     private static final String NETWORK_ID = "networkId";
 
+    private static final String NETWORK_ID_KEY = "networkId";
+
     private static final String NETWORK_RG = "networkRg";
 
     @InjectMocks
@@ -309,7 +311,7 @@ public class AzureNetworkConnectorTest {
         String resourceGroupName = "resourceGroupName";
         String cidrBlock = "10.0.0.0/16";
 
-        Network network = new Network(null, Map.of(AzureUtils.NETWORK_ID, networkId));
+        Network network = new Network(null, Map.of(NETWORK_ID_KEY, networkId));
         CloudCredential credential = new CloudCredential();
         com.microsoft.azure.management.network.Network azureNetwork = mock(com.microsoft.azure.management.network.Network.class);
 
@@ -328,7 +330,7 @@ public class AzureNetworkConnectorTest {
         String networkId = "vnet-1";
         String resourceGroupName = "resourceGroupName";
 
-        Network network = new Network(null, Map.of(AzureUtils.NETWORK_ID, networkId));
+        Network network = new Network(null, Map.of(NETWORK_ID_KEY, networkId));
         CloudCredential credential = new CloudCredential();
         com.microsoft.azure.management.network.Network azureNetwork = mock(com.microsoft.azure.management.network.Network.class);
 
@@ -354,7 +356,7 @@ public class AzureNetworkConnectorTest {
         String cidrBlock1 = "10.0.0.0/16";
         String cidrBlock2 = "10.23.0.0/16";
 
-        Network network = new Network(null, Map.of(AzureUtils.NETWORK_ID, networkId));
+        Network network = new Network(null, Map.of(NETWORK_ID_KEY, networkId));
         CloudCredential credential = new CloudCredential();
         com.microsoft.azure.management.network.Network azureNetwork = mock(com.microsoft.azure.management.network.Network.class);
 
@@ -373,7 +375,7 @@ public class AzureNetworkConnectorTest {
         String networkId = "vnet-1";
         String resourceGroupName = "resourceGroupName";
 
-        Network network = new Network(null, Map.of(AzureUtils.NETWORK_ID, networkId));
+        Network network = new Network(null, Map.of(NETWORK_ID_KEY, networkId));
         CloudCredential credential = new CloudCredential();
 
         when(azureClientService.getClient(credential)).thenReturn(azureClient);

--- a/common/src/main/java/com/sequenceiq/cloudbreak/constant/AzureConstants.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/constant/AzureConstants.java
@@ -1,0 +1,20 @@
+package com.sequenceiq.cloudbreak.constant;
+
+public class AzureConstants {
+
+    public static final String RESOURCE_GROUP_NAME = "resourceGroupName";
+
+    public static final String NETWORK_ID = "networkId";
+
+    public static final String SUBNET_ID = "subnetId";
+
+    public static final String NO_PUBLIC_IP = "noPublicIp";
+
+    public static final String DATABASE_PRIVATE_DNS_ZONE_ID = "databasePrivateDsZoneId";
+
+    public static final String AKS_PRIVATE_DNS_ZONE_ID = "aksPrivateDnsZoneId";
+
+    private AzureConstants() {
+    }
+
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/network/AzureNetworkV4Parameters.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/network/AzureNetworkV4Parameters.java
@@ -1,5 +1,12 @@
 package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.network;
 
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.AKS_PRIVATE_DNS_ZONE_ID;
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.DATABASE_PRIVATE_DNS_ZONE_ID;
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.NETWORK_ID;
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.NO_PUBLIC_IP;
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.RESOURCE_GROUP_NAME;
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.SUBNET_ID;
+
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -32,6 +39,9 @@ public class AzureNetworkV4Parameters extends MappableBase implements JsonEntity
 
     @ApiModelProperty
     private String databasePrivateDnsZoneId;
+
+    @ApiModelProperty
+    private String aksPrivateDnsZoneId;
 
     public Boolean getNoPublicIp() {
         return noPublicIp;
@@ -73,14 +83,23 @@ public class AzureNetworkV4Parameters extends MappableBase implements JsonEntity
         this.databasePrivateDnsZoneId = databasePrivateDnsZoneId;
     }
 
+    public String getAksPrivateDnsZoneId() {
+        return aksPrivateDnsZoneId;
+    }
+
+    public void setAksPrivateDnsZoneId(String aksPrivateDnsZoneId) {
+        this.aksPrivateDnsZoneId = aksPrivateDnsZoneId;
+    }
+
     @Override
     public Map<String, Object> asMap() {
         Map<String, Object> map = super.asMap();
-        putIfValueNotNull(map, "noPublicIp", noPublicIp);
-        putIfValueNotNull(map, "resourceGroupName", resourceGroupName);
-        putIfValueNotNull(map, "networkId", networkId);
-        putIfValueNotNull(map, "subnetId", subnetId);
-        putIfValueNotNull(map, "databasePrivateDsZoneId", databasePrivateDnsZoneId);
+        putIfValueNotNull(map, NO_PUBLIC_IP, noPublicIp);
+        putIfValueNotNull(map, RESOURCE_GROUP_NAME, resourceGroupName);
+        putIfValueNotNull(map, NETWORK_ID, networkId);
+        putIfValueNotNull(map, SUBNET_ID, subnetId);
+        putIfValueNotNull(map, DATABASE_PRIVATE_DNS_ZONE_ID, databasePrivateDnsZoneId);
+        putIfValueNotNull(map, AKS_PRIVATE_DNS_ZONE_ID, aksPrivateDnsZoneId);
         return map;
     }
 
@@ -93,10 +112,11 @@ public class AzureNetworkV4Parameters extends MappableBase implements JsonEntity
 
     @Override
     public void parse(Map<String, Object> parameters) {
-        noPublicIp = getBoolean(parameters, "noPublicIp");
-        resourceGroupName = getParameterOrNull(parameters, "resourceGroupName");
-        networkId = getParameterOrNull(parameters, "networkId");
-        subnetId = getParameterOrNull(parameters, "subnetId");
-        databasePrivateDnsZoneId = getParameterOrNull(parameters, "databasePrivateDsZoneId");
+        noPublicIp = getBoolean(parameters, NO_PUBLIC_IP);
+        resourceGroupName = getParameterOrNull(parameters, RESOURCE_GROUP_NAME);
+        networkId = getParameterOrNull(parameters, NETWORK_ID);
+        subnetId = getParameterOrNull(parameters, SUBNET_ID);
+        databasePrivateDnsZoneId = getParameterOrNull(parameters, DATABASE_PRIVATE_DNS_ZONE_ID);
+        aksPrivateDnsZoneId = getParameterOrNull(parameters, AKS_PRIVATE_DNS_ZONE_ID);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/AzureEnvironmentNetworkConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/AzureEnvironmentNetworkConverter.java
@@ -1,5 +1,10 @@
 package com.sequenceiq.cloudbreak.converter.v4.environment.network;
 
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.DATABASE_PRIVATE_DNS_ZONE_ID;
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.NETWORK_ID;
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.NO_PUBLIC_IP;
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.RESOURCE_GROUP_NAME;
+
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
@@ -22,10 +27,10 @@ public class AzureEnvironmentNetworkConverter extends EnvironmentBaseNetworkConv
     Map<String, Object> getAttributesForLegacyNetwork(EnvironmentNetworkResponse source) {
         EnvironmentNetworkAzureParams azure = source.getAzure();
         return Map.of(
-                "networkId", azure.getNetworkId(),
-                "resourceGroupName", azure.getResourceGroupName(),
-                "noPublicIp", azure.getNoPublicIp(),
-                "databasePrivateDsZoneId", getDatabasePrivateDnsZoneId(azure)
+                NETWORK_ID, azure.getNetworkId(),
+                RESOURCE_GROUP_NAME, azure.getResourceGroupName(),
+                NO_PUBLIC_IP, azure.getNoPublicIp(),
+                DATABASE_PRIVATE_DNS_ZONE_ID, getDatabasePrivateDnsZoneId(azure)
         );
     }
 

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/NetworkV1ToNetworkV4Converter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/NetworkV1ToNetworkV4Converter.java
@@ -33,6 +33,7 @@ import com.sequenceiq.distrox.api.v1.distrox.model.network.azure.AzureNetworkV1P
 import com.sequenceiq.distrox.api.v1.distrox.model.network.gcp.GcpNetworkV1Parameters;
 import com.sequenceiq.distrox.api.v1.distrox.model.network.mock.MockNetworkV1Parameters;
 import com.sequenceiq.distrox.api.v1.distrox.model.network.yarn.YarnNetworkV1Parameters;
+import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkAzureParams;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
 
@@ -125,10 +126,12 @@ public class NetworkV1ToNetworkV4Converter {
         AzureNetworkV4Parameters response = new AzureNetworkV4Parameters();
 
         if (azureNetworkV1Parameters != null) {
-            response.setNetworkId(networkResponse.getAzure().getNetworkId());
-            response.setNoPublicIp(networkResponse.getAzure().getNoPublicIp());
-            response.setResourceGroupName(networkResponse.getAzure().getResourceGroupName());
-            response.setDatabasePrivateDnsZoneId(networkResponse.getAzure().getDatabasePrivateDnsZoneId());
+            EnvironmentNetworkAzureParams networkAzureParams = networkResponse.getAzure();
+            response.setNetworkId(networkAzureParams.getNetworkId());
+            response.setNoPublicIp(networkAzureParams.getNoPublicIp());
+            response.setResourceGroupName(networkAzureParams.getResourceGroupName());
+            response.setDatabasePrivateDnsZoneId(networkAzureParams.getDatabasePrivateDnsZoneId());
+            response.setAksPrivateDnsZoneId(networkAzureParams.getAksPrivateDnsZoneId());
             String subnetId = azureNetworkV1Parameters.getSubnetId();
             if (!Strings.isNullOrEmpty(subnetId)) {
                 response.setSubnetId(subnetId);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/AzureEnvironmentNetworkConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/AzureEnvironmentNetworkConverterTest.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.converter.v4.environment.network;
 
 import static com.sequenceiq.cloudbreak.common.network.NetworkConstants.CLOUD_PLATFORM;
 import static com.sequenceiq.cloudbreak.common.network.NetworkConstants.ENDPOINT_GATEWAY_SUBNET_ID;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
@@ -27,6 +28,20 @@ import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentN
 @MockitoSettings
 class AzureEnvironmentNetworkConverterTest {
 
+    private static final String DATABASE_PRIVATE_DNS_ZONE_ID = "my_database_private_dns_zone_id";
+
+    private static final String DATABASE_PRIVATE_DNS_ZONE_ID_KEY = "databasePrivateDsZoneId";
+
+    private static final String NETWORK_ID = "my_network_id";
+
+    private static final String NETWORK_ID_KEY = "networkId";
+
+    private static final String RESOURCE_GROUP_NAME = "my_resource_group";
+
+    private static final String RESOURCE_GROUP_NAME_KEY = "resourceGroupName";
+
+    private static final String NO_PUBLIC_IP_KEY = "noPublicIp";
+
     @Mock
     private MissingResourceNameGenerator missingResourceNameGenerator;
 
@@ -47,8 +62,8 @@ class AzureEnvironmentNetworkConverterTest {
         when(cloudSubnet.getId()).thenReturn("my_cloud_subnet");
 
         when(environmentNetworkResponse.getAzure()).thenReturn(azure);
-        when(azure.getNetworkId()).thenReturn("my_network_id");
-        when(azure.getResourceGroupName()).thenReturn("my_resource_group");
+        when(azure.getNetworkId()).thenReturn(NETWORK_ID);
+        when(azure.getResourceGroupName()).thenReturn(RESOURCE_GROUP_NAME);
         when(azure.getNoPublicIp()).thenReturn(true);
 
         Network result = converter.convertToLegacyNetwork(environmentNetworkResponse, "my-az");
@@ -62,15 +77,18 @@ class AzureEnvironmentNetworkConverterTest {
         EnvironmentNetworkResponse environmentNetworkResponse = mock(EnvironmentNetworkResponse.class);
         EnvironmentNetworkAzureParams azure = mock(EnvironmentNetworkAzureParams.class);
         when(environmentNetworkResponse.getAzure()).thenReturn(azure);
-        when(azure.getNetworkId()).thenReturn("my_network_id");
-        when(azure.getResourceGroupName()).thenReturn("my_resource_group");
+        when(azure.getNetworkId()).thenReturn(NETWORK_ID);
+        when(azure.getResourceGroupName()).thenReturn(RESOURCE_GROUP_NAME);
         when(azure.getNoPublicIp()).thenReturn(true);
+        when(azure.getDatabasePrivateDnsZoneId()).thenReturn(DATABASE_PRIVATE_DNS_ZONE_ID);
 
         Map<String, Object> result = converter.getAttributesForLegacyNetwork(environmentNetworkResponse);
 
-        assertEquals("my_network_id", result.get("networkId"));
-        assertEquals("my_resource_group", result.get("resourceGroupName"));
-        assertEquals(true, result.get("noPublicIp"));
+        assertThat(result).hasSize(4);
+        assertEquals(NETWORK_ID, result.get(NETWORK_ID_KEY));
+        assertEquals(RESOURCE_GROUP_NAME, result.get(RESOURCE_GROUP_NAME_KEY));
+        assertEquals(true, result.get(NO_PUBLIC_IP_KEY));
+        assertEquals(DATABASE_PRIVATE_DNS_ZONE_ID, result.get(DATABASE_PRIVATE_DNS_ZONE_ID_KEY));
     }
 
     @Test

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
@@ -30,14 +30,16 @@ public class EnvironmentModelDescription {
     public static final String GCP_SPECIFIC_PARAMETERS = "GCP-specific properties of the network";
     public static final String YARN_SPECIFIC_PARAMETERS = "Yarn-specific properties of the network";
     public static final String MOCK_PARAMETERS = "Mock-specific properties of the network";
-    public static final String AWS_VPC_ID = "AWS VPC id of the specified networks";
+    public static final String AWS_VPC_ID = "AWS VPC ID of the specified networks";
     public static final String GCP_NETWORK_ID = "Gcp network id";
     public static final String GCP_SHARED_PROJECT_ID = "Gcp shared project id";
     public static final String GCP_NO_PUBLIC_IP = "Gcp no public ip";
     public static final String GCP_NO_FIREWALL_RULES = "Gcp no firewall rules";
 
     public static final String AZURE_RESOURCE_GROUP_NAME = "Azure Resource Group Name of the specified network";
-    public static final String AZURE_PRIVATE_DNS_ZONE_ID = "Full resource id of an existing azure private DNS zone";
+    public static final String AZURE_PRIVATE_DNS_ZONE_ID = "Full resource ID of an existing Azure private DNS zone";
+
+    public static final String AZURE_AKS_PRIVATE_DNS_ZONE_ID = "Full resource ID of an existing Azure private DNS zone for a private AKS cluster";
     public static final String AZURE_NETWORK_ID = "Azure Network ID of the specified network";
     public static final String AZURE_NO_PUBLIC_IP = "Azure Network is private if this flag is true";
 
@@ -111,7 +113,7 @@ public class EnvironmentModelDescription {
     public static final String YARN_PARAMETERS = "YARN Specific parameters.";
 
     public static final String RESOURCE_GROUP_PARAMETERS = "Azure resource group parameters.";
-    public static final String EXISTING_RESOURCE_GROUP_NAME = "Name of an existing azure resource group.";
+    public static final String EXISTING_RESOURCE_GROUP_NAME = "Name of an existing Azure resource group.";
     public static final String RESOURCE_GROUP_NAME = "Name of the Azure resource group.";
     public static final String RESOURCE_GROUP_USAGE = "Resource group usage: single resource group for all resources where possible "
             + "or use multiple resource groups.";

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/EnvironmentNetworkAzureParams.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/EnvironmentNetworkAzureParams.java
@@ -28,6 +28,10 @@ public class EnvironmentNetworkAzureParams {
     @ApiModelProperty(value = EnvironmentModelDescription.AZURE_PRIVATE_DNS_ZONE_ID)
     private String databasePrivateDnsZoneId;
 
+    @Size(max = 255)
+    @ApiModelProperty(value = EnvironmentModelDescription.AZURE_AKS_PRIVATE_DNS_ZONE_ID)
+    private String aksPrivateDnsZoneId;
+
     @NotNull
     @ApiModelProperty(EnvironmentModelDescription.AZURE_NO_PUBLIC_IP)
     private Boolean noPublicIp;
@@ -64,12 +68,21 @@ public class EnvironmentNetworkAzureParams {
         this.databasePrivateDnsZoneId = databasePrivateDnsZoneId;
     }
 
+    public String getAksPrivateDnsZoneId() {
+        return aksPrivateDnsZoneId;
+    }
+
+    public void setAksPrivateDnsZoneId(String aksPrivateDnsZoneId) {
+        this.aksPrivateDnsZoneId = aksPrivateDnsZoneId;
+    }
+
     @Override
     public String toString() {
         return "EnvironmentNetworkAzureParams{" +
                 "networkId='" + networkId + '\'' +
                 ", resourceGroupName='" + resourceGroupName + '\'' +
                 ", databasePrivateDnsZoneId='" + databasePrivateDnsZoneId + '\'' +
+                ", aksPrivateDnsZoneId='" + aksPrivateDnsZoneId + '\'' +
                 ", noPublicIp=" + noPublicIp +
                 '}';
     }
@@ -82,6 +95,8 @@ public class EnvironmentNetworkAzureParams {
         private Boolean noPublicIp;
 
         private String databasePrivateDnsZoneId;
+
+        private String aksPrivateDnsZoneId;
 
         private EnvironmentNetworkAzureParamsBuilder() {
         }
@@ -110,12 +125,18 @@ public class EnvironmentNetworkAzureParams {
             return this;
         }
 
+        public EnvironmentNetworkAzureParamsBuilder withAksPrivateDnsZoneId(String aksPrivateDnsZoneId) {
+            this.aksPrivateDnsZoneId = aksPrivateDnsZoneId;
+            return this;
+        }
+
         public EnvironmentNetworkAzureParams build() {
             EnvironmentNetworkAzureParams environmentNetworkAzureParams = new EnvironmentNetworkAzureParams();
             environmentNetworkAzureParams.setNetworkId(networkId);
             environmentNetworkAzureParams.setResourceGroupName(resourceGroupName);
             environmentNetworkAzureParams.setNoPublicIp(noPublicIp);
             environmentNetworkAzureParams.setDatabasePrivateDnsZoneId(databasePrivateDnsZoneId);
+            environmentNetworkAzureParams.setAksPrivateDnsZoneId(aksPrivateDnsZoneId);
             return environmentNetworkAzureParams;
         }
     }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/NetworkDtoToResponseConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/NetworkDtoToResponseConverter.java
@@ -61,6 +61,7 @@ public class NetworkDtoToResponseConverter {
                         .withResourceGroupName(p.getResourceGroupName())
                         .withNoPublicIp(p.isNoPublicIp())
                         .withDatabasePrivateDnsZoneId(p.getDatabasePrivateDnsZoneId())
+                        .withAksPrivateDnsZoneId(p.getAksPrivateDnsZoneId())
                         .build()))
                 .withGcp(getIfNotNull(network.getGcp(), p -> EnvironmentNetworkGcpParams.EnvironmentNetworkGcpParamsBuilder
                         .anEnvironmentNetworkGcpParamsBuilder()

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/NetworkRequestToDtoConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/NetworkRequestToDtoConverter.java
@@ -46,6 +46,7 @@ public class NetworkRequestToDtoConverter {
                     .withNoPublicIp(Boolean.TRUE.equals(network.getAzure().getNoPublicIp()))
                     .withResourceGroupName(network.getAzure().getResourceGroupName())
                     .withDatabasePrivateDnsZoneId(network.getAzure().getDatabasePrivateDnsZoneId())
+                    .withAksPrivateDnsZoneId(network.getAzure().getAksPrivateDnsZoneId())
                     .build();
             builder.withAzure(azureParams);
             builder.withNetworkId(network.getAzure().getNetworkId());

--- a/environment/src/main/java/com/sequenceiq/environment/network/dao/domain/AzureNetwork.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/dao/domain/AzureNetwork.java
@@ -14,6 +14,8 @@ public class AzureNetwork extends BaseNetwork {
 
     private String databasePrivateDnsZoneId;
 
+    private String aksPrivateDnsZoneId;
+
     @Override
     public String getNetworkId() {
         return networkId;
@@ -47,6 +49,14 @@ public class AzureNetwork extends BaseNetwork {
         this.databasePrivateDnsZoneId = databasePrivateDnsZoneId;
     }
 
+    public String getAksPrivateDnsZoneId() {
+        return aksPrivateDnsZoneId;
+    }
+
+    public void setAksPrivateDnsZoneId(String aksPrivateDnsZoneId) {
+        this.aksPrivateDnsZoneId = aksPrivateDnsZoneId;
+    }
+
     @Override
     public String toString() {
         return "AzureNetwork{" +
@@ -54,6 +64,7 @@ public class AzureNetwork extends BaseNetwork {
                 ", resourceGroupName='" + resourceGroupName + '\'' +
                 ", noPublicIp=" + noPublicIp +
                 ", databasePrivateDnsZoneId='" + databasePrivateDnsZoneId + '\'' +
+                ", aksPrivateDnsZoneId='" + aksPrivateDnsZoneId + '\'' +
                 "} " + super.toString();
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/network/v1/converter/AzureEnvironmentNetworkConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/v1/converter/AzureEnvironmentNetworkConverter.java
@@ -1,8 +1,9 @@
 package com.sequenceiq.environment.network.v1.converter;
 
-import static com.sequenceiq.cloudbreak.cloud.azure.AzureUtils.DATABASE_PRIVATE_DS_ZONE_ID;
-import static com.sequenceiq.cloudbreak.cloud.azure.AzureUtils.NETWORK_ID;
-import static com.sequenceiq.cloudbreak.cloud.azure.AzureUtils.RG_NAME;
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.AKS_PRIVATE_DNS_ZONE_ID;
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.DATABASE_PRIVATE_DNS_ZONE_ID;
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.NETWORK_ID;
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.RESOURCE_GROUP_NAME;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -46,6 +47,7 @@ public class AzureEnvironmentNetworkConverter extends EnvironmentBaseNetworkConv
             azureNetwork.setNetworkId(azureParams.getNetworkId());
             azureNetwork.setResourceGroupName(azureParams.getResourceGroupName());
             azureNetwork.setNoPublicIp(azureParams.isNoPublicIp());
+            azureNetwork.setAksPrivateDnsZoneId(azureParams.getAksPrivateDnsZoneId());
             if (ServiceEndpointCreation.ENABLED_PRIVATE_ENDPOINT.equals(network.getServiceEndpointCreation())) {
                 azureNetwork.setDatabasePrivateDnsZoneId(azureParams.getDatabasePrivateDnsZoneId());
             }
@@ -99,6 +101,7 @@ public class AzureEnvironmentNetworkConverter extends EnvironmentBaseNetworkConv
                                 .withResourceGroupName(azureNetwork.getResourceGroupName())
                                 .withNoPublicIp(azureNetwork.getNoPublicIp())
                                 .withDatabasePrivateDnsZoneId(azureNetwork.getDatabasePrivateDnsZoneId())
+                                .withAksPrivateDnsZoneId(azureNetwork.getAksPrivateDnsZoneId())
                                 .build())
                 .build();
     }
@@ -127,9 +130,10 @@ public class AzureEnvironmentNetworkConverter extends EnvironmentBaseNetworkConv
     public Network convertToNetwork(BaseNetwork baseNetwork) {
         AzureNetwork azureNetwork = (AzureNetwork) baseNetwork;
         Map<String, Object> param = new HashMap<>();
-        param.put(RG_NAME, azureNetwork.getResourceGroupName());
+        param.put(RESOURCE_GROUP_NAME, azureNetwork.getResourceGroupName());
         param.put(NETWORK_ID, azureNetwork.getNetworkId());
-        param.put(DATABASE_PRIVATE_DS_ZONE_ID, azureNetwork.getDatabasePrivateDnsZoneId());
+        param.put(DATABASE_PRIVATE_DNS_ZONE_ID, azureNetwork.getDatabasePrivateDnsZoneId());
+        param.put(AKS_PRIVATE_DNS_ZONE_ID, azureNetwork.getAksPrivateDnsZoneId());
         return new Network(null, param);
     }
 }

--- a/environment/src/main/resources/schema/app/20221114171700_CB-19610_Support_customer_provided_AKS_private_DNS_zones.sql
+++ b/environment/src/main/resources/schema/app/20221114171700_CB-19610_Support_customer_provided_AKS_private_DNS_zones.sql
@@ -1,0 +1,9 @@
+-- // CB-19610 Support customer provided AKS private DNS zones
+-- Migration SQL that makes the change goes here.
+ALTER TABLE environment_network ADD COLUMN IF NOT EXISTS aksprivatednszoneid VARCHAR(255);
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+ALTER TABLE environment_network DROP COLUMN IF EXISTS aksprivatednszoneid;
+

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/NetworkDtoToResponseConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/NetworkDtoToResponseConverterTest.java
@@ -70,6 +70,8 @@ public class NetworkDtoToResponseConverterTest {
         assertEquals(network.getAzure().isNoPublicIp(), actual.getAzure().getNoPublicIp());
         assertEquals(network.getAzure().getNetworkId(), actual.getAzure().getNetworkId());
         assertEquals(network.getAzure().getResourceGroupName(), actual.getAzure().getResourceGroupName());
+        assertEquals(network.getAzure().getDatabasePrivateDnsZoneId(), actual.getAzure().getDatabasePrivateDnsZoneId());
+        assertEquals(network.getAzure().getAksPrivateDnsZoneId(), actual.getAzure().getAksPrivateDnsZoneId());
         assertNull(actual.getAws());
         assertNull(actual.getYarn());
         assertNull(actual.getMock());
@@ -158,6 +160,8 @@ public class NetworkDtoToResponseConverterTest {
                 .withNoPublicIp(true)
                 .withResourceGroupName("resource-group")
                 .withNetworkId("network-id")
+                .withDatabasePrivateDnsZoneId("database-private-dns-zone-id")
+                .withAksPrivateDnsZoneId("aks-private-dns-zone-id")
                 .build();
     }
 

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/NetworkRequestToDtoConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/NetworkRequestToDtoConverterTest.java
@@ -62,6 +62,8 @@ public class NetworkRequestToDtoConverterTest {
         assertEquals(network.getAzure().getNetworkId(), actual.getAzure().getNetworkId());
         assertEquals(network.getAzure().getResourceGroupName(), actual.getAzure().getResourceGroupName());
         assertEquals(network.getAzure().getNoPublicIp(), actual.getAzure().isNoPublicIp());
+        assertEquals(network.getAzure().getDatabasePrivateDnsZoneId(), actual.getAzure().getDatabasePrivateDnsZoneId());
+        assertEquals(network.getAzure().getAksPrivateDnsZoneId(), actual.getAzure().getAksPrivateDnsZoneId());
         assertCommonFields(network, actual);
     }
 
@@ -123,6 +125,8 @@ public class NetworkRequestToDtoConverterTest {
         azureParams.setNetworkId(NETWORK_ID);
         azureParams.setResourceGroupName("resource-group");
         azureParams.setNoPublicIp(true);
+        azureParams.setDatabasePrivateDnsZoneId("database-private-dns-zone-id");
+        azureParams.setAksPrivateDnsZoneId("aks-private-dns-zone-id");
         return azureParams;
     }
 

--- a/environment/src/test/java/com/sequenceiq/environment/network/v1/converter/AzureEnvironmentNetworkConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/network/v1/converter/AzureEnvironmentNetworkConverterTest.java
@@ -19,7 +19,6 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
-import com.sequenceiq.cloudbreak.cloud.azure.AzureUtils;
 import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
 import com.sequenceiq.cloudbreak.cloud.model.Network;
 import com.sequenceiq.cloudbreak.cloud.model.network.CreatedCloudNetwork;
@@ -78,6 +77,10 @@ class AzureEnvironmentNetworkConverterTest {
     private static final String SUBNET_CIDR_2 = "2.2.2.2/24";
 
     private static final String RESOURCE_GROUP_NAME = "resourceGroup";
+
+    private static final String RESOURCE_GROUP_NAME_KEY = "resourceGroupName";
+
+    private static final String NETWORK_ID_KEY = "networkId";
 
     @Mock
     private EnvironmentViewConverter environmentViewConverter;
@@ -227,8 +230,8 @@ class AzureEnvironmentNetworkConverterTest {
 
         Network network = underTest.convertToNetwork(azureNetwork);
 
-        assertEquals(RESOURCE_GROUP_NAME, network.getStringParameter(AzureUtils.RG_NAME));
-        assertEquals(NETWORK_ID, network.getStringParameter(AzureUtils.NETWORK_ID));
+        assertEquals(RESOURCE_GROUP_NAME, network.getStringParameter(RESOURCE_GROUP_NAME_KEY));
+        assertEquals(NETWORK_ID, network.getStringParameter(NETWORK_ID_KEY));
     }
 
     private Set<CreatedSubnet> createCreatedSubnets() {

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/network/AzureNetworkParameters.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/network/AzureNetworkParameters.java
@@ -1,5 +1,10 @@
 package com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network;
 
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.NETWORK_ID;
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.NO_PUBLIC_IP;
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.RESOURCE_GROUP_NAME;
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.SUBNET_ID;
+
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -63,10 +68,10 @@ public class AzureNetworkParameters extends MappableBase {
     @Override
     public Map<String, Object> asMap() {
         Map<String, Object> map = super.asMap();
-        putIfValueNotNull(map, "noPublicIp", noPublicIp);
-        putIfValueNotNull(map, "resourceGroupName", resourceGroupName);
-        putIfValueNotNull(map, "networkId", networkId);
-        putIfValueNotNull(map, "subnetId", subnetId);
+        putIfValueNotNull(map, NO_PUBLIC_IP, noPublicIp);
+        putIfValueNotNull(map, RESOURCE_GROUP_NAME, resourceGroupName);
+        putIfValueNotNull(map, NETWORK_ID, networkId);
+        putIfValueNotNull(map, SUBNET_ID, subnetId);
         return map;
     }
 
@@ -79,10 +84,10 @@ public class AzureNetworkParameters extends MappableBase {
 
     @Override
     public void parse(Map<String, Object> parameters) {
-        noPublicIp = getBoolean(parameters, "noPublicIp");
-        resourceGroupName = getParameterOrNull(parameters, "resourceGroupName");
-        networkId = getParameterOrNull(parameters, "networkId");
-        subnetId = getParameterOrNull(parameters, "subnetId");
+        noPublicIp = getBoolean(parameters, NO_PUBLIC_IP);
+        resourceGroupName = getParameterOrNull(parameters, RESOURCE_GROUP_NAME);
+        networkId = getParameterOrNull(parameters, NETWORK_ID);
+        subnetId = getParameterOrNull(parameters, SUBNET_ID);
     }
 
     @Override

--- a/structuredevent-model/src/main/java/com/sequenceiq/environment/network/dto/AzureParams.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/environment/network/dto/AzureParams.java
@@ -14,11 +14,14 @@ public class AzureParams {
 
     private String databasePrivateDnsZoneId;
 
+    private String aksPrivateDnsZoneId;
+
     private AzureParams(Builder builder) {
         networkId = builder.networkId;
         resourceGroupName = builder.resourceGroupName;
         noPublicIp = builder.noPublicIp;
         databasePrivateDnsZoneId = builder.databasePrivateDnsZoneId;
+        aksPrivateDnsZoneId = builder.aksPrivateDnsZoneId;
     }
 
     public String getNetworkId() {
@@ -53,6 +56,14 @@ public class AzureParams {
         this.databasePrivateDnsZoneId = databasePrivateDnsZoneId;
     }
 
+    public String getAksPrivateDnsZoneId() {
+        return aksPrivateDnsZoneId;
+    }
+
+    public void setAksPrivateDnsZoneId(String aksPrivateDnsZoneId) {
+        this.aksPrivateDnsZoneId = aksPrivateDnsZoneId;
+    }
+
     @Override
     public String toString() {
         return "AzureParams{" +
@@ -60,6 +71,7 @@ public class AzureParams {
                 ", resourceGroupName='" + resourceGroupName + '\'' +
                 ", noPublicIp=" + noPublicIp +
                 ", databasePrivateDnsZoneId='" + databasePrivateDnsZoneId + '\'' +
+                ", aksPrivateDnsZoneId='" + aksPrivateDnsZoneId + '\'' +
                 '}';
     }
 
@@ -76,6 +88,8 @@ public class AzureParams {
         private boolean noPublicIp;
 
         private String databasePrivateDnsZoneId;
+
+        private String aksPrivateDnsZoneId;
 
         private Builder() {
         }
@@ -97,6 +111,11 @@ public class AzureParams {
 
         public Builder withDatabasePrivateDnsZoneId(String databasePrivateDnsZoneId) {
             this.databasePrivateDnsZoneId = databasePrivateDnsZoneId;
+            return this;
+        }
+
+        public Builder withAksPrivateDnsZoneId(String aksPrivateDnsZoneId) {
+            this.aksPrivateDnsZoneId = aksPrivateDnsZoneId;
             return this;
         }
 


### PR DESCRIPTION
Liftie and AKS based CDP services allow the customer to specify a private DNS zone id for AKS. The zone should be provided during environment creation and is stored in environment service.

This commit adds code to POST, GET and store the private DNS zone id. The zone id can always be specified, irrespective of if private endpoints are used or not in the environment. There is no validation as of yet, will be added in a later commit.

See detailed description in the commit message.