### PR TITLE
CB-18996 Add Kudu config provider for Ranger

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-rt-data-mart.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-rt-data-mart.bp
@@ -43,10 +43,6 @@
           {
             "refName": "kudu-MASTER-BASE",
             "roleType": "KUDU_MASTER",
-            "configs": [ {
-              "name": "ranger_kudu_plugin_service_name",
-              "value": "{{GENERATED_RANGER_SERVICE_NAME}}"
-            } ],
             "base": true
           },
           {

--- a/core/src/main/resources/defaults/blueprints/7.2.11/cdp-rt-data-mart.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.11/cdp-rt-data-mart.bp
@@ -43,10 +43,6 @@
           {
             "refName": "kudu-MASTER-BASE",
             "roleType": "KUDU_MASTER",
-            "configs": [ {
-              "name": "ranger_kudu_plugin_service_name",
-              "value": "{{GENERATED_RANGER_SERVICE_NAME}}"
-            } ],
             "base": true
           },
           {

--- a/core/src/main/resources/defaults/blueprints/7.2.8/cdp-rt-data-mart.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.8/cdp-rt-data-mart.bp
@@ -43,10 +43,6 @@
           {
             "refName": "kudu-MASTER-BASE",
             "roleType": "KUDU_MASTER",
-            "configs": [ {
-              "name": "ranger_kudu_plugin_service_name",
-              "value": "{{GENERATED_RANGER_SERVICE_NAME}}"
-            } ],
             "base": true
           },
           {

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-rt-data-mart.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-rt-data-mart.bp
@@ -43,10 +43,6 @@
           {
             "refName": "kudu-MASTER-BASE",
             "roleType": "KUDU_MASTER",
-            "configs": [ {
-              "name": "ranger_kudu_plugin_service_name",
-              "value": "{{GENERATED_RANGER_SERVICE_NAME}}"
-            } ],
             "base": true
           },
           {

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kudu/KuduConfigs.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kudu/KuduConfigs.java
@@ -1,0 +1,14 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.kudu;
+
+public class KuduConfigs {
+
+    static final String RANGER_KUDU_PLUGIN_SERVICE_NAME = "ranger_kudu_plugin_service_name";
+
+    static final String GENERATED_RANGER_SERVICE_NAME = "{{GENERATED_RANGER_SERVICE_NAME}}";
+
+    static final String KUDU_FS_WAL_DIRS = "fs_wal_dir";
+
+    static final String KUDU_FS_DATA_DIRS = "fs_data_dirs";
+
+    private KuduConfigs() { }
+}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kudu/KuduServiceConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kudu/KuduServiceConfigProvider.java
@@ -1,0 +1,42 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.kudu;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERA_STACK_VERSION_7_2_11;
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.google.api.client.util.Lists;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateComponentConfigProvider;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+
+@Component
+public class KuduServiceConfigProvider implements CmTemplateComponentConfigProvider {
+
+    @Override
+    public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject source) {
+        ArrayList<ApiClusterTemplateConfig> configs = Lists.newArrayList();
+
+        String cdhVersion = templateProcessor.getStackVersion();
+        if (isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERA_STACK_VERSION_7_2_11)) {
+            configs.add(config(KuduConfigs.RANGER_KUDU_PLUGIN_SERVICE_NAME, KuduConfigs.GENERATED_RANGER_SERVICE_NAME));
+        }
+
+        return configs;
+    }
+
+    @Override
+    public String getServiceType() {
+        return KuduRoles.KUDU_SERVICE;
+    }
+
+    @Override
+    public List<String> getRoleTypes() {
+        return List.of(KuduRoles.KUDU_MASTER);
+    }
+}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kudu/KuduVolumeConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kudu/KuduVolumeConfigProvider.java
@@ -17,10 +17,6 @@ import com.sequenceiq.cloudbreak.template.views.HostgroupView;
 @Component
 public class KuduVolumeConfigProvider implements CmHostGroupRoleConfigProvider {
 
-    private static final String KUDU_FS_WAL_DIRS = "fs_wal_dir";
-
-    private static final String KUDU_FS_DATA_DIRS = "fs_data_dirs";
-
     @Override
     public List<ApiClusterTemplateConfig> getRoleConfigs(String roleType, HostgroupView hostGroupView, TemplatePreparationObject source) {
 
@@ -32,8 +28,8 @@ public class KuduVolumeConfigProvider implements CmHostGroupRoleConfigProvider {
                 Integer walVolumeCount = hostGroupView.getVolumeCount() > 0 ? 1 : 0;
                 Integer dataDirVolumeIndex = hostGroupView.getVolumeCount() <= 1 ? 1 : 2;
                 return List.of(
-                        config(KUDU_FS_WAL_DIRS, buildVolumePathStringZeroVolumeHandled(walVolumeCount, directorySuffix)),
-                        config(KUDU_FS_DATA_DIRS,
+                        config(KuduConfigs.KUDU_FS_WAL_DIRS, buildVolumePathStringZeroVolumeHandled(walVolumeCount, directorySuffix)),
+                        config(KuduConfigs.KUDU_FS_DATA_DIRS,
                                 buildVolumePathFromVolumeIndexZeroVolumeHandled(dataDirVolumeIndex, hostGroupView.getVolumeCount(), directorySuffix))
                 );
             default:

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kudu/KuduServiceConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kudu/KuduServiceConfigProviderTest.java
@@ -1,0 +1,54 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.kudu;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kudu.KuduConfigs.GENERATED_RANGER_SERVICE_NAME;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kudu.KuduConfigs.RANGER_KUDU_PLUGIN_SERVICE_NAME;
+import static com.sequenceiq.cloudbreak.util.FileReaderUtils.readFileFromClasspathQuietly;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.cloudbreak.template.views.BlueprintView;
+
+@ExtendWith(MockitoExtension.class)
+class KuduServiceConfigProviderTest {
+    private final KuduServiceConfigProvider subject = new KuduServiceConfigProvider();
+
+    @Test
+    public void testRangerPluginServiceConfig7210() {
+        CmTemplateProcessor templateProcessor = new CmTemplateProcessor(readFileFromClasspathQuietly("input/cdp-data-mart.bp"));
+        templateProcessor.setCdhVersion("7.2.10");
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject(templateProcessor, "7.2.10");
+
+        List<ApiClusterTemplateConfig> serviceConfigs = subject.getServiceConfigs(templateProcessor, preparationObject);
+
+        assertEquals(0, serviceConfigs.size());
+    }
+
+    @Test
+    public void testRangerPluginServiceConfig7211() {
+        CmTemplateProcessor templateProcessor = new CmTemplateProcessor(readFileFromClasspathQuietly("input/cdp-data-mart.bp"));
+        templateProcessor.setCdhVersion("7.2.11");
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject(templateProcessor, "7.2.11");
+
+        List<ApiClusterTemplateConfig> serviceConfigs = subject.getServiceConfigs(templateProcessor, preparationObject);
+
+        assertEquals(1, serviceConfigs.size());
+        assertTrue(serviceConfigs.contains(config(RANGER_KUDU_PLUGIN_SERVICE_NAME, GENERATED_RANGER_SERVICE_NAME)));
+    }
+
+    private TemplatePreparationObject getTemplatePreparationObject(CmTemplateProcessor processor, String version) {
+        TemplatePreparationObject preparationObject = TemplatePreparationObject.Builder.builder()
+            .withBlueprintView(new BlueprintView("text", version, "CDH", processor))
+            .build();
+        return preparationObject;
+    }
+}


### PR DESCRIPTION
022d165 fixed a bug with Kudu's Ranger policies, but at around the same time, the blueprint for 7.2.12 was created. Unfortunately, this change wasn't copied over, so this doesn't work in newer CDP versions.

Additionally, the fix was done only in the blueprint level, so Ranger integration wouldn't work with custom blueprints uploaded by users, unless they copied over this change as well.

This commit removes this extra config from the RTDM blueprints and adds it in a ConfigProvider instead that applies to versions 7.2.11 and above.

See detailed description in the commit message.