### PR TITLE
CB-19968 add salt version check for monitoring enablement

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecorator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecorator.java
@@ -22,6 +22,7 @@ import com.sequenceiq.cloudbreak.auth.altus.model.AltusCredential;
 import com.sequenceiq.cloudbreak.auth.altus.model.CdpAccessKeyType;
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.cloud.model.StackTags;
+import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
@@ -43,6 +44,7 @@ import com.sequenceiq.cloudbreak.telemetry.monitoring.MonitoringClusterType;
 import com.sequenceiq.cloudbreak.telemetry.monitoring.MonitoringConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.monitoring.MonitoringServiceType;
 import com.sequenceiq.cloudbreak.telemetry.monitoring.MonitoringUrlResolver;
+import com.sequenceiq.cloudbreak.util.VersionComparator;
 import com.sequenceiq.cloudbreak.view.ClusterView;
 import com.sequenceiq.cloudbreak.view.StackView;
 import com.sequenceiq.common.api.telemetry.model.CdpCredential;
@@ -54,6 +56,8 @@ import com.sequenceiq.common.api.telemetry.model.VmLog;
 
 @Component
 public class TelemetryDecorator implements TelemetryContextProvider<StackDto> {
+
+    private static final String CB_VERSION_WITH_VM_AGENT_REMOVAL = "2.65.0-b62";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TelemetryDecorator.class);
 
@@ -71,12 +75,15 @@ public class TelemetryDecorator implements TelemetryContextProvider<StackDto> {
 
     private final ComponentConfigProviderService componentConfigProviderService;
 
+    private final ClusterComponentConfigProvider clusterComponentConfigProvider;
+
     public TelemetryDecorator(AltusMachineUserService altusMachineUserService,
             VmLogsService vmLogsService,
             EntitlementService entitlementService,
             DataBusEndpointProvider dataBusEndpointProvider,
             MonitoringConfiguration monitoringConfiguration,
             ComponentConfigProviderService componentConfigProviderService,
+            ClusterComponentConfigProvider clusterComponentConfigProvider,
             @Value("${info.app.version:}") String version) {
         this.altusMachineUserService = altusMachineUserService;
         this.vmLogsService = vmLogsService;
@@ -85,6 +92,7 @@ public class TelemetryDecorator implements TelemetryContextProvider<StackDto> {
         this.monitoringUrlResolver = new MonitoringUrlResolver(
                 monitoringConfiguration.getRemoteWriteUrl(), monitoringConfiguration.getPaasRemoteWriteUrl());
         this.componentConfigProviderService = componentConfigProviderService;
+        this.clusterComponentConfigProvider = clusterComponentConfigProvider;
         this.version = version;
     }
 
@@ -142,13 +150,12 @@ public class TelemetryDecorator implements TelemetryContextProvider<StackDto> {
         Telemetry telemetry = telemetryContext.getTelemetry();
         NodeStatusContext nodeStatusContext = telemetryContext.getNodeStatusContext();
         builder.withClusterType(MonitoringClusterType.CLOUDERA_MANAGER);
-        if (entitlementService.isComputeMonitoringEnabled(accountId)) {
+        if (entitlementService.isComputeMonitoringEnabled(accountId) && !isSaltComponentCbVersionBeforeVmAgentRemoved(cluster)) {
             builder.enabled();
             MonitoringCredential credential = getOrRefreshMonitoringCredential(stack, accountId, telemetry, monitoringCredential, cdpAccessKeyType);
             builder.withCredential(credential);
             MonitoringAuthConfig cmAuthConfig = null;
-            if (cluster != null && cluster.getCloudbreakClusterManagerMonitoringUser() != null
-                    && cluster.getCloudbreakClusterManagerMonitoringPassword() != null) {
+            if (cluster.getCloudbreakClusterManagerMonitoringUser() != null && cluster.getCloudbreakClusterManagerMonitoringPassword() != null) {
                 String cmMonitoringUser = cluster.getCloudbreakClusterManagerMonitoringUser();
                 char[] cmMonitoringPassword = cluster.getCloudbreakClusterManagerMonitoringPassword().toCharArray();
                 cmAuthConfig = new MonitoringAuthConfig(cmMonitoringUser, cmMonitoringPassword);
@@ -167,6 +174,21 @@ public class TelemetryDecorator implements TelemetryContextProvider<StackDto> {
         }
         builder.withSharedPassword(nodeStatusContext.getPassword());
         return builder.build();
+    }
+
+    private boolean isSaltComponentCbVersionBeforeVmAgentRemoved(ClusterView cluster) {
+        if (cluster == null) {
+            return true;
+        } else {
+            String saltCbVersion = clusterComponentConfigProvider.getSaltStateComponentCbVersion(cluster.getId());
+            if (saltCbVersion == null) {
+                return true;
+            } else {
+                VersionComparator versionComparator = new VersionComparator();
+                int compare = versionComparator.compare(() -> saltCbVersion, () -> CB_VERSION_WITH_VM_AGENT_REMOVAL);
+                return compare < 0;
+            }
+        }
     }
 
     private MeteringContext createMeteringContext(StackView stack, Telemetry telemetry) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecoratorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecoratorTest.java
@@ -25,6 +25,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.auth.altus.model.AltusCredential;
 import com.sequenceiq.cloudbreak.auth.altus.model.CdpAccessKeyType;
+import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
@@ -70,6 +71,9 @@ public class TelemetryDecoratorTest {
     private Telemetry telemetry;
 
     @Mock
+    private ClusterComponentConfigProvider clusterComponentConfigProvider;
+
+    @Mock
     private Logging logging;
 
     @Mock
@@ -79,7 +83,7 @@ public class TelemetryDecoratorTest {
     public void setUp() {
         initMocks();
         underTest = new TelemetryDecorator(altusMachineUserService, vmLogsService, entitlementService,
-                dataBusEndpointProvider, monitoringConfiguration, componentConfigProviderService, "1.0.0");
+                dataBusEndpointProvider, monitoringConfiguration, componentConfigProviderService, clusterComponentConfigProvider, "1.0.0");
     }
 
     @Test
@@ -95,6 +99,7 @@ public class TelemetryDecoratorTest {
         given(entitlementService.isComputeMonitoringEnabled(anyString())).willReturn(true);
         given(telemetry.getMonitoring()).willReturn(monitoring);
         given(monitoring.getRemoteWriteUrl()).willReturn("https://remotewrite:80/api/v1/write");
+        given(clusterComponentConfigProvider.getSaltStateComponentCbVersion(2L)).willReturn("2.65.0-b62");
         // WHEN
         TelemetryContext result = underTest.createTelemetryContext(createStack());
         // THEN
@@ -129,6 +134,7 @@ public class TelemetryDecoratorTest {
         given(entitlementService.isComputeMonitoringEnabled(anyString())).willReturn(true);
         given(telemetry.getMonitoring()).willReturn(monitoring);
         given(monitoring.getRemoteWriteUrl()).willReturn("https://remotewrite:80/api/v1/write");
+        given(clusterComponentConfigProvider.getSaltStateComponentCbVersion(2L)).willReturn("2.65.0-b62");
         // WHEN
         TelemetryContext result = underTest.createTelemetryContext(createStack());
         // THEN
@@ -137,6 +143,79 @@ public class TelemetryDecoratorTest {
         assertFalse(result.getMeteringContext().isEnabled());
         assertTrue(result.getMonitoringContext().isEnabled());
         verify(altusMachineUserService, times(1)).storeMonitoringCredential(any(Optional.class), any(Stack.class), any(CdpAccessKeyType.class));
+    }
+
+    @Test
+    public void testCreateTelemetryContextWithMonitoringOnlyAndMajorVersionChanged() {
+        // GIVEN
+        given(telemetry.isAnyDataBusBasedFeatureEnablred()).willReturn(false);
+        given(telemetry.isComputeMonitoringEnabled()).willReturn(true);
+        given(entitlementService.isComputeMonitoringEnabled(anyString())).willReturn(true);
+        given(telemetry.getMonitoring()).willReturn(monitoring);
+        given(monitoring.getRemoteWriteUrl()).willReturn("https://remotewrite:80/api/v1/write");
+        given(clusterComponentConfigProvider.getSaltStateComponentCbVersion(2L)).willReturn("3.65.0-b620000");
+        // WHEN
+        TelemetryContext result = underTest.createTelemetryContext(createStack());
+        // THEN
+        assertFalse(result.getDatabusContext().isEnabled());
+        assertFalse(result.getLogShipperContext().isEnabled());
+        assertFalse(result.getMeteringContext().isEnabled());
+        assertTrue(result.getMonitoringContext().isEnabled());
+        verify(altusMachineUserService, times(1)).storeMonitoringCredential(any(Optional.class), any(Stack.class), any(CdpAccessKeyType.class));
+    }
+
+    @Test
+    public void testMonitoringIsTurnedOffIfEntitlementIsGrantedButSaltVersionIsTooOld() {
+        // GIVEN
+        given(telemetry.isAnyDataBusBasedFeatureEnablred()).willReturn(false);
+        given(telemetry.isComputeMonitoringEnabled()).willReturn(false);
+        given(entitlementService.isComputeMonitoringEnabled(anyString())).willReturn(true);
+        given(clusterComponentConfigProvider.getSaltStateComponentCbVersion(2L)).willReturn("2.65.0-b61");
+        telemetry.setMonitoring(monitoring);
+        // WHEN
+        TelemetryContext result = underTest.createTelemetryContext(createStack());
+        // THEN
+        assertFalse(result.getDatabusContext().isEnabled());
+        assertFalse(result.getLogShipperContext().isEnabled());
+        assertFalse(result.getMeteringContext().isEnabled());
+        assertFalse(result.getMonitoringContext().isEnabled());
+        verify(altusMachineUserService, times(0)).storeMonitoringCredential(any(Optional.class), any(Stack.class), any(CdpAccessKeyType.class));
+    }
+
+    @Test
+    public void testMonitoringIsTurnedOffIfEntitlementIsGrantedButSaltVersionIsVeryOld() {
+        // GIVEN
+        given(telemetry.isAnyDataBusBasedFeatureEnablred()).willReturn(false);
+        given(telemetry.isComputeMonitoringEnabled()).willReturn(false);
+        given(entitlementService.isComputeMonitoringEnabled(anyString())).willReturn(true);
+        given(clusterComponentConfigProvider.getSaltStateComponentCbVersion(2L)).willReturn("2.21.0-b10000");
+        telemetry.setMonitoring(monitoring);
+        // WHEN
+        TelemetryContext result = underTest.createTelemetryContext(createStack());
+        // THEN
+        assertFalse(result.getDatabusContext().isEnabled());
+        assertFalse(result.getLogShipperContext().isEnabled());
+        assertFalse(result.getMeteringContext().isEnabled());
+        assertFalse(result.getMonitoringContext().isEnabled());
+        verify(altusMachineUserService, times(0)).storeMonitoringCredential(any(Optional.class), any(Stack.class), any(CdpAccessKeyType.class));
+    }
+
+    @Test
+    public void testMonitoringIsTurnedOffIfEntitlementIsGrantedButSaltVersionIsUnkown() {
+        // GIVEN
+        given(telemetry.isAnyDataBusBasedFeatureEnablred()).willReturn(false);
+        given(telemetry.isComputeMonitoringEnabled()).willReturn(false);
+        given(entitlementService.isComputeMonitoringEnabled(anyString())).willReturn(true);
+        given(clusterComponentConfigProvider.getSaltStateComponentCbVersion(2L)).willReturn(null);
+        telemetry.setMonitoring(monitoring);
+        // WHEN
+        TelemetryContext result = underTest.createTelemetryContext(createStack());
+        // THEN
+        assertFalse(result.getDatabusContext().isEnabled());
+        assertFalse(result.getLogShipperContext().isEnabled());
+        assertFalse(result.getMeteringContext().isEnabled());
+        assertFalse(result.getMonitoringContext().isEnabled());
+        verify(altusMachineUserService, times(0)).storeMonitoringCredential(any(Optional.class), any(Stack.class), any(CdpAccessKeyType.class));
     }
 
     @Test
@@ -202,6 +281,7 @@ public class TelemetryDecoratorTest {
         stack.setCloudPlatform("AWS");
         stack.setId(1L);
         Cluster cluster = new Cluster();
+        cluster.setId(2L);
         cluster.setName("cl1");
         cluster.setCloudbreakClusterManagerMonitoringUser("myUsr");
         cluster.setCloudbreakClusterManagerMonitoringPassword("myPass");


### PR DESCRIPTION
We tested with 2.65.0-b62 salt version, so we only trust this version and we can make sure this version properly works. https://github.com/hortonworks/cloudbreak/commit/df926b9417a6f32ef00e6565002dc51d0cc7b917