### PR TITLE
CB-19903 Enabled platforms should take care about gov platforms

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/account/PreferencesService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/account/PreferencesService.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.service.account;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.FeatureSwitchV4.DISABLE_SHOW_BLUEPRINT;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.FeatureSwitchV4.DISABLE_SHOW_CLI;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -54,10 +55,12 @@ public class PreferencesService {
     }
 
     public Set<String> enabledPlatforms() {
-        Set<String> platforms;
-        platforms = enabledPlatforms.isEmpty()
-                ? cloudConstants.stream().map(cloudConstant -> cloudConstant.platform().value()).collect(Collectors.toSet())
-                : Sets.newHashSet(enabledPlatforms.split(","));
+        Set<String> platforms = Collections.emptySet();
+        if (enabledPlatformConfigurationsAreEmpty()) {
+            platforms = cloudConstants.stream().map(cloudConstant -> cloudConstant.platform().value()).collect(Collectors.toSet());
+        } else if (!Strings.isNullOrEmpty(enabledPlatforms)) {
+            platforms = Sets.newHashSet(enabledPlatforms.split(","));
+        }
         return platforms;
     }
 
@@ -105,4 +108,7 @@ public class PreferencesService {
         return result;
     }
 
+    private boolean enabledPlatformConfigurationsAreEmpty() {
+        return Strings.isNullOrEmpty(enabledPlatforms) && Strings.isNullOrEmpty(enabledGovPlatforms);
+    }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/account/PreferencesServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/account/PreferencesServiceTest.java
@@ -1,0 +1,88 @@
+package com.sequenceiq.cloudbreak.service.account;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.util.ReflectionUtils;
+
+import com.sequenceiq.cloudbreak.cloud.CloudConstant;
+import com.sequenceiq.cloudbreak.cloud.model.Platform;
+
+@ExtendWith(MockitoExtension.class)
+class PreferencesServiceTest {
+
+    private static final String PLATFORM_AWS = "AWS";
+
+    private static final String PLATFORM_GCP = "GCP";
+
+    private static final String PLATFORM_AZURE = "AZURE";
+
+    @Spy
+    private ArrayList<CloudConstant> cloudConstants;
+
+    @Mock
+    private CloudConstant cloudConstantAws;
+
+    @Mock
+    private CloudConstant cloudConstantGcp;
+
+    @Mock
+    private CloudConstant cloudConstantAzure;
+
+    @InjectMocks
+    private PreferencesService victim;
+
+    @BeforeEach
+    void initTest() {
+        cloudConstants.add(cloudConstantAzure);
+        cloudConstants.add(cloudConstantAws);
+        cloudConstants.add(cloudConstantGcp);
+    }
+
+    @Test
+    void enabledPlatformsShouldComeFromCloudConstants() {
+        when(cloudConstantAzure.platform()).thenReturn(Platform.platform(PLATFORM_AZURE));
+        when(cloudConstantAws.platform()).thenReturn(Platform.platform(PLATFORM_AWS));
+        when(cloudConstantGcp.platform()).thenReturn(Platform.platform(PLATFORM_GCP));
+
+        Set<String> actual = victim.enabledPlatforms();
+        Set<String> expected = Set.of(PLATFORM_AWS, PLATFORM_GCP, PLATFORM_AZURE);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void enabledPlatformsShouldBeEmpty() {
+        Field enabledGovPlatformsField = ReflectionUtils.findField(PreferencesService.class, "enabledGovPlatforms");
+        ReflectionUtils.makeAccessible(enabledGovPlatformsField);
+        ReflectionUtils.setField(enabledGovPlatformsField, victim, PLATFORM_AWS);
+
+        Set<String> actual = victim.enabledPlatforms();
+        Set<String> expected = Set.of();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void enabledPlatformsShouldComeFromProperty() {
+        Field enabledGovPlatformsField = ReflectionUtils.findField(PreferencesService.class, "enabledPlatforms");
+        ReflectionUtils.makeAccessible(enabledGovPlatformsField);
+        ReflectionUtils.setField(enabledGovPlatformsField, victim, PLATFORM_AWS + "," + PLATFORM_GCP);
+
+        Set<String> actual = victim.enabledPlatforms();
+        Set<String> expected = Set.of(PLATFORM_AWS, PLATFORM_GCP);
+
+        assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
The original implementation returned all supported platforms based on cloud constants when it was not defined explicitly by 'cb.enabledplatforms'. Now we have gov platform support as well ('cb.enabledgovplatforms') so the default behaviour of 'supported platforms' should not take effect in case of existing gov platform.

See detailed description in the commit message.