### PR TITLE
CB-19563, CB-19672 - Private endpoints for old clusters should be handled properly

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureCloudResourceService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureCloudResourceService.java
@@ -53,6 +53,11 @@ public class AzureCloudResourceService {
                 .collect(Collectors.toList());
     }
 
+    public List<ResourceType> getPrivateEndpointRdsResourceTypes() {
+        return List.of(ResourceType.AZURE_DNS_ZONE_GROUP,
+                ResourceType.AZURE_PRIVATE_ENDPOINT);
+    }
+
     public List<CloudResource> getDeploymentCloudResources(Deployment templateDeployment) {
         PagedList<DeploymentOperation> operations = templateDeployment.deploymentOperations().list();
         List<CloudResource> resourceList = operations.stream()

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
@@ -384,6 +384,6 @@ public class AzureResourceConnector extends AbstractResourceConnector {
     @Override
     public void upgradeDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
             PersistenceNotifier persistenceNotifier, TargetMajorVersion targetMajorVersion, List<CloudResource> resources) {
-        azureDatabaseResourceService.upgradeDatabaseServer(authenticatedContext, stack, persistenceNotifier, targetMajorVersion);
+        azureDatabaseResourceService.upgradeDatabaseServer(authenticatedContext, stack, persistenceNotifier, targetMajorVersion, resources);
     }
 }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceType.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceType.java
@@ -1,0 +1,40 @@
+package com.sequenceiq.cloudbreak.cloud.azure;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.sequenceiq.common.api.type.ResourceType;
+
+public enum AzureResourceType {
+
+    DATABASE_SERVER("DatabaseServer", ResourceType.AZURE_DATABASE),
+    PRIVATE_ENDPOINT("PrivateEndpoint", ResourceType.AZURE_PRIVATE_ENDPOINT),
+    PRIVATE_DNS_ZONE_GROUP("PrivateDnsZoneGroup", ResourceType.AZURE_DNS_ZONE_GROUP),
+    RESOURCE_GROUP("ResourceGroup", ResourceType.AZURE_RESOURCE_GROUP);
+
+    private static final Map<ResourceType, AzureResourceType> BY_RESOURCE_TYPE = Stream.of(AzureResourceType.values())
+            .collect(Collectors.toUnmodifiableMap(AzureResourceType::getResourceType, Function.identity()));
+
+    private final String azureType;
+
+    private final ResourceType resourceType;
+
+    AzureResourceType(String azureType, ResourceType resourceType) {
+        this.azureType = azureType;
+        this.resourceType = resourceType;
+    }
+
+    public String getAzureType() {
+        return azureType;
+    }
+
+    public ResourceType getResourceType() {
+        return resourceType;
+    }
+
+    public static AzureResourceType getByResourceType(ResourceType resourceType) {
+        return BY_RESOURCE_TYPE.get(resourceType);
+    }
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtils.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtils.java
@@ -616,6 +616,16 @@ public class AzureUtils {
     }
 
     @Retryable(backoff = @Backoff(delay = 1000, multiplier = 2, maxDelay = 10000), maxAttempts = 5)
+    public Optional<String> deletePrivateDnsZoneGroup(AzureClient azureClient, String id, boolean cancelException) {
+        return handleDeleteErrors(azureClient::deleteGenericResourceById, "PrivateDnsZoneGroup", id, cancelException);
+    }
+
+    @Retryable(backoff = @Backoff(delay = 1000, multiplier = 2, maxDelay = 10000), maxAttempts = 5)
+    public Optional<String> deleteGenericResourceById(AzureClient azureClient, String id, AzureResourceType resourceType) {
+        return handleDeleteErrors(azureClient::deleteGenericResourceById, resourceType.getAzureType(), id, false);
+    }
+
+    @Retryable(backoff = @Backoff(delay = 1000, multiplier = 2, maxDelay = 10000), maxAttempts = 5)
     public Optional<String> deleteResourceGroup(AzureClient azureClient, String resourceGroupId, boolean cancelException) {
         return handleDeleteErrors(azureClient::deleteResourceGroup, "ResourceGroup", resourceGroupId, cancelException);
     }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureCloudResourceServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureCloudResourceServiceTest.java
@@ -70,7 +70,7 @@ public class AzureCloudResourceServiceTest {
     private Deployment deployment;
 
     @Test
-    public void getListWithKnownSuccededCloudResource() {
+    public void getListWithKnownSucceededCloudResource() {
         TargetResource t = new TargetResource();
         t.withResourceType(MICROSOFT_COMPUTE_VIRTUAL_MACHINES);
         t.withResourceName(VM_NAME);

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnectorTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnectorTest.java
@@ -45,6 +45,7 @@ import com.sequenceiq.cloudbreak.common.database.TargetMajorVersion;
 import com.sequenceiq.cloudbreak.service.Retry;
 import com.sequenceiq.common.api.adjustment.AdjustmentTypeWithThreshold;
 import com.sequenceiq.common.api.type.AdjustmentType;
+import com.sequenceiq.common.api.type.ResourceType;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AzureResourceConnectorTest {
@@ -239,9 +240,12 @@ public class AzureResourceConnectorTest {
     public void testUpgradeDatabaseServer() {
         DatabaseStack databaseStack = mock(DatabaseStack.class);
         PersistenceNotifier persistenceNotifier = mock(PersistenceNotifier.class);
+        CloudResource resource1 = new CloudResource.Builder().withType(ResourceType.AZURE_DATABASE).withName("resource1").build();
+        CloudResource resource2 = new CloudResource.Builder().withType(ResourceType.AZURE_PRIVATE_ENDPOINT).withName("resource2").build();
 
-        underTest.upgradeDatabaseServer(ac, databaseStack, persistenceNotifier, TargetMajorVersion.VERSION_11, List.of());
+        underTest.upgradeDatabaseServer(ac, databaseStack, persistenceNotifier, TargetMajorVersion.VERSION_11, List.of(resource1, resource2));
         verify(azureDatabaseResourceService, times(1))
-                .upgradeDatabaseServer(eq(ac), eq(databaseStack), eq(persistenceNotifier), eq(TargetMajorVersion.VERSION_11));
+                .upgradeDatabaseServer(eq(ac), eq(databaseStack), eq(persistenceNotifier),
+                        eq(TargetMajorVersion.VERSION_11), eq(List.of(resource1, resource2)));
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/network/NetworkParameterAdder.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/network/NetworkParameterAdder.java
@@ -8,6 +8,7 @@ import javax.inject.Inject;
 import org.springframework.stereotype.Service;
 
 import com.google.common.base.Strings;
+import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.converter.ServiceEndpointCreationToEndpointTypeConverter;
 import com.sequenceiq.common.model.PrivateEndpointType;
@@ -104,7 +105,7 @@ public class NetworkParameterAdder {
                 .stream()
                 .findFirst()
                 .map(csn -> subnetListerService.expandAzureResourceId(csn, detailedEnvironmentResponse, subscriptionId))
-                .map(sn -> sn.getId()).orElseThrow(() -> new RedbeamsException("It is not possible to create private endpoints for database: " +
+                .map(CloudSubnet::getId).orElseThrow(() -> new RedbeamsException("It is not possible to create private endpoints for database: " +
                         "there are no subnets with privateEndpointNetworkPolicies disabled"));
     }
 }


### PR DESCRIPTION
All the Private Endpoint related cloud resources for the given RDS stack get deleted and re-created instead of marking them
`DETACHED` and re-attach them afterwards.

This prevents us from naming errors like in CB-19574, when subnet naming
convention change results in inconsistent naming of a Private Endpoint
resource.