### PR TITLE
CB-19662 Migrate azure cloud modules from junit4 to junit5. Make sure…

### DIFF
--- a/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/PlatformParametersTest.java
+++ b/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/PlatformParametersTest.java
@@ -9,9 +9,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Lists;
 import com.sequenceiq.cloudbreak.cloud.model.DiskType;
@@ -28,7 +28,7 @@ public class PlatformParametersTest {
 
     private TestPlatformParameters underTest = new TestPlatformParameters();
 
-    @Before
+    @BeforeEach
     public void before() {
         underTest = new TestPlatformParameters();
     }
@@ -36,9 +36,9 @@ public class PlatformParametersTest {
     @Test
     public void getRegionByNameIfValueNotConfigured() {
         DiskTypes diskTypes = underTest.diskTypes();
-        Assert.assertEquals(1L, diskTypes.displayNames().entrySet().size());
-        Assert.assertEquals(1L, diskTypes.diskMapping().entrySet().size());
-        Assert.assertEquals("testDiskType", diskTypes.defaultType().value());
+        Assertions.assertEquals(1L, diskTypes.displayNames().entrySet().size());
+        Assertions.assertEquals(1L, diskTypes.diskMapping().entrySet().size());
+        Assertions.assertEquals("testDiskType", diskTypes.defaultType().value());
     }
 
     static class TestPlatformParameters implements PlatformParameters {

--- a/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/model/SubnetSelectionResultTest.java
+++ b/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/model/SubnetSelectionResultTest.java
@@ -1,12 +1,12 @@
 package com.sequenceiq.cloudbreak.cloud.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SubnetSelectionResultTest {
 

--- a/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/model/TargetGroupPortPairTest.java
+++ b/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/model/TargetGroupPortPairTest.java
@@ -1,11 +1,11 @@
 package com.sequenceiq.cloudbreak.cloud.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TargetGroupPortPairTest {
 

--- a/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/model/filesystem/efs/LifeCycleStateTest.java
+++ b/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/model/filesystem/efs/LifeCycleStateTest.java
@@ -1,9 +1,9 @@
 package com.sequenceiq.cloudbreak.cloud.model.filesystem.efs;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LifeCycleStateTest {
     @Test

--- a/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/model/filesystem/efs/ThroughputModeTest.java
+++ b/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/model/filesystem/efs/ThroughputModeTest.java
@@ -1,8 +1,8 @@
 package com.sequenceiq.cloudbreak.cloud.model.filesystem.efs;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ThroughputModeTest {
     @Test

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureCloudResourceServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureCloudResourceServiceTest.java
@@ -1,6 +1,6 @@
 package com.sequenceiq.cloudbreak.cloud.azure;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -8,13 +8,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.microsoft.azure.PagedList;
 import com.microsoft.azure.management.compute.ManagedDiskParameters;
@@ -35,7 +35,7 @@ import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.ResourceType;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AzureCloudResourceServiceTest {
 
     private static final String MICROSOFT_COMPUTE_VIRTUAL_MACHINES = "Microsoft.Compute/virtualMachines";

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureCredentialConnectorTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureCredentialConnectorTest.java
@@ -1,10 +1,10 @@
 package com.sequenceiq.cloudbreak.cloud.azure;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
@@ -16,8 +16,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.codec.binary.Base64;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -72,7 +72,7 @@ public class AzureCredentialConnectorTest {
     @Mock
     private CredentialSender credentialSender;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
     }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureDnsZoneServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureDnsZoneServiceTest.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.cloudbreak.cloud.azure;
 
 import static com.sequenceiq.common.api.type.ResourceType.AZURE_PRIVATE_DNS_ZONE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -12,12 +14,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.microsoft.azure.management.network.Network;
 import com.microsoft.azure.management.resources.Subscription;
@@ -29,7 +31,7 @@ import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AzureDnsZoneServiceTest {
 
     private static final Long STACK_ID = 12L;
@@ -65,7 +67,7 @@ public class AzureDnsZoneServiceTest {
     @Mock
     private AzureClient client;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         CloudContext cloudContext = CloudContext.Builder.builder()
                 .withId(STACK_ID)
@@ -76,10 +78,6 @@ public class AzureDnsZoneServiceTest {
         CloudCredential cloudCredential = new CloudCredential(STACK_ID.toString(), "", "account");
         ac = new AuthenticatedContext(cloudContext, cloudCredential);
 
-        when(azureResourceIdProviderService.generateDeploymentId(any(), any(), any())).thenReturn(DEPLOYMENT_ID);
-        when(azureResourceDeploymentHelperService.getAzureNetwork(any(), any(), any())).thenReturn(mock(Network.class));
-        when(client.getCurrentSubscription()).thenReturn(mock(Subscription.class));
-        when(client.getCurrentSubscription().subscriptionId()).thenReturn(SUBSCRIPTION_ID);
         when(azurePrivateEndpointServicesProvider.getCdpManagedDnsZones(any()))
                 .thenReturn(List.of(AzurePrivateDnsZoneServiceEnum.STORAGE, AzurePrivateDnsZoneServiceEnum.POSTGRES));
     }
@@ -88,6 +86,7 @@ public class AzureDnsZoneServiceTest {
     public void testCheckOrCreateWhenAllResourceExists() {
 
         when(client.checkIfDnsZonesDeployed(any(), any())).thenReturn(true);
+
         underTest.checkOrCreateDnsZones(ac, client, getNetworkView(), RESOURCE_GROUP, Collections.emptyMap(), Set.of());
 
         verify(azureResourcePersistenceHelperService, times(0)).persistCloudResource(any(), any(), any(), any());
@@ -100,7 +99,10 @@ public class AzureDnsZoneServiceTest {
 
     @Test
     public void testCheckOrCreateWhenDnsZoneResourceNotExistsButRequested() {
-
+        when(azureResourceIdProviderService.generateDeploymentId(any(), any(), any())).thenReturn(DEPLOYMENT_ID);
+        when(azureResourceDeploymentHelperService.getAzureNetwork(any(), any(), any())).thenReturn(mock(Network.class));
+        when(client.getCurrentSubscription()).thenReturn(mock(Subscription.class));
+        when(client.getCurrentSubscription().subscriptionId()).thenReturn(SUBSCRIPTION_ID);
         when(client.checkIfDnsZonesDeployed(any(), any())).thenReturn(false);
         when(azureResourcePersistenceHelperService.isRequested(DEPLOYMENT_ID, AZURE_PRIVATE_DNS_ZONE)).thenReturn(true);
 
@@ -115,7 +117,10 @@ public class AzureDnsZoneServiceTest {
 
     @Test
     public void testCheckOrCreateWhenDnsZoneResourceNotExistsAndNotRequestedButAlreadyCreatedInDatabase() {
-
+        when(azureResourceIdProviderService.generateDeploymentId(any(), any(), any())).thenReturn(DEPLOYMENT_ID);
+        when(azureResourceDeploymentHelperService.getAzureNetwork(any(), any(), any())).thenReturn(mock(Network.class));
+        when(client.getCurrentSubscription()).thenReturn(mock(Subscription.class));
+        when(client.getCurrentSubscription().subscriptionId()).thenReturn(SUBSCRIPTION_ID);
         when(client.checkIfDnsZonesDeployed(any(), any())).thenReturn(false);
         when(azureResourcePersistenceHelperService.isRequested(DEPLOYMENT_ID, AZURE_PRIVATE_DNS_ZONE)).thenReturn(false);
         when(azureResourcePersistenceHelperService.isCreated(DEPLOYMENT_ID, AZURE_PRIVATE_DNS_ZONE)).thenReturn(true);
@@ -131,7 +136,10 @@ public class AzureDnsZoneServiceTest {
 
     @Test
     public void testCheckOrCreateWhenDnsZoneResourceNotExistsAndNotRequestedAndNotCreatedInDatabase() {
-
+        when(azureResourceIdProviderService.generateDeploymentId(any(), any(), any())).thenReturn(DEPLOYMENT_ID);
+        when(azureResourceDeploymentHelperService.getAzureNetwork(any(), any(), any())).thenReturn(mock(Network.class));
+        when(client.getCurrentSubscription()).thenReturn(mock(Subscription.class));
+        when(client.getCurrentSubscription().subscriptionId()).thenReturn(SUBSCRIPTION_ID);
         when(client.checkIfDnsZonesDeployed(any(), any())).thenReturn(false);
         when(azureResourcePersistenceHelperService.isRequested(DEPLOYMENT_ID, AZURE_PRIVATE_DNS_ZONE)).thenReturn(false);
         when(azureResourcePersistenceHelperService.isCreated(DEPLOYMENT_ID, AZURE_PRIVATE_DNS_ZONE)).thenReturn(false);
@@ -145,15 +153,22 @@ public class AzureDnsZoneServiceTest {
         verify(azureResourceDeploymentHelperService, times(0)).pollForCreation(any(), any());
     }
 
-    @Test(expected = CloudConnectorException.class)
+    @Test
     public void testCheckOrCreateWhenDnsZoneResourceNotExistsAndNotRequestedAndNotCreatedInDatabaseAndError() {
-
+        when(azureResourceIdProviderService.generateDeploymentId(any(), any(), any())).thenReturn(DEPLOYMENT_ID);
+        when(azureResourceDeploymentHelperService.getAzureNetwork(any(), any(), any())).thenReturn(mock(Network.class));
+        when(client.getCurrentSubscription()).thenReturn(mock(Subscription.class));
+        when(client.getCurrentSubscription().subscriptionId()).thenReturn(SUBSCRIPTION_ID);
         when(client.checkIfDnsZonesDeployed(any(), any())).thenReturn(false);
         when(azureResourcePersistenceHelperService.isRequested(DEPLOYMENT_ID, AZURE_PRIVATE_DNS_ZONE)).thenReturn(false);
         when(azureResourcePersistenceHelperService.isCreated(DEPLOYMENT_ID, AZURE_PRIVATE_DNS_ZONE)).thenReturn(false);
-        doThrow(new CloudConnectorException("", null)).when(azureResourceDeploymentHelperService).deployTemplate(any(), any());
+        doThrow(new CloudConnectorException("some message", null)).when(azureResourceDeploymentHelperService).deployTemplate(any(), any());
 
-        underTest.checkOrCreateDnsZones(ac, client, getNetworkView(), RESOURCE_GROUP, Collections.emptyMap(), Set.of());
+        CloudConnectorException exception = assertThrows(CloudConnectorException.class, () -> {
+            underTest.checkOrCreateDnsZones(ac, client, getNetworkView(), RESOURCE_GROUP, Collections.emptyMap(), Set.of());
+        });
+
+        assertEquals("some message", exception.getMessage());
 
         verify(azureResourcePersistenceHelperService, times(1)).persistCloudResource(any(), any(), any(), any());
         verify(azureResourcePersistenceHelperService, times(0)).updateCloudResource(any(), any(), any(), any(), any());

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureLoadBalancerMetadataCollectorTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureLoadBalancerMetadataCollectorTest.java
@@ -9,11 +9,11 @@ import static org.mockito.Mockito.when;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.microsoft.azure.management.compute.AvailabilitySet;
 import com.microsoft.azure.management.network.LoadBalancerBackend;
@@ -29,7 +29,7 @@ import com.sequenceiq.cloudbreak.cloud.model.Location;
 import com.sequenceiq.cloudbreak.cloud.model.Region;
 import com.sequenceiq.cloudbreak.cloud.model.instance.AvailabilitySetNameService;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AzureLoadBalancerMetadataCollectorTest {
 
     private static final Long WORKSPACE_ID = 1L;

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureMetadataCollectorTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureMetadataCollectorTest.java
@@ -1,7 +1,7 @@
 package com.sequenceiq.cloudbreak.cloud.azure;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
@@ -15,11 +15,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.microsoft.azure.management.compute.VirtualMachine;
 import com.microsoft.azure.management.network.NetworkInterface;
@@ -42,7 +42,7 @@ import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.LoadBalancerType;
 import com.sequenceiq.common.api.type.ResourceType;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AzureMetadataCollectorTest {
 
     private static final List<CloudInstance> KNOWN_INSTANCES = Collections.emptyList();

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureNetworkDnsZoneTemplateBuilderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureNetworkDnsZoneTemplateBuilderTest.java
@@ -1,6 +1,6 @@
 package com.sequenceiq.cloudbreak.cloud.azure;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -9,12 +9,12 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.ui.freemarker.FreeMarkerConfigurationFactoryBean;
 
@@ -25,7 +25,7 @@ import com.sequenceiq.cloudbreak.util.FreeMarkerTemplateUtils;
 
 import freemarker.template.TemplateException;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AzureNetworkDnsZoneTemplateBuilderTest {
 
     @Mock
@@ -34,7 +34,7 @@ public class AzureNetworkDnsZoneTemplateBuilderTest {
     @InjectMocks
     private AzureNetworkDnsZoneTemplateBuilder underTest;
 
-    @Before
+    @BeforeEach
     public void before() throws IOException, TemplateException {
         FreeMarkerConfigurationFactoryBean factoryBean = new FreeMarkerConfigurationFactoryBean();
         factoryBean.setPreferFileSystemAccess(false);

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureNetworkLinkServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureNetworkLinkServiceTest.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.cloudbreak.cloud.azure;
 
 import static com.sequenceiq.common.api.type.ResourceType.AZURE_VIRTUAL_NETWORK_LINK;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -12,12 +14,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.microsoft.azure.management.network.Network;
 import com.microsoft.azure.management.resources.Subscription;
@@ -29,7 +31,7 @@ import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AzureNetworkLinkServiceTest {
 
     private static final Long STACK_ID = 12L;
@@ -65,7 +67,7 @@ public class AzureNetworkLinkServiceTest {
     @Mock
     private AzureClient client;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         CloudContext cloudContext = CloudContext.Builder.builder()
                 .withId(STACK_ID)
@@ -75,10 +77,6 @@ public class AzureNetworkLinkServiceTest {
         CloudCredential cloudCredential = new CloudCredential(STACK_ID.toString(), "", "account");
         ac = new AuthenticatedContext(cloudContext, cloudCredential);
 
-        when(azureResourceIdProviderService.generateDeploymentId(any(), any(), any())).thenReturn(DEPLOYMENT_ID);
-        when(azureResourceDeploymentHelperService.getAzureNetwork(any(), any(), any())).thenReturn(mock(Network.class));
-        when(client.getCurrentSubscription()).thenReturn(mock(Subscription.class));
-        when(client.getCurrentSubscription().subscriptionId()).thenReturn(SUBSCRIPTION_ID);
         when(azurePrivateEndpointServicesProvider.getCdpManagedDnsZones(any()))
                 .thenReturn(List.of(AzurePrivateDnsZoneServiceEnum.STORAGE, AzurePrivateDnsZoneServiceEnum.POSTGRES));
     }
@@ -100,7 +98,9 @@ public class AzureNetworkLinkServiceTest {
 
     @Test
     public void testCheckOrCreateWhenNetworkLinkNotExistsButRequested() {
-
+        when(azureResourceIdProviderService.generateDeploymentId(any(), any(), any())).thenReturn(DEPLOYMENT_ID);
+        when(client.getCurrentSubscription()).thenReturn(mock(Subscription.class));
+        when(client.getCurrentSubscription().subscriptionId()).thenReturn(SUBSCRIPTION_ID);
         when(client.checkIfNetworkLinksDeployed(any(), any(), any())).thenReturn(false);
         when(azureResourcePersistenceHelperService.isRequested(DEPLOYMENT_ID, AZURE_VIRTUAL_NETWORK_LINK)).thenReturn(true);
 
@@ -115,7 +115,10 @@ public class AzureNetworkLinkServiceTest {
 
     @Test
     public void testCheckOrCreateWhenNetworkLinkNotExistsAndNotRequestedButAlreadyCreatedInDatabase() {
-
+        when(azureResourceIdProviderService.generateDeploymentId(any(), any(), any())).thenReturn(DEPLOYMENT_ID);
+        when(azureResourceDeploymentHelperService.getAzureNetwork(any(), any(), any())).thenReturn(mock(Network.class));
+        when(client.getCurrentSubscription()).thenReturn(mock(Subscription.class));
+        when(client.getCurrentSubscription().subscriptionId()).thenReturn(SUBSCRIPTION_ID);
         when(client.checkIfNetworkLinksDeployed(any(), any(), any())).thenReturn(false);
         when(azureResourcePersistenceHelperService.isRequested(DEPLOYMENT_ID, AZURE_VIRTUAL_NETWORK_LINK)).thenReturn(false);
         when(azureResourcePersistenceHelperService.isCreated(DEPLOYMENT_ID, AZURE_VIRTUAL_NETWORK_LINK)).thenReturn(true);
@@ -131,7 +134,10 @@ public class AzureNetworkLinkServiceTest {
 
     @Test
     public void testCheckOrCreateWhenNetworkLinkNotExistsAndNotRequestedAndNotCreatedInDatabase() {
-
+        when(azureResourceIdProviderService.generateDeploymentId(any(), any(), any())).thenReturn(DEPLOYMENT_ID);
+        when(azureResourceDeploymentHelperService.getAzureNetwork(any(), any(), any())).thenReturn(mock(Network.class));
+        when(client.getCurrentSubscription()).thenReturn(mock(Subscription.class));
+        when(client.getCurrentSubscription().subscriptionId()).thenReturn(SUBSCRIPTION_ID);
         when(client.checkIfNetworkLinksDeployed(any(), any(), any())).thenReturn(false);
         when(azureResourcePersistenceHelperService.isRequested(DEPLOYMENT_ID, AZURE_VIRTUAL_NETWORK_LINK)).thenReturn(false);
         when(azureResourcePersistenceHelperService.isCreated(DEPLOYMENT_ID, AZURE_VIRTUAL_NETWORK_LINK)).thenReturn(false);
@@ -145,16 +151,23 @@ public class AzureNetworkLinkServiceTest {
         verify(azureResourceDeploymentHelperService, times(0)).pollForCreation(any(), any());
     }
 
-    @Test(expected = CloudConnectorException.class)
+    @Test
     public void testCheckOrCreateWhenNetworkLinkNotExistsAndNotRequestedAndNotCreatedInDatabaseAndError() {
-
+        when(azureResourceIdProviderService.generateDeploymentId(any(), any(), any())).thenReturn(DEPLOYMENT_ID);
+        when(azureResourceDeploymentHelperService.getAzureNetwork(any(), any(), any())).thenReturn(mock(Network.class));
+        when(client.getCurrentSubscription()).thenReturn(mock(Subscription.class));
+        when(client.getCurrentSubscription().subscriptionId()).thenReturn(SUBSCRIPTION_ID);
         when(client.checkIfNetworkLinksDeployed(any(), any(), any())).thenReturn(false);
         when(azureResourcePersistenceHelperService.isRequested(DEPLOYMENT_ID, AZURE_VIRTUAL_NETWORK_LINK)).thenReturn(false);
         when(azureResourcePersistenceHelperService.isCreated(DEPLOYMENT_ID, AZURE_VIRTUAL_NETWORK_LINK)).thenReturn(false);
         when(azurePrivateEndpointServicesProvider.getCdpManagedDnsZones(any())).thenReturn(List.of(AzurePrivateDnsZoneServiceEnum.POSTGRES));
-        doThrow(new CloudConnectorException("", null)).when(azureResourceDeploymentHelperService).deployTemplate(any(), any());
+        doThrow(new CloudConnectorException("text", null)).when(azureResourceDeploymentHelperService).deployTemplate(any(), any());
 
-        underTest.checkOrCreateNetworkLinks(ac, client, getNetworkView(), RESOURCE_GROUP, Collections.emptyMap(), Set.of());
+        CloudConnectorException exception = assertThrows(CloudConnectorException.class, () -> {
+            underTest.checkOrCreateNetworkLinks(ac, client, getNetworkView(), RESOURCE_GROUP, Collections.emptyMap(), Set.of());
+        });
+
+        assertEquals("text", exception.getMessage());
 
         verify(azureResourcePersistenceHelperService, times(1)).persistCloudResource(any(), any(), any(), any());
         verify(azureResourcePersistenceHelperService, times(0)).updateCloudResource(any(), any(), any(), any(), any());

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureNetworkTemplateBuilderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureNetworkTemplateBuilderTest.java
@@ -1,7 +1,7 @@
 package com.sequenceiq.cloudbreak.cloud.azure;
 
 import static com.sequenceiq.cloudbreak.cloud.model.network.SubnetType.PUBLIC;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.mock;
@@ -13,12 +13,12 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.ui.freemarker.FreeMarkerConfigurationFactoryBean;
 
@@ -36,7 +36,7 @@ import com.sequenceiq.common.model.PrivateEndpointType;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AzureNetworkTemplateBuilderTest {
 
     private static final String ENV_NAME = "testEnv";
@@ -57,7 +57,7 @@ public class AzureNetworkTemplateBuilderTest {
     @Mock
     private FreeMarkerTemplateUtils freeMarkerTemplateUtils;
 
-    @Before
+    @BeforeEach
     public void before() throws IOException, TemplateException {
         FreeMarkerConfigurationFactoryBean factoryBean = new FreeMarkerConfigurationFactoryBean();
         factoryBean.setPreferFileSystemAccess(false);

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePlatformParametersTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePlatformParametersTest.java
@@ -1,17 +1,17 @@
 package com.sequenceiq.cloudbreak.cloud.azure;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.security.SecureRandom;
 import java.util.Map;
 
 import org.hamcrest.core.IsInstanceOf;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 
 import com.google.common.collect.Maps;
@@ -42,7 +42,7 @@ public class AzurePlatformParametersTest {
     @InjectMocks
     private AzurePlatformParameters underTest;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         initMocks(this);
     }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePremiumInstanceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePremiumInstanceTest.java
@@ -2,31 +2,21 @@ package com.sequenceiq.cloudbreak.cloud.azure;
 
 import java.util.Arrays;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.cloud.azure.validator.AzurePremiumValidatorService;
 
-@RunWith(Parameterized.class)
+@ExtendWith(MockitoExtension.class)
 public class AzurePremiumInstanceTest {
 
     @InjectMocks
     private final AzurePremiumValidatorService underTest = new AzurePremiumValidatorService();
 
-    private final String instanceType;
-
-    private final boolean premiumInstance;
-
-    public AzurePremiumInstanceTest(String instanceType, boolean premiumInstance) {
-        this.instanceType = instanceType;
-        this.premiumInstance = premiumInstance;
-    }
-
-    @Parameters(name = "{index}: instanceType is premium({0})={1}")
     public static Iterable<Object[]> data() {
         return Arrays.asList(new Object[][]{
                 {"Standard_A4", false},
@@ -182,8 +172,9 @@ public class AzurePremiumInstanceTest {
         });
     }
 
-    @Test
-    public void testPremiumInstanceWhichDependsOnThePremiumVariable() {
-        Assert.assertEquals(premiumInstance, underTest.validPremiumConfiguration(instanceType));
+    @ParameterizedTest(name = "{index}: instanceType is premium({0})={1}")
+    @MethodSource("data")
+    public void testPremiumInstanceWhichDependsOnThePremiumVariable(String instanceType, boolean premiumInstance) {
+        Assertions.assertEquals(premiumInstance, underTest.validPremiumConfiguration(instanceType));
     }
 }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnectorTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnectorTest.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.cloud.azure;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -12,13 +13,13 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.microsoft.azure.management.resources.Deployment;
 import com.microsoft.azure.management.resources.DeploymentExportResult;
@@ -46,7 +47,7 @@ import com.sequenceiq.cloudbreak.service.Retry;
 import com.sequenceiq.common.api.adjustment.AdjustmentTypeWithThreshold;
 import com.sequenceiq.common.api.type.AdjustmentType;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AzureResourceConnectorTest {
 
     private static final AdjustmentType ADJUSTMENT_TYPE = AdjustmentType.EXACT;
@@ -124,7 +125,7 @@ public class AzureResourceConnectorTest {
 
     private Image imageModel;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         DeploymentExportResult deploymentExportResult = mock(DeploymentExportResult.class);
         Group group = mock(Group.class);
@@ -136,19 +137,19 @@ public class AzureResourceConnectorTest {
         AzureImage image = new AzureImage("id", "name", true);
         imageModel = new Image(IMAGE_NAME, new HashMap<>(), "centos7", "redhat7", "", "default", "default-id", new HashMap<>());
 
-        when(stack.getGroups()).thenReturn(groups);
-        when(stack.getNetwork()).thenReturn(network);
-        when(stack.getImage()).thenReturn(imageModel);
-        when(ac.getCloudContext()).thenReturn(cloudContext);
-        when(ac.getParameter(AzureClient.class)).thenReturn(client);
-        when(ac.getCloudCredential()).thenReturn(new CloudCredential("aCredentialId", "aCredentialName", "account"));
-        when(azureUtils.getStackName(cloudContext)).thenReturn(STACK_NAME);
-        when(azureStorage.getCustomImage(any(), any(), any())).thenReturn(image);
-        when(deployment.exportTemplate()).thenReturn(deploymentExportResult);
-        when(azureResourceGroupMetadataProvider.getResourceGroupName(cloudContext, stack)).thenReturn(RESOURCE_GROUP_NAME);
-        when(azureCloudResourceService.getDeploymentCloudResources(deployment)).thenReturn(instances);
-        when(azureCloudResourceService.getInstanceCloudResources(STACK_NAME, instances, groups, RESOURCE_GROUP_NAME)).thenReturn(instances);
-        when(azureStackViewProvider.getAzureStack(any(), eq(stack), eq(client), eq(ac))).thenReturn(azureStackView);
+        lenient().when(stack.getGroups()).thenReturn(groups);
+        lenient().when(stack.getNetwork()).thenReturn(network);
+        lenient().when(stack.getImage()).thenReturn(imageModel);
+        lenient().when(ac.getCloudContext()).thenReturn(cloudContext);
+        lenient().when(ac.getParameter(AzureClient.class)).thenReturn(client);
+        lenient().when(ac.getCloudCredential()).thenReturn(new CloudCredential("aCredentialId", "aCredentialName", "account"));
+        lenient().when(azureUtils.getStackName(cloudContext)).thenReturn(STACK_NAME);
+        lenient().when(azureStorage.getCustomImage(any(), any(), any())).thenReturn(image);
+        lenient().when(deployment.exportTemplate()).thenReturn(deploymentExportResult);
+        lenient().when(azureResourceGroupMetadataProvider.getResourceGroupName(cloudContext, stack)).thenReturn(RESOURCE_GROUP_NAME);
+        lenient().when(azureCloudResourceService.getDeploymentCloudResources(deployment)).thenReturn(instances);
+        lenient().when(azureCloudResourceService.getInstanceCloudResources(STACK_NAME, instances, groups, RESOURCE_GROUP_NAME)).thenReturn(instances);
+        lenient().when(azureStackViewProvider.getAzureStack(any(), eq(stack), eq(client), eq(ac))).thenReturn(azureStackView);
     }
 
     @Test
@@ -221,7 +222,7 @@ public class AzureResourceConnectorTest {
     @Test
     public void testLaunchLoadBalancerHandlesGracefully() throws Exception {
         List<CloudResourceStatus> cloudResourceStatuses = underTest.launchLoadBalancers(ac, stack, notifier);
-        Assert.assertEquals(0, cloudResourceStatuses.size());
+        Assertions.assertEquals(0, cloudResourceStatuses.size());
     }
 
     @Test
@@ -231,7 +232,7 @@ public class AzureResourceConnectorTest {
                 .thenReturn(List.of(new CloudResourceStatus(instances.get(0), ResourceStatus.DELETED)));
         List<CloudResourceStatus> statuses = underTest.terminate(ac, stack, new ArrayList<>(instances));
         for (CloudResourceStatus status : statuses) {
-            Assert.assertEquals(ResourceStatus.DELETED, status.getStatus());
+            Assertions.assertEquals(ResourceStatus.DELETED, status.getStatus());
         }
     }
 

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStorageTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStorageTest.java
@@ -1,7 +1,7 @@
 package com.sequenceiq.cloudbreak.cloud.azure;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -11,8 +11,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -65,7 +65,7 @@ public class AzureStorageTest {
     @InjectMocks
     private AzureStorage underTest;
 
-    @Before
+    @BeforeEach
     public void setup() {
         MockitoAnnotations.initMocks(this);
     }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClientTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClientTest.java
@@ -14,7 +14,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -130,7 +130,7 @@ class AzureClientTest {
 
         underTest.attachDiskToVm(disk, virtualMachine);
         verify(virtualMachineUpdate, times(1)).withDataDiskDefaultCachingType(captor.capture());
-        Assert.assertEquals(CachingTypes.NONE, captor.getValue());
+        Assertions.assertEquals(CachingTypes.NONE, captor.getValue());
     }
 
     @Test
@@ -155,7 +155,7 @@ class AzureClientTest {
 
         underTest.attachDiskToVm(disk, virtualMachine);
         verify(virtualMachineUpdate, times(1)).withDataDiskDefaultCachingType(captor.capture());
-        Assert.assertEquals(CachingTypes.READ_ONLY, captor.getValue());
+        Assertions.assertEquals(CachingTypes.READ_ONLY, captor.getValue());
     }
 
     @Test
@@ -180,7 +180,7 @@ class AzureClientTest {
 
         underTest.attachDiskToVm(disk, virtualMachine);
         verify(virtualMachineUpdate, times(1)).withDataDiskDefaultCachingType(captor.capture());
-        Assert.assertEquals(CachingTypes.READ_ONLY, captor.getValue());
+        Assertions.assertEquals(CachingTypes.READ_ONLY, captor.getValue());
     }
 
     @Test
@@ -212,11 +212,11 @@ class AzureClientTest {
                 .withPermissions(new Permissions().withKeys(List.of(KeyPermissions.WRAP_KEY, KeyPermissions.UNWRAP_KEY))));
 
 
-        Assert.assertTrue(underTest.checkKeyVaultAccessPolicyListForServicePrincipal(accessPolicies, "100"));
-        Assert.assertFalse(underTest.checkKeyVaultAccessPolicyListForServicePrincipal(accessPolicies, "200"));
-        Assert.assertFalse(underTest.checkKeyVaultAccessPolicyListForServicePrincipal(accessPolicies, "300"));
-        Assert.assertFalse(underTest.checkKeyVaultAccessPolicyListForServicePrincipal(accessPolicies, "400"));
-        Assert.assertFalse(underTest.checkKeyVaultAccessPolicyListForServicePrincipal(accessPolicies, "dummy"));
+        Assertions.assertTrue(underTest.checkKeyVaultAccessPolicyListForServicePrincipal(accessPolicies, "100"));
+        Assertions.assertFalse(underTest.checkKeyVaultAccessPolicyListForServicePrincipal(accessPolicies, "200"));
+        Assertions.assertFalse(underTest.checkKeyVaultAccessPolicyListForServicePrincipal(accessPolicies, "300"));
+        Assertions.assertFalse(underTest.checkKeyVaultAccessPolicyListForServicePrincipal(accessPolicies, "400"));
+        Assertions.assertFalse(underTest.checkKeyVaultAccessPolicyListForServicePrincipal(accessPolicies, "dummy"));
     }
 
     @Test

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureImageInfoServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureImageInfoServiceTest.java
@@ -1,12 +1,12 @@
 package com.sequenceiq.cloudbreak.cloud.azure.image;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -49,7 +49,7 @@ public class AzureImageInfoServiceTest {
     @Mock
     private AzureClient azureClient;
 
-    @Before
+    @BeforeEach
     public void setup() {
         MockitoAnnotations.initMocks(this);
     }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureManagedImageServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureManagedImageServiceTest.java
@@ -1,20 +1,20 @@
 package com.sequenceiq.cloudbreak.cloud.azure.image;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 
-import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.microsoft.azure.management.compute.VirtualMachineCustomImage;
 import com.microsoft.azure.management.compute.implementation.ImageInner;
@@ -22,7 +22,7 @@ import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
 import com.sequenceiq.cloudbreak.cloud.azure.util.AzureAuthExceptionHandler;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AzureManagedImageServiceTest {
 
     private static final String RESOURCE_GROUP = "resource-group";
@@ -80,8 +80,7 @@ public class AzureManagedImageServiceTest {
         when(image.inner()).thenReturn(imageInner);
         when(imageInner.provisioningState()).thenReturn("Failed");
 
-        CloudConnectorException actual = Assertions.assertThrows(CloudConnectorException.class, () ->
-                underTest.findVirtualMachineCustomImage(azureImageInfo, azureClient));
+        CloudConnectorException actual = assertThrows(CloudConnectorException.class, () -> underTest.findVirtualMachineCustomImage(azureImageInfo, azureClient));
 
         assertEquals("Image (resource-group/image-name-with-region) creation failed in Azure, please check the reason on Azure Portal!", actual.getMessage());
         verify(azureClient).findImage(RESOURCE_GROUP, IMAGE_NAME_WITH_REGION);

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureResourceIdProviderServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureResourceIdProviderServiceTest.java
@@ -1,7 +1,9 @@
 package com.sequenceiq.cloudbreak.cloud.azure.image;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
 
 import com.sequenceiq.cloudbreak.cloud.azure.resource.AzureResourceIdProviderService;
 
@@ -27,7 +29,7 @@ public class AzureResourceIdProviderServiceTest {
 
         String actual = underTest.generateImageId(SUBSCRIPTION_ID, RESOURCE_GROUP, IMAGE_NAME);
 
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -36,7 +38,7 @@ public class AzureResourceIdProviderServiceTest {
 
         String actual = underTest.generateDeploymentId(SUBSCRIPTION_ID, RESOURCE_GROUP, DEPLOYMENT_NAME);
 
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -46,36 +48,60 @@ public class AzureResourceIdProviderServiceTest {
 
         String actual = underTest.generateNetworkLinkId(SUBSCRIPTION_ID, RESOURCE_GROUP, SERVICE_ID, NETWORK_ID);
 
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGenerateImageIdShouldThrowExceptionWhenSubscriptionIdIsNull() {
-        underTest.generateImageId(null, RESOURCE_GROUP, IMAGE_NAME);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            underTest.generateImageId(null, RESOURCE_GROUP, IMAGE_NAME);
+        });
+
+        assertEquals("Subscription id must not be null or empty.", exception.getMessage());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGenerateImageIdShouldThrowExceptionWhenResourceGroupIsNull() {
-        underTest.generateImageId(SUBSCRIPTION_ID, null, IMAGE_NAME);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            underTest.generateImageId(SUBSCRIPTION_ID, null, IMAGE_NAME);
+        });
+
+        assertEquals("Resource group must not be null or empty.", exception.getMessage());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGenerateImageIdShouldThrowExceptionWhenTheImageNameIsNull() {
-        underTest.generateImageId(SUBSCRIPTION_ID, RESOURCE_GROUP, null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            underTest.generateImageId(SUBSCRIPTION_ID, RESOURCE_GROUP, null);
+        });
+
+        assertEquals("Image name must not be null or empty.", exception.getMessage());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGenerateDnsZoneDeploymentIdShouldThrowExceptionWhenSubscriptionIdIsNull() {
-        underTest.generateImageId(null, RESOURCE_GROUP, IMAGE_NAME);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            underTest.generateImageId(null, RESOURCE_GROUP, IMAGE_NAME);
+        });
+
+        assertEquals("Subscription id must not be null or empty.", exception.getMessage());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGenerateDnsZoneDeploymentIdShouldThrowExceptionWhenResourceGroupIsNull() {
-        underTest.generateImageId(SUBSCRIPTION_ID, null, IMAGE_NAME);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            underTest.generateImageId(SUBSCRIPTION_ID, null, IMAGE_NAME);
+        });
+
+        assertEquals("Resource group must not be null or empty.", exception.getMessage());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGenerateDnsZoneDeploymentIdShouldThrowExceptionWhenDeploymentIdIsNull() {
-        underTest.generateImageId(SUBSCRIPTION_ID, RESOURCE_GROUP, null);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            underTest.generateImageId(SUBSCRIPTION_ID, RESOURCE_GROUP, null);
+        });
+
+        assertEquals("Image name must not be null or empty.", exception.getMessage());
     }
 }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureRegionProviderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureRegionProviderTest.java
@@ -8,13 +8,13 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.microsoft.azure.management.resources.fluentcore.arm.Region;
@@ -24,7 +24,7 @@ import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 import com.sequenceiq.cloudbreak.service.CloudbreakResourceReaderService;
 import com.sequenceiq.cloudbreak.util.FileReaderUtils;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AzureRegionProviderTest {
 
     private static final String ENABLED_REGIONS_FILE = "enabled-regions";
@@ -37,7 +37,7 @@ public class AzureRegionProviderTest {
 
     private String testRegionsJson;
 
-    @Before
+    @BeforeEach
     public void before() throws IOException {
         ReflectionTestUtils.setField(underTest, "armZoneParameterDefault", "North Europe");
         testRegionsJson = getTestRegions();
@@ -53,7 +53,7 @@ public class AzureRegionProviderTest {
 
         assertRegionNames(actual, azureRegions);
         assertCoordinates(actual);
-        Assert.assertEquals("North Europe", actual.getDefaultRegion());
+        Assertions.assertEquals("North Europe", actual.getDefaultRegion());
     }
 
     @Test
@@ -64,7 +64,7 @@ public class AzureRegionProviderTest {
         CloudRegions actual = underTest.regions(null, azureRegions, List.of());
 
         assertRegionNames(actual, supportedAzureRegions);
-        Assert.assertEquals("North Europe", actual.getDefaultRegion());
+        Assertions.assertEquals("North Europe", actual.getDefaultRegion());
     }
 
     private String getTestRegions() throws IOException {
@@ -80,7 +80,7 @@ public class AzureRegionProviderTest {
     }
 
     private void assertRegionNames(CloudRegions actual, Collection<Region> azureRegions) {
-        Assert.assertTrue(azureRegions.stream()
+        Assertions.assertTrue(azureRegions.stream()
                 .allMatch(region -> actual.getCloudRegions().keySet()
                         .stream().map(com.sequenceiq.cloudbreak.cloud.model.Region::getRegionName)
                         .collect(Collectors.toSet())
@@ -89,7 +89,7 @@ public class AzureRegionProviderTest {
 
     private void assertCoordinates(CloudRegions actual) throws IOException {
         RegionCoordinateSpecifications regionCoordinateSpecifications = getRegionsFromFile();
-        Assert.assertTrue(actual.getCoordinates().values().stream()
+        Assertions.assertTrue(actual.getCoordinates().values().stream()
                 .allMatch(coordinate -> regionCoordinateSpecifications.getItems().stream()
                         .anyMatch(region -> region.getLatitude().equals(coordinate.getLatitude().toString()) &&
                                 region.getLongitude().equals(coordinate.getLongitude().toString()))));

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/storage/SkuTypeResolverTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/storage/SkuTypeResolverTest.java
@@ -1,37 +1,29 @@
 package com.sequenceiq.cloudbreak.cloud.azure.storage;
 
-import static org.junit.runners.Parameterized.Parameters;
-
 import java.util.Arrays;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.microsoft.azure.management.storage.StorageAccountSkuType;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureDiskType;
 
-@RunWith(Parameterized.class)
+@ExtendWith(MockitoExtension.class)
 public class SkuTypeResolverTest {
 
-    private SkuTypeResolver underTest;
+    private SkuTypeResolver underTest = new SkuTypeResolver();
 
-    private DiskTypeSkuPair pair;
-
-    public SkuTypeResolverTest(DiskTypeSkuPair pair) {
-        this.pair = pair;
-        underTest = new SkuTypeResolver();
-    }
-
-    @Test
-    public void testResolving() {
+    @ParameterizedTest(name = "{index}: ({0})={1}")
+    @MethodSource("data")
+    public void testResolving(DiskTypeSkuPair pair) {
         StorageAccountSkuType result = underTest.resolveFromAzureDiskType(pair.getAzureDiskType());
 
-        Assert.assertEquals(pair.getExpectedStorageAccountSkuType().name(), result.name());
+        Assertions.assertEquals(pair.getExpectedStorageAccountSkuType().name(), result.name());
     }
 
-    @Parameters(name = "{index}: ({0})={1}")
     public static Iterable<DiskTypeSkuPair> data() {
         return Arrays.asList(DiskTypeSkuPair.values());
     }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/subnet/selector/AzureSubnetSelectorServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/subnet/selector/AzureSubnetSelectorServiceTest.java
@@ -2,13 +2,13 @@ package com.sequenceiq.cloudbreak.cloud.azure.subnet.selector;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
 import com.sequenceiq.cloudbreak.cloud.model.SubnetSelectionParameters;

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/task/image/AzureManagedImageCreationPollerTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/task/image/AzureManagedImageCreationPollerTest.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.cloud.azure.task.image;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
@@ -7,26 +9,19 @@ import static org.mockito.Mockito.when;
 
 import java.util.concurrent.TimeoutException;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.cloud.azure.image.AzureImageInfo;
 import com.sequenceiq.cloudbreak.cloud.azure.task.AzurePollTaskFactory;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.scheduler.SyncPollingScheduler;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AzureManagedImageCreationPollerTest {
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @Mock
     private AzurePollTaskFactory azurePollTaskFactory;
@@ -37,20 +32,18 @@ public class AzureManagedImageCreationPollerTest {
     @InjectMocks
     private AzureManagedImageCreationPoller underTest;
 
-    @Before
-    public void setup() {
-        MockitoAnnotations.initMocks(this);
-    }
-
     @Test
     public void testWhenTimeoutExceptionThenIsNotCaught() throws Exception {
         AuthenticatedContext ac = mock(AuthenticatedContext.class);
         AzureManagedImageCreationCheckerContext checkerContext = mock(AzureManagedImageCreationCheckerContext.class);
         when(checkerContext.getAzureImageInfo()).thenReturn(new AzureImageInfo("", "", "", "", ""));
 
-        when(syncPollingScheduler.schedule(any(), anyInt(), anyInt(), anyInt())).thenThrow(new TimeoutException());
-        thrown.expect(TimeoutException.class);
+        when(syncPollingScheduler.schedule(any(), anyInt(), anyInt(), anyInt())).thenThrow(new TimeoutException("some text"));
 
-        underTest.startPolling(ac, checkerContext);
+        TimeoutException exception = assertThrows(TimeoutException.class, () -> {
+            underTest.startPolling(ac, checkerContext);
+        });
+
+        assertEquals("some text", exception.getMessage());
     }
 }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/template/AzureTemplateDeploymentServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/template/AzureTemplateDeploymentServiceTest.java
@@ -1,7 +1,7 @@
 package com.sequenceiq.cloudbreak.cloud.azure.template;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/template/AzureTransientDeploymentServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/template/AzureTransientDeploymentServiceTest.java
@@ -1,6 +1,6 @@
 package com.sequenceiq.cloudbreak.cloud.azure.template;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -8,11 +8,11 @@ import static org.mockito.Mockito.when;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.microsoft.azure.management.resources.Deployment;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureCloudResourceService;
@@ -22,7 +22,7 @@ import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.ResourceType;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AzureTransientDeploymentServiceTest {
 
     private static final String RESOURCE_GROUP = "resource_group";

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/upscale/AzureUpscaleServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/upscale/AzureUpscaleServiceTest.java
@@ -1,8 +1,8 @@
 package com.sequenceiq.cloudbreak.cloud.azure.upscale;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
@@ -15,14 +15,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.microsoft.azure.CloudError;
 import com.microsoft.azure.CloudException;
@@ -56,7 +55,7 @@ import com.sequenceiq.common.api.type.AdjustmentType;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.ResourceType;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AzureUpscaleServiceTest {
 
     private static final Map<String, Object> PARAMETERS = Collections.emptyMap();
@@ -105,7 +104,7 @@ public class AzureUpscaleServiceTest {
     @Mock
     private AzureCloudResourceService azureCloudResourceService;
 
-    @Before
+    @BeforeEach
     public void before() {
         when(azureUtils.getStackName(any(CloudContext.class))).thenReturn(STACK_NAME);
         when(azureResourceGroupMetadataProvider.getResourceGroupName(any(CloudContext.class), eq(stack))).thenReturn(RESOURCE_GROUP);
@@ -177,7 +176,7 @@ public class AzureUpscaleServiceTest {
                 .thenThrow(cloudException);
 
         AdjustmentTypeWithThreshold adjustmentTypeWithThreshold = new AdjustmentTypeWithThreshold(AdjustmentType.EXACT, 0L);
-        QuotaExceededException quotaExceededException = Assertions.assertThrows(QuotaExceededException.class, () -> {
+        QuotaExceededException quotaExceededException = assertThrows(QuotaExceededException.class, () -> {
             underTest.upscale(ac, stack, resources, azureStackView, client,
                     adjustmentTypeWithThreshold);
         });

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/util/CustomVMImageNameProviderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/util/CustomVMImageNameProviderTest.java
@@ -1,13 +1,13 @@
 package com.sequenceiq.cloudbreak.cloud.azure.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.regex.Pattern;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 
 public class CustomVMImageNameProviderTest {
@@ -18,7 +18,7 @@ public class CustomVMImageNameProviderTest {
     @InjectMocks
     private CustomVMImageNameProvider underTest;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         initMocks(this);
     }
@@ -30,8 +30,8 @@ public class CustomVMImageNameProviderTest {
 
         String actual = underTest.getImageNameWithRegion(region, vhdName);
 
-        Assert.assertTrue(IMAGE_NAME_PATTERN.matcher(actual).matches());
-        Assert.assertEquals("cb-hdp-26-1907121707-osDisk.cc5baaaa-717e-4551-b7ae-aaaa03c72a6a.vhd-westus", actual);
+        Assertions.assertTrue(IMAGE_NAME_PATTERN.matcher(actual).matches());
+        Assertions.assertEquals("cb-hdp-26-1907121707-osDisk.cc5baaaa-717e-4551-b7ae-aaaa03c72a6a.vhd-westus", actual);
     }
 
     @Test
@@ -41,8 +41,8 @@ public class CustomVMImageNameProviderTest {
 
         String actual = underTest.getImageNameWithRegion(region, vhdName);
 
-        Assert.assertTrue(IMAGE_NAME_PATTERN.matcher(actual).matches());
-        Assert.assertEquals("cb-hdp-26-1907121707-osDisk.cc5baaaa-717e-4551-b7ae-aaaa03c72a6a.v-southeastasia", actual);
+        Assertions.assertTrue(IMAGE_NAME_PATTERN.matcher(actual).matches());
+        Assertions.assertEquals("cb-hdp-26-1907121707-osDisk.cc5baaaa-717e-4551-b7ae-aaaa03c72a6a.v-southeastasia", actual);
     }
 
     @Test
@@ -52,8 +52,8 @@ public class CustomVMImageNameProviderTest {
 
         String actual = underTest.getImageNameWithRegion(region, vhdName);
 
-        Assert.assertTrue(IMAGE_NAME_PATTERN.matcher(actual).matches());
-        Assert.assertEquals("cb-hdp-26-1907121707-osDisk.cc5baaaa-717e-4551-b7ae-aaaa03c72a6aa.-southeastasia", actual);
+        Assertions.assertTrue(IMAGE_NAME_PATTERN.matcher(actual).matches());
+        Assertions.assertEquals("cb-hdp-26-1907121707-osDisk.cc5baaaa-717e-4551-b7ae-aaaa03c72a6aa.-southeastasia", actual);
     }
 
     @Test
@@ -63,8 +63,8 @@ public class CustomVMImageNameProviderTest {
 
         String actual = underTest.getImageNameWithRegion(region, vhdName);
 
-        Assert.assertTrue(IMAGE_NAME_PATTERN.matcher(actual).matches());
-        Assert.assertEquals("cb-hdp-26-1907121707-osDisk.cc5baaaa-717e-4551-b7ae-aaaa03c72a6aa--southeastasia", actual);
+        Assertions.assertTrue(IMAGE_NAME_PATTERN.matcher(actual).matches());
+        Assertions.assertEquals("cb-hdp-26-1907121707-osDisk.cc5baaaa-717e-4551-b7ae-aaaa03c72a6aa--southeastasia", actual);
     }
 
     @Test
@@ -74,8 +74,8 @@ public class CustomVMImageNameProviderTest {
 
         String actual = underTest.getImageNameWithRegion(region, vhdName);
 
-        Assert.assertTrue(IMAGE_NAME_PATTERN.matcher(actual).matches());
-        Assert.assertEquals("cb-hdp-26-1907121707-osDisk123.cc5baaaa-717e-4551-b7ae-aaaa03c72a6-southeastasia", actual);
+        Assertions.assertTrue(IMAGE_NAME_PATTERN.matcher(actual).matches());
+        Assertions.assertEquals("cb-hdp-26-1907121707-osDisk123.cc5baaaa-717e-4551-b7ae-aaaa03c72a6-southeastasia", actual);
     }
 
     @Test

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/AzureAcceleratedNetworkValidatorTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/AzureAcceleratedNetworkValidatorTest.java
@@ -6,12 +6,12 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.sequenceiq.cloudbreak.cloud.azure.util.AzureVirtualMachineTypeProvider;
@@ -19,7 +19,7 @@ import com.sequenceiq.cloudbreak.cloud.azure.view.AzureStackView;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 import com.sequenceiq.cloudbreak.util.FileReaderUtils;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AzureAcceleratedNetworkValidatorTest {
 
     @Mock
@@ -38,7 +38,7 @@ public class AzureAcceleratedNetworkValidatorTest {
 
         Map<String, Boolean> actual = underTest.validate(azureStackView);
 
-        actual.forEach((key, value) -> Assert.assertTrue(value));
+        actual.forEach((key, value) -> Assertions.assertTrue(value));
     }
 
     @Test
@@ -48,7 +48,7 @@ public class AzureAcceleratedNetworkValidatorTest {
 
         Map<String, Boolean> actual = underTest.validate(azureStackView);
 
-        actual.forEach((key, value) -> Assert.assertFalse(value));
+        actual.forEach((key, value) -> Assertions.assertFalse(value));
     }
 
     @Test
@@ -58,7 +58,7 @@ public class AzureAcceleratedNetworkValidatorTest {
 
         Map<String, Boolean> actual = underTest.validate(azureStackView);
 
-        actual.forEach((key, value) -> Assert.assertFalse(value));
+        actual.forEach((key, value) -> Assertions.assertFalse(value));
     }
 
     @Test
@@ -68,7 +68,7 @@ public class AzureAcceleratedNetworkValidatorTest {
 
         Map<String, Boolean> actual = underTest.validate(azureStackView);
 
-        actual.forEach((key, value) -> Assert.assertFalse(value));
+        actual.forEach((key, value) -> Assertions.assertFalse(value));
     }
 
     private Set<String> getSupportedVmTypes() throws IOException {

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/AzureIDBrokerObjectStorageValidatorTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/AzureIDBrokerObjectStorageValidatorTest.java
@@ -1,10 +1,11 @@
 package com.sequenceiq.cloudbreak.cloud.azure.validator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -15,14 +16,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.microsoft.azure.PagedList;
 import com.microsoft.azure.management.graphrbac.implementation.RoleAssignmentInner;
@@ -46,7 +47,7 @@ import com.sequenceiq.common.model.CloudIdentityType;
 import com.sequenceiq.common.model.CloudStorageCdpService;
 import com.sequenceiq.common.model.FileSystemType;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AzureIDBrokerObjectStorageValidatorTest {
 
     private static final CloudStorageCdpService SERVICE_1 = CloudStorageCdpService.ZEPPELIN_NOTEBOOK;
@@ -135,24 +136,24 @@ public class AzureIDBrokerObjectStorageValidatorTest {
     @Spy
     private Identity assumer;
 
-    @Before
+    @BeforeEach
     public void setup() {
-        when(client.getIdentityById(LOG_IDENTITY)).thenReturn(logger);
-        when(client.getIdentityById(ASSUMER_IDENTITY)).thenReturn(assumer);
-        when(client.getCurrentSubscription()).thenReturn(mock(Subscription.class));
-        when(client.getCurrentSubscription().subscriptionId()).thenReturn(SUBSCRIPTION_ID);
-        when(client.getResourceGroup(RESOURCE_GROUP_NAME)).thenReturn(resourceGroup);
-        when(client.getStorageAccount(any(), any())).thenReturn(Optional.of(storageAccount));
-        when(storageAccount.isHnsEnabled()).thenReturn(Boolean.TRUE);
-        when(resourceGroup.id()).thenReturn(RESOURCE_GROUP_ID);
+        lenient().when(client.getIdentityById(LOG_IDENTITY)).thenReturn(logger);
+        lenient().when(client.getIdentityById(ASSUMER_IDENTITY)).thenReturn(assumer);
+        lenient().when(client.getCurrentSubscription()).thenReturn(mock(Subscription.class));
+        lenient().when(client.getCurrentSubscription().subscriptionId()).thenReturn(SUBSCRIPTION_ID);
+        lenient().when(client.getResourceGroup(RESOURCE_GROUP_NAME)).thenReturn(resourceGroup);
+        lenient().when(client.getStorageAccount(any(), any())).thenReturn(Optional.of(storageAccount));
+        lenient().when(storageAccount.isHnsEnabled()).thenReturn(Boolean.TRUE);
+        lenient().when(resourceGroup.id()).thenReturn(RESOURCE_GROUP_ID);
         AdlsGen2Config adlsGen2Config = new AdlsGen2Config("abfs://", ABFS_FILESYSTEM_NAME, ABFS_STORAGE_ACCOUNT_NAME, false);
-        when(adlsGen2ConfigGenerator.generateStorageConfig(anyString())).thenReturn(adlsGen2Config);
-        when(logger.id()).thenReturn(LOG_IDENTITY);
-        when(logger.principalId()).thenReturn(LOG_IDENTITY_PRINCIPAL_ID);
-        when(assumer.id()).thenReturn(ASSUMER_IDENTITY);
-        when(assumer.principalId()).thenReturn(ASSUMER_IDENTITY_PRINCIPAL_ID);
-        when(azureStorage.findStorageAccountIdInVisibleSubscriptions(any(), anyString())).thenReturn(Optional.of(ABFS_STORAGE_ACCOUNT_ID));
-        when(entitlementService.isDatalakeBackupRestorePrechecksEnabled(any())).thenReturn(true);
+        lenient().when(adlsGen2ConfigGenerator.generateStorageConfig(anyString())).thenReturn(adlsGen2Config);
+        lenient().when(logger.id()).thenReturn(LOG_IDENTITY);
+        lenient().when(logger.principalId()).thenReturn(LOG_IDENTITY_PRINCIPAL_ID);
+        lenient().when(assumer.id()).thenReturn(ASSUMER_IDENTITY);
+        lenient().when(assumer.principalId()).thenReturn(ASSUMER_IDENTITY_PRINCIPAL_ID);
+        lenient().when(azureStorage.findStorageAccountIdInVisibleSubscriptions(any(), anyString())).thenReturn(Optional.of(ABFS_STORAGE_ACCOUNT_ID));
+        lenient().when(entitlementService.isDatalakeBackupRestorePrechecksEnabled(any())).thenReturn(true);
     }
 
     @Test
@@ -482,8 +483,8 @@ public class AzureIDBrokerObjectStorageValidatorTest {
 
         RoleASsignmentBuilder(AzureClient client) {
             roleAssignmentsPagedList = Mockito.spy(PagedList.class);
-            when(client.listRoleAssignments()).thenReturn(roleAssignmentsPagedList);
-            when(client.listRoleAssignmentsByScopeInner(any())).thenReturn(roleAssignmentsPagedList);
+            lenient().when(client.listRoleAssignments()).thenReturn(roleAssignmentsPagedList);
+            lenient().when(client.listRoleAssignmentsByScopeInner(any())).thenReturn(roleAssignmentsPagedList);
         }
 
         RoleASsignmentBuilder withAssignment(String principalId, String scope) {

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureNetworkViewTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureNetworkViewTest.java
@@ -4,8 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 import com.sequenceiq.cloudbreak.cloud.model.Network;
@@ -26,7 +26,7 @@ public class AzureNetworkViewTest {
 
     private AzureNetworkView underTest;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         initMocks(this);
 


### PR DESCRIPTION
… that we have only a handful of classes remaining on junit4

See detailed description in the commit message.