### PR TITLE
CB-18849 Commanding Datahub DB upgrade applied to the dataLake

### DIFF
--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXUpgradeV1Controller.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXUpgradeV1Controller.java
@@ -76,8 +76,7 @@ public class DistroXUpgradeV1Controller implements DistroXUpgradeV1Endpoint {
 
     @Override
     @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.UPGRADE_DATAHUB)
-    public DistroXRdsUpgradeV1Response upgradeRdsByCrn(@ValidCrn(resource = CrnResourceDescriptor.DATAHUB)
-        @ResourceCrn String crn, @Valid DistroXRdsUpgradeV1Request distroxRdsUpgradeRequest) {
+    public DistroXRdsUpgradeV1Response upgradeRdsByCrn(@ResourceCrn String crn, DistroXRdsUpgradeV1Request distroxRdsUpgradeRequest) {
         NameOrCrn nameOrCrn = NameOrCrn.ofCrn(crn);
         return upgradeRds(distroxRdsUpgradeRequest, nameOrCrn);
     }

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxUpgradeEndpoint.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxUpgradeEndpoint.java
@@ -76,7 +76,7 @@ public interface SdxUpgradeEndpoint {
     @Path("/crn/{crn}/upgrade_rds")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Upgrades the database server of the data lake", nickname = "upgradeDatalakeDatabaseByCrn")
-    SdxUpgradeDatabaseServerResponse upgradeDatabaseServerByCrn(@PathParam("crn") String clusterCrn, @Valid SdxUpgradeDatabaseServerRequest
-            sdxUpgradeDatabaseServerRequest);
+    SdxUpgradeDatabaseServerResponse upgradeDatabaseServerByCrn(@ValidCrn(resource = CrnResourceDescriptor.DATALAKE) @PathParam("crn") String clusterCrn,
+            @Valid SdxUpgradeDatabaseServerRequest sdxUpgradeDatabaseServerRequest);
 
 }

--- a/datalake/src/test/java/com/sequenceiq/datalake/controller/sdx/SdxUpgradeControllerTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/controller/sdx/SdxUpgradeControllerTest.java
@@ -28,6 +28,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.common.database.TargetMajorVersion;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.datalake.service.upgrade.SdxRuntimeUpgradeService;
 import com.sequenceiq.datalake.service.upgrade.ccm.SdxCcmUpgradeService;
 import com.sequenceiq.datalake.service.upgrade.database.SdxDatabaseServerUpgradeService;
@@ -285,6 +286,21 @@ class SdxUpgradeControllerTest {
 
         assertEquals(response, sdxUpgradeDatabaseServerResponse);
         verify(sdxDatabaseServerUpgradeService).upgrade(NameOrCrn.ofName(CLUSTER_NAME), targetMajorVersion);
+    }
+
+    @Test
+    void testUpgradeDatabaseServerByNameSdxClusterDoesNotExist() {
+        SdxUpgradeDatabaseServerRequest request = new SdxUpgradeDatabaseServerRequest();
+        TargetMajorVersion targetMajorVersion = TargetMajorVersion.VERSION_11;
+        request.setTargetMajorVersion(targetMajorVersion);
+
+        doThrow(new NotFoundException("SDX cluster 'testCluster' not found."))
+                .when(sdxDatabaseServerUpgradeService).upgrade(eq(NameOrCrn.ofName(CLUSTER_NAME)), eq(targetMajorVersion));
+
+        NotFoundException exception = doAs(USER_CRN, () -> Assertions.assertThrows(NotFoundException.class,
+                () -> underTest.upgradeDatabaseServerByName(CLUSTER_NAME, request)));
+
+        assertEquals(exception.getMessage(), "SDX cluster 'testCluster' not found.");
     }
 
     @Test

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxServiceTest.java
@@ -46,6 +46,7 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -397,6 +398,25 @@ class SdxServiceTest {
         when(sdxClusterRepository.findByAccountIdAndCrnAndDeletedIsNull(eq("hortonworks"), eq(ENVIRONMENT_CRN))).thenReturn(Optional.of(sdxCluser));
         SdxCluster returnedSdxCluster = underTest.getByNameOrCrn(USER_CRN, NameOrCrn.ofCrn(ENVIRONMENT_CRN));
         assertEquals(sdxCluser, returnedSdxCluster);
+    }
+
+    @Test
+    void testGetSdxClusterByNameOrCrnWhenClusterCrnProvidedThrowsExceptionIfClusterDoesNotExists() {
+        SdxCluster sdxCluser = new SdxCluster();
+        sdxCluser.setEnvName("env");
+        sdxCluser.setClusterName(CLUSTER_NAME);
+        when(sdxClusterRepository.findByAccountIdAndCrnAndDeletedIsNull(eq("hortonworks"), eq(ENVIRONMENT_CRN))).thenReturn(Optional.empty());
+        Assertions.assertThatCode(() -> underTest.getByNameOrCrn(USER_CRN, NameOrCrn.ofCrn(ENVIRONMENT_CRN)))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("SDX cluster '" + ENVIRONMENT_CRN + "' not found.");
+    }
+
+    @Test
+    void testGetSdxClusterByNameOrCrnWhenClusterNameProvidedThrowsExceptionIfClusterDoesNotExists() {
+        when(sdxClusterRepository.findByAccountIdAndClusterNameAndDeletedIsNullAndDetachedIsFalse(anyString(), anyString())).thenReturn(Optional.empty());
+        Assertions.assertThatCode(() -> underTest.getByNameOrCrn(USER_CRN, NameOrCrn.ofName(CLUSTER_NAME)))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("SDX cluster '" + CLUSTER_NAME + "' not found.");
     }
 
     @Test


### PR DESCRIPTION
Added validation to accept Datalake CRN or Cluster name only for datalake database upgrade

Also fixed DH end point to give correct error message if it is called with DL CRN

See detailed description in the commit message.