### PR TITLE
CB-19550 On Aws after Rds upgrade the newly created custom parameter group won't be deleted during cluster termination

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/ResourceConnector.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/ResourceConnector.java
@@ -125,7 +125,7 @@ public interface ResourceConnector {
      * @throws Exception in case of any error
      */
     void upgradeDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack, PersistenceNotifier persistenceNotifier,
-            TargetMajorVersion targetMajorVersion) throws Exception;
+            TargetMajorVersion targetMajorVersion, List<CloudResource> resources) throws Exception;
 
     /**
      * Invoked to check whether the resources have already reached a StatusGroup.PERMANENT state.

--- a/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/ResourceConnectorTest.java
+++ b/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/ResourceConnectorTest.java
@@ -60,7 +60,7 @@ class ResourceConnectorTest {
 
         @Override
         public void upgradeDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
-                PersistenceNotifier persistenceNotifier, TargetMajorVersion targetMajorVersion) {
+                PersistenceNotifier persistenceNotifier, TargetMajorVersion targetMajorVersion, List<CloudResource> resources) {
         }
 
         @Override

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsParameterGroupService.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsParameterGroupService.java
@@ -1,0 +1,73 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.amazonaws.services.rds.model.Parameter;
+import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonRdsClient;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.AwsRdsCustomParameterSupplier;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.AwsRdsVersionOperations;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.RdsEngineVersion;
+import com.sequenceiq.cloudbreak.cloud.aws.view.AwsRdsDbParameterGroupView;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseServer;
+import com.sequenceiq.common.api.type.ResourceType;
+
+@Component
+public class AwsRdsParameterGroupService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsRdsParameterGroupService.class);
+
+    @Inject
+    private AwsRdsVersionOperations awsRdsVersionOperations;
+
+    @Inject
+    private AwsRdsCustomParameterSupplier awsRdsCustomParameterSupplier;
+
+    public String createParameterGroupWithCustomSettings(AmazonRdsClient rdsClient, DatabaseServer databaseServer, RdsEngineVersion upgradeTargetVersion) {
+        AwsRdsDbParameterGroupView awsRdsDbParameterGroupView = new AwsRdsDbParameterGroupView(databaseServer, awsRdsVersionOperations);
+        String dbParameterGroupName = String.format("%s-v%s", awsRdsDbParameterGroupView.getDBParameterGroupName(), upgradeTargetVersion.getMajorVersion());
+        String dbParameterGroupFamily = awsRdsVersionOperations.getDBParameterGroupFamily(databaseServer.getEngine(), upgradeTargetVersion.getVersion());
+        String serverId = databaseServer.getServerId();
+        String dbParameterGroupDescription = String.format("DB parameter group for %s", serverId);
+
+        createParameterGroupIfNeeded(rdsClient, dbParameterGroupName, dbParameterGroupFamily, dbParameterGroupDescription);
+        changeParameterInGroup(rdsClient, dbParameterGroupName);
+        return dbParameterGroupName;
+    }
+
+    private void changeParameterInGroup(AmazonRdsClient rdsClient, String dbParameterGroupName) {
+        List<Parameter> parametersToChange = awsRdsCustomParameterSupplier.getParametersToChange();
+        rdsClient.changeParameterInGroup(dbParameterGroupName, parametersToChange);
+        LOGGER.debug("Changed RDS parameters in parameters group. Parameter group name: {}. parameters: {}", dbParameterGroupName, parametersToChange);
+    }
+
+    private void createParameterGroupIfNeeded(AmazonRdsClient rdsClient, String dbParameterGroupName, String dbParameterGroupFamily, String
+            dbParameterGroupDescription) {
+        if (!rdsClient.isDbParameterGroupPresent(dbParameterGroupName)) {
+            LOGGER.debug("Creating a custom parameter group for RDS. DbParameterGroupName: {}, family: {}", dbParameterGroupName, dbParameterGroupFamily);
+            rdsClient.createParameterGroup(dbParameterGroupFamily, dbParameterGroupName, dbParameterGroupDescription);
+        } else {
+            LOGGER.debug("Custom parameter group with name {} already exists", dbParameterGroupName);
+        }
+    }
+
+    public List<CloudResource> removeFormerParamGroups(AmazonRdsClient rdsClient, DatabaseServer databaseServer, List<CloudResource> cloudResources) {
+        List<CloudResource> removedResources = List.of();
+        if (databaseServer.isUseSslEnforcement()) {
+            removedResources = cloudResources.stream()
+                    .filter(cloudResource -> ResourceType.RDS_DB_PARAMETER_GROUP == cloudResource.getType())
+                    .collect(Collectors.toList());
+            removedResources.forEach(cloudResource -> rdsClient.deleteParameterGroup(cloudResource.getName()));
+            LOGGER.debug("The following parameter groups have been deleted: {}", removedResources);
+        } else {
+            LOGGER.debug("Parameter group deletion is skipped as CB hadn't created one during RDS creation");
+        }
+        return removedResources;
+    }
+}

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnector.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnector.java
@@ -132,9 +132,9 @@ public class AwsResourceConnector implements ResourceConnector {
 
     @Override
     public void upgradeDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
-            PersistenceNotifier persistenceNotifier, TargetMajorVersion targetMajorVersion) {
+            PersistenceNotifier persistenceNotifier, TargetMajorVersion targetMajorVersion, List<CloudResource> resources) {
         LOGGER.debug("Starting the upgrade of database server to {}", targetMajorVersion);
-        awsRdsUpgradeService.upgrade(authenticatedContext, stack, targetMajorVersion);
+        awsRdsUpgradeService.upgrade(authenticatedContext, stack, targetMajorVersion, persistenceNotifier, resources);
     }
 
     private boolean deployingToSameVPC(AwsNetworkView awsNetworkView, boolean existingVPC) {

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsParameterGroupServiceTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsParameterGroupServiceTest.java
@@ -1,0 +1,104 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.amazonaws.services.rds.model.Parameter;
+import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonRdsClient;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.AwsRdsCustomParameterSupplier;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.AwsRdsVersionOperations;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.RdsEngineVersion;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseEngine;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseServer;
+import com.sequenceiq.common.api.type.ResourceType;
+
+@ExtendWith(MockitoExtension.class)
+public class AwsRdsParameterGroupServiceTest {
+    private static final String DB_SERVER_ID = "dbServerId";
+
+    private static final String PARAMETER_GROUP_FAMILY = "parameterGroupFamily";
+
+    @Mock
+    private AwsRdsVersionOperations awsRdsVersionOperations;
+
+    @Mock
+    private AwsRdsCustomParameterSupplier awsRdsCustomParameterSupplier;
+
+    @Mock
+    private AmazonRdsClient rdsClient;
+
+    @InjectMocks
+    private AwsRdsParameterGroupService underTest;
+
+    @Test
+    void testCreateParameterGroupWithCustomSettings() {
+        DatabaseServer databaseServer = mock(DatabaseServer.class);
+        when(databaseServer.getServerId()).thenReturn(DB_SERVER_ID);
+        when(databaseServer.getEngine()).thenReturn(DatabaseEngine.POSTGRESQL);
+        when(awsRdsVersionOperations.getDBParameterGroupFamily(DatabaseEngine.POSTGRESQL, "highestVersion")).thenReturn(PARAMETER_GROUP_FAMILY);
+        String dbParameterGroupName = "dpg-" + DB_SERVER_ID + "-vhighestVersion";
+        when(rdsClient.isDbParameterGroupPresent(dbParameterGroupName)).thenReturn(false);
+        List<Parameter> customParameterList = List.of(new Parameter());
+        when(awsRdsCustomParameterSupplier.getParametersToChange()).thenReturn(customParameterList);
+
+        underTest.createParameterGroupWithCustomSettings(rdsClient, databaseServer, new RdsEngineVersion("highestVersion"));
+
+        verify(rdsClient).createParameterGroup(PARAMETER_GROUP_FAMILY, dbParameterGroupName, "DB parameter group for " + DB_SERVER_ID);
+        verify(rdsClient).changeParameterInGroup(dbParameterGroupName, customParameterList);
+    }
+
+    @Test
+    void testCreateParameterGroupWithCustomSettingsWhenParameterGroupIsFound() {
+        DatabaseServer databaseServer = mock(DatabaseServer.class);
+        when(databaseServer.getServerId()).thenReturn(DB_SERVER_ID);
+        when(databaseServer.getEngine()).thenReturn(DatabaseEngine.POSTGRESQL);
+        when(awsRdsVersionOperations.getDBParameterGroupFamily(DatabaseEngine.POSTGRESQL, "highestVersion")).thenReturn(PARAMETER_GROUP_FAMILY);
+        String dbParameterGroupName = "dpg-" + DB_SERVER_ID + "-vhighestVersion";
+        when(rdsClient.isDbParameterGroupPresent(dbParameterGroupName)).thenReturn(true);
+
+        underTest.createParameterGroupWithCustomSettings(rdsClient, databaseServer, new RdsEngineVersion("highestVersion"));
+
+        verify(rdsClient, never()).createParameterGroup(anyString(), anyString(), anyString());
+        verify(rdsClient).changeParameterInGroup(eq(dbParameterGroupName), any());
+    }
+
+    @Test
+    void testRemoveFormerParamGroupsWhenNoSsl() {
+        DatabaseServer databaseServer = mock(DatabaseServer.class);
+        List<CloudResource> resources = List.of(new CloudResource.Builder().withType(ResourceType.RDS_DB_PARAMETER_GROUP).withName("resource1").build(),
+                new CloudResource.Builder().withType(ResourceType.AWS_INSTANCE).withName("resource2").build());
+        List<CloudResource> actualResult = underTest.removeFormerParamGroups(rdsClient, databaseServer, resources);
+        Assertions.assertEquals(0, actualResult.size());
+        verify(rdsClient, never()).deleteParameterGroup(anyString());
+    }
+
+    @Test
+    void testRemoveFormerParamGroupsWhenSslEnabled() {
+        DatabaseServer databaseServer = mock(DatabaseServer.class);
+        when(databaseServer.isUseSslEnforcement()).thenReturn(true);
+        List<CloudResource> resources = List.of(
+                new CloudResource.Builder().withType(ResourceType.RDS_DB_PARAMETER_GROUP).withName("paramgroup1").build(),
+                new CloudResource.Builder().withType(ResourceType.RDS_DB_PARAMETER_GROUP).withName("paramgroup2").build(),
+                new CloudResource.Builder().withType(ResourceType.AWS_INSTANCE).withName("instance1").build());
+        List<CloudResource> actualResult = underTest.removeFormerParamGroups(rdsClient, databaseServer, resources);
+        Assertions.assertEquals(2, actualResult.size());
+        verify(rdsClient, times(1)).deleteParameterGroup("paramgroup1");
+        verify(rdsClient, times(1)).deleteParameterGroup("paramgroup2");
+    }
+}

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/AwsRdsUpgradeServiceTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/AwsRdsUpgradeServiceTest.java
@@ -1,11 +1,14 @@
 package com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,17 +22,21 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.cloud.aws.AwsCloudFormationClient;
 import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonRdsClient;
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.AwsRdsParameterGroupService;
 import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.AwsRdsUpgradeValidatorService;
 import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.RdsInfo;
 import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.upgrade.operation.RdsState;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.DatabaseServer;
 import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.cloudbreak.cloud.model.Location;
 import com.sequenceiq.cloudbreak.cloud.model.Region;
+import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
 import com.sequenceiq.cloudbreak.common.database.Version;
+import com.sequenceiq.common.api.type.ResourceType;
 
 @ExtendWith(MockitoExtension.class)
 public class AwsRdsUpgradeServiceTest {
@@ -62,7 +69,16 @@ public class AwsRdsUpgradeServiceTest {
     private DatabaseServer databaseServer;
 
     @Mock
+    private CloudContext cloudContext;
+
+    @Mock
     private AuthenticatedContext ac;
+
+    @Mock
+    private AwsRdsParameterGroupService awsRdsParameterGroupService;
+
+    @Mock
+    private PersistenceNotifier persistenceNotifier;
 
     private final Version targetMajorVersion = () -> TARGET_VERSION;
 
@@ -77,15 +93,19 @@ public class AwsRdsUpgradeServiceTest {
     @Test
     void testUpgrade() {
         RdsInfo rdsInfo = new RdsInfo(RdsState.AVAILABLE, null, null);
+        List<CloudResource> resources = List.of(new CloudResource.Builder().withType(ResourceType.RDS_DB_PARAMETER_GROUP).withName("resource1").build(),
+                new CloudResource.Builder().withType(ResourceType.RDS_DB_PARAMETER_GROUP).withName("resource2").build());
         when(awsRdsUpgradeSteps.getRdsInfo(rdsClient, DB_INSTANCE_IDENTIFIER)).thenReturn(rdsInfo);
         when(awsRdsUpgradeValidatorService.isRdsMajorVersionSmallerThanTarget(rdsInfo, targetMajorVersion)).thenReturn(true);
-
-        underTest.upgrade(ac, databaseStack, targetMajorVersion);
+        when(awsRdsParameterGroupService.removeFormerParamGroups(any(AmazonRdsClient.class), eq(databaseServer), eq(List.of())))
+                .thenReturn(resources);
+        underTest.upgrade(ac, databaseStack, targetMajorVersion, persistenceNotifier, List.of());
 
         InOrder inOrder = Mockito.inOrder(awsRdsUpgradeValidatorService, awsRdsUpgradeSteps);
         inOrder.verify(awsRdsUpgradeValidatorService).validateRdsIsAvailableOrUpgrading(rdsInfo);
-        inOrder.verify(awsRdsUpgradeSteps).upgradeRds(rdsClient, databaseServer, rdsInfo, targetMajorVersion);
+        inOrder.verify(awsRdsUpgradeSteps).upgradeRds(ac, rdsClient, databaseServer, rdsInfo, targetMajorVersion);
         inOrder.verify(awsRdsUpgradeSteps).waitForUpgrade(ac, rdsClient, databaseServer);
+        verify(persistenceNotifier, times(2)).notifyDeletion(any(CloudResource.class), eq(cloudContext));
     }
 
     @Test
@@ -94,12 +114,12 @@ public class AwsRdsUpgradeServiceTest {
         when(awsRdsUpgradeSteps.getRdsInfo(rdsClient, DB_INSTANCE_IDENTIFIER)).thenReturn(rdsInfo);
         when(awsRdsUpgradeValidatorService.isRdsMajorVersionSmallerThanTarget(rdsInfo, targetMajorVersion)).thenReturn(true);
 
-        underTest.upgrade(ac, databaseStack, targetMajorVersion);
+        underTest.upgrade(ac, databaseStack, targetMajorVersion, persistenceNotifier, List.of());
 
         InOrder inOrder = Mockito.inOrder(awsRdsUpgradeValidatorService, awsRdsUpgradeSteps);
         inOrder.verify(awsRdsUpgradeValidatorService).validateRdsIsAvailableOrUpgrading(rdsInfo);
         inOrder.verify(awsRdsUpgradeSteps).waitForUpgrade(ac, rdsClient, databaseServer);
-        verify(awsRdsUpgradeSteps, never()).upgradeRds(rdsClient, databaseServer, rdsInfo, targetMajorVersion);
+        verify(awsRdsUpgradeSteps, never()).upgradeRds(ac, rdsClient, databaseServer, rdsInfo, targetMajorVersion);
     }
 
     @Test
@@ -110,10 +130,10 @@ public class AwsRdsUpgradeServiceTest {
         doThrow(CloudConnectorException.class).when(awsRdsUpgradeValidatorService).validateRdsIsAvailableOrUpgrading(rdsInfo);
 
         Assertions.assertThrows(CloudConnectorException.class, () ->
-            underTest.upgrade(ac, databaseStack, targetMajorVersion)
+            underTest.upgrade(ac, databaseStack, targetMajorVersion, persistenceNotifier, List.of())
         );
 
-        verify(awsRdsUpgradeSteps, never()).upgradeRds(rdsClient, databaseServer, rdsInfo, targetMajorVersion);
+        verify(awsRdsUpgradeSteps, never()).upgradeRds(ac, rdsClient, databaseServer, rdsInfo, targetMajorVersion);
         verify(awsRdsUpgradeSteps, never()).waitForUpgrade(ac, rdsClient, databaseServer);
     }
 
@@ -122,15 +142,15 @@ public class AwsRdsUpgradeServiceTest {
         RdsInfo rdsInfo = new RdsInfo(RdsState.AVAILABLE, null, null);
         when(awsRdsUpgradeSteps.getRdsInfo(rdsClient, DB_INSTANCE_IDENTIFIER)).thenReturn(rdsInfo);
         when(awsRdsUpgradeValidatorService.isRdsMajorVersionSmallerThanTarget(rdsInfo, targetMajorVersion)).thenReturn(true);
-        doThrow(CloudConnectorException.class).when(awsRdsUpgradeSteps).upgradeRds(rdsClient, databaseServer, rdsInfo, targetMajorVersion);
+        doThrow(CloudConnectorException.class).when(awsRdsUpgradeSteps).upgradeRds(ac, rdsClient, databaseServer, rdsInfo, targetMajorVersion);
 
         Assertions.assertThrows(CloudConnectorException.class, () ->
-                underTest.upgrade(ac, databaseStack, targetMajorVersion)
+                underTest.upgrade(ac, databaseStack, targetMajorVersion, persistenceNotifier, List.of())
         );
 
         InOrder inOrder = Mockito.inOrder(awsRdsUpgradeValidatorService, awsRdsUpgradeSteps);
         inOrder.verify(awsRdsUpgradeValidatorService).validateRdsIsAvailableOrUpgrading(rdsInfo);
-        inOrder.verify(awsRdsUpgradeSteps).upgradeRds(rdsClient, databaseServer, rdsInfo, targetMajorVersion);
+        inOrder.verify(awsRdsUpgradeSteps).upgradeRds(ac, rdsClient, databaseServer, rdsInfo, targetMajorVersion);
         verify(awsRdsUpgradeSteps, never()).waitForUpgrade(ac, rdsClient, databaseServer);
     }
 
@@ -140,17 +160,16 @@ public class AwsRdsUpgradeServiceTest {
         when(awsRdsUpgradeSteps.getRdsInfo(rdsClient, DB_INSTANCE_IDENTIFIER)).thenReturn(rdsInfo);
         when(awsRdsUpgradeValidatorService.isRdsMajorVersionSmallerThanTarget(rdsInfo, targetMajorVersion)).thenReturn(false);
 
-        underTest.upgrade(ac, databaseStack, targetMajorVersion);
+        underTest.upgrade(ac, databaseStack, targetMajorVersion, persistenceNotifier, List.of());
 
-        verify(awsRdsUpgradeSteps, never()).upgradeRds(rdsClient, databaseServer, rdsInfo, targetMajorVersion);
+        verify(awsRdsUpgradeSteps, never()).upgradeRds(ac, rdsClient, databaseServer, rdsInfo, targetMajorVersion);
         verify(awsRdsUpgradeSteps, never()).waitForUpgrade(ac, rdsClient, databaseServer);
     }
 
     private void setupAuthenticatedContext() {
-        CloudContext cc = mock(CloudContext.class);
         Location location = Location.location(Region.region(REGION_NAME));
-        when(cc.getLocation()).thenReturn(location);
-        when(ac.getCloudContext()).thenReturn(cc);
+        when(cloudContext.getLocation()).thenReturn(location);
+        when(ac.getCloudContext()).thenReturn(cloudContext);
     }
 
 }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
@@ -383,7 +383,7 @@ public class AzureResourceConnector extends AbstractResourceConnector {
 
     @Override
     public void upgradeDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
-            PersistenceNotifier persistenceNotifier, TargetMajorVersion targetMajorVersion) {
+            PersistenceNotifier persistenceNotifier, TargetMajorVersion targetMajorVersion, List<CloudResource> resources) {
         azureDatabaseResourceService.upgradeDatabaseServer(authenticatedContext, stack, persistenceNotifier, targetMajorVersion);
     }
 }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnectorTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnectorTest.java
@@ -240,7 +240,7 @@ public class AzureResourceConnectorTest {
         DatabaseStack databaseStack = mock(DatabaseStack.class);
         PersistenceNotifier persistenceNotifier = mock(PersistenceNotifier.class);
 
-        underTest.upgradeDatabaseServer(ac, databaseStack, persistenceNotifier, TargetMajorVersion.VERSION_11);
+        underTest.upgradeDatabaseServer(ac, databaseStack, persistenceNotifier, TargetMajorVersion.VERSION_11, List.of());
         verify(azureDatabaseResourceService, times(1))
                 .upgradeDatabaseServer(eq(ac), eq(databaseStack), eq(persistenceNotifier), eq(TargetMajorVersion.VERSION_11));
     }

--- a/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockResourceConnector.java
+++ b/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockResourceConnector.java
@@ -118,7 +118,7 @@ public class MockResourceConnector implements ResourceConnector {
 
     @Override
     public void upgradeDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
-            PersistenceNotifier persistenceNotifier, TargetMajorVersion targetMajorVersion) {
+            PersistenceNotifier persistenceNotifier, TargetMajorVersion targetMajorVersion, List<CloudResource> resources) {
     }
 
     @Override

--- a/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/AbstractResourceConnector.java
+++ b/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/AbstractResourceConnector.java
@@ -136,7 +136,7 @@ public abstract class AbstractResourceConnector implements ResourceConnector {
 
     @Override
     public void upgradeDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
-            PersistenceNotifier persistenceNotifier, TargetMajorVersion targetMajorVersion) throws Exception {
+            PersistenceNotifier persistenceNotifier, TargetMajorVersion targetMajorVersion, List<CloudResource> resources) throws Exception {
         databaseServerUpgradeService.upgrade(authenticatedContext, stack, persistenceNotifier, targetMajorVersion);
     }
 

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnResourceConnector.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnResourceConnector.java
@@ -114,7 +114,7 @@ public class YarnResourceConnector implements ResourceConnector {
 
     @Override
     public void upgradeDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
-            PersistenceNotifier persistenceNotifier, TargetMajorVersion targetMajorVersion) {
+            PersistenceNotifier persistenceNotifier, TargetMajorVersion targetMajorVersion, List<CloudResource> resources) {
         throw new UnsupportedOperationException("Database server upgrade is not supported for " + getClass().getName());
     }
 

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/upgrade/handler/UpgradeDatabaseServerHandlerTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/upgrade/handler/UpgradeDatabaseServerHandlerTest.java
@@ -27,6 +27,7 @@ import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
 import com.sequenceiq.redbeams.domain.stack.DatabaseServer;
 import com.sequenceiq.redbeams.flow.redbeams.upgrade.event.UpgradeDatabaseServerRequest;
+import com.sequenceiq.redbeams.service.stack.DBResourceService;
 import com.sequenceiq.redbeams.service.stack.DBStackService;
 
 import reactor.bus.Event;
@@ -60,6 +61,9 @@ public class UpgradeDatabaseServerHandlerTest {
 
     @Mock
     private ResourceConnector resourceConnector;
+
+    @Mock
+    private DBResourceService dbResourceService;
 
     @InjectMocks
     private UpgradeDatabaseServerHandler underTest;


### PR DESCRIPTION
CB-19550 On Aws after Rds upgrade the newly created custom parameter group won't be deleted during cluster termination

The fix contains the following steps:
* During rds upgrade the new parameter group will be stored in the resource table in redbeams db
* After successfull rds upgrade the previous parameter group will be deleted from aws and from resource table in redbeams db
* During termination the stored parameter group will be deleted on AWS

See detailed description in the commit message.