### PR TITLE
CB-19939 in the newer version of podam then changed the xml library f…

### DIFF
--- a/authorization-common/build.gradle
+++ b/authorization-common/build.gradle
@@ -38,7 +38,8 @@ dependencies {
   testImplementation group: 'org.springframework.boot',  name: 'spring-boot-starter-test',       version: springBootVersion
   testImplementation group: 'org.awaitility',            name: 'awaitility',                     version: awaitilityVersion
 
-  implementation(group: 'uk.co.jemos.podam',             name: 'podam',                           version: '7.1.0.RELEASE') {
+  //this needs to stay as implementation as other module include EnforceAuthorizationTestUtil
+  implementation(group: 'uk.co.jemos.podam',             name: 'podam',                           version: '7.2.11.RELEASE') {
     exclude group: 'javax.annotation',                   module: 'jsr250-api'
   }
   implementation     group: 'org.springframework.boot',  name: 'spring-boot-starter',             version: springBootVersion

--- a/cloud-consumption-api/build.gradle
+++ b/cloud-consumption-api/build.gradle
@@ -22,8 +22,6 @@ dependencies {
     implementation     group: "org.glassfish.jersey.ext",      name: "jersey-proxy-client",            version: jerseyCoreVersion
     implementation     group: "org.glassfish.jersey.media",    name: "jersey-media-json-jackson",      version: jerseyCoreVersion
     implementation     group: "javax.activation",              name: "activation",                     version: javaxActivationVersion
-    implementation     group: "com.sun.xml.ws",                name: "rt",                             version: "2.3.0"
-    implementation     group: "com.sun.xml.ws",                name: "jaxws-rt",                       version: "2.3.0"
     implementation     group: "io.opentracing.contrib",        name: "opentracing-jaxrs2",             version: opentracingJaxrs2Version
     testImplementation group: "org.assertj",                   name: "assertj-core",                   version: assertjVersion
     testImplementation group: "com.openpojo",                  name: "openpojo",                       version: openPojoVersion

--- a/environment-api/build.gradle
+++ b/environment-api/build.gradle
@@ -23,8 +23,6 @@ dependencies {
     implementation     group: "org.glassfish.jersey.ext",      name: "jersey-proxy-client",            version: jerseyCoreVersion
     implementation     group: "org.glassfish.jersey.media",    name: "jersey-media-json-jackson",      version: jerseyCoreVersion
     implementation     group: "javax.activation",              name: "activation",                     version: javaxActivationVersion
-    implementation     group: "com.sun.xml.ws",                name: "rt",                             version: "2.3.0"
-    implementation     group: "com.sun.xml.ws",                name: "jaxws-rt",                       version: "2.3.0"
     implementation     group: "io.opentracing.contrib",        name: "opentracing-jaxrs2",             version: opentracingJaxrs2Version
     testImplementation group: "org.assertj",                   name: "assertj-core",                   version: assertjVersion
     testImplementation group: "com.openpojo",                  name: "openpojo",                       version: openPojoVersion


### PR DESCRIPTION
podam then changed the xml library from [xml-apis » xml-apis] to [javax.xml.bind » jaxb-api]

Retring the removal of [com.sun.xml.ws]

See:
https://mvnrepository.com/artifact/uk.co.jemos.podam/podam/7.2.0.RELEASE

https://mvnrepository.com/artifact/uk.co.jemos.podam/podam/7.2.11.RELEASE

See detailed description in the commit message.