### PR TITLE
CB-19719 E2E test single resource group should not have cloud cost ignore

### DIFF
--- a/integration-test/README.md
+++ b/integration-test/README.md
@@ -65,6 +65,9 @@ To launch the Integration Test application you should execute the `com.sequencei
 ## Run E2E Tests on your local machine
 You should have a running [Cloudbreak](https://github.com/hortonworks/cloudbreak) before start testing, and after a successful build, you should have the `integration-test.jar` file at `integration-test/build/libs/`.
 
+> **Note:**
+> For Azure E2E tests a new resource group at Azure subscription is createing before test run. The new Azure resource group name should be set at `integrationtest.azure.resourcegroup.name` application parameter or environment variable.
+
 ### Run a selected E2E test in Terminal
 1. Create your own and separate test folder on your local machine, for example `~/integration-test`
 2. Create your own `aplication.yml` file there

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurevm/action/AzureClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurevm/action/AzureClientActions.java
@@ -168,45 +168,55 @@ public class AzureClientActions {
 
     public ResourceGroup createResourceGroup(String resourceGroupName, Map<String, String> tags) {
         if (StringUtils.isNotBlank(resourceGroupName)) {
-            LOGGER.info(format("Creating resource group '%s'...", resourceGroupName));
-            Map<String, String> allTags = new HashMap<>();
-            allTags.putAll(tags);
-            allTags.putAll(commonCloudProperties.getTags());
-            ResourceGroup resourceGroup;
-            resourceGroup = azure.resourceGroups().define(resourceGroupName)
-                    .withRegion(azureProperties.getRegion())
-                    .withTags(allTags)
-                    .create();
-            if (resourceGroup.provisioningState().equalsIgnoreCase("Succeeded")) {
-                LOGGER.info(format("New resource group '%s' has been created.", resourceGroupName));
-                Log.then(LOGGER, format(" New resource group '%s' has been created. ", resourceGroupName));
-                return resourceGroup;
+            if (!resourceGroupExists(resourceGroupName)) {
+                LOGGER.info(format("Creating resource group '%s'...", resourceGroupName));
+                Map<String, String> allTags = new HashMap<>();
+                allTags.putAll(tags);
+                allTags.putAll(commonCloudProperties.getTags());
+                ResourceGroup resourceGroup;
+                resourceGroup = azure.resourceGroups().define(resourceGroupName)
+                        .withRegion(azureProperties.getRegion())
+                        .withTags(allTags)
+                        .create();
+                if (resourceGroup.provisioningState().equalsIgnoreCase("Succeeded")) {
+                    LOGGER.info(format("New resource group '%s' has been created.", resourceGroupName));
+                    Log.then(LOGGER, format(" New resource group '%s' has been created. ", resourceGroupName));
+                    return resourceGroup;
+                } else {
+                    LOGGER.error("Failed to provision the resource group '{}'!", resourceGroupName);
+                    throw new TestFailException(format("Failed to provision the resource group '%s'!", resourceGroupName));
+                }
             } else {
-                LOGGER.error("Failed to provision the resource group '{}'!", resourceGroupName);
-                throw new TestFailException(format("Failed to provision the resource group '%s'!", resourceGroupName));
+                LOGGER.warn(format("Resource group already exist! So creating new resource group with name '%s' is not necessary.",
+                        resourceGroupName));
+                return azure.resourceGroups().getByName(resourceGroupName);
             }
         } else {
-            LOGGER.error("Resource group name has not been provided! So create new resource group for environment is not possible.");
-            throw new TestFailException("Resource group name has not been provided! So create new resource group for environment is not possible.");
+            LOGGER.error("Resource group name has not been provided! So creating new resource group for test is not possible. " +
+                    "Please set a valid Azure resource group name at 'integrationtest.azure.resourcegroup.name' variable in the 'application.yml'" +
+                    " or as environment variable!");
+            throw new TestFailException("Resource group name has not been provided! So creating new resource group for test is not possible. " +
+                    "Please set a valid Azure resource group name at 'integrationtest.azure.resourcegroup.name' variable in the 'application.yml'" +
+                    " or as environment variable!");
         }
     }
 
     public void deleteResourceGroup(String resourceGroupName) {
         if (StringUtils.isNotBlank(resourceGroupName) && resourceGroupExists(resourceGroupName)) {
-            LOGGER.info(String.format("Removing resource group '%s'...", resourceGroupName));
+            LOGGER.info(format("Removing resource group '%s'...", resourceGroupName));
             azure.resourceGroups().deleteByName(resourceGroupName);
         } else {
-            LOGGER.info(String.format("Resource group ('%s') has already been removed at Azure or name is null!", resourceGroupName));
+            LOGGER.info(format("Resource group ('%s') has already been removed at Azure or name is null!", resourceGroupName));
         }
     }
 
     private boolean resourceGroupExists(String resourceGroupName) {
         boolean exists = azure.resourceGroups().contain(resourceGroupName);
         if (exists) {
-            LOGGER.info(String.format("Found resource group with name '%s'", resourceGroupName));
+            LOGGER.info(format("Found resource group with name '%s'", resourceGroupName));
             return true;
         } else {
-            LOGGER.info(String.format("Resource group '%s' is not present", resourceGroupName));
+            LOGGER.info(format("Resource group '%s' is not present", resourceGroupName));
             return false;
         }
     }


### PR DESCRIPTION
Azure setup for E2E tests should consist of 2 Resource Groups:
- Volatile resource group with expensive and frequent deploys (can't have cloud cost ignore tag)
- Resource group for static resources (can have cloud cost ignore tag; eg.: storage accounts)