### PR TITLE
CB-19624 AKS private DNS zone - validations

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePrivateDnsZoneDescriptor.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePrivateDnsZoneDescriptor.java
@@ -1,0 +1,16 @@
+package com.sequenceiq.cloudbreak.cloud.azure;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+public interface AzurePrivateDnsZoneDescriptor {
+
+    String getResourceType();
+
+    String getSubResource();
+
+    String getDnsZoneName();
+
+    List<Pattern> getDnsZoneNamePatterns();
+
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePrivateDnsZoneRegistrationEnum.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePrivateDnsZoneRegistrationEnum.java
@@ -1,0 +1,69 @@
+package com.sequenceiq.cloudbreak.cloud.azure;
+
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * This enum contains possible private DNS zones that are only registered in environment service, but are not used by cloudbreak.
+ */
+public enum AzurePrivateDnsZoneRegistrationEnum implements AzurePrivateDnsZoneDescriptor {
+
+    AKS("Microsoft.ContainerService/managedClusters", "managedClusters",
+            "privatelink.{region}.azmk8s.io or {subzone}.privatelink.{region}.azmk8s.io",
+            List.of(DnsZoneNamePatternConstants.AKS_DNS_ZONE_NAME_PATTERN_REGION,
+                    DnsZoneNamePatternConstants.AKS_DNS_ZONE_NAME_PATTERN_SUBZONE_AND_REGION));
+
+    private final String resourceType;
+
+    private final String subResource;
+
+    private final String dnsZoneName;
+
+    private final List<Pattern> dnsZoneNameRegexPatterns;
+
+    AzurePrivateDnsZoneRegistrationEnum(String resourceType, String subResource, String dnsZoneName, List<String> dnsZoneNameTemplate) {
+        this.resourceType = resourceType;
+        this.subResource = subResource;
+        this.dnsZoneName = dnsZoneName;
+        this.dnsZoneNameRegexPatterns = dnsZoneNameTemplate.stream().map(Pattern::compile).collect(Collectors.toList());
+    }
+
+    public String getResourceType() {
+        return resourceType;
+    }
+
+    public String getSubResource() {
+        return subResource;
+    }
+
+    @Override
+    public String getDnsZoneName() {
+        return dnsZoneName;
+    }
+
+    @Override
+    public List<Pattern> getDnsZoneNamePatterns() {
+        return dnsZoneNameRegexPatterns;
+    }
+
+    @Override
+    public String toString() {
+        return "AzurePrivateDnsZoneRegistrationEnum{" +
+                "resourceType='" + resourceType + '\'' +
+                ", subResource='" + subResource + '\'' +
+                ", dnsZoneName='" + dnsZoneName + '\'' +
+                ", dnsZoneNameRegexPatterns=" + dnsZoneNameRegexPatterns +
+                "} " + super.toString();
+    }
+
+    private static class DnsZoneNamePatternConstants {
+        private static final String AKS_DNS_ZONE_NAME_PATTERN_REGION = "privatelink\\.[a-z\\d-]+.azmk8s.io";
+
+        private static final String AKS_DNS_ZONE_NAME_PATTERN_SUBZONE_AND_REGION = "[\\w+-]+\\.privatelink\\.[a-z\\d-]+.azmk8s.io";
+
+        private DnsZoneNamePatternConstants() {
+        }
+    }
+
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePrivateDnsZoneServiceEnum.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePrivateDnsZoneServiceEnum.java
@@ -3,14 +3,17 @@ package com.sequenceiq.cloudbreak.cloud.azure;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 
+import java.util.List;
 import java.util.Map;
-import java.util.StringJoiner;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-public enum AzurePrivateDnsZoneServiceEnum {
+public enum AzurePrivateDnsZoneServiceEnum implements AzurePrivateDnsZoneDescriptor {
 
-    POSTGRES("Microsoft.DBforPostgreSQL/servers", "postgresqlServer", "privatelink.postgres.database.azure.com", "postgres.database.azure.com"),
-    STORAGE("Microsoft.Storage/storageAccounts", "Blob", "privatelink.blob.core.windows.net", "blob.core.windows.net");
+    POSTGRES("Microsoft.DBforPostgreSQL/servers", "postgresqlServer", "privatelink.postgres.database.azure.com",
+            "postgres.database.azure.com", "privatelink\\.postgres\\.database\\.azure\\.com"),
+    STORAGE("Microsoft.Storage/storageAccounts", "Blob", "privatelink.blob.core.windows.net",
+            "blob.core.windows.net", "privatelink\\.blob\\.core\\.windows\\.net");
 
     private static final Map<String, AzurePrivateDnsZoneServiceEnum> SERVICE_MAP_BY_RESOURCE;
 
@@ -20,12 +23,15 @@ public enum AzurePrivateDnsZoneServiceEnum {
 
     private final String dnsZoneName;
 
+    private final Pattern dnsZoneNamePattern;
+
     private final String dnsZoneForwarder;
 
-    AzurePrivateDnsZoneServiceEnum(String resourceType, String subResource, String dnsZoneName, String dnsZoneForwarder) {
+    AzurePrivateDnsZoneServiceEnum(String resourceType, String subResource, String dnsZoneName, String dnsZoneNamePattern, String dnsZoneForwarder) {
         this.resourceType = resourceType;
         this.subResource = subResource;
         this.dnsZoneName = dnsZoneName;
+        this.dnsZoneNamePattern = Pattern.compile(dnsZoneNamePattern);
         this.dnsZoneForwarder = dnsZoneForwarder;
     }
 
@@ -39,6 +45,11 @@ public enum AzurePrivateDnsZoneServiceEnum {
 
     public String getDnsZoneName() {
         return dnsZoneName;
+    }
+
+    @Override
+    public List<Pattern> getDnsZoneNamePatterns() {
+        return List.of(dnsZoneNamePattern);
     }
 
     public String getDnsZoneForwarder() {
@@ -55,11 +66,13 @@ public enum AzurePrivateDnsZoneServiceEnum {
 
     @Override
     public String toString() {
-        return new StringJoiner(", ", AzurePrivateDnsZoneServiceEnum.class.getSimpleName() + "[", "]")
-                .add("resourceType='" + resourceType + "'")
-                .add("subResource='" + subResource + "'")
-                .add("dnsZoneName='" + dnsZoneName + "'")
-                .add("dnsZoneForwarder='" + dnsZoneForwarder + "'")
-                .toString();
+        return "AzurePrivateDnsZoneServiceEnum{" +
+                "resourceType='" + resourceType + '\'' +
+                ", subResource='" + subResource + '\'' +
+                ", dnsZoneName='" + dnsZoneName + '\'' +
+                ", dnsZoneNamePattern=" + dnsZoneNamePattern +
+                ", dnsZoneForwarder='" + dnsZoneForwarder + '\'' +
+                "} " + super.toString();
     }
+
 }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzureExistingPrivateDnsZoneValidatorService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzureExistingPrivateDnsZoneValidatorService.java
@@ -10,7 +10,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.microsoft.azure.arm.resources.ResourceId;
-import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneServiceEnum;
+import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneDescriptor;
 import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
 import com.sequenceiq.cloudbreak.validation.ValidationResult;
 
@@ -23,7 +23,7 @@ public class AzureExistingPrivateDnsZoneValidatorService {
     private AzurePrivateDnsZoneValidatorService azurePrivateDnsZoneValidatorService;
 
     public ValidationResult.ValidationResultBuilder validate(AzureClient azureClient, String networkResourceGroupName,
-            String networkName, Map<AzurePrivateDnsZoneServiceEnum, String> serviceToPrivateDnsZoneId, ValidationResult.ValidationResultBuilder resultBuilder) {
+            String networkName, Map<AzurePrivateDnsZoneDescriptor, String> serviceToPrivateDnsZoneId, ValidationResult.ValidationResultBuilder resultBuilder) {
         serviceToPrivateDnsZoneId.forEach((service, privateDnsZoneId) -> {
             try {
                 ResourceId privateDnsZoneResourceId = ResourceId.fromString(privateDnsZoneId);

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzurePrivateDnsZoneMatcherService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzurePrivateDnsZoneMatcherService.java
@@ -1,0 +1,22 @@
+package com.sequenceiq.cloudbreak.cloud.azure.validator.privatedns;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneDescriptor;
+
+@Service
+public class AzurePrivateDnsZoneMatcherService {
+
+    public boolean isZoneNameMatchingPattern(AzurePrivateDnsZoneDescriptor privateDnsZoneDescriptor, String privateDnsZoneName) {
+        return privateDnsZoneDescriptor.getDnsZoneNamePatterns().stream().anyMatch(namePattern -> matches(privateDnsZoneName, namePattern));
+    }
+
+    private static boolean matches(String privateDnsZoneName, Pattern namePattern) {
+        Matcher matcher = namePattern.matcher(privateDnsZoneName);
+        return matcher.matches();
+    }
+
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzurePrivateDnsZoneValidatorService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzurePrivateDnsZoneValidatorService.java
@@ -7,6 +7,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import javax.inject.Inject;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -15,7 +17,7 @@ import com.microsoft.azure.PagedList;
 import com.microsoft.azure.arm.resources.ResourceId;
 import com.microsoft.azure.management.privatedns.v2018_09_01.PrivateZone;
 import com.microsoft.azure.management.privatedns.v2018_09_01.implementation.VirtualNetworkLinkInner;
-import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneServiceEnum;
+import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneDescriptor;
 import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
 import com.sequenceiq.cloudbreak.validation.ValidationResult;
 
@@ -24,11 +26,14 @@ public class AzurePrivateDnsZoneValidatorService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AzurePrivateDnsZoneValidatorService.class);
 
-    public ValidationResult.ValidationResultBuilder existingPrivateDnsZoneNameIsSupported(AzurePrivateDnsZoneServiceEnum serviceEnum,
+    @Inject
+    private AzurePrivateDnsZoneMatcherService azurePrivateDnsZoneMatcherService;
+
+    public ValidationResult.ValidationResultBuilder existingPrivateDnsZoneNameIsSupported(AzurePrivateDnsZoneDescriptor dnsZoneDescriptor,
             ResourceId existingPrivateDnsZoneResourceId, ValidationResult.ValidationResultBuilder resultBuilder) {
-        if (!serviceEnum.getDnsZoneName().equals(existingPrivateDnsZoneResourceId.name())) {
+        if (!azurePrivateDnsZoneMatcherService.isZoneNameMatchingPattern(dnsZoneDescriptor, existingPrivateDnsZoneResourceId.name())) {
             String validationMessage = String.format("The provided private DNS zone %s is not a valid DNS zone name for %s. Please use a DNS zone with " +
-                    "name %s and try again.", existingPrivateDnsZoneResourceId.id(), serviceEnum.getResourceType(), serviceEnum.getDnsZoneName());
+                    "name %s and try again.", existingPrivateDnsZoneResourceId.id(), dnsZoneDescriptor.getResourceType(), dnsZoneDescriptor.getDnsZoneName());
             addValidationError(validationMessage, resultBuilder);
         }
         return resultBuilder;

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzurePrivateDnsZoneMatcherServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzurePrivateDnsZoneMatcherServiceTest.java
@@ -1,0 +1,56 @@
+package com.sequenceiq.cloudbreak.cloud.azure.validator.privatedns;
+
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneDescriptor;
+
+public class AzurePrivateDnsZoneMatcherServiceTest {
+
+    private static final String ZONE_NAME = "zoneName";
+
+    private final AzurePrivateDnsZoneMatcherService underTest = new AzurePrivateDnsZoneMatcherService();
+
+    @Test
+    void testIsZoneNameMatchingPatternWhenMatchesThenReturnsTrue() {
+        Pattern pattern = mock(Pattern.class);
+        Matcher matcher = mock(Matcher.class);
+        when(pattern.matcher(ZONE_NAME)).thenReturn(matcher);
+        AzurePrivateDnsZoneDescriptor descriptor = mock(AzurePrivateDnsZoneDescriptor.class);
+        when(descriptor.getDnsZoneNamePatterns()).thenReturn(List.of(pattern));
+        when(matcher.matches()).thenReturn(true);
+
+        boolean matchingResult = underTest.isZoneNameMatchingPattern(descriptor, ZONE_NAME);
+
+        assertTrue(matchingResult);
+        verify(pattern).matcher(ZONE_NAME);
+        verify(matcher).matches();
+    }
+
+    @Test
+    void testIsZoneNameMatchingPatternWhenNoMatchThenReturnsFalse() {
+        Pattern pattern = mock(Pattern.class);
+        Matcher matcher = mock(Matcher.class);
+        when(pattern.matcher(ZONE_NAME)).thenReturn(matcher);
+        AzurePrivateDnsZoneDescriptor descriptor = mock(AzurePrivateDnsZoneDescriptor.class);
+        when(descriptor.getDnsZoneNamePatterns()).thenReturn(List.of(pattern));
+        when(matcher.matches()).thenReturn(false);
+
+        boolean matchingResult = underTest.isZoneNameMatchingPattern(descriptor, ZONE_NAME);
+
+        assertFalse(matchingResult);
+        verify(pattern).matcher(ZONE_NAME);
+        verify(matcher).matches();
+    }
+
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/PrivateDnsZoneValidationTestConstants.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/PrivateDnsZoneValidationTestConstants.java
@@ -15,7 +15,7 @@ public class PrivateDnsZoneValidationTestConstants {
 
     static final String ZONE_NAME_POSTGRES = "privatelink.postgres.database.azure.com";
 
-    static final String PRIVATE_DNS_ZONE_ID = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s";
+    static final String PRIVATE_DNS_ZONE_ID_TEMPLATE = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s";
 
     static final String NETWORK_SUBSCRIPTION_ID = "networkSubscriptionId";
 
@@ -35,7 +35,7 @@ public class PrivateDnsZoneValidationTestConstants {
     }
 
     static ResourceId getPrivateDnsZoneResourceId(String resourceGroupName) {
-        String privateDnsZoneId = String.format(PRIVATE_DNS_ZONE_ID, SUBSCRIPTION_ID, resourceGroupName, ZONE_NAME_POSTGRES);
+        String privateDnsZoneId = String.format(PRIVATE_DNS_ZONE_ID_TEMPLATE, SUBSCRIPTION_ID, resourceGroupName, ZONE_NAME_POSTGRES);
         return ResourceId.fromString(privateDnsZoneId);
     }
 
@@ -44,7 +44,7 @@ public class PrivateDnsZoneValidationTestConstants {
     }
 
     private static String getPrivateDnsZoneId(String resourceGroupName, String zoneName) {
-        return String.format(PRIVATE_DNS_ZONE_ID, SUBSCRIPTION_ID, resourceGroupName, zoneName);
+        return String.format(PRIVATE_DNS_ZONE_ID_TEMPLATE, SUBSCRIPTION_ID, resourceGroupName, zoneName);
     }
 
     static class TestPagedList<E> extends PagedList<E> {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/network/azure/AzureEnvironmentNetworkValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/network/azure/AzureEnvironmentNetworkValidator.java
@@ -51,8 +51,9 @@ public class AzureEnvironmentNetworkValidator implements EnvironmentNetworkValid
         if (environmentValidationDto.getValidationType() == ValidationType.ENVIRONMENT_CREATION) {
             azurePrivateEndpointValidator.checkNetworkPoliciesWhenExistingNetwork(networkDto, cloudNetworks, resultBuilder);
             azurePrivateEndpointValidator.checkMultipleResourceGroup(resultBuilder, environmentDto, networkDto);
-            azurePrivateEndpointValidator.checkExistingPrivateDnsZone(resultBuilder, environmentDto, networkDto);
+            azurePrivateEndpointValidator.checkExistingServicePrivateDnsZone(resultBuilder, environmentDto, networkDto);
             azurePrivateEndpointValidator.checkNewPrivateDnsZone(resultBuilder, environmentDto, networkDto);
+            azurePrivateEndpointValidator.checkExistingRegisteredOnlyPrivateDnsZone(resultBuilder, environmentDto, networkDto);
         } else {
             LOGGER.debug("Skipping Private Endpoint related validations as they have been validated before during env creation");
         }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/network/azure/AzureExistingPrivateDnsZonesService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/network/azure/AzureExistingPrivateDnsZonesService.java
@@ -6,27 +6,53 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneDescriptor;
+import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneRegistrationEnum;
 import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneServiceEnum;
 import com.sequenceiq.environment.network.dto.NetworkDto;
 
 @Service
 public class AzureExistingPrivateDnsZonesService {
 
-    public Map<AzurePrivateDnsZoneServiceEnum, String> getExistingZones(NetworkDto networkDto) {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AzureExistingPrivateDnsZonesService.class);
+
+    public Map<AzurePrivateDnsZoneServiceEnum, String> getExistingServiceZones(NetworkDto networkDto) {
         Map<AzurePrivateDnsZoneServiceEnum, String> result = new HashMap<>();
+        Optional.ofNullable(networkDto.getAzure().getDatabasePrivateDnsZoneId())
+                .ifPresent(privateDnsZone -> result.put(AzurePrivateDnsZoneServiceEnum.POSTGRES, privateDnsZone));
+        LOGGER.debug("Existing service private DNS zones: {}", result);
+        return result;
+    }
+
+    public Map<AzurePrivateDnsZoneDescriptor, String> getExistingServiceZonesAsDescriptors(NetworkDto networkDto) {
+        Map<AzurePrivateDnsZoneDescriptor, String> result = new HashMap<>();
         Optional.ofNullable(networkDto.getAzure().getDatabasePrivateDnsZoneId())
                 .ifPresent(privateDnsZone -> result.put(AzurePrivateDnsZoneServiceEnum.POSTGRES, privateDnsZone));
         return result;
     }
 
-    public Set<AzurePrivateDnsZoneServiceEnum> getServicesWithExistingZones(NetworkDto networkDto) {
-        return getExistingZones(networkDto).keySet();
+    public Map<AzurePrivateDnsZoneDescriptor, String> getExistingRegisteredOnlyZonesAsDescriptors(NetworkDto networkDto) {
+        Map<AzurePrivateDnsZoneDescriptor, String> result = new HashMap<>();
+        Optional.ofNullable(networkDto.getAzure().getAksPrivateDnsZoneId())
+                .ifPresent(aksDnsZone -> result.put(AzurePrivateDnsZoneRegistrationEnum.AKS, aksDnsZone));
+        LOGGER.debug("Existing registered only private DNS zones: {}", result);
+        return result;
     }
 
-    public boolean hasNoExistingZones(NetworkDto networkDto) {
-        return getExistingZones(networkDto).isEmpty();
+    public Set<AzurePrivateDnsZoneServiceEnum> getServicesWithExistingZones(NetworkDto networkDto) {
+        return getExistingServiceZones(networkDto).keySet();
+    }
+
+    public boolean hasNoExistingServiceZones(NetworkDto networkDto) {
+        return getExistingServiceZones(networkDto).isEmpty();
+    }
+
+    public boolean hasNoExistingRegisteredOnlyZones(NetworkDto networkDto) {
+        return getExistingRegisteredOnlyZonesAsDescriptors(networkDto).isEmpty();
     }
 
     public Set<String> getServiceNamesWithExistingZones(NetworkDto networkDto) {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/network/azure/AzurePrivateEndpointValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/network/azure/AzurePrivateEndpointValidator.java
@@ -89,8 +89,9 @@ public class AzurePrivateEndpointValidator {
         }
     }
 
-    public void checkExistingPrivateDnsZone(ValidationResult.ValidationResultBuilder resultBuilder, EnvironmentDto environmentDto, NetworkDto networkDto) {
-        if (azureExistingPrivateDnsZonesService.hasNoExistingZones(networkDto)) {
+    public void checkExistingServicePrivateDnsZone(ValidationResult.ValidationResultBuilder resultBuilder, EnvironmentDto environmentDto,
+            NetworkDto networkDto) {
+        if (azureExistingPrivateDnsZonesService.hasNoExistingServiceZones(networkDto)) {
             LOGGER.debug("No existing private DNS zones are used, nothing to do.");
             return;
         }
@@ -102,8 +103,22 @@ public class AzurePrivateEndpointValidator {
             CloudCredential cloudCredential = credentialToCloudCredentialConverter.convert(environmentDto.getCredential());
             AzureClient azureClient = azureClientService.getClient(cloudCredential);
             azureExistingPrivateDnsZoneValidatorService.validate(azureClient, networkDto.getAzure().getResourceGroupName(), networkDto.getAzure().getNetworkId(),
-                    azureExistingPrivateDnsZonesService.getExistingZones(networkDto), resultBuilder);
+                    azureExistingPrivateDnsZonesService.getExistingServiceZonesAsDescriptors(networkDto), resultBuilder);
         }
+    }
+
+    public void checkExistingRegisteredOnlyPrivateDnsZone(ValidationResult.ValidationResultBuilder resultBuilder, EnvironmentDto environmentDto,
+            NetworkDto networkDto) {
+        if (azureExistingPrivateDnsZonesService.hasNoExistingRegisteredOnlyZones(networkDto)) {
+            LOGGER.debug("No existing private DNS zones are used, nothing to do.");
+            return;
+        }
+
+        CloudCredential cloudCredential = credentialToCloudCredentialConverter.convert(environmentDto.getCredential());
+        AzureClient azureClient = azureClientService.getClient(cloudCredential);
+        azureExistingPrivateDnsZoneValidatorService.validate(azureClient, networkDto.getAzure().getResourceGroupName(), networkDto.getAzure().getNetworkId(),
+                azureExistingPrivateDnsZonesService.getExistingRegisteredOnlyZonesAsDescriptors(networkDto), resultBuilder);
+
     }
 
     public void checkNewPrivateDnsZone(ValidationResult.ValidationResultBuilder resultBuilder, EnvironmentDto environmentDto, NetworkDto networkDto) {

--- a/environment/src/test/java/com/sequenceiq/environment/environment/validation/network/azure/AzureEnvironmentNetworkValidatorTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/validation/network/azure/AzureEnvironmentNetworkValidatorTest.java
@@ -100,7 +100,7 @@ class AzureEnvironmentNetworkValidatorTest {
         verify(azurePrivateEndpointValidator).checkMultipleResourceGroup(validationResultBuilder, environmentDto,
                 networkDto);
         verify(azurePrivateEndpointValidator).checkNewPrivateDnsZone(validationResultBuilder, environmentDto, networkDto);
-        verify(azurePrivateEndpointValidator).checkExistingPrivateDnsZone(validationResultBuilder, environmentDto, networkDto);
+        verify(azurePrivateEndpointValidator).checkExistingServicePrivateDnsZone(validationResultBuilder, environmentDto, networkDto);
     }
 
     @Test
@@ -118,7 +118,8 @@ class AzureEnvironmentNetworkValidatorTest {
         verify(azurePrivateEndpointValidator, never()).checkNewPrivateDnsZone(any(), any(), any());
         verify(azurePrivateEndpointValidator, never()).checkMultipleResourceGroup(any(), any(), any());
         verify(azurePrivateEndpointValidator, never()).checkNewPrivateDnsZone(any(), any(), any());
-        verify(azurePrivateEndpointValidator, never()).checkExistingPrivateDnsZone(any(), any(), any());
+        verify(azurePrivateEndpointValidator, never()).checkExistingServicePrivateDnsZone(any(), any(), any());
+        verify(azurePrivateEndpointValidator, never()).checkExistingRegisteredOnlyPrivateDnsZone(any(), any(), any());
         assertFalse(validationResultBuilder.build().hasError());
     }
 

--- a/environment/src/test/java/com/sequenceiq/environment/environment/validation/network/azure/AzureExistingPrivateDnsZonesServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/validation/network/azure/AzureExistingPrivateDnsZonesServiceTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneDescriptor;
+import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneRegistrationEnum;
 import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneServiceEnum;
 import com.sequenceiq.environment.network.dto.AzureParams;
 import com.sequenceiq.environment.network.dto.NetworkDto;
@@ -17,29 +19,69 @@ import com.sequenceiq.environment.network.dto.NetworkDto;
 @ExtendWith(MockitoExtension.class)
 public class AzureExistingPrivateDnsZonesServiceTest {
 
+    private static final String POSTGRES_PRIVATE_DNS_ZONE_ID = "postgresPrivateDnsZoneId";
+
+    private static final String AKS_PRIVATE_DNS_ZONE_ID = "aksPrivateDnsZoneId";
+
     private final AzureExistingPrivateDnsZonesService underTest = new AzureExistingPrivateDnsZonesService();
 
     @Test
-    void testGetExistingZonesWhenPostgresPresent() {
-        NetworkDto networkDto = getNetworkDto("postgresPrivateDnsZoneId");
+    void testGetExistingServiceZonesWhenPostgresPresent() {
+        NetworkDto networkDto = getNetworkDto(POSTGRES_PRIVATE_DNS_ZONE_ID, null);
 
-        Map<AzurePrivateDnsZoneServiceEnum, String> existingZones = underTest.getExistingZones(networkDto);
+        Map<AzurePrivateDnsZoneServiceEnum, String> existingZones = underTest.getExistingServiceZones(networkDto);
 
-        assertEquals("postgresPrivateDnsZoneId", existingZones.get(AzurePrivateDnsZoneServiceEnum.POSTGRES));
+        assertEquals(POSTGRES_PRIVATE_DNS_ZONE_ID, existingZones.get(AzurePrivateDnsZoneServiceEnum.POSTGRES));
     }
 
     @Test
-    void testGetExistingZonesWhenPostgresNotPresent() {
-        NetworkDto networkDto = getNetworkDto(null);
+    void testGetExistingServiceZonesWhenPostgresNotPresent() {
+        NetworkDto networkDto = getNetworkDto(null, null);
 
-        Map<AzurePrivateDnsZoneServiceEnum, String> existingZones = underTest.getExistingZones(networkDto);
+        Map<AzurePrivateDnsZoneServiceEnum, String> existingZones = underTest.getExistingServiceZones(networkDto);
+
+        assertThat(existingZones).isEmpty();
+    }
+
+    @Test
+    void testGetExistingServiceZonesAsDescriptorsWhenPostgresPresent() {
+        NetworkDto networkDto = getNetworkDto(POSTGRES_PRIVATE_DNS_ZONE_ID, null);
+
+        Map<AzurePrivateDnsZoneDescriptor, String> existingZones = underTest.getExistingServiceZonesAsDescriptors(networkDto);
+
+        assertEquals(POSTGRES_PRIVATE_DNS_ZONE_ID, existingZones.get(AzurePrivateDnsZoneServiceEnum.POSTGRES));
+    }
+
+    @Test
+    void testGetExistingServiceZonesAsDescriptorsWhenPostgresNotPresent() {
+        NetworkDto networkDto = getNetworkDto(null, null);
+
+        Map<AzurePrivateDnsZoneDescriptor, String> existingZones = underTest.getExistingServiceZonesAsDescriptors(networkDto);
+
+        assertThat(existingZones).isEmpty();
+    }
+
+    @Test
+    void testGetExistingRegisteredOnlyZonesAsDescriptorsWhenAksPresent() {
+        NetworkDto networkDto = getNetworkDto(null, AKS_PRIVATE_DNS_ZONE_ID);
+
+        Map<AzurePrivateDnsZoneDescriptor, String> existingZones = underTest.getExistingRegisteredOnlyZonesAsDescriptors(networkDto);
+
+        assertEquals(AKS_PRIVATE_DNS_ZONE_ID, existingZones.get(AzurePrivateDnsZoneRegistrationEnum.AKS));
+    }
+
+    @Test
+    void testGetExistingRegisteredOnlyZonesAsDescriptorsWhenAksNotPresent() {
+        NetworkDto networkDto = getNetworkDto(null, null);
+
+        Map<AzurePrivateDnsZoneDescriptor, String> existingZones = underTest.getExistingRegisteredOnlyZonesAsDescriptors(networkDto);
 
         assertThat(existingZones).isEmpty();
     }
 
     @Test
     void testGetServicesWithExistingZonesWhenPostgresWithExistingPrivateDnsZone() {
-        NetworkDto networkDto = getNetworkDto("postgresPrivateDnsZoneId");
+        NetworkDto networkDto = getNetworkDto(POSTGRES_PRIVATE_DNS_ZONE_ID, null);
 
         Set<AzurePrivateDnsZoneServiceEnum> servicesWithPrivateDnsZones = underTest.getServicesWithExistingZones(networkDto);
 
@@ -49,7 +91,7 @@ public class AzureExistingPrivateDnsZonesServiceTest {
 
     @Test
     void testGetServicesWithExistingZonesWhenNoServicesWithExistingPrivateDnsZone() {
-        NetworkDto networkDto = getNetworkDto(null);
+        NetworkDto networkDto = getNetworkDto(null, null);
 
         Set<AzurePrivateDnsZoneServiceEnum> servicesWithPrivateDnsZones = underTest.getServicesWithExistingZones(networkDto);
 
@@ -58,7 +100,7 @@ public class AzureExistingPrivateDnsZonesServiceTest {
 
     @Test
     void testGetServiceNamesWithExistingZonesWhenPostgresWithExistingPrivateDnsZone() {
-        NetworkDto networkDto = getNetworkDto("postgresPrivateDnsZoneId");
+        NetworkDto networkDto = getNetworkDto(POSTGRES_PRIVATE_DNS_ZONE_ID, null);
 
         Set<String> servicesWithPrivateDnsZones = underTest.getServiceNamesWithExistingZones(networkDto);
 
@@ -68,18 +110,29 @@ public class AzureExistingPrivateDnsZonesServiceTest {
 
     @Test
     void testGetServiceNamesWithExistingZonesWhenNoServicesWithExistingPrivateDnsZone() {
-        NetworkDto networkDto = getNetworkDto(null);
+        NetworkDto networkDto = getNetworkDto(null, null);
 
         Set<String> servicesWithPrivateDnsZones = underTest.getServiceNamesWithExistingZones(networkDto);
 
         assertThat(servicesWithPrivateDnsZones).isEmpty();
     }
 
-    private NetworkDto getNetworkDto(String postgresPrivateDnsZoneId) {
+    @Test
+    void testGetExistingRegisteredOnlyZonesAsDescriptors() {
+        NetworkDto networkDto = getNetworkDto(null, AKS_PRIVATE_DNS_ZONE_ID);
+
+        Set<String> servicesWithPrivateDnsZones = underTest.getServiceNamesWithExistingZones(networkDto);
+
+        assertThat(servicesWithPrivateDnsZones).isEmpty();
+
+    }
+
+    private NetworkDto getNetworkDto(String postgresPrivateDnsZoneId, String aksPrivateDnsZoneId) {
         return NetworkDto.builder()
                 .withAzure(
                         AzureParams.builder()
                                 .withDatabasePrivateDnsZoneId(postgresPrivateDnsZoneId)
+                                .withAksPrivateDnsZoneId(aksPrivateDnsZoneId)
                                 .build()
                 )
                 .build();

--- a/environment/src/test/java/com/sequenceiq/environment/environment/validation/network/azure/AzurePrivateEndpointValidatorTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/validation/network/azure/AzurePrivateEndpointValidatorTest.java
@@ -46,6 +46,8 @@ public class AzurePrivateEndpointValidatorTest {
 
     private static final String EXISTING_DATABASE_PRIVATE_DNS_ZONE_ID = "existingDatabasePrivateDnsZoneId";
 
+    private static final String EXISTING_AKS_PRIVATE_DNS_ZONE_ID = "existingAksPrivateDnsZoneId";
+
     @Mock
     private AzureCloudSubnetParametersService azureCloudSubnetParametersService;
 
@@ -175,7 +177,7 @@ public class AzurePrivateEndpointValidatorTest {
     void testCheckNewPrivateDnsZoneWhenExistingDnsZone() {
         ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
         EnvironmentDto environmentDto = getEnvironmentDto(MY_SINGLE_RG, ResourceGroupUsagePattern.USE_SINGLE);
-        AzureParams azureParams = getAzureParams(EXISTING_DATABASE_PRIVATE_DNS_ZONE_ID);
+        AzureParams azureParams = getAzureParams(EXISTING_DATABASE_PRIVATE_DNS_ZONE_ID, null);
 
         underTest.checkNewPrivateDnsZone(validationResultBuilder, environmentDto, getNetworkDto(azureParams));
 
@@ -200,13 +202,13 @@ public class AzurePrivateEndpointValidatorTest {
     }
 
     @Test
-    void testCheckExistingPrivateDnsZoneWhenNoExistingDnsZonesProvided() {
+    void testCheckExistingServicePrivateDnsZoneWhenNoExistingDnsZonesProvided() {
         ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
         EnvironmentDto environmentDto = getEnvironmentDto(null, ResourceGroupUsagePattern.USE_SINGLE);
         NetworkDto networkDto = getNetworkDto(getAzureParams(), ServiceEndpointCreation.ENABLED_PRIVATE_ENDPOINT);
-        when(azureExistingPrivateDnsZonesService.hasNoExistingZones(networkDto)).thenReturn(true);
+        when(azureExistingPrivateDnsZonesService.hasNoExistingServiceZones(networkDto)).thenReturn(true);
 
-        underTest.checkExistingPrivateDnsZone(validationResultBuilder, environmentDto, networkDto);
+        underTest.checkExistingServicePrivateDnsZone(validationResultBuilder, environmentDto, networkDto);
 
         verify(credentialToCloudCredentialConverter, never()).convert(any());
         verify(azureClientService, never()).getClient(any());
@@ -214,13 +216,13 @@ public class AzurePrivateEndpointValidatorTest {
     }
 
     @Test
-    void testCheckExistingPrivateDnsZoneWhenNotPrivateEndpoint() {
+    void testCheckExistingServicePrivateDnsZoneWhenNotPrivateEndpoint() {
         ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
-        AzureParams azureParams = getAzureParams(EXISTING_DATABASE_PRIVATE_DNS_ZONE_ID);
+        AzureParams azureParams = getAzureParams(EXISTING_DATABASE_PRIVATE_DNS_ZONE_ID, null);
         NetworkDto networkDto = getNetworkDto(azureParams, ServiceEndpointCreation.DISABLED);
-        when(azureExistingPrivateDnsZonesService.hasNoExistingZones(networkDto)).thenReturn(false);
+        when(azureExistingPrivateDnsZonesService.hasNoExistingServiceZones(networkDto)).thenReturn(false);
 
-        underTest.checkExistingPrivateDnsZone(validationResultBuilder, new EnvironmentDto(), networkDto);
+        underTest.checkExistingServicePrivateDnsZone(validationResultBuilder, new EnvironmentDto(), networkDto);
 
         assertTrue(validationResultBuilder.build().hasError());
         NetworkTestUtils.checkErrorsPresent(validationResultBuilder, List.of(
@@ -229,29 +231,60 @@ public class AzurePrivateEndpointValidatorTest {
     }
 
     @Test
-    void testCheckExistingPrivateDnsZoneWhenPrivateEndpoint() {
+    void testCheckExistingServicePrivateDnsZoneWhenPrivateEndpoint() {
         ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
-        AzureParams azureParams = getAzureParams(EXISTING_DATABASE_PRIVATE_DNS_ZONE_ID);
+        AzureParams azureParams = getAzureParams(EXISTING_DATABASE_PRIVATE_DNS_ZONE_ID, null);
         NetworkDto networkDto = getNetworkDto(azureParams);
-        when(azureExistingPrivateDnsZonesService.hasNoExistingZones(networkDto)).thenReturn(false);
+        when(azureExistingPrivateDnsZonesService.hasNoExistingServiceZones(networkDto)).thenReturn(false);
 
-        underTest.checkExistingPrivateDnsZone(validationResultBuilder, new EnvironmentDto(), networkDto);
+        underTest.checkExistingServicePrivateDnsZone(validationResultBuilder, new EnvironmentDto(), networkDto);
 
         assertFalse(validationResultBuilder.build().hasError());
         verify(credentialToCloudCredentialConverter).convert(any());
         verify(azureClientService).getClient(any());
-        verify(azureExistingPrivateDnsZoneValidatorService).validate(any(), any(), any(), any(), any());
+        verify(azureExistingPrivateDnsZoneValidatorService).validate(any(), any(), any(), any(), eq(validationResultBuilder));
+    }
+
+    @Test
+    void testCheckExistingRegisteredOnlyPrivateDnsZoneWhenNoRegisteredOnlyZones() {
+        ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
+        AzureParams azureParams = getAzureParams(null, null);
+        NetworkDto networkDto = getNetworkDto(azureParams);
+        when(azureExistingPrivateDnsZonesService.hasNoExistingRegisteredOnlyZones(networkDto)).thenReturn(true);
+
+        underTest.checkExistingRegisteredOnlyPrivateDnsZone(validationResultBuilder, new EnvironmentDto(), networkDto);
+
+        assertFalse(validationResultBuilder.build().hasError());
+        verify(credentialToCloudCredentialConverter, never()).convert(any());
+        verify(azureClientService, never()).getClient(any());
+        verify(azureExistingPrivateDnsZoneValidatorService, never()).validate(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void testCheckExistingRegisteredOnlyPrivateDnsZoneWhenExistingRegisteredDnsZoneProvided() {
+        ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
+        AzureParams azureParams = getAzureParams(null, EXISTING_AKS_PRIVATE_DNS_ZONE_ID);
+        NetworkDto networkDto = getNetworkDto(azureParams);
+        when(azureExistingPrivateDnsZonesService.hasNoExistingRegisteredOnlyZones(networkDto)).thenReturn(false);
+
+        underTest.checkExistingRegisteredOnlyPrivateDnsZone(validationResultBuilder, new EnvironmentDto(), networkDto);
+
+        assertFalse(validationResultBuilder.build().hasError());
+        verify(credentialToCloudCredentialConverter).convert(any());
+        verify(azureClientService).getClient(any());
+        verify(azureExistingPrivateDnsZoneValidatorService).validate(any(), any(), any(), any(), eq(validationResultBuilder));
     }
 
     private AzureParams getAzureParams() {
-        return getAzureParams(null);
+        return getAzureParams(null, null);
     }
 
-    private AzureParams getAzureParams(String databasePrivateDnsZoneId) {
+    private AzureParams getAzureParams(String databasePrivateDnsZoneId, String aksPrivateDnsZoneId) {
         return AzureParams.builder()
                 .withNetworkId(NETWORK_ID)
                 .withResourceGroupName("networkResourceGroupName")
                 .withDatabasePrivateDnsZoneId(databasePrivateDnsZoneId)
+                .withAksPrivateDnsZoneId(aksPrivateDnsZoneId)
                 .build();
     }
 


### PR DESCRIPTION
It is possible to register an Azure AKS private DNS zone to environment service. It is not used by cloudbreak, but environment services is used as the info source on the AKS private DNS zone. The current commit introduces some basic validations for the DNS zone:
- does it name match that of the AKS
- does it exist
- is it connected to the VNET passed to the environment

Note, that Azure AKS DNS zone names, unlike that of the Postgres, are variable:
- have a region in their name
- can have a subzone That is, instead of exact name matching, now a regex matching is used.

See detailed description in the commit message.