### PR TITLE
CB-19390

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterServiceRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterServiceRunner.java
@@ -51,13 +51,13 @@ public class ClusterServiceRunner {
     @Inject
     private GatewayService gatewayService;
 
-    public void runClusterManagerServices(StackDto stackDto) {
+    public void runClusterManagerServices(StackDto stackDto, boolean runPreServiceDeploymentRecipe) {
         ClusterView cluster = stackDto.getCluster();
 
         generateGatewaySignKeys(stackDto.getGateway());
 
         MDCBuilder.buildMdcContext(cluster);
-        hostRunner.runClusterServices(stackDto, Map.of());
+        hostRunner.runClusterServices(stackDto, Map.of(), runPreServiceDeploymentRecipe);
         for (InstanceMetadataView instanceMetaData : stackDto.getRunningInstanceMetaDataSet()) {
             instanceMetaDataService.updateInstanceStatus(instanceMetaData, InstanceStatus.SERVICES_RUNNING);
         }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/ClusterCreationActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/ClusterCreationActions.java
@@ -322,7 +322,7 @@ public class ClusterCreationActions {
 
             @Override
             protected Selectable createRequest(ClusterCreationViewContext context) {
-                return new StartAmbariServicesRequest(context.getStackId(), true);
+                return new StartAmbariServicesRequest(context.getStackId(), true, true);
             }
         };
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/salt/update/SaltUpdateActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/salt/update/SaltUpdateActions.java
@@ -91,7 +91,8 @@ public class SaltUpdateActions {
 
             @Override
             protected Selectable createRequest(ClusterViewContext context) {
-                return new StartAmbariServicesRequest(context.getStackId(), false);
+                return new StartAmbariServicesRequest(context.getStackId(),
+                        false, false);
             }
         };
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/StartAmbariServicesRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/StartAmbariServicesRequest.java
@@ -8,15 +8,23 @@ public class StartAmbariServicesRequest extends StackEvent {
 
     private final boolean defaultClusterManagerAuth;
 
+    private final boolean runPreServiceDeploymentRecipe;
+
     @JsonCreator
     public StartAmbariServicesRequest(
             @JsonProperty("resourceId") Long stackId,
-            @JsonProperty("defaultClusterManagerAuth") boolean defaultClusterManagerAuth) {
+            @JsonProperty("defaultClusterManagerAuth") boolean defaultClusterManagerAuth,
+            @JsonProperty("runPreServiceDeploymentRecipe") boolean runPreServiceDeploymentRecipe) {
         super(stackId);
         this.defaultClusterManagerAuth = defaultClusterManagerAuth;
+        this.runPreServiceDeploymentRecipe = runPreServiceDeploymentRecipe;
     }
 
     public boolean isDefaultClusterManagerAuth() {
         return defaultClusterManagerAuth;
+    }
+
+    public boolean isRunPreServiceDeploymentRecipe() {
+        return runPreServiceDeploymentRecipe;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/orchestration/StartAmbariServicesHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/orchestration/StartAmbariServicesHandler.java
@@ -48,7 +48,7 @@ public class StartAmbariServicesHandler implements EventHandler<StartAmbariServi
         try {
             StackDto stack = stackDtoService.getById(stackId);
             String clusterManagerIp = clusterServiceRunner.updateClusterManagerClientConfig(stack);
-            clusterServiceRunner.runClusterManagerServices(stack);
+            clusterServiceRunner.runClusterManagerServices(stack, request.isRunPreServiceDeploymentRecipe());
             clusterApiConnectors.getConnector(stack, clusterManagerIp).waitForServer(request.isDefaultClusterManagerAuth());
             response = new StartClusterManagerServicesSuccess(stackId);
         } catch (Exception e) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/orchestration/StartAmbariServicesHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/orchestration/StartAmbariServicesHandlerTest.java
@@ -84,7 +84,8 @@ class StartAmbariServicesHandlerTest {
     @ValueSource(booleans = { false, true })
     void testAcceptWhenExceptionThenFailure(boolean defaultClusterManagerAuth) {
         when(stackDtoService.getById(STACK_ID)).thenReturn(stack);
-        doThrow(new CloudbreakServiceException(EXCEPTION_MESSAGE)).when(clusterServiceRunner).runClusterManagerServices(stack);
+        doThrow(new CloudbreakServiceException(EXCEPTION_MESSAGE)).when(clusterServiceRunner).runClusterManagerServices(stack, true);
+
         underTest.accept(getEvent(defaultClusterManagerAuth));
 
         ArgumentCaptor<Event> resultCaptor = ArgumentCaptor.forClass(Event.class);
@@ -101,7 +102,7 @@ class StartAmbariServicesHandlerTest {
 
     private Event<StartAmbariServicesRequest> getEvent(boolean defaultClusterManagerAuth) {
         StartAmbariServicesRequest startAmbariServicesRequest =
-                new StartAmbariServicesRequest(STACK_ID, defaultClusterManagerAuth);
+                new StartAmbariServicesRequest(STACK_ID, defaultClusterManagerAuth, true);
         Event<StartAmbariServicesRequest> handlerEvent = mock(Event.class);
         when(handlerEvent.getData()).thenReturn(startAmbariServicesRequest);
         return handlerEvent;


### PR DESCRIPTION
1. Added condition to not run pre-service deployment checks for recipes for salt update, from ClusterHostServiceRunner.
2. Added new test case for verifying that recipe check is not done when passed in the right value.
3. Updated existing unit test cases.
