### PR TITLE
CB-19811 - Image list could not be cleared during image selection

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ProviderSpecificImageFilter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ProviderSpecificImageFilter.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.service.image;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -31,7 +32,7 @@ public class ProviderSpecificImageFilter {
                 .map(platform -> filterImages(platform.name(), imageList))
                 .flatMap(List::stream)
                 .collect(Collectors.toSet());
-        return List.copyOf(uniqueImages);
+        return new ArrayList<>(uniqueImages);
     }
 
     private List<Image> filterImages(String cloudPlatform, List<Image> imageList) {


### PR DESCRIPTION
Image filter should have returned a mutable list implementation as it turned out there is a specific code path which tries to delete from the filtered image list:

```
if (!imageFilter.isBaseImageEnabled()) {
    baseImages.clear();
}
```

