### PR TITLE
CB-19881 - add end time to flow check endpoint.

### DIFF
--- a/flow-api/src/main/java/com/sequenceiq/flow/api/model/FlowCheckResponse.java
+++ b/flow-api/src/main/java/com/sequenceiq/flow/api/model/FlowCheckResponse.java
@@ -13,6 +13,8 @@ public class FlowCheckResponse {
 
     private Boolean latestFlowFinalizedAndFailed;
 
+    private Long endTime;
+
     public String getFlowId() {
         return flowId;
     }
@@ -43,5 +45,13 @@ public class FlowCheckResponse {
 
     public void setLatestFlowFinalizedAndFailed(Boolean latestFlowFinalizedAndFailed) {
         this.latestFlowFinalizedAndFailed = latestFlowFinalizedAndFailed;
+    }
+
+    public Long getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(Long endTime) {
+        this.endTime = endTime;
     }
 }

--- a/flow/src/main/java/com/sequenceiq/flow/core/FlowLogService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/FlowLogService.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import com.sequenceiq.cloudbreak.common.event.Payload;
-import com.sequenceiq.cloudbreak.common.service.TransactionService;
+import com.sequenceiq.cloudbreak.common.service.TransactionService.TransactionExecutionException;
 import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 import com.sequenceiq.flow.core.config.FlowConfiguration;
 import com.sequenceiq.flow.domain.FlowChainLog;
@@ -20,11 +20,11 @@ public interface FlowLogService {
 
     Iterable<FlowLog> saveAll(Iterable<FlowLog> entities);
 
-    FlowLog close(Long resourceId, String flowId, boolean failed, Map<Object, Object> contextParams) throws TransactionService.TransactionExecutionException;
+    FlowLog close(Long resourceId, String flowId, boolean failed, Map<Object, Object> contextParams) throws TransactionExecutionException;
 
-    FlowLog cancel(Long resourceId, String flowId) throws TransactionService.TransactionExecutionException;
+    FlowLog cancel(Long resourceId, String flowId) throws TransactionExecutionException;
 
-    FlowLog terminate(Long resourceId, String flowId) throws TransactionService.TransactionExecutionException;
+    FlowLog terminate(Long resourceId, String flowId) throws TransactionExecutionException;
 
     void saveChain(String flowChainId, String parentFlowChainId, FlowTriggerEventQueue chain, String flowTriggerUserCrn);
 
@@ -72,5 +72,7 @@ public interface FlowLogService {
 
     List<FlowLogWithoutPayload> findAllWithoutPayloadByFlowIdOrderByCreatedDesc(String flowId);
 
-    List<FlowLogWithoutPayload> getFlowLogsWithoutPayloadByFlowIdsCreatedDesc(Set<String> relatedFlowIds);
+    List<FlowLogWithoutPayload> getFlowLogsWithoutPayloadByFlowChainIdsCreatedDesc(Set<String> relatedFlowIds);
+
+    List<FlowLog> findAllFlowByFlowChainId(Set<String> chainIds);
 }

--- a/flow/src/main/java/com/sequenceiq/flow/domain/FlowLogWithoutPayload.java
+++ b/flow/src/main/java/com/sequenceiq/flow/domain/FlowLogWithoutPayload.java
@@ -8,6 +8,8 @@ public interface FlowLogWithoutPayload {
 
     Long getCreated();
 
+    Long getEndTime();
+
     String getFlowId();
 
     String getFlowChainId();

--- a/flow/src/main/java/com/sequenceiq/flow/repository/FlowLogRepository.java
+++ b/flow/src/main/java/com/sequenceiq/flow/repository/FlowLogRepository.java
@@ -104,6 +104,7 @@ public interface FlowLogRepository extends CrudRepository<FlowLog, Long> {
     @Query("SELECT fl.flowId as flowId, " +
             "fl.resourceId as resourceId, " +
             "fl.created as created, " +
+            "fl.endTime as endTime, " +
             "fl.flowChainId as flowChainId, " +
             "fl.nextEvent as nextEvent, " +
             "fl.payloadType as payloadType, " +
@@ -117,9 +118,9 @@ public interface FlowLogRepository extends CrudRepository<FlowLog, Long> {
             "fl.flowTriggerUserCrn as flowTriggerUserCrn, " +
             "fl.operationType as operationType " +
             "FROM FlowLog fl " +
-            "WHERE fl.flowId IN (:flowIds) " +
+            "WHERE fl.flowChainId IN (:chainIds) " +
             "ORDER BY fl.created DESC")
-    List<FlowLogWithoutPayload> findAllWithoutPayloadByFlowIdsCreatedDesc(@Param("flowIds") Set<String> flowIds);
+    List<FlowLogWithoutPayload> findAllWithoutPayloadByChainIdsCreatedDesc(@Param("chainIds") Set<String> chainIds);
 
     @Query("SELECT fl.flowId as flowId, " +
             "fl.resourceId as resourceId, " +
@@ -140,4 +141,7 @@ public interface FlowLogRepository extends CrudRepository<FlowLog, Long> {
             "WHERE fl.flowId = :flowId " +
             "ORDER BY fl.created desc")
     List<FlowLogWithoutPayload> findAllWithoutPayloadByFlowIdOrderByCreatedDesc(@Param("flowId") String flowId);
+
+    @Query("SELECT fl FROM FlowLog fl WHERE fl.flowChainId IN (:chainIds) AND fl.currentState <> 'FINISHED' ORDER BY fl.created DESC")
+    List<FlowLog> findAllByFlowChainIdOrderByCreatedDesc(@Param("chainIds") Set<String> chainIds);
 }

--- a/flow/src/main/java/com/sequenceiq/flow/service/FlowService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/service/FlowService.java
@@ -5,9 +5,13 @@ import static com.sequenceiq.cloudbreak.service.flowlog.FlowLogUtil.isFlowInFail
 import static java.util.stream.Collectors.toSet;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BinaryOperator;
 import java.util.stream.Collectors;
 
 import javax.annotation.Resource;
@@ -130,14 +134,29 @@ public class FlowService {
             LOGGER.info("Checking if there is an active flow based on flow chain id {}", chainId);
             List<FlowChainLog> relatedChains = flowChainLogService.getRelatedFlowChainLogs(flowChains);
             Set<String> relatedChainIds = relatedChains.stream().map(FlowChainLog::getFlowChainId).collect(toSet());
-            Set<String> relatedFlowIds = flowLogDBService.getFlowIdsByChainIds(relatedChainIds);
-            List<FlowLogWithoutPayload> relatedFlowLogs = flowLogDBService.getFlowLogsWithoutPayloadByFlowIdsCreatedDesc(relatedFlowIds);
+            List<FlowLogWithoutPayload> relatedFlowLogs = flowLogDBService.getFlowLogsWithoutPayloadByFlowChainIdsCreatedDesc(relatedChainIds);
             flowCheckResponse.setHasActiveFlow(!completed("Flow chain", chainId, relatedChains, relatedFlowLogs));
             flowCheckResponse.setLatestFlowFinalizedAndFailed(isFlowInFailedState(relatedFlowLogs, failHandledEvents));
-            return flowCheckResponse;
+            setEndTimeOnFlowCheckResponse(flowCheckResponse, relatedFlowLogs);
         } else {
             flowCheckResponse.setHasActiveFlow(Boolean.FALSE);
-            return flowCheckResponse;
+        }
+        return flowCheckResponse;
+    }
+
+    public void setEndTimeOnFlowCheckResponse(FlowCheckResponse flowCheckResponse, List<FlowLogWithoutPayload> relatedFlowLogs) {
+        if (!flowCheckResponse.getHasActiveFlow() && !relatedFlowLogs.isEmpty()) {
+            Map<String, Optional<FlowLogWithoutPayload>> latestFlowsByCreatedMap = relatedFlowLogs.stream()
+                    .filter(s -> !Objects.equals(s.getCurrentState(), "FINISHED"))
+                    .collect(Collectors.groupingBy(FlowLogWithoutPayload::getFlowId,
+                        Collectors.reducing(BinaryOperator.maxBy(Comparator.comparing(FlowLogWithoutPayload::getCreated)))));
+            List<FlowLogWithoutPayload> flowLogForEndTime = latestFlowsByCreatedMap.values().stream()
+                    .filter(Optional::isPresent).map(Optional::get).collect(Collectors.toList());
+            Optional<Long> flowEndTime = flowLogForEndTime.stream().map(FlowLogWithoutPayload::getEndTime)
+                    .filter(Objects::nonNull).max(Long::compareTo);
+            if (flowEndTime.isPresent()) {
+                flowCheckResponse.setEndTime(flowEndTime.get());
+            }
         }
     }
 
@@ -149,16 +168,14 @@ public class FlowService {
             LOGGER.info("Checking if there is an active flow based on flow chain id {}", chainId);
             List<FlowChainLog> relatedChains = flowChainLogService.getRelatedFlowChainLogs(flowChains);
             Set<String> relatedChainIds = relatedChains.stream().map(FlowChainLog::getFlowChainId).collect(toSet());
-            Set<String> relatedFlowIds = flowLogDBService.getFlowIdsByChainIds(relatedChainIds);
-            List<FlowLogWithoutPayload> relatedFlowLogs = flowLogDBService.getFlowLogsWithoutPayloadByFlowIdsCreatedDesc(relatedFlowIds);
+            List<FlowLogWithoutPayload> relatedFlowLogs = flowLogDBService.getFlowLogsWithoutPayloadByFlowChainIdsCreatedDesc(relatedChainIds);
             validateResourceId(relatedFlowLogs, resourceIdList);
             flowCheckResponse.setHasActiveFlow(!completed("Flow chain", chainId, relatedChains, relatedFlowLogs));
             flowCheckResponse.setLatestFlowFinalizedAndFailed(isFlowInFailedState(relatedFlowLogs, failHandledEvents));
-            return flowCheckResponse;
         } else {
             flowCheckResponse.setHasActiveFlow(Boolean.FALSE);
-            return flowCheckResponse;
         }
+        return flowCheckResponse;
     }
 
     private void validateResourceId(List<FlowLogWithoutPayload> flowLogs, List<Long> resourceIdList) {

--- a/flow/src/main/resources/schema/flow/20221201084526_CB-19881_add_index_to_flowlog_table.sql
+++ b/flow/src/main/resources/schema/flow/20221201084526_CB-19881_add_index_to_flowlog_table.sql
@@ -1,0 +1,10 @@
+-- // CB-19881 Add index to flowlog table
+-- Migration SQL that makes the change goes here.
+
+CREATE INDEX IF NOT EXISTS idx_flowlog_flowchainid
+    ON flowlog (flowchainid);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+DROP INDEX IF EXISTS idx_flowlog_flowchainid;


### PR DESCRIPTION
1. Added new method FlowLogRepository to get all flow related information using flowChainId.
2. Edited existing method in FlowLogRepository to return FlowLogWithoutPayload using flowChainId instead of flowLogId (checked to see where else this is being used and safely edited it).
3. Added login in FlowService to check if all flows in a chain is complete before adding an end time to FlowCheckResponse.

See detailed description in the commit message.