### PR TITLE
CB-19624 AKS private DNS zone - validations, corrected

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePrivateDnsZoneDescriptor.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePrivateDnsZoneDescriptor.java
@@ -1,0 +1,16 @@
+package com.sequenceiq.cloudbreak.cloud.azure;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+public interface AzurePrivateDnsZoneDescriptor {
+
+    String getResourceType();
+
+    String getSubResource();
+
+    String getDnsZoneName();
+
+    List<Pattern> getDnsZoneNamePatterns();
+
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePrivateDnsZoneRegistrationEnum.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePrivateDnsZoneRegistrationEnum.java
@@ -1,0 +1,66 @@
+package com.sequenceiq.cloudbreak.cloud.azure;
+
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * This enum contains possible private DNS zones that are only registered in environment service, but are not used by cloudbreak.
+ */
+public enum AzurePrivateDnsZoneRegistrationEnum implements AzurePrivateDnsZoneDescriptor {
+
+    AKS("Microsoft.ContainerService/managedClusters", "managedClusters",
+            "privatelink.{region}.azmk8s.io or {subzone}.privatelink.{region}.azmk8s.io",
+            List.of(AzurePrivateDnsZoneRegistrationEnum.AKS_DNS_ZONE_NAME_PATTERN_REGION,
+                    AzurePrivateDnsZoneRegistrationEnum.AKS_DNS_ZONE_NAME_PATTERN_SUBZONE_AND_REGION));
+
+    private static final String AKS_DNS_ZONE_NAME_PATTERN_REGION = "privatelink\\.[a-z\\d-]+.azmk8s.io";
+
+    private static final String AKS_DNS_ZONE_NAME_PATTERN_SUBZONE_AND_REGION = "[\\w+-]+\\.privatelink\\.[a-z\\d-]+.azmk8s.io";
+
+    private final String resourceType;
+
+    private final String subResource;
+
+    private final String dnsZoneName;
+
+    private final List<Pattern> dnsZoneNameRegexPatterns;
+
+    AzurePrivateDnsZoneRegistrationEnum(String resourceType, String subResource, String dnsZoneName, List<String> dnsZoneNameTemplate) {
+        this.resourceType = resourceType;
+        this.subResource = subResource;
+        this.dnsZoneName = dnsZoneName;
+        this.dnsZoneNameRegexPatterns = dnsZoneNameTemplate.stream().map(Pattern::compile).collect(Collectors.toList());
+    }
+
+    @Override
+    public String getResourceType() {
+        return resourceType;
+    }
+
+    @Override
+    public String getSubResource() {
+        return subResource;
+    }
+
+    @Override
+    public String getDnsZoneName() {
+        return dnsZoneName;
+    }
+
+    @Override
+    public List<Pattern> getDnsZoneNamePatterns() {
+        return dnsZoneNameRegexPatterns;
+    }
+
+    @Override
+    public String toString() {
+        return "AzurePrivateDnsZoneRegistrationEnum{" +
+                "resourceType='" + resourceType + '\'' +
+                ", subResource='" + subResource + '\'' +
+                ", dnsZoneName='" + dnsZoneName + '\'' +
+                ", dnsZoneNameRegexPatterns=" + dnsZoneNameRegexPatterns +
+                "} " + super.toString();
+    }
+
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePrivateDnsZoneServiceEnum.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePrivateDnsZoneServiceEnum.java
@@ -3,14 +3,24 @@ package com.sequenceiq.cloudbreak.cloud.azure;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 
+import java.util.List;
 import java.util.Map;
-import java.util.StringJoiner;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-public enum AzurePrivateDnsZoneServiceEnum {
+/*
+Azure private DNS zones that can be registered and used by cloudbreak are listed below.
+ */
+public enum AzurePrivateDnsZoneServiceEnum implements AzurePrivateDnsZoneDescriptor {
 
-    POSTGRES("Microsoft.DBforPostgreSQL/servers", "postgresqlServer", "privatelink.postgres.database.azure.com", "postgres.database.azure.com"),
-    STORAGE("Microsoft.Storage/storageAccounts", "Blob", "privatelink.blob.core.windows.net", "blob.core.windows.net");
+    POSTGRES("Microsoft.DBforPostgreSQL/servers", "postgresqlServer", "privatelink.postgres.database.azure.com",
+            "postgres.database.azure.com", AzurePrivateDnsZoneServiceEnum.POSTGRES_DNS_ZONE_NAME_PATTERN),
+    STORAGE("Microsoft.Storage/storageAccounts", "Blob", "privatelink.blob.core.windows.net",
+            "blob.core.windows.net", AzurePrivateDnsZoneServiceEnum.STORAGE_DNS_ZONE_NAME_PATTERN);
+
+    private static final String POSTGRES_DNS_ZONE_NAME_PATTERN = "privatelink\\.postgres\\.database\\.azure\\.com";
+
+    private static final String STORAGE_DNS_ZONE_NAME_PATTERN = "privatelink\\.blob\\.core\\.windows\\.net";
 
     private static final Map<String, AzurePrivateDnsZoneServiceEnum> SERVICE_MAP_BY_RESOURCE;
 
@@ -20,25 +30,36 @@ public enum AzurePrivateDnsZoneServiceEnum {
 
     private final String dnsZoneName;
 
+    private final Pattern dnsZoneNamePattern;
+
     private final String dnsZoneForwarder;
 
-    AzurePrivateDnsZoneServiceEnum(String resourceType, String subResource, String dnsZoneName, String dnsZoneForwarder) {
+    AzurePrivateDnsZoneServiceEnum(String resourceType, String subResource, String dnsZoneName, String dnsZoneForwarder, String dnsZoneNamePattern) {
         this.resourceType = resourceType;
         this.subResource = subResource;
         this.dnsZoneName = dnsZoneName;
+        this.dnsZoneNamePattern = Pattern.compile(dnsZoneNamePattern);
         this.dnsZoneForwarder = dnsZoneForwarder;
     }
 
+    @Override
     public String getResourceType() {
         return resourceType;
     }
 
+    @Override
     public String getSubResource() {
         return subResource;
     }
 
+    @Override
     public String getDnsZoneName() {
         return dnsZoneName;
+    }
+
+    @Override
+    public List<Pattern> getDnsZoneNamePatterns() {
+        return List.of(dnsZoneNamePattern);
     }
 
     public String getDnsZoneForwarder() {
@@ -55,11 +76,13 @@ public enum AzurePrivateDnsZoneServiceEnum {
 
     @Override
     public String toString() {
-        return new StringJoiner(", ", AzurePrivateDnsZoneServiceEnum.class.getSimpleName() + "[", "]")
-                .add("resourceType='" + resourceType + "'")
-                .add("subResource='" + subResource + "'")
-                .add("dnsZoneName='" + dnsZoneName + "'")
-                .add("dnsZoneForwarder='" + dnsZoneForwarder + "'")
-                .toString();
+        return "AzurePrivateDnsZoneServiceEnum{" +
+                "resourceType='" + resourceType + '\'' +
+                ", subResource='" + subResource + '\'' +
+                ", dnsZoneName='" + dnsZoneName + '\'' +
+                ", dnsZoneNamePattern=" + dnsZoneNamePattern +
+                ", dnsZoneForwarder='" + dnsZoneForwarder + '\'' +
+                "} " + super.toString();
     }
+
 }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzureExistingPrivateDnsZoneValidatorService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzureExistingPrivateDnsZoneValidatorService.java
@@ -9,7 +9,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
-import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneServiceEnum;
+import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneDescriptor;
 import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
 import com.sequenceiq.cloudbreak.validation.ValidationResult;
 
@@ -22,7 +22,7 @@ public class AzureExistingPrivateDnsZoneValidatorService {
     private AzurePrivateDnsZoneValidatorService azurePrivateDnsZoneValidatorService;
 
     public ValidationResult.ValidationResultBuilder validate(AzureClient azureClient, String networkResourceGroupName,
-            String networkName, Map<AzurePrivateDnsZoneServiceEnum, String> serviceToPrivateDnsZoneId, ValidationResult.ValidationResultBuilder resultBuilder) {
+            String networkName, Map<AzurePrivateDnsZoneDescriptor, String> serviceToPrivateDnsZoneId, ValidationResult.ValidationResultBuilder resultBuilder) {
         serviceToPrivateDnsZoneId.forEach((service, privateDnsZoneId) -> {
             try {
                 ResourceId privateDnsZoneResourceId = ResourceId.fromString(privateDnsZoneId);

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzurePrivateDnsZoneMatcherService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzurePrivateDnsZoneMatcherService.java
@@ -1,0 +1,22 @@
+package com.sequenceiq.cloudbreak.cloud.azure.validator.privatedns;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneDescriptor;
+
+@Service
+public class AzurePrivateDnsZoneMatcherService {
+
+    public boolean zoneNameMatchesPattern(AzurePrivateDnsZoneDescriptor privateDnsZoneDescriptor, String privateDnsZoneName) {
+        return privateDnsZoneDescriptor.getDnsZoneNamePatterns().stream().anyMatch(namePattern -> matches(privateDnsZoneName, namePattern));
+    }
+
+    private static boolean matches(String privateDnsZoneName, Pattern namePattern) {
+        Matcher matcher = namePattern.matcher(privateDnsZoneName);
+        return matcher.matches();
+    }
+
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzurePrivateDnsZoneValidatorService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzurePrivateDnsZoneValidatorService.java
@@ -7,13 +7,15 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import javax.inject.Inject;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.azure.resourcemanager.privatedns.models.PrivateDnsZone;
 import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
-import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneServiceEnum;
+import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneDescriptor;
 import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
 import com.sequenceiq.cloudbreak.validation.ValidationResult;
 import com.sequenceiq.cloudbreak.validation.ValidationResult.ValidationResultBuilder;
@@ -23,11 +25,14 @@ public class AzurePrivateDnsZoneValidatorService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AzurePrivateDnsZoneValidatorService.class);
 
-    public ValidationResultBuilder existingPrivateDnsZoneNameIsSupported(AzurePrivateDnsZoneServiceEnum serviceEnum,
-            ResourceId existingPrivateDnsZoneResourceId, ValidationResultBuilder resultBuilder) {
-        if (!serviceEnum.getDnsZoneName().equals(existingPrivateDnsZoneResourceId.name())) {
+    @Inject
+    private AzurePrivateDnsZoneMatcherService azurePrivateDnsZoneMatcherService;
+
+    public ValidationResult.ValidationResultBuilder existingPrivateDnsZoneNameIsSupported(AzurePrivateDnsZoneDescriptor dnsZoneDescriptor,
+            ResourceId existingPrivateDnsZoneResourceId, ValidationResult.ValidationResultBuilder resultBuilder) {
+        if (!azurePrivateDnsZoneMatcherService.zoneNameMatchesPattern(dnsZoneDescriptor, existingPrivateDnsZoneResourceId.name())) {
             String validationMessage = String.format("The provided private DNS zone %s is not a valid DNS zone name for %s. Please use a DNS zone with " +
-                    "name %s and try again.", existingPrivateDnsZoneResourceId.id(), serviceEnum.getResourceType(), serviceEnum.getDnsZoneName());
+                    "name %s and try again.", existingPrivateDnsZoneResourceId.id(), dnsZoneDescriptor.getResourceType(), dnsZoneDescriptor.getDnsZoneName());
             addValidationError(validationMessage, resultBuilder);
         }
         return resultBuilder;

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePrivateDnsZoneRegistrationEnumTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePrivateDnsZoneRegistrationEnumTest.java
@@ -1,0 +1,116 @@
+package com.sequenceiq.cloudbreak.cloud.azure;
+
+import static com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneRegistrationEnum.AKS;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class AzurePrivateDnsZoneRegistrationEnumTest {
+    @Test
+    void testNumberOfZoneTypes() {
+        assertEquals(1, testServicesSource().count(), "Please add tests for missing enums");
+    }
+
+    @Test
+    void testZoneNamePatternCount() {
+        assertThat(AKS.getDnsZoneNamePatterns()).asList().hasSize(2);
+    }
+
+    @ParameterizedTest
+    @MethodSource("testZoneNamePatterns")
+    void testPatterns(AzurePrivateDnsZoneRegistrationEnum serviceEnum, String testZoneName, Boolean shouldMatch) {
+        boolean zoneNameMatchedByPattern = serviceEnum.getDnsZoneNamePatterns().stream()
+                .map(pattern -> pattern.matcher(testZoneName))
+                .anyMatch(Matcher::matches);
+        assertEquals(shouldMatch, zoneNameMatchedByPattern);
+    }
+
+    private static Object[][] testZoneNamePatterns() {
+        return new Object[][]{
+                {AKS, "privatelink.region.azmk8s.io", true},
+                {AKS, "privatelink.region2.azmk8s.io", true},
+                {AKS, "privatelink.region-2.azmk8s.io", true},
+                {AKS, "PrivateLink.REGION-2.Azmk8s.Io", false},
+                {AKS, "region-2.azmk8s.io", false},
+                {AKS, "privatelink.region-2.azmk8s.badpart", false},
+                {AKS, "privatelink.region-2.badpart.io", false},
+                {AKS, "badpart.region-2.amzk8s.io", false},
+
+                {AKS, "mysubzonename.privatelink.region.azmk8s.io", true},
+                {AKS, "mySubZoneName.privatelink.region.azmk8s.io", true},
+                {AKS, "MY-SUB-ZONE-NAME.privatelink.region.azmk8s.io", true},
+                {AKS, "mysubsubzonename.mysubzonename.privatelink.region.azmk8s.io", false},
+                {AKS, "mysubzonename.privatelink.region.azmk8s.badpart", false},
+                {AKS, "mysubzonename.privatelink.region.badpart.io", false},
+                {AKS, "mysubzonename.badpart.region.azmk8s.io", false},
+
+        };
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "testServicesSource")
+    void testRegistrationEnumValues(Pair<AzurePrivateDnsZoneRegistrationEnum, AzurePrivateDnsZoneRegistrationEnumValues> serviceEnumAndExpectedValues) {
+        AzurePrivateDnsZoneRegistrationEnum serviceEnum = serviceEnumAndExpectedValues.getKey();
+        AzurePrivateDnsZoneRegistrationEnumValues expectedValues = serviceEnumAndExpectedValues.getValue();
+
+        assertEquals(expectedValues.getResourceType(), serviceEnum.getResourceType());
+        assertEquals(expectedValues.getSubResource(), serviceEnum.getSubResource());
+        assertEquals(expectedValues.getDnsZoneName(), serviceEnum.getDnsZoneName());
+        List<String> dnsZoneNamePatterns = serviceEnum.getDnsZoneNamePatterns().stream().map(Pattern::pattern).collect(Collectors.toList());
+        assertThat(dnsZoneNamePatterns).asList().hasSameElementsAs(expectedValues.getDnsZoneNameRegexPatterns());
+    }
+
+    private static Stream<Pair<AzurePrivateDnsZoneRegistrationEnum, AzurePrivateDnsZoneRegistrationEnumValues>> testServicesSource() {
+        return Stream.of(
+                Pair.of(AKS, new AzurePrivateDnsZoneRegistrationEnumValues(
+                        "Microsoft.ContainerService/managedClusters",
+                        "managedClusters",
+                        "privatelink.{region}.azmk8s.io or {subzone}.privatelink.{region}.azmk8s.io",
+                        List.of("privatelink\\.[a-z\\d-]+.azmk8s.io", "[\\w+-]+\\.privatelink\\.[a-z\\d-]+.azmk8s.io")))
+        );
+    }
+
+    private static class AzurePrivateDnsZoneRegistrationEnumValues {
+        private final String resourceType;
+
+        private final String subResource;
+
+        private final String dnsZoneName;
+
+        private final List<String> dnsZoneNameRegexPatterns;
+
+        private AzurePrivateDnsZoneRegistrationEnumValues(String resourceType, String subResource, String dnsZoneName, List<String> dnsZoneNameRegexPatterns) {
+            this.resourceType = resourceType;
+            this.subResource = subResource;
+            this.dnsZoneName = dnsZoneName;
+            this.dnsZoneNameRegexPatterns = dnsZoneNameRegexPatterns;
+        }
+
+        private String getResourceType() {
+            return resourceType;
+        }
+
+        private String getSubResource() {
+            return subResource;
+        }
+
+        private String getDnsZoneName() {
+            return dnsZoneName;
+        }
+
+        private List<String> getDnsZoneNameRegexPatterns() {
+            return dnsZoneNameRegexPatterns;
+        }
+    }
+
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePrivateDnsZoneServiceEnumTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePrivateDnsZoneServiceEnumTest.java
@@ -1,0 +1,138 @@
+package com.sequenceiq.cloudbreak.cloud.azure;
+
+import static com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneServiceEnum.POSTGRES;
+import static com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneServiceEnum.STORAGE;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class AzurePrivateDnsZoneServiceEnumTest {
+
+    @Test
+    void testNumberOfZoneTypes() {
+        assertEquals(2, testServicesSource().count(), "Please add test for missing enums");
+    }
+
+    @Test
+    void testZoneNamePatternCount() {
+        assertThat(POSTGRES.getDnsZoneNamePatterns()).asList().hasSize(1);
+        assertThat(STORAGE.getDnsZoneNamePatterns()).asList().hasSize(1);
+    }
+
+    @ParameterizedTest
+    @MethodSource("testZoneNamePatterns")
+    void testPatterns(AzurePrivateDnsZoneServiceEnum serviceEnum, String testZoneName, Boolean shouldMatch) {
+        boolean zoneNameMatchedByPattern = serviceEnum.getDnsZoneNamePatterns().stream()
+                .map(pattern -> pattern.matcher(testZoneName))
+                .anyMatch(Matcher::matches);
+        assertEquals(shouldMatch, zoneNameMatchedByPattern);
+    }
+
+    private static Object[][] testZoneNamePatterns() {
+        return new Object[][]{
+                {POSTGRES, "privatelink.postgres.database.azure.com", true},
+                {POSTGRES, "postgres.database.azure.com", false},
+                {POSTGRES, "mypostgres.privatelink.postgres.database.azure.com", false},
+                {POSTGRES, "privatelink.postgres.database.azure.comx", false},
+                {POSTGRES, "privatelink.postgres.database.azurex.com", false},
+                {POSTGRES, "privatelink.postgres.databasex.azure.com", false},
+                {POSTGRES, "privatelink.postgresx.database.azure.com", false},
+                {POSTGRES, "privatelinkx.postgres.database.azure.com", false},
+
+                {STORAGE, "privatelink.blob.core.windows.net", true},
+                {STORAGE, "blob.core.windows.net", false},
+                {STORAGE, "mystorage.privatelink.blob.core.windows.net", false},
+                {STORAGE, "privatelink.blob.core.windows.netx", false},
+                {STORAGE, "privatelink.blob.core.windowsx.net", false},
+                {STORAGE, "privatelink.blob.corex.windows.net", false},
+                {STORAGE, "privatelink.blobx.core.windows.net", false},
+                {STORAGE, "privatelinkx.blob.core.windows.net", false},
+        };
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "testServicesSource")
+    void testServiceEnumValues(Pair<AzurePrivateDnsZoneServiceEnum, AzurePrivateDnsZoneServiceEnumValues> serviceEnumAndExpectedValues) {
+        AzurePrivateDnsZoneServiceEnum serviceEnum = serviceEnumAndExpectedValues.getKey();
+        AzurePrivateDnsZoneServiceEnumValues expectedValues = serviceEnumAndExpectedValues.getValue();
+
+        assertEquals(expectedValues.getResourceType(), serviceEnum.getResourceType());
+        assertEquals(expectedValues.getSubResource(), serviceEnum.getSubResource());
+        assertEquals(expectedValues.getDnsZoneName(), serviceEnum.getDnsZoneName());
+        assertEquals(expectedValues.getDnsZoneForwarder(), serviceEnum.getDnsZoneForwarder());
+        assertThat(expectedValues.getDnsZoneNamePattern()).asList().hasSize(1);
+        List<String> dnsZoneNamePatterns = serviceEnum.getDnsZoneNamePatterns().stream().map(Pattern::pattern).collect(Collectors.toList());
+        assertThat(dnsZoneNamePatterns).asList().hasSameElementsAs(expectedValues.getDnsZoneNamePattern());
+    }
+
+    private static Stream<Pair<AzurePrivateDnsZoneServiceEnum, AzurePrivateDnsZoneServiceEnumValues>> testServicesSource() {
+        return Stream.of(
+                Pair.of(POSTGRES, new AzurePrivateDnsZoneServiceEnumValues(
+                        "Microsoft.DBforPostgreSQL/servers",
+                        "postgresqlServer",
+                        "privatelink.postgres.database.azure.com",
+                        "postgres.database.azure.com",
+                        List.of("privatelink\\.postgres\\.database\\.azure\\.com"))),
+
+                Pair.of(STORAGE, new AzurePrivateDnsZoneServiceEnumValues(
+                        "Microsoft.Storage/storageAccounts",
+                        "Blob",
+                        "privatelink.blob.core.windows.net",
+                        "blob.core.windows.net",
+                        List.of("privatelink\\.blob\\.core\\.windows\\.net")
+                ))
+        );
+    }
+
+    private static class AzurePrivateDnsZoneServiceEnumValues {
+        private final String resourceType;
+
+        private final String subResource;
+
+        private final String dnsZoneName;
+
+        private final String dnsZoneForwarder;
+
+        private final List<String> dnsZoneNamePattern;
+
+        private AzurePrivateDnsZoneServiceEnumValues(String resourceType, String subResource, String dnsZoneName, String dnsZoneForwarder,
+                List<String> dnsZoneNamePattern) {
+            this.resourceType = resourceType;
+            this.subResource = subResource;
+            this.dnsZoneName = dnsZoneName;
+            this.dnsZoneNamePattern = dnsZoneNamePattern;
+            this.dnsZoneForwarder = dnsZoneForwarder;
+        }
+
+        private String getResourceType() {
+            return resourceType;
+        }
+
+        private String getSubResource() {
+            return subResource;
+        }
+
+        private String getDnsZoneName() {
+            return dnsZoneName;
+        }
+
+        private List<String> getDnsZoneNamePattern() {
+            return dnsZoneNamePattern;
+        }
+
+        private String getDnsZoneForwarder() {
+            return dnsZoneForwarder;
+        }
+    }
+
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzureExistingPrivateDnsZoneValidatorServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzureExistingPrivateDnsZoneValidatorServiceTest.java
@@ -9,11 +9,10 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-import java.security.InvalidParameterException;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,13 +21,20 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.azure.resourcemanager.resources.fluentcore.arm.ResourceId;
-import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneServiceEnum;
+import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneDescriptor;
 import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
 import com.sequenceiq.cloudbreak.cloud.azure.validator.ValidationTestUtil;
 import com.sequenceiq.cloudbreak.validation.ValidationResult;
 
 @ExtendWith(MockitoExtension.class)
 public class AzureExistingPrivateDnsZoneValidatorServiceTest {
+
+    private static final String AZURE_RESOURCE_ID_TEMPLATE =
+            "/subscriptions/subscriptionid/resourceGroups/rgname/providers/Microsoft.Network/privateDnsZones/%s";
+
+    private static final String VALID_PRIVATE_DNS_ZONE_ID = String.format(AZURE_RESOURCE_ID_TEMPLATE, "validPrivateDnsZoneId");
+
+    private static final String INVALID_PRIVATE_DNS_ZONE_ID = "invalidPrivateDnsZoneId";
 
     @Mock
     private AzurePrivateDnsZoneValidatorService azurePrivateDnsZoneValidatorService;
@@ -43,12 +49,13 @@ public class AzureExistingPrivateDnsZoneValidatorServiceTest {
     void testValidate() {
         ValidationResult.ValidationResultBuilder resultBuilder = new ValidationResult.ValidationResultBuilder();
         ResourceId privateDnsZoneId = getPrivateDnsZoneResourceId();
-        Map<AzurePrivateDnsZoneServiceEnum, String> serviceToPrivateDnsZoneId = Map.of(AzurePrivateDnsZoneServiceEnum.POSTGRES, privateDnsZoneId.id());
+        AzurePrivateDnsZoneDescriptor azurePrivateDnsZoneDescriptor = new AzurePrivateDnsZoneDescriptorTestImpl("privateDnsZoneService");
+        Map<AzurePrivateDnsZoneDescriptor, String> serviceToPrivateDnsZoneId = Map.of(azurePrivateDnsZoneDescriptor, privateDnsZoneId.id());
 
         resultBuilder = underTest.validate(azureClient, NETWORK_RESOURCE_GROUP_NAME, NETWORK_NAME, serviceToPrivateDnsZoneId, resultBuilder);
 
         assertFalse(resultBuilder.build().hasError());
-        verify(azurePrivateDnsZoneValidatorService).existingPrivateDnsZoneNameIsSupported(eq(AzurePrivateDnsZoneServiceEnum.POSTGRES), any(),
+        verify(azurePrivateDnsZoneValidatorService).existingPrivateDnsZoneNameIsSupported(eq(azurePrivateDnsZoneDescriptor), any(),
                 eq(resultBuilder));
         verify(azurePrivateDnsZoneValidatorService).privateDnsZoneExists(eq(azureClient), any(), eq(resultBuilder));
         verify(azurePrivateDnsZoneValidatorService).privateDnsZoneConnectedToNetwork(eq(azureClient), eq(NETWORK_RESOURCE_GROUP_NAME), eq(NETWORK_NAME), any(),
@@ -58,13 +65,13 @@ public class AzureExistingPrivateDnsZoneValidatorServiceTest {
     @Test
     void testValidateWhenInvalidPrivateDnsZoneResourceId() {
         ValidationResult.ValidationResultBuilder resultBuilder = new ValidationResult.ValidationResultBuilder();
-        String privateDnsZoneId = "invalidPrivateDnsZoneId";
-        Map<AzurePrivateDnsZoneServiceEnum, String> serviceToPrivateDnsZoneId = Map.of(AzurePrivateDnsZoneServiceEnum.POSTGRES, privateDnsZoneId);
+        AzurePrivateDnsZoneDescriptor azurePrivateDnsZoneDescriptor = new AzurePrivateDnsZoneDescriptorTestImpl("privateDnsZoneService");
+        Map<AzurePrivateDnsZoneDescriptor, String> serviceToPrivateDnsZoneId = Map.of(azurePrivateDnsZoneDescriptor, INVALID_PRIVATE_DNS_ZONE_ID);
 
         resultBuilder = underTest.validate(azureClient, NETWORK_RESOURCE_GROUP_NAME, NETWORK_NAME, serviceToPrivateDnsZoneId, resultBuilder);
 
         ValidationTestUtil.checkErrorsPresent(resultBuilder, List.of("The provided private DNS zone id invalidPrivateDnsZoneId for service " +
-                "Microsoft.DBforPostgreSQL/servers is not a valid azure resource id."));
+                "privateDnsZoneService is not a valid azure resource id."));
         verify(azurePrivateDnsZoneValidatorService, never()).existingPrivateDnsZoneNameIsSupported(any(), any(), eq(resultBuilder));
         verify(azurePrivateDnsZoneValidatorService, never()).privateDnsZoneExists(any(), any(), any());
         verify(azurePrivateDnsZoneValidatorService, never()).privateDnsZoneConnectedToNetwork(any(), anyString(), anyString(), any(), any());
@@ -73,32 +80,53 @@ public class AzureExistingPrivateDnsZoneValidatorServiceTest {
     @Test
     void testValidateWhenValidAndInvalidPrivateDnsZoneResourceId() {
         ValidationResult.ValidationResultBuilder resultBuilder = new ValidationResult.ValidationResultBuilder();
-        ResourceId privateDnsZoneIdPostgres = getPrivateDnsZoneResourceId();
-        String privateDnsZoneIdStorage = "invalidPrivateDnsZoneId";
-        Map<AzurePrivateDnsZoneServiceEnum, String> serviceToPrivateDnsZoneId = Map.of(
-                AzurePrivateDnsZoneServiceEnum.POSTGRES, privateDnsZoneIdPostgres.id(),
-                AzurePrivateDnsZoneServiceEnum.STORAGE, privateDnsZoneIdStorage
+        AzurePrivateDnsZoneDescriptor azurePrivateDnsZoneDescriptorA = new AzurePrivateDnsZoneDescriptorTestImpl("privateDnsZoneServiceA");
+        AzurePrivateDnsZoneDescriptor azurePrivateDnsZoneDescriptorB = new AzurePrivateDnsZoneDescriptorTestImpl("privateDnsZoneServiceB");
+        Map<AzurePrivateDnsZoneDescriptor, String> serviceToPrivateDnsZoneId = Map.of(
+                azurePrivateDnsZoneDescriptorA, VALID_PRIVATE_DNS_ZONE_ID,
+                azurePrivateDnsZoneDescriptorB, INVALID_PRIVATE_DNS_ZONE_ID
         );
-        when(azurePrivateDnsZoneValidatorService.existingPrivateDnsZoneNameIsSupported(any(), any(), any())).thenAnswer(invocation -> {
-            ValidationResult.ValidationResultBuilder validationResultBuilder = invocation.getArgument(2);
-            ResourceId privateDnsZoneId = invocation.getArgument(1);
-            if (privateDnsZoneId.id().equals(privateDnsZoneIdStorage)) {
-                throw new InvalidParameterException();
-            }
-            return validationResultBuilder;
-        });
 
         resultBuilder = underTest.validate(azureClient, NETWORK_RESOURCE_GROUP_NAME, NETWORK_NAME, serviceToPrivateDnsZoneId, resultBuilder);
 
         ValidationTestUtil.checkErrorsPresent(resultBuilder, List.of("The provided private DNS zone id invalidPrivateDnsZoneId for service " +
-                "Microsoft.Storage/storageAccounts is not a valid azure resource id."));
-        verify(azurePrivateDnsZoneValidatorService).existingPrivateDnsZoneNameIsSupported(eq(AzurePrivateDnsZoneServiceEnum.POSTGRES), any(),
+                "privateDnsZoneServiceB is not a valid azure resource id."));
+        verify(azurePrivateDnsZoneValidatorService).existingPrivateDnsZoneNameIsSupported(eq(azurePrivateDnsZoneDescriptorA), any(),
                 eq(resultBuilder));
         verify(azurePrivateDnsZoneValidatorService).privateDnsZoneExists(eq(azureClient), any(), eq(resultBuilder));
         verify(azurePrivateDnsZoneValidatorService).privateDnsZoneConnectedToNetwork(eq(azureClient), eq(NETWORK_RESOURCE_GROUP_NAME), eq(NETWORK_NAME),
                 any(), eq(resultBuilder));
 
-        verify(azurePrivateDnsZoneValidatorService, never()).existingPrivateDnsZoneNameIsSupported(eq(AzurePrivateDnsZoneServiceEnum.STORAGE), any(), any());
+        verify(azurePrivateDnsZoneValidatorService, never()).existingPrivateDnsZoneNameIsSupported(eq(azurePrivateDnsZoneDescriptorB), any(), any());
+    }
+
+    private static class AzurePrivateDnsZoneDescriptorTestImpl implements AzurePrivateDnsZoneDescriptor {
+
+        private final String resourceType;
+
+        private AzurePrivateDnsZoneDescriptorTestImpl(String resourceType) {
+            this.resourceType = resourceType;
+        }
+
+        @Override
+        public String getResourceType() {
+            return resourceType;
+        }
+
+        @Override
+        public String getSubResource() {
+            return "SubResourceTest";
+        }
+
+        @Override
+        public String getDnsZoneName() {
+            return "ZoneNameTest";
+        }
+
+        @Override
+        public List<Pattern> getDnsZoneNamePatterns() {
+            return List.of(Pattern.compile("ZoneNamePatternTest"));
+        }
     }
 
 }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzurePrivateDnsZoneMatcherServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/AzurePrivateDnsZoneMatcherServiceTest.java
@@ -1,0 +1,56 @@
+package com.sequenceiq.cloudbreak.cloud.azure.validator.privatedns;
+
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneDescriptor;
+
+public class AzurePrivateDnsZoneMatcherServiceTest {
+
+    private static final String ZONE_NAME = "zoneName";
+
+    private final AzurePrivateDnsZoneMatcherService underTest = new AzurePrivateDnsZoneMatcherService();
+
+    @Test
+    void testIsZoneNameMatchingPatternWhenMatchesThenReturnsTrue() {
+        Pattern pattern = mock(Pattern.class);
+        Matcher matcher = mock(Matcher.class);
+        when(pattern.matcher(ZONE_NAME)).thenReturn(matcher);
+        AzurePrivateDnsZoneDescriptor descriptor = mock(AzurePrivateDnsZoneDescriptor.class);
+        when(descriptor.getDnsZoneNamePatterns()).thenReturn(List.of(pattern));
+        when(matcher.matches()).thenReturn(true);
+
+        boolean matchingResult = underTest.zoneNameMatchesPattern(descriptor, ZONE_NAME);
+
+        assertTrue(matchingResult);
+        verify(pattern).matcher(ZONE_NAME);
+        verify(matcher).matches();
+    }
+
+    @Test
+    void testIsZoneNameMatchingPatternWhenNoMatchThenReturnsFalse() {
+        Pattern pattern = mock(Pattern.class);
+        Matcher matcher = mock(Matcher.class);
+        when(pattern.matcher(ZONE_NAME)).thenReturn(matcher);
+        AzurePrivateDnsZoneDescriptor descriptor = mock(AzurePrivateDnsZoneDescriptor.class);
+        when(descriptor.getDnsZoneNamePatterns()).thenReturn(List.of(pattern));
+        when(matcher.matches()).thenReturn(false);
+
+        boolean matchingResult = underTest.zoneNameMatchesPattern(descriptor, ZONE_NAME);
+
+        assertFalse(matchingResult);
+        verify(pattern).matcher(ZONE_NAME);
+        verify(matcher).matches();
+    }
+
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/PrivateDnsZoneValidationTestConstants.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/privatedns/PrivateDnsZoneValidationTestConstants.java
@@ -12,7 +12,7 @@ public class PrivateDnsZoneValidationTestConstants {
 
     static final String ZONE_NAME_POSTGRES = "privatelink.postgres.database.azure.com";
 
-    static final String PRIVATE_DNS_ZONE_ID = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s";
+    static final String PRIVATE_DNS_ZONE_ID_TEMPLATE = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s";
 
     static final String NETWORK_SUBSCRIPTION_ID = "networkSubscriptionId";
 
@@ -32,7 +32,7 @@ public class PrivateDnsZoneValidationTestConstants {
     }
 
     static ResourceId getPrivateDnsZoneResourceId(String resourceGroupName) {
-        String privateDnsZoneId = String.format(PRIVATE_DNS_ZONE_ID, SUBSCRIPTION_ID, resourceGroupName, ZONE_NAME_POSTGRES);
+        String privateDnsZoneId = String.format(PRIVATE_DNS_ZONE_ID_TEMPLATE, SUBSCRIPTION_ID, resourceGroupName, ZONE_NAME_POSTGRES);
         return ResourceId.fromString(privateDnsZoneId);
     }
 
@@ -41,6 +41,6 @@ public class PrivateDnsZoneValidationTestConstants {
     }
 
     private static String getPrivateDnsZoneId(String resourceGroupName, String zoneName) {
-        return String.format(PRIVATE_DNS_ZONE_ID, SUBSCRIPTION_ID, resourceGroupName, zoneName);
+        return String.format(PRIVATE_DNS_ZONE_ID_TEMPLATE, SUBSCRIPTION_ID, resourceGroupName, zoneName);
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/network/azure/AzureEnvironmentNetworkValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/network/azure/AzureEnvironmentNetworkValidator.java
@@ -51,8 +51,9 @@ public class AzureEnvironmentNetworkValidator implements EnvironmentNetworkValid
         if (environmentValidationDto.getValidationType() == ValidationType.ENVIRONMENT_CREATION) {
             azurePrivateEndpointValidator.checkNetworkPoliciesWhenExistingNetwork(networkDto, cloudNetworks, resultBuilder);
             azurePrivateEndpointValidator.checkMultipleResourceGroup(resultBuilder, environmentDto, networkDto);
-            azurePrivateEndpointValidator.checkExistingPrivateDnsZone(resultBuilder, environmentDto, networkDto);
+            azurePrivateEndpointValidator.checkExistingManagedPrivateDnsZone(resultBuilder, environmentDto, networkDto);
             azurePrivateEndpointValidator.checkNewPrivateDnsZone(resultBuilder, environmentDto, networkDto);
+            azurePrivateEndpointValidator.checkExistingRegisteredOnlyPrivateDnsZone(resultBuilder, environmentDto, networkDto);
         } else {
             LOGGER.debug("Skipping Private Endpoint related validations as they have been validated before during env creation");
         }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/network/azure/AzureExistingPrivateDnsZonesService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/network/azure/AzureExistingPrivateDnsZonesService.java
@@ -6,31 +6,57 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneDescriptor;
+import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneRegistrationEnum;
 import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneServiceEnum;
 import com.sequenceiq.environment.network.dto.NetworkDto;
 
 @Service
 public class AzureExistingPrivateDnsZonesService {
 
-    public Map<AzurePrivateDnsZoneServiceEnum, String> getExistingZones(NetworkDto networkDto) {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AzureExistingPrivateDnsZonesService.class);
+
+    public Map<AzurePrivateDnsZoneServiceEnum, String> getExistingManagedZones(NetworkDto networkDto) {
         Map<AzurePrivateDnsZoneServiceEnum, String> result = new HashMap<>();
+        Optional.ofNullable(networkDto.getAzure().getDatabasePrivateDnsZoneId())
+                .ifPresent(privateDnsZone -> result.put(AzurePrivateDnsZoneServiceEnum.POSTGRES, privateDnsZone));
+        LOGGER.debug("Existing service private DNS zones: {}", result);
+        return result;
+    }
+
+    public Map<AzurePrivateDnsZoneDescriptor, String> getExistingManagedZonesAsDescriptors(NetworkDto networkDto) {
+        Map<AzurePrivateDnsZoneDescriptor, String> result = new HashMap<>();
         Optional.ofNullable(networkDto.getAzure().getDatabasePrivateDnsZoneId())
                 .ifPresent(privateDnsZone -> result.put(AzurePrivateDnsZoneServiceEnum.POSTGRES, privateDnsZone));
         return result;
     }
 
-    public Set<AzurePrivateDnsZoneServiceEnum> getServicesWithExistingZones(NetworkDto networkDto) {
-        return getExistingZones(networkDto).keySet();
+    public Map<AzurePrivateDnsZoneDescriptor, String> getExistingRegisteredOnlyZonesAsDescriptors(NetworkDto networkDto) {
+        Map<AzurePrivateDnsZoneDescriptor, String> result = new HashMap<>();
+        Optional.ofNullable(networkDto.getAzure().getAksPrivateDnsZoneId())
+                .ifPresent(aksDnsZone -> result.put(AzurePrivateDnsZoneRegistrationEnum.AKS, aksDnsZone));
+        LOGGER.debug("Existing registered only private DNS zones: {}", result);
+        return result;
     }
 
-    public boolean hasNoExistingZones(NetworkDto networkDto) {
-        return getExistingZones(networkDto).isEmpty();
+    public Set<AzurePrivateDnsZoneServiceEnum> getServicesWithExistingManagedZones(NetworkDto networkDto) {
+        return getExistingManagedZones(networkDto).keySet();
     }
 
-    public Set<String> getServiceNamesWithExistingZones(NetworkDto networkDto) {
-        return getServicesWithExistingZones(networkDto).stream()
+    public boolean hasNoExistingManagedZones(NetworkDto networkDto) {
+        return getExistingManagedZones(networkDto).isEmpty();
+    }
+
+    public boolean hasNoExistingRegisteredOnlyZones(NetworkDto networkDto) {
+        return getExistingRegisteredOnlyZonesAsDescriptors(networkDto).isEmpty();
+    }
+
+    public Set<String> getServiceNamesWithExistingManagedZones(NetworkDto networkDto) {
+        return getServicesWithExistingManagedZones(networkDto).stream()
                 .map(Enum::name)
                 .collect(Collectors.toSet());
     }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/network/azure/AzurePrivateEndpointValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/network/azure/AzurePrivateEndpointValidator.java
@@ -89,8 +89,9 @@ public class AzurePrivateEndpointValidator {
         }
     }
 
-    public void checkExistingPrivateDnsZone(ValidationResult.ValidationResultBuilder resultBuilder, EnvironmentDto environmentDto, NetworkDto networkDto) {
-        if (azureExistingPrivateDnsZonesService.hasNoExistingZones(networkDto)) {
+    public void checkExistingManagedPrivateDnsZone(ValidationResult.ValidationResultBuilder resultBuilder, EnvironmentDto environmentDto,
+            NetworkDto networkDto) {
+        if (azureExistingPrivateDnsZonesService.hasNoExistingManagedZones(networkDto)) {
             LOGGER.debug("No existing private DNS zones are used, nothing to do.");
             return;
         }
@@ -102,8 +103,22 @@ public class AzurePrivateEndpointValidator {
             CloudCredential cloudCredential = credentialToCloudCredentialConverter.convert(environmentDto.getCredential());
             AzureClient azureClient = azureClientService.getClient(cloudCredential);
             azureExistingPrivateDnsZoneValidatorService.validate(azureClient, networkDto.getAzure().getResourceGroupName(), networkDto.getAzure().getNetworkId(),
-                    azureExistingPrivateDnsZonesService.getExistingZones(networkDto), resultBuilder);
+                    azureExistingPrivateDnsZonesService.getExistingManagedZonesAsDescriptors(networkDto), resultBuilder);
         }
+    }
+
+    public void checkExistingRegisteredOnlyPrivateDnsZone(ValidationResult.ValidationResultBuilder resultBuilder, EnvironmentDto environmentDto,
+            NetworkDto networkDto) {
+        if (azureExistingPrivateDnsZonesService.hasNoExistingRegisteredOnlyZones(networkDto)) {
+            LOGGER.debug("No existing private DNS zones are used, nothing to do.");
+            return;
+        }
+
+        CloudCredential cloudCredential = credentialToCloudCredentialConverter.convert(environmentDto.getCredential());
+        AzureClient azureClient = azureClientService.getClient(cloudCredential);
+        azureExistingPrivateDnsZoneValidatorService.validate(azureClient, networkDto.getAzure().getResourceGroupName(), networkDto.getAzure().getNetworkId(),
+                azureExistingPrivateDnsZonesService.getExistingRegisteredOnlyZonesAsDescriptors(networkDto), resultBuilder);
+
     }
 
     public void checkNewPrivateDnsZone(ValidationResult.ValidationResultBuilder resultBuilder, EnvironmentDto environmentDto, NetworkDto networkDto) {
@@ -113,7 +128,7 @@ public class AzurePrivateEndpointValidator {
             Optional<String> resourceGroupName = getAzureResourceGroupDto(environmentDto)
                     .map(AzureResourceGroupDto::getName);
             resourceGroupName.ifPresent(rgName -> azureNewPrivateDnsZoneValidatorService.zonesNotConnectedToNetwork(azureClient,
-                    networkDto.getAzure().getNetworkId(), rgName, azureExistingPrivateDnsZonesService.getServicesWithExistingZones(networkDto),
+                    networkDto.getAzure().getNetworkId(), rgName, azureExistingPrivateDnsZonesService.getServicesWithExistingManagedZones(networkDto),
                     resultBuilder));
         }
     }

--- a/environment/src/main/java/com/sequenceiq/environment/network/service/NetworkCreationRequestFactory.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/service/NetworkCreationRequestFactory.java
@@ -101,7 +101,7 @@ public class NetworkCreationRequestFactory {
                 .withCloudContext(getCloudContext(environment))
                 .withRegion(Region.region(environment.getLocation().getName()))
                 .withPrivateEndpointsEnabled(ServiceEndpointCreation.ENABLED_PRIVATE_ENDPOINT == networkDto.getServiceEndpointCreation())
-                .withServicesWithExistingPrivateDnsZones(azureExistingPrivateDnsZonesService.getServiceNamesWithExistingZones(networkDto))
+                .withServicesWithExistingPrivateDnsZones(azureExistingPrivateDnsZonesService.getServiceNamesWithExistingManagedZones(networkDto))
                 .withTags(environmentTagProvider.getTags(environment, environment.getNetwork().getResourceCrn()));
         getResourceGroupName(environment).ifPresent(builder::withResourceGroup);
         return builder.build();

--- a/environment/src/test/java/com/sequenceiq/environment/environment/validation/network/azure/AzureEnvironmentNetworkValidatorTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/validation/network/azure/AzureEnvironmentNetworkValidatorTest.java
@@ -100,7 +100,7 @@ class AzureEnvironmentNetworkValidatorTest {
         verify(azurePrivateEndpointValidator).checkMultipleResourceGroup(validationResultBuilder, environmentDto,
                 networkDto);
         verify(azurePrivateEndpointValidator).checkNewPrivateDnsZone(validationResultBuilder, environmentDto, networkDto);
-        verify(azurePrivateEndpointValidator).checkExistingPrivateDnsZone(validationResultBuilder, environmentDto, networkDto);
+        verify(azurePrivateEndpointValidator).checkExistingManagedPrivateDnsZone(validationResultBuilder, environmentDto, networkDto);
     }
 
     @Test
@@ -118,7 +118,8 @@ class AzureEnvironmentNetworkValidatorTest {
         verify(azurePrivateEndpointValidator, never()).checkNewPrivateDnsZone(any(), any(), any());
         verify(azurePrivateEndpointValidator, never()).checkMultipleResourceGroup(any(), any(), any());
         verify(azurePrivateEndpointValidator, never()).checkNewPrivateDnsZone(any(), any(), any());
-        verify(azurePrivateEndpointValidator, never()).checkExistingPrivateDnsZone(any(), any(), any());
+        verify(azurePrivateEndpointValidator, never()).checkExistingManagedPrivateDnsZone(any(), any(), any());
+        verify(azurePrivateEndpointValidator, never()).checkExistingRegisteredOnlyPrivateDnsZone(any(), any(), any());
         assertFalse(validationResultBuilder.build().hasError());
     }
 

--- a/environment/src/test/java/com/sequenceiq/environment/environment/validation/network/azure/AzureExistingPrivateDnsZonesServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/validation/network/azure/AzureExistingPrivateDnsZonesServiceTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneDescriptor;
+import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneRegistrationEnum;
 import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneServiceEnum;
 import com.sequenceiq.environment.network.dto.AzureParams;
 import com.sequenceiq.environment.network.dto.NetworkDto;
@@ -17,69 +19,120 @@ import com.sequenceiq.environment.network.dto.NetworkDto;
 @ExtendWith(MockitoExtension.class)
 public class AzureExistingPrivateDnsZonesServiceTest {
 
+    private static final String POSTGRES_PRIVATE_DNS_ZONE_ID = "postgresPrivateDnsZoneId";
+
+    private static final String AKS_PRIVATE_DNS_ZONE_ID = "aksPrivateDnsZoneId";
+
     private final AzureExistingPrivateDnsZonesService underTest = new AzureExistingPrivateDnsZonesService();
 
     @Test
-    void testGetExistingZonesWhenPostgresPresent() {
-        NetworkDto networkDto = getNetworkDto("postgresPrivateDnsZoneId");
+    void testGetExistingManagedZonesWhenPostgresPresent() {
+        NetworkDto networkDto = getNetworkDto(POSTGRES_PRIVATE_DNS_ZONE_ID, null);
 
-        Map<AzurePrivateDnsZoneServiceEnum, String> existingZones = underTest.getExistingZones(networkDto);
+        Map<AzurePrivateDnsZoneServiceEnum, String> existingZones = underTest.getExistingManagedZones(networkDto);
 
-        assertEquals("postgresPrivateDnsZoneId", existingZones.get(AzurePrivateDnsZoneServiceEnum.POSTGRES));
+        assertEquals(POSTGRES_PRIVATE_DNS_ZONE_ID, existingZones.get(AzurePrivateDnsZoneServiceEnum.POSTGRES));
     }
 
     @Test
-    void testGetExistingZonesWhenPostgresNotPresent() {
-        NetworkDto networkDto = getNetworkDto(null);
+    void testGetExistingManagedZonesWhenPostgresNotPresent() {
+        NetworkDto networkDto = getNetworkDto(null, null);
 
-        Map<AzurePrivateDnsZoneServiceEnum, String> existingZones = underTest.getExistingZones(networkDto);
+        Map<AzurePrivateDnsZoneServiceEnum, String> existingZones = underTest.getExistingManagedZones(networkDto);
 
         assertThat(existingZones).isEmpty();
     }
 
     @Test
-    void testGetServicesWithExistingZonesWhenPostgresWithExistingPrivateDnsZone() {
-        NetworkDto networkDto = getNetworkDto("postgresPrivateDnsZoneId");
+    void testGetExistingManagedZonesAsDescriptorsWhenPostgresPresent() {
+        NetworkDto networkDto = getNetworkDto(POSTGRES_PRIVATE_DNS_ZONE_ID, null);
 
-        Set<AzurePrivateDnsZoneServiceEnum> servicesWithPrivateDnsZones = underTest.getServicesWithExistingZones(networkDto);
+        Map<AzurePrivateDnsZoneDescriptor, String> existingZones = underTest.getExistingManagedZonesAsDescriptors(networkDto);
+
+        assertEquals(POSTGRES_PRIVATE_DNS_ZONE_ID, existingZones.get(AzurePrivateDnsZoneServiceEnum.POSTGRES));
+    }
+
+    @Test
+    void testGetExistingManagedZonesAsDescriptorsWhenPostgresNotPresent() {
+        NetworkDto networkDto = getNetworkDto(null, null);
+
+        Map<AzurePrivateDnsZoneDescriptor, String> existingZones = underTest.getExistingManagedZonesAsDescriptors(networkDto);
+
+        assertThat(existingZones).isEmpty();
+    }
+
+    @Test
+    void testGetExistingRegisteredOnlyZonesAsDescriptorsWhenAksPresent() {
+        NetworkDto networkDto = getNetworkDto(null, AKS_PRIVATE_DNS_ZONE_ID);
+
+        Map<AzurePrivateDnsZoneDescriptor, String> existingZones = underTest.getExistingRegisteredOnlyZonesAsDescriptors(networkDto);
+
+        assertEquals(AKS_PRIVATE_DNS_ZONE_ID, existingZones.get(AzurePrivateDnsZoneRegistrationEnum.AKS));
+    }
+
+    @Test
+    void testGetExistingRegisteredOnlyZonesAsDescriptorsWhenAksNotPresent() {
+        NetworkDto networkDto = getNetworkDto(null, null);
+
+        Map<AzurePrivateDnsZoneDescriptor, String> existingZones = underTest.getExistingRegisteredOnlyZonesAsDescriptors(networkDto);
+
+        assertThat(existingZones).isEmpty();
+    }
+
+    @Test
+    void testGetServicesWithExistingManagedZonesWhenPostgresWithExistingPrivateDnsZone() {
+        NetworkDto networkDto = getNetworkDto(POSTGRES_PRIVATE_DNS_ZONE_ID, null);
+
+        Set<AzurePrivateDnsZoneServiceEnum> servicesWithPrivateDnsZones = underTest.getServicesWithExistingManagedZones(networkDto);
 
         assertThat(servicesWithPrivateDnsZones).hasSize(1);
         assertThat(servicesWithPrivateDnsZones).contains(AzurePrivateDnsZoneServiceEnum.POSTGRES);
     }
 
     @Test
-    void testGetServicesWithExistingZonesWhenNoServicesWithExistingPrivateDnsZone() {
-        NetworkDto networkDto = getNetworkDto(null);
+    void testGetServicesWithExistingManagedZonesWhenNoServicesWithExistingPrivateDnsZone() {
+        NetworkDto networkDto = getNetworkDto(null, null);
 
-        Set<AzurePrivateDnsZoneServiceEnum> servicesWithPrivateDnsZones = underTest.getServicesWithExistingZones(networkDto);
+        Set<AzurePrivateDnsZoneServiceEnum> servicesWithPrivateDnsZones = underTest.getServicesWithExistingManagedZones(networkDto);
 
         assertThat(servicesWithPrivateDnsZones).isEmpty();
     }
 
     @Test
-    void testGetServiceNamesWithExistingZonesWhenPostgresWithExistingPrivateDnsZone() {
-        NetworkDto networkDto = getNetworkDto("postgresPrivateDnsZoneId");
+    void testGetServiceNamesWithExistingManagedZonesWhenPostgresWithExistingPrivateDnsZone() {
+        NetworkDto networkDto = getNetworkDto(POSTGRES_PRIVATE_DNS_ZONE_ID, null);
 
-        Set<String> servicesWithPrivateDnsZones = underTest.getServiceNamesWithExistingZones(networkDto);
+        Set<String> servicesWithPrivateDnsZones = underTest.getServiceNamesWithExistingManagedZones(networkDto);
 
         assertThat(servicesWithPrivateDnsZones).hasSize(1);
         assertThat(servicesWithPrivateDnsZones).contains(AzurePrivateDnsZoneServiceEnum.POSTGRES.name());
     }
 
     @Test
-    void testGetServiceNamesWithExistingZonesWhenNoServicesWithExistingPrivateDnsZone() {
-        NetworkDto networkDto = getNetworkDto(null);
+    void testGetServiceNamesWithExistingManagedZonesWhenNoServicesWithExistingPrivateDnsZone() {
+        NetworkDto networkDto = getNetworkDto(null, null);
 
-        Set<String> servicesWithPrivateDnsZones = underTest.getServiceNamesWithExistingZones(networkDto);
+        Set<String> servicesWithPrivateDnsZones = underTest.getServiceNamesWithExistingManagedZones(networkDto);
 
         assertThat(servicesWithPrivateDnsZones).isEmpty();
     }
 
-    private NetworkDto getNetworkDto(String postgresPrivateDnsZoneId) {
+    @Test
+    void testGetExistingRegisteredOnlyZonesAsDescriptors() {
+        NetworkDto networkDto = getNetworkDto(null, AKS_PRIVATE_DNS_ZONE_ID);
+
+        Set<String> servicesWithPrivateDnsZones = underTest.getServiceNamesWithExistingManagedZones(networkDto);
+
+        assertThat(servicesWithPrivateDnsZones).isEmpty();
+
+    }
+
+    private NetworkDto getNetworkDto(String postgresPrivateDnsZoneId, String aksPrivateDnsZoneId) {
         return NetworkDto.builder()
                 .withAzure(
                         AzureParams.builder()
                                 .withDatabasePrivateDnsZoneId(postgresPrivateDnsZoneId)
+                                .withAksPrivateDnsZoneId(aksPrivateDnsZoneId)
                                 .build()
                 )
                 .build();


### PR DESCRIPTION
It is possible to register an Azure AKS private DNS zone to environment service. It is not used by cloudbreak, but environment services is used as the info source on the AKS private DNS zone. The current commit introduces some basic validations for the DNS zone:
- does it name match that of the AKS
- does it exist
- is it connected to the VNET passed to the environment

Note, that some parts of an Azure AKS DNS zone name, unlike that of the Postgres, are variable:
- have a region in their name
- can have a subzone

That is, instead of exact name matching, now a regex matching is used. The original code was refactored accordingly. The regex for a subzone was compiled via testing the Azure UI. Testing was done via curl commands and adding unit tests.

Correction: the original implementation contained a bug that prevented customers to create an env with preexisting private DNS zone for Postgres. The present commit is corrected and contains tests against that error.

See detailed description in the commit message.