### PR TITLE
CB-18306 Azure error messages are quite ugly due to line breaks and json format

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureCredentialConnector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureCredentialConnector.java
@@ -24,6 +24,7 @@ import com.sequenceiq.cloudbreak.cloud.azure.view.AzureCredentialView;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.credential.CredentialNotifier;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredentialStatus;
 import com.sequenceiq.cloudbreak.cloud.model.CredentialStatus;
@@ -90,7 +91,7 @@ public class AzureCredentialConnector implements CredentialConnector {
             LOGGER.warn(exceptionMessage, e);
             String errorMessage = Objects.requireNonNullElse(exceptionExtractor.extractErrorMessage(e),
                     String.format("Could not verify the credential on Azure. Original message: %s", exceptionMessage));
-            return new CloudCredentialStatus(cloudCredential, CredentialStatus.FAILED, e, errorMessage);
+            return new CloudCredentialStatus(cloudCredential, CredentialStatus.FAILED, new CloudConnectorException(errorMessage), errorMessage);
         }
         return new CloudCredentialStatus(cloudCredential, CredentialStatus.VERIFIED);
     }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/util/AzureAuthExceptionHandler.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/util/AzureAuthExceptionHandler.java
@@ -2,7 +2,11 @@ package com.sequenceiq.cloudbreak.cloud.azure.util;
 
 import java.util.function.Supplier;
 
+import javax.inject.Inject;
+
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.microsoft.aad.adal4j.AuthenticationException;
@@ -10,13 +14,18 @@ import com.sequenceiq.cloudbreak.client.ProviderAuthenticationFailedException;
 
 @Component
 public class AzureAuthExceptionHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AzureAuthExceptionHandler.class);
+
+    @Inject
+    private AzureExceptionExtractor azureExceptionExtractor;
 
     public <T> T handleAuthException(Supplier<T> function) {
         try {
             return function.get();
         } catch (RuntimeException e) {
             if (ExceptionUtils.indexOfThrowable(e, AuthenticationException.class) != -1) {
-                throw new ProviderAuthenticationFailedException(e);
+                LOGGER.warn("AuthenticationException has thrown during azure operation", e);
+                throw new ProviderAuthenticationFailedException(azureExceptionExtractor.extractErrorMessage(e));
             } else {
                 throw e;
             }
@@ -28,7 +37,8 @@ public class AzureAuthExceptionHandler {
             function.run();
         } catch (RuntimeException e) {
             if (ExceptionUtils.indexOfThrowable(e, AuthenticationException.class) != -1) {
-                throw new ProviderAuthenticationFailedException(e);
+                LOGGER.warn("AuthenticationException has thrown during azure operation", e);
+                throw new ProviderAuthenticationFailedException(azureExceptionExtractor.extractErrorMessage(e));
             } else {
                 throw e;
             }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/util/AzureExceptionExtractor.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/util/AzureExceptionExtractor.java
@@ -4,7 +4,10 @@ import static com.sequenceiq.cloudbreak.util.NullUtil.getIfNotNull;
 import static com.sequenceiq.cloudbreak.util.NullUtil.getIfNotNullOtherwise;
 
 import java.io.IOException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.springframework.stereotype.Component;
 
@@ -13,8 +16,11 @@ import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 
 @Component
 public class AzureExceptionExtractor {
-
     public static final String AZURE_EMBEDDED_ERROR_DESCRIPTION_ATTRIBUTE = "error_description";
+
+    public static final String AZURE_EMBEDDED_ERROR_ATTRIBUTE = "error";
+
+    public static final String AZURE_EMBEDDED_ERROR_URI_ATTRIBUTE = "error_uri";
 
     public String extractErrorMessage(Throwable t) {
         Throwable rootCause = ExceptionUtils.getRootCause(t);
@@ -22,16 +28,20 @@ public class AzureExceptionExtractor {
     }
 
     private String getTransformedErrorMessage(Throwable t) {
-        String errorDescription = t.getMessage();
-        if (errorDescription != null) {
-            JsonNode json;
+        if (t.getMessage() != null) {
             try {
-                json = JsonUtil.readTree(errorDescription);
-                errorDescription = getIfNotNullOtherwise(json.get(AZURE_EMBEDDED_ERROR_DESCRIPTION_ATTRIBUTE), JsonNode::asText, errorDescription);
+                JsonNode json = JsonUtil.readTree(t.getMessage());
+                String result = Stream.of(AZURE_EMBEDDED_ERROR_DESCRIPTION_ATTRIBUTE, AZURE_EMBEDDED_ERROR_ATTRIBUTE, AZURE_EMBEDDED_ERROR_URI_ATTRIBUTE)
+                        .map(key -> getIfNotNullOtherwise(json.get(key), node -> key + ": " + node.asText(), ""))
+                        .filter(StringUtils::isNotBlank)
+                        .collect(Collectors.joining(", "));
+                return StringUtils.isBlank(result) ? t.getMessage() : result;
             } catch (IOException ignore) {
                 // not a JSON, no problem
+                return t.getMessage();
             }
+        } else {
+            return null;
         }
-        return errorDescription;
     }
 }


### PR DESCRIPTION
CB-18306 Azure error messages are quite ugly due to line breaks and json format

* AzureExceptionExtractor improvement: extract error and error_uri json parameters from the azure exception message next to the error_description.
* AzureAuthExceptionHandler will throw new ProviderAuthenticationFailedException with the extracted error message. No exception chain will be used, as the exception mapper send the root exception's message via the API
* AzureCredentialConnector.verify will throw new CloudConnectorException with the extracted error message as well
* The original exception will be logged before the extraction

See detailed description in the commit message.