### PR TITLE
CB-20036 Fix: deserialization of SdxBackupStatusResponse

### DIFF
--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxBackupStatusResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxBackupStatusResponse.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.sdx.api.model;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -20,13 +22,21 @@ public class SdxBackupStatusResponse {
     @ApiModelProperty(ModelDescriptions.OPERATION_STATUS_REASON)
     private String reason;
 
+    @ApiModelProperty(ModelDescriptions.BACKUP_INCLUDED_DATA)
+    private List<String> includedData;
+
+    @ApiModelProperty(ModelDescriptions.BACKUP_TIMESTAMP)
+    private String timestamp;
+
     public SdxBackupStatusResponse() {
     }
 
-    public SdxBackupStatusResponse(String operationId, String status, String reason) {
+    public SdxBackupStatusResponse(String operationId, String status, String reason, List<String> includedData, String timestamp) {
         this.operationId = operationId;
         this.status = status;
         this.reason = reason;
+        this.includedData = includedData;
+        this.timestamp = timestamp;
     }
 
     public String getOperationId() {
@@ -43,6 +53,14 @@ public class SdxBackupStatusResponse {
 
     public void setOperationId(String operationId) {
         this.operationId = operationId;
+    }
+
+    public List<String> getIncludedData() {
+        return includedData;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
     }
 
     @Override


### PR DESCRIPTION
**Cause**
Missing default constructor

**Test:**

1) Manual:
-- created backup via cdp-cli
-- verified new fields are presented in HTTP request for backup status
-- restored backup via cdp-cli
-- verified status on CDP UI

1) E2E SdxBackupRestoreTests locally:

```shell
export DATALAKE_NAME=aws-test-09654d49f8
http --json --headers --body GET localhost:8086/dl/api/sdx/$DATALAKE_NAME/getBackupDatalakeStatus x-cdp-actor-crn:$ACTOR_ID x-cdp-request-id:`uuidgen`
```
```json
{
    "includedData": [
        "RANGER_AUDITS",
        "RANGER_PERMISSIONS",
        "HMS_METADATA",
        "ATLAS_METADATA",
        "ATLAS_INDEXES"
    ],
    "operationId": "debcb773-3a6f-429b-904b-4af0d437be60",
    "reason": "No failure messages found",
    "status": "SUCCESSFUL",
    "timestamp": "2022-12-13T13:29:55.000189+00:00"
}
```
![image](https://user-images.githubusercontent.com/1827293/207350859-74aa0b9d-82f3-4e53-9d49-40ba0229368f.png)

