### PR TITLE
CB-19650 Purge stale Scaling Activities from periscope

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/config/ScalingActivityCleanupConfig.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/config/ScalingActivityCleanupConfig.java
@@ -1,0 +1,15 @@
+package com.sequenceiq.periscope.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ScalingActivityCleanupConfig {
+
+    @Value("${periscope.scaling-activity.cleanup-event-age.hours:24}")
+    private long cleanupDurationHours;
+
+    public long getCleanupDurationHours() {
+        return cleanupDurationHours;
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/model/ScalingActivities.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/model/ScalingActivities.java
@@ -1,0 +1,55 @@
+package com.sequenceiq.periscope.model;
+
+import java.util.Set;
+
+import com.sequenceiq.periscope.monitor.Monitored;
+
+public class ScalingActivities implements Monitored {
+
+    private long id;
+
+    private Set<Long> activityIds;
+
+    private long lastEvaluated;
+
+    public ScalingActivities() {
+    }
+
+    public ScalingActivities(long id, Set<Long> activityIds) {
+        this.id = id;
+        this.activityIds = activityIds;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public Set<Long> getActivityIds() {
+        return activityIds;
+    }
+
+    public void setActivityIds(Set<Long> activityIds) {
+        this.activityIds = activityIds;
+    }
+
+    public long getLastEvaluated() {
+        return lastEvaluated;
+    }
+
+    @Override
+    public void setLastEvaluated(long lastEvaluated) {
+        this.lastEvaluated = lastEvaluated;
+    }
+
+    @Override
+    public String toString() {
+        return "ScalingActivities{" +
+                "activities=" + activityIds +
+                ", lastEvaluated=" + lastEvaluated +
+                '}';
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/CleanupMonitor.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/CleanupMonitor.java
@@ -1,0 +1,59 @@
+package com.sequenceiq.periscope.monitor;
+
+import static com.sequenceiq.periscope.api.model.ActivityStatus.DOWNSCALE_TRIGGER_FAILED;
+import static com.sequenceiq.periscope.api.model.ActivityStatus.METRICS_COLLECTION_FAILED;
+import static com.sequenceiq.periscope.api.model.ActivityStatus.SCALING_FLOW_FAILED;
+import static com.sequenceiq.periscope.api.model.ActivityStatus.SCALING_FLOW_SUCCESS;
+import static com.sequenceiq.periscope.api.model.ActivityStatus.UPSCALE_TRIGGER_FAILED;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.periscope.api.model.ActivityStatus;
+import com.sequenceiq.periscope.model.ScalingActivities;
+import com.sequenceiq.periscope.monitor.evaluator.EvaluatorExecutor;
+import com.sequenceiq.periscope.monitor.evaluator.cleanup.ActivityCleanupEvaluator;
+import com.sequenceiq.periscope.service.ha.PeriscopeNodeService;
+
+@Component
+@ConditionalOnProperty(prefix = "periscope.enabledAutoscaleMonitors.cleanup-monitor", name = "enabled", havingValue = "true")
+public class CleanupMonitor extends ScalingActivityMonitor {
+
+    private final AtomicLong scalingActivitiesIdGenerator = new AtomicLong(0L);
+
+    @Override
+    protected List<ScalingActivities> getMonitored() {
+        Set<ActivityStatus> statuses = EnumSet.of(SCALING_FLOW_FAILED, SCALING_FLOW_SUCCESS, METRICS_COLLECTION_FAILED, UPSCALE_TRIGGER_FAILED,
+                DOWNSCALE_TRIGGER_FAILED);
+        PeriscopeNodeService periscopeNodeService = getPeriscopeNodeService();
+        if (periscopeNodeService.isLeader(getPeriscopeNodeConfig().getId())) {
+            Set<Long> activityIdsToCleanup = getScalingActivityService().findAllInStatusesThatStartedBefore(statuses,
+                    getCleanupConfig().getCleanupDurationHours());
+            return activityIdsToCleanup.isEmpty() ? emptyList() :
+                    singletonList(new ScalingActivities(scalingActivitiesIdGenerator.incrementAndGet(), activityIdsToCleanup));
+        }
+        return emptyList();
+    }
+
+    @Override
+    public String getIdentifier() {
+        return "scaling-activity-cleanup-monitor";
+    }
+
+    @Override
+    public String getTriggerExpression() {
+        return MonitorUpdateRate.EVERY_TEN_MIN_RATE_CRON;
+    }
+
+    @Override
+    public Class<? extends EvaluatorExecutor> getEvaluatorType(ScalingActivities monitored) {
+        return ActivityCleanupEvaluator.class;
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/ScalingActivityMonitor.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/ScalingActivityMonitor.java
@@ -1,0 +1,63 @@
+package com.sequenceiq.periscope.monitor;
+
+import org.quartz.JobExecutionContext;
+
+import com.sequenceiq.periscope.config.ScalingActivityCleanupConfig;
+import com.sequenceiq.periscope.model.ScalingActivities;
+import com.sequenceiq.periscope.monitor.context.EvaluatorContext;
+import com.sequenceiq.periscope.monitor.context.ScalingActivitiesEvaluatorContext;
+import com.sequenceiq.periscope.monitor.evaluator.EvaluatorExecutor;
+import com.sequenceiq.periscope.service.ScalingActivityService;
+import com.sequenceiq.periscope.service.ha.PeriscopeNodeConfig;
+import com.sequenceiq.periscope.service.ha.PeriscopeNodeService;
+
+public abstract class ScalingActivityMonitor extends AbstractMonitor<ScalingActivities> {
+
+    private ScalingActivityService scalingActivityService;
+
+    private PeriscopeNodeConfig periscopeNodeConfig;
+
+    private PeriscopeNodeService periscopeNodeService;
+
+    private ScalingActivityCleanupConfig cleanupConfig;
+
+    public ScalingActivityService getScalingActivityService() {
+        return scalingActivityService;
+    }
+
+    public ScalingActivityCleanupConfig getCleanupConfig() {
+        return cleanupConfig;
+    }
+
+    public PeriscopeNodeConfig getPeriscopeNodeConfig() {
+        return periscopeNodeConfig;
+    }
+
+    public PeriscopeNodeService getPeriscopeNodeService() {
+        return periscopeNodeService;
+    }
+
+    @Override
+    void evalContext(JobExecutionContext context) {
+        super.evalContext(context);
+        this.scalingActivityService = getApplicationContext().getBean(ScalingActivityService.class);
+        this.cleanupConfig = getApplicationContext().getBean(ScalingActivityCleanupConfig.class);
+        this.periscopeNodeConfig = getApplicationContext().getBean(PeriscopeNodeConfig.class);
+        this.periscopeNodeService = getApplicationContext().getBean(PeriscopeNodeService.class);
+    }
+
+    @Override
+    protected void save(ScalingActivities monitored) {
+
+    }
+
+    @Override
+    protected EvaluatorExecutor getEvaluatorExecutorBean(ScalingActivities monitored) {
+        return getApplicationContext().getBean(getEvaluatorType(monitored).getSimpleName(), EvaluatorExecutor.class);
+    }
+
+    @Override
+    public EvaluatorContext getContext(ScalingActivities monitored) {
+        return new ScalingActivitiesEvaluatorContext(monitored);
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/context/ScalingActivitiesEvaluatorContext.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/context/ScalingActivitiesEvaluatorContext.java
@@ -1,0 +1,22 @@
+package com.sequenceiq.periscope.monitor.context;
+
+import com.sequenceiq.periscope.model.ScalingActivities;
+
+public class ScalingActivitiesEvaluatorContext implements EvaluatorContext {
+
+    private final ScalingActivities scalingActivities;
+
+    public ScalingActivitiesEvaluatorContext(ScalingActivities scalingActivities) {
+        this.scalingActivities = scalingActivities;
+    }
+
+    @Override
+    public Object getData() {
+        return scalingActivities;
+    }
+
+    @Override
+    public long getItemId() {
+        return scalingActivities.getId();
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/cleanup/ActivityCleanupEvaluator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/cleanup/ActivityCleanupEvaluator.java
@@ -1,0 +1,70 @@
+package com.sequenceiq.periscope.monitor.evaluator.cleanup;
+
+import java.util.Objects;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.periscope.model.ScalingActivities;
+import com.sequenceiq.periscope.monitor.context.EvaluatorContext;
+import com.sequenceiq.periscope.monitor.context.ScalingActivitiesEvaluatorContext;
+import com.sequenceiq.periscope.monitor.evaluator.EvaluatorExecutor;
+import com.sequenceiq.periscope.service.ScalingActivityService;
+
+@Component("ActivityCleanupEvaluator")
+@Scope("prototype")
+public class ActivityCleanupEvaluator extends EvaluatorExecutor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ActivityCleanupEvaluator.class);
+
+    private static final String EVALUATOR_NAME = ActivityCleanupEvaluator.class.getName();
+
+    @Inject
+    private ScalingActivityService scalingActivityService;
+
+    private ScalingActivities scalingActivities;
+
+    @Nonnull
+    @Override
+    public EvaluatorContext getContext() {
+        return new ScalingActivitiesEvaluatorContext(scalingActivities);
+    }
+
+    @Override
+    public String getName() {
+        return EVALUATOR_NAME;
+    }
+
+    @Override
+    public void setContext(EvaluatorContext context) {
+        this.scalingActivities = (ScalingActivities) context.getData();
+    }
+
+    @Override
+    protected void execute() {
+        if (Objects.isNull(scalingActivities)) {
+            LOGGER.info("No scalingActivities found");
+            return;
+        }
+
+        LOGGER.info("Executing ScalingActivityCleanupEvaluator: {}", scalingActivities.getId());
+
+        try {
+            if (scalingActivities.getActivityIds().isEmpty()) {
+                LOGGER.info("No activityIds present for ScalingActivityCleanup, skipping request to purge scalingActivity");
+            } else {
+                LOGGER.info("Purging {} scalingActivity Ids as part of cleanup", scalingActivities.getActivityIds().size());
+                scalingActivityService.deleteScalingActivityByIds(scalingActivities.getActivityIds());
+            }
+        } catch (Exception e) {
+            LOGGER.error("Exception occurred when executing ScalingActivityCleanupEvaluator: {}", scalingActivities.getId(), e);
+        } finally {
+            LOGGER.info("Finished executing ScalingActivityCleanupEvaluator: {}", scalingActivities.getId());
+        }
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/executor/ExecutorServiceWithRegistry.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/executor/ExecutorServiceWithRegistry.java
@@ -24,16 +24,16 @@ public class ExecutorServiceWithRegistry {
     @Qualifier("periscopeListeningScheduledExecutorService")
     private ExecutorService executorService;
 
-    public void submitIfAbsent(EvaluatorExecutor evaluatorExecutor, long clusterId) {
-        if (evaluatorExecutorRegistry.putIfAbsent(evaluatorExecutor, clusterId)) {
+    public void submitIfAbsent(EvaluatorExecutor evaluatorExecutor, long resourceId) {
+        if (evaluatorExecutorRegistry.putIfAbsent(evaluatorExecutor, resourceId)) {
             try {
                 executorService.submit(evaluatorExecutor);
             } catch (RejectedExecutionException e) {
-                evaluatorExecutorRegistry.remove(evaluatorExecutor, clusterId);
+                evaluatorExecutorRegistry.remove(evaluatorExecutor, resourceId);
                 throw e;
             }
         } else {
-            LOGGER.info("Evaluator {} is not accepted for cluster {}", evaluatorExecutor.getName(), clusterId);
+            LOGGER.info("Evaluator {} is not accepted for resource {}", evaluatorExecutor.getName(), resourceId);
         }
     }
 

--- a/autoscale/src/main/java/com/sequenceiq/periscope/repository/ScalingActivityRepository.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/repository/ScalingActivityRepository.java
@@ -45,6 +45,13 @@ public interface ScalingActivityRepository extends CrudRepository<ScalingActivit
     List<ScalingActivity> findAllByClusterBetweenInterval(@Param("clusterId") Long clusterId, @Param("startTimeFrom") Date startTimeFrom,
             @Param("startTimeUntil") Date startTimeUntil);
 
+    @Query("SELECT st.id FROM ScalingActivity st WHERE st.endTime <= :endTimeBefore")
+    List<Long> findAllIdsWithEndTimeBefore(@Param("endTimeBefore") Date endTimeBefore);
+
+    @Query("SELECT st.id FROM ScalingActivity st WHERE st.activityStatus IN :statuses AND st.startTime <= :startTimeBefore")
+    List<Long> findAllIdsInActivityStatusesWithStartTimeBefore(@Param("statuses") Collection<ActivityStatus> statuses,
+            @Param("startTimeBefore") Date startTimeBefore);
+
     @Modifying
     @Query("DELETE FROM ScalingActivity st WHERE st.cluster.id = :clusterId")
     void deleteAllByCluster(@Param("clusterId") Long clusterId);

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/RejectedThreadService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/RejectedThreadService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.AutoscaleStackV4Response;
 import com.sequenceiq.periscope.model.RejectedThread;
+import com.sequenceiq.periscope.model.ScalingActivities;
 import com.sequenceiq.periscope.monitor.evaluator.EvaluatorExecutor;
 
 @Service
@@ -40,8 +41,10 @@ public class RejectedThreadService {
             rejectedThread = createOrUpdateRejectedThread(data, stackId);
         } else if (data instanceof Long) {
             rejectedThread = createOrUpdateRejectedThread(Collections.singletonMap("id", data), (Long) data);
+        } else if (data instanceof ScalingActivities) {
+            rejectedThread = createOrUpdateRejectedThread(data, ((ScalingActivities) data).getId());
         } else {
-            throw new IllegalArgumentException("The given data is not match to AutoscaleStackResponse or Long, not possible to create");
+            throw new IllegalArgumentException("The given data does not match AutoscaleStackResponse, Long or ScalingActivities, not possible to create");
         }
 
         LOGGER.debug("Rejected task: {}, count: {}", rejectedThread.getJson(), rejectedThread.getRejectedCount());
@@ -66,10 +69,12 @@ public class RejectedThreadService {
         RejectedThread removed;
         if (data instanceof AutoscaleStackV4Response) {
             removed = rejectedThreads.remove(((AutoscaleStackV4Response) data).getStackId());
+        } else if (data instanceof ScalingActivities) {
+            removed = rejectedThreads.remove(((ScalingActivities) data).getId());
         } else if (data instanceof Long) {
             removed = rejectedThreads.remove(data);
         } else {
-            throw new IllegalArgumentException("The given data is not match to AutoscaleStackResponse or Long, so not removable");
+            throw new IllegalArgumentException("The given data does not match AutoscaleStackResponse, Long or ScalingActivities so not removable");
         }
         if (removed != null) {
             LOGGER.debug("Rejected thread removed {} with count {}", removed.getJson(), removed.getRejectedCount());

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/ha/PeriscopeNodeService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/ha/PeriscopeNodeService.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.periscope.service.ha;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.lang.String.format;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
+import com.sequenceiq.periscope.repository.PeriscopeNodeRepository;
+
+@Service
+public class PeriscopeNodeService {
+
+    @Inject
+    private PeriscopeNodeRepository periscopeNodeRepository;
+
+    public boolean isLeader(String nodeId) {
+        return isNullOrEmpty(nodeId) || periscopeNodeRepository.findById(nodeId).orElseThrow(() -> new NotFoundException(format("PeriscopeNode '%s' not found",
+                nodeId))).isLeader();
+    }
+}

--- a/autoscale/src/main/resources/application.yml
+++ b/autoscale/src/main/resources/application.yml
@@ -62,6 +62,10 @@ periscope:
       enabled: true
     delete-monitor:
       enabled: true
+    cleanup-monitor:
+      enabled: true
+  scaling-activity:
+    cleanup-event-age.hours: 24
 
 cb:
   server:

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/CleanupMonitorTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/CleanupMonitorTest.java
@@ -1,0 +1,87 @@
+package com.sequenceiq.periscope.monitor;
+
+import static java.util.Collections.emptySet;
+import static java.util.UUID.randomUUID;
+import static java.util.stream.Collectors.toSet;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.LongStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.periscope.config.ScalingActivityCleanupConfig;
+import com.sequenceiq.periscope.model.ScalingActivities;
+import com.sequenceiq.periscope.service.ScalingActivityService;
+import com.sequenceiq.periscope.service.ha.PeriscopeNodeConfig;
+import com.sequenceiq.periscope.service.ha.PeriscopeNodeService;
+
+@ExtendWith(MockitoExtension.class)
+class CleanupMonitorTest {
+
+    private static final String TEST_NODE_ID = randomUUID().toString();
+
+    private static final Long TEST_CLEANUP_DURATION = 24L;
+
+    @InjectMocks
+    private CleanupMonitor underTest;
+
+    @Mock
+    private PeriscopeNodeService nodeService;
+
+    @Mock
+    private ScalingActivityService scalingActivityService;
+
+    @Mock
+    private PeriscopeNodeConfig nodeConfig;
+
+    @Mock
+    private ScalingActivityCleanupConfig cleanupConfig;
+
+    @Test
+    void testGetMonitoredForActivityIdsWithLeader() {
+        Set<Long> activityIds = LongStream.range(0, 5).boxed().collect(toSet());
+
+        doReturn(TEST_NODE_ID).when(nodeConfig).getId();
+        doReturn(Boolean.TRUE).when(nodeService).isLeader(TEST_NODE_ID);
+        doReturn(TEST_CLEANUP_DURATION).when(cleanupConfig).getCleanupDurationHours();
+        doReturn(activityIds).when(scalingActivityService).findAllInStatusesThatStartedBefore(anyCollection(), anyLong());
+
+        List<ScalingActivities> result = underTest.getMonitored();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.iterator().next().getActivityIds()).hasSameElementsAs(activityIds);
+    }
+
+    @Test
+    void testGetMonitoredForNoActivityIdsWithLeader() {
+        doReturn(TEST_NODE_ID).when(nodeConfig).getId();
+        doReturn(Boolean.TRUE).when(nodeService).isLeader(TEST_NODE_ID);
+        doReturn(TEST_CLEANUP_DURATION).when(cleanupConfig).getCleanupDurationHours();
+        doReturn(emptySet()).when(scalingActivityService).findAllInStatusesThatStartedBefore(anyCollection(), anyLong());
+
+        List<ScalingActivities> result = underTest.getMonitored();
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void testGetMonitoredForNoActivityIdsAndNotWithLeader() {
+        doReturn(TEST_NODE_ID).when(nodeConfig).getId();
+        doReturn(Boolean.FALSE).when(nodeService).isLeader(TEST_NODE_ID);
+
+        List<ScalingActivities> result = underTest.getMonitored();
+
+        assertThat(result).isEmpty();
+        verifyNoInteractions(scalingActivityService);
+    }
+}

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/cleanup/ActivityCleanupEvaluatorTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/cleanup/ActivityCleanupEvaluatorTest.java
@@ -1,0 +1,90 @@
+package com.sequenceiq.periscope.monitor.evaluator.cleanup;
+
+import static java.util.stream.Collectors.toSet;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.Set;
+import java.util.stream.LongStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.periscope.model.ScalingActivities;
+import com.sequenceiq.periscope.monitor.context.ScalingActivitiesEvaluatorContext;
+import com.sequenceiq.periscope.monitor.executor.ExecutorServiceWithRegistry;
+import com.sequenceiq.periscope.service.ScalingActivityService;
+
+@ExtendWith(MockitoExtension.class)
+class ActivityCleanupEvaluatorTest {
+
+    private static final Long TEST_SCALING_ACTIVITIES_ID = 1L;
+
+    @Mock
+    private ScalingActivityService scalingActivityService;
+
+    @Mock
+    private ExecutorServiceWithRegistry executorServiceWithRegistry;
+
+    @Captor
+    private ArgumentCaptor<Set<Long>> captor;
+
+    @InjectMocks
+    private ActivityCleanupEvaluator underTest;
+
+    @Test
+    void testRunCallsFinishedWhenException() {
+        underTest.setContext(new ScalingActivitiesEvaluatorContext(getScalingActivities(10)));
+        doThrow(new RuntimeException("test exception")).when(scalingActivityService).deleteScalingActivityByIds(anySet());
+
+        underTest.run();
+
+        verify(executorServiceWithRegistry).finished(underTest, TEST_SCALING_ACTIVITIES_ID);
+    }
+
+    @Test
+    void testExecuteWhenScalingActivitiesAreNull() {
+        underTest.setContext(new ScalingActivitiesEvaluatorContext(null));
+
+        underTest.execute();
+
+        verifyNoInteractions(scalingActivityService);
+    }
+
+    @Test
+    void testExecuteWhenScalingActivityIdsAreEmpty() {
+        underTest.setContext(new ScalingActivitiesEvaluatorContext(getScalingActivities(0)));
+
+        underTest.execute();
+
+        verifyNoInteractions(scalingActivityService);
+    }
+
+    @Test
+    void testExecuteWithScalingActivities() {
+        ScalingActivities activities = getScalingActivities(10);
+        underTest.setContext(new ScalingActivitiesEvaluatorContext(activities));
+
+        underTest.execute();
+
+        verify(scalingActivityService, times(1)).deleteScalingActivityByIds(captor.capture());
+        Set<Long> idsToDelete = captor.getValue();
+        assertThat(idsToDelete).hasSameElementsAs(activities.getActivityIds());
+    }
+
+    private ScalingActivities getScalingActivities(int count) {
+        ScalingActivities scalingActivities = new ScalingActivities();
+        scalingActivities.setId(TEST_SCALING_ACTIVITIES_ID);
+        scalingActivities.setActivityIds(LongStream.range(1, count).boxed().collect(toSet()));
+        return scalingActivities;
+    }
+}

--- a/autoscale/src/test/java/com/sequenceiq/periscope/service/ha/PeriscopeNodeServiceTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/service/ha/PeriscopeNodeServiceTest.java
@@ -1,0 +1,71 @@
+package com.sequenceiq.periscope.service.ha;
+
+import static java.lang.String.format;
+import static java.util.UUID.randomUUID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
+import com.sequenceiq.periscope.domain.PeriscopeNode;
+import com.sequenceiq.periscope.repository.PeriscopeNodeRepository;
+
+@ExtendWith(MockitoExtension.class)
+class PeriscopeNodeServiceTest {
+
+    @InjectMocks
+    private PeriscopeNodeService underTest;
+
+    @Mock
+    private PeriscopeNodeRepository nodeRepository;
+
+    @Test
+    void testIsLeader() {
+        String uuid = randomUUID().toString();
+        PeriscopeNode node = getPeriscopeNode(uuid, Boolean.TRUE);
+
+        doReturn(Optional.of(node)).when(nodeRepository).findById(uuid);
+
+        assertThat(underTest.isLeader(uuid)).isTrue();
+    }
+
+    @Test
+    void testIsLeaderForNullNodeId() {
+        assertThat(underTest.isLeader(null)).isTrue();
+    }
+
+    @Test
+    void testIsNotLeader() {
+        String uuid = randomUUID().toString();
+        PeriscopeNode node = getPeriscopeNode(uuid, Boolean.FALSE);
+
+        doReturn(Optional.of(node)).when(nodeRepository).findById(uuid);
+
+        assertThat(underTest.isLeader(uuid)).isFalse();
+    }
+
+    @Test
+    void testThrowsExceptionWhenLeaderNotFound() {
+        doReturn(Optional.empty()).when(nodeRepository).findById(anyString());
+
+        String uuid = randomUUID().toString();
+        assertThatThrownBy(() -> underTest.isLeader(uuid)).isInstanceOf(NotFoundException.class).hasMessage(format("PeriscopeNode '%s' not found", uuid));
+    }
+
+    private PeriscopeNode getPeriscopeNode(String uuid, boolean leader) {
+        PeriscopeNode node = new PeriscopeNode();
+        node.setLeader(leader);
+        node.setUuid(uuid);
+        return node;
+    }
+
+}


### PR DESCRIPTION
#### Overview
 - Added a new monitor to run at a frequency of 10 min, which collects scalingActivityIds older than a set duration
 - Corresponding evaluator will publish an event, whose handler will perform deletion of records.

#### TODO
- [x] UT coverage for new evaluator and handler classes, along with existing repository layer class 

See detailed description in the commit message.