### PR TITLE
CB-19810 Redbeams CloudResourcePersisterService multiple deletion does not work properly

### DIFF
--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsTerminateService.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsTerminateService.java
@@ -95,7 +95,7 @@ public class AwsRdsTerminateService {
         CloudContext cloudContext = ac.getCloudContext();
         AmazonRdsClient rdsClient = awsClient.createRdsClient(credentialView, regionName);
         awsRdsParameterGroupService.removeFormerParamGroups(rdsClient, stack.getDatabaseServer(), resources);
-        resources.forEach(resource -> persistenceNotifier.notifyDeletion(resource, cloudContext));
+        persistenceNotifier.notifyDeletions(resources, cloudContext);
 
         // FIXME
         return List.of();

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/AwsRdsUpgradeService.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/AwsRdsUpgradeService.java
@@ -53,7 +53,7 @@ public class AwsRdsUpgradeService {
             upgradeRdsIfNotUpgradingAlready(ac, targetMajorVersion, databaseServer, rdsClient, rdsInfo, persistenceNotifier);
             waitForRdsUpgrade(ac, databaseServer, rdsClient);
             List<CloudResource> removedResources = awsRdsParameterGroupService.removeFormerParamGroups(rdsClient, dbStack.getDatabaseServer(), cloudResources);
-            removedResources.forEach(resource -> persistenceNotifier.notifyDeletion(resource, ac.getCloudContext()));
+            persistenceNotifier.notifyDeletions(removedResources, ac.getCloudContext());
         }
         LOGGER.debug("RDS upgrade done for DB: {}", dbInstanceIdentifier);
     }
@@ -67,7 +67,7 @@ public class AwsRdsUpgradeService {
         if (AVAILABLE == rdsInfo.getRdsState()) {
             LOGGER.debug("RDS {} is in available state, calling upgrade.", databaseServer.getServerId());
             List<CloudResource> newResources = awsRdsUpgradeSteps.upgradeRds(ac, rdsClient, databaseServer, rdsInfo, targetMajorVersion);
-            newResources.forEach(cloudResource -> persistenceNotifier.notifyAllocation(cloudResource, ac.getCloudContext()));
+            persistenceNotifier.notifyAllocations(newResources, ac.getCloudContext());
         } else {
             LOGGER.debug("RDS {} is already upgrading, proceeding to wait for upgrade", databaseServer.getServerId());
         }

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/AwsRdsUpgradeServiceTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/upgrade/AwsRdsUpgradeServiceTest.java
@@ -105,7 +105,7 @@ public class AwsRdsUpgradeServiceTest {
         inOrder.verify(awsRdsUpgradeValidatorService).validateRdsIsAvailableOrUpgrading(rdsInfo);
         inOrder.verify(awsRdsUpgradeSteps).upgradeRds(ac, rdsClient, databaseServer, rdsInfo, targetMajorVersion);
         inOrder.verify(awsRdsUpgradeSteps).waitForUpgrade(ac, rdsClient, databaseServer);
-        verify(persistenceNotifier, times(2)).notifyDeletion(any(CloudResource.class), eq(cloudContext));
+        verify(persistenceNotifier, times(1)).notifyDeletions(resources, cloudContext);
     }
 
     @Test

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/cloud/CloudResourcePersisterService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/cloud/CloudResourcePersisterService.java
@@ -3,6 +3,7 @@ package com.sequenceiq.redbeams.service.cloud;
 import static com.sequenceiq.redbeams.exception.NotFoundException.notFound;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -82,9 +83,15 @@ public class CloudResourcePersisterService implements Persister<ResourceNotifica
     public ResourceNotification delete(ResourceNotification notification) {
         LOGGER.debug("DBResource deletion notification received: {}", notification);
         Long stackId = notification.getCloudContext().getId();
-        CloudResource cloudResource = notification.getCloudResource();
-        dbResourceService.findByStackAndNameAndType(stackId, cloudResource.getName(), cloudResource.getType())
-                .ifPresent(value -> dbResourceService.delete(value));
+        List<CloudResource> cloudResources = notification.getCloudResources();
+        AtomicInteger deleted = new AtomicInteger(0);
+        cloudResources.stream()
+                .filter(cr -> resourceExists(stackId, cr))
+                .forEach(cloudResource -> {
+                    deleteResource(stackId, cloudResource);
+                    deleted.incrementAndGet();
+                });
+        LOGGER.debug("There are {} deleted resource(s)", deleted.get());
         return notification;
     }
 
@@ -92,5 +99,19 @@ public class CloudResourcePersisterService implements Persister<ResourceNotifica
         if (persistedResource != null) {
             resource.setId(persistedResource.getId());
         }
+    }
+
+    private boolean resourceExists(Long stackId, CloudResource cloudResource) {
+        boolean exists = dbResourceService.existsByStackAndNameAndType(stackId, cloudResource.getName(), cloudResource.getType());
+        String id = cloudResource.getName();
+        if (exists) {
+            LOGGER.debug("{} and {} already exists in DB for stack.", id, cloudResource.getType());
+        }
+        return exists;
+    }
+
+    private void deleteResource(Long stackId, CloudResource cloudResource) {
+        dbResourceService.findByStackAndNameAndType(stackId, cloudResource.getName(), cloudResource.getType())
+                .ifPresent(value -> dbResourceService.delete(value));
     }
 }


### PR DESCRIPTION
CB-19810 Redbeams CloudResourcePersisterService multiple deletion does not work properly

The fix is to use notification.getCloudResources() instead of getCloudResource() in redbeams CloudResourcePersisterService.delete() method.
