### PR TITLE
CB-20087 make GCP cloud resource names unique to a stack

### DIFF
--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/group/GcpInstanceGroupResourceBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/group/GcpInstanceGroupResourceBuilder.java
@@ -35,7 +35,7 @@ public class GcpInstanceGroupResourceBuilder extends AbstractGcpGroupBuilder {
 
     @Override
     public CloudResource create(GcpContext context, AuthenticatedContext auth, Group group, Network network) {
-        String resourceName = getResourceNameService().resourceName(resourceType(), context.getName(), group.getName());
+        String resourceName = getResourceNameService().resourceName(resourceType(), context.getName(), group.getName(), auth.getCloudContext().getId());
         return createNamedResource(resourceType(), resourceName, context.getLocation().getAvailabilityZone().value());
     }
 

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpBackendServiceResourceBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpBackendServiceResourceBuilder.java
@@ -31,7 +31,7 @@ import com.sequenceiq.cloudbreak.cloud.model.TargetGroupPortPair;
 import com.sequenceiq.common.api.type.ResourceType;
 
 /**
- * Responsible for CRUD opertaions of a GCP Backend Service Resource
+ * Responsible for CRUD operations of a GCP Backend Service Resource
  * A backend service could have multiple definitions, but currently the only one used is based on instance groups
  * Set the health check mentod to be used for the related instance groups
  */
@@ -93,7 +93,7 @@ public class GcpBackendServiceResourceBuilder extends AbstractGcpLoadBalancerBui
                 TargetGroupPortPair targetGroupPortPair = new TargetGroupPortPair(trafficPort, hcPort);
                 groups.addAll(loadBalancer.getPortToTargetGroupMapping().get(targetGroupPortPair));
             }
-            makeBackendForTargetGroup(context, loadBalancer, projectId, zone, groups, backends);
+            makeBackendForTargetGroup(context, auth, loadBalancer, projectId, zone, groups, backends);
 
             backendService.setBackends(backends);
             backendService.setName(buildableResource.getName());
@@ -126,11 +126,12 @@ public class GcpBackendServiceResourceBuilder extends AbstractGcpLoadBalancerBui
                 .collect(Collectors.toList());
     }
 
-    private void makeBackendForTargetGroup(GcpContext context, CloudLoadBalancer loadBalancer, String projectId, String zone,
+    private void makeBackendForTargetGroup(GcpContext context, AuthenticatedContext auth, CloudLoadBalancer loadBalancer, String projectId, String zone,
             Set<Group> groups, List<Backend> backends) {
         for (Group group : groups) {
             Backend backend = new Backend();
-            String groupname = getResourceNameService().resourceName(ResourceType.GCP_INSTANCE_GROUP, context.getName(), group.getName());
+            String groupname = getResourceNameService()
+                    .resourceName(ResourceType.GCP_INSTANCE_GROUP, context.getName(), group.getName(), auth.getCloudContext().getId());
             backend.setGroup(String.format(GCP_INSTANCEGROUP_REFERENCE_FORMAT,
                     projectId, zone, groupname));
             backend.setBalancingMode(CONNECTION);

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/service/GcpResourceNameService.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/service/GcpResourceNameService.java
@@ -149,14 +149,17 @@ public class GcpResourceNameService extends CloudbreakResourceNameService {
         return subnetName;
     }
 
+    @SuppressWarnings("checkstyle:MagicNumber")
     private String gcpGroupResourceName(Object[] parts) {
-        checkArgs(2, parts);
+        checkArgs(3, parts);
         String name;
         String stackName = String.valueOf(parts[0]);
         String groupName = String.valueOf(parts[1]);
+        String datalake = String.valueOf(parts[2]);
         name = normalize(stackName);
         name = adjustPartLength(name);
         name = appendPart(name, normalize(groupName));
+        name = appendPart(name, normalize(datalake));
         name = adjustBaseLength(name, maxResourceNameLength);
         return name;
     }

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/group/GcpInstanceGroupResourceBuilderTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/group/GcpInstanceGroupResourceBuilderTest.java
@@ -4,6 +4,7 @@ package com.sequenceiq.cloudbreak.cloud.gcp.group;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -50,7 +52,7 @@ public class GcpInstanceGroupResourceBuilderTest {
     @Mock
     private GcpContext gcpContext;
 
-    @Mock
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private AuthenticatedContext authenticatedContext;
 
     @Mock
@@ -123,6 +125,7 @@ public class GcpInstanceGroupResourceBuilderTest {
         when(gcpContext.getLocation()).thenReturn(location);
         when(location.getAvailabilityZone()).thenReturn(availabilityZone);
         when(availabilityZone.value()).thenReturn("zone");
+        when(authenticatedContext.getCloudContext().getId()).thenReturn(111L);
 
         CloudResource cloudResource = underTest.create(gcpContext, authenticatedContext, group, network);
 
@@ -130,16 +133,22 @@ public class GcpInstanceGroupResourceBuilderTest {
     }
 
     @Test
-    public void testBuild() throws Exception {
+    public void testCloudResourceBoundToStack() throws Exception {
+
         when(gcpContext.getName()).thenReturn("name");
         when(group.getName()).thenReturn("group");
         when(gcpContext.getLocation()).thenReturn(location);
         when(location.getAvailabilityZone()).thenReturn(availabilityZone);
         when(availabilityZone.value()).thenReturn("zone");
+        when(authenticatedContext.getCloudContext().getId()).thenReturn(111L);
 
-        CloudResource cloudResource = underTest.create(gcpContext, authenticatedContext, group, network);
+        CloudResource cloudResource1 = underTest.create(gcpContext, authenticatedContext, group, network);
 
-        Assertions.assertTrue(cloudResource.getName().startsWith("name-group"));
+        reset(authenticatedContext);
+        when(authenticatedContext.getCloudContext().getId()).thenReturn(222L);
+        CloudResource cloudResource2 = underTest.create(gcpContext, authenticatedContext, group, network);
+
+        Assertions.assertNotEquals(cloudResource1.getName(), cloudResource2.getName());
     }
 
     @Test

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpBackendServiceResourceBuilderTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpBackendServiceResourceBuilderTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -50,7 +51,7 @@ public class GcpBackendServiceResourceBuilderTest {
     @Mock
     private GcpContext gcpContext;
 
-    @Mock
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private AuthenticatedContext authenticatedContext;
 
     @Mock
@@ -116,7 +117,7 @@ public class GcpBackendServiceResourceBuilderTest {
     }
 
     @Test
-    public void testBuildWithSeperateHCPort() throws Exception {
+    public void testBuildWithSeparateHCPort() throws Exception {
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("hcport", 8080);
         parameters.put("trafficport", 80);
@@ -163,6 +164,7 @@ public class GcpBackendServiceResourceBuilderTest {
         when(operation.getName()).thenReturn("name");
         when(operation.getHttpErrorStatusCode()).thenReturn(null);
         when(gcpLoadBalancerTypeConverter.getScheme(any(CloudLoadBalancer.class))).thenCallRealMethod();
+        when(authenticatedContext.getCloudContext().getId()).thenReturn(111L);
 
         List<CloudResource> cloudResources = underTest.build(gcpContext, authenticatedContext,
                 Collections.singletonList(resource), cloudLoadBalancer, cloudStack);
@@ -222,6 +224,7 @@ public class GcpBackendServiceResourceBuilderTest {
         when(operation.getName()).thenReturn("name");
         when(operation.getHttpErrorStatusCode()).thenReturn(null);
         when(gcpLoadBalancerTypeConverter.getScheme(any(CloudLoadBalancer.class))).thenCallRealMethod();
+        when(authenticatedContext.getCloudContext().getId()).thenReturn(111L);
 
         List<CloudResource> cloudResources = underTest.build(gcpContext, authenticatedContext,
                 Collections.singletonList(resource), cloudLoadBalancer, cloudStack);

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/service/GcpResourceNameServiceTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/service/GcpResourceNameServiceTest.java
@@ -149,14 +149,13 @@ public class GcpResourceNameServiceTest {
     @Test
     public void shouldGenerateGcpInstanceGroupResourceWehenPartsProvided() {
         // GIVEN
-        Object[] parts = {"stack", "group"};
+        Object[] parts = {"stack", "group", "1234"};
 
         // WHEN
         String resourceName = subject.resourceName(ResourceType.GCP_INSTANCE_GROUP, parts);
 
         // THEN
-        Assert.assertNotNull("The generated name must not be null!", resourceName);
-        Assert.assertEquals("Should have both parts", 2L, resourceName.split("-").length);
-        Assert.assertTrue("The resource name is not the expected one!", resourceName.startsWith("stack-group"));
+        Assert.assertEquals("The instance group resource name should include stack name, stack id and a group name",
+                "stack-group-1234", resourceName);
     }
 }


### PR DESCRIPTION
If we resize the DataLake we create new resources from a blueprint with the same names as in the old DataLake and this causes GCP to request creation requests due to name conflict.
Name strategy before: DATALAKE_NAME-templateName
# Example: 
we create an environment with LightDuty DL. DL blueprint is [datalake/src/main/resources/duties/7.2.15/gcp/light_duty.json](https://github.com/hortonworks/cloudbreak/blob/master/datalake/src/main/resources/duties/7.2.15/gcp/light_duty.json)
 and datalake name is "butterfly". Among other things this will request an _idBroker_ instanceGroup (line 12) and create a cloud resource with the name "butterfly-idBroker"

Later on we decide to resize the DL to Medium Duty. This will use [datalake/src/main/resources/duties/7.2.15/gcp/medium_duty_ha.json](https://github.com/hortonworks/cloudbreak/blob/master/datalake/src/main/resources/duties/7.2.15/gcp/medium_duty_ha.json) blueprint and will request another instanceGroup _idBroker_ (line 80) so a cloud resource with the name "butterfly-idBroker" will be attempted to be created. This request will be requected by GCP due to name uniqueness constraint.

# Proposed solution:
 add the _stack id_ to the name. When we resize we create a new Stack so this will make names stack-bounded and prevent resource name conflicts on GCP.


*Note: same approach is already used in AWS resource naming*