### PR TITLE
CB-19526 Upgrade with image id should ignore if image is not part of …

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogService.java
@@ -846,7 +846,7 @@ public class ImageCatalogService extends AbstractWorkspaceAwareResourceService<I
         return imageCatalogProvider.getImageCatalogMetaData(defaultCatalogUrl).getRuntimeVersions();
     }
 
-    public ImageFilterResult getImageFilterResult(Long workspaceId, String imageCatalogName, ImageCatalogPlatform imageCatalogPlatform)
+    public ImageFilterResult getImageFilterResult(Long workspaceId, String imageCatalogName, ImageCatalogPlatform imageCatalogPlatform, boolean getAllImages)
             throws CloudbreakImageCatalogException {
         ImageCatalog imageCatalog = getImageCatalogByName(workspaceId, imageCatalogName);
         if (isCustomImageCatalog(imageCatalog)) {
@@ -854,7 +854,11 @@ public class ImageCatalogService extends AbstractWorkspaceAwareResourceService<I
             return new ImageFilterResult(statedImages.getImages().getCdhImages());
         } else {
             CloudbreakImageCatalogV3 v3ImageCatalog = imageCatalogProvider.getImageCatalogV3(imageCatalog.getImageCatalogUrl());
-            return imageCatalogServiceProxy.getImageFilterResult(v3ImageCatalog);
+            if (getAllImages) {
+                return new ImageFilterResult(v3ImageCatalog.getImages().getCdhImages());
+            } else {
+                return imageCatalogServiceProxy.getImageFilterResult(v3ImageCatalog);
+            }
         }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeAvailabilityService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeAvailabilityService.java
@@ -75,8 +75,9 @@ public class ClusterUpgradeAvailabilityService {
     @Inject
     private InstanceMetaDataService instanceMetaDataService;
 
-    public UpgradeV4Response checkForUpgradesByName(Stack stack, boolean lockComponents, boolean replaceVms, InternalUpgradeSettings internalUpgradeSettings) {
-        UpgradeV4Response upgradeOptions = checkForUpgrades(stack, lockComponents, internalUpgradeSettings);
+    public UpgradeV4Response checkForUpgradesByName(Stack stack, boolean lockComponents, boolean replaceVms, InternalUpgradeSettings internalUpgradeSettings,
+            boolean getAllImages) {
+        UpgradeV4Response upgradeOptions = checkForUpgrades(stack, lockComponents, internalUpgradeSettings, getAllImages);
         upgradeOptions.setReplaceVms(replaceVms);
         if (StringUtils.isEmpty(upgradeOptions.getReason())) {
             if (!stack.getStatus().isAvailable()) {
@@ -141,7 +142,7 @@ public class ClusterUpgradeAvailabilityService {
         return upgradeCandidates;
     }
 
-    public UpgradeV4Response checkForUpgrades(Stack stack, boolean lockComponents, InternalUpgradeSettings internalUpgradeSettings) {
+    public UpgradeV4Response checkForUpgrades(Stack stack, boolean lockComponents, InternalUpgradeSettings internalUpgradeSettings, boolean getAllImages) {
         String accountId = Crn.safeFromString(stack.getResourceCrn()).getAccountId();
         UpgradeV4Response upgradeOptions = new UpgradeV4Response();
         try {
@@ -151,7 +152,7 @@ public class ClusterUpgradeAvailabilityService {
             Image image = imageCatalogService
                     .getImage(workspaceId, currentImage.getImageCatalogUrl(), currentImage.getImageCatalogName(), currentImage.getImageId())
                     .getImage();
-            ImageFilterParams imageFilterParams = imageFilterParamsFactory.create(image, lockComponents, stack, internalUpgradeSettings);
+            ImageFilterParams imageFilterParams = imageFilterParamsFactory.create(image, lockComponents, stack, internalUpgradeSettings, getAllImages);
             ImageFilterResult imageFilterResult = filterImages(accountId, workspaceId, currentImage.getImageCatalogName(), imageFilterParams);
             LOGGER.info(String.format("%d possible image found for stack upgrade.", imageFilterResult.getImages().size()));
             upgradeOptions = createResponse(image, imageFilterResult, stack.getCloudPlatform(), stack.getRegion(), currentImage.getImageCatalogName());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ImageFilterParamsFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ImageFilterParamsFactory.java
@@ -37,10 +37,10 @@ public class ImageFilterParamsFactory {
     @Inject
     private PlatformStringTransformer platformStringTransformer;
 
-    public ImageFilterParams create(Image image, boolean lockComponents, Stack stack, InternalUpgradeSettings internalUpgradeSettings) {
+    public ImageFilterParams create(Image image, boolean lockComponents, Stack stack, InternalUpgradeSettings internalUpgradeSettings, boolean getAllImages) {
         return new ImageFilterParams(image, lockComponents, getStackRelatedParcels(stack), stack.getType(),
                 getBlueprint(stack), stack.getId(), internalUpgradeSettings, platformStringTransformer.getPlatformStringForImageCatalog(stack.cloudPlatform(),
-                stack.getPlatformVariant()), stack.cloudPlatform(), stack.getRegion());
+                stack.getPlatformVariant()), stack.cloudPlatform(), stack.getRegion(), getAllImages);
     }
 
     public Map<String, String> getStackRelatedParcels(StackDtoDelegate stack) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/ClusterUpgradeImageFilter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/ClusterUpgradeImageFilter.java
@@ -33,8 +33,8 @@ public class ClusterUpgradeImageFilter {
 
     private ImageFilterResult getImageFilterResult(Long workspaceId, String imageCatalogName, ImageFilterParams imageFilterParams) {
         try {
-            ImageFilterResult imageFilterResult
-                    = imageCatalogService.getImageFilterResult(workspaceId, imageCatalogName, imageFilterParams.getImageCatalogPlatform());
+            ImageFilterResult imageFilterResult = imageCatalogService
+                    .getImageFilterResult(workspaceId, imageCatalogName, imageFilterParams.getImageCatalogPlatform(), imageFilterParams.isGetAllImages());
             return imageFilterResult.getImages().isEmpty() ? imageFilterResult : filterImages(imageFilterResult, imageFilterParams);
         } catch (Exception ex) {
             LOGGER.error("Error during image filtering.", ex);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/ImageFilterParams.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/ImageFilterParams.java
@@ -31,8 +31,11 @@ public class ImageFilterParams {
 
     private final String region;
 
+    private final boolean getAllImages;
+
     public ImageFilterParams(Image currentImage, boolean lockComponents, Map<String, String> stackRelatedParcels, StackType stackType, Blueprint blueprint,
-            Long stackId, InternalUpgradeSettings internalUpgradeSettings, ImageCatalogPlatform imageCatalogPlatform, String cloudPlatform, String region) {
+            Long stackId, InternalUpgradeSettings internalUpgradeSettings, ImageCatalogPlatform imageCatalogPlatform, String cloudPlatform, String region,
+            boolean getAllImages) {
         this.currentImage = currentImage;
         this.lockComponents = lockComponents;
         this.stackRelatedParcels = stackRelatedParcels;
@@ -43,6 +46,7 @@ public class ImageFilterParams {
         this.imageCatalogPlatform = imageCatalogPlatform;
         this.cloudPlatform = cloudPlatform;
         this.region = region;
+        this.getAllImages = getAllImages;
     }
 
     public Image getCurrentImage() {
@@ -89,6 +93,10 @@ public class ImageFilterParams {
         return region;
     }
 
+    public boolean isGetAllImages() {
+        return getAllImages;
+    }
+
     @SuppressWarnings("checkstyle:CyclomaticComplexity")
     @Override
     public boolean equals(Object o) {
@@ -108,12 +116,13 @@ public class ImageFilterParams {
                 Objects.equals(imageCatalogPlatform, that.imageCatalogPlatform) &&
                 Objects.equals(stackId, that.stackId) &&
                 Objects.equals(cloudPlatform, that.cloudPlatform) &&
-                Objects.equals(region, that.region);
+                Objects.equals(region, that.region) &&
+                Objects.equals(getAllImages, that.getAllImages);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(currentImage, lockComponents, stackRelatedParcels, stackType, blueprint, stackId, internalUpgradeSettings,
-                imageCatalogPlatform, cloudPlatform, region);
+                imageCatalogPlatform, cloudPlatform, region, getAllImages);
     }
 }

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackUpgradeOperations.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackUpgradeOperations.java
@@ -120,8 +120,9 @@ public class StackUpgradeOperations {
                                 stackInstanceCount.getInstanceCount(), upgradeNodeCountLimit));
             }
         }
+        boolean getAllImages = request.getImageId() != null;
         UpgradeV4Response upgradeResponse = clusterUpgradeAvailabilityService.checkForUpgradesByName(stack, osUpgrade, replaceVms,
-                request.getInternalUpgradeSettings());
+                request.getInternalUpgradeSettings(), getAllImages);
         if (CollectionUtils.isNotEmpty(upgradeResponse.getUpgradeCandidates())) {
             clusterUpgradeAvailabilityService.filterUpgradeOptions(accountId, upgradeResponse, request, stack.isDatalake());
         }

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/service/upgrade/DistroXUpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/service/upgrade/DistroXUpgradeService.java
@@ -103,8 +103,9 @@ public class DistroXUpgradeService {
         LOGGER.info("DH Runtime Upgrade entitlement: {}", dataHubRuntimeUpgradeEnabled);
         boolean dataHubOsUpgradeEntitled = upgradeAvailabilityService.isOsUpgradeEnabledByAccountId(accountId);
         LOGGER.info("DH OS Upgrade entitlement: {}", dataHubOsUpgradeEntitled);
+        boolean getAllImages = imageId != null;
         UpgradeV4Response upgradeOptions = clusterUpgradeAvailabilityService.checkForUpgrades(stack, true,
-                new InternalUpgradeSettings(false, dataHubRuntimeUpgradeEnabled, dataHubOsUpgradeEntitled));
+                new InternalUpgradeSettings(false, dataHubRuntimeUpgradeEnabled, dataHubOsUpgradeEntitled), getAllImages);
         if (upgradeOptions.getUpgradeCandidates().isEmpty()) {
             throw new BadRequestException("There is no available image for upgrade.");
         }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogServiceTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -977,7 +978,7 @@ public class ImageCatalogServiceTest {
         when(imageCatalogRepository.findByNameAndWorkspaceId(CUSTOM_CATALOG_NAME, WORKSPACE_ID)).thenReturn(Optional.of(imageCatalog));
         when(customImageProvider.mergeSourceImageAndCustomImageProperties(any(), any(), any(), any())).thenReturn(statedImage);
 
-        ImageFilterResult actual = underTest.getImageFilterResult(WORKSPACE_ID, CUSTOM_CATALOG_NAME, IMAGE_CATALOG_PLATFORM);
+        ImageFilterResult actual = underTest.getImageFilterResult(WORKSPACE_ID, CUSTOM_CATALOG_NAME, IMAGE_CATALOG_PLATFORM, false);
 
         assertEquals(1, actual.getImages().size());
         assertEquals(image, actual.getImages().get(0));
@@ -994,10 +995,24 @@ public class ImageCatalogServiceTest {
         PrefixMatchImages prefixMatchImages = new PrefixMatchImages(Collections.singleton("3cba3cd0-a169-4d62-8bc5-709df5f73b50"), emptySet(), emptySet());
         when(prefixMatcherService.prefixMatchForCBVersion(any(), any())).thenReturn(prefixMatchImages);
 
-        ImageFilterResult actual = underTest.getImageFilterResult(WORKSPACE_ID, "catalog", IMAGE_CATALOG_PLATFORM);
+        ImageFilterResult actual = underTest.getImageFilterResult(WORKSPACE_ID, "catalog", IMAGE_CATALOG_PLATFORM, false);
 
         assertEquals(1, actual.getImages().size());
         assertEquals("3cba3cd0-a169-4d62-8bc5-709df5f73b50", actual.getImages().get(0).getUuid());
+    }
+
+    @Test
+    public void testImageCatalogImageFilterResultWithGetAllImages() throws CloudbreakImageCatalogException, IOException {
+        ImageCatalog imageCatalog = new ImageCatalog();
+        imageCatalog.setImageCatalogUrl(DEFAULT_CATALOG_URL);
+
+        setupImageCatalogProvider(DEFAULT_CATALOG_URL, V3_CB_CATALOG_FILE);
+        when(imageCatalogRepository.findByNameAndWorkspaceId("catalog", WORKSPACE_ID)).thenReturn(Optional.of(imageCatalog));
+
+        ImageFilterResult actual = underTest.getImageFilterResult(WORKSPACE_ID, "catalog", IMAGE_CATALOG_PLATFORM, true);
+
+        assertEquals(8, actual.getImages().size());
+        verifyNoInteractions(prefixMatcherService);
     }
 
     private void setupImageCatalogProvider(String catalogUrl, String catalogFile) throws IOException, CloudbreakImageCatalogException {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeAvailabilityServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeAvailabilityServiceTest.java
@@ -139,7 +139,7 @@ public class ClusterUpgradeAvailabilityServiceTest {
         ImageFilterParams imageFilterParams = createImageFilterParams(stack, currentImageFromCatalog);
         UpgradeV4Response response = new UpgradeV4Response();
 
-        when(imageFilterParamsFactory.create(currentImageFromCatalog, lockComponents, stack, INTERNAL_UPGRADE_SETTINGS)).thenReturn(imageFilterParams);
+        when(imageFilterParamsFactory.create(currentImageFromCatalog, lockComponents, stack, INTERNAL_UPGRADE_SETTINGS, false)).thenReturn(imageFilterParams);
         when(imageService.getImage(stack.getId())).thenReturn(currentImage);
         when(imageCatalogService.getImage(WORKSPACE_ID, currentImage.getImageCatalogUrl(), currentImage.getImageCatalogName(), currentImage.getImageId()))
                 .thenReturn(StatedImage.statedImage(currentImageFromCatalog, CATALOG_URL, CATALOG_NAME));
@@ -149,7 +149,7 @@ public class ClusterUpgradeAvailabilityServiceTest {
                 currentImage.getImageCatalogName())).thenReturn(response);
         when(instanceMetaDataService.anyInstanceStopped(stack.getId())).thenReturn(true);
 
-        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, true, INTERNAL_UPGRADE_SETTINGS);
+        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, true, INTERNAL_UPGRADE_SETTINGS, false);
 
         assertEquals("Cannot upgrade cluster because there is stopped instance.", actual.getReason());
         assertEquals(response, actual);
@@ -166,7 +166,7 @@ public class ClusterUpgradeAvailabilityServiceTest {
         ImageFilterParams imageFilterParams = createImageFilterParams(stack, currentImageFromCatalog);
         UpgradeV4Response response = new UpgradeV4Response();
 
-        when(imageFilterParamsFactory.create(currentImageFromCatalog, lockComponents, stack, INTERNAL_UPGRADE_SETTINGS)).thenReturn(imageFilterParams);
+        when(imageFilterParamsFactory.create(currentImageFromCatalog, lockComponents, stack, INTERNAL_UPGRADE_SETTINGS, false)).thenReturn(imageFilterParams);
         when(clusterRepairService.repairWithDryRun(stack.getId())).thenReturn(result);
         when(result.isError()).thenReturn(false);
         when(imageService.getImage(stack.getId())).thenReturn(currentImage);
@@ -178,7 +178,7 @@ public class ClusterUpgradeAvailabilityServiceTest {
                 currentImage.getImageCatalogName())).thenReturn(response);
         when(instanceMetaDataService.anyInstanceStopped(stack.getId())).thenReturn(false);
 
-        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, true, INTERNAL_UPGRADE_SETTINGS);
+        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, true, INTERNAL_UPGRADE_SETTINGS, false);
 
         assertEquals(response, actual);
     }
@@ -194,7 +194,7 @@ public class ClusterUpgradeAvailabilityServiceTest {
         ImageFilterParams imageFilterParams = createImageFilterParams(stack, currentImageFromCatalog);
         UpgradeV4Response response = new UpgradeV4Response();
 
-        when(imageFilterParamsFactory.create(currentImageFromCatalog, lockComponents, stack, INTERNAL_UPGRADE_SETTINGS)).thenReturn(imageFilterParams);
+        when(imageFilterParamsFactory.create(currentImageFromCatalog, lockComponents, stack, INTERNAL_UPGRADE_SETTINGS, false)).thenReturn(imageFilterParams);
         when(clusterRepairService.repairWithDryRun(stack.getId())).thenReturn(result);
         when(result.isError()).thenReturn(false);
         when(imageService.getImage(stack.getId())).thenReturn(currentImage);
@@ -206,7 +206,7 @@ public class ClusterUpgradeAvailabilityServiceTest {
                 currentImage.getImageCatalogName())).thenReturn(response);
         when(instanceMetaDataService.anyInstanceStopped(stack.getId())).thenReturn(false);
 
-        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, true, INTERNAL_UPGRADE_SETTINGS);
+        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, true, INTERNAL_UPGRADE_SETTINGS, false);
 
         assertEquals(response, actual);
     }
@@ -225,13 +225,13 @@ public class ClusterUpgradeAvailabilityServiceTest {
                 .thenReturn(StatedImage.statedImage(currentImageFromCatalog, CATALOG_URL, CATALOG_NAME));
         ImageFilterResult filteredImages = createFilteredImages(properImage);
         ImageFilterParams imageFilterParams = createImageFilterParams(stack, currentImageFromCatalog);
-        when(imageFilterParamsFactory.create(currentImageFromCatalog, lockComponents, stack, INTERNAL_UPGRADE_SETTINGS)).thenReturn(imageFilterParams);
+        when(imageFilterParamsFactory.create(currentImageFromCatalog, lockComponents, stack, INTERNAL_UPGRADE_SETTINGS, false)).thenReturn(imageFilterParams);
         when(clusterUpgradeImageFilter.filter(ACCOUNT_ID, WORKSPACE_ID, CATALOG_NAME, imageFilterParams)).thenReturn(filteredImages);
         when(upgradeOptionsResponseFactory.createV4Response(currentImageFromCatalog, filteredImages, stack.getCloudPlatform(), stack.getRegion(),
                 currentImage.getImageCatalogName())).thenReturn(response);
         when(instanceMetaDataService.anyInstanceStopped(stack.getId())).thenReturn(false);
 
-        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, false, INTERNAL_UPGRADE_SETTINGS);
+        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, false, INTERNAL_UPGRADE_SETTINGS, false);
 
         assertEquals(response, actual);
         verifyNoInteractions(clusterRepairService);
@@ -242,7 +242,7 @@ public class ClusterUpgradeAvailabilityServiceTest {
         Stack stack = createStack(createStackStatus(Status.AVAILABLE), DATALAKE_STACK_TYPE);
         when(imageService.getImage(stack.getId())).thenThrow(new CloudbreakImageNotFoundException("Image not found."));
 
-        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, true, INTERNAL_UPGRADE_SETTINGS);
+        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, true, INTERNAL_UPGRADE_SETTINGS, false);
 
         assertNull(actual.getCurrent());
         assertNull(actual.getUpgradeCandidates());
@@ -266,13 +266,13 @@ public class ClusterUpgradeAvailabilityServiceTest {
         when(imageService.getImage(stack.getId())).thenReturn(currentImage);
         when(imageCatalogService.getImage(WORKSPACE_ID, currentImage.getImageCatalogUrl(), currentImage.getImageCatalogName(), currentImage.getImageId()))
                 .thenReturn(StatedImage.statedImage(currentImageFromCatalog, CATALOG_URL, CATALOG_NAME));
-        when(imageFilterParamsFactory.create(currentImageFromCatalog, lockComponents, stack, INTERNAL_UPGRADE_SETTINGS)).thenReturn(imageFilterParams);
+        when(imageFilterParamsFactory.create(currentImageFromCatalog, lockComponents, stack, INTERNAL_UPGRADE_SETTINGS, false)).thenReturn(imageFilterParams);
         ImageFilterResult filteredImages = createFilteredImages(properImage);
         when(clusterUpgradeImageFilter.filter(ACCOUNT_ID, WORKSPACE_ID, CATALOG_NAME, imageFilterParams)).thenReturn(filteredImages);
         when(upgradeOptionsResponseFactory.createV4Response(currentImageFromCatalog, filteredImages, stack.getCloudPlatform(), stack.getRegion(),
                 currentImage.getImageCatalogName())).thenReturn(response);
 
-        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, true, INTERNAL_UPGRADE_SETTINGS);
+        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, true, INTERNAL_UPGRADE_SETTINGS, false);
 
         assertNull(actual.getCurrent());
         assertEquals(1, actual.getUpgradeCandidates().size());
@@ -305,7 +305,7 @@ public class ClusterUpgradeAvailabilityServiceTest {
         when(imageCatalogService.getImage(WORKSPACE_ID, currentImage.getImageCatalogUrl(), currentImage.getImageCatalogName(), currentImage.getImageId()))
                 .thenReturn(StatedImage.statedImage(currentImageFromCatalog, CATALOG_URL, CATALOG_NAME));
         ImageFilterResult filteredImages = createFilteredImages(properImage);
-        when(imageFilterParamsFactory.create(currentImageFromCatalog, lockComponents, stack, INTERNAL_UPGRADE_SETTINGS)).thenReturn(imageFilterParams);
+        when(imageFilterParamsFactory.create(currentImageFromCatalog, lockComponents, stack, INTERNAL_UPGRADE_SETTINGS, false)).thenReturn(imageFilterParams);
         when(clusterUpgradeImageFilter.filter(ACCOUNT_ID, WORKSPACE_ID, CATALOG_NAME, imageFilterParams)).thenReturn(filteredImages);
         when(upgradeOptionsResponseFactory.createV4Response(currentImageFromCatalog, filteredImages, stack.getCloudPlatform(), stack.getRegion(),
                 currentImage.getImageCatalogName())).thenReturn(response);
@@ -314,7 +314,7 @@ public class ClusterUpgradeAvailabilityServiceTest {
         when(repairValidation.getValidationErrors()).thenReturn(Collections.singletonList(validationError));
         when(instanceMetaDataService.anyInstanceStopped(stack.getId())).thenReturn(false);
 
-        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, true, INTERNAL_UPGRADE_SETTINGS);
+        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, true, INTERNAL_UPGRADE_SETTINGS, false);
 
         assertNull(actual.getCurrent());
         assertEquals(1, actual.getUpgradeCandidates().size());
@@ -478,12 +478,12 @@ public class ClusterUpgradeAvailabilityServiceTest {
         when(imageService.getImage(stack.getId())).thenReturn(currentImage);
         when(imageCatalogService.getImage(WORKSPACE_ID, currentImage.getImageCatalogUrl(), currentImage.getImageCatalogName(), currentImage.getImageId()))
                 .thenReturn(StatedImage.statedImage(image, null, CATALOG_NAME));
-        when(imageFilterParamsFactory.create(image, lockComponents, stack, INTERNAL_UPGRADE_SETTINGS)).thenReturn(imageFilterParams);
+        when(imageFilterParamsFactory.create(image, lockComponents, stack, INTERNAL_UPGRADE_SETTINGS, false)).thenReturn(imageFilterParams);
         when(clusterUpgradeImageFilter.filter(ACCOUNT_ID, WORKSPACE_ID, currentImage.getImageCatalogName(), imageFilterParams)).thenReturn(filteredImages);
         when(upgradeOptionsResponseFactory.createV4Response(image, filteredImages, CLOUD_PLATFORM, REGION, CATALOG_NAME)).thenReturn(upgradeResponse);
         when(upgradeResponse.getReason()).thenReturn("done");
 
-        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, true, INTERNAL_UPGRADE_SETTINGS);
+        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, true, INTERNAL_UPGRADE_SETTINGS, false);
 
         assertEquals(upgradeResponse, actual);
     }
@@ -537,6 +537,6 @@ public class ClusterUpgradeAvailabilityServiceTest {
 
     private ImageFilterParams createImageFilterParams(Stack stack, Image currentImageFromCatalog) {
         return new ImageFilterParams(currentImageFromCatalog, lockComponents, activatedParcels,
-                stack.getType(), null, STACK_ID, INTERNAL_UPGRADE_SETTINGS, imageCatalogPlatform(CLOUD_PLATFORM), CLOUD_PLATFORM, REGION);
+                stack.getType(), null, STACK_ID, INTERNAL_UPGRADE_SETTINGS, imageCatalogPlatform(CLOUD_PLATFORM), CLOUD_PLATFORM, REGION, false);
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ImageFilterParamsFactoryTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ImageFilterParamsFactoryTest.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.service.upgrade;
 
 import static com.sequenceiq.cloudbreak.service.image.catalog.model.ImageCatalogPlatform.imageCatalogPlatform;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -65,7 +66,7 @@ public class ImageFilterParamsFactoryTest {
         when(parcelService.getParcelComponentsByBlueprint(stack)).thenReturn(clusterComponents);
         when(clouderaManagerProductsProvider.findCdhProduct(clusterComponents)).thenReturn(Optional.of(createCMProduct(cdhName, cdhVersion)));
 
-        ImageFilterParams actual = underTest.create(image, true, stack, new InternalUpgradeSettings(false, true, true));
+        ImageFilterParams actual = underTest.create(image, true, stack, new InternalUpgradeSettings(false, true, true), false);
 
         assertEquals(image, actual.getCurrentImage());
         assertTrue(actual.isLockComponents());
@@ -74,6 +75,7 @@ public class ImageFilterParamsFactoryTest {
         assertEquals(blueprint, actual.getBlueprint());
         assertEquals(STACK_ID, actual.getStackId());
         assertEquals(CLOUD_PLATFORM, actual.getImageCatalogPlatform().nameToUpperCase());
+        assertFalse(actual.isGetAllImages());
         verify(parcelService).getParcelComponentsByBlueprint(stack);
         verify(clouderaManagerProductsProvider).findCdhProduct(clusterComponents);
     }
@@ -93,7 +95,7 @@ public class ImageFilterParamsFactoryTest {
         when(parcelService.getParcelComponentsByBlueprint(stack)).thenReturn(cdhClusterComponent);
         when(clouderaManagerProductsProvider.getProducts(cdhClusterComponent)).thenReturn(Set.of(spark, nifi));
 
-        ImageFilterParams actual = underTest.create(image, true, stack, new InternalUpgradeSettings(true, true, true));
+        ImageFilterParams actual = underTest.create(image, true, stack, new InternalUpgradeSettings(true, true, true), false);
 
         assertEquals(image, actual.getCurrentImage());
         assertTrue(actual.isLockComponents());
@@ -104,6 +106,7 @@ public class ImageFilterParamsFactoryTest {
         assertEquals(blueprint, actual.getBlueprint());
         assertEquals(STACK_ID, actual.getStackId());
         assertEquals(CLOUD_PLATFORM, actual.getImageCatalogPlatform().nameToUpperCase());
+        assertFalse(actual.isGetAllImages());
         verify(parcelService).getParcelComponentsByBlueprint(stack);
         verify(clouderaManagerProductsProvider).getProducts(cdhClusterComponent);
     }
@@ -117,7 +120,7 @@ public class ImageFilterParamsFactoryTest {
 
         when(parcelService.getParcelComponentsByBlueprint(stack)).thenReturn(Collections.singleton(clusterComponent));
 
-        underTest.create(image, true, stack, new InternalUpgradeSettings(false, true, true));
+        underTest.create(image, true, stack, new InternalUpgradeSettings(false, true, true), false);
 
         verify(parcelService).getParcelComponentsByBlueprint(stack);
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/UpgradePermissionProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/UpgradePermissionProviderTest.java
@@ -58,7 +58,7 @@ public class UpgradePermissionProviderTest {
         Image candidateImage = createImage(componentVersion, "2001");
         ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, true, Map.of(), DATALAKE_STACK_TYPE, null, STACK_ID,
                 new InternalUpgradeSettings(false, true, true), imageCatalogPlatform(CLOUD_PLATFORM),
-                CLOUD_PLATFORM, REGION);
+                CLOUD_PLATFORM, REGION, false);
 
         when(componentBuildNumberComparator.compare(currentImage, candidateImage, ImagePackageVersion.CDH_BUILD_NUMBER.getKey())).thenReturn(true);
         when(supportedRuntimes.isSupported("7.2.1")).thenReturn(true);
@@ -77,7 +77,7 @@ public class UpgradePermissionProviderTest {
         Image candidateImage = createImage(componentVersion, "2001");
         ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, true, Map.of(), DATALAKE_STACK_TYPE, null, STACK_ID,
                 new InternalUpgradeSettings(false, true, true), imageCatalogPlatform(CLOUD_PLATFORM),
-                CLOUD_PLATFORM, REGION);
+                CLOUD_PLATFORM, REGION, false);
 
         when(componentBuildNumberComparator.compare(currentImage, candidateImage, ImagePackageVersion.CDH_BUILD_NUMBER.getKey())).thenReturn(false);
         when(supportedRuntimes.isSupported("7.2.1")).thenReturn(true);
@@ -97,7 +97,7 @@ public class UpgradePermissionProviderTest {
         Image candidateImage = createImage(targetVersion, "2001");
         ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, true, Map.of(), DATALAKE_STACK_TYPE, null, STACK_ID,
                 new InternalUpgradeSettings(false, true, true), imageCatalogPlatform(CLOUD_PLATFORM),
-                CLOUD_PLATFORM, REGION);
+                CLOUD_PLATFORM, REGION, false);
 
         when(componentVersionComparator.permitCmAndStackUpgradeByComponentVersion(currentVersion, targetVersion)).thenReturn(true);
         when(upgradeMatrixService.permitByUpgradeMatrix(currentVersion, targetVersion)).thenReturn(true);
@@ -119,7 +119,7 @@ public class UpgradePermissionProviderTest {
         Image candidateImage = createImage(targetVersion, "2001");
         ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, true, Map.of(), DATALAKE_STACK_TYPE, null, STACK_ID,
                 new InternalUpgradeSettings(false, true, true), imageCatalogPlatform(CLOUD_PLATFORM),
-                CLOUD_PLATFORM, REGION);
+                CLOUD_PLATFORM, REGION, false);
 
         when(componentVersionComparator.permitCmAndStackUpgradeByComponentVersion(currentVersion, targetVersion)).thenReturn(false);
         when(supportedRuntimes.isSupported("7.1.2")).thenReturn(true);
@@ -139,7 +139,7 @@ public class UpgradePermissionProviderTest {
         Image candidateImage = createImage(targetVersion, "2001");
         ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, true, Map.of(), DATALAKE_STACK_TYPE, null, STACK_ID,
                 new InternalUpgradeSettings(false, true, true), imageCatalogPlatform(CLOUD_PLATFORM),
-                CLOUD_PLATFORM, REGION);
+                CLOUD_PLATFORM, REGION, false);
 
         when(componentVersionComparator.permitCmAndStackUpgradeByComponentVersion(currentVersion, targetVersion)).thenReturn(true);
         when(upgradeMatrixService.permitByUpgradeMatrix(currentVersion, targetVersion)).thenReturn(false);
@@ -161,7 +161,7 @@ public class UpgradePermissionProviderTest {
         Image candidateImage = createImage(targetVersion, "2001");
         ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, true, Map.of(), StackType.WORKLOAD, null, STACK_ID,
                 new InternalUpgradeSettings(false, true, true), imageCatalogPlatform(CLOUD_PLATFORM),
-                CLOUD_PLATFORM, REGION);
+                CLOUD_PLATFORM, REGION, false);
 
         when(componentVersionComparator.permitCmAndStackUpgradeByComponentVersion(currentVersion, targetVersion)).thenReturn(true);
         when(supportedRuntimes.isSupported("7.2.2")).thenReturn(true);
@@ -182,7 +182,7 @@ public class UpgradePermissionProviderTest {
         Image candidateImage = createImage(targetVersion, "2001");
         ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, true, Map.of(), DATALAKE_STACK_TYPE, null, STACK_ID,
                 new InternalUpgradeSettings(false, true, true), imageCatalogPlatform(CLOUD_PLATFORM),
-                CLOUD_PLATFORM, REGION);
+                CLOUD_PLATFORM, REGION, false);
 
         when(componentVersionComparator.permitCmAndStackUpgradeByComponentVersion(currentVersion, targetVersion)).thenReturn(true);
 
@@ -200,7 +200,7 @@ public class UpgradePermissionProviderTest {
         Image candidateImage = createImage("7.2.1", null);
         ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, true, Map.of(), DATALAKE_STACK_TYPE, null, STACK_ID,
                 new InternalUpgradeSettings(false, true, true), imageCatalogPlatform(CLOUD_PLATFORM),
-                CLOUD_PLATFORM, REGION);
+                CLOUD_PLATFORM, REGION, false);
 
         when(componentBuildNumberComparator.compare(currentImage, candidateImage, ImagePackageVersion.CDH_BUILD_NUMBER.getKey())).thenReturn(false);
         when(supportedRuntimes.isSupported("7.2.1")).thenReturn(true);
@@ -220,7 +220,7 @@ public class UpgradePermissionProviderTest {
         Image candidateImage = createImage(targetVersion, "2010");
         ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, true, Map.of(), DATALAKE_STACK_TYPE, null, STACK_ID,
                 new InternalUpgradeSettings(false, true, true), imageCatalogPlatform(CLOUD_PLATFORM),
-                CLOUD_PLATFORM, REGION);
+                CLOUD_PLATFORM, REGION, false);
 
         when(supportedRuntimes.isSupported("7.2.10")).thenReturn(false);
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/BlueprintBasedUpgradeValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/BlueprintBasedUpgradeValidatorTest.java
@@ -84,7 +84,7 @@ class BlueprintBasedUpgradeValidatorTest {
     private ImageFilterParams createImageFilterParams(String blueprintName, StackType stackType) {
         Blueprint blueprint = new Blueprint();
         blueprint.setName(blueprintName);
-        return new ImageFilterParams(null, true, null, stackType, blueprint, null, new InternalUpgradeSettings(true, true, true), null, null, null);
+        return new ImageFilterParams(null, true, null, stackType, blueprint, null, new InternalUpgradeSettings(true, true, true), null, null, null, false);
     }
 
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/ClusterUpgradeImageFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/ClusterUpgradeImageFilterTest.java
@@ -93,7 +93,8 @@ public class ClusterUpgradeImageFilterTest {
         String errorMessage = "There are no available image";
         ImageFilterResult imageFilterResult = new ImageFilterResult(Collections.emptyList(), errorMessage);
         when(blueprintBasedUpgradeValidator.isValidBlueprint(imageFilterParams, ACCOUNT_ID)).thenReturn(new BlueprintValidationResult(true));
-        when(imageCatalogService.getImageFilterResult(WORKSPACE_ID, IMAGE_CATALOG_NAME, imageFilterParams.getImageCatalogPlatform()))
+        when(imageCatalogService
+                .getImageFilterResult(WORKSPACE_ID, IMAGE_CATALOG_NAME, imageFilterParams.getImageCatalogPlatform(), imageFilterParams.isGetAllImages()))
                 .thenReturn(imageFilterResult);
 
         ImageFilterResult actual = underTest.filter(ACCOUNT_ID, WORKSPACE_ID, IMAGE_CATALOG_NAME, imageFilterParams);
@@ -110,7 +111,8 @@ public class ClusterUpgradeImageFilterTest {
         ImageFilterResult imageFilterResult = new ImageFilterResult(images, EMPTY_REASON);
         ImageFilterResult otherImageFilterResult = new ImageFilterResult(otherImages, EMPTY_REASON);
         when(blueprintBasedUpgradeValidator.isValidBlueprint(imageFilterParams, ACCOUNT_ID)).thenReturn(new BlueprintValidationResult(true));
-        when(imageCatalogService.getImageFilterResult(WORKSPACE_ID, IMAGE_CATALOG_NAME, imageFilterParams.getImageCatalogPlatform()))
+        when(imageCatalogService
+                .getImageFilterResult(WORKSPACE_ID, IMAGE_CATALOG_NAME, imageFilterParams.getImageCatalogPlatform(), imageFilterParams.isGetAllImages()))
                 .thenReturn(imageFilterResult);
         when(imageFilterUpgradeService.filterImages(imageFilterResult, imageFilterParams)).thenReturn(otherImageFilterResult);
 
@@ -122,7 +124,7 @@ public class ClusterUpgradeImageFilterTest {
     private ImageFilterParams createImageFilterParams() {
         return new ImageFilterParams(image, false, Collections.emptyMap(), StackType.DATALAKE, new Blueprint(), STACK_ID,
                 new InternalUpgradeSettings(false, true, true), imageCatalogPlatform(CLOUD_PLATFORM),
-                CLOUD_PLATFORM, REGION);
+                CLOUD_PLATFORM, REGION, false);
     }
 
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/CsdLocationFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/CsdLocationFilterTest.java
@@ -31,7 +31,7 @@ public class CsdLocationFilterTest {
     @Test
     public void testFilterImageShouldReturnTrueWhenTheStackTypeIsNotWorkload() {
         assertTrue(underTest.filterImage(null, null, new ImageFilterParams(null, false, null, StackType.DATALAKE, null, STACK_ID,
-                new InternalUpgradeSettings(false, true, true), imageCatalogPlatform(CLOUD_PLATFORM), CLOUD_PLATFORM, REGION)));
+                new InternalUpgradeSettings(false, true, true), imageCatalogPlatform(CLOUD_PLATFORM), CLOUD_PLATFORM, REGION, false)));
     }
 
     @Test
@@ -113,7 +113,7 @@ public class CsdLocationFilterTest {
 
     private ImageFilterParams createImageFilterParams(Map<String, String> stackRelatedParcels) {
         return new ImageFilterParams(null, false, stackRelatedParcels, StackType.WORKLOAD, null, STACK_ID,
-                new InternalUpgradeSettings(false, true, true), imageCatalogPlatform(CLOUD_PLATFORM), CLOUD_PLATFORM, REGION);
+                new InternalUpgradeSettings(false, true, true), imageCatalogPlatform(CLOUD_PLATFORM), CLOUD_PLATFORM, REGION, false);
     }
 
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/PreWarmParcelLocationFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/PreWarmParcelLocationFilterTest.java
@@ -32,7 +32,7 @@ public class PreWarmParcelLocationFilterTest {
     @Test
     public void testFilterImageShouldReturnTrueWhenTheStackTypeIsNotWorkload() {
         assertTrue(underTest.filterImage(null, null, new ImageFilterParams(null, false, null, StackType.DATALAKE, null, STACK_ID,
-                new InternalUpgradeSettings(false, true, true), imageCatalogPlatform(CLOUD_PLATFORM), CLOUD_PLATFORM, REGION)));
+                new InternalUpgradeSettings(false, true, true), imageCatalogPlatform(CLOUD_PLATFORM), CLOUD_PLATFORM, REGION, false)));
     }
 
     @Test
@@ -142,7 +142,7 @@ public class PreWarmParcelLocationFilterTest {
 
     private ImageFilterParams createImageFilterParams(Map<String, String> stackRelatedParcels) {
         return new ImageFilterParams(null, false, stackRelatedParcels, StackType.WORKLOAD, null, STACK_ID, new InternalUpgradeSettings(false, true,
-                true), imageCatalogPlatform(CLOUD_PLATFORM), CLOUD_PLATFORM, REGION);
+                true), imageCatalogPlatform(CLOUD_PLATFORM), CLOUD_PLATFORM, REGION, false);
     }
 
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/CloudPlatformBasedUpgradeImageFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/CloudPlatformBasedUpgradeImageFilterTest.java
@@ -61,7 +61,7 @@ class CloudPlatformBasedUpgradeImageFilterTest {
     }
 
     private ImageFilterParams createImageFilterParams() {
-        return new ImageFilterParams(null, false, null, null, null, null, null, imageCatalogPlatform(AWS.name()), null, null);
+        return new ImageFilterParams(null, false, null, null, null, null, null, imageCatalogPlatform(AWS.name()), null, null, false);
     }
 
     private Image createImage(String imageId, String cloudPlatform) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/CmAndStackVersionUpgradeImageFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/CmAndStackVersionUpgradeImageFilterTest.java
@@ -114,7 +114,7 @@ class CmAndStackVersionUpgradeImageFilterTest {
 
     private ImageFilterParams createImageFilterParams(boolean lockComponents) {
         return new ImageFilterParams(currentImage, lockComponents, activatedParcels, StackType.DATALAKE, null, 1L, new InternalUpgradeSettings(false, true,
-                true), imageCatalogPlatform("AWS"), null, null);
+                true), imageCatalogPlatform("AWS"), null, null, false);
     }
 
     private void assertLockedCommon(ImageFilterResult actual) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/CurrentImageUpgradeImageFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/CurrentImageUpgradeImageFilterTest.java
@@ -73,7 +73,7 @@ class CurrentImageUpgradeImageFilterTest {
     }
 
     private ImageFilterParams createImageFilterParams() {
-        return new ImageFilterParams(createImage(CURRENT_IMAGE_ID), false, null, null, null, CURRENT_STACK_ID, null, null, null, null);
+        return new ImageFilterParams(createImage(CURRENT_IMAGE_ID), false, null, null, null, CURRENT_STACK_ID, null, null, null, null, false);
     }
 
     private Image createImage(String imageId) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/ImageCreationBasedUpgradeImageFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/ImageCreationBasedUpgradeImageFilterTest.java
@@ -192,6 +192,6 @@ class ImageCreationBasedUpgradeImageFilterTest {
     }
 
     private ImageFilterParams createImageFilterParams(Image currentImage) {
-        return new ImageFilterParams(currentImage, false, null, null, null, null, null, null, null, null);
+        return new ImageFilterParams(currentImage, false, null, null, null, null, null, null, null, null, false);
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/ImageNameUpgradeImageFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/ImageNameUpgradeImageFilterTest.java
@@ -88,6 +88,6 @@ class ImageNameUpgradeImageFilterTest {
     }
 
     private ImageFilterParams createImageFilterParams(String platform, String region) {
-        return new ImageFilterParams(null, false, null, null, null, null, null, imageCatalogPlatform(platform), platform, region);
+        return new ImageFilterParams(null, false, null, null, null, null, null, imageCatalogPlatform(platform), platform, region, false);
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/OsVersionBasedUpgradeImageFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/filter/OsVersionBasedUpgradeImageFilterTest.java
@@ -77,7 +77,7 @@ class OsVersionBasedUpgradeImageFilterTest {
     }
 
     private ImageFilterParams createImageFilterParams() {
-        return new ImageFilterParams(createImage("current-image", CURRENT_OS, CURRENT_OS_TYPE), false, null, null, null, null, null, null, null, null);
+        return new ImageFilterParams(createImage("current-image", CURRENT_OS, CURRENT_OS_TYPE), false, null, null, null, null, null, null, null, null, false);
     }
 
     private Image createImage(String imageId, String os, String osType) {

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/StackUpgradeOperationsTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/StackUpgradeOperationsTest.java
@@ -167,7 +167,9 @@ class StackUpgradeOperationsTest {
         when(instanceGroupService.getByStackAndFetchTemplates(STACK_ID)).thenReturn(Collections.emptySet());
         when(upgradeService.isOsUpgrade(request)).thenReturn(false);
         when(upgradePreconditionService.notUsingEphemeralVolume(stack)).thenReturn(false);
-        when(clusterUpgradeAvailabilityService.checkForUpgradesByName(stack, false, false, request.getInternalUpgradeSettings())).thenReturn(upgradeResponse);
+        when(clusterUpgradeAvailabilityService
+                .checkForUpgradesByName(stack, false, false, request.getInternalUpgradeSettings(), false))
+                .thenReturn(upgradeResponse);
         when(entitlementService.runtimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(true);
 
         UpgradeV4Response actual = underTest.checkForClusterUpgrade(ACCOUNT_ID, stack, request);
@@ -176,7 +178,8 @@ class StackUpgradeOperationsTest {
         verify(instanceGroupService).getByStackAndFetchTemplates(STACK_ID);
         verify(upgradeService).isOsUpgrade(request);
         verify(upgradePreconditionService).notUsingEphemeralVolume(stack);
-        verify(clusterUpgradeAvailabilityService).checkForUpgradesByName(stack, false, false, request.getInternalUpgradeSettings());
+        verify(clusterUpgradeAvailabilityService)
+                .checkForUpgradesByName(stack, false, false, request.getInternalUpgradeSettings(), false);
         verify(clusterUpgradeAvailabilityService).filterUpgradeOptions(ACCOUNT_ID, upgradeResponse, request, false);
         verify(entitlementService).runtimeUpgradeEnabled(ACCOUNT_ID);
     }
@@ -192,7 +195,9 @@ class StackUpgradeOperationsTest {
         when(instanceCount.getInstanceCount()).thenReturn(INSTANCE_COUNT);
         when(instanceMetaDataService.countByStackId(STACK_ID)).thenReturn(instanceCount);
         when(limitConfiguration.getUpgradeNodeCountLimit(any())).thenReturn(NODE_LIMIT);
-        when(clusterUpgradeAvailabilityService.checkForUpgradesByName(stack, false, true, request.getInternalUpgradeSettings())).thenReturn(upgradeResponse);
+        when(clusterUpgradeAvailabilityService
+                .checkForUpgradesByName(stack, false, true, request.getInternalUpgradeSettings(), false))
+                .thenReturn(upgradeResponse);
         when(entitlementService.runtimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(true);
 
         UpgradeV4Response actual = underTest.checkForClusterUpgrade(ACCOUNT_ID, stack, request);
@@ -202,7 +207,8 @@ class StackUpgradeOperationsTest {
         verify(upgradeService).isOsUpgrade(request);
         verify(instanceGroupService).getByStackAndFetchTemplates(STACK_ID);
         verify(limitConfiguration).getUpgradeNodeCountLimit(any());
-        verify(clusterUpgradeAvailabilityService).checkForUpgradesByName(stack, false, true, request.getInternalUpgradeSettings());
+        verify(clusterUpgradeAvailabilityService)
+                .checkForUpgradesByName(stack, false, true, request.getInternalUpgradeSettings(), false);
         verify(clusterUpgradeAvailabilityService).filterUpgradeOptions(ACCOUNT_ID, upgradeResponse, request, false);
         verify(entitlementService).runtimeUpgradeEnabled(ACCOUNT_ID);
         verifyNoInteractions(upgradePreconditionService);
@@ -221,7 +227,9 @@ class StackUpgradeOperationsTest {
         when(instanceCount.getInstanceCount()).thenReturn(INSTANCE_COUNT);
         when(instanceMetaDataService.countByStackId(STACK_ID)).thenReturn(instanceCount);
         when(limitConfiguration.getUpgradeNodeCountLimit(any())).thenReturn(NODE_LIMIT);
-        when(clusterUpgradeAvailabilityService.checkForUpgradesByName(stack, false, true, request.getInternalUpgradeSettings())).thenReturn(upgradeResponse);
+        when(clusterUpgradeAvailabilityService
+                .checkForUpgradesByName(stack, false, true, request.getInternalUpgradeSettings(), false))
+                .thenReturn(upgradeResponse);
         when(entitlementService.runtimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(true);
         when(stackDtoService.findAllByEnvironmentCrnAndStackType(ENVIRONMENT_CRN, List.of(StackType.WORKLOAD))).thenReturn(List.of(stackDto));
 
@@ -232,7 +240,8 @@ class StackUpgradeOperationsTest {
         verify(upgradeService).isOsUpgrade(request);
         verify(instanceGroupService).getByStackAndFetchTemplates(STACK_ID);
         verify(limitConfiguration).getUpgradeNodeCountLimit(any());
-        verify(clusterUpgradeAvailabilityService).checkForUpgradesByName(stack, false, true, request.getInternalUpgradeSettings());
+        verify(clusterUpgradeAvailabilityService)
+                .checkForUpgradesByName(stack, false, true, request.getInternalUpgradeSettings(), false);
         verify(clusterUpgradeAvailabilityService).filterUpgradeOptions(ACCOUNT_ID, upgradeResponse, request, true);
         verify(entitlementService).runtimeUpgradeEnabled(ACCOUNT_ID);
         verify(upgradePreconditionService).checkForRunningAttachedClusters(List.of(stackDto), request.isSkipDataHubValidation(), ACCOUNT_ID);
@@ -252,7 +261,9 @@ class StackUpgradeOperationsTest {
         when(instanceCount.getInstanceCount()).thenReturn(INSTANCE_COUNT);
         when(instanceMetaDataService.countByStackId(STACK_ID)).thenReturn(instanceCount);
         when(limitConfiguration.getUpgradeNodeCountLimit(any())).thenReturn(NODE_LIMIT);
-        when(clusterUpgradeAvailabilityService.checkForUpgradesByName(stack, false, true, request.getInternalUpgradeSettings())).thenReturn(upgradeResponse);
+        when(clusterUpgradeAvailabilityService
+                .checkForUpgradesByName(stack, false, true, request.getInternalUpgradeSettings(), false))
+                .thenReturn(upgradeResponse);
         when(entitlementService.runtimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(true);
 
         UpgradeV4Response actual = underTest.checkForClusterUpgrade(ACCOUNT_ID, stack, request);
@@ -262,7 +273,8 @@ class StackUpgradeOperationsTest {
         verify(upgradeService).isOsUpgrade(request);
         verify(instanceGroupService).getByStackAndFetchTemplates(STACK_ID);
         verify(limitConfiguration).getUpgradeNodeCountLimit(any());
-        verify(clusterUpgradeAvailabilityService).checkForUpgradesByName(stack, false, true, request.getInternalUpgradeSettings());
+        verify(clusterUpgradeAvailabilityService)
+                .checkForUpgradesByName(stack, false, true, request.getInternalUpgradeSettings(), false);
         verify(clusterUpgradeAvailabilityService).filterUpgradeOptions(ACCOUNT_ID, upgradeResponse, request, true);
         verify(entitlementService).runtimeUpgradeEnabled(ACCOUNT_ID);
         verifyNoInteractions(upgradePreconditionService, clusterDBValidationService);
@@ -282,7 +294,8 @@ class StackUpgradeOperationsTest {
         when(instanceCount.getInstanceCount()).thenReturn(INSTANCE_COUNT);
         when(instanceMetaDataService.countByStackId(STACK_ID)).thenReturn(instanceCount);
         when(limitConfiguration.getUpgradeNodeCountLimit(any())).thenReturn(NODE_LIMIT);
-        when(clusterUpgradeAvailabilityService.checkForUpgradesByName(stack, false, true, request.getInternalUpgradeSettings()))
+        when(clusterUpgradeAvailabilityService
+                .checkForUpgradesByName(stack, false, true, request.getInternalUpgradeSettings(), false))
                 .thenReturn(upgradeResponseToReturn);
         when(entitlementService.runtimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(true);
         when(upgradePreconditionService.checkForRunningAttachedClusters(List.of(stackDto), request.isSkipDataHubValidation(), ACCOUNT_ID))
@@ -298,7 +311,8 @@ class StackUpgradeOperationsTest {
         verify(upgradeService).isOsUpgrade(request);
         verify(instanceGroupService).getByStackAndFetchTemplates(STACK_ID);
         verify(limitConfiguration).getUpgradeNodeCountLimit(any());
-        verify(clusterUpgradeAvailabilityService).checkForUpgradesByName(stack, false, true, request.getInternalUpgradeSettings());
+        verify(clusterUpgradeAvailabilityService)
+                .checkForUpgradesByName(stack, false, true, request.getInternalUpgradeSettings(), false);
         verify(clusterUpgradeAvailabilityService).filterUpgradeOptions(ACCOUNT_ID, upgradeResponseToReturn, request, true);
         verify(entitlementService).runtimeUpgradeEnabled(ACCOUNT_ID);
         verify(upgradePreconditionService).checkForRunningAttachedClusters(List.of(stackDto), request.isSkipDataHubValidation(), ACCOUNT_ID);
@@ -320,7 +334,8 @@ class StackUpgradeOperationsTest {
         when(instanceCount.getInstanceCount()).thenReturn(INSTANCE_COUNT);
         when(instanceMetaDataService.countByStackId(STACK_ID)).thenReturn(instanceCount);
         when(limitConfiguration.getUpgradeNodeCountLimit(any())).thenReturn(NODE_LIMIT);
-        when(clusterUpgradeAvailabilityService.checkForUpgradesByName(stack, false, true, request.getInternalUpgradeSettings()))
+        when(clusterUpgradeAvailabilityService
+                .checkForUpgradesByName(stack, false, true, request.getInternalUpgradeSettings(), false))
                 .thenReturn(upgradeResponseToReturn);
         when(entitlementService.runtimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(true);
         when(entitlementService.datahubRuntimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(true);
@@ -335,12 +350,40 @@ class StackUpgradeOperationsTest {
         verify(upgradeService).isOsUpgrade(request);
         verify(instanceGroupService).getByStackAndFetchTemplates(STACK_ID);
         verify(limitConfiguration).getUpgradeNodeCountLimit(any());
-        verify(clusterUpgradeAvailabilityService).checkForUpgradesByName(stack, false, true, request.getInternalUpgradeSettings());
+        verify(clusterUpgradeAvailabilityService)
+                .checkForUpgradesByName(stack, false, true, request.getInternalUpgradeSettings(), false);
         verify(clusterUpgradeAvailabilityService).filterUpgradeOptions(ACCOUNT_ID, upgradeResponseToReturn, request, true);
         verify(entitlementService).runtimeUpgradeEnabled(ACCOUNT_ID);
         verify(upgradePreconditionService).checkForRunningAttachedClusters(List.of(stackDto), request.isSkipDataHubValidation(), ACCOUNT_ID);
         verify(upgradePreconditionService, times(0)).checkForNonUpgradeableAttachedClusters(List.of(stackDto));
         verifyNoInteractions(clusterDBValidationService);
+    }
+
+    @Test
+    void testCheckForClusterUpgradeShouldReturnUpgradeCandidatesWhenImageIdIsPresentInRequest() {
+        Stack stack = createStack(StackType.WORKLOAD);
+        UpgradeV4Request request = createUpgradeRequest(null, null);
+        request.setImageId(IMAGE_ID);
+        UpgradeV4Response upgradeResponse = new UpgradeV4Response();
+        upgradeResponse.setUpgradeCandidates(List.of(new ImageInfoV4Response()));
+        when(instanceGroupService.getByStackAndFetchTemplates(STACK_ID)).thenReturn(Collections.emptySet());
+        when(upgradeService.isOsUpgrade(request)).thenReturn(false);
+        when(upgradePreconditionService.notUsingEphemeralVolume(stack)).thenReturn(false);
+        when(clusterUpgradeAvailabilityService
+                .checkForUpgradesByName(stack, false, false, request.getInternalUpgradeSettings(), true))
+                .thenReturn(upgradeResponse);
+        when(entitlementService.runtimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(true);
+
+        UpgradeV4Response actual = underTest.checkForClusterUpgrade(ACCOUNT_ID, stack, request);
+
+        assertEquals(upgradeResponse, actual);
+        verify(instanceGroupService).getByStackAndFetchTemplates(STACK_ID);
+        verify(upgradeService).isOsUpgrade(request);
+        verify(upgradePreconditionService).notUsingEphemeralVolume(stack);
+        verify(clusterUpgradeAvailabilityService)
+                .checkForUpgradesByName(stack, false, false, request.getInternalUpgradeSettings(), true);
+        verify(clusterUpgradeAvailabilityService).filterUpgradeOptions(ACCOUNT_ID, upgradeResponse, request, false);
+        verify(entitlementService).runtimeUpgradeEnabled(ACCOUNT_ID);
     }
 
     @Test

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/service/upgrade/DistroXUpgradeServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/service/upgrade/DistroXUpgradeServiceTest.java
@@ -349,7 +349,7 @@ class DistroXUpgradeServiceTest {
         UpgradeV4Response response = new UpgradeV4Response();
         response.setReplaceVms(true);
         response.setUpgradeCandidates(List.of(mock(ImageInfoV4Response.class)));
-        when(clusterUpgradeAvailabilityService.checkForUpgrades(eq(stack), eq(true), any())).thenReturn(response);
+        when(clusterUpgradeAvailabilityService.checkForUpgrades(eq(stack), eq(true), any(), eq(true))).thenReturn(response);
         ImageInfoV4Response imageInfoV4Response = new ImageInfoV4Response();
         imageInfoV4Response.setImageId("imageID");
         imageInfoV4Response.setImageCatalogName("catalogName");
@@ -362,7 +362,7 @@ class DistroXUpgradeServiceTest {
         underTest.triggerOsUpgradeByUpgradeSets(CLUSTER, WS_ID, "imageID", upgradeSets);
         ArgumentCaptor<InternalUpgradeSettings> internalUpgradeSettingsArgumentCaptor = ArgumentCaptor.forClass(InternalUpgradeSettings.class);
         verify(clusterUpgradeAvailabilityService, times(1)).checkForUpgrades(eq(stack), eq(true),
-                internalUpgradeSettingsArgumentCaptor.capture());
+                internalUpgradeSettingsArgumentCaptor.capture(), eq(true));
         assertFalse(internalUpgradeSettingsArgumentCaptor.getValue().isSkipValidations());
         ArgumentCaptor<ImageChangeDto> imageChangeDtoCaptor = ArgumentCaptor.forClass(ImageChangeDto.class);
         verify(upgradeService, times(1)).osUpgradeByUpgradeSets(eq(stack), imageChangeDtoCaptor.capture(), eq(upgradeSets));


### PR DESCRIPTION
…the  section

Currently the 'images' section in the image catalog only contains the latest image for a given runtime. This means the even though a specific image id is provided in the upgrade command it will only allow the upgrade if the provided image id is present in the 'images' section, which makes the explicit image id option pointless. This change adresses this issue by modifying the image filtering logic to return all the available images if a specific image id is provided and use those images as base pool for filtering the images and checking if the image with the given image id exists. The change was tested manually with multiple upgrade option/scenarion on both DLs and DHs and the change is also covered by UTs. I tried to make the change as non-distruptive to the current image filtering logic as possible to not break current functionality. If an image id is not specified (e.g. list available images for upgrade, UI dropbox, etc) the original logic is used and only the latest images are shown.

See detailed description in the commit message.