### PR TITLE
CB-20004 Failed usersync caused by authorization failure

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/ums/EnvironmentAccessChecker.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/ums/EnvironmentAccessChecker.java
@@ -10,14 +10,12 @@ import org.slf4j.LoggerFactory;
 
 import com.cloudera.thunderhead.service.authorization.AuthorizationProto.RightCheck;
 import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
+import com.sequenceiq.cloudbreak.auth.altus.exception.UnauthorizedException;
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.auth.crn.CrnParseException;
 import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
 import com.sequenceiq.freeipa.service.freeipa.user.UserSyncConstants;
 import com.sequenceiq.freeipa.service.freeipa.user.model.EnvironmentAccessRights;
-
-import io.grpc.Status.Code;
-import io.grpc.StatusRuntimeException;
 
 public class EnvironmentAccessChecker {
     private static final Logger LOGGER = LoggerFactory.getLogger(EnvironmentAccessChecker.class);
@@ -40,7 +38,7 @@ public class EnvironmentAccessChecker {
      * @throws CrnParseException    if the environmentCrn does not match the CRN pattern or cannot be parsed
      */
     public EnvironmentAccessChecker(GrpcUmsClient grpcUmsClient, String environmentCrn, List<RightCheck> rightChecks,
-        RegionAwareInternalCrnGeneratorFactory regionAwareInternalCrnGeneratorFactory) {
+            RegionAwareInternalCrnGeneratorFactory regionAwareInternalCrnGeneratorFactory) {
         this.grpcUmsClient = requireNonNull(grpcUmsClient, "grpcUmsClient is null");
         Crn.safeFromString(environmentCrn);
         this.environmentCrn = environmentCrn;
@@ -51,23 +49,14 @@ public class EnvironmentAccessChecker {
 
     public EnvironmentAccessRights hasAccess(String memberCrn) {
         requireNonNull(memberCrn, "memberCrn is null");
-
         try {
             List<Boolean> hasRights = grpcUmsClient.hasRightsNoCache(memberCrn, rightChecks,
                     regionAwareInternalCrnGeneratorFactory);
             return new EnvironmentAccessRights(hasRights.get(0), hasRights.get(1));
-        } catch (StatusRuntimeException e) {
-            // NOT_FOUND errors indicate that a user/machineUser has been deleted after we have
-            // retrieved the list of users/machineUsers from the UMS. Treat these users as if
-            // they do not have the right to access this environment and belong to no groups.
-            if (e.getStatus().getCode() == Code.NOT_FOUND) {
-                LOGGER.warn("Member CRN {} not found in UMS. Treating as if member has no rights to environment {}: {}",
-                        memberCrn, environmentCrn, e.getLocalizedMessage());
-                return new EnvironmentAccessRights(false, false);
-            } else {
-                throw e;
-            }
-
+        } catch (UnauthorizedException e) {
+            LOGGER.warn("Member CRN {} not found in UMS. Treating as if member has no rights to environment {}: {}",
+                    memberCrn, environmentCrn, e.getLocalizedMessage());
+            return new EnvironmentAccessRights(false, false);
         }
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/ums/EnvironmentAccessCheckerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/ums/EnvironmentAccessCheckerTest.java
@@ -23,13 +23,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.cloudera.thunderhead.service.authorization.AuthorizationProto;
 import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
+import com.sequenceiq.cloudbreak.auth.altus.exception.UnauthorizedException;
 import com.sequenceiq.cloudbreak.auth.crn.CrnParseException;
 import com.sequenceiq.freeipa.service.freeipa.user.UserSyncConstants;
 import com.sequenceiq.freeipa.service.freeipa.user.model.EnvironmentAccessRights;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
 
 @ExtendWith(MockitoExtension.class)
 class EnvironmentAccessCheckerTest {
@@ -39,10 +38,10 @@ class EnvironmentAccessCheckerTest {
     private static final String NOT_CRN = "not:a:crn:";
 
     private static final String ENV_CRN = "crn:cdp:environments:us-west-1:"
-            + ACCOUNT_ID + ":environment:" + UUID.randomUUID().toString();
+            + ACCOUNT_ID + ":environment:" + UUID.randomUUID();
 
     private static final String MEMBER_CRN = "crn:cdp:environments:us-west-1:"
-            + ACCOUNT_ID + ":user:" + UUID.randomUUID().toString();
+            + ACCOUNT_ID + ":user:" + UUID.randomUUID();
 
     @Mock
     private GrpcUmsClient grpcUmsClient;
@@ -89,8 +88,8 @@ class EnvironmentAccessCheckerTest {
     void testEnvironmentAccessCheckerCreatesRightEnvironmentAccessRights() {
         EnvironmentAccessChecker underTest = environmentAccessCheckerFactory.create(ENV_CRN);
 
-        for (boolean hasAccess : new boolean[] { false, true}) {
-            for (boolean ipaAdmin : new boolean[] { false, true}) {
+        for (boolean hasAccess : new boolean[]{false, true}) {
+            for (boolean ipaAdmin : new boolean[]{false, true}) {
                 when(grpcUmsClient.hasRightsNoCache(eq(MEMBER_CRN), anyList(), any()))
                         .thenReturn(List.of(hasAccess, ipaAdmin));
 
@@ -106,7 +105,7 @@ class EnvironmentAccessCheckerTest {
     void testEnvironmentAccessCheckerNoAccessIfMemberNotFound() {
         EnvironmentAccessChecker underTest = environmentAccessCheckerFactory.create(ENV_CRN);
 
-        Throwable ex = new StatusRuntimeException(Status.Code.NOT_FOUND.toStatus());
+        Throwable ex = new UnauthorizedException();
         when(grpcUmsClient.hasRightsNoCache(eq(MEMBER_CRN), anyList(), any()))
                 .thenThrow(ex);
 


### PR DESCRIPTION
`GrpcUmsClient` switched from throwing `StatusRuntimeException` to `UnauthorizedException` when the user/right is missing. This change was not handled on usersync side, causing usersync failures.

See detailed description in the commit message.