### PR TITLE
CDPSDX-3779 better estimation on database backup size

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
@@ -8,6 +8,8 @@ set -o nounset
 set -o pipefail
 
 LOGFILE=/var/log/dl_postgres_backup.log
+COMPRESS_FLAG="-Z 9"
+
 echo "Logs at ${LOGFILE}"
 
 exec 3>&1 4>&2
@@ -157,7 +159,7 @@ backup_database_for_service() {
 
   doLog "INFO Dumping ${SERVICE}"
   LOCAL_BACKUP=${DATE_DIR}/${SERVICE}_backup
-  pg_dump --host="$HOST" --port="$PORT" --username="$USERNAME" --dbname="$SERVICE" --format=plain --file="$LOCAL_BACKUP" > >(tee -a $LOGFILE) 2> >(tee -a $LOGFILE >&2) || errorExit "Unable to dump ${SERVICE}"
+  pg_dump --host="$HOST" --port="$PORT" --username="$USERNAME" --dbname="$SERVICE" $COMPRESS_FLAG --format=plain --file="$LOCAL_BACKUP" > >(tee -a $LOGFILE) 2> >(tee -a $LOGFILE >&2) || errorExit "Unable to dump ${SERVICE}"
   if [[ "$CLOSECONNECTIONS" == "true" ]]; then
     limit_incomming_connection $SERVICE -1
   fi


### PR DESCRIPTION
## Problem statement: 
we want to estimate how big our database backup will be.
## Proposed solution

Previously used _pg_database_size_  gives us the size of a database on disk. This includes data not used during backup - indexes, dead entries before vacuum other support structures etc. 

The new estimator query only takes into account data from public tables which should give a better estimate.

## Additional change
In order to keep backup smaller the `-Z 9` option is added for compression. Smaller backup takes less time to write to temp location (disk) and then to a cloud bucket.

## Testing
Short cycle:
- create LightDuty and login to _master_
- update salt (if not updated)
- perform backup and check database backup files successfully created in the cloud
- execute `/opt/salt/scripts/get_database_sizes.sh "" "" ""` to check sizes determined without errors

Full cycle:
- Start a backup procedure `cdp datalake backup-datalake --datalake-name $DATALAKE_NAME`
- request _determine datalake size_  `https --json --headers --body POST http://localhost:9091/cb/api/v4/1/stacks/$DATALAKE_NAME/determine_datalake_data_sizes operationId==$OPERATION_ID x-cdp-actor-crn:$ACTOR_ID x-cdp-request-id:`uuidgen` `
- check the _datalakdr.datalakedrstatusentity_internalstaterecords table for data `select * from datalakedrstatusentity_internalstaterecords where datalakedrstatusentity_droperationid = $OPERATION_ID`
- check the cloud backup location for database files
