### PR TITLE
CB-16771 return with PAAS TargetPlatform if the crn did not match to any crn we assume.

### DIFF
--- a/sdx-connector/src/main/java/com/sequenceiq/cloudbreak/saas/sdx/TargetPlatform.java
+++ b/sdx-connector/src/main/java/com/sequenceiq/cloudbreak/saas/sdx/TargetPlatform.java
@@ -2,12 +2,17 @@ package com.sequenceiq.cloudbreak.saas.sdx;
 
 import java.util.Arrays;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.sequenceiq.cloudbreak.auth.crn.CrnResourceDescriptor;
-import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 
 public enum TargetPlatform {
+
     SAAS(CrnResourceDescriptor.SDX_SAAS_INSTANCE),
     PAAS(CrnResourceDescriptor.DATALAKE);
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TargetPlatform.class);
 
     private CrnResourceDescriptor crnResourceDescriptor;
 
@@ -23,6 +28,9 @@ public enum TargetPlatform {
         return Arrays.stream(values())
                 .filter(platform -> platform.getCrnResourceDescriptor().equals(CrnResourceDescriptor.getByCrnString(crn)))
                 .findFirst()
-                .orElseThrow(() -> new NotFoundException(String.format("There is no SDX platform based on CRN %s", crn)));
+                .orElseGet(() -> {
+                    LOGGER.warn("Based on CRN we were not able to decide the target platform, fallback to PAAS");
+                    return PAAS;
+                });
     }
 }


### PR DESCRIPTION
There was a bug in the past where DLs created with DH crns, this is why we need this.
