### PR TITLE
CB-20087 make GCP cloud resource names unique to a stack

### DIFF
--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilder.java
@@ -120,7 +120,7 @@ public class GcpInstanceResourceBuilder extends AbstractGcpComputeBuilder {
 
     @Override
     public List<CloudResource> build(GcpContext context, CloudInstance cloudInstance, long privateId, AuthenticatedContext auth,
-        Group group, List<CloudResource> buildableResource, CloudStack cloudStack) throws Exception {
+            Group group, List<CloudResource> buildableResource, CloudStack cloudStack) throws Exception {
         InstanceTemplate template = group.getReferenceInstanceTemplate();
         String projectId = context.getProjectId();
         String location = cloudInstance.getAvailabilityZone();
@@ -364,7 +364,7 @@ public class GcpInstanceResourceBuilder extends AbstractGcpComputeBuilder {
 
     @Override
     public CloudResource update(GcpContext context, CloudResource resource, CloudInstance cloudInstance,
-        AuthenticatedContext auth, CloudStack cloudStack) throws Exception {
+            AuthenticatedContext auth, CloudStack cloudStack) throws Exception {
         String projectId = gcpStackUtil.getProjectId(auth.getCloudCredential());
         String availabilityZone = cloudInstance.getAvailabilityZone();
         Compute compute = context.getCompute();
@@ -484,7 +484,8 @@ public class GcpInstanceResourceBuilder extends AbstractGcpComputeBuilder {
 
     private List<CloudResource> filterGroupFromName(List<CloudResource> resources, String filterString) {
         return Optional.ofNullable(resources).orElseGet(List::of).stream()
-                .filter(resource -> resource.getName().endsWith(filterString))
+                .filter(resource ->
+                        StringUtils.equals(filterString, getResourceNameService().decodeInstanceGroupResourceNameFromString(resource.getName()).getGroupName()))
                 .collect(Collectors.toList());
     }
 
@@ -516,7 +517,7 @@ public class GcpInstanceResourceBuilder extends AbstractGcpComputeBuilder {
     }
 
     private Operation executeStartOperation(String projectId, String availabilityZone, Compute compute, String instanceId, InstanceTemplate template,
-                                            List<AttachedDisk> disks) throws IOException {
+            List<AttachedDisk> disks) throws IOException {
 
         if (customGcpDiskEncryptionService.hasCustomEncryptionRequested(template)) {
             LOGGER.info("Start the instance with custom encryption: {}", instanceId);

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/group/GcpInstanceGroupResourceBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/group/GcpInstanceGroupResourceBuilder.java
@@ -35,7 +35,7 @@ public class GcpInstanceGroupResourceBuilder extends AbstractGcpGroupBuilder {
 
     @Override
     public CloudResource create(GcpContext context, AuthenticatedContext auth, Group group, Network network) {
-        String resourceName = getResourceNameService().resourceName(resourceType(), context.getName(), group.getName());
+        String resourceName = getResourceNameService().resourceName(resourceType(), context.getName(), group.getName(), auth.getCloudContext().getId());
         return createNamedResource(resourceType(), resourceName, context.getLocation().getAvailabilityZone().value());
     }
 

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpBackendServiceResourceBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpBackendServiceResourceBuilder.java
@@ -31,7 +31,7 @@ import com.sequenceiq.cloudbreak.cloud.model.TargetGroupPortPair;
 import com.sequenceiq.common.api.type.ResourceType;
 
 /**
- * Responsible for CRUD opertaions of a GCP Backend Service Resource
+ * Responsible for CRUD operations of a GCP Backend Service Resource
  * A backend service could have multiple definitions, but currently the only one used is based on instance groups
  * Set the health check mentod to be used for the related instance groups
  */
@@ -93,7 +93,7 @@ public class GcpBackendServiceResourceBuilder extends AbstractGcpLoadBalancerBui
                 TargetGroupPortPair targetGroupPortPair = new TargetGroupPortPair(trafficPort, hcPort);
                 groups.addAll(loadBalancer.getPortToTargetGroupMapping().get(targetGroupPortPair));
             }
-            makeBackendForTargetGroup(context, loadBalancer, projectId, zone, groups, backends);
+            makeBackendForTargetGroup(context, auth, loadBalancer, projectId, zone, groups, backends);
 
             backendService.setBackends(backends);
             backendService.setName(buildableResource.getName());
@@ -126,11 +126,12 @@ public class GcpBackendServiceResourceBuilder extends AbstractGcpLoadBalancerBui
                 .collect(Collectors.toList());
     }
 
-    private void makeBackendForTargetGroup(GcpContext context, CloudLoadBalancer loadBalancer, String projectId, String zone,
+    private void makeBackendForTargetGroup(GcpContext context, AuthenticatedContext auth, CloudLoadBalancer loadBalancer, String projectId, String zone,
             Set<Group> groups, List<Backend> backends) {
         for (Group group : groups) {
             Backend backend = new Backend();
-            String groupname = getResourceNameService().resourceName(ResourceType.GCP_INSTANCE_GROUP, context.getName(), group.getName());
+            String groupname = getResourceNameService()
+                    .resourceName(ResourceType.GCP_INSTANCE_GROUP, context.getName(), group.getName(), auth.getCloudContext().getId());
             backend.setGroup(String.format(GCP_INSTANCEGROUP_REFERENCE_FORMAT,
                     projectId, zone, groupname));
             backend.setBalancingMode(CONNECTION);

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/service/naming/GcpInstanceGroupResourceName.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/service/naming/GcpInstanceGroupResourceName.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.cloudbreak.cloud.gcp.service.naming;
+
+public class GcpInstanceGroupResourceName {
+
+    private final String stackName;
+
+    private final String groupName;
+
+    private final String suffix;
+
+    public GcpInstanceGroupResourceName(String stackName, String groupName, String suffix) {
+        this.stackName = stackName;
+        this.groupName = groupName;
+        this.suffix = suffix;
+    }
+
+    public String getStackName() {
+        return stackName;
+    }
+
+    public String getGroupName() {
+        return groupName;
+    }
+
+    public String getSuffix() {
+        return suffix;
+    }
+
+    @Override
+    public String toString() {
+        return "GcpInstanceGroupResourceName{" +
+                "stackName='" + stackName + '\'' +
+                ", groupName='" + groupName + '\'' +
+                ", suffix='" + suffix + '\'' +
+                '}';
+    }
+}

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilderTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilderTest.java
@@ -403,7 +403,7 @@ public class GcpInstanceResourceBuilderTest {
         CloudResource instanceGroup = CloudResource.builder()
                 .withType(ResourceType.GCP_INSTANCE_GROUP)
                 .withStatus(CommonStatus.CREATED)
-                .withName(group.getName())
+                .withName("test-master-1")
                 .withGroup(group.getName())
                 .build();
         context.addGroupResources(group.getName(), Collections.singletonList(instanceGroup));
@@ -412,7 +412,7 @@ public class GcpInstanceResourceBuilderTest {
         InstanceGroups.List list = mock(InstanceGroups.List.class);
         when(instanceGroups.list(anyString(), anyString())).thenReturn(list);
         InstanceGroupList instanceGroupList = new InstanceGroupList();
-        instanceGroupList.setItems(singletonList(new InstanceGroup().setName(group.getName())));
+        instanceGroupList.setItems(singletonList(new InstanceGroup().setName("test-master-1")));
         when(list.execute()).thenReturn(instanceGroupList);
         when(addInstances.execute()).thenReturn(addOperation);
 
@@ -440,35 +440,38 @@ public class GcpInstanceResourceBuilderTest {
 
         Operation addOperation = new Operation();
         addOperation.setName("operation");
-        CloudResource instanceGroup = CloudResource.builder()
+        CloudResource masterInstanceGroup = CloudResource.builder()
                 .withType(ResourceType.GCP_INSTANCE_GROUP)
                 .withStatus(CommonStatus.CREATED)
-                .withName(group.getName())
+                .withName("test-master-1")
                 .withGroup(group.getName())
                 .build();
-        CloudResource instanceGroup2 = CloudResource.builder()
+        CloudResource gatewayInstanceGroup = CloudResource.builder()
                 .withType(ResourceType.GCP_INSTANCE_GROUP)
                 .withStatus(CommonStatus.CREATED)
-                .withName("gateway")
+                .withName("test-gateway-1")
+                .withGroup(group.getName())
                 .build();
-        CloudResource instanceGroup3 = CloudResource.builder()
+        CloudResource idBrokerInstanceGroup = CloudResource.builder()
                 .withType(ResourceType.GCP_INSTANCE_GROUP)
                 .withStatus(CommonStatus.CREATED)
-                .withName("idbroker")
+                .withName("test-idbroker-1")
+                .withGroup(group.getName())
                 .build();
-        CloudResource instanceGroup4 = CloudResource.builder()
+        CloudResource master0InstanceGroup = CloudResource.builder()
                 .withType(ResourceType.GCP_INSTANCE_GROUP)
                 .withStatus(CommonStatus.CREATED)
-                .withName("free-master0")
+                .withName("test-master0-1")
+                .withGroup(group.getName())
                 .build();
-        context.addGroupResources(group.getName(), List.of(instanceGroup4, instanceGroup2, instanceGroup, instanceGroup3));
+        context.addGroupResources(group.getName(), List.of(master0InstanceGroup, gatewayInstanceGroup, masterInstanceGroup, idBrokerInstanceGroup));
         when(compute.instanceGroups()).thenReturn(instanceGroups);
         ArgumentCaptor<String> groupName = ArgumentCaptor.forClass(String.class);
         when(instanceGroups.addInstances(anyString(), anyString(), groupName.capture(), any())).thenReturn(addInstances);
         InstanceGroups.List list = mock(InstanceGroups.List.class);
         when(instanceGroups.list(anyString(), anyString())).thenReturn(list);
         InstanceGroupList instanceGroupList = new InstanceGroupList();
-        instanceGroupList.setItems(singletonList(new InstanceGroup().setName(group.getName())));
+        instanceGroupList.setItems(singletonList(new InstanceGroup().setName(masterInstanceGroup.getName())));
         when(list.execute()).thenReturn(instanceGroupList);
         when(addInstances.execute()).thenReturn(addOperation);
 
@@ -477,7 +480,7 @@ public class GcpInstanceResourceBuilderTest {
 
         // THEN
         verify(compute).instances();
-        assertEquals("master", groupName.getValue());
+        assertEquals(masterInstanceGroup.getName(), groupName.getValue());
         verify(instances).insert(anyString(), anyString(), instanceArg.capture());
         assertNull(instanceArg.getValue().getHostname());
     }

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/group/GcpInstanceGroupResourceBuilderTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/group/GcpInstanceGroupResourceBuilderTest.java
@@ -4,6 +4,7 @@ package com.sequenceiq.cloudbreak.cloud.gcp.group;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -50,7 +52,7 @@ public class GcpInstanceGroupResourceBuilderTest {
     @Mock
     private GcpContext gcpContext;
 
-    @Mock
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private AuthenticatedContext authenticatedContext;
 
     @Mock
@@ -123,23 +125,30 @@ public class GcpInstanceGroupResourceBuilderTest {
         when(gcpContext.getLocation()).thenReturn(location);
         when(location.getAvailabilityZone()).thenReturn(availabilityZone);
         when(availabilityZone.value()).thenReturn("zone");
+        when(authenticatedContext.getCloudContext().getId()).thenReturn(111L);
 
         CloudResource cloudResource = underTest.create(gcpContext, authenticatedContext, group, network);
 
-        Assertions.assertTrue(cloudResource.getName().startsWith("name-group"));
+        Assertions.assertEquals("name-group-111", cloudResource.getName());
     }
 
     @Test
-    public void testBuild() throws Exception {
+    public void testCloudResourceBoundToStack() throws Exception {
+
         when(gcpContext.getName()).thenReturn("name");
         when(group.getName()).thenReturn("group");
         when(gcpContext.getLocation()).thenReturn(location);
         when(location.getAvailabilityZone()).thenReturn(availabilityZone);
         when(availabilityZone.value()).thenReturn("zone");
+        when(authenticatedContext.getCloudContext().getId()).thenReturn(111L);
 
-        CloudResource cloudResource = underTest.create(gcpContext, authenticatedContext, group, network);
+        CloudResource cloudResource1 = underTest.create(gcpContext, authenticatedContext, group, network);
 
-        Assertions.assertTrue(cloudResource.getName().startsWith("name-group"));
+        reset(authenticatedContext);
+        when(authenticatedContext.getCloudContext().getId()).thenReturn(222L);
+        CloudResource cloudResource2 = underTest.create(gcpContext, authenticatedContext, group, network);
+
+        Assertions.assertNotEquals(cloudResource1.getName(), cloudResource2.getName());
     }
 
     @Test

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpBackendServiceResourceBuilderTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpBackendServiceResourceBuilderTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -50,7 +51,7 @@ public class GcpBackendServiceResourceBuilderTest {
     @Mock
     private GcpContext gcpContext;
 
-    @Mock
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private AuthenticatedContext authenticatedContext;
 
     @Mock
@@ -116,7 +117,7 @@ public class GcpBackendServiceResourceBuilderTest {
     }
 
     @Test
-    public void testBuildWithSeperateHCPort() throws Exception {
+    public void testBuildWithSeparateHCPort() throws Exception {
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("hcport", 8080);
         parameters.put("trafficport", 80);
@@ -163,6 +164,7 @@ public class GcpBackendServiceResourceBuilderTest {
         when(operation.getName()).thenReturn("name");
         when(operation.getHttpErrorStatusCode()).thenReturn(null);
         when(gcpLoadBalancerTypeConverter.getScheme(any(CloudLoadBalancer.class))).thenCallRealMethod();
+        when(authenticatedContext.getCloudContext().getId()).thenReturn(111L);
 
         List<CloudResource> cloudResources = underTest.build(gcpContext, authenticatedContext,
                 Collections.singletonList(resource), cloudLoadBalancer, cloudStack);
@@ -222,6 +224,7 @@ public class GcpBackendServiceResourceBuilderTest {
         when(operation.getName()).thenReturn("name");
         when(operation.getHttpErrorStatusCode()).thenReturn(null);
         when(gcpLoadBalancerTypeConverter.getScheme(any(CloudLoadBalancer.class))).thenCallRealMethod();
+        when(authenticatedContext.getCloudContext().getId()).thenReturn(111L);
 
         List<CloudResource> cloudResources = underTest.build(gcpContext, authenticatedContext,
                 Collections.singletonList(resource), cloudLoadBalancer, cloudStack);

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/service/GcpResourceNameServiceTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/service/GcpResourceNameServiceTest.java
@@ -1,11 +1,10 @@
 package com.sequenceiq.cloudbreak.cloud.gcp.service;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import com.sequenceiq.cloudbreak.cloud.service.ResourceNameService;
 import com.sequenceiq.common.api.type.LoadBalancerType;
 import com.sequenceiq.common.api.type.ResourceType;
 
@@ -13,7 +12,7 @@ public class GcpResourceNameServiceTest {
 
     private static final String MAX_RESOURCE_NAME_LENGTH = "63";
 
-    private ResourceNameService subject;
+    private GcpResourceNameService subject;
 
     @BeforeEach
     public void setUp() {
@@ -30,8 +29,8 @@ public class GcpResourceNameServiceTest {
         String networkResourceName = subject.resourceName(ResourceType.GCP_NETWORK, (Object[]) parts);
 
         // THEN
-        Assert.assertNotNull("The generated name must not be null!", networkResourceName);
-        Assert.assertEquals("The timestamp must be appended", 2L, networkResourceName.split("-").length);
+        Assertions.assertNotNull(networkResourceName, "The generated name must not be null!");
+        Assertions.assertEquals(2L, networkResourceName.split("-").length, "The timestamp must be appended");
     }
 
     @Test
@@ -43,9 +42,9 @@ public class GcpResourceNameServiceTest {
         String resourceName = subject.resourceName(ResourceType.GCP_FIREWALL_INTERNAL, stackName);
 
         // THEN
-        Assert.assertNotNull("The generated name must not be null!", resourceName);
-        Assert.assertEquals("The timestamp must be appended", 3L, resourceName.split("-").length);
-        Assert.assertEquals("The resource name suffix is not the expected one!", "internal", resourceName.split("-")[1]);
+        Assertions.assertNotNull(resourceName, "The generated name must not be null!");
+        Assertions.assertEquals(3L, resourceName.split("-").length, "The timestamp must be appended");
+        Assertions.assertEquals("internal", resourceName.split("-")[1], "The resource name suffix is not the expected one!");
     }
 
     @Test
@@ -57,9 +56,9 @@ public class GcpResourceNameServiceTest {
         String resourceName = subject.resourceName(ResourceType.GCP_FIREWALL_IN, stackName);
 
         // THEN
-        Assert.assertNotNull("The generated name must not be null!", resourceName);
-        Assert.assertEquals("The timestamp must be appended", 3L, resourceName.split("-").length);
-        Assert.assertEquals("The resource name suffix is not the expected one!", "in", resourceName.split("-")[1]);
+        Assertions.assertNotNull(resourceName, "The generated name must not be null!");
+        Assertions.assertEquals(resourceName.split("-").length, 3L, "The timestamp must be appended");
+        Assertions.assertEquals(resourceName.split("-")[1], "in", "The resource name suffix is not the expected one!");
     }
 
     @Test
@@ -72,12 +71,12 @@ public class GcpResourceNameServiceTest {
         String resourceName = subject.resourceName(ResourceType.GCP_RESERVED_IP, parts);
 
         // THEN
-        Assert.assertNotNull("The generated name must not be null!", resourceName);
-        Assert.assertEquals("The timestamp must be appended!", 4L, resourceName.split("-").length);
-        Assert.assertEquals("The resource name suffix is not the excepted one!", "thisisaverylongtextw", resourceName.split("-")[0]);
-        Assert.assertEquals("The instance group name is not the excepted one!", "t", resourceName.split("-")[1]);
-        Assert.assertEquals("The private id is not the excepted one!", "8999", resourceName.split("-")[2]);
-        Assert.assertTrue("The resource name length is wrong", resourceName.length() < Integer.parseInt(MAX_RESOURCE_NAME_LENGTH));
+        Assertions.assertNotNull(resourceName, "The generated name must not be null!");
+        Assertions.assertEquals(resourceName.split("-").length, 4L, "The timestamp must be appended!");
+        Assertions.assertEquals(resourceName.split("-")[0], "thisisaverylongtextw", "The resource name suffix is not the excepted one!");
+        Assertions.assertEquals(resourceName.split("-")[1], "t", "The instance group name is not the excepted one!");
+        Assertions.assertEquals(resourceName.split("-")[2], "8999", "The private id is not the excepted one!");
+        Assertions.assertTrue(resourceName.length() < Integer.parseInt(MAX_RESOURCE_NAME_LENGTH), "The resource name length is wrong");
     }
 
     @Test
@@ -89,9 +88,9 @@ public class GcpResourceNameServiceTest {
         String resourceName = subject.resourceName(ResourceType.GCP_ATTACHED_DISKSET, parts);
 
         // THEN
-        Assert.assertNotNull("The generated name must not be null!", resourceName);
-        Assert.assertEquals("The timestamp must be appended", 5L, resourceName.split("-").length);
-        Assert.assertTrue("The resource name is not the expected one!", resourceName.startsWith("stack-g-3-2"));
+        Assertions.assertNotNull(resourceName, "The generated name must not be null!");
+        Assertions.assertEquals(resourceName.split("-").length, 5L, "The timestamp must be appended");
+        Assertions.assertTrue(resourceName.startsWith("stack-g-3-2"), "The resource name is not the expected one!");
 
 
     }
@@ -103,9 +102,9 @@ public class GcpResourceNameServiceTest {
         String resourceName = subject.resourceName(ResourceType.GCP_HEALTH_CHECK, parts);
 
 
-        Assert.assertNotNull("The generated name must not be null!", resourceName);
-        Assert.assertTrue("The resource name is not the expected one!", resourceName.startsWith("stack-public-8080"));
-        Assert.assertEquals("The timestamp must be appended", 4L, resourceName.split("-").length);
+        Assertions.assertNotNull(resourceName, "The generated name must not be null!");
+        Assertions.assertTrue(resourceName.startsWith("stack-public-8080"), "The resource name is not the expected one!");
+        Assertions.assertEquals(resourceName.split("-").length, 4L, "The timestamp must be appended");
 
     }
 
@@ -119,12 +118,12 @@ public class GcpResourceNameServiceTest {
         String resourceName = subject.resourceName(ResourceType.GCP_INSTANCE, parts);
 
         //THEN
-        Assert.assertNotNull("The generated name must not be null!", resourceName);
-        Assert.assertEquals("The timestamp must be appended!", 4L, resourceName.split("-").length);
-        Assert.assertEquals("The resource name suffix is not the excepted one!", "thisisaverylongtextw", resourceName.split("-")[0]);
-        Assert.assertEquals("The instance group name is not the excepted one!", "t", resourceName.split("-")[1]);
-        Assert.assertEquals("The private is not the excepted one!", "8999", resourceName.split("-")[2]);
-        Assert.assertTrue("The resource name length is wrong", resourceName.length() < Integer.parseInt(MAX_RESOURCE_NAME_LENGTH));
+        Assertions.assertNotNull(resourceName, "The generated name must not be null!");
+        Assertions.assertEquals(resourceName.split("-").length, 4L, "The timestamp must be appended!");
+        Assertions.assertEquals(resourceName.split("-")[0], "thisisaverylongtextw", "The resource name suffix is not the excepted one!");
+        Assertions.assertEquals(resourceName.split("-")[1], "t", "The instance group name is not the excepted one!");
+        Assertions.assertEquals(resourceName.split("-")[2], "8999", "The private is not the excepted one!");
+        Assertions.assertTrue(resourceName.length() < Integer.parseInt(MAX_RESOURCE_NAME_LENGTH), "The resource name length is wrong");
     }
 
     @Test
@@ -137,26 +136,27 @@ public class GcpResourceNameServiceTest {
         String resourceName = subject.resourceName(ResourceType.GCP_INSTANCE, parts);
 
         //THEN
-        Assert.assertNotNull("The generated name must not be null!", resourceName);
-        Assert.assertEquals("The timestamp must be appended!", 4L, resourceName.split("-").length);
-        Assert.assertEquals("The resource name suffix is not the excepted one!", "stackname", resourceName.split("-")[0]);
-        Assert.assertEquals("The instance group name is not the excepted one!", "t", resourceName.split("-")[1]);
-        Assert.assertEquals("The private is not the excepted one!", "8999", resourceName.split("-")[2]);
-        Assert.assertTrue("The resource name length is wrong", resourceName.length() < Integer.parseInt(MAX_RESOURCE_NAME_LENGTH));
+        Assertions.assertNotNull(resourceName, "The generated name must not be null!");
+        Assertions.assertEquals(resourceName.split("-").length, 4L, "The timestamp must be appended!");
+        Assertions.assertEquals(resourceName.split("-")[0], "stackname", "The resource name suffix is not the excepted one!");
+        Assertions.assertEquals(resourceName.split("-")[1], "t", "The instance group name is not the excepted one!");
+        Assertions.assertEquals(resourceName.split("-")[2], "8999", "The private is not the excepted one!");
+        Assertions.assertTrue(resourceName.length() < Integer.parseInt(MAX_RESOURCE_NAME_LENGTH), "The resource name length is wrong");
 
     }
 
     @Test
     public void shouldGenerateGcpInstanceGroupResourceWehenPartsProvided() {
         // GIVEN
-        Object[] parts = {"stack", "group"};
+        Object[] parts = {"stack", "group", "1234"};
 
         // WHEN
         String resourceName = subject.resourceName(ResourceType.GCP_INSTANCE_GROUP, parts);
 
         // THEN
-        Assert.assertNotNull("The generated name must not be null!", resourceName);
-        Assert.assertEquals("Should have both parts", 2L, resourceName.split("-").length);
-        Assert.assertTrue("The resource name is not the expected one!", resourceName.startsWith("stack-group"));
+        Assertions.assertEquals(
+                "stack-group-1234", resourceName, "The instance group resource name should include stack name, stack id and a group name");
+        Assertions.assertEquals("group", subject.decodeInstanceGroupResourceNameFromString(resourceName).getGroupName());
+        Assertions.assertEquals("stack", subject.decodeInstanceGroupResourceNameFromString(resourceName).getStackName());
     }
 }

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/service/naming/GcpInstanceGroupResourceNameTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/service/naming/GcpInstanceGroupResourceNameTest.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.cloudbreak.cloud.gcp.service.naming;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.cloud.gcp.service.GcpResourceNameService;
+
+class GcpInstanceGroupResourceNameTest {
+    private final GcpResourceNameService subject = new GcpResourceNameService();
+
+    @Test
+    void testLegacyName() {
+        GcpInstanceGroupResourceName resourceName = subject.decodeInstanceGroupResourceNameFromString("test-master");
+        Assertions.assertEquals("test", resourceName.getStackName());
+        Assertions.assertEquals("master", resourceName.getGroupName());
+    }
+
+    @Test
+    void testNewStackName() {
+        GcpInstanceGroupResourceName resourceName = subject.decodeInstanceGroupResourceNameFromString("test-master-1");
+        Assertions.assertEquals("test", resourceName.getStackName());
+        Assertions.assertEquals("master", resourceName.getGroupName());
+        Assertions.assertEquals("1", resourceName.getSuffix());
+    }
+
+    @Test
+    void testUnsupported() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> subject.decodeInstanceGroupResourceNameFromString("master"));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> subject.decodeInstanceGroupResourceNameFromString("test-master-11-new"));
+    }
+}


### PR DESCRIPTION
# History
- functionality is previously merged
- was reverted due to e2e test failure 
- This PR contains a fix for a bug found: network is not assigned to an instance group. Root cause: using strings for resource identification and string manipulation to extract information from the resource names (find a resource group to assign an instance to).
- also with refactoring on _GcpInstanceResourceBuilder.assignToExistingInstanceGroup_  

# Motivation
If we resize the DataLake we create new resources from a blueprint with the same names as in the old DataLake and this causes GCP to request creation requests due to name conflict.
Name strategy before: DATALAKE_NAME-templateName

## Example:
we create an environment with LightDuty DL. DL blueprint is [datalake/src/main/resources/duties/7.2.15/gcp/light_duty.json](https://github.com/hortonworks/cloudbreak/blob/master/datalake/src/main/resources/duties/7.2.15/gcp/light_duty.json)
and datalake name is "butterfly". Among other things this will request an idBroker instanceGroup (line 12) and create a cloud resource with the name "butterfly-idBroker"

Later on we decide to resize the DL to Medium Duty. This will use [datalake/src/main/resources/duties/7.2.15/gcp/medium_duty_ha.json](https://github.com/hortonworks/cloudbreak/blob/master/datalake/src/main/resources/duties/7.2.15/gcp/medium_duty_ha.json) blueprint and will request another instanceGroup idBroker (line 80) so a cloud resource with the name "butterfly-idBroker" will be attempted to be created. This request will be requected by GCP due to name uniqueness constraint.

## Proposed solution:
add the _stack id_ to the name. When we resize we create a new Stack so this will make names stack-bounded and prevent resource name conflicts on GCP.
