### PR TITLE
CB-20154 Remove 'modifyproxy' state from top.sls

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/top.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/top.sls
@@ -14,7 +14,6 @@ base:
     - ntp
     - postgresql.root-certs
     - sshd
-    - modifyproxy
 
   'G@roles:ad_member and G@os_family:RedHat':
     - match: compound


### PR DESCRIPTION
This state should not be applied automatically, a separate state.apply call should be issues when needed

See detailed description in the commit message.