### PR TITLE
CB-20304 GCP Sdx Backup and Restore is failing, hive_backup and ranger_backup is 0

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazons3/action/S3ClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazons3/action/S3ClientActions.java
@@ -104,10 +104,10 @@ public class S3ClientActions extends S3Client {
                 } while (filteredObjectSummaries.isEmpty() && objectListing.isTruncated());
 
                 if (filteredObjectSummaries.isEmpty()) {
-                    LOGGER.error("Amazon S3 object: {} has 0 sub-objects!", selectedObject);
-                    throw new TestFailException(format("Amazon S3 object: %s has 0 sub-objects!", selectedObject));
+                    LOGGER.error("Amazon S3 object: {} has 0 sub-objects or it is not present!", selectedObject);
+                    throw new TestFailException(format("Amazon S3 object: %s has 0 sub-objects or it is not present!", selectedObject));
                 } else {
-                    Log.log(LOGGER, format(" Amazon S3 object: %s contains %d sub-objects.",
+                    Log.log(LOGGER, format(" Amazon S3 object: %s contains %d sub-objects or present with occurences.",
                             selectedObject, filteredObjectSummaries.size()));
                 }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurecloudblob/action/AzureCloudBlobClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurecloudblob/action/AzureCloudBlobClientActions.java
@@ -292,7 +292,7 @@ public class AzureCloudBlobClientActions extends AzureCloudBlobClient {
             List<ListBlobItem> listBlobItems = StreamSupport
                     .stream(blobListing.spliterator(), false)
                     .collect(Collectors.toList());
-            Log.log(LOGGER, format(" Azure Blob Directory: %s contains %d sub-objects.",
+            Log.log(LOGGER, format(" Azure Blob: %s contains %d sub-objects or present with occurences.",
                     keyPrefix, listBlobItems.size()));
 
             for (ListBlobItem blob : blobListing) {
@@ -337,7 +337,7 @@ public class AzureCloudBlobClientActions extends AzureCloudBlobClient {
             List<ListBlobItem> listBlobItems = StreamSupport
                     .stream(blobListing.spliterator(), false)
                     .collect(Collectors.toList());
-            Log.log(LOGGER, format(" Azure Blob Directory: %s contains %d sub-objects.",
+            Log.log(LOGGER, format(" Azure Blob: %s contains %d sub-objects or present with occurences.",
                     selectedDirectory, listBlobItems.size()));
 
             for (ListBlobItem blob : blobListing) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpUtil.java
@@ -5,7 +5,6 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -49,28 +48,20 @@ public class GcpUtil {
     }
 
     public void cloudStorageListContainer(String baseLocation, String selectedObject, boolean zeroContent) {
-        listSelectedObject(StringUtils.join(List.of(baseLocation, selectedObject), "/"), zeroContent);
+        gcpClientActions.listBucketSelectedObject(baseLocation, selectedObject, zeroContent);
     }
 
     public void cloudStorageListContainerFreeIpa(String baseLocation, String clusterName, String crn) {
-        listSelectedObject(StringUtils.join(List.of(baseLocation, "cluster-logs", "freeipa"), "/"));
+        gcpClientActions.listBucketSelectedObject(baseLocation, "cluster-logs/freeipa", false);
     }
 
     public void cloudStorageListContainerDataLake(String baseLocation, String clusterName, String crn) {
-        listSelectedObject(StringUtils.join(List.of(baseLocation, "cluster-logs", "datalake"), "/"));
+        gcpClientActions.listBucketSelectedObject(baseLocation, "cluster-logs/datalake", false);
     }
 
     public void cloudStorageDeleteContainer(String baseLocation) {
         String bucketName = gcpStackUtil.getBucketName(baseLocation);
         gcpClientActions.deleteNonVersionedBucket(bucketName);
-    }
-
-    private void listSelectedObject(String baseLocation) {
-        listSelectedObject(baseLocation, false);
-    }
-
-    private void listSelectedObject(String baseLocation, boolean zeroContent) {
-        gcpClientActions.listBucketSelectedObject(baseLocation, zeroContent);
     }
 
     public String getFreeIpaLogsUrl(String clusterName, String crn, String baseLocation) {


### PR DESCRIPTION
MOW-Dev API GCP E2E are failing, because of `testSDXBackupRestoreCanBeSuccessful` is failing with `hive_backup has 0 sub-objects`. The path contains two file objects and not directory ones: `hive_backup` and `ranger_backup`. So here the GCP object listing and validation is needed to be updated, similar as is at AWS and AZURE.