### PR TITLE
CB-19729 refactor GCP stop

### DIFF
--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsComputeResourceService.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsComputeResourceService.java
@@ -39,7 +39,7 @@ public class AwsComputeResourceService {
             AdjustmentTypeWithThreshold adjustmentTypeWithThreshold, List<CloudResource> instances, List<CloudResource> networkResources) {
         LOGGER.info("Build AWS compute resources for launch with adjustment type and threshold: {}", adjustmentTypeWithThreshold);
         CloudContext cloudContext = ac.getCloudContext();
-        ResourceBuilderContext context = contextBuilder.contextInit(cloudContext, ac, stack.getNetwork(), null, true);
+        ResourceBuilderContext context = contextBuilder.contextInit(cloudContext, ac, stack.getNetwork(), true);
         context.addNetworkResources(networkResources);
         LOGGER.info("Added AWS network resources to resource builder context for launch: {}", networkResources);
         awsContextService.addInstancesToContext(instances, context, stack.getGroups());
@@ -53,7 +53,7 @@ public class AwsComputeResourceService {
         LOGGER.info("Build AWS compute resources for upscale with adjustment type and threshold: {}. Groups with new instances: {}",
                 adjustmentTypeWithThreshold, groupsWithNewInstances);
         CloudContext cloudContext = ac.getCloudContext();
-        ResourceBuilderContext context = contextBuilder.contextInit(cloudContext, ac, stack.getNetwork(), null, true);
+        ResourceBuilderContext context = contextBuilder.contextInit(cloudContext, ac, stack.getNetwork(), true);
         context.addNetworkResources(networkResources);
         LOGGER.info("Added AWS network resources to resource builder context for upscale: {}", networkResources);
 
@@ -72,7 +72,7 @@ public class AwsComputeResourceService {
 
     public List<CloudResourceStatus> deleteComputeResources(AuthenticatedContext ac, CloudStack stack, List<CloudResource> cloudResources) {
         CloudContext cloudContext = ac.getCloudContext();
-        ResourceBuilderContext context = contextBuilder.contextInit(cloudContext, ac, stack.getNetwork(), null, true);
+        ResourceBuilderContext context = contextBuilder.contextInit(cloudContext, ac, stack.getNetwork(), true);
 
         return computeResourceService.deleteResources(context, ac, cloudResources, false);
     }

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsUpscaleService.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsUpscaleService.java
@@ -176,7 +176,7 @@ public class AwsUpscaleService {
         if (entitlementService.isUnboundEliminationSupported(accountId) && entitlementService.targetedUpscaleSupported(accountId)) {
             result = Stream.of("running", "stopped");
         }
-        LOGGER.info("Allowed instance states in the scaled group: {}", result);
+        LOGGER.info("Allowed instance states in the scaled group: {}", result.collect(Collectors.joining(",")));
         return result;
     }
 

--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/context/AwsContextBuilder.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/context/AwsContextBuilder.java
@@ -1,7 +1,5 @@
 package com.sequenceiq.cloudbreak.cloud.aws.common.context;
 
-import java.util.List;
-
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.cloud.aws.common.AwsConstants;
@@ -10,7 +8,6 @@ import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonElasticLoadBalanc
 import com.sequenceiq.cloudbreak.cloud.aws.common.view.AuthenticatedContextView;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
-import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.Location;
 import com.sequenceiq.cloudbreak.cloud.model.Network;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
@@ -23,7 +20,7 @@ public class AwsContextBuilder implements ResourceContextBuilder<AwsContext> {
     private static final int PARALLEL_RESOURCE_REQUEST = 30;
 
     @Override
-    public AwsContext contextInit(CloudContext context, AuthenticatedContext auth, Network network, List<CloudResource> resources, boolean build) {
+    public AwsContext contextInit(CloudContext context, AuthenticatedContext auth, Network network, boolean build) {
         Location location = context.getLocation();
         AuthenticatedContextView authenticatedContextView = new AuthenticatedContextView(auth);
         AmazonEc2Client amazonEC2Client = authenticatedContextView.getAmazonEC2Client();

--- a/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsNativeResourceConnectorTest.java
+++ b/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsNativeResourceConnectorTest.java
@@ -98,7 +98,7 @@ public class AwsNativeResourceConnectorTest {
     public void testUpscale() throws QuotaExceededException {
         when(ac.getCloudContext()).thenReturn(cloudContext);
         when(contextBuilders.get(any())).thenReturn(resourceContextBuilder);
-        when(resourceContextBuilder.contextInit(any(), any(), any(), any(), anyBoolean())).thenReturn(awsContext);
+        when(resourceContextBuilder.contextInit(any(), any(), any(), anyBoolean())).thenReturn(awsContext);
         when(networkResourceService.getNetworkResources(any(), any())).thenReturn(Collections.emptyList());
         when(commonAwsClient.createElasticLoadBalancingClient(any(), any())).thenReturn(elasticLoadBalancingClient);
         when(cloudContext.getLocation()).thenReturn(Location.location(Region.region(REGION_NAME), AvailabilityZone.availabilityZone(AZ)));
@@ -113,7 +113,7 @@ public class AwsNativeResourceConnectorTest {
         when(ac.getCloudContext()).thenReturn(cloudContext);
         when(cloudContext.getId()).thenReturn(0L);
         when(contextBuilders.get(any())).thenReturn(resourceContextBuilder);
-        when(resourceContextBuilder.contextInit(any(), any(), any(), any(), anyBoolean())).thenReturn(awsContext);
+        when(resourceContextBuilder.contextInit(any(), any(), any(), anyBoolean())).thenReturn(awsContext);
         when(resourceRetriever.findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, 0L))
                 .thenReturn(Collections.emptyList());
 

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/AzureComputeResourceService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/AzureComputeResourceService.java
@@ -77,7 +77,7 @@ public class AzureComputeResourceService {
     }
 
     private AzureContext initContext(AuthenticatedContext ac, CloudStack cloudStack) {
-        AzureContext context = contextBuilder.contextInit(ac.getCloudContext(), ac, cloudStack.getNetwork(), null, true);
+        AzureContext context = contextBuilder.contextInit(ac.getCloudContext(), ac, cloudStack.getNetwork(), true);
         String stackCrn = cloudStack.getParameters().getOrDefault(PlatformParametersConsts.RESOURCE_CRN_PARAMETER, "");
         if (stackCrn.isEmpty()) {
             LOGGER.warn("Stack crn is not set in CloudStack, it can cause errors during infrastructure creation!");

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/context/AzureContextBuilder.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/context/AzureContextBuilder.java
@@ -1,13 +1,10 @@
 package com.sequenceiq.cloudbreak.cloud.azure.context;
 
-import java.util.List;
-
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.cloud.azure.AzureConstants;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
-import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.Location;
 import com.sequenceiq.cloudbreak.cloud.model.Network;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
@@ -20,7 +17,7 @@ public class AzureContextBuilder implements ResourceContextBuilder<AzureContext>
     private static final int PARALLEL_RESOURCE_REQUEST = 30;
 
     @Override
-    public AzureContext contextInit(CloudContext context, AuthenticatedContext auth, Network network, List<CloudResource> resources, boolean build) {
+    public AzureContext contextInit(CloudContext context, AuthenticatedContext auth, Network network, boolean build) {
         Location location = context.getLocation();
         return new AzureContext(context.getName(), location, PARALLEL_RESOURCE_REQUEST, build);
     }

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpCredentialConnector.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpCredentialConnector.java
@@ -48,7 +48,7 @@ public class GcpCredentialConnector implements CredentialConnector {
     public CloudCredentialStatus verify(@Nonnull AuthenticatedContext authenticatedContext, CredentialVerificationContext credentialVerificationContext) {
         LOGGER.debug("Verify credential: {}", authenticatedContext.getCloudCredential());
         gcpCredentialFactory.prepareCredential(authenticatedContext.getCloudCredential());
-        GcpContext gcpContext = gcpContextBuilder.contextInit(authenticatedContext.getCloudContext(), authenticatedContext, null, null, false);
+        GcpContext gcpContext = gcpContextBuilder.contextInit(authenticatedContext.getCloudContext(), authenticatedContext, null, false);
         try {
             gcpCredentialVerifier.checkGcpContextValidity(gcpContext);
             gcpCredentialVerifier.preCheckOfGooglePermission(gcpContext);

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpNetworkConnector.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpNetworkConnector.java
@@ -105,7 +105,7 @@ public class GcpNetworkConnector extends AbstractGcpResourceBuilder implements D
         CloudContext cloudContext = getCloudContext(networkCreationRequest);
         AuthenticatedContext auth = new AuthenticatedContext(cloudContext, networkCreationRequest.getCloudCredential());
         Network network = buildNetworkForCreation(networkCreationRequest);
-        GcpContext context = contextBuilders.contextInit(cloudContext, auth, network, null, true);
+        GcpContext context = contextBuilders.contextInit(cloudContext, auth, network, true);
 
         try {
             CloudResource networkResource = createNetwork(context, auth, network);
@@ -128,7 +128,7 @@ public class GcpNetworkConnector extends AbstractGcpResourceBuilder implements D
         CloudContext cloudContext = getCloudContext(networkDeletionRequest);
         AuthenticatedContext auth = new AuthenticatedContext(cloudContext, networkDeletionRequest.getCloudCredential());
         Network network = buildNetworkForDeletion(networkDeletionRequest);
-        GcpContext context = contextBuilders.contextInit(cloudContext, auth, network, null, true);
+        GcpContext context = contextBuilders.contextInit(cloudContext, auth, network, true);
 
         try {
             for (String subnetId : networkDeletionRequest.getSubnetIds()) {

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpResourceConnector.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpResourceConnector.java
@@ -59,7 +59,7 @@ public class GcpResourceConnector extends AbstractResourceConnector {
         CloudContext cloudContext = auth.getCloudContext();
         Platform platform = cloudContext.getPlatform();
 
-        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, auth, stack.getNetwork(), List.of(), true);
+        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, auth, stack.getNetwork(), true);
 
         return loadBalancerResourceService.buildResources(context, auth, stack);
     }

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilder.java
@@ -401,6 +401,11 @@ public class GcpInstanceResourceBuilder extends AbstractGcpComputeBuilder {
         return ORDER;
     }
 
+    @Override
+    public boolean isInstanceBuilder() {
+        return true;
+    }
+
     private Collection<AttachedDisk> getBootDiskList(List<CloudResource> resources, String projectId, String zone) {
         Collection<AttachedDisk> listOfDisks = new ArrayList<>();
         for (CloudResource resource : filterResourcesByType(resources, ResourceType.GCP_DISK)) {

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/context/GcpContextBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/context/GcpContextBuilder.java
@@ -1,7 +1,5 @@
 package com.sequenceiq.cloudbreak.cloud.gcp.context;
 
-import java.util.List;
-
 import javax.inject.Inject;
 
 import org.springframework.stereotype.Service;
@@ -13,7 +11,6 @@ import com.sequenceiq.cloudbreak.cloud.gcp.GcpConstants;
 import com.sequenceiq.cloudbreak.cloud.gcp.client.GcpComputeFactory;
 import com.sequenceiq.cloudbreak.cloud.gcp.util.GcpStackUtil;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
-import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.Location;
 import com.sequenceiq.cloudbreak.cloud.model.Network;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
@@ -32,7 +29,7 @@ public class GcpContextBuilder implements ResourceContextBuilder<GcpContext> {
     private GcpStackUtil gcpStackUtil;
 
     @Override
-    public GcpContext contextInit(CloudContext context, AuthenticatedContext auth, Network network, List<CloudResource> resources, boolean build) {
+    public GcpContext contextInit(CloudContext context, AuthenticatedContext auth, Network network, boolean build) {
         CloudCredential credential = auth.getCloudCredential();
         String projectId = gcpStackUtil.getProjectId(credential);
         String serviceAccountId = gcpStackUtil.getServiceAccountId(credential);

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpCredentialConnectorTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpCredentialConnectorTest.java
@@ -105,7 +105,7 @@ public class GcpCredentialConnectorTest {
     public void testForNullExceptionOnVerifyPermissionCheck() throws IOException {
         AuthenticatedContext authContext = createAuthContext();
         String expectionReasonMessage = "exception message";
-        when(contextBuilder.contextInit(authContext.getCloudContext(), authContext, null, null, false)).thenReturn(context);
+        when(contextBuilder.contextInit(authContext.getCloudContext(), authContext, null, false)).thenReturn(context);
         doThrow(new BadRequestException(expectionReasonMessage)).when(gcpCredentialVerifier).preCheckOfGooglePermission(context);
 
         CloudCredentialStatus status = underTest.verify(authContext, CREDENTIAL_VERIFICATION_CONTEXT);
@@ -123,7 +123,7 @@ public class GcpCredentialConnectorTest {
     @Test
     public void testPassingVerifyPermissionCheck() {
         AuthenticatedContext authContext = createAuthContext();
-        when(contextBuilder.contextInit(authContext.getCloudContext(), authContext, null, null, false)).thenReturn(context);
+        when(contextBuilder.contextInit(authContext.getCloudContext(), authContext, null, false)).thenReturn(context);
 
         CloudCredentialStatus status = underTest.verify(authContext, CREDENTIAL_VERIFICATION_CONTEXT);
 
@@ -139,7 +139,7 @@ public class GcpCredentialConnectorTest {
     @Test
     public void testForFailedStatusBecauseMissingPrjId() throws InvalidGcpContextException {
         final AuthenticatedContext authContext = createAuthContext();
-        when(contextBuilder.contextInit(authContext.getCloudContext(), authContext, null, null, false)).thenReturn(context);
+        when(contextBuilder.contextInit(authContext.getCloudContext(), authContext, null, false)).thenReturn(context);
         doThrow(new NullPointerException()).when(gcpCredentialVerifier).checkGcpContextValidity(context);
 
         CloudCredentialStatus status = underTest.verify(authContext, CREDENTIAL_VERIFICATION_CONTEXT);
@@ -156,7 +156,7 @@ public class GcpCredentialConnectorTest {
     @Test
     public void testForFailedStatusBecauseMissingServiceAccId() throws InvalidGcpContextException {
         final AuthenticatedContext authContext = createAuthContext();
-        when(contextBuilder.contextInit(authContext.getCloudContext(), authContext, null, null, false)).thenReturn(context);
+        when(contextBuilder.contextInit(authContext.getCloudContext(), authContext, null, false)).thenReturn(context);
         doThrow(new NullPointerException()).when(gcpCredentialVerifier).checkGcpContextValidity(context);
 
         CloudCredentialStatus status = underTest.verify(authContext, CREDENTIAL_VERIFICATION_CONTEXT);
@@ -173,7 +173,7 @@ public class GcpCredentialConnectorTest {
     @Test
     public void testForFailedStatusBecauseMissingCompute() throws IOException {
         final AuthenticatedContext authContext = createAuthContext();
-        when(contextBuilder.contextInit(authContext.getCloudContext(), authContext, null, null, false)).thenReturn(context);
+        when(contextBuilder.contextInit(authContext.getCloudContext(), authContext, null, false)).thenReturn(context);
         doThrow(new NullPointerException()).when(gcpCredentialVerifier).preCheckOfGooglePermission(context);
 
         CloudCredentialStatus status = underTest.verify(authContext, CREDENTIAL_VERIFICATION_CONTEXT);

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpNetworkConnectorTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpNetworkConnectorTest.java
@@ -121,7 +121,6 @@ public class GcpNetworkConnectorTest {
                 any(CloudContext.class),
                 any(AuthenticatedContext.class),
                 any(Network.class),
-                any(),
                 anyBoolean()))
                 .thenReturn(gcpContext);
 
@@ -194,7 +193,6 @@ public class GcpNetworkConnectorTest {
                 any(CloudContext.class),
                 any(AuthenticatedContext.class),
                 any(Network.class),
-                any(),
                 anyBoolean()))
                 .thenReturn(gcpContext);
 
@@ -276,7 +274,6 @@ public class GcpNetworkConnectorTest {
                 any(CloudContext.class),
                 any(AuthenticatedContext.class),
                 any(Network.class),
-                any(),
                 anyBoolean()))
                 .thenReturn(gcpContext);
 
@@ -361,7 +358,6 @@ public class GcpNetworkConnectorTest {
                 any(CloudContext.class),
                 any(AuthenticatedContext.class),
                 any(Network.class),
-                any(),
                 anyBoolean()))
                 .thenReturn(gcpContext);
 
@@ -432,7 +428,6 @@ public class GcpNetworkConnectorTest {
                 any(CloudContext.class),
                 any(AuthenticatedContext.class),
                 any(Network.class),
-                any(),
                 anyBoolean()))
                 .thenReturn(gcpContext);
 

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpResourceConnectorTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpResourceConnectorTest.java
@@ -121,7 +121,6 @@ public class GcpResourceConnectorTest {
                 any(CloudContext.class),
                 any(AuthenticatedContext.class),
                 any(Network.class),
-                anyList(),
                 anyBoolean())).thenReturn(resourceBuilderContext);
 
         when(loadBalancerResourceService.buildResources(
@@ -209,7 +208,6 @@ public class GcpResourceConnectorTest {
                 any(CloudContext.class),
                 any(AuthenticatedContext.class),
                 any(Network.class),
-                anyList(),
                 anyBoolean())).thenReturn(resourceBuilderContext);
         when(networkResourceService.getNetworkResources(any(Variant.class), anyList())).thenReturn(new ArrayList<>());
         doNothing().when(resourceBuilderContext).addNetworkResources(anyCollection());

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/context/GcpContextBuilderTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/context/GcpContextBuilderTest.java
@@ -4,8 +4,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
-
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -64,7 +62,6 @@ public class GcpContextBuilderTest {
                 context,
                 auth,
                 mock(Network.class),
-                new ArrayList<>(),
                 true);
         Assert.assertEquals("ProjectId", gcpContext.getProjectId());
         Assert.assertEquals(true, gcpContext.getNoPublicIp());

--- a/cloud-template/build.gradle
+++ b/cloud-template/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 
     implementation group: 'org.slf4j',                     name: 'slf4j-api',                      version: slf4jApiVersion
 
+    testImplementation group: 'org.assertj',               name: 'assertj-core',                   version: assertjVersion
     testImplementation (group: 'org.mockito',              name: 'mockito-core',                   version: mockitoVersion) {
       exclude group: 'org.hamcrest'
     }

--- a/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/AbstractInstanceConnector.java
+++ b/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/AbstractInstanceConnector.java
@@ -33,10 +33,10 @@ public abstract class AbstractInstanceConnector implements InstanceConnector {
         Platform platform = cloudContext.getPlatform();
 
         //context
-        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, ac, null, resources, false);
+        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, ac, null, false);
 
         //compute
-        return computeResourceService.stopInstances(context, ac, resources, vms);
+        return computeResourceService.stopInstances(context, ac, vms);
     }
 
     @Override
@@ -45,10 +45,10 @@ public abstract class AbstractInstanceConnector implements InstanceConnector {
         Platform platform = cloudContext.getPlatform();
 
         //context
-        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, ac, null, resources, true);
+        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, ac, null, true);
 
         //compute
-        return computeResourceService.startInstances(context, ac, resources, vms);
+        return computeResourceService.startInstances(context, ac, vms);
     }
 
 }

--- a/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/AbstractResourceConnector.java
+++ b/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/AbstractResourceConnector.java
@@ -102,7 +102,7 @@ public abstract class AbstractResourceConnector implements ResourceConnector {
         Platform platform = cloudContext.getPlatform();
 
         //context
-        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, auth, stack.getNetwork(), null, true);
+        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, auth, stack.getNetwork(), true);
 
         //network
         List<CloudResourceStatus> cloudResourceStatuses = networkResourceService.buildResources(context, auth, stack.getNetwork(), stack.getCloudSecurity());
@@ -146,7 +146,7 @@ public abstract class AbstractResourceConnector implements ResourceConnector {
         Platform platform = cloudContext.getPlatform();
 
         //context
-        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, auth, stack.getNetwork(), cloudResources, false);
+        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, auth, stack.getNetwork(), false);
 
         //loadBalancer
         List<CloudResourceStatus> cloudResourceStatuses = loadBalancerResourceService.deleteResources(context, auth, cloudResources, false);
@@ -199,7 +199,7 @@ public abstract class AbstractResourceConnector implements ResourceConnector {
         Variant variant = cloudContext.getVariant();
 
         //context
-        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, auth, stack.getNetwork(), resources, true);
+        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, auth, stack.getNetwork(), true);
 
         //network
         context.addNetworkResources(networkResourceService.getNetworkResources(variant, resources));
@@ -260,7 +260,7 @@ public abstract class AbstractResourceConnector implements ResourceConnector {
         Platform platform = cloudContext.getPlatform();
 
         //context
-        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, auth, stack.getNetwork(), resources, false);
+        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, auth, stack.getNetwork(), false);
 
         //compute
         return computeResourceService.deleteResources(context, auth, resourcesToRemove, true);
@@ -274,7 +274,7 @@ public abstract class AbstractResourceConnector implements ResourceConnector {
         Variant variant = cloudContext.getVariant();
 
         //context
-        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, auth, stack.getNetwork(), resources, true);
+        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, auth, stack.getNetwork(), true);
 
         //group
         List<CloudResource> groupResources = groupResourceService.getGroupResources(variant, resources);

--- a/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/ComputeResourceBuilder.java
+++ b/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/ComputeResourceBuilder.java
@@ -150,4 +150,8 @@ public interface ComputeResourceBuilder<C extends ResourceBuilderContext> extend
      */
     ResourceType resourceType();
 
+    default boolean isInstanceBuilder() {
+        return false;
+    }
+
 }

--- a/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/ResourceContextBuilder.java
+++ b/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/ResourceContextBuilder.java
@@ -1,11 +1,8 @@
 package com.sequenceiq.cloudbreak.cloud.template;
 
-import java.util.List;
-
 import com.sequenceiq.cloudbreak.cloud.CloudPlatformAware;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
-import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.Network;
 import com.sequenceiq.cloudbreak.cloud.template.context.ResourceBuilderContext;
 
@@ -23,10 +20,9 @@ public interface ResourceContextBuilder<C extends ResourceBuilderContext> extend
      * @param cloudContext Context for the specific cloud stack.
      * @param auth         Authenticated context is provided to be able to send the requests to the cloud provider.
      * @param network      Network can provide extra information during compute resource creation time
-     * @param resources    The context can be initialized with base resources.
      * @param build        Provides a simple boolean flag used to determine creation/deletion or stop/start
      * @return Returns the initialized context object.
      */
-    C contextInit(CloudContext cloudContext, AuthenticatedContext auth, Network network, List<CloudResource> resources, boolean build);
+    C contextInit(CloudContext cloudContext, AuthenticatedContext auth, Network network, boolean build);
 
 }

--- a/cloud-template/src/test/java/com/sequenceiq/cloudbreak/cloud/template/compute/ComputeResourceServiceTest.java
+++ b/cloud-template/src/test/java/com/sequenceiq/cloudbreak/cloud/template/compute/ComputeResourceServiceTest.java
@@ -1,0 +1,97 @@
+package com.sequenceiq.cloudbreak.cloud.template.compute;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.task.AsyncTaskExecutor;
+
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
+import com.sequenceiq.cloudbreak.cloud.model.CloudVmInstanceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.Variant;
+import com.sequenceiq.cloudbreak.cloud.scheduler.SyncPollingScheduler;
+import com.sequenceiq.cloudbreak.cloud.task.PollTask;
+import com.sequenceiq.cloudbreak.cloud.template.ComputeResourceBuilder;
+import com.sequenceiq.cloudbreak.cloud.template.context.ResourceBuilderContext;
+import com.sequenceiq.cloudbreak.cloud.template.init.ResourceBuilders;
+import com.sequenceiq.cloudbreak.cloud.template.task.ResourcePollTaskFactory;
+
+@ExtendWith(MockitoExtension.class)
+class ComputeResourceServiceTest {
+
+    @InjectMocks
+    private ComputeResourceService computeResourceService;
+
+    @Mock
+    private ResourceBuilders resourceBuilders;
+
+    @Mock
+    private ResourceActionFactory resourceActionFactory;
+
+    @Mock
+    private AsyncTaskExecutor resourceBuilderExecutor;
+
+    @Mock
+    private ResourcePollTaskFactory resourcePollTaskFactory;
+
+    @Mock
+    private SyncPollingScheduler<List<CloudVmInstanceStatus>> syncVMPollingScheduler;
+
+    @Test
+    public void startInstancesTest() throws Exception {
+        when(resourceBuilders.getStopStartBatchSize(any())).thenReturn(10);
+        ComputeResourceBuilder computeResourceBuilder = mock(ComputeResourceBuilder.class);
+        when(computeResourceBuilder.isInstanceBuilder()).thenReturn(true);
+        when(resourceBuilders.compute(any())).thenReturn(List.of(computeResourceBuilder));
+        ResourceStopStartCallable resourceStopStartCallable = mock(ResourceStopStartCallable.class);
+        when(resourceActionFactory.buildStopStartCallable(any())).thenReturn(resourceStopStartCallable);
+        Future future = mock(Future.class);
+        ResourceRequestResult resourceRequestResult = mock(ResourceRequestResult.class);
+        when(future.get()).thenReturn(resourceRequestResult);
+        when(resourceBuilderExecutor.submit(any(Callable.class))).thenReturn(future);
+        ResourceBuilderContext resourceBuilderContext = mock(ResourceBuilderContext.class);
+        CloudContext cloudContext = mock(CloudContext.class);
+        Variant variant = Variant.variant("AWS");
+        when(cloudContext.getVariant()).thenReturn(variant);
+        AuthenticatedContext authenticatedContext = new AuthenticatedContext(cloudContext, new CloudCredential());
+        CloudInstance cloudInstance1 = mock(CloudInstance.class);
+        CloudInstance cloudInstance2 = mock(CloudInstance.class);
+        CloudVmInstanceStatus cloudVmInstanceStatus1 = new CloudVmInstanceStatus(cloudInstance1, InstanceStatus.STOPPED);
+        CloudVmInstanceStatus cloudVmInstanceStatus2 = new CloudVmInstanceStatus(cloudInstance2, InstanceStatus.STOPPED);
+        when(resourceRequestResult.getResult()).thenReturn(List.of(cloudVmInstanceStatus1, cloudVmInstanceStatus2));
+        List<CloudInstance> cloudInstanceList = List.of(cloudInstance1, cloudInstance2);
+        PollTask pollTask = mock(PollTask.class);
+        when(resourcePollTaskFactory.newPollComputeStatusTask(eq(computeResourceBuilder), eq(authenticatedContext), eq(resourceBuilderContext),
+                        eq(cloudInstanceList))).thenReturn(pollTask);
+        computeResourceService.startInstances(resourceBuilderContext, authenticatedContext, cloudInstanceList);
+        verify(resourceBuilders, times(1)).getStopStartBatchSize(variant);
+        verify(resourceBuilders, times(1)).compute(variant);
+        verify(computeResourceBuilder, times(1)).isInstanceBuilder();
+        ArgumentCaptor<ResourceStopStartCallablePayload> resourceStopStartCallablePayloadArgumentCaptor =
+                ArgumentCaptor.forClass(ResourceStopStartCallablePayload.class);
+        verify(resourceActionFactory, times(1)).buildStopStartCallable(resourceStopStartCallablePayloadArgumentCaptor.capture());
+        ResourceStopStartCallablePayload resourceStopStartCallablePayload = resourceStopStartCallablePayloadArgumentCaptor.getValue();
+        assertThat(resourceStopStartCallablePayload.getInstances()).containsExactlyInAnyOrder(cloudInstance1, cloudInstance2);
+        verify(resourceBuilderExecutor, times(1)).submit(resourceStopStartCallable);
+        verify(syncVMPollingScheduler, times(1)).schedule(pollTask);
+
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/migration/handler/CreateResourcesHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/migration/handler/CreateResourcesHandler.java
@@ -57,7 +57,7 @@ public class CreateResourcesHandler implements CloudPlatformEventHandler<CreateR
             CloudStack cloudStack = request.getCloudStack();
             AuthenticatedContext ac = awsAuthenticator.authenticate(cloudContext, cloudCredential);
             Network network = cloudStack.getNetwork();
-            AwsContext awsContext = awsContextBuilder.contextInit(cloudContext, ac, network, List.of(), true);
+            AwsContext awsContext = awsContextBuilder.contextInit(cloudContext, ac, network, true);
             for (ResourceRecreator resourceRecreator : resourceRecreators) {
                 resourceRecreator.recreate(request, awsContext, ac);
             }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/stack/migration/handler/CreateResourcesHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/stack/migration/handler/CreateResourcesHandlerTest.java
@@ -5,8 +5,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -76,7 +74,7 @@ public class CreateResourcesHandlerTest {
 
         when(cloudStack.getNetwork()).thenReturn(network);
         when(awsAuthenticator.authenticate(cloudContext, cloudCredential)).thenReturn(ac);
-        when(awsContextBuilder.contextInit(cloudContext, ac, network, List.of(), true)).thenReturn(awsContext);
+        when(awsContextBuilder.contextInit(cloudContext, ac, network, true)).thenReturn(awsContext);
 
         underTest.accept(event);
 
@@ -94,7 +92,7 @@ public class CreateResourcesHandlerTest {
         when(cloudStack.getNetwork()).thenReturn(network);
         when(awsAuthenticator.authenticate(cloudContext, cloudCredential)).thenReturn(ac);
         RuntimeException value = new RuntimeException();
-        when(awsContextBuilder.contextInit(cloudContext, ac, network, List.of(), true)).thenThrow(value);
+        when(awsContextBuilder.contextInit(cloudContext, ac, network, true)).thenThrow(value);
 
         underTest.accept(event);
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/migration/handler/CreateResourcesHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/migration/handler/CreateResourcesHandler.java
@@ -57,7 +57,7 @@ public class CreateResourcesHandler implements CloudPlatformEventHandler<CreateR
             CloudStack cloudStack = request.getCloudStack();
             AuthenticatedContext ac = awsAuthenticator.authenticate(cloudContext, cloudCredential);
             Network network = cloudStack.getNetwork();
-            AwsContext awsContext = awsContextBuilder.contextInit(cloudContext, ac, network, List.of(), true);
+            AwsContext awsContext = awsContextBuilder.contextInit(cloudContext, ac, network, true);
             for (ResourceRecreator resourceRecreator : resourceRecreators) {
                 resourceRecreator.recreate(request, awsContext, ac);
             }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/migration/handler/CreateResourcesHandlerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/migration/handler/CreateResourcesHandlerTest.java
@@ -5,8 +5,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -76,7 +74,7 @@ public class CreateResourcesHandlerTest {
 
         when(cloudStack.getNetwork()).thenReturn(network);
         when(awsAuthenticator.authenticate(cloudContext, cloudCredential)).thenReturn(ac);
-        when(awsContextBuilder.contextInit(cloudContext, ac, network, List.of(), true)).thenReturn(awsContext);
+        when(awsContextBuilder.contextInit(cloudContext, ac, network, true)).thenReturn(awsContext);
 
         underTest.accept(event);
 
@@ -94,7 +92,7 @@ public class CreateResourcesHandlerTest {
         when(cloudStack.getNetwork()).thenReturn(network);
         when(awsAuthenticator.authenticate(cloudContext, cloudCredential)).thenReturn(ac);
         RuntimeException value = new RuntimeException();
-        when(awsContextBuilder.contextInit(cloudContext, ac, network, List.of(), true)).thenThrow(value);
+        when(awsContextBuilder.contextInit(cloudContext, ac, network, true)).thenThrow(value);
 
         underTest.accept(event);
 


### PR DESCRIPTION
If an instance and the related disk creation finished at the same time, then they will have the same resource name: https://github.com/hortonworks/cloudbreak/blob/39ad3cbd6e285cf6dc95028e0bad620e0c7f1a61/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/service/GcpResourceNameService.java#L112

https://github.com/hortonworks/cloudbreak/blob/39ad3cbd6e285cf6dc95028e0bad620e0c7f1a61/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/service/GcpResourceNameService.java#L49-L57

The stop logic tries to find instance resource by name here (I think the creator wanted to find the instance resource builder with this "creative" logic): https://github.com/hortonworks/cloudbreak/blob/115451c8a2c883967d1447f5695dae2bc9c3736e/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/compute/ComputeResourceService.java#L143

https://github.com/hortonworks/cloudbreak/blob/115451c8a2c883967d1447f5695dae2bc9c3736e/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/compute/ComputeResourceService.java#L245-L259

The result is the code wants to stop the disk, but it does not implement the stop method, and it returns null which causes NPE.

I think the problem is we don't know which builder is an instance builder class, so I add a new isInstanceBuilder() method to ComputeResourceBuilder, so we can find out which one is an instance builder.

See detailed description in the commit message.