### PR TITLE
CB-19716 Implemented entitlement based controll on turning monitoring on

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringUrlResolver.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringUrlResolver.java
@@ -1,0 +1,40 @@
+package com.sequenceiq.cloudbreak.telemetry.monitoring;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MonitoringUrlResolver {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MonitoringUrlResolver.class);
+
+    private static final String ACCOUNT_ID_TEMPLATE = "$accountid";
+
+    private final String monitoringEndpointConfig;
+
+    private final String monitoringPaasEndpointConfig;
+
+    public MonitoringUrlResolver(String monitoringEndpointConfig, String monitoringPaasEndpointConfig) {
+        this.monitoringEndpointConfig = monitoringEndpointConfig;
+        if (StringUtils.isBlank(monitoringPaasEndpointConfig)) {
+            this.monitoringPaasEndpointConfig = monitoringEndpointConfig;
+        } else {
+            this.monitoringPaasEndpointConfig = monitoringPaasEndpointConfig;
+        }
+    }
+
+    public String resolve(String accountId, boolean saasEnabled) {
+        String urlTemplate = saasEnabled ? monitoringEndpointConfig : monitoringPaasEndpointConfig;
+        return resolve(accountId, urlTemplate);
+    }
+
+    public String resolve(String accountId, String urlTemplate) {
+        if (StringUtils.isNoneBlank(urlTemplate, accountId)) {
+            String url = urlTemplate.replace(ACCOUNT_ID_TEMPLATE, accountId);
+            LOGGER.info("Generated monitoring URL {}.", url);
+            return url;
+        }
+        LOGGER.info("Generated monitoring URL {}.", urlTemplate);
+        return urlTemplate;
+    }
+}

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringUrlResolverTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringUrlResolverTest.java
@@ -1,0 +1,46 @@
+package com.sequenceiq.cloudbreak.telemetry.monitoring;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class MonitoringUrlResolverTest {
+
+    private MonitoringUrlResolver underTest;
+
+    @BeforeEach
+    public void setUp() {
+        underTest = new MonitoringUrlResolver(
+                "http://localhost/saas/$accountid",
+                "http://localhost/$accountid");
+    }
+
+    @Test
+    public void shouldReturnPaasUrlWithAccountIdResolved() {
+        String url = underTest.resolve("123", false);
+
+        assertEquals("http://localhost/123", url);
+    }
+
+    @Test
+    public void shouldReturnSaasUrlWithAccountIdResolved() {
+        String url = underTest.resolve("123", true);
+
+        assertEquals("http://localhost/saas/123", url);
+    }
+
+    @Test
+    public void shouldReturnCustomUrlWithAccountIdResolved() {
+        String url = underTest.resolve("123", "http://localhost/paas/$accountid");
+
+        assertEquals("http://localhost/paas/123", url);
+    }
+
+    @Test
+    public void shouldReturnCustomUrlWithOriginalAccountId() {
+        String url = underTest.resolve("123", "http://localhost/paas/456");
+
+        assertEquals("http://localhost/paas/456", url);
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecoratorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecoratorTest.java
@@ -35,7 +35,7 @@ import com.sequenceiq.cloudbreak.telemetry.DataBusEndpointProvider;
 import com.sequenceiq.cloudbreak.telemetry.VmLogsService;
 import com.sequenceiq.cloudbreak.telemetry.context.TelemetryContext;
 import com.sequenceiq.cloudbreak.telemetry.fluent.FluentClusterType;
-import com.sequenceiq.cloudbreak.telemetry.monitoring.MonitoringConfigService;
+import com.sequenceiq.cloudbreak.telemetry.monitoring.MonitoringConfiguration;
 import com.sequenceiq.cloudbreak.workspace.model.User;
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
 import com.sequenceiq.common.api.telemetry.model.DataBusCredential;
@@ -49,7 +49,7 @@ public class TelemetryDecoratorTest {
     private TelemetryDecorator underTest;
 
     @Mock
-    private MonitoringConfigService monitoringConfigService;
+    private MonitoringConfiguration monitoringConfiguration;
 
     @Mock
     private AltusMachineUserService altusMachineUserService;
@@ -79,7 +79,7 @@ public class TelemetryDecoratorTest {
     public void setUp() {
         initMocks();
         underTest = new TelemetryDecorator(altusMachineUserService, vmLogsService, entitlementService,
-                dataBusEndpointProvider, monitoringConfigService, componentConfigProviderService, "1.0.0");
+                dataBusEndpointProvider, monitoringConfiguration, componentConfigProviderService, "1.0.0");
     }
 
     @Test


### PR DESCRIPTION
Implemented entitlement based controll on turning monitoring on. For freeipa monitoring is turned on during freeipa repair with REBUILD option. For datalake and datahub a simple stop/start is enough to turn on monitoring.

This feature is needed in 2.65 to enable saas team to turn on monitoring on production clusters.