### PR TITLE
CB-19614 Update the db root ssl cert on the Cluster VM

### DIFF
--- a/common/src/test/java/com/sequenceiq/cloudbreak/util/UnusedInjectChecker.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/util/UnusedInjectChecker.java
@@ -15,19 +15,28 @@ import javax.inject.Inject;
 import org.reflections.Reflections;
 import org.reflections.scanners.MemberUsageScanner;
 import org.reflections.scanners.Scanners;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class UnusedInjectChecker {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UnusedInjectChecker.class);
 
     public void check() {
         Reflections reflections = new Reflections("com.sequenceiq",
                 Scanners.FieldsAnnotated,
+                Scanners.TypesAnnotated,
+                Scanners.SubTypes,
                 new MemberUsageScanner());
 
         Map<String, Set<String>> unusedFields = new HashMap<>();
         reflections.getFieldsAnnotatedWith(Inject.class).forEach(field -> {
             try {
-                Set<String> usages = reflections.getStore().getOrDefault(MemberUsageScanner.class.getSimpleName(), Collections.emptyMap())
-                        .getOrDefault(reflections.toName((AnnotatedElement) field), Collections.emptySet());
+                Set<String> usages = new HashSet<>();
+                for (String s : reflections.getStore().keySet()) {
+                    usages.addAll(reflections.getStore().getOrDefault(s, Collections.emptyMap())
+                            .getOrDefault(reflections.toName((AnnotatedElement) field), Collections.emptySet()));
+                }
                 if (usages.isEmpty()) {
                     String className = field.getDeclaringClass().getName();
                     unusedFields.computeIfAbsent(className, key -> new HashSet<>()).add(field.toString());
@@ -43,7 +52,9 @@ public class UnusedInjectChecker {
             fields.add(key + ": " + String.join(", ", value));
         });
         if (!unusedFields.isEmpty()) {
-            fail(String.format("Classes with unused injected fields: %s%s", lineSeparator(), String.join(lineSeparator(), fields)));
+            String format = String.format("Classes with unused injected fields: %s%s", lineSeparator(), String.join(lineSeparator(), fields));
+            LOGGER.error(format);
+            fail(format);
         }
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterService.java
@@ -500,9 +500,10 @@ public class ClusterService {
         return repository.getById(id);
     }
 
-    public void updateDbSslCert(Long clusterId, RedbeamsDbCertificateProvider.RedbeamsDbSslDetails relatedSslCerts) {
+    public String updateDbSslCert(Long clusterId, RedbeamsDbCertificateProvider.RedbeamsDbSslDetails relatedSslCerts) {
         Set<String> rootSslCerts = relatedSslCerts.getSslCerts();
         String allCerts = String.join("\n", rootSslCerts);
         repository.updateDbSslCert(clusterId, allCerts, relatedSslCerts.isSslEnabledForStack());
+        return allCerts;
     }
 }

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/root-certs.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/root-certs.sls
@@ -9,5 +9,10 @@ create-root-certs-file:
     - user: root
     - group: root
     - mode: 644
-    - unless: test -f {{ postgresql.root_certs_file }}
+
+cm-server-restart-root-cert-changed:
+  service.running:
+    - name: cloudera-scm-server
+    - watch:
+        - file: create-root-certs-file
 {% endif %}


### PR DESCRIPTION
in the new flow step, we need to do:

* read the saved SSL certs from the Cluster entity
* if  the cluster is under provision, the cert is empty, so we need to check that here: PostgresConfigService#decorateServicePillarWithPostgresIfNeeded
** if cluster.dbsslCert is empty, get from the Redbeams as of now and update it
** if not, read from the cluster entity
* restart the CM, because the auto-restart is set to true
the base logic is implemented during the provision, maybe we can reuse that