### PR TITLE
CRB-2367 FIPS for AWS

### DIFF
--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsValidatorsTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsValidatorsTest.java
@@ -50,6 +50,9 @@ import com.sequenceiq.cloudbreak.cloud.aws.common.AwsSessionCredentialClient;
 import com.sequenceiq.cloudbreak.cloud.aws.common.AwsTagValidator;
 import com.sequenceiq.cloudbreak.cloud.aws.common.CommonAwsClient;
 import com.sequenceiq.cloudbreak.cloud.aws.common.config.AwsConfig;
+import com.sequenceiq.cloudbreak.cloud.aws.common.endpoint.AwsEndpointProvider;
+import com.sequenceiq.cloudbreak.cloud.aws.common.endpoint.AwsRegionEndpointProvider;
+import com.sequenceiq.cloudbreak.cloud.aws.common.endpoint.AwsServiceEndpointProvider;
 import com.sequenceiq.cloudbreak.cloud.aws.common.loadbalancer.LoadBalancerTypeConverter;
 import com.sequenceiq.cloudbreak.cloud.aws.common.mapper.SdkClientExceptionMapper;
 import com.sequenceiq.cloudbreak.cloud.aws.common.subnetselector.SubnetFilterStrategyMultiplePreferPrivate;
@@ -91,6 +94,9 @@ class AwsValidatorsTest {
 
     @Inject
     private AwsStackValidator awsStackValidatorUnderTest;
+
+    @Mock
+    private AwsEndpointProvider awsEndpointProvider;
 
     @Mock
     private AmazonCloudFormationClient amazonCloudFormationClient;
@@ -255,6 +261,9 @@ class AwsValidatorsTest {
             SubnetFilterStrategyMultiplePreferPublic.class,
             SubnetFilterStrategyMultiplePreferPrivate.class,
             SubnetSelectorService.class,
+            AwsEndpointProvider.class,
+            AwsRegionEndpointProvider.class,
+            AwsServiceEndpointProvider.class,
     })
     static class Config {
 

--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/endpoint/AwsEndpointProvider.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/endpoint/AwsEndpointProvider.java
@@ -1,0 +1,42 @@
+package com.sequenceiq.cloudbreak.cloud.aws.common.endpoint;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.amazonaws.client.builder.AwsClientBuilder;
+
+@Component
+public class AwsEndpointProvider {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsEndpointProvider.class);
+
+    @Value("${aws.fips.use.endpoint:false}")
+    private boolean fipsEnabled;
+
+    @Inject
+    private AwsRegionEndpointProvider awsRegionEndpointProvider;
+
+    @Inject
+    private AwsServiceEndpointProvider awsServiceEndpointProvider;
+
+    public <T extends AwsClientBuilder> void setupEndpoint(T clientBuilder, String service, String region, boolean govCloud) {
+        if (fipsEnabled && govCloud) {
+            LOGGER.debug("Aws FIPS endpoint will be used for {} service in {} region on govcloud", service, region);
+            clientBuilder.withEndpointConfiguration(endpointConfiguration(service, region, govCloud));
+        } else {
+            LOGGER.debug("Default aws endpoint will be used for {} service in {} region, govcloud: {}", service, region, govCloud);
+            clientBuilder.withRegion(region);
+        }
+    }
+
+    AwsClientBuilder.EndpointConfiguration endpointConfiguration(String service, String region, boolean govCloud) {
+        String servicePart = awsServiceEndpointProvider.service(service, govCloud);
+        String regionPart = awsRegionEndpointProvider.region(service, region, govCloud);
+        String endpoint = String.format("https://%s.%s.amazonaws.com", servicePart, regionPart);
+        LOGGER.debug("The aws endpoint for the {} service: {}", service, endpoint);
+        return new AwsClientBuilder.EndpointConfiguration(endpoint, region);
+    }
+}

--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/endpoint/AwsRegionEndpointProvider.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/endpoint/AwsRegionEndpointProvider.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.cloudbreak.cloud.aws.common.endpoint;
+
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AwsRegionEndpointProvider {
+
+    @Value("${aws.fips.region.independent.services:iam}")
+    private Set<String> regionIndependentServices;
+
+    public String region(String service, String region, boolean govCloud) {
+        return regionIndependentServices.contains(service) ? centralRegion(region, govCloud) : region;
+    }
+
+    private String centralRegion(String region, boolean govCloud) {
+        return govCloud ? "us-gov" : region;
+    }
+}

--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/endpoint/AwsServiceEndpointProvider.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/endpoint/AwsServiceEndpointProvider.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.cloudbreak.cloud.aws.common.endpoint;
+
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AwsServiceEndpointProvider {
+
+    @Value("${aws.fips.suffixed.services:kms,elasticfilesystem,s3}")
+    private Set<String> fipsSuffixedServices;
+
+    public String service(String service, boolean govCloud) {
+        return fipsSuffixedServices.contains(service) ? centralService(service, govCloud) : service;
+    }
+
+    private String centralService(String service, boolean govCloud) {
+        return govCloud ? (service + "-fips") : service;
+    }
+}

--- a/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/AwsAuthenticatorTest.java
+++ b/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/AwsAuthenticatorTest.java
@@ -27,6 +27,9 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonEc2Client;
+import com.sequenceiq.cloudbreak.cloud.aws.common.endpoint.AwsEndpointProvider;
+import com.sequenceiq.cloudbreak.cloud.aws.common.endpoint.AwsRegionEndpointProvider;
+import com.sequenceiq.cloudbreak.cloud.aws.common.endpoint.AwsServiceEndpointProvider;
 import com.sequenceiq.cloudbreak.cloud.aws.common.mapper.SdkClientExceptionMapper;
 import com.sequenceiq.cloudbreak.cloud.aws.common.util.AwsPageCollector;
 import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsCredentialView;
@@ -133,7 +136,10 @@ class AwsAuthenticatorTest {
             AwsSessionCredentialClient.class,
             AwsDefaultZoneProvider.class,
             AwsEnvironmentVariableChecker.class,
-            RetryService.class
+            RetryService.class,
+            AwsEndpointProvider.class,
+            AwsRegionEndpointProvider.class,
+            AwsServiceEndpointProvider.class
     })
     static class Config {
     }

--- a/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/AwsInstanceConnectorTest.java
+++ b/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/AwsInstanceConnectorTest.java
@@ -56,6 +56,9 @@ import com.amazonaws.services.ec2.model.StopInstancesRequest;
 import com.amazonaws.services.ec2.model.StopInstancesResult;
 import com.dyngr.exception.PollerStoppedException;
 import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonEc2Client;
+import com.sequenceiq.cloudbreak.cloud.aws.common.endpoint.AwsEndpointProvider;
+import com.sequenceiq.cloudbreak.cloud.aws.common.endpoint.AwsRegionEndpointProvider;
+import com.sequenceiq.cloudbreak.cloud.aws.common.endpoint.AwsServiceEndpointProvider;
 import com.sequenceiq.cloudbreak.cloud.aws.common.mapper.SdkClientExceptionMapper;
 import com.sequenceiq.cloudbreak.cloud.aws.common.poller.PollerUtil;
 import com.sequenceiq.cloudbreak.cloud.aws.common.util.AwsInstanceStatusMapper;
@@ -467,7 +470,10 @@ class AwsInstanceConnectorTest {
             AwsSessionCredentialClient.class,
             AwsDefaultZoneProvider.class,
             AwsEnvironmentVariableChecker.class,
-            RetryService.class
+            RetryService.class,
+            AwsEndpointProvider.class,
+            AwsRegionEndpointProvider.class,
+            AwsServiceEndpointProvider.class
     })
     static class Config {
     }

--- a/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/endpoint/AwsEndpointProviderTest.java
+++ b/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/endpoint/AwsEndpointProviderTest.java
@@ -1,0 +1,65 @@
+package com.sequenceiq.cloudbreak.cloud.aws.common.endpoint;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+@ExtendWith(MockitoExtension.class)
+class AwsEndpointProviderTest {
+
+    private static final String REGION = "region";
+
+    private static final String SERVICE = "service";
+
+    @Mock
+    private AwsRegionEndpointProvider awsRegionEndpointProvider;
+
+    @Mock
+    private AwsServiceEndpointProvider awsServiceEndpointProvider;
+
+    @InjectMocks
+    private AwsEndpointProvider underTest;
+
+    @ParameterizedTest(name = "With fipsEnabled={0}, govCloud: {1}, shouldRunEndpointConfig: {2}, expected: {3}")
+    @MethodSource("scenariosToGenerateEndpointConfig")
+    public void testValidateCloudStorageType(boolean fipsEnabled, boolean govCloud, boolean shouldRunEndpointConfig, String expected) {
+        ReflectionTestUtils.setField(underTest, "fipsEnabled", fipsEnabled);
+        AmazonS3ClientBuilder clientBuilder = AmazonS3ClientBuilder.standard()
+                .withForceGlobalBucketAccessEnabled(Boolean.TRUE);
+
+        if (shouldRunEndpointConfig) {
+            when(awsServiceEndpointProvider.service(SERVICE, govCloud)).thenReturn(SERVICE);
+            when(awsRegionEndpointProvider.region(SERVICE, REGION, govCloud)).thenReturn(REGION);
+        }
+
+        underTest.setupEndpoint(clientBuilder, SERVICE, REGION, govCloud);
+
+        if (shouldRunEndpointConfig) {
+            AwsClientBuilder.EndpointConfiguration endpoint = clientBuilder.getEndpoint();
+            assertEquals(expected, endpoint.getServiceEndpoint());
+        } else {
+            String region = clientBuilder.getRegion();
+            assertEquals(expected, region);
+        }
+    }
+
+    static Object[][] scenariosToGenerateEndpointConfig() {
+        return new Object[][]{
+                { true,  true,  true, "https://service.region.amazonaws.com"},
+                { true,  false, false, "region"},
+                { false, true,  false, "region"},
+                { false, false, false, "region"},
+        };
+    }
+
+}

--- a/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/endpoint/AwsRegionEndpointProviderTest.java
+++ b/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/endpoint/AwsRegionEndpointProviderTest.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.cloudbreak.cloud.aws.common.endpoint;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class AwsRegionEndpointProviderTest {
+
+    private AwsRegionEndpointProvider underTest = new AwsRegionEndpointProvider();
+
+    @BeforeEach
+    public void before() {
+        ReflectionTestUtils.setField(underTest, "regionIndependentServices", Set.of("iam"));
+    }
+
+    @ParameterizedTest(name = "With service: {0}, with region: {1}, with govCloud: {2}, expected: {3}.")
+    @MethodSource("scenariosForRegionProvider")
+    public void test(String inputService, String inputRegion, boolean govCloud, String expected) {
+        String region = underTest.region(inputService, inputRegion, govCloud);
+        assertEquals(expected, region);
+    }
+
+    static Object[][] scenariosForRegionProvider() {
+        return new Object[][]{
+                {"iam", "usgw1", true, "us-gov"},
+                {"iam", "usgw1", false, "usgw1"},
+                {"iam", "us-east-1", true, "us-gov"},
+                {"iam", "us-east-1", false, "us-east-1"},
+        };
+    }
+
+}

--- a/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/endpoint/AwsServiceEndpointProviderTest.java
+++ b/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/endpoint/AwsServiceEndpointProviderTest.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.cloudbreak.cloud.aws.common.endpoint;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class AwsServiceEndpointProviderTest {
+
+    private AwsServiceEndpointProvider underTest = new AwsServiceEndpointProvider();
+
+    @BeforeEach
+    public void before() {
+        ReflectionTestUtils.setField(underTest, "fipsSuffixedServices", Set.of("kms", "elasticfilesystem", "s3"));
+    }
+
+    @ParameterizedTest(name = "With service: {0}, with govCloud: {1}, expected: {2}.")
+    @MethodSource("scenariosForServiceProvider")
+    public void test(String inputService, boolean govCloud, String expected) {
+        String region = underTest.service(inputService, govCloud);
+        assertEquals(expected, region);
+    }
+
+    static Object[][] scenariosForServiceProvider() {
+        return new Object[][]{
+                {"kms", true, "kms-fips"},
+                {"kms", false, "kms"},
+
+                {"elasticfilesystem", true, "elasticfilesystem-fips"},
+                {"elasticfilesystem", false, "elasticfilesystem"},
+
+                {"s3", true, "s3-fips"},
+                {"s3", false, "s3"},
+
+                {"autoscale", true, "autoscale"},
+                {"autoscale", false, "autoscale"},
+        };
+    }
+
+}

--- a/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/validator/AwsStorageValidatorsTest.java
+++ b/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/validator/AwsStorageValidatorsTest.java
@@ -43,6 +43,9 @@ import com.sequenceiq.cloudbreak.cloud.aws.common.AwsSessionCredentialClient;
 import com.sequenceiq.cloudbreak.cloud.aws.common.AwsTagValidator;
 import com.sequenceiq.cloudbreak.cloud.aws.common.CommonAwsClient;
 import com.sequenceiq.cloudbreak.cloud.aws.common.config.AwsConfig;
+import com.sequenceiq.cloudbreak.cloud.aws.common.endpoint.AwsEndpointProvider;
+import com.sequenceiq.cloudbreak.cloud.aws.common.endpoint.AwsRegionEndpointProvider;
+import com.sequenceiq.cloudbreak.cloud.aws.common.endpoint.AwsServiceEndpointProvider;
 import com.sequenceiq.cloudbreak.cloud.aws.common.loadbalancer.LoadBalancerTypeConverter;
 import com.sequenceiq.cloudbreak.cloud.aws.common.mapper.SdkClientExceptionMapper;
 import com.sequenceiq.cloudbreak.cloud.aws.common.subnetselector.SubnetFilterStrategyMultiplePreferPrivate;
@@ -246,7 +249,10 @@ public class AwsStorageValidatorsTest {
             SubnetFilterStrategyMultiplePreferPublic.class,
             SubnetFilterStrategyMultiplePreferPrivate.class,
             SubnetSelectorService.class,
-            AwsPageCollector.class
+            AwsPageCollector.class,
+            AwsEndpointProvider.class,
+            AwsRegionEndpointProvider.class,
+            AwsServiceEndpointProvider.class
     })
     static class Config {
 

--- a/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsNativeMetadataCollectorApiIntegrationTest.java
+++ b/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsNativeMetadataCollectorApiIntegrationTest.java
@@ -32,6 +32,9 @@ import com.sequenceiq.cloudbreak.cloud.aws.common.AwsSessionCredentialClient;
 import com.sequenceiq.cloudbreak.cloud.aws.common.AwsTagValidator;
 import com.sequenceiq.cloudbreak.cloud.aws.common.CommonAwsClient;
 import com.sequenceiq.cloudbreak.cloud.aws.common.config.AwsConfig;
+import com.sequenceiq.cloudbreak.cloud.aws.common.endpoint.AwsEndpointProvider;
+import com.sequenceiq.cloudbreak.cloud.aws.common.endpoint.AwsRegionEndpointProvider;
+import com.sequenceiq.cloudbreak.cloud.aws.common.endpoint.AwsServiceEndpointProvider;
 import com.sequenceiq.cloudbreak.cloud.aws.common.loadbalancer.LoadBalancerTypeConverter;
 import com.sequenceiq.cloudbreak.cloud.aws.common.mapper.SdkClientExceptionMapper;
 import com.sequenceiq.cloudbreak.cloud.aws.common.subnetselector.SubnetFilterStrategyMultiplePreferPrivate;
@@ -177,7 +180,10 @@ class AwsNativeMetadataCollectorApiIntegrationTest {
             SubnetSelectorService.class,
             AwsEncodedAuthorizationFailureMessageDecoder.class,
             AwsConfig.class,
-            AwsPageCollector.class
+            AwsPageCollector.class,
+            AwsEndpointProvider.class,
+            AwsRegionEndpointProvider.class,
+            AwsServiceEndpointProvider.class
     })
     static class AwsNativeMetadataCollectorTestConfig {
 


### PR DESCRIPTION
… enabled. aws.fips.use.endpoint mut be true to enable this logic. By default it must be supported by AWS sdk but because of a bug we need this workaround until we do not upgrade to aws sdk v2.

See detailed description in the commit message.