### PR TITLE
CB-18225 import Cloudera's openssl-provider library and configure it to be the most prior java security provider for FIPS

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/PeriscopeApplication.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/PeriscopeApplication.java
@@ -9,6 +9,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 
+import com.sequenceiq.cloudbreak.util.FipsOpenSSLLoaderUtil;
+
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @Configuration
@@ -19,6 +21,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 public class PeriscopeApplication {
 
     public static void main(String[] args) {
+        FipsOpenSSLLoaderUtil.registerOpenSSLJniProvider();
         if (!versionedApplication().showVersionInfo(args)) {
             if (args.length == 0) {
                 SpringApplication.run(PeriscopeApplication.class);

--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/ConsumptionApplication.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/ConsumptionApplication.java
@@ -6,6 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+import com.sequenceiq.cloudbreak.util.FipsOpenSSLLoaderUtil;
+
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @EnableSwagger2
@@ -15,6 +17,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 public class ConsumptionApplication {
 
     public static void main(String[] args) {
+        FipsOpenSSLLoaderUtil.registerOpenSSLJniProvider();
         SpringApplication.run(ConsumptionApplication.class, args);
     }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -88,6 +88,7 @@ dependencies {
   api group: 'org.springframework.security',        name: 'spring-security-jwt',              version: '1.0.8.RELEASE'
   api group: 'org.springframework.security',        name: 'spring-security-core',             version: springSecurityVersion
   api group: 'org.springframework.security',        name: 'spring-security-config',           version: springSecurityVersion
+  api group: 'com.cloudera.crypto',                 name: 'openssl-provider',                 version: clouderaCryptoOpenSslProviderVersion
 
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test',       version: springBootVersion
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation', version: springBootVersion

--- a/common/src/main/java/com/sequenceiq/cloudbreak/util/FipsOpenSSLLoaderUtil.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/util/FipsOpenSSLLoaderUtil.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.cloudbreak.util;
+
+import java.security.Provider;
+import java.security.Security;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.cloudera.crypto.provider.OpenSSLJniProvider;
+
+public class FipsOpenSSLLoaderUtil {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FipsOpenSSLLoaderUtil.class);
+
+    // CHECKSTYLE:OFF
+    /**
+     * Based on FIPS default configuration for OpenJDK11 the following provider should exist in FIPS environments
+     * https://access.redhat.com/documentation/en-us/openjdk/11/html-single/configuring_openjdk_11_on_rhel_with_fips/index#ref_openjdk-default-fips-configuration_openjdk
+     */
+    // CHECKSTYLE:ON
+    private static final String SUN_PKCS_11_NSS_FIPS_PROVIDER_NAME = "SunPKCS11-NSS-FIPS";
+
+    private FipsOpenSSLLoaderUtil() {
+    }
+
+    public static void registerOpenSSLJniProvider() {
+        Provider sunNSSFipsProvider = Security.getProvider(SUN_PKCS_11_NSS_FIPS_PROVIDER_NAME);
+        if (sunNSSFipsProvider != null) {
+            LOGGER.info("Registering OpenSSLJniProvider, because FIPS related security provider '{}' is available.", SUN_PKCS_11_NSS_FIPS_PROVIDER_NAME);
+            OpenSSLJniProvider.register();
+        } else {
+            LOGGER.info("OpenSSLJniProvider doesn't need to be registered because '{}' is NOT available.", SUN_PKCS_11_NSS_FIPS_PROVIDER_NAME);
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/CloudbreakApplication.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/CloudbreakApplication.java
@@ -14,6 +14,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 import com.sequenceiq.cloudbreak.structuredevent.service.CDPFlowStructuredEventHandler;
+import com.sequenceiq.cloudbreak.util.FipsOpenSSLLoaderUtil;
 
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
@@ -28,6 +29,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 @EnableAutoConfiguration(exclude = WebMvcMetricsAutoConfiguration.class)
 public class CloudbreakApplication {
     public static void main(String[] args) {
+        FipsOpenSSLLoaderUtil.registerOpenSSLJniProvider();
         if (!versionedApplication().showVersionInfo(args)) {
             if (args.length == 0) {
                 SpringApplication.run(CloudbreakApplication.class);

--- a/datalake/src/main/java/com/sequenceiq/datalake/DatalakeApplication.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/DatalakeApplication.java
@@ -5,6 +5,8 @@ import org.springframework.boot.actuate.autoconfigure.metrics.web.servlet.WebMvc
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
+import com.sequenceiq.cloudbreak.util.FipsOpenSSLLoaderUtil;
+
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @EnableJpaRepositories(basePackages = { "com.sequenceiq" })
@@ -13,6 +15,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 public class DatalakeApplication {
 
     public static void main(String[] args) {
+        FipsOpenSSLLoaderUtil.registerOpenSSLJniProvider();
         SpringApplication.run(DatalakeApplication.class, args);
     }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -76,6 +76,7 @@ ext {
 
   // Cloudera
   cmClientVersion = '7.6.0'
+  clouderaCryptoOpenSslProviderVersion = '1.0.0-b8'
 
   // Testing
   assertjVersion = '3.21.0'

--- a/docker-autoscale/Dockerfile
+++ b/docker-autoscale/Dockerfile
@@ -27,4 +27,12 @@ RUN ( unzip periscope.jar schema/* -d / ) || \
 COPY bootstrap/start_autoscale_app.sh /
 COPY bootstrap/wait_for_autoscale_api.sh /
 
+# Add OpenSSL provider to Java security policy file (FIPS enabled mode only).
+# - insert a line: fips.provider.1=OpenSSL
+# - increase the index for other fips.provider lines.
+RUN JAVA_SECURITY_POLICY_FILE=$JAVA_HOME/conf/security/java.security \
+&& for I in {20..1}; do J=$((I+1)); sed -i "s/fips.provider.$I=/fips.provider.$J=/" $JAVA_SECURITY_POLICY_FILE; done \
+&& N=$(grep -m 1 -n "^fips\.provider\.[[:digit:]]=" $JAVA_SECURITY_POLICY_FILE | cut -d: -f1) \
+&& sed -i "$N i fips.provider.1=OpenSSL" $JAVA_SECURITY_POLICY_FILE
+
 ENTRYPOINT ["/start_autoscale_app.sh"]

--- a/docker-cloudbreak/Dockerfile
+++ b/docker-cloudbreak/Dockerfile
@@ -27,4 +27,12 @@ RUN ( unzip cloudbreak.jar schema/* -d / ) || \
 COPY bootstrap/start_cloudbreak_app.sh /
 COPY bootstrap/wait_for_cloudbreak_api.sh /
 
+# Add OpenSSL provider to Java security policy file (FIPS enabled mode only).
+# - insert a line: fips.provider.1=OpenSSL
+# - increase the index for other fips.provider lines.
+RUN JAVA_SECURITY_POLICY_FILE=$JAVA_HOME/conf/security/java.security \
+&& for I in {20..1}; do J=$((I+1)); sed -i "s/fips.provider.$I=/fips.provider.$J=/" $JAVA_SECURITY_POLICY_FILE; done \
+&& N=$(grep -m 1 -n "^fips\.provider\.[[:digit:]]=" $JAVA_SECURITY_POLICY_FILE | cut -d: -f1) \
+&& sed -i "$N i fips.provider.1=OpenSSL" $JAVA_SECURITY_POLICY_FILE
+
 ENTRYPOINT ["/start_cloudbreak_app.sh"]

--- a/docker-consumption/Dockerfile
+++ b/docker-consumption/Dockerfile
@@ -27,4 +27,12 @@ RUN ( unzip consumption.jar schema/* -d / ) || \
 COPY bootstrap/start_consumption_app.sh /
 COPY bootstrap/wait_for_consumption_api.sh /
 
+# Add OpenSSL provider to Java security policy file (FIPS enabled mode only).
+# - insert a line: fips.provider.1=OpenSSL
+# - increase the index for other fips.provider lines.
+RUN JAVA_SECURITY_POLICY_FILE=$JAVA_HOME/conf/security/java.security \
+&& for I in {20..1}; do J=$((I+1)); sed -i "s/fips.provider.$I=/fips.provider.$J=/" $JAVA_SECURITY_POLICY_FILE; done \
+&& N=$(grep -m 1 -n "^fips\.provider\.[[:digit:]]=" $JAVA_SECURITY_POLICY_FILE | cut -d: -f1) \
+&& sed -i "$N i fips.provider.1=OpenSSL" $JAVA_SECURITY_POLICY_FILE
+
 ENTRYPOINT ["/start_consumption_app.sh"]

--- a/docker-datalake/Dockerfile
+++ b/docker-datalake/Dockerfile
@@ -27,4 +27,12 @@ RUN ( unzip datalake.jar schema/* -d / ) || \
 COPY bootstrap/start_datalake_app.sh /
 COPY bootstrap/wait_for_datalake_api.sh /
 
+# Add OpenSSL provider to Java security policy file (FIPS enabled mode only).
+# - insert a line: fips.provider.1=OpenSSL
+# - increase the index for other fips.provider lines.
+RUN JAVA_SECURITY_POLICY_FILE=$JAVA_HOME/conf/security/java.security \
+&& for I in {20..1}; do J=$((I+1)); sed -i "s/fips.provider.$I=/fips.provider.$J=/" $JAVA_SECURITY_POLICY_FILE; done \
+&& N=$(grep -m 1 -n "^fips\.provider\.[[:digit:]]=" $JAVA_SECURITY_POLICY_FILE | cut -d: -f1) \
+&& sed -i "$N i fips.provider.1=OpenSSL" $JAVA_SECURITY_POLICY_FILE
+
 ENTRYPOINT ["/start_datalake_app.sh"]

--- a/docker-environment/Dockerfile
+++ b/docker-environment/Dockerfile
@@ -27,4 +27,12 @@ RUN ( unzip environment.jar schema/* -d / ) || \
 COPY bootstrap/start_environment_app.sh /
 COPY bootstrap/wait_for_environment_api.sh /
 
+# Add OpenSSL provider to Java security policy file (FIPS enabled mode only).
+# - insert a line: fips.provider.1=OpenSSL
+# - increase the index for other fips.provider lines.
+RUN JAVA_SECURITY_POLICY_FILE=$JAVA_HOME/conf/security/java.security \
+&& for I in {20..1}; do J=$((I+1)); sed -i "s/fips.provider.$I=/fips.provider.$J=/" $JAVA_SECURITY_POLICY_FILE; done \
+&& N=$(grep -m 1 -n "^fips\.provider\.[[:digit:]]=" $JAVA_SECURITY_POLICY_FILE | cut -d: -f1) \
+&& sed -i "$N i fips.provider.1=OpenSSL" $JAVA_SECURITY_POLICY_FILE
+
 ENTRYPOINT ["/start_environment_app.sh"]

--- a/docker-freeipa/Dockerfile
+++ b/docker-freeipa/Dockerfile
@@ -27,4 +27,12 @@ RUN ( unzip freeipa.jar schema/* -d / ) || \
 COPY bootstrap/start_freeipa_app.sh /
 COPY bootstrap/wait_for_freeipa_api.sh /
 
+# Add OpenSSL provider to Java security policy file (FIPS enabled mode only).
+# - insert a line: fips.provider.1=OpenSSL
+# - increase the index for other fips.provider lines.
+RUN JAVA_SECURITY_POLICY_FILE=$JAVA_HOME/conf/security/java.security \
+&& for I in {20..1}; do J=$((I+1)); sed -i "s/fips.provider.$I=/fips.provider.$J=/" $JAVA_SECURITY_POLICY_FILE; done \
+&& N=$(grep -m 1 -n "^fips\.provider\.[[:digit:]]=" $JAVA_SECURITY_POLICY_FILE | cut -d: -f1) \
+&& sed -i "$N i fips.provider.1=OpenSSL" $JAVA_SECURITY_POLICY_FILE
+
 ENTRYPOINT ["/start_freeipa_app.sh"]

--- a/docker-redbeams/Dockerfile
+++ b/docker-redbeams/Dockerfile
@@ -27,4 +27,12 @@ RUN ( unzip redbeams.jar schema/* -d / ) || \
 COPY bootstrap/start_redbeams_app.sh /
 COPY bootstrap/wait_for_redbeams_api.sh /
 
+# Add OpenSSL provider to Java security policy file (FIPS enabled mode only).
+# - insert a line: fips.provider.1=OpenSSL
+# - increase the index for other fips.provider lines.
+RUN JAVA_SECURITY_POLICY_FILE=$JAVA_HOME/conf/security/java.security \
+&& for I in {20..1}; do J=$((I+1)); sed -i "s/fips.provider.$I=/fips.provider.$J=/" $JAVA_SECURITY_POLICY_FILE; done \
+&& N=$(grep -m 1 -n "^fips\.provider\.[[:digit:]]=" $JAVA_SECURITY_POLICY_FILE | cut -d: -f1) \
+&& sed -i "$N i fips.provider.1=OpenSSL" $JAVA_SECURITY_POLICY_FILE
+
 ENTRYPOINT ["/start_redbeams_app.sh"]

--- a/environment/src/main/java/com/sequenceiq/environment/EnvironmentApplication.java
+++ b/environment/src/main/java/com/sequenceiq/environment/EnvironmentApplication.java
@@ -7,6 +7,8 @@ import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+import com.sequenceiq.cloudbreak.util.FipsOpenSSLLoaderUtil;
+
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @EnableSwagger2
@@ -17,6 +19,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 public class EnvironmentApplication {
 
     public static void main(String[] args) {
+        FipsOpenSSLLoaderUtil.registerOpenSSLJniProvider();
         SpringApplication.run(EnvironmentApplication.class, args);
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/FreeIpaApplication.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/FreeIpaApplication.java
@@ -5,6 +5,8 @@ import org.springframework.boot.actuate.autoconfigure.metrics.web.servlet.WebMvc
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
+import com.sequenceiq.cloudbreak.util.FipsOpenSSLLoaderUtil;
+
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @EnableSwagger2
@@ -13,6 +15,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 public class FreeIpaApplication {
 
     public static void main(String[] args) {
+        FipsOpenSSLLoaderUtil.registerOpenSSLJniProvider();
         SpringApplication.run(FreeIpaApplication.class, args);
     }
 

--- a/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
+++ b/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
@@ -251,6 +251,7 @@ import com.sequenceiq.cloudbreak.auth.crn.CrnResourceDescriptor;
 import com.sequenceiq.cloudbreak.util.SanitizerUtil;
 import com.sequenceiq.thunderhead.grpc.GrpcActorContext;
 import com.sequenceiq.thunderhead.model.AltusToken;
+import com.sequenceiq.thunderhead.service.MockUmsService;
 import com.sequenceiq.thunderhead.util.CrnHelper;
 import com.sequenceiq.thunderhead.util.IniUtil;
 import com.sequenceiq.thunderhead.util.JsonUtil;
@@ -268,7 +269,7 @@ public class MockUserManagementService extends UserManagementImplBase {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MockUserManagementService.class);
 
-    private static final MacSigner SIGNATURE_VERIFIER = new MacSigner("titok");
+    private static final MacSigner SIGNATURE_VERIFIER = new MacSigner(MockUmsService.MAC_SIGNER_SECRET_KEY);
 
     private static final String ALTUS_ACCESS_KEY_ID = "altus_access_key_id";
 

--- a/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/service/MockUmsService.java
+++ b/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/service/MockUmsService.java
@@ -30,7 +30,9 @@ import com.sequenceiq.thunderhead.util.JsonUtil;
 @Service
 public class MockUmsService {
 
-    public static final MacSigner SIGNATURE_VERIFIER = new MacSigner("titok");
+    public static final String MAC_SIGNER_SECRET_KEY = "titokamisokkaldesokkaldesokkalhosszabbhogyfipscompliantlegyen";
+
+    public static final MacSigner SIGNATURE_VERIFIER = new MacSigner(MAC_SIGNER_SECRET_KEY);
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MockUmsService.class);
 

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/RedbeamsApplication.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/RedbeamsApplication.java
@@ -6,12 +6,15 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+import com.sequenceiq.cloudbreak.util.FipsOpenSSLLoaderUtil;
+
 @EnableScheduling
 @EnableJpaRepositories(basePackages = "com.sequenceiq")
 @SpringBootApplication(scanBasePackages = "com.sequenceiq", exclude = WebMvcMetricsAutoConfiguration.class)
 public class RedbeamsApplication {
 
     public static void main(String[] args) {
+        FipsOpenSSLLoaderUtil.registerOpenSSLJniProvider();
         SpringApplication.run(RedbeamsApplication.class, args);
     }
 


### PR DESCRIPTION
CB-18225 import Cloudera's openssl-provider library and configure it to be the most prior java security provider for FIPS

Changes:
 - Register the com.cloudera.crypto.openssl-provider as default security provider for FIPS
 - Register the new provider manually in our services application class, only for FIPS enabled environments
 - Make stronger signer secret in mock-thunderhead to run in FIPS env

**The following log messages has been added and occurred during testing to indicates the working of the util on FIPS enabled and non-FIPS enabled environments:**
`2022-12-20 15:35:27,894 [main] registerOpenSSLJniProvider:26 INFO  c.s.c.u.FipsOpenSSLLoaderUtil - [type:springLog] [crn:] [name:] [flow:] [requestid:] [tenant:] [userCrn:] [environment:] [traceId:] [spanId:] Registering OpenSSLJniProvider, because FIPS related security provider 'SunPKCS11-NSS-FIPS' is available.`

`2022-12-20 15:27:07,297 [main] registerOpenSSLJniProvider:29 INFO  c.s.c.u.FipsOpenSSLLoaderUtil - [type:springLog] [crn:] [name:] [flow:] [requestid:] [tenant:] [userCrn:] [environment:] [traceId:] [spanId:] OpenSSLJniProvider doesn't need to be registered because 'SunPKCS11-NSS-FIPS' is NOT available.`