### PR TITLE
CB-19714 switch to http://nexus-private.hortonworks.com:8081 

### DIFF
--- a/docker-autoscale/Dockerfile
+++ b/docker-autoscale/Dockerfile
@@ -3,7 +3,7 @@ FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-openjdk-11-runtim
 MAINTAINER info@cloudera.com
 
 # REPO URL to download jar
-ARG REPO_URL=http://repo.hortonworks.com/content/repositories/releases
+ARG REPO_URL=https://nexus-private.hortonworks.com/nexus/content/groups/public
 ARG VERSION=''
 
 ENV VERSION ${VERSION}

--- a/docker-cloudbreak/Dockerfile
+++ b/docker-cloudbreak/Dockerfile
@@ -3,7 +3,7 @@ FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-openjdk-11-runtim
 MAINTAINER info@cloudera.com
 
 # REPO URL to download jar
-ARG REPO_URL=https://repo.hortonworks.com/content/repositories/releases
+ARG REPO_URL=https://nexus-private.hortonworks.com/nexus/content/groups/public
 ARG VERSION=''
 
 ENV VERSION ${VERSION}

--- a/docker-consumption/Dockerfile
+++ b/docker-consumption/Dockerfile
@@ -3,7 +3,7 @@ FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-openjdk-11-runtim
 MAINTAINER info@cloudera.com
 
 # REPO URL to download jar
-ARG REPO_URL=https://repo.hortonworks.com/content/repositories/releases
+ARG REPO_URL=https://nexus-private.hortonworks.com/nexus/content/groups/public
 ARG VERSION=''
 
 ENV VERSION ${VERSION}

--- a/docker-datalake/Dockerfile
+++ b/docker-datalake/Dockerfile
@@ -3,7 +3,7 @@ FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-openjdk-11-runtim
 MAINTAINER info@cloudera.com
 
 # REPO URL to download jar
-ARG REPO_URL=https://repo.hortonworks.com/content/repositories/releases
+ARG REPO_URL=https://nexus-private.hortonworks.com/nexus/content/groups/public
 ARG VERSION=''
 
 ENV VERSION ${VERSION}

--- a/docker-environment/Dockerfile
+++ b/docker-environment/Dockerfile
@@ -3,7 +3,7 @@ FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-openjdk-11-runtim
 MAINTAINER info@cloudera.com
 
 # REPO URL to download jar
-ARG REPO_URL=https://repo.hortonworks.com/content/repositories/releases
+ARG REPO_URL=https://nexus-private.hortonworks.com/nexus/content/groups/public
 ARG VERSION=''
 
 ENV VERSION ${VERSION}

--- a/docker-freeipa/Dockerfile
+++ b/docker-freeipa/Dockerfile
@@ -3,7 +3,7 @@ FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-openjdk-11-runtim
 MAINTAINER info@cloudera.com
 
 # REPO URL to download jar
-ARG REPO_URL=https://repo.hortonworks.com/content/repositories/releases
+ARG REPO_URL=https://nexus-private.hortonworks.com/nexus/content/groups/public
 ARG VERSION=''
 
 ENV VERSION ${VERSION}

--- a/docker-redbeams/Dockerfile
+++ b/docker-redbeams/Dockerfile
@@ -3,7 +3,7 @@ FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-openjdk-11-runtim
 MAINTAINER info@cloudera.com
 
 # REPO URL to download jar
-ARG REPO_URL=https://repo.hortonworks.com/content/repositories/releases
+ARG REPO_URL=https://nexus-private.hortonworks.com/nexus/content/groups/public
 ARG VERSION=''
 
 ENV VERSION ${VERSION}

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,12 @@ org.gradle.logging.level=lifecycle
 
 # Version definitions have been moved to dependencies.gradle
 
+#added due to a JDK 11 bug with TLSv1.3, https://bugs.openjdk.org/browse/JDK-8213202
+GRADLE_OPTS="-Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2,-Djdk.tls.client.protocols=TLSv1.2"
+JAVA_TOOL_OPTIONS="-Dhttps.protocols=TLSv1.2,-Djdk.tls.client.protocols=TLSv1.2"
+
 # Repo Urls
-repoUrl=https://repo.hortonworks.com/content/repositories/releases/
+repoUrl=https://nexus-private.hortonworks.com/nexus/content/groups/public
 repoMirrorUrl=https://maven.jenkins.cloudera.com/artifactory/cloudera-mirrors/
 springRepoUrl=https://repo.spring.io/libs-release
 cdpRepoUrl=https://repository.cloudera.com/artifactory/cloudera-repos/

--- a/mock-infrastructure/Dockerfile
+++ b/mock-infrastructure/Dockerfile
@@ -2,7 +2,7 @@ FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-openjdk-11-runtim
 MAINTAINER info@cloudera.com
 
 # REPO URL to download jar
-ARG REPO_URL=https://repo.hortonworks.com/content/repositories/releases
+ARG REPO_URL=https://nexus-private.hortonworks.com/nexus/content/groups/public
 ARG VERSION=''
 
 ENV VERSION ${VERSION}

--- a/mock-thunderhead/Dockerfile
+++ b/mock-thunderhead/Dockerfile
@@ -2,7 +2,7 @@ FROM docker-private.infra.cloudera.com/cloudera_base/ubi8/cldr-openjdk-11-runtim
 MAINTAINER info@cloudera.com
 
 # REPO URL to download jar
-ARG REPO_URL=https://repo.hortonworks.com/content/repositories/releases
+ARG REPO_URL=https://nexus-private.hortonworks.com/nexus/content/groups/public
 ARG VERSION=''
 
 ENV VERSION ${VERSION}


### PR DESCRIPTION
from https://repo.hortonworks.com/ for stability reason.

Releng not responded to my query what is the exact mirror of the `/releases` repository in the new nexus. I've did a quick sweep but did not seem to find a 1-1 match.
Therefore I've specified the rooth path of the repository.