### PR TITLE
[CDPSDX-3334] Allow backup/restore for GCP. 

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -1024,9 +1024,6 @@ public class SdxService implements ResourceIdProvider, PayloadContextProvider, H
                 .ifPresent(existedSdx -> {
                     throw new BadRequestException("SDX which is detached already exists for the environment. SDX name: " + existedSdx.getClusterName());
                 });
-        if (sdxCluster.getCloudStorageFileSystemType() != null && sdxCluster.getCloudStorageFileSystemType().isGcs()) {
-            throw new BadRequestException("Unsupported cloud provider GCP. SDX name: " + sdxCluster.getClusterName());
-        }
     }
 
     private void validateRuntimeAndImage(SdxClusterRequest clusterRequest, DetailedEnvironmentResponse environment,

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/dr/SdxBackupRestoreService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/dr/SdxBackupRestoreService.java
@@ -557,43 +557,32 @@ public class SdxBackupRestoreService {
      * @param entitlementEnabled Whether the entitlement required for backups with this operation is enabled.
      * @return true if backup can be performed, False otherwise.
      */
-    @SuppressWarnings("checkstyle:NPathComplexity")
     public boolean shouldSdxBackupBePerformed(SdxCluster cluster, boolean entitlementEnabled) {
         String reason = null;
         if (!entitlementEnabled) {
-            LOGGER.info("Backup not triggered. Reason: Required entitlement for backup during this operation not enabled for this account");
-            return false;
-        }
-        if (!datalakeDrConfig.isConfigured()) {
-            LOGGER.info("Backup not triggered. Reason: Datalake DR is not configured!");
-            return false;
-        }
+            reason = "Required entitlement for backup during this operation not enabled for this account.";
+        } else if (!datalakeDrConfig.isConfigured()) {
+            reason = "Datalake DR is not configured!";
+        } else {
+            DetailedEnvironmentResponse environmentResponse = environmentClientService.getByName(cluster.getEnvName());
+            CloudPlatform cloudPlatform = CloudPlatform.valueOf(environmentResponse.getCloudPlatform());
+            if (CloudPlatform.MOCK.equalsIgnoreCase(cloudPlatform.name())) {
+                return true;
+            }
 
-        DetailedEnvironmentResponse environmentResponse = environmentClientService.getByName(cluster.getEnvName());
-        CloudPlatform cloudPlatform = CloudPlatform.valueOf(environmentResponse.getCloudPlatform());
-        if (CloudPlatform.MOCK.equalsIgnoreCase(cloudPlatform.name())) {
-            LOGGER.info("Backup triggered on MOCK cloud platform");
-            return true;
+            if (isVersionOlderThan(cluster, "7.2.1")) {
+                reason = "Unsupported runtime: " + cluster.getRuntime();
+            } else if (cluster.getCloudStorageFileSystemType() == null) {
+                reason = "Cloud storage not initialized";
+            } else if (cluster.getCloudStorageFileSystemType().isAdlsGen2() &&
+                    isVersionOlderThan(cluster, "7.2.2")) {
+                reason = "Unsupported cloud provider Azure on runtime: " + cluster.getRuntime();
+            }
         }
-
-        if (isVersionOlderThan(cluster, "7.2.1")) {
-            LOGGER.info("Backup not triggered. Reason: Unsupported runtime {}", cluster.getRuntime());
+        if (reason != null) {
+            LOGGER.info("Backup not triggered. Reason: " + reason);
             return false;
         }
-        if (cluster.getCloudStorageFileSystemType() == null) {
-            LOGGER.info("Backup not triggered. Reason: Cloud storage not initialized");
-            return false;
-        }
-        if (cluster.getCloudStorageFileSystemType().isAdlsGen2() && isVersionOlderThan(cluster, "7.2.2")) {
-            LOGGER.info("Backup not triggered. Reason: Unsupported cloud provider Azure on runtime:  {}", cluster.getRuntime());
-            return false;
-        }
-
-        if (cluster.getCloudStorageFileSystemType().isGcs() && isVersionOlderThan(cluster, "7.2.15")) {
-            LOGGER.info("Backup not triggered. Reason: Unsupported cloud provider GCP on runtime:  {}", cluster.getRuntime());
-            return false;
-        }
-
         return true;
     }
 


### PR DESCRIPTION
Remove check which prevents backup/restore on GCP while doing upgrade and resize flows.
# Motivation
Backup/restore were not fully supported previously on GCP so flows exclude backup step for it. Now we have GCP backup/restore working and tested for a long time we can enable this functionality as part of the flow.

# Testing
## Upgrade.
- set the `auth.mock.datalake.backup.on.upgrade.enable` property to `true` (default is `false`) in mock-thunderhead application.yaml file.
- start mock-thunderhead with this properties
- create a GCP environment with datalake version 7.2.15
- upgrade the environment to 7.2.16
- check backup has been created as part of the flow

## Resize
- set the `auth.mock.datalake.backup.on.resize.enable` property to `true` (default is `false`) in mock-thunderhead application.yaml file.
- start mock-thunderhead with this properties
- create a GCP environment with Light Duty datalake
- resize the environment (to Medium Duty)
- check backup has been created as part of the flow