### PR TITLE
CB-10852 Fix DatabaseType deprecations Profiler RdsConfigProvider naming

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/database/base/DatabaseType.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/database/base/DatabaseType.java
@@ -3,12 +3,17 @@ package com.sequenceiq.cloudbreak.api.endpoint.v4.database.base;
 public enum DatabaseType {
     HIVE,
     RANGER,
+    @Deprecated
     DRUID,
+    @Deprecated
     SUPERSET,
     OOZIE,
+    @Deprecated
     AMBARI,
     CLOUDERA_MANAGER,
+    @Deprecated
     CLOUDERA_MANAGER_MANAGEMENT_SERVICE_REPORTS_MANAGER,
+    @Deprecated
     BEACON,
     REGISTRY,
     HIVE_DAS,

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/ProfilerAdminRdsConfigProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/ProfilerAdminRdsConfigProvider.java
@@ -11,7 +11,7 @@ import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessorFactory;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
 
 @Component
-public class ProfilerAdminConfigProvider extends AbstractRdsConfigProvider {
+public class ProfilerAdminRdsConfigProvider extends AbstractRdsConfigProvider {
     private static final String PILLAR_KEY = "profiler_admin";
 
     @Value("${cb.profiler.admin.database.user:profiler_agent}")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/ProfilerMetricsRdsConfigProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/ProfilerMetricsRdsConfigProvider.java
@@ -11,7 +11,7 @@ import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessorFactory;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
 
 @Component
-public class ProfilerMetricsConfigProvider extends AbstractRdsConfigProvider {
+public class ProfilerMetricsRdsConfigProvider extends AbstractRdsConfigProvider {
     private static final String PILLAR_KEY = "profiler_metrics";
 
     @Value("${cb.profiler.metrics.database.user:profiler_metric}")


### PR DESCRIPTION
* `DatabaseType`: Add `@Deprecated` to the following constants: `DRUID`, `SUPERSET`, `AMBARI`, `CLOUDERA_MANAGER_MANAGEMENT_SERVICE_REPORTS_MANAGER`, `BEACON`.
* `ProfilerAdminConfigProvider` & `ProfilerMetricsConfigProvider`: Rename them by inserting `Rds` before `ConfigProvider`. Both are subclasses of `AbstractRdsConfigProvider`.
