### PR TITLE
CB-19667 Fix userdata generation for proxy modification

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/util/UserDataReplacer.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/util/UserDataReplacer.java
@@ -1,0 +1,46 @@
+package com.sequenceiq.cloudbreak.util;
+
+public class UserDataReplacer {
+
+    private static final String EXPORT_PREFIX_FORMAT = "export %s=";
+
+    private String userData;
+
+    public UserDataReplacer(String userData) {
+        this.userData = userData;
+    }
+
+    public UserDataReplacer replace(String parameter, Object newValue) {
+        return replaceInternal(parameter, false, newValue);
+    }
+
+    public UserDataReplacer replaceQuoted(String parameter, Object newValue) {
+        return replaceInternal(parameter, true, newValue);
+    }
+
+    private UserDataReplacer replaceInternal(String parameter, boolean quoted, Object newValue) {
+        String format = EXPORT_PREFIX_FORMAT + (quoted ? "\"%s\"" : "%s") + "\n";
+        String oldValueSearchPattern = String.format(EXPORT_PREFIX_FORMAT, parameter);
+        String newFormattedValue = String.format(format, parameter, newValue);
+
+        if (userData.contains(oldValueSearchPattern)) {
+            String oldValueRegex = oldValueSearchPattern + ".*\n";
+            if (newValue != null) {
+                // replace parameter
+                userData = userData.replaceAll(oldValueRegex, newFormattedValue);
+            } else {
+                // remove parameter
+                userData = userData.replaceAll(oldValueRegex, "");
+            }
+        } else if (newValue != null) {
+            // add new parameter
+            int indexAfterLastExport = userData.indexOf("\n", userData.lastIndexOf("export")) + 1;
+            userData = userData.substring(0, indexAfterLastExport) + newFormattedValue + userData.substring(indexAfterLastExport);
+        }
+        return this;
+    }
+
+    public String getUserData() {
+        return userData;
+    }
+}

--- a/common/src/test/java/com/sequenceiq/cloudbreak/util/UserDataReplacerTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/util/UserDataReplacerTest.java
@@ -1,0 +1,49 @@
+package com.sequenceiq.cloudbreak.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class UserDataReplacerTest {
+
+    @Test
+    void replace() {
+        String result = new UserDataReplacer("export PARAM=true\n")
+                .replace("PARAM", false)
+                .getUserData();
+        assertThat(result).isEqualTo("export PARAM=false\n");
+    }
+
+    @Test
+    void add() {
+        String result = new UserDataReplacer("export PARAM=true\n")
+                .replaceQuoted("PARAM2", "newValue")
+                .getUserData();
+        assertThat(result).isEqualTo("export PARAM=true\nexport PARAM2=\"newValue\"\n");
+    }
+
+    @Test
+    void remove() {
+        String result = new UserDataReplacer("export PARAM=true\nexport PARAM2=\"oldValue\"\n")
+                .replaceQuoted("PARAM2", null)
+                .getUserData();
+        assertThat(result).isEqualTo("export PARAM=true\n");
+    }
+
+    @Test
+    void same() {
+        String result = new UserDataReplacer("export PARAM=true\n")
+                .replace("PARAM", true)
+                .getUserData();
+        assertThat(result).isEqualTo("export PARAM=true\n");
+    }
+
+    @Test
+    void bothNull() {
+        String result = new UserDataReplacer("export PARAM=true\n")
+                .replace("PARAM2", null)
+                .getUserData();
+        assertThat(result).isEqualTo("export PARAM=true\n");
+    }
+
+}

--- a/environment-common/src/main/java/com/sequenceiq/cloudbreak/service/proxy/ProxyConfigUserDataReplacer.java
+++ b/environment-common/src/main/java/com/sequenceiq/cloudbreak/service/proxy/ProxyConfigUserDataReplacer.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.cloudbreak.service.proxy;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.dto.ProxyAuthentication;
+import com.sequenceiq.cloudbreak.dto.ProxyConfig;
+import com.sequenceiq.cloudbreak.util.UserDataReplacer;
+
+@Service
+public class ProxyConfigUserDataReplacer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProxyConfigUserDataReplacer.class);
+
+    @Inject
+    private ProxyConfigDtoService proxyConfigDtoService;
+
+    public String replaceProxyConfigInUserDataByEnvCrn(String userData, String envCrn) {
+        Optional<ProxyConfig> proxyConfigOptional = proxyConfigDtoService.getByEnvironmentCrn(envCrn);
+        LOGGER.info("Replacing proxy config in user data to {}", proxyConfigOptional.map(ProxyConfig::getCrn).orElse(null));
+        Optional<ProxyAuthentication> proxyConfigOptionalAuth = proxyConfigOptional.flatMap(ProxyConfig::getProxyAuthentication);
+        return new UserDataReplacer(userData)
+                .replace("IS_PROXY_ENABLED", proxyConfigOptional.isPresent())
+                .replace("PROXY_HOST", proxyConfigOptional.map(ProxyConfig::getServerHost).orElse(null))
+                .replace("PROXY_PORT", proxyConfigOptional.map(ProxyConfig::getServerPort).orElse(null))
+                .replace("PROXY_PROTOCOL", proxyConfigOptional.map(ProxyConfig::getProtocol).orElse(null))
+                .replaceQuoted("PROXY_USER", proxyConfigOptionalAuth.map(ProxyAuthentication::getUserName).orElse(null))
+                .replaceQuoted("PROXY_PASSWORD", proxyConfigOptionalAuth.map(ProxyAuthentication::getPassword).orElse(null))
+                .replaceQuoted("PROXY_NO_PROXY_HOSTS", proxyConfigOptional.map(ProxyConfig::getNoProxyHosts).orElse(null))
+                .getUserData();
+    }
+}

--- a/environment-common/src/test/java/com/sequenceiq/cloudbreak/service/proxy/ProxyConfigUserDataReplacerTest.java
+++ b/environment-common/src/test/java/com/sequenceiq/cloudbreak/service/proxy/ProxyConfigUserDataReplacerTest.java
@@ -1,0 +1,106 @@
+package com.sequenceiq.cloudbreak.service.proxy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.dto.ProxyAuthentication;
+import com.sequenceiq.cloudbreak.dto.ProxyConfig;
+import com.sequenceiq.cloudbreak.util.FileReaderUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ProxyConfigUserDataReplacerTest {
+
+    private static final String ENV_CRN = "env-crn";
+
+    private static String noProxyUserData;
+
+    private static String proxyUserData;
+
+    @Mock
+    private ProxyConfigDtoService proxyConfigDtoService;
+
+    @InjectMocks
+    private ProxyConfigUserDataReplacer underTest;
+
+    @BeforeAll
+    static void init() throws IOException {
+        noProxyUserData = FileReaderUtils.readFileFromClasspath("com/sequenceiq/cloudbreak/service/proxy/userdata/no-proxy-userdata");
+        proxyUserData = FileReaderUtils.readFileFromClasspath("com/sequenceiq/cloudbreak/service/proxy/userdata/proxy-userdata");
+    }
+
+    @BeforeEach
+    void setUp() {
+        ProxyConfig proxyConfig = ProxyConfig.builder()
+                .withCrn("crn")
+                .withName("name")
+                .withServerHost("1.2.3.4")
+                .withServerPort(1234)
+                .withProtocol("http")
+                .withProxyAuthentication(ProxyAuthentication.builder().withUserName("username").withPassword("password").build())
+                .withNoProxyHosts("noproxy")
+                .build();
+        lenient().when(proxyConfigDtoService.getByEnvironmentCrn(ENV_CRN)).thenReturn(Optional.of(proxyConfig));
+    }
+
+    @Test
+    void addProxy() {
+        String result = underTest.replaceProxyConfigInUserDataByEnvCrn(noProxyUserData, ENV_CRN);
+
+        assertEquals(proxyUserData, result);
+    }
+
+    @Test
+    void removeProxy() {
+        when(proxyConfigDtoService.getByEnvironmentCrn(ENV_CRN)).thenReturn(Optional.empty());
+
+        String result = underTest.replaceProxyConfigInUserDataByEnvCrn(proxyUserData, ENV_CRN);
+
+        assertEquals(noProxyUserData, result);
+    }
+
+    @Test
+    void changeProxy() {
+        ProxyConfig newProxyConfig = ProxyConfig.builder()
+                .withCrn("crn")
+                .withName("name")
+                .withServerHost("1.2.3.5")
+                .withServerPort(1235)
+                .withProtocol("https")
+                .withProxyAuthentication(ProxyAuthentication.builder().withUserName("username2").withPassword("password2").build())
+                .withNoProxyHosts("noproxy2")
+                .build();
+        when(proxyConfigDtoService.getByEnvironmentCrn(ENV_CRN)).thenReturn(Optional.of(newProxyConfig));
+
+        String result = underTest.replaceProxyConfigInUserDataByEnvCrn(proxyUserData, ENV_CRN);
+
+        assertFalse(result.contains("IS_PROXY_ENABLED=false\n"));
+        assertTrue(result.contains("IS_PROXY_ENABLED=true\n"));
+        assertFalse(result.contains("PROXY_HOST=1.2.3.4\n"));
+        assertTrue(result.contains("PROXY_HOST=1.2.3.5\n"));
+        assertFalse(result.contains("PROXY_PORT=1234\n"));
+        assertTrue(result.contains("PROXY_PORT=1235\n"));
+        assertFalse(result.contains("PROXY_PROTOCOL=http\n"));
+        assertTrue(result.contains("PROXY_PROTOCOL=https\n"));
+        assertFalse(result.contains("PROXY_USER=\"username\"\n"));
+        assertTrue(result.contains("PROXY_USER=\"username2\"\n"));
+        assertFalse(result.contains("PROXY_PASSWORD=\"password\"\n"));
+        assertTrue(result.contains("PROXY_PASSWORD=\"password2\"\n"));
+        assertFalse(result.contains("PROXY_NO_PROXY_HOSTS=\"noproxy\"\n"));
+        assertTrue(result.contains("PROXY_NO_PROXY_HOSTS=\"noproxy2\"\n"));
+    }
+
+}

--- a/environment-common/src/test/resources/com/sequenceiq/cloudbreak/service/proxy/userdata/no-proxy-userdata
+++ b/environment-common/src/test/resources/com/sequenceiq/cloudbreak/service/proxy/userdata/no-proxy-userdata
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+## logging
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+set -x
+
+export ENVIRONMENT_CRN="crn:cdp:environments:us-west-1:9d74eee4-1cad-45d7-b645-7ccf9edbb73d:environment:e89ff689-59a1-48a4-96ac-6397f5db8b09"
+export CLOUD_PLATFORM="AWS"
+export START_LABEL=97
+export PLATFORM_DISK_PREFIX=xvd
+export LAZY_FORMAT_DISK_LIMIT=12
+export IS_GATEWAY=true
+export TMP_SSH_KEY="dummy"
+export SSH_USER=cloudbreak
+export SALT_BOOT_PASSWORD=...
+export SALT_BOOT_SIGN_KEY=...
+export CB_CERT=...
+export IS_CCM_ENABLED=false
+export IS_CCM_V2_ENABLED=false
+export IS_PROXY_ENABLED=false
+
+touch /tmp/cb-custom-data-default.txt
+
+/usr/bin/user-data-helper.sh "$@" &> /var/log/user-data.log
+
+chmod o-rwx /var/log/user-data.log
+chmod o-rwx /cdp/bin/*
+chmod o-rwx -R /etc/certs/ || :

--- a/environment-common/src/test/resources/com/sequenceiq/cloudbreak/service/proxy/userdata/proxy-userdata
+++ b/environment-common/src/test/resources/com/sequenceiq/cloudbreak/service/proxy/userdata/proxy-userdata
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+## logging
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+set -x
+
+export ENVIRONMENT_CRN="crn:cdp:environments:us-west-1:9d74eee4-1cad-45d7-b645-7ccf9edbb73d:environment:e89ff689-59a1-48a4-96ac-6397f5db8b09"
+export CLOUD_PLATFORM="AWS"
+export START_LABEL=97
+export PLATFORM_DISK_PREFIX=xvd
+export LAZY_FORMAT_DISK_LIMIT=12
+export IS_GATEWAY=true
+export TMP_SSH_KEY="dummy"
+export SSH_USER=cloudbreak
+export SALT_BOOT_PASSWORD=...
+export SALT_BOOT_SIGN_KEY=...
+export CB_CERT=...
+export IS_CCM_ENABLED=false
+export IS_CCM_V2_ENABLED=false
+export IS_PROXY_ENABLED=true
+export PROXY_HOST=1.2.3.4
+export PROXY_PORT=1234
+export PROXY_PROTOCOL=http
+export PROXY_USER="username"
+export PROXY_PASSWORD="password"
+export PROXY_NO_PROXY_HOSTS="noproxy"
+
+touch /tmp/cb-custom-data-default.txt
+
+/usr/bin/user-data-helper.sh "$@" &> /var/log/user-data.log
+
+chmod o-rwx /var/log/user-data.log
+chmod o-rwx /cdp/bin/*
+chmod o-rwx -R /etc/certs/ || :

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/EnvironmentReactorFlowManager.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/EnvironmentReactorFlowManager.java
@@ -152,7 +152,12 @@ public class EnvironmentReactorFlowManager {
     public FlowIdentifier triggerEnvironmentProxyConfigModification(EnvironmentDto environment, ProxyConfig proxyConfig) {
         LOGGER.info("Environment proxy config modification flow triggered.");
         EnvProxyModificationDefaultEvent envProxyModificationEvent =
-                new EnvProxyModificationDefaultEvent(EnvProxyModificationStateSelectors.MODIFY_PROXY_START_EVENT.selector(), environment, proxyConfig);
+                EnvProxyModificationDefaultEvent.builder()
+                        .withSelector(EnvProxyModificationStateSelectors.MODIFY_PROXY_START_EVENT.selector())
+                        .withEnvironmentDto(environment)
+                        .withProxyConfig(proxyConfig)
+                        .withPreviousProxyConfig(environment.getProxyConfig())
+                        .build();
         return eventSender.sendEvent(envProxyModificationEvent, new Event.Headers(getFlowTriggerUsercrn(ThreadBasedUserCrnProvider.getUserCrn())));
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/ProxyConfigModificationFreeipaStateAction.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/ProxyConfigModificationFreeipaStateAction.java
@@ -37,7 +37,12 @@ public class ProxyConfigModificationFreeipaStateAction extends AbstractEnvProxyM
                 EnvProxyModificationState.PROXY_CONFIG_MODIFICATION_START_STATE);
 
         String selector = EnvProxyModificationHandlerSelectors.TRACK_FREEIPA_PROXY_MODIFICATION_EVENT.selector();
-        EnvironmentEvent event = new EnvProxyModificationDefaultEvent(selector, environmentDto, payload.getProxyConfig());
+        EnvironmentEvent event = EnvProxyModificationDefaultEvent.builder()
+                .withSelector(selector)
+                .withEnvironmentDto(environmentDto)
+                .withProxyConfig(payload.getProxyConfig())
+                .withPreviousProxyConfig(context.getPreviousProxyConfig())
+                .build();
         sendEvent(context, selector, event);
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/ProxyConfigModificationStartStateAction.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/ProxyConfigModificationStartStateAction.java
@@ -37,7 +37,12 @@ public class ProxyConfigModificationStartStateAction extends AbstractEnvProxyMod
                 EnvProxyModificationState.PROXY_CONFIG_MODIFICATION_START_STATE);
 
         String selector = EnvProxyModificationHandlerSelectors.SAVE_NEW_PROXY_ASSOCIATION_HANDLER_EVENT.selector();
-        EnvironmentEvent event = new EnvProxyModificationDefaultEvent(selector, environmentDto, payload.getProxyConfig());
+        EnvironmentEvent event = EnvProxyModificationDefaultEvent.builder()
+                .withSelector(selector)
+                .withEnvironmentDto(environmentDto)
+                .withProxyConfig(payload.getProxyConfig())
+                .withPreviousProxyConfig(context.getPreviousProxyConfig())
+                .build();
         sendEvent(context, selector, event);
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/event/EnvProxyModificationDefaultEvent.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/event/EnvProxyModificationDefaultEvent.java
@@ -4,6 +4,9 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.AcceptResult;
+import com.sequenceiq.cloudbreak.common.json.JsonIgnoreDeserialization;
+import com.sequenceiq.cloudbreak.eventbus.Promise;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
 import com.sequenceiq.environment.proxy.domain.ProxyConfig;
 import com.sequenceiq.flow.reactor.api.event.BaseFlowEvent;
@@ -14,14 +17,19 @@ public class EnvProxyModificationDefaultEvent extends BaseFlowEvent implements P
 
     private final ProxyConfig proxyConfig;
 
+    private final ProxyConfig previousProxyConfig;
+
     @JsonCreator
     public EnvProxyModificationDefaultEvent(
             @JsonProperty("selector") String selector,
             @JsonProperty("environmentDto") EnvironmentDto environmentDto,
-            @JsonProperty("proxyConfig") ProxyConfig proxyConfig) {
-        super(selector, environmentDto.getId(), environmentDto.getResourceCrn());
+            @JsonProperty("proxyConfig") ProxyConfig proxyConfig,
+            @JsonProperty("previousProxyConfig") ProxyConfig previousProxyConfig,
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
+        super(selector, environmentDto.getId(), environmentDto.getResourceCrn(), accepted);
         this.environmentDto = environmentDto;
         this.proxyConfig = proxyConfig;
+        this.previousProxyConfig = previousProxyConfig;
     }
 
     @Override
@@ -35,6 +43,11 @@ public class EnvProxyModificationDefaultEvent extends BaseFlowEvent implements P
     }
 
     @Override
+    public ProxyConfig getPreviousProxyConfig() {
+        return previousProxyConfig;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -43,11 +56,61 @@ public class EnvProxyModificationDefaultEvent extends BaseFlowEvent implements P
             return false;
         }
         EnvProxyModificationDefaultEvent that = (EnvProxyModificationDefaultEvent) o;
-        return Objects.equals(environmentDto, that.environmentDto) && Objects.equals(proxyConfig, that.proxyConfig);
+        return Objects.equals(environmentDto, that.environmentDto)
+                && Objects.equals(proxyConfig, that.proxyConfig)
+                && Objects.equals(previousProxyConfig, that.previousProxyConfig);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(environmentDto, proxyConfig);
+    }
+
+    public static EnvProxyModificationDefaultEventBuilder builder() {
+        return new EnvProxyModificationDefaultEventBuilder();
+    }
+
+    public static final class EnvProxyModificationDefaultEventBuilder {
+        private EnvironmentDto environmentDto;
+
+        private ProxyConfig proxyConfig;
+
+        private ProxyConfig previousProxyConfig;
+
+        private String selector;
+
+        private Promise<AcceptResult> accepted;
+
+        private EnvProxyModificationDefaultEventBuilder() {
+        }
+
+        public EnvProxyModificationDefaultEventBuilder withEnvironmentDto(EnvironmentDto environmentDto) {
+            this.environmentDto = environmentDto;
+            return this;
+        }
+
+        public EnvProxyModificationDefaultEventBuilder withProxyConfig(ProxyConfig proxyConfig) {
+            this.proxyConfig = proxyConfig;
+            return this;
+        }
+
+        public EnvProxyModificationDefaultEventBuilder withPreviousProxyConfig(ProxyConfig previousProxyConfig) {
+            this.previousProxyConfig = previousProxyConfig;
+            return this;
+        }
+
+        public EnvProxyModificationDefaultEventBuilder withSelector(String selector) {
+            this.selector = selector;
+            return this;
+        }
+
+        public EnvProxyModificationDefaultEventBuilder withAccepted(Promise<AcceptResult> accepted) {
+            this.accepted = accepted;
+            return this;
+        }
+
+        public EnvProxyModificationDefaultEvent build() {
+            return new EnvProxyModificationDefaultEvent(selector, environmentDto, proxyConfig, previousProxyConfig, accepted);
+        }
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/event/EnvProxyModificationFailedEvent.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/event/EnvProxyModificationFailedEvent.java
@@ -4,6 +4,9 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.AcceptResult;
+import com.sequenceiq.cloudbreak.common.json.JsonIgnoreDeserialization;
+import com.sequenceiq.cloudbreak.eventbus.Promise;
 import com.sequenceiq.environment.environment.EnvironmentStatus;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
 import com.sequenceiq.environment.proxy.domain.ProxyConfig;
@@ -15,18 +18,23 @@ public class EnvProxyModificationFailedEvent extends BaseFailedFlowEvent impleme
 
     private final ProxyConfig proxyConfig;
 
+    private final ProxyConfig previousProxyConfig;
+
     private final EnvironmentStatus environmentStatus;
 
     @JsonCreator
     public EnvProxyModificationFailedEvent(
             @JsonProperty("environmentDto") EnvironmentDto environmentDto,
             @JsonProperty("proxyConfig") ProxyConfig proxyConfig,
+            @JsonProperty("previousProxyConfig") ProxyConfig previousProxyConfig,
             @JsonProperty("environmentStatus") EnvironmentStatus environmentStatus,
-            @JsonProperty("exception") Exception exception) {
+            @JsonProperty("exception") Exception exception,
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(EnvProxyModificationStateSelectors.FAILED_MODIFY_PROXY_EVENT.selector(),
-                environmentDto.getResourceId(), environmentDto.getName(), environmentDto.getResourceCrn(), exception);
+                environmentDto.getResourceId(), accepted, environmentDto.getName(), environmentDto.getResourceCrn(), exception);
         this.environmentDto = environmentDto;
         this.proxyConfig = proxyConfig;
+        this.previousProxyConfig = previousProxyConfig;
         this.environmentStatus = environmentStatus;
     }
 
@@ -38,6 +46,11 @@ public class EnvProxyModificationFailedEvent extends BaseFailedFlowEvent impleme
     @Override
     public ProxyConfig getProxyConfig() {
         return proxyConfig;
+    }
+
+    @Override
+    public ProxyConfig getPreviousProxyConfig() {
+        return previousProxyConfig;
     }
 
     public EnvironmentStatus getEnvironmentStatus() {
@@ -53,11 +66,69 @@ public class EnvProxyModificationFailedEvent extends BaseFailedFlowEvent impleme
             return false;
         }
         EnvProxyModificationFailedEvent that = (EnvProxyModificationFailedEvent) o;
-        return Objects.equals(environmentDto, that.environmentDto) && environmentStatus == that.environmentStatus;
+        return Objects.equals(environmentDto, that.environmentDto)
+                && Objects.equals(proxyConfig, that.proxyConfig)
+                && Objects.equals(previousProxyConfig, that.previousProxyConfig)
+                && environmentStatus == that.environmentStatus;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(environmentDto, environmentStatus);
+        return Objects.hash(environmentDto, proxyConfig, previousProxyConfig, environmentStatus);
+    }
+
+    public static EnvProxyModificationFailedEventBuilder builder() {
+        return new EnvProxyModificationFailedEventBuilder();
+    }
+
+    public static final class EnvProxyModificationFailedEventBuilder {
+        private EnvironmentDto environmentDto;
+
+        private ProxyConfig proxyConfig;
+
+        private ProxyConfig previousProxyConfig;
+
+        private EnvironmentStatus environmentStatus;
+
+        private Exception exception;
+
+        private Promise<AcceptResult> accepted;
+
+        private EnvProxyModificationFailedEventBuilder() {
+        }
+
+        public EnvProxyModificationFailedEventBuilder withEnvironmentDto(EnvironmentDto environmentDto) {
+            this.environmentDto = environmentDto;
+            return this;
+        }
+
+        public EnvProxyModificationFailedEventBuilder withProxyConfig(ProxyConfig proxyConfig) {
+            this.proxyConfig = proxyConfig;
+            return this;
+        }
+
+        public EnvProxyModificationFailedEventBuilder withPreviousProxyConfig(ProxyConfig previousProxyConfig) {
+            this.previousProxyConfig = previousProxyConfig;
+            return this;
+        }
+
+        public EnvProxyModificationFailedEventBuilder withEnvironmentStatus(EnvironmentStatus environmentStatus) {
+            this.environmentStatus = environmentStatus;
+            return this;
+        }
+
+        public EnvProxyModificationFailedEventBuilder withException(Exception exception) {
+            this.exception = exception;
+            return this;
+        }
+
+        public EnvProxyModificationFailedEventBuilder withAccepted(Promise<AcceptResult> accepted) {
+            this.accepted = accepted;
+            return this;
+        }
+
+        public EnvProxyModificationFailedEvent build() {
+            return new EnvProxyModificationFailedEvent(environmentDto, proxyConfig, previousProxyConfig, environmentStatus, exception, accepted);
+        }
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/event/ProxyConfigModificationEvent.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/event/ProxyConfigModificationEvent.java
@@ -6,4 +6,6 @@ import com.sequenceiq.environment.proxy.domain.ProxyConfig;
 public interface ProxyConfigModificationEvent extends EnvironmentEvent {
 
     ProxyConfig getProxyConfig();
+
+    ProxyConfig getPreviousProxyConfig();
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/handler/EnvProxyModificationSaveAssociationHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/modify/proxy/handler/EnvProxyModificationSaveAssociationHandler.java
@@ -34,12 +34,21 @@ public class EnvProxyModificationSaveAssociationHandler extends EventSenderAware
         try {
             EnvironmentDto environmentDto = environmentService.updateProxyConfig(eventData.getEnvironmentDto().getId(), eventData.getProxyConfig());
 
-            EnvProxyModificationDefaultEvent envProxyModificationEvent = new EnvProxyModificationDefaultEvent(
-                    EnvProxyModificationStateSelectors.MODIFY_PROXY_FREEIPA_EVENT.selector(), environmentDto, eventData.getProxyConfig());
+            EnvProxyModificationDefaultEvent envProxyModificationEvent = EnvProxyModificationDefaultEvent.builder()
+                    .withSelector(EnvProxyModificationStateSelectors.MODIFY_PROXY_FREEIPA_EVENT.selector())
+                    .withEnvironmentDto(environmentDto)
+                    .withProxyConfig(eventData.getProxyConfig())
+                    .withPreviousProxyConfig(eventData.getPreviousProxyConfig())
+                    .build();
             eventSender().sendEvent(envProxyModificationEvent, event.getHeaders());
         } catch (Exception e) {
-            EnvProxyModificationFailedEvent envProxyModificationFailedEvent = new EnvProxyModificationFailedEvent(
-                    eventData.getEnvironmentDto(), eventData.getProxyConfig(), EnvironmentStatus.PROXY_CONFIG_MODIFICATION_FAILED, e);
+            EnvProxyModificationFailedEvent envProxyModificationFailedEvent = EnvProxyModificationFailedEvent.builder()
+                    .withEnvironmentDto(eventData.getEnvironmentDto())
+                    .withProxyConfig(eventData.getProxyConfig())
+                    .withPreviousProxyConfig(eventData.getPreviousProxyConfig())
+                    .withEnvironmentStatus(EnvironmentStatus.PROXY_CONFIG_MODIFICATION_FAILED)
+                    .withException(e)
+                    .build();
             eventSender().sendEvent(envProxyModificationFailedEvent, event.getHeaders());
         }
     }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/freeipa/FreeIpaPollerService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/freeipa/FreeIpaPollerService.java
@@ -90,8 +90,8 @@ public class FreeIpaPollerService {
         }
     }
 
-    public void waitForModifyProxyConfig(Long envId, String envCrn) {
-        OperationStatus status = freeIpaService.modifyProxyConfig(envCrn);
+    public void waitForModifyProxyConfig(Long envId, String envCrn, String previousProxyCrn) {
+        OperationStatus status = freeIpaService.modifyProxyConfig(envCrn, previousProxyCrn);
         if (status.getStatus() != OperationState.COMPLETED) {
             try {
                 Polling.stopAfterAttempt(modifyProxyAttempt)

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/freeipa/FreeIpaService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/freeipa/FreeIpaService.java
@@ -231,12 +231,12 @@ public class FreeIpaService {
         }
     }
 
-    public OperationStatus modifyProxyConfig(String environmentCrn) {
+    public OperationStatus modifyProxyConfig(String environmentCrn, String previousProxyCrn) {
         try {
-            LOGGER.debug("Calling FreeIPA modify proxy config for environment {}", environmentCrn);
+            LOGGER.debug("Calling FreeIPA modify proxy config for environment {} with previousProxyCrn {}", environmentCrn, previousProxyCrn);
             return ThreadBasedUserCrnProvider.doAsInternalActor(
                     regionAwareInternalCrnGeneratorFactory.iam().getInternalCrnForServiceAsString(),
-                    initiatorUserCrn -> freeIpaV1Endpoint.modifyProxyConfigInternal(environmentCrn, initiatorUserCrn));
+                    initiatorUserCrn -> freeIpaV1Endpoint.modifyProxyConfigInternal(environmentCrn, previousProxyCrn, initiatorUserCrn));
         } catch (WebApplicationException e) {
             String errorMessage = webApplicationExceptionMessageExtractor.getErrorMessage(e);
             LOGGER.error("Failed to modify proxy config on FreeIpa for environment {} due to: {}", environmentCrn, errorMessage, e);

--- a/environment/src/test/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/AbstractEnvProxyModificationActionTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/AbstractEnvProxyModificationActionTest.java
@@ -87,14 +87,15 @@ class AbstractEnvProxyModificationActionTest {
 
     @Test
     void createFlowContextWithVariable() {
-        ProxyConfig proxyConfig1 = mock(ProxyConfig.class);
-        when(extendedState.getVariables()).thenReturn(new HashMap<>(Map.of(AbstractEnvProxyModificationAction.PREVIOUS_PROXY_CONFIG, proxyConfig1)));
+        ProxyConfig proxyConfig = mock(ProxyConfig.class);
+        when(extendedState.getVariables())
+                .thenReturn(new HashMap<>(Map.of(AbstractEnvProxyModificationAction.PREVIOUS_PROXY_CONFIG, Optional.of(proxyConfig))));
 
         EnvProxyModificationContext result = underTest.createFlowContext(flowParameters, stateContext, payload);
 
         assertThat(result)
                 .returns(flowParameters, CommonContext::getFlowParameters)
-                .returns(proxyConfig1, EnvProxyModificationContext::getPreviousProxyConfig);
+                .returns(proxyConfig, EnvProxyModificationContext::getPreviousProxyConfig);
     }
 
     @Test

--- a/environment/src/test/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/ProxyConfigModificationFinishedStateActionTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/ProxyConfigModificationFinishedStateActionTest.java
@@ -50,6 +50,9 @@ class ProxyConfigModificationFinishedStateActionTest extends ActionTest {
     @Mock
     private ProxyConfig proxyConfig;
 
+    @Mock
+    private ProxyConfig previousProxyConfig;
+
     @Captor
     private ArgumentCaptor<UsageProto.CDPEnvironmentProxyConfigEditEvent> usageEventCaptor;
 
@@ -60,7 +63,12 @@ class ProxyConfigModificationFinishedStateActionTest extends ActionTest {
         super.setUp(context);
         when(environmentDto.getResourceCrn()).thenReturn(ENV_CRN);
         when(proxyConfig.getResourceCrn()).thenReturn(PROXY_CRN);
-        payload = new EnvProxyModificationDefaultEvent("selector", environmentDto, proxyConfig);
+        payload = EnvProxyModificationDefaultEvent.builder()
+                .withSelector("selector")
+                .withEnvironmentDto(environmentDto)
+                .withProxyConfig(proxyConfig)
+                .withPreviousProxyConfig(previousProxyConfig)
+                .build();
     }
 
     @Test

--- a/environment/src/test/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/ProxyConfigModificationFreeipaStateActionTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/ProxyConfigModificationFreeipaStateActionTest.java
@@ -56,6 +56,7 @@ class ProxyConfigModificationFreeipaStateActionTest extends ActionTest {
                 EnvironmentStatus.PROXY_CONFIG_MODIFICATION_ON_FREEIPA_IN_PROGRESS, ResourceEvent.ENVIRONMENT_PROXY_CONFIG_MODIFICATION_ON_FREEIPA_STARTED,
                 EnvProxyModificationState.PROXY_CONFIG_MODIFICATION_START_STATE);
         String selector = EnvProxyModificationHandlerSelectors.TRACK_FREEIPA_PROXY_MODIFICATION_EVENT.selector();
-        verifySendEvent(context, selector, new EnvProxyModificationDefaultEvent(selector, environmentDto, payload.getProxyConfig()));
+        verifySendEvent(context, selector,
+                new EnvProxyModificationDefaultEvent(selector, environmentDto, payload.getProxyConfig(), payload.getPreviousProxyConfig(), payload.accepted()));
     }
 }

--- a/environment/src/test/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/ProxyConfigModificationStartStateActionTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/flow/modify/proxy/action/ProxyConfigModificationStartStateActionTest.java
@@ -58,7 +58,7 @@ class ProxyConfigModificationStartStateActionTest extends ActionTest {
                 EnvProxyModificationState.PROXY_CONFIG_MODIFICATION_START_STATE);
 
         String selector = EnvProxyModificationHandlerSelectors.SAVE_NEW_PROXY_ASSOCIATION_HANDLER_EVENT.selector();
-        EnvProxyModificationDefaultEvent event = new EnvProxyModificationDefaultEvent(selector, environmentDto, proxyConfig);
+        EnvProxyModificationDefaultEvent event = new EnvProxyModificationDefaultEvent(selector, environmentDto, proxyConfig, null, null);
         verifySendEvent(context, selector, event);
     }
 

--- a/environment/src/test/java/com/sequenceiq/environment/environment/flow/modify/proxy/handler/EnvProxyModificationSaveAssociationHandlerTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/flow/modify/proxy/handler/EnvProxyModificationSaveAssociationHandlerTest.java
@@ -46,11 +46,19 @@ class EnvProxyModificationSaveAssociationHandlerTest {
     @Mock
     private ProxyConfig proxyConfig;
 
+    @Mock
+    private ProxyConfig previousProxyConfig;
+
     private EnvProxyModificationDefaultEvent event;
 
     @BeforeEach
     void setUp() {
-        event = new EnvProxyModificationDefaultEvent(SELECTOR, environmentDto, proxyConfig);
+        event = EnvProxyModificationDefaultEvent.builder()
+                .withSelector(SELECTOR)
+                .withEnvironmentDto(environmentDto)
+                .withProxyConfig(proxyConfig)
+                .withPreviousProxyConfig(previousProxyConfig)
+                .build();
         lenient().when(environmentDto.getId()).thenReturn(ENV_ID);
         lenient().when(environmentService.findById(ENV_ID)).thenReturn(Optional.of(environmentDto));
     }
@@ -62,7 +70,7 @@ class EnvProxyModificationSaveAssociationHandlerTest {
         underTest.accept(wrappedEvent);
 
         EnvProxyModificationDefaultEvent envProxyModificationEvent = new EnvProxyModificationDefaultEvent(
-                EnvProxyModificationStateSelectors.FINISH_MODIFY_PROXY_EVENT.selector(), environmentDto, proxyConfig);
+                EnvProxyModificationStateSelectors.FINISH_MODIFY_PROXY_EVENT.selector(), environmentDto, proxyConfig, previousProxyConfig, null);
         verify(environmentService).updateProxyConfig(ENV_ID, proxyConfig);
         verify(eventSender).sendEvent(envProxyModificationEvent, wrappedEvent.getHeaders());
     }
@@ -75,7 +83,7 @@ class EnvProxyModificationSaveAssociationHandlerTest {
         underTest.accept(wrappedEvent);
 
         EnvProxyModificationFailedEvent envProxyModificationFailedEvent = new EnvProxyModificationFailedEvent(
-                environmentDto, proxyConfig, EnvironmentStatus.PROXY_CONFIG_MODIFICATION_FAILED, cause);
+                environmentDto, proxyConfig, previousProxyConfig, EnvironmentStatus.PROXY_CONFIG_MODIFICATION_FAILED, cause, null);
         verify(environmentService).updateProxyConfig(ENV_ID, proxyConfig);
         verify(eventSender).sendEvent(envProxyModificationFailedEvent, wrappedEvent.getHeaders());
     }

--- a/flow/src/main/java/com/sequenceiq/flow/reactor/api/event/BaseFlowEvent.java
+++ b/flow/src/main/java/com/sequenceiq/flow/reactor/api/event/BaseFlowEvent.java
@@ -35,7 +35,7 @@ public class BaseFlowEvent implements IdempotentEvent<BaseFlowEvent>, ResourceCr
         this.selector = selector;
         this.resourceId = resourceId;
         this.resourceCrn = resourceCrn;
-        this.accepted = accepted;
+        this.accepted = Objects.requireNonNullElse(accepted, new Promise<>());
     }
 
     @Override

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
@@ -306,6 +306,7 @@ public interface FreeIpaV1Endpoint {
             notes = FreeIpaNotes.FREEIPA_NOTES, nickname = "internalModifyProxyConfigByEnvironmentV1")
     OperationStatus modifyProxyConfigInternal(
             @ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT) @QueryParam("environment") @NotEmpty String environmentCrn,
+            @ValidCrn(resource = CrnResourceDescriptor.PROXY) @QueryParam("previousProxy") String previousProxyCrn,
             @ValidCrn(resource = { CrnResourceDescriptor.USER, CrnResourceDescriptor.MACHINE_USER })
             @QueryParam("initiatorUserCrn") @NotEmpty String initiatorUserCrn);
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaV1Controller.java
@@ -445,9 +445,10 @@ public class FreeIpaV1Controller implements FreeIpaV1Endpoint {
     @InternalOnly
     public OperationStatus modifyProxyConfigInternal(
             @ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT) @ResourceCrn @NotEmpty String environmentCrn,
+            @ValidCrn(resource = CrnResourceDescriptor.PROXY) @ResourceCrn String previousProxyCrn,
             @ValidCrn(resource = { CrnResourceDescriptor.USER, CrnResourceDescriptor.MACHINE_USER }) @InitiatorUserCrn @NotEmpty String initiatorUserCrn) {
         String accountId = crnService.getCurrentAccountId();
-        return modifyProxyConfigService.modifyProxyConfig(environmentCrn, accountId);
+        return modifyProxyConfigService.modifyProxyConfig(environmentCrn, previousProxyCrn, accountId);
     }
 
     @Override

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/ModifyProxyConfigFlowEventChainFactory.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/ModifyProxyConfigFlowEventChainFactory.java
@@ -28,10 +28,15 @@ public class ModifyProxyConfigFlowEventChainFactory implements FlowEventChainFac
         flowEventChain.add(new SaltUpdateTriggerEvent(event.getResourceId(), event.accepted(), true, false, event.getOperationId()));
         flowEventChain.add(new ModifyProxyConfigTriggerEvent(event.getResourceId(), event.accepted(), event.getOperationId()));
         flowEventChain.add(
-                new UserDataUpdateRequest(UpdateUserDataEvents.UPDATE_USERDATA_TRIGGER_EVENT.event(), event.getResourceId(), event.accepted())
+                UserDataUpdateRequest.builder()
+                        .withSelector(UpdateUserDataEvents.UPDATE_USERDATA_TRIGGER_EVENT.event())
+                        .withStackId(event.getResourceId())
+                        .withModifyProxyConfig(true)
+                        .withAccepted(event.accepted())
                         .withOperationId(event.getOperationId())
-                        .withIsChained(true)
-                        .withIsFinal(true));
+                        .withChained(true)
+                        .withFinalFlow(true)
+                        .build());
         return new FlowTriggerEventQueue(getName(), event, flowEventChain);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/UpgradeCcmFlowEventChainFactory.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/UpgradeCcmFlowEventChainFactory.java
@@ -29,10 +29,15 @@ public class UpgradeCcmFlowEventChainFactory implements FlowEventChainFactory<Up
                 event.getOldTunnel(), event.accepted())
                 .withIsChained(true)
                 .withIsFinal(false));
-        flowEventChain.add(new UserDataUpdateRequest(UpdateUserDataEvents.UPDATE_USERDATA_TRIGGER_EVENT.event(), event.getResourceId(), event.getOldTunnel())
-                .withOperationId(event.getOperationId())
-                .withIsChained(true)
-                .withIsFinal(true));
+        flowEventChain.add(
+                UserDataUpdateRequest.builder()
+                        .withSelector(UpdateUserDataEvents.UPDATE_USERDATA_TRIGGER_EVENT.event())
+                        .withStackId(event.getResourceId())
+                        .withOldTunnel(event.getOldTunnel())
+                        .withOperationId(event.getOperationId())
+                        .withChained(true)
+                        .withFinalFlow(true)
+                        .build());
         return new FlowTriggerEventQueue(getName(), event, flowEventChain);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/StackEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/StackEvent.java
@@ -38,7 +38,7 @@ public class StackEvent implements IdempotentEvent<StackEvent> {
             @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         this.selector = selector;
         this.stackId = stackId;
-        this.accepted = accepted;
+        this.accepted = Objects.requireNonNullElse(accepted, new Promise<>());
     }
 
     @Override

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/event/ModifyProxyFlowChainTriggerEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/modify/proxy/event/ModifyProxyFlowChainTriggerEvent.java
@@ -13,9 +13,12 @@ public class ModifyProxyFlowChainTriggerEvent extends StackEvent {
 
     private final String operationId;
 
-    public ModifyProxyFlowChainTriggerEvent(String selector, Long stackId, String operationId) {
+    private final String previousProxyConfigCrn;
+
+    public ModifyProxyFlowChainTriggerEvent(String selector, Long stackId, String operationId, String previousProxyConfigCrn) {
         super(selector, stackId);
         this.operationId = operationId;
+        this.previousProxyConfigCrn = previousProxyConfigCrn;
     }
 
     @JsonCreator
@@ -23,25 +26,32 @@ public class ModifyProxyFlowChainTriggerEvent extends StackEvent {
             @JsonProperty("selector") String selector,
             @JsonProperty("operationId") String operationId,
             @JsonProperty("resourceId") Long stackId,
+            @JsonProperty("previousProxyConfigCrn") String previousProxyConfigCrn,
             @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, stackId, accepted);
         this.operationId = operationId;
+        this.previousProxyConfigCrn = previousProxyConfigCrn;
     }
 
     public String getOperationId() {
         return operationId;
     }
 
+    public String getPreviousProxyConfigCrn() {
+        return previousProxyConfigCrn;
+    }
+
     @Override
     public boolean equalsEvent(StackEvent other) {
         return isClassAndEqualsEvent(ModifyProxyFlowChainTriggerEvent.class, other,
-                event -> Objects.equals(operationId, event.operationId));
+                event -> Objects.equals(operationId, event.operationId) && Objects.equals(previousProxyConfigCrn, event.previousProxyConfigCrn));
     }
 
     @Override
     public String toString() {
         return "ModifyProxyFlowChainTriggerEvent{" +
                 "operationId='" + operationId + '\'' +
+                "previousProxyConfigCrn='" + previousProxyConfigCrn + '\'' +
                 "} " + super.toString();
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/action/UserDataUpdateActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/action/UserDataUpdateActions.java
@@ -50,11 +50,16 @@ public class UserDataUpdateActions {
         return new AbstractUserDataUpdateAction<>(UserDataUpdateRequest.class) {
             @Override
             protected void doExecute(StackContext context, UserDataUpdateRequest payload, Map<Object, Object> variables) throws Exception {
-                LOGGER.info("Recreate userdata for new freeipa instances");
+                LOGGER.info("Update userdata for new freeipa instances");
                 setOperationId(variables, payload.getOperationId());
                 setChainedAction(variables, payload.isChained());
                 setFinalChain(variables, payload.isFinalFlow());
-                sendEvent(context, new UserDataUpdateRequest(context.getStack().getId(), payload.getOldTunnel()));
+                sendEvent(context,
+                        UserDataUpdateRequest.builder()
+                                .withStackId(context.getStack().getId())
+                                .withOldTunnel(payload.getOldTunnel())
+                                .withModifyProxyConfig(payload.isModifyProxyConfig())
+                                .build());
             }
 
             @Override

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/event/UserDataUpdateRequest.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/event/UserDataUpdateRequest.java
@@ -3,43 +3,38 @@ package com.sequenceiq.freeipa.flow.stack.update.event;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.common.event.AcceptResult;
+import com.sequenceiq.cloudbreak.common.json.JsonIgnoreDeserialization;
 import com.sequenceiq.cloudbreak.eventbus.Promise;
 import com.sequenceiq.common.api.type.Tunnel;
 import com.sequenceiq.freeipa.flow.stack.StackEvent;
 
 public class UserDataUpdateRequest extends StackEvent {
-    private String operationId;
+    private final String operationId;
 
     private final Tunnel oldTunnel;
 
-    private boolean chained;
+    private final boolean modifyProxyConfig;
 
-    private boolean finalFlow = true;
+    private final boolean chained;
 
-    public UserDataUpdateRequest(Long stackId, Tunnel oldTunnel) {
-        super(stackId);
-        this.operationId = null;
-        this.oldTunnel = oldTunnel;
-    }
+    private final boolean finalFlow;
 
     @JsonCreator
     public UserDataUpdateRequest(
             @JsonProperty("selector") String selector,
             @JsonProperty("resourceId") Long stackId,
-            @JsonProperty("oldTunnel") Tunnel oldTunnel) {
-        super(selector, stackId);
-        this.operationId = null;
-        this.oldTunnel = oldTunnel;
-    }
-
-    public UserDataUpdateRequest(String selector, Long stackId, Promise<AcceptResult> accepted) {
+            @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted,
+            @JsonProperty("operationId") String operationId,
+            @JsonProperty("oldTunnel") Tunnel oldTunnel,
+            @JsonProperty("modifyProxyConfig") boolean modifyProxyConfig,
+            @JsonProperty("chained") boolean chained,
+            @JsonProperty("finalFlow") boolean finalFlow) {
         super(selector, stackId, accepted);
-        this.oldTunnel = null;
-    }
-
-    public UserDataUpdateRequest withOperationId(String operationId) {
         this.operationId = operationId;
-        return this;
+        this.oldTunnel = oldTunnel;
+        this.modifyProxyConfig = modifyProxyConfig;
+        this.chained = chained;
+        this.finalFlow = finalFlow;
     }
 
     public String getOperationId() {
@@ -50,14 +45,8 @@ public class UserDataUpdateRequest extends StackEvent {
         return oldTunnel;
     }
 
-    public UserDataUpdateRequest withIsChained(boolean chained) {
-        this.chained = chained;
-        return this;
-    }
-
-    public UserDataUpdateRequest withIsFinal(boolean finalFlow) {
-        this.finalFlow = finalFlow;
-        return this;
+    public boolean isModifyProxyConfig() {
+        return modifyProxyConfig;
     }
 
     public boolean isChained() {
@@ -68,25 +57,83 @@ public class UserDataUpdateRequest extends StackEvent {
         return finalFlow;
     }
 
-    public void setChained(boolean chained) {
-        this.chained = chained;
-    }
-
-    public void setFinalFlow(boolean finalFlow) {
-        this.finalFlow = finalFlow;
-    }
-
-    public void setOperationId(String operationId) {
-        this.operationId = operationId;
-    }
-
     @Override
     public String toString() {
         return "UserDataUpdateRequest{" +
                 "operationId='" + operationId + '\'' +
                 ", oldTunnel=" + oldTunnel +
+                ", modifyProxyConfig=" + modifyProxyConfig +
                 ", chained=" + chained +
                 ", finalFlow=" + finalFlow +
                 "} " + super.toString();
+    }
+
+    public static UserDataUpdateRequestBuilder builder() {
+        return new UserDataUpdateRequestBuilder();
+    }
+
+    public static final class UserDataUpdateRequestBuilder {
+        private String selector;
+
+        private Long stackId;
+
+        private Promise<AcceptResult> accepted;
+
+        private String operationId;
+
+        private Tunnel oldTunnel;
+
+        private boolean modifyProxyConfig;
+
+        private boolean chained;
+
+        private boolean finalFlow = true;
+
+        private UserDataUpdateRequestBuilder() {
+        }
+
+        public UserDataUpdateRequestBuilder withSelector(String selector) {
+            this.selector = selector;
+            return this;
+        }
+
+        public UserDataUpdateRequestBuilder withStackId(Long stackId) {
+            this.stackId = stackId;
+            return this;
+        }
+
+        public UserDataUpdateRequestBuilder withAccepted(Promise<AcceptResult> accepted) {
+            this.accepted = accepted;
+            return this;
+        }
+
+        public UserDataUpdateRequestBuilder withOperationId(String operationId) {
+            this.operationId = operationId;
+            return this;
+        }
+
+        public UserDataUpdateRequestBuilder withOldTunnel(Tunnel oldTunnel) {
+            this.oldTunnel = oldTunnel;
+            return this;
+        }
+
+        public UserDataUpdateRequestBuilder withModifyProxyConfig(boolean modifyProxyConfig) {
+            this.modifyProxyConfig = modifyProxyConfig;
+            return this;
+        }
+
+        public UserDataUpdateRequestBuilder withChained(boolean chained) {
+            this.chained = chained;
+            return this;
+        }
+
+        public UserDataUpdateRequestBuilder withFinalFlow(boolean finalFlow) {
+            this.finalFlow = finalFlow;
+            return this;
+        }
+
+        public UserDataUpdateRequest build() {
+            return new UserDataUpdateRequest(selector, stackId, accepted, operationId, oldTunnel, modifyProxyConfig, chained, finalFlow);
+        }
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/handler/UpdateUserDataHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/handler/UpdateUserDataHandler.java
@@ -43,10 +43,11 @@ public class UpdateUserDataHandler extends ExceptionCatcherEventHandler<UserData
         try {
             LOGGER.info("Updating userData in the stack's current used image entity...");
             if (request.getOldTunnel() != null) {
+                LOGGER.info("Updating userdata for CCM upgrade");
                 switch (request.getOldTunnel()) {
                     case CCM:
                         LOGGER.debug("Regenerating user data from request payload.");
-                        userDataService.regenerateUserData(request.getResourceId());
+                        userDataService.regenerateUserDataForCcmUpgrade(request.getResourceId());
                         break;
                     case CCMV2:
                         LOGGER.debug("Updating Jumpgate flag only.");
@@ -55,9 +56,10 @@ public class UpdateUserDataHandler extends ExceptionCatcherEventHandler<UserData
                     default:
                         throw new IllegalStateException(String.format("Upgrade from %s is not implemented", request.getOldTunnel()));
                 }
-            } else {
-                LOGGER.debug("Old tunnel type was not provided, regenerating user data from request payload.");
-                userDataService.regenerateUserData(request.getResourceId());
+            }
+            if (request.isModifyProxyConfig()) {
+                LOGGER.info("Updating userdata for proxy modification");
+                userDataService.updateProxyConfig(request.getResourceId());
             }
             return new UserDataUpdateSuccess(request.getResourceId());
         } catch (Exception e) {

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/controller/FreeIpaV1ControllerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/controller/FreeIpaV1ControllerTest.java
@@ -296,9 +296,9 @@ class FreeIpaV1ControllerTest {
     void modifyProxyConfigInternalTest() {
         when(crnService.getCurrentAccountId()).thenReturn(ACCOUNT_ID);
         OperationStatus operationStatus = new OperationStatus();
-        when(modifyProxyConfigService.modifyProxyConfig(ENVIRONMENT_CRN, ACCOUNT_ID)).thenReturn(operationStatus);
+        when(modifyProxyConfigService.modifyProxyConfig(ENVIRONMENT_CRN, null, ACCOUNT_ID)).thenReturn(operationStatus);
 
-        OperationStatus result = underTest.modifyProxyConfigInternal(ENVIRONMENT_CRN, ACCOUNT_ID);
+        OperationStatus result = underTest.modifyProxyConfigInternal(ENVIRONMENT_CRN, null, ACCOUNT_ID);
 
         assertThat(result).isEqualTo(operationStatus);
     }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/chain/UpgradeCcmFlowChainIntegrationTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/chain/UpgradeCcmFlowChainIntegrationTest.java
@@ -169,7 +169,7 @@ class UpgradeCcmFlowChainIntegrationTest {
 
     @Test
     public void testUpdateUserDataFailsInChain() throws Exception {
-        doThrow(new BadRequestException()).when(userDataService).regenerateUserData(STACK_ID);
+        doThrow(new BadRequestException()).when(userDataService).regenerateUserDataForCcmUpgrade(STACK_ID);
         testFlow(CALLED_ONCE_TILL_GENERATE_USERDATA, true, false);
     }
 
@@ -234,7 +234,7 @@ class UpgradeCcmFlowChainIntegrationTest {
         inOrder.verify(upgradeCcmService, times(expected[i++])).removeMina(STACK_ID);
         inOrder.verify(upgradeCcmService, times(expected[i++])).deregisterMinaState(STACK_ID);
         inOrder.verify(upgradeCcmService, times(expected[i++])).deregisterMina(STACK_ID);
-        inOrder.verify(userDataService, times(expected[i++])).regenerateUserData(STACK_ID);
+        inOrder.verify(userDataService, times(expected[i++])).regenerateUserDataForCcmUpgrade(STACK_ID);
         inOrder.verify(resourcesApi, times(expected[i++])).updateUserData(any(), any(), any(), eq(USER_DATA_MAP));
     }
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/update/UpdateUserDataFlowIntegrationTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/update/UpdateUserDataFlowIntegrationTest.java
@@ -141,7 +141,7 @@ class UpdateUserDataFlowIntegrationTest {
 
     @Test
     public void testUserDataUpdateWhenNewUserDataFails() throws Exception {
-        doThrow(new BadRequestException()).when(userDataService).regenerateUserData(STACK_ID);
+        doThrow(new BadRequestException()).when(userDataService).regenerateUserDataForCcmUpgrade(STACK_ID);
         testFlow(CALLED_ONCE_TILL_GENERATE_USERDATA, false);
     }
 
@@ -164,7 +164,7 @@ class UpdateUserDataFlowIntegrationTest {
     private void verifyServiceCalls(int tillInt) {
         final int[] expected = new int[ALL_CALLED_ONCE];
         Arrays.fill(expected, 0, tillInt, 1);
-        verify(userDataService, times(expected[0])).regenerateUserData(STACK_ID);
+        verify(userDataService, times(expected[0])).regenerateUserDataForCcmUpgrade(STACK_ID);
     }
 
     private void flowFinishedSuccessfully() {
@@ -178,7 +178,12 @@ class UpdateUserDataFlowIntegrationTest {
         return ThreadBasedUserCrnProvider.doAs(
                 USER_CRN,
                 () -> freeIpaFlowManager.notify(selector,
-                        new UserDataUpdateRequest(selector, STACK_ID, Tunnel.CCM).withOperationId("opi")));
+                        UserDataUpdateRequest.builder()
+                                .withSelector(selector)
+                                .withStackId(STACK_ID)
+                                .withOldTunnel(Tunnel.CCM)
+                                .withOperationId("opi")
+                                .build()));
     }
 
     private void letItFlow(FlowIdentifier flowIdentifier) {

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/userdata/UserDataServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/userdata/UserDataServiceTest.java
@@ -1,20 +1,25 @@
 package com.sequenceiq.freeipa.service.image.userdata;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.assertj.core.api.AbstractStringAssert;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.task.AsyncTaskExecutor;
 
 import com.sequenceiq.cloudbreak.service.proxy.ProxyConfigDtoService;
+import com.sequenceiq.cloudbreak.service.proxy.ProxyConfigUserDataReplacer;
 import com.sequenceiq.freeipa.entity.ImageEntity;
+import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.service.CredentialService;
 import com.sequenceiq.freeipa.service.client.CachedEnvironmentClientService;
 import com.sequenceiq.freeipa.service.cloud.PlatformParameterService;
@@ -25,6 +30,8 @@ import com.sequenceiq.freeipa.service.stack.StackService;
 class UserDataServiceTest {
 
     private static final long STACK_ID = 123L;
+
+    private static final String ENV_CRN = "env-crn";
 
     @Mock
     private UserDataBuilder userDataBuilder;
@@ -53,18 +60,55 @@ class UserDataServiceTest {
     @Mock
     private CachedEnvironmentClientService environmentClientService;
 
+    @Mock
+    private ProxyConfigUserDataReplacer proxyConfigUserDataReplacer;
+
     @InjectMocks
     private UserDataService underTest;
 
+    @Captor
+    private ArgumentCaptor<ImageEntity> imageCaptor;
+
+    @Mock
+    private Stack stack;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(stackService.getStackById(STACK_ID)).thenReturn(stack);
+        lenient().when(stack.getEnvironmentCrn()).thenReturn(ENV_CRN);
+    }
+
     @Test
     void updateJumpgateFlagOnly() {
-        ImageEntity image = new ImageEntity();
-        image.setUserdata("FLAG=foo\nIS_CCM_ENABLED=true\nIS_CCM_V2_ENABLED=false\nIS_CCM_V2_JUMPGATE_ENABLED=false\nOTHER_FLAG=bar");
-        when(imageService.getByStackId(STACK_ID)).thenReturn(image);
+        setUserData("export FLAG=foo\nexport IS_CCM_ENABLED=true\nexport IS_CCM_V2_ENABLED=false\n" +
+                "export IS_CCM_V2_JUMPGATE_ENABLED=false\nexport OTHER_FLAG=bar");
+
         underTest.updateJumpgateFlagOnly(STACK_ID);
-        ArgumentCaptor<ImageEntity> imageCaptor = ArgumentCaptor.forClass(ImageEntity.class);
-        verify(imageService, times(1)).save(imageCaptor.capture());
-        assertThat(imageCaptor.getValue().getUserdata())
-                .isEqualTo("FLAG=foo\nIS_CCM_ENABLED=false\nIS_CCM_V2_ENABLED=true\nIS_CCM_V2_JUMPGATE_ENABLED=true\nOTHER_FLAG=bar");
+
+        assertThatUserData().isEqualTo("export FLAG=foo\nexport IS_CCM_ENABLED=false\nexport IS_CCM_V2_ENABLED=true\n" +
+                "export IS_CCM_V2_JUMPGATE_ENABLED=true\nexport OTHER_FLAG=bar");
+    }
+
+    @Test
+    void updateProxyConfig() {
+        String userData = "userdata";
+        setUserData(userData);
+        String replacedUserData = "replaced-userdata";
+        when(proxyConfigUserDataReplacer.replaceProxyConfigInUserDataByEnvCrn(userData, ENV_CRN)).thenReturn(replacedUserData);
+
+        underTest.updateProxyConfig(STACK_ID);
+
+        assertThatUserData().isEqualTo(replacedUserData);
+    }
+
+    private void setUserData(String userData) {
+        ImageEntity image = new ImageEntity();
+        image.setUserdata(userData);
+        when(imageService.getByStackId(STACK_ID)).thenReturn(image);
+    }
+
+    private AbstractStringAssert<?> assertThatUserData() {
+        verify(imageService).save(imageCaptor.capture());
+        return assertThat(imageCaptor.getValue().getUserdata());
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeipaModifyProxyConfigServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeipaModifyProxyConfigServiceTest.java
@@ -94,7 +94,7 @@ class FreeipaModifyProxyConfigServiceTest {
     void validateWithoutEntitlement() {
         when(entitlementService.isEditProxyConfigEnabled(ACCOUNT_ID)).thenReturn(false);
 
-        Assertions.assertThatThrownBy(() -> underTest.modifyProxyConfig(ENV_CRN, ACCOUNT_ID))
+        Assertions.assertThatThrownBy(() -> underTest.modifyProxyConfig(ENV_CRN, null, ACCOUNT_ID))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage("Proxy config modification is not enabled in your account");
     }
@@ -103,7 +103,7 @@ class FreeipaModifyProxyConfigServiceTest {
     void validateNonAvailableEnv() {
         when(stackStatus.getStatus()).thenReturn(Status.CREATE_FAILED);
 
-        Assertions.assertThatThrownBy(() -> underTest.modifyProxyConfig(ENV_CRN, ACCOUNT_ID))
+        Assertions.assertThatThrownBy(() -> underTest.modifyProxyConfig(ENV_CRN, null, ACCOUNT_ID))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage("Proxy config modification is not supported in current FreeIpa status: CREATE_FAILED");
     }
@@ -112,7 +112,7 @@ class FreeipaModifyProxyConfigServiceTest {
     void failToStartOperation() {
         when(operation.getStatus()).thenReturn(OperationState.FAILED);
 
-        OperationStatus result = underTest.modifyProxyConfig(ENV_CRN, ACCOUNT_ID);
+        OperationStatus result = underTest.modifyProxyConfig(ENV_CRN, null, ACCOUNT_ID);
 
         assertThat(result).isEqualTo(operationStatus);
         verifyStartOperation();
@@ -129,14 +129,14 @@ class FreeipaModifyProxyConfigServiceTest {
         OperationStatus failedOperationStatus = mock(OperationStatus.class);
         when(operationConverter.convert(failedOperation)).thenReturn(failedOperationStatus);
 
-        OperationStatus result = underTest.modifyProxyConfig(ENV_CRN, ACCOUNT_ID);
+        OperationStatus result = underTest.modifyProxyConfig(ENV_CRN, null, ACCOUNT_ID);
 
         assertThat(result).isEqualTo(failedOperationStatus);
     }
 
     @Test
     void success() {
-        OperationStatus result = underTest.modifyProxyConfig(ENV_CRN, ACCOUNT_ID);
+        OperationStatus result = underTest.modifyProxyConfig(ENV_CRN, null, ACCOUNT_ID);
 
         assertThat(result).isEqualTo(operationStatus);
         verify(stackUpdater).updateStackStatus(stack, MODIFY_PROXY_CONFIG_REQUESTED, "Starting proxy config modification");


### PR DESCRIPTION
The old implementation tried to regenerate the whole userdata, but it did not contain the CCM connection details, as they are not stored after creation. The new implementation simply replaces the proxy related variables in the userdata.

See detailed description in the commit message.