### PR TITLE
CB-19899 Jaxb is not used by Cloudbreak, we can eliminate the depende…

### DIFF
--- a/autoscale/build.gradle
+++ b/autoscale/build.gradle
@@ -129,9 +129,6 @@ dependencyManagement {
         dependency group: 'com.fasterxml.jackson.core',    name: 'jackson-databind',               version: jacksonDatabindVersion
         dependency group: 'javax.mail',                    name: 'mail',                           version: '1.5.0-b01'
         dependency group: 'dnsjava',                       name: 'dnsjava',                        version: '2.1.7'
-        dependency group: 'javax.xml.bind',                name: 'jaxb-api',                       version: '2.3.0'
-        dependency group: 'com.sun.xml.bind',              name: 'jaxb-impl',                      version: '2.3.0'
-        dependency group: 'org.glassfish.jaxb',            name: 'jaxb-runtime',                   version: '2.3.0'
         dependency group: 'org.springframework',           name: 'spring-context-support',         version: springFrameworkVersion
         dependency group: 'com.zaxxer',                    name: 'HikariCP',                       version: '3.2.0'
 
@@ -181,10 +178,6 @@ dependencies {
     }
 
     implementation group: 'com.sequenceiq',                name: 'consul-api'
-
-    runtimeOnly group: 'javax.xml.bind',                name: 'jaxb-api'
-    runtimeOnly group: 'com.sun.xml.bind',              name: 'jaxb-impl'
-    runtimeOnly group: 'org.glassfish.jaxb',            name: 'jaxb-runtime'
 
     testImplementation group: 'org.springframework.boot',  name: 'spring-boot-starter-test'
     testImplementation group: 'org.mockito',               name: 'mockito-core'

--- a/cloud-consumption-api/build.gradle
+++ b/cloud-consumption-api/build.gradle
@@ -22,9 +22,6 @@ dependencies {
     implementation     group: "org.glassfish.jersey.ext",      name: "jersey-proxy-client",            version: jerseyCoreVersion
     implementation     group: "org.glassfish.jersey.media",    name: "jersey-media-json-jackson",      version: jerseyCoreVersion
     implementation     group: "javax.activation",              name: "activation",                     version: javaxActivationVersion
-    implementation     group: "javax.xml.bind",                name: "jaxb-api",                       version: "2.3.0"
-    implementation     group: "com.sun.xml.bind",              name: "jaxb-impl",                      version: "2.3.0"
-    implementation     group: "com.sun.xml.bind",              name: "jaxb-core",                      version: "2.3.0"
     implementation     group: "com.sun.xml.ws",                name: "rt",                             version: "2.3.0"
     implementation     group: "com.sun.xml.ws",                name: "jaxws-rt",                       version: "2.3.0"
     implementation     group: "io.opentracing.contrib",        name: "opentracing-jaxrs2",             version: opentracingJaxrs2Version

--- a/cloud-consumption/build.gradle
+++ b/cloud-consumption/build.gradle
@@ -54,7 +54,6 @@ dependencies {
     implementation     group: 'dnsjava',                   name: 'dnsjava'
     implementation     group: 'io.springfox',              name: 'springfox-boot-starter'
     implementation     group: 'io.swagger',                name: 'swagger-jersey2-jaxrs'
-    implementation     group: 'javax.xml.bind',            name: 'jaxb-api'
     implementation     group: 'org.glassfish.jersey.core', name: 'jersey-server'
     implementation     group: 'org.mybatis',               name: 'mybatis-migrations'
     implementation     group: 'org.postgresql',            name: 'postgresql'
@@ -81,8 +80,6 @@ dependencies {
         because 'because there is no jar for 2.4.3 in maven central repo...'
     }
 
-    runtimeOnly            group: 'com.sun.xml.bind',          name: 'jaxb-impl'
-    runtimeOnly            group: 'org.glassfish.jaxb',        name: 'jaxb-runtime'
 
     testImplementation ('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'junit'
@@ -99,9 +96,6 @@ dependencies {
         implementation     group: 'dnsjava',                   name: 'dnsjava',                        version: '2.1.7'
         implementation     group: 'io.springfox',              name: 'springfox-boot-starter',         version: swaggerSpringFoxVersion
         implementation     group: 'io.swagger',                name: 'swagger-jersey2-jaxrs',          version: swaggerVersion
-        implementation     group: 'javax.xml.bind',            name: 'jaxb-api',                       version: '2.3.1'
-        runtimeOnly        group: 'com.sun.xml.bind',          name: 'jaxb-impl',                      version: '2.3.0'
-        runtimeOnly        group: 'org.glassfish.jaxb',        name: 'jaxb-runtime',                   version: '2.3.0'
         implementation     group: 'org.glassfish.jersey.core', name: 'jersey-server',                  version: jerseyCoreVersion
         implementation     group: 'org.mybatis',               name: 'mybatis-migrations',             version: mybatisMigrationVersion
         implementation     group: 'org.postgresql',            name: 'postgresql',                     version: postgreSQLVersion

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -156,7 +156,6 @@ dependencyManagement {
     dependency group: 'org.freemarker',                     name: 'freemarker',                  version: freemarkerVersion
     dependency group: 'org.postgresql',                     name: 'postgresql',                  version: postgreSQLVersion
     dependency group: 'org.glassfish.jersey.media',         name: 'jersey-media-multipart',      version: jerseyCoreVersion
-    dependency group: 'javax.xml.bind',                     name: 'jaxb-api',                    version: '2.3.0'
     dependency group: 'org.mybatis',                        name: 'mybatis-migrations',          version: mybatisMigrationVersion
     dependency group: 'org.mockito',                        name: 'mockito-core',                version: mockitoVersion
     dependency group: 'org.apache.commons',                 name: 'commons-collections4',        version: commonsCollections4Version
@@ -200,7 +199,6 @@ dependencies {
   implementation group: 'com.github.fommil',                  name: 'openssh'
 
   implementation group: 'javax.mail',                         name: 'mail'
-  implementation group: 'javax.xml.bind',                     name: 'jaxb-api'
   implementation group: 'dnsjava',                            name: 'dnsjava'
 
   implementation group: 'io.springfox',                       name: 'springfox-boot-starter'

--- a/datalake/build.gradle
+++ b/datalake/build.gradle
@@ -78,8 +78,6 @@ dependencies {
   implementation     ("io.swagger:swagger-jersey2-jaxrs:$swaggerVersion") {
     exclude group: 'org.yaml'
   }
-  implementation     group: 'javax.xml.bind',            name: 'jaxb-api',                        version: '2.3.1'
-  implementation     group: 'org.glassfish.jaxb',        name: 'jaxb-runtime',                    version: '2.3.1'
   implementation     group: 'org.glassfish.jersey.core', name: 'jersey-server',                   version: jerseyCoreVersion
   implementation     group: 'org.glassfish.jersey.media',name: 'jersey-media-json-jackson',       version: jerseyCoreVersion
   implementation     group: 'org.mybatis',               name: 'mybatis-migrations',              version: mybatisMigrationVersion

--- a/environment-api/build.gradle
+++ b/environment-api/build.gradle
@@ -23,9 +23,6 @@ dependencies {
     implementation     group: "org.glassfish.jersey.ext",      name: "jersey-proxy-client",            version: jerseyCoreVersion
     implementation     group: "org.glassfish.jersey.media",    name: "jersey-media-json-jackson",      version: jerseyCoreVersion
     implementation     group: "javax.activation",              name: "activation",                     version: javaxActivationVersion
-    implementation     group: "javax.xml.bind",                name: "jaxb-api",                       version: "2.3.0"
-    implementation     group: "com.sun.xml.bind",              name: "jaxb-impl",                      version: "2.3.0"
-    implementation     group: "com.sun.xml.bind",              name: "jaxb-core",                      version: "2.3.0"
     implementation     group: "com.sun.xml.ws",                name: "rt",                             version: "2.3.0"
     implementation     group: "com.sun.xml.ws",                name: "jaxws-rt",                       version: "2.3.0"
     implementation     group: "io.opentracing.contrib",        name: "opentracing-jaxrs2",             version: opentracingJaxrs2Version

--- a/environment/build.gradle
+++ b/environment/build.gradle
@@ -87,7 +87,6 @@ dependencies {
     implementation    (group: "io.swagger",                name: "swagger-jersey2-jaxrs",                    version: swaggerVersion) {
         exclude group: "org.yaml", module: "snakeyaml"
     }
-    implementation     group: "javax.xml.bind",            name: "jaxb-api",                                 version: "2.3.1"
     implementation     group: "org.glassfish.jersey.core", name: "jersey-server",                            version: jerseyCoreVersion
     implementation     group: "org.mybatis",               name: "mybatis-migrations",                       version: mybatisMigrationVersion
     implementation     group: "org.postgresql",            name: "postgresql",                               version: postgreSQLVersion

--- a/freeipa/build.gradle
+++ b/freeipa/build.gradle
@@ -51,8 +51,6 @@ dependencies {
   implementation     ('io.swagger:swagger-jersey2-jaxrs') {
     exclude group: 'org.yaml'
   }
-  implementation     group: 'javax.xml.bind',            name: 'jaxb-api'
-  implementation     group: 'org.glassfish.jaxb',        name: 'jaxb-runtime',                         version: '2.3.1'
   implementation     group: 'javax.activation',          name: 'activation',                           version: '1.1.1'
   implementation     group: 'org.glassfish.jersey.core', name: 'jersey-server'
   implementation     group: 'org.mybatis',               name: 'mybatis-migrations'
@@ -100,7 +98,6 @@ dependencies {
     implementation     group: 'dnsjava',                   name: 'dnsjava',                        version: '2.1.7'
     implementation     group: 'io.springfox',              name: 'springfox-boot-starter',         version: swaggerSpringFoxVersion
     implementation     group: 'io.swagger',                name: 'swagger-jersey2-jaxrs',          version: swaggerVersion
-    implementation     group: 'javax.xml.bind',            name: 'jaxb-api',                       version: '2.3.1'
     implementation     group: 'org.glassfish.jersey.core', name: 'jersey-server',                  version: jerseyCoreVersion
     implementation     group: 'org.mybatis',               name: 'mybatis-migrations',             version: mybatisMigrationVersion
     implementation     group: 'org.postgresql',            name: 'postgresql',                     version: postgreSQLVersion

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -184,7 +184,6 @@ dependencies {
   }
   implementation group: 'com.fasterxml.jackson.core',    name: 'jackson-databind',               version: jacksonDatabindVersion
 
-  runtimeOnly group: 'javax.xml.bind',                name: 'jaxb-api', version: '2.3.0'
 }
 
 test {

--- a/redbeams/build.gradle
+++ b/redbeams/build.gradle
@@ -53,7 +53,6 @@ dependencies {
   implementation     group: 'dnsjava',                   name: 'dnsjava'
   implementation     group: 'io.springfox',              name: 'springfox-boot-starter'
   implementation     group: 'io.swagger',                name: 'swagger-jersey2-jaxrs'
-  implementation     group: 'javax.xml.bind',            name: 'jaxb-api'
   implementation     group: 'org.glassfish.jersey.core', name: 'jersey-server'
   implementation     group: 'org.mybatis',               name: 'mybatis-migrations'
   implementation     group: 'org.postgresql',            name: 'postgresql'
@@ -77,9 +76,6 @@ dependencies {
     because 'because there is no jar for 2.4.3 in maven central repo...'
   }
 
-  runtimeOnly            group: 'com.sun.xml.bind',          name: 'jaxb-impl'
-  runtimeOnly            group: 'org.glassfish.jaxb',        name: 'jaxb-runtime'
-
   testImplementation ('org.springframework.boot:spring-boot-starter-test') {
     exclude group: 'junit'
   }
@@ -95,9 +91,6 @@ dependencies {
     implementation     group: 'dnsjava',                   name: 'dnsjava',                        version: '2.1.7'
     implementation     group: 'io.springfox',              name: 'springfox-boot-starter',         version: swaggerSpringFoxVersion
     implementation     group: 'io.swagger',                name: 'swagger-jersey2-jaxrs',          version: swaggerVersion
-    implementation     group: 'javax.xml.bind',            name: 'jaxb-api',                       version: '2.3.1'
-    runtimeOnly        group: 'com.sun.xml.bind',          name: 'jaxb-impl',                      version: '2.3.0'
-    runtimeOnly        group: 'org.glassfish.jaxb',        name: 'jaxb-runtime',                   version: '2.3.0'
     implementation     group: 'org.glassfish.jersey.core', name: 'jersey-server',                  version: jerseyCoreVersion
     implementation     group: 'org.mybatis',               name: 'mybatis-migrations',             version: mybatisMigrationVersion
     implementation     group: 'org.postgresql',            name: 'postgresql',                     version: postgreSQLVersion


### PR DESCRIPTION
…ncies, and anyway the jaxb 2.3 is a 5 years old library

See detailed description in the commit message.