### PR TITLE
CB-20216: Prevent CB from forcefully installing psycopg2 2.7.5 on RHEL8

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/init.sls
@@ -24,7 +24,7 @@ install-cloudera-manager-agent:
 
 {% endif %}
 
-{%- if not salt['pkg.version']('python-psycopg2') and not salt['pkg.version']('python2-psycopg2') %}
+{%- if not salt['pkg.version']('python-psycopg2') and not salt['pkg.version']('python2-psycopg2') and not salt['pkg.version']('python38-psycopg2') %}
 install-psycopg2:
   cmd.run:
     - name: pip install psycopg2==2.7.5 --ignore-installed


### PR DESCRIPTION
Same PR as #14020 but for 2.67

This originally was meant for 2.67 but sadly by the time comments and random GitHub check failures got ironed out, 2.67 got branched.