### PR TITLE
CB-18829 Add syncall salt call after uploading pillars

### DIFF
--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
@@ -533,6 +533,7 @@ public class SaltOrchestrator implements HostOrchestrator {
         try (SaltConnector sc = saltService.createSaltConnector(primaryGateway)) {
             saveHostsPillar(stack, exitModel, gatewayTargets, sc);
             saveCustomPillars(saltConfig, exitModel, gatewayTargets, sc);
+            runSyncAll(sc, gatewayTargets, allNodes, exitModel);
         } catch (ExecutionException e) {
             LOGGER.warn("Error occurred during bootstrap", e);
             if (e.getCause() instanceof CloudbreakOrchestratorFailedException) {


### PR DESCRIPTION
During recipe execution we noticed the pillars returned by salt command (eg pillar.get) are stale while the files are up to date. After calling syncall command the pillars seems to be up to date. This has caused salt rendering issues during our e2e tests.

See detailed description in the commit message.