### PR TITLE
CB-19725 Enable DB SSL for DH CM

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/conf/ExternalDatabaseConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/conf/ExternalDatabaseConfig.java
@@ -37,6 +37,9 @@ public class ExternalDatabaseConfig {
     @Value("${cb.externaldatabase.pause.supported.platform:AWS,GCP}")
     private Set<CloudPlatform> dbServicePauseSupportedPlatforms;
 
+    @Value("${cb.externaldatabase.sslenforcement.supported.platform:AWS,AZURE}")
+    private Set<CloudPlatform> dbServiceSslEnforcementSupportedPlatforms;
+
     @Inject
     private Set<DatabaseServerParameterDecorator> databaseServerParameterDecorators;
 
@@ -48,6 +51,10 @@ public class ExternalDatabaseConfig {
 
     public boolean isExternalDatabasePauseSupportedFor(CloudPlatform cloudPlatform) {
         return dbServicePauseSupportedPlatforms.contains(cloudPlatform);
+    }
+
+    public boolean isExternalDatabaseSslEnforcementSupportedFor(CloudPlatform cloudPlatform) {
+        return dbServiceSslEnforcementSupportedPlatforms.contains(cloudPlatform);
     }
 
     public Set<CloudPlatform> getSupportedExternalDatabasePlatforms() {
@@ -105,4 +112,5 @@ public class ExternalDatabaseConfig {
         }
         return Optional.of(JsonUtil.readValue(databaseTemplateJson, DatabaseStackConfig.class));
     }
+
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/ExternalDatabaseService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/ExternalDatabaseService.java
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeUnit;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -20,9 +21,16 @@ import com.dyngr.core.AttemptResult;
 import com.dyngr.core.AttemptResults;
 import com.google.common.base.Strings;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseAvailabilityType;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.cloud.model.StackTags;
+import com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessorFactory;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.conf.ExternalDatabaseConfig;
+import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.repository.cluster.ClusterRepository;
@@ -37,6 +45,8 @@ import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvi
 import com.sequenceiq.flow.api.model.FlowCheckResponse;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.AllocateDatabaseServerV4Request;
+import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.SslConfigV4Request;
+import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.SslMode;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.UpgradeDatabaseServerV4Request;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.UpgradeTargetMajorVersion;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerV4Response;
@@ -51,6 +61,8 @@ public class ExternalDatabaseService {
     public static final int DURATION_IN_MINUTES_FOR_DB_POLLING = 60;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ExternalDatabaseService.class);
+
+    private static final String SSL_ENFORCEMENT_MIN_RUNTIME_VERSION = "7.2.2";
 
     private static final PollingConfig DB_POLLING_CONFIG = PollingConfig.builder()
             .withSleepTime(SLEEP_TIME_IN_SEC_FOR_DB_POLLING)
@@ -70,14 +82,24 @@ public class ExternalDatabaseService {
 
     private final DatabaseObtainerService databaseObtainerService;
 
+    private final EntitlementService entitlementService;
+
+    private final ExternalDatabaseConfig externalDatabaseConfig;
+
+    private final CmTemplateProcessorFactory cmTemplateProcessorFactory;
+
     public ExternalDatabaseService(RedbeamsClientService redbeamsClient, ClusterRepository clusterRepository,
             Map<CloudPlatform, DatabaseStackConfig> dbConfigs, Map<CloudPlatform, DatabaseServerParameterDecorator> parameterDecoratorMap,
-            DatabaseObtainerService databaseObtainerService) {
+            DatabaseObtainerService databaseObtainerService, EntitlementService entitlementService, ExternalDatabaseConfig externalDatabaseConfig,
+            CmTemplateProcessorFactory cmTemplateProcessorFactory) {
         this.redbeamsClient = redbeamsClient;
         this.clusterRepository = clusterRepository;
         this.dbConfigs = dbConfigs;
         this.parameterDecoratorMap = parameterDecoratorMap;
         this.databaseObtainerService = databaseObtainerService;
+        this.entitlementService = entitlementService;
+        this.externalDatabaseConfig = externalDatabaseConfig;
+        this.cmTemplateProcessorFactory = cmTemplateProcessorFactory;
     }
 
     public void provisionDatabase(Cluster cluster, DatabaseAvailabilityType externalDatabase, DetailedEnvironmentResponse environment) {
@@ -86,9 +108,8 @@ public class ExternalDatabaseService {
         try {
             Optional<DatabaseServerV4Response> existingDatabase = findExistingDatabase(cluster, environment.getCrn());
             if (existingDatabase.isPresent()) {
-                String dbCrn = existingDatabase.get().getCrn();
-                LOGGER.debug("Found existing database with CRN {}", dbCrn);
-                databaseCrn = dbCrn;
+                databaseCrn = existingDatabase.get().getCrn();
+                LOGGER.debug("Found existing database with CRN {}", databaseCrn);
             } else {
                 LOGGER.debug("Requesting new database server creation");
                 AllocateDatabaseServerV4Request request = getDatabaseRequest(environment, externalDatabase, cluster);
@@ -223,13 +244,52 @@ public class ExternalDatabaseService {
         AllocateDatabaseServerV4Request req = new AllocateDatabaseServerV4Request();
         req.setEnvironmentCrn(environment.getCrn());
         CloudPlatform cloudPlatform = CloudPlatform.valueOf(environment.getCloudPlatform().toUpperCase(Locale.US));
-        String databaseEngineVersion = Optional.ofNullable(cluster).map(Cluster::getStack).map(Stack::getExternalDatabaseEngineVersion).orElse(null);
+        Stack stack = cluster.getStack();
+        String databaseEngineVersion = Optional.ofNullable(stack).map(Stack::getExternalDatabaseEngineVersion).orElse(null);
         req.setDatabaseServer(getDatabaseServerStackRequest(cloudPlatform, externalDatabase, databaseEngineVersion));
-        if (cluster.getStack() != null) {
-            req.setClusterCrn(cluster.getStack().getResourceCrn());
-            req.setTags(getUserDefinedTags(cluster.getStack()));
+        if (stack != null) {
+            req.setClusterCrn(stack.getResourceCrn());
+            req.setTags(getUserDefinedTags(stack));
         }
+        configureSslEnforcement(req, cloudPlatform, cluster);
         return req;
+    }
+
+    private void configureSslEnforcement(AllocateDatabaseServerV4Request req, CloudPlatform cloudPlatform, Cluster cluster) {
+        String runtime = getRuntime(cluster);
+        if (externalDatabaseConfig.isExternalDatabaseSslEnforcementSupportedFor(cloudPlatform) && isSslEnforcementSupportedForRuntime(runtime)
+                && entitlementService.databaseWireEncryptionDatahubEnabled(Crn.safeFromString(cluster.getEnvironmentCrn()).getAccountId())) {
+            LOGGER.info("Applying external DB SSL enforcement for cloud platform {} and runtime version {}", cloudPlatform, runtime);
+            SslConfigV4Request sslConfigV4Request = new SslConfigV4Request();
+            sslConfigV4Request.setSslMode(SslMode.ENABLED);
+            req.setSslConfig(sslConfigV4Request);
+        } else {
+            LOGGER.info("Skipping external DB SSL enforcement for cloud platform {} and runtime version {}", cloudPlatform, runtime);
+        }
+    }
+
+    private String getRuntime(Cluster cluster) {
+        String runtime = null;
+        Optional<String> blueprintTextOpt = Optional.ofNullable(cluster.getBlueprint()).map(Blueprint::getBlueprintText);
+        if (blueprintTextOpt.isPresent()) {
+            CmTemplateProcessor cmTemplateProcessor = cmTemplateProcessorFactory.get(blueprintTextOpt.get());
+            runtime = cmTemplateProcessor.getStackVersion();
+            LOGGER.info("Blueprint text is available for stack, found runtime version '{}'", runtime);
+        } else {
+            LOGGER.warn("Blueprint text is unavailable for stack, thus runtime version cannot be determined.");
+        }
+        return runtime;
+    }
+
+    private boolean isSslEnforcementSupportedForRuntime(String runtime) {
+        if (StringUtils.isBlank(runtime)) {
+            // While this may happen for custom data lakes, it is not possible for DH clusters
+            LOGGER.info("Runtime version is NOT specified, external DB SSL enforcement is NOT permitted");
+            return false;
+        }
+        boolean permitted = CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited(() -> runtime, () -> SSL_ENFORCEMENT_MIN_RUNTIME_VERSION);
+        LOGGER.info("External DB SSL enforcement {} permitted for runtime version {}", permitted ? "is" : "is NOT", runtime);
+        return permitted;
     }
 
     private Map<String, String> getUserDefinedTags(Stack stack) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/RedbeamsDbCertificateProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/RedbeamsDbCertificateProvider.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -14,7 +15,6 @@ import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.service.sharedservice.DatalakeService;
-import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.view.ClusterView;
 import com.sequenceiq.cloudbreak.view.StackView;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.SslMode;
@@ -27,16 +27,13 @@ public class RedbeamsDbCertificateProvider {
 
     private final RedbeamsDbServerConfigurer dbServerConfigurer;
 
-    private final StackService stackService;
-
     private final DatalakeService datalakeService;
 
     private final String certsPath;
 
     public RedbeamsDbCertificateProvider(RedbeamsDbServerConfigurer dbServerConfigurer,
-            StackService stackService, DatalakeService datalakeService, @Value("${cb.externaldatabase.ssl.rootcerts.path:}") String certsPath) {
+            DatalakeService datalakeService, @Value("${cb.externaldatabase.ssl.rootcerts.path:}") String certsPath) {
         this.dbServerConfigurer = dbServerConfigurer;
-        this.stackService = stackService;
         this.datalakeService = datalakeService;
         this.certsPath = certsPath;
     }
@@ -45,13 +42,16 @@ public class RedbeamsDbCertificateProvider {
         return certsPath;
     }
 
-    public Set<String> getRelatedSslCerts(StackDto stackDto) {
-        Set<String> result = new HashSet<>();
-        getDatalakeDatabaseRootCerts(stackDto.getStack(), result);
+    public RedbeamsDbSslDetails getRelatedSslCerts(StackDto stackDto) {
+        Set<String> relatedSslCerts = new HashSet<>();
+        getDatalakeDatabaseRootCerts(stackDto.getStack(), relatedSslCerts);
         ClusterView cluster = stackDto.getCluster();
-        result.addAll(getDatabaseRootCerts(cluster.getName(), cluster.getDatabaseServerCrn(), stackDto.getStack().getResourceCrn()));
+        Set<String> sslCertsForStack = getDatabaseRootCerts(cluster.getName(), cluster.getDatabaseServerCrn(), stackDto.getStack().getResourceCrn());
+        relatedSslCerts.addAll(sslCertsForStack);
         //TODO persist the gathered certs for the cluster to support cert rotation in the future
-        return result;
+
+        // Note: When stackDto is a DH, relatedSslCerts is the union of DL + DH certs, and sslEnabledForStack is purely determined by the presence of DH certs.
+        return new RedbeamsDbSslDetails(relatedSslCerts, !sslCertsForStack.isEmpty());
     }
 
     private void getDatalakeDatabaseRootCerts(StackView stack, Set<String> result) {
@@ -70,19 +70,50 @@ public class RedbeamsDbCertificateProvider {
     private Set<String> getDatabaseRootCerts(String clusterName, String dbServerCrn, String stackResourceCrn) {
         Set<String> result = new HashSet<>();
         if (dbServerConfigurer.isRemoteDatabaseNeeded(dbServerCrn)) {
-            LOGGER.info("Gathering cluster's(crn:'{}', name: '{}') remote database root certificates", stackResourceCrn, clusterName);
+            LOGGER.info("Gathering cluster's(crn:'{}', name: '{}') remote database('{}') root certificates", stackResourceCrn, clusterName, dbServerCrn);
             DatabaseServerV4Response databaseServer = dbServerConfigurer.getDatabaseServer(dbServerCrn);
             SslConfigV4Response sslConfig = databaseServer.getSslConfig();
             if (sslConfig != null) {
                 if (SslMode.isEnabled(sslConfig.getSslMode())) {
                     Set<String> sslCertificates = sslConfig.getSslCertificates();
+                    if (CollectionUtils.isEmpty(sslCertificates)) {
+                        throw new IllegalStateException(
+                                String.format("External DB SSL enforcement is enabled for cluster(crn:'%s', name: '%s') and remote database('%s')," +
+                                                "but no certificates have been returned!", stackResourceCrn, clusterName, dbServerCrn));
+                    }
                     result.addAll(sslCertificates);
-                    LOGGER.info("Number of certificates found:'{}' for cluster(crn:'{}', name: '{}')", sslCertificates.size(), stackResourceCrn, clusterName);
+                    LOGGER.info("Number of certificates found:'{}' for cluster(crn:'{}', name: '{}') and remote database('{}')", sslCertificates.size(),
+                            stackResourceCrn, clusterName, dbServerCrn);
+                } else {
+                    LOGGER.info("External DB SSL enforcement is disabled for the cluster's(crn:'{}', name: '{}') remote database('{}').", stackResourceCrn,
+                            clusterName, dbServerCrn);
                 }
             } else {
-                LOGGER.info("There no SSL config could be found for the remote database('{}').", dbServerCrn);
+                LOGGER.info("No SSL config could be found for the cluster's(crn:'{}', name: '{}') remote database('{}').", stackResourceCrn, clusterName,
+                        dbServerCrn);
             }
+        } else {
+            LOGGER.info("No remote database is configured for cluster(crn:'{}', name: '{}')", stackResourceCrn, clusterName);
         }
         return result;
+    }
+
+    public static class RedbeamsDbSslDetails {
+        private final Set<String> sslCerts;
+
+        private final boolean sslEnabledForStack;
+
+        public RedbeamsDbSslDetails(Set<String> sslCerts, boolean sslEnabledForStack) {
+            this.sslCerts = sslCerts;
+            this.sslEnabledForStack = sslEnabledForStack;
+        }
+
+        public Set<String> getSslCerts() {
+            return sslCerts;
+        }
+
+        public boolean isSslEnabledForStack() {
+            return sslEnabledForStack;
+        }
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/conf/ExternalDatabaseConfigTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/conf/ExternalDatabaseConfigTest.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.cloudbreak.conf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+
+class ExternalDatabaseConfigTest {
+
+    private ExternalDatabaseConfig underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new ExternalDatabaseConfig();
+
+        ReflectionTestUtils.setField(underTest, "dbServiceSslEnforcementSupportedPlatforms", Set.of(CloudPlatform.AWS, CloudPlatform.AZURE));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(value = CloudPlatform.class, names = {"AWS", "AZURE"}, mode = EnumSource.Mode.INCLUDE)
+    void isExternalDatabaseSslEnforcementSupportedForTestWhenTrue(CloudPlatform cloudPlatform) {
+        assertThat(underTest.isExternalDatabaseSslEnforcementSupportedFor(cloudPlatform)).isTrue();
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(value = CloudPlatform.class, names = {"AWS", "AZURE"}, mode = EnumSource.Mode.EXCLUDE)
+    void isExternalDatabaseSslEnforcementSupportedForTestWhenFalse(CloudPlatform cloudPlatform) {
+        assertThat(underTest.isExternalDatabaseSslEnforcementSupportedFor(cloudPlatform)).isFalse();
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/ExternalDatabaseServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/ExternalDatabaseServiceTest.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.core.flow2.externaldatabase;
 
+import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -27,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -35,8 +37,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.dyngr.core.AttemptResults;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseAvailabilityType;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.cloud.model.StackTags;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessorFactory;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.conf.ExternalDatabaseConfig;
+import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.repository.cluster.ClusterRepository;
@@ -50,24 +59,43 @@ import com.sequenceiq.flow.api.model.FlowCheckResponse;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.flow.api.model.FlowType;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.AllocateDatabaseServerV4Request;
+import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.SslConfigV4Request;
+import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.SslMode;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.UpgradeDatabaseServerV4Request;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.UpgradeTargetMajorVersion;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerStatusV4Response;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerV4Response;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.UpgradeDatabaseServerV4Response;
+import com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4StackRequest;
 
 @ExtendWith(MockitoExtension.class)
 class ExternalDatabaseServiceTest {
 
     private static final CloudPlatform CLOUD_PLATFORM = CloudPlatform.AZURE;
 
-    private static final String ENV_CRN = "envCRN";
+    private static final String ACCOUNT_ID = "accountId";
+
+    private static final String ENV_CRN = "crn:cdp:environments:us-west-1:" + ACCOUNT_ID + ":environment:envResourceId";
 
     private static final String RDBMS_CRN = "rdbmsCRN";
 
     private static final String CLUSTER_CRN = "clusterCRN";
 
     private static final String RDBMS_FLOW_ID = "flowId";
+
+    private static final String INSTANCE_TYPE = "instance";
+
+    private static final String VENDOR = "vendor";
+
+    private static final long VOLUME_SIZE = 1234L;
+
+    private static final String BLUEPRINT_TEXT = "blueprintText";
+
+    private static final String STACK_VERSION_GOOD_MINIMAL = "7.2.2";
+
+    private static final String STACK_VERSION_GOOD = "7.2.15";
+
+    private static final String STACK_VERSION_BAD = "7.2.1";
 
     @Mock
     private RedbeamsClientService redbeamsClient;
@@ -86,17 +114,30 @@ class ExternalDatabaseServiceTest {
     @Mock
     private DatabaseServerParameterDecorator dbServerParameterDecorator;
 
+    @Mock
+    private EntitlementService entitlementService;
+
+    @Mock
+    private ExternalDatabaseConfig externalDatabaseConfig;
+
+    @Mock
+    private CmTemplateProcessorFactory cmTemplateProcessorFactory;
+
     private ExternalDatabaseService underTest;
 
     private DetailedEnvironmentResponse environmentResponse;
 
+    @Mock
+    private CmTemplateProcessor cmTemplateProcessor;
+
     @BeforeEach
     void setUp() {
-        underTest = new ExternalDatabaseService(redbeamsClient, clusterRepository, dbConfigs, parameterDecoratorMap, databaseObtainerService);
+        underTest = new ExternalDatabaseService(redbeamsClient, clusterRepository, dbConfigs, parameterDecoratorMap, databaseObtainerService,
+                entitlementService, externalDatabaseConfig, cmTemplateProcessorFactory);
         environmentResponse = new DetailedEnvironmentResponse();
         environmentResponse.setCloudPlatform(CLOUD_PLATFORM.name());
         environmentResponse.setCrn(ENV_CRN);
-        dbConfigs.put(CLOUD_PLATFORM, new DatabaseStackConfig("instance", "vendor", 1234));
+        dbConfigs.put(CLOUD_PLATFORM, new DatabaseStackConfig(INSTANCE_TYPE, VENDOR, VOLUME_SIZE));
         lenient().when(parameterDecoratorMap.get(CLOUD_PLATFORM)).thenReturn(dbServerParameterDecorator);
     }
 
@@ -110,8 +151,8 @@ class ExternalDatabaseServiceTest {
 
     @ParameterizedTest
     @EnumSource(DatabaseAvailabilityType.class)
-    void provisionDatabase(DatabaseAvailabilityType availabilty) throws JsonProcessingException {
-        Assumptions.assumeTrue(!availabilty.isEmbedded());
+    void provisionDatabase(DatabaseAvailabilityType availability) throws JsonProcessingException {
+        Assumptions.assumeTrue(!availability.isEmbedded());
 
         DatabaseServerStatusV4Response createResponse = new DatabaseServerStatusV4Response();
         createResponse.setResourceCrn(RDBMS_CRN);
@@ -123,7 +164,7 @@ class ExternalDatabaseServiceTest {
         when(redbeamsClient.create(any())).thenReturn(createResponse);
         when(databaseObtainerService.obtainAttemptResult(eq(cluster), eq(DatabaseOperation.CREATION), eq(RDBMS_CRN), eq(true)))
                 .thenReturn(AttemptResults.finishWith(new DatabaseServerV4Response()));
-        underTest.provisionDatabase(cluster, availabilty, environmentResponse);
+        underTest.provisionDatabase(cluster, availability, environmentResponse);
 
         ArgumentCaptor<DatabaseServerParameter> serverParameterCaptor = ArgumentCaptor.forClass(DatabaseServerParameter.class);
         verify(redbeamsClient).getByClusterCrn(ENV_CRN, CLUSTER_CRN);
@@ -132,7 +173,7 @@ class ExternalDatabaseServiceTest {
         verify(dbServerParameterDecorator).setParameters(any(), serverParameterCaptor.capture());
         verify(clusterRepository).save(cluster);
         DatabaseServerParameter paramValue = serverParameterCaptor.getValue();
-        assertThat(paramValue.isHighlyAvailable()).isEqualTo(availabilty == DatabaseAvailabilityType.HA);
+        assertThat(paramValue.isHighlyAvailable()).isEqualTo(availability == DatabaseAvailabilityType.HA);
     }
 
     @ParameterizedTest
@@ -166,7 +207,14 @@ class ExternalDatabaseServiceTest {
 
         verify(redbeamsClient, never()).getByClusterCrn(nullable(String.class), nullable(String.class));
         ArgumentCaptor<DatabaseServerParameter> serverParameterCaptor = ArgumentCaptor.forClass(DatabaseServerParameter.class);
-        verify(redbeamsClient).create(any(AllocateDatabaseServerV4Request.class));
+
+        ArgumentCaptor<AllocateDatabaseServerV4Request> allocateRequestCaptor = ArgumentCaptor.forClass(AllocateDatabaseServerV4Request.class);
+        verify(redbeamsClient).create(allocateRequestCaptor.capture());
+        AllocateDatabaseServerV4Request allocateRequest = allocateRequestCaptor.getValue();
+        assertThat(allocateRequest).isNotNull();
+        assertThat(allocateRequest.getTags()).isNotNull();
+        assertThat(allocateRequest.getTags()).isEmpty();
+
         verify(cluster).setDatabaseServerCrn(RDBMS_CRN);
         verify(dbServerParameterDecorator).setParameters(any(), serverParameterCaptor.capture());
         verify(clusterRepository).save(cluster);
@@ -195,6 +243,146 @@ class ExternalDatabaseServiceTest {
     }
 
     @Test
+    void provisionDatabaseTestSslWhenUnsupportedCloudPlatform() throws JsonProcessingException {
+        when(externalDatabaseConfig.isExternalDatabaseSslEnforcementSupportedFor(CLOUD_PLATFORM)).thenReturn(false);
+
+        Blueprint blueprint = new Blueprint();
+        blueprint.setBlueprintText(BLUEPRINT_TEXT);
+        when(cmTemplateProcessorFactory.get(BLUEPRINT_TEXT)).thenReturn(cmTemplateProcessor);
+        when(cmTemplateProcessor.getStackVersion()).thenReturn(STACK_VERSION_GOOD);
+
+        provisionDatabaseTestSslInternal(blueprint, false);
+
+        verify(entitlementService, never()).databaseWireEncryptionDatahubEnabled(anyString());
+    }
+
+    private void provisionDatabaseTestSslInternal(Blueprint blueprint, boolean sslEnabledExpected) throws JsonProcessingException {
+        DatabaseServerStatusV4Response createResponse = new DatabaseServerStatusV4Response();
+        createResponse.setResourceCrn(RDBMS_CRN);
+        Cluster cluster = new Cluster();
+        Stack stack = new Stack();
+        stack.setResourceCrn(CLUSTER_CRN);
+        Map<String, String> userDefinedTags = Map.ofEntries(entry("key1", "value1"), entry("key2", "value2"));
+        StackTags stackTags = new StackTags(userDefinedTags, Map.of(), Map.of());
+        stack.setTags(new Json(stackTags));
+        cluster.setStack(stack);
+        cluster.setBlueprint(blueprint);
+        cluster.setEnvironmentCrn(ENV_CRN);
+
+        when(redbeamsClient.getByClusterCrn(ENV_CRN, CLUSTER_CRN)).thenReturn(null);
+        when(redbeamsClient.create(any(AllocateDatabaseServerV4Request.class))).thenReturn(createResponse);
+        when(databaseObtainerService.obtainAttemptResult(cluster, DatabaseOperation.CREATION, RDBMS_CRN, true))
+                .thenReturn(AttemptResults.finishWith(new DatabaseServerV4Response()));
+
+        underTest.provisionDatabase(cluster, DatabaseAvailabilityType.HA, environmentResponse);
+
+        assertThat(cluster.getDatabaseServerCrn()).isEqualTo(RDBMS_CRN);
+        verify(clusterRepository).save(cluster);
+
+        ArgumentCaptor<DatabaseServerV4StackRequest> databaseServerCaptor = ArgumentCaptor.forClass(DatabaseServerV4StackRequest.class);
+        ArgumentCaptor<DatabaseServerParameter> serverParameterCaptor = ArgumentCaptor.forClass(DatabaseServerParameter.class);
+        verify(dbServerParameterDecorator).setParameters(databaseServerCaptor.capture(), serverParameterCaptor.capture());
+
+        DatabaseServerParameter serverParameter = serverParameterCaptor.getValue();
+        assertThat(serverParameter).isNotNull();
+        assertThat(serverParameter.isHighlyAvailable()).isTrue();
+
+        ArgumentCaptor<AllocateDatabaseServerV4Request> allocateRequestCaptor = ArgumentCaptor.forClass(AllocateDatabaseServerV4Request.class);
+        verify(redbeamsClient).create(allocateRequestCaptor.capture());
+        AllocateDatabaseServerV4Request allocateRequest = allocateRequestCaptor.getValue();
+        assertThat(allocateRequest).isNotNull();
+        assertThat(allocateRequest.getEnvironmentCrn()).isEqualTo(ENV_CRN);
+        assertThat(allocateRequest.getClusterCrn()).isEqualTo(CLUSTER_CRN);
+
+        DatabaseServerV4StackRequest databaseServer = databaseServerCaptor.getValue();
+        assertThat(allocateRequest.getDatabaseServer()).isSameAs(databaseServer);
+        assertThat(databaseServer).isNotNull();
+        assertThat(databaseServer.getInstanceType()).isEqualTo(INSTANCE_TYPE);
+        assertThat(databaseServer.getDatabaseVendor()).isEqualTo(VENDOR);
+        assertThat(databaseServer.getStorageSize()).isEqualTo(VOLUME_SIZE);
+
+        Map<String, String> tags = allocateRequest.getTags();
+        assertThat(tags).isNotNull();
+        assertThat(tags).isEqualTo(userDefinedTags);
+
+        SslConfigV4Request sslConfig = allocateRequest.getSslConfig();
+        if (sslEnabledExpected) {
+            assertThat(sslConfig).isNotNull();
+            assertThat(sslConfig.getSslMode()).isEqualTo(SslMode.ENABLED);
+        } else {
+            assertThat(sslConfig).isNull();
+        }
+    }
+
+    @Test
+    void provisionDatabaseTestSslWhenNoBlueprint() throws JsonProcessingException {
+        when(externalDatabaseConfig.isExternalDatabaseSslEnforcementSupportedFor(CLOUD_PLATFORM)).thenReturn(true);
+
+        provisionDatabaseTestSslInternal(null, false);
+
+        verify(cmTemplateProcessorFactory, never()).get(anyString());
+        verify(cmTemplateProcessor, never()).getStackVersion();
+        verify(entitlementService, never()).databaseWireEncryptionDatahubEnabled(anyString());
+    }
+
+    @Test
+    void provisionDatabaseTestSslWhenNoBlueprintText() throws JsonProcessingException {
+        when(externalDatabaseConfig.isExternalDatabaseSslEnforcementSupportedFor(CLOUD_PLATFORM)).thenReturn(true);
+
+        Blueprint blueprint = new Blueprint();
+        blueprint.setBlueprintText(null);
+
+        provisionDatabaseTestSslInternal(blueprint, false);
+
+        verify(cmTemplateProcessorFactory, never()).get(anyString());
+        verify(cmTemplateProcessor, never()).getStackVersion();
+        verify(entitlementService, never()).databaseWireEncryptionDatahubEnabled(anyString());
+    }
+
+    @ParameterizedTest(name = "runtime={0}")
+    @ValueSource(strings = {"", " ", STACK_VERSION_BAD})
+    @NullSource
+    void provisionDatabaseTestSslWhenBadRuntime(String runtime) throws JsonProcessingException {
+        when(externalDatabaseConfig.isExternalDatabaseSslEnforcementSupportedFor(CLOUD_PLATFORM)).thenReturn(true);
+
+        Blueprint blueprint = new Blueprint();
+        blueprint.setBlueprintText(BLUEPRINT_TEXT);
+        when(cmTemplateProcessorFactory.get(BLUEPRINT_TEXT)).thenReturn(cmTemplateProcessor);
+        when(cmTemplateProcessor.getStackVersion()).thenReturn(runtime);
+
+        provisionDatabaseTestSslInternal(blueprint, false);
+
+        verify(entitlementService, never()).databaseWireEncryptionDatahubEnabled(anyString());
+    }
+
+    @Test
+    void provisionDatabaseTestSslWhenNotEntitled() throws JsonProcessingException {
+        when(externalDatabaseConfig.isExternalDatabaseSslEnforcementSupportedFor(CLOUD_PLATFORM)).thenReturn(true);
+
+        Blueprint blueprint = new Blueprint();
+        blueprint.setBlueprintText(BLUEPRINT_TEXT);
+        when(cmTemplateProcessorFactory.get(BLUEPRINT_TEXT)).thenReturn(cmTemplateProcessor);
+        when(cmTemplateProcessor.getStackVersion()).thenReturn(STACK_VERSION_GOOD);
+        when(entitlementService.databaseWireEncryptionDatahubEnabled(ACCOUNT_ID)).thenReturn(false);
+
+        provisionDatabaseTestSslInternal(blueprint, false);
+    }
+
+    @ParameterizedTest(name = "runtime={0}")
+    @ValueSource(strings = {STACK_VERSION_GOOD_MINIMAL, STACK_VERSION_GOOD})
+    void provisionDatabaseTestSslWhenSslEnabled(String runtime) throws JsonProcessingException {
+        when(externalDatabaseConfig.isExternalDatabaseSslEnforcementSupportedFor(CLOUD_PLATFORM)).thenReturn(true);
+
+        Blueprint blueprint = new Blueprint();
+        blueprint.setBlueprintText(BLUEPRINT_TEXT);
+        when(cmTemplateProcessorFactory.get(BLUEPRINT_TEXT)).thenReturn(cmTemplateProcessor);
+        when(cmTemplateProcessor.getStackVersion()).thenReturn(runtime);
+        when(entitlementService.databaseWireEncryptionDatahubEnabled(ACCOUNT_ID)).thenReturn(true);
+
+        provisionDatabaseTestSslInternal(blueprint, true);
+    }
+
+    @Test
     void terminateDatabaseWhenCrnNull() {
         Cluster cluster = new Cluster();
         cluster.setDatabaseServerCrn(null);
@@ -211,7 +399,7 @@ class ExternalDatabaseServiceTest {
         DatabaseServerV4Response deleteResponse = new DatabaseServerV4Response();
         deleteResponse.setCrn(RDBMS_CRN);
         when(databaseObtainerService.obtainAttemptResult(eq(cluster), eq(DatabaseOperation.START), eq(RDBMS_CRN), eq(false)))
-                .thenReturn(AttemptResults.finishWith(new DatabaseServerV4Response()));
+                .thenReturn(AttemptResults.finishWith(deleteResponse));
 
         underTest.startDatabase(cluster, DatabaseAvailabilityType.HA, environmentResponse);
 

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/start.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/start.sls
@@ -10,8 +10,8 @@ init-cloudera-manager-db:
         - user: {{ cloudera_manager.cloudera_manager_database.connectionUserName }}
         - pass: {{ cloudera_manager.cloudera_manager_database.connectionPassword }}
 
-#Configure JDBC URL for CM if client side certification validation is enabled for the Datalake cluster
-{% if postgresql.ssl_enabled == True and salt['pillar.get']('telemetry:clusterType') == "datalake" %}
+# Configure JDBC URL for CM if client side DB server certificate validation is enabled for the cluster
+{% if postgresql.ssl_enabled == True %}
 replace-db-connection-url:
   file.replace:
     - name: /etc/cloudera-scm-server/db.properties
@@ -20,6 +20,7 @@ replace-db-connection-url:
     - append_if_not_found: True
     - require:
         - cmd: init-cloudera-manager-db
+        - file: {{ postgresql.root_certs_file }}
 {% endif %}
 
 # We need to restart the CM if the frontend URL has been changed (e.g. switching to PEM based DNS name)

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/root-certs.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/root-certs.sls
@@ -1,6 +1,6 @@
 {%- from 'postgresql/settings.sls' import postgresql with context %}
 
-{% if postgresql.ssl_enabled == True %}
+{% if postgresql.root_certs_enabled == True %}
 create-root-certs-file:
   file.managed:
     - name: {{ postgresql.root_certs_file }}

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/settings.sls
@@ -1,10 +1,12 @@
-{% set ssl_enabled = salt['pillar.get']('postgres_root_certs:ssl_certs') is defined and salt['pillar.get']('postgres_root_certs:ssl_certs')|length > 1 %}
+{% set root_certs_enabled = salt['pillar.get']('postgres_root_certs:ssl_certs') is defined and salt['pillar.get']('postgres_root_certs:ssl_certs')|length > 1 %}
 {% set root_certs = salt['pillar.get']('postgres_root_certs:ssl_certs') %}
 {% set root_certs_file = salt['pillar.get']('postgres_root_certs:ssl_certs_file_path') %}
+{% set ssl_enabled = salt['pillar.get']('postgres_root_certs:ssl_enabled', 'False') == 'true' %}
 
 {% set postgresql = {} %}
 {% do postgresql.update({
     'ssl_enabled': ssl_enabled,
     'root_certs': root_certs,
-    'root_certs_file': root_certs_file
+    'root_certs_file': root_certs_file,
+    'root_certs_enabled': root_certs_enabled
 }) %}


### PR DESCRIPTION
* If applicable, configure the DH external DB with SSL enforcement.
  * Prerequisites: AWS or Azure cloud platform, DH runtime >= 7.2.2, entitlement `CDP_CB_DATABASE_WIRE_ENCRYPTION_DATAHUB` (see #13824) granted for the tenant.
* When the external DB has SSL enforcement, configure DH CM Server to require SSL connections. Like for its DL counterpart, CM Server DB connections are initiated with `sslmode=verify-full`, i.e. using DB server certificate chain and host name verification.
* DB server root certs are deployed to the cluster in the following cases:
  * Cluster is a DL and its external DB has SSL enforcement. The cert bundle will contain the DL DB root certs only.
  * Cluster is a DH having an embedded DB, but the DL has an external DB with SSL enforcement. The cert bundle will contain the DL DB root certs only. (SSL is not yet supported for the embedded DB.)
  * Cluster is a DH having an external DB with SSL enforcement, and the DL also has an external DB with SSL enforcement. The cert bundle will contain the union of the DL and DH DB root certs (without repetitions).
* Apply some code cleanup and fix typos.
* Testing:
  * Manual test of all DB SSL combinations (DL off & DH off; DL on & DH off; DL off & DH on; DL on & DH on) in a commercial AWS region.
  * Added new UT & adapted existing ones.
