### PR TITLE
CB-20083 Removes no-ntp flag from ipa-replica-install

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_replica_install.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_replica_install.sh
@@ -120,8 +120,10 @@ ipa-replica-install \
           --no-dnssec-validation \
 {%- endif %}
           --unattended \
-          --dirsrv-config-file /opt/salt/initial-ldap-conf.ldif \
-          --no-ntp
+{%- if grains['os_family'] == 'RedHat' and grains['osmajorrelease'] | int == 7 %}
+          --no-ntp \
+{%- endif %}
+          --dirsrv-config-file /opt/salt/initial-ldap-conf.ldif
 
 set +e
 


### PR DESCRIPTION
Validation has been applied to avoid ntp config change in case of already installed ipa client.
https://github.com/freeipa/freeipa/commit/2fba5acc5245caf62ec9af8b8707c13f59bfcff4

FreeIPA related e2e tests are passed with centos7 image: http://ci-cloudbreak.eng.hortonworks.com/job/cloudbreak-pull-request-builder-aws-test/31166/testngreports/com.sequenceiq.it.cloudbreak.testcase.e2e.freeipa/

FreeIPA related e2e tests are passed with redhat8 image as well: http://ci-cloudbreak.eng.hortonworks.com/job/cloudbreak-pull-request-builder-aws-test/31170/testngreports/com.sequenceiq.it.cloudbreak.testcase.e2e.freeipa/