### PR TITLE
CB-15640 make our PasswordUtil FIPS compliant

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/util/FreeIpaPasswordUtil.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/util/FreeIpaPasswordUtil.java
@@ -4,8 +4,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.commons.lang3.RandomStringUtils;
-
 public class FreeIpaPasswordUtil {
 
     private static final int PWD_PREFIX_LENGTH = 3;
@@ -18,10 +16,10 @@ public class FreeIpaPasswordUtil {
     }
 
     public static String generatePassword() {
-        String upperCaseLetters = RandomStringUtils.randomAlphabetic(PWD_PART_LENGTH).toUpperCase();
-        String lowerCaseLetters = RandomStringUtils.randomAlphabetic(PWD_PART_LENGTH).toLowerCase();
-        String pwdPrefix = RandomStringUtils.randomAlphabetic(PWD_PREFIX_LENGTH);
-        String numbers = RandomStringUtils.randomNumeric(PWD_PART_LENGTH);
+        String upperCaseLetters = PasswordUtil.getRandomAlphabetic(PWD_PART_LENGTH).toUpperCase();
+        String lowerCaseLetters = PasswordUtil.getRandomAlphabetic(PWD_PART_LENGTH).toLowerCase();
+        String pwdPrefix = PasswordUtil.getRandomAlphabetic(PWD_PREFIX_LENGTH);
+        String numbers = PasswordUtil.getRandomNumeric(PWD_PART_LENGTH);
         String raw = upperCaseLetters.concat(lowerCaseLetters).concat(numbers).concat(SPECIAL_CHARS);
         List<String> list = Arrays.asList(raw.split(""));
         Collections.shuffle(list);

--- a/common/src/main/java/com/sequenceiq/cloudbreak/util/PasswordUtil.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/util/PasswordUtil.java
@@ -1,28 +1,35 @@
 package com.sequenceiq.cloudbreak.util;
 
-import java.math.BigInteger;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 
 import org.apache.commons.lang3.RandomStringUtils;
 
 public class PasswordUtil {
 
-    private static final int PWD_LENGTH = 128;
+    private static final int PWD_LENGTH = 26;
 
-    private static final int RADIX = 32;
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     private PasswordUtil() {
     }
 
     public static String generatePassword() {
-        try {
-            MessageDigest messageDigest = MessageDigest.getInstance("MD5");
-            String raw = RandomStringUtils.randomAscii(PWD_LENGTH);
-            byte[] digest = messageDigest.digest(raw.getBytes());
-            return new BigInteger(1, digest).toString(RADIX);
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
+        return getRandomLettersAndNumbers(PWD_LENGTH);
+    }
+
+    public static String getRandomLettersAndNumbers(int count) {
+        return generate(count, true, true);
+    }
+
+    public static String getRandomAlphabetic(int count) {
+        return generate(count, true, false);
+    }
+
+    public static String getRandomNumeric(int count) {
+        return generate(count, false, true);
+    }
+
+    private static String generate(int count, boolean letters, boolean numbers) {
+        return RandomStringUtils.random(count, 0, 0, letters, numbers, null, SECURE_RANDOM);
     }
 }

--- a/common/src/test/java/com/sequenceiq/cloudbreak/util/PasswordUtilTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/util/PasswordUtilTest.java
@@ -1,0 +1,51 @@
+package com.sequenceiq.cloudbreak.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class PasswordUtilTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PasswordUtilTest.class);
+
+    @Test
+    void testGeneratePassword() {
+        long startInMillis = System.currentTimeMillis();
+        String actual = PasswordUtil.generatePassword();
+        long endInMillis = System.currentTimeMillis();
+        LOGGER.info("Password has been generated within {}ms the generated password: '{}'", endInMillis - startInMillis, actual);
+        Assertions.assertEquals(26, actual.length());
+        Assertions.assertTrue(actual.chars().allMatch(charAsInt -> Character.isDigit(charAsInt)
+                || Character.isUpperCase(charAsInt)
+                || Character.isLowerCase(charAsInt)));
+        Assertions.assertTrue(actual.chars().anyMatch(Character::isUpperCase));
+        Assertions.assertTrue(actual.chars().anyMatch(Character::isLowerCase));
+        Assertions.assertTrue(actual.chars().anyMatch(Character::isDigit));
+    }
+
+    @Test
+    void testGenerateRandomAlphabetic() {
+        long startInMillis = System.currentTimeMillis();
+        int expectedCount = 12;
+        String actual = PasswordUtil.getRandomAlphabetic(expectedCount);
+        long endInMillis = System.currentTimeMillis();
+        LOGGER.info("Random string with only alphabetic chars has been generated within {}ms the generated password: '{}'", endInMillis - startInMillis,
+                actual);
+        Assertions.assertEquals(expectedCount, actual.length());
+        Assertions.assertTrue(actual.chars().allMatch(Character::isAlphabetic));
+        Assertions.assertTrue(actual.chars().anyMatch(Character::isUpperCase));
+        Assertions.assertTrue(actual.chars().anyMatch(Character::isLowerCase));
+    }
+
+    @Test
+    void testGenerateRandomNumeric() {
+        long startInMillis = System.currentTimeMillis();
+        int expectedCount = 16;
+        String actual = PasswordUtil.getRandomNumeric(expectedCount);
+        long endInMillis = System.currentTimeMillis();
+        LOGGER.info("Random string with only numeric chars has been generated within {}ms the generated password: '{}'", endInMillis - startInMillis,
+                actual);
+        Assertions.assertEquals(expectedCount, actual.length());
+        Assertions.assertTrue(actual.chars().allMatch(Character::isDigit));
+    }
+}


### PR DESCRIPTION
CB-15640 make our PasswordUtil FIPS compliant

**Changes:**
 - refactor FreeIpaPasswordUtil to use our PasswordUtil
 - use org.apache.commons.lang3.RandomStringUtils only in PasswordUtil
 - configure org.apache.commons.lang3.RandomStringUtils with SecureRandom
 - unit test to cover generations
 - remove unnecessary hashing with MD5 and BigInteger's toString with Radix operations
 - keep backward compatibility with 26 chars length

See detailed description in the commit message.