### PR TITLE
CB-19958 Environmentservice rescheduling missing envs in FREEIPA_UNREACHABLE, FREEIPA_UNHEALTHY status

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/environment/EnvironmentStatus.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/EnvironmentStatus.java
@@ -1,6 +1,11 @@
 package com.sequenceiq.environment.environment;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableSet;
 
 public enum EnvironmentStatus {
 
@@ -176,6 +181,16 @@ public enum EnvironmentStatus {
             FREEIPA_CREATION_IN_PROGRESS,
             AVAILABLE);
 
+    public static final Set<EnvironmentStatus> CREATE_IN_PROGRESS_STATES = Set.of(
+            CREATION_INITIATED,
+            NETWORK_CREATION_IN_PROGRESS,
+            PUBLICKEY_CREATE_IN_PROGRESS,
+            ENVIRONMENT_RESOURCE_ENCRYPTION_INITIALIZATION_IN_PROGRESS,
+            ENVIRONMENT_VALIDATION_IN_PROGRESS,
+            ENVIRONMENT_INITIALIZATION_IN_PROGRESS,
+            FREEIPA_CREATION_IN_PROGRESS
+    );
+
     public static final Set<EnvironmentStatus> DELETE_IN_PROGRESS_STATES = Set.of(
             NETWORK_DELETE_IN_PROGRESS,
             FREEIPA_DELETE_IN_PROGRESS,
@@ -188,6 +203,7 @@ public enum EnvironmentStatus {
             DATAHUB_CLUSTERS_DELETE_IN_PROGRESS,
             DATALAKE_CLUSTERS_DELETE_IN_PROGRESS,
             PUBLICKEY_DELETE_IN_PROGRESS,
+            EVENT_CLEANUP_IN_PROGRESS,
             EXPERIENCE_DELETE_IN_PROGRESS,
             ENVIRONMENT_RESOURCE_ENCRYPTION_DELETE_IN_PROGRESS,
             ENVIRONMENT_ENCRYPTION_RESOURCES_DELETED
@@ -213,6 +229,17 @@ public enum EnvironmentStatus {
 
     EnvironmentStatus(com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus responseStatus) {
         this.responseStatus = responseStatus;
+    }
+
+    public static List<EnvironmentStatus> skipFromStatusChecker() {
+        return ImmutableSet.of(
+                        Set.of(ARCHIVED,
+                                CREATE_FAILED,
+                                DELETE_FAILED,
+                                FREEIPA_DELETED_ON_PROVIDER_SIDE),
+                        DELETE_IN_PROGRESS_STATES,
+                        CREATE_IN_PROGRESS_STATES)
+                .stream().flatMap(Collection::stream).collect(Collectors.toList());
     }
 
     public com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus getResponseStatus() {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/repository/EnvironmentRepository.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/repository/EnvironmentRepository.java
@@ -111,8 +111,9 @@ public interface EnvironmentRepository extends AccountAwareResourceRepository<En
     List<Environment> findAllByAccountIdAndParentEnvIdAndArchivedIsFalse(@Param("accountId") String accountId,
             @Param("parentEnvironmentId") Long parentEnvironmentId);
 
-    @Query("SELECT e.resourceCrn as remoteResourceId, e.id as localId, e.name as name FROM Environment e WHERE e.archived = false and e.status in (:statuses)")
-    List<JobResource> findAllRunningAndStatusIn(@Param("statuses") Collection<EnvironmentStatus> statuses);
+    @Query("SELECT e.resourceCrn as remoteResourceId, e.id as localId, e.name as name FROM Environment e WHERE e.archived = false " +
+            "and e.status not in (:statuses)")
+    List<JobResource> findAllRunningAndStatusNotIn(@Param("statuses") Collection<EnvironmentStatus> statuses);
 
     @Query("SELECT new com.sequenceiq.authorization.service.list.ResourceWithId(e.id, e.resourceCrn) FROM Environment e " +
             "WHERE e.accountId = :accountId AND e.archived = false")

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentService.java
@@ -422,37 +422,7 @@ public class EnvironmentService extends AbstractAccountAwareResourceService<Envi
     }
 
     public List<JobResource> findAllForAutoSync() {
-        return environmentRepository.findAllRunningAndStatusIn(List.of(
-                EnvironmentStatus.AVAILABLE,
-                EnvironmentStatus.UPDATE_FAILED,
-                EnvironmentStatus.START_DATAHUB_FAILED,
-                EnvironmentStatus.START_DATALAKE_FAILED,
-                EnvironmentStatus.START_FREEIPA_FAILED,
-                EnvironmentStatus.START_DATAHUB_STARTED,
-                EnvironmentStatus.START_DATALAKE_STARTED,
-                EnvironmentStatus.START_FREEIPA_STARTED,
-                EnvironmentStatus.START_SYNCHRONIZE_USERS_STARTED,
-                EnvironmentStatus.START_SYNCHRONIZE_USERS_FAILED,
-                EnvironmentStatus.STOP_DATAHUB_FAILED,
-                EnvironmentStatus.STOP_DATALAKE_FAILED,
-                EnvironmentStatus.STOP_FREEIPA_FAILED,
-                EnvironmentStatus.STOP_DATAHUB_STARTED,
-                EnvironmentStatus.STOP_DATALAKE_STARTED,
-                EnvironmentStatus.STOP_FREEIPA_STARTED,
-                EnvironmentStatus.ENV_STOPPED,
-                EnvironmentStatus.UPGRADE_CCM_FAILED,
-                EnvironmentStatus.UPGRADE_CCM_ON_DATAHUB_IN_PROGRESS,
-                EnvironmentStatus.UPGRADE_CCM_ON_DATAHUB_FAILED,
-                EnvironmentStatus.UPGRADE_CCM_ON_DATALAKE_IN_PROGRESS,
-                EnvironmentStatus.UPGRADE_CCM_ON_DATALAKE_FAILED,
-                EnvironmentStatus.UPGRADE_CCM_ON_FREEIPA_IN_PROGRESS,
-                EnvironmentStatus.UPGRADE_CCM_ON_FREEIPA_FAILED,
-                EnvironmentStatus.UPGRADE_CCM_TUNNEL_UPDATE_IN_PROGRESS,
-                EnvironmentStatus.UPGRADE_CCM_TUNNEL_UPDATE_FAILED,
-                EnvironmentStatus.UPGRADE_CCM_VALIDATION_IN_PROGRESS,
-                EnvironmentStatus.UPGRADE_CCM_VALIDATION_FAILED,
-                EnvironmentStatus.UPGRADE_CCM_ROLLING_BACK
-        ));
+        return environmentRepository.findAllRunningAndStatusNotIn(EnvironmentStatus.skipFromStatusChecker());
     }
 
     @Override


### PR DESCRIPTION
If an env is in "FREEIPA_UNHEALTHY", then we don't schedule it on a pod restart because this list does not contain these statuses:

https://github.com/hortonworks/cloudbreak/blob/a6e0c4d027bdbbe46da6d4fe0a5d0faaa7d480bf/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentService.java#L424-L456

It should not work like this.

We should specify the disallowed statuses.