### PR TITLE
CB-20006 Edge case: Heartbeatservice restarts flow at the moment of flow finalizing

### DIFF
--- a/flow/src/main/java/com/sequenceiq/cloudbreak/service/ha/HeartbeatService.java
+++ b/flow/src/main/java/com/sequenceiq/cloudbreak/service/ha/HeartbeatService.java
@@ -137,10 +137,11 @@ public class HeartbeatService {
             }
 
             String nodeId = nodeConfig.getId();
+            Set<String> runningFlowIdsSnapshot = runningFlows.getRunningFlowIdsSnapshot();
             Set<String> allMyFlows = flowLogService.findAllByCloudbreakNodeId(nodeId).stream()
                     .map(FlowLog::getFlowId).collect(Collectors.toSet());
             LOGGER.info("All my flows: {}", allMyFlows);
-            Set<String> newFlows = allMyFlows.stream().filter(f -> runningFlows.get(f) == null).collect(Collectors.toSet());
+            Set<String> newFlows = allMyFlows.stream().filter(f -> !runningFlowIdsSnapshot.contains(f)).collect(Collectors.toSet());
             LOGGER.info("Restarted flows: {}", newFlows);
             for (String flow : newFlows) {
                 try {

--- a/flow/src/main/java/com/sequenceiq/flow/cleanup/FlowCleanupJob.java
+++ b/flow/src/main/java/com/sequenceiq/flow/cleanup/FlowCleanupJob.java
@@ -61,7 +61,7 @@ public class FlowCleanupJob extends TracedQuartzJob {
     }
 
     private void purgeFlowStatCache() {
-        flowStatCache.cleanOldCacheEntries(runningFlows.getRunningFlowIds());
+        flowStatCache.cleanOldCacheEntries(runningFlows.getRunningFlowIdsSnapshot());
     }
 
     public void purgeFinalisedFlowLogs() throws TransactionService.TransactionExecutionException {

--- a/flow/src/main/java/com/sequenceiq/flow/core/FlowRegister.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/FlowRegister.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.flow.core;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -52,6 +53,10 @@ public class FlowRegister {
         metricService.submit(FlowMetricType.ACTIVE_FLOWS, runningFlows.size());
         LOGGER.info("Running flows after removal: {}", runningFlows.keySet());
         return pair == null ? null : pair.getLeft();
+    }
+
+    public Set<String> getRunningFlowIdsSnapshot() {
+        return new HashSet<>(runningFlows.keySet());
     }
 
     public Set<String> getRunningFlowIds() {

--- a/flow/src/test/java/com/sequenceiq/cloudbreak/service/HeartbeatServiceTest.java
+++ b/flow/src/test/java/com/sequenceiq/cloudbreak/service/HeartbeatServiceTest.java
@@ -167,7 +167,7 @@ public class HeartbeatServiceTest {
         myNewFlowLogs.addAll(node2FlowLogs);
         when(flowLogService.findAllByCloudbreakNodeId(MY_ID)).thenReturn(myNewFlowLogs);
 
-        when(runningFlows.get(any())).thenReturn(null);
+        when(runningFlows.getRunningFlowIdsSnapshot()).thenReturn(Set.of());
 
         heartbeatService.scheduledFlowDistribution();
 
@@ -219,7 +219,7 @@ public class HeartbeatServiceTest {
         myNewFlowLogs.addAll(node2FlowLogs);
         when(flowLogService.findAllByCloudbreakNodeId(MY_ID)).thenReturn(myNewFlowLogs);
 
-        when(runningFlows.get(any())).thenReturn(null);
+        when(runningFlows.getRunningFlowIdsSnapshot()).thenReturn(Set.of());
 
         heartbeatService.scheduledFlowDistribution();
 
@@ -271,7 +271,7 @@ public class HeartbeatServiceTest {
         myNewFlowLogs.addAll(node2FlowLogs);
         when(flowLogService.findAllByCloudbreakNodeId(MY_ID)).thenReturn(myNewFlowLogs);
 
-        when(runningFlows.get(any())).thenReturn(null);
+        when(runningFlows.getRunningFlowIdsSnapshot()).thenReturn(Set.of());
 
         List<Long> stackIds = myNewFlowLogs.stream().map(FlowLog::getResourceId).distinct().collect(Collectors.toList());
         when(haApplication.getDeletingResources(anySet())).thenReturn(Set.of(stackIds.get(0), stackIds.get(2)));
@@ -336,7 +336,7 @@ public class HeartbeatServiceTest {
         myNewFlowLogs.addAll(node2FlowLogs);
         when(flowLogService.findAllByCloudbreakNodeId(MY_ID)).thenReturn(myNewFlowLogs);
 
-        when(runningFlows.get(any())).thenReturn(null);
+        when(runningFlows.getRunningFlowIdsSnapshot()).thenReturn(Set.of());
 
         List<Long> stackIds = myNewFlowLogs.stream().map(FlowLog::getResourceId).distinct().collect(Collectors.toList());
         when(haApplication.getDeletingResources(anySet())).thenReturn(Set.of(stackIds.get(0), stackIds.get(2)));
@@ -387,7 +387,7 @@ public class HeartbeatServiceTest {
         myNewFlowLogs.addAll(node1FlowLogs.stream().filter(fl -> fl.getFlowId().equalsIgnoreCase(suspendedFlows.get(2))).collect(Collectors.toList()));
         when(flowLogService.findAllByCloudbreakNodeId(MY_ID)).thenReturn(myNewFlowLogs);
 
-        when(runningFlows.get(any())).thenReturn(null);
+        when(runningFlows.getRunningFlowIdsSnapshot()).thenReturn(Set.of());
 
         when(flowLogService.saveAll(anyCollection())).thenThrow(new OptimisticLockingFailureException("Someone already distributed the flows.."));
 
@@ -427,7 +427,7 @@ public class HeartbeatServiceTest {
         List<FlowLog> myNewFlowLogs = node1FlowLogs.stream().filter(fl -> fl.getFlowId().equalsIgnoreCase(suspendedFlows.get(0))).collect(Collectors.toList());
         when(flowLogService.findAllByCloudbreakNodeId(MY_ID)).thenReturn(new HashSet<>(myNewFlowLogs));
 
-        when(runningFlows.get(any())).thenReturn(null);
+        when(runningFlows.getRunningFlowIdsSnapshot()).thenReturn(Set.of());
 
         when(flowLogService.saveAll(anyCollection())).thenThrow(new OptimisticLockingFailureException("Someone already distributed the flows.."));
 


### PR DESCRIPTION
Heartbeatservice tries to check if any flow should be restarted; meanwhile, a flow can be in the finalization process. The flowLogService.findAllByCloudbreakNodeId returns the flow, but at the same time we removed the flow from the runningFlows. In this case, heartbeatservice will restart the flow, but it should not be restarted.