### PR TITLE
CB-19623 - Add option to disable outbound load balancer creation

### DIFF
--- a/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
@@ -148,6 +148,9 @@ public class EnvironmentModelDescription {
     public static final String ENVIRONMENT_DOMAIN_NAME = "The domain name that's has been generated for the environment.";
 
     public static final String AWS_DISK_ENCRYPTION_PARAMETERS = "AWS Disk encryption parameters";
+
+    public static final String NO_OUTBOUND_LOAD_BALANCER = "Flag that marks the request to not create an outbound load balancer";
+
     private EnvironmentModelDescription() {
     }
 }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/azure/AzureEnvironmentParameters.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/azure/AzureEnvironmentParameters.java
@@ -22,6 +22,9 @@ public class AzureEnvironmentParameters implements Serializable {
     @ApiModelProperty(EnvironmentModelDescription.RESOURCE_ENCRYPTION_PARAMETERS)
     private AzureResourceEncryptionParameters resourceEncryptionParameters;
 
+    @ApiModelProperty(EnvironmentModelDescription.NO_OUTBOUND_LOAD_BALANCER)
+    private boolean noOutboundLoadBalancer;
+
     public AzureResourceGroup getResourceGroup() {
         return resourceGroup;
     }
@@ -38,11 +41,20 @@ public class AzureEnvironmentParameters implements Serializable {
         this.resourceEncryptionParameters = resourceEncryptionParameters;
     }
 
+    public boolean isNoOutboundLoadBalancer() {
+        return noOutboundLoadBalancer;
+    }
+
+    public void setNoOutboundLoadBalancer(boolean noOutboundLoadBalancer) {
+        this.noOutboundLoadBalancer = noOutboundLoadBalancer;
+    }
+
     @Override
     public String toString() {
         return "AzureEnvironmentParameters{" +
                 "resourceGroup=" + resourceGroup +
                 ", resourceEncryptionParameters=" + resourceEncryptionParameters +
+                ", noOutboundLoadBalancer=" + noOutboundLoadBalancer +
                 '}';
     }
 
@@ -55,6 +67,8 @@ public class AzureEnvironmentParameters implements Serializable {
         private AzureResourceGroup azureResourceGroup;
 
         private AzureResourceEncryptionParameters resourceEncryptionParameters;
+
+        private boolean noOutboundLoadBalancer;
 
         private Builder() {
         }
@@ -69,10 +83,16 @@ public class AzureEnvironmentParameters implements Serializable {
             return this;
         }
 
+        public Builder withNoOutboundLoadBalancer(boolean noOutboundLoadBalancer) {
+            this.noOutboundLoadBalancer = noOutboundLoadBalancer;
+            return this;
+        }
+
         public AzureEnvironmentParameters build() {
             AzureEnvironmentParameters azureEnvironmentParameters = new AzureEnvironmentParameters();
             azureEnvironmentParameters.setResourceGroup(azureResourceGroup);
             azureEnvironmentParameters.setResourceEncryptionParameters(resourceEncryptionParameters);
+            azureEnvironmentParameters.setNoOutboundLoadBalancer(noOutboundLoadBalancer);
             return azureEnvironmentParameters;
         }
     }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverter.java
@@ -262,6 +262,10 @@ public class EnvironmentApiConverter {
                                 .map(this::azureResourceEncryptionParametersToAzureEncryptionParametersDto)
                                 .orElse(null)
                 )
+                .withNoOutboundLoadBalancer(
+                        Optional.ofNullable(azureEnvironmentParameters)
+                                .map(AzureEnvironmentParameters::isNoOutboundLoadBalancer)
+                                .orElse(false))
                 .build();
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverter.java
@@ -255,6 +255,9 @@ public class EnvironmentResponseConverter {
         return AzureEnvironmentParameters.builder()
                 .withAzureResourceGroup(getIfNotNull(resourceGroupDto, this::azureParametersToAzureResourceGroup))
                 .withResourceEncryptionParameters(getIfNotNull(resourceEncryptionParametersDto, this::azureParametersToAzureResourceEncryptionParameters))
+                .withNoOutboundLoadBalancer(Optional.ofNullable(parameters.getAzureParametersDto())
+                                                    .map(AzureParametersDto::isNoOutboundLoadBalancer)
+                                                    .orElse(false))
                 .build();
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/parameters/dao/domain/AzureParameters.java
+++ b/environment/src/main/java/com/sequenceiq/environment/parameters/dao/domain/AzureParameters.java
@@ -43,6 +43,9 @@ public class AzureParameters extends BaseParameters implements AccountIdAwareRes
     @Column(name = "encryption_key_resource_group_name")
     private String encryptionKeyResourceGroupName;
 
+    @Column(name = "no_outbound_load_balancer")
+    private boolean noOutboundLoadBalancer;
+
     public String getResourceGroupName() {
         return resourceGroupName;
     }
@@ -94,5 +97,13 @@ public class AzureParameters extends BaseParameters implements AccountIdAwareRes
 
     public void setEncryptionKeyResourceGroupName(String encryptionKeyResourceGroupName) {
         this.encryptionKeyResourceGroupName = encryptionKeyResourceGroupName;
+    }
+
+    public boolean isNoOutboundLoadBalancer() {
+        return noOutboundLoadBalancer;
+    }
+
+    public void setNoOutboundLoadBalancer(boolean noOutboundLoadBalancer) {
+        this.noOutboundLoadBalancer = noOutboundLoadBalancer;
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/parameters/v1/converter/AzureEnvironmentParametersConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/parameters/v1/converter/AzureEnvironmentParametersConverter.java
@@ -52,6 +52,9 @@ public class AzureEnvironmentParametersConverter extends BaseEnvironmentParamete
                 .map(AzureParametersDto::getAzureResourceEncryptionParametersDto)
                 .map(AzureResourceEncryptionParametersDto::getEncryptionKeyResourceGroupName)
                 .orElse(null));
+        azureParameters.setNoOutboundLoadBalancer(azureParametersDto
+                .map(AzureParametersDto::isNoOutboundLoadBalancer)
+                .orElse(false));
     }
 
     @Override
@@ -71,6 +74,8 @@ public class AzureEnvironmentParametersConverter extends BaseEnvironmentParamete
                                 .withDiskEncryptionSetId(azureParameters.getDiskEncryptionSetId())
                                 .withEncryptionKeyResourceGroupName(azureParameters.getEncryptionKeyResourceGroupName())
                                 .build())
+                .withNoOutboundLoadBalancer(
+                        azureParameters.isNoOutboundLoadBalancer())
                 .build());
     }
 }

--- a/environment/src/main/resources/schema/app/20221206104600_CB-19623_add_no_outbound_load_balancer.sql
+++ b/environment/src/main/resources/schema/app/20221206104600_CB-19623_add_no_outbound_load_balancer.sql
@@ -1,0 +1,8 @@
+-- // CB-19623 - Add option to disable  outbound load balancer creation
+-- Migration SQL that makes the change goes here.
+ALTER TABLE environment_parameters ADD COLUMN IF NOT EXISTS no_outbound_load_balancer bool NULL DEFAULT false;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+ALTER TABLE environment_parameters DROP COLUMN IF EXISTS no_outbound_load_balancer;
+

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverterTest.java
@@ -447,6 +447,7 @@ public class EnvironmentApiConverterTest {
                 actual.getAzureParametersDto().getAzureResourceEncryptionParametersDto().getEncryptionKeyUrl());
         assertEquals(request.getAzure().getResourceEncryptionParameters().getEncryptionKeyResourceGroupName(),
                 actual.getAzureParametersDto().getAzureResourceEncryptionParametersDto().getEncryptionKeyResourceGroupName());
+        assertEquals(request.getAzure().isNoOutboundLoadBalancer(), actual.getAzureParametersDto().isNoOutboundLoadBalancer());
     }
 
     private void assertAwsParameters(EnvironmentRequest request, ParametersDto actual) {
@@ -545,6 +546,7 @@ public class EnvironmentApiConverterTest {
                         .withEncryptionKeyResourceGroupName(KEY_URL_RESOURCE_GROUP)
                         .build()
         );
+        azureEnvironmentParameters.setNoOutboundLoadBalancer(false);
         return azureEnvironmentParameters;
     }
 

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverterTest.java
@@ -260,6 +260,7 @@ public class EnvironmentResponseConverterTest {
                 azureEnvironmentParameters.getResourceEncryptionParameters().getEncryptionKeyUrl());
         assertEquals("dummy-des-id", azureEnvironmentParameters.getResourceEncryptionParameters().getDiskEncryptionSetId());
         assertEquals("dummyResourceGroupName", azureEnvironmentParameters.getResourceEncryptionParameters().getEncryptionKeyResourceGroupName());
+        assertEquals(azureParametersDto.isNoOutboundLoadBalancer(), azureEnvironmentParameters.isNoOutboundLoadBalancer());
     }
 
     private void assertGcpParameters(GcpParametersDto gcpParametersDto, GcpEnvironmentParameters gcpEnvironmentParameters) {
@@ -337,6 +338,7 @@ public class EnvironmentResponseConverterTest {
                                         .withDiskEncryptionSetId("dummy-des-id")
                                         .withEncryptionKeyResourceGroupName("dummyResourceGroupName")
                                         .build())
+                        .withNoOutboundLoadBalancer(true)
                         .build())
                 .build();
     }

--- a/environment/src/test/java/com/sequenceiq/environment/parameters/v1/converter/AzureEnvironmentParametersConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/parameters/v1/converter/AzureEnvironmentParametersConverterTest.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.environment.parameters.v1.converter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -61,6 +62,7 @@ public class AzureEnvironmentParametersConverterTest {
                                     .withEncryptionKeyUrl(KEY_URL)
                                     .withEncryptionKeyResourceGroupName(KEY_RESOURCE_GROUP_NAME)
                                     .build())
+                            .withNoOutboundLoadBalancer(true)
                             .build())
                     .build();
             Environment environment = new Environment();
@@ -77,6 +79,7 @@ public class AzureEnvironmentParametersConverterTest {
             assertEquals(ID, azureResult.getId());
             assertEquals(KEY_URL, azureResult.getEncryptionKeyUrl());
             assertEquals(KEY_RESOURCE_GROUP_NAME, azureResult.getEncryptionKeyResourceGroupName());
+            assertTrue(azureResult.isNoOutboundLoadBalancer());
         }
 
         @Test
@@ -90,6 +93,7 @@ public class AzureEnvironmentParametersConverterTest {
             parameters.setEncryptionKeyUrl(KEY_URL);
             parameters.setDiskEncryptionSetId("DummyDesId");
             parameters.setEncryptionKeyResourceGroupName(KEY_RESOURCE_GROUP_NAME);
+            parameters.setNoOutboundLoadBalancer(true);
 
             ParametersDto result = underTest.convertToDto(parameters);
 
@@ -99,5 +103,6 @@ public class AzureEnvironmentParametersConverterTest {
             assertEquals(KEY_URL, result.getAzureParametersDto().getAzureResourceEncryptionParametersDto().getEncryptionKeyUrl());
             assertEquals("DummyDesId", result.getAzureParametersDto().getAzureResourceEncryptionParametersDto().getDiskEncryptionSetId());
             assertEquals(KEY_RESOURCE_GROUP_NAME, result.getAzureParametersDto().getAzureResourceEncryptionParametersDto().getEncryptionKeyResourceGroupName());
+            assertTrue(result.getAzureParametersDto().isNoOutboundLoadBalancer());
         }
 }

--- a/mock-thunderhead/src/main/resources/application.yml
+++ b/mock-thunderhead/src/main/resources/application.yml
@@ -44,7 +44,7 @@ auth:
     datalake:
       efs.enable: false
       customimage.enable: true
-      loadbalancer.enable: false
+      loadbalancer.enable: true
       backup.on.upgrade.enable: false
       backup.on.resize.enable: true
       light.to.medium.migration.enable: true

--- a/structuredevent-model/src/main/java/com/sequenceiq/environment/parameter/dto/AzureParametersDto.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/environment/parameter/dto/AzureParametersDto.java
@@ -10,9 +10,12 @@ public class AzureParametersDto {
 
     private final AzureResourceEncryptionParametersDto azureResourceEncryptionParametersDto;
 
+    private final boolean noOutboundLoadBalancer;
+
     private AzureParametersDto(Builder builder) {
         azureResourceGroupDto = builder.azureResourceGroupDto;
         azureResourceEncryptionParametersDto = builder.azureResourceEncryptionParametersDto;
+        noOutboundLoadBalancer = builder.noOutboundLoadBalancer;
     }
 
     public AzureResourceGroupDto getAzureResourceGroupDto() {
@@ -21,6 +24,10 @@ public class AzureParametersDto {
 
     public AzureResourceEncryptionParametersDto getAzureResourceEncryptionParametersDto() {
         return azureResourceEncryptionParametersDto;
+    }
+
+    public boolean isNoOutboundLoadBalancer() {
+        return noOutboundLoadBalancer;
     }
 
     public static Builder builder() {
@@ -32,6 +39,7 @@ public class AzureParametersDto {
         return "AzureParametersDto{"
                 + "azureResourceGroupDto=" + azureResourceGroupDto
                 + ", azureResourceEncryptionParametersDto=" + azureResourceEncryptionParametersDto
+                + ", isNoOutboundLoadBalancer=" + noOutboundLoadBalancer
                 + '}';
     }
 
@@ -42,6 +50,8 @@ public class AzureParametersDto {
 
         private AzureResourceEncryptionParametersDto azureResourceEncryptionParametersDto;
 
+        private boolean noOutboundLoadBalancer;
+
         public Builder withAzureResourceGroupDto(AzureResourceGroupDto azureResourceGroupDto) {
             this.azureResourceGroupDto = azureResourceGroupDto;
             return this;
@@ -49,6 +59,11 @@ public class AzureParametersDto {
 
         public Builder withAzureResourceEncryptionParametersDto(AzureResourceEncryptionParametersDto azureResourceEncryptionParametersDto) {
             this.azureResourceEncryptionParametersDto = azureResourceEncryptionParametersDto;
+            return this;
+        }
+
+        public Builder withNoOutboundLoadBalancer(boolean noOutboundLoadBalancer) {
+            this.noOutboundLoadBalancer = noOutboundLoadBalancer;
             return this;
         }
 


### PR DESCRIPTION
Azure Option to disable the outbound load balancer creation that otherwise is created by default.

Testing:
Post to `/environmentservice/api/v1/env`

Condition:
When the Public endpoint gateway is disable and it's a private network and noOutboundLoadBalancer is true
Should create just the one load balancer (private)

When the noOutboundLoadBalancer is false
Should create two load balancers (private and outbound)

Example Json:
`{
	"name": "rod-env-azure-05-001",
	"credentialName": "rod-cred",
	"regions": ["West US 2"],
	"location": {
		"name": "West US 2"
	},
	"network": {
		"subnetIds": ["sdx-daily.internal.0.westus2"],
		"serviceEndpointCreation": "ENABLED",
		"publicEndpointAccessGateway": "DISABLED",
		"azure": {
			"networkId": "sdx-daily",
			"resourceGroupName": "sdx-daily",
			"noPublicIp": true
		}
	},
	"telemetry": {
		"logging": {
			"storageLocation": "abfs://data@rodnorazsan.dfs.core.windows.net",
			"adlsGen2": {
				"managedIdentity": "/subscriptions/94359766-1315-49e2-b5da-7578f428b58b/resourcegroups/rod-no-raz-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/loggerIdentity"
			}
		},
		"features": {}
	},
	"authentication": {
		"publicKey": "XXXXXXXXXXXXXXXXXXXXXXXX"
	},
	"freeIpa": {
		"create": true,
		"instanceCountByGroup": 2
	},
	"securityAccess": {
		"cidr": "0.0.0.0/0"
	},
	"tunnel": "DIRECT",
	"overrideTunnel": false,
	"azure": {
		"resourceGroup": {
			"name": "rod-no-raz-rg",
			"resourceGroupUsage": "SINGLE"
		},
        "noOutboundLoadBalancer": false
	},
	"tags": {
		"owner": "ralves",
        "project": "SDX"
	}
}`