### PR TITLE
CB-19868 Retain flow information for atleast 24 hours after completion

### DIFF
--- a/flow/build.gradle
+++ b/flow/build.gradle
@@ -43,6 +43,7 @@ dependencies {
   testImplementation group: 'org.springframework.security',      name: 'spring-security-web',            version: springSecurityVersion
   testImplementation group: 'org.springframework.boot',          name: 'spring-boot-starter-test',       version: springBootVersion
   testImplementation group: 'org.awaitility',                    name: 'awaitility',                     version: awaitilityVersion
+  testImplementation group: 'com.h2database',                    name: 'h2',                             version: h2databaseVersion
   testImplementation group: 'org.testcontainers',                name: 'postgresql',                     version: testContainersVersion
   testImplementation group: 'org.testcontainers',                name: 'junit-jupiter',                  version: testContainersVersion
   testImplementation project(path: ':authorization-common', configuration: 'tests')

--- a/flow/src/main/java/com/sequenceiq/flow/cleanup/FlowCleanupConfig.java
+++ b/flow/src/main/java/com/sequenceiq/flow/cleanup/FlowCleanupConfig.java
@@ -9,7 +9,14 @@ public class FlowCleanupConfig {
     @Value("${flowcleanup.intervalhours:24}")
     private int intervalInHours;
 
+    @Value("${flowcleanup.retention.period.hours:24}")
+    private int retentionPeriodInHours;
+
     public int getIntervalInHours() {
         return intervalInHours;
+    }
+
+    public int getRetentionPeriodInHours() {
+        return retentionPeriodInHours;
     }
 }

--- a/flow/src/main/java/com/sequenceiq/flow/core/FlowLogService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/FlowLogService.java
@@ -68,7 +68,7 @@ public interface FlowLogService {
 
     List<FlowLog> findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(Long id);
 
-    int purgeFinalizedFlowLogs();
+    int purgeFinalizedFlowLogs(int retentionPeriodHours);
 
     List<FlowLogWithoutPayload> findAllWithoutPayloadByFlowIdOrderByCreatedDesc(String flowId);
 

--- a/flow/src/main/java/com/sequenceiq/flow/repository/FlowLogRepository.java
+++ b/flow/src/main/java/com/sequenceiq/flow/repository/FlowLogRepository.java
@@ -83,8 +83,8 @@ public interface FlowLogRepository extends CrudRepository<FlowLog, Long> {
     void updateLastLogStatusInFlow(@Param("id") Long id, @Param("stateStatus") StateStatus stateStatus, @Param("endTime") Long endTime);
 
     @Modifying
-    @Query("DELETE FROM FlowLog fl WHERE fl.finalized = TRUE")
-    int purgeFinalizedFlowLogs();
+    @Query("DELETE FROM FlowLog fl WHERE fl.finalized = TRUE AND fl.endTime <= :endTime")
+    int purgeFinalizedFlowLogs(@Param("endTime") Long endTime);
 
     List<FlowLog> findAllByResourceIdOrderByCreatedDesc(Long resourceId);
 

--- a/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowLogDBService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowLogDBService.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.flow.service.flowlog;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -304,8 +305,9 @@ public class FlowLogDBService implements FlowLogService {
     }
 
     @Override
-    public int purgeFinalizedFlowLogs() {
-        return flowLogRepository.purgeFinalizedFlowLogs();
+    public int purgeFinalizedFlowLogs(int retentionPeriodHours) {
+        long endTimeUpperBound = clock.nowMinus(Duration.ofHours(retentionPeriodHours)).toEpochMilli();
+        return flowLogRepository.purgeFinalizedFlowLogs(endTimeUpperBound);
     }
 
     @Override

--- a/flow/src/test/java/com/sequenceiq/flow/repository/FlowLogRepositoryTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/repository/FlowLogRepositoryTest.java
@@ -1,0 +1,76 @@
+package com.sequenceiq.flow.repository;
+
+import static com.sequenceiq.flow.api.model.operation.OperationType.PROVISION;
+import static com.sequenceiq.flow.api.model.operation.OperationType.UNKNOWN;
+import static com.sequenceiq.flow.domain.StateStatus.FAILED;
+import static com.sequenceiq.flow.domain.StateStatus.PENDING;
+import static com.sequenceiq.flow.domain.StateStatus.SUCCESSFUL;
+import static java.time.Instant.now;
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static java.util.Arrays.asList;
+import static java.util.UUID.randomUUID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.sequenceiq.flow.api.model.operation.OperationType;
+import com.sequenceiq.flow.domain.FlowLog;
+import com.sequenceiq.flow.domain.StateStatus;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(initializers = RepositoryTestConfig.RepositoryTestInitializer.class, classes = RepositoryTestConfig.class)
+@DataJpaTest
+class FlowLogRepositoryTest {
+
+    private static final AtomicInteger TEST_RESOURCE_ID = new AtomicInteger(1234);
+
+    private static final String TEST_CURRENT_FLOW_STATE = "CURRENT_FLOW_STATE";
+
+    @Inject
+    private FlowLogRepository underTest;
+
+    @Test
+    void testPurgeFinalizedFlowLogs() {
+        FlowLog flowLog1 = createFlowLog(Boolean.TRUE, PENDING, PROVISION);
+
+        FlowLog flowLog2 = createFlowLog(Boolean.TRUE, PENDING, PROVISION);
+        flowLog2.setEndTime(nowMinus(Duration.of(45, MINUTES)).toEpochMilli());
+
+        FlowLog flowLog3 = createFlowLog(Boolean.TRUE, PENDING, PROVISION);
+        flowLog3.setEndTime(nowMinus(Duration.of(30, MINUTES)).toEpochMilli());
+
+        FlowLog flowLog4 = createFlowLog(Boolean.TRUE, SUCCESSFUL, UNKNOWN);
+        flowLog4.setEndTime(nowMinus(Duration.of(20, MINUTES)).toEpochMilli());
+
+        FlowLog flowLog5 = createFlowLog(Boolean.FALSE, SUCCESSFUL, PROVISION);
+        FlowLog flowLog6 = createFlowLog(Boolean.FALSE, FAILED, UNKNOWN);
+
+        saveFlowLogs(flowLog1, flowLog2, flowLog3, flowLog4, flowLog5, flowLog6);
+
+        int result = underTest.purgeFinalizedFlowLogs(nowMinus(Duration.of(30, MINUTES)).toEpochMilli());
+
+        assertThat(result).isEqualTo(2);
+    }
+
+    private Instant nowMinus(Duration of) {
+        return now().minus(of);
+    }
+
+    private FlowLog createFlowLog(boolean finalized, StateStatus status, OperationType type) {
+        return new FlowLog((long) TEST_RESOURCE_ID.incrementAndGet(), randomUUID().toString(), TEST_CURRENT_FLOW_STATE, finalized, status, type);
+    }
+
+    private void saveFlowLogs(FlowLog... flowLogs) {
+        underTest.saveAll(asList(flowLogs));
+    }
+}

--- a/flow/src/test/java/com/sequenceiq/flow/repository/RepositoryTestConfig.java
+++ b/flow/src/test/java/com/sequenceiq/flow/repository/RepositoryTestConfig.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.flow.repository;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@EnableAutoConfiguration
+@EnableJpaRepositories(basePackages = "com.sequenceiq.flow.repository")
+@EntityScan(basePackages = "com.sequenceiq.flow.domain")
+public class RepositoryTestConfig {
+
+    public static class RepositoryTestInitializer implements ApplicationContextInitializer<GenericApplicationContext> {
+
+        @Override
+        public void initialize(GenericApplicationContext applicationContext) {
+            TestPropertyValues.of(
+                    "spring.datasource.url=jdbc:h2:mem:test",
+                    "spring.jpa.properties.hibernate.show_sql=false",
+                    "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect"
+            ).applyTo(applicationContext.getEnvironment());
+        }
+    }
+}


### PR DESCRIPTION
#### Changes 
- Added a configurable endTimeDuration to flow cleanup configs
 - Propagate this param to the service layer and compute the endTimeUpperBound epoch ms
 - Purge flow logs below computed upper bound

#### Testing
 - Repository test for FlowLogRepository to verify correct behaviour

See detailed description in the commit message.