### PR TITLE
CB-20208 Ensure password complexity is always satisfied

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/util/FreeIpaPasswordUtil.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/util/FreeIpaPasswordUtil.java
@@ -1,10 +1,13 @@
 package com.sequenceiq.cloudbreak.util;
 
+import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 public class FreeIpaPasswordUtil {
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     private static final int PWD_PREFIX_LENGTH = 3;
 
@@ -22,7 +25,8 @@ public class FreeIpaPasswordUtil {
         String numbers = PasswordUtil.getRandomNumeric(PWD_PART_LENGTH);
         String raw = upperCaseLetters.concat(lowerCaseLetters).concat(numbers).concat(SPECIAL_CHARS);
         List<String> list = Arrays.asList(raw.split(""));
-        Collections.shuffle(list);
+        Collections.shuffle(list, SECURE_RANDOM);
         return pwdPrefix.concat(String.join("", list));
     }
+
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/util/PasswordUtil.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/util/PasswordUtil.java
@@ -1,12 +1,17 @@
 package com.sequenceiq.cloudbreak.util;
 
 import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import org.apache.commons.lang3.RandomStringUtils;
 
 public class PasswordUtil {
 
-    private static final int PWD_LENGTH = 26;
+    private static final int PWD_PREFIX_LENGTH = 6;
+
+    private static final int PWD_PART_LENGTH = 10;
 
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
@@ -14,11 +19,13 @@ public class PasswordUtil {
     }
 
     public static String generatePassword() {
-        return getRandomLettersAndNumbers(PWD_LENGTH);
-    }
-
-    public static String getRandomLettersAndNumbers(int count) {
-        return generate(count, true, true);
+        String prefix = PasswordUtil.getRandomAlphabetic(PWD_PREFIX_LENGTH);
+        String letters = PasswordUtil.getRandomAlphabetic(PWD_PART_LENGTH);
+        String numbers = PasswordUtil.getRandomNumeric(PWD_PART_LENGTH);
+        String raw = letters.concat(numbers);
+        List<String> list = Arrays.asList(raw.split(""));
+        Collections.shuffle(list, SECURE_RANDOM);
+        return prefix.concat(String.join("", list));
     }
 
     public static String getRandomAlphabetic(int count) {
@@ -32,4 +39,5 @@ public class PasswordUtil {
     private static String generate(int count, boolean letters, boolean numbers) {
         return RandomStringUtils.random(count, 0, 0, letters, numbers, null, SECURE_RANDOM);
     }
+
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/cluster/ClusterV4Request.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/cluster/ClusterV4Request.java
@@ -30,9 +30,10 @@ public class ClusterV4Request implements JsonEntity {
     @ApiModelProperty(hidden = true)
     private String name;
 
-    @Size(max = 15, min = 5, message = "The length of the username has to be in range of 5 to 15")
+    @Size(max = 15, min = 5, message = "The length of the username has to be in the range of 5 to 15 characters")
     @Pattern(regexp = "(^[a-z][-a-z0-9]*[a-z0-9]$)",
-            message = "The username can only contain lowercase alphanumeric characters and hyphens and has start with an alphanumeric character")
+            message = "The username may only contain lowercase alphanumeric characters and hyphens, has to start with a letter and end with an " +
+                    "alphanumeric character")
     @ApiModelProperty(value = StackModelDescription.USERNAME)
     private String userName;
 
@@ -40,7 +41,7 @@ public class ClusterV4Request implements JsonEntity {
             @Pattern(regexp = "^.*[a-zA-Z].*$", message = "The password should contain at least one letter."),
             @Pattern(regexp = "^.*[0-9].*$", message = "The password should contain at least one number.")
     })
-    @Size(max = 100, min = 8, message = "The length of the password has to be in range of 8 to 100")
+    @Size(max = 100, min = 8, message = "The length of the password has to be in the range of 8 to 100 characters")
     @ApiModelProperty(value = StackModelDescription.PASSWORD)
     private String password;
 

--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/model/cluster/DistroXClusterV1Request.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/model/cluster/DistroXClusterV1Request.java
@@ -27,9 +27,10 @@ import io.swagger.annotations.ApiModelProperty;
 @JsonInclude(Include.NON_NULL)
 public class DistroXClusterV1Request implements Serializable {
 
-    @Size(max = 15, min = 5, message = "The length of the username has to be in range of 5 to 15")
+    @Size(max = 15, min = 5, message = "The length of the username has to be in the range of 5 to 15 characters")
     @Pattern(regexp = "(^[a-z][-a-z0-9]*[a-z0-9]$)",
-            message = "The username can only contain lowercase alphanumeric characters and hyphens and has start with an alphanumeric character")
+            message = "The username may only contain lowercase alphanumeric characters and hyphens, has to start with a letter and end with an " +
+                    "alphanumeric character")
     @ApiModelProperty(value = StackModelDescription.USERNAME, required = true)
     private String userName;
 
@@ -37,7 +38,7 @@ public class DistroXClusterV1Request implements Serializable {
             @Pattern(regexp = "^.*[a-zA-Z].*$", message = "The password should contain at least one letter."),
             @Pattern(regexp = "^.*[0-9].*$", message = "The password should contain at least one number.")
     })
-    @Size(max = 100, min = 8, message = "The length of the password has to be in range of 8 to 100")
+    @Size(max = 100, min = 8, message = "The length of the password has to be in the range of 8 to 100 characters")
     @ApiModelProperty(value = StackModelDescription.PASSWORD, required = true)
     private String password;
 


### PR DESCRIPTION
* `ClusterV4Request`, `DistroXClusterV1Request`: Fix validation error messages for `userName` and `password`.
* `FreeIpaPasswordUtil.generatePassword()`, `PasswordUtil.generatePassword()`: Use `SecureRandom` for the `Collections.shuffle()` call.
* `PasswordUtil`:
  * `generatePassword()`: Change logic to an adaptation of `FreeIpaPasswordUtil.generatePassword()`. The generated password will always start with a 6-char prefix of letters, followed by a random mix of 10-10 numbers and letters, thus still giving a total of 26 characters. While the letter prefix is not a strict requirement for sake of validations in `ClusterV4Request` & `DistroXClusterV1Request`, it still makes sense to use a behavior consistent with the FreeIPA password.
  * Remove unused `getRandomLettersAndNumbers()`.
