### PR TITLE
CB-20174 Generate embedded PostgreSQL server cert using FMS

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/init.sls
@@ -67,6 +67,28 @@ init-services-db-remote:
     - group: root
     - mode: 755
 
+{%- if postgresql.ssl_enabled == True %}
+
+/opt/salt/scripts/create_embeddeddb_certificate.sh:
+  file.managed:
+    - makedirs: True
+    - user: root
+    - group: postgres
+    - mode: 750
+    - source: salt://postgresql/scripts/create_embeddeddb_certificate.sh
+    - template: jinja
+    - context:
+        postgres_directory: {{ postgres_directory }}
+
+create_embeddeddb_certificate:
+  cmd.run:
+    - name: /opt/salt/scripts/create_embeddeddb_certificate.sh
+    - require:
+      - file: /opt/salt/scripts/create_embeddeddb_certificate.sh
+    - unless: test -f {{ postgres_directory }}/certs/postgres.cert
+
+{%- endif %}
+
 {%- endif %}
 
 {%- if salt['pillar.get']('postgres:postgres_version', '10') | int == 11 %}

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/create_embeddeddb_certificate.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/create_embeddeddb_certificate.sh
@@ -1,0 +1,27 @@
+{%- set postgres_fqdn = salt['grains.get']('fqdn') %}
+{%- set cm_keytab = salt['pillar.get']('keytab:CM') %}
+#!/usr/bin/env bash
+set -e
+
+function cleanup() {
+  kdestroy
+}
+
+trap cleanup EXIT
+
+CM_KEYTAB_FILE={{ cm_keytab.path }}
+CM_PRINCIPAL={{ cm_keytab.principal }}
+CERTS_DIR={{ postgres_directory }}/certs
+
+kinit -kt $CM_KEYTAB_FILE $CM_PRINCIPAL
+
+mkdir -p ${CERTS_DIR}
+
+openssl req -nodes -newkey rsa:2048 -days 365 -keyout ${CERTS_DIR}/postgres.key -out ${CERTS_DIR}/postgres.csr -subj "/CN={{postgres_fqdn}}"
+ipa cert-request ${CERTS_DIR}/postgres.csr --principal=postgres/{{ postgres_fqdn }} --add --certificate-out=${CERTS_DIR}/postgres.cert
+
+chown -R postgres:postgres ${CERTS_DIR}
+chmod 600 ${CERTS_DIR}/postgres.key
+rm -f ${CERTS_DIR}/postgres.csr
+
+set +e


### PR DESCRIPTION
* Extend the postgres/init salt state with certificate generation when postgres ssl is enabled
* Create a rsa:2048 keypair using openssl
* Sign the certificate with freeipa

First the certificate generation and sign was planned to be implemented in FMS service via API, but for this
the postgres server host has to be registered in FreeIPA. The host registration is happening during salt highstate,
so it is not possible to sign the certificate before salt highstate has finished. This is the reason why we choose
the previously described solution for certificate generation.
