### PR TITLE
CB-19561 - Marketplace image should be chosen if CDP_AZURE_IMAGE_MARK…

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/catalog/Image.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/catalog/Image.java
@@ -124,6 +124,27 @@ public class Image {
         this.sourceImageId = sourceImageId;
     }
 
+    public Image(Image that, Map<String, Map<String, String>> imageSetsByProvider) {
+        this.date = that.date;
+        this.created = that.created;
+        this.published = that.published;
+        this.description = that.description;
+        this.os = that.os;
+        this.uuid = that.uuid;
+        this.version = that.version;
+        this.repo = (that.repo == null) ? Collections.emptyMap() : that.repo;
+        this.imageSetsByProvider = imageSetsByProvider;
+        this.stackDetails = that.stackDetails;
+        this.osType = that.osType;
+        this.packageVersions = that.packageVersions;
+        this.preWarmParcels = (that.preWarmParcels == null) ? Collections.emptyList() : that.preWarmParcels;
+        this.preWarmCsd = (that.preWarmCsd == null) ? Collections.emptyList() : that.preWarmCsd;
+        this.cmBuildNumber = that.cmBuildNumber;
+        this.advertised = that.advertised;
+        this.baseParcelUrl = that.baseParcelUrl;
+        this.sourceImageId = that.sourceImageId;
+    }
+
     @JsonProperty(DATE)
     public String getDate() {
         return date;

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureImageFilter.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureImageFilter.java
@@ -4,6 +4,7 @@ import static com.sequenceiq.cloudbreak.cloud.azure.image.marketplace.AzureMarke
 import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AZURE;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -37,6 +38,7 @@ public class AzureImageFilter implements ImageFilter {
             List<Image> filteredImageList = imageList.stream()
                     .filter(image -> image.getImageSetsByProvider().containsKey(AZURE.name().toLowerCase()))
                     .filter(this::checkIfMarketplaceImage)
+                    .map(this::removeNonMarketplaceRegions)
                     .collect(Collectors.toList());
             LOGGER.debug("After filtering, the following image ids remained available for selection: {}", getImageIds(filteredImageList));
             return filteredImageList;
@@ -60,5 +62,14 @@ public class AzureImageFilter implements ImageFilter {
                 .map(azureMarketplaceImageProviderService::hasMarketplaceFormat)
                 .findFirst()
                 .orElse(false);
+    }
+
+    private Image removeNonMarketplaceRegions(Image image) {
+        Map<String, Map<String, String>> filteredMap = image.getImageSetsByProvider().entrySet()
+                .stream()
+                .filter(i -> i.getValue().containsKey(MARKETPLACE_REGION))
+                .collect(Collectors.toMap(Map.Entry::getKey, i -> Map.of(MARKETPLACE_REGION, i.getValue().get(MARKETPLACE_REGION))));
+
+        return new Image(image, filteredMap);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageService.java
@@ -222,20 +222,19 @@ public class ImageService {
         String translatedRegion = cloudPlatformConnectors.getDefault(platform(cloudPlatform.toUpperCase())).regionToDisplayName(region);
         if (imagesForPlatform.isPresent()) {
             Map<String, String> imagesByRegion = imagesForPlatform.get();
-            Optional<String> imageNameOpt = findStringKeyWithEqualsIgnoreCase(translatedRegion, imagesByRegion);
-            if (imageNameOpt.isEmpty()) {
-                imageNameOpt = findStringKeyWithEqualsIgnoreCase(DEFAULT_REGION, imagesByRegion);
-            }
-            if (imageNameOpt.isPresent()) {
-                return imageNameOpt.get();
-            }
-            String msg = String.format("Virtual machine image couldn't be found in image: '%s' for the selected platform: '%s' and region: '%s'.",
-                    imgFromCatalog, platformString, translatedRegion);
-            throw new CloudbreakImageNotFoundException(msg);
+            return selectImageByRegion(translatedRegion, imagesByRegion, platformString.nameToLowerCase());
         }
         String msg = String.format("The selected image: '%s' doesn't contain virtual machine image for the selected platform: '%s'.",
                 imgFromCatalog, platformString);
         throw new CloudbreakImageNotFoundException(msg);
+    }
+
+    private String selectImageByRegion(String translatedRegion, Map<String, String> imagesByRegion, String platform) throws CloudbreakImageNotFoundException {
+            return findStringKeyWithEqualsIgnoreCase(DEFAULT_REGION, imagesByRegion)
+                    .or(() -> findStringKeyWithEqualsIgnoreCase(translatedRegion, imagesByRegion))
+                    .orElseThrow(() -> new CloudbreakImageNotFoundException(
+                            String.format("Virtual machine image couldn't be found in image: '%s' for the selected platform: '%s' and region: '%s'.",
+                                    imagesByRegion, platform, translatedRegion)));
     }
 
     private <T> Optional<T> findStringKeyWithEqualsIgnoreCase(String key, Map<String, T> map) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageServiceTest.java
@@ -1,18 +1,26 @@
 package com.sequenceiq.cloudbreak.service.image;
 
+import static com.sequenceiq.cloudbreak.service.image.ImageTestUtil.DEFAULT_REGION;
+import static com.sequenceiq.cloudbreak.service.image.ImageTestUtil.INVALID_PLATFORM;
 import static com.sequenceiq.cloudbreak.service.image.ImageTestUtil.PLATFORM;
+import static com.sequenceiq.cloudbreak.service.image.ImageTestUtil.REGION;
 import static com.sequenceiq.cloudbreak.service.image.catalog.model.ImageCatalogPlatform.imageCatalogPlatform;
-import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.stream.Stream;
 
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -26,6 +34,8 @@ import com.sequenceiq.cloudbreak.TestUtil;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.image.ImageSettingsV4Request;
 import com.sequenceiq.cloudbreak.cloud.CloudConnector;
 import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
+import com.sequenceiq.cloudbreak.cloud.model.Platform;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
 import com.sequenceiq.cloudbreak.cmtemplate.utils.BlueprintUtils;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
@@ -34,6 +44,7 @@ import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
 import com.sequenceiq.cloudbreak.domain.ImageCatalog;
 import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
 import com.sequenceiq.cloudbreak.service.StackMatrixService;
+import com.sequenceiq.cloudbreak.service.image.catalog.model.ImageCatalogPlatform;
 import com.sequenceiq.cloudbreak.workspace.model.Workspace;
 
 public class ImageServiceTest {
@@ -51,6 +62,10 @@ public class ImageServiceTest {
     private static final long USER_ID = 1000L;
 
     private static final String USER_ID_STRING = "aUserId";
+
+    private static final String EXISTING_ID = "ami-09fea90f257c85513";
+
+    private static final String DEFAULT_REGION_EXISTING_ID = "ami-09fea90f257c85514";
 
     @Mock
     private ImageCatalogService imageCatalogService;
@@ -99,6 +114,9 @@ public class ImageServiceTest {
         imageSettingsV4Request.setOs(OS);
         when(blueprintUtils.getCDHStackVersion(any())).thenReturn(STACK_VERSION);
         when(imageCatalogService.getImageCatalogByName(WORKSPACE_ID, "aCatalog")).thenReturn(getImageCatalog());
+        CloudConnector connector = mock(CloudConnector.class);
+        when(cloudPlatformConnectors.getDefault(Platform.platform(PLATFORM))).thenReturn(connector);
+        when(connector.regionToDisplayName(REGION)).thenReturn(REGION);
     }
 
     @Test
@@ -312,6 +330,59 @@ public class ImageServiceTest {
                 image -> true);
         assertEquals("uuid", statedImage.getImage().getUuid());
         assertTrue(statedImage.getImage().isPrewarmed());
+    }
+
+    @Test
+    public void tesDetermineImageNameFound() throws CloudbreakImageNotFoundException {
+        Image image = mock(Image.class);
+        ImageCatalogPlatform imageCatalogPlatform = imageCatalogPlatform(PLATFORM);
+
+        when(image.getImageSetsByProvider()).thenReturn(Collections.singletonMap(PLATFORM, Collections.singletonMap(REGION, EXISTING_ID)));
+
+        String imageName = underTest.determineImageName(PLATFORM, imageCatalogPlatform, REGION, image);
+        assertEquals("ami-09fea90f257c85513", imageName);
+    }
+
+    @Test
+    public void tesDetermineImageNameFoundDefaultPreferred() throws CloudbreakImageNotFoundException {
+        Image image = mock(Image.class);
+        ImageCatalogPlatform imageCatalogPlatform = imageCatalogPlatform(PLATFORM);
+
+        when(image.getImageSetsByProvider()).thenReturn(Collections.singletonMap(PLATFORM,
+                Map.of(
+                        REGION, EXISTING_ID,
+                        DEFAULT_REGION, DEFAULT_REGION_EXISTING_ID)));
+
+        String imageName = underTest.determineImageName(PLATFORM, imageCatalogPlatform, REGION, image);
+        assertEquals("ami-09fea90f257c85514", imageName);
+    }
+
+    @Test
+    public void tesDetermineImageNameNotFound() {
+        Image image = mock(Image.class);
+        ImageCatalogPlatform imageCatalogPlatform = imageCatalogPlatform(PLATFORM);
+
+        when(image.getImageSetsByProvider()).thenReturn(Collections.singletonMap(PLATFORM, Collections.singletonMap(REGION, EXISTING_ID)));
+
+        Exception exception = assertThrows(CloudbreakImageNotFoundException.class, () ->
+                underTest.determineImageName(PLATFORM, imageCatalogPlatform, "fake-region", image));
+        String exceptionMessage = "Virtual machine image couldn't be found in image";
+        MatcherAssert.assertThat(exception.getMessage(), CoreMatchers.containsString(exceptionMessage));
+    }
+
+    @Test
+    public void tesDetermineImageNameImageForPlatformNotFound() {
+        Image image = mock(Image.class);
+        ImageCatalogPlatform imageCatalogPlatform = imageCatalogPlatform(PLATFORM);
+
+        when(image.getImageSetsByProvider()).thenReturn(Collections.singletonMap(INVALID_PLATFORM, Collections.singletonMap(REGION, EXISTING_ID)));
+        when(image.toString()).thenReturn("Image");
+
+        Exception exception = assertThrows(CloudbreakImageNotFoundException.class, () ->
+                underTest.determineImageName(PLATFORM, imageCatalogPlatform, REGION, image));
+        String exceptionMessage = "The selected image: 'Image' "
+                + "doesn't contain virtual machine image for the selected platform: 'ImageCatalogPlatform{platform='azure'}'.";
+        MatcherAssert.assertThat(exception.getMessage(), CoreMatchers.containsString(exceptionMessage));
     }
 
     private ImageCatalog getImageCatalog() {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageTestUtil.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageTestUtil.java
@@ -12,6 +12,12 @@ public class ImageTestUtil {
 
     public static final String PLATFORM = "AZURE";
 
+    public static final String INVALID_PLATFORM = "AAAZURE";
+
+    public static final String REGION = "West US 2";
+
+    public static final String DEFAULT_REGION = "default";
+
     private ImageTestUtil() {
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/ImageService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/ImageService.java
@@ -163,16 +163,20 @@ public class ImageService {
         Optional<Map<String, String>> imagesForPlatform = findStringKeyWithEqualsIgnoreCase(platformString, imgFromCatalog.getImageSetsByProvider());
         if (imagesForPlatform.isPresent()) {
             Map<String, String> imagesByRegion = imagesForPlatform.get();
-            return findStringKeyWithEqualsIgnoreCase(region, imagesByRegion)
-                    .or(() -> findStringKeyWithEqualsIgnoreCase(DEFAULT_REGION, imagesByRegion))
-                    .orElseThrow(() -> new ImageNotFoundException(
-                            String.format("Virtual machine image couldn't be found in image: '%s' for the selected platform: '%s' and region: '%s'.",
-                                    imgFromCatalog, platformString, region)));
+            return selectImageByRegion(platformString, region, imgFromCatalog, imagesByRegion);
         } else {
             String msg = String.format("The selected image: '%s' doesn't contain virtual machine image for the selected platform: '%s'.",
                     imgFromCatalog, platformString);
             throw new ImageNotFoundException(msg);
         }
+    }
+
+    private String selectImageByRegion(String platformString, String region, Image imgFromCatalog, Map<String, String> imagesByRegion) {
+        return findStringKeyWithEqualsIgnoreCase(DEFAULT_REGION, imagesByRegion)
+                .or(() -> findStringKeyWithEqualsIgnoreCase(region, imagesByRegion))
+                .orElseThrow(() -> new ImageNotFoundException(
+                        String.format("Virtual machine image couldn't be found in image: '%s' for the selected platform: '%s' and region: '%s'.",
+                                imgFromCatalog, platformString, region)));
     }
 
     private <T> Optional<T> findStringKeyWithEqualsIgnoreCase(String key, Map<String, T> map) {


### PR DESCRIPTION
…ETPLACE_ONLY is granted

As we do not use `default` regions anymore for any providers except for the new Azure Marketplace usage, it is safe to assume that we would like to prefer the image with `default` region if an image with both the actual region and the `default` region is present in the image catalog.

This eventually results in preferring the Azure Marketplace images in every scenario which is the desired case.

See detailed description in the commit message.