### PR TITLE
CB-16136:Set Cloud Type Variable in CM

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.core.bootstrap.service.host;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_0_2;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_0;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_1;
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_6_2;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
 import static com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterDeletionBasedExitCriteriaModel.clusterDeletionBasedModel;
 import static com.sequenceiq.cloudbreak.util.NullUtil.throwIfNull;
@@ -654,6 +655,8 @@ public class ClusterHostServiceRunner {
                                 "missed_heartbeat_interval", cmMissedHeartbeatInterval,
                                 "disable_auto_bundle_collection", disableAutoBundleCollection,
                                 "set_cdp_env", isVersionNewerOrEqualThanLimited(cmVersion, CLOUDERAMANAGER_VERSION_7_0_2),
+                                "cloud_provider_setup_supported", isVersionNewerOrEqualThanLimited(cmVersion, CLOUDERAMANAGER_VERSION_7_6_2),
+                                "cloud_provider", stackDto.getCloudPlatform(),
                                 "deterministic_uid_gid", isVersionNewerOrEqualThanLimited(cmVersion, CLOUDERAMANAGER_VERSION_7_2_1),
                                 "cloudera_scm_sudo_access", CMRepositoryVersionUtil.isSudoAccessNeededForHostCertRotation(clouderaManagerRepo)),
                         "mgmt_service_directories", serviceLocations.getAllVolumePath(),

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/init.sls
@@ -34,7 +34,10 @@ add_settings_file_to_cfm_server_args:
   file.replace:
     - name: /etc/default/cloudera-scm-server
     - pattern: "CMF_SERVER_ARGS=.*"
-{% if salt['pillar.get']('cloudera-manager:settings:set_cdp_env') == True %}
+{% if salt['pillar.get']('cloudera-manager:settings:cloud_provider_setup_supported') == True %}
+    - repl: CMF_SERVER_ARGS="-i /etc/cloudera-scm-server/cm.settings -cp {{ cloudera_manager.settings.cloud_provider }} -env PUBLIC_CLOUD"
+    - unless: grep "CMF_SERVER_ARGS=\"-i /etc/cloudera-scm-server/cm.settings -cp {{ cloudera_manager.settings.cloud_provider }}\"" /etc/default/cloudera-scm-server
+{% elif salt['pillar.get']('cloudera-manager:settings:set_cdp_env') == True and salt['pillar.get']('cloudera-manager:settings:cloud_provider_setup_supported') == False %}
     - repl: CMF_SERVER_ARGS="-i /etc/cloudera-scm-server/cm.settings -env PUBLIC_CLOUD"
     - unless: grep "CMF_SERVER_ARGS=\"-i /etc/cloudera-scm-server/cm.settings -env PUBLIC_CLOUD\"" /etc/default/cloudera-scm-server
 {% else %}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
@@ -50,6 +50,8 @@ public class CMRepositoryVersionUtil {
 
     public static final Versioned CLOUDERAMANAGER_VERSION_7_6_0 = () -> "7.6.0";
 
+    public static final Versioned CLOUDERAMANAGER_VERSION_7_6_2 = () -> "7.6.2";
+
     public static final Versioned CLOUDERAMANAGER_VERSION_7_7_1 = () -> "7.7.1";
 
     public static final Versioned CLOUDERA_STACK_VERSION_7_2_7 = () -> "7.2.7";


### PR DESCRIPTION
Added the -cp option to indicate the cloud provider to CM server file.

The screenshot shared below is from the file /etc/default/cloudera-scm-server file 

Before the change:

<img width="624" alt="Screenshot 2022-12-26 at 10 08 59 PM" src="https://user-images.githubusercontent.com/7271603/209813660-90e816aa-4d2f-481b-b323-0f3b351842c7.png">

After the change :

`CMF_SERVER_ARGS="-i /etc/cloudera-scm-server/cm.settings -cp  AWS -env PUBLIC_CLOUD"`

This change is applicable only If the CM version is greater than or equal to 7.6.2 as per the comment mentioned in the jira CB-16136. Screenshot of the same below 

<img width="977" alt="Screenshot 2022-12-28 at 6 11 58 PM" src="https://user-images.githubusercontent.com/7271603/209814055-69a9b71f-0829-47f8-ae82-c705304c070a.png">

