### PR TITLE
CB-11898 Run the syncer in every state of Freeipa except terminate an…

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/repository/StackRepository.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/repository/StackRepository.java
@@ -35,8 +35,8 @@ public interface StackRepository extends AccountAwareResourceRepository<Stack, L
 
     @Query("SELECT s.id as localId, s.resourceCrn as remoteResourceId, s.name as name " +
             "FROM Stack s " +
-            "WHERE s.terminated = -1 and s.stackStatus.status in (:statuses)")
-    List<JobResource> findAllRunningAndStatusIn(@Param("statuses") Collection<Status> statuses);
+            "WHERE s.terminated = -1 and s.stackStatus.status not in (:statuses)")
+    List<JobResource> findAllRunningAndStatusNotIn(@Param("statuses") Collection<Status> statuses);
 
     @Query("SELECT s FROM Stack s LEFT JOIN FETCH s.instanceGroups ig LEFT JOIN FETCH ig.instanceMetaData WHERE s.id= :id ")
     Optional<Stack> findOneWithLists(@Param("id") Long id);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
@@ -1,5 +1,12 @@
 package com.sequenceiq.freeipa.service.stack;
 
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.CREATE_IN_PROGRESS;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.DELETED_ON_PROVIDER_SIDE;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.DELETE_COMPLETED;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.DELETE_IN_PROGRESS;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.REQUESTED;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.STACK_AVAILABLE;
+
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -55,19 +62,13 @@ public class StackService implements EnvironmentPropertyProvider, PayloadContext
     }
 
     public List<JobResource> findAllForAutoSync() {
-        return stackRepository.findAllRunningAndStatusIn(List.of(
-                Status.AVAILABLE,
-                Status.UPDATE_FAILED,
-                Status.START_FAILED,
-                Status.STOP_FAILED,
-                Status.UNREACHABLE,
-                Status.UNHEALTHY,
-                Status.UNKNOWN,
-                Status.STOPPED,
-                Status.START_IN_PROGRESS,
-                Status.STOP_IN_PROGRESS,
-                Status.STOP_REQUESTED,
-                Status.START_REQUESTED));
+        return stackRepository.findAllRunningAndStatusNotIn(List.of(
+                REQUESTED,
+                CREATE_IN_PROGRESS,
+                STACK_AVAILABLE,
+                DELETE_IN_PROGRESS,
+                DELETE_COMPLETED,
+                DELETED_ON_PROVIDER_SIDE));
     }
 
     public Stack getByIdWithListsInTransaction(Long id) {


### PR DESCRIPTION
…d provision

We should specify the disallowed statuses because if we introduce a new status, then we will not reschedule stacks in this status

See detailed description in the commit message.