### PR TITLE
CB-19951 Implement SSL for Hue DB

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/inifile/IniFile.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/inifile/IniFile.java
@@ -1,0 +1,140 @@
+package com.sequenceiq.cloudbreak.cmtemplate.inifile;
+
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.annotation.Nonnull;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+
+public class IniFile {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(IniFile.class);
+
+    private static final String NL_REGEX = "\n";
+
+    private static final Pattern SECTION_PATTERN = Pattern.compile("(\\[+)\\s*([a-zA-Z0-9_-]+)\\s*(]+)");
+
+    private static final int GROUP_SECTION_OPEN = 1;
+
+    private static final int GROUP_SECTION_ID = 2;
+
+    private static final int GROUP_SECTION_CLOSE = 3;
+
+    private static final String COMMENT_MARKER = "#";
+
+    private static final Pattern CONFIG_PATTERN = Pattern.compile("([a-zA-Z0-9_-]+)\\s*=(.*)");
+
+    private static final int GROUP_CONFIG_KEY = 1;
+
+    private static final int GROUP_CONFIG_VALUE = 2;
+
+    private final IniFileSection rootSection;
+
+    // Only to be instantiated via IniFileFactory
+    IniFile() {
+        rootSection = new IniFileSection();
+    }
+
+    @VisibleForTesting
+    IniFile(IniFileSection rootSection) {
+        this.rootSection = rootSection;
+    }
+
+    public void addContent(String content) {
+        Deque<IniFileSection> activeSections = new LinkedList<>();
+        activeSections.push(rootSection);
+        List<String> lines = Arrays.asList(content.split(NL_REGEX));
+        lines.forEach(line -> processLine(activeSections, line));
+    }
+
+    @Nonnull
+    public String print() {
+        StringBuilder sb = new StringBuilder();
+        rootSection.print(sb);
+        return sb.toString();
+    }
+
+    private void processLine(Deque<IniFileSection> activeSections, String line) {
+        String trimmedLine = line.trim();
+        if (trimmedLine.isEmpty() || isComment(trimmedLine)) {
+            LOGGER.info("Ignoring line: {}", trimmedLine);
+            return;
+        }
+
+        Matcher sectionMatcher = SECTION_PATTERN.matcher(trimmedLine);
+        if (sectionMatcher.matches()) {
+            changeSection(activeSections, sectionMatcher);
+            return;
+        }
+
+        Matcher configMatcher = CONFIG_PATTERN.matcher(trimmedLine);
+        if (configMatcher.matches()) {
+            addConfig(activeSections, configMatcher);
+            return;
+        }
+
+        throw new IllegalArgumentException(String.format("Invalid line: %s", trimmedLine));
+    }
+
+    private boolean isComment(String trimmedLine) {
+        return trimmedLine.startsWith(COMMENT_MARKER);
+    }
+
+    private void changeSection(Deque<IniFileSection> activeSections, Matcher sectionMatcher) {
+        int activeSectionLevel = activeSections.size() - 1;
+        int newSectionLevel = getSectionLevel(sectionMatcher);
+        String normalizedSectionName = getNormalizedSectionName(sectionMatcher);
+        validateSectionLevel(activeSectionLevel, newSectionLevel, activeSections.peek().getQualifiedName(), normalizedSectionName);
+
+        // This is a no-op if newSectionLevel > activeSectionLevel (actually newSectionLevel == activeSectionLevel + 1)
+        for (int i = 0; i < activeSectionLevel - newSectionLevel + 1; i++) {
+            activeSections.pop();
+        }
+
+        IniFileSection newSection = activeSections.peek().getChildSectionOrCreateIfAbsent(normalizedSectionName);
+        activeSections.push(newSection);
+        LOGGER.info("New active section '{}'", newSection.getQualifiedName());
+    }
+
+    private int getSectionLevel(Matcher sectionMatcher) {
+        String open = sectionMatcher.group(GROUP_SECTION_OPEN);
+        String close = sectionMatcher.group(GROUP_SECTION_CLOSE);
+        int openLength = open.length();
+        if (openLength != close.length()) {
+            throw new IllegalArgumentException(String.format("Malformed section header: '%s'", sectionMatcher.group()));
+        }
+        return openLength;
+    }
+
+    @Nonnull
+    private String getNormalizedSectionName(Matcher sectionMatcher) {
+        return sectionMatcher.group(GROUP_SECTION_OPEN) + sectionMatcher.group(GROUP_SECTION_ID) + sectionMatcher.group(GROUP_SECTION_CLOSE);
+    }
+
+    private void validateSectionLevel(int activeSectionLevel, int newSectionLevel, String activeSectionNames, String newSectionName) {
+        if (newSectionLevel <= activeSectionLevel) {
+            return;
+        }
+        if (newSectionLevel != activeSectionLevel + 1) {
+            throw new IllegalArgumentException(
+                    String.format("Invalid section level transition: active level %d, new level %d, active sections '%s', new section '%s'",
+                            activeSectionLevel, newSectionLevel, activeSectionNames, newSectionName));
+        }
+    }
+
+    private void addConfig(Deque<IniFileSection> activeSections, Matcher configMatcher) {
+        String key = configMatcher.group(GROUP_CONFIG_KEY);
+        String value = configMatcher.group(GROUP_CONFIG_VALUE).trim();
+        activeSections.peek().addConfig(key, value);
+        LOGGER.info("Setting config: key '{}', value '{}'", key, value);
+    }
+
+}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/inifile/IniFileFactory.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/inifile/IniFileFactory.java
@@ -1,0 +1,12 @@
+package com.sequenceiq.cloudbreak.cmtemplate.inifile;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class IniFileFactory {
+
+    public IniFile create() {
+        return new IniFile();
+    }
+
+}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/inifile/IniFileSection.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/inifile/IniFileSection.java
@@ -1,0 +1,130 @@
+package com.sequenceiq.cloudbreak.cmtemplate.inifile;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Objects.requireNonNull;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+
+class IniFileSection {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(IniFileSection.class);
+
+    private static final String EMPTY_NAME = "";
+
+    private static final String QUALIFIED_DELIMITER = " ";
+
+    private static final char NL = '\n';
+
+    private static final String CONFIG_VALUE_DELIMITER = "=";
+
+    private final Map<String, IniFileSection> childSectionsByName = new LinkedHashMap<>();
+
+    private final Map<String, String> configsByName = new LinkedHashMap<>();
+
+    private final String name;
+
+    private final String parentSectionNames;
+
+    private final boolean root;
+
+    // Constructor for the root section
+    IniFileSection() {
+        name = EMPTY_NAME;
+        parentSectionNames = EMPTY_NAME;
+        root = true;
+    }
+
+    // Constructor for non-root sections
+    IniFileSection(String name, String parentSectionNames) {
+        if (isNullOrEmpty(name)) {
+            throw new IllegalArgumentException("'name' must not be empty");
+        }
+        this.name = name;
+        this.parentSectionNames = requireNonNull(parentSectionNames, "'parentSectionNames' must not be null");
+        root = false;
+    }
+
+    @Nonnull
+    String getQualifiedName() {
+        if (root) {
+            return EMPTY_NAME;
+        } else {
+            return parentSectionNames.isEmpty() ? name : String.join(QUALIFIED_DELIMITER, parentSectionNames, name);
+        }
+    }
+
+    @VisibleForTesting
+    @Nonnull
+    String getQualifiedConfigKey(String key) {
+        String qualifiedName = getQualifiedName();
+        return qualifiedName.isEmpty() ? key : String.join(QUALIFIED_DELIMITER, qualifiedName, key);
+    }
+
+    @Nonnull
+    IniFileSection getChildSectionOrCreateIfAbsent(String childName) {
+        return childSectionsByName.computeIfAbsent(childName, k -> new IniFileSection(childName, getQualifiedName()));
+    }
+
+    void addConfig(String key, String value) {
+        if (isNullOrEmpty(key)) {
+            throw new IllegalArgumentException("'key' must not be empty");
+        }
+        requireNonNull(value, "'value' must not be null");
+        if (configsByName.containsKey(key)) {
+            String oldValue = configsByName.get(key);
+            LOGGER.warn("Overwriting config '{}': old value '{}', new value '{}'", getQualifiedConfigKey(key), oldValue, value);
+        }
+        configsByName.put(key, value);
+    }
+
+    void print(StringBuilder sb) {
+        requireNonNull(sb, "'sb' must not be null");
+        if (!root) {
+            sb.append(name)
+                    .append(NL);
+        }
+        configsByName.forEach((key, value) -> sb.append(key)
+                .append(CONFIG_VALUE_DELIMITER)
+                .append(value)
+                .append(NL));
+        childSectionsByName.values().forEach(s -> s.print(sb));
+    }
+
+    @VisibleForTesting
+    @Nonnull
+    Map<String, IniFileSection> getChildSectionsByName() {
+        return childSectionsByName;
+    }
+
+    @VisibleForTesting
+    @Nonnull
+    Map<String, String> getConfigsByName() {
+        return configsByName;
+    }
+
+    @VisibleForTesting
+    @Nonnull
+    String getName() {
+        return name;
+    }
+
+    @VisibleForTesting
+    @Nonnull
+    String getParentSectionNames() {
+        return parentSectionNames;
+    }
+
+    @VisibleForTesting
+    boolean isRoot() {
+        return root;
+    }
+
+}

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hue/HueConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hue/HueConfigProviderTest.java
@@ -1,26 +1,36 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.hue;
 
+import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import java.util.AbstractMap.SimpleEntry;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
-import com.cloudera.api.swagger.model.ApiClusterTemplateVariable;
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
+import com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigTestUtil;
+import com.sequenceiq.cloudbreak.cmtemplate.inifile.IniFile;
+import com.sequenceiq.cloudbreak.cmtemplate.inifile.IniFileFactory;
+import com.sequenceiq.cloudbreak.common.type.Versioned;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.gateway.Gateway;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject.Builder;
@@ -28,6 +38,7 @@ import com.sequenceiq.cloudbreak.template.model.GeneralClusterConfigs;
 import com.sequenceiq.cloudbreak.template.views.BlueprintView;
 import com.sequenceiq.cloudbreak.template.views.RdsView;
 
+@ExtendWith(MockitoExtension.class)
 public class HueConfigProviderTest {
 
     private static final String HUE = "HUE";
@@ -44,153 +55,193 @@ public class HueConfigProviderTest {
 
     private static final String PASSWORD = "password";
 
+    @Mock
+    private IniFileFactory iniFileFactory;
+
+    @InjectMocks
     private HueConfigProvider underTest;
 
-    @Before
-    public void setUp() {
-        underTest = new HueConfigProvider();
-    }
+    @Mock
+    private IniFile safetyValve;
 
     @Test
     public void getServiceConfigs() {
-        BlueprintView blueprintView = getMockBlueprintView("7.0.2", "7.0.2");
+        BlueprintView blueprintView = getMockBlueprintView("7.1.0");
 
-        TemplatePreparationObject tpo = new Builder().withBlueprintView(blueprintView).build();
+        RdsView rdsConfig = mock(RdsView.class);
+        when(rdsConfig.getType()).thenReturn(HUE);
+        when(rdsConfig.getHost()).thenReturn(HOST);
+        when(rdsConfig.getDatabaseName()).thenReturn(DB_NAME);
+        when(rdsConfig.getPort()).thenReturn(PORT);
+        when(rdsConfig.getSubprotocol()).thenReturn(DB_PROVIDER);
+        when(rdsConfig.getConnectionUserName()).thenReturn(USER_NAME);
+        when(rdsConfig.getConnectionPassword()).thenReturn(PASSWORD);
+
+        TemplatePreparationObject tpo = new Builder()
+                .withRdsViews(Set.of(rdsConfig))
+                .withBlueprintView(blueprintView)
+                .withProductDetails(generateCmRepo(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_1_0), null)
+                .build();
+
+        when(iniFileFactory.create()).thenReturn(safetyValve);
+        when(safetyValve.print()).thenReturn("");
+
         List<ApiClusterTemplateConfig> result = underTest.getServiceConfigs(null, tpo);
-        Map<String, String> paramToVariable =
-                result.stream().collect(Collectors.toMap(ApiClusterTemplateConfig::getName, ApiClusterTemplateConfig::getVariable));
-        assertThat(paramToVariable).containsOnly(
-                new SimpleEntry<>("database_host", "hue-hue_database_host"),
-                new SimpleEntry<>("database_port", "hue-hue_database_port"),
-                new SimpleEntry<>("database_name", "hue-hue_database_name"),
-                new SimpleEntry<>("database_type", "hue-hue_database_type"),
-                new SimpleEntry<>("database_user", "hue-hue_database_user"),
-                new SimpleEntry<>("database_password", "hue-hue_database_password")
-        );
+
+        verify(safetyValve, never()).addContent(anyString());
+        Map<String, String> configToValue = ConfigTestUtil.getConfigNameToValueMap(result);
+        assertThat(configToValue).containsOnly(
+                entry("database_host", HOST),
+                entry("database_port", PORT),
+                entry("database_name", DB_NAME),
+                entry("database_type", DB_PROVIDER),
+                entry("database_user", USER_NAME),
+                entry("database_password", PASSWORD));
+
+        Map<String, String> configToVariable = ConfigTestUtil.getConfigNameToVariableNameMap(result);
+        assertThat(configToVariable).isEmpty();
+    }
+
+    @Test
+    public void getServiceConfigsTestWhenGoodCmVersionButDbSslIsNotRequested() {
+        BlueprintView blueprintView = getMockBlueprintView("7.2.2");
+
+        RdsView rdsConfig = mock(RdsView.class);
+        when(rdsConfig.getType()).thenReturn(HUE);
+        when(rdsConfig.getHost()).thenReturn(HOST);
+        when(rdsConfig.getDatabaseName()).thenReturn(DB_NAME);
+        when(rdsConfig.getPort()).thenReturn(PORT);
+        when(rdsConfig.getSubprotocol()).thenReturn(DB_PROVIDER);
+        when(rdsConfig.getConnectionUserName()).thenReturn(USER_NAME);
+        when(rdsConfig.getConnectionPassword()).thenReturn(PASSWORD);
+        when(rdsConfig.isUseSsl()).thenReturn(false);
+
+        TemplatePreparationObject tpo = new Builder()
+                .withRdsViews(Set.of(rdsConfig))
+                .withBlueprintView(blueprintView)
+                .withProductDetails(generateCmRepo(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_2), null)
+                .build();
+
+        when(iniFileFactory.create()).thenReturn(safetyValve);
+        when(safetyValve.print()).thenReturn("");
+
+        List<ApiClusterTemplateConfig> result = underTest.getServiceConfigs(null, tpo);
+
+        verify(safetyValve, never()).addContent(anyString());
+        Map<String, String> configToValue = ConfigTestUtil.getConfigNameToValueMap(result);
+        assertThat(configToValue).containsOnly(
+                entry("database_host", HOST),
+                entry("database_port", PORT),
+                entry("database_name", DB_NAME),
+                entry("database_type", DB_PROVIDER),
+                entry("database_user", USER_NAME),
+                entry("database_password", PASSWORD));
+
+        Map<String, String> configToVariable = ConfigTestUtil.getConfigNameToVariableNameMap(result);
+        assertThat(configToVariable).isEmpty();
+    }
+
+    @Test
+    public void getServiceConfigsTestWhenDbSsl() {
+        BlueprintView blueprintView = getMockBlueprintView("7.2.2");
+
+        RdsView rdsConfig = mock(RdsView.class);
+        when(rdsConfig.getType()).thenReturn(HUE);
+        when(rdsConfig.getHost()).thenReturn(HOST);
+        when(rdsConfig.getDatabaseName()).thenReturn(DB_NAME);
+        when(rdsConfig.getPort()).thenReturn(PORT);
+        when(rdsConfig.getSubprotocol()).thenReturn(DB_PROVIDER);
+        when(rdsConfig.getConnectionUserName()).thenReturn(USER_NAME);
+        when(rdsConfig.getConnectionPassword()).thenReturn(PASSWORD);
+        when(rdsConfig.isUseSsl()).thenReturn(true);
+        when(rdsConfig.getSslCertificateFilePath()).thenReturn("/foo/bar.pem");
+
+        TemplatePreparationObject tpo = new Builder()
+                .withRdsViews(Set.of(rdsConfig))
+                .withBlueprintView(blueprintView)
+                .withProductDetails(generateCmRepo(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_2), null)
+                .build();
+
+        when(iniFileFactory.create()).thenReturn(safetyValve);
+        String expectedSafetyValveValue = "[desktop]\n[[database]]\noptions='{\"sslmode\": \"verify-full\", \"sslrootcert\": \"/foo/bar.pem\"}'";
+        when(safetyValve.print()).thenReturn(expectedSafetyValveValue);
+
+        List<ApiClusterTemplateConfig> result = underTest.getServiceConfigs(null, tpo);
+
+        verify(safetyValve).addContent(expectedSafetyValveValue);
+        verifyNoMoreInteractions(safetyValve);
+        Map<String, String> configToValue = ConfigTestUtil.getConfigNameToValueMap(result);
+        assertThat(configToValue).containsOnly(
+                entry("database_host", HOST),
+                entry("database_port", PORT),
+                entry("database_name", DB_NAME),
+                entry("database_type", DB_PROVIDER),
+                entry("database_user", USER_NAME),
+                entry("database_password", PASSWORD),
+                entry("hue_service_safety_valve", expectedSafetyValveValue));
+
+        Map<String, String> configToVariable = ConfigTestUtil.getConfigNameToVariableNameMap(result);
+        assertThat(configToVariable).isEmpty();
     }
 
     @Test
     public void getServiceConfigsWhenKnoxConfiguredToExternalDomain() {
-        BlueprintView blueprintView = getMockBlueprintView("7.0.2", "7.0.2");
+        BlueprintView blueprintView = getMockBlueprintView("7.0.1");
 
+        RdsView rdsConfig = mock(RdsView.class);
+        when(rdsConfig.getType()).thenReturn(HUE);
+        when(rdsConfig.getConnectionUserName()).thenReturn(USER_NAME);
+        when(rdsConfig.getConnectionPassword()).thenReturn(PASSWORD);
+        when(rdsConfig.getHost()).thenReturn(HOST);
+        when(rdsConfig.getDatabaseName()).thenReturn(DB_NAME);
+        when(rdsConfig.getPort()).thenReturn(PORT);
+        when(rdsConfig.getSubprotocol()).thenReturn(DB_PROVIDER);
+
+        String expectedExternalFQDN = "myaddress.cloudera.site";
+        String expectedInternalFQDN = "private-gateway.cloudera.site";
         GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
-        generalClusterConfigs.setExternalFQDN("myaddress.cloudera.site");
+        generalClusterConfigs.setExternalFQDN(expectedExternalFQDN);
         generalClusterConfigs.setKnoxUserFacingCertConfigured(true);
-        generalClusterConfigs.setPrimaryGatewayInstanceDiscoveryFQDN(Optional.of("private-gateway.cloudera.site"));
+        generalClusterConfigs.setPrimaryGatewayInstanceDiscoveryFQDN(Optional.of(expectedInternalFQDN));
+
         TemplatePreparationObject tpo = new Builder()
                 .withGeneralClusterConfigs(generalClusterConfigs)
-                .withBlueprintView(blueprintView)
                 .withGateway(new Gateway(), "", new HashSet<>())
+                .withBlueprintView(blueprintView)
+                .withProductDetails(generateCmRepo(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_0_1), null)
+                .withRdsViews(Set.of(rdsConfig))
                 .build();
+
+        when(iniFileFactory.create()).thenReturn(safetyValve);
+        String proxyHostsExpected = String.join(",", expectedInternalFQDN, expectedExternalFQDN);
+        String expectedSafetyValveValue = "[desktop]\n[[knox]]\nknox_proxyhosts=".concat(proxyHostsExpected);
+        when(safetyValve.print()).thenReturn(expectedSafetyValveValue);
+
         List<ApiClusterTemplateConfig> result = underTest.getServiceConfigs(null, tpo);
-        Map<String, String> paramToVariable =
-                result.stream().collect(Collectors.toMap(ApiClusterTemplateConfig::getName, ApiClusterTemplateConfig::getVariable));
-        assertThat(paramToVariable).containsOnly(
-                new SimpleEntry<>("database_host", "hue-hue_database_host"),
-                new SimpleEntry<>("database_port", "hue-hue_database_port"),
-                new SimpleEntry<>("database_name", "hue-hue_database_name"),
-                new SimpleEntry<>("database_type", "hue-hue_database_type"),
-                new SimpleEntry<>("database_user", "hue-hue_database_user"),
-                new SimpleEntry<>("database_password", "hue-hue_database_password"),
-                new SimpleEntry<>("hue_service_safety_valve", "hue-hue_service_safety_valve")
-        );
+
+        verify(safetyValve).addContent(expectedSafetyValveValue);
+        verifyNoMoreInteractions(safetyValve);
+        verify(rdsConfig, never()).getSslCertificateFilePath();
+        Map<String, String> configToValue = ConfigTestUtil.getConfigNameToValueMap(result);
+        assertThat(configToValue).containsOnly(
+                entry("database_host", HOST),
+                entry("database_port", PORT),
+                entry("database_name", DB_NAME),
+                entry("database_type", DB_PROVIDER),
+                entry("database_user", USER_NAME),
+                entry("database_password", PASSWORD),
+                entry("hue_service_safety_valve", expectedSafetyValveValue));
+
+        Map<String, String> configToVariable = ConfigTestUtil.getConfigNameToVariableNameMap(result);
+        assertThat(configToVariable).isEmpty();
     }
 
     @Test
-    public void getServiceConfigVariables() {
-        BlueprintView blueprintView = getMockBlueprintView("7.2.0", "7.1.0");
+    public void getServiceConfigsWhenKnoxConfiguredToExternalDomainWhenNoSafetyValve() {
+        BlueprintView blueprintView = getMockBlueprintView("7.1.0");
 
         RdsView rdsConfig = mock(RdsView.class);
         when(rdsConfig.getType()).thenReturn(HUE);
-        when(rdsConfig.getHost()).thenReturn(HOST);
-        when(rdsConfig.getDatabaseName()).thenReturn(DB_NAME);
-        when(rdsConfig.getPort()).thenReturn(PORT);
-        when(rdsConfig.getSubprotocol()).thenReturn(DB_PROVIDER);
-        when(rdsConfig.getConnectionURL()).thenReturn(String.format("jdbc:%s://%s:%s/%s", DB_PROVIDER, HOST, PORT, DB_NAME));
-        when(rdsConfig.getConnectionUserName()).thenReturn(USER_NAME);
-        when(rdsConfig.getConnectionPassword()).thenReturn(PASSWORD);
-        TemplatePreparationObject tpo = new Builder()
-                .withRdsViews(Set.of(rdsConfig))
-                .withBlueprintView(blueprintView)
-                .build();
-
-        List<ApiClusterTemplateVariable> result = underTest.getServiceConfigVariables(tpo);
-        Map<String, String> paramToVariable =
-                result.stream().collect(Collectors.toMap(ApiClusterTemplateVariable::getName, ApiClusterTemplateVariable::getValue));
-        assertThat(paramToVariable).containsOnly(
-                new SimpleEntry<>("hue-hue_database_host", HOST),
-                new SimpleEntry<>("hue-hue_database_port", PORT),
-                new SimpleEntry<>("hue-hue_database_name", DB_NAME),
-                new SimpleEntry<>("hue-hue_database_type", DB_PROVIDER),
-                new SimpleEntry<>("hue-hue_database_user", USER_NAME),
-                new SimpleEntry<>("hue-hue_database_password", PASSWORD));
-    }
-
-    @Test
-    public void getServiceConfigVariablesWhenKnoxConfiguredToExternalDomain() {
-        BlueprintView blueprintView = getMockBlueprintView("7.0.1", "7.0.1");
-
-        RdsView rdsConfig = mock(RdsView.class);
-        when(rdsConfig.getType()).thenReturn(HUE);
-        when(rdsConfig.getConnectionURL()).thenReturn(String.format("jdbc:%s://%s:%s/%s", DB_PROVIDER, HOST, PORT, DB_NAME));
-        when(rdsConfig.getConnectionUserName()).thenReturn(USER_NAME);
-        when(rdsConfig.getConnectionPassword()).thenReturn(PASSWORD);
-        when(rdsConfig.getHost()).thenReturn(HOST);
-        when(rdsConfig.getDatabaseName()).thenReturn(DB_NAME);
-        when(rdsConfig.getPort()).thenReturn(PORT);
-        when(rdsConfig.getSubprotocol()).thenReturn(DB_PROVIDER);
-        when(rdsConfig.getHost()).thenReturn(HOST);
-        when(rdsConfig.getDatabaseName()).thenReturn(DB_NAME);
-        when(rdsConfig.getPort()).thenReturn(PORT);
-        when(rdsConfig.getSubprotocol()).thenReturn(DB_PROVIDER);
-
-        String expectedExternalFQDN = "myaddress.cloudera.site";
-        String expectedInternalFQDN = "private-gateway.cloudera.site";
-        GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
-        generalClusterConfigs.setExternalFQDN(expectedExternalFQDN);
-        generalClusterConfigs.setKnoxUserFacingCertConfigured(true);
-        generalClusterConfigs.setPrimaryGatewayInstanceDiscoveryFQDN(Optional.of(expectedInternalFQDN));
-
-        TemplatePreparationObject tpo = new Builder()
-                .withGeneralClusterConfigs(generalClusterConfigs)
-                .withGateway(new Gateway(), "", new HashSet<>())
-                .withBlueprintView(blueprintView)
-                .withRdsViews(Set.of(rdsConfig))
-                .build();
-
-        List<ApiClusterTemplateVariable> result = underTest.getServiceConfigVariables(tpo);
-        Map<String, String> paramToVariable =
-                result.stream().collect(Collectors.toMap(ApiClusterTemplateVariable::getName, ApiClusterTemplateVariable::getValue));
-        String proxyHostsExpected1 = String.join(",", expectedInternalFQDN, expectedExternalFQDN);
-        String proxyHostsExpected2 = String.join(",", expectedExternalFQDN, expectedInternalFQDN);
-        String expectedSafetyValveValue1 = "[desktop]\n[[knox]]\nknox_proxyhosts=".concat(proxyHostsExpected1);
-        String expectedSafetyValveValue2 = "[desktop]\n[[knox]]\nknox_proxyhosts=".concat(proxyHostsExpected2);
-        assertEquals(7, paramToVariable.size());
-        assertThat(paramToVariable).contains(
-                new SimpleEntry<>("hue-hue_database_host", HOST),
-                new SimpleEntry<>("hue-hue_database_port", PORT),
-                new SimpleEntry<>("hue-hue_database_name", DB_NAME),
-                new SimpleEntry<>("hue-hue_database_type", DB_PROVIDER),
-                new SimpleEntry<>("hue-hue_database_user", USER_NAME),
-                new SimpleEntry<>("hue-hue_database_password", PASSWORD));
-        assertThat(paramToVariable).containsAnyOf(
-                new SimpleEntry<>("hue-hue_service_safety_valve", expectedSafetyValveValue1),
-                new SimpleEntry<>("hue-hue_service_safety_valve", expectedSafetyValveValue2));
-    }
-
-    @Test
-    public void getServiceConfigVariablesWhenKnoxConfiguredToExternalDomainWhenNoSafetyValve() {
-        BlueprintView blueprintView = mock(BlueprintView.class);
-        when(blueprintView.getVersion()).thenReturn("7.1.0");
-
-        CmTemplateProcessor templateProcessor = mock(CmTemplateProcessor.class);
-        when(templateProcessor.getVersion()).thenReturn(Optional.ofNullable("7.1.0"));
-
-        when(blueprintView.getProcessor()).thenReturn(templateProcessor);
-
-        RdsView rdsConfig = mock(RdsView.class);
-        when(rdsConfig.getType()).thenReturn(HUE);
-        when(rdsConfig.getConnectionURL()).thenReturn(String.format("jdbc:%s://%s:%s/%s", DB_PROVIDER, HOST, PORT, DB_NAME));
         when(rdsConfig.getConnectionUserName()).thenReturn(USER_NAME);
         when(rdsConfig.getConnectionPassword()).thenReturn(PASSWORD);
         when(rdsConfig.getHost()).thenReturn(HOST);
@@ -209,25 +260,84 @@ public class HueConfigProviderTest {
                 .withGeneralClusterConfigs(generalClusterConfigs)
                 .withGateway(new Gateway(), "", new HashSet<>())
                 .withBlueprintView(blueprintView)
+                .withProductDetails(generateCmRepo(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_1_0), null)
                 .withRdsViews(Set.of(rdsConfig))
                 .build();
 
-        List<ApiClusterTemplateVariable> result = underTest.getServiceConfigVariables(tpo);
-        Map<String, String> paramToVariable =
-                result.stream().collect(Collectors.toMap(ApiClusterTemplateVariable::getName, ApiClusterTemplateVariable::getValue));
-        String proxyHostsExpected1 = String.join(",", expectedInternalFQDN, expectedExternalFQDN);
-        String proxyHostsExpected2 = String.join(",", expectedExternalFQDN, expectedInternalFQDN);
-        assertEquals(7, paramToVariable.size());
-        assertThat(paramToVariable).contains(
-                new SimpleEntry<>("hue-hue_database_host", HOST),
-                new SimpleEntry<>("hue-hue_database_port", PORT),
-                new SimpleEntry<>("hue-hue_database_name", DB_NAME),
-                new SimpleEntry<>("hue-hue_database_type", DB_PROVIDER),
-                new SimpleEntry<>("hue-hue_database_user", USER_NAME),
-                new SimpleEntry<>("hue-hue_database_password", PASSWORD));
-        assertThat(paramToVariable).containsAnyOf(
-            new SimpleEntry<>("hue-knox_proxyhosts", proxyHostsExpected1),
-            new SimpleEntry<>("hue-knox_proxyhosts", proxyHostsExpected2));
+        when(iniFileFactory.create()).thenReturn(safetyValve);
+        when(safetyValve.print()).thenReturn("");
+
+        List<ApiClusterTemplateConfig> result = underTest.getServiceConfigs(null, tpo);
+
+        verify(safetyValve, never()).addContent(anyString());
+        Map<String, String> configToValue = ConfigTestUtil.getConfigNameToValueMap(result);
+        String proxyHostsExpected = String.join(",", expectedInternalFQDN, expectedExternalFQDN);
+        assertThat(configToValue).containsOnly(
+                entry("database_host", HOST),
+                entry("database_port", PORT),
+                entry("database_name", DB_NAME),
+                entry("database_type", DB_PROVIDER),
+                entry("database_user", USER_NAME),
+                entry("database_password", PASSWORD),
+                entry("knox_proxyhosts", proxyHostsExpected));
+
+        Map<String, String> configToVariable = ConfigTestUtil.getConfigNameToVariableNameMap(result);
+        assertThat(configToVariable).isEmpty();
+    }
+
+    // Note: Due to the conflicting CM version requirements, it is impossible to have both the Knox Proxy Hosts and DB SSL settings in the Safety Valve!
+    @Test
+    public void getServiceConfigsWhenKnoxConfiguredToExternalDomainWhenNoSafetyValveAndDbSsl() {
+        BlueprintView blueprintView = getMockBlueprintView("7.2.2");
+
+        RdsView rdsConfig = mock(RdsView.class);
+        when(rdsConfig.getType()).thenReturn(HUE);
+        when(rdsConfig.getConnectionUserName()).thenReturn(USER_NAME);
+        when(rdsConfig.getConnectionPassword()).thenReturn(PASSWORD);
+        when(rdsConfig.getHost()).thenReturn(HOST);
+        when(rdsConfig.getDatabaseName()).thenReturn(DB_NAME);
+        when(rdsConfig.getPort()).thenReturn(PORT);
+        when(rdsConfig.getSubprotocol()).thenReturn(DB_PROVIDER);
+        when(rdsConfig.isUseSsl()).thenReturn(true);
+        when(rdsConfig.getSslCertificateFilePath()).thenReturn("/foo/bar.pem");
+
+        String expectedExternalFQDN = "myaddress.cloudera.site";
+        String expectedInternalFQDN = "private-gateway.cloudera.site";
+        GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
+        generalClusterConfigs.setExternalFQDN(expectedExternalFQDN);
+        generalClusterConfigs.setKnoxUserFacingCertConfigured(true);
+        generalClusterConfigs.setPrimaryGatewayInstanceDiscoveryFQDN(Optional.of(expectedInternalFQDN));
+
+        TemplatePreparationObject tpo = new Builder()
+                .withGeneralClusterConfigs(generalClusterConfigs)
+                .withGateway(new Gateway(), "", new HashSet<>())
+                .withBlueprintView(blueprintView)
+                .withProductDetails(generateCmRepo(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_2), null)
+                .withRdsViews(Set.of(rdsConfig))
+                .build();
+
+        when(iniFileFactory.create()).thenReturn(safetyValve);
+        String expectedSafetyValveValue = "[desktop]\n[[database]]\noptions='{\"sslmode\": \"verify-full\", \"sslrootcert\": \"/foo/bar.pem\"}'";
+        when(safetyValve.print()).thenReturn(expectedSafetyValveValue);
+
+        List<ApiClusterTemplateConfig> result = underTest.getServiceConfigs(null, tpo);
+
+        verify(safetyValve).addContent(expectedSafetyValveValue);
+        verifyNoMoreInteractions(safetyValve);
+        Map<String, String> configToValue = ConfigTestUtil.getConfigNameToValueMap(result);
+        String proxyHostsExpected = String.join(",", expectedInternalFQDN, expectedExternalFQDN);
+        assertThat(configToValue).containsOnly(
+                entry("database_host", HOST),
+                entry("database_port", PORT),
+                entry("database_name", DB_NAME),
+                entry("database_type", DB_PROVIDER),
+                entry("database_user", USER_NAME),
+                entry("database_password", PASSWORD),
+                entry("knox_proxyhosts", proxyHostsExpected),
+                entry("hue_service_safety_valve", expectedSafetyValveValue));
+
+        Map<String, String> configToVariable = ConfigTestUtil.getConfigNameToVariableNameMap(result);
+        assertThat(configToVariable).isEmpty();
     }
 
     @Test
@@ -248,51 +358,48 @@ public class HueConfigProviderTest {
 
         RdsView rdsConfig = mock(RdsView.class);
         when(rdsConfig.getType()).thenReturn(HUE);
-        when(rdsConfig.getConnectionURL()).thenReturn(String.format("jdbc:%s://%s:%s/%s", DB_PROVIDER, HOST, PORT, DB_NAME));
-        when(rdsConfig.getConnectionUserName()).thenReturn(USER_NAME);
-        when(rdsConfig.getConnectionPassword()).thenReturn(PASSWORD);
+
         TemplatePreparationObject tpo = new Builder().withRdsViews(Set.of(rdsConfig)).build();
 
         boolean result = underTest.isConfigurationNeeded(mockTemplateProcessor, tpo);
+
         assertThat(result).isTrue();
     }
 
     @Test
     @SuppressWarnings("unchecked")
-    public void isConfigurationNeededFalseWhenNoHueOnClusterr() {
+    public void isConfigurationNeededFalseWhenNoHueOnCluster() {
         CmTemplateProcessor mockTemplateProcessor = mock(CmTemplateProcessor.class);
         when(mockTemplateProcessor.isRoleTypePresentInService(anyString(), any(List.class))).thenReturn(false);
 
         RdsView rdsConfig = mock(RdsView.class);
         when(rdsConfig.getType()).thenReturn(HUE);
-        when(rdsConfig.getConnectionURL()).thenReturn(String.format("jdbc:%s://%s:%s/%s", DB_PROVIDER, HOST, PORT, DB_NAME));
-        when(rdsConfig.getConnectionUserName()).thenReturn(USER_NAME);
-        when(rdsConfig.getConnectionPassword()).thenReturn(PASSWORD);
+
         TemplatePreparationObject tpo = new Builder().withRdsViews(Set.of(rdsConfig)).build();
 
         boolean result = underTest.isConfigurationNeeded(mockTemplateProcessor, tpo);
+
         assertThat(result).isFalse();
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void isConfigurationNeededFalseWhenNoDBRegistered() {
         CmTemplateProcessor mockTemplateProcessor = mock(CmTemplateProcessor.class);
-        when(mockTemplateProcessor.isRoleTypePresentInService(anyString(), any(List.class))).thenReturn(true);
 
         TemplatePreparationObject tpo = new Builder().build();
 
         boolean result = underTest.isConfigurationNeeded(mockTemplateProcessor, tpo);
+
         assertThat(result).isFalse();
+        verifyNoInteractions(mockTemplateProcessor);
     }
 
     @Test
-    public void getProxyHostsWhenLoadBalancerConfigured() {
-        BlueprintView blueprintView = getMockBlueprintView("7.0.1", "7.0.1");
+    public void getServiceConfigsWhenKnoxConfiguredWithLoadBalancer() {
+        BlueprintView blueprintView = getMockBlueprintView("7.0.1");
 
         RdsView rdsConfig = mock(RdsView.class);
         when(rdsConfig.getType()).thenReturn(HUE);
-        when(rdsConfig.getConnectionURL()).thenReturn(String.format("jdbc:%s://%s:%s/%s", DB_PROVIDER, HOST, PORT, DB_NAME));
         when(rdsConfig.getConnectionUserName()).thenReturn(USER_NAME);
         when(rdsConfig.getConnectionPassword()).thenReturn(PASSWORD);
         when(rdsConfig.getHost()).thenReturn(HOST);
@@ -309,27 +416,40 @@ public class HueConfigProviderTest {
         generalClusterConfigs.setLoadBalancerGatewayFqdn(Optional.of(expectedLBFQDN));
 
         TemplatePreparationObject tpo = new Builder()
-            .withGeneralClusterConfigs(generalClusterConfigs)
-            .withGateway(new Gateway(), "", new HashSet<>())
-            .withBlueprintView(blueprintView)
-            .withRdsViews(Set.of(rdsConfig))
-            .build();
+                .withGeneralClusterConfigs(generalClusterConfigs)
+                .withGateway(new Gateway(), "", new HashSet<>())
+                .withBlueprintView(blueprintView)
+                .withProductDetails(generateCmRepo(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_0_1), null)
+                .withRdsViews(Set.of(rdsConfig))
+                .build();
 
-        List<ApiClusterTemplateVariable> result = underTest.getServiceConfigVariables(tpo);
-        Map<String, String> paramToVariable =
-            result.stream().collect(Collectors.toMap(ApiClusterTemplateVariable::getName, ApiClusterTemplateVariable::getValue));
-        String proxyHostsExpected1 = String.join(",", expectedExternalFQDN, expectedLBFQDN);
-        String proxyHostsExpected2 = String.join(",", expectedLBFQDN, expectedExternalFQDN);
-        String expectedSafetyValveValue1 = "[desktop]\n[[knox]]\nknox_proxyhosts=".concat(proxyHostsExpected1);
-        String expectedSafetyValveValue2 = "[desktop]\n[[knox]]\nknox_proxyhosts=".concat(proxyHostsExpected2);
-        assertThat(paramToVariable).containsAnyOf(
-            new SimpleEntry<>("hue-hue_service_safety_valve", expectedSafetyValveValue1),
-            new SimpleEntry<>("hue-hue_service_safety_valve", expectedSafetyValveValue2));
+        when(iniFileFactory.create()).thenReturn(safetyValve);
+        String proxyHostsExpected = String.join(",", expectedExternalFQDN, expectedLBFQDN);
+        String expectedSafetyValveValue = "[desktop]\n[[knox]]\nknox_proxyhosts=".concat(proxyHostsExpected);
+        when(safetyValve.print()).thenReturn(expectedSafetyValveValue);
+
+        List<ApiClusterTemplateConfig> result = underTest.getServiceConfigs(null, tpo);
+
+        verify(safetyValve).addContent(expectedSafetyValveValue);
+        verifyNoMoreInteractions(safetyValve);
+        verify(rdsConfig, never()).getSslCertificateFilePath();
+        Map<String, String> configToValue = ConfigTestUtil.getConfigNameToValueMap(result);
+        assertThat(configToValue).containsOnly(
+                entry("database_host", HOST),
+                entry("database_port", PORT),
+                entry("database_name", DB_NAME),
+                entry("database_type", DB_PROVIDER),
+                entry("database_user", USER_NAME),
+                entry("database_password", PASSWORD),
+                entry("hue_service_safety_valve", expectedSafetyValveValue));
+
+        Map<String, String> configToVariable = ConfigTestUtil.getConfigNameToVariableNameMap(result);
+        assertThat(configToVariable).isEmpty();
     }
 
     @Test
-    public void getProxyHostsWhenLoadBalancerConfiguredPost710() {
-        BlueprintView blueprintView = getMockBlueprintView("7.2.0", "7.1.0");
+    public void getServiceConfigsWhenKnoxConfiguredWithLoadBalancerPost710() {
+        BlueprintView blueprintView = getMockBlueprintView("7.1.0");
 
         RdsView rdsConfig = mock(RdsView.class);
         when(rdsConfig.getType()).thenReturn(HUE);
@@ -337,7 +457,6 @@ public class HueConfigProviderTest {
         when(rdsConfig.getDatabaseName()).thenReturn(DB_NAME);
         when(rdsConfig.getPort()).thenReturn(PORT);
         when(rdsConfig.getSubprotocol()).thenReturn(DB_PROVIDER);
-        when(rdsConfig.getConnectionURL()).thenReturn(String.format("jdbc:%s://%s:%s/%s", DB_PROVIDER, HOST, PORT, DB_NAME));
         when(rdsConfig.getConnectionUserName()).thenReturn(USER_NAME);
         when(rdsConfig.getConnectionPassword()).thenReturn(PASSWORD);
 
@@ -350,25 +469,36 @@ public class HueConfigProviderTest {
         generalClusterConfigs.setLoadBalancerGatewayFqdn(Optional.of(expectedLBFQDN));
 
         TemplatePreparationObject tpo = new Builder()
-            .withGeneralClusterConfigs(generalClusterConfigs)
-            .withGateway(new Gateway(), "", new HashSet<>())
-            .withBlueprintView(blueprintView)
-            .withRdsViews(Set.of(rdsConfig))
-            .build();
+                .withGeneralClusterConfigs(generalClusterConfigs)
+                .withGateway(new Gateway(), "", new HashSet<>())
+                .withBlueprintView(blueprintView)
+                .withProductDetails(generateCmRepo(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_1_0), null)
+                .withRdsViews(Set.of(rdsConfig))
+                .build();
 
-        List<ApiClusterTemplateVariable> result = underTest.getServiceConfigVariables(tpo);
-        Map<String, String> paramToVariable =
-            result.stream().collect(Collectors.toMap(ApiClusterTemplateVariable::getName, ApiClusterTemplateVariable::getValue));
-        String proxyHostsExpected1 = String.join(",", expectedExternalFQDN, expectedLBFQDN);
-        String proxyHostsExpected2 = String.join(",", expectedLBFQDN, expectedExternalFQDN);
-        assertThat(paramToVariable).containsAnyOf(
-            new SimpleEntry<>("hue-knox_proxyhosts", proxyHostsExpected1),
-            new SimpleEntry<>("hue-knox_proxyhosts", proxyHostsExpected2));
+        when(iniFileFactory.create()).thenReturn(safetyValve);
+        when(safetyValve.print()).thenReturn("");
+
+        List<ApiClusterTemplateConfig> result = underTest.getServiceConfigs(null, tpo);
+
+        verify(safetyValve, never()).addContent(anyString());
+        Map<String, String> configToValue = ConfigTestUtil.getConfigNameToValueMap(result);
+        String proxyHostsExpected = String.join(",", expectedExternalFQDN, expectedLBFQDN);
+        assertThat(configToValue).containsOnly(
+                entry("database_host", HOST),
+                entry("database_port", PORT),
+                entry("database_name", DB_NAME),
+                entry("database_type", DB_PROVIDER),
+                entry("database_user", USER_NAME),
+                entry("database_password", PASSWORD),
+                entry("knox_proxyhosts", proxyHostsExpected));
+
+        Map<String, String> configToVariable = ConfigTestUtil.getConfigNameToVariableNameMap(result);
+        assertThat(configToVariable).isEmpty();
     }
 
-    private BlueprintView getMockBlueprintView(String bpVersion, String tmplVersion) {
+    private BlueprintView getMockBlueprintView(String tmplVersion) {
         BlueprintView blueprintView = mock(BlueprintView.class);
-        when(blueprintView.getVersion()).thenReturn(bpVersion);
 
         CmTemplateProcessor templateProcessor = mock(CmTemplateProcessor.class);
         when(templateProcessor.getVersion()).thenReturn(Optional.ofNullable(tmplVersion));
@@ -377,4 +507,13 @@ public class HueConfigProviderTest {
         when(blueprintView.getProcessor()).thenReturn(templateProcessor);
         return blueprintView;
     }
+
+    private ClouderaManagerRepo generateCmRepo(Versioned version) {
+        return new ClouderaManagerRepo()
+                .withBaseUrl("baseurl")
+                .withGpgKeyUrl("gpgurl")
+                .withPredefined(true)
+                .withVersion(version.getVersion());
+    }
+
 }

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/inifile/IniFileFactoryTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/inifile/IniFileFactoryTest.java
@@ -1,0 +1,22 @@
+package com.sequenceiq.cloudbreak.cmtemplate.inifile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class IniFileFactoryTest {
+
+    private IniFileFactory underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new IniFileFactory();
+    }
+
+    @Test
+    void createTest() {
+        assertThat(underTest.create()).isNotNull();
+    }
+
+}

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/inifile/IniFileSectionTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/inifile/IniFileSectionTest.java
@@ -1,0 +1,333 @@
+package com.sequenceiq.cloudbreak.cmtemplate.inifile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class IniFileSectionTest {
+
+    private static final String NAME = "name";
+
+    private static final String PARENT_SECTION_NAMES = "parentSectionNames";
+
+    private static final String QUALIFIED_NAME = PARENT_SECTION_NAMES + " " + NAME;
+
+    private static final String EMPTY_NAME = "";
+
+    private static final String EMPTY_KEY = "";
+
+    private static final String KEY = "key";
+
+    private static final String KEY_2 = "key2";
+
+    private static final String CHILD_NAME = "childName";
+
+    private static final String CHILD_NAME_2 = "childName2";
+
+    private static final String VALUE = "value";
+
+    private static final String VALUE_2 = "value2";
+
+    @Nonnull
+    private static IniFileSection rootSection() {
+        return new IniFileSection();
+    }
+
+    @Nonnull
+    private static IniFileSection regularSectionTopLevel() {
+        return new IniFileSection(NAME, EMPTY_NAME);
+    }
+
+    @Nonnull
+    private static IniFileSection regularSectionLowerLevel() {
+        return new IniFileSection(NAME, PARENT_SECTION_NAMES);
+    }
+
+    @Test
+    void constructorTestRootSection() {
+        IniFileSection underTest = rootSection();
+
+        assertThat(underTest.getName()).isEqualTo(EMPTY_NAME);
+        assertThat(underTest.getParentSectionNames()).isEqualTo(EMPTY_NAME);
+        assertThat(underTest.isRoot()).isEqualTo(true);
+
+        validateEmptyChildSectionsAndConfigs(underTest);
+    }
+
+    private void validateEmptyChildSectionsAndConfigs(IniFileSection underTest) {
+        Map<String, IniFileSection> childSectionsByName = underTest.getChildSectionsByName();
+        assertThat(childSectionsByName).isNotNull();
+        assertThat(childSectionsByName).isEmpty();
+
+        Map<String, String> configsByName = underTest.getConfigsByName();
+        assertThat(configsByName).isNotNull();
+        assertThat(configsByName).isEmpty();
+    }
+
+    @ParameterizedTest(name = "name={0}")
+    @ValueSource(strings = {EMPTY_NAME})
+    @NullSource
+    void constructorTestRegularSectionWhenEmptyName(String name) {
+        IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class,
+                () -> new IniFileSection(name, PARENT_SECTION_NAMES));
+
+        assertThat(illegalArgumentException).hasMessage("'name' must not be empty");
+    }
+
+    @Test
+    void constructorTestRegularSectionWhenNullParentSectionNames() {
+        NullPointerException nullPointerException = assertThrows(NullPointerException.class, () -> new IniFileSection(NAME, null));
+
+        assertThat(nullPointerException).hasMessage("'parentSectionNames' must not be null");
+    }
+
+    @Test
+    void constructorTestRegularSectionWhenSuccess() {
+        IniFileSection underTest = regularSectionLowerLevel();
+
+        assertThat(underTest.getName()).isEqualTo(NAME);
+        assertThat(underTest.getParentSectionNames()).isEqualTo(PARENT_SECTION_NAMES);
+        assertThat(underTest.isRoot()).isEqualTo(false);
+
+        validateEmptyChildSectionsAndConfigs(underTest);
+    }
+
+    static Object[][] getQualifiedNameTestDataProvider() {
+        return new Object[][]{
+                // testCaseName, underTest, resultExpected
+                {"rootSection", rootSection(), EMPTY_NAME},
+                {"regularSectionTopLevel", regularSectionTopLevel(), NAME},
+                {"regularSectionLowerLevel", regularSectionLowerLevel(), QUALIFIED_NAME},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("getQualifiedNameTestDataProvider")
+    void getQualifiedNameTest(String testCaseName, IniFileSection underTest, String resultExpected) {
+        assertThat(underTest.getQualifiedName()).isEqualTo(resultExpected);
+    }
+
+    static Object[][] getQualifiedConfigKeyTestDataProvider() {
+        return new Object[][]{
+                // testCaseName, underTest, resultExpected
+                {"rootSection", rootSection(), KEY},
+                {"regularSectionLowerLevel", regularSectionLowerLevel(), QUALIFIED_NAME + " " + KEY},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("getQualifiedConfigKeyTestDataProvider")
+    void getQualifiedConfigKeyTest(String testCaseName, IniFileSection underTest, String resultExpected) {
+        assertThat(underTest.getQualifiedConfigKey(KEY)).isEqualTo(resultExpected);
+    }
+
+    @Test
+    void getChildSectionOrCreateIfAbsentTestWhenAbsent() {
+        IniFileSection underTest = regularSectionLowerLevel();
+        Map<String, IniFileSection> childSectionsByName = underTest.getChildSectionsByName();
+        validateEmptyChildSectionsAndConfigs(underTest);
+
+        IniFileSection result = underTest.getChildSectionOrCreateIfAbsent(CHILD_NAME);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getQualifiedName()).isEqualTo(QUALIFIED_NAME + " " + CHILD_NAME);
+        validateEmptyChildSectionsAndConfigs(result);
+        assertThat(result.getName()).isEqualTo(CHILD_NAME);
+        assertThat(result.getParentSectionNames()).isEqualTo(QUALIFIED_NAME);
+
+        assertThat(childSectionsByName).hasSize(1);
+        assertThat(childSectionsByName.get(CHILD_NAME)).isSameAs(result);
+    }
+
+    @Test
+    void getChildSectionOrCreateIfAbsentTestWhenPresent() {
+        IniFileSection underTest = regularSectionLowerLevel();
+        Map<String, IniFileSection> childSectionsByName = underTest.getChildSectionsByName();
+        validateEmptyChildSectionsAndConfigs(underTest);
+
+        IniFileSection child = underTest.getChildSectionOrCreateIfAbsent(CHILD_NAME);
+        validateEmptyChildSectionsAndConfigs(child);
+        assertThat(childSectionsByName).hasSize(1);
+        assertThat(childSectionsByName.get(CHILD_NAME)).isSameAs(child);
+
+        assertThat(underTest.getChildSectionOrCreateIfAbsent(CHILD_NAME)).isSameAs(child);
+        assertThat(childSectionsByName).hasSize(1);
+        assertThat(childSectionsByName.get(CHILD_NAME)).isSameAs(child);
+    }
+
+    @Test
+    void getChildSectionOrCreateIfAbsentTestWhenMultipleChildSections() {
+        IniFileSection underTest = regularSectionLowerLevel();
+        Map<String, IniFileSection> childSectionsByName = underTest.getChildSectionsByName();
+        validateEmptyChildSectionsAndConfigs(underTest);
+
+        IniFileSection result = underTest.getChildSectionOrCreateIfAbsent(CHILD_NAME);
+        IniFileSection result2 = underTest.getChildSectionOrCreateIfAbsent(CHILD_NAME_2);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getQualifiedName()).isEqualTo(QUALIFIED_NAME + " " + CHILD_NAME);
+        validateEmptyChildSectionsAndConfigs(result);
+        assertThat(result.getName()).isEqualTo(CHILD_NAME);
+        assertThat(result.getParentSectionNames()).isEqualTo(QUALIFIED_NAME);
+
+        assertThat(result2).isNotNull();
+        assertThat(result2.getQualifiedName()).isEqualTo(QUALIFIED_NAME + " " + CHILD_NAME_2);
+        validateEmptyChildSectionsAndConfigs(result2);
+        assertThat(result2.getName()).isEqualTo(CHILD_NAME_2);
+        assertThat(result2.getParentSectionNames()).isEqualTo(QUALIFIED_NAME);
+
+        assertThat(childSectionsByName).hasSize(2);
+        assertThat(childSectionsByName.get(CHILD_NAME)).isSameAs(result);
+        assertThat(childSectionsByName.get(CHILD_NAME_2)).isSameAs(result2);
+    }
+
+    @ParameterizedTest(name = "key={0}")
+    @ValueSource(strings = {EMPTY_KEY})
+    @NullSource
+    void addConfigTestWhenEmptyKey(String key) {
+        IniFileSection underTest = rootSection();
+        IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class,
+                () -> underTest.addConfig(key, VALUE));
+
+        assertThat(illegalArgumentException).hasMessage("'key' must not be empty");
+    }
+
+    @Test
+    void addConfigTestWhenNullValue() {
+        IniFileSection underTest = rootSection();
+        NullPointerException nullPointerException = assertThrows(NullPointerException.class, () -> underTest.addConfig(KEY, null));
+
+        assertThat(nullPointerException).hasMessage("'value' must not be null");
+    }
+
+    @Test
+    void addConfigTestWhenSingleNewConfig() {
+        IniFileSection underTest = rootSection();
+        Map<String, String> configsByName = underTest.getConfigsByName();
+        validateEmptyChildSectionsAndConfigs(underTest);
+
+        underTest.addConfig(KEY, VALUE);
+
+        assertThat(configsByName).hasSize(1);
+        assertThat(configsByName.get(KEY)).isEqualTo(VALUE);
+    }
+
+    @Test
+    void addConfigTestWhenExistingConfig() {
+        IniFileSection underTest = rootSection();
+        Map<String, String> configsByName = underTest.getConfigsByName();
+        validateEmptyChildSectionsAndConfigs(underTest);
+
+        underTest.addConfig(KEY, VALUE);
+        assertThat(configsByName).hasSize(1);
+        assertThat(configsByName.get(KEY)).isEqualTo(VALUE);
+
+        underTest.addConfig(KEY, VALUE_2);
+
+        assertThat(configsByName).hasSize(1);
+        assertThat(configsByName.get(KEY)).isEqualTo(VALUE_2);
+    }
+
+    @Test
+    void addConfigTestWhenMultipleNewConfigs() {
+        IniFileSection underTest = rootSection();
+        Map<String, String> configsByName = underTest.getConfigsByName();
+        validateEmptyChildSectionsAndConfigs(underTest);
+
+        underTest.addConfig(KEY, VALUE);
+        underTest.addConfig(KEY_2, VALUE_2);
+
+        assertThat(configsByName).hasSize(2);
+        assertThat(configsByName.get(KEY)).isEqualTo(VALUE);
+        assertThat(configsByName.get(KEY_2)).isEqualTo(VALUE_2);
+    }
+
+    @Test
+    void printTestWhenNullStringBuilder() {
+        IniFileSection underTest = rootSection();
+        NullPointerException nullPointerException = assertThrows(NullPointerException.class, () -> underTest.print(null));
+
+        assertThat(nullPointerException).hasMessage("'sb' must not be null");
+    }
+
+    @Nonnull
+    private static String section(int sectionIndex) {
+        return String.format("section_%d", sectionIndex);
+    }
+
+    @Nonnull
+    private static String key(int sectionIndex, int keyIndex) {
+        return String.format("key_%d_%d", sectionIndex, keyIndex);
+    }
+
+    @Nonnull
+    private static String value(int sectionIndex, int valueIndex) {
+        return String.format("value_%d_%d", sectionIndex, valueIndex);
+    }
+
+    @Nonnull
+    private static IniFileSection sectionTree(boolean globalConfigs, int topChildNum, boolean topChildConfigs, boolean lowerChild,
+            boolean lowerChildConfigs) {
+        IniFileSection rootSection = rootSection();
+        if (globalConfigs) {
+            rootSection.addConfig(KEY, VALUE);
+            rootSection.addConfig(KEY_2, VALUE_2);
+        }
+        int sectionIndex = 0;
+        for (int i = 0; i < topChildNum; i++) {
+            sectionIndex++;
+            IniFileSection topChildSection = rootSection.getChildSectionOrCreateIfAbsent(section(sectionIndex));
+            if (topChildConfigs) {
+                topChildSection.addConfig(key(sectionIndex, 1), value(sectionIndex, 1));
+            }
+            if (lowerChild) {
+                sectionIndex++;
+                IniFileSection lowerChildSection = topChildSection.getChildSectionOrCreateIfAbsent(section(sectionIndex));
+                if (lowerChildConfigs) {
+                    lowerChildSection.addConfig(key(sectionIndex, 1), value(sectionIndex, 1));
+                    lowerChildSection.addConfig(key(sectionIndex, 2), value(sectionIndex, 2));
+                }
+            }
+        }
+        return rootSection;
+    }
+
+    static Object[][] printTestWhenSuccessDataProvider() {
+        return new Object[][]{
+                // testCaseName, underTest, resultExpected
+                {"empty rootSection", rootSection(), ""},
+                {"rootSection with global configs only", sectionTree(true, 0, false, false, false), "key=value\nkey2=value2\n"},
+                {"rootSection with a single child section only", sectionTree(false, 1, false, false, false), "section_1\n"},
+                {"rootSection with a single child section only and child configs", sectionTree(false, 1, true, false, false), "section_1\nkey_1_1=value_1_1\n"},
+                {"rootSection with global configs and single child section", sectionTree(true, 1, true, false, false),
+                        "key=value\nkey2=value2\nsection_1\nkey_1_1=value_1_1\n"},
+                {"rootSection with global configs and two child sections", sectionTree(true, 2, true, false, false),
+                        "key=value\nkey2=value2\nsection_1\nkey_1_1=value_1_1\nsection_2\nkey_2_1=value_2_1\n"},
+                {"rootSection with global configs and four child sections and two levels", sectionTree(true, 2, true, true, false),
+                        "key=value\nkey2=value2\nsection_1\nkey_1_1=value_1_1\nsection_2\nsection_3\nkey_3_1=value_3_1\nsection_4\n"},
+                {"rootSection with four child sections and two levels and configs everywhere", sectionTree(true, 2, true, true, true),
+                        "key=value\nkey2=value2\nsection_1\nkey_1_1=value_1_1\nsection_2\nkey_2_1=value_2_1\nkey_2_2=value_2_2\n" +
+                                "section_3\nkey_3_1=value_3_1\nsection_4\nkey_4_1=value_4_1\nkey_4_2=value_4_2\n"},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("printTestWhenSuccessDataProvider")
+    void printTestWhenSuccess(String testCaseName, IniFileSection underTest, String resultExpected) {
+        StringBuilder sb = new StringBuilder();
+
+        underTest.print(sb);
+
+        assertThat(sb.toString()).isEqualTo(resultExpected);
+    }
+
+}

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/inifile/IniFileTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/inifile/IniFileTest.java
@@ -1,0 +1,314 @@
+package com.sequenceiq.cloudbreak.cmtemplate.inifile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class IniFileTest {
+
+    @Mock
+    private IniFileSection rootSection;
+
+    @InjectMocks
+    private IniFile underTest;
+
+    @Test
+    void printTest() {
+        doAnswer(invocation -> {
+            StringBuilder sb = invocation.getArgument(0, StringBuilder.class);
+            sb.append("foo");
+            return null;
+        }).when(rootSection).print(any(StringBuilder.class));
+
+        assertThat(underTest.print()).isEqualTo("foo");
+    }
+
+    @Test
+    void addContentTestWhenNull() {
+        assertThrows(NullPointerException.class, () -> underTest.addContent(null));
+
+        verifyNoInteractions(rootSection);
+    }
+
+    @ParameterizedTest(name = "content={0}")
+    @ValueSource(strings = {"", "\n", "\n\n"})
+    void addContentTestWhenEmpty(String content) {
+        underTest.addContent(content);
+
+        verifyNoInteractions(rootSection);
+    }
+
+    @ParameterizedTest(name = "content={0}")
+    @ValueSource(strings = {" ", "  \n", "\t"})
+    void addContentTestWhenWhitespaceOnly(String content) {
+        underTest.addContent(content);
+
+        verifyNoInteractions(rootSection);
+    }
+
+    @ParameterizedTest(name = "content={0}")
+    @ValueSource(strings = {"#", "  #", " # ", "#foo", "## hello", "#a#", "#[foo]", "#setting=something"})
+    void addContentTestWhenCommentOnly(String content) {
+        underTest.addContent(content);
+
+        verifyNoInteractions(rootSection);
+    }
+
+    @ParameterizedTest(name = "content={0}")
+    @ValueSource(strings = {"[foo]]", "[[foo]"})
+    void addContentTestWhenMismatchingSectionBracketCounts(String content) {
+        IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> underTest.addContent(content));
+
+        assertThat(illegalArgumentException).hasMessage(String.format("Malformed section header: '%s'", content));
+
+        verifyNoInteractions(rootSection);
+    }
+
+    @ParameterizedTest(name = "content={0}")
+    @ValueSource(strings = {"[foo]", "[ foo]", "[foo ]", "[ foo ]", " [foo] ", " [ foo ] "})
+    void addContentTestWhenSingleSectionSimple(String content) {
+        when(rootSection.getQualifiedName()).thenReturn("root");
+        IniFileSection newSection = mock(IniFileSection.class);
+        when(rootSection.getChildSectionOrCreateIfAbsent("[foo]")).thenReturn(newSection);
+        when(newSection.getQualifiedName()).thenReturn("first");
+
+        underTest.addContent(content);
+
+        verifyNoMoreInteractions(rootSection, newSection);
+    }
+
+    @Test
+    void addContentTestWhenSingleSectionComplex() {
+        when(rootSection.getQualifiedName()).thenReturn("root");
+        IniFileSection newSection = mock(IniFileSection.class);
+        when(rootSection.getChildSectionOrCreateIfAbsent("[abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWXYZ-0123456789]")).thenReturn(newSection);
+        when(newSection.getQualifiedName()).thenReturn("first");
+
+        underTest.addContent("[abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWXYZ-0123456789]");
+
+        verifyNoMoreInteractions(rootSection, newSection);
+    }
+
+    @Test
+    void addContentTestWhenSingleSectionButInvalidLevelTransition() {
+        when(rootSection.getQualifiedName()).thenReturn("root");
+
+        IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> underTest.addContent("[[foo]]"));
+
+        assertThat(illegalArgumentException)
+                .hasMessage("Invalid section level transition: active level 0, new level 2, active sections 'root', new section '[[foo]]'");
+
+        verifyNoMoreInteractions(rootSection);
+    }
+
+    @Test
+    void addContentTestWhenSingleSectionTwice() {
+        when(rootSection.getQualifiedName()).thenReturn("root");
+        IniFileSection newSection = mock(IniFileSection.class);
+        when(rootSection.getChildSectionOrCreateIfAbsent("[foo]")).thenReturn(newSection);
+        when(newSection.getQualifiedName()).thenReturn("first");
+
+        underTest.addContent("[foo]\n[foo]");
+
+        verifyNoMoreInteractions(rootSection, newSection);
+    }
+
+    @Test
+    void addContentTestWhenTwoSectionsSameLevel() {
+        when(rootSection.getQualifiedName()).thenReturn("root");
+        IniFileSection newSection1 = mock(IniFileSection.class);
+        when(rootSection.getChildSectionOrCreateIfAbsent("[foo]")).thenReturn(newSection1);
+        when(newSection1.getQualifiedName()).thenReturn("first");
+        IniFileSection newSection2 = mock(IniFileSection.class);
+        when(rootSection.getChildSectionOrCreateIfAbsent("[bar]")).thenReturn(newSection2);
+        when(newSection2.getQualifiedName()).thenReturn("second");
+
+        underTest.addContent("[foo]\n[bar]");
+
+        verifyNoMoreInteractions(rootSection, newSection1, newSection2);
+    }
+
+    @Test
+    void addContentTestWhenTwoSectionsDifferentLevels() {
+        when(rootSection.getQualifiedName()).thenReturn("root");
+        IniFileSection newSection1 = mock(IniFileSection.class);
+        when(rootSection.getChildSectionOrCreateIfAbsent("[foo]")).thenReturn(newSection1);
+        when(newSection1.getQualifiedName()).thenReturn("first");
+        IniFileSection newSection2 = mock(IniFileSection.class);
+        when(newSection1.getChildSectionOrCreateIfAbsent("[[bar]]")).thenReturn(newSection2);
+        when(newSection2.getQualifiedName()).thenReturn("second");
+
+        underTest.addContent("[foo]\n[[bar]]");
+
+        verifyNoMoreInteractions(rootSection, newSection1, newSection2);
+    }
+
+    @Test
+    void addContentTestWhenThreeSectionsIncreasingLevels() {
+        when(rootSection.getQualifiedName()).thenReturn("root");
+        IniFileSection newSection1 = mock(IniFileSection.class);
+        when(rootSection.getChildSectionOrCreateIfAbsent("[foo]")).thenReturn(newSection1);
+        when(newSection1.getQualifiedName()).thenReturn("first");
+        IniFileSection newSection2 = mock(IniFileSection.class);
+        when(newSection1.getChildSectionOrCreateIfAbsent("[[bar]]")).thenReturn(newSection2);
+        when(newSection2.getQualifiedName()).thenReturn("second");
+        IniFileSection newSection3 = mock(IniFileSection.class);
+        when(newSection2.getChildSectionOrCreateIfAbsent("[[[dummy]]]")).thenReturn(newSection3);
+        when(newSection3.getQualifiedName()).thenReturn("third");
+
+        underTest.addContent("[foo]\n[[ bar]]\n[[[dummy ]]]");
+
+        verifyNoMoreInteractions(rootSection, newSection1, newSection2, newSection3);
+    }
+
+    @Test
+    void addContentTestWhenThreeSectionsLevelsOneTwoOne() {
+        when(rootSection.getQualifiedName()).thenReturn("root");
+        IniFileSection newSection1 = mock(IniFileSection.class);
+        when(rootSection.getChildSectionOrCreateIfAbsent("[foo]")).thenReturn(newSection1);
+        when(newSection1.getQualifiedName()).thenReturn("first");
+        IniFileSection newSection2 = mock(IniFileSection.class);
+        when(newSection1.getChildSectionOrCreateIfAbsent("[[bar]]")).thenReturn(newSection2);
+        when(newSection2.getQualifiedName()).thenReturn("second");
+        IniFileSection newSection3 = mock(IniFileSection.class);
+        when(rootSection.getChildSectionOrCreateIfAbsent("[dummy]")).thenReturn(newSection3);
+        when(newSection3.getQualifiedName()).thenReturn("third");
+
+        underTest.addContent("[foo]\n[[bar]]\n[dummy]");
+
+        verifyNoMoreInteractions(rootSection, newSection1, newSection2, newSection3);
+    }
+
+    @Test
+    void addContentTestWhenFourSectionsLevelsOneTwoThreeTwo() {
+        when(rootSection.getQualifiedName()).thenReturn("root");
+        IniFileSection newSection1 = mock(IniFileSection.class);
+        when(rootSection.getChildSectionOrCreateIfAbsent("[foo]")).thenReturn(newSection1);
+        when(newSection1.getQualifiedName()).thenReturn("first");
+        IniFileSection newSection2 = mock(IniFileSection.class);
+        when(newSection1.getChildSectionOrCreateIfAbsent("[[bar]]")).thenReturn(newSection2);
+        when(newSection2.getQualifiedName()).thenReturn("second");
+        IniFileSection newSection3 = mock(IniFileSection.class);
+        when(newSection2.getChildSectionOrCreateIfAbsent("[[[dummy]]]")).thenReturn(newSection3);
+        when(newSection3.getQualifiedName()).thenReturn("third");
+        IniFileSection newSection4 = mock(IniFileSection.class);
+        when(newSection1.getChildSectionOrCreateIfAbsent("[[boom]]")).thenReturn(newSection4);
+        when(newSection4.getQualifiedName()).thenReturn("fourth");
+
+        underTest.addContent("[foo]\n[[bar]]\n[[[dummy]]]\n[[boom]]");
+
+        verifyNoMoreInteractions(rootSection, newSection1, newSection2, newSection3, newSection4);
+    }
+
+    @Test
+    void addContentTestWhenFourSectionsLevelsOneTwoThreeOne() {
+        when(rootSection.getQualifiedName()).thenReturn("root");
+        IniFileSection newSection1 = mock(IniFileSection.class);
+        when(rootSection.getChildSectionOrCreateIfAbsent("[foo]")).thenReturn(newSection1);
+        when(newSection1.getQualifiedName()).thenReturn("first");
+        IniFileSection newSection2 = mock(IniFileSection.class);
+        when(newSection1.getChildSectionOrCreateIfAbsent("[[bar]]")).thenReturn(newSection2);
+        when(newSection2.getQualifiedName()).thenReturn("second");
+        IniFileSection newSection3 = mock(IniFileSection.class);
+        when(newSection2.getChildSectionOrCreateIfAbsent("[[[dummy]]]")).thenReturn(newSection3);
+        when(newSection3.getQualifiedName()).thenReturn("third");
+        IniFileSection newSection4 = mock(IniFileSection.class);
+        when(rootSection.getChildSectionOrCreateIfAbsent("[boom]")).thenReturn(newSection4);
+        when(newSection4.getQualifiedName()).thenReturn("fourth");
+
+        underTest.addContent("[foo]\n[[bar]]\n[[[dummy]]]\n[boom]");
+
+        verifyNoMoreInteractions(rootSection, newSection1, newSection2, newSection3, newSection4);
+    }
+
+    @ParameterizedTest(name = "content={0}")
+    @ValueSource(strings = {"setting=something", "setting =something", "setting= something", "setting = something", " setting=something ",
+            " setting = something "})
+    void addContentTestWhenSingleGlobalConfigWithValue(String content) {
+        underTest.addContent(content);
+
+        verify(rootSection).addConfig("setting", "something");
+        verifyNoMoreInteractions(rootSection);
+    }
+
+    @ParameterizedTest(name = "content={0}")
+    @ValueSource(strings = {"setting=", "setting= "})
+    void addContentTestWhenSingleGlobalConfigNoValue(String content) {
+        underTest.addContent(content);
+
+        verify(rootSection).addConfig("setting", "");
+        verifyNoMoreInteractions(rootSection);
+    }
+
+    @Test
+    void addContentTestWhenSingleGlobalConfigWithValueComplex() {
+        underTest.addContent("abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWXYZ-0123456789=[something]#text=,'$';{\"\"}");
+
+        verify(rootSection).addConfig("abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWXYZ-0123456789", "[something]#text=,'$';{\"\"}");
+        verifyNoMoreInteractions(rootSection);
+    }
+
+    @Test
+    void addContentTestWhenTwoGlobalConfigs() {
+        underTest.addContent("setting=something\nproperty=override");
+
+        verify(rootSection).addConfig("setting", "something");
+        verify(rootSection).addConfig("property", "override");
+        verifyNoMoreInteractions(rootSection);
+    }
+
+    @Test
+    void addContentTestWhenFourSectionsLevelsOneTwoThreeOneAndConfigs() {
+        when(rootSection.getQualifiedName()).thenReturn("root");
+        IniFileSection newSection1 = mock(IniFileSection.class);
+        when(rootSection.getChildSectionOrCreateIfAbsent("[foo]")).thenReturn(newSection1);
+        when(newSection1.getQualifiedName()).thenReturn("first");
+        IniFileSection newSection2 = mock(IniFileSection.class);
+        when(newSection1.getChildSectionOrCreateIfAbsent("[[bar]]")).thenReturn(newSection2);
+        when(newSection2.getQualifiedName()).thenReturn("second");
+        IniFileSection newSection3 = mock(IniFileSection.class);
+        when(newSection2.getChildSectionOrCreateIfAbsent("[[[dummy]]]")).thenReturn(newSection3);
+        when(newSection3.getQualifiedName()).thenReturn("third");
+        IniFileSection newSection4 = mock(IniFileSection.class);
+        when(rootSection.getChildSectionOrCreateIfAbsent("[boom]")).thenReturn(newSection4);
+        when(newSection4.getQualifiedName()).thenReturn("fourth");
+
+        underTest.addContent("conf0=val0\n[foo]\nconf1=val1\n[[bar]]\nconf2=val2\nconf3=val3\n[[[dummy]]]\nconf4=val4\n[boom]\nconf5=val5\n[foo]\nconf6=val6");
+
+        verify(rootSection).addConfig("conf0", "val0");
+        verify(newSection1).addConfig("conf1", "val1");
+        verify(newSection2).addConfig("conf2", "val2");
+        verify(newSection2).addConfig("conf3", "val3");
+        verify(newSection3).addConfig("conf4", "val4");
+        verify(newSection4).addConfig("conf5", "val5");
+        verify(newSection1).addConfig("conf6", "val6");
+        verifyNoMoreInteractions(rootSection, newSection1, newSection2, newSection3, newSection4);
+    }
+
+    @ParameterizedTest(name = "content={0}")
+    @ValueSource(strings = {"[foo", "[foo[", "[]", "[@]", "[foo@bar]", "[foo]bar", "[foo][bar]", "[foo][[bar]]", "[ [foo] ]", "=", "=foo", "foo", "[foo#]",
+            "setting[=something", "setting#=something", "[foo]setting=something"})
+    void addContentTestWhenInvalidLine(String content) {
+        IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> underTest.addContent(content));
+
+        assertThat(illegalArgumentException).hasMessage("Invalid line: " + content);
+
+        verifyNoInteractions(rootSection);
+    }
+
+}

--- a/template-manager-cmtemplate/src/test/resources/input/clouderamanager-existing-conf.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/clouderamanager-existing-conf.bp
@@ -167,6 +167,34 @@
       ]
     },
     {
+      "refName": "hue",
+      "serviceType": "HUE",
+      "serviceConfigs": [
+        {
+          "name": "hue_service_safety_valve",
+          "value": "[desktop]\napp_blacklist=spark,zookeeper,hbase,impala,search,sqoop,security,pig"
+        }
+      ],
+      "roleConfigGroups": [
+        {
+          "refName": "hue-HUE_SERVER-BASE",
+          "roleType": "HUE_SERVER",
+          "base": true,
+          "configs": [
+            {
+              "name": "hue_server_hue_safety_valve",
+              "value": "[dashboard]\nhas_sql_enabled=true"
+            }
+          ]
+        },
+        {
+          "refName": "hue-HUE_LOAD_BALANCER-BASE",
+          "roleType": "HUE_LOAD_BALANCER",
+          "base": true
+        }
+      ]
+    },
+    {
       "refName": "hive",
       "serviceType": "HIVE",
       "serviceConfigs": [
@@ -227,6 +255,8 @@
         "hive-GATEWAY-BASE",
         "hive-HIVEMETASTORE-BASE",
         "hive-HIVESERVER2-BASE",
+        "hue-HUE_LOAD_BALANCER-BASE",
+        "hue-HUE_SERVER-BASE",
         "impala-CATALOGSERVER-BASE",
         "impala-STATESTORE-BASE",
         "kafka-KAFKA_BROKER-BASE",

--- a/template-manager-cmtemplate/src/test/resources/input/hue-ssl.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/hue-ssl.bp
@@ -1,0 +1,38 @@
+{
+  "cdhVersion": "7.2.11",
+  "displayName": "Hue only",
+  "services": [
+    {
+      "refName": "hue",
+      "serviceType": "HUE",
+      "serviceConfigs": [
+        {
+          "name": "hue_service_safety_valve",
+          "value": "[desktop]\napp_blacklist=spark,zookeeper,hbase,impala,search,sqoop,security,pig"
+        }
+      ],
+      "roleConfigGroups": [
+        {
+          "refName": "hue-HUE_SERVER-BASE",
+          "roleType": "HUE_SERVER",
+          "base": true
+        },
+        {
+          "refName": "hue-HUE_LOAD_BALANCER-BASE",
+          "roleType": "HUE_LOAD_BALANCER",
+          "base": true
+        }
+      ]
+    }
+  ],
+  "hostTemplates": [
+    {
+      "refName": "master",
+      "cardinality": 1,
+      "roleConfigGroupsRefNames": [
+        "hue-HUE_SERVER-BASE",
+        "hue-HUE_LOAD_BALANCER-BASE"
+      ]
+    }
+  ]
+}

--- a/template-manager-cmtemplate/src/test/resources/output/hue-ssl.bp
+++ b/template-manager-cmtemplate/src/test/resources/output/hue-ssl.bp
@@ -1,0 +1,96 @@
+{
+  "cdhVersion": "7.2.11",
+  "displayName": "testcluster",
+  "cmVersion": "7.4.3",
+  "services": [
+    {
+      "refName": "hue",
+      "serviceType": "HUE",
+      "serviceConfigs": [
+        {
+          "name": "database_type",
+          "value": "postgresql"
+        },
+        {
+          "name": "database_user",
+          "value": "heyitsme"
+        },
+        {
+          "name": "database_name",
+          "value": "hue"
+        },
+        {
+          "name": "database_host",
+          "value": "10.1.1.1"
+        },
+        {
+          "name": "database_port",
+          "value": "5432"
+        },
+        {
+          "name": "database_password",
+          "value": "iamsoosecure"
+        },
+        {
+          "name": "hue_service_safety_valve",
+          "value": "[desktop]\napp_blacklist=spark,zookeeper,hbase,impala,search,sqoop,security,pig\n[[database]]\noptions='{\"sslmode\": \"verify-full\", \"sslrootcert\": \"/foo/bar.pem\"}'\n"
+        }
+      ],
+      "roleConfigGroups": [
+        {
+          "refName": "hue-HUE_SERVER-BASE",
+          "roleType": "HUE_SERVER",
+          "base": true
+        },
+        {
+          "refName": "hue-HUE_LOAD_BALANCER-BASE",
+          "roleType": "HUE_LOAD_BALANCER",
+          "base": true
+        }
+      ]
+    }
+  ],
+  "hostTemplates": [
+    {
+      "refName": "master",
+      "cardinality": 1,
+      "roleConfigGroupsRefNames": [
+        "hue-HUE_SERVER-BASE",
+        "hue-HUE_LOAD_BALANCER-BASE"
+      ]
+    }
+  ],
+  "instantiator": {
+    "clusterName": "testcluster",
+    "hosts": [
+      {
+        "hostName": "host3",
+        "hostTemplateRefName": "worker"
+      },
+      {
+        "hostName": "host4",
+        "hostTemplateRefName": "worker"
+      },
+      {
+        "hostName": "host1",
+        "hostTemplateRefName": "master"
+      },
+      {
+        "hostName": "host2",
+        "hostTemplateRefName": "master"
+      }
+    ],
+    "keepHostTemplates": true,
+    "lenient": true
+  },
+  "tags": [
+    {
+      "name": "_cldr_cb_origin",
+      "value": "cloudbreak"
+    },
+    {
+      "name": "_cldr_cb_clustertype",
+      "value": "Data Hub"
+    }
+  ]
+}


### PR DESCRIPTION
* `HueConfigProvider`:
  * Add DB SSL configs to Hue service safety valve if needed.
  * Eliminate template variables. All settings are now set as regular name-value configs.
* `CmTemplateProcessor.chooseApiClusterTemplateConfig()`: Add support for merging INI file safety valve values.
* Fix various typos and other code clean-up.
* Testing:
  * Manual test with a Data Engineering DH in a commercial AWS region.
  * Added new UT & adapted existing ones.
