### PR TITLE
CB-20056 Prevent duplicate ClusterPertain records from being persiste…

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/controller/AutoScaleClusterCommonService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/controller/AutoScaleClusterCommonService.java
@@ -178,12 +178,13 @@ public class AutoScaleClusterCommonService implements AuthorizationResourceCrnPr
     @Override
     @Retryable(value = NotFoundException.class, maxAttempts = 3, backoff = @Backoff(delay = 5000))
     public String getResourceCrnByResourceName(String clusterName) {
+        // All controller methods annotated with @CheckPermissionByResourceName will forcefully sync a cluster to periscope for a successful authz check
         return getClusterByCrnOrName(NameOrCrn.ofName(clusterName)).getStackCrn();
     }
 
     @Override
     public Optional<String> getEnvironmentCrnByResourceCrn(String resourceCrn) {
-        return Optional.ofNullable(getClusterByCrnOrName(NameOrCrn.ofCrn(resourceCrn)).getEnvironmentCrn());
+        return clusterService.findOneByStackCrnAndTenant(resourceCrn, restRequestThreadLocalService.getCloudbreakTenant()).map(Cluster::getEnvironmentCrn);
     }
 
     public Optional<String> determineLoadBasedPolicyHostGroup(Cluster cluster) {

--- a/autoscale/src/main/java/com/sequenceiq/periscope/repository/ClusterPertainRepository.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/repository/ClusterPertainRepository.java
@@ -13,5 +13,5 @@ import com.sequenceiq.periscope.domain.ClusterPertain;
 @EntityType(entityClass = ClusterPertain.class)
 @Transactional(Transactional.TxType.REQUIRED)
 public interface ClusterPertainRepository extends CrudRepository<ClusterPertain, Long> {
-    Optional<ClusterPertain> findByUserCrn(@Param("userCrn") String userCrn);
+    Optional<ClusterPertain> findFirstByUserCrn(@Param("userCrn") String userCrn);
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/ClusterService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/ClusterService.java
@@ -97,7 +97,7 @@ public class ClusterService {
         ClusterPertain clusterPertain =
                 new ClusterPertain(stack.getTenant(), stack.getWorkspaceId(), stack.getUserId(), stack.getUserCrn());
         cluster.setClusterPertain(
-                clusterPertainRepository.findByUserCrn(clusterPertain.getUserCrn())
+                clusterPertainRepository.findFirstByUserCrn(clusterPertain.getUserCrn())
                         .orElseGet(() -> clusterPertainRepository.save(clusterPertain)));
 
         cluster = save(cluster);

--- a/autoscale/src/test/java/com/sequenceiq/periscope/endpointtests/DistroXAutoScaleClusterV1EndpointTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/endpointtests/DistroXAutoScaleClusterV1EndpointTest.java
@@ -166,7 +166,7 @@ public class DistroXAutoScaleClusterV1EndpointTest {
                 .addEntitlements(UserManagementProto.Entitlement.newBuilder().setEntitlementName("DATAHUB_GCP_STOP_START_SCALING").build())
                 .build();
         testCluster.setClusterPertain(
-                clusterPertainRepsitory.findByUserCrn(clusterPertain.getUserCrn())
+                clusterPertainRepsitory.findFirstByUserCrn(clusterPertain.getUserCrn())
                         .orElseGet(() -> clusterPertainRepsitory.save(clusterPertain)));
         clusterRepository.save(testCluster);
 


### PR DESCRIPTION
…d due to simultaneous authz checks

- Due to multiple periscope API invocations from the UI, the associated authorization checks will introduce a new periscope cluster record into the DB, causing record duplication
- This could prevent new users from creating a cluster and enabling autoscaling because of `NonUniqueResultException` when fetching values from the ClusterPertain entity

See detailed description in the commit message.