### PR TITLE
CB-19967 - DH admin operations are allowed when data lake backup is in progress

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/datalake/DataLakeStatusCheckerService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/datalake/DataLakeStatusCheckerService.java
@@ -30,4 +30,17 @@ public class DataLakeStatusCheckerService {
             throw new BadRequestException("This action requires the Data Lake to be available, but the status is " + sdxCluster.getStatusReason());
         }
     }
+
+    public void validateAvailableState(StackView stack) {
+        if (StackType.WORKLOAD.equals(stack.getType())) {
+            sdxClientService
+                    .getByEnvironmentCrn(stack.getEnvironmentCrn())
+                    .forEach(sdxClusterResponse -> {
+                        if (!sdxClusterResponse.getStatus().isAvailable()) {
+                            throw new BadRequestException("This action requires the Data Lake to be available, but the status is "
+                                    + sdxClusterResponse.getStatusReason());
+                        }
+                    });
+        }
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
@@ -390,7 +390,7 @@ public class StackOperationService {
     FlowIdentifier start(StackView stack) {
         FlowIdentifier flowIdentifier = FlowIdentifier.notTriggered();
         environmentService.checkEnvironmentStatus(stack, EnvironmentStatus.startable());
-        dataLakeStatusCheckerService.validateRunningState(stack);
+        dataLakeStatusCheckerService.validateAvailableState(stack);
         if (stack.isAvailable()) {
             eventService.fireCloudbreakEvent(stack.getId(), AVAILABLE.name(), STACK_START_IGNORED);
         } else if (stack.isReadyForStart() || stack.isStartFailed()) {

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/SdxConverter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/SdxConverter.java
@@ -8,7 +8,6 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.cluster.sharedse
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.distrox.api.v1.distrox.model.sharedservice.SdxV1Request;
 import com.sequenceiq.sdx.api.model.SdxClusterResponse;
-import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 
 @Component
 public class SdxConverter {
@@ -20,7 +19,7 @@ public class SdxConverter {
             LOGGER.info("We don't attach the cluster to any Datalake, because the environment has not SDX. So we continue the creation as simple WORKLOAD.");
             return null;
         }
-        if (sdx.getStatus() != SdxClusterStatusResponse.RUNNING) {
+        if (!sdx.getStatus().isAvailable()) {
             throw new BadRequestException(
                     String.format("Your current Environment %s contains one Data Lake the name of which is %s. " +
                             "This Data Lake should be in running/available state but currently it is in '%s' instead of Running. " +

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/datalake/DataLakeStatusCheckerServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/datalake/DataLakeStatusCheckerServiceTest.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.service.datalake;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
@@ -52,6 +53,27 @@ public class DataLakeStatusCheckerServiceTest {
         when(sdxClientService.getByEnvironmentCrn(ENVIRONMENT_CRN)).thenReturn(sdxClusterResponses);
 
         underTest.validateRunningState(stack);
+    }
+
+    @Test
+    public void testValidateAvailableStateShouldNotThrowExceptionWhenInBackup() {
+        Stack stack = createStack();
+        List<SdxClusterResponse> sdxClusterResponses = createSdxResponse(SdxClusterStatusResponse.DATALAKE_BACKUP_INPROGRESS, "Backup in Progress");
+
+        when(sdxClientService.getByEnvironmentCrn(ENVIRONMENT_CRN)).thenReturn(sdxClusterResponses);
+
+        underTest.validateAvailableState(stack);
+    }
+
+    @Test
+    public void testValidateAvailableStateShouldThrowExceptionWhenSdxIsNotAvailable() {
+        Stack stack = createStack();
+        List<SdxClusterResponse> sdxClusterResponses = createSdxResponse(SdxClusterStatusResponse.DATALAKE_VERTICAL_SCALE_ON_DATALAKE_IN_PROGRESS,
+                "Vertical Scale in Progress");
+
+        when(sdxClientService.getByEnvironmentCrn(ENVIRONMENT_CRN)).thenReturn(sdxClusterResponses);
+
+        assertThrows(BadRequestException.class, () -> underTest.validateAvailableState(stack));
     }
 
     private Stack createStack() {

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/SdxConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/SdxConverterTest.java
@@ -3,6 +3,8 @@ package com.sequenceiq.distrox.v1.distrox.converter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -26,11 +28,12 @@ public class SdxConverterTest {
         Assertions.assertNull(sdxRequest);
     }
 
-    @Test
-    public void testGetSharedServiceWhenSdxIsRunning() {
+    @ParameterizedTest
+    @EnumSource(value = SdxClusterStatusResponse.class, names = {"RUNNING", "DATALAKE_BACKUP_INPROGRESS"})
+    public void testGetSharedServiceWhenSdxIsAvailable(SdxClusterStatusResponse status) {
         SdxClusterResponse sdxClusterResponse = new SdxClusterResponse();
         sdxClusterResponse.setName("some-sdx");
-        sdxClusterResponse.setStatus(SdxClusterStatusResponse.RUNNING);
+        sdxClusterResponse.setStatus(status);
 
         SharedServiceV4Request sdxRequest = underTest.getSharedService(sdxClusterResponse);
 

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterStatusResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterStatusResponse.java
@@ -72,4 +72,8 @@ public enum SdxClusterStatusResponse {
     public boolean isRunning() {
         return RUNNING.equals(this);
     }
+
+    public boolean isAvailable() {
+        return RUNNING.equals(this) || DATALAKE_BACKUP_INPROGRESS.equals(this);
+    }
 }

--- a/datalake/src/test/java/com/sequenceiq/sdx/api/model/SdxClusterStatusResponseTest.java
+++ b/datalake/src/test/java/com/sequenceiq/sdx/api/model/SdxClusterStatusResponseTest.java
@@ -1,5 +1,8 @@
 package com.sequenceiq.sdx.api.model;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -19,4 +22,15 @@ public class SdxClusterStatusResponseTest {
         DatalakeStatusEnum.valueOf(sdxClusterStatusResponse.name());
     }
 
+    @ParameterizedTest
+    @EnumSource(value = SdxClusterStatusResponse.class, names = {"RUNNING", "DATALAKE_BACKUP_INPROGRESS"})
+    void testAvailableStatus(SdxClusterStatusResponse status) {
+        assertTrue(status.isAvailable());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = SdxClusterStatusResponse.class, names = {"SALT_UPDATE_IN_PROGRESS", "PROVISIONING_FAILED", "DATALAKE_UPGRADE_PREPARATION_IN_PROGRESS"})
+    void testNotAvailableStatus(SdxClusterStatusResponse status) {
+        assertFalse(status.isAvailable());
+    }
 }

--- a/sdx-connector/src/main/java/com/sequenceiq/cloudbreak/saas/sdx/PaasSdxService.java
+++ b/sdx-connector/src/main/java/com/sequenceiq/cloudbreak/saas/sdx/PaasSdxService.java
@@ -77,7 +77,7 @@ public class PaasSdxService extends AbstractSdxService<SdxClusterStatusResponse>
 
     @Override
     public StatusCheckResult getAvailabilityStatusCheckResult(SdxClusterStatusResponse status) {
-        return SdxClusterStatusResponse.RUNNING.equals(status) ? StatusCheckResult.AVAILABLE : StatusCheckResult.NOT_AVAILABLE;
+        return status.isAvailable() ? StatusCheckResult.AVAILABLE : StatusCheckResult.NOT_AVAILABLE;
     }
 
 }

--- a/sdx-connector/src/test/java/com/sequenceiq/cloudbreak/saas/sdx/PaasSdxServiceTest.java
+++ b/sdx-connector/src/test/java/com/sequenceiq/cloudbreak/saas/sdx/PaasSdxServiceTest.java
@@ -19,6 +19,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.saas.sdx.polling.PollingResult;
+import com.sequenceiq.cloudbreak.saas.sdx.status.StatusCheckResult;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.flow.api.model.FlowType;
 import com.sequenceiq.sdx.api.endpoint.SdxEndpoint;
@@ -66,6 +67,14 @@ public class PaasSdxServiceTest {
     public void testGetDeletePollingResult() {
         assertEquals(PollingResult.IN_PROGRESS, underTest.getDeletePollingResultByStatus(SdxClusterStatusResponse.STACK_DELETION_IN_PROGRESS));
         assertEquals(PollingResult.FAILED, underTest.getDeletePollingResultByStatus(SdxClusterStatusResponse.DELETE_FAILED));
+    }
+
+    @Test
+    public void testGetAvailabilityStatusCheckResult() {
+        assertEquals(StatusCheckResult.AVAILABLE, underTest.getAvailabilityStatusCheckResult(SdxClusterStatusResponse.RUNNING));
+        assertEquals(StatusCheckResult.AVAILABLE, underTest.getAvailabilityStatusCheckResult(SdxClusterStatusResponse.DATALAKE_BACKUP_INPROGRESS));
+        assertEquals(StatusCheckResult.NOT_AVAILABLE, underTest.getAvailabilityStatusCheckResult(SdxClusterStatusResponse.RECOVERY_IN_PROGRESS));
+        assertEquals(StatusCheckResult.NOT_AVAILABLE, underTest.getAvailabilityStatusCheckResult(SdxClusterStatusResponse.DATALAKE_UPGRADE_CCM_IN_PROGRESS));
     }
 
     private SdxClusterResponse getSdxClusterResponse() {


### PR DESCRIPTION
Some data hub operations (Create/Start) were failing when the datalake backup was in progress. Since the backup should not interfere in this feature the block was removed. The datahub admin operations are allowed in running and backup in progress after this change.

Obs: stop and delete currently already work, so no change needed in these cases.

Tests:

Scenario 1:
Create a new DH when a backup is in progress without errors.
Backup created with `cdp datalake backup-datalake --datalake-name`

Scenario 2:
Start a DH when a backup is in progress without errors.

Scenario 3:
DH admin operations should be blocked when DL is restoring a backup.