### PR TITLE
CB-20216: Prevent CB from forcefully installing psycopg2 2.7.5 on RHEL8

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/init.sls
@@ -24,7 +24,7 @@ install-cloudera-manager-agent:
 
 {% endif %}
 
-{%- if not salt['pkg.version']('python-psycopg2') and not salt['pkg.version']('python2-psycopg2') %}
+{%- if not salt['pkg.version']('python-psycopg2') and not salt['pkg.version']('python2-psycopg2') and not salt['pkg.version']('python38-psycopg2') %}
 install-psycopg2:
   cmd.run:
     - name: pip install psycopg2==2.7.5 --ignore-installed


### PR DESCRIPTION
Package check that prevents unnecessary installation is only valid for CentOS 7, so added an additional check for RHEL8 as well.