### PR TITLE
CB-16143 remove unnecessary .java extension from aws-long-running-e2e -native-tests.yaml

### DIFF
--- a/integration-test/src/main/resources/testsuites/e2e/aws-longrunning-e2e-native-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/aws-longrunning-e2e-native-tests.yaml
@@ -3,7 +3,7 @@ tests:
   - name: "aws_longrunning_e2e_native_tests"
     classes:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.freeipa.FreeIpaUpgradeNativeTests
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxNativeMigrationTests.java
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxNativeMigrationTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXUpgradeTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.freeipa.FreeIpaUpgradeTests
         includedMethods:


### PR DESCRIPTION
CB-16143 remove unnecessary .java extension from aws-long-running-e2e -native-tests.yaml