### PR TITLE
CB-19983 Introduce E2E Azure Resource Group Name and Usage as defaults for Test Application Config

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/MeasuredTestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/MeasuredTestContext.java
@@ -9,6 +9,7 @@ import org.springframework.context.ApplicationContext;
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.common.api.type.Tunnel;
+import com.sequenceiq.it.TestParameter;
 import com.sequenceiq.it.cloudbreak.MicroserviceClient;
 import com.sequenceiq.it.cloudbreak.SdxClient;
 import com.sequenceiq.it.cloudbreak.action.Action;
@@ -50,6 +51,11 @@ public class MeasuredTestContext extends MockedTestContext {
     @Override
     public TestContext as(CloudbreakUser cloudbreakUser) {
         return wrappedTestContext.as(cloudbreakUser);
+    }
+
+    @Override
+    public TestParameter getTestParameter() {
+        return wrappedTestContext.getTestParameter();
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
@@ -4,9 +4,9 @@ import static com.sequenceiq.it.cloudbreak.context.RunningParameter.emptyRunning
 import static java.lang.String.format;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -166,6 +166,10 @@ public abstract class TestContext implements ApplicationContextAware {
     private boolean initialized;
 
     private CloudbreakUser actingUser;
+
+    public TestParameter getTestParameter() {
+        return testParameter;
+    }
 
     public Map<String, CloudbreakTestDto> getResourceNames() {
         return resourceNames;
@@ -452,18 +456,18 @@ public abstract class TestContext implements ApplicationContextAware {
         Log.as(LOGGER, cloudbreakUser.toString());
         setActingUser(cloudbreakUser);
         if (clients.get(cloudbreakUser.getAccessKey()) == null) {
-            CloudbreakClient cloudbreakClient = CloudbreakClient.createProxyCloudbreakClient(testParameter, cloudbreakUser,
+            CloudbreakClient cloudbreakClient = CloudbreakClient.createProxyCloudbreakClient(getTestParameter(), cloudbreakUser,
                     regionAwareInternalCrnGeneratorFactory.iam());
-            FreeIpaClient freeIpaClient = FreeIpaClient.createProxyFreeIpaClient(testParameter, cloudbreakUser,
+            FreeIpaClient freeIpaClient = FreeIpaClient.createProxyFreeIpaClient(getTestParameter(), cloudbreakUser,
                     regionAwareInternalCrnGeneratorFactory.iam());
-            EnvironmentClient environmentClient = EnvironmentClient.createProxyEnvironmentClient(testParameter, cloudbreakUser,
+            EnvironmentClient environmentClient = EnvironmentClient.createProxyEnvironmentClient(getTestParameter(), cloudbreakUser,
                     regionAwareInternalCrnGeneratorFactory.iam());
-            SdxClient sdxClient = SdxClient.createProxySdxClient(testParameter, cloudbreakUser);
+            SdxClient sdxClient = SdxClient.createProxySdxClient(getTestParameter(), cloudbreakUser);
             UmsClient umsClient = UmsClient.createProxyUmsClient(tracer, umsHost, umsPort);
             SdxSaasItClient sdxSaasItClient = SdxSaasItClient.createProxySdxSaasClient(tracer, umsHost, regionAwareInternalCrnGeneratorFactory);
             AuthDistributorClient authDistributorClient = AuthDistributorClient.createProxyAuthDistributorClient(tracer,
                     regionAwareInternalCrnGeneratorFactory, authDistributorHost);
-            RedbeamsClient redbeamsClient = RedbeamsClient.createProxyRedbeamsClient(testParameter, cloudbreakUser);
+            RedbeamsClient redbeamsClient = RedbeamsClient.createProxyRedbeamsClient(getTestParameter(), cloudbreakUser);
             Map<Class<? extends MicroserviceClient>, MicroserviceClient> clientMap = Map.of(
                     CloudbreakClient.class, cloudbreakClient,
                     FreeIpaClient.class, freeIpaClient,
@@ -481,18 +485,18 @@ public abstract class TestContext implements ApplicationContextAware {
 
     private void initMicroserviceClientsForUMSAccountAdmin(CloudbreakUser accountAdmin) {
         if (clients.get(accountAdmin.getAccessKey()) == null) {
-            CloudbreakClient cloudbreakClient = CloudbreakClient.createProxyCloudbreakClient(testParameter, accountAdmin,
+            CloudbreakClient cloudbreakClient = CloudbreakClient.createProxyCloudbreakClient(getTestParameter(), accountAdmin,
                     regionAwareInternalCrnGeneratorFactory.iam());
-            FreeIpaClient freeIpaClient = FreeIpaClient.createProxyFreeIpaClient(testParameter, accountAdmin,
+            FreeIpaClient freeIpaClient = FreeIpaClient.createProxyFreeIpaClient(getTestParameter(), accountAdmin,
                     regionAwareInternalCrnGeneratorFactory.iam());
-            EnvironmentClient environmentClient = EnvironmentClient.createProxyEnvironmentClient(testParameter, accountAdmin,
+            EnvironmentClient environmentClient = EnvironmentClient.createProxyEnvironmentClient(getTestParameter(), accountAdmin,
                     regionAwareInternalCrnGeneratorFactory.iam());
-            SdxClient sdxClient = SdxClient.createProxySdxClient(testParameter, accountAdmin);
+            SdxClient sdxClient = SdxClient.createProxySdxClient(getTestParameter(), accountAdmin);
             UmsClient umsClient = UmsClient.createProxyUmsClient(tracer, umsHost, umsPort);
             SdxSaasItClient sdxSaasItClient = SdxSaasItClient.createProxySdxSaasClient(tracer, umsHost, regionAwareInternalCrnGeneratorFactory);
             AuthDistributorClient authDistributorClient = AuthDistributorClient.createProxyAuthDistributorClient(tracer,
                     regionAwareInternalCrnGeneratorFactory, authDistributorHost);
-            RedbeamsClient redbeamsClient = RedbeamsClient.createProxyRedbeamsClient(testParameter, accountAdmin);
+            RedbeamsClient redbeamsClient = RedbeamsClient.createProxyRedbeamsClient(getTestParameter(), accountAdmin);
             Map<Class<? extends MicroserviceClient>, MicroserviceClient> clientMap = Map.of(
                     CloudbreakClient.class, cloudbreakClient,
                     FreeIpaClient.class, freeIpaClient,
@@ -533,7 +537,7 @@ public abstract class TestContext implements ApplicationContextAware {
 
     public String getActingUserAccessKey() {
         if (this.actingUser == null) {
-            return testParameter.get(CloudbreakTest.ACCESS_KEY);
+            return getTestParameter().get(CloudbreakTest.ACCESS_KEY);
         }
         return actingUser.getAccessKey();
     }
@@ -582,8 +586,8 @@ public abstract class TestContext implements ApplicationContextAware {
      * - environment variable: INTEGRATIONTEST_USER_CRN
      */
     private Optional<Crn> getUserParameterCrn() {
-        if (StringUtils.isNotBlank(testParameter.get(CloudbreakTest.USER_CRN))) {
-            return Optional.ofNullable(Crn.fromString(testParameter.get(CloudbreakTest.USER_CRN)));
+        if (StringUtils.isNotBlank(getTestParameter().get(CloudbreakTest.USER_CRN))) {
+            return Optional.ofNullable(Crn.fromString(getTestParameter().get(CloudbreakTest.USER_CRN)));
         }
         return Optional.empty();
     }
@@ -632,8 +636,8 @@ public abstract class TestContext implements ApplicationContextAware {
      * - environment variable: INTEGRATIONTEST_USER_NAME
      */
     private Optional<String> getUserParameterName() {
-        if (StringUtils.isNotBlank(testParameter.get(CloudbreakTest.USER_NAME))) {
-            return Optional.of(testParameter.get(CloudbreakTest.USER_NAME));
+        if (StringUtils.isNotBlank(getTestParameter().get(CloudbreakTest.USER_NAME))) {
+            return Optional.of(getTestParameter().get(CloudbreakTest.USER_NAME));
         }
         return Optional.empty();
     }
@@ -688,7 +692,7 @@ public abstract class TestContext implements ApplicationContextAware {
     public CloudbreakUser getActingUser() {
         if (actingUser == null) {
             LOGGER.info(" Requested acting user is NULL. So we are falling back to Default user with \nACCESS_KEY: {} \nSECRET_KEY: {}",
-                    testParameter.get(CloudbreakTest.ACCESS_KEY), testParameter.get(CloudbreakTest.SECRET_KEY));
+                    getTestParameter().get(CloudbreakTest.ACCESS_KEY), getTestParameter().get(CloudbreakTest.SECRET_KEY));
             setActingUser(cloudbreakActor.defaultUser());
         } else {
             LOGGER.info(" Found acting user is present with details:: \nDisplay Name: {} \nAccess Key: {} \nSecret Key: {} \nCRN: {} \nAdmin: {}" +
@@ -747,7 +751,7 @@ public abstract class TestContext implements ApplicationContextAware {
     }
 
     public String getCreationTimestampTag() {
-        return String.valueOf(new Date().getTime());
+        return String.valueOf(Instant.now().getEpochSecond());
     }
 
     public <O extends CloudbreakTestDto> O init(Class<O> clss) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXClusterCreationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXClusterCreationTest.java
@@ -19,7 +19,6 @@ import com.sequenceiq.common.api.telemetry.request.LoggingRequest;
 import com.sequenceiq.common.api.telemetry.request.TelemetryRequest;
 import com.sequenceiq.common.model.FileSystemType;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
-import com.sequenceiq.it.TestParameter;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.assertion.audit.DatahubAuditGrpcServiceAssertion;
 import com.sequenceiq.it.cloudbreak.client.BlueprintTestClient;
@@ -85,9 +84,6 @@ public class DistroXClusterCreationTest extends AbstractClouderaManagerTest {
 
     @Inject
     private FreeIpaTestClient freeIpaTestClient;
-
-    @Inject
-    private TestParameter testParameter;
 
     @Override
     protected void setupTest(TestContext testContext) {
@@ -190,7 +186,7 @@ public class DistroXClusterCreationTest extends AbstractClouderaManagerTest {
                 .mockCm().cmImportClusterTemplate().post()
                 .bodyContains(String.format("\"clusterName\":\"%s\"", testContext.get(DistroXTestDto.class).getName()), 1).verify()
                 .mockCm().cmImportClusterTemplate().post().bodyContains("repositories", 1).verify()
-                .mockCm().cmImportClusterTemplate().post().bodyContains(testParameter.get(IMAGE_CATALOG_MOCK_SERVER_ROOT), 4).verify()
+                .mockCm().cmImportClusterTemplate().post().bodyContains(testContext.getTestParameter().get(IMAGE_CATALOG_MOCK_SERVER_ROOT), 4).verify()
                 .validate();
     }
 

--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -212,8 +212,8 @@ integrationtest:
         loggerIdentity:
       secure: false
     resourcegroup:
-      usage: MULTIPLE
-      name:
+      usage: SINGLE_WITH_DEDICATED_STORAGE_ACCOUNT
+      name: cb-e2e-westus2-tmp
     marketplace:
       freeipa:
         image:


### PR DESCRIPTION
Azure E2E resource group usage has been changed from `MULTIPLE` to `SINGLE_WITH_DEDICATED_STORAGE_ACCOUNT` with `cb-e2e-westus2-tmp` dedicated resource group. Beyond these `createResourceGroup` init method got some improvements and fixes.