### PR TITLE
CB-19884 Introduce Telemetry for E2E createDefaultEnvironment method

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/AbstractE2ETest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/AbstractE2ETest.java
@@ -15,7 +15,10 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Listeners;
 
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.telemetry.TelemetryTestDto;
 import com.sequenceiq.it.cloudbreak.testcase.AbstractIntegrationTest;
 import com.sequenceiq.it.cloudbreak.util.spot.SpotRetryOnceTestListener;
 import com.sequenceiq.it.cloudbreak.util.spot.SpotRetryUtil;
@@ -58,6 +61,27 @@ public abstract class AbstractE2ETest extends AbstractIntegrationTest {
             ((TestContext) data[0]).getResourceNames().values().forEach(value -> tagsUtil.verifyTags(value, (TestContext) data[0]));
         }
         spotUtil.setUseSpotInstances(Boolean.FALSE);
+    }
+
+    /**
+     * Overrides the integration test environment creation with setting Telemetry up for E2E resources by default.
+     *
+     * @param testContext   Spring offers ApplicationContextAware interface to provide configuration of the Integration Test ApplicationContext.
+     *                      Should not be null!
+     */
+    @Override
+    protected void createDefaultEnvironment(TestContext testContext) {
+        testContext
+                .given("telemetry", TelemetryTestDto.class)
+                    .withLogging()
+                    .withReportClusterLogs()
+                .given(EnvironmentTestDto.class)
+                    .withTelemetry("telemetry")
+                    .withCreateFreeIpa(Boolean.FALSE)
+                .when(getEnvironmentTestClient().create())
+                .await(EnvironmentStatus.AVAILABLE)
+                .when(getEnvironmentTestClient().describe())
+                .validate();
     }
 
     /**

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/freeipa/FreeIpaRebuildTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/freeipa/FreeIpaRebuildTests.java
@@ -12,7 +12,6 @@ import com.sequenceiq.it.cloudbreak.client.FreeIpaTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
-import com.sequenceiq.it.cloudbreak.dto.telemetry.TelemetryTestDto;
 import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
 
 public class FreeIpaRebuildTests extends AbstractE2ETest {
@@ -38,12 +37,9 @@ public class FreeIpaRebuildTests extends AbstractE2ETest {
         int instanceCountByGroup = 2;
 
         testContext
-                .given("telemetry", TelemetryTestDto.class)
-                .withLogging()
-                .withReportClusterLogs()
                 .given(freeIpa, FreeIpaTestDto.class)
-                .withFreeIpaHa(instanceGroupCount, instanceCountByGroup)
-                .withTelemetry("telemetry")
+                    .withFreeIpaHa(instanceGroupCount, instanceCountByGroup)
+                    .withTelemetry("telemetry")
                 .when(freeIpaTestClient.create(), key(freeIpa))
                 .await(FREEIPA_AVAILABLE)
                 .when(freeIpaTestClient.delete())

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/freeipa/FreeIpaRecipeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/freeipa/FreeIpaRecipeTests.java
@@ -24,7 +24,6 @@ import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaUpscaleTestDto;
 import com.sequenceiq.it.cloudbreak.dto.recipe.RecipeTestDto;
-import com.sequenceiq.it.cloudbreak.dto.telemetry.TelemetryTestDto;
 import com.sequenceiq.it.cloudbreak.exception.TestFailException;
 import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
 import com.sequenceiq.it.cloudbreak.util.RecipeUtil;
@@ -77,9 +76,6 @@ public class FreeIpaRecipeTests extends AbstractE2ETest {
                 .when(recipeTestClient.createV4(), key("post1")).getResponse().getName();
 
         testContext
-                .given("telemetry", TelemetryTestDto.class)
-                    .withLogging()
-                    .withReportClusterLogs()
                 .given(FreeIpaTestDto.class)
                     .withFreeIpaHa(INSTANCEGROUP_COUNT, INSTANCE_COUNT_BY_GROUP)
                     .withTelemetry("telemetry")
@@ -117,9 +113,6 @@ public class FreeIpaRecipeTests extends AbstractE2ETest {
                 .when(recipeTestClient.createV4(), key("post2")).getResponse().getName();
 
         testContext
-                .given("telemetry", TelemetryTestDto.class)
-                    .withLogging()
-                    .withReportClusterLogs()
                 .given(FreeIpaTestDto.class)
                     .withTelemetry("telemetry")
                     .withRecipes(Set.of(preRecipeName, postInstallRecipeName))
@@ -130,7 +123,7 @@ public class FreeIpaRecipeTests extends AbstractE2ETest {
                 .then(RecipeTestAssertion.validateFilesOnFreeIpa(POST_INSTALL_FILEPATH, POST_INSTALL_FILENAME, 1, sshJUtil))
                 .when(freeIpaTestClient.detachRecipes(List.of(preRecipeName, postInstallRecipeName)))
                 .given(FreeIpaUpscaleTestDto.class)
-                .withAvailabilityType(AvailabilityType.HA)
+                    .withAvailabilityType(AvailabilityType.HA)
                 .when(freeIpaTestClient.upscale())
                 .await(Status.AVAILABLE)
                 .given(FreeIpaTestDto.class)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/freeipa/FreeIpaScalingTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/freeipa/FreeIpaScalingTests.java
@@ -26,7 +26,6 @@ import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaDownscaleTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaUpscaleTestDto;
-import com.sequenceiq.it.cloudbreak.dto.telemetry.TelemetryTestDto;
 import com.sequenceiq.it.cloudbreak.exception.TestFailException;
 import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
 
@@ -52,11 +51,8 @@ public class FreeIpaScalingTests extends AbstractE2ETest {
         Set<String> primaryGatewayInstanceId = new HashSet<>();
 
         testContext
-                .given("telemetry", TelemetryTestDto.class)
-                .withLogging()
-                .withReportClusterLogs()
                 .given(freeIpa, FreeIpaTestDto.class)
-                .withTelemetry("telemetry")
+                    .withTelemetry("telemetry")
                 .when(freeIpaTestClient.create(), key(freeIpa))
                 .await(FREEIPA_AVAILABLE)
                 .then((tc, testDto, client) -> {
@@ -66,7 +62,7 @@ public class FreeIpaScalingTests extends AbstractE2ETest {
                 })
 
                 .given(FreeIpaUpscaleTestDto.class)
-                .withAvailabilityType(AvailabilityType.HA)
+                    .withAvailabilityType(AvailabilityType.HA)
                 .when(freeIpaTestClient.upscale(), key(freeIpa))
                 .await(FREEIPA_AVAILABLE)
                 .then((tc, testDto, client) -> {
@@ -77,7 +73,7 @@ public class FreeIpaScalingTests extends AbstractE2ETest {
                 })
 
                 .given(FreeIpaDownscaleTestDto.class)
-                .withAvailabilityType(AvailabilityType.TWO_NODE_BASED)
+                    .withAvailabilityType(AvailabilityType.TWO_NODE_BASED)
                 .when(freeIpaTestClient.downscale())
                 .await(FREEIPA_AVAILABLE)
                 .then((tc, testDto, client) -> {
@@ -88,7 +84,7 @@ public class FreeIpaScalingTests extends AbstractE2ETest {
                 })
 
                 .given(FreeIpaUpscaleTestDto.class)
-                .withAvailabilityType(AvailabilityType.HA)
+                    .withAvailabilityType(AvailabilityType.HA)
                 .when(freeIpaTestClient.upscale(), key(freeIpa))
                 .await(FREEIPA_AVAILABLE)
                 .then((tc, testDto, client) -> {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/freeipa/FreeIpaTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/freeipa/FreeIpaTests.java
@@ -23,7 +23,6 @@ import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaUserSyncTestDto;
 import com.sequenceiq.it.cloudbreak.dto.recipe.RecipeTestDto;
-import com.sequenceiq.it.cloudbreak.dto.telemetry.TelemetryTestDto;
 import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
 import com.sequenceiq.it.cloudbreak.util.RecipeUtil;
 import com.sequenceiq.it.cloudbreak.util.ssh.SshJUtil;
@@ -78,9 +77,6 @@ public class FreeIpaTests extends AbstractE2ETest {
                     .withContent(recipeUtil.generatePreDeploymentRecipeContent(applicationContext))
                     .withRecipeType(PRE_SERVICE_DEPLOYMENT)
                 .when(recipeTestClient.createV4(), key("preDeployment"))
-                .given("telemetry", TelemetryTestDto.class)
-                    .withLogging()
-                    .withReportClusterLogs()
                 .given(freeIpa, FreeIpaTestDto.class)
                     .withFreeIpaHa(instanceGroupCount, instanceCountByGroup)
                     .withTelemetry("telemetry")

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/freeipa/FreeIpaUpgradeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/freeipa/FreeIpaUpgradeTests.java
@@ -44,7 +44,6 @@ import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaOperationStatusTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
-import com.sequenceiq.it.cloudbreak.dto.telemetry.TelemetryTestDto;
 import com.sequenceiq.it.cloudbreak.exception.TestFailException;
 import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
 import com.sequenceiq.it.cloudbreak.util.ssh.action.SshJClientActions;
@@ -86,17 +85,14 @@ public class FreeIpaUpgradeTests extends AbstractE2ETest {
         sdxDatabaseRequest.setCreate(false);
 
         testContext
-                .given("telemetry", TelemetryTestDto.class)
-                .withLogging()
-                .withReportClusterLogs()
                 .given(freeIpa, FreeIpaTestDto.class)
-                .withTelemetry("telemetry")
-                .withUpgradeCatalogAndImage()
+                    .withTelemetry("telemetry")
+                    .withUpgradeCatalogAndImage()
                 .when(freeIpaTestClient.create(), key(freeIpa))
                 .await(FREEIPA_AVAILABLE)
                 .given(SdxTestDto.class)
-                .withCloudStorage()
-                .withExternalDatabase(sdxDatabaseRequest)
+                    .withCloudStorage()
+                    .withExternalDatabase(sdxDatabaseRequest)
                 .when(sdxTestClient.create())
                 .await(SdxClusterStatusResponse.RUNNING)
                 .given(freeIpa, FreeIpaTestDto.class)
@@ -126,25 +122,22 @@ public class FreeIpaUpgradeTests extends AbstractE2ETest {
         sdxDatabaseRequest.setCreate(false);
 
         testContext
-                .given("telemetry", TelemetryTestDto.class)
-                .withLogging()
-                .withReportClusterLogs()
                 .given(freeIpa, FreeIpaTestDto.class)
-                .withFreeIpaHa(1, 3)
-                .withTelemetry("telemetry")
-                .withUpgradeCatalogAndImage()
+                    .withFreeIpaHa(1, 3)
+                    .withTelemetry("telemetry")
+                    .withUpgradeCatalogAndImage()
                 .when(freeIpaTestClient.create(), key(freeIpa))
                 .await(FREEIPA_AVAILABLE)
                 .given(SdxTestDto.class)
-                .withCloudStorage()
-                .withExternalDatabase(sdxDatabaseRequest)
+                    .withCloudStorage()
+                    .withExternalDatabase(sdxDatabaseRequest)
                 .when(sdxTestClient.create())
                 .await(SdxClusterStatusResponse.RUNNING)
                 .given(freeIpa, FreeIpaTestDto.class)
                 .when(freeIpaTestClient.upgrade())
                 .await(Status.UPDATE_IN_PROGRESS, waitForFlow().withWaitForFlow(Boolean.FALSE))
                 .given(FreeIpaOperationStatusTestDto.class)
-                .withOperationId(((FreeIpaTestDto) testContext.get(freeIpa)).getOperationId())
+                    .withOperationId(((FreeIpaTestDto) testContext.get(freeIpa)).getOperationId())
                 .then((tc, testDto, freeIpaClient) -> testFreeIpaAvailabilityDuringUpgrade(tc, testDto, freeIpaClient, freeIpa))
                 .await(COMPLETED, waitForFlow().withWaitForFlow(Boolean.FALSE).withTimeoutChecker(new AbsolutTimeBasedTimeoutChecker(TWO_HOURS_IN_SEC)))
                 .given(freeIpa, FreeIpaTestDto.class)


### PR DESCRIPTION
The commonly used `createDefaultEnvironment` method does not contains Telemetry related steps. So neither SDX, DistroX nor FreeIPA are created with Telemetry in these environments by default (expect if the Telemetry is defined directly for these resources in the related test). So we should introduce the well-known Telemetry related steps here by default to can get cluster-logs for FreeIPA, SDX and DistroX by default.

Where the Telemetry is applied along with the test steps and the `createDefaultEnvironment` is used, we should remove redundant Telemetry definition from test.