### PR TITLE
CB-20127 Add ldapsync binduser to `admins` group on FreeIPA

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientExceptionUtil.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientExceptionUtil.java
@@ -176,6 +176,37 @@ public class FreeIpaClientExceptionUtil {
         }
     }
 
+    public static void ignoreEmptyModException(FreeIpaClientRunnable runnable, String message, Object... messageParams)
+            throws FreeIpaClientException {
+        try {
+            runnable.run();
+        } catch (FreeIpaClientException e) {
+            if (isEmptyModlistException(e)) {
+                Optional.ofNullable(message).ifPresentOrElse(
+                        msg -> LOGGER.debug(msg, messageParams),
+                        () -> LOGGER.debug("No modification was needed in FreeIPA is ignored. Exception message: {}", e.getMessage()));
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    public static <T> Optional<T> ignoreDuplicateExceptionWithValue(FreeIpaClientCallable<T> callable, String message, Object... messageParams)
+            throws FreeIpaClientException {
+        try {
+            return Optional.ofNullable(callable.run());
+        } catch (FreeIpaClientException e) {
+            if (isDuplicateEntryException(e)) {
+                Optional.ofNullable(message).ifPresentOrElse(
+                        msg -> LOGGER.debug(msg, messageParams),
+                        () -> LOGGER.debug("Already present in FreeIPA, exception is ignored. Exception message: {}", e.getMessage()));
+                return Optional.empty();
+            } else {
+                throw e;
+            }
+        }
+    }
+
     private static boolean isRetryable(FreeIpaClientException e) {
         return isExceptionWithErrorCode(e, RETRYABLE_ERROR_CODES) || isExceptionWithHttpCode(retryableHttpCodes, e) || isExceptionWithIOExceptionCause(e);
     }

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/model/Permission.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/model/Permission.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.freeipa.client.model;
 
 import java.util.List;
-import java.util.StringJoiner;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -23,6 +22,10 @@ public class Permission {
 
     @JsonDeserialize(using = ListFlatteningDeserializer.class)
     private String ipapermlocation;
+
+    private List<String> ipapermincludedattr;
+
+    private List<String> ipapermright;
 
     public String getCn() {
         return cn;
@@ -72,15 +75,33 @@ public class Permission {
         this.ipapermlocation = ipapermlocation;
     }
 
+    public List<String> getIpapermincludedattr() {
+        return ipapermincludedattr;
+    }
+
+    public void setIpapermincludedattr(List<String> ipapermincludedattr) {
+        this.ipapermincludedattr = ipapermincludedattr;
+    }
+
+    public List<String> getIpapermright() {
+        return ipapermright;
+    }
+
+    public void setIpapermright(List<String> ipapermright) {
+        this.ipapermright = ipapermright;
+    }
+
     @Override
     public String toString() {
-        return new StringJoiner(", ", Permission.class.getSimpleName() + "[", "]")
-                .add("cn='" + cn + "'")
-                .add("dn='" + dn + "'")
-                .add("ipapermbindruletype=" + ipapermbindruletype)
-                .add("ipapermissiontype=" + ipapermissiontype)
-                .add("ipapermdefaultattr=" + ipapermdefaultattr)
-                .add("ipapermlocation='" + ipapermlocation + "'")
-                .toString();
+        return "Permission{" +
+                "cn='" + cn + '\'' +
+                ", dn='" + dn + '\'' +
+                ", ipapermbindruletype=" + ipapermbindruletype +
+                ", ipapermissiontype=" + ipapermissiontype +
+                ", ipapermdefaultattr=" + ipapermdefaultattr +
+                ", ipapermlocation='" + ipapermlocation + '\'' +
+                ", ipapermincludedattr=" + ipapermincludedattr +
+                ", ipapermright=" + ipapermright +
+                '}';
     }
 }

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/model/Right.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/model/Right.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.freeipa.client.model;
+
+public enum Right {
+    WRITE,
+    READ,
+    SEARCH,
+    COMPARE,
+    ADD,
+    DELETE,
+    ALL;
+
+    private String value;
+
+    Right() {
+        value = name().toLowerCase();
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/operation/GroupAddMemberOperation.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/operation/GroupAddMemberOperation.java
@@ -62,12 +62,18 @@ public class GroupAddMemberOperation extends AbstractFreeipaOperation<Group> {
             } else {
                 // TODO specialize RPCResponse completed/failed objects
                 LOGGER.error("Failed to add {} to group '{}': {}", users, group, rpcResponse.getFailed());
-                warnings.accept(group, String.format("Failed to add users to group: %s", rpcResponse.getFailed()));
+                if (warnings != null) {
+                    warnings.accept(group, String.format("Failed to add users to group: %s", rpcResponse.getFailed()));
+                }
             }
             return Optional.of(rpcResponse.getResult());
         } catch (FreeIpaClientException e) {
             LOGGER.error("Failed to add {} to group '{}'", users, group, e);
-            warnings.accept(group, String.format("Failed to add users %s to group: %s", users, e.getMessage()));
+            if (warnings != null) {
+                warnings.accept(group, String.format("Failed to add users %s to group: %s", users, e.getMessage()));
+            } else {
+                throw e;
+            }
             freeIpaClient.checkIfClientStillUsable(e);
         }
         return Optional.empty();

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/operation/PermissionAddOperation.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/operation/PermissionAddOperation.java
@@ -1,0 +1,46 @@
+package com.sequenceiq.freeipa.client.operation;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.freeipa.client.model.Permission;
+import com.sequenceiq.freeipa.client.model.Right;
+
+public class PermissionAddOperation extends AbstractFreeIpaAddOperation<Permission> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PermissionAddOperation.class);
+
+    private final List<String> right;
+
+    private final String type;
+
+    private final List<String> attributes;
+
+    public PermissionAddOperation(String flag, List<Right> right, String type, List<String> attributes) {
+        super(flag, Permission.class);
+        this.right = right.stream().map(Right::getValue).collect(Collectors.toList());
+        this.type = type;
+        this.attributes = attributes;
+    }
+
+    @Override
+    protected Map<String, Object> getParams() {
+        return Map.of("ipapermright", right,
+                "type", type,
+                "attrs", attributes);
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return LOGGER;
+    }
+
+    @Override
+    public String getOperationName() {
+        return "permission_add";
+    }
+}

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/operation/SetWlCredentialOperation.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/operation/SetWlCredentialOperation.java
@@ -9,6 +9,10 @@ import org.apache.commons.lang3.StringUtils;
 
 public class SetWlCredentialOperation extends UserModOperation {
 
+    public static final String CDP_HASHED_PASSWORD = "cdpHashedPassword";
+
+    public static final String CDP_UNENCRYPTED_KRB_PRINCIPAL_KEY = "cdpUnencryptedKrbPrincipalKey";
+
     private String hashedPassword;
 
     private String unencryptedKrbPrincipalKey;
@@ -44,8 +48,8 @@ public class SetWlCredentialOperation extends UserModOperation {
         Map<String, Object> params = sensitiveMap();
         List<String> attributes = new ArrayList<>();
         if (StringUtils.isNotBlank(hashedPassword)) {
-            attributes.add("cdpHashedPassword=" + hashedPassword);
-            attributes.add("cdpUnencryptedKrbPrincipalKey=" + unencryptedKrbPrincipalKey);
+            attributes.add(CDP_HASHED_PASSWORD + "=" + hashedPassword);
+            attributes.add(CDP_UNENCRYPTED_KRB_PRINCIPAL_KEY + "=" + unencryptedKrbPrincipalKey);
             attributes.add("krbPasswordExpiration=" + expiration);
         }
 

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/operation/SudoCommandAddOperation.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/operation/SudoCommandAddOperation.java
@@ -1,12 +1,8 @@
 package com.sequenceiq.freeipa.client.operation;
 
-import java.util.Optional;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sequenceiq.freeipa.client.FreeIpaClient;
-import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.client.model.SudoCommand;
 
 public class SudoCommandAddOperation extends AbstractFreeIpaAddOperation<SudoCommand> {
@@ -14,7 +10,7 @@ public class SudoCommandAddOperation extends AbstractFreeIpaAddOperation<SudoCom
     private static final Logger LOGGER = LoggerFactory.getLogger(SudoCommandAddOperation.class);
 
     private SudoCommandAddOperation(String name) {
-        super(name);
+        super(name, SudoCommand.class);
     }
 
     public static SudoCommandAddOperation create(String name) {
@@ -24,11 +20,6 @@ public class SudoCommandAddOperation extends AbstractFreeIpaAddOperation<SudoCom
     @Override
     public String getOperationName() {
         return "sudocmd_add";
-    }
-
-    @Override
-    public Optional<SudoCommand> invoke(FreeIpaClient freeIpaClient) throws FreeIpaClientException {
-        return invokeAdd(freeIpaClient, SudoCommand.class);
     }
 
     @Override

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/operation/SudoRuleAddAllowCommandOperation.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/operation/SudoRuleAddAllowCommandOperation.java
@@ -1,13 +1,10 @@
 package com.sequenceiq.freeipa.client.operation;
 
 import java.util.Map;
-import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sequenceiq.freeipa.client.FreeIpaClient;
-import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.client.model.SudoRule;
 
 public class SudoRuleAddAllowCommandOperation extends AbstractFreeIpaAddOperation<SudoRule> {
@@ -17,7 +14,7 @@ public class SudoRuleAddAllowCommandOperation extends AbstractFreeIpaAddOperatio
     private final String command;
 
     private SudoRuleAddAllowCommandOperation(String name, String command) {
-        super(name);
+        super(name, SudoRule.class);
         this.command = command;
     }
 
@@ -33,11 +30,6 @@ public class SudoRuleAddAllowCommandOperation extends AbstractFreeIpaAddOperatio
     @Override
     protected Map<String, Object> getParams() {
         return Map.of("sudocmd", command);
-    }
-
-    @Override
-    public Optional<SudoRule> invoke(FreeIpaClient freeIpaClient) throws FreeIpaClientException {
-        return invokeAdd(freeIpaClient, SudoRule.class);
     }
 
     @Override

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/operation/SudoRuleAddDenyCommandOperation.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/operation/SudoRuleAddDenyCommandOperation.java
@@ -1,13 +1,10 @@
 package com.sequenceiq.freeipa.client.operation;
 
 import java.util.Map;
-import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sequenceiq.freeipa.client.FreeIpaClient;
-import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.client.model.SudoRule;
 
 public class SudoRuleAddDenyCommandOperation  extends AbstractFreeIpaAddOperation<SudoRule> {
@@ -17,7 +14,7 @@ public class SudoRuleAddDenyCommandOperation  extends AbstractFreeIpaAddOperatio
     private final String command;
 
     private SudoRuleAddDenyCommandOperation(String name, String command) {
-        super(name);
+        super(name, SudoRule.class);
         this.command = command;
     }
 
@@ -33,11 +30,6 @@ public class SudoRuleAddDenyCommandOperation  extends AbstractFreeIpaAddOperatio
     @Override
     protected Map<String, Object> getParams() {
         return Map.of("sudocmd", command);
-    }
-
-    @Override
-    public Optional<SudoRule> invoke(FreeIpaClient freeIpaClient) throws FreeIpaClientException {
-        return invokeAdd(freeIpaClient, SudoRule.class);
     }
 
     @Override

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/operation/SudoRuleAddGroupOperation.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/operation/SudoRuleAddGroupOperation.java
@@ -1,13 +1,10 @@
 package com.sequenceiq.freeipa.client.operation;
 
 import java.util.Map;
-import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sequenceiq.freeipa.client.FreeIpaClient;
-import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.client.model.SudoRule;
 
 public class SudoRuleAddGroupOperation extends AbstractFreeIpaAddOperation<SudoRule> {
@@ -17,7 +14,7 @@ public class SudoRuleAddGroupOperation extends AbstractFreeIpaAddOperation<SudoR
     private final String group;
 
     private SudoRuleAddGroupOperation(String name, String group) {
-        super(name);
+        super(name, SudoRule.class);
         this.group = group;
     }
 
@@ -33,11 +30,6 @@ public class SudoRuleAddGroupOperation extends AbstractFreeIpaAddOperation<SudoR
     @Override
     protected Map<String, Object> getParams() {
         return Map.of("group", group);
-    }
-
-    @Override
-    public Optional<SudoRule> invoke(FreeIpaClient freeIpaClient) throws FreeIpaClientException {
-        return invokeAdd(freeIpaClient, SudoRule.class);
     }
 
     @Override

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/operation/SudoRuleAddOperation.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/operation/SudoRuleAddOperation.java
@@ -1,13 +1,10 @@
 package com.sequenceiq.freeipa.client.operation;
 
 import java.util.Map;
-import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sequenceiq.freeipa.client.FreeIpaClient;
-import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.client.model.SudoRule;
 
 public class SudoRuleAddOperation extends AbstractFreeIpaAddOperation<SudoRule> {
@@ -19,7 +16,7 @@ public class SudoRuleAddOperation extends AbstractFreeIpaAddOperation<SudoRule> 
     private final boolean hostCategoryAll;
 
     private SudoRuleAddOperation(String name, boolean hostCategoryAll, AbstractFreeipaOperation<SudoRule> getOperation) {
-        super(name, getOperation);
+        super(name, getOperation, SudoRule.class);
         this.hostCategoryAll = hostCategoryAll;
     }
 
@@ -35,11 +32,6 @@ public class SudoRuleAddOperation extends AbstractFreeIpaAddOperation<SudoRule> 
     @Override
     protected Map<String, Object> getParams() {
         return hostCategoryAll ? HOST_CATEGORY_ALL : Map.of();
-    }
-
-    @Override
-    public Optional<SudoRule> invoke(FreeIpaClient freeIpaClient) throws FreeIpaClientException {
-        return invokeAdd(freeIpaClient, SudoRule.class);
     }
 
     @Override

--- a/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/operation/AbstractFreeIpaAddOperationTest.java
+++ b/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/operation/AbstractFreeIpaAddOperationTest.java
@@ -73,12 +73,12 @@ public class AbstractFreeIpaAddOperationTest {
         THROWS_OTHER_EXCEPTION
     }
 
-    private class FreeIpaAddOperation extends AbstractFreeIpaAddOperation<Object> {
+    private static class FreeIpaAddOperation extends AbstractFreeIpaAddOperation<Object> {
 
-        private FreeIpaAddOperationBehaviour behaviour;
+        private final FreeIpaAddOperationBehaviour behaviour;
 
         private FreeIpaAddOperation(String name, AbstractFreeipaOperation<Object> getOperation, FreeIpaAddOperationBehaviour behaviour) {
-            super(name, getOperation);
+            super(name, getOperation, Object.class);
             this.behaviour = behaviour;
         }
 
@@ -90,11 +90,6 @@ public class AbstractFreeIpaAddOperationTest {
         @Override
         public String getOperationName() {
             return OPERATION_NAME;
-        }
-
-        @Override
-        public Optional<Object> invoke(FreeIpaClient freeipaClient) throws FreeIpaClientException {
-            return invokeAdd(freeIpaClient, Object.class);
         }
 
         @Override


### PR DESCRIPTION
As the ldapsync user need to modify the `admins` group membership, it doesn't make any sense to create fine grain permissions for it, as it would provide only some security through obscurity.
Get rid off the previous role memberhsip as admins don't need anything else.