### PR TITLE
CB-15187 Make Salt update unavailable if datalake/datahub is in delet…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/ClusterCommonService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/ClusterCommonService.java
@@ -306,7 +306,15 @@ public class ClusterCommonService {
     public FlowIdentifier updateSalt(NameOrCrn nameOrCrn, String accountId) {
         StackView stack = stackDtoService.getStackViewByNameOrCrn(nameOrCrn, accountId);
         MDCBuilder.buildMdcContext(stack);
-        return clusterOperationService.updateSalt(stack.getId());
+        Status status = stack.getStatus();
+        if (status.isStopState() || status.isTerminatedOrDeletionInProgress()) {
+            String message = String.format("SaltStack update cannot be initiated as stack '%s' is currently in '%s' state.",
+                    stack.getName(), status);
+            LOGGER.info(message);
+            throw new BadRequestException(message);
+        } else {
+            return clusterOperationService.updateSalt(stack.getId());
+        }
     }
 
     public FlowIdentifier updatePillarConfiguration(NameOrCrn nameOrCrn, String accountId) {

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -1381,6 +1381,15 @@ public class SdxService implements ResourceIdProvider, PayloadContextProvider, H
     }
 
     public FlowIdentifier updateSalt(SdxCluster sdxCluster) {
-        return sdxReactorFlowManager.triggerSaltUpdate(sdxCluster);
+        SdxStatusEntity sdxStatus = sdxStatusService.getActualStatusForSdx(sdxCluster);
+        DatalakeStatusEnum status = sdxStatus.getStatus();
+        if (status.isStopState() || status.isDeleteInProgressOrCompleted()) {
+            String message = String.format("SaltStack update cannot be initiated as datalake '%s' is currently in '%s' state.",
+                    sdxCluster.getName(), status);
+            LOGGER.info(message);
+            throw new BadRequestException(message);
+        } else {
+            return sdxReactorFlowManager.triggerSaltUpdate(sdxCluster);
+        }
     }
 }


### PR DESCRIPTION
…ed/delete in progress/stopped/stop in progress state.

Salt update for Datalakes and Datahub, both for public and private APIs, will throw BadRequestException n request time if the cluster is in deleted or stopped state or it is being dtopped or deleted.

See detailed description in the commit message.