### PR TITLE
CB-19579 CB-19578 Enable faillock for Redhat 8

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/top.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/top.sls
@@ -32,6 +32,7 @@ base:
              - nodestatus
              - freeipa.patch-pki-tomcat
              - freeipa.ldapagent
+             - faillock
 
            'roles:freeipa_replica':
              - match: grain
@@ -42,6 +43,7 @@ base:
              - nodestatus
              - freeipa.patch-pki-tomcat
              - freeipa.ldapagent
+             - faillock
 
            'roles:freeipa_primary_replacement':
              - match: grain
@@ -53,6 +55,7 @@ base:
              - nodestatus
              - freeipa.patch-pki-tomcat
              - freeipa.ldapagent
+             - faillock
 
            'recipes:post-cluster-install':
              - match: grain

--- a/orchestrator-salt/src/main/resources/salt-common/salt/faillock/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/faillock/init.sls
@@ -1,0 +1,6 @@
+{% if grains['os_family'] == 'RedHat' and grains['osmajorrelease'] | int == 8 %}
+enable-faillock:
+  cmd.run:
+    - name: authselect enable-feature with-faillock
+    - unless: grep -q "with-faillock" /etc/authselect/authselect.conf
+{% endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/top.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/top.sls
@@ -22,6 +22,7 @@ base:
   'G@roles:ipa_member and G@os_family:RedHat':
     - match: compound
     - sssd.ipa
+    - faillock
 
   'G@roles:manager_upgrade and G@roles:manager_server':
     - match: compound


### PR DESCRIPTION
When an instance is joining FreeIPA the SSSD and auth is reconfigured on RH8 so faillock has to be reenabled. The faillock configuration is part of the iamge.

Image related changes: https://github.com/hortonworks/cloudbreak-images/pull/755

See detailed description in the commit message.