### PR TITLE
CB-18161 Parcel Availability Checker should retry failed requests

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/parcel/ParcelAvailabilityService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/parcel/ParcelAvailabilityService.java
@@ -6,12 +6,11 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 
 import org.slf4j.Logger;
@@ -19,8 +18,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
-import com.sequenceiq.cloudbreak.auth.PaywallCredentialPopulator;
-import com.sequenceiq.cloudbreak.client.RestClientFactory;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.common.exception.UpgradeValidationFailedException;
 import com.sequenceiq.cloudbreak.dto.StackDto;
@@ -40,10 +37,7 @@ public class ParcelAvailabilityService {
     private StackDtoService stackDtoService;
 
     @Inject
-    private RestClientFactory restClientFactory;
-
-    @Inject
-    private PaywallCredentialPopulator paywallCredentialPopulator;
+    private ParcelService parcelService;
 
     @Inject
     private CmUrlProvider cmUrlProvider;
@@ -73,7 +67,7 @@ public class ParcelAvailabilityService {
     private String buildErrorMessage(Image image, String cmRpmUrl, Set<String> unavailableParcels) {
         StringBuilder errorMessageBuilder = new StringBuilder();
         if (unavailableParcels.contains(cmRpmUrl)) {
-            errorMessageBuilder.append("Failed to access Clouder Manager RPM: ").append(cmRpmUrl);
+            errorMessageBuilder.append("Failed to access Cloudera Manager RPM: ").append(cmRpmUrl);
             unavailableParcels.remove(cmRpmUrl);
         }
         if (!unavailableParcels.isEmpty()) {
@@ -88,11 +82,11 @@ public class ParcelAvailabilityService {
     }
 
     private Map<String, Optional<Response>> getParcelsByResponse(Set<String> requiredParcelsFromImage) {
-        Client client = restClientFactory.getOrCreateDefault();
         return requiredParcelsFromImage.stream()
                 .collect(Collectors.toMap(
-                        url -> url,
-                        url -> getHeadResponse(client, url)));
+                        Function.identity(),
+                        this::getHeadResponse
+                ));
     }
 
     private Set<String> getUnavailableParcels(Map<String, Optional<Response>> parcelsByResponse) {
@@ -102,25 +96,22 @@ public class ParcelAvailabilityService {
                 .collect(Collectors.toSet());
     }
 
+    private Optional<Response> getHeadResponse(String url) {
+        Optional<Response> response = Optional.empty();
+        try {
+            response = parcelService.getHeadResponseForParcel(url);
+        } catch (Exception e) {
+            LOGGER.warn("Could not get the size of the parcel: {} Reason: {}", url, e.getMessage());
+        }
+        return response;
+    }
+
     private boolean isArchiveUrl(Map.Entry<String, Optional<Response>> entry) {
         return ARCHIVE_URL_PATTERN.matcher(entry.getKey()).find();
     }
 
     private boolean isNotAvailable(Map.Entry<String, Optional<Response>> entry) {
         return entry.getValue().isEmpty() || entry.getValue().get().getStatus() != HttpStatus.OK.value();
-    }
-
-    private Optional<Response> getHeadResponse(Client client, String url) {
-        try {
-            WebTarget target = client.target(url);
-            paywallCredentialPopulator.populateWebTarget(url, target);
-            Response response = target.request().head();
-            LOGGER.debug("Head request was successful for {} status: {}", url, response.getStatus());
-            return Optional.of(response);
-        } catch (Exception e) {
-            LOGGER.warn("Could not get the size of the parcel: {} Reason: {}", url, e.getMessage(), e);
-            return Optional.empty();
-        }
     }
 
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/parcel/ParcelService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/parcel/ParcelService.java
@@ -3,17 +3,29 @@ package com.sequenceiq.cloudbreak.service.parcel;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.retry.support.RetrySynchronizationManager;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.auth.PaywallCredentialPopulator;
+import com.sequenceiq.cloudbreak.client.RestClientFactory;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.cloud.model.component.StackType;
@@ -33,9 +45,16 @@ import com.sequenceiq.cloudbreak.view.ClusterView;
 import com.sequenceiq.cloudbreak.view.StackView;
 
 @Service
+@EnableRetry
 public class ParcelService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ParcelService.class);
+
+    @Value("#{'${cb.http.retryableStatusCodes:}'.split(',')}")
+    private List<Integer> retryableHttpCodes;
+
+    @Value("${cb.parcel.retry.maxAttempts:5}")
+    private Integer retryMaxAttempts;
 
     @Inject
     private ClusterComponentConfigProvider clusterComponentConfigProvider;
@@ -54,6 +73,12 @@ public class ParcelService {
 
     @Inject
     private ImageReaderService imageReaderService;
+
+    @Inject
+    private RestClientFactory restClientFactory;
+
+    @Inject
+    private PaywallCredentialPopulator paywallCredentialPopulator;
 
     public Set<ClusterComponentView> getParcelComponentsByBlueprint(StackDtoDelegate stack) {
         return getParcelComponentsByBlueprint(stack.getStack(), stack.getCluster(), stack.getBlueprint());
@@ -156,5 +181,28 @@ public class ParcelService {
                 .map(cmp -> cmProductMap.get(cmp.getName()))
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
+    }
+
+    @Retryable(value = Exception.class, maxAttemptsExpression = "${cb.parcel.retry.maxAttempts:5}",
+            backoff = @Backoff(delayExpression = "${cb.parcel.retry.backOffDelay:2000}",
+                    multiplierExpression = "${cb.parcel.retry.backOffMultiplier:2}"))
+    public Optional<Response> getHeadResponseForParcel(String url) {
+        Client client = restClientFactory.getOrCreateDefault();
+        WebTarget target = client.target(url);
+        paywallCredentialPopulator.populateWebTarget(url, target);
+        Response response = target.request().head();
+        LOGGER.info("Head request for {} status: {}", url, response.getStatus());
+        if (retryableHttpCodes.contains(response.getStatus())) {
+            if (RetrySynchronizationManager.getContext().getRetryCount() < retryMaxAttempts - 1) {
+                LOGGER.info("Retry for Http Status {}", response.getStatus());
+                throw new RuntimeException(String.format("Got Http Status %s", response.getStatus()));
+            } else {
+                /**
+                 * This is to ensure that Http code is returned instead of throwing exception when retry is exhausted.
+                 */
+                LOGGER.info("Retry exhausted");
+            }
+        }
+        return Optional.of(response);
     }
 }

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -673,6 +673,8 @@ cb:
     port: 9443
   knox:
     port: 8443
+  http:
+    retryableStatusCodes: 403,408,425,429,502,503,504,509
   https:
     port: 443
   ssh:
@@ -824,6 +826,13 @@ cb:
         roles:
           - role: GATEWAY
             required: false
+  parcel:
+    retry:
+      maxAttempts: 5
+      backOffDelay: 2000
+      backOffMultiplier: 2
+
+
 
 cluster:
   monitoring:

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/parcel/ParcelServiceIntTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/parcel/ParcelServiceIntTest.java
@@ -1,0 +1,153 @@
+package com.sequenceiq.cloudbreak.service.parcel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.stubbing.OngoingStubbing;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.sequenceiq.cloudbreak.auth.PaywallCredentialPopulator;
+import com.sequenceiq.cloudbreak.client.RestClientFactory;
+import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
+import com.sequenceiq.cloudbreak.service.upgrade.ClusterComponentUpdater;
+import com.sequenceiq.cloudbreak.service.upgrade.sync.component.ImageReaderService;
+
+@SpringBootTest
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {ParcelService.class})
+@TestPropertySource(properties = {"cb.parcel.retry.maxAttempts=5", "cb.parcel.retry.backOffDelay=500",
+        "cb.parcel.retry.backOffMultiplier=2"})
+public class ParcelServiceIntTest {
+
+    private static final String ARCHIVE_PARCEL = "https://archive.cloudera.com/parcel";
+
+    private static final String ERROR_MESSAGE = "Failed to fetch the head";
+
+    @Autowired
+    private ParcelService underTest;
+
+    @MockBean
+    private ClusterComponentConfigProvider clusterComponentConfigProvider;
+
+    @MockBean
+    private ClouderaManagerProductTransformer clouderaManagerProductTransformer;
+
+    @MockBean
+    private ParcelFilterService parcelFilterService;
+
+    @MockBean
+    private ClusterApiConnectors clusterApiConnectors;
+
+    @MockBean
+    private ClusterComponentUpdater clusterComponentUpdater;
+
+    @MockBean
+    private ImageReaderService imageReaderService;
+
+    @MockBean
+    private RestClientFactory restClientFactory;
+
+    @MockBean
+    private PaywallCredentialPopulator paywallCredentialPopulator;
+
+    @MockBean
+    private Client client;
+
+    @Test
+    void testGetHeadResponseForParcelShouldReturnResponseForNonRetryableStatus() {
+        when(restClientFactory.getOrCreateDefault()).thenReturn(client);
+        setUpMocks(0, null, List.of(200));
+        Optional<Response> actual = underTest.getHeadResponseForParcel(ARCHIVE_PARCEL);
+        assertEquals(actual.get().getStatus(), 200);
+        verify(restClientFactory, times(1)).getOrCreateDefault();
+    }
+
+    @Test
+    void testGetHeadResponseForParcelShouldReturnResponseAfterRetryWithRetryableStatus() {
+        when(restClientFactory.getOrCreateDefault()).thenReturn(client);
+        setUpMocks(0, null, List.of(403, 403, 200));
+        Optional<Response> actual = underTest.getHeadResponseForParcel(ARCHIVE_PARCEL);
+        assertEquals(actual.get().getStatus(), 200);
+        verify(restClientFactory, times(3)).getOrCreateDefault();
+    }
+
+    @Test
+    void testGetHeadResponseForParcelShouldReturnResponseAfterRetryWithRetryableAndNonTryableStatus() {
+        when(restClientFactory.getOrCreateDefault()).thenReturn(client);
+        setUpMocks(0, null, List.of(403, 403, 404, 200));
+        Optional<Response> actual = underTest.getHeadResponseForParcel(ARCHIVE_PARCEL);
+        assertEquals(actual.get().getStatus(), 404);
+        verify(restClientFactory, times(3)).getOrCreateDefault();
+    }
+
+    @Test
+    void testGetHeadResponseForParcelShouldReturnResponseAfterMaxRetryWithRetryableStatus() {
+        when(restClientFactory.getOrCreateDefault()).thenReturn(client);
+        setUpMocks(0, null, List.of(403, 403, 403, 403, 200));
+        Optional<Response> actual = underTest.getHeadResponseForParcel(ARCHIVE_PARCEL);
+        assertEquals(actual.get().getStatus(), 200);
+        verify(restClientFactory, times(5)).getOrCreateDefault();
+    }
+
+    @Test
+    void testGetHeadResponseForParcelShouldThrowExceptionAfterRetryExhaustedWithRetryableStatus() {
+        when(restClientFactory.getOrCreateDefault()).thenReturn(client);
+        setUpMocks(0, null, List.of(403, 403, 403, 403, 403, 200));
+        Optional<Response> actual = underTest.getHeadResponseForParcel(ARCHIVE_PARCEL);
+        assertEquals(actual.get().getStatus(), 403);
+        verify(restClientFactory, times(5)).getOrCreateDefault();
+    }
+
+    @Test
+    void testGetHeadResponseForParcelShouldReturnResponseAfterRetryWithException() {
+        when(restClientFactory.getOrCreateDefault()).thenReturn(client);
+        setUpMocks(4, new RuntimeException(ERROR_MESSAGE), List.of(200));
+        Optional<Response> actual = underTest.getHeadResponseForParcel(ARCHIVE_PARCEL);
+        assertEquals(actual.get().getStatus(), 200);
+        verify(restClientFactory, times(5)).getOrCreateDefault();
+    }
+
+    @Test
+    void testGetHeadResponseForParcelThrowsExceptionAfterRetryExhaustedWithException() {
+        when(restClientFactory.getOrCreateDefault()).thenReturn(client);
+        setUpMocks(5, new RuntimeException(ERROR_MESSAGE), List.of(200));
+        RuntimeException runtimeException = assertThrows(RuntimeException.class, () -> underTest.getHeadResponseForParcel(ARCHIVE_PARCEL));
+        assertEquals(runtimeException.getMessage(), ERROR_MESSAGE);
+        verify(restClientFactory, times(5)).getOrCreateDefault();
+    }
+
+    private void setUpMocks(int exceptionCount, Exception e, List<Integer> statuses) {
+        WebTarget webTarget = mock(WebTarget.class);
+        Invocation.Builder request = mock(Invocation.Builder.class);
+        when(client.target(ARCHIVE_PARCEL)).thenReturn(webTarget);
+        when(webTarget.request()).thenReturn(request);
+        OngoingStubbing<Response> ongoingStubbing = null;
+        while (exceptionCount-- > 0) {
+            ongoingStubbing = (ongoingStubbing == null) ? when(request.head()).thenThrow(e) : ongoingStubbing.thenThrow(e);
+        }
+        for (int status :statuses) {
+            Response response = Response.status(status).build();
+            ongoingStubbing = (ongoingStubbing == null) ? when(request.head()).thenReturn(response) : ongoingStubbing.thenReturn(response);
+        }
+    }
+}


### PR DESCRIPTION
During upgrade, We have seen cases where Parcel availability check fails but later it is successful. To reduce the failures, we are adding retry policy to check parcel availability.

See detailed description in the commit message.