### PR TITLE
CB-20153 - Move noOutboundLoadBalancer field from Azure Environment to Azure Network

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/constant/AzureConstants.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/constant/AzureConstants.java
@@ -14,6 +14,8 @@ public class AzureConstants {
 
     public static final String AKS_PRIVATE_DNS_ZONE_ID = "aksPrivateDnsZoneId";
 
+    public static final String NO_OUTBOUND_LOAD_BALANCER = "noOutboundLoadBalancer";
+
     private AzureConstants() {
     }
 

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/network/AzureNetworkV4Parameters.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/network/AzureNetworkV4Parameters.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.network;
 import static com.sequenceiq.cloudbreak.constant.AzureConstants.AKS_PRIVATE_DNS_ZONE_ID;
 import static com.sequenceiq.cloudbreak.constant.AzureConstants.DATABASE_PRIVATE_DNS_ZONE_ID;
 import static com.sequenceiq.cloudbreak.constant.AzureConstants.NETWORK_ID;
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.NO_OUTBOUND_LOAD_BALANCER;
 import static com.sequenceiq.cloudbreak.constant.AzureConstants.NO_PUBLIC_IP;
 import static com.sequenceiq.cloudbreak.constant.AzureConstants.RESOURCE_GROUP_NAME;
 import static com.sequenceiq.cloudbreak.constant.AzureConstants.SUBNET_ID;
@@ -42,6 +43,9 @@ public class AzureNetworkV4Parameters extends MappableBase implements JsonEntity
 
     @ApiModelProperty
     private String aksPrivateDnsZoneId;
+
+    @ApiModelProperty
+    private boolean noOutboundLoadBalancer;
 
     public Boolean getNoPublicIp() {
         return noPublicIp;
@@ -91,6 +95,14 @@ public class AzureNetworkV4Parameters extends MappableBase implements JsonEntity
         this.aksPrivateDnsZoneId = aksPrivateDnsZoneId;
     }
 
+    public boolean isNoOutboundLoadBalancer() {
+        return noOutboundLoadBalancer;
+    }
+
+    public void setNoOutboundLoadBalancer(boolean noOutboundLoadBalancer) {
+        this.noOutboundLoadBalancer = noOutboundLoadBalancer;
+    }
+
     @Override
     public Map<String, Object> asMap() {
         Map<String, Object> map = super.asMap();
@@ -100,6 +112,7 @@ public class AzureNetworkV4Parameters extends MappableBase implements JsonEntity
         putIfValueNotNull(map, SUBNET_ID, subnetId);
         putIfValueNotNull(map, DATABASE_PRIVATE_DNS_ZONE_ID, databasePrivateDnsZoneId);
         putIfValueNotNull(map, AKS_PRIVATE_DNS_ZONE_ID, aksPrivateDnsZoneId);
+        putIfValueNotNull(map, NO_OUTBOUND_LOAD_BALANCER, noOutboundLoadBalancer);
         return map;
     }
 
@@ -118,5 +131,6 @@ public class AzureNetworkV4Parameters extends MappableBase implements JsonEntity
         subnetId = getParameterOrNull(parameters, SUBNET_ID);
         databasePrivateDnsZoneId = getParameterOrNull(parameters, DATABASE_PRIVATE_DNS_ZONE_ID);
         aksPrivateDnsZoneId = getParameterOrNull(parameters, AKS_PRIVATE_DNS_ZONE_ID);
+        noOutboundLoadBalancer = getBoolean(parameters, NO_OUTBOUND_LOAD_BALANCER);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/AzureEnvironmentNetworkConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/AzureEnvironmentNetworkConverter.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.converter.v4.environment.network;
 
 import static com.sequenceiq.cloudbreak.constant.AzureConstants.DATABASE_PRIVATE_DNS_ZONE_ID;
 import static com.sequenceiq.cloudbreak.constant.AzureConstants.NETWORK_ID;
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.NO_OUTBOUND_LOAD_BALANCER;
 import static com.sequenceiq.cloudbreak.constant.AzureConstants.NO_PUBLIC_IP;
 import static com.sequenceiq.cloudbreak.constant.AzureConstants.RESOURCE_GROUP_NAME;
 
@@ -30,7 +31,8 @@ public class AzureEnvironmentNetworkConverter extends EnvironmentBaseNetworkConv
                 NETWORK_ID, azure.getNetworkId(),
                 RESOURCE_GROUP_NAME, azure.getResourceGroupName(),
                 NO_PUBLIC_IP, azure.getNoPublicIp(),
-                DATABASE_PRIVATE_DNS_ZONE_ID, getDatabasePrivateDnsZoneId(azure)
+                DATABASE_PRIVATE_DNS_ZONE_ID, getDatabasePrivateDnsZoneId(azure),
+                NO_OUTBOUND_LOAD_BALANCER, azure.isNoOutboundLoadBalancer()
         );
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/loadbalancer/LoadBalancerConfigService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/loadbalancer/LoadBalancerConfigService.java
@@ -59,7 +59,7 @@ import com.sequenceiq.common.api.type.LoadBalancerSku;
 import com.sequenceiq.common.api.type.LoadBalancerType;
 import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
 import com.sequenceiq.common.api.type.TargetGroupType;
-import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureEnvironmentParameters;
+import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkAzureParams;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
 
@@ -343,7 +343,7 @@ public class LoadBalancerConfigService {
 
             if (isNetworkUsingPrivateSubnet(stack.getNetwork(), environment.getNetwork())) {
                 setupLoadBalancer(dryRun, stack, loadBalancers, knoxTargetGroup.get(), LoadBalancerType.PRIVATE);
-                if (shouldCreateOutboundLoadBalancer(createPublicLb, stack, sku, environment)) {
+                if (shouldCreateOutboundLoadBalancer(createPublicLb, stack, sku, environment.getNetwork())) {
                     LOGGER.debug("Found private only Azure load balancer configuration; creating outbound public load balancer for egress.");
                     setupLoadBalancer(dryRun, stack, loadBalancers, knoxTargetGroup.get(), LoadBalancerType.OUTBOUND);
                 }
@@ -360,13 +360,13 @@ public class LoadBalancerConfigService {
         }
     }
 
-    private boolean shouldCreateOutboundLoadBalancer(boolean createPublicLb, Stack stack, LoadBalancerSku sku, DetailedEnvironmentResponse environment) {
+    private boolean shouldCreateOutboundLoadBalancer(boolean createPublicLb, Stack stack, LoadBalancerSku sku, EnvironmentNetworkResponse network) {
         return !createPublicLb
                 && AZURE.equalsIgnoreCase(stack.getCloudPlatform())
                 && LoadBalancerSku.STANDARD.equals(sku)
-                && !Optional.of(environment)
-                            .map(DetailedEnvironmentResponse::getAzure)
-                            .map(AzureEnvironmentParameters::isNoOutboundLoadBalancer)
+                && !Optional.of(network)
+                            .map(EnvironmentNetworkResponse::getAzure)
+                            .map(EnvironmentNetworkAzureParams::isNoOutboundLoadBalancer)
                             .orElse(false);
     }
 

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/NetworkV1ToNetworkV4Converter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/NetworkV1ToNetworkV4Converter.java
@@ -132,6 +132,7 @@ public class NetworkV1ToNetworkV4Converter {
             response.setResourceGroupName(networkAzureParams.getResourceGroupName());
             response.setDatabasePrivateDnsZoneId(networkAzureParams.getDatabasePrivateDnsZoneId());
             response.setAksPrivateDnsZoneId(networkAzureParams.getAksPrivateDnsZoneId());
+            response.setNoOutboundLoadBalancer(networkAzureParams.isNoOutboundLoadBalancer());
             String subnetId = azureNetworkV1Parameters.getSubnetId();
             if (!Strings.isNullOrEmpty(subnetId)) {
                 response.setSubnetId(subnetId);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/AzureEnvironmentNetworkConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/AzureEnvironmentNetworkConverterTest.java
@@ -5,6 +5,7 @@ import static com.sequenceiq.cloudbreak.common.network.NetworkConstants.ENDPOINT
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -41,6 +42,8 @@ class AzureEnvironmentNetworkConverterTest {
     private static final String RESOURCE_GROUP_NAME_KEY = "resourceGroupName";
 
     private static final String NO_PUBLIC_IP_KEY = "noPublicIp";
+
+    private static final String NO_OUTBOUND_LOAD_BALANCER_KEY = "noOutboundLoadBalancer";
 
     @Mock
     private MissingResourceNameGenerator missingResourceNameGenerator;
@@ -81,14 +84,16 @@ class AzureEnvironmentNetworkConverterTest {
         when(azure.getResourceGroupName()).thenReturn(RESOURCE_GROUP_NAME);
         when(azure.getNoPublicIp()).thenReturn(true);
         when(azure.getDatabasePrivateDnsZoneId()).thenReturn(DATABASE_PRIVATE_DNS_ZONE_ID);
+        when(azure.isNoOutboundLoadBalancer()).thenReturn(true);
 
         Map<String, Object> result = converter.getAttributesForLegacyNetwork(environmentNetworkResponse);
 
-        assertThat(result).hasSize(4);
+        assertThat(result).hasSize(5);
         assertEquals(NETWORK_ID, result.get(NETWORK_ID_KEY));
         assertEquals(RESOURCE_GROUP_NAME, result.get(RESOURCE_GROUP_NAME_KEY));
         assertEquals(true, result.get(NO_PUBLIC_IP_KEY));
         assertEquals(DATABASE_PRIVATE_DNS_ZONE_ID, result.get(DATABASE_PRIVATE_DNS_ZONE_ID_KEY));
+        assertTrue((Boolean) result.get(NO_OUTBOUND_LOAD_BALANCER_KEY));
     }
 
     @Test

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/loadbalancer/LoadBalancerConfigServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/loadbalancer/LoadBalancerConfigServiceTest.java
@@ -62,7 +62,7 @@ import com.sequenceiq.common.api.type.LoadBalancerCreation;
 import com.sequenceiq.common.api.type.LoadBalancerSku;
 import com.sequenceiq.common.api.type.LoadBalancerType;
 import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
-import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureEnvironmentParameters;
+import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkAzureParams;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
 
@@ -1220,11 +1220,11 @@ public class LoadBalancerConfigServiceTest extends SubnetTest {
 
     private DetailedEnvironmentResponse createAzureEnvironment(CloudSubnet subnet, boolean enableEndpointGateway, boolean noOutboundLoadBalancer) {
         DetailedEnvironmentResponse environment = createEnvironment(subnet, enableEndpointGateway, AZURE);
-        AzureEnvironmentParameters azureParameters = new AzureEnvironmentParameters()
-                .builder()
+        EnvironmentNetworkAzureParams azureParameters = EnvironmentNetworkAzureParams.EnvironmentNetworkAzureParamsBuilder
+                .anEnvironmentNetworkAzureParams()
                 .withNoOutboundLoadBalancer(noOutboundLoadBalancer)
                 .build();
-        environment.setAzure(azureParameters);
+        environment.getNetwork().setAzure(azureParameters);
         return environment;
     }
 }

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/NetworkV1ToNetworkV4ConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/NetworkV1ToNetworkV4ConverterTest.java
@@ -63,6 +63,8 @@ public class NetworkV1ToNetworkV4ConverterTest {
 
     private static final String PUBLIC_SUBNET_ID = "public-subnet-123";
 
+    private static final boolean NO_OUTBOUND_LOAD_BALANCER = true;
+
     @InjectMocks
     private NetworkV1ToNetworkV4Converter underTest;
 
@@ -202,6 +204,7 @@ public class NetworkV1ToNetworkV4ConverterTest {
         assertEquals(networkV4Request.createAzure().getNetworkId(), VPC_ID);
         assertEquals(networkV4Request.createAzure().getResourceGroupName(), GROUP_NAME);
         assertEquals(networkV4Request.createAzure().getSubnetId(), SUBNET_ID);
+        assertEquals(networkV4Request.createAzure().isNoOutboundLoadBalancer(), NO_OUTBOUND_LOAD_BALANCER);
     }
 
     @Test
@@ -216,6 +219,7 @@ public class NetworkV1ToNetworkV4ConverterTest {
         assertEquals(networkV4Request.createAzure().getNetworkId(), VPC_ID);
         assertEquals(networkV4Request.createAzure().getResourceGroupName(), GROUP_NAME);
         assertTrue(SUBNET_IDS.contains(networkV4Request.createAzure().getSubnetId()));
+        assertEquals(networkV4Request.createAzure().isNoOutboundLoadBalancer(), NO_OUTBOUND_LOAD_BALANCER);
     }
 
     @Test
@@ -388,7 +392,7 @@ public class NetworkV1ToNetworkV4ConverterTest {
         EnvironmentNetworkAzureParams environmentNetworkAzureParams = new EnvironmentNetworkAzureParams();
         environmentNetworkAzureParams.setNetworkId(VPC_ID);
         environmentNetworkAzureParams.setResourceGroupName(GROUP_NAME);
-
+        environmentNetworkAzureParams.setNoOutboundLoadBalancer(NO_OUTBOUND_LOAD_BALANCER);
 
         environmentNetworkResponse.setAzure(environmentNetworkAzureParams);
 

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/EnvironmentNetworkAzureParams.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/EnvironmentNetworkAzureParams.java
@@ -36,6 +36,9 @@ public class EnvironmentNetworkAzureParams {
     @ApiModelProperty(EnvironmentModelDescription.AZURE_NO_PUBLIC_IP)
     private Boolean noPublicIp;
 
+    @ApiModelProperty(EnvironmentModelDescription.NO_OUTBOUND_LOAD_BALANCER)
+    private boolean noOutboundLoadBalancer;
+
     public String getNetworkId() {
         return networkId;
     }
@@ -76,6 +79,14 @@ public class EnvironmentNetworkAzureParams {
         this.aksPrivateDnsZoneId = aksPrivateDnsZoneId;
     }
 
+    public boolean isNoOutboundLoadBalancer() {
+        return noOutboundLoadBalancer;
+    }
+
+    public void setNoOutboundLoadBalancer(boolean noOutboundLoadBalancer) {
+        this.noOutboundLoadBalancer = noOutboundLoadBalancer;
+    }
+
     @Override
     public String toString() {
         return "EnvironmentNetworkAzureParams{" +
@@ -84,6 +95,7 @@ public class EnvironmentNetworkAzureParams {
                 ", databasePrivateDnsZoneId='" + databasePrivateDnsZoneId + '\'' +
                 ", aksPrivateDnsZoneId='" + aksPrivateDnsZoneId + '\'' +
                 ", noPublicIp=" + noPublicIp +
+                ", noOutboundLoadBalancer=" + noOutboundLoadBalancer +
                 '}';
     }
 
@@ -97,6 +109,8 @@ public class EnvironmentNetworkAzureParams {
         private String databasePrivateDnsZoneId;
 
         private String aksPrivateDnsZoneId;
+
+        private boolean noOutboundLoadBalancer;
 
         private EnvironmentNetworkAzureParamsBuilder() {
         }
@@ -130,6 +144,11 @@ public class EnvironmentNetworkAzureParams {
             return this;
         }
 
+        public EnvironmentNetworkAzureParamsBuilder withNoOutboundLoadBalancer(boolean noOutboundLoadBalancer) {
+            this.noOutboundLoadBalancer = noOutboundLoadBalancer;
+            return this;
+        }
+
         public EnvironmentNetworkAzureParams build() {
             EnvironmentNetworkAzureParams environmentNetworkAzureParams = new EnvironmentNetworkAzureParams();
             environmentNetworkAzureParams.setNetworkId(networkId);
@@ -137,6 +156,7 @@ public class EnvironmentNetworkAzureParams {
             environmentNetworkAzureParams.setNoPublicIp(noPublicIp);
             environmentNetworkAzureParams.setDatabasePrivateDnsZoneId(databasePrivateDnsZoneId);
             environmentNetworkAzureParams.setAksPrivateDnsZoneId(aksPrivateDnsZoneId);
+            environmentNetworkAzureParams.setNoOutboundLoadBalancer(noOutboundLoadBalancer);
             return environmentNetworkAzureParams;
         }
     }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/azure/AzureEnvironmentParameters.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/azure/AzureEnvironmentParameters.java
@@ -22,9 +22,6 @@ public class AzureEnvironmentParameters implements Serializable {
     @ApiModelProperty(EnvironmentModelDescription.RESOURCE_ENCRYPTION_PARAMETERS)
     private AzureResourceEncryptionParameters resourceEncryptionParameters;
 
-    @ApiModelProperty(EnvironmentModelDescription.NO_OUTBOUND_LOAD_BALANCER)
-    private boolean noOutboundLoadBalancer;
-
     public AzureResourceGroup getResourceGroup() {
         return resourceGroup;
     }
@@ -41,20 +38,11 @@ public class AzureEnvironmentParameters implements Serializable {
         this.resourceEncryptionParameters = resourceEncryptionParameters;
     }
 
-    public boolean isNoOutboundLoadBalancer() {
-        return noOutboundLoadBalancer;
-    }
-
-    public void setNoOutboundLoadBalancer(boolean noOutboundLoadBalancer) {
-        this.noOutboundLoadBalancer = noOutboundLoadBalancer;
-    }
-
     @Override
     public String toString() {
         return "AzureEnvironmentParameters{" +
                 "resourceGroup=" + resourceGroup +
                 ", resourceEncryptionParameters=" + resourceEncryptionParameters +
-                ", noOutboundLoadBalancer=" + noOutboundLoadBalancer +
                 '}';
     }
 
@@ -67,8 +55,6 @@ public class AzureEnvironmentParameters implements Serializable {
         private AzureResourceGroup azureResourceGroup;
 
         private AzureResourceEncryptionParameters resourceEncryptionParameters;
-
-        private boolean noOutboundLoadBalancer;
 
         private Builder() {
         }
@@ -83,16 +69,10 @@ public class AzureEnvironmentParameters implements Serializable {
             return this;
         }
 
-        public Builder withNoOutboundLoadBalancer(boolean noOutboundLoadBalancer) {
-            this.noOutboundLoadBalancer = noOutboundLoadBalancer;
-            return this;
-        }
-
         public AzureEnvironmentParameters build() {
             AzureEnvironmentParameters azureEnvironmentParameters = new AzureEnvironmentParameters();
             azureEnvironmentParameters.setResourceGroup(azureResourceGroup);
             azureEnvironmentParameters.setResourceEncryptionParameters(resourceEncryptionParameters);
-            azureEnvironmentParameters.setNoOutboundLoadBalancer(noOutboundLoadBalancer);
             return azureEnvironmentParameters;
         }
     }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverter.java
@@ -262,10 +262,6 @@ public class EnvironmentApiConverter {
                                 .map(this::azureResourceEncryptionParametersToAzureEncryptionParametersDto)
                                 .orElse(null)
                 )
-                .withNoOutboundLoadBalancer(
-                        Optional.ofNullable(azureEnvironmentParameters)
-                                .map(AzureEnvironmentParameters::isNoOutboundLoadBalancer)
-                                .orElse(false))
                 .build();
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverter.java
@@ -255,9 +255,6 @@ public class EnvironmentResponseConverter {
         return AzureEnvironmentParameters.builder()
                 .withAzureResourceGroup(getIfNotNull(resourceGroupDto, this::azureParametersToAzureResourceGroup))
                 .withResourceEncryptionParameters(getIfNotNull(resourceEncryptionParametersDto, this::azureParametersToAzureResourceEncryptionParameters))
-                .withNoOutboundLoadBalancer(Optional.ofNullable(parameters.getAzureParametersDto())
-                                                    .map(AzureParametersDto::isNoOutboundLoadBalancer)
-                                                    .orElse(false))
                 .build();
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/NetworkDtoToResponseConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/NetworkDtoToResponseConverter.java
@@ -62,6 +62,7 @@ public class NetworkDtoToResponseConverter {
                         .withNoPublicIp(p.isNoPublicIp())
                         .withDatabasePrivateDnsZoneId(p.getDatabasePrivateDnsZoneId())
                         .withAksPrivateDnsZoneId(p.getAksPrivateDnsZoneId())
+                        .withNoOutboundLoadBalancer(p.isNoOutboundLoadBalancer())
                         .build()))
                 .withGcp(getIfNotNull(network.getGcp(), p -> EnvironmentNetworkGcpParams.EnvironmentNetworkGcpParamsBuilder
                         .anEnvironmentNetworkGcpParamsBuilder()

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/NetworkRequestToDtoConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/NetworkRequestToDtoConverter.java
@@ -47,6 +47,7 @@ public class NetworkRequestToDtoConverter {
                     .withResourceGroupName(network.getAzure().getResourceGroupName())
                     .withDatabasePrivateDnsZoneId(network.getAzure().getDatabasePrivateDnsZoneId())
                     .withAksPrivateDnsZoneId(network.getAzure().getAksPrivateDnsZoneId())
+                    .withNoOutboundLoadBalancer(network.getAzure().isNoOutboundLoadBalancer())
                     .build();
             builder.withAzure(azureParams);
             builder.withNetworkId(network.getAzure().getNetworkId());

--- a/environment/src/main/java/com/sequenceiq/environment/network/dao/domain/AzureNetwork.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/dao/domain/AzureNetwork.java
@@ -16,6 +16,8 @@ public class AzureNetwork extends BaseNetwork {
 
     private String aksPrivateDnsZoneId;
 
+    private boolean noOutboundLoadBalancer;
+
     @Override
     public String getNetworkId() {
         return networkId;
@@ -57,6 +59,14 @@ public class AzureNetwork extends BaseNetwork {
         this.aksPrivateDnsZoneId = aksPrivateDnsZoneId;
     }
 
+    public boolean isNoOutboundLoadBalancer() {
+        return noOutboundLoadBalancer;
+    }
+
+    public void setNoOutboundLoadBalancer(boolean noOutboundLoadBalancer) {
+        this.noOutboundLoadBalancer = noOutboundLoadBalancer;
+    }
+
     @Override
     public String toString() {
         return "AzureNetwork{" +
@@ -65,6 +75,7 @@ public class AzureNetwork extends BaseNetwork {
                 ", noPublicIp=" + noPublicIp +
                 ", databasePrivateDnsZoneId='" + databasePrivateDnsZoneId + '\'' +
                 ", aksPrivateDnsZoneId='" + aksPrivateDnsZoneId + '\'' +
+                ", noOutboundLoadBalancer='" + noOutboundLoadBalancer + '\'' +
                 "} " + super.toString();
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/network/v1/converter/AzureEnvironmentNetworkConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/v1/converter/AzureEnvironmentNetworkConverter.java
@@ -3,6 +3,7 @@ package com.sequenceiq.environment.network.v1.converter;
 import static com.sequenceiq.cloudbreak.constant.AzureConstants.AKS_PRIVATE_DNS_ZONE_ID;
 import static com.sequenceiq.cloudbreak.constant.AzureConstants.DATABASE_PRIVATE_DNS_ZONE_ID;
 import static com.sequenceiq.cloudbreak.constant.AzureConstants.NETWORK_ID;
+import static com.sequenceiq.cloudbreak.constant.AzureConstants.NO_OUTBOUND_LOAD_BALANCER;
 import static com.sequenceiq.cloudbreak.constant.AzureConstants.RESOURCE_GROUP_NAME;
 
 import java.util.HashMap;
@@ -48,6 +49,7 @@ public class AzureEnvironmentNetworkConverter extends EnvironmentBaseNetworkConv
             azureNetwork.setResourceGroupName(azureParams.getResourceGroupName());
             azureNetwork.setNoPublicIp(azureParams.isNoPublicIp());
             azureNetwork.setAksPrivateDnsZoneId(azureParams.getAksPrivateDnsZoneId());
+            azureNetwork.setNoOutboundLoadBalancer(azureParams.isNoOutboundLoadBalancer());
             if (ServiceEndpointCreation.ENABLED_PRIVATE_ENDPOINT.equals(network.getServiceEndpointCreation())) {
                 azureNetwork.setDatabasePrivateDnsZoneId(azureParams.getDatabasePrivateDnsZoneId());
             }
@@ -102,6 +104,7 @@ public class AzureEnvironmentNetworkConverter extends EnvironmentBaseNetworkConv
                                 .withNoPublicIp(azureNetwork.getNoPublicIp())
                                 .withDatabasePrivateDnsZoneId(azureNetwork.getDatabasePrivateDnsZoneId())
                                 .withAksPrivateDnsZoneId(azureNetwork.getAksPrivateDnsZoneId())
+                                .withNoOutboundLoadBalancer(azureNetwork.isNoOutboundLoadBalancer())
                                 .build())
                 .build();
     }
@@ -134,6 +137,7 @@ public class AzureEnvironmentNetworkConverter extends EnvironmentBaseNetworkConv
         param.put(NETWORK_ID, azureNetwork.getNetworkId());
         param.put(DATABASE_PRIVATE_DNS_ZONE_ID, azureNetwork.getDatabasePrivateDnsZoneId());
         param.put(AKS_PRIVATE_DNS_ZONE_ID, azureNetwork.getAksPrivateDnsZoneId());
+        param.put(NO_OUTBOUND_LOAD_BALANCER, azureNetwork.isNoOutboundLoadBalancer());
         return new Network(null, param);
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/parameters/dao/domain/AzureParameters.java
+++ b/environment/src/main/java/com/sequenceiq/environment/parameters/dao/domain/AzureParameters.java
@@ -43,9 +43,6 @@ public class AzureParameters extends BaseParameters implements AccountIdAwareRes
     @Column(name = "encryption_key_resource_group_name")
     private String encryptionKeyResourceGroupName;
 
-    @Column(name = "no_outbound_load_balancer")
-    private boolean noOutboundLoadBalancer;
-
     public String getResourceGroupName() {
         return resourceGroupName;
     }
@@ -97,13 +94,5 @@ public class AzureParameters extends BaseParameters implements AccountIdAwareRes
 
     public void setEncryptionKeyResourceGroupName(String encryptionKeyResourceGroupName) {
         this.encryptionKeyResourceGroupName = encryptionKeyResourceGroupName;
-    }
-
-    public boolean isNoOutboundLoadBalancer() {
-        return noOutboundLoadBalancer;
-    }
-
-    public void setNoOutboundLoadBalancer(boolean noOutboundLoadBalancer) {
-        this.noOutboundLoadBalancer = noOutboundLoadBalancer;
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/parameters/v1/converter/AzureEnvironmentParametersConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/parameters/v1/converter/AzureEnvironmentParametersConverter.java
@@ -52,9 +52,6 @@ public class AzureEnvironmentParametersConverter extends BaseEnvironmentParamete
                 .map(AzureParametersDto::getAzureResourceEncryptionParametersDto)
                 .map(AzureResourceEncryptionParametersDto::getEncryptionKeyResourceGroupName)
                 .orElse(null));
-        azureParameters.setNoOutboundLoadBalancer(azureParametersDto
-                .map(AzureParametersDto::isNoOutboundLoadBalancer)
-                .orElse(false));
     }
 
     @Override
@@ -74,8 +71,6 @@ public class AzureEnvironmentParametersConverter extends BaseEnvironmentParamete
                                 .withDiskEncryptionSetId(azureParameters.getDiskEncryptionSetId())
                                 .withEncryptionKeyResourceGroupName(azureParameters.getEncryptionKeyResourceGroupName())
                                 .build())
-                .withNoOutboundLoadBalancer(
-                        azureParameters.isNoOutboundLoadBalancer())
                 .build());
     }
 }

--- a/environment/src/main/resources/schema/app/20221222165000_CB-20153_move_no_outbound_load_balancer_to_network.sql
+++ b/environment/src/main/resources/schema/app/20221222165000_CB-20153_move_no_outbound_load_balancer_to_network.sql
@@ -1,0 +1,10 @@
+-- // CB-20153 - Move noOutboundLoadBalancer to network.
+-- Migration SQL that makes the change goes here.
+ALTER TABLE environment_parameters DROP COLUMN IF EXISTS no_outbound_load_balancer;
+ALTER TABLE environment_network ADD COLUMN IF NOT EXISTS nooutboundloadbalancer bool NULL DEFAULT false;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+ALTER TABLE environment_network DROP COLUMN IF EXISTS nooutboundloadbalancer;
+ALTER TABLE environment_parameters ADD COLUMN IF NOT EXISTS no_outbound_load_balancer bool NULL DEFAULT false;
+

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverterTest.java
@@ -447,7 +447,6 @@ public class EnvironmentApiConverterTest {
                 actual.getAzureParametersDto().getAzureResourceEncryptionParametersDto().getEncryptionKeyUrl());
         assertEquals(request.getAzure().getResourceEncryptionParameters().getEncryptionKeyResourceGroupName(),
                 actual.getAzureParametersDto().getAzureResourceEncryptionParametersDto().getEncryptionKeyResourceGroupName());
-        assertEquals(request.getAzure().isNoOutboundLoadBalancer(), actual.getAzureParametersDto().isNoOutboundLoadBalancer());
     }
 
     private void assertAwsParameters(EnvironmentRequest request, ParametersDto actual) {
@@ -546,7 +545,6 @@ public class EnvironmentApiConverterTest {
                         .withEncryptionKeyResourceGroupName(KEY_URL_RESOURCE_GROUP)
                         .build()
         );
-        azureEnvironmentParameters.setNoOutboundLoadBalancer(false);
         return azureEnvironmentParameters;
     }
 

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverterTest.java
@@ -260,7 +260,6 @@ public class EnvironmentResponseConverterTest {
                 azureEnvironmentParameters.getResourceEncryptionParameters().getEncryptionKeyUrl());
         assertEquals("dummy-des-id", azureEnvironmentParameters.getResourceEncryptionParameters().getDiskEncryptionSetId());
         assertEquals("dummyResourceGroupName", azureEnvironmentParameters.getResourceEncryptionParameters().getEncryptionKeyResourceGroupName());
-        assertEquals(azureParametersDto.isNoOutboundLoadBalancer(), azureEnvironmentParameters.isNoOutboundLoadBalancer());
     }
 
     private void assertGcpParameters(GcpParametersDto gcpParametersDto, GcpEnvironmentParameters gcpEnvironmentParameters) {
@@ -338,7 +337,6 @@ public class EnvironmentResponseConverterTest {
                                         .withDiskEncryptionSetId("dummy-des-id")
                                         .withEncryptionKeyResourceGroupName("dummyResourceGroupName")
                                         .build())
-                        .withNoOutboundLoadBalancer(true)
                         .build())
                 .build();
     }

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/NetworkDtoToResponseConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/NetworkDtoToResponseConverterTest.java
@@ -72,6 +72,7 @@ public class NetworkDtoToResponseConverterTest {
         assertEquals(network.getAzure().getResourceGroupName(), actual.getAzure().getResourceGroupName());
         assertEquals(network.getAzure().getDatabasePrivateDnsZoneId(), actual.getAzure().getDatabasePrivateDnsZoneId());
         assertEquals(network.getAzure().getAksPrivateDnsZoneId(), actual.getAzure().getAksPrivateDnsZoneId());
+        assertEquals(network.getAzure().isNoOutboundLoadBalancer(), actual.getAzure().isNoOutboundLoadBalancer());
         assertNull(actual.getAws());
         assertNull(actual.getYarn());
         assertNull(actual.getMock());
@@ -162,6 +163,7 @@ public class NetworkDtoToResponseConverterTest {
                 .withNetworkId("network-id")
                 .withDatabasePrivateDnsZoneId("database-private-dns-zone-id")
                 .withAksPrivateDnsZoneId("aks-private-dns-zone-id")
+                .withNoOutboundLoadBalancer(true)
                 .build();
     }
 

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/NetworkRequestToDtoConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/NetworkRequestToDtoConverterTest.java
@@ -64,6 +64,7 @@ public class NetworkRequestToDtoConverterTest {
         assertEquals(network.getAzure().getNoPublicIp(), actual.getAzure().isNoPublicIp());
         assertEquals(network.getAzure().getDatabasePrivateDnsZoneId(), actual.getAzure().getDatabasePrivateDnsZoneId());
         assertEquals(network.getAzure().getAksPrivateDnsZoneId(), actual.getAzure().getAksPrivateDnsZoneId());
+        assertEquals(network.getAzure().isNoOutboundLoadBalancer(), actual.getAzure().isNoOutboundLoadBalancer());
         assertCommonFields(network, actual);
     }
 
@@ -127,6 +128,7 @@ public class NetworkRequestToDtoConverterTest {
         azureParams.setNoPublicIp(true);
         azureParams.setDatabasePrivateDnsZoneId("database-private-dns-zone-id");
         azureParams.setAksPrivateDnsZoneId("aks-private-dns-zone-id");
+        azureParams.setNoOutboundLoadBalancer(true);
         return azureParams;
     }
 

--- a/environment/src/test/java/com/sequenceiq/environment/parameters/v1/converter/AzureEnvironmentParametersConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/parameters/v1/converter/AzureEnvironmentParametersConverterTest.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.environment.parameters.v1.converter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -62,7 +61,6 @@ public class AzureEnvironmentParametersConverterTest {
                                     .withEncryptionKeyUrl(KEY_URL)
                                     .withEncryptionKeyResourceGroupName(KEY_RESOURCE_GROUP_NAME)
                                     .build())
-                            .withNoOutboundLoadBalancer(true)
                             .build())
                     .build();
             Environment environment = new Environment();
@@ -79,7 +77,6 @@ public class AzureEnvironmentParametersConverterTest {
             assertEquals(ID, azureResult.getId());
             assertEquals(KEY_URL, azureResult.getEncryptionKeyUrl());
             assertEquals(KEY_RESOURCE_GROUP_NAME, azureResult.getEncryptionKeyResourceGroupName());
-            assertTrue(azureResult.isNoOutboundLoadBalancer());
         }
 
         @Test
@@ -93,7 +90,6 @@ public class AzureEnvironmentParametersConverterTest {
             parameters.setEncryptionKeyUrl(KEY_URL);
             parameters.setDiskEncryptionSetId("DummyDesId");
             parameters.setEncryptionKeyResourceGroupName(KEY_RESOURCE_GROUP_NAME);
-            parameters.setNoOutboundLoadBalancer(true);
 
             ParametersDto result = underTest.convertToDto(parameters);
 
@@ -103,6 +99,5 @@ public class AzureEnvironmentParametersConverterTest {
             assertEquals(KEY_URL, result.getAzureParametersDto().getAzureResourceEncryptionParametersDto().getEncryptionKeyUrl());
             assertEquals("DummyDesId", result.getAzureParametersDto().getAzureResourceEncryptionParametersDto().getDiskEncryptionSetId());
             assertEquals(KEY_RESOURCE_GROUP_NAME, result.getAzureParametersDto().getAzureResourceEncryptionParametersDto().getEncryptionKeyResourceGroupName());
-            assertTrue(result.getAzureParametersDto().isNoOutboundLoadBalancer());
         }
 }

--- a/structuredevent-model/src/main/java/com/sequenceiq/environment/network/dto/AzureParams.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/environment/network/dto/AzureParams.java
@@ -16,11 +16,14 @@ public class AzureParams {
 
     private String aksPrivateDnsZoneId;
 
+    private boolean noOutboundLoadBalancer;
+
     private AzureParams(Builder builder) {
         networkId = builder.networkId;
         resourceGroupName = builder.resourceGroupName;
         noPublicIp = builder.noPublicIp;
         databasePrivateDnsZoneId = builder.databasePrivateDnsZoneId;
+        noOutboundLoadBalancer = builder.noOutboundLoadBalancer;
         aksPrivateDnsZoneId = builder.aksPrivateDnsZoneId;
     }
 
@@ -64,6 +67,14 @@ public class AzureParams {
         this.aksPrivateDnsZoneId = aksPrivateDnsZoneId;
     }
 
+    public boolean isNoOutboundLoadBalancer() {
+        return noOutboundLoadBalancer;
+    }
+
+    public void setNoOutboundLoadBalancer(boolean noOutboundLoadBalancer) {
+        this.noOutboundLoadBalancer = noOutboundLoadBalancer;
+    }
+
     @Override
     public String toString() {
         return "AzureParams{" +
@@ -72,6 +83,7 @@ public class AzureParams {
                 ", noPublicIp=" + noPublicIp +
                 ", databasePrivateDnsZoneId='" + databasePrivateDnsZoneId + '\'' +
                 ", aksPrivateDnsZoneId='" + aksPrivateDnsZoneId + '\'' +
+                ", noOutboundLoadBalancer='" + noOutboundLoadBalancer + '\'' +
                 '}';
     }
 
@@ -90,6 +102,8 @@ public class AzureParams {
         private String databasePrivateDnsZoneId;
 
         private String aksPrivateDnsZoneId;
+
+        private boolean noOutboundLoadBalancer;
 
         private Builder() {
         }
@@ -116,6 +130,11 @@ public class AzureParams {
 
         public Builder withAksPrivateDnsZoneId(String aksPrivateDnsZoneId) {
             this.aksPrivateDnsZoneId = aksPrivateDnsZoneId;
+            return this;
+        }
+
+        public Builder withNoOutboundLoadBalancer(boolean noOutboundLoadBalancer) {
+            this.noOutboundLoadBalancer = noOutboundLoadBalancer;
             return this;
         }
 

--- a/structuredevent-model/src/main/java/com/sequenceiq/environment/parameter/dto/AzureParametersDto.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/environment/parameter/dto/AzureParametersDto.java
@@ -10,12 +10,9 @@ public class AzureParametersDto {
 
     private final AzureResourceEncryptionParametersDto azureResourceEncryptionParametersDto;
 
-    private final boolean noOutboundLoadBalancer;
-
     private AzureParametersDto(Builder builder) {
         azureResourceGroupDto = builder.azureResourceGroupDto;
         azureResourceEncryptionParametersDto = builder.azureResourceEncryptionParametersDto;
-        noOutboundLoadBalancer = builder.noOutboundLoadBalancer;
     }
 
     public AzureResourceGroupDto getAzureResourceGroupDto() {
@@ -24,10 +21,6 @@ public class AzureParametersDto {
 
     public AzureResourceEncryptionParametersDto getAzureResourceEncryptionParametersDto() {
         return azureResourceEncryptionParametersDto;
-    }
-
-    public boolean isNoOutboundLoadBalancer() {
-        return noOutboundLoadBalancer;
     }
 
     public static Builder builder() {
@@ -39,7 +32,6 @@ public class AzureParametersDto {
         return "AzureParametersDto{"
                 + "azureResourceGroupDto=" + azureResourceGroupDto
                 + ", azureResourceEncryptionParametersDto=" + azureResourceEncryptionParametersDto
-                + ", isNoOutboundLoadBalancer=" + noOutboundLoadBalancer
                 + '}';
     }
 
@@ -50,8 +42,6 @@ public class AzureParametersDto {
 
         private AzureResourceEncryptionParametersDto azureResourceEncryptionParametersDto;
 
-        private boolean noOutboundLoadBalancer;
-
         public Builder withAzureResourceGroupDto(AzureResourceGroupDto azureResourceGroupDto) {
             this.azureResourceGroupDto = azureResourceGroupDto;
             return this;
@@ -59,11 +49,6 @@ public class AzureParametersDto {
 
         public Builder withAzureResourceEncryptionParametersDto(AzureResourceEncryptionParametersDto azureResourceEncryptionParametersDto) {
             this.azureResourceEncryptionParametersDto = azureResourceEncryptionParametersDto;
-            return this;
-        }
-
-        public Builder withNoOutboundLoadBalancer(boolean noOutboundLoadBalancer) {
-            this.noOutboundLoadBalancer = noOutboundLoadBalancer;
             return this;
         }
 


### PR DESCRIPTION
Context: This [PR](https://github.com/hortonworks/cloudbreak/pull/13925) creates the noOutboundLoadBalancer field in the Azure Environment params but it should be in the Azure Network.
This PR fix it without any change in the feature.

Test:

Testing:
Post to /environmentservice/api/v1/env

Condition:
When the Public endpoint gateway is disabled and it's a private network and noOutboundLoadBalancer is true
Should create just one load balancer (private)

When the noOutboundLoadBalancer is false
Should create two load balancers (private and outbound)

Json:
noOutboundLoadBalancer inside the network.azure
`{
	"name": "rod-env-no-outbound",
	"credentialName": "rod-cred",
	"regions": ["West US 2"],
	"location": {
		"name": "West US 2"
	},
	"network": {
		"subnetIds": ["sdx-daily.internal.0.westus2"],
		"serviceEndpointCreation": "ENABLED",
		"publicEndpointAccessGateway": "DISABLED",
		"azure": {
			"networkId": "sdx-daily",
			"resourceGroupName": "sdx-daily",
			"noPublicIp": true,
                        "noOutboundLoadBalancer": true
		}
	},
	"telemetry": {
		"logging": {
			"storageLocation": "abfs://data@rodnorazsan.dfs.core.windows.net",
			"adlsGen2": {
				"managedIdentity": "/subscriptions/94359766-1315-49e2-b5da-7578f428b58b/resourcegroups/rod-no-raz-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/loggerIdentity"
			}
		},
		"features": {}
	},
	"authentication": {
		"publicKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDEyHedSTmrdbtoh0ys0iNVK6M9tOQrzUk6F1GVVvBnz+9fGtEpy3Y4AJZOU/qWZzcktjHZl06tpRPLfRqs5fEYJVndsB7+nXOadsOL1XASlWDdTSEwYBuD4pQweoNuxVbE2INJsASLAL76wNnfHWz1sUPGXGkM7io9aPVjePQB7KaC+0f//6dtcsOY/1fBXXJhpc20/RvWQwzfN04rDKk5RF1zjbKpsuULO8xfiIqpjmPkHeVHK4OjExafGpN8BtjEWC8oVhrMpAj1L8N/mpJBCJKacTDBlgglSgGPc9W7Hf3Y1EeGGBMy5wHBCQ03t0ystOqBnsvDLqH5yf+OWuEp"
	},
	"freeIpa": {
		"create": true,
		"instanceCountByGroup": 2
	},
	"securityAccess": {
		"cidr": "0.0.0.0/0"
	},
	"tunnel": "DIRECT",
	"overrideTunnel": false,
	"azure": {
		"resourceGroup": {
			"name": "rod-no-raz-rg",
			"resourceGroupUsage": "SINGLE"
		}
	},
	"tags": {
		"owner": "ralves",
        "project": "SDX"
	}
}`