### PR TITLE
CB-19914 Increase the maxRetryCount for E2E tests to extend the Waiting Limit

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
@@ -116,7 +116,7 @@ public abstract class TestContext implements ApplicationContextAware {
     @Value("#{'${integrationtest.cloudProvider}'.equals('MOCK') ? 300 : ${integrationtest.testsuite.maxRetry:2700}}")
     private int maxRetry;
 
-    @Value("#{'${integrationtest.cloudProvider}'.equals('MOCK') ? 3 : ${integrationtest.testsuite.maxRetryCount:3}}")
+    @Value("#{'${integrationtest.cloudProvider}'.equals('MOCK') ? 3 : ${integrationtest.testsuite.maxRetryCount:5}}")
     private int maxRetryCount;
 
     @Value("${integrationtest.ums.host:localhost}")


### PR DESCRIPTION
GCP API Longrunning E2E Build #1677 is failing, because of `testSDXMultiRepairIDBRokerAndMasterWithTerminatedEC2Instances`. Here the Waiting for the `DELETED_ON_PROVIDER_SIDE` state of cluster is cancelled, because of `CLUSTER_UNREACHABLE` failed state. The root cause here is the `Update deprecated cluster status from: UNREACHABLE to: DELETED_ON_PROVIDER_SIDE` has been done 3 seconds after the final wait cycle was ended.

So we should wait longer in case of E2E tests (because of provider or CB can be slower in case of increased load). We can accomplish this with the help of `maxRetryCount` parameter.