### PR TITLE
CB-18948 Targeted Endpoint Access Gateway creation - AWS

### DIFF
--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsLoadBalancerLaunchService.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsLoadBalancerLaunchService.java
@@ -217,11 +217,12 @@ public class AwsLoadBalancerLaunchService {
             LOGGER.debug(String.format("Checking final status of AWS target group %s", listener.getTargetGroup().getName()));
             createSuccess = createSuccess && isResourceStatusGood(summaries, listener.getTargetGroup().getName());
         }
-
+        Map<String, Object> params = Map.of(CloudResource.ATTRIBUTES, loadBalancer.getScheme().getLoadBalancerType());
         CloudResource.Builder cloudResource = new CloudResource.Builder()
             .withStatus(createSuccess ? CommonStatus.CREATED : CommonStatus.FAILED)
             .withType(ELASTIC_LOAD_BALANCER)
             .withAvailabilityZone(ac.getCloudContext().getLocation().getAvailabilityZone().value())
+            .withParameters(params)
             .withName(loadBalancer.getName());
 
         return new CloudResourceStatus(cloudResource.build(),

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsLoadBalancerLaunchServiceTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsLoadBalancerLaunchServiceTest.java
@@ -10,6 +10,7 @@ import static com.sequenceiq.common.api.type.InstanceGroupType.GATEWAY;
 import static com.sequenceiq.common.api.type.ResourceType.AWS_INSTANCE;
 import static com.sequenceiq.common.api.type.ResourceType.ELASTIC_LOAD_BALANCER;
 import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -27,6 +28,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
@@ -74,7 +76,7 @@ import com.sequenceiq.common.api.type.LoadBalancerType;
 import com.sequenceiq.common.api.type.OutboundInternetTraffic;
 
 @ExtendWith(MockitoExtension.class)
-class AwsLaunchServiceLoadBalancerTest {
+class AwsLoadBalancerLaunchServiceTest {
 
     private static final String PRIVATE_ID_1 = "private-id-1";
 
@@ -173,10 +175,11 @@ class AwsLaunchServiceLoadBalancerTest {
         when(cloudContext.getLocation()).thenReturn(location);
         when(location.getAvailabilityZone()).thenReturn(availabilityZone("az1"));
 
-        underTest.updateCloudformationWithLoadBalancers(ac, cloudStack, null, null);
+        List<CloudResourceStatus> statuses = underTest.updateCloudformationWithLoadBalancers(ac, cloudStack, null, null);
 
         verify(cfClient, times(2)).updateStack(any());
         verify(result, times(4)).getStackResourceSummaries();
+        assertEquals(LoadBalancerType.PRIVATE, statuses.get(0).getCloudResource().getParameter(CloudResource.ATTRIBUTES, LoadBalancerType.class));
     }
 
     @Test
@@ -198,10 +201,11 @@ class AwsLaunchServiceLoadBalancerTest {
         when(cloudContext.getLocation()).thenReturn(location);
         when(location.getAvailabilityZone()).thenReturn(availabilityZone("az1"));
 
-        underTest.updateCloudformationWithLoadBalancers(ac, cloudStack, null, null);
+        List<CloudResourceStatus> statuses = underTest.updateCloudformationWithLoadBalancers(ac, cloudStack, null, null);
 
         verify(cfClient, times(2)).updateStack(any());
         verify(result, times(4)).getStackResourceSummaries();
+        assertEquals(LoadBalancerType.PUBLIC, statuses.get(0).getCloudResource().getParameter(CloudResource.ATTRIBUTES, LoadBalancerType.class));
     }
 
     @Test
@@ -223,10 +227,15 @@ class AwsLaunchServiceLoadBalancerTest {
         when(cloudContext.getLocation()).thenReturn(location);
         when(location.getAvailabilityZone()).thenReturn(availabilityZone("az1"));
 
-        underTest.updateCloudformationWithLoadBalancers(ac, cloudStack, null, null);
+        List<CloudResourceStatus> statuses = underTest.updateCloudformationWithLoadBalancers(ac, cloudStack, null, null);
 
         verify(cfClient, times(2)).updateStack(any());
         verify(result, times(5)).getStackResourceSummaries();
+        Set<LoadBalancerType> loadBalancerTypes = statuses.stream()
+                .map(CloudResourceStatus::getCloudResource)
+                .map(r -> r.getParameter(CloudResource.ATTRIBUTES, LoadBalancerType.class))
+                .collect(Collectors.toSet());
+        assertThat(loadBalancerTypes).containsExactlyInAnyOrder(LoadBalancerType.PUBLIC, LoadBalancerType.PRIVATE);
     }
 
     @Test
@@ -384,6 +393,7 @@ class AwsLaunchServiceLoadBalancerTest {
         assertEquals(com.sequenceiq.cloudbreak.cloud.model.ResourceStatus.CREATED, statuses.get(0).getStatus());
         assertEquals(CREATED, statuses.get(0).getCloudResource().getStatus());
         assertEquals(ELASTIC_LOAD_BALANCER, statuses.get(0).getCloudResource().getType());
+        assertEquals(LoadBalancerType.PRIVATE, statuses.get(0).getCloudResource().getParameter(CloudResource.ATTRIBUTES, LoadBalancerType.class));
     }
 
     @Test
@@ -412,6 +422,7 @@ class AwsLaunchServiceLoadBalancerTest {
         assertEquals(com.sequenceiq.cloudbreak.cloud.model.ResourceStatus.FAILED, statuses.get(0).getStatus());
         assertEquals(FAILED, statuses.get(0).getCloudResource().getStatus());
         assertEquals(ELASTIC_LOAD_BALANCER, statuses.get(0).getCloudResource().getType());
+        assertEquals(LoadBalancerType.PRIVATE, statuses.get(0).getCloudResource().getParameter(CloudResource.ATTRIBUTES, LoadBalancerType.class));
     }
 
     @Test
@@ -440,6 +451,7 @@ class AwsLaunchServiceLoadBalancerTest {
         assertEquals(com.sequenceiq.cloudbreak.cloud.model.ResourceStatus.FAILED, statuses.get(0).getStatus());
         assertEquals(FAILED, statuses.get(0).getCloudResource().getStatus());
         assertEquals(ELASTIC_LOAD_BALANCER, statuses.get(0).getCloudResource().getType());
+        assertEquals(LoadBalancerType.PRIVATE, statuses.get(0).getCloudResource().getParameter(CloudResource.ATTRIBUTES, LoadBalancerType.class));
     }
 
     @Test
@@ -468,6 +480,7 @@ class AwsLaunchServiceLoadBalancerTest {
         assertEquals(com.sequenceiq.cloudbreak.cloud.model.ResourceStatus.FAILED, statuses.get(0).getStatus());
         assertEquals(FAILED, statuses.get(0).getCloudResource().getStatus());
         assertEquals(ELASTIC_LOAD_BALANCER, statuses.get(0).getCloudResource().getType());
+        assertEquals(LoadBalancerType.PRIVATE, statuses.get(0).getCloudResource().getParameter(CloudResource.ATTRIBUTES, LoadBalancerType.class));
     }
 
     @Test

--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/connector/resource/AwsLoadBalancerCommonService.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/connector/resource/AwsLoadBalancerCommonService.java
@@ -50,7 +50,7 @@ public class AwsLoadBalancerCommonService {
                 .map(lb -> lb.getType().name())
                 .collect(Collectors.toSet());
         Set<String> awsTypes = awsLoadBalancers.stream()
-                .map(lb -> AwsLoadBalancerScheme.INTERNAL.awsScheme().equals(lb.getAwsScheme()) ? "PRIVATE" : "PUBLIC")
+                .map(lb -> lb.getScheme().getLoadBalancerType().name())
                 .collect(Collectors.toSet());
         if (!requestedTypes.equals(awsTypes)) {
             throw new CloudConnectorException(String.format("Can not create all requested AWS load balancers. " +
@@ -86,7 +86,7 @@ public class AwsLoadBalancerCommonService {
             LOGGER.debug("Private load balancer detected. Using instance subnet for load balancer creation.");
             populateSubnetIds(awsNetworkView, cloudLoadBalancer, subnetIds);
         } else {
-            LOGGER.debug("Public load balancer detected. Using endpoint gateway subnet for load balancer creation.");
+            LOGGER.debug("{} load balancer detected. Using endpoint gateway subnet for load balancer creation.", type);
             subnetIds.addAll(awsNetworkView.getEndpointGatewaySubnetList());
             subnetIds.addAll(getEndpointGatewayMultiAZSubnets(cloudLoadBalancer));
             if (subnetIds.isEmpty()) {

--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/loadbalancer/AwsLoadBalancer.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/loadbalancer/AwsLoadBalancer.java
@@ -11,8 +11,6 @@ public class AwsLoadBalancer {
 
     private final AwsLoadBalancerScheme scheme;
 
-    private final String awsScheme;
-
     private final String name;
 
     private final List<AwsListener> listeners;
@@ -25,7 +23,6 @@ public class AwsLoadBalancer {
 
     public AwsLoadBalancer(AwsLoadBalancerScheme scheme) {
         this.scheme = scheme;
-        this.awsScheme = scheme.awsScheme();
         this.name = getLoadBalancerName(scheme);
         this.listeners = new ArrayList<>();
         this.subnetIds = new HashSet<>();
@@ -64,8 +61,12 @@ public class AwsLoadBalancer {
         this.arn = arn;
     }
 
+    /**
+     * AWS Scheme getter, needed for the aws-cf-stack.ftl FreeMarker template, used in model.
+     * @return AWS scheme ("internet-facing" or "internal")
+     */
     public String getAwsScheme() {
-        return awsScheme;
+        return scheme.awsScheme();
     }
 
     public boolean isListenerConfigSet() {

--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/loadbalancer/AwsLoadBalancerScheme.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/loadbalancer/AwsLoadBalancerScheme.java
@@ -1,16 +1,38 @@
 package com.sequenceiq.cloudbreak.cloud.aws.common.loadbalancer;
 
+import com.sequenceiq.common.api.type.LoadBalancerType;
+
 public enum AwsLoadBalancerScheme {
-    INTERNET_FACING("internet-facing", "External"),
-    INTERNAL("internal", "Internal");
+
+    /**
+     * It is used as an internet facing Load Balancer that has public IP address and can route traffic to private networks.
+     * Placed in a public subnet.
+     */
+    INTERNET_FACING("internet-facing", "External", LoadBalancerType.PUBLIC),
+
+    /**
+     * It is used as an internal Load Balancer by users who have access to the private network where this Load Balancer resides.
+     * It has private IP address and can route traffic to private networks.
+     * Placed in a private subnet.
+     */
+    GATEWAY_PRIVATE("internal", "GwayPriv", LoadBalancerType.GATEWAY_PRIVATE),
+
+    /**
+     * It is used as an internal Load Balancer for CDP Runtime services. It has private IP address and can route traffic to private networks.
+     * Placed in a private subnet.
+     */
+    INTERNAL("internal", "Internal", LoadBalancerType.PRIVATE);
 
     private final String awsScheme;
 
     private final String resourceName;
 
-    AwsLoadBalancerScheme(String awsScheme, String resourceName) {
+    private final LoadBalancerType loadBalancerType;
+
+    AwsLoadBalancerScheme(String awsScheme, String resourceName, LoadBalancerType loadBalancerType) {
         this.awsScheme = awsScheme;
         this.resourceName = resourceName;
+        this.loadBalancerType = loadBalancerType;
     }
 
     public String awsScheme() {
@@ -19,5 +41,9 @@ public enum AwsLoadBalancerScheme {
 
     public String resourceName() {
         return resourceName;
+    }
+
+    public LoadBalancerType getLoadBalancerType() {
+        return loadBalancerType;
     }
 }

--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/loadbalancer/LoadBalancerTypeConverter.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/loadbalancer/LoadBalancerTypeConverter.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.cloud.aws.common.loadbalancer;
 
+import static com.sequenceiq.cloudbreak.cloud.aws.common.loadbalancer.AwsLoadBalancerScheme.GATEWAY_PRIVATE;
 import static com.sequenceiq.cloudbreak.cloud.aws.common.loadbalancer.AwsLoadBalancerScheme.INTERNAL;
 import static com.sequenceiq.cloudbreak.cloud.aws.common.loadbalancer.AwsLoadBalancerScheme.INTERNET_FACING;
 
@@ -15,12 +16,22 @@ public class LoadBalancerTypeConverter {
         switch (type) {
             case PUBLIC:
                 return INTERNET_FACING;
+            case GATEWAY_PRIVATE:
+                return GATEWAY_PRIVATE;
             case PRIVATE:
             default:
                 return INTERNAL;
         }
     }
 
+    /**
+     * Converts AWS API LB scheme to CB internal LB type.
+     * The latter contains an extra GATEWAY_PRIVATE which is determined in the {@link AwsNativeMetadataCollector#describeLoadBalancer}
+     * based on CloudResource metadata.
+     *
+     * @param type AWS Load Balancer Scheme ("internet-facing" or "internal") from AWS API response
+     * @return CB-internal {@link LoadBalancerType}
+     */
     public LoadBalancerType convert(String type) {
         LoadBalancerSchemeEnum awsLoadBalancerScheme = LoadBalancerSchemeEnum.fromValue(type);
         switch (awsLoadBalancerScheme) {

--- a/cloud-aws-native/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/resource/loadbalancer/AwsNativeLoadBalancerLaunchService.java
+++ b/cloud-aws-native/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/resource/loadbalancer/AwsNativeLoadBalancerLaunchService.java
@@ -168,11 +168,13 @@ public class AwsNativeLoadBalancerLaunchService {
                     .orElseThrow()
                     .getLoadBalancerArn();
             context.setLoadBalancerArn(loadBalancerArn);
+            Map<String, Object> params = Map.of(CloudResource.ATTRIBUTES, awsLoadBalancer.getScheme().getLoadBalancerType());
             loadBalancerResource = new CloudResource.Builder()
                     .withName(loadBalancerName)
                     .withType(ResourceType.ELASTIC_LOAD_BALANCER)
                     .withReference(loadBalancerArn)
                     .withStatus(CommonStatus.CREATED)
+                    .withParameters(params)
                     .build();
             context.getPersistenceNotifier().notifyAllocation(loadBalancerResource, context.getCloudContext());
         }

--- a/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/resource/loadbalancer/AwsNativeLoadBalancerLaunchServiceTest.java
+++ b/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/resource/loadbalancer/AwsNativeLoadBalancerLaunchServiceTest.java
@@ -4,6 +4,7 @@ import static com.sequenceiq.cloudbreak.cloud.aws.resource.loadbalancer.AwsNativ
 import static com.sequenceiq.cloudbreak.cloud.aws.resource.loadbalancer.AwsNativeLoadBalancerLaunchService.DUPLICATE_LOAD_BALANCER_NAME_ERROR_CODE;
 import static com.sequenceiq.cloudbreak.cloud.aws.resource.loadbalancer.AwsNativeLoadBalancerLaunchService.DUPLICATE_TARGET_GROUP_NAME_ERROR_CODE;
 import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -16,12 +17,15 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
@@ -62,6 +66,7 @@ import com.sequenceiq.cloudbreak.cloud.notification.PersistenceRetriever;
 import com.sequenceiq.cloudbreak.cloud.service.ResourceRetriever;
 import com.sequenceiq.cloudbreak.common.network.NetworkConstants;
 import com.sequenceiq.common.api.type.CommonStatus;
+import com.sequenceiq.common.api.type.LoadBalancerType;
 import com.sequenceiq.common.api.type.ResourceType;
 
 @ExtendWith(MockitoExtension.class)
@@ -100,6 +105,14 @@ class AwsNativeLoadBalancerLaunchServiceTest {
     private static final String TG_NAME_EXTERNAL_NEW = "sta-TG443External-20221028102030";
 
     private static final String TG_NAME_EXTERNAL_NO_HASH = "sta-TG443External";
+
+    private static final String LB_NAME_GWAYPRIV_NEW = "stackn-LBGwayPriv-20221028102030";
+
+    private static final String LB_NAME_GWAYPRIV_NO_HASH = "stackn-LBGwayPriv";
+
+    private static final String TG_NAME_GWAYPRIV_NEW = "sta-TG443GwayPriv-20221028102030";
+
+    private static final String TG_NAME_GWAYPRIV_NO_HASH = "sta-TG443GwayPriv";
 
     private static final String INTERNAL = "Internal";
 
@@ -217,6 +230,7 @@ class AwsNativeLoadBalancerLaunchServiceTest {
         ArgumentCaptor<CloudResource> cloudResourceArgumentCaptor = ArgumentCaptor.forClass(CloudResource.class);
         verify(persistenceNotifier, times(1)).notifyAllocation(cloudResourceArgumentCaptor.capture(), any());
         assertEquals(ResourceType.ELASTIC_LOAD_BALANCER, cloudResourceArgumentCaptor.getValue().getType());
+        assertEquals(LoadBalancerType.PRIVATE, cloudResourceArgumentCaptor.getValue().getParameter(CloudResource.ATTRIBUTES, LoadBalancerType.class));
     }
 
     @Test
@@ -243,6 +257,7 @@ class AwsNativeLoadBalancerLaunchServiceTest {
         ArgumentCaptor<CloudResource> cloudResourceArgumentCaptor = ArgumentCaptor.forClass(CloudResource.class);
         verify(persistenceNotifier, times(1)).notifyAllocation(cloudResourceArgumentCaptor.capture(), any());
         assertEquals(ResourceType.ELASTIC_LOAD_BALANCER, cloudResourceArgumentCaptor.getValue().getType());
+        assertEquals(LoadBalancerType.PRIVATE, cloudResourceArgumentCaptor.getValue().getParameter(CloudResource.ATTRIBUTES, LoadBalancerType.class));
     }
 
     @Test
@@ -280,6 +295,11 @@ class AwsNativeLoadBalancerLaunchServiceTest {
                 .anyMatch(cloudResource -> ResourceType.ELASTIC_LOAD_BALANCER.equals(cloudResource.getType())));
         assertTrue(cloudResourceArgumentCaptor.getAllValues().stream()
                 .anyMatch(cloudResource -> ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP.equals(cloudResource.getType())));
+        Set<LoadBalancerType> loadBalancerTypes = cloudResourceArgumentCaptor.getAllValues().stream()
+                .filter(r -> ResourceType.ELASTIC_LOAD_BALANCER == r.getType())
+                .map(r -> r.getParameter(CloudResource.ATTRIBUTES, LoadBalancerType.class))
+                .collect(Collectors.toSet());
+        assertThat(loadBalancerTypes).containsExactly(LoadBalancerType.PRIVATE);
     }
 
     @Test
@@ -320,6 +340,11 @@ class AwsNativeLoadBalancerLaunchServiceTest {
                 .anyMatch(cloudResource -> ResourceType.ELASTIC_LOAD_BALANCER.equals(cloudResource.getType())));
         assertTrue(cloudResourceArgumentCaptor.getAllValues().stream()
                 .anyMatch(cloudResource -> ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP.equals(cloudResource.getType())));
+        Set<LoadBalancerType> loadBalancerTypes = cloudResourceArgumentCaptor.getAllValues().stream()
+                .filter(r -> ResourceType.ELASTIC_LOAD_BALANCER == r.getType())
+                .map(r -> r.getParameter(CloudResource.ATTRIBUTES, LoadBalancerType.class))
+                .collect(Collectors.toSet());
+        assertThat(loadBalancerTypes).containsExactly(LoadBalancerType.PRIVATE);
     }
 
     @Test
@@ -365,6 +390,11 @@ class AwsNativeLoadBalancerLaunchServiceTest {
                 .anyMatch(cloudResource -> ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP.equals(cloudResource.getType())));
         assertTrue(cloudResourceArgumentCaptor.getAllValues().stream()
                 .anyMatch(cloudResource -> ResourceType.ELASTIC_LOAD_BALANCER_LISTENER.equals(cloudResource.getType())));
+        Set<LoadBalancerType> loadBalancerTypes = cloudResourceArgumentCaptor.getAllValues().stream()
+                .filter(r -> ResourceType.ELASTIC_LOAD_BALANCER == r.getType())
+                .map(r -> r.getParameter(CloudResource.ATTRIBUTES, LoadBalancerType.class))
+                .collect(Collectors.toSet());
+        assertThat(loadBalancerTypes).containsExactly(LoadBalancerType.PRIVATE);
     }
 
     @Test
@@ -413,28 +443,31 @@ class AwsNativeLoadBalancerLaunchServiceTest {
                 .anyMatch(cloudResource -> ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP.equals(cloudResource.getType())));
         assertTrue(cloudResourceArgumentCaptor.getAllValues().stream()
                 .anyMatch(cloudResource -> ResourceType.ELASTIC_LOAD_BALANCER_LISTENER.equals(cloudResource.getType())));
+        Set<LoadBalancerType> loadBalancerTypes = cloudResourceArgumentCaptor.getAllValues().stream()
+                .filter(r -> ResourceType.ELASTIC_LOAD_BALANCER == r.getType())
+                .map(r -> r.getParameter(CloudResource.ATTRIBUTES, LoadBalancerType.class))
+                .collect(Collectors.toSet());
+        assertThat(loadBalancerTypes).containsExactly(LoadBalancerType.PRIVATE);
     }
 
     @ParameterizedTest(name = "{0}")
-    @ValueSource(booleans = {false, true})
-    void testLaunchLoadBalancerResourcesWhenAllResourcesCouldBeCreated(boolean internal) {
+    @EnumSource(AwsLoadBalancerScheme.class)
+    void testLaunchLoadBalancerResourcesWhenAllResourcesCouldBeCreated(AwsLoadBalancerScheme awsLoadBalancerScheme) {
         CloudStack stack = getCloudStack();
-        when(loadBalancerCommonService.getAwsLoadBalancers(any(), any(), any())).thenReturn(List.of(
-                getAwsLoadBalancer(internal ? AwsLoadBalancerScheme.INTERNAL : AwsLoadBalancerScheme.INTERNET_FACING)));
-        String scheme = internal ? INTERNAL : EXTERNAL;
-        String lbNameNew = internal ? LB_NAME_INTERNAL_NEW : LB_NAME_EXTERNAL_NEW;
-        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER, STACK_NAME, scheme)).thenReturn(lbNameNew);
-        when(resourceNameService.trimHash(lbNameNew)).thenReturn(internal ? LB_NAME_INTERNAL_NO_HASH : LB_NAME_EXTERNAL_NO_HASH);
+        when(loadBalancerCommonService.getAwsLoadBalancers(any(), any(), any())).thenReturn(List.of(getAwsLoadBalancer(awsLoadBalancerScheme)));
+        String lbNameNew = getLbName(awsLoadBalancerScheme);
+        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER, STACK_NAME, awsLoadBalancerScheme.resourceName())).thenReturn(lbNameNew);
+        when(resourceNameService.trimHash(lbNameNew)).thenReturn(getLbNameNoHash(awsLoadBalancerScheme));
         when(resourceRetriever
                 .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER, STACK_ID)).thenReturn(List.of());
         LoadBalancer loadBalancer = new LoadBalancer()
                 .withLoadBalancerArn("anARN");
         CreateLoadBalancerResult loadBalancerResult = new CreateLoadBalancerResult().withLoadBalancers(loadBalancer);
         when(loadBalancingClient.registerLoadBalancer(any())).thenReturn(loadBalancerResult);
-        String tgNameNew = internal ? TG_NAME_INTERNAL_NEW : TG_NAME_EXTERNAL_NEW;
-        when(resourceNameService.resourceName(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, STACK_NAME, scheme, USER_FACING_PORT))
-                .thenReturn(tgNameNew);
-        when(resourceNameService.trimHash(tgNameNew)).thenReturn(internal ? TG_NAME_INTERNAL_NO_HASH : TG_NAME_EXTERNAL_NO_HASH);
+        String tgNameNew = getTgName(awsLoadBalancerScheme);
+        when(resourceNameService.resourceName(
+                ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, STACK_NAME, awsLoadBalancerScheme.resourceName(), USER_FACING_PORT)).thenReturn(tgNameNew);
+        when(resourceNameService.trimHash(tgNameNew)).thenReturn(getTgNameNoHash(awsLoadBalancerScheme));
         when(resourceRetriever
                 .findAllByStatusAndTypeAndStack(CommonStatus.CREATED, ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, STACK_ID)).thenReturn(List.of());
         TargetGroup targetGroup = new TargetGroup()
@@ -466,6 +499,11 @@ class AwsNativeLoadBalancerLaunchServiceTest {
         assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER, ResourceStatus.CREATED));
         assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, ResourceStatus.CREATED));
         assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER_LISTENER, ResourceStatus.CREATED));
+        Set<LoadBalancerType> loadBalancerTypes = cloudResourceArgumentCaptor.getAllValues().stream()
+                .filter(r -> ResourceType.ELASTIC_LOAD_BALANCER == r.getType())
+                .map(r -> r.getParameter(CloudResource.ATTRIBUTES, LoadBalancerType.class))
+                .collect(Collectors.toSet());
+        assertThat(loadBalancerTypes).containsExactly(awsLoadBalancerScheme.getLoadBalancerType());
     }
 
     @ParameterizedTest(name = "{0}")
@@ -582,6 +620,11 @@ class AwsNativeLoadBalancerLaunchServiceTest {
         assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER, ResourceStatus.CREATED));
         assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, ResourceStatus.CREATED));
         assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER_LISTENER, ResourceStatus.CREATED));
+        Set<LoadBalancerType> loadBalancerTypes = cloudResourceArgumentCaptor.getAllValues().stream()
+                .filter(r -> ResourceType.ELASTIC_LOAD_BALANCER == r.getType())
+                .map(r -> r.getParameter(CloudResource.ATTRIBUTES, LoadBalancerType.class))
+                .collect(Collectors.toSet());
+        assertThat(loadBalancerTypes).containsExactly(existingInternal ? LoadBalancerType.PUBLIC : LoadBalancerType.PRIVATE);
     }
 
     @ParameterizedTest(name = "{0}")
@@ -638,6 +681,11 @@ class AwsNativeLoadBalancerLaunchServiceTest {
         assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER, ResourceStatus.CREATED));
         assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, ResourceStatus.CREATED));
         assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER_LISTENER, ResourceStatus.CREATED));
+        Set<LoadBalancerType> loadBalancerTypes = cloudResourceArgumentCaptor.getAllValues().stream()
+                .filter(r -> ResourceType.ELASTIC_LOAD_BALANCER == r.getType())
+                .map(r -> r.getParameter(CloudResource.ATTRIBUTES, LoadBalancerType.class))
+                .collect(Collectors.toSet());
+        assertThat(loadBalancerTypes).containsExactly(internal ? LoadBalancerType.PRIVATE : LoadBalancerType.PUBLIC);
     }
 
     @ParameterizedTest(name = "{0}")
@@ -699,6 +747,11 @@ class AwsNativeLoadBalancerLaunchServiceTest {
         assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER, ResourceStatus.CREATED));
         assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, ResourceStatus.CREATED));
         assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER_LISTENER, ResourceStatus.CREATED));
+        Set<LoadBalancerType> loadBalancerTypes = cloudResourceArgumentCaptor.getAllValues().stream()
+                .filter(r -> ResourceType.ELASTIC_LOAD_BALANCER == r.getType())
+                .map(r -> r.getParameter(CloudResource.ATTRIBUTES, LoadBalancerType.class))
+                .collect(Collectors.toSet());
+        assertThat(loadBalancerTypes).containsExactly(existingInternal ? LoadBalancerType.PUBLIC : LoadBalancerType.PRIVATE);
     }
 
     @ParameterizedTest(name = "{0}")
@@ -755,6 +808,11 @@ class AwsNativeLoadBalancerLaunchServiceTest {
         assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER, ResourceStatus.CREATED));
         assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, ResourceStatus.CREATED));
         assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER_LISTENER, ResourceStatus.CREATED));
+        Set<LoadBalancerType> loadBalancerTypes = cloudResourceArgumentCaptor.getAllValues().stream()
+                .filter(r -> ResourceType.ELASTIC_LOAD_BALANCER == r.getType())
+                .map(r -> r.getParameter(CloudResource.ATTRIBUTES, LoadBalancerType.class))
+                .collect(Collectors.toSet());
+        assertThat(loadBalancerTypes).containsExactly(internal ? LoadBalancerType.PRIVATE : LoadBalancerType.PUBLIC);
     }
 
     @ParameterizedTest(name = "{0}")
@@ -817,6 +875,11 @@ class AwsNativeLoadBalancerLaunchServiceTest {
         assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER, ResourceStatus.CREATED));
         assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP, ResourceStatus.CREATED));
         assertTrue(resourceExistsWithTypeAndStatus(statuses, ResourceType.ELASTIC_LOAD_BALANCER_LISTENER, ResourceStatus.CREATED));
+        Set<LoadBalancerType> loadBalancerTypes = cloudResourceArgumentCaptor.getAllValues().stream()
+                .filter(r -> ResourceType.ELASTIC_LOAD_BALANCER == r.getType())
+                .map(r -> r.getParameter(CloudResource.ATTRIBUTES, LoadBalancerType.class))
+                .collect(Collectors.toSet());
+        assertThat(loadBalancerTypes).containsExactly(existingInternal ? LoadBalancerType.PUBLIC : LoadBalancerType.PRIVATE);
     }
 
     private CloudStack getCloudStack() {
@@ -840,4 +903,55 @@ class AwsNativeLoadBalancerLaunchServiceTest {
                 .anyMatch(status -> resourceType.equals(status.getCloudResource().getType()) && resourceStatus.equals(status.getStatus()));
     }
 
+    private String getLbName(AwsLoadBalancerScheme awsLoadBalancerScheme) {
+        switch (awsLoadBalancerScheme) {
+            case INTERNET_FACING:
+                return LB_NAME_EXTERNAL_NEW;
+            case GATEWAY_PRIVATE:
+                return LB_NAME_GWAYPRIV_NEW;
+            case INTERNAL:
+                return LB_NAME_INTERNAL_NEW;
+            default:
+                throw new IllegalStateException("Unexpected value: " + awsLoadBalancerScheme);
+        }
+    }
+
+    private String getLbNameNoHash(AwsLoadBalancerScheme awsLoadBalancerScheme) {
+        switch (awsLoadBalancerScheme) {
+            case INTERNET_FACING:
+                return LB_NAME_EXTERNAL_NO_HASH;
+            case GATEWAY_PRIVATE:
+                return LB_NAME_GWAYPRIV_NO_HASH;
+            case INTERNAL:
+                return LB_NAME_INTERNAL_NO_HASH;
+            default:
+                throw new IllegalStateException("Unexpected value: " + awsLoadBalancerScheme);
+        }
+    }
+
+    private String getTgName(AwsLoadBalancerScheme awsLoadBalancerScheme) {
+        switch (awsLoadBalancerScheme) {
+            case INTERNET_FACING:
+                return TG_NAME_EXTERNAL_NEW;
+            case GATEWAY_PRIVATE:
+                return TG_NAME_GWAYPRIV_NEW;
+            case INTERNAL:
+                return TG_NAME_INTERNAL_NEW;
+            default:
+                throw new IllegalStateException("Unexpected value: " + awsLoadBalancerScheme);
+        }
+    }
+
+    private String getTgNameNoHash(AwsLoadBalancerScheme awsLoadBalancerScheme) {
+        switch (awsLoadBalancerScheme) {
+            case INTERNET_FACING:
+                return TG_NAME_EXTERNAL_NO_HASH;
+            case GATEWAY_PRIVATE:
+                return TG_NAME_GWAYPRIV_NO_HASH;
+            case INTERNAL:
+                return TG_NAME_INTERNAL_NO_HASH;
+            default:
+                throw new IllegalStateException("Unexpected value: " + awsLoadBalancerScheme);
+        }
+    }
 }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureMetadataCollector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureMetadataCollector.java
@@ -154,8 +154,8 @@ public class AzureMetadataCollector implements MetadataCollector {
                 Optional<String> ip;
                 if (LoadBalancerType.PUBLIC.equals(type)) {
                     ip = lookupPublicIp(resourceGroup, azureClient, loadBalancerName);
-                } else if (LoadBalancerType.PRIVATE.equals(type)) {
-                    ip = lookupPrivateIp(resourceGroup, azureClient, loadBalancerName);
+                } else if (LoadBalancerType.PRIVATE.equals(type) || LoadBalancerType.GATEWAY_PRIVATE.equals(type)) {
+                    ip = lookupPrivateIp(resourceGroup, azureClient, loadBalancerName, type);
                 } else {
                     ip = Optional.empty();
                 }
@@ -186,8 +186,8 @@ public class AzureMetadataCollector implements MetadataCollector {
         return azurePlatformResources.collectInstanceStorageCount(ac, instanceTypes);
     }
 
-    private Optional<String> lookupPrivateIp(String resourceGroup, AzureClient azureClient, String loadBalancerName) {
-        List<String> privateIps = azureClient.getLoadBalancerIps(resourceGroup, loadBalancerName, LoadBalancerType.PRIVATE);
+    private Optional<String> lookupPrivateIp(String resourceGroup, AzureClient azureClient, String loadBalancerName, LoadBalancerType type) {
+        List<String> privateIps = azureClient.getLoadBalancerIps(resourceGroup, loadBalancerName, type);
         if (privateIps.isEmpty()) {
             LOGGER.warn("Unable to find private ip address for load balancer {}", loadBalancerName);
             return Optional.empty();

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
@@ -746,6 +746,7 @@ public class AzureClient {
     public List<String> getLoadBalancerIps(String resourceGroupName, String loadBalancerName, LoadBalancerType loadBalancerType) {
         switch (loadBalancerType) {
             case PRIVATE:
+            case GATEWAY_PRIVATE:
                 return getLoadBalancerPrivateIps(resourceGroupName, loadBalancerName);
             case PUBLIC:
                 return getLoadBalancerIps(resourceGroupName, loadBalancerName);

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureMetadataCollectorTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureMetadataCollectorTest.java
@@ -43,7 +43,7 @@ import com.sequenceiq.common.api.type.LoadBalancerType;
 import com.sequenceiq.common.api.type.ResourceType;
 
 @ExtendWith(MockitoExtension.class)
-public class AzureMetadataCollectorTest {
+class AzureMetadataCollectorTest {
 
     private static final List<CloudInstance> KNOWN_INSTANCES = Collections.emptyList();
 
@@ -81,6 +81,8 @@ public class AzureMetadataCollectorTest {
 
     private static final String SECOND_PUBLIC_IP = "10.32.13.1";
 
+    private static final String GATEWAY_PRIVATE_IP = "10.132.113.101";
+
     @InjectMocks
     private AzureMetadataCollector underTest;
 
@@ -106,7 +108,7 @@ public class AzureMetadataCollectorTest {
     private AzureLoadBalancerMetadataCollector azureLbMetadataCollector;
 
     @Test
-    public void testCollectShouldReturnsTheAllVmMetadata() {
+    void testCollectShouldReturnsTheAllVmMetadata() {
         List<CloudResource> resources = Collections.emptyList();
         List<CloudInstance> vms = createVms();
         CloudResource cloudResource = createCloudResource();
@@ -190,7 +192,7 @@ public class AzureMetadataCollectorTest {
     }
 
     @Test
-    public void testCollectSinglePublicLoadBalancer() {
+    void testCollectSinglePublicLoadBalancer() {
         List<CloudResource> resources = new ArrayList<>();
         CloudResource cloudResource = createCloudResource();
 
@@ -200,7 +202,7 @@ public class AzureMetadataCollectorTest {
         when(azureUtils.getTemplateResource(resources)).thenReturn(cloudResource);
         when(azureUtils.getStackName(any())).thenReturn(STACK_NAME);
 
-        final String loadBalancerName = AzureLoadBalancer.getLoadBalancerName(LoadBalancerType.PUBLIC, STACK_NAME);
+        String loadBalancerName = AzureLoadBalancer.getLoadBalancerName(LoadBalancerType.PUBLIC, STACK_NAME);
         when(azureClient.getLoadBalancerIps(RESOURCE_GROUP_NAME, loadBalancerName, LoadBalancerType.PUBLIC))
                 .thenReturn(List.of(PUBLIC_IP));
 
@@ -215,7 +217,7 @@ public class AzureMetadataCollectorTest {
     }
 
     @Test
-    public void testCollectSinglePublicLoadBalancerWithMultipleIps() {
+    void testCollectSinglePublicLoadBalancerWithMultipleIps() {
         List<CloudResource> resources = new ArrayList<>();
         CloudResource cloudResource = createCloudResource();
 
@@ -225,7 +227,7 @@ public class AzureMetadataCollectorTest {
         when(azureUtils.getTemplateResource(resources)).thenReturn(cloudResource);
         when(azureUtils.getStackName(any())).thenReturn(STACK_NAME);
 
-        final String loadBalancerName = AzureLoadBalancer.getLoadBalancerName(LoadBalancerType.PUBLIC, STACK_NAME);
+        String loadBalancerName = AzureLoadBalancer.getLoadBalancerName(LoadBalancerType.PUBLIC, STACK_NAME);
         when(azureClient.getLoadBalancerIps(RESOURCE_GROUP_NAME, loadBalancerName, LoadBalancerType.PUBLIC))
                 .thenReturn(List.of(PUBLIC_IP, SECOND_PUBLIC_IP));
 
@@ -234,16 +236,15 @@ public class AzureMetadataCollectorTest {
 
         List<CloudLoadBalancerMetadata> result = underTest.collectLoadBalancer(authenticatedContext, List.of(LoadBalancerType.PUBLIC), resources);
 
-
         // We're retrieving only one Public IP address by design
         assertEquals(1, result.size());
         assertEquals(LoadBalancerType.PUBLIC, result.get(0).getType());
-        final String resultIpAddress = result.get(0).getIp();
+        String resultIpAddress = result.get(0).getIp();
         assertTrue(PUBLIC_IP.equals(resultIpAddress) || SECOND_PUBLIC_IP.equals(resultIpAddress));
     }
 
     @Test
-    public void testCollectPublicAndPrivateLoadBalancer() {
+    void testCollectPublicAndPrivateLoadBalancer() {
         List<CloudResource> resources = new ArrayList<>();
         CloudResource cloudResource = createCloudResource();
 
@@ -253,11 +254,11 @@ public class AzureMetadataCollectorTest {
         when(azureUtils.getTemplateResource(resources)).thenReturn(cloudResource);
         when(azureUtils.getStackName(any())).thenReturn(STACK_NAME);
 
-        final String publicLoadBalancerName = AzureLoadBalancer.getLoadBalancerName(LoadBalancerType.PUBLIC, STACK_NAME);
+        String publicLoadBalancerName = AzureLoadBalancer.getLoadBalancerName(LoadBalancerType.PUBLIC, STACK_NAME);
         when(azureClient.getLoadBalancerIps(RESOURCE_GROUP_NAME, publicLoadBalancerName, LoadBalancerType.PUBLIC))
                 .thenReturn(List.of(PUBLIC_IP));
 
-        final String privateLoadBalancerName = AzureLoadBalancer.getLoadBalancerName(LoadBalancerType.PRIVATE, STACK_NAME);
+        String privateLoadBalancerName = AzureLoadBalancer.getLoadBalancerName(LoadBalancerType.PRIVATE, STACK_NAME);
         when(azureClient.getLoadBalancerIps(RESOURCE_GROUP_NAME, privateLoadBalancerName, LoadBalancerType.PRIVATE))
                 .thenReturn(List.of(PRIVATE_IP));
 
@@ -282,7 +283,7 @@ public class AzureMetadataCollectorTest {
     }
 
     @Test
-    public void testCollectPrivateLoadBalancer() {
+    void testCollectPrivateLoadBalancer() {
         List<CloudResource> resources = new ArrayList<>();
         CloudResource cloudResource = createCloudResource();
 
@@ -292,7 +293,7 @@ public class AzureMetadataCollectorTest {
         when(azureUtils.getTemplateResource(resources)).thenReturn(cloudResource);
         when(azureUtils.getStackName(any())).thenReturn(STACK_NAME);
 
-        final String privateLoadBalancerName = AzureLoadBalancer.getLoadBalancerName(LoadBalancerType.PRIVATE, STACK_NAME);
+        String privateLoadBalancerName = AzureLoadBalancer.getLoadBalancerName(LoadBalancerType.PRIVATE, STACK_NAME);
         when(azureClient.getLoadBalancerIps(RESOURCE_GROUP_NAME, privateLoadBalancerName, LoadBalancerType.PRIVATE))
                 .thenReturn(List.of(PRIVATE_IP));
 
@@ -307,7 +308,7 @@ public class AzureMetadataCollectorTest {
     }
 
     @Test
-    public void testCollectPrivateLoadBalancerWithMultipleIps() {
+    void testCollectGatewayPrivateLoadBalancer() {
         List<CloudResource> resources = new ArrayList<>();
         CloudResource cloudResource = createCloudResource();
 
@@ -317,7 +318,32 @@ public class AzureMetadataCollectorTest {
         when(azureUtils.getTemplateResource(resources)).thenReturn(cloudResource);
         when(azureUtils.getStackName(any())).thenReturn(STACK_NAME);
 
-        final String privateLoadBalancerName = AzureLoadBalancer.getLoadBalancerName(LoadBalancerType.PRIVATE, STACK_NAME);
+        String privateLoadBalancerName = AzureLoadBalancer.getLoadBalancerName(LoadBalancerType.GATEWAY_PRIVATE, STACK_NAME);
+        when(azureClient.getLoadBalancerIps(RESOURCE_GROUP_NAME, privateLoadBalancerName, LoadBalancerType.GATEWAY_PRIVATE))
+                .thenReturn(List.of(GATEWAY_PRIVATE_IP));
+
+        when(authenticatedContext.getParameter(AzureClient.class)).thenReturn(azureClient);
+        when(azureLbMetadataCollector.getParameters(any(), anyString(), anyString())).thenReturn(Map.of());
+
+        List<CloudLoadBalancerMetadata> result = underTest.collectLoadBalancer(authenticatedContext, List.of(LoadBalancerType.GATEWAY_PRIVATE), resources);
+
+        assertEquals(1, result.size());
+        assertEquals(LoadBalancerType.GATEWAY_PRIVATE, result.get(0).getType());
+        assertEquals(GATEWAY_PRIVATE_IP, result.get(0).getIp());
+    }
+
+    @Test
+    void testCollectPrivateLoadBalancerWithMultipleIps() {
+        List<CloudResource> resources = new ArrayList<>();
+        CloudResource cloudResource = createCloudResource();
+
+        when(authenticatedContext.getCloudContext()).thenReturn(mockCloudContext);
+        when(mockCloudContext.getName()).thenReturn(RESOURCE_GROUP_NAME);
+
+        when(azureUtils.getTemplateResource(resources)).thenReturn(cloudResource);
+        when(azureUtils.getStackName(any())).thenReturn(STACK_NAME);
+
+        String privateLoadBalancerName = AzureLoadBalancer.getLoadBalancerName(LoadBalancerType.PRIVATE, STACK_NAME);
         when(azureClient.getLoadBalancerIps(RESOURCE_GROUP_NAME, privateLoadBalancerName, LoadBalancerType.PRIVATE))
                 .thenReturn(List.of(PRIVATE_IP, "10.23.12.1"));
 
@@ -332,7 +358,7 @@ public class AzureMetadataCollectorTest {
     }
 
     @Test
-    public void testCollectLoadBalancerWithNoIps() {
+    void testCollectLoadBalancerWithNoIps() {
         List<CloudResource> resources = new ArrayList<>();
         CloudResource cloudResource = createCloudResource();
 
@@ -353,7 +379,7 @@ public class AzureMetadataCollectorTest {
     }
 
     @Test
-    public void testCollectLoadBalancerSkipsMetadataWhenRuntimeExceptionIsThrown() {
+    void testCollectLoadBalancerSkipsMetadataWhenRuntimeExceptionIsThrown() {
         List<CloudResource> resources = new ArrayList<>();
         CloudResource cloudResource = createCloudResource();
 
@@ -363,7 +389,7 @@ public class AzureMetadataCollectorTest {
         when(azureUtils.getTemplateResource(resources)).thenReturn(cloudResource);
         when(azureUtils.getStackName(any())).thenReturn(STACK_NAME);
 
-        final String privateLoadBalancerName = AzureLoadBalancer.getLoadBalancerName(LoadBalancerType.PRIVATE, STACK_NAME);
+        String privateLoadBalancerName = AzureLoadBalancer.getLoadBalancerName(LoadBalancerType.PRIVATE, STACK_NAME);
         when(azureClient.getLoadBalancerIps(RESOURCE_GROUP_NAME, privateLoadBalancerName, LoadBalancerType.PRIVATE))
                 .thenThrow(new RuntimeException());
 

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpLoadBalancerScheme.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpLoadBalancerScheme.java
@@ -4,6 +4,7 @@ import com.sequenceiq.common.api.type.LoadBalancerType;
 
 public enum GcpLoadBalancerScheme {
     INTERNAL("INTERNAL", LoadBalancerType.PRIVATE),
+    GATEWAY_INTERNAL("INTERNAL", LoadBalancerType.GATEWAY_PRIVATE),
     EXTERNAL("EXTERNAL", LoadBalancerType.PUBLIC);
 
     private final String gcpType;

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpLoadBalancerTypeConverter.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpLoadBalancerTypeConverter.java
@@ -1,10 +1,12 @@
 package com.sequenceiq.cloudbreak.cloud.gcp.loadbalancer;
 
 import static com.sequenceiq.cloudbreak.cloud.gcp.loadbalancer.GcpLoadBalancerScheme.EXTERNAL;
+import static com.sequenceiq.cloudbreak.cloud.gcp.loadbalancer.GcpLoadBalancerScheme.GATEWAY_INTERNAL;
 import static com.sequenceiq.cloudbreak.cloud.gcp.loadbalancer.GcpLoadBalancerScheme.INTERNAL;
 
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.cloud.gcp.GcpMetadataCollector;
 import com.sequenceiq.cloudbreak.cloud.model.CloudLoadBalancer;
 
 @Component
@@ -14,12 +16,22 @@ public class GcpLoadBalancerTypeConverter {
         switch (cloudLoadBalancer.getType()) {
             case PUBLIC:
                 return EXTERNAL;
+            case GATEWAY_PRIVATE:
+                return GATEWAY_INTERNAL;
             case PRIVATE:
             default:
                 return INTERNAL;
         }
     }
 
+    /**
+     * Converts GCP API LB scheme to CB internal GCP LB scheme.
+     * The latter contains an extra GATEWAY_PRIVATE which is determined in the {@link GcpMetadataCollector#collectLoadBalancer}
+     * based on CloudResource metadata.
+     *
+     * @param gcpType GCP Load Balancer Scheme (EXTERNAL or INTERNAL) from GCP API response
+     * @return CB-internal GCP-specific LB scheme
+     */
     public GcpLoadBalancerScheme getScheme(String gcpType) {
         if (EXTERNAL.getGcpType().equals(gcpType)) {
             return EXTERNAL;

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpMetadataCollectorTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpMetadataCollectorTest.java
@@ -1,12 +1,16 @@
 package com.sequenceiq.cloudbreak.cloud.gcp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -19,25 +23,34 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.google.api.services.compute.Compute;
 import com.google.api.services.compute.model.AccessConfig;
+import com.google.api.services.compute.model.ForwardingRule;
+import com.google.api.services.compute.model.ForwardingRuleList;
 import com.google.api.services.compute.model.NetworkInterface;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.gcp.client.GcpComputeFactory;
+import com.sequenceiq.cloudbreak.cloud.gcp.loadbalancer.GcpLoadBalancerScheme;
+import com.sequenceiq.cloudbreak.cloud.gcp.loadbalancer.GcpLoadBalancerTypeConverter;
 import com.sequenceiq.cloudbreak.cloud.gcp.util.GcpStackUtil;
 import com.sequenceiq.cloudbreak.cloud.model.AvailabilityZone;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
+import com.sequenceiq.cloudbreak.cloud.model.CloudLoadBalancerMetadata;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudVmMetaDataStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.Location;
+import com.sequenceiq.cloudbreak.cloud.model.Region;
 import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.CommonStatus;
+import com.sequenceiq.common.api.type.LoadBalancerType;
 import com.sequenceiq.common.api.type.ResourceType;
 
 @ExtendWith(MockitoExtension.class)
-public class GcpMetadataCollectorTest {
+class GcpMetadataCollectorTest {
 
     private static final String AZ = "europe-north1";
 
@@ -57,11 +70,21 @@ public class GcpMetadataCollectorTest {
 
     private static final String DISC_NAME = "testcluster-w-network";
 
+    private static final String PUBLIC_LB_NAME = "publicLb";
+
+    private static final String PRIVATE_LB_NAME = "privateLb";
+
+    private static final String GATEWAY_PRIVATE_LB_NAME = "gwPrivateLb";
+
     private static final List<CloudInstance> KNOWN_INSTANCES = Collections.emptyList();
 
     private static final String PUBLIC_IP = "192.168.1.1";
 
     private static final String PRIVATE_IP = "10.10.1.1";
+
+    private static final String PROJECT_ID = "projectId";
+
+    private static final String REGION = "region";
 
     @InjectMocks
     private GcpMetadataCollector underTest;
@@ -72,19 +95,26 @@ public class GcpMetadataCollectorTest {
     @Mock
     private GcpStackUtil gcpStackUtil;
 
+    @Mock
+    private GcpComputeFactory gcpComputeFactory;
+
+    @Mock
+    private GcpLoadBalancerTypeConverter gcpLoadBalancerTypeConverter;
+
     private AuthenticatedContext authenticatedContext;
 
     private List<CloudResource> resources;
 
     @BeforeEach
-    public void before() {
+    void before() {
         authenticatedContext = createAuthenticatedContext();
         resources = createCloudResources();
-        when(gcpStackUtil.getPrivateId(anyString())).thenReturn(1L);
+        lenient().when(gcpStackUtil.getPrivateId(anyString())).thenReturn(1L);
+        lenient().when(gcpStackUtil.getProjectId(any(CloudCredential.class))).thenReturn(PROJECT_ID);
     }
 
     @Test
-    public void testCollectShouldReturnsWithTheVmMetadataListWithoutError() {
+    void testCollectShouldReturnsWithTheVmMetadataListWithoutError() {
         List<CloudInstance> vms = createVms();
         Map<String, Optional<NetworkInterface>> networkInterfaces = createNetworkInterfaces();
         when(gcpNetworkInterfaceProvider.provide(eq(authenticatedContext), any())).thenReturn(networkInterfaces);
@@ -108,7 +138,7 @@ public class GcpMetadataCollectorTest {
     }
 
     @Test
-    public void testCollectShouldReturnsWithVmsInUnknownStatusWhenThereAreNoNetworkInterfaceFound() {
+    void testCollectShouldReturnsWithVmsInUnknownStatusWhenThereAreNoNetworkInterfaceFound() {
         List<CloudInstance> vms = createVms();
         Map<String, Optional<NetworkInterface>> networkInterfaces = createEmptyNetworkInterfaces();
         when(gcpNetworkInterfaceProvider.provide(eq(authenticatedContext), any())).thenReturn(networkInterfaces);
@@ -132,7 +162,7 @@ public class GcpMetadataCollectorTest {
     }
 
     @Test
-    public void testCollectShouldReturnsWithVmsInTerminatedStatusWhenThereAreMoVmFound() {
+    void testCollectShouldReturnsWithVmsInTerminatedStatusWhenThereAreMoVmFound() {
         List<CloudInstance> vms = createVmsWithOtherIds();
         Map<String, Optional<NetworkInterface>> networkInterfaces = createEmptyNetworkInterfaces();
         when(gcpNetworkInterfaceProvider.provide(eq(authenticatedContext), any())).thenReturn(networkInterfaces);
@@ -153,6 +183,63 @@ public class GcpMetadataCollectorTest {
         assertEquals(InstanceStatus.TERMINATED, vm3.getCloudVmInstanceStatus().getStatus());
         assertNull(vm3.getMetaData().getPublicIp());
         assertNull(vm3.getMetaData().getPrivateIp());
+    }
+
+    @Test
+    void testCollectLoadBalancerPublicAndPrivate() throws IOException {
+        Compute compute = mock(Compute.class);
+        when(gcpComputeFactory.buildCompute(authenticatedContext.getCloudCredential())).thenReturn(compute);
+        Compute.ForwardingRules forwardingRules = mock(Compute.ForwardingRules.class);
+        when(compute.forwardingRules()).thenReturn(forwardingRules);
+        Compute.ForwardingRules.List forwardingRulesList = mock(Compute.ForwardingRules.List.class);
+        when(forwardingRules.list(PROJECT_ID, REGION)).thenReturn(forwardingRulesList);
+        ForwardingRuleList fwList = new ForwardingRuleList();
+        ForwardingRule fwr1 = new ForwardingRule();
+        fwr1.setIPAddress("ipaddr1");
+        fwr1.setName(PRIVATE_LB_NAME);
+        fwr1.setLoadBalancingScheme("INTERNAL");
+        ForwardingRule fwr2 = new ForwardingRule();
+        fwr2.setIPAddress("ipaddr2");
+        fwr2.setName(PUBLIC_LB_NAME);
+        fwr2.setLoadBalancingScheme("EXTERNAL");
+        fwList.setItems(List.of(fwr1, fwr2));
+        when(forwardingRulesList.execute()).thenReturn(fwList);
+        when(gcpLoadBalancerTypeConverter.getScheme("INTERNAL")).thenReturn(GcpLoadBalancerScheme.INTERNAL);
+        when(gcpLoadBalancerTypeConverter.getScheme("EXTERNAL")).thenReturn(GcpLoadBalancerScheme.EXTERNAL);
+
+        List<CloudLoadBalancerMetadata> result =
+                underTest.collectLoadBalancer(authenticatedContext, List.of(LoadBalancerType.PUBLIC, LoadBalancerType.PRIVATE), resources);
+
+        assertThat(result).hasSize(2);
+        assertThat(result).map(CloudLoadBalancerMetadata::getType).containsExactlyInAnyOrder(LoadBalancerType.PUBLIC, LoadBalancerType.PRIVATE);
+    }
+
+    @Test
+    void testCollectLoadBalancerGatewayAndPrivate() throws IOException {
+        Compute compute = mock(Compute.class);
+        when(gcpComputeFactory.buildCompute(authenticatedContext.getCloudCredential())).thenReturn(compute);
+        Compute.ForwardingRules forwardingRules = mock(Compute.ForwardingRules.class);
+        when(compute.forwardingRules()).thenReturn(forwardingRules);
+        Compute.ForwardingRules.List forwardingRulesList = mock(Compute.ForwardingRules.List.class);
+        when(forwardingRules.list(PROJECT_ID, REGION)).thenReturn(forwardingRulesList);
+        ForwardingRuleList fwList = new ForwardingRuleList();
+        ForwardingRule fwr1 = new ForwardingRule();
+        fwr1.setIPAddress("ipaddr1");
+        fwr1.setName(PRIVATE_LB_NAME);
+        fwr1.setLoadBalancingScheme("INTERNAL");
+        ForwardingRule fwr2 = new ForwardingRule();
+        fwr2.setIPAddress("ipaddr2");
+        fwr2.setName(GATEWAY_PRIVATE_LB_NAME);
+        fwr2.setLoadBalancingScheme("INTERNAL");
+        fwList.setItems(List.of(fwr1, fwr2));
+        when(forwardingRulesList.execute()).thenReturn(fwList);
+        when(gcpLoadBalancerTypeConverter.getScheme("INTERNAL")).thenReturn(GcpLoadBalancerScheme.INTERNAL);
+
+        List<CloudLoadBalancerMetadata> result =
+                underTest.collectLoadBalancer(authenticatedContext, List.of(LoadBalancerType.GATEWAY_PRIVATE, LoadBalancerType.PRIVATE), resources);
+
+        assertThat(result).hasSize(2);
+        assertThat(result).map(CloudLoadBalancerMetadata::getType).containsExactlyInAnyOrder(LoadBalancerType.GATEWAY_PRIVATE, LoadBalancerType.PRIVATE);
     }
 
     private CloudVmMetaDataStatus getVm(String name, List<CloudVmMetaDataStatus> actual) {
@@ -211,12 +298,12 @@ public class GcpMetadataCollectorTest {
 
     private AuthenticatedContext createAuthenticatedContext() {
         CloudContext cloudContext = createCloudContext();
-        CloudCredential cloudCredential = new CloudCredential("1", "gcp-cred", Collections.singletonMap("projectId", "gcp-cred"), "acc");
+        CloudCredential cloudCredential = new CloudCredential("1", "gcp-cred", Collections.singletonMap(PROJECT_ID, "gcp-cred"), "acc");
         return new AuthenticatedContext(cloudContext, cloudCredential);
     }
 
     private CloudContext createCloudContext() {
-        Location location = Location.location(null, AvailabilityZone.availabilityZone(AZ));
+        Location location = Location.location(Region.region(REGION), AvailabilityZone.availabilityZone(AZ));
         return CloudContext.Builder.builder()
                 .withName("test-cluster")
                 .withLocation(location)
@@ -226,19 +313,26 @@ public class GcpMetadataCollectorTest {
 
     private List<CloudResource> createCloudResources() {
         return List.of(
-                createCloudResource(INSTANCE_NAME_1, ResourceType.GCP_INSTANCE),
-                createCloudResource(INSTANCE_NAME_2, ResourceType.GCP_INSTANCE),
-                createCloudResource(INSTANCE_NAME_3, ResourceType.GCP_INSTANCE),
-                createCloudResource(DISC_NAME, ResourceType.GCP_ATTACHED_DISK),
-                createCloudResource(NETWORK_NAME, ResourceType.GCP_NETWORK));
+            createCloudResource(INSTANCE_NAME_1, ResourceType.GCP_INSTANCE),
+            createCloudResource(INSTANCE_NAME_2, ResourceType.GCP_INSTANCE),
+            createCloudResource(INSTANCE_NAME_3, ResourceType.GCP_INSTANCE),
+            createCloudResource(DISC_NAME, ResourceType.GCP_ATTACHED_DISK),
+            createCloudResource(NETWORK_NAME, ResourceType.GCP_NETWORK),
+            createCloudResource(PUBLIC_LB_NAME, ResourceType.GCP_FORWARDING_RULE, Map.of(CloudResource.ATTRIBUTES, LoadBalancerType.PUBLIC)),
+            createCloudResource(GATEWAY_PRIVATE_LB_NAME, ResourceType.GCP_FORWARDING_RULE, Map.of(CloudResource.ATTRIBUTES, LoadBalancerType.GATEWAY_PRIVATE)),
+            createCloudResource(PRIVATE_LB_NAME, ResourceType.GCP_FORWARDING_RULE, Map.of(CloudResource.ATTRIBUTES, LoadBalancerType.PRIVATE)));
     }
 
     private CloudResource createCloudResource(String name, ResourceType type) {
+        return createCloudResource(name, type, Collections.emptyMap());
+    }
+
+    private CloudResource createCloudResource(String name, ResourceType type, Map<String, Object> params) {
         return CloudResource.builder()
                 .withName(name)
                 .withType(type)
                 .withStatus(CommonStatus.CREATED)
-                .withParameters(Collections.emptyMap())
+                .withParameters(params)
                 .build();
     }
 }

--- a/common-model/src/main/java/com/sequenceiq/common/api/type/LoadBalancerType.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/type/LoadBalancerType.java
@@ -1,7 +1,55 @@
 package com.sequenceiq.common.api.type;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum LoadBalancerType {
+    /**
+     * Internet-facing public Load Balancer for the Gateway (CM/Knox)
+     */
     PUBLIC,
+
+    /**
+     * Internal Load Balancer for CDP Runtime services, e.g. Oozie
+     */
     PRIVATE,
-    OUTBOUND
+
+    /**
+     * Private Load Balancer for the Gateway (CM/Knox)
+     */
+    GATEWAY_PRIVATE,
+
+    /**
+     * Azure-specific Load Balancer type
+     */
+    OUTBOUND;
+
+    private final Class<LoadBalancerType> attributeType = LoadBalancerType.class;
+
+    /**
+     * Needed for serialization
+     * @return name of the enum
+     */
+    public String getName() {
+        return name();
+    }
+
+    /**
+     * Needed for serialization
+     * @return class of the current enum
+     */
+    public Class<LoadBalancerType> getAttributeType() {
+        return attributeType;
+    }
+
+    /**
+     * Needed for deserialization
+     * @param name String representation of the enum to be deserialized
+     */
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public static LoadBalancerType create(@JsonProperty("name") String name) {
+        return valueOf(name);
+    }
 }

--- a/core-model/src/test/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/TargetGroupTest.java
+++ b/core-model/src/test/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/TargetGroupTest.java
@@ -9,10 +9,10 @@ import org.junit.jupiter.api.Test;
 
 import com.sequenceiq.common.api.type.TargetGroupType;
 
-public class TargetGroupTest {
+class TargetGroupTest {
 
     @Test
-    public void testSetCannotContainDuplicateTypes() {
+    void testSetCannotContainDuplicateTypes() {
         TargetGroup tg1 = new TargetGroup();
         tg1.setType(TargetGroupType.KNOX);
         TargetGroup tg2 = new TargetGroup();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/StackToTemplatePreparationObjectConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/StackToTemplatePreparationObjectConverter.java
@@ -69,7 +69,7 @@ import com.sequenceiq.cloudbreak.service.idbroker.IdBrokerService;
 import com.sequenceiq.cloudbreak.service.identitymapping.AwsMockAccountMappingService;
 import com.sequenceiq.cloudbreak.service.identitymapping.AzureMockAccountMappingService;
 import com.sequenceiq.cloudbreak.service.identitymapping.GcpMockAccountMappingService;
-import com.sequenceiq.cloudbreak.service.loadbalancer.LoadBalancerConfigService;
+import com.sequenceiq.cloudbreak.service.loadbalancer.LoadBalancerFqdnUtil;
 import com.sequenceiq.cloudbreak.service.rdsconfig.RedbeamsDbCertificateProvider;
 import com.sequenceiq.cloudbreak.service.sharedservice.DatalakeService;
 import com.sequenceiq.cloudbreak.tag.AccountTagValidationFailed;
@@ -182,7 +182,7 @@ public class StackToTemplatePreparationObjectConverter {
     private GrpcUmsClient grpcUmsClient;
 
     @Inject
-    private LoadBalancerConfigService loadBalancerConfigService;
+    private LoadBalancerFqdnUtil loadBalancerFqdnUtil;
 
     @Inject
     private TransactionService transactionService;
@@ -418,7 +418,7 @@ public class StackToTemplatePreparationObjectConverter {
                 generalClusterConfigs.setPrimaryGatewayInstanceDiscoveryFQDN(Optional.of(stack.getPrimaryGatewayInstance().getDiscoveryFQDN()));
             }
         }
-        generalClusterConfigs.setLoadBalancerGatewayFqdn(Optional.ofNullable(loadBalancerConfigService.getLoadBalancerUserFacingFQDN(source.getId())));
+        generalClusterConfigs.setLoadBalancerGatewayFqdn(Optional.ofNullable(loadBalancerFqdnUtil.getLoadBalancerUserFacingFQDN(source.getId())));
         generalClusterConfigs.setAccountId(Optional.ofNullable(Crn.safeFromString(source.getResourceCrn()).getAccountId()));
         return generalClusterConfigs;
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverter.java
@@ -80,7 +80,7 @@ import com.sequenceiq.cloudbreak.dto.StackDtoDelegate;
 import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
 import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
 import com.sequenceiq.cloudbreak.service.image.ImageService;
-import com.sequenceiq.cloudbreak.service.loadbalancer.LoadBalancerConfigService;
+import com.sequenceiq.cloudbreak.service.loadbalancer.TargetGroupPortProvider;
 import com.sequenceiq.cloudbreak.service.stack.DefaultRootVolumeSizeProvider;
 import com.sequenceiq.cloudbreak.service.stack.InstanceGroupService;
 import com.sequenceiq.cloudbreak.service.stack.LoadBalancerPersistenceService;
@@ -135,7 +135,7 @@ public class StackToCloudStackConverter {
     private InstanceGroupService instanceGroupService;
 
     @Inject
-    private LoadBalancerConfigService loadBalancerConfigService;
+    private TargetGroupPortProvider targetGroupPortProvider;
 
     public CloudStack convert(StackDtoDelegate stack) {
         return convert(stack, Collections.emptySet());
@@ -339,7 +339,7 @@ public class StackToCloudStackConverter {
         for (LoadBalancer loadBalancer : loadBalancerPersistenceService.findByStackId(stack.getId())) {
             CloudLoadBalancer cloudLoadBalancer = new CloudLoadBalancer(loadBalancer.getType(), loadBalancer.getSku());
             for (TargetGroup targetGroup : targetGroupPersistenceService.findByLoadBalancerId(loadBalancer.getId())) {
-                Set<TargetGroupPortPair> portPairs = loadBalancerConfigService.getTargetGroupPortPairs(targetGroup);
+                Set<TargetGroupPortPair> portPairs = targetGroupPortProvider.getTargetGroupPortPairs(targetGroup);
                 Set<String> targetInstanceGroupName = instanceGroupService.findByTargetGroupId(targetGroup.getId()).stream()
                         .map(InstanceGroupView::getGroupName)
                         .collect(Collectors.toSet());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/EnvironmentBaseNetworkConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/EnvironmentBaseNetworkConverter.java
@@ -11,9 +11,12 @@ import java.util.Optional;
 import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
 import com.sequenceiq.cloudbreak.common.converter.MissingResourceNameGenerator;
 import com.sequenceiq.cloudbreak.common.json.Json;
@@ -30,6 +33,9 @@ public abstract class EnvironmentBaseNetworkConverter implements EnvironmentNetw
 
     @Inject
     private SubnetSelector subnetSelector;
+
+    @Inject
+    private EntitlementService entitlementService;
 
     @Override
     public Network convertToLegacyNetwork(EnvironmentNetworkResponse source, String availabilityZone) {
@@ -57,10 +63,15 @@ public abstract class EnvironmentBaseNetworkConverter implements EnvironmentNetw
         attributes.put(SUBNET_ID, cloudSubnet.getId());
         attributes.put(CLOUD_PLATFORM, getCloudPlatform().name());
         attributes.putAll(getAttributesForLegacyNetwork(source));
-        if (PublicEndpointAccessGateway.ENABLED.equals(source.getPublicEndpointAccessGateway())) {
+        if (PublicEndpointAccessGateway.ENABLED.equals(source.getPublicEndpointAccessGateway()) || isTargetingEndpointGateway(source)) {
             attachEndpointGatewaySubnet(source, attributes, cloudSubnet);
         }
         return attributes;
+    }
+
+    private boolean isTargetingEndpointGateway(EnvironmentNetworkResponse network) {
+        return entitlementService.isTargetingSubnetsForEndpointAccessGatewayEnabled(ThreadBasedUserCrnProvider.getAccountId()) &&
+                CollectionUtils.isNotEmpty(network.getEndpointGatewaySubnetIds());
     }
 
     /**

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverter.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -539,8 +540,8 @@ public class StackV4RequestToStackConverter {
                 instanceGroupNetworkV4Request.getAws() != null) {
             EnvironmentNetworkResponse envNetwork = environment == null ? null : environment.getNetwork();
             if (envNetwork != null) {
-                if (PublicEndpointAccessGateway.ENABLED.equals(envNetwork.getPublicEndpointAccessGateway())) {
-                    LOGGER.info("Found AWS stack with endpoint gatewy enabled. Selecting endpoint gateway subnet ids.");
+                if (PublicEndpointAccessGateway.ENABLED.equals(envNetwork.getPublicEndpointAccessGateway()) || isTargetingEndpointGateway(envNetwork)) {
+                    LOGGER.info("Found AWS stack with endpoint gateway enabled. Selecting endpoint gateway subnet ids.");
                     List<String> subnetIds = instanceGroupNetworkV4Request.getAws().getSubnetIds();
                     LOGGER.debug("Endpoint gateway selection: Found instance group network subnet list of {} for instance group {}",
                             subnetIds, instanceGroupName);
@@ -566,6 +567,11 @@ public class StackV4RequestToStackConverter {
                 }
             }
         }
+    }
+
+    private boolean isTargetingEndpointGateway(EnvironmentNetworkResponse network) {
+        return entitlementService.isTargetingSubnetsForEndpointAccessGatewayEnabled(ThreadBasedUserCrnProvider.getAccountId()) &&
+                CollectionUtils.isNotEmpty(network.getEndpointGatewaySubnetIds());
     }
 
     private void setNetworkIfApplicable(StackV4Request source, Stack stack, DetailedEnvironmentResponse environment) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/loadbalancer/LoadBalancerToLoadBalancerResponseConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/loadbalancer/LoadBalancerToLoadBalancerResponseConverter.java
@@ -32,7 +32,7 @@ import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.azure.AzureTargetGrou
 import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.gcp.GcpLoadBalancerConfigDb;
 import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.gcp.GcpLoadBalancerNamesDb;
 import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.gcp.GcpTargetGroupConfigDb;
-import com.sequenceiq.cloudbreak.service.loadbalancer.LoadBalancerConfigService;
+import com.sequenceiq.cloudbreak.service.loadbalancer.TargetGroupPortProvider;
 import com.sequenceiq.cloudbreak.service.stack.InstanceGroupService;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.cloudbreak.service.stack.TargetGroupPersistenceService;
@@ -51,7 +51,7 @@ public class LoadBalancerToLoadBalancerResponseConverter {
     private InstanceMetaDataService instanceMetaDataService;
 
     @Inject
-    private LoadBalancerConfigService loadBalancerConfigService;
+    private TargetGroupPortProvider targetGroupPortProvider;
 
     public LoadBalancerResponse convert(LoadBalancer source) {
         LoadBalancerResponse response = new LoadBalancerResponse();
@@ -110,7 +110,7 @@ public class LoadBalancerToLoadBalancerResponseConverter {
             .map(InstanceMetaData::getInstanceId)
             .collect(Collectors.toSet());
         TargetGroupConfigDbWrapper targetGroupConfig = targetGroup.getProviderConfig();
-        Set<TargetGroupPortPair> portPairs = loadBalancerConfigService.getTargetGroupPortPairs(targetGroup);
+        Set<TargetGroupPortPair> portPairs = targetGroupPortProvider.getTargetGroupPortPairs(targetGroup);
 
         return portPairs.stream()
             .map(portPair -> mapPortPairToTargetGroup(instanceIds, targetGroupConfig, portPair))

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
@@ -105,7 +105,7 @@ import com.sequenceiq.cloudbreak.service.environment.EnvironmentConfigProvider;
 import com.sequenceiq.cloudbreak.service.gateway.GatewayService;
 import com.sequenceiq.cloudbreak.service.hostgroup.HostGroupService;
 import com.sequenceiq.cloudbreak.service.idbroker.IdBrokerService;
-import com.sequenceiq.cloudbreak.service.loadbalancer.LoadBalancerConfigService;
+import com.sequenceiq.cloudbreak.service.loadbalancer.LoadBalancerFqdnUtil;
 import com.sequenceiq.cloudbreak.service.proxy.ProxyConfigProvider;
 import com.sequenceiq.cloudbreak.service.rdsconfig.RdsConfigWithoutClusterService;
 import com.sequenceiq.cloudbreak.service.stack.TargetedUpscaleSupportService;
@@ -220,7 +220,7 @@ public class ClusterHostServiceRunner {
     private HostAttributeDecorator hostAttributeDecorator;
 
     @Inject
-    private LoadBalancerConfigService loadBalancerConfigService;
+    private LoadBalancerFqdnUtil loadBalancerFqdnUtil;
 
     @Inject
     private IdBrokerService idBrokerService;
@@ -788,7 +788,7 @@ public class ClusterHostServiceRunner {
             gateway.put("userfacingcert", stackDto.getSecurityConfig().getUserFacingCert());
         }
 
-        String fqdn = loadBalancerConfigService.getLoadBalancerUserFacingFQDN(stack.getId());
+        String fqdn = loadBalancerFqdnUtil.getLoadBalancerUserFacingFQDN(stack.getId());
         fqdn = isEmpty(fqdn) ? cluster.getFqdn() : fqdn;
 
         if (isNotEmpty(fqdn)) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/UpdateServiceConfigHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/UpdateServiceConfigHandler.java
@@ -21,7 +21,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.stack.loadbalancer.UpdateServ
 import com.sequenceiq.cloudbreak.reactor.api.event.stack.loadbalancer.UpdateServiceConfigRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.stack.loadbalancer.UpdateServiceConfigSuccess;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
-import com.sequenceiq.cloudbreak.service.loadbalancer.LoadBalancerConfigService;
+import com.sequenceiq.cloudbreak.service.loadbalancer.LoadBalancerFqdnUtil;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 import com.sequenceiq.cloudbreak.view.StackView;
 import com.sequenceiq.flow.event.EventSelectorUtil;
@@ -47,7 +47,7 @@ public class UpdateServiceConfigHandler extends ExceptionCatcherEventHandler<Upd
     private ClusterApiConnectors clusterApiConnectors;
 
     @Inject
-    private LoadBalancerConfigService loadBalancerConfigService;
+    private LoadBalancerFqdnUtil loadBalancerFqdnUtil;
 
     @Override
     public String selector() {
@@ -73,7 +73,7 @@ public class UpdateServiceConfigHandler extends ExceptionCatcherEventHandler<Upd
                 proxyhosts.add(stackDto.getPrimaryGatewayInstance().getDiscoveryFQDN());
                 proxyhosts.add(stackDto.getCluster().getFqdn());
             }
-            String loadBalancerFqdn = loadBalancerConfigService.getLoadBalancerUserFacingFQDN(stack.getId());
+            String loadBalancerFqdn = loadBalancerFqdnUtil.getLoadBalancerUserFacingFQDN(stack.getId());
             if (StringUtils.isNotEmpty(loadBalancerFqdn)) {
                 proxyhosts.add(loadBalancerFqdn);
             }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/loadbalancer/KnoxGroupDeterminer.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/loadbalancer/KnoxGroupDeterminer.java
@@ -1,0 +1,58 @@
+package com.sequenceiq.cloudbreak.service.loadbalancer;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.knox.KnoxRoles;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.common.api.type.InstanceGroupType;
+
+@Service
+public class KnoxGroupDeterminer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KnoxGroupDeterminer.class);
+
+    public Set<String> getKnoxGatewayGroupNames(Stack stack) {
+        MDCBuilder.buildMdcContext(stack);
+        LOGGER.debug("Fetching list of instance groups with Knox gateway installed");
+        Set<String> groupNames = new HashSet<>();
+        Cluster cluster = stack.getCluster();
+        if (cluster != null) {
+            LOGGER.debug("Checking if Knox gateway is explicitly defined");
+            CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(cluster.getBlueprint().getBlueprintText());
+            groupNames = cmTemplateProcessor.getHostGroupsWithComponent(KnoxRoles.KNOX_GATEWAY);
+        }
+        Set<String> gatewayGroupNames = stack.getInstanceGroups().stream()
+                .filter(i -> InstanceGroupType.isGateway(i.getInstanceGroupType()))
+                .map(InstanceGroup::getGroupName)
+                .collect(Collectors.toSet());
+
+        if (groupNames.isEmpty()) {
+            LOGGER.debug("Knox gateway is not explicitly defined; searching for CM gateway hosts");
+            groupNames = gatewayGroupNames;
+        } else if (!gatewayGroupNames.containsAll(groupNames)) {
+            LOGGER.error("KNOX can only be installed on instance group where type is GATEWAY. As per the template " + cluster.getBlueprint().getName() +
+                    " KNOX_GATEWAY role config is present in groups " + groupNames  + " while the GATEWAY nodeType is available for instance group " +
+                    gatewayGroupNames);
+            throw new CloudbreakServiceException("KNOX can only be installed on instance group where type is GATEWAY. As per the template " +
+                    cluster.getBlueprint().getName() + " KNOX_GATEWAY role config is present in groups " + groupNames  +
+                    " while the GATEWAY nodeType is available for instance group " + gatewayGroupNames);
+        }
+
+        if (groupNames.isEmpty()) {
+            LOGGER.info("No Knox gateway instance groups found");
+        }
+        return groupNames;
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/loadbalancer/LoadBalancerConfigConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/loadbalancer/LoadBalancerConfigConverter.java
@@ -36,7 +36,7 @@ public class LoadBalancerConfigConverter {
     static final String MISSING_CLOUD_RESOURCE = "Could not find cloud resource corresponding to this traffic port.";
 
     @Inject
-    private LoadBalancerConfigService loadBalancerConfigService;
+    private TargetGroupPortProvider targetGroupPortProvider;
 
     public LoadBalancerConfigDbWrapper convertLoadBalancer(String cloudPlatform, CloudLoadBalancerMetadata cloudLoadBalancerMetadata) {
         switch (cloudPlatform) {
@@ -134,7 +134,7 @@ public class LoadBalancerConfigConverter {
     }
 
     private Set<Integer> getTrafficPorts(TargetGroup targetGroup) {
-        return loadBalancerConfigService.getTargetGroupPortPairs(targetGroup).stream()
+        return targetGroupPortProvider.getTargetGroupPortPairs(targetGroup).stream()
                 .map(TargetGroupPortPair::getTrafficPort)
                 .collect(Collectors.toSet());
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/loadbalancer/LoadBalancerEnabler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/loadbalancer/LoadBalancerEnabler.java
@@ -1,0 +1,95 @@
+package com.sequenceiq.cloudbreak.service.loadbalancer;
+
+import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AWS;
+import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AZURE;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.common.api.type.LoadBalancerCreation;
+import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
+import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
+
+@Service
+public class LoadBalancerEnabler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LoadBalancerEnabler.class);
+
+    @Value("${cb.loadBalancer.supportedPlatforms:}")
+    private String supportedPlatforms;
+
+    @Inject
+    private EntitlementService entitlementService;
+
+    private Set<String> supportedPlatformSet;
+
+    @PostConstruct
+    public void init() {
+        supportedPlatformSet = supportedPlatforms == null
+                ? Set.of()
+                : Arrays.stream(supportedPlatforms.split(",")).collect(Collectors.toSet());
+    }
+
+    public boolean isLoadBalancerEnabled(StackType type, String cloudPlatform, DetailedEnvironmentResponse environment, boolean enableLoadBalancerOnStack) {
+        return !type.equals(StackType.TEMPLATE) &&
+                supportedPlatformSet.contains(cloudPlatform) &&
+                !isLoadBalancerDisabled(environment) &&
+                (enableLoadBalancerOnStack || isLoadBalancerEnabledForDatalake(type, environment) || isLoadBalancerEnabledForDatahub(type, environment));
+    }
+
+    public boolean isEndpointGatewayEnabled(String accountId, EnvironmentNetworkResponse network) {
+        boolean result = network != null && (network.getPublicEndpointAccessGateway() == PublicEndpointAccessGateway.ENABLED ||
+                entitlementService.isTargetingSubnetsForEndpointAccessGatewayEnabled(accountId) &&
+                        CollectionUtils.isNotEmpty(network.getEndpointGatewaySubnetIds()));
+        if (result) {
+            LOGGER.debug("Endpoint access gateway is enabled. A load balancer will be created with{} public IP.",
+                    network.getPublicEndpointAccessGateway() == PublicEndpointAccessGateway.ENABLED ? "" : "out");
+        } else {
+            LOGGER.debug("Endpoint access gateway is disabled.");
+        }
+        return result;
+    }
+
+    private boolean isLoadBalancerDisabled(DetailedEnvironmentResponse environment) {
+        return environment != null && environment.getNetwork() != null &&
+                LoadBalancerCreation.DISABLED.equals(environment.getNetwork().getLoadBalancerCreation());
+    }
+
+    private boolean isLoadBalancerEnabledForDatalake(StackType type, DetailedEnvironmentResponse environment) {
+        return StackType.DATALAKE.equals(type) && environment != null &&
+                (isDatalakeLoadBalancerEntitlementEnabled(environment.getAccountId(), environment.getCloudPlatform()) ||
+                        !isLoadBalancerEntitlementRequiredForCloudProvider(environment.getCloudPlatform()) ||
+                        isEndpointGatewayEnabled(environment.getAccountId(), environment.getNetwork()));
+    }
+
+    private boolean isLoadBalancerEnabledForDatahub(StackType type, DetailedEnvironmentResponse environment) {
+        return StackType.WORKLOAD.equals(type) && environment != null &&
+                isEndpointGatewayEnabled(environment.getAccountId(), environment.getNetwork());
+    }
+
+    private boolean isDatalakeLoadBalancerEntitlementEnabled(String accountId, String cloudPlatform) {
+        if (AZURE.equalsIgnoreCase(cloudPlatform)) {
+            return entitlementService.azureDatalakeLoadBalancerEnabled(accountId);
+        } else {
+            return entitlementService.datalakeLoadBalancerEnabled(accountId);
+        }
+    }
+
+    private boolean isLoadBalancerEntitlementRequiredForCloudProvider(String cloudPlatform) {
+        return !AWS.equalsIgnoreCase(cloudPlatform);
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/loadbalancer/LoadBalancerFqdnUtil.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/loadbalancer/LoadBalancerFqdnUtil.java
@@ -1,0 +1,56 @@
+package com.sequenceiq.cloudbreak.service.loadbalancer;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.LoadBalancer;
+import com.sequenceiq.cloudbreak.service.stack.LoadBalancerPersistenceService;
+import com.sequenceiq.common.api.type.LoadBalancerType;
+
+@Service
+public class LoadBalancerFqdnUtil {
+
+    @Inject
+    private LoadBalancerPersistenceService loadBalancerPersistenceService;
+
+    /*
+     * Favors public, then gateway_private over private
+     */
+    public String getLoadBalancerUserFacingFQDN(Long stackId) {
+        Set<LoadBalancer> loadBalancers = loadBalancerPersistenceService.findByStackId(stackId).stream()
+                .filter(lb -> StringUtils.isNotBlank(lb.getDns()) ||
+                        StringUtils.isNotBlank(lb.getIp()) || StringUtils.isNotBlank(lb.getFqdn()))
+                .collect(Collectors.toSet());
+
+        return findLbNameForType(loadBalancers, LoadBalancerType.PUBLIC)
+                .orElse(findLbNameForType(loadBalancers, LoadBalancerType.GATEWAY_PRIVATE)
+                        .orElseGet(() -> findAnyLbNameOrNull(loadBalancers)));
+    }
+
+    private Optional<String> findLbNameForType(Set<LoadBalancer> loadBalancers, LoadBalancerType loadBalancerType) {
+        return loadBalancers.stream()
+                .filter(lb -> loadBalancerType.equals(lb.getType()))
+                .findAny().map(this::getBestAddressable);
+    }
+
+    private String findAnyLbNameOrNull(Set<LoadBalancer> loadBalancers) {
+        return loadBalancers.stream().findAny()
+                .map(this::getBestAddressable).orElse(null);
+    }
+
+    private String getBestAddressable(LoadBalancer lb) {
+        if (StringUtils.isNotBlank(lb.getFqdn())) {
+            return lb.getFqdn();
+        }
+        if (StringUtils.isNotBlank(lb.getDns())) {
+            return lb.getDns();
+        }
+        return lb.getIp();
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/loadbalancer/OozieTargetGroupProvisioner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/loadbalancer/OozieTargetGroupProvisioner.java
@@ -1,0 +1,74 @@
+package com.sequenceiq.cloudbreak.service.loadbalancer;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERA_STACK_VERSION_7_2_11;
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
+
+import java.util.Optional;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.oozie.OozieRoles;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.TargetGroup;
+import com.sequenceiq.common.api.type.TargetGroupType;
+
+@Service
+public class OozieTargetGroupProvisioner {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OozieTargetGroupProvisioner.class);
+
+    public Optional<TargetGroup> setupOozieHATargetGroup(Stack stack, boolean dryRun) {
+        Optional<InstanceGroup> oozieInstanceGroup = getOozieHAInstanceGroup(stack);
+
+        if (oozieInstanceGroup.isPresent()) {
+            LOGGER.info("Oozie HA instance group found; enabling Oozie load balancer configuration.");
+            TargetGroup oozieTargetGroup = new TargetGroup();
+            if (CloudPlatform.GCP.equalsIgnoreCase(stack.getCloudPlatform())) {
+                oozieTargetGroup.setType(TargetGroupType.OOZIE_GCP);
+            } else {
+                oozieTargetGroup.setType(TargetGroupType.OOZIE);
+            }
+            oozieTargetGroup.setInstanceGroups(Set.of(oozieInstanceGroup.get()));
+            if (!dryRun) {
+                LOGGER.debug("Adding target group to Oozie HA instance group.");
+                oozieInstanceGroup.get().addTargetGroup(oozieTargetGroup);
+            } else {
+                LOGGER.debug("Dry run, skipping instance group/target group linkage for Oozie.");
+            }
+            return Optional.of(oozieTargetGroup);
+        } else {
+            LOGGER.info("Oozie HA instance group not found; not enabling Oozie load balancer configuration.");
+            return Optional.empty();
+        }
+    }
+
+    private Optional<InstanceGroup> getOozieHAInstanceGroup(Stack stack) {
+        Cluster cluster = stack.getCluster();
+        if (cluster != null) {
+            CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(cluster.getBlueprint().getBlueprintText());
+            String cdhVersion = cmTemplateProcessor.getStackVersion();
+            if (cdhVersion != null && isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERA_STACK_VERSION_7_2_11)) {
+                Set<String> oozieGroupNames = getOozieGroups(cmTemplateProcessor);
+                return stack.getInstanceGroups().stream()
+                        .filter(ig -> oozieGroupNames.contains(ig.getGroupName()))
+                        .filter(ig -> ig.getNodeCount() > 1)
+                        .findFirst();
+            }
+        }
+        return Optional.empty();
+    }
+
+    private Set<String> getOozieGroups(CmTemplateProcessor cmTemplateProcessor) {
+        LOGGER.debug("Fetching list of instance groups with Oozie installed");
+        Set<String> groupNames = cmTemplateProcessor.getHostGroupsWithComponent(OozieRoles.OOZIE_SERVER);
+        LOGGER.info("Oozie instance groups are {}", groupNames);
+        return groupNames;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/loadbalancer/TargetGroupPortProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/loadbalancer/TargetGroupPortProvider.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.cloudbreak.service.loadbalancer;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.oozie.OozieHAConfigProvider.OOZIE_HTTPS_PORT;
+
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cloud.model.TargetGroupPortPair;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.TargetGroup;
+
+@Service
+public class TargetGroupPortProvider {
+
+    @Value("${cb.https.port:443}")
+    private String httpsPort;
+
+    @Value("${cb.knox.port:8443}")
+    private String knoxServicePort;
+
+    public Set<TargetGroupPortPair> getTargetGroupPortPairs(TargetGroup targetGroup) {
+        switch (targetGroup.getType()) {
+            case KNOX:
+                return Set.of(new TargetGroupPortPair(Integer.parseInt(httpsPort), Integer.parseInt(knoxServicePort)));
+            case OOZIE:
+                return Set.of(new TargetGroupPortPair(Integer.parseInt(OOZIE_HTTPS_PORT), Integer.parseInt(OOZIE_HTTPS_PORT)));
+            case OOZIE_GCP:
+                return Set.of(new TargetGroupPortPair(Integer.parseInt(OOZIE_HTTPS_PORT), Integer.parseInt(knoxServicePort)));
+            default:
+                return Set.of();
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/MetadataSetupService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/MetadataSetupService.java
@@ -65,6 +65,8 @@ public class MetadataSetupService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MetadataSetupService.class);
 
+    private static final String ENDPOINT_SUFFIX = "gateway";
+
     @Inject
     private ImageService imageService;
 
@@ -385,7 +387,7 @@ public class MetadataSetupService {
                 loadBalancerEntry.setHostedZoneId(cloudLoadBalancerMetadata.getHostedZoneId());
                 loadBalancerEntry.setIp(cloudLoadBalancerMetadata.getIp());
                 loadBalancerEntry.setType(cloudLoadBalancerMetadata.getType());
-                String endpoint = loadBalancerConfigService.generateLoadBalancerEndpoint(stack);
+                String endpoint = generateLoadBalancerEndpoint(stack);
 
                 List<StackIdView> byEnvironmentCrnAndStackType = stackService.getByEnvironmentCrnAndStackType(stack.getEnvironmentCrn(), StackType.DATALAKE);
                 List<StackStatus> stoppedDatalakes = byEnvironmentCrnAndStackType
@@ -445,6 +447,14 @@ public class MetadataSetupService {
             }
         }
         return new LoadBalancer();
+    }
+
+    private String generateLoadBalancerEndpoint(StackView stack) {
+        StringBuilder name = new StringBuilder()
+                .append(stack.getName())
+                .append('-')
+                .append(ENDPOINT_SUFFIX);
+        return name.toString();
     }
 
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/util/StackUtil.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/util/StackUtil.java
@@ -48,7 +48,7 @@ import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.model.NodeReachabilityResult;
 import com.sequenceiq.cloudbreak.service.GatewayConfigService;
 import com.sequenceiq.cloudbreak.service.environment.credential.CredentialClientService;
-import com.sequenceiq.cloudbreak.service.loadbalancer.LoadBalancerConfigService;
+import com.sequenceiq.cloudbreak.service.loadbalancer.LoadBalancerFqdnUtil;
 import com.sequenceiq.cloudbreak.view.ClusterView;
 import com.sequenceiq.cloudbreak.view.InstanceGroupView;
 import com.sequenceiq.cloudbreak.view.InstanceMetadataView;
@@ -69,7 +69,7 @@ public class StackUtil {
     private CredentialClientService credentialClientService;
 
     @Inject
-    private LoadBalancerConfigService loadBalancerConfigService;
+    private LoadBalancerFqdnUtil loadBalancerFqdnUtil;
 
     @Inject
     private HostOrchestrator hostOrchestrator;
@@ -237,7 +237,7 @@ public class StackUtil {
     }
 
     public String extractClusterManagerAddress(StackDtoDelegate stack) {
-        String fqdn = loadBalancerConfigService.getLoadBalancerUserFacingFQDN(stack.getId());
+        String fqdn = loadBalancerFqdnUtil.getLoadBalancerUserFacingFQDN(stack.getId());
         ClusterView cluster = stack.getCluster();
         fqdn = isEmpty(fqdn) ? cluster.getFqdn() : fqdn;
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverterTest.java
@@ -38,7 +38,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -77,7 +76,7 @@ import com.sequenceiq.cloudbreak.dto.InstanceGroupDto;
 import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
 import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
 import com.sequenceiq.cloudbreak.service.image.ImageService;
-import com.sequenceiq.cloudbreak.service.loadbalancer.LoadBalancerConfigService;
+import com.sequenceiq.cloudbreak.service.loadbalancer.TargetGroupPortProvider;
 import com.sequenceiq.cloudbreak.service.securityrule.SecurityRuleService;
 import com.sequenceiq.cloudbreak.service.stack.DefaultRootVolumeSizeProvider;
 import com.sequenceiq.cloudbreak.service.stack.InstanceGroupService;
@@ -190,7 +189,7 @@ public class StackToCloudStackConverterTest {
     private InstanceGroupService instanceGroupService;
 
     @Mock
-    private LoadBalancerConfigService loadBalancerConfigService;
+    private TargetGroupPortProvider targetGroupPortProvider;
 
     @Mock
     private DetailedEnvironmentResponse environment;
@@ -206,7 +205,7 @@ public class StackToCloudStackConverterTest {
         when(blueprint.getBlueprintText()).thenReturn(BLUEPRINT_TEXT);
         when(cluster.getExtendedBlueprintText()).thenReturn(BLUEPRINT_TEXT);
         when(cmTemplateProcessorFactory.get(anyString())).thenReturn(cmTemplateProcessor);
-        when(cmTemplateProcessor.getComponentsByHostGroup()).thenReturn(Mockito.mock(Map.class));
+        when(cmTemplateProcessor.getComponentsByHostGroup()).thenReturn(mock(Map.class));
         when(cloudFileSystemViewProvider.getCloudFileSystemView(any(), any(), any())).thenReturn(Optional.empty());
         DetailedEnvironmentResponse environmentResponse = new DetailedEnvironmentResponse();
         environmentResponse.setCloudPlatform(CloudPlatform.AWS.name());
@@ -1056,7 +1055,7 @@ public class StackToCloudStackConverterTest {
         when(targetGroupPersistenceService.findByLoadBalancerId(anyLong())).thenReturn(Set.of(targetGroup));
         when(instanceGroupService.findByTargetGroupId(anyLong())).thenReturn(List.of(instanceGroup1, instanceGroup2));
         TargetGroupPortPair targetGroupPortPair = new TargetGroupPortPair(443, 8443);
-        when(loadBalancerConfigService.getTargetGroupPortPairs(any(TargetGroup.class))).thenReturn(Set.of(targetGroupPortPair));
+        when(targetGroupPortProvider.getTargetGroupPortPairs(any(TargetGroup.class))).thenReturn(Set.of(targetGroupPortPair));
 
         CloudStack result = underTest.convert(stack);
 
@@ -1100,7 +1099,7 @@ public class StackToCloudStackConverterTest {
         when(loadBalancerPersistenceService.findByStackId(anyLong())).thenReturn(Set.of(internalLoadBalancer, externalLoadBalancer));
         when(targetGroupPersistenceService.findByLoadBalancerId(anyLong())).thenReturn(Set.of(targetGroup));
         when(instanceGroupService.findByTargetGroupId(anyLong())).thenReturn(List.of(instanceGroup1, instanceGroup2));
-        when(loadBalancerConfigService.getTargetGroupPortPairs(any(TargetGroup.class))).thenReturn(Set.of(new TargetGroupPortPair(443, 8443)));
+        when(targetGroupPortProvider.getTargetGroupPortPairs(any(TargetGroup.class))).thenReturn(Set.of(new TargetGroupPortPair(443, 8443)));
         when(stack.getStack()).thenReturn(stack);
 
         CloudStack result = underTest.convert(stack);
@@ -1140,7 +1139,7 @@ public class StackToCloudStackConverterTest {
         when(loadBalancerPersistenceService.findByStackId(anyLong())).thenReturn(Set.of(loadBalancer));
         when(targetGroupPersistenceService.findByLoadBalancerId(anyLong())).thenReturn(Set.of(targetGroup));
         when(instanceGroupService.findByTargetGroupId(anyLong())).thenReturn(List.of(instanceGroup1));
-        when(loadBalancerConfigService.getTargetGroupPortPairs(any(TargetGroup.class))).thenReturn(Set.of(targetGroupPortPair));
+        when(targetGroupPortProvider.getTargetGroupPortPairs(any(TargetGroup.class))).thenReturn(Set.of(targetGroupPortPair));
 
         CloudStack result = underTest.convert(stack);
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/stack/loadbalancer/LoadBalancerToLoadBalancerResponseConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/stack/loadbalancer/LoadBalancerToLoadBalancerResponseConverterTest.java
@@ -39,7 +39,7 @@ import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.azure.AzureTargetGrou
 import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.gcp.GcpLoadBalancerConfigDb;
 import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.gcp.GcpLoadBalancerNamesDb;
 import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.gcp.GcpTargetGroupConfigDb;
-import com.sequenceiq.cloudbreak.service.loadbalancer.LoadBalancerConfigService;
+import com.sequenceiq.cloudbreak.service.loadbalancer.TargetGroupPortProvider;
 import com.sequenceiq.cloudbreak.service.stack.InstanceGroupService;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.cloudbreak.service.stack.TargetGroupPersistenceService;
@@ -83,7 +83,7 @@ public class LoadBalancerToLoadBalancerResponseConverterTest extends AbstractEnt
     private InstanceMetaDataService instanceMetaDataService;
 
     @Mock
-    private LoadBalancerConfigService loadBalancerConfigService;
+    private TargetGroupPortProvider targetGroupPortProvider;
 
     @InjectMocks
     private LoadBalancerToLoadBalancerResponseConverter underTest;
@@ -93,7 +93,7 @@ public class LoadBalancerToLoadBalancerResponseConverterTest extends AbstractEnt
         MockitoAnnotations.initMocks(this);
         when(instanceGroupService.findByTargetGroupId(any())).thenReturn(List.of(new InstanceGroup()));
         when(instanceMetaDataService.findAliveInstancesInInstanceGroup(any())).thenReturn(ceateInstanceMetadata());
-        when(loadBalancerConfigService.getTargetGroupPortPairs(any())).thenReturn(Set.of(new TargetGroupPortPair(PORT, PORT)));
+        when(targetGroupPortProvider.getTargetGroupPortPairs(any())).thenReturn(Set.of(new TargetGroupPortPair(PORT, PORT)));
     }
 
     @Test

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v2/StackToTemplatePreparationObjectConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v2/StackToTemplatePreparationObjectConverterTest.java
@@ -87,7 +87,7 @@ import com.sequenceiq.cloudbreak.service.environment.tag.AccountTagClientService
 import com.sequenceiq.cloudbreak.service.hostgroup.HostGroupService;
 import com.sequenceiq.cloudbreak.service.idbroker.IdBrokerService;
 import com.sequenceiq.cloudbreak.service.identitymapping.AwsMockAccountMappingService;
-import com.sequenceiq.cloudbreak.service.loadbalancer.LoadBalancerConfigService;
+import com.sequenceiq.cloudbreak.service.loadbalancer.LoadBalancerFqdnUtil;
 import com.sequenceiq.cloudbreak.service.rdsconfig.RedbeamsDbCertificateProvider;
 import com.sequenceiq.cloudbreak.service.sharedservice.DatalakeService;
 import com.sequenceiq.cloudbreak.structuredevent.CloudbreakRestRequestThreadLocalService;
@@ -267,7 +267,7 @@ public class StackToTemplatePreparationObjectConverterTest {
     private CloudCredential cloudCredential;
 
     @Mock
-    private LoadBalancerConfigService loadBalancerConfigService;
+    private LoadBalancerFqdnUtil loadBalancerFqdnUtil;
 
     @BeforeEach
     public void setUp() throws IOException, TransactionService.TransactionExecutionException {
@@ -306,7 +306,7 @@ public class StackToTemplatePreparationObjectConverterTest {
         when(stackMock.getCluster()).thenReturn(sourceCluster);
         when(accountTagClientService.list()).thenReturn(new HashMap<>());
         when(entitlementService.internalTenant(anyString())).thenReturn(true);
-        when(loadBalancerConfigService.getLoadBalancerUserFacingFQDN(anyLong())).thenReturn(null);
+        when(loadBalancerFqdnUtil.getLoadBalancerUserFacingFQDN(anyLong())).thenReturn(null);
         Credential credential = Credential.builder()
                 .crn("aCredentialCRN")
                 .attributes(new Json(""))
@@ -713,7 +713,7 @@ public class StackToTemplatePreparationObjectConverterTest {
     @Test
     public void testConvertWhenLoadBalanceExistsFqdnIsSet() {
         String lbUrl = "loadbalancer.domain";
-        when(loadBalancerConfigService.getLoadBalancerUserFacingFQDN(anyLong())).thenReturn(lbUrl);
+        when(loadBalancerFqdnUtil.getLoadBalancerUserFacingFQDN(anyLong())).thenReturn(lbUrl);
         when(blueprintViewProvider.getBlueprintView(any())).thenReturn(getBlueprintView());
         when(stackMock.getStack()).thenReturn(stackMock);
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/EnvironmentBaseNetworkConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/EnvironmentBaseNetworkConverterTest.java
@@ -26,6 +26,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
 import com.sequenceiq.cloudbreak.common.converter.MissingResourceNameGenerator;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
@@ -36,7 +37,7 @@ import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
 
 @ExtendWith(MockitoExtension.class)
-public class EnvironmentBaseNetworkConverterTest extends SubnetTest {
+class EnvironmentBaseNetworkConverterTest extends SubnetTest {
 
     private static final String USER_CRN = "crn:cdp:iam:us-west-1:" + UUID.randomUUID() + ":user:" + UUID.randomUUID();
 
@@ -53,8 +54,11 @@ public class EnvironmentBaseNetworkConverterTest extends SubnetTest {
     @Mock
     private SubnetSelector subnetSelector;
 
+    @Mock
+    private EntitlementService entitlementService;
+
     @Test
-    public void testConvertToLegacyNetworkWhenSubnetNotFound() {
+    void testConvertToLegacyNetworkWhenSubnetNotFound() {
         EnvironmentNetworkResponse source = new EnvironmentNetworkResponse();
         source.setSubnetMetas(Map.of("key", getCloudSubnet("any")));
         when(subnetSelector.chooseSubnet(any(), anyMap(), anyString(), any())).thenReturn(Optional.empty());
@@ -66,7 +70,7 @@ public class EnvironmentBaseNetworkConverterTest extends SubnetTest {
     }
 
     @Test
-    public void testConvertToLegacyNetworkWhenSubnetFound() {
+    void testConvertToLegacyNetworkWhenSubnetFound() {
         CloudSubnet subnet = getCloudSubnet(EU_AZ);
         Map<String, CloudSubnet> metas = Map.of("key", subnet);
         EnvironmentNetworkResponse source = setupResponse();
@@ -85,7 +89,7 @@ public class EnvironmentBaseNetworkConverterTest extends SubnetTest {
     }
 
     @Test
-    public void testConvertToLegacyNetworkWithEndpointAccessGateway() {
+    void testConvertToLegacyNetworkWithEndpointAccessGateway() {
         CloudSubnet privateSubnet = getCloudSubnet(AZ_1);
         CloudSubnet publicSubnet = getPublicCloudSubnet(PUBLIC_ID_1, AZ_1);
         EnvironmentNetworkResponse source = setupResponse();
@@ -106,7 +110,30 @@ public class EnvironmentBaseNetworkConverterTest extends SubnetTest {
     }
 
     @Test
-    public void testConvertToLegacyNetworkWithEndpointAccessGatewayNoPublicSubnets() {
+    void testConvertToLegacyNetworkWithPrivateEndpointAccessGateway() {
+        CloudSubnet privateSubnet = getCloudSubnet(AZ_1);
+        CloudSubnet publicSubnet = getPublicCloudSubnet(PRIVATE_ID_1, AZ_1);
+        EnvironmentNetworkResponse source = setupResponse();
+        source.setSubnetMetas(Map.of("key", privateSubnet));
+        when(entitlementService.isTargetingSubnetsForEndpointAccessGatewayEnabled(any())).thenReturn(true);
+        source.setPublicEndpointAccessGateway(PublicEndpointAccessGateway.DISABLED);
+        source.setEndpointGatewaySubnetIds(Set.of(PRIVATE_ID_1));
+        source.setGatewayEndpointSubnetMetas(Map.of("public-key", publicSubnet));
+
+        when(subnetSelector.chooseSubnet(any(), eq(source.getSubnetMetas()), eq(AZ_1), eq(SelectionFallbackStrategy.ALLOW_FALLBACK)))
+                .thenReturn(Optional.of(privateSubnet));
+        when(subnetSelector.chooseSubnetForEndpointGateway(eq(source), eq(privateSubnet.getId()))).thenReturn(Optional.of(publicSubnet));
+
+        Network[] network = new Network[1];
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> {
+            network[0] = underTest.convertToLegacyNetwork(source, AZ_1);
+        });
+
+        assertEquals(PRIVATE_ID_1, network[0].getAttributes().getValue(ENDPOINT_GATEWAY_SUBNET_ID));
+    }
+
+    @Test
+    void testConvertToLegacyNetworkWithEndpointAccessGatewayNoPublicSubnets() {
         CloudSubnet privateSubnet = getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1);
         EnvironmentNetworkResponse source = setupResponse();
         source.setSubnetMetas(Map.of("key", privateSubnet));
@@ -123,7 +150,7 @@ public class EnvironmentBaseNetworkConverterTest extends SubnetTest {
     }
 
     @Test
-    public void testEndpointGatewayIsDisabledd() {
+    void testEndpointGatewayIsDisabled() {
         CloudSubnet privateSubnet = getCloudSubnet(AZ_1);
         CloudSubnet publicSubnet = getPublicCloudSubnet(PUBLIC_ID_1, AZ_1);
         EnvironmentNetworkResponse source = setupResponse();

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverterTest.java
@@ -9,7 +9,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -28,8 +28,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
@@ -39,7 +37,6 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.cluster.ClusterV
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.InstanceGroupV4Request;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
-import com.sequenceiq.cloudbreak.auth.security.authentication.AuthenticatedUserService;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.common.mappable.Mappable;
@@ -61,15 +58,11 @@ import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.LoadBalancer;
 import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.TargetGroup;
-import com.sequenceiq.cloudbreak.dto.credential.Credential;
 import com.sequenceiq.cloudbreak.kerberos.KerberosConfigService;
-import com.sequenceiq.cloudbreak.service.account.PreferencesService;
 import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
-import com.sequenceiq.cloudbreak.service.environment.credential.CredentialClientService;
 import com.sequenceiq.cloudbreak.service.loadbalancer.LoadBalancerConfigService;
 import com.sequenceiq.cloudbreak.service.sharedservice.DatalakeService;
 import com.sequenceiq.cloudbreak.service.stack.GatewaySecurityGroupDecorator;
-import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.service.stack.TargetedUpscaleSupportService;
 import com.sequenceiq.cloudbreak.service.workspace.WorkspaceService;
 import com.sequenceiq.cloudbreak.structuredevent.CloudbreakRestRequestThreadLocalService;
@@ -90,7 +83,6 @@ import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentN
 import com.sequenceiq.environment.api.v1.environment.model.response.TagResponse;
 
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
 class StackV4RequestToStackConverterTest extends AbstractJsonConverterTest<StackV4Request> {
 
     private static final String USER_CRN = "crn:cdp:iam:us-west-1:1234:user:1";
@@ -105,22 +97,10 @@ class StackV4RequestToStackConverterTest extends AbstractJsonConverterTest<Stack
     private StackV4RequestToStackConverter underTest;
 
     @Mock
-    private AuthenticatedUserService authenticatedUserService;
-
-    @Mock
-    private PreferencesService preferencesService;
-
-    @Mock
-    private StackService stackService;
-
-    @Mock
     private CloudbreakRestRequestThreadLocalService restRequestThreadLocalService;
 
     @Mock
     private WorkspaceService workspaceService;
-
-    @Mock
-    private CredentialClientService credentialClientService;
 
     @Mock
     private ProviderParameterCalculator providerParameterCalculator;
@@ -194,39 +174,42 @@ class StackV4RequestToStackConverterTest extends AbstractJsonConverterTest<Stack
     @Mock
     private EntitlementService entitlementService;
 
-    private Credential credential;
-
     @BeforeEach
     void setUp() {
-        when(restRequestThreadLocalService.getCloudbreakUser()).thenReturn(cloudbreakUser);
-        when(cloudbreakUser.getUsername()).thenReturn("username");
-        when(restRequestThreadLocalService.getRequestedWorkspaceId()).thenReturn(1L);
-        when(workspaceService.getForCurrentUser()).thenReturn(workspace);
-        when(workspace.getId()).thenReturn(1L);
+        lenient().when(restRequestThreadLocalService.getCloudbreakUser()).thenReturn(cloudbreakUser);
+        lenient().when(cloudbreakUser.getUsername()).thenReturn("username");
+        lenient().when(restRequestThreadLocalService.getRequestedWorkspaceId()).thenReturn(1L);
+        lenient().when(workspaceService.getForCurrentUser()).thenReturn(workspace);
+        lenient().when(workspace.getId()).thenReturn(1L);
         DetailedEnvironmentResponse environmentResponse = new DetailedEnvironmentResponse();
         environmentResponse.setCredential(credentialResponse);
         environmentResponse.setCloudPlatform("AWS");
         environmentResponse.setTunnel(Tunnel.DIRECT);
         environmentResponse.setTags(new TagResponse());
-        when(environmentClientService.getByName(anyString())).thenReturn(environmentResponse);
-        when(environmentClientService.getByCrn(anyString())).thenReturn(environmentResponse);
-        when(kerberosConfigService.get(anyString(), anyString())).thenReturn(Optional.empty());
-        when(costTagging.mergeTags(any(CDPTagMergeRequest.class))).thenReturn(new HashMap<>());
-        when(datalakeService.getDatalakeCrn(any(), any())).thenReturn("crn");
-        when(targetedUpscaleSupportService.isUnboundEliminationSupported(anyString())).thenReturn(Boolean.FALSE);
-        credential = Credential.builder()
-                .cloudPlatform("AWS")
-                .build();
+        lenient().when(environmentClientService.getByName(anyString())).thenReturn(environmentResponse);
+        lenient().when(environmentClientService.getByCrn(anyString())).thenReturn(environmentResponse);
+        lenient().when(kerberosConfigService.get(anyString(), anyString())).thenReturn(Optional.empty());
+        lenient().when(costTagging.mergeTags(any(CDPTagMergeRequest.class))).thenReturn(new HashMap<>());
+        lenient().when(datalakeService.getDatalakeCrn(any(), any())).thenReturn("crn");
+        lenient().when(targetedUpscaleSupportService.isUnboundEliminationSupported(anyString())).thenReturn(Boolean.FALSE);
+
+        // GIVEN
+        InstanceGroup instanceGroup = new InstanceGroup();
+        SecurityGroup securityGroup = new SecurityGroup();
+        instanceGroup.setSecurityGroup(securityGroup);
+        instanceGroup.setInstanceGroupType(InstanceGroupType.GATEWAY);
+        instanceGroup.setGroupName("master");
+        lenient().when(stackAuthenticationV4RequestToStackAuthenticationConverter.convert(any(StackAuthenticationV4Request.class)))
+                .thenReturn(new StackAuthentication());
+        lenient().when(instanceGroupV4RequestToInstanceGroupConverter.convert(any(InstanceGroupV4Request.class), anyString())).thenReturn(instanceGroup);
+
     }
 
     @Test
-    public void testConvert() {
-        initMocks();
+    void testConvert() {
         setDefaultRegions(AWS);
         StackV4Request request = getRequest("stack.json");
 
-        given(credentialClientService.getByCrn(anyString())).willReturn(credential);
-        given(credentialClientService.getByName(anyString())).willReturn(credential);
         given(providerParameterCalculator.get(request)).willReturn(getMappable());
         given(clusterV4RequestToClusterConverter.convert(any(ClusterV4Request.class))).willReturn(new Cluster());
         given(telemetryConverter.convert(eq(null), eq(StackType.WORKLOAD), anyString())).willReturn(new Telemetry());
@@ -253,13 +236,10 @@ class StackV4RequestToStackConverterTest extends AbstractJsonConverterTest<Stack
     }
 
     @Test
-    public void testConvertShouldHaveDefaultTags() {
-        initMocks();
+    void testConvertShouldHaveDefaultTags() {
         setDefaultRegions(AWS);
         StackV4Request request = getRequest("stack-without-tags.json");
 
-        given(credentialClientService.getByName(anyString())).willReturn(credential);
-        given(credentialClientService.getByCrn(anyString())).willReturn(credential);
         given(providerParameterCalculator.get(request)).willReturn(getMappable());
         given(clusterV4RequestToClusterConverter.convert(any(ClusterV4Request.class))).willReturn(new Cluster());
         given(autoTlsFlagPreparatory.provideAutoTlsFlag(any(ClusterV4Request.class), any(Stack.class), any(Optional.class))).willReturn(Boolean.TRUE);
@@ -295,8 +275,7 @@ class StackV4RequestToStackConverterTest extends AbstractJsonConverterTest<Stack
     }
 
     @Test
-    public void testConvertWithLoginUserName() {
-        initMocks();
+    void testConvertWithLoginUserName() {
         setDefaultRegions(AWS);
         // WHEN
         BadRequestException expectedException = Assertions.assertThrows(BadRequestException.class,
@@ -307,7 +286,7 @@ class StackV4RequestToStackConverterTest extends AbstractJsonConverterTest<Stack
     }
 
     @Test
-    public void testWhenRegionIsEmptyButDefaultRegionsAreEmptyThenBadRequestExceptionComes() {
+    void testWhenRegionIsEmptyButDefaultRegionsAreEmptyThenBadRequestExceptionComes() {
         setDefaultRegions(null);
         StackV4Request request = getRequest("stack.json");
         request.setCloudPlatform(MOCK);
@@ -335,12 +314,7 @@ class StackV4RequestToStackConverterTest extends AbstractJsonConverterTest<Stack
         StackV4Request request = getRequest("stack.json");
         request.setCloudPlatform(MOCK);
         request.getPlacement().setRegion(null);
-        InstanceGroup instanceGroup = mock(InstanceGroup.class);
 
-        when(instanceGroup.getInstanceGroupType()).thenReturn(InstanceGroupType.GATEWAY);
-        given(credentialClientService.getByName(anyString())).willReturn(credential);
-        given(credentialClientService.getByCrn(anyString())).willReturn(credential);
-        given(instanceGroupV4RequestToInstanceGroupConverter.convert(any(InstanceGroupV4Request.class), anyString())).willReturn(instanceGroup);
         given(providerParameterCalculator.get(request)).willReturn(getMappable());
         given(clusterV4RequestToClusterConverter.convert(any(ClusterV4Request.class))).willReturn(new Cluster());
         given(autoTlsFlagPreparatory.provideAutoTlsFlag(any(ClusterV4Request.class), any(Stack.class), any(Optional.class))).willReturn(Boolean.TRUE);
@@ -352,8 +326,7 @@ class StackV4RequestToStackConverterTest extends AbstractJsonConverterTest<Stack
     }
 
     @Test
-    public void testConvertWithKnoxLoadBalancer() {
-        initMocks();
+    void testConvertWithKnoxLoadBalancer() {
         setDefaultRegions(AWS);
         StackV4Request request = getRequest("stack-datalake-with-instancegroups.json");
         ReflectionTestUtils.setField(underTest, "defaultRegions", "AWS:eu-west-2");
@@ -363,10 +336,7 @@ class StackV4RequestToStackConverterTest extends AbstractJsonConverterTest<Stack
         loadBalancer.setType(LoadBalancerType.PRIVATE);
         loadBalancer.setTargetGroupSet(Set.of(targetGroup));
 
-        given(credentialClientService.getByCrn(anyString())).willReturn(credential);
-        given(credentialClientService.getByName(anyString())).willReturn(credential);
         given(providerParameterCalculator.get(request)).willReturn(getMappable());
-        given(clusterV4RequestToClusterConverter.convert(any(ClusterV4Request.class))).willReturn(new Cluster());
         given(telemetryConverter.convert(eq(null), eq(StackType.DATALAKE), anyString())).willReturn(new Telemetry());
         given(loadBalancerConfigService.createLoadBalancers(any(), any(), eq(request))).willReturn(Set.of(loadBalancer));
         // WHEN
@@ -378,17 +348,12 @@ class StackV4RequestToStackConverterTest extends AbstractJsonConverterTest<Stack
     }
 
     @Test
-    public void testNoLoadBalancersCreatedWhenEntitlementIsDisabled() {
-        initMocks();
+    void testNoLoadBalancersCreatedWhenEntitlementIsDisabled() {
         setDefaultRegions(AWS);
         StackV4Request request = getRequest("stack-datalake-with-instancegroups.json");
 
-        given(credentialClientService.getByCrn(anyString())).willReturn(credential);
-        given(credentialClientService.getByName(anyString())).willReturn(credential);
         given(providerParameterCalculator.get(request)).willReturn(getMappable());
-        given(clusterV4RequestToClusterConverter.convert(any(ClusterV4Request.class))).willReturn(new Cluster());
         given(telemetryConverter.convert(eq(null), eq(StackType.DATALAKE), anyString())).willReturn(new Telemetry());
-        given(loadBalancerConfigService.getKnoxGatewayGroups(any(Stack.class))).willReturn(Set.of("master"));
         // WHEN
         Stack stack = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.convert(request));
         // THEN
@@ -396,7 +361,7 @@ class StackV4RequestToStackConverterTest extends AbstractJsonConverterTest<Stack
     }
 
     @Test
-    public void testNoEndpointGatewayLoadBalancerWhenEntitlementIsDisabled() {
+    void testNoEndpointGatewayLoadBalancerWhenEntitlementIsDisabled() {
         StackV4Request request = setupForEndpointGateway(true);
         // WHEN
         Stack stack = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.convert(request));
@@ -405,7 +370,7 @@ class StackV4RequestToStackConverterTest extends AbstractJsonConverterTest<Stack
     }
 
     @Test
-    public void testNoEndpointGatewayLoadBalancerWhenFlagIsDisabled() {
+    void testNoEndpointGatewayLoadBalancerWhenFlagIsDisabled() {
         StackV4Request request = setupForEndpointGateway(false);
         // WHEN
         Stack stack = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.convert(request));
@@ -418,19 +383,7 @@ class StackV4RequestToStackConverterTest extends AbstractJsonConverterTest<Stack
         return StackV4Request.class;
     }
 
-    private void initMocks() {
-        // GIVEN
-        InstanceGroup instanceGroup = new InstanceGroup();
-        SecurityGroup securityGroup = new SecurityGroup();
-        instanceGroup.setSecurityGroup(securityGroup);
-        instanceGroup.setInstanceGroupType(InstanceGroupType.GATEWAY);
-        instanceGroup.setGroupName("master");
-        given(stackAuthenticationV4RequestToStackAuthenticationConverter.convert(any(StackAuthenticationV4Request.class))).willReturn(new StackAuthentication());
-        given(instanceGroupV4RequestToInstanceGroupConverter.convert(any(InstanceGroupV4Request.class), anyString())).willReturn(instanceGroup);
-    }
-
     private StackV4Request setupForEndpointGateway(boolean enabled) {
-        initMocks();
         ReflectionTestUtils.setField(underTest, "defaultRegions", "AWS:eu-west-2");
         StackV4Request request = getRequest("stack-datalake-with-instancegroups.json");
 
@@ -442,15 +395,10 @@ class StackV4RequestToStackConverterTest extends AbstractJsonConverterTest<Stack
         environmentResponse.setTunnel(Tunnel.DIRECT);
         environmentResponse.setTags(new TagResponse());
         environmentResponse.setNetwork(networkResponse);
-        when(environmentClientService.getByName(anyString())).thenReturn(environmentResponse);
         when(environmentClientService.getByCrn(anyString())).thenReturn(environmentResponse);
 
-        given(credentialClientService.getByCrn(anyString())).willReturn(credential);
-        given(credentialClientService.getByName(anyString())).willReturn(credential);
         given(providerParameterCalculator.get(request)).willReturn(getMappable());
-        given(clusterV4RequestToClusterConverter.convert(any(ClusterV4Request.class))).willReturn(new Cluster());
         given(telemetryConverter.convert(eq(null), eq(StackType.DATALAKE), anyString())).willReturn(new Telemetry());
-        given(loadBalancerConfigService.getKnoxGatewayGroups(any(Stack.class))).willReturn(Set.of("master"));
 
         return request;
     }
@@ -462,7 +410,7 @@ class StackV4RequestToStackConverterTest extends AbstractJsonConverterTest<Stack
     private String getTestRegion(CloudPlatform platform) {
         String region = TEST_REGIONS.get(platform);
         if (region != null) {
-            return platform.name() + ":" + region;
+            return platform.name() + ':' + region;
         }
         throw new IllegalArgumentException("No region has found for platform: " + platform);
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunnerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunnerTest.java
@@ -96,7 +96,7 @@ import com.sequenceiq.cloudbreak.service.environment.EnvironmentConfigProvider;
 import com.sequenceiq.cloudbreak.service.gateway.GatewayService;
 import com.sequenceiq.cloudbreak.service.hostgroup.HostGroupService;
 import com.sequenceiq.cloudbreak.service.idbroker.IdBrokerService;
-import com.sequenceiq.cloudbreak.service.loadbalancer.LoadBalancerConfigService;
+import com.sequenceiq.cloudbreak.service.loadbalancer.LoadBalancerFqdnUtil;
 import com.sequenceiq.cloudbreak.service.proxy.ProxyConfigProvider;
 import com.sequenceiq.cloudbreak.service.rdsconfig.RdsConfigWithoutClusterService;
 import com.sequenceiq.cloudbreak.service.sharedservice.DatalakeService;
@@ -212,7 +212,7 @@ class ClusterHostServiceRunnerTest {
     private HostAttributeDecorator hostAttributeDecorator;
 
     @Mock
-    private LoadBalancerConfigService loadBalancerConfigService;
+    private LoadBalancerFqdnUtil loadBalancerFqdnUtil;
 
     @Mock
     private IdBrokerService idBrokerService;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/network/SubnetTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/network/SubnetTest.java
@@ -11,6 +11,8 @@ public class SubnetTest {
 
     protected static final String PRIVATE_ID_1 = "private-id-1";
 
+    protected static final String PRIVATE_ID_2 = "private-id-2";
+
     protected static final String PUBLIC_ID_1 = "public-id-1";
 
     protected CloudSubnet getPublicCloudSubnet(String id, String availabilityZone) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/loadbalancer/KnoxGroupDeterminerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/loadbalancer/KnoxGroupDeterminerTest.java
@@ -1,0 +1,132 @@
+package com.sequenceiq.cloudbreak.service.loadbalancer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.domain.Blueprint;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.util.FileReaderUtils;
+import com.sequenceiq.cloudbreak.workspace.model.Tenant;
+import com.sequenceiq.cloudbreak.workspace.model.Workspace;
+import com.sequenceiq.common.api.type.InstanceGroupType;
+
+@ExtendWith(MockitoExtension.class)
+class KnoxGroupDeterminerTest {
+
+    @Mock
+    private Blueprint blueprint;
+
+    @InjectMocks
+    private KnoxGroupDeterminer underTest;
+
+    @Test
+    void testGetKnoxGatewayThrowsErrorWhenKnoxExplicitlyDefined() {
+        Set<String> groups = Set.of("master");
+        Cluster cluster = new Cluster();
+        cluster.setBlueprint(blueprint);
+        Stack stack = new Stack();
+        Workspace workspace = new Workspace();
+        workspace.setName("tenant");
+        Tenant tenant = new Tenant();
+        tenant.setName("tenant");
+        workspace.setTenant(tenant);
+        stack.setWorkspace(workspace);
+        InstanceGroup instanceGroup = new InstanceGroup();
+        instanceGroup.setGroupName("master");
+        InstanceGroup instanceGroup1 = new InstanceGroup();
+        instanceGroup1.setGroupName("gateway");
+        instanceGroup1.setInstanceGroupType(InstanceGroupType.GATEWAY);
+        stack.setInstanceGroups(Set.of(instanceGroup, instanceGroup1));
+        stack.setCluster(cluster);
+
+        when(blueprint.getBlueprintText()).thenReturn(getBlueprintText("input/clouderamanager-knox.bp"));
+        when(blueprint.getName()).thenReturn("dummy");
+        CloudbreakServiceException exception = assertThrows(CloudbreakServiceException.class,
+                () -> underTest.getKnoxGatewayGroupNames(stack));
+        assertEquals(exception.getMessage(), "KNOX can only be installed on instance group where type is GATEWAY. As per the template " +
+                "dummy" + " KNOX_GATEWAY role config is present in groups " + groups +
+                " while the GATEWAY nodeType is available for instance group " + Set.of("gateway"));
+    }
+
+    @Test
+    void testGetKnoxGatewayWhenKnoxExplicitlyDefined() {
+        Set<String> groups = Set.of("master");
+        Cluster cluster = new Cluster();
+        cluster.setBlueprint(blueprint);
+        Stack stack = new Stack();
+        Workspace workspace = new Workspace();
+        workspace.setName("tenant");
+        Tenant tenant = new Tenant();
+        tenant.setName("tenant");
+        workspace.setTenant(tenant);
+        stack.setWorkspace(workspace);
+        InstanceGroup instanceGroup = new InstanceGroup();
+        instanceGroup.setGroupName("master");
+        instanceGroup.setInstanceGroupType(InstanceGroupType.GATEWAY);
+        stack.setInstanceGroups(Set.of(instanceGroup));
+        stack.setCluster(cluster);
+
+        when(blueprint.getBlueprintText()).thenReturn(getBlueprintText("input/clouderamanager-knox.bp"));
+
+        Set<String> selectedGroups = underTest.getKnoxGatewayGroupNames(stack);
+        assertEquals(groups, selectedGroups);
+    }
+
+    @Test
+    void testGetKnoxGatewayWhenKnoxImplicitlyDefinedByGatewayGroup() {
+        Set<String> groups = Set.of("gateway");
+        InstanceGroup instanceGroup = new InstanceGroup();
+        instanceGroup.setGroupName("gateway");
+        instanceGroup.setInstanceGroupType(InstanceGroupType.GATEWAY);
+        Cluster cluster = new Cluster();
+        cluster.setBlueprint(blueprint);
+        Stack stack = new Stack();
+        stack.setCluster(cluster);
+        stack.setInstanceGroups(Set.of(instanceGroup));
+        Workspace workspace = new Workspace();
+        workspace.setName("tenant");
+        Tenant tenant = new Tenant();
+        tenant.setName("tenant");
+        workspace.setTenant(tenant);
+        stack.setWorkspace(workspace);
+        when(blueprint.getBlueprintText()).thenReturn("{}");
+
+        Set<String> selectedGroups = underTest.getKnoxGatewayGroupNames(stack);
+        assertEquals(groups, selectedGroups);
+    }
+
+    @Test
+    void testGetKnoxGatewayWhenNoGateway() {
+        Cluster cluster = new Cluster();
+        cluster.setBlueprint(blueprint);
+        Stack stack = new Stack();
+        stack.setCluster(cluster);
+        Workspace workspace = new Workspace();
+        workspace.setName("tenant");
+        Tenant tenant = new Tenant();
+        tenant.setName("tenant");
+        workspace.setTenant(tenant);
+        stack.setWorkspace(workspace);
+        when(blueprint.getBlueprintText()).thenReturn("{}");
+
+        Set<String> selectedGroups = underTest.getKnoxGatewayGroupNames(stack);
+        assertThat(selectedGroups).isEmpty();
+    }
+
+    private String getBlueprintText(String path) {
+        return FileReaderUtils.readFileFromClasspathQuietly(path);
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/loadbalancer/LoadBalancerConfigConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/loadbalancer/LoadBalancerConfigConverterTest.java
@@ -61,7 +61,7 @@ public class LoadBalancerConfigConverterTest {
     private static final String BACKEND_SERVICE_NAME = "backend-service-name";
 
     @Mock
-    private LoadBalancerConfigService loadBalancerConfigService;
+    private TargetGroupPortProvider targetGroupPortProvider;
 
     @InjectMocks
     private LoadBalancerConfigConverter underTest;
@@ -92,7 +92,7 @@ public class LoadBalancerConfigConverterTest {
         targetGroup.setType(TargetGroupType.KNOX);
         TargetGroupPortPair portPair = new TargetGroupPortPair(PORT1, PORT2);
 
-        when(loadBalancerConfigService.getTargetGroupPortPairs(eq(targetGroup))).thenReturn(Set.of(portPair));
+        when(targetGroupPortProvider.getTargetGroupPortPairs(eq(targetGroup))).thenReturn(Set.of(portPair));
 
         TargetGroupConfigDbWrapper targetGroupConfigDbWrapper = underTest.convertTargetGroup(AWS, cloudLoadBalancerMetadata, targetGroup);
         assertNotNull(targetGroupConfigDbWrapper.getAwsConfig());
@@ -114,7 +114,7 @@ public class LoadBalancerConfigConverterTest {
         TargetGroupPortPair portPair1 = new TargetGroupPortPair(PORT1, PORT1);
         TargetGroupPortPair portPair2 = new TargetGroupPortPair(PORT2, PORT2);
 
-        when(loadBalancerConfigService.getTargetGroupPortPairs(eq(targetGroup))).thenReturn(Set.of(portPair1, portPair2));
+        when(targetGroupPortProvider.getTargetGroupPortPairs(eq(targetGroup))).thenReturn(Set.of(portPair1, portPair2));
 
         TargetGroupConfigDbWrapper targetGroupConfigDbWrapper = underTest.convertTargetGroup(AWS, cloudLoadBalancerMetadata, targetGroup);
         assertNotNull(targetGroupConfigDbWrapper.getAwsConfig());
@@ -133,7 +133,7 @@ public class LoadBalancerConfigConverterTest {
         TargetGroupPortPair portPair1 = new TargetGroupPortPair(PORT1, PORT1);
         TargetGroupPortPair portPair2 = new TargetGroupPortPair(PORT2, PORT2);
 
-        when(loadBalancerConfigService.getTargetGroupPortPairs(eq(targetGroup))).thenReturn(Set.of(portPair1, portPair2));
+        when(targetGroupPortProvider.getTargetGroupPortPairs(eq(targetGroup))).thenReturn(Set.of(portPair1, portPair2));
 
         TargetGroupConfigDbWrapper targetGroupConfigDbWrapper = underTest.convertTargetGroup(AWS, cloudLoadBalancerMetadata, targetGroup);
         assertNotNull(targetGroupConfigDbWrapper.getAwsConfig());
@@ -169,7 +169,7 @@ public class LoadBalancerConfigConverterTest {
         targetGroup.setType(TargetGroupType.KNOX);
         TargetGroupPortPair portPair = new TargetGroupPortPair(PORT1, PORT2);
 
-        when(loadBalancerConfigService.getTargetGroupPortPairs(eq(targetGroup))).thenReturn(Set.of(portPair));
+        when(targetGroupPortProvider.getTargetGroupPortPairs(eq(targetGroup))).thenReturn(Set.of(portPair));
 
         TargetGroupConfigDbWrapper targetGroupConfigDbWrapper = underTest.convertTargetGroup(AZURE, cloudLoadBalancerMetadata, targetGroup);
         assertNotNull(targetGroupConfigDbWrapper.getAzureConfig());
@@ -194,7 +194,7 @@ public class LoadBalancerConfigConverterTest {
         TargetGroupPortPair portPair2 = new TargetGroupPortPair(PORT2, PORT2);
         TargetGroupPortPair portPair3 = new TargetGroupPortPair(PORT3, PORT3);
 
-        when(loadBalancerConfigService.getTargetGroupPortPairs(eq(targetGroup))).thenReturn(Set.of(portPair1, portPair2, portPair3));
+        when(targetGroupPortProvider.getTargetGroupPortPairs(eq(targetGroup))).thenReturn(Set.of(portPair1, portPair2, portPair3));
 
         TargetGroupConfigDbWrapper targetGroupConfigDbWrapper = underTest.convertTargetGroup(AZURE, cloudLoadBalancerMetadata, targetGroup);
         assertNotNull(targetGroupConfigDbWrapper.getAzureConfig());
@@ -230,7 +230,7 @@ public class LoadBalancerConfigConverterTest {
         targetGroup.setType(TargetGroupType.KNOX);
         TargetGroupPortPair portPair = new TargetGroupPortPair(PORT1, PORT2);
 
-        when(loadBalancerConfigService.getTargetGroupPortPairs(eq(targetGroup))).thenReturn(Set.of(portPair));
+        when(targetGroupPortProvider.getTargetGroupPortPairs(eq(targetGroup))).thenReturn(Set.of(portPair));
 
         TargetGroupConfigDbWrapper targetGroupConfigDbWrapper = underTest.convertTargetGroup(GCP, cloudLoadBalancerMetadata, targetGroup);
         assertNotNull(targetGroupConfigDbWrapper.getGcpConfig());

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/loadbalancer/LoadBalancerEnablerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/loadbalancer/LoadBalancerEnablerTest.java
@@ -1,0 +1,116 @@
+package com.sequenceiq.cloudbreak.service.loadbalancer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.common.api.type.LoadBalancerCreation;
+import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
+import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
+
+@ExtendWith(MockitoExtension.class)
+class LoadBalancerEnablerTest {
+
+    private static final String ACCOUNT_ID = "accountId";
+
+    @Mock
+    private EntitlementService entitlementService;
+
+    @InjectMocks
+    private LoadBalancerEnabler underTest;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(underTest, "supportedPlatforms", "AWS,AZURE");
+        underTest.init();
+    }
+
+    @ParameterizedTest(name = "StackType = {0}, Cloud = {1}, PEAG = {2}, Subnets = {3}, EnvLBCreation = {4}, EnableStackLb = {5} then result is {6}")
+    @MethodSource("isLoadBalancerEnabledScenarios")
+    void isLoadBalancerEnabled(StackType stackType, String cloudPlatform, PublicEndpointAccessGateway peag, Set<String> subnetIds,
+            LoadBalancerCreation networkLoadBalancerCreation, boolean enableLoadBalancerOnStack, boolean expected) {
+        DetailedEnvironmentResponse environment = prepareEnvironment(cloudPlatform, peag, subnetIds, networkLoadBalancerCreation);
+        assertThat(underTest.isLoadBalancerEnabled(stackType, cloudPlatform, environment, enableLoadBalancerOnStack)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest(name = "PEAG = {0}, Subnets = {1}, TargetingEntitled = {2}, then result is {3}")
+    @MethodSource("isEndpointGatewayEnabledScenarios")
+    void isEndpointGatewayEnabled(PublicEndpointAccessGateway peag, Set<String> subnetIds, boolean targetingEntitled, boolean expected) {
+        EnvironmentNetworkResponse network = createNetwork(peag, subnetIds);
+        lenient().when(entitlementService.isTargetingSubnetsForEndpointAccessGatewayEnabled(ACCOUNT_ID)).thenReturn(targetingEntitled);
+        assertThat(underTest.isEndpointGatewayEnabled(ACCOUNT_ID, network)).isEqualTo(expected);
+    }
+
+    private DetailedEnvironmentResponse prepareEnvironment(String cloudPlatform, PublicEndpointAccessGateway peag, Set<String> subnetIds,
+            LoadBalancerCreation loadBalancerCreation) {
+        EnvironmentNetworkResponse network = EnvironmentNetworkResponse.builder()
+                .withLoadBalancerCreation(loadBalancerCreation)
+                .withUsePublicEndpointAccessGateway(peag)
+                .withEndpointGatewaySubnetIds(subnetIds)
+                .build();
+        return DetailedEnvironmentResponse.builder()
+                .withNetwork(network)
+                .withCloudPlatform(cloudPlatform)
+                .withAccountId(ACCOUNT_ID)
+                .build();
+    }
+
+    private EnvironmentNetworkResponse createNetwork(PublicEndpointAccessGateway peag, Set<String> subnetIds) {
+        return EnvironmentNetworkResponse.builder()
+                .withUsePublicEndpointAccessGateway(peag)
+                .withEndpointGatewaySubnetIds(subnetIds)
+                .build();
+    }
+
+    // @formatter:off
+    // CHECKSTYLE:OFF
+    static Object[][] isLoadBalancerEnabledScenarios() {
+        // note: there would be 2⁶ or 2⁷ or even more combination of input paramters
+        return new Object[][] {
+            { StackType.TEMPLATE, "AWS",     PublicEndpointAccessGateway.ENABLED,  Set.of("subnet1", "subnet2"), LoadBalancerCreation.ENABLED,  true,  false },
+            { StackType.WORKLOAD, "UNKNOWN", PublicEndpointAccessGateway.ENABLED,  Set.of("subnet1", "subnet2"), LoadBalancerCreation.ENABLED,  true,  false },
+            { StackType.WORKLOAD, "AWS",     PublicEndpointAccessGateway.ENABLED,  Set.of("subnet1", "subnet2"), LoadBalancerCreation.DISABLED, true,  false },
+            { StackType.WORKLOAD, "AWS",     PublicEndpointAccessGateway.DISABLED, Set.of("subnet1", "subnet2"), LoadBalancerCreation.ENABLED,  false, false },
+            { StackType.WORKLOAD, "AWS",     PublicEndpointAccessGateway.DISABLED, Set.of("subnet1", "subnet2"), LoadBalancerCreation.ENABLED,  true,  true },
+            { StackType.WORKLOAD, "AWS",     PublicEndpointAccessGateway.ENABLED,  Set.of("subnet1", "subnet2"), LoadBalancerCreation.ENABLED,  false, true },
+            { StackType.DATALAKE, "UNKNOWN", PublicEndpointAccessGateway.ENABLED,  Set.of("subnet1", "subnet2"), LoadBalancerCreation.ENABLED,  true,  false },
+            { StackType.DATALAKE, "AWS",     PublicEndpointAccessGateway.ENABLED,  Set.of("subnet1", "subnet2"), LoadBalancerCreation.DISABLED, true,  false },
+            { StackType.DATALAKE, "AWS",     PublicEndpointAccessGateway.DISABLED, Set.of("subnet1", "subnet2"), LoadBalancerCreation.ENABLED,  false, true },
+            { StackType.DATALAKE, "AZURE",   PublicEndpointAccessGateway.DISABLED, Set.of("subnet1", "subnet2"), LoadBalancerCreation.ENABLED,  false, false },
+            { StackType.DATALAKE, "AWS",     PublicEndpointAccessGateway.DISABLED, Set.of("subnet1", "subnet2"), LoadBalancerCreation.ENABLED,  true,  true },
+            { StackType.DATALAKE, "AWS",     PublicEndpointAccessGateway.ENABLED,  Set.of("subnet1", "subnet2"), LoadBalancerCreation.ENABLED,  false, true },
+        };
+    }
+
+    static Object[][] isEndpointGatewayEnabledScenarios() {
+        return new Object[][] {
+            { null,                                 null,                         false, false },
+            { null,                                 null,                         true,  false },
+            { null,                                 Set.of("subnet1", "subnet2"), false, false },
+            { null,                                 Set.of("subnet1", "subnet2"), true,  true },
+            { PublicEndpointAccessGateway.DISABLED, null,                         false, false },
+            { PublicEndpointAccessGateway.DISABLED, null,                         true,  false },
+            { PublicEndpointAccessGateway.DISABLED, Set.of("subnet1", "subnet2"), false, false },
+            { PublicEndpointAccessGateway.DISABLED, Set.of("subnet1", "subnet2"), true,  true },
+            { PublicEndpointAccessGateway.ENABLED,  null,                         false, true },
+            { PublicEndpointAccessGateway.ENABLED,  null,                         true,  true },
+            { PublicEndpointAccessGateway.ENABLED,  Set.of("subnet1", "subnet2"), false, true },
+            { PublicEndpointAccessGateway.ENABLED,  Set.of("subnet1", "subnet2"), true, true },
+        };
+    }
+    // CHECKSTYLE:ON
+    // @formatter:on
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/loadbalancer/LoadBalancerFqdnUtilTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/loadbalancer/LoadBalancerFqdnUtilTest.java
@@ -1,0 +1,202 @@
+package com.sequenceiq.cloudbreak.service.loadbalancer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.LoadBalancer;
+import com.sequenceiq.cloudbreak.service.stack.LoadBalancerPersistenceService;
+import com.sequenceiq.common.api.type.LoadBalancerType;
+
+@ExtendWith(MockitoExtension.class)
+class LoadBalancerFqdnUtilTest {
+
+    private static final String PUBLIC_DNS = "public.dns";
+
+    private static final String PUBLIC_FQDN = "public.fqdn";
+
+    private static final String PUBLIC_IP = "public.ip";
+
+    private static final String PRIVATE_DNS = "private.dns";
+
+    private static final String PRIVATE_FQDN = "private.fqdn";
+
+    private static final String PRIVATE_IP = "private.ip";
+
+    @Mock
+    private LoadBalancerPersistenceService loadBalancerPersistenceService;
+
+    @InjectMocks
+    private LoadBalancerFqdnUtil underTest;
+
+    @Test
+    void testGetLoadBalancerUserFacingFQDN() {
+        Set<LoadBalancer> loadBalancers = createLoadBalancers();
+
+        when(loadBalancerPersistenceService.findByStackId(0L)).thenReturn(loadBalancers);
+
+        String fqdn = underTest.getLoadBalancerUserFacingFQDN(0L);
+        assertEquals(PUBLIC_FQDN, fqdn);
+    }
+
+    @Test
+    void testGetLoadBalancerUserFacingFQDNNoLBs() {
+        Set<LoadBalancer> loadBalancers = Set.of();
+
+        when(loadBalancerPersistenceService.findByStackId(0L)).thenReturn(loadBalancers);
+
+        String fqdn = underTest.getLoadBalancerUserFacingFQDN(0L);
+        assertNull(fqdn);
+    }
+
+    @Test
+    void testGetLoadBalancerUserFacingFQDNPrivateOnly() {
+        Set<LoadBalancer> loadBalancers = createPrivateOnlyLoadBalancer();
+
+        when(loadBalancerPersistenceService.findByStackId(0L)).thenReturn(loadBalancers);
+
+        String fqdn = underTest.getLoadBalancerUserFacingFQDN(0L);
+        assertEquals(PRIVATE_FQDN, fqdn);
+    }
+
+    @Test
+    void testGetLoadBalancerUserFacingFQDNPublicMissingAll() {
+        Set<LoadBalancer> loadBalancers = createLoadBalancers();
+        LoadBalancer publicLoadBalancer = loadBalancers.stream()
+                .filter(lb -> LoadBalancerType.PUBLIC.equals(lb.getType()))
+                .findFirst().get();
+        publicLoadBalancer.setFqdn(null);
+        publicLoadBalancer.setIp(null);
+        publicLoadBalancer.setDns(null);
+
+        when(loadBalancerPersistenceService.findByStackId(0L)).thenReturn(loadBalancers);
+
+        String fqdn = underTest.getLoadBalancerUserFacingFQDN(0L);
+        assertEquals(PRIVATE_FQDN, fqdn);
+    }
+
+    @Test
+    void testGetLoadBalancerUserFacingFQDNPublicMissingFQDN() {
+        Set<LoadBalancer> loadBalancers = createLoadBalancers();
+        LoadBalancer publicLoadBalancer = loadBalancers.stream()
+                .filter(lb -> LoadBalancerType.PUBLIC.equals(lb.getType()))
+                .findFirst().get();
+        publicLoadBalancer.setFqdn(null);
+
+        when(loadBalancerPersistenceService.findByStackId(0L)).thenReturn(loadBalancers);
+
+        String fqdn = underTest.getLoadBalancerUserFacingFQDN(0L);
+        assertEquals(PUBLIC_DNS, fqdn);
+    }
+
+    @Test
+    void testGetLoadBalancerUserFacingFQDNNoPublicPrivateMissingFQDN() {
+        Set<LoadBalancer> loadBalancers = createPrivateOnlyLoadBalancer();
+        LoadBalancer privateLoadBalancer = loadBalancers.stream()
+                .filter(lb -> LoadBalancerType.PRIVATE.equals(lb.getType()))
+                .findFirst().get();
+        privateLoadBalancer.setFqdn(null);
+        privateLoadBalancer.setIp(null);
+
+        when(loadBalancerPersistenceService.findByStackId(0L)).thenReturn(loadBalancers);
+
+        String fqdn = underTest.getLoadBalancerUserFacingFQDN(0L);
+        assertEquals(PRIVATE_DNS, fqdn);
+    }
+
+    @Test
+    void testGetLoadBalancerUserFacingFQDNNoPublicPrivateMissingFQDNNoDNS() {
+        Set<LoadBalancer> loadBalancers = createPrivateOnlyLoadBalancer();
+        LoadBalancer privateLoadBalancer = loadBalancers.stream()
+                .filter(lb -> LoadBalancerType.PRIVATE.equals(lb.getType()))
+                .findFirst().get();
+        privateLoadBalancer.setFqdn(null);
+        privateLoadBalancer.setDns(null);
+
+        when(loadBalancerPersistenceService.findByStackId(0L)).thenReturn(loadBalancers);
+
+        String fqdn = underTest.getLoadBalancerUserFacingFQDN(0L);
+        assertEquals(PRIVATE_IP, fqdn);
+    }
+
+    @Test
+    void testGetLoadBalancerUserFacingFQDNIPOnlyMissingFQDN() {
+        Set<LoadBalancer> loadBalancers = createLoadBalancers();
+        LoadBalancer publicLoadBalancer = loadBalancers.stream()
+                .filter(lb -> LoadBalancerType.PUBLIC.equals(lb.getType()))
+                .findFirst().get();
+        publicLoadBalancer.setFqdn(null);
+        publicLoadBalancer.setDns(null);
+
+        when(loadBalancerPersistenceService.findByStackId(0L)).thenReturn(loadBalancers);
+
+        String fqdn = underTest.getLoadBalancerUserFacingFQDN(0L);
+        assertEquals(PUBLIC_IP, fqdn);
+    }
+
+    @Test
+    void testGetLoadBalancerUserFacingFQDNNoFqdnSet() {
+        Set<LoadBalancer> loadBalancers = createLoadBalancers();
+        LoadBalancer publicLoadBalancer = loadBalancers.stream()
+                .filter(lb -> LoadBalancerType.PUBLIC.equals(lb.getType()))
+                .findFirst().get();
+        publicLoadBalancer.setFqdn(null);
+        publicLoadBalancer.setIp(null);
+        publicLoadBalancer.setDns(null);
+
+        LoadBalancer privateLoadBalancer = loadBalancers.stream()
+                .filter(lb -> LoadBalancerType.PRIVATE.equals(lb.getType()))
+                .findFirst().get();
+        privateLoadBalancer.setFqdn(null);
+        privateLoadBalancer.setDns(null);
+        privateLoadBalancer.setIp(null);
+
+        when(loadBalancerPersistenceService.findByStackId(0L)).thenReturn(loadBalancers);
+
+        String fqdn = underTest.getLoadBalancerUserFacingFQDN(0L);
+        assertNull(fqdn);
+    }
+
+    private Set<LoadBalancer> createLoadBalancers(boolean createPrivate, boolean createPublic, boolean createOutbound) {
+        Set<LoadBalancer> loadBalancers = new HashSet<>();
+        if (createPrivate) {
+            LoadBalancer privateLoadBalancer = new LoadBalancer();
+            privateLoadBalancer.setType(LoadBalancerType.PRIVATE);
+            privateLoadBalancer.setFqdn(PRIVATE_FQDN);
+            privateLoadBalancer.setDns(PRIVATE_DNS);
+            privateLoadBalancer.setIp(PRIVATE_IP);
+            loadBalancers.add(privateLoadBalancer);
+        }
+        if (createPublic) {
+            LoadBalancer publicLoadBalancer = new LoadBalancer();
+            publicLoadBalancer.setType(LoadBalancerType.PUBLIC);
+            publicLoadBalancer.setFqdn(PUBLIC_FQDN);
+            publicLoadBalancer.setDns(PUBLIC_DNS);
+            publicLoadBalancer.setIp(PUBLIC_IP);
+            loadBalancers.add(publicLoadBalancer);
+        }
+        if (createOutbound) {
+            LoadBalancer outboundLoadBalancer = new LoadBalancer();
+            outboundLoadBalancer.setType(LoadBalancerType.OUTBOUND);
+            loadBalancers.add(outboundLoadBalancer);
+        }
+        return loadBalancers;
+    }
+
+    private Set<LoadBalancer> createLoadBalancers() {
+        return createLoadBalancers(true, true, false);
+    }
+
+    private Set<LoadBalancer> createPrivateOnlyLoadBalancer() {
+        return createLoadBalancers(true, false, false);
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/loadbalancer/OozieTargetGroupProvisionerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/loadbalancer/OozieTargetGroupProvisionerTest.java
@@ -1,0 +1,89 @@
+package com.sequenceiq.cloudbreak.service.loadbalancer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.sequenceiq.cloudbreak.domain.Blueprint;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.TargetGroup;
+import com.sequenceiq.cloudbreak.util.FileReaderUtils;
+import com.sequenceiq.common.api.type.TargetGroupType;
+
+class OozieTargetGroupProvisionerTest {
+
+    private OozieTargetGroupProvisioner underTest;
+
+    private String blueprintText = getBlueprintText("input/cdp-data-engineering.bp");
+
+    @BeforeEach
+    void setUp() {
+        underTest = new OozieTargetGroupProvisioner();
+    }
+
+    @ParameterizedTest
+    @MethodSource("scenarios")
+    void setupOozieHATargetGroup(String cloudPlatform, String instanceGroupName, int nodeCount, String runtimeVersion,
+            boolean resultPresent, TargetGroupType targetGroupType) {
+
+        Stack stack = new Stack();
+        stack.setName("TestStack");
+        Cluster cluster = new Cluster();
+        Blueprint blueprint = new Blueprint();
+        blueprintText = blueprintText.replace('"' + "7.2.16" + '"', '"' + runtimeVersion + '"');
+        blueprint.setBlueprintText(blueprintText);
+        cluster.setBlueprint(blueprint);
+        InstanceGroup ig = new InstanceGroup();
+        ig.setGroupName(instanceGroupName);
+        ig.setStack(stack);
+        Set<InstanceMetaData> imSet = new HashSet<>();
+        for (int i = 0; i < nodeCount; i++) {
+            imSet.add(new InstanceMetaData());
+        }
+        ig.setInstanceMetaData(imSet);
+        Set<InstanceGroup> instanceGroups = Set.of(ig);
+        stack.setCluster(cluster);
+        stack.setCloudPlatform(cloudPlatform);
+        stack.setInstanceGroups(instanceGroups);
+
+        Optional<TargetGroup> resultOpt = underTest.setupOozieHATargetGroup(stack, false);
+
+        if (resultPresent) {
+            assertThat(resultOpt).isPresent();
+            assertThat(resultOpt).hasValueSatisfying(tg -> {
+                assertThat(tg.getType()).isEqualTo(targetGroupType);
+                assertThat(tg.getInstanceGroups()).isEqualTo(Set.of(ig));
+                assertThat(ig.getTargetGroups()).contains(tg);
+            });
+        } else {
+            assertThat(resultOpt).isEmpty();
+        }
+    }
+
+    // @formatter:off
+    // CHECKSTYLE:OFF
+    static Object[][] scenarios() {
+        return new Object[][] {
+                { "AWS",   "master", 2, "7.2.16", true, TargetGroupType.OOZIE },
+                { "GCP",   "master", 2, "7.2.16", true, TargetGroupType.OOZIE_GCP },
+                { "AZURE", "master", 2, "7.2.16", true, TargetGroupType.OOZIE },
+                { "AWS",   "mastr2", 2, "7.2.16", false, null },
+                { "AWS",   "master", 2, "7.2.10", false, null },
+        };
+    }
+    // CHECKSTYLE:ON
+    // @formatter:on
+
+    private String getBlueprintText(String path) {
+        return FileReaderUtils.readFileFromClasspathQuietly(path);
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/MetadataSetupServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/MetadataSetupServiceTest.java
@@ -78,7 +78,7 @@ import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.LoadBalancerType;
 
 @ExtendWith(MockitoExtension.class)
-public class MetadataSetupServiceTest {
+class MetadataSetupServiceTest {
 
     private static final Long STACK_ID = 1L;
 
@@ -175,14 +175,14 @@ public class MetadataSetupServiceTest {
     private Image image;
 
     @BeforeEach
-    public void before() {
+    void before() {
         stack = new Stack();
         stack.setId(STACK_ID);
         image = createImage();
     }
 
     @Test
-    public void saveInstanceMetaDataTestShouldNotSaveInstancesWhenImageNotFound() throws CloudbreakImageNotFoundException {
+    void saveInstanceMetaDataTestShouldNotSaveInstancesWhenImageNotFound() throws CloudbreakImageNotFoundException {
         InstanceGroup instanceGroup = new InstanceGroup();
         instanceGroup.setId(INSTANCE_GROUP_ID);
         instanceGroup.setGroupName(GROUP_NAME);
@@ -201,7 +201,7 @@ public class MetadataSetupServiceTest {
     }
 
     @Test
-    public void saveInstanceMetaDataTestOneNewInstance()
+    void saveInstanceMetaDataTestOneNewInstance()
             throws CloudbreakImageNotFoundException {
         when(imageService.getImage(STACK_ID)).thenReturn(image);
         InstanceGroup instanceGroup = new InstanceGroup();
@@ -230,7 +230,7 @@ public class MetadataSetupServiceTest {
     }
 
     @Test
-    public void saveInstanceMetaDataTestExistingAvailableInstance() {
+    void saveInstanceMetaDataTestExistingAvailableInstance() {
         InstanceGroup instanceGroup = new InstanceGroup();
         instanceGroup.setId(INSTANCE_GROUP_ID);
         instanceGroup.setGroupName(GROUP_NAME);
@@ -260,7 +260,7 @@ public class MetadataSetupServiceTest {
     }
 
     @Test
-    public void saveLoadBalancerMetadata() {
+    void saveLoadBalancerMetadata() {
         stack.setName(STACK_NAME);
         stack.setCloudPlatform("DEFAULT");
         stack.setEnvironmentCrn(STACK_CRN);
@@ -272,7 +272,6 @@ public class MetadataSetupServiceTest {
         Set<LoadBalancer> loadBalancerSet = new HashSet<>();
         loadBalancerSet.add(loadBalancer);
         when(loadBalancerPersistenceService.findByStackId(STACK_ID)).thenReturn(loadBalancerSet);
-        when(loadBalancerConfigService.generateLoadBalancerEndpoint(stack)).thenCallRealMethod();
 
         StackStatus stackStatus = new StackStatus();
         stackStatus.setStatus(Status.AVAILABLE);
@@ -298,7 +297,7 @@ public class MetadataSetupServiceTest {
     }
 
     @Test
-    public void saveLoadBalancerMetadataAndSetEndpointToOldStack() {
+    void saveLoadBalancerMetadataAndSetEndpointToOldStack() {
         Stack oldStack = new Stack();
         oldStack.setId(OLD_STACK_ID);
         oldStack.setName(OLD_STACK_NAME);
@@ -330,7 +329,6 @@ public class MetadataSetupServiceTest {
         loadBalancerSet.add(loadBalancer);
         when(loadBalancerPersistenceService.findByStackId(STACK_ID)).thenReturn(loadBalancerSet);
         when(loadBalancerPersistenceService.findByStackId(OLD_STACK_ID)).thenReturn(new HashSet<>());
-        when(loadBalancerConfigService.generateLoadBalancerEndpoint(stack)).thenCallRealMethod();
 
         StackIdView stackIdView = new StackIdViewImpl(STACK_ID, STACK_NAME, "no");
 
@@ -365,7 +363,7 @@ public class MetadataSetupServiceTest {
     }
 
     @Test
-    public void saveInstanceMetaDataTestOneTerminatedInstance() {
+    void saveInstanceMetaDataTestOneTerminatedInstance() {
         Stack stack = new Stack();
         stack.setId(STACK_ID);
         InstanceGroup instanceGroup = new InstanceGroup();
@@ -395,7 +393,7 @@ public class MetadataSetupServiceTest {
     }
 
     @Test
-    public void saveInstanceMetaDataTestOneZombieInstance() {
+    void saveInstanceMetaDataTestOneZombieInstance() {
         Stack stack = new Stack();
         stack.setId(STACK_ID);
         InstanceGroup instanceGroup = new InstanceGroup();
@@ -438,7 +436,7 @@ public class MetadataSetupServiceTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("saveInstanceMetaDataTestServerFlagIsAlreadySetDataProvider")
-    public void saveInstanceMetaDataTestServerFlagIsAlreadySet(String testCaseName, String subnetId, String availabilityZone, String rackId)
+    void saveInstanceMetaDataTestServerFlagIsAlreadySet(String testCaseName, String subnetId, String availabilityZone, String rackId)
             throws CloudbreakImageNotFoundException {
         when(imageService.getImage(STACK_ID)).thenReturn(image);
         InstanceGroup instanceGroup = new InstanceGroup();
@@ -475,7 +473,7 @@ public class MetadataSetupServiceTest {
     }
 
     @Test
-    public void testSaveInstanceMetadataAndSelectTheRightPGW() throws CloudbreakImageNotFoundException {
+    void testSaveInstanceMetadataAndSelectTheRightPGW() throws CloudbreakImageNotFoundException {
         List<CloudVmMetaDataStatus> cloudVmMetaDataStatuses = new ArrayList<>();
         cloudVmMetaDataStatuses.add(new CloudVmMetaDataStatus(new CloudVmInstanceStatus(new CloudInstance("id1", new InstanceTemplate("medium", "gateway",
                 10L, Collections.emptyList(), InstanceStatus.CREATED, Map.of(), 40L, "imageid", TemporaryStorage.ATTACHED_VOLUMES, 0L), null, "subnet", "az"),
@@ -543,7 +541,7 @@ public class MetadataSetupServiceTest {
     }
 
     @Test
-    public void testSaveInstanceMetadataAndSelectTheRightPGWButFQDNDidNotMatchSoFallback() throws CloudbreakImageNotFoundException {
+    void testSaveInstanceMetadataAndSelectTheRightPGWButFQDNDidNotMatchSoFallback() throws CloudbreakImageNotFoundException {
         List<CloudVmMetaDataStatus> cloudVmMetaDataStatuses = new ArrayList<>();
         cloudVmMetaDataStatuses.add(new CloudVmMetaDataStatus(new CloudVmInstanceStatus(new CloudInstance("id1", new InstanceTemplate("medium", "gateway",
                 10L, Collections.emptyList(), InstanceStatus.CREATED, Map.of(), 40L, "imageid", TemporaryStorage.ATTACHED_VOLUMES, 0L), null, "subnet", "az"),

--- a/core/src/test/resources/input/cdp-data-engineering.bp
+++ b/core/src/test/resources/input/cdp-data-engineering.bp
@@ -1,0 +1,539 @@
+{
+  "cdhVersion": "7.2.16",
+  "displayName": "dataengineering",
+  "blueprintUpgradeOption": "GA",
+  "services": [
+    {
+      "refName": "zookeeper",
+      "serviceType": "ZOOKEEPER",
+      "serviceConfigs": [
+        {
+          "name": "service_config_suppression_server_count_validator",
+          "value": "true"
+        }
+      ],
+      "roleConfigGroups": [
+        {
+          "refName": "zookeeper-SERVER-BASE",
+          "roleType": "SERVER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "hdfs",
+      "serviceType": "HDFS",
+      "serviceConfigs": [
+        {
+          "name": "hdfs_verify_ec_with_topology_enabled",
+          "value": false
+        },
+        {
+          "name": "core_site_safety_valve",
+          "value": "<property><name>fs.s3a.buffer.dir</name><value>${env.LOCAL_DIRS:-${hadoop.tmp.dir}}/s3a</value></property><property><name>fs.s3a.committer.name</name><value>directory</value></property><property><name>fs.azure.buffer.dir</name><value>${env.LOCAL_DIRS:-${hadoop.tmp.dir}}/abfs</value></property><property><name>hadoop.mapreduce.fileoutputcommitter.algorithm.version.v1.experimental.parallel.rename.recovery</name><value>true</value></property><property><name>hadoop.mapreduce.fileoutputcommitter.algorithm.version.v1.experimental.parallel.task.commit</name><value>true</value></property><property><name>hadoop.mapreduce.fileoutputcommitter.algorithm.version.v1.experimental.mv.threads</name><value>16</value></property>"
+        }
+      ],
+      "roleConfigGroups": [
+        {
+          "refName": "hdfs-NAMENODE-BASE",
+          "roleType": "NAMENODE",
+          "base": true,
+          "configs": [
+            {
+              "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
+              "value": "true"
+            },
+            {
+              "name": "role_config_suppression_fs_trash_interval_minimum_validator",
+              "value": "true"
+            },
+            {
+              "name": "fs_trash_interval",
+              "value": "0"
+            },
+            {
+              "name": "fs_trash_checkpoint_interval",
+              "value": "0"
+            },
+            {
+              "name": "erasure_coding_default_policy",
+              "value": " "
+            }
+          ]
+        },
+        {
+          "refName": "hdfs-SECONDARYNAMENODE-BASE",
+          "roleType": "SECONDARYNAMENODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-DATANODE-BASE",
+          "roleType": "DATANODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-BALANCER-BASE",
+          "roleType": "BALANCER",
+          "base": true
+        },
+        {
+          "refName": "hdfs-GATEWAY-BASE",
+          "roleType": "GATEWAY",
+          "base": true,
+          "configs": [
+            {
+              "name": "dfs_client_use_trash",
+              "value": false
+            },
+            {
+              "name": "role_config_suppression_hdfs_trash_disabled_validator",
+              "value": "true"
+            },
+            {
+              "name": "hdfs_client_env_safety_valve",
+              "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "refName": "yarn",
+      "serviceType": "YARN",
+      "serviceConfigs": [
+        {
+          "name": "yarn_admin_acl",
+          "value": "yarn,hive,hdfs,mapred"
+        },
+        {
+          "name": "yarn_service_mapred_safety_valve",
+          "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property><property><name>mapreduce.input.fileinputformat.list-status.num-threads</name><value>100</value></property>"
+        }
+      ],
+      "roleConfigGroups": [
+        {
+          "refName": "yarn-RESOURCEMANAGER-BASE",
+          "roleType": "RESOURCEMANAGER",
+          "base": true,
+          "configs": [
+            {
+              "name": "resourcemanager_config_safety_valve",
+              "value": "<property><name>yarn.scheduler.configuration.store.class</name><value>zk</value></property>"
+            },
+            {
+              "name": "yarn_resourcemanager_scheduler_class",
+              "value": "org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler"
+            },
+            {
+              "name": "yarn_scheduler_capacity_resource_calculator",
+              "value": "org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator"
+            },
+            {
+              "name": "resourcemanager_capacity_scheduler_configuration",
+              "value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property></configuration>"
+            }
+          ]
+        },
+        {
+          "refName": "yarn-NODEMANAGER-WORKER",
+          "roleType": "NODEMANAGER",
+          "base": false
+        },
+        {
+          "refName": "yarn-NODEMANAGER-COMPUTE",
+          "roleType": "NODEMANAGER",
+          "base": false
+        },
+        {
+          "refName": "yarn-JOBHISTORY-BASE",
+          "roleType": "JOBHISTORY",
+          "base": true
+        },
+        {
+          "refName": "yarn-GATEWAY-BASE",
+          "roleType": "GATEWAY",
+          "base": true,
+          "configs": [
+            {
+              "name": "mapreduce_client_env_safety_valve",
+              "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "refName": "spark_on_yarn",
+      "serviceType": "SPARK_ON_YARN",
+      "roleConfigGroups": [
+        {
+          "refName": "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+          "roleType": "SPARK_YARN_HISTORY_SERVER",
+          "base": true
+        },
+        {
+          "refName": "spark_on_yarn-GATEWAY-BASE",
+          "roleType": "GATEWAY",
+          "base": true,
+          "configs": [
+            {
+              "name": "spark-conf/spark-defaults.conf_client_config_safety_valve",
+              "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl\nspark.hadoop.mapreduce.fileoutputcommitter.algorithm.version=1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "refName": "tez",
+      "serviceType": "TEZ",
+      "serviceConfigs": [
+        {
+          "name": "yarn_service",
+          "ref": "yarn"
+        },
+        {
+          "name": "tez.am.container.reuse.non-local-fallback.enabled",
+          "value": "true"
+        },
+        {
+          "name": "tez.am.container.reuse.locality.delay-allocation-millis",
+          "value": "0"
+        },
+        {
+          "name": "tez.am.launch.cmd-opts",
+          "value": "-XX:+PrintGCDetails -verbose:gc -XX:+UseNUMA -XX:+UseG1GC -XX:+ResizeTLAB"
+        },
+        {
+          "name": "tez.task.launch.cmd-opts",
+          "value": "-XX:+PrintGCDetails -verbose:gc -XX:+UseNUMA -XX:+UseG1GC -XX:+ResizeTLAB"
+        },
+        {
+          "name": "tez.grouping.split-waves",
+          "value": 1.4
+        },
+        {
+          "name": "tez.grouping.min-size",
+          "value": 268435456
+        },
+        {
+          "name": "tez.grouping.max-size",
+          "value": 268435456
+        }
+      ],
+      "roleConfigGroups": [
+        {
+          "refName": "tez-GATEWAY-BASE",
+          "roleType": "GATEWAY",
+          "base": true,
+          "configs": [
+            {
+               "name": "tez-conf/tez-site.xml_client_config_safety_valve",
+               "value": "<property><name>tez.runtime.pipelined.sorter.lazy-allocate.memory</name><value>true</value></property>"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "refName": "hms",
+      "serviceType": "HIVE",
+      "displayName": "Hive Metastore",
+      "roleConfigGroups": [
+        {
+          "refName": "hms-GATEWAY-BASE",
+          "roleType": "GATEWAY",
+          "base": true
+        },
+        {
+          "refName": "hms-HIVEMETASTORE-BASE",
+          "roleType": "HIVEMETASTORE",
+          "base": true,
+          "configs": [
+            {
+              "name": "hive_metastore_config_safety_valve",
+              "value": "<property><name>hive.metastore.try.direct.sql.ddl</name><value>true</value></property>"
+            },
+            {
+              "name": "hive_compactor_initiator_on",
+              "value": "false"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "refName": "hive_on_tez",
+      "serviceType": "HIVE_ON_TEZ",
+      "displayName": "Hive",
+      "serviceConfigs": [
+        {
+          "name": "hms_connector",
+          "ref": "hms"
+        },
+        {
+          "name": "tez_service",
+          "ref": "tez"
+        },
+        {
+          "name": "zookeeper_service",
+          "ref": "zookeeper"
+        },
+        {
+          "name": "mapreduce_yarn_service",
+          "ref": "yarn"
+        },
+        {
+          "name": "tez_auto_reducer_parallelism",
+          "value": "false"
+        },
+        {
+          "name": "hive_service_config_safety_valve",
+          "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property><property><name>hive.server2.tez.session.lifetime</name><value>30m</value></property>
+                      <property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property><property><name>hive.orc.splits.include.fileid</name><value>false</value></property><property><name>hive.hook.proto.events.clean.freq</name><value>1h</value></property>
+                      <property><name>hive.metastore.try.direct.sql.ddl</name><value>true</value></property><property><name>parquet.compression</name><value>SNAPPY</value></property><property><name>hive.privilege.synchronizer</name><value>false</value></property>"
+        }
+      ],
+      "roleConfigGroups": [
+        {
+          "refName": "hive_on_tez-GATEWAY-BASE",
+          "roleType": "GATEWAY",
+          "base": true
+        },
+        {
+          "refName": "hive_on_tez-HIVESERVER2-BASE",
+          "roleType": "HIVESERVER2",
+          "base": true,
+          "configs": [
+            {
+              "name": "hive_server2_transport_mode",
+              "value": "http"
+            },
+            {
+              "name": "hiveserver2_mv_files_thread",
+              "value": 20
+            },
+            {
+              "name": "hiveserver2_load_dynamic_partitions_thread_count",
+              "value": 20
+            },
+            {
+              "name": "hiveserver2_idle_session_timeout",
+              "value": 14400000
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "refName": "hue",
+      "serviceType": "HUE",
+      "serviceConfigs": [
+        {
+          "name": "hue_service_safety_valve",
+          "value": "[desktop]\napp_blacklist=spark,zookeeper,hbase,impala,search,sqoop,security,pig"
+        }
+      ],
+      "roleConfigGroups": [
+        {
+          "refName": "hue-HUE_SERVER-BASE",
+          "roleType": "HUE_SERVER",
+          "base": true
+        },
+        {
+          "refName": "hue-HUE_LOAD_BALANCER-BASE",
+          "roleType": "HUE_LOAD_BALANCER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "livy",
+      "serviceType": "LIVY",
+      "roleConfigGroups": [
+        {
+          "refName": "livy-GATEWAY-BASE",
+          "roleType": "GATEWAY",
+          "base": true
+        },
+        {
+          "refName": "livy-LIVY_SERVER-BASE",
+          "roleType": "LIVY_SERVER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "zeppelin",
+      "serviceType": "ZEPPELIN",
+      "serviceConfigs": [
+        {
+          "name": "yarn_service",
+          "ref": "yarn"
+        },
+        {
+          "name": "hdfs_service",
+          "ref": "hdfs"
+        },
+        {
+          "name": "spark_on_yarn_service",
+          "ref": "spark_on_yarn"
+        }
+      ],
+      "roleConfigGroups": [
+        {
+          "refName": "zeppelin-ZEPPELIN_SERVER-BASE",
+          "roleType": "ZEPPELIN_SERVER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "das",
+      "serviceType": "DAS",
+      "roleConfigGroups": [
+        {
+          "refName": "das-DAS_WEBAPP",
+          "roleType": "DAS_WEBAPP",
+          "base": true,
+          "configs": [
+            {
+              "name": "data_analytics_studio_admin_users",
+              "value": "*"
+            }
+          ]
+        },
+        {
+          "refName": "das-DAS_EVENT_PROCESSOR",
+          "roleType": "DAS_EVENT_PROCESSOR",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "query_processor",
+      "serviceType": "QUERY_PROCESSOR",
+      "roleConfigGroups": [
+        {
+          "refName": "query_processor-QUERY_PROCESSOR",
+          "roleType": "QUERY_PROCESSOR",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "oozie",
+      "serviceType": "OOZIE",
+      "roleConfigGroups": [
+        {
+          "refName": "oozie-OOZIE_SERVER-BASE",
+          "roleType": "OOZIE_SERVER",
+          "configs": [
+            {
+              "name": "oozie_config_safety_valve",
+              "value": "<property><name>oozie.service.HadoopAccessorService.nameNode.whitelist</name><value></value></property>"
+            }
+          ],
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "sqoop",
+      "serviceType": "SQOOP_CLIENT",
+      "roleConfigGroups": [
+        {
+          "refName": "sqoop-SQOOP_CLIENT-GATEWAY-BASE",
+          "roleType": "GATEWAY",
+          "configs": [ ],
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "queuemanager",
+      "serviceType": "QUEUEMANAGER",
+      "serviceConfigs": [
+        {
+          "name": "kerberos.auth.enabled",
+          "value": "true"
+        }
+      ],
+      "roleConfigGroups": [
+        {
+          "refName": "yarn-QUEUEMANAGER_WEBAPP-BASE",
+          "roleType": "QUEUEMANAGER_WEBAPP",
+          "base": true
+        },
+        {
+          "refName": "yarn-QUEUEMANAGER_STORE-BASE",
+          "roleType": "QUEUEMANAGER_STORE",
+          "base": true
+        }
+      ]
+    }
+  ],
+  "hostTemplates": [
+    {
+      "refName": "master",
+      "cardinality": 1,
+      "roleConfigGroupsRefNames": [
+        "hdfs-BALANCER-BASE",
+        "hdfs-NAMENODE-BASE",
+        "hdfs-SECONDARYNAMENODE-BASE",
+        "hdfs-GATEWAY-BASE",
+        "hms-GATEWAY-BASE",
+        "hms-HIVEMETASTORE-BASE",
+        "hive_on_tez-HIVESERVER2-BASE",
+        "hive_on_tez-GATEWAY-BASE",
+        "hue-HUE_LOAD_BALANCER-BASE",
+        "hue-HUE_SERVER-BASE",
+        "tez-GATEWAY-BASE",
+        "spark_on_yarn-GATEWAY-BASE",
+        "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+        "livy-LIVY_SERVER-BASE",
+        "zeppelin-ZEPPELIN_SERVER-BASE",
+        "oozie-OOZIE_SERVER-BASE",
+        "sqoop-SQOOP_CLIENT-GATEWAY-BASE",
+        "yarn-JOBHISTORY-BASE",
+        "yarn-RESOURCEMANAGER-BASE",
+        "zookeeper-SERVER-BASE",
+        "das-DAS_WEBAPP",
+        "das-DAS_EVENT_PROCESSOR",
+        "query_processor-QUERY_PROCESSOR",
+        "yarn-QUEUEMANAGER_WEBAPP-BASE",
+        "yarn-QUEUEMANAGER_STORE-BASE",
+        "yarn-GATEWAY-BASE"
+      ]
+    },
+    {
+      "refName": "worker",
+      "cardinality": 3,
+      "roleConfigGroupsRefNames": [
+        "hdfs-DATANODE-BASE",
+        "yarn-NODEMANAGER-WORKER"
+      ]
+    },
+    {
+      "refName": "compute",
+      "cardinality": 0,
+      "roleConfigGroupsRefNames": [
+        "yarn-NODEMANAGER-COMPUTE"
+      ]
+    },
+    {
+      "refName": "gateway",
+      "cardinality": 0,
+      "roleConfigGroupsRefNames": [
+        "hdfs-GATEWAY-BASE",
+        "hms-GATEWAY-BASE",
+        "hive_on_tez-GATEWAY-BASE",
+        "tez-GATEWAY-BASE",
+        "spark_on_yarn-GATEWAY-BASE",
+        "livy-GATEWAY-BASE",
+        "yarn-GATEWAY-BASE",
+        "sqoop-SQOOP_CLIENT-GATEWAY-BASE"
+      ]
+    }
+  ]
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -84,7 +84,7 @@ ext {
   hamcrestVersion = '2.2'
   junitVersion = '4.13.2'
   junitJupiterVersion = '5.7.0'
-  mockitoVersion = '3.6.28'
+  mockitoVersion = '3.12.4'
   openPojoVersion = '0.8.12'
   testContainersVersion = '1.16.0'
   testNgVersion = '7.3.0'

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/EnvironmentReactorFlowManager.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/EnvironmentReactorFlowManager.java
@@ -7,11 +7,13 @@ import static com.sequenceiq.environment.environment.flow.deletion.event.EnvDele
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.eventbus.Event;
 import com.sequenceiq.cloudbreak.eventbus.Promise;
 import com.sequenceiq.common.api.type.DataHubStartAction;
@@ -54,11 +56,14 @@ public class EnvironmentReactorFlowManager {
 
     private final StackService stackService;
 
+    private final EntitlementService entitlementService;
+
     public EnvironmentReactorFlowManager(EventSender eventSender,
-            FlowCancelService flowCancelService, StackService stackService) {
+            FlowCancelService flowCancelService, StackService stackService, EntitlementService entitlementService) {
         this.eventSender = eventSender;
         this.flowCancelService = flowCancelService;
         this.stackService = stackService;
+        this.entitlementService = entitlementService;
     }
 
     public FlowIdentifier triggerCreationFlow(long envId, String envName, String userCrn, String envCrn) {
@@ -162,11 +167,12 @@ public class EnvironmentReactorFlowManager {
     }
 
     public FlowIdentifier triggerLoadBalancerUpdateFlow(EnvironmentDto environmentDto, Long envId, String envName, String envCrn,
-            PublicEndpointAccessGateway endpointAccessGateway, Set<String> subnetIds, String userCrn) {
+            PublicEndpointAccessGateway endpointAccessGateway, Set<String> endpointGatewaySubnetIds, String userCrn) {
         LOGGER.info("Load balancer update flow triggered.");
-        if (PublicEndpointAccessGateway.ENABLED.equals(endpointAccessGateway)) {
-            if (subnetIds != null && !subnetIds.isEmpty()) {
-                LOGGER.debug("Adding Endpoint Gateway with subnet ids {}", subnetIds);
+        if (PublicEndpointAccessGateway.ENABLED.equals(endpointAccessGateway) ||
+                entitlementService.isTargetingSubnetsForEndpointAccessGatewayEnabled(environmentDto.getAccountId())) {
+            if (CollectionUtils.isNotEmpty(endpointGatewaySubnetIds)) {
+                LOGGER.debug("Adding Endpoint Gateway with subnet ids {}", endpointGatewaySubnetIds);
             } else {
                 LOGGER.debug("Adding Endpoint Gateway using environment subnets.");
             }
@@ -179,7 +185,7 @@ public class EnvironmentReactorFlowManager {
                 .withResourceCrn(envCrn)
                 .withEnvironmentDto(environmentDto)
                 .withEndpointAccessGateway(endpointAccessGateway)
-                .withSubnetIds(subnetIds)
+                .withSubnetIds(endpointGatewaySubnetIds)
                 .build();
 
         return eventSender.sendEvent(loadBalancerUpdateEvent, new Event.Headers(getFlowTriggerUsercrn(userCrn)));

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/loadbalancer/handler/LoadBalancerStackUpdateHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/loadbalancer/handler/LoadBalancerStackUpdateHandler.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.environment.environment.flow.loadbalancer.handler;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -39,8 +40,9 @@ public class LoadBalancerStackUpdateHandler extends EventSenderAwareHandler<Envi
         EnvironmentDto environmentDto = environmentLoadBalancerDto.getEnvironmentDto();
         try {
             LOGGER.debug("Initating stack load balancer update");
-            loadBalancerPollerService.updateStackWithLoadBalancer(environmentDto.getId(), environmentDto.getResourceCrn(),
-                environmentDto.getName(), environmentLoadBalancerDto.getEndpointAccessGateway());
+            loadBalancerPollerService.updateStackWithLoadBalancer(environmentDto.getAccountId(), environmentDto.getResourceCrn(),
+                environmentDto.getName(), environmentLoadBalancerDto.getEndpointAccessGateway(),
+                    CollectionUtils.isNotEmpty(environmentLoadBalancerDto.getEndpointGatewaySubnetIds()));
 
             LOGGER.debug("Stack load balancer update complete.");
             LoadBalancerUpdateEvent loadBalancerUpdateEvent = LoadBalancerUpdateEvent.LoadBalancerUpdateEventBuilder.aLoadBalancerUpdateEvent()

--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/validators/NetworkCreationValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/validators/NetworkCreationValidator.java
@@ -3,7 +3,7 @@ package com.sequenceiq.environment.environment.validation.validators;
 import java.util.Map;
 import java.util.Objects;
 
-import org.apache.commons.collections4.SetUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,7 +94,7 @@ public class NetworkCreationValidator {
 
     private void validateNetworkCidrAndEndpointGatewaySubnet(NetworkDto network, ValidationResultBuilder resultBuilder) {
         if (Objects.nonNull(network) && StringUtils.isNotEmpty(network.getNetworkCidr()) &&
-                !SetUtils.emptyIfNull(network.getEndpointGatewaySubnetIds()).isEmpty()) {
+                CollectionUtils.isNotEmpty(network.getEndpointGatewaySubnetIds())) {
 
             String message = String.format("The Endpoint Gateway Subnet IDs must not be defined if CIDR ('%s') is present!", network.getNetworkCidr());
             LOGGER.info(message);

--- a/environment/src/main/java/com/sequenceiq/environment/network/service/LoadBalancerEntitlementService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/service/LoadBalancerEntitlementService.java
@@ -5,7 +5,7 @@ import java.util.Set;
 import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
 
-import org.apache.commons.collections4.SetUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
@@ -20,8 +20,8 @@ public class LoadBalancerEntitlementService {
 
     public void validateNetworkForEndpointGateway(String cloudPlatform, String environmentName, Set<String> endpointGatewaySubnetIds) {
         if (!isEndpointGatewayEntitlementEnabledForPlatform(cloudPlatform)
-                && !SetUtils.emptyIfNull(endpointGatewaySubnetIds).isEmpty()) {
-            throw new BadRequestException(String.format("Environment %s cannot be created. Public Endpoint Gateway is not " +
+                && CollectionUtils.isNotEmpty(endpointGatewaySubnetIds)) {
+            throw new BadRequestException(String.format("Environment %s cannot be created. Endpoint Gateway is not " +
                     "supported on %s platform, or the Endpoint Gateway entitlement is missing.", environmentName, cloudPlatform));
         }
     }

--- a/environment/src/test/java/com/sequenceiq/environment/environment/flow/EnvironmentReactorFlowManagerTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/flow/EnvironmentReactorFlowManagerTest.java
@@ -2,15 +2,20 @@ package com.sequenceiq.environment.environment.flow;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -19,10 +24,14 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.eventbus.Event;
+import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
 import com.sequenceiq.environment.environment.domain.EnvironmentView;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
 import com.sequenceiq.environment.environment.flow.deletion.event.EnvDeleteEvent;
+import com.sequenceiq.environment.environment.flow.loadbalancer.event.LoadBalancerUpdateEvent;
+import com.sequenceiq.environment.environment.flow.loadbalancer.event.LoadBalancerUpdateStateSelectors;
 import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationDefaultEvent;
 import com.sequenceiq.environment.environment.flow.modify.proxy.event.EnvProxyModificationStateSelectors;
 import com.sequenceiq.environment.environment.service.stack.StackService;
@@ -41,6 +50,8 @@ class EnvironmentReactorFlowManagerTest {
 
     private static final String ENVIRONMENT_NAME = "environmentName";
 
+    private static final String ENVIRONMENT_CRN = "envCrn";
+
     private static final String USER_CRN = "userCrn";
 
     @Mock
@@ -51,6 +62,9 @@ class EnvironmentReactorFlowManagerTest {
 
     @Mock
     private StackService stackService;
+
+    @Mock
+    private EntitlementService entitlementService;
 
     @InjectMocks
     private EnvironmentReactorFlowManager underTest;
@@ -63,6 +77,9 @@ class EnvironmentReactorFlowManagerTest {
 
     @Captor
     private ArgumentCaptor<EnvProxyModificationDefaultEvent> envProxyModificationDefaultEventCaptor;
+
+    @Captor
+    private ArgumentCaptor<LoadBalancerUpdateEvent> loadbalancerUpdateEventCaptor;
 
     @Captor
     private ArgumentCaptor<Event.Headers> headersCaptor;
@@ -114,6 +131,41 @@ class EnvironmentReactorFlowManagerTest {
                 .returns(environmentDto, EnvProxyModificationDefaultEvent::getEnvironmentDto)
                 .returns(proxyConfig, EnvProxyModificationDefaultEvent::getProxyConfig);
         verifyHeaders();
+    }
+
+    @ParameterizedTest
+    @MethodSource("triggerLoadBalancerUpdateFlowScenarios")
+    void triggerLoadBalancerUpdateFlow(boolean targetingEntitled, PublicEndpointAccessGateway peag) {
+        EnvironmentDto environmentDto = mock(EnvironmentDto.class);
+        lenient().when(entitlementService.isTargetingSubnetsForEndpointAccessGatewayEnabled(any())).thenReturn(targetingEntitled);
+        when(eventSender.sendEvent(any(LoadBalancerUpdateEvent.class), any(Event.Headers.class))).thenReturn(flowIdentifier);
+
+        Set<String> subnets = Set.of("subnetId1", "subnetId2");
+        FlowIdentifier result = ThreadBasedUserCrnProvider.doAs(USER_CRN,
+                () -> underTest.triggerLoadBalancerUpdateFlow(environmentDto, ENVIRONMENT_ID, ENVIRONMENT_NAME, ENVIRONMENT_CRN,
+                        peag, subnets, USER_CRN));
+
+        assertThat(result).isEqualTo(flowIdentifier);
+        verify(eventSender).sendEvent(loadbalancerUpdateEventCaptor.capture(), headersCaptor.capture());
+        LoadBalancerUpdateEvent event = loadbalancerUpdateEventCaptor.getValue();
+        assertThat(event)
+                .returns(LoadBalancerUpdateStateSelectors.LOAD_BALANCER_UPDATE_START_EVENT.selector(), BaseFlowEvent::selector)
+                .returns(environmentDto, LoadBalancerUpdateEvent::getEnvironmentDto)
+                .returns(ENVIRONMENT_CRN, LoadBalancerUpdateEvent::getResourceCrn)
+                .returns(ENVIRONMENT_ID, LoadBalancerUpdateEvent::getResourceId)
+                .returns(ENVIRONMENT_NAME, LoadBalancerUpdateEvent::getResourceName)
+                .returns(peag, LoadBalancerUpdateEvent::getEndpointAccessGateway)
+                .returns(subnets, LoadBalancerUpdateEvent::getSubnetIds);
+        verifyHeaders();
+    }
+
+    public static Stream<Arguments> triggerLoadBalancerUpdateFlowScenarios() {
+        return Stream.of(
+                Arguments.of(true, PublicEndpointAccessGateway.ENABLED),
+                Arguments.of(false, PublicEndpointAccessGateway.ENABLED),
+                Arguments.of(true, PublicEndpointAccessGateway.DISABLED),
+                Arguments.of(false, PublicEndpointAccessGateway.DISABLED)
+        );
     }
 
     private void verifyEnvDeleteEvent(boolean forcedExpected, String selectorExpected) {

--- a/environment/src/test/java/com/sequenceiq/environment/environment/flow/loadbalancer/handler/LoadBalancerEnvUpdateHandlerTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/flow/loadbalancer/handler/LoadBalancerEnvUpdateHandlerTest.java
@@ -1,0 +1,213 @@
+package com.sequenceiq.environment.environment.flow.loadbalancer.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
+import com.sequenceiq.cloudbreak.eventbus.Event;
+import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
+import com.sequenceiq.environment.environment.EnvironmentStatus;
+import com.sequenceiq.environment.environment.domain.Environment;
+import com.sequenceiq.environment.environment.dto.EnvironmentDto;
+import com.sequenceiq.environment.environment.dto.EnvironmentLoadBalancerDto;
+import com.sequenceiq.environment.environment.flow.loadbalancer.event.LoadBalancerUpdateEvent;
+import com.sequenceiq.environment.environment.flow.loadbalancer.event.LoadBalancerUpdateFailedEvent;
+import com.sequenceiq.environment.environment.flow.loadbalancer.event.LoadBalancerUpdateHandlerSelectors;
+import com.sequenceiq.environment.environment.flow.loadbalancer.event.LoadBalancerUpdateStateSelectors;
+import com.sequenceiq.environment.environment.service.EnvironmentService;
+import com.sequenceiq.environment.environment.service.network.NetworkMetadataValidationService;
+import com.sequenceiq.environment.network.NetworkService;
+import com.sequenceiq.environment.network.dao.domain.BaseNetwork;
+import com.sequenceiq.environment.network.dto.NetworkDto;
+import com.sequenceiq.flow.reactor.api.event.EventSender;
+
+@ExtendWith(MockitoExtension.class)
+class LoadBalancerEnvUpdateHandlerTest {
+
+    private static final String ENV_CRN = "someCrnValue";
+
+    private static final String ENV_NAME = "envName";
+
+    private static final long ENV_ID = 100L;
+
+    @Mock
+    private NetworkMetadataValidationService networkValidationService;
+
+    @Mock
+    private NetworkService networkService;
+
+    @Mock
+    private EnvironmentService environmentService;
+
+    @Mock
+    private EntitlementService entitlementService;
+
+    @Mock
+    private EventSender eventSender;
+
+    @Mock
+    private Event<EnvironmentLoadBalancerDto> environmentLbDtoEvent;
+
+    @Mock
+    private EnvironmentLoadBalancerDto environmentLoadBalancerDto;
+
+    @Mock
+    private EnvironmentDto environmentDto;
+
+    @Mock
+    private Event.Headers eventHeaders;
+
+    @Mock
+    private NetworkDto networkDto;
+
+    private BaseNetwork network;
+
+    @Captor
+    private ArgumentCaptor<LoadBalancerUpdateEvent> updateEventCaptor;
+
+    @Captor
+    private ArgumentCaptor<LoadBalancerUpdateFailedEvent> failedEventCaptor;
+
+    @Captor
+    private ArgumentCaptor<BaseNetwork> networkCaptor;
+
+    @InjectMocks
+    private LoadBalancerEnvUpdateHandler underTest;
+
+    private Environment environment;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(environmentLbDtoEvent.getData()).thenReturn(environmentLoadBalancerDto);
+        lenient().when(environmentLbDtoEvent.getHeaders()).thenReturn(eventHeaders);
+        lenient().when(environmentLoadBalancerDto.getEnvironmentDto()).thenReturn(environmentDto);
+        lenient().when(environmentDto.getResourceCrn()).thenReturn(ENV_CRN);
+        lenient().when(environmentDto.getId()).thenReturn(ENV_ID);
+        lenient().when(environmentDto.getResourceId()).thenReturn(ENV_ID);
+        lenient().when(environmentDto.getNetwork()).thenReturn(networkDto);
+        network = new BaseNetwork() {
+            @Override
+            public String getNetworkId() {
+                return "networkId";
+            }
+
+            @Override
+            public String toString() {
+                return super.toString();
+            }
+        };
+        environment = new Environment();
+        environment.setId(ENV_ID);
+        environment.setName(ENV_NAME);
+        environment.setResourceCrn(ENV_CRN);
+        environment.setNetwork(network);
+    }
+
+    @Test
+    void selector() {
+        assertThat(underTest.selector()).isEqualTo(LoadBalancerUpdateHandlerSelectors.ENVIRONMENT_UPDATE_HANDLER_EVENT.name());
+    }
+
+    @Test
+    void noEnvironment() {
+        when(environmentService.findEnvironmentByIdOrThrow(ENV_ID)).thenThrow(new IllegalStateException("not found"));
+
+        underTest.accept(environmentLbDtoEvent);
+        verifyLoadBalancerEnvUpdateFailedEvent(environmentLbDtoEvent, "not found");
+    }
+
+    @ParameterizedTest(name = "PublicEndpointAccessGateway = {0} Subnets = {1} Targeting enabled = {2}")
+    @MethodSource("noLbScenario")
+    void acceptNoLoadBalancerNeeded(PublicEndpointAccessGateway peag, Set<String> subnets, boolean targetingEnabled) {
+        when(environmentService.findEnvironmentByIdOrThrow(ENV_ID)).thenReturn(environment);
+        when(environmentLoadBalancerDto.getEndpointAccessGateway()).thenReturn(peag);
+        when(environmentLoadBalancerDto.getEndpointGatewaySubnetIds()).thenReturn(subnets);
+        when(entitlementService.isTargetingSubnetsForEndpointAccessGatewayEnabled(any())).thenReturn(targetingEnabled);
+        underTest.accept(environmentLbDtoEvent);
+
+        verifyNoInteractions(networkService);
+        verifyLoadBalancerEnvUpdateEvent(environmentLbDtoEvent, peag, subnets);
+    }
+
+    public static Stream<Arguments> noLbScenario() {
+        return Stream.of(
+                Arguments.of(null, Set.of("subnet1", "subnet2"), false),
+                Arguments.of(PublicEndpointAccessGateway.DISABLED, Set.of("subnet1", "subnet2"), false),
+                Arguments.of(PublicEndpointAccessGateway.DISABLED, Set.of(), true),
+                Arguments.of(PublicEndpointAccessGateway.DISABLED, null, true)
+        );
+    }
+
+    @ParameterizedTest(name = "PublicEndpointAccessGateway = {0} Subnets = {1} Targeting enabled = {2}")
+    @MethodSource("lbScenario")
+    void acceptLoadBalancerNeeded(PublicEndpointAccessGateway peag, Set<String> subnets, boolean targetingEnabled) {
+        when(environmentService.findEnvironmentByIdOrThrow(ENV_ID)).thenReturn(environment);
+        when(environmentLoadBalancerDto.getEndpointAccessGateway()).thenReturn(peag);
+        when(environmentLoadBalancerDto.getEndpointGatewaySubnetIds()).thenReturn(subnets);
+        lenient().when(entitlementService.isTargetingSubnetsForEndpointAccessGatewayEnabled(any())).thenReturn(targetingEnabled);
+        Map<String, CloudSubnet> cloudSubnets = Map.of("subnet1", new CloudSubnet("sn1", "name1"), "subnet2", new CloudSubnet("sn2", "name2"));
+        when(networkValidationService.getEndpointGatewaySubnetMetadata(environment, environmentDto)).thenReturn(cloudSubnets);
+        underTest.accept(environmentLbDtoEvent);
+
+        verify(networkService).save(networkCaptor.capture());
+        BaseNetwork network = networkCaptor.getValue();
+        assertThat(network.getPublicEndpointAccessGateway()).isEqualTo(peag);
+        assertThat(network.getEndpointGatewaySubnetMetas()).isEqualTo(cloudSubnets);
+        verifyLoadBalancerEnvUpdateEvent(environmentLbDtoEvent, peag, subnets);
+    }
+
+    public static Stream<Arguments> lbScenario() {
+        return Stream.of(
+                Arguments.of(PublicEndpointAccessGateway.ENABLED, Set.of(), false),
+                Arguments.of(PublicEndpointAccessGateway.ENABLED, Set.of(), true),
+                Arguments.of(PublicEndpointAccessGateway.ENABLED, Set.of("subnet1", "subnet2"), true),
+                Arguments.of(PublicEndpointAccessGateway.DISABLED, Set.of("subnet1", "subnet2"), true),
+                Arguments.of(null, Set.of("subnet1", "subnet2"), true)
+        );
+    }
+
+    private void verifyLoadBalancerEnvUpdateEvent(Event<EnvironmentLoadBalancerDto> event, PublicEndpointAccessGateway peag, Set<String> subnets) {
+        Event.Headers headers = event.getHeaders();
+        verify(eventSender).sendEvent(updateEventCaptor.capture(), eq(headers));
+        assertThat(updateEventCaptor.getValue())
+                .returns(LoadBalancerUpdateStateSelectors.LOAD_BALANCER_STACK_UPDATE_EVENT.selector(), LoadBalancerUpdateEvent::selector)
+                .returns(ENV_ID, LoadBalancerUpdateEvent::getResourceId)
+                .returns(ENV_NAME, LoadBalancerUpdateEvent::getResourceName)
+                .returns(ENV_CRN, LoadBalancerUpdateEvent::getResourceCrn)
+                .returns(environment, LoadBalancerUpdateEvent::getEnvironment)
+                .returns(environmentDto, LoadBalancerUpdateEvent::getEnvironmentDto)
+                .returns(peag, LoadBalancerUpdateEvent::getEndpointAccessGateway)
+                .returns(subnets, LoadBalancerUpdateEvent::getSubnetIds);
+    }
+
+    private void verifyLoadBalancerEnvUpdateFailedEvent(Event<EnvironmentLoadBalancerDto> event, String message) {
+        Event.Headers headers = event.getHeaders();
+        verify(eventSender).sendEvent(failedEventCaptor.capture(), eq(headers));
+        assertThat(failedEventCaptor.getValue())
+                .returns(LoadBalancerUpdateStateSelectors.FAILED_LOAD_BALANCER_UPDATE_EVENT.selector(), LoadBalancerUpdateFailedEvent::selector)
+                .returns(EnvironmentStatus.LOAD_BALANCER_ENV_UPDATE_FAILED, LoadBalancerUpdateFailedEvent::getEnvironmentStatus)
+                .returns(message, e -> e.getException().getMessage());
+    }
+}

--- a/environment/src/test/java/com/sequenceiq/environment/environment/flow/loadbalancer/handler/LoadBalancerStackUpdateHandlerTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/flow/loadbalancer/handler/LoadBalancerStackUpdateHandlerTest.java
@@ -1,0 +1,159 @@
+package com.sequenceiq.environment.environment.flow.loadbalancer.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.eventbus.Event;
+import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
+import com.sequenceiq.environment.environment.EnvironmentStatus;
+import com.sequenceiq.environment.environment.domain.Environment;
+import com.sequenceiq.environment.environment.dto.EnvironmentDto;
+import com.sequenceiq.environment.environment.dto.EnvironmentLoadBalancerDto;
+import com.sequenceiq.environment.environment.flow.loadbalancer.event.LoadBalancerUpdateEvent;
+import com.sequenceiq.environment.environment.flow.loadbalancer.event.LoadBalancerUpdateFailedEvent;
+import com.sequenceiq.environment.environment.flow.loadbalancer.event.LoadBalancerUpdateHandlerSelectors;
+import com.sequenceiq.environment.environment.flow.loadbalancer.event.LoadBalancerUpdateStateSelectors;
+import com.sequenceiq.environment.environment.service.LoadBalancerPollerService;
+import com.sequenceiq.environment.network.dao.domain.BaseNetwork;
+import com.sequenceiq.environment.network.dto.NetworkDto;
+import com.sequenceiq.flow.reactor.api.event.EventSender;
+
+@ExtendWith(MockitoExtension.class)
+class LoadBalancerStackUpdateHandlerTest {
+
+    private static final String ENV_CRN = "someCrnValue";
+
+    private static final String ENV_NAME = "envName";
+
+    private static final long ENV_ID = 100L;
+
+    private static final String ACCOUNT_ID = "account";
+
+    @Mock
+    private LoadBalancerPollerService loadBalancerPollerService;
+
+    @Mock
+    private EventSender eventSender;
+
+    @Mock
+    private Event<EnvironmentLoadBalancerDto> environmentLbDtoEvent;
+
+    @Mock
+    private EnvironmentLoadBalancerDto environmentLoadBalancerDto;
+
+    @Mock
+    private EnvironmentDto environmentDto;
+
+    @Mock
+    private Event.Headers eventHeaders;
+
+    @Mock
+    private NetworkDto networkDto;
+
+    @Captor
+    private ArgumentCaptor<LoadBalancerUpdateEvent> updateEventCaptor;
+
+    @Captor
+    private ArgumentCaptor<LoadBalancerUpdateFailedEvent> failedEventCaptor;
+
+    @InjectMocks
+    private LoadBalancerStackUpdateHandler underTest;
+
+    private Environment environment;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(environmentLbDtoEvent.getData()).thenReturn(environmentLoadBalancerDto);
+        lenient().when(environmentLbDtoEvent.getHeaders()).thenReturn(eventHeaders);
+        lenient().when(environmentLoadBalancerDto.getEnvironmentDto()).thenReturn(environmentDto);
+        lenient().when(environmentDto.getResourceCrn()).thenReturn(ENV_CRN);
+        lenient().when(environmentDto.getId()).thenReturn(ENV_ID);
+        lenient().when(environmentDto.getResourceId()).thenReturn(ENV_ID);
+        lenient().when(environmentDto.getName()).thenReturn(ENV_NAME);
+        lenient().when(environmentDto.getNetwork()).thenReturn(networkDto);
+        lenient().when(environmentDto.getAccountId()).thenReturn(ACCOUNT_ID);
+        BaseNetwork network = new BaseNetwork() {
+            @Override
+            public String getNetworkId() {
+                return "networkId";
+            }
+
+            @Override
+            public String toString() {
+                return super.toString();
+            }
+        };
+        environment = new Environment();
+        environment.setId(ENV_ID);
+        environment.setName(ENV_NAME);
+        environment.setResourceCrn(ENV_CRN);
+        environment.setNetwork(network);
+    }
+
+    @Test
+    void selector() {
+        assertThat(underTest.selector()).isEqualTo(LoadBalancerUpdateHandlerSelectors.STACK_UPDATE_HANDLER_EVENT.name());
+    }
+
+    @Test
+    void pollerFailure() {
+        doThrow(new IllegalStateException("not found")).when(loadBalancerPollerService).updateStackWithLoadBalancer(
+                nullable(String.class), nullable(String.class), nullable(String.class), nullable(PublicEndpointAccessGateway.class), anyBoolean());
+
+        underTest.accept(environmentLbDtoEvent);
+        verifyLoadBalancerStackUpdateFailedEvent(environmentLbDtoEvent, "not found");
+    }
+
+    @ParameterizedTest
+    @EnumSource(PublicEndpointAccessGateway.class)
+    void accept(PublicEndpointAccessGateway peag) {
+        when(environmentLoadBalancerDto.getEndpointAccessGateway()).thenReturn(peag);
+        Set<String> subnetIds = Set.of("subnet1", "subnet2");
+        when(environmentLoadBalancerDto.getEndpointGatewaySubnetIds()).thenReturn(subnetIds);
+        underTest.accept(environmentLbDtoEvent);
+        verify(loadBalancerPollerService)
+                .updateStackWithLoadBalancer(eq(ACCOUNT_ID), eq(ENV_CRN), eq(ENV_NAME), eq(peag), eq(true));
+        verifyLoadBalancerStackUpdateEvent(environmentLbDtoEvent, peag, subnetIds);
+    }
+
+    private void verifyLoadBalancerStackUpdateEvent(Event<EnvironmentLoadBalancerDto> event, PublicEndpointAccessGateway peag, Set<String> subnets) {
+        Event.Headers headers = event.getHeaders();
+        verify(eventSender).sendEvent(updateEventCaptor.capture(), eq(headers));
+        assertThat(updateEventCaptor.getValue())
+                .returns(LoadBalancerUpdateStateSelectors.FINISH_LOAD_BALANCER_UPDATE_EVENT.selector(), LoadBalancerUpdateEvent::selector)
+                .returns(ENV_ID, LoadBalancerUpdateEvent::getResourceId)
+                .returns(ENV_NAME, LoadBalancerUpdateEvent::getResourceName)
+                .returns(ENV_CRN, LoadBalancerUpdateEvent::getResourceCrn)
+                .returns(environmentDto, LoadBalancerUpdateEvent::getEnvironmentDto)
+                .returns(peag, LoadBalancerUpdateEvent::getEndpointAccessGateway)
+                .returns(subnets, LoadBalancerUpdateEvent::getSubnetIds);
+    }
+
+    private void verifyLoadBalancerStackUpdateFailedEvent(Event<EnvironmentLoadBalancerDto> event, String message) {
+        Event.Headers headers = event.getHeaders();
+        verify(eventSender).sendEvent(failedEventCaptor.capture(), eq(headers));
+        assertThat(failedEventCaptor.getValue())
+                .returns(LoadBalancerUpdateStateSelectors.FAILED_LOAD_BALANCER_UPDATE_EVENT.selector(), LoadBalancerUpdateFailedEvent::selector)
+                .returns(EnvironmentStatus.LOAD_BALANCER_STACK_UPDATE_FAILED, LoadBalancerUpdateFailedEvent::getEnvironmentStatus)
+                .returns(message, e -> e.getException().getMessage());
+    }
+}

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentLoadBalancerServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentLoadBalancerServiceTest.java
@@ -9,26 +9,28 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
-import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
 import com.sequenceiq.environment.environment.domain.Environment;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
 import com.sequenceiq.environment.environment.dto.EnvironmentLoadBalancerDto;
 import com.sequenceiq.environment.environment.flow.EnvironmentReactorFlowManager;
+import com.sequenceiq.environment.network.dto.NetworkDto;
 import com.sequenceiq.environment.network.service.LoadBalancerEntitlementService;
 
-@ExtendWith(SpringExtension.class)
+@ExtendWith(MockitoExtension.class)
 class EnvironmentLoadBalancerServiceTest {
 
     private static final String USER_CRN = "crn:cdp:iam:us-west-1:1234:user:1";
@@ -54,12 +56,17 @@ class EnvironmentLoadBalancerServiceTest {
 
     @Test
     void testNoEnvironmentFound() {
-        EnvironmentLoadBalancerDto environmentLbDto = EnvironmentLoadBalancerDto.builder()
-            .withEndpointAccessGateway(PublicEndpointAccessGateway.ENABLED)
-            .build();
+        EnvironmentLoadBalancerDto environmentLbDto = EnvironmentLoadBalancerDto.builder().build();
+        NetworkDto network = NetworkDto.builder()
+                .withEndpointGatewaySubnetMetas(Map.of(
+                        "subnet1", new CloudSubnet("11", "subnet1"),
+                        "subnet2", new CloudSubnet("22", "subnet2")
+                ))
+                .build();
         EnvironmentDto environmentDto = EnvironmentDto.builder()
             .withName(ENV_NAME)
             .withResourceCrn(ENV_CRN)
+            .withNetwork(network)
             .build();
         String expectedError = String.format("Could not find environment '%s' using crn '%s'", ENV_NAME, ENV_CRN);
 
@@ -77,12 +84,17 @@ class EnvironmentLoadBalancerServiceTest {
     }
 
     @Test
-    void testEndpointGatewayEnabled() {
-        EnvironmentLoadBalancerDto environmentLbDto = EnvironmentLoadBalancerDto.builder()
-            .withEndpointAccessGateway(PublicEndpointAccessGateway.ENABLED)
-            .build();
+    void testEndpointGatewaySubnetsProvided() {
+        EnvironmentLoadBalancerDto environmentLbDto = EnvironmentLoadBalancerDto.builder().build();
+        NetworkDto network = NetworkDto.builder()
+                .withEndpointGatewaySubnetMetas(Map.of(
+                        "subnet1", new CloudSubnet("11", "subnet1"),
+                        "subnet2", new CloudSubnet("22", "subnet2")
+                ))
+                .build();
         EnvironmentDto environmentDto = EnvironmentDto.builder()
             .withResourceCrn(ENV_CRN)
+            .withNetwork(network)
             .build();
 
         when(environmentService.findByResourceCrnAndAccountIdAndArchivedIsFalse(anyString(), anyString()))
@@ -99,9 +111,7 @@ class EnvironmentLoadBalancerServiceTest {
 
     @Test
     void testDataLakeLoadBalancerEnabled() {
-        EnvironmentLoadBalancerDto environmentLbDto = EnvironmentLoadBalancerDto.builder()
-            .withEndpointAccessGateway(PublicEndpointAccessGateway.DISABLED)
-            .build();
+        EnvironmentLoadBalancerDto environmentLbDto = EnvironmentLoadBalancerDto.builder().build();
         EnvironmentDto environmentDto = EnvironmentDto.builder()
             .withResourceCrn(ENV_CRN)
             .build();
@@ -121,9 +131,7 @@ class EnvironmentLoadBalancerServiceTest {
 
     @Test
     void testNoEntitlements() {
-        EnvironmentLoadBalancerDto environmentLbDto = EnvironmentLoadBalancerDto.builder()
-            .withEndpointAccessGateway(PublicEndpointAccessGateway.DISABLED)
-            .build();
+        EnvironmentLoadBalancerDto environmentLbDto = EnvironmentLoadBalancerDto.builder().build();
         EnvironmentDto environmentDto = EnvironmentDto.builder()
             .withResourceCrn(ENV_CRN)
             .build();

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/network/NetworkMetadataValidationServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/network/NetworkMetadataValidationServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import java.util.Map;
@@ -21,9 +22,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
+import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
 import com.sequenceiq.environment.environment.domain.Environment;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
 import com.sequenceiq.environment.network.CloudNetworkService;
+import com.sequenceiq.environment.network.dao.domain.AwsNetwork;
+import com.sequenceiq.environment.network.dto.NetworkDto;
 
 @ExtendWith(MockitoExtension.class)
 class NetworkMetadataValidationServiceTest extends NetworkTest {
@@ -39,8 +43,8 @@ class NetworkMetadataValidationServiceTest extends NetworkTest {
 
     @BeforeEach
     void setUp() {
-        when(entitlementService.endpointGatewaySkipValidation(any())).thenReturn(false);
-        when(entitlementService.isTargetingSubnetsForEndpointAccessGatewayEnabled(any())).thenReturn(false);
+        lenient().when(entitlementService.endpointGatewaySkipValidation(any())).thenReturn(false);
+        lenient().when(entitlementService.isTargetingSubnetsForEndpointAccessGatewayEnabled(any())).thenReturn(false);
     }
 
     @Test
@@ -90,7 +94,9 @@ class NetworkMetadataValidationServiceTest extends NetworkTest {
 
     private void assertWithPrivateSubnetsAllowed() {
         EnvironmentDto environmentDto = createEnvironmentDto();
-        Environment environment = createEnvironment(createNetwork());
+        AwsNetwork network = createNetwork();
+        network.setPublicEndpointAccessGateway(PublicEndpointAccessGateway.DISABLED);
+        Environment environment = createEnvironment(network);
 
         Map<String, CloudSubnet> endpointGatewaySubnets = createDefaultPublicSubnets();
         endpointGatewaySubnets.putAll(createDefaultPrivateSubnets());
@@ -102,6 +108,30 @@ class NetworkMetadataValidationServiceTest extends NetworkTest {
 
         assertEquals(4, subnetResult.size());
         assertEquals(Set.of(ID_1, ID_2, PUBLIC_ID_1, PUBLIC_ID_2), subnetResult.keySet());
+    }
+
+    @Test
+    public void testWithEndpointGatewayPrivateSubnetsPublicEndpointAccessGatewayEnabled() {
+        when(entitlementService.isTargetingSubnetsForEndpointAccessGatewayEnabled(any())).thenReturn(true);
+        Map<String, CloudSubnet> subnets = createDefaultPublicSubnets();
+        Map<String, CloudSubnet> endpointGatewaySubnets = createDefaultPrivateSubnets();
+        EnvironmentDto environmentDto = createEnvironmentDto();
+        environmentDto.setNetwork(NetworkDto.builder()
+                .withSubnetMetas(subnets)
+                .withEndpointGatewaySubnetMetas(endpointGatewaySubnets)
+                .build());
+        AwsNetwork network = createNetwork();
+        network.setPublicEndpointAccessGateway(PublicEndpointAccessGateway.ENABLED);
+        network.setSubnetMetas(subnets);
+        network.setEndpointGatewaySubnetMetas(endpointGatewaySubnets);
+        Environment environment = createEnvironment(network);
+
+        when(cloudNetworkService.retrieveEndpointGatewaySubnetMetadata(any(EnvironmentDto.class), any())).thenReturn(endpointGatewaySubnets);
+
+        BadRequestException exception = assertThrows(BadRequestException.class, () ->
+                ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.getEndpointGatewaySubnetMetadata(environment, environmentDto)));
+
+        assertTrue(exception.getMessage().startsWith("All subnets that are provided as Endpoint Access Gateway Subnet are PRIVATE"));
     }
 
     @Test

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Internal load balancers in private networks can be created as Endpoint Access Gateway if explicitly requested.
For this purpose, a new Load Balancer Type is introduced, the GATEWAY_PRIVATE.

Refactored the overly complex `LoadBalancerConfigService`.

Goodies: bump Gradle and Mockito version

See detailed description in the commit message.