### PR TITLE
CDPSDX-3783: Update the DatalakeDrResponseConvert

### DIFF
--- a/datalake-dr-connector/src/main/java/com/sequenceiq/cloudbreak/datalakedr/converter/OperationEnum.java
+++ b/datalake-dr-connector/src/main/java/com/sequenceiq/cloudbreak/datalakedr/converter/OperationEnum.java
@@ -17,7 +17,9 @@ public enum OperationEnum {
     SOLR_FULLTEXT_INDEX_DELETE("Solr delete fulltext_index"),
     SOLR_RANGER_AUDITS_DELETE("Solr delete ranger_audits"),
     SOLR_VERTEX_INDEX_DELETE("Solr delete vertex_index"),
-    DATABASE("Database");
+    DATABASE("Database"),
+    STORAGE_PERMISSION_VALIDATION_PRECHECK("Storage permission validation"),
+    RANGER_AUDIT_VALIDATION_PRECHECK("Ranger audit collection validation");
 
     private final String description;
 

--- a/datalake-dr-connector/src/main/java/com/sequenceiq/cloudbreak/datalakedr/model/DatalakeBackupStatusResponse.java
+++ b/datalake-dr-connector/src/main/java/com/sequenceiq/cloudbreak/datalakedr/model/DatalakeBackupStatusResponse.java
@@ -33,7 +33,7 @@ public class DatalakeBackupStatusResponse {
         return state != State.IN_PROGRESS && state != State.STARTED;
     }
 
-    public boolean failed() {
+    public boolean isFailed() {
         return state.equals(State.FAILED) || state.equals(State.VALIDATION_FAILED);
     }
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/DatalakeBackupActions.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/DatalakeBackupActions.java
@@ -103,7 +103,7 @@ public class DatalakeBackupActions {
                 variables.put(BACKUP_ID, backupStatusResponse.getBackupId());
                 variables.put(OPERATION_ID, backupStatusResponse.getBackupId());
                 payload.getDrStatus().setOperationId(backupStatusResponse.getBackupId());
-                if (!backupStatusResponse.failed()) {
+                if (!backupStatusResponse.isFailed()) {
                     sendEvent(context, DatalakeDatabaseBackupStartEvent.from(payload, backupStatusResponse.getBackupId()));
                 } else {
                     sendEvent(context, DATALAKE_BACKUP_FAILED_EVENT.event(), payload);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/DatalakeRestoreActions.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/DatalakeRestoreActions.java
@@ -116,7 +116,7 @@ public class DatalakeRestoreActions {
                 variables.put(BACKUP_ID, restoreStatusResponse.getBackupId());
                 variables.put(OPERATION_ID, restoreStatusResponse.getRestoreId());
                 payload.getDrStatus().setOperationId(restoreStatusResponse.getRestoreId());
-                if (!restoreStatusResponse.failed()) {
+                if (!restoreStatusResponse.isFailed()) {
                     sendEvent(context, DatalakeDatabaseRestoreStartEvent.from(payload, context.getSdxId(), restoreStatusResponse.getBackupId(),
                             restoreStatusResponse.getRestoreId()));
                 } else {

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/validation/DatalakeBackupValidationActions.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/validation/DatalakeBackupValidationActions.java
@@ -76,7 +76,7 @@ public class DatalakeBackupValidationActions {
                         sdxBackupRestoreService.triggerDatalakeBackupValidation(payload.getResourceId(), payload.getBackupLocation(), payload.getUserId());
                 variables.put(BACKUP_ID, backupStatusResponse.getBackupId());
                 payload.getDrStatus().setOperationId(backupStatusResponse.getBackupId());
-                if (!backupStatusResponse.failed()) {
+                if (!backupStatusResponse.isFailed()) {
                     sendEvent(context, DATALAKE_BACKUP_VALIDATION_IN_PROGRESS_EVENT.event(), payload);
                 } else {
                     LOGGER.error("Failed to initiate backup validation for cluster {}.", sdxCluster.getClusterName());

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/dr/SdxBackupRestoreService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/dr/SdxBackupRestoreService.java
@@ -450,7 +450,7 @@ public class SdxBackupRestoreService {
                     return AttemptResults.justContinue();
                 } else {
                     LOGGER.info("Backup for datalake {} complete with status {}", sdxCluster.getClusterName(), response.getState());
-                    if (response.getState() == DatalakeBackupStatusResponse.State.FAILED) {
+                    if (response.isFailed()) {
                         return sdxFullDrFailed(sdxCluster, response.getFailureReason(), pollingMessage);
                     } else {
                         return sdxFullDrSucceeded(sdxCluster, response);
@@ -525,7 +525,7 @@ public class SdxBackupRestoreService {
                     return AttemptResults.justContinue();
                 } else {
                     LOGGER.info("Restore for datalake {} complete with status {}", sdxCluster.getClusterName(), response.getState());
-                    if (response.getState() == DatalakeBackupStatusResponse.State.FAILED) {
+                    if (response.isFailed()) {
                         return sdxFullDrFailed(sdxCluster, response.getFailureReason(), pollingMessage);
                     } else {
                         return sdxFullDrSucceeded(sdxCluster, response);


### PR DESCRIPTION
[CDPSDX-3783](https://jira.cloudera.com/browse/CDPSDX-3783): Update the `DatalakeDrResponseConvert` to handle the `VALIDATION_FAILED` state. 
[**IMPROVEMENT**]: Use the `isFailed` method rather than the `getState` and validate the `state` value.
[**Rasason**]: the upgrade and the resize flow do not handle the `VALIDATION_FAILED` state. Therefore, if something fails in the backup or restore process. The flow continues, which can cause data loss in the `Datalake`.
Test cases:
with `cbd`

**Upgrade** light duty dl with 7.2.12 to 7.2.16
* validation failed case - the upgrade failed. 
* validation success case - the upgrade run without any error.

**Resize** light duty dl to medium duty
* validation failed case - the resize failed.
* validation success case - the resize run without any error.