### PR TITLE
CB-19909 Update CM IP in cluster object if it has changed

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterServiceRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterServiceRunner.java
@@ -51,7 +51,7 @@ public class ClusterServiceRunner {
     @Inject
     private GatewayService gatewayService;
 
-    public void runAmbariServices(StackDto stackDto) {
+    public void runClusterManagerServices(StackDto stackDto) {
         ClusterView cluster = stackDto.getCluster();
 
         generateGatewaySignKeys(stackDto.getGateway());
@@ -70,10 +70,13 @@ public class ClusterServiceRunner {
         }
     }
 
-    public String updateAmbariClientConfig(StackDto stackDto) {
+    public String updateClusterManagerClientConfig(StackDto stackDto) {
         String gatewayIp = gatewayConfigService.getPrimaryGatewayIp(stackDto);
-        HttpClientConfig ambariClientConfig = buildAmbariClientConfig(stackDto.getStack(), gatewayIp);
-        clusterService.updateAmbariClientConfig(stackDto.getCluster().getId(), ambariClientConfig);
+        if (!gatewayIp.equals(stackDto.getClusterManagerIp())) {
+            LOGGER.debug("Cluster manager IP has changed from {} to {}, updating cluster metadata.", stackDto.getClusterManagerIp(), gatewayIp);
+            HttpClientConfig clusterManagerClientConfig = buildClusterManagerClientConfig(stackDto.getStack(), gatewayIp);
+            clusterService.updateClusterManagerClientConfig(stackDto.getCluster().getId(), clusterManagerClientConfig);
+        }
         return gatewayIp;
     }
 
@@ -97,7 +100,7 @@ public class ClusterServiceRunner {
         return hostRunner.changePrimaryGateway(stackDto);
     }
 
-    private HttpClientConfig buildAmbariClientConfig(StackView stack, String gatewayPublicIp) {
+    private HttpClientConfig buildClusterManagerClientConfig(StackView stack, String gatewayPublicIp) {
         return tlsSecurityService.buildTLSClientConfigForPrimaryGateway(stack.getId(), gatewayPublicIp, stack.getCloudPlatform());
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpscaleService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpscaleService.java
@@ -67,7 +67,7 @@ public class ClusterManagerUpscaleService {
         NodeReachabilityResult nodeReachabilityResult = hostRunner.addClusterServices(stackDto, hostGroupWithAdjustment, repair);
         String clusterManagerIp = stackDto.getClusterManagerIp();
         if (primaryGatewayChanged) {
-            clusterManagerIp = clusterServiceRunner.updateAmbariClientConfig(stackDto);
+            clusterManagerIp = clusterServiceRunner.updateClusterManagerClientConfig(stackDto);
         }
         clusterService.updateInstancesToRunning(stackId, nodeReachabilityResult.getReachableNodes());
         clusterService.updateInstancesToZombie(stackId, nodeReachabilityResult.getUnreachableNodes());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/orchestration/StartAmbariServicesHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/orchestration/StartAmbariServicesHandler.java
@@ -47,11 +47,8 @@ public class StartAmbariServicesHandler implements EventHandler<StartAmbariServi
         Selectable response;
         try {
             StackDto stack = stackDtoService.getById(stackId);
-            String clusterManagerIp = stack.getClusterManagerIp();
-            if (clusterManagerIp == null) {
-                clusterManagerIp = clusterServiceRunner.updateAmbariClientConfig(stack);
-            }
-            clusterServiceRunner.runAmbariServices(stack);
+            String clusterManagerIp = clusterServiceRunner.updateClusterManagerClientConfig(stack);
+            clusterServiceRunner.runClusterManagerServices(stack);
             clusterApiConnectors.getConnector(stack, clusterManagerIp).waitForServer(request.isDefaultClusterManagerAuth());
             response = new StartClusterManagerServicesSuccess(stackId);
         } catch (Exception e) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterService.java
@@ -199,11 +199,11 @@ public class ClusterService {
         return repository.findOneByStackId(stackId);
     }
 
-    public Cluster updateAmbariClientConfig(Long clusterId, HttpClientConfig ambariClientConfig) {
+    public Cluster updateClusterManagerClientConfig(Long clusterId, HttpClientConfig clusterManagerClientConfig) {
         Cluster cluster = getCluster(clusterId);
-        cluster.setClusterManagerIp(ambariClientConfig.getApiAddress());
+        cluster.setClusterManagerIp(clusterManagerClientConfig.getApiAddress());
         cluster = repository.save(cluster);
-        LOGGER.info("Updated cluster: [ambariIp: '{}'].", ambariClientConfig.getApiAddress());
+        LOGGER.info("Updated cluster: [clusterManagerIp: '{}'].", clusterManagerClientConfig.getApiAddress());
         return cluster;
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterServiceRunnerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterServiceRunnerTest.java
@@ -1,10 +1,13 @@
 package com.sequenceiq.cloudbreak.core.bootstrap.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Assertions;
@@ -14,20 +17,25 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.sequenceiq.cloudbreak.client.HttpClientConfig;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.ClusterHostServiceRunner;
-import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.service.GatewayConfigService;
+import com.sequenceiq.cloudbreak.service.TlsSecurityService;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
+import com.sequenceiq.cloudbreak.view.ClusterView;
+import com.sequenceiq.cloudbreak.view.StackView;
 
 @ExtendWith(MockitoExtension.class)
 class ClusterServiceRunnerTest {
 
-    @Mock
-    private StackDto stackDto;
+    private static final String IP_1 = "1.2.3.4";
+
+    private static final String IP_2 = "4.3.2.1";
 
     @Mock
-    private Cluster cluster;
+    private StackDto stackDto;
 
     @Mock
     private StackDtoService stackDtoService;
@@ -37,6 +45,12 @@ class ClusterServiceRunnerTest {
 
     @Mock
     private ClusterHostServiceRunner hostRunner;
+
+    @Mock
+    private GatewayConfigService gatewayConfigService;
+
+    @Mock
+    private TlsSecurityService tlsSecurityService;
 
     @InjectMocks
     private ClusterServiceRunner underTest;
@@ -70,5 +84,38 @@ class ClusterServiceRunnerTest {
         when(stackDtoService.getById(anyLong())).thenReturn(stackDto);
         underTest.redeployStates(1L);
         verify(hostRunner).redeployStates(stackDto);
+    }
+
+    @Test
+    void testUpdateAmbariClientConfigIpNotChanged() {
+        when(gatewayConfigService.getPrimaryGatewayIp(stackDto)).thenReturn(IP_1);
+        when(stackDto.getClusterManagerIp()).thenReturn(IP_1);
+
+        String result = underTest.updateClusterManagerClientConfig(stackDto);
+
+        assertEquals(IP_1, result);
+        verifyNoInteractions(tlsSecurityService);
+        verifyNoInteractions(clusterService);
+    }
+
+    @Test
+    void testUpdateAmbariClientConfigIpChanged() {
+        when(gatewayConfigService.getPrimaryGatewayIp(stackDto)).thenReturn(IP_2);
+        when(stackDto.getClusterManagerIp()).thenReturn(IP_1);
+        StackView stack = mock(StackView.class);
+        when(stackDto.getStack()).thenReturn(stack);
+        when(stack.getId()).thenReturn(42L);
+        when(stack.getCloudPlatform()).thenReturn("platform");
+        HttpClientConfig config = mock(HttpClientConfig.class);
+        when(tlsSecurityService.buildTLSClientConfigForPrimaryGateway(42L, IP_2, "platform")).thenReturn(config);
+        ClusterView cluster = mock(ClusterView.class);
+        when(stackDto.getCluster()).thenReturn(cluster);
+        when(cluster.getId()).thenReturn(24L);
+
+        String result = underTest.updateClusterManagerClientConfig(stackDto);
+
+        assertEquals(IP_2, result);
+        verify(tlsSecurityService).buildTLSClientConfigForPrimaryGateway(42L, IP_2, "platform");
+        verify(clusterService).updateClusterManagerClientConfig(24L, config);
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpscaleServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpscaleServiceTest.java
@@ -84,7 +84,7 @@ public class ClusterManagerUpscaleServiceTest {
         when(clusterHostServiceRunner.addClusterServices(eq(stackDto), any(), anyBoolean()))
                 .thenReturn(new NodeReachabilityResult(Set.of(), Set.of()));
         doNothing().when(clusterService).updateInstancesToRunning(eq(STACK_ID), any());
-        when(clusterServiceRunner.updateAmbariClientConfig(eq(stackDto))).thenReturn("clusterIp");
+        when(clusterServiceRunner.updateClusterManagerClientConfig(eq(stackDto))).thenReturn("clusterIp");
         when(clusterApiConnectors.getConnector(eq(stackDto), eq("clusterIp"))).thenReturn(clusterApi);
 
         underTest.upscaleClusterManager(STACK_ID, Collections.singletonMap("hg", 1), true, false);


### PR DESCRIPTION
When doing upgrade recovery it can happen that the CM master node gets a new IP address and when starting to check the CM server startup via CM API the old IP is used for calling the API. This change maked sure that the metadata in cluster that contains the CM server IP is updated upon IP change.

See detailed description in the commit message.