### PR TITLE
CB-19971 Remove NotNull from subscriptionId and tenantId

### DIFF
--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/credential/model/parameters/azure/AzureCredentialRequestParameters.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/credential/model/parameters/azure/AzureCredentialRequestParameters.java
@@ -3,7 +3,6 @@ package com.sequenceiq.environment.api.v1.credential.model.parameters.azure;
 import java.io.Serializable;
 
 import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -17,12 +16,10 @@ import io.swagger.annotations.ApiModelProperty;
 @JsonInclude(Include.NON_NULL)
 public class AzureCredentialRequestParameters implements Serializable {
 
-    @NotNull
-    @ApiModelProperty(required = true, example = "a8d4457d-310v-41p6-sc53-14g8d733e514")
+    @ApiModelProperty(example = "a8d4457d-310v-41p6-sc53-14g8d733e514")
     private String subscriptionId;
 
-    @NotNull
-    @ApiModelProperty(required = true, example = "b10u3481-2451-10ba-7sfd-9o2d1v60185d")
+    @ApiModelProperty(example = "b10u3481-2451-10ba-7sfd-9o2d1v60185d")
     private String tenantId;
 
     @Valid

--- a/environment/src/main/java/com/sequenceiq/environment/credential/validation/aws/AzureCredentialValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/validation/aws/AzureCredentialValidator.java
@@ -1,13 +1,22 @@
 package com.sequenceiq.environment.credential.validation.aws;
 
+import java.io.IOException;
+
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.validation.ValidationResult;
 import com.sequenceiq.cloudbreak.validation.ValidationResult.ValidationResultBuilder;
+import com.sequenceiq.common.api.credential.AppAuthenticationType;
+import com.sequenceiq.environment.api.v1.credential.model.parameters.azure.AppBasedRequest;
+import com.sequenceiq.environment.api.v1.credential.model.parameters.azure.AzureCredentialRequestParameters;
 import com.sequenceiq.environment.api.v1.credential.model.request.CredentialRequest;
+import com.sequenceiq.environment.credential.attributes.CredentialAttributes;
+import com.sequenceiq.environment.credential.attributes.azure.AzureCredentialAttributes;
 import com.sequenceiq.environment.credential.domain.Credential;
 import com.sequenceiq.environment.credential.validation.ProviderCredentialValidator;
 
@@ -23,11 +32,49 @@ public class AzureCredentialValidator implements ProviderCredentialValidator {
 
     @Override
     public ValidationResult validateCreate(CredentialRequest credentialRequest, ValidationResultBuilder resultBuilder) {
+        AzureCredentialRequestParameters azureCredentialRequestParameters = credentialRequest.getAzure();
+        if (azureCredentialRequestParameters == null) {
+            resultBuilder.error("Azure specific parameters are missing from the credential creation request");
+        } else if (azureCredentialRequestParameters.getAppBased() == null && azureCredentialRequestParameters.getRoleBased() == null) {
+            resultBuilder.error("appBaseRequest or roleBasedRequest have to be defined in azure specific parameters");
+        } else {
+            AppBasedRequest appBasedRequest = azureCredentialRequestParameters.getAppBased();
+            if (appBasedRequest == null || appBasedRequest.getAuthenticationType() == AppAuthenticationType.SECRET) {
+                if (StringUtils.isBlank(azureCredentialRequestParameters.getSubscriptionId())) {
+                    resultBuilder.error("subscriptionId is mandatory for " + (appBasedRequest == null ? " role based " : " secret based ") +
+                            " azure credential creation");
+                }
+                if (StringUtils.isBlank(azureCredentialRequestParameters.getTenantId())) {
+                    resultBuilder.error("tenantId is mandatory for " + (appBasedRequest == null ? " role based " : " secret based ") +
+                            " azure credential creation");
+                }
+            }
+        }
         return resultBuilder.build();
     }
 
     @Override
     public ValidationResult validateUpdate(Credential original, Credential newCred, ValidationResultBuilder resultBuilder) {
+        if (newCred.getAttributes() == null) {
+            resultBuilder.error("Credential attributes are missing from the credential modification request");
+        } else {
+            try {
+                CredentialAttributes attributes = new Json(newCred.getAttributes()).get(CredentialAttributes.class);
+                if (attributes.getAzure() == null) {
+                    resultBuilder.error("Azure specific parameters are missing from the credential modification request");
+                } else {
+                    AzureCredentialAttributes azureCredentialAttributes = attributes.getAzure();
+                    if (StringUtils.isBlank(azureCredentialAttributes.getSubscriptionId())) {
+                        resultBuilder.error("subscriptionId is mandatory for azure credential modification");
+                    }
+                    if (StringUtils.isBlank(azureCredentialAttributes.getTenantId())) {
+                        resultBuilder.error("tenantId is mandatory for azure credential modification");
+                    }
+                }
+            } catch (IOException ex) {
+                resultBuilder.error("Provider specific attributes cannot be read: " + ex.getMessage());
+            }
+        }
         return resultBuilder.build();
     }
 }

--- a/environment/src/test/java/com/sequenceiq/environment/credential/validation/AzureCredentialValidatorTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/credential/validation/AzureCredentialValidatorTest.java
@@ -1,0 +1,177 @@
+package com.sequenceiq.environment.credential.validation;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.common.json.JsonUtil;
+import com.sequenceiq.cloudbreak.validation.ValidationResult;
+import com.sequenceiq.common.api.credential.AppAuthenticationType;
+import com.sequenceiq.environment.api.v1.credential.model.parameters.azure.AppBasedRequest;
+import com.sequenceiq.environment.api.v1.credential.model.parameters.azure.AzureCredentialRequestParameters;
+import com.sequenceiq.environment.api.v1.credential.model.parameters.azure.RoleBasedRequest;
+import com.sequenceiq.environment.api.v1.credential.model.request.CredentialRequest;
+import com.sequenceiq.environment.credential.attributes.CredentialAttributes;
+import com.sequenceiq.environment.credential.attributes.azure.AzureCredentialAttributes;
+import com.sequenceiq.environment.credential.domain.Credential;
+import com.sequenceiq.environment.credential.validation.aws.AzureCredentialValidator;
+
+@ExtendWith(MockitoExtension.class)
+public class AzureCredentialValidatorTest {
+    @InjectMocks
+    private AzureCredentialValidator underTest;
+
+    @Test
+    void testValidateCreateValidCertBased() {
+        CredentialRequest credentialRequest = new CredentialRequest();
+        AzureCredentialRequestParameters azureCredentialRequestParameters = new AzureCredentialRequestParameters();
+        AppBasedRequest appBasedRequest = new AppBasedRequest();
+        appBasedRequest.setAuthenticationType(AppAuthenticationType.CERTIFICATE);
+        azureCredentialRequestParameters.setAppBased(appBasedRequest);
+        credentialRequest.setAzure(azureCredentialRequestParameters);
+        ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
+        ValidationResult validationResult = underTest.validateCreate(credentialRequest, validationResultBuilder);
+        Assertions.assertFalse(validationResult.hasError());
+    }
+
+    @Test
+    void testValidateCreateValidSecretBased() {
+        CredentialRequest credentialRequest = new CredentialRequest();
+        AzureCredentialRequestParameters azureCredentialRequestParameters = new AzureCredentialRequestParameters();
+        azureCredentialRequestParameters.setSubscriptionId("subscription");
+        azureCredentialRequestParameters.setTenantId("tenant");
+        AppBasedRequest appBasedRequest = new AppBasedRequest();
+        appBasedRequest.setAuthenticationType(AppAuthenticationType.SECRET);
+        azureCredentialRequestParameters.setAppBased(appBasedRequest);
+        credentialRequest.setAzure(azureCredentialRequestParameters);
+        ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
+        ValidationResult validationResult = underTest.validateCreate(credentialRequest, validationResultBuilder);
+        Assertions.assertFalse(validationResult.hasError());
+    }
+
+    @Test
+    void testValidateCreateInvalidSecretBased() {
+        CredentialRequest credentialRequest = new CredentialRequest();
+        AzureCredentialRequestParameters azureCredentialRequestParameters = new AzureCredentialRequestParameters();
+        AppBasedRequest appBasedRequest = new AppBasedRequest();
+        appBasedRequest.setAuthenticationType(AppAuthenticationType.SECRET);
+        azureCredentialRequestParameters.setAppBased(appBasedRequest);
+        credentialRequest.setAzure(azureCredentialRequestParameters);
+        ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
+        ValidationResult validationResult = underTest.validateCreate(credentialRequest, validationResultBuilder);
+        Assertions.assertTrue(validationResult.hasError());
+        Assertions.assertEquals(validationResult.getErrors().size(), 2);
+        Assertions.assertTrue(validationResult.getErrors().get(0).startsWith("subscriptionId is mandatory for"));
+        Assertions.assertTrue(validationResult.getErrors().get(1).startsWith("tenantId is mandatory for"));
+    }
+
+    @Test
+    void testValidateCreateWhenAppBasedAndRoleBasedAreNull() {
+        CredentialRequest credentialRequest = new CredentialRequest();
+        AzureCredentialRequestParameters azureCredentialRequestParameters = new AzureCredentialRequestParameters();
+        credentialRequest.setAzure(azureCredentialRequestParameters);
+        ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
+        ValidationResult validationResult = underTest.validateCreate(credentialRequest, validationResultBuilder);
+        Assertions.assertTrue(validationResult.hasError());
+        Assertions.assertEquals(validationResult.getErrors().size(), 1);
+        Assertions.assertEquals(validationResult.getErrors().get(0), "appBaseRequest or roleBasedRequest have to be defined in azure specific parameters");
+    }
+
+    @Test
+    void testValidateCreateInvalidRoleBased() {
+        CredentialRequest credentialRequest = new CredentialRequest();
+        AzureCredentialRequestParameters azureCredentialRequestParameters = new AzureCredentialRequestParameters();
+        RoleBasedRequest roleBasedRequest = new RoleBasedRequest();
+        azureCredentialRequestParameters.setRoleBased(roleBasedRequest);
+        credentialRequest.setAzure(azureCredentialRequestParameters);
+        ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
+        ValidationResult validationResult = underTest.validateCreate(credentialRequest, validationResultBuilder);
+        Assertions.assertTrue(validationResult.hasError());
+        Assertions.assertEquals(validationResult.getErrors().size(), 2);
+        Assertions.assertTrue(validationResult.getErrors().get(0).startsWith("subscriptionId is mandatory for"));
+        Assertions.assertTrue(validationResult.getErrors().get(1).startsWith("tenantId is mandatory for"));
+    }
+
+    @Test
+    void testValidateCreateWhenAzureParamsAreMissing() {
+        CredentialRequest credentialRequest = new CredentialRequest();
+        ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
+        ValidationResult validationResult = underTest.validateCreate(credentialRequest, validationResultBuilder);
+        Assertions.assertTrue(validationResult.hasError());
+        Assertions.assertEquals(validationResult.getErrors().size(), 1);
+        Assertions.assertEquals(validationResult.getErrors().get(0), "Azure specific parameters are missing from the credential creation request");
+    }
+
+    @Test
+    void testValidateUpdateValidAppBased() throws Exception {
+        Credential origCred = new Credential();
+        Credential newCred = new Credential();
+        CredentialAttributes credentialAttributes = new CredentialAttributes();
+        AzureCredentialAttributes azureCredentialAttributes = new AzureCredentialAttributes();
+        azureCredentialAttributes.setSubscriptionId("subscription");
+        azureCredentialAttributes.setTenantId("tenant");
+        credentialAttributes.setAzure(azureCredentialAttributes);
+        newCred.setAttributes(JsonUtil.writeValueAsString(credentialAttributes));
+        newCred.setAttributes(new Json(credentialAttributes).getValue());
+        ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
+        ValidationResult validationResult = underTest.validateUpdate(origCred, newCred, validationResultBuilder);
+        Assertions.assertFalse(validationResult.hasError());
+    }
+
+    @Test
+    void testValidateUpdateWhenCredentialAttributesAreMissing() {
+        Credential origCred = new Credential();
+        Credential newCred = new Credential();
+        ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
+        ValidationResult validationResult = underTest.validateUpdate(origCred, newCred, validationResultBuilder);
+        Assertions.assertTrue(validationResult.hasError());
+        Assertions.assertEquals(validationResult.getErrors().size(), 1);
+        Assertions.assertEquals(validationResult.getErrors().get(0), "Credential attributes are missing from the credential modification request");
+    }
+
+    @Test
+    void testValidateUpdateWhenCredentialAttributesJsonIsIllegal() {
+        Credential origCred = new Credential();
+        Credential newCred = new Credential();
+        newCred.setAttributes("not a json");
+        ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
+        ValidationResult validationResult = underTest.validateUpdate(origCred, newCred, validationResultBuilder);
+        Assertions.assertTrue(validationResult.hasError());
+        Assertions.assertEquals(validationResult.getErrors().size(), 1);
+        Assertions.assertTrue(validationResult.getErrors().get(0).startsWith("Provider specific attributes cannot be read"));
+    }
+
+    @Test
+    void testValidateUpdateMissingIds() throws Exception {
+        Credential origCred = new Credential();
+        Credential newCred = new Credential();
+        CredentialAttributes credentialAttributes = new CredentialAttributes();
+        AzureCredentialAttributes azureCredentialAttributes = new AzureCredentialAttributes();
+        credentialAttributes.setAzure(azureCredentialAttributes);
+        newCred.setAttributes(JsonUtil.writeValueAsString(credentialAttributes));
+        newCred.setAttributes(new Json(credentialAttributes).getValue());
+        ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
+        ValidationResult validationResult = underTest.validateUpdate(origCred, newCred, validationResultBuilder);
+        Assertions.assertTrue(validationResult.hasError());
+        Assertions.assertEquals(validationResult.getErrors().size(), 2);
+        Assertions.assertEquals(validationResult.getErrors().get(0), "subscriptionId is mandatory for azure credential modification");
+        Assertions.assertEquals(validationResult.getErrors().get(1), "tenantId is mandatory for azure credential modification");
+    }
+
+    @Test
+    void testValidateUpdateWhenAzureAttributesAreMissing() throws Exception {
+        Credential origCred = new Credential();
+        Credential newCred = new Credential();
+        CredentialAttributes credentialAttributes = new CredentialAttributes();
+        newCred.setAttributes(JsonUtil.writeValueAsString(credentialAttributes));
+        newCred.setAttributes(new Json(credentialAttributes).getValue());
+        ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
+        ValidationResult validationResult = underTest.validateUpdate(origCred, newCred, validationResultBuilder);
+        Assertions.assertTrue(validationResult.hasError());
+        Assertions.assertEquals(validationResult.getErrors().size(), 1);
+        Assertions.assertEquals(validationResult.getErrors().get(0), "Azure specific parameters are missing from the credential modification request");
+    }
+}


### PR DESCRIPTION
* Remove NotNull annotation from subscriptionId and tenantId field in AzureCredentialRequestParameters
* Remove required flag from ApiModelProperty on these fields
* Azure credential validation improvement: subscriptionId and tenantId are not required in case of certificate based credential.

See detailed description in the commit message.