### PR TITLE
CB-20098 Update userdata of each Launch Template separately

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/ResourceConnector.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/ResourceConnector.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.cloud;
 
 import java.util.List;
+import java.util.Map;
 
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.exception.QuotaExceededException;
@@ -16,6 +17,7 @@ import com.sequenceiq.cloudbreak.cloud.model.database.CloudDatabaseServerSslCert
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
 import com.sequenceiq.cloudbreak.common.database.TargetMajorVersion;
 import com.sequenceiq.common.api.adjustment.AdjustmentTypeWithThreshold;
+import com.sequenceiq.common.api.type.InstanceGroupType;
 
 /**
  * Cloudbreak handles the entities on the Cloud provider side as generic resources and supports CRUD operations on them.
@@ -240,14 +242,15 @@ public interface ResourceConnector {
             throws Exception;
 
     /**
-     * Update yser data for the cluster instances which contains parameters for user-data scricpt run during intsances' bootstrap.
+     * Update user data for the cluster instances which contains parameters for user-data script run during instances' bootstrap.
      *
      * @param authenticatedContext the authenticated context which holds the client object
      * @param stack                contains the full description of the new infrastructure (e.g new security groups)
-     * @param userData             the user data
+     * @param userData             the user data by instance group type
      * @throws Exception in case of any error
      */
-    void updateUserData(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources, String userData) throws Exception;
+    void updateUserData(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources, Map<InstanceGroupType, String> userData)
+            throws Exception;
 
     /**
      * Update of infrastructure on Cloud platform, add new instances. It does not need to wait/block until the infrastructure update is

--- a/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/ResourceConnectorTest.java
+++ b/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/ResourceConnectorTest.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.cloud;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,6 +22,7 @@ import com.sequenceiq.cloudbreak.cloud.model.TlsInfo;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
 import com.sequenceiq.cloudbreak.common.database.TargetMajorVersion;
 import com.sequenceiq.common.api.adjustment.AdjustmentTypeWithThreshold;
+import com.sequenceiq.common.api.type.InstanceGroupType;
 
 @ExtendWith(MockitoExtension.class)
 class ResourceConnectorTest {
@@ -123,7 +125,8 @@ class ResourceConnectorTest {
         }
 
         @Override
-        public void updateUserData(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources, String userData) {
+        public void updateUserData(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources,
+                Map<InstanceGroupType, String> userData) {
 
         }
 

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnector.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnector.java
@@ -5,6 +5,7 @@ import static java.util.Collections.singletonList;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 
@@ -34,6 +35,7 @@ import com.sequenceiq.cloudbreak.cloud.model.database.CloudDatabaseServerSslCert
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
 import com.sequenceiq.cloudbreak.common.database.TargetMajorVersion;
 import com.sequenceiq.common.api.adjustment.AdjustmentTypeWithThreshold;
+import com.sequenceiq.common.api.type.InstanceGroupType;
 
 import freemarker.template.Configuration;
 
@@ -189,8 +191,8 @@ public class AwsResourceConnector implements ResourceConnector {
     }
 
     @Override
-    public void updateUserData(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> cloudResources, String userData)
-            throws Exception {
+    public void updateUserData(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> cloudResources,
+            Map<InstanceGroupType, String> userData) throws Exception {
         awsUpdateService.updateUserData(authenticatedContext, stack, cloudResources, userData);
     }
 

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsUpdateServiceTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsUpdateServiceTest.java
@@ -1,34 +1,37 @@
 package com.sequenceiq.cloudbreak.cloud.aws.connector.resource;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.cloud.UpdateType;
 import com.sequenceiq.cloudbreak.cloud.aws.AwsImageUpdateService;
 import com.sequenceiq.cloudbreak.cloud.aws.AwsLaunchTemplateUpdateService;
+import com.sequenceiq.cloudbreak.cloud.aws.LaunchTemplateField;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
+import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.ResourceType;
 
-public class AwsUpdateServiceTest {
+@ExtendWith(MockitoExtension.class)
+class AwsUpdateServiceTest {
 
     @Mock
     private AwsImageUpdateService awsImageUpdateService;
@@ -45,13 +48,8 @@ public class AwsUpdateServiceTest {
     @InjectMocks
     private AwsUpdateService underTest;
 
-    @Before
-    public void setUp() {
-        MockitoAnnotations.initMocks(this);
-    }
-
     @Test
-    public void updateCloudFormationTemplateResourceWithImageParameter() {
+    void updateCloudFormationTemplateResourceWithImageParameter() {
         CloudResource cloudResource = CloudResource.builder()
                 .withName("cf")
                 .withType(ResourceType.CLOUDFORMATION_STACK)
@@ -67,7 +65,7 @@ public class AwsUpdateServiceTest {
     }
 
     @Test
-    public void updateCloudFormationTemplateResourceWithoutImageParameter() {
+    void updateCloudFormationTemplateResourceWithoutImageParameter() {
         CloudResource cloudResource = CloudResource.builder()
                 .withName("cf")
                 .withType(ResourceType.CLOUDFORMATION_STACK)
@@ -76,8 +74,6 @@ public class AwsUpdateServiceTest {
                 .withName("cf")
                 .withType(ResourceType.AWS_LAUNCHCONFIGURATION)
                 .build();
-        when(stack.getTemplate()).thenReturn("AWS::EC2::LaunchTemplate");
-        doNothing().when(awsLaunchTemplateUpdateService).updateLaunchTemplate(anyMap(), any(), anyString(), any());
 
         List<CloudResourceStatus> statuses = underTest.update(ac, stack, List.of(cloudResource, launch), UpdateType.IMAGE_UPDATE);
 
@@ -86,7 +82,7 @@ public class AwsUpdateServiceTest {
     }
 
     @Test
-    public void updateRandomResource() {
+    void updateRandomResource() {
         CloudResource cloudResource = CloudResource.builder()
                 .withName("cf")
                 .withType(ResourceType.AWS_LAUNCHCONFIGURATION)
@@ -97,11 +93,40 @@ public class AwsUpdateServiceTest {
                 .withType(ResourceType.CLOUDFORMATION_STACK)
                 .withParams(Collections.singletonMap(CloudResource.IMAGE, "dummy"))
                 .build();
-        doNothing().when(awsLaunchTemplateUpdateService).updateLaunchTemplate(anyMap(), any(), anyString(), any());
 
         List<CloudResourceStatus> statuses = underTest.update(ac, stack, List.of(cloudResource, cf), UpdateType.IMAGE_UPDATE);
 
         verify(awsImageUpdateService, times(0)).updateImage(ac, stack, cloudResource);
         assertEquals(1, statuses.size());
+    }
+
+    @Test
+    void updateUserData() {
+        when(stack.getTemplate()).thenReturn("AWS::EC2::LaunchTemplate");
+        Group coreGroup = mock(Group.class);
+        when(coreGroup.getType()).thenReturn(InstanceGroupType.CORE);
+        Group gatewayGroup = mock(Group.class);
+        when(gatewayGroup.getType()).thenReturn(InstanceGroupType.GATEWAY);
+        when(stack.getGroups()).thenReturn(List.of(coreGroup, gatewayGroup));
+
+        Map<InstanceGroupType, String> userData = Map.of(
+                InstanceGroupType.CORE, "core",
+                InstanceGroupType.GATEWAY, "gateway"
+        );
+
+        CloudResource cf = CloudResource.builder()
+                .withName("cf")
+                .withType(ResourceType.CLOUDFORMATION_STACK)
+                .withParams(Collections.singletonMap(CloudResource.IMAGE, "dummy"))
+                .build();
+
+        underTest.updateUserData(ac, stack, List.of(cf), userData);
+
+        String encodedCoreUserData = Base64.getEncoder().encodeToString(userData.get(InstanceGroupType.CORE).getBytes());
+        Map<LaunchTemplateField, String> coreFields = Map.of(LaunchTemplateField.USER_DATA, encodedCoreUserData);
+        verify(awsLaunchTemplateUpdateService).updateLaunchTemplate(coreFields, ac, cf.getName(), coreGroup);
+        String encodedGatewayUserData = Base64.getEncoder().encodeToString(userData.get(InstanceGroupType.GATEWAY).getBytes());
+        Map<LaunchTemplateField, String> gatewayFields = Map.of(LaunchTemplateField.USER_DATA, encodedGatewayUserData);
+        verify(awsLaunchTemplateUpdateService).updateLaunchTemplate(gatewayFields, ac, cf.getName(), gatewayGroup);
     }
 }

--- a/cloud-aws-native/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsNativeResourceConnector.java
+++ b/cloud-aws-native/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsNativeResourceConnector.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.cloud.aws;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -32,6 +33,7 @@ import com.sequenceiq.cloudbreak.cloud.service.ResourceRetriever;
 import com.sequenceiq.cloudbreak.cloud.template.AbstractResourceConnector;
 import com.sequenceiq.common.api.adjustment.AdjustmentTypeWithThreshold;
 import com.sequenceiq.common.api.type.CommonStatus;
+import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.ResourceType;
 
 @Component
@@ -69,7 +71,8 @@ public class AwsNativeResourceConnector extends AbstractResourceConnector {
     }
 
     @Override
-    public void updateUserData(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources, String userData) {
+    public void updateUserData(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources,
+            Map<InstanceGroupType, String> userData) {
         LOGGER.info("Update userdata is not implemented on AWS Native!");
     }
 

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 
@@ -48,6 +49,7 @@ import com.sequenceiq.cloudbreak.common.database.TargetMajorVersion;
 import com.sequenceiq.cloudbreak.service.Retry.ActionFailedException;
 import com.sequenceiq.cloudbreak.util.NullUtil;
 import com.sequenceiq.common.api.adjustment.AdjustmentTypeWithThreshold;
+import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.ResourceType;
 
 @Service
@@ -328,7 +330,8 @@ public class AzureResourceConnector extends AbstractResourceConnector {
     }
 
     @Override
-    public void updateUserData(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources, String userData) {
+    public void updateUserData(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources,
+            Map<InstanceGroupType, String> userData) {
         LOGGER.info("Update userdata is not implemented on Azure!");
     }
 

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpResourceConnector.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpResourceConnector.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.cloud.gcp;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 
@@ -26,6 +27,7 @@ import com.sequenceiq.cloudbreak.cloud.template.AbstractResourceConnector;
 import com.sequenceiq.cloudbreak.cloud.template.context.ResourceBuilderContext;
 import com.sequenceiq.cloudbreak.cloud.template.init.ContextBuilders;
 import com.sequenceiq.cloudbreak.cloud.template.loadbalancer.LoadBalancerResourceService;
+import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.ResourceType;
 
 @Service
@@ -113,7 +115,8 @@ public class GcpResourceConnector extends AbstractResourceConnector {
     }
 
     @Override
-    public void updateUserData(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources, String userData) {
+    public void updateUserData(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources,
+            Map<InstanceGroupType, String> userData) {
         LOGGER.info("Update userdata is not implemented on GCP!");
     }
 }

--- a/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockResourceConnector.java
+++ b/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockResourceConnector.java
@@ -8,6 +8,7 @@ import static java.util.Collections.emptyList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -43,6 +44,7 @@ import com.sequenceiq.cloudbreak.common.database.TargetMajorVersion;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.common.api.adjustment.AdjustmentTypeWithThreshold;
 import com.sequenceiq.common.api.type.CommonStatus;
+import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.ResourceType;
 
 @Service
@@ -157,7 +159,8 @@ public class MockResourceConnector implements ResourceConnector {
     }
 
     @Override
-    public void updateUserData(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources, String userData) {
+    public void updateUserData(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources,
+            Map<InstanceGroupType, String> userData) {
 
     }
 

--- a/cloud-template/src/test/java/com/sequenceiq/cloudbreak/cloud/template/AbstractResourceConnectorTest.java
+++ b/cloud-template/src/test/java/com/sequenceiq/cloudbreak/cloud/template/AbstractResourceConnectorTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ import com.sequenceiq.cloudbreak.cloud.model.VolumeSetAttributes;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
 import com.sequenceiq.cloudbreak.cloud.template.context.ResourceBuilderContext;
 import com.sequenceiq.common.api.type.CommonStatus;
+import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.ResourceType;
 
 @ExtendWith(MockitoExtension.class)
@@ -55,7 +57,8 @@ public class AbstractResourceConnectorTest {
             }
 
             @Override
-            public void updateUserData(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources, String userData) {
+            public void updateUserData(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources,
+                    Map<InstanceGroupType, String> userData) {
 
             }
 

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnResourceConnector.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnResourceConnector.java
@@ -57,6 +57,7 @@ import com.sequenceiq.cloudbreak.cloud.yarn.loadbalancer.service.launch.YarnLoad
 import com.sequenceiq.cloudbreak.cloud.yarn.status.YarnApplicationStatus;
 import com.sequenceiq.cloudbreak.common.database.TargetMajorVersion;
 import com.sequenceiq.common.api.adjustment.AdjustmentTypeWithThreshold;
+import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.ResourceType;
 
 @Service
@@ -254,7 +255,8 @@ public class YarnResourceConnector implements ResourceConnector {
     }
 
     @Override
-    public void updateUserData(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources, String userData) {
+    public void updateUserData(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources,
+            Map<InstanceGroupType, String> userData) {
         LOGGER.info("Update userdata is not implemented on Yarn!");
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/update/userdata/UserDataUpdateActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/update/userdata/UserDataUpdateActions.java
@@ -69,9 +69,9 @@ public class UserDataUpdateActions {
             @Override
             protected Selectable createRequest(StackContext context) {
                 StackDtoDelegate stack = context.getStack();
-                String userData;
+                Map<InstanceGroupType, String> userData;
                 try {
-                    userData = imageService.getImage(stack.getId()).getUserdata().get(InstanceGroupType.GATEWAY);
+                    userData = imageService.getImage(stack.getId()).getUserdata();
                 } catch (CloudbreakImageNotFoundException e) {
                     return new UserDataUpdateFailed(stack.getId(), e);
                 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/userdata/UserDataUpdateOnProviderRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/userdata/UserDataUpdateOnProviderRequest.java
@@ -1,20 +1,22 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.stack.userdata;
 
 import java.util.List;
+import java.util.Map;
 
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.event.resource.CloudStackRequest;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.common.api.type.InstanceGroupType;
 
 public class UserDataUpdateOnProviderRequest extends CloudStackRequest<UserDataUpdateOnProviderResult> {
     private final List<CloudResource> cloudResources;
 
-    private final String userData;
+    private final Map<InstanceGroupType, String> userData;
 
     public UserDataUpdateOnProviderRequest(CloudContext cloudContext, CloudCredential cloudCredential, CloudStack cloudStack, List<CloudResource> cloudResources,
-            String userData) {
+            Map<InstanceGroupType, String> userData) {
         super(cloudContext, cloudCredential, cloudStack);
         this.cloudResources = cloudResources;
         this.userData = userData;
@@ -24,7 +26,7 @@ public class UserDataUpdateOnProviderRequest extends CloudStackRequest<UserDataU
         return cloudResources;
     }
 
-    public String getUserData() {
+    public Map<InstanceGroupType, String> getUserData() {
         return userData;
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpgradeCcmFlowChainIntegrationTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpgradeCcmFlowChainIntegrationTest.java
@@ -126,6 +126,8 @@ class UpgradeCcmFlowChainIntegrationTest {
 
     private static final String USER_DATA = "hello hello is there anybody out there";
 
+    private static final Map<InstanceGroupType, String> USER_DATA_MAP = Map.of(InstanceGroupType.GATEWAY, USER_DATA);
+
     private static final long STACK_ID = 1L;
 
     private static final int ALL_CALLED_ONCE = 4;
@@ -264,7 +266,7 @@ class UpgradeCcmFlowChainIntegrationTest {
     @BeforeEach
     public void setup() throws CloudbreakImageNotFoundException {
         mockStackService();
-        Image image = new Image("alma", Map.of(InstanceGroupType.GATEWAY, USER_DATA), "", "", "", "", "", null);
+        Image image = new Image("alma", USER_DATA_MAP, "", "", "", "", "", null);
         when(imageService.getImage(STACK_ID)).thenReturn(image);
 
         CloudConnector connector = mock(CloudConnector.class);
@@ -317,7 +319,7 @@ class UpgradeCcmFlowChainIntegrationTest {
 
     private void verifyFinishingStatCalls(boolean saltUpdateSuccess, boolean ccmUpgradeSuccess, boolean userDataUpdateSuccess) throws Exception {
         verify(upgradeCcmService, times(ccmUpgradeSuccess ? 1 : 0)).ccmUpgradeFinished(eq(1L), eq(0L), anyBoolean());
-        verify(resourcesApi, times(userDataUpdateSuccess ? 1 : 0)).updateUserData(any(), any(), any(), eq(USER_DATA));
+        verify(resourcesApi, times(userDataUpdateSuccess ? 1 : 0)).updateUserData(any(), any(), any(), eq(USER_DATA_MAP));
         verify(upgradeCcmService, times(ccmUpgradeSuccess || !saltUpdateSuccess ? 0 : 1)).ccmUpgradeFailed(any(), anyLong());
         verify(clusterApi, times(saltUpdateSuccess ? 1 : 0)).waitForServer(anyBoolean());
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/handler/UpdateUserDataOnProviderHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/handler/UpdateUserDataOnProviderHandler.java
@@ -2,6 +2,8 @@ package com.sequenceiq.freeipa.flow.stack.update.handler;
 
 import static com.sequenceiq.freeipa.flow.stack.update.UpdateUserDataEvents.UPDATE_USERDATA_FAILED_EVENT;
 
+import java.util.Map;
+
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
@@ -14,6 +16,7 @@ import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.eventbus.Event;
+import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
 import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
@@ -48,7 +51,8 @@ public class UpdateUserDataOnProviderHandler extends ExceptionCatcherEventHandle
             AuthenticatedContext auth = connector.authentication().authenticate(request.getCloudContext(), request.getCloudCredential());
             CloudStack stack = request.getCloudStack();
 
-            connector.resources().updateUserData(auth, stack, request.getCloudResources(), request.getUserData());
+            Map<InstanceGroupType, String> userData = Map.of(InstanceGroupType.GATEWAY, request.getUserData());
+            connector.resources().updateUserData(auth, stack, request.getCloudResources(), userData);
             return new UserDataUpdateOnProviderResult(request.getResourceId());
         } catch (Exception e) {
             LOGGER.error("Updating user data on provider side has failed", e);

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/chain/UpgradeCcmFlowChainIntegrationTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/chain/UpgradeCcmFlowChainIntegrationTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
+import java.util.Map;
 import java.util.UUID;
 
 import javax.inject.Inject;
@@ -42,6 +43,7 @@ import com.sequenceiq.cloudbreak.cloud.CloudConnector;
 import com.sequenceiq.cloudbreak.cloud.ResourceConnector;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
+import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.Tunnel;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.flow.core.chain.FlowChains;
@@ -89,6 +91,8 @@ class UpgradeCcmFlowChainIntegrationTest {
     private static final String USER_CRN = "crn:cdp:iam:us-west-1:" + UUID.randomUUID() + ":user:" + UUID.randomUUID();
 
     private static final String USER_DATA = "hello hello is there anybody out there";
+
+    private static final Map<InstanceGroupType, String> USER_DATA_MAP = Map.of(InstanceGroupType.GATEWAY, USER_DATA);
 
     private static final long STACK_ID = 1L;
 
@@ -190,7 +194,7 @@ class UpgradeCcmFlowChainIntegrationTest {
 
     private void verifyFinishingStatCalls(boolean ccmUpgradeSuccess, boolean userDataUpdateSuccess, boolean minaRemoved) throws Exception {
         verify(upgradeCcmService, times(ccmUpgradeSuccess ? 1 : 0)).finishedState(STACK_ID, minaRemoved);
-        verify(resourcesApi, times(userDataUpdateSuccess ? 1 : 0)).updateUserData(any(), any(), any(), eq(USER_DATA));
+        verify(resourcesApi, times(userDataUpdateSuccess ? 1 : 0)).updateUserData(any(), any(), any(), eq(USER_DATA_MAP));
 
         ArgumentCaptor<UpgradeCcmContext> contextCaptor = ArgumentCaptor.forClass(UpgradeCcmContext.class);
         ArgumentCaptor<UpgradeCcmFailureEvent> payloadCaptor = ArgumentCaptor.forClass(UpgradeCcmFailureEvent.class);
@@ -231,7 +235,7 @@ class UpgradeCcmFlowChainIntegrationTest {
         inOrder.verify(upgradeCcmService, times(expected[i++])).deregisterMinaState(STACK_ID);
         inOrder.verify(upgradeCcmService, times(expected[i++])).deregisterMina(STACK_ID);
         inOrder.verify(userDataService, times(expected[i++])).regenerateUserData(STACK_ID);
-        inOrder.verify(resourcesApi, times(expected[i++])).updateUserData(any(), any(), any(), eq(USER_DATA));
+        inOrder.verify(resourcesApi, times(expected[i++])).updateUserData(any(), any(), any(), eq(USER_DATA_MAP));
     }
 
     private void flowFinishedSuccessfully(int numberOfRanFlows) {

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/update/UpdateUserDataFlowIntegrationTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/update/UpdateUserDataFlowIntegrationTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
+import java.util.Map;
 import java.util.UUID;
 
 import javax.inject.Inject;
@@ -35,6 +36,7 @@ import com.sequenceiq.cloudbreak.cloud.CloudConnector;
 import com.sequenceiq.cloudbreak.cloud.ResourceConnector;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
+import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.Tunnel;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.flow.core.FlowRegister;
@@ -70,6 +72,8 @@ class UpdateUserDataFlowIntegrationTest {
     private static final int CALLED_ONCE_TILL_GENERATE_USERDATA = 1;
 
     private static final String USER_DATA = "hello hello is there anybody out there";
+
+    private static final Map<InstanceGroupType, String> USER_DATA_MAP = Map.of(InstanceGroupType.GATEWAY, USER_DATA);
 
     @Inject
     private FlowRegister flowRegister;
@@ -151,7 +155,7 @@ class UpdateUserDataFlowIntegrationTest {
     }
 
     private void verifyFinishingStatCalls(boolean success) throws Exception {
-        verify(resourcesApi, times(success ? 1 : 0)).updateUserData(any(), any(), any(), eq(USER_DATA));
+        verify(resourcesApi, times(success ? 1 : 0)).updateUserData(any(), any(), any(), eq(USER_DATA_MAP));
         verify(operationService, times(success ? 1 : 0)).completeOperation(any(), any(), any(), any());
         verify(operationService, times(success ? 0 : 1)).failOperation(any(), any(), any());
 


### PR DESCRIPTION
The old implementation updated each Launch Template of AWS CF stacks with the gateway's userdata, now it updates each separately with it own userdata.

See detailed description in the commit message.