### PR TITLE
CB-19852: Add rolling upgrade parameter for Data Hub upgrade public API

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/model/upgrade/DistroXUpgradeV1Request.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/model/upgrade/DistroXUpgradeV1Request.java
@@ -15,6 +15,8 @@ public class DistroXUpgradeV1Request {
 
     private Boolean dryRun;
 
+    private Boolean rollingUpgradeEnabled;
+
     private DistroXUpgradeShowAvailableImages showAvailableImages;
 
     private DistroXUpgradeReplaceVms replaceVms;
@@ -53,6 +55,14 @@ public class DistroXUpgradeV1Request {
 
     public void setDryRun(Boolean dryRun) {
         this.dryRun = dryRun;
+    }
+
+    public Boolean getRollingUpgradeEnabled() {
+        return rollingUpgradeEnabled;
+    }
+
+    public void setRollingUpgradeEnabled(Boolean rollingUpgradeEnabled) {
+        this.rollingUpgradeEnabled = rollingUpgradeEnabled;
     }
 
     public DistroXUpgradeShowAvailableImages getShowAvailableImages() {

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXUpgradeV1Controller.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXUpgradeV1Controller.java
@@ -123,7 +123,7 @@ public class DistroXUpgradeV1Controller implements DistroXUpgradeV1Endpoint {
         InternalUpgradeSettings internalUpgradeSettings = new InternalUpgradeSettings(true,
                 upgradeAvailabilityService.isRuntimeUpgradeEnabledByUserCrn(initiatorUserCrn),
                 upgradeAvailabilityService.isOsUpgradeEnabledByUserCrn(initiatorUserCrn),
-                Boolean.TRUE.equals(rollingUpgradeEnabled));
+                Boolean.TRUE.equals(rollingUpgradeEnabled) || Boolean.TRUE.equals(distroxUpgradeRequest.getRollingUpgradeEnabled()));
         UpgradeV4Request request = upgradeConverter.convert(distroxUpgradeRequest, internalUpgradeSettings);
         return upgradeCluster(clusterName, request, nameOrCrn, false);
     }
@@ -137,7 +137,7 @@ public class DistroXUpgradeV1Controller implements DistroXUpgradeV1Endpoint {
         InternalUpgradeSettings internalUpgradeSettings = new InternalUpgradeSettings(true,
                 upgradeAvailabilityService.isRuntimeUpgradeEnabledByUserCrn(initiatorUserCrn),
                 upgradeAvailabilityService.isOsUpgradeEnabledByUserCrn(initiatorUserCrn),
-                Boolean.TRUE.equals(rollingUpgradeEnabled));
+                Boolean.TRUE.equals(rollingUpgradeEnabled) || Boolean.TRUE.equals(distroxUpgradeRequest.getRollingUpgradeEnabled()));
         UpgradeV4Request request = upgradeConverter.convert(distroxUpgradeRequest, internalUpgradeSettings);
         return upgradeCluster(clusterCrn, request, nameOrCrn, false);
     }
@@ -164,7 +164,7 @@ public class DistroXUpgradeV1Controller implements DistroXUpgradeV1Endpoint {
         boolean dataHubRuntimeUpgradeEnabled = upgradeAvailabilityService.isRuntimeUpgradeEnabledByAccountId(accountId);
         boolean dataHubOsUpgradeEntitled = upgradeAvailabilityService.isOsUpgradeEnabledByAccountId(accountId);
         UpgradeV4Request request = upgradeConverter.convert(distroxUpgradeRequest, new InternalUpgradeSettings(false, dataHubRuntimeUpgradeEnabled,
-                dataHubOsUpgradeEntitled));
+                dataHubOsUpgradeEntitled, Boolean.TRUE.equals(distroxUpgradeRequest.getRollingUpgradeEnabled())));
         return upgradeCluster(clusterNameOrCrn, request, nameOrCrn, upgradePreparation);
     }
 

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXUpgradeV1ControllerTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXUpgradeV1ControllerTest.java
@@ -39,6 +39,8 @@ class DistroXUpgradeV1ControllerTest {
 
     private static final String USER_CRN = "crn:cdp:iam:us-west-1:1234:user:1";
 
+    private static final String INTERNAL_CRN = "crn:cdp:iam:us-west-1:altus:user:__internal__actor__";
+
     private static final String CLUSTER_NAME = "clusterName";
 
     private static final String DATAHUB_CRN = "crn:cdp:iam:us-west-1:1234:datahub:1";
@@ -182,6 +184,43 @@ class DistroXUpgradeV1ControllerTest {
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.prepareClusterUpgradeByCrn(CLUSTER_NAME, distroxUpgradeRequest));
 
         verify(upgradeService).triggerUpgrade(NameOrCrn.ofCrn(CLUSTER_NAME), WORKSPACE_ID, USER_CRN, upgradeV4Request, true);
+    }
+
+    @Test
+    public void testRollingUpgradeCalledWithCrn() {
+        DistroXUpgradeV1Request distroxUpgradeRequest = new DistroXUpgradeV1Request();
+        distroxUpgradeRequest.setRollingUpgradeEnabled(true);
+        UpgradeV4Request upgradeV4Request = new UpgradeV4Request();
+        upgradeV4Request.setDryRun(Boolean.FALSE);
+        InternalUpgradeSettings internalUpgradeSettings = new InternalUpgradeSettings(false, true, true, true);
+        when(upgradeAvailabilityService.isRuntimeUpgradeEnabledByAccountId(ACCOUNT_ID)).thenReturn(true);
+        when(upgradeAvailabilityService.isOsUpgradeEnabledByAccountId(ACCOUNT_ID)).thenReturn(true);
+        when(upgradeConverter.convert(distroxUpgradeRequest, internalUpgradeSettings)).thenReturn(upgradeV4Request);
+        UpgradeV4Response upgradeV4Response = new UpgradeV4Response();
+        when(upgradeService.triggerUpgrade(NameOrCrn.ofCrn(CLUSTER_NAME), WORKSPACE_ID, USER_CRN, upgradeV4Request, false)).thenReturn(upgradeV4Response);
+        when(upgradeConverter.convert(upgradeV4Response)).thenReturn(new DistroXUpgradeV1Response());
+
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.upgradeClusterByCrn(CLUSTER_NAME, distroxUpgradeRequest));
+
+        verify(upgradeConverter).convert(distroxUpgradeRequest, internalUpgradeSettings);
+        verify(upgradeService).triggerUpgrade(NameOrCrn.ofCrn(CLUSTER_NAME), WORKSPACE_ID, USER_CRN, upgradeV4Request, false);
+    }
+
+    @Test
+    public void testInternalRollingUpgradeCalledWithCrn() {
+        DistroXUpgradeV1Request distroxUpgradeRequest = new DistroXUpgradeV1Request();
+        UpgradeV4Request upgradeV4Request = new UpgradeV4Request();
+        upgradeV4Request.setDryRun(Boolean.FALSE);
+        InternalUpgradeSettings internalUpgradeSettings = new InternalUpgradeSettings(true, false, false, true);
+        when(upgradeConverter.convert(distroxUpgradeRequest, internalUpgradeSettings)).thenReturn(upgradeV4Request);
+        UpgradeV4Response upgradeV4Response = new UpgradeV4Response();
+        when(upgradeService.triggerUpgrade(NameOrCrn.ofCrn(CLUSTER_NAME), WORKSPACE_ID, INTERNAL_CRN, upgradeV4Request, false)).thenReturn(upgradeV4Response);
+        when(upgradeConverter.convert(upgradeV4Response)).thenReturn(new DistroXUpgradeV1Response());
+
+        ThreadBasedUserCrnProvider.doAs(INTERNAL_CRN, () -> underTest.upgradeClusterByCrnInternal(CLUSTER_NAME, distroxUpgradeRequest, USER_CRN, true));
+
+        verify(upgradeConverter).convert(distroxUpgradeRequest, internalUpgradeSettings);
+        verify(upgradeService).triggerUpgrade(NameOrCrn.ofCrn(CLUSTER_NAME), WORKSPACE_ID, INTERNAL_CRN, upgradeV4Request, false);
     }
 
     @Test


### PR DESCRIPTION
In this commit I've added the rollingUpgradeEnabled parameter to the DistroXUpgradeV1Request. With this addition we can initiate the rolling upgrade from the public API as well.