### PR TITLE
CB-19687: Added a quick workaround to support SaltStack 3005.1

### DIFF
--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/client/SaltConnector.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/client/SaltConnector.java
@@ -189,17 +189,8 @@ public class SaltConnector implements Closeable {
         if ("state.show_sls".equals(fun)) {
             form.param("full_return", "True");
         }
-        if (arg != null) {
-            if (clientType.equals(SaltClientType.LOCAL) || clientType.equals(SaltClientType.LOCAL_ASYNC)) {
-                for (String a : arg) {
-                    form.param("arg", a);
-                }
-            } else {
-                for (int i = 0; i < arg.length - 1; i += 2) {
-                    form.param(arg[i], arg[i + 1]);
-                }
-            }
-        }
+        form = addExtraArguments(clientType, form, arg);
+
         Response response = endpointInvocation(SaltEndpoint.SALT_RUN.getContextPath(), toJson(form.asMap()).getBytes())
                 .post(Entity.form(form));
         T responseEntity = JaxRSUtil.response(response, clazz);
@@ -243,6 +234,26 @@ public class SaltConnector implements Closeable {
         LOGGER.debug("Executing salt upload with permission. targets: {}, path: {}, fileName: {}, permission: {}", targets, path, fileName, permission);
         Response distributeResponse = upload(SaltEndpoint.BOOT_FILE_DISTRIBUTE.getContextPath(), targets, path, fileName, permission, content);
         return getGenericResponses(targets, path, fileName, content, distributeResponse);
+    }
+
+    private Form addExtraArguments(SaltClientType clientType, Form form, String[] arg) {
+        if (arg != null) {
+            if (clientType.equals(SaltClientType.LOCAL) || clientType.equals(SaltClientType.LOCAL_ASYNC)) {
+                for (String a : arg) {
+                    form.param("arg", a);
+                }
+                // This is needed because of a bug in Saltstack 3005.1, which will be only fixed in 3006.x
+                // see details at: https://github.com/saltstack/salt/issues/62624
+                if (arg.length < 2) {
+                    form.param("arg", "s3005fix=true");
+                }
+            } else {
+                for (int i = 0; i < arg.length - 1; i += 2) {
+                    form.param(arg[i], arg[i + 1]);
+                }
+            }
+        }
+        return form;
     }
 
     private GenericResponses getGenericResponses(Iterable<String> targets, String path, String fileName, byte[] content, Response distributeResponse)


### PR DESCRIPTION
The workaround is to add an additional "arg" with a dummy value, but besides the workaround I had to do a small refactor to satisfy CheckStyle's cyclomatic complexity criteria as well.