### PR TITLE
CB-20081 Adding measurement to FreeIPA launch

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaCreationService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaCreationService.java
@@ -165,9 +165,11 @@ public class FreeIpaCreationService {
 
         String template = templateService.waitGetTemplate(getPlatformTemplateRequest);
         stack.setTemplate(template);
-        SecurityConfig securityConfig = tlsSecurityService.generateSecurityKeys(accountId);
+        SecurityConfig securityConfig = measure(() -> tlsSecurityService.generateSecurityKeys(accountId), LOGGER,
+                "Generating security keys took {} ms for {}", stack.getName());
         multiAzValidator.validateMultiAzForStack(stack.getPlatformvariant(), stack.getInstanceGroups());
-        freeIpaRecommendationService.validateCustomInstanceType(stack, credential);
+        measure(() -> freeIpaRecommendationService.validateCustomInstanceType(stack, credential), LOGGER,
+                "Validating custom instance type took {} ms for {}", stack.getName());
         try {
             Triple<Stack, ImageEntity, FreeIpa> stackImageFreeIpaTuple = transactionService.required(() -> {
                 SecurityConfig savedSecurityConfig = securityConfigService.save(securityConfig);


### PR DESCRIPTION
Adding two measurements when launching FreeIPA to be able to see which step could consume a lot of time in case of a failure.

See detailed description in the commit message.