### PR TITLE
CB-19889 Each test case should have own Cloud Storage Base Location

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/AbstractCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/AbstractCloudProvider.java
@@ -12,6 +12,7 @@ import javax.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.BaseImageV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImageV4Response;
@@ -58,6 +59,8 @@ public abstract class AbstractCloudProvider implements CloudProvider {
             + "UEeab6CB4MUzsqF7vGTFUjwWirG/XU5pYXFUBhi8xzey+KS9KVrQ+UuKJh/AN9iSQeMV+rgT1yF5+etVH+bK1/37QCKp3+mCqjFzPyQOrvkGZv4sYyRwX7BKBLleQmIVWpofpj"
             + "T7BfcCxH877RzC5YMIi65aBc82Dl6tH6OEiP7mzByU52yvH6JFuwZ/9fWj1vXCWJzxx2w0F1OU8Zwg8gNNzL+SVb9+xfBE7xBHMpYFg72hBWPh862Ce36F4NZd3MpWMSjMmpDPh"
             + " centos";
+
+    private static final int OBJECT_NAME_MAX_LENGTH = 63;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractCloudProvider.class);
 
@@ -371,5 +374,31 @@ public abstract class AbstractCloudProvider implements CloudProvider {
     @Override
     public EnvironmentNetworkTestDto newNetwork(EnvironmentNetworkTestDto network) {
         return network;
+    }
+
+    protected String getSuiteName() {
+        String suiteName = trimObjectName(getTestLabels()[0]);
+        if (StringUtils.isBlank(suiteName)) {
+            throw new IllegalArgumentException("Cloud Storage base location path cannot be generated, because of the Test Suite Name is null or empty!");
+        } else {
+            return suiteName;
+        }
+    }
+
+    protected String getTestName() {
+        String testName = trimObjectName(getTestLabels()[1]);
+        if (StringUtils.isBlank(testName)) {
+            throw new IllegalArgumentException("Cloud Storage base location path cannot be generated, because of the Test Name is null or empty!");
+        } else {
+            return testName;
+        }
+    }
+
+    protected String[] getTestLabels() {
+        return StringUtils.split(StringUtils.lowerCase(MDC.get("testlabel")), ".");
+    }
+
+    protected String trimObjectName(String name) {
+        return (name.length() > OBJECT_NAME_MAX_LENGTH) ? name.substring(0, OBJECT_NAME_MAX_LENGTH) : name;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProvider.java
@@ -381,7 +381,8 @@ public class AwsCloudProvider extends AbstractCloudProvider {
 
     @Override
     public String getBaseLocation() {
-        return String.join("/", awsProperties.getCloudStorage().getBaseLocation(), DEFAULT_STORAGE_NAME);
+        return String.join("/", awsProperties.getCloudStorage().getBaseLocation(), trimObjectName(DEFAULT_STORAGE_NAME),
+                getSuiteName(), getTestName());
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
@@ -380,7 +380,8 @@ public class AzureCloudProvider extends AbstractCloudProvider {
 
     @Override
     public String getBaseLocation() {
-        return String.join("/", azureProperties.getCloudStorage().getBaseLocation(), DEFAULT_STORAGE_NAME);
+        return String.join("/", azureProperties.getCloudStorage().getBaseLocation(), trimObjectName(DEFAULT_STORAGE_NAME),
+                getSuiteName(), getTestName());
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpCloudProvider.java
@@ -430,7 +430,8 @@ public class GcpCloudProvider extends AbstractCloudProvider {
 
     @Override
     public String getBaseLocation() {
-        return String.join("/", gcpProperties.getCloudStorage().getBaseLocation(), DEFAULT_STORAGE_NAME);
+        return String.join("/", gcpProperties.getCloudStorage().getBaseLocation(), trimObjectName(DEFAULT_STORAGE_NAME),
+                getSuiteName(), getTestName());
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/mock/MockCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/mock/MockCloudProvider.java
@@ -426,7 +426,8 @@ public class MockCloudProvider extends AbstractCloudProvider {
 
     @Override
     public String getBaseLocation() {
-        return String.join("/", mockProperties.getCloudStorage().getBaseLocation(), DEFAULT_STORAGE_NAME);
+        return String.join("/", mockProperties.getCloudStorage().getBaseLocation(), trimObjectName(DEFAULT_STORAGE_NAME),
+                getSuiteName(), getTestName());
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazons3/action/S3ClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazons3/action/S3ClientActions.java
@@ -3,6 +3,7 @@ package com.sequenceiq.it.cloudbreak.util.aws.amazons3.action;
 import static java.lang.String.format;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -14,7 +15,6 @@ import org.springframework.stereotype.Component;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3URI;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest.KeyVersion;
 import com.amazonaws.services.s3.model.ListObjectsRequest;
@@ -33,14 +33,14 @@ public class S3ClientActions extends S3Client {
 
     public void deleteNonVersionedBucket(String baseLocation) {
         AmazonS3 s3Client = buildS3Client();
-        String bucketName = getBucketName();
-        String prefix = StringUtils.substringAfterLast(baseLocation, "/");
+        String bucketName = getBucketName(baseLocation);
+        String keyPrefix = getKeyPrefix(baseLocation);
 
         if (s3Client.doesBucketExistV2(bucketName)) {
             try {
                 ListObjectsRequest listObjectsRequest = new ListObjectsRequest()
                         .withBucketName(bucketName)
-                        .withPrefix(prefix);
+                        .withPrefix(keyPrefix);
                 ObjectListing objectListing = s3Client.listObjects(listObjectsRequest);
 
                 do {
@@ -72,16 +72,15 @@ public class S3ClientActions extends S3Client {
 
     public void listBucketSelectedObject(String baseLocation, String selectedObject, boolean zeroContent) {
         AmazonS3 s3Client = buildS3Client();
-        String bucketName = getBucketName();
-        AmazonS3URI amazonS3URI = new AmazonS3URI(getBaseLocationUri());
+        String bucketName = getBucketName(baseLocation);
+        String keyPrefix = getKeyPrefix(baseLocation);
         List<S3ObjectSummary> filteredObjectSummaries;
-        String keyPrefix = StringUtils.substringAfterLast(baseLocation, "/");
 
         if (StringUtils.isEmpty(selectedObject)) {
             selectedObject = "ranger";
         }
 
-        Log.log(LOGGER, format(" Amazon S3 URI: %s", amazonS3URI));
+        Log.log(LOGGER, format(" Amazon S3 URI: %s", getBaseLocationUri(baseLocation)));
         Log.log(LOGGER, format(" Amazon S3 Bucket: %s", bucketName));
         Log.log(LOGGER, format(" Amazon S3 Key Prefix: %s", keyPrefix));
         Log.log(LOGGER, format(" Amazon S3 Object: %s", selectedObject));
@@ -143,36 +142,20 @@ public class S3ClientActions extends S3Client {
     }
 
     public String getLoggingUrl(String baseLocation, String clusterLogPath) {
-        AmazonS3 s3Client = buildS3Client();
-        AmazonS3URI amazonS3URI = new AmazonS3URI(getBaseLocationUri());
-        String bucketName = amazonS3URI.getBucket();
-        String keyPrefix = StringUtils.substringAfterLast(baseLocation, "/");
+        URI baseLocationUri = getBaseLocationUri(baseLocation);
+        String bucketName = getBucketName(baseLocation);
+        String logPath = baseLocationUri.getPath();
+        String deploymentS3Console = "https://s3.console.aws.amazon.com/s3/buckets/";
 
-        Log.log(LOGGER, format(" Amazon S3 URI: %s", amazonS3URI));
+        Log.log(LOGGER, format(" Amazon S3 URI: %s", baseLocationUri));
         Log.log(LOGGER, format(" Amazon S3 Bucket: %s", bucketName));
-        Log.log(LOGGER, format(" Amazon S3 Key Prefix: %s",  keyPrefix));
+        Log.log(LOGGER, format(" Amazon S3 Log Path: %s",  logPath));
         Log.log(LOGGER, format(" Amazon S3 Cluster Logs: %s", clusterLogPath));
 
-        if (s3Client.doesBucketExistV2(bucketName)) {
-            try {
-                String deploymentS3Console = "https://s3.console.aws.amazon.com/s3/buckets/";
-                if (StringUtils.containsIgnoreCase(amazonS3URI.getRegion(), "us-gov")) {
-                    deploymentS3Console = "https://console.amazonaws-us-gov.com/s3/buckets/";
-                }
-                return format("%s%s?region=%s&prefix=%s%s/&showversions=false",
-                        deploymentS3Console, bucketName, amazonS3URI.getRegion(), keyPrefix, clusterLogPath);
-            } catch (AmazonServiceException e) {
-                LOGGER.error("Amazon S3 couldn't process the call. So it has been returned with error!", e);
-                throw new TestFailException("Amazon S3 couldn't process the call.", e);
-            } catch (SdkClientException e) {
-                LOGGER.error("Amazon S3 response could not been parsed, because of error!", e);
-                throw new TestFailException("Amazon S3 response could not been parsed", e);
-            } finally {
-                s3Client.shutdown();
-            }
-        } else {
-            LOGGER.error("Amazon S3 bucket is NOT present with name: {}", bucketName);
-            throw new TestFailException("Amazon S3 bucket is NOT present with name: " + bucketName);
+        if (StringUtils.containsIgnoreCase(getAwsProperties().getRegion(), "us-gov")) {
+            deploymentS3Console = "https://console.amazonaws-us-gov.com/s3/buckets/";
         }
+        return format("%s%s?region=%s&prefix=%s%s/&showversions=false",
+                deploymentS3Console, bucketName, getAwsProperties().getRegion(), getKeyPrefix(baseLocation), clusterLogPath);
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/action/GcpClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/action/GcpClientActions.java
@@ -5,7 +5,6 @@ import static java.lang.String.format;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -277,21 +276,27 @@ public class GcpClientActions extends GcpClient {
         }
     }
 
+    public String getBucketName(String baseLocation) {
+        URI baseLocationUri = getBaseLocationUri(baseLocation);
+        return baseLocationUri.getHost();
+    }
+
+    public String getKeyPrefix(String baseLocation) {
+        URI baseLocationUri = getBaseLocationUri(baseLocation);
+        return StringUtils.removeStart(baseLocationUri.getPath(), "/");
+    }
+
     public void listBucketSelectedObject(String baseLocation, boolean zeroContent) {
         Storage storage = buildStorage();
         URI baseLocationUri = getBaseLocationUri(baseLocation);
-        String bucketName = baseLocationUri.getHost();
-        String selectedObjectPath = baseLocationUri.getPath();
-        String keyPrefix = Arrays.stream(StringUtils.split(baseLocationUri.getPath(), "/"))
-                .filter(StringUtils::isNotEmpty)
-                .collect(Collectors.toList()).get(0);
+        String bucketName = getBucketName(baseLocation);
+        String keyPrefix = getKeyPrefix(baseLocation);
         Page<Blob> blobs;
         List<Blob> filteredBlobs = new ArrayList<>();
 
         Log.log(LOGGER, format(" Google GCS URI: %s", baseLocationUri));
         Log.log(LOGGER, format(" Google GCS Bucket: %s", bucketName));
         Log.log(LOGGER, format(" Google GCS Key Prefix: %s", keyPrefix));
-        Log.log(LOGGER, format(" Google GCS Object: %s", selectedObjectPath));
 
         try {
             /**
@@ -322,15 +327,15 @@ public class GcpClientActions extends GcpClient {
             throw new TestFailException(format(" Google GCS path: '%s' does not exist! ", keyPrefix));
         } else {
             for (Blob blob : blobs.iterateAll()) {
-                if (StringUtils.remove(blob.getName(), "/").contains(StringUtils.remove(selectedObjectPath, "/"))) {
+                if (StringUtils.remove(blob.getName(), "/").contains(StringUtils.remove(keyPrefix, "/"))) {
                     filteredBlobs.add(blob);
                 }
             }
             if (CollectionUtils.isEmpty(filteredBlobs)) {
-                Log.error(LOGGER, "Google GCS object: %s has 0 sub-objects!", selectedObjectPath);
-                throw new TestFailException(format("Google GCS object: %s has 0 sub-objects!", selectedObjectPath));
+                Log.error(LOGGER, "Google GCS object: %s has 0 sub-objects!", keyPrefix);
+                throw new TestFailException(format("Google GCS object: %s has 0 sub-objects!", keyPrefix));
             } else {
-                Log.log(LOGGER, format(" Google GCS object: '%s' contains '%d' sub-objects.", selectedObjectPath, filteredBlobs.size()));
+                Log.log(LOGGER, format(" Google GCS object: '%s' contains '%d' sub-objects.", keyPrefix, filteredBlobs.size()));
                 for (Blob filteredBlob : filteredBlobs.stream().limit(10).collect(Collectors.toList())) {
                     if (filteredBlob.getSize().compareTo(0L) == 0 && !zeroContent) {
                         /**
@@ -340,10 +345,10 @@ public class GcpClientActions extends GcpClient {
                          * - BlobInfo.isDirectory() returns true
                          */
                         if (filteredBlob.isDirectory()) {
-                            LOGGER.warn("Google GCS path: '{}' has 0 bytes of content!", selectedObjectPath);
+                            LOGGER.warn("Google GCS path: '{}' has 0 bytes of content!", keyPrefix);
                         } else {
-                            LOGGER.error("Google GCS path: '{}' has 0 bytes of content!", selectedObjectPath);
-                            throw new TestFailException(format("Google GCS path: '%s' has 0 bytes of content!", selectedObjectPath));
+                            LOGGER.error("Google GCS path: '{}' has 0 bytes of content!", keyPrefix);
+                            throw new TestFailException(format("Google GCS path: '%s' has 0 bytes of content!", keyPrefix));
                         }
                     }
                 }
@@ -354,17 +359,13 @@ public class GcpClientActions extends GcpClient {
     public void deleteNonVersionedBucket(String baseLocation) {
         Storage storage = buildStorage();
         URI baseLocationUri = getBaseLocationUri(baseLocation);
-        String bucketName = baseLocationUri.getHost();
-        String selectedObjectPath = baseLocationUri.getPath();
-        String keyPrefix = Arrays.stream(StringUtils.split(selectedObjectPath, "/"))
-                .filter(StringUtils::isNotEmpty)
-                .collect(Collectors.toList()).get(0);
+        String bucketName = getBucketName(baseLocation);
+        String keyPrefix = getKeyPrefix(baseLocation);
         Blob blob;
 
         Log.log(LOGGER, format(" Google GCS URI: %s", baseLocationUri));
         Log.log(LOGGER, format(" Google GCS Bucket: %s", bucketName));
         Log.log(LOGGER, format(" Google GCS Key Prefix: %s", keyPrefix));
-        Log.log(LOGGER, format(" Google GCS Object: %s", selectedObjectPath));
 
         try {
             blob = storage.get(bucketName, keyPrefix);
@@ -388,11 +389,15 @@ public class GcpClientActions extends GcpClient {
 
     public String getLoggingUrl(String baseLocation, String clusterLogPath) {
         URI baseLocationUri = getBaseLocationUri(baseLocation);
-        String bucketName = baseLocationUri.getHost();
-        String keyPrefix = Arrays.stream(StringUtils.split(baseLocationUri.getPath(), "/"))
-                .filter(StringUtils::isNotEmpty)
-                .collect(Collectors.toList()).get(0);
+        String bucketName = getBucketName(baseLocation);
+        String logPath = baseLocationUri.getPath();
+
+        Log.log(LOGGER, format(" Google GCS URI: %s", baseLocationUri));
+        Log.log(LOGGER, format(" Google GCS Bucket: %s", bucketName));
+        Log.log(LOGGER, format(" Google GCS Log Path: %s", logPath));
+        Log.log(LOGGER, format(" Google GCS Cluster Logs: %s", clusterLogPath));
+
         return format("https://console.cloud.google.com/storage/browser/%s/%s%s?project=gcp-dev-cloudbreak",
-                    bucketName, keyPrefix, clusterLogPath);
+                bucketName, getKeyPrefix(baseLocation), clusterLogPath);
     }
 }


### PR DESCRIPTION
Audit dir creation sometimes flaky. The cause can be the same storage location for audit logs for all the test resources even if the test class contains more than one test cases.