### PR TITLE
[CB-19827] More checks on SdxBackupRestoreTest - database backup files

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/SdxBackupRestoreTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/SdxBackupRestoreTest.java
@@ -68,6 +68,9 @@ public class SdxBackupRestoreTest extends PreconditionSdxE2ETest {
                 .then(this::validateDatalakeStatus)
                 .then((tc, testDto, client) -> {
                     getCloudFunctionality(tc).cloudStorageListContainer(cloudStorageBaseLocation, backupObject, true);
+                    String databaseBackupLocation = cloudStorageBaseLocation + '/' + backupObject + '/' + backupId + "_database_backup";
+                    getCloudFunctionality(tc).cloudStorageListContainer(databaseBackupLocation, "hive_backup", true);
+                    getCloudFunctionality(tc).cloudStorageListContainer(databaseBackupLocation, "ranger_backup", true);
                     return testDto;
                 })
                 .validate();


### PR DESCRIPTION
This change also adds a check on database backup folder - verified _hive_ and _ranger_ database backup files presence.

Tested locally on AWS datalake