### PR TITLE
CB-18840 Expose LDAP agent version on FMS API

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaModelDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaModelDescriptions.java
@@ -85,6 +85,7 @@ public class FreeIpaModelDescriptions {
         public static final String IMAGE_CATALOG = "custom image catalog URL";
         public static final String IMAGE_ID = "virtual machine image id from ImageCatalog, machines of the cluster will be started from this image";
         public static final String OS_TYPE = "os type of the image, this property is only considered when no specific image id is provided";
+        public static final String LDAP_AGENT_VERSION = "LDAP agent version present on the image, if the image contains LDAP agent.";
     }
 
     public static class NetworkModelDescription {

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/image/ImageSettingsResponse.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/image/ImageSettingsResponse.java
@@ -3,11 +3,31 @@ package com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.image;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.doc.FreeIpaModelDescriptions;
 
 import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 
 @ApiModel("ImageSettingsV1Response")
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(Include.NON_NULL)
 public class ImageSettingsResponse extends ImageSettingsBase {
+
+    @ApiModelProperty(FreeIpaModelDescriptions.ImageSettingsModelDescription.LDAP_AGENT_VERSION)
+    private String ldapAgentVersion;
+
+    public String getLdapAgentVersion() {
+        return ldapAgentVersion;
+    }
+
+    public void setLdapAgentVersion(String ldapAgentVersion) {
+        this.ldapAgentVersion = ldapAgentVersion;
+    }
+
+    @Override
+    public String toString() {
+        return "ImageSettingsResponse{" +
+                "ldapAgentVersion='" + ldapAgentVersion + '\'' +
+                "} " + super.toString();
+    }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/image/ImageToImageEntityConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/image/ImageToImageEntityConverter.java
@@ -13,6 +13,12 @@ public class ImageToImageEntityConverter {
         imageEntity.setImageId(source.getUuid());
         imageEntity.setOs(source.getOs());
         imageEntity.setOsType(source.getOsType());
+        imageEntity.setDate(source.getDate());
+        imageEntity.setLdapAgentVersion(extractLdapAgentVersion(source));
         return imageEntity;
+    }
+
+    public String extractLdapAgentVersion(Image image) {
+        return image.getPackageVersions() == null ? null : image.getPackageVersions().get("freeipa-ldap-agent");
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/image/ImageToImageSettingsResponseConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/image/ImageToImageSettingsResponseConverter.java
@@ -14,6 +14,7 @@ public class ImageToImageSettingsResponseConverter implements Converter<ImageEnt
         response.setCatalog(source.getImageCatalogUrl());
         response.setId(source.getImageId());
         response.setOs(source.getOs());
+        response.setLdapAgentVersion(source.getLdapAgentVersion());
         return response;
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/ImageEntity.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/ImageEntity.java
@@ -47,6 +47,8 @@ public class ImageEntity {
     @Column(name = "image_date")
     private String date;
 
+    private String ldapAgentVersion;
+
     public String getImageName() {
         return imageName;
     }
@@ -127,6 +129,14 @@ public class ImageEntity {
         this.date = date;
     }
 
+    public String getLdapAgentVersion() {
+        return ldapAgentVersion;
+    }
+
+    public void setLdapAgentVersion(String ldapAgentVersion) {
+        this.ldapAgentVersion = ldapAgentVersion;
+    }
+
     @Override
     public String toString() {
         return "ImageEntity{" +
@@ -139,6 +149,7 @@ public class ImageEntity {
                 ", imageId='" + imageId + '\'' +
                 ", imageCatalogName='" + imageCatalogName + '\'' +
                 ", date='" + date + '\'' +
+                ", ldapAgentVersion='" + ldapAgentVersion + '\'' +
                 '}';
     }
 
@@ -163,11 +174,12 @@ public class ImageEntity {
                 && Objects.equals(imageCatalogUrl, that.imageCatalogUrl)
                 && Objects.equals(imageId, that.imageId)
                 && Objects.equals(imageCatalogName, that.imageCatalogName)
+                && Objects.equals(ldapAgentVersion, that.ldapAgentVersion)
                 && Objects.equals(date, that.date);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, imageName, userdata, os, osType, imageCatalogUrl, imageId, imageCatalogName, date);
+        return Objects.hash(id, imageName, userdata, os, osType, imageCatalogUrl, imageId, imageCatalogName, date, ldapAgentVersion);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/ImageService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/ImageService.java
@@ -51,9 +51,6 @@ public class ImageService {
     @Value("${freeipa.image.catalog.default.os}")
     private String defaultOs;
 
-    @Value("${info.app.version:}")
-    private String freeIpaVersion;
-
     public ImageEntity create(Stack stack, ImageSettingsRequest imageRequest) {
         Pair<ImageWrapper, String> imageWrapperAndNamePair = fetchImageWrapperAndName(stack, imageRequest);
         ImageEntity imageEntity = createImageEntity(stack, imageWrapperAndNamePair);
@@ -67,7 +64,6 @@ public class ImageService {
         imageEntity.setImageName(imageWrapperAndNamePair.getRight());
         imageEntity.setImageCatalogUrl(imageWrapper.getCatalogUrl());
         imageEntity.setImageCatalogName(imageWrapper.getCatalogName());
-        imageEntity.setDate(imageWrapper.getImage().getDate());
         return imageEntity;
     }
 
@@ -117,6 +113,7 @@ public class ImageService {
         imageEntity.setImageCatalogUrl(imageWrapper.getCatalogUrl());
         imageEntity.setImageCatalogName(imageWrapper.getCatalogName());
         imageEntity.setDate(imageWrapper.getImage().getDate());
+        imageEntity.setLdapAgentVersion(imageConverter.extractLdapAgentVersion(imageWrapper.getImage()));
         return imageEntity;
     }
 

--- a/freeipa/src/main/resources/schema/app/20221118110148_CB-18840_Add_ldapagentversion_column_to_image_table.sql
+++ b/freeipa/src/main/resources/schema/app/20221118110148_CB-18840_Add_ldapagentversion_column_to_image_table.sql
@@ -1,0 +1,11 @@
+-- // CB-18840 Add ldapagentversion column to image table
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE image ADD COLUMN IF NOT EXISTS ldapagentversion VARCHAR(255);
+ALTER TABLE image_history ADD COLUMN IF NOT EXISTS ldapagentversion VARCHAR(255);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE image DROP COLUMN IF EXISTS ldapagentversion;
+ALTER TABLE image_history DROP COLUMN IF EXISTS ldapagentversion;

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/image/ImageToImageEntityConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/image/ImageToImageEntityConverterTest.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.freeipa.converter.image;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.Image;
+import com.sequenceiq.freeipa.entity.ImageEntity;
+
+class ImageToImageEntityConverterTest {
+
+    private ImageToImageEntityConverter underTest = new ImageToImageEntityConverter();
+
+    @Test
+    void testConversion() {
+        Image source = new Image(1L, "date", "", "arch", "1-2-a-b", Map.of(), "manjaro", Map.of("freeipa-ldap-agent", "1.2.3"), false);
+
+        ImageEntity result = underTest.convert(source);
+
+        assertEquals(source.getUuid(), result.getImageId());
+        assertEquals(source.getOs(), result.getOs());
+        assertEquals(source.getOsType(), result.getOsType());
+        assertEquals(source.getDate(), result.getDate());
+        assertEquals("1.2.3", result.getLdapAgentVersion());
+    }
+
+    @Test
+    void testExtractLdapAgentVersion() {
+        Image source = new Image(1L, "date", "", "arch", "1-2-a-b", Map.of(), "manjaro", Map.of("freeipa-ldap-agent", "1.2.3"), false);
+
+        String result = underTest.extractLdapAgentVersion(source);
+
+        assertEquals("1.2.3", result);
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/image/ImageToImageSettingsResponseConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/image/ImageToImageSettingsResponseConverterTest.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.freeipa.converter.image;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.image.ImageSettingsResponse;
+import com.sequenceiq.freeipa.entity.ImageEntity;
+
+class ImageToImageSettingsResponseConverterTest {
+
+    private ImageToImageSettingsResponseConverter underTest = new ImageToImageSettingsResponseConverter();
+
+    @Test
+    void testConversion() {
+        ImageEntity source = new ImageEntity();
+        source.setImageId("imgid");
+        source.setImageCatalogUrl("caturl");
+        source.setOs("manjaro");
+        source.setLdapAgentVersion("1.2.3");
+
+        ImageSettingsResponse result = underTest.convert(source);
+
+        assertEquals(source.getImageId(), result.getId());
+        assertEquals(source.getImageCatalogUrl(), result.getCatalog());
+        assertEquals(source.getOs(), result.getOs());
+        assertEquals(source.getLdapAgentVersion(), result.getLdapAgentVersion());
+    }
+}


### PR DESCRIPTION
Store LDAP agent version to `ImageEntity` when creating FreeIPA. Also update it during upgrade. The version is exposed in `DescribeFreeIpaResponse#image` under `ldapAgentVersion` field.

See detailed description in the commit message.