### PR TITLE
CB-20328 Implement embedded PostgreSQL TLS

### DIFF
--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/RdsSslMode.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/RdsSslMode.java
@@ -7,4 +7,8 @@ public enum RdsSslMode {
     public static boolean isEnabled(RdsSslMode mode) {
         return ENABLED.equals(mode);
     }
+
+    public static RdsSslMode fromBoolean(boolean sslEnforcementEnabled) {
+        return sslEnforcementEnabled ? ENABLED : DISABLED;
+    }
 }

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/dto/DatabaseSslDetails.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/dto/DatabaseSslDetails.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.cloudbreak.dto;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Set;
+
+public class DatabaseSslDetails {
+    private Set<String> sslCerts;
+
+    private boolean sslEnabledForStack;
+
+    public DatabaseSslDetails(Set<String> sslCerts, boolean sslEnabledForStack) {
+        this.sslCerts = requireNonNull(sslCerts);
+        this.sslEnabledForStack = sslEnabledForStack;
+    }
+
+    public Set<String> getSslCerts() {
+        return sslCerts;
+    }
+
+    public void setSslCerts(Set<String> sslCerts) {
+        this.sslCerts = requireNonNull(sslCerts);
+    }
+
+    public String getSslCertBundle() {
+        return String.join("\n", getSslCerts());
+    }
+
+    public boolean isSslEnabledForStack() {
+        return sslEnabledForStack;
+    }
+
+    public void setSslEnabledForStack(boolean sslEnabledForStack) {
+        this.sslEnabledForStack = sslEnabledForStack;
+    }
+
+    @Override
+    public String toString() {
+        return "DatabaseSslDetails{" +
+                "sslCerts=" + sslCerts +
+                ", sslEnabledForStack=" + sslEnabledForStack +
+                '}';
+    }
+}

--- a/core-model/src/test/java/com/sequenceiq/cloudbreak/domain/RdsSslModeTest.java
+++ b/core-model/src/test/java/com/sequenceiq/cloudbreak/domain/RdsSslModeTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class RdsSslModeTest {
 
-    static Object[][] sslDataProvider() {
+    static Object[][] sslModeDataProvider() {
         return new Object[][]{
                 // testCaseName sslMode resultExpected
                 {"sslMode=null", null, false},
@@ -17,9 +17,23 @@ class RdsSslModeTest {
     }
 
     @ParameterizedTest(name = "{0}")
-    @MethodSource("sslDataProvider")
+    @MethodSource("sslModeDataProvider")
     void isEnabledTest(String testCaseName, RdsSslMode sslMode, boolean resultExpected) {
         assertThat(RdsSslMode.isEnabled(sslMode)).isEqualTo(resultExpected);
+    }
+
+    static Object[][] sslEnforcementDataProvider() {
+        return new Object[][]{
+                // sslEnforcementEnabled, resultExpected
+                {false, RdsSslMode.DISABLED},
+                {true, RdsSslMode.ENABLED},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("sslEnforcementDataProvider")
+    void fromBooleanTest(boolean sslEnforcementEnabled, RdsSslMode resultExpected) {
+        assertThat(RdsSslMode.fromBoolean(sslEnforcementEnabled)).isEqualTo(resultExpected);
     }
 
 }

--- a/core-model/src/test/java/com/sequenceiq/cloudbreak/dto/DatabaseSslDetailsTest.java
+++ b/core-model/src/test/java/com/sequenceiq/cloudbreak/dto/DatabaseSslDetailsTest.java
@@ -1,0 +1,69 @@
+package com.sequenceiq.cloudbreak.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class DatabaseSslDetailsTest {
+
+    static Object[][] constructorTestDataProvider() {
+        return new Object[][]{
+                // sslCerts, sslEnabledForStack
+                {Set.of(), false},
+                {Set.of("foo"), false},
+                {Set.of("foo"), true},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("constructorTestDataProvider")
+    void constructorTest(Set<String> sslCerts, boolean sslEnabledForStack) {
+        DatabaseSslDetails underTest = new DatabaseSslDetails(sslCerts, sslEnabledForStack);
+
+        assertThat(underTest.getSslCerts()).isSameAs(sslCerts);
+        assertThat(underTest.isSslEnabledForStack()).isEqualTo(sslEnabledForStack);
+    }
+
+    @Test
+    void constructorTestNullCertsSet() {
+        Assertions.assertThrows(NullPointerException.class, () -> new DatabaseSslDetails(null, false));
+    }
+
+    @Test
+    void setSslCertsTestNull() {
+        DatabaseSslDetails underTest = new DatabaseSslDetails(Set.of(), false);
+
+        Assertions.assertThrows(NullPointerException.class, () -> underTest.setSslCerts(null));
+    }
+
+    @SafeVarargs
+    private static <T> Set<T> linkedHashSet(T... elements) {
+        return new LinkedHashSet<>(Arrays.asList(elements));
+    }
+
+    static Object[][] getSslCertBundleTestDataProvider() {
+        return new Object[][]{
+                // sslCerts, resultExpected
+                {Set.of(), ""},
+                {Set.of("foo"), "foo"},
+                {linkedHashSet("foo", "bar"), "foo\nbar"},
+                {linkedHashSet("foo", "bar", "baz"), "foo\nbar\nbaz"},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("getSslCertBundleTestDataProvider")
+    void getSslCertBundleTest(Set<String> sslCerts, String resultExpected) {
+        DatabaseSslDetails underTest = new DatabaseSslDetails(sslCerts, false);
+
+        assertThat(underTest.getSslCertBundle()).isEqualTo(resultExpected);
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/StackToTemplatePreparationObjectConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/StackToTemplatePreparationObjectConverter.java
@@ -59,6 +59,7 @@ import com.sequenceiq.cloudbreak.ldap.LdapConfigService;
 import com.sequenceiq.cloudbreak.service.GatewayConfigService;
 import com.sequenceiq.cloudbreak.service.ServiceEndpointCollector;
 import com.sequenceiq.cloudbreak.service.blueprint.BlueprintViewProvider;
+import com.sequenceiq.cloudbreak.service.cluster.DatabaseSslService;
 import com.sequenceiq.cloudbreak.service.customconfigs.CustomConfigurationsService;
 import com.sequenceiq.cloudbreak.service.customconfigs.CustomConfigurationsViewProvider;
 import com.sequenceiq.cloudbreak.service.datalake.SdxClientService;
@@ -70,7 +71,6 @@ import com.sequenceiq.cloudbreak.service.identitymapping.AwsMockAccountMappingSe
 import com.sequenceiq.cloudbreak.service.identitymapping.AzureMockAccountMappingService;
 import com.sequenceiq.cloudbreak.service.identitymapping.GcpMockAccountMappingService;
 import com.sequenceiq.cloudbreak.service.loadbalancer.LoadBalancerFqdnUtil;
-import com.sequenceiq.cloudbreak.service.rdsconfig.RedbeamsDbCertificateProvider;
 import com.sequenceiq.cloudbreak.service.sharedservice.DatalakeService;
 import com.sequenceiq.cloudbreak.tag.AccountTagValidationFailed;
 import com.sequenceiq.cloudbreak.template.BlueprintProcessingException;
@@ -113,7 +113,7 @@ public class StackToTemplatePreparationObjectConverter {
     private PostgresConfigService postgresConfigService;
 
     @Inject
-    private RedbeamsDbCertificateProvider dbCertificateProvider;
+    private DatabaseSslService databaseSslService;
 
     @Inject
     private FileSystemConfigurationProvider fileSystemConfigurationProvider;
@@ -234,7 +234,7 @@ public class StackToTemplatePreparationObjectConverter {
 
             BlueprintView blueprintView = blueprintViewProvider.getBlueprintView(source.getBlueprint());
             Optional<String> version = Optional.ofNullable(blueprintView.getVersion());
-            String sslCertsFilePath = dbCertificateProvider.getSslCertsFilePath();
+            String sslCertsFilePath = databaseSslService.getSslCertsFilePath();
             Set<RdsConfigWithoutCluster> rdsConfigWithoutClusters = postgresConfigService.createRdsConfigIfNeeded(source);
             Set<RdsView> rdsViews = rdsConfigWithoutClusters.stream()
                     .map(e -> rdsViewProvider.getRdsView(e, sslCertsFilePath))

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterDbCertRotationHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterDbCertRotationHandler.java
@@ -7,12 +7,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.dto.DatabaseSslDetails;
 import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.eventbus.Event;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.ClusterDbCertRotationRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.ClusterDbCertRotationResult;
-import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
-import com.sequenceiq.cloudbreak.service.rdsconfig.RedbeamsDbCertificateProvider;
+import com.sequenceiq.cloudbreak.service.cluster.DatabaseSslService;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
@@ -24,13 +24,10 @@ public class ClusterDbCertRotationHandler extends ExceptionCatcherEventHandler<C
     private static final Logger LOGGER = LoggerFactory.getLogger(ClusterDbCertRotationHandler.class);
 
     @Inject
-    private RedbeamsDbCertificateProvider dbCertificateProvider;
-
-    @Inject
     private StackDtoService stackDtoService;
 
     @Inject
-    private ClusterService clusterService;
+    private DatabaseSslService databaseSslService;
 
     @Override
     public String selector() {
@@ -48,8 +45,9 @@ public class ClusterDbCertRotationHandler extends ExceptionCatcherEventHandler<C
         ClusterDbCertRotationRequest request = event.getData();
         Long resourceId = event.getData().getResourceId();
         StackDto stackDto = stackDtoService.getById(resourceId);
-        RedbeamsDbCertificateProvider.RedbeamsDbSslDetails relatedSslCerts = dbCertificateProvider.getRelatedSslCerts(stackDto);
-        clusterService.updateDbSslCert(stackDto.getCluster().getId(), relatedSslCerts);
+        DatabaseSslDetails sslDetails = databaseSslService.getDbSslDetailsForRotationAndUpdateInCluster(stackDto);
+        LOGGER.info("SslDetails after rotation: {}", sslDetails);
         return new ClusterDbCertRotationResult(request);
     }
+
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterService.java
@@ -62,6 +62,7 @@ import com.sequenceiq.cloudbreak.domain.stack.cluster.gateway.Gateway;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.domain.view.RdsConfigWithoutCluster;
+import com.sequenceiq.cloudbreak.dto.DatabaseSslDetails;
 import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.dto.StackDtoDelegate;
 import com.sequenceiq.cloudbreak.repository.cluster.ClusterRepository;
@@ -72,7 +73,6 @@ import com.sequenceiq.cloudbreak.service.altus.AltusMachineUserService;
 import com.sequenceiq.cloudbreak.service.filesystem.FileSystemConfigService;
 import com.sequenceiq.cloudbreak.service.gateway.GatewayService;
 import com.sequenceiq.cloudbreak.service.rdsconfig.RdsConfigWithoutClusterService;
-import com.sequenceiq.cloudbreak.service.rdsconfig.RedbeamsDbCertificateProvider;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.cloudbreak.service.stack.RuntimeVersionService;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
@@ -501,10 +501,8 @@ public class ClusterService {
         return repository.getById(id);
     }
 
-    public String updateDbSslCert(Long clusterId, RedbeamsDbCertificateProvider.RedbeamsDbSslDetails relatedSslCerts) {
-        Set<String> rootSslCerts = relatedSslCerts.getSslCerts();
-        String allCerts = String.join("\n", rootSslCerts);
-        repository.updateDbSslCert(clusterId, allCerts, relatedSslCerts.isSslEnabledForStack());
-        return allCerts;
+    public void updateDbSslCert(Long clusterId, DatabaseSslDetails sslDetails) {
+        repository.updateDbSslCert(clusterId, sslDetails.getSslCertBundle(), sslDetails.isSslEnabledForStack());
     }
+
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/freeipa/FreeipaClientService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/freeipa/FreeipaClientService.java
@@ -53,11 +53,11 @@ public class FreeipaClientService {
             }
         } catch (WebApplicationException e) {
             String errorMessage = webApplicationExceptionMessageExtractor.getErrorMessage(e);
-            String message = String.format("Failed to GET FreeIPA by environment crn: %s, due to: %s. %s.", environmentCrn, e.getMessage(), errorMessage);
+            String message = String.format("Failed to GET FreeIPA by environment CRN: %s, due to: %s. %s.", environmentCrn, e.getMessage(), errorMessage);
             LOGGER.error(message, e);
             throw new CloudbreakServiceException(message, e);
         } catch (ProcessingException | IllegalStateException e) {
-            String message = String.format("Failed to GET FreeIPA by environment crn: %s, due to: %s.", environmentCrn, e.getMessage());
+            String message = String.format("Failed to GET FreeIPA by environment CRN: %s, due to: %s.", environmentCrn, e.getMessage());
             LOGGER.error(message, e);
             throw new CloudbreakServiceException(message, e);
         }
@@ -76,11 +76,11 @@ public class FreeipaClientService {
             return Optional.empty();
         } catch (WebApplicationException e) {
             String errorMessage = webApplicationExceptionMessageExtractor.getErrorMessage(e);
-            String message = String.format("Failed to GET FreeIPA by environment crn: %s, due to: %s. %s.", environmentCrn, e.getMessage(), errorMessage);
+            String message = String.format("Failed to GET FreeIPA by environment CRN: %s, due to: %s. %s.", environmentCrn, e.getMessage(), errorMessage);
             LOGGER.error(message, e);
             throw new CloudbreakServiceException(message, e);
         } catch (ProcessingException | IllegalStateException e) {
-            String message = String.format("Failed to GET FreeIPA by environment crn: %s, due to: %s.", environmentCrn, e.getMessage());
+            String message = String.format("Failed to GET FreeIPA by environment CRN: %s, due to: %s.", environmentCrn, e.getMessage());
             LOGGER.error(message, e);
             throw new CloudbreakServiceException(message, e);
         }
@@ -121,4 +121,27 @@ public class FreeipaClientService {
     public List<String> recipes(String accountId) {
         return utilV1Endpoint.usedRecipes(accountId);
     }
+
+    public String getRootCertificateByEnvironmentCrn(String environmentCrn) {
+        try {
+            if (RegionAwareInternalCrnGeneratorUtil.isInternalCrn(ThreadBasedUserCrnProvider.getUserCrn())) {
+                LOGGER.info("The user CRN is internal CRN, so we call freeipa on internal endpoint");
+                String accountId = Crn.fromString(environmentCrn).getAccountId();
+                return freeIpaV1Endpoint.getRootCertificateInternal(environmentCrn, accountId);
+            } else {
+                return freeIpaV1Endpoint.getRootCertificate(environmentCrn);
+            }
+        } catch (WebApplicationException e) {
+            String errorMessage = webApplicationExceptionMessageExtractor.getErrorMessage(e);
+            String message = String.format("Failed to GET FreeIPA root certificate by environment CRN: %s, due to: %s. %s.", environmentCrn, e.getMessage(),
+                    errorMessage);
+            LOGGER.error(message, e);
+            throw new CloudbreakServiceException(message, e);
+        } catch (ProcessingException | IllegalStateException e) {
+            String message = String.format("Failed to GET FreeIPA root certificate by environment CRN: %s, due to: %s.", environmentCrn, e.getMessage());
+            LOGGER.error(message, e);
+            throw new CloudbreakServiceException(message, e);
+        }
+    }
+
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v2/StackToTemplatePreparationObjectConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v2/StackToTemplatePreparationObjectConverterTest.java
@@ -78,6 +78,7 @@ import com.sequenceiq.cloudbreak.ldap.LdapConfigService;
 import com.sequenceiq.cloudbreak.service.GatewayConfigService;
 import com.sequenceiq.cloudbreak.service.ServiceEndpointCollector;
 import com.sequenceiq.cloudbreak.service.blueprint.BlueprintViewProvider;
+import com.sequenceiq.cloudbreak.service.cluster.DatabaseSslService;
 import com.sequenceiq.cloudbreak.service.cluster.InstanceGroupMetadataCollector;
 import com.sequenceiq.cloudbreak.service.customconfigs.CustomConfigurationsService;
 import com.sequenceiq.cloudbreak.service.customconfigs.CustomConfigurationsViewProvider;
@@ -89,7 +90,6 @@ import com.sequenceiq.cloudbreak.service.hostgroup.HostGroupService;
 import com.sequenceiq.cloudbreak.service.idbroker.IdBrokerService;
 import com.sequenceiq.cloudbreak.service.identitymapping.AwsMockAccountMappingService;
 import com.sequenceiq.cloudbreak.service.loadbalancer.LoadBalancerFqdnUtil;
-import com.sequenceiq.cloudbreak.service.rdsconfig.RedbeamsDbCertificateProvider;
 import com.sequenceiq.cloudbreak.service.sharedservice.DatalakeService;
 import com.sequenceiq.cloudbreak.structuredevent.CloudbreakRestRequestThreadLocalService;
 import com.sequenceiq.cloudbreak.tag.CostTagging;
@@ -159,7 +159,7 @@ public class StackToTemplatePreparationObjectConverterTest {
     private SdxClientService sdxClientService;
 
     @Mock
-    private RedbeamsDbCertificateProvider dbCertificateProvider;
+    private DatabaseSslService databaseSslService;
 
     @Mock
     private FileSystemConfigurationProvider fileSystemConfigurationProvider;
@@ -278,7 +278,7 @@ public class StackToTemplatePreparationObjectConverterTest {
 
     @BeforeEach
     public void setUp() throws IOException, TransactionService.TransactionExecutionException {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         doAnswer(invocation -> {
             invocation.getArgument(0, Runnable.class).run();
             return null;
@@ -336,7 +336,7 @@ public class StackToTemplatePreparationObjectConverterTest {
         when(idBrokerService.getByCluster(anyLong())).thenReturn(idbroker);
         when(idBrokerService.save(any(IdBroker.class))).thenReturn(idbroker);
         when(grpcUmsClient.listServicePrincipalCloudIdentities(anyString(), anyString())).thenReturn(Collections.EMPTY_LIST);
-        when(dbCertificateProvider.getSslCertsFilePath()).thenReturn(SSL_CERTS_FILE_PATH);
+        when(databaseSslService.getSslCertsFilePath()).thenReturn(SSL_CERTS_FILE_PATH);
         when(stackMock.getId()).thenReturn(1L);
         when(generalClusterConfigsProvider.generalClusterConfigs(any(StackDtoDelegate.class), any(Credential.class)))
                 .thenReturn(new GeneralClusterConfigs());

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/container/postgres/PostgresConfigServiceSSLSaltConfigTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/container/postgres/PostgresConfigServiceSSLSaltConfigTest.java
@@ -1,0 +1,65 @@
+package com.sequenceiq.cloudbreak.core.bootstrap.service.container.postgres;
+
+import static java.util.Map.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+public class PostgresConfigServiceSSLSaltConfigTest {
+
+    @Test
+    void defaultConstructorTest() {
+        PostgresConfigService.SSLSaltConfig underTest = new PostgresConfigService.SSLSaltConfig();
+
+        assertThat(underTest.getRootCertsBundle()).isEqualTo("");
+        assertThat(underTest.isSslEnabled()).isFalse();
+        assertThat(underTest.isRestartRequired()).isFalse();
+    }
+
+    @Test
+    void setRootCertsBundleTestWhenNull() {
+        PostgresConfigService.SSLSaltConfig underTest = new PostgresConfigService.SSLSaltConfig();
+
+        assertThrows(NullPointerException.class, () -> underTest.setRootCertsBundle(null));
+    }
+
+    @Test
+    void toMapTestWhenDefault() {
+        PostgresConfigService.SSLSaltConfig underTest = new PostgresConfigService.SSLSaltConfig();
+
+        Map<String, Object> result = underTest.toMap();
+
+        assertThat(result).isNotNull();
+        assertThat(result).isEqualTo(Map.ofEntries(entry("ssl_certs", ""), entry("ssl_restart_required", "false"), entry("ssl_enabled", "false")));
+    }
+
+    @Test
+    void toMapTestWhenSslWithoutRestart() {
+        PostgresConfigService.SSLSaltConfig underTest = new PostgresConfigService.SSLSaltConfig();
+        underTest.setRestartRequired(false);
+        underTest.setSslEnabled(true);
+        underTest.setRootCertsBundle("myCert");
+
+        Map<String, Object> result = underTest.toMap();
+
+        assertThat(result).isNotNull();
+        assertThat(result).isEqualTo(Map.ofEntries(entry("ssl_certs", "myCert"), entry("ssl_restart_required", "false"), entry("ssl_enabled", "true")));
+    }
+
+    @Test
+    void toMapTestWhenSslWithRestart() {
+        PostgresConfigService.SSLSaltConfig underTest = new PostgresConfigService.SSLSaltConfig();
+        underTest.setRestartRequired(true);
+        underTest.setSslEnabled(true);
+        underTest.setRootCertsBundle("myCert");
+
+        Map<String, Object> result = underTest.toMap();
+
+        assertThat(result).isNotNull();
+        assertThat(result).isEqualTo(Map.ofEntries(entry("ssl_certs", "myCert"), entry("ssl_restart_required", "true"), entry("ssl_enabled", "true")));
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterDbCertRotationHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterDbCertRotationHandlerTest.java
@@ -1,13 +1,9 @@
 package com.sequenceiq.cloudbreak.reactor.handler.cluster;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import java.util.Set;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -22,16 +18,12 @@ import com.sequenceiq.cloudbreak.eventbus.Event;
 import com.sequenceiq.cloudbreak.eventbus.EventBus;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.ClusterDbCertRotationRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.ClusterDbCertRotationResult;
-import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
-import com.sequenceiq.cloudbreak.service.rdsconfig.RedbeamsDbCertificateProvider;
+import com.sequenceiq.cloudbreak.service.cluster.DatabaseSslService;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
-import com.sequenceiq.cloudbreak.view.ClusterView;
 import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 @ExtendWith(MockitoExtension.class)
 public class ClusterDbCertRotationHandlerTest {
-
-    private static final Long CLUSTER_ID = 12L;
 
     private static final Long STACK_ID = 1L;
 
@@ -39,10 +31,9 @@ public class ClusterDbCertRotationHandlerTest {
     private ClusterDbCertRotationHandler underTest;
 
     @Mock
-    private ClusterService clusterService;
+    private DatabaseSslService databaseSslService;
 
-    @Mock
-    private RedbeamsDbCertificateProvider dbCertificateProvider;
+    // TODO add new dependencies
 
     @Mock
     private StackDtoService stackDtoService;
@@ -51,23 +42,17 @@ public class ClusterDbCertRotationHandlerTest {
     private StackDto stackDto;
 
     @Mock
-    private ClusterView clusterView;
-
-    @Mock
     private EventBus eventBus;
 
     @Test
     public void testDoAccept() {
-        Set<String> rootSslCerts = Set.of("any-db-cert");
         HandlerEvent<ClusterDbCertRotationRequest> handlerEvent = mock(HandlerEvent.class);
         when(handlerEvent.getData()).thenReturn(new ClusterDbCertRotationRequest(STACK_ID));
         when(stackDtoService.getById(STACK_ID)).thenReturn(stackDto);
-        when(clusterView.getId()).thenReturn(CLUSTER_ID);
-        when(stackDto.getCluster()).thenReturn(clusterView);
-        RedbeamsDbCertificateProvider.RedbeamsDbSslDetails redbeamsSslDetails = new RedbeamsDbCertificateProvider.RedbeamsDbSslDetails(rootSslCerts, true);
-        when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(redbeamsSslDetails);
+
         underTest.doAccept(handlerEvent);
-        verify(clusterService).updateDbSslCert(12L, redbeamsSslDetails);
+
+        verify(databaseSslService).getDbSslDetailsForRotationAndUpdateInCluster(stackDto);
     }
 
     @Test
@@ -76,13 +61,15 @@ public class ClusterDbCertRotationHandlerTest {
         when(event.getData()).thenReturn(new ClusterDbCertRotationRequest(STACK_ID));
         when(stackDtoService.getById(STACK_ID)).thenReturn(stackDto);
         when(event.getHeaders()).thenReturn(new Event.Headers());
-        when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenThrow(new RuntimeException("any-error"));
+        when(databaseSslService.getDbSslDetailsForRotationAndUpdateInCluster(stackDto)).thenThrow(new RuntimeException("any-error"));
         ArgumentCaptor<Event<ClusterDbCertRotationResult>> failureEventCapture = ArgumentCaptor.forClass(Event.class);
+
         underTest.accept(event);
-        verify(clusterService, never()).updateDbSslCert(any(), any());
+
         verify(eventBus).notify(eq("CLUSTERDBCERTROTATIONRESULT_ERROR"), failureEventCapture.capture());
         Event<ClusterDbCertRotationResult> failureEvent = failureEventCapture.getValue();
         Assertions.assertThat(failureEvent.getData().getErrorDetails().getMessage()).isEqualTo("any-error");
         Assertions.assertThat(failureEvent.getData().getStatusReason()).isEqualTo("Cannot rotate the DB root CERT on the cluster");
     }
+
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ClusterServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ClusterServiceTest.java
@@ -54,10 +54,10 @@ import com.sequenceiq.cloudbreak.common.type.HealthCheckType;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.dto.DatabaseSslDetails;
 import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.dto.StackDtoDelegate;
 import com.sequenceiq.cloudbreak.repository.cluster.ClusterRepository;
-import com.sequenceiq.cloudbreak.service.rdsconfig.RedbeamsDbCertificateProvider;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.cloudbreak.service.stack.RuntimeVersionService;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
@@ -150,7 +150,7 @@ class ClusterServiceTest {
             String name, HealthCheckResult healthCheckResult, InstanceStatus expectedInstanceStatus, String expectedStatusReason, int expectedCount) {
         when(runtimeVersionService.getRuntimeVersion(anyLong())).thenReturn(Optional.of("7.2.11"));
         StackDto stack = setupStack(STACK_ID);
-        setupClusterApi(stack, healthCheckResult, expectedStatusReason);
+        setupClusterApi(healthCheckResult, expectedStatusReason);
         setupInstanceMetadata(stack);
         ArgumentCaptor<InstanceMetadataView> captor = ArgumentCaptor.forClass(InstanceMetadataView.class);
 
@@ -207,8 +207,10 @@ class ClusterServiceTest {
 
     @Test
     void testUpdateDbSslCertWhenCertIsEmpty() {
-        RedbeamsDbCertificateProvider.RedbeamsDbSslDetails relatedCerts = new RedbeamsDbCertificateProvider.RedbeamsDbSslDetails(emptySet(), false);
-        underTest.updateDbSslCert(CLUSTER_ID, relatedCerts);
+        DatabaseSslDetails sslDetails = new DatabaseSslDetails(emptySet(), false);
+
+        underTest.updateDbSslCert(CLUSTER_ID, sslDetails);
+
         verify(repository).updateDbSslCert(CLUSTER_ID, "", false);
     }
 
@@ -217,8 +219,10 @@ class ClusterServiceTest {
         Set<String> certs = new LinkedHashSet<>();
         certs.add("cert1");
         certs.add("cert2");
-        RedbeamsDbCertificateProvider.RedbeamsDbSslDetails relatedCerts = new RedbeamsDbCertificateProvider.RedbeamsDbSslDetails(certs, false);
-        underTest.updateDbSslCert(CLUSTER_ID, relatedCerts);
+        DatabaseSslDetails sslDetails = new DatabaseSslDetails(certs, false);
+
+        underTest.updateDbSslCert(CLUSTER_ID, sslDetails);
+
         verify(repository).updateDbSslCert(CLUSTER_ID, "cert1\ncert2", false);
     }
 
@@ -227,8 +231,10 @@ class ClusterServiceTest {
         Set<String> certs = new LinkedHashSet<>();
         certs.add("cert1");
         certs.add("cert2");
-        RedbeamsDbCertificateProvider.RedbeamsDbSslDetails relatedCerts = new RedbeamsDbCertificateProvider.RedbeamsDbSslDetails(certs, true);
-        underTest.updateDbSslCert(CLUSTER_ID, relatedCerts);
+        DatabaseSslDetails sslDetails = new DatabaseSslDetails(certs, true);
+
+        underTest.updateDbSslCert(CLUSTER_ID, sslDetails);
+
         verify(repository).updateDbSslCert(CLUSTER_ID, "cert1\ncert2", true);
     }
 
@@ -279,7 +285,7 @@ class ClusterServiceTest {
         return instanceMetadata;
     }
 
-    private void setupClusterApi(StackDto stack, HealthCheckResult healthCheckResult, String statusReason) {
+    private void setupClusterApi(HealthCheckResult healthCheckResult, String statusReason) {
         ClusterApi connector = mock(ClusterApi.class);
         ClusterStatusService clusterStatusService = mock(ClusterStatusService.class);
         when(clusterStatusService.isClusterManagerRunning()).thenReturn(true);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/DatabaseSslServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/DatabaseSslServiceTest.java
@@ -1,0 +1,743 @@
+package com.sequenceiq.cloudbreak.service.cluster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.dto.DatabaseSslDetails;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.service.freeipa.FreeipaClientService;
+import com.sequenceiq.cloudbreak.service.rdsconfig.RedbeamsDbCertificateProvider;
+import com.sequenceiq.cloudbreak.service.rdsconfig.RedbeamsDbServerConfigurer;
+import com.sequenceiq.cloudbreak.service.sharedservice.DatalakeService;
+import com.sequenceiq.cloudbreak.view.ClusterView;
+import com.sequenceiq.cloudbreak.view.StackView;
+
+@ExtendWith(MockitoExtension.class)
+class DatabaseSslServiceTest {
+
+    private static final String SSL_CERTS_FILE_PATH = "/foo/bar.pem";
+
+    private static final String CERT_EXTERNAL_1 = "certExternal1";
+
+    private static final String CERT_EXTERNAL_2 = "certExternal2";
+
+    private static final String CERT_EMBEDDED = "certEmbedded";
+
+    private static final String DATABASE_SERVER_CRN = "databaseServerCrn";
+
+    private static final String DATABASE_SERVER_CRN_DATALAKE = "databaseServerCrnDatalake";
+
+    private static final Long CLUSTER_ID = 12L;
+
+    private static final String ENVIRONMENT_CRN = "environmentCrn";
+
+    @Mock
+    private RedbeamsDbServerConfigurer dbServerConfigurer;
+
+    @Mock
+    private RedbeamsDbCertificateProvider dbCertificateProvider;
+
+    @Mock
+    private EmbeddedDatabaseService embeddedDatabaseService;
+
+    @Mock
+    private FreeipaClientService freeipaClientService;
+
+    @Mock
+    private DatalakeService datalakeService;
+
+    @Mock
+    private ClusterService clusterService;
+
+    @InjectMocks
+    private DatabaseSslService underTest;
+
+    @Mock
+    private StackDto stackDto;
+
+    @Mock
+    private StackView stackView;
+
+    @Mock
+    private ClusterView clusterView;
+
+    @Mock
+    private Stack datalakeStack;
+
+    @Mock
+    private Cluster datalakeCluster;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(underTest, "certsPath", SSL_CERTS_FILE_PATH);
+
+        lenient().when(stackDto.getStack()).thenReturn(stackView);
+        lenient().when(stackDto.getCluster()).thenReturn(clusterView);
+        lenient().when(clusterView.getDatabaseServerCrn()).thenReturn(DATABASE_SERVER_CRN);
+    }
+
+    @Test
+    void getSslCertsFilePathTest() {
+        assertThat(underTest.getSslCertsFilePath()).isEqualTo(SSL_CERTS_FILE_PATH);
+    }
+
+    static Object[][] isDbSslEnabledByClusterViewDataProvider() {
+        return new Object[][]{
+                // dbSslEnabled, resultExpected
+                {null, false},
+                {false, false},
+                {true, true},
+        };
+    }
+
+    @ParameterizedTest(name = "{1},{0}")
+    @MethodSource("isDbSslEnabledByClusterViewDataProvider")
+    void isDbSslEnabledByClusterViewTest(Boolean dbSslEnabled, boolean resultExpected) {
+        when(clusterView.getDbSslEnabled()).thenReturn(dbSslEnabled);
+
+        assertThat(underTest.isDbSslEnabledByClusterView(stackView, clusterView)).isEqualTo(resultExpected);
+    }
+
+    static Object[][] externalDbSslDetailsDataProvider() {
+        return new Object[][]{
+                // sslCerts, sslEnabledForStack
+                {Set.of(), false},
+                {Set.of(CERT_EXTERNAL_1), true},
+                {Set.of(CERT_EXTERNAL_1, CERT_EXTERNAL_2), true},
+        };
+    }
+
+    @ParameterizedTest(name = "{1},{0}")
+    @MethodSource("externalDbSslDetailsDataProvider")
+    void getDbSslDetailsForCreationAndUpdateInClusterTestWhenDatalakeWithExternalDb(Set<String> sslCerts, boolean sslEnabledForStack) {
+        DatabaseSslDetails sslDetails = new DatabaseSslDetails(sslCerts, sslEnabledForStack);
+        when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(true);
+        when(stackView.getType()).thenReturn(StackType.DATALAKE);
+        when(clusterView.getId()).thenReturn(CLUSTER_ID);
+
+        DatabaseSslDetails result = underTest.getDbSslDetailsForCreationAndUpdateInCluster(stackDto);
+
+        assertThat(result).isSameAs(sslDetails);
+        assertThat(result.getSslCerts()).isEqualTo(sslCerts);
+        assertThat(result.isSslEnabledForStack()).isEqualTo(sslEnabledForStack);
+
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(datalakeService, never()).getDatalakeStackByDatahubStack(any(StackView.class));
+        verify(freeipaClientService, never()).getRootCertificateByEnvironmentCrn(anyString());
+        verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
+    }
+
+    @ParameterizedTest(name = "{1},{0}")
+    @MethodSource("externalDbSslDetailsDataProvider")
+    void getDbSslDetailsForCreationAndUpdateInClusterTestWhenDatahubWithExternalDbButNoDatalake(Set<String> sslCerts, boolean sslEnabledForStack) {
+        DatabaseSslDetails sslDetails = new DatabaseSslDetails(sslCerts, sslEnabledForStack);
+        when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(true);
+        when(stackView.getType()).thenReturn(StackType.WORKLOAD);
+        when(datalakeService.getDatalakeStackByDatahubStack(stackView)).thenReturn(Optional.empty());
+        when(clusterView.getId()).thenReturn(CLUSTER_ID);
+
+        DatabaseSslDetails result = underTest.getDbSslDetailsForCreationAndUpdateInCluster(stackDto);
+
+        assertThat(result).isSameAs(sslDetails);
+        assertThat(result.getSslCerts()).isEqualTo(sslCerts);
+        assertThat(result.isSslEnabledForStack()).isEqualTo(sslEnabledForStack);
+
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(freeipaClientService, never()).getRootCertificateByEnvironmentCrn(anyString());
+        verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
+    }
+
+    @ParameterizedTest(name = "{1},{0}")
+    @MethodSource("externalDbSslDetailsDataProvider")
+    void getDbSslDetailsForCreationAndUpdateInClusterTestWhenDatahubAndDatalakeAndExternalDbOnly(Set<String> sslCerts, boolean sslEnabledForStack) {
+        DatabaseSslDetails sslDetails = new DatabaseSslDetails(sslCerts, sslEnabledForStack);
+        when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(true);
+        when(stackView.getType()).thenReturn(StackType.WORKLOAD);
+        when(datalakeService.getDatalakeStackByDatahubStack(stackView)).thenReturn(Optional.of(datalakeStack));
+        when(datalakeStack.getCluster()).thenReturn(datalakeCluster);
+        when(datalakeCluster.getDatabaseServerCrn()).thenReturn(DATABASE_SERVER_CRN_DATALAKE);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN_DATALAKE)).thenReturn(true);
+        when(clusterView.getId()).thenReturn(CLUSTER_ID);
+
+        DatabaseSslDetails result = underTest.getDbSslDetailsForCreationAndUpdateInCluster(stackDto);
+
+        assertThat(result).isSameAs(sslDetails);
+        assertThat(result.getSslCerts()).isEqualTo(sslCerts);
+        assertThat(result.isSslEnabledForStack()).isEqualTo(sslEnabledForStack);
+
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(freeipaClientService, never()).getRootCertificateByEnvironmentCrn(anyString());
+        verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
+    }
+
+    @Test
+    void getDbSslDetailsForCreationAndUpdateInClusterTestWhenDatalakeWithEmbeddedDbNoSsl() {
+        DatabaseSslDetails sslDetails = new DatabaseSslDetails(Set.of(), false);
+        when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(false);
+        when(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(stackView, clusterView)).thenReturn(false);
+        when(stackView.getType()).thenReturn(StackType.DATALAKE);
+        when(clusterView.getId()).thenReturn(CLUSTER_ID);
+
+        DatabaseSslDetails result = underTest.getDbSslDetailsForCreationAndUpdateInCluster(stackDto);
+
+        assertThat(result).isSameAs(sslDetails);
+        assertThat(result.getSslCerts()).isEmpty();
+        assertThat(result.isSslEnabledForStack()).isFalse();
+
+        verify(datalakeService, never()).getDatalakeStackByDatahubStack(any(StackView.class));
+        verify(freeipaClientService, never()).getRootCertificateByEnvironmentCrn(anyString());
+        verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
+    }
+
+    @Test
+    void getDbSslDetailsForCreationAndUpdateInClusterTestWhenDatahubWithEmbeddedDbNoSslButNoDatalake() {
+        DatabaseSslDetails sslDetails = new DatabaseSslDetails(Set.of(), false);
+        when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(false);
+        when(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(stackView, clusterView)).thenReturn(false);
+        when(stackView.getType()).thenReturn(StackType.WORKLOAD);
+        when(datalakeService.getDatalakeStackByDatahubStack(stackView)).thenReturn(Optional.empty());
+        when(clusterView.getId()).thenReturn(CLUSTER_ID);
+
+        DatabaseSslDetails result = underTest.getDbSslDetailsForCreationAndUpdateInCluster(stackDto);
+
+        assertThat(result).isSameAs(sslDetails);
+        assertThat(result.getSslCerts()).isEmpty();
+        assertThat(result.isSslEnabledForStack()).isFalse();
+
+        verify(freeipaClientService, never()).getRootCertificateByEnvironmentCrn(anyString());
+        verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
+    }
+
+    @ParameterizedTest(name = "{1},{0}")
+    @MethodSource("externalDbSslDetailsDataProvider")
+    void getDbSslDetailsForCreationAndUpdateInClusterTestWhenDatahubWithExternalDbAndDatalakeWithEmbeddedDbNoSsl(Set<String> sslCerts,
+            boolean sslEnabledForStack) {
+        DatabaseSslDetails sslDetails = new DatabaseSslDetails(sslCerts, sslEnabledForStack);
+        when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(true);
+        when(stackView.getType()).thenReturn(StackType.WORKLOAD);
+        when(datalakeService.getDatalakeStackByDatahubStack(stackView)).thenReturn(Optional.of(datalakeStack));
+        when(datalakeStack.getCluster()).thenReturn(datalakeCluster);
+        when(datalakeCluster.getDatabaseServerCrn()).thenReturn(DATABASE_SERVER_CRN_DATALAKE);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN_DATALAKE)).thenReturn(false);
+        when(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(datalakeStack, datalakeCluster)).thenReturn(false);
+        when(clusterView.getId()).thenReturn(CLUSTER_ID);
+
+        DatabaseSslDetails result = underTest.getDbSslDetailsForCreationAndUpdateInCluster(stackDto);
+
+        assertThat(result).isSameAs(sslDetails);
+        assertThat(result.getSslCerts()).isEqualTo(sslCerts);
+        assertThat(result.isSslEnabledForStack()).isEqualTo(sslEnabledForStack);
+
+        verifyNoMoreInteractions(embeddedDatabaseService);
+        verify(freeipaClientService, never()).getRootCertificateByEnvironmentCrn(anyString());
+        verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
+    }
+
+    static Object[][] externalDbSslCertsDataProvider() {
+        return new Object[][]{
+                // sslCerts
+                {Set.of()},
+                {Set.of(CERT_EXTERNAL_1)},
+                {Set.of(CERT_EXTERNAL_1, CERT_EXTERNAL_2)},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("externalDbSslCertsDataProvider")
+    void getDbSslDetailsForCreationAndUpdateInClusterTestWhenDatahubWithEmbeddedDbNoSslAndDatalakeWithExternalDb(Set<String> sslCerts) {
+        DatabaseSslDetails sslDetails = new DatabaseSslDetails(sslCerts, false);
+        when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(false);
+        when(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(stackView, clusterView)).thenReturn(false);
+        when(stackView.getType()).thenReturn(StackType.WORKLOAD);
+        when(datalakeService.getDatalakeStackByDatahubStack(stackView)).thenReturn(Optional.of(datalakeStack));
+        when(datalakeStack.getCluster()).thenReturn(datalakeCluster);
+        when(datalakeCluster.getDatabaseServerCrn()).thenReturn(DATABASE_SERVER_CRN_DATALAKE);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN_DATALAKE)).thenReturn(true);
+        when(clusterView.getId()).thenReturn(CLUSTER_ID);
+
+        DatabaseSslDetails result = underTest.getDbSslDetailsForCreationAndUpdateInCluster(stackDto);
+
+        assertThat(result).isSameAs(sslDetails);
+        assertThat(result.getSslCerts()).isEqualTo(sslCerts);
+        assertThat(result.isSslEnabledForStack()).isFalse();
+
+        verifyNoMoreInteractions(embeddedDatabaseService);
+        verify(freeipaClientService, never()).getRootCertificateByEnvironmentCrn(anyString());
+        verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("externalDbSslCertsDataProvider")
+    void getDbSslDetailsForCreationAndUpdateInClusterTestWhenStackWithEmbeddedDbSsl(Set<String> sslCerts) {
+        DatabaseSslDetails sslDetails = new DatabaseSslDetails(sslCerts, false);
+        when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(false);
+        when(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(stackView, clusterView)).thenReturn(true);
+        when(stackView.getEnvironmentCrn()).thenReturn(ENVIRONMENT_CRN);
+        when(freeipaClientService.getRootCertificateByEnvironmentCrn(ENVIRONMENT_CRN)).thenReturn(CERT_EMBEDDED);
+        when(clusterView.getId()).thenReturn(CLUSTER_ID);
+
+        DatabaseSslDetails result = underTest.getDbSslDetailsForCreationAndUpdateInCluster(stackDto);
+
+        assertThat(result).isSameAs(sslDetails);
+        assertThat(result.getSslCerts()).isNotNull();
+        assertThat(result.getSslCerts()).hasSize(sslCerts.size() + 1);
+        assertThat(result.getSslCerts()).containsAll(sslCerts);
+        assertThat(result.getSslCerts()).contains(CERT_EMBEDDED);
+        assertThat(result.isSslEnabledForStack()).isTrue();
+
+        verify(stackView, never()).getType();
+        verify(datalakeService, never()).getDatalakeStackByDatahubStack(any(StackView.class));
+        verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
+    }
+
+    @ParameterizedTest(name = "rootCertificate={0}")
+    @ValueSource(strings = {"", " "})
+    @NullSource
+    void getDbSslDetailsForCreationAndUpdateInClusterTestWhenStackWithEmbeddedDbSslAndBlankFreeIpaRootCert(String rootCertificate) {
+        DatabaseSslDetails sslDetails = new DatabaseSslDetails(Set.of(), false);
+        when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(false);
+        when(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(stackView, clusterView)).thenReturn(true);
+        when(stackView.getEnvironmentCrn()).thenReturn(ENVIRONMENT_CRN);
+        when(freeipaClientService.getRootCertificateByEnvironmentCrn(ENVIRONMENT_CRN)).thenReturn(rootCertificate);
+
+        IllegalStateException illegalStateException = assertThrows(IllegalStateException.class,
+                () -> underTest.getDbSslDetailsForCreationAndUpdateInCluster(stackDto));
+
+        assertThat(illegalStateException).hasMessage("Got a blank FreeIPA root certificate.");
+
+        verify(stackView, never()).getType();
+        verify(datalakeService, never()).getDatalakeStackByDatahubStack(any(StackView.class));
+        verify(clusterService, never()).updateDbSslCert(anyLong(), any(DatabaseSslDetails.class));
+    }
+
+    @Test
+    void getDbSslDetailsForCreationAndUpdateInClusterTestWhenStackWithEmbeddedDbAndMismatchingSslDetailsFlag() {
+        DatabaseSslDetails sslDetails = new DatabaseSslDetails(Set.of(), true);
+        when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(false);
+
+        IllegalStateException illegalStateException = assertThrows(IllegalStateException.class,
+                () -> underTest.getDbSslDetailsForCreationAndUpdateInCluster(stackDto));
+
+        assertThat(illegalStateException).hasMessage("Mismatching sslDetails.sslEnabledForStack in RedbeamsDbCertificateProvider response. " +
+                "Expecting false because the stack uses an embedded DB, but it was true.");
+
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(stackView, never()).getType();
+        verify(datalakeService, never()).getDatalakeStackByDatahubStack(any(StackView.class));
+        verify(freeipaClientService, never()).getRootCertificateByEnvironmentCrn(anyString());
+        verify(clusterService, never()).updateDbSslCert(anyLong(), any(DatabaseSslDetails.class));
+    }
+
+    @Test
+    void getDbSslDetailsForCreationAndUpdateInClusterTestWhenDatahubWithEmbeddedDbNoSslAndDatalakeWithEmbeddedDbSsl() {
+        DatabaseSslDetails sslDetails = new DatabaseSslDetails(Set.of(), false);
+        when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(false);
+        when(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(stackView, clusterView)).thenReturn(false);
+        when(stackView.getType()).thenReturn(StackType.WORKLOAD);
+        when(datalakeService.getDatalakeStackByDatahubStack(stackView)).thenReturn(Optional.of(datalakeStack));
+        when(datalakeStack.getCluster()).thenReturn(datalakeCluster);
+        when(datalakeCluster.getDatabaseServerCrn()).thenReturn(DATABASE_SERVER_CRN_DATALAKE);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN_DATALAKE)).thenReturn(false);
+        when(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(datalakeStack, datalakeCluster)).thenReturn(true);
+        when(stackView.getEnvironmentCrn()).thenReturn(ENVIRONMENT_CRN);
+        when(freeipaClientService.getRootCertificateByEnvironmentCrn(ENVIRONMENT_CRN)).thenReturn(CERT_EMBEDDED);
+        when(clusterView.getId()).thenReturn(CLUSTER_ID);
+
+        DatabaseSslDetails result = underTest.getDbSslDetailsForCreationAndUpdateInCluster(stackDto);
+
+        assertThat(result).isSameAs(sslDetails);
+        assertThat(result.getSslCerts()).isEqualTo(Set.of(CERT_EMBEDDED));
+        assertThat(result.isSslEnabledForStack()).isFalse();
+
+        verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
+    }
+
+    @ParameterizedTest(name = "{1},{0}")
+    @MethodSource("externalDbSslDetailsDataProvider")
+    void getDbSslDetailsForCreationAndUpdateInClusterTestWhenDatahubWithExternalDbAndDatalakeWithEmbeddedDbSsl(Set<String> sslCerts,
+            boolean sslEnabledForStack) {
+        DatabaseSslDetails sslDetails = new DatabaseSslDetails(sslCerts, sslEnabledForStack);
+        when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(true);
+        when(stackView.getType()).thenReturn(StackType.WORKLOAD);
+        when(datalakeService.getDatalakeStackByDatahubStack(stackView)).thenReturn(Optional.of(datalakeStack));
+        when(datalakeStack.getCluster()).thenReturn(datalakeCluster);
+        when(datalakeCluster.getDatabaseServerCrn()).thenReturn(DATABASE_SERVER_CRN_DATALAKE);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN_DATALAKE)).thenReturn(false);
+        when(embeddedDatabaseService.isSslEnforcementForEmbeddedDatabaseEnabled(datalakeStack, datalakeCluster)).thenReturn(true);
+        when(stackView.getEnvironmentCrn()).thenReturn(ENVIRONMENT_CRN);
+        when(freeipaClientService.getRootCertificateByEnvironmentCrn(ENVIRONMENT_CRN)).thenReturn(CERT_EMBEDDED);
+        when(clusterView.getId()).thenReturn(CLUSTER_ID);
+
+        DatabaseSslDetails result = underTest.getDbSslDetailsForCreationAndUpdateInCluster(stackDto);
+
+        assertThat(result).isSameAs(sslDetails);
+        assertThat(result.getSslCerts()).isNotNull();
+        assertThat(result.getSslCerts()).hasSize(sslCerts.size() + 1);
+        assertThat(result.getSslCerts()).containsAll(sslCerts);
+        assertThat(result.getSslCerts()).contains(CERT_EMBEDDED);
+        assertThat(result.isSslEnabledForStack()).isEqualTo(sslEnabledForStack);
+
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(stackView, clusterView);
+        verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
+    }
+
+    @ParameterizedTest(name = "{1},{0}")
+    @MethodSource("externalDbSslDetailsDataProvider")
+    void getDbSslDetailsForRotationAndUpdateInClusterTestWhenDatalakeWithExternalDb(Set<String> sslCerts, boolean sslEnabledForStack) {
+        DatabaseSslDetails sslDetails = new DatabaseSslDetails(sslCerts, sslEnabledForStack);
+        when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(true);
+        when(stackView.getType()).thenReturn(StackType.DATALAKE);
+        when(clusterView.getId()).thenReturn(CLUSTER_ID);
+
+        DatabaseSslDetails result = underTest.getDbSslDetailsForRotationAndUpdateInCluster(stackDto);
+
+        assertThat(result).isSameAs(sslDetails);
+        assertThat(result.getSslCerts()).isEqualTo(sslCerts);
+        assertThat(result.isSslEnabledForStack()).isEqualTo(sslEnabledForStack);
+
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(clusterView, never()).getDbSslEnabled();
+        verify(datalakeService, never()).getDatalakeStackByDatahubStack(any(StackView.class));
+        verify(freeipaClientService, never()).getRootCertificateByEnvironmentCrn(anyString());
+        verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
+    }
+
+    @ParameterizedTest(name = "{1},{0}")
+    @MethodSource("externalDbSslDetailsDataProvider")
+    void getDbSslDetailsForRotationAndUpdateInClusterTestWhenDatahubWithExternalDbButNoDatalake(Set<String> sslCerts, boolean sslEnabledForStack) {
+        DatabaseSslDetails sslDetails = new DatabaseSslDetails(sslCerts, sslEnabledForStack);
+        when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(true);
+        when(stackView.getType()).thenReturn(StackType.WORKLOAD);
+        when(datalakeService.getDatalakeStackByDatahubStack(stackView)).thenReturn(Optional.empty());
+        when(clusterView.getId()).thenReturn(CLUSTER_ID);
+
+        DatabaseSslDetails result = underTest.getDbSslDetailsForRotationAndUpdateInCluster(stackDto);
+
+        assertThat(result).isSameAs(sslDetails);
+        assertThat(result.getSslCerts()).isEqualTo(sslCerts);
+        assertThat(result.isSslEnabledForStack()).isEqualTo(sslEnabledForStack);
+
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(clusterView, never()).getDbSslEnabled();
+        verify(freeipaClientService, never()).getRootCertificateByEnvironmentCrn(anyString());
+        verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
+    }
+
+    @ParameterizedTest(name = "{1},{0}")
+    @MethodSource("externalDbSslDetailsDataProvider")
+    void getDbSslDetailsForRotationAndUpdateInClusterTestWhenDatahubAndDatalakeAndExternalDbOnly(Set<String> sslCerts, boolean sslEnabledForStack) {
+        DatabaseSslDetails sslDetails = new DatabaseSslDetails(sslCerts, sslEnabledForStack);
+        when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(true);
+        when(stackView.getType()).thenReturn(StackType.WORKLOAD);
+        when(datalakeService.getDatalakeStackByDatahubStack(stackView)).thenReturn(Optional.of(datalakeStack));
+        when(datalakeStack.getCluster()).thenReturn(datalakeCluster);
+        when(datalakeCluster.getDatabaseServerCrn()).thenReturn(DATABASE_SERVER_CRN_DATALAKE);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN_DATALAKE)).thenReturn(true);
+        when(clusterView.getId()).thenReturn(CLUSTER_ID);
+
+        DatabaseSslDetails result = underTest.getDbSslDetailsForRotationAndUpdateInCluster(stackDto);
+
+        assertThat(result).isSameAs(sslDetails);
+        assertThat(result.getSslCerts()).isEqualTo(sslCerts);
+        assertThat(result.isSslEnabledForStack()).isEqualTo(sslEnabledForStack);
+
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(clusterView, never()).getDbSslEnabled();
+        verify(datalakeCluster, never()).getDbSslEnabled();
+        verify(freeipaClientService, never()).getRootCertificateByEnvironmentCrn(anyString());
+        verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false})
+    @NullSource
+    void getDbSslDetailsForRotationAndUpdateInClusterTestWhenDatalakeWithEmbeddedDbNoSsl(Boolean sslEnabledForStack) {
+        DatabaseSslDetails sslDetails = new DatabaseSslDetails(Set.of(), false);
+        when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(false);
+        when(stackView.getType()).thenReturn(StackType.DATALAKE);
+        when(clusterView.getDbSslEnabled()).thenReturn(sslEnabledForStack);
+        when(clusterView.getId()).thenReturn(CLUSTER_ID);
+
+        DatabaseSslDetails result = underTest.getDbSslDetailsForRotationAndUpdateInCluster(stackDto);
+
+        assertThat(result).isSameAs(sslDetails);
+        assertThat(result.getSslCerts()).isEmpty();
+        assertThat(result.isSslEnabledForStack()).isFalse();
+
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(datalakeService, never()).getDatalakeStackByDatahubStack(any(StackView.class));
+        verify(freeipaClientService, never()).getRootCertificateByEnvironmentCrn(anyString());
+        verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false})
+    @NullSource
+    void getDbSslDetailsForRotationAndUpdateInClusterTestWhenDatahubWithEmbeddedDbNoSslButNoDatalake(Boolean sslEnabledForStack) {
+        DatabaseSslDetails sslDetails = new DatabaseSslDetails(Set.of(), false);
+        when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(false);
+        when(stackView.getType()).thenReturn(StackType.WORKLOAD);
+        when(datalakeService.getDatalakeStackByDatahubStack(stackView)).thenReturn(Optional.empty());
+        when(clusterView.getDbSslEnabled()).thenReturn(sslEnabledForStack);
+        when(clusterView.getId()).thenReturn(CLUSTER_ID);
+
+        DatabaseSslDetails result = underTest.getDbSslDetailsForRotationAndUpdateInCluster(stackDto);
+
+        assertThat(result).isSameAs(sslDetails);
+        assertThat(result.getSslCerts()).isEmpty();
+        assertThat(result.isSslEnabledForStack()).isFalse();
+
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(freeipaClientService, never()).getRootCertificateByEnvironmentCrn(anyString());
+        verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
+    }
+
+    static Object[][] datahubWithExternalDbAndDatalakeWithEmbeddedDbNoSslDataProvider() {
+        return new Object[][]{
+                // sslCerts, sslEnabledForStack, sslEnabledForDatalake
+                {Set.of(), false, false},
+                {Set.of(), false, null},
+                {Set.of(CERT_EXTERNAL_1), true, false},
+                {Set.of(CERT_EXTERNAL_1), true, null},
+                {Set.of(CERT_EXTERNAL_1, CERT_EXTERNAL_2), true, false},
+                {Set.of(CERT_EXTERNAL_1, CERT_EXTERNAL_2), true, null},
+        };
+    }
+
+    @ParameterizedTest(name = "{1},{0},{2}")
+    @MethodSource("datahubWithExternalDbAndDatalakeWithEmbeddedDbNoSslDataProvider")
+    void getDbSslDetailsForRotationAndUpdateInClusterTestWhenDatahubWithExternalDbAndDatalakeWithEmbeddedDbNoSsl(Set<String> sslCerts,
+            boolean sslEnabledForStack, Boolean sslEnabledForDatalake) {
+        DatabaseSslDetails sslDetails = new DatabaseSslDetails(sslCerts, sslEnabledForStack);
+        when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(true);
+        when(stackView.getType()).thenReturn(StackType.WORKLOAD);
+        when(datalakeService.getDatalakeStackByDatahubStack(stackView)).thenReturn(Optional.of(datalakeStack));
+        when(datalakeStack.getCluster()).thenReturn(datalakeCluster);
+        when(datalakeCluster.getDatabaseServerCrn()).thenReturn(DATABASE_SERVER_CRN_DATALAKE);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN_DATALAKE)).thenReturn(false);
+        when(datalakeCluster.getDbSslEnabled()).thenReturn(sslEnabledForDatalake);
+        when(clusterView.getId()).thenReturn(CLUSTER_ID);
+
+        DatabaseSslDetails result = underTest.getDbSslDetailsForRotationAndUpdateInCluster(stackDto);
+
+        assertThat(result).isSameAs(sslDetails);
+        assertThat(result.getSslCerts()).isEqualTo(sslCerts);
+        assertThat(result.isSslEnabledForStack()).isEqualTo(sslEnabledForStack);
+
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(clusterView, never()).getDbSslEnabled();
+        verify(freeipaClientService, never()).getRootCertificateByEnvironmentCrn(anyString());
+        verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
+    }
+
+    static Object[][] datahubWithEmbeddedDbNoSslAndDatalakeWithExternalDbDataProvider() {
+        return new Object[][]{
+                // sslCerts, sslEnabledForStack
+                {Set.of(), false},
+                {Set.of(), null},
+                {Set.of(CERT_EXTERNAL_1), false},
+                {Set.of(CERT_EXTERNAL_1), null},
+                {Set.of(CERT_EXTERNAL_1, CERT_EXTERNAL_2), false},
+                {Set.of(CERT_EXTERNAL_1, CERT_EXTERNAL_2), null},
+        };
+    }
+
+    @ParameterizedTest(name = "{1},{0}")
+    @MethodSource("datahubWithEmbeddedDbNoSslAndDatalakeWithExternalDbDataProvider")
+    void getDbSslDetailsForRotationAndUpdateInClusterTestWhenDatahubWithEmbeddedDbNoSslAndDatalakeWithExternalDb(Set<String> sslCerts,
+            Boolean sslEnabledForStack) {
+        DatabaseSslDetails sslDetails = new DatabaseSslDetails(sslCerts, false);
+        when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(false);
+        when(clusterView.getDbSslEnabled()).thenReturn(sslEnabledForStack);
+        when(stackView.getType()).thenReturn(StackType.WORKLOAD);
+        when(datalakeService.getDatalakeStackByDatahubStack(stackView)).thenReturn(Optional.of(datalakeStack));
+        when(datalakeStack.getCluster()).thenReturn(datalakeCluster);
+        when(datalakeCluster.getDatabaseServerCrn()).thenReturn(DATABASE_SERVER_CRN_DATALAKE);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN_DATALAKE)).thenReturn(true);
+        when(clusterView.getId()).thenReturn(CLUSTER_ID);
+
+        DatabaseSslDetails result = underTest.getDbSslDetailsForRotationAndUpdateInCluster(stackDto);
+
+        assertThat(result).isSameAs(sslDetails);
+        assertThat(result.getSslCerts()).isEqualTo(sslCerts);
+        assertThat(result.isSslEnabledForStack()).isFalse();
+
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(datalakeCluster, never()).getDbSslEnabled();
+        verify(freeipaClientService, never()).getRootCertificateByEnvironmentCrn(anyString());
+        verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("externalDbSslCertsDataProvider")
+    void getDbSslDetailsForRotationAndUpdateInClusterTestWhenStackWithEmbeddedDbSsl(Set<String> sslCerts) {
+        DatabaseSslDetails sslDetails = new DatabaseSslDetails(sslCerts, false);
+        when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(false);
+        when(clusterView.getDbSslEnabled()).thenReturn(true);
+        when(stackView.getEnvironmentCrn()).thenReturn(ENVIRONMENT_CRN);
+        when(freeipaClientService.getRootCertificateByEnvironmentCrn(ENVIRONMENT_CRN)).thenReturn(CERT_EMBEDDED);
+        when(clusterView.getId()).thenReturn(CLUSTER_ID);
+
+        DatabaseSslDetails result = underTest.getDbSslDetailsForRotationAndUpdateInCluster(stackDto);
+
+        assertThat(result).isSameAs(sslDetails);
+        assertThat(result.getSslCerts()).isNotNull();
+        assertThat(result.getSslCerts()).hasSize(sslCerts.size() + 1);
+        assertThat(result.getSslCerts()).containsAll(sslCerts);
+        assertThat(result.getSslCerts()).contains(CERT_EMBEDDED);
+        assertThat(result.isSslEnabledForStack()).isTrue();
+
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(stackView, never()).getType();
+        verify(datalakeService, never()).getDatalakeStackByDatahubStack(any(StackView.class));
+        verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
+    }
+
+    @ParameterizedTest(name = "rootCertificate={0}")
+    @ValueSource(strings = {"", " "})
+    @NullSource
+    void getDbSslDetailsForRotationAndUpdateInClusterTestWhenStackWithEmbeddedDbSslAndBlankFreeIpaRootCert(String rootCertificate) {
+        DatabaseSslDetails sslDetails = new DatabaseSslDetails(Set.of(), false);
+        when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(false);
+        when(clusterView.getDbSslEnabled()).thenReturn(true);
+        when(stackView.getEnvironmentCrn()).thenReturn(ENVIRONMENT_CRN);
+        when(freeipaClientService.getRootCertificateByEnvironmentCrn(ENVIRONMENT_CRN)).thenReturn(rootCertificate);
+
+        IllegalStateException illegalStateException = assertThrows(IllegalStateException.class,
+                () -> underTest.getDbSslDetailsForRotationAndUpdateInCluster(stackDto));
+
+        assertThat(illegalStateException).hasMessage("Got a blank FreeIPA root certificate.");
+
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(stackView, never()).getType();
+        verify(datalakeService, never()).getDatalakeStackByDatahubStack(any(StackView.class));
+        verify(clusterService, never()).updateDbSslCert(anyLong(), any(DatabaseSslDetails.class));
+    }
+
+    @Test
+    void getDbSslDetailsForRotationAndUpdateInClusterTestWhenStackWithEmbeddedDbAndMismatchingSslDetailsFlag() {
+        DatabaseSslDetails sslDetails = new DatabaseSslDetails(Set.of(), true);
+        when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(false);
+
+        IllegalStateException illegalStateException = assertThrows(IllegalStateException.class,
+                () -> underTest.getDbSslDetailsForRotationAndUpdateInCluster(stackDto));
+
+        assertThat(illegalStateException).hasMessage("Mismatching sslDetails.sslEnabledForStack in RedbeamsDbCertificateProvider response. " +
+                "Expecting false because the stack uses an embedded DB, but it was true.");
+
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(clusterView, never()).getDbSslEnabled();
+        verify(stackView, never()).getType();
+        verify(datalakeService, never()).getDatalakeStackByDatahubStack(any(StackView.class));
+        verify(freeipaClientService, never()).getRootCertificateByEnvironmentCrn(anyString());
+        verify(clusterService, never()).updateDbSslCert(anyLong(), any(DatabaseSslDetails.class));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false})
+    @NullSource
+    void getDbSslDetailsForRotationAndUpdateInClusterTestWhenDatahubWithEmbeddedDbNoSslAndDatalakeWithEmbeddedDbSsl(Boolean sslEnabledForStack) {
+        DatabaseSslDetails sslDetails = new DatabaseSslDetails(Set.of(), false);
+        when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(false);
+        when(clusterView.getDbSslEnabled()).thenReturn(sslEnabledForStack);
+        when(stackView.getType()).thenReturn(StackType.WORKLOAD);
+        when(datalakeService.getDatalakeStackByDatahubStack(stackView)).thenReturn(Optional.of(datalakeStack));
+        when(datalakeStack.getCluster()).thenReturn(datalakeCluster);
+        when(datalakeCluster.getDatabaseServerCrn()).thenReturn(DATABASE_SERVER_CRN_DATALAKE);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN_DATALAKE)).thenReturn(false);
+        when(datalakeCluster.getDbSslEnabled()).thenReturn(true);
+        when(stackView.getEnvironmentCrn()).thenReturn(ENVIRONMENT_CRN);
+        when(freeipaClientService.getRootCertificateByEnvironmentCrn(ENVIRONMENT_CRN)).thenReturn(CERT_EMBEDDED);
+        when(clusterView.getId()).thenReturn(CLUSTER_ID);
+
+        DatabaseSslDetails result = underTest.getDbSslDetailsForRotationAndUpdateInCluster(stackDto);
+
+        assertThat(result).isSameAs(sslDetails);
+        assertThat(result.getSslCerts()).isEqualTo(Set.of(CERT_EMBEDDED));
+        assertThat(result.isSslEnabledForStack()).isFalse();
+
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
+    }
+
+    @ParameterizedTest(name = "{1},{0}")
+    @MethodSource("externalDbSslDetailsDataProvider")
+    void getDbSslDetailsForRotationAndUpdateInClusterTestWhenDatahubWithExternalDbAndDatalakeWithEmbeddedDbSsl(Set<String> sslCerts,
+            boolean sslEnabledForStack) {
+        DatabaseSslDetails sslDetails = new DatabaseSslDetails(sslCerts, sslEnabledForStack);
+        when(dbCertificateProvider.getRelatedSslCerts(stackDto)).thenReturn(sslDetails);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN)).thenReturn(true);
+        when(stackView.getType()).thenReturn(StackType.WORKLOAD);
+        when(datalakeService.getDatalakeStackByDatahubStack(stackView)).thenReturn(Optional.of(datalakeStack));
+        when(datalakeStack.getCluster()).thenReturn(datalakeCluster);
+        when(datalakeCluster.getDatabaseServerCrn()).thenReturn(DATABASE_SERVER_CRN_DATALAKE);
+        when(dbServerConfigurer.isRemoteDatabaseRequested(DATABASE_SERVER_CRN_DATALAKE)).thenReturn(false);
+        when(datalakeCluster.getDbSslEnabled()).thenReturn(true);
+        when(stackView.getEnvironmentCrn()).thenReturn(ENVIRONMENT_CRN);
+        when(freeipaClientService.getRootCertificateByEnvironmentCrn(ENVIRONMENT_CRN)).thenReturn(CERT_EMBEDDED);
+        when(clusterView.getId()).thenReturn(CLUSTER_ID);
+
+        DatabaseSslDetails result = underTest.getDbSslDetailsForRotationAndUpdateInCluster(stackDto);
+
+        assertThat(result).isSameAs(sslDetails);
+        assertThat(result.getSslCerts()).isNotNull();
+        assertThat(result.getSslCerts()).hasSize(sslCerts.size() + 1);
+        assertThat(result.getSslCerts()).containsAll(sslCerts);
+        assertThat(result.getSslCerts()).contains(CERT_EMBEDDED);
+        assertThat(result.isSslEnabledForStack()).isEqualTo(sslEnabledForStack);
+
+        verify(embeddedDatabaseService, never()).isSslEnforcementForEmbeddedDatabaseEnabled(any(StackView.class), any(ClusterView.class));
+        verify(clusterView, never()).getDbSslEnabled();
+        verify(clusterService).updateDbSslCert(CLUSTER_ID, result);
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/EmbeddedDatabaseServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/EmbeddedDatabaseServiceTest.java
@@ -1,25 +1,38 @@
 package com.sequenceiq.cloudbreak.service.cluster;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceMetadataType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseAvailabilityType;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.cloud.service.CloudParameterCache;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessorFactory;
+import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.domain.Template;
 import com.sequenceiq.cloudbreak.domain.VolumeTemplate;
 import com.sequenceiq.cloudbreak.domain.VolumeUsageType;
@@ -28,23 +41,55 @@ import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.dto.InstanceGroupDto;
 import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.service.blueprint.BlueprintService;
+import com.sequenceiq.cloudbreak.view.ClusterView;
+import com.sequenceiq.cloudbreak.view.StackView;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 
 @ExtendWith(MockitoExtension.class)
 public class EmbeddedDatabaseServiceTest {
     private static final String CLOUDPLATFORM = "cloudplatform";
 
+    private static final String ACCOUNT_ID = "6f53f8a0-d5e8-45e6-ab11-cce9b53f7aad";
+
+    private static final String STACK_CRN = "crn:cdp:datalake:us-west-1:" + ACCOUNT_ID + ":datalake:" + UUID.randomUUID();
+
+    private static final Long CLUSTER_ID = 123L;
+
+    private static final String BLUEPRINT_TEXT = "blueprintText";
+
+    private static final String STACK_VERSION_GOOD_MINIMAL = "7.2.2";
+
+    private static final String STACK_VERSION_GOOD = "7.2.15";
+
+    private static final String STACK_VERSION_BAD = "7.2.1";
+
     @Mock
     private CloudParameterCache cloudParameterCache;
 
+    @Mock
+    private EntitlementService entitlementService;
+
+    @Mock
+    private CmTemplateProcessorFactory cmTemplateProcessorFactory;
+
+    @Mock
+    private BlueprintService blueprintService;
+
     @InjectMocks
     private EmbeddedDatabaseService underTest;
+
+    @Mock
+    private ClusterView clusterView;
+
+    @Mock
+    private CmTemplateProcessor cmTemplateProcessor;
 
     @Test
     public void testIsEmbeddedDatabaseOnAttachedDiskEnabled() {
         // GIVEN
         StackDto stack = createStack(1);
-        Mockito.when(cloudParameterCache.isVolumeAttachmentSupported(CLOUDPLATFORM)).thenReturn(true);
+        when(cloudParameterCache.isVolumeAttachmentSupported(CLOUDPLATFORM)).thenReturn(true);
         // WHEN
         boolean actualResult = underTest.isEmbeddedDatabaseOnAttachedDiskEnabled(stack, null);
         // THEN
@@ -55,7 +100,7 @@ public class EmbeddedDatabaseServiceTest {
     public void testIsEmbeddedDatabaseOnAttachedDiskEnabledWhenNoDisksAttachedSupported() {
         // GIVEN
         StackDto stack = createStack(0);
-        Mockito.when(cloudParameterCache.isVolumeAttachmentSupported(CLOUDPLATFORM)).thenReturn(false);
+        when(cloudParameterCache.isVolumeAttachmentSupported(CLOUDPLATFORM)).thenReturn(false);
         // WHEN
         boolean actualResult = underTest.isEmbeddedDatabaseOnAttachedDiskEnabled(stack, null);
         // THEN
@@ -92,6 +137,62 @@ public class EmbeddedDatabaseServiceTest {
         when(stack.getExternalDatabaseCreationType()).thenReturn(DatabaseAvailabilityType.ON_ROOT_VOLUME);
         // WHEN
         boolean actualResult = underTest.isEmbeddedDatabaseOnAttachedDiskEnabled(stack, null);
+        // THEN
+        assertFalse(actualResult);
+    }
+
+    @Test
+    public void testIsEmbeddedDatabaseOnAttachedDiskEnabledByStackView() {
+        // GIVEN
+        StackView stack = createStackView(1);
+        when(cloudParameterCache.isVolumeAttachmentSupported(CLOUDPLATFORM)).thenReturn(true);
+        // WHEN
+        boolean actualResult = underTest.isEmbeddedDatabaseOnAttachedDiskEnabledByStackView(stack, null);
+        // THEN
+        assertTrue(actualResult);
+    }
+
+    @Test
+    public void testIsEmbeddedDatabaseOnAttachedDiskEnabledByStackViewWhenNoDisksAttachedSupported() {
+        // GIVEN
+        StackView stack = createStackView(0);
+        when(cloudParameterCache.isVolumeAttachmentSupported(CLOUDPLATFORM)).thenReturn(false);
+        // WHEN
+        boolean actualResult = underTest.isEmbeddedDatabaseOnAttachedDiskEnabledByStackView(stack, null);
+        // THEN
+        assertFalse(actualResult);
+    }
+
+    @Test
+    public void testIsEmbeddedDatabaseOnAttachedDiskEnabledByStackViewWhenExternalDBUsed() {
+        // GIVEN
+        StackView stack = createStackView(0);
+        when(stack.getExternalDatabaseCreationType()).thenReturn(DatabaseAvailabilityType.NON_HA);
+        // WHEN
+        boolean actualResult = underTest.isEmbeddedDatabaseOnAttachedDiskEnabledByStackView(stack, null);
+        // THEN
+        assertFalse(actualResult);
+    }
+
+    @Test
+    public void testIsEmbeddedDatabaseOnAttachedDiskEnabledByStackViewWhenExternalDBCrnSet() {
+        // GIVEN
+        StackView stack = createStackView(0);
+        Cluster cluster = new Cluster();
+        cluster.setDatabaseServerCrn("dbcrn");
+        // WHEN
+        boolean actualResult = underTest.isEmbeddedDatabaseOnAttachedDiskEnabledByStackView(stack, cluster);
+        // THEN
+        assertFalse(actualResult);
+    }
+
+    @Test
+    public void testIsEmbeddedDatabaseOnAttachedDiskEnabledByStackViewWhenEmbeddedDbOnRootDisk() {
+        // GIVEN
+        StackView stack = createStackView(0);
+        when(stack.getExternalDatabaseCreationType()).thenReturn(DatabaseAvailabilityType.ON_ROOT_VOLUME);
+        // WHEN
+        boolean actualResult = underTest.isEmbeddedDatabaseOnAttachedDiskEnabledByStackView(stack, null);
         // THEN
         assertFalse(actualResult);
     }
@@ -148,6 +249,106 @@ public class EmbeddedDatabaseServiceTest {
         assertFalse(actualResult);
     }
 
+    static Object[][] isSslEnforcementForEmbeddedDatabaseEnabledDataProvider() {
+        return new Object[][]{
+                // stackType, dlEntitlementEnabled, dhEntitlementEnabled, embeddedDatabaseOnAttachedDiskEnabled, resultExpected
+                {StackType.DATALAKE, false, false, false, false},
+                {StackType.DATALAKE, false, false, true, false},
+                {StackType.DATALAKE, true, false, false, false},
+                {StackType.DATALAKE, true, false, true, true},
+                {StackType.WORKLOAD, false, false, false, false},
+                {StackType.WORKLOAD, false, false, true, false},
+                {StackType.WORKLOAD, false, true, false, false},
+                {StackType.WORKLOAD, false, true, true, true},
+                {StackType.TEMPLATE, true, true, true, false},
+                {StackType.LEGACY, true, true, true, false},
+        };
+    }
+
+    @ParameterizedTest()
+    @MethodSource("isSslEnforcementForEmbeddedDatabaseEnabledDataProvider")
+    void isSslEnforcementForEmbeddedDatabaseEnabledTestWhenPrerequisitesWithGoodRuntime(StackType stackType, boolean dlEntitlementEnabled,
+            boolean dhEntitlementEnabled, boolean embeddedDatabaseOnAttachedDiskEnabled, boolean resultExpected) {
+        Blueprint blueprint = new Blueprint();
+        blueprint.setBlueprintText(BLUEPRINT_TEXT);
+        Optional<Blueprint> blueprintOptional = Optional.of(blueprint);
+        when(cmTemplateProcessorFactory.get(BLUEPRINT_TEXT)).thenReturn(cmTemplateProcessor);
+        when(cmTemplateProcessor.getStackVersion()).thenReturn(STACK_VERSION_GOOD);
+
+        isSslEnforcementForEmbeddedDatabaseEnabledTestInternal(stackType, dlEntitlementEnabled, dhEntitlementEnabled, embeddedDatabaseOnAttachedDiskEnabled,
+                blueprintOptional, resultExpected);
+    }
+
+    private void isSslEnforcementForEmbeddedDatabaseEnabledTestInternal(StackType stackType, boolean dlEntitlementEnabled, boolean dhEntitlementEnabled,
+            boolean embeddedDatabaseOnAttachedDiskEnabled, Optional<Blueprint> blueprintOptional, boolean resultExpected) {
+        StackView stackView;
+        if (embeddedDatabaseOnAttachedDiskEnabled) {
+            stackView = createStackView(1);
+            lenient().when(cloudParameterCache.isVolumeAttachmentSupported(CLOUDPLATFORM)).thenReturn(true);
+        } else {
+            stackView = createStackView(0);
+            lenient().when(cloudParameterCache.isVolumeAttachmentSupported(CLOUDPLATFORM)).thenReturn(false);
+        }
+        when(stackView.getResourceCrn()).thenReturn(STACK_CRN);
+        when(stackView.getType()).thenReturn(stackType);
+
+        when(clusterView.getId()).thenReturn(CLUSTER_ID);
+        lenient().when(clusterView.getDatabaseServerCrn()).thenReturn(null);
+
+        when(blueprintService.getByClusterId(CLUSTER_ID)).thenReturn(blueprintOptional);
+
+        lenient().when(entitlementService.databaseWireEncryptionEnabled(ACCOUNT_ID)).thenReturn(dlEntitlementEnabled);
+        lenient().when(entitlementService.databaseWireEncryptionDatahubEnabled(ACCOUNT_ID)).thenReturn(dhEntitlementEnabled);
+
+        assertThat(underTest.isSslEnforcementForEmbeddedDatabaseEnabled(stackView, clusterView)).isEqualTo(resultExpected);
+    }
+
+    private void isSslEnforcementForEmbeddedDatabaseEnabledTestInternalBlueprintOnly(Optional<Blueprint> blueprintOptional, boolean resultExpected) {
+        isSslEnforcementForEmbeddedDatabaseEnabledTestInternal(StackType.DATALAKE, true, false, true, blueprintOptional, resultExpected);
+    }
+
+    @Test
+    void isSslEnforcementForEmbeddedDatabaseEnabledTestWhenNoBlueprint() {
+        isSslEnforcementForEmbeddedDatabaseEnabledTestInternalBlueprintOnly(Optional.empty(), false);
+
+        verify(cmTemplateProcessorFactory, never()).get(anyString());
+        verify(cmTemplateProcessor, never()).getStackVersion();
+    }
+
+    @Test
+    void isSslEnforcementForEmbeddedDatabaseEnabledTestWhenNoBlueprintText() {
+        Blueprint blueprint = new Blueprint();
+        blueprint.setBlueprintText(null);
+
+        isSslEnforcementForEmbeddedDatabaseEnabledTestInternalBlueprintOnly(Optional.of(blueprint), false);
+
+        verify(cmTemplateProcessorFactory, never()).get(anyString());
+        verify(cmTemplateProcessor, never()).getStackVersion();
+    }
+
+    @ParameterizedTest(name = "runtime={0}")
+    @ValueSource(strings = {"", " ", STACK_VERSION_BAD})
+    @NullSource
+    void isSslEnforcementForEmbeddedDatabaseEnabledTestWhenBadRuntime(String runtime) {
+        Blueprint blueprint = new Blueprint();
+        blueprint.setBlueprintText(BLUEPRINT_TEXT);
+        when(cmTemplateProcessorFactory.get(BLUEPRINT_TEXT)).thenReturn(cmTemplateProcessor);
+        when(cmTemplateProcessor.getStackVersion()).thenReturn(runtime);
+
+        isSslEnforcementForEmbeddedDatabaseEnabledTestInternalBlueprintOnly(Optional.of(blueprint), false);
+    }
+
+    @ParameterizedTest(name = "runtime={0}")
+    @ValueSource(strings = {STACK_VERSION_GOOD_MINIMAL, STACK_VERSION_GOOD})
+    void isSslEnforcementForEmbeddedDatabaseEnabledTestWhenGoodRuntime(String runtime) {
+        Blueprint blueprint = new Blueprint();
+        blueprint.setBlueprintText(BLUEPRINT_TEXT);
+        when(cmTemplateProcessorFactory.get(BLUEPRINT_TEXT)).thenReturn(cmTemplateProcessor);
+        when(cmTemplateProcessor.getStackVersion()).thenReturn(runtime);
+
+        isSslEnforcementForEmbeddedDatabaseEnabledTestInternalBlueprintOnly(Optional.of(blueprint), true);
+    }
+
     private StackDto createStack(int volumeCount) {
         StackDto stack = mock(StackDto.class);
         InstanceGroup masterGroup = new InstanceGroup();
@@ -177,6 +378,24 @@ public class EmbeddedDatabaseServiceTest {
         instanceMetaData.setInstanceMetadataType(InstanceMetadataType.GATEWAY_PRIMARY);
         masterGroup.setInstanceMetaData(Set.of(instanceMetaData));
         lenient().when(stack.getInstanceGroupDtos()).thenReturn(List.of(new InstanceGroupDto(masterGroup, List.of(instanceMetaData))));
+        return stack;
+    }
+
+    private StackView createStackView(int volumeCount) {
+        StackView stack = mock(StackView.class);
+        InstanceGroup masterGroup = new InstanceGroup();
+        masterGroup.setInstanceGroupType(InstanceGroupType.GATEWAY);
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+        instanceMetaData.setInstanceGroup(masterGroup);
+        instanceMetaData.setInstanceMetadataType(InstanceMetadataType.GATEWAY_PRIMARY);
+        masterGroup.setInstanceMetaData(Set.of(instanceMetaData));
+        Template template = new Template();
+        VolumeTemplate volumeTemplate = new VolumeTemplate();
+        volumeTemplate.setVolumeCount(volumeCount);
+        volumeTemplate.setUsageType(VolumeUsageType.DATABASE);
+        template.setVolumeTemplates(Set.of(volumeTemplate));
+        masterGroup.setTemplate(template);
+        lenient().when(stack.getCloudPlatform()).thenReturn(CLOUDPLATFORM);
         return stack;
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/freeipa/FreeipaClientServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/freeipa/FreeipaClientServiceTest.java
@@ -1,0 +1,120 @@
+package com.sequenceiq.cloudbreak.service.freeipa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.WebApplicationException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.common.exception.WebApplicationExceptionMessageExtractor;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.FreeIpaV1Endpoint;
+import com.sequenceiq.freeipa.api.v1.util.UtilV1Endpoint;
+
+@ExtendWith(MockitoExtension.class)
+class FreeipaClientServiceTest {
+    private static final String ACCOUNT_ID = "cloudera";
+
+    private static final String ENV_CRN = "crn:cdp:environments:us-west-1:" + ACCOUNT_ID + ":environment:" + UUID.randomUUID();
+
+    private static final String USER_CRN = "crn:cdp:iam:us-west-1:" + ACCOUNT_ID + ":user:test@cloudera.com";
+
+    private static final String INTERNAL_ACTOR_CRN = "crn:cdp:iam:us-west-1:altus:user:__internal__actor__";
+
+    private static final String ROOT_CERTIFICATE = "rootCertificate";
+
+    private static final String ERROR_MSG = "fatal error";
+
+    private static final String EXTRACTED_ERROR_MSG = "extracted error";
+
+    @Mock
+    private FreeIpaV1Endpoint freeIpaV1Endpoint;
+
+    @Mock
+    private UtilV1Endpoint utilV1Endpoint;
+
+    @Mock
+    private WebApplicationExceptionMessageExtractor webApplicationExceptionMessageExtractor;
+
+    @Mock
+    private RegionAwareInternalCrnGeneratorFactory regionAwareInternalCrnGeneratorFactory;
+
+    @InjectMocks
+    private FreeipaClientService underTest;
+
+    @Test
+    void getRootCertificateByEnvironmentCrnTestRegularActor() {
+        when(freeIpaV1Endpoint.getRootCertificate(ENV_CRN)).thenReturn(ROOT_CERTIFICATE);
+
+        String result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.getRootCertificateByEnvironmentCrn(ENV_CRN));
+
+        assertThat(result).isEqualTo(ROOT_CERTIFICATE);
+        verify(freeIpaV1Endpoint, never()).getRootCertificateInternal(anyString(), anyString());
+        verify(webApplicationExceptionMessageExtractor, never()).getErrorMessage(any(Exception.class));
+    }
+
+    @Test
+    void getRootCertificateByEnvironmentCrnTestInternalActor() {
+        when(freeIpaV1Endpoint.getRootCertificateInternal(ENV_CRN, ACCOUNT_ID)).thenReturn(ROOT_CERTIFICATE);
+
+        String result = ThreadBasedUserCrnProvider.doAsInternalActor(INTERNAL_ACTOR_CRN, () -> underTest.getRootCertificateByEnvironmentCrn(ENV_CRN));
+
+        assertThat(result).isEqualTo(ROOT_CERTIFICATE);
+        verify(freeIpaV1Endpoint, never()).getRootCertificate(anyString());
+        verify(webApplicationExceptionMessageExtractor, never()).getErrorMessage(any(Exception.class));
+    }
+
+    @Test
+    void getRootCertificateByEnvironmentCrnTestWebApplicationException() {
+        WebApplicationException e = new WebApplicationException(ERROR_MSG);
+        when(freeIpaV1Endpoint.getRootCertificate(ENV_CRN)).thenThrow(e);
+        when(webApplicationExceptionMessageExtractor.getErrorMessage(e)).thenReturn(EXTRACTED_ERROR_MSG);
+
+        CloudbreakServiceException cloudbreakServiceException = Assertions.assertThrows(CloudbreakServiceException.class,
+                () -> ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.getRootCertificateByEnvironmentCrn(ENV_CRN)));
+
+        assertThat(cloudbreakServiceException).hasCauseReference(e);
+        assertThat(cloudbreakServiceException).hasMessage(String.format("Failed to GET FreeIPA root certificate by environment CRN: %s, due to: %s. %s.",
+                ENV_CRN, ERROR_MSG, EXTRACTED_ERROR_MSG));
+        verify(freeIpaV1Endpoint, never()).getRootCertificateInternal(anyString(), anyString());
+    }
+
+    @Test
+    void getRootCertificateByEnvironmentCrnTestProcessingException() {
+        getRootCertificateByEnvironmentCrnTestExceptionWithoutExtractionInternal(new ProcessingException(ERROR_MSG));
+    }
+
+    private void getRootCertificateByEnvironmentCrnTestExceptionWithoutExtractionInternal(Exception e) {
+        when(freeIpaV1Endpoint.getRootCertificate(ENV_CRN)).thenThrow(e);
+
+        CloudbreakServiceException cloudbreakServiceException = Assertions.assertThrows(CloudbreakServiceException.class,
+                () -> ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.getRootCertificateByEnvironmentCrn(ENV_CRN)));
+
+        assertThat(cloudbreakServiceException).hasCauseReference(e);
+        assertThat(cloudbreakServiceException).hasMessage(String.format("Failed to GET FreeIPA root certificate by environment CRN: %s, due to: %s.",
+                ENV_CRN, ERROR_MSG));
+        verify(freeIpaV1Endpoint, never()).getRootCertificateInternal(anyString(), anyString());
+        verify(webApplicationExceptionMessageExtractor, never()).getErrorMessage(any(Exception.class));
+    }
+
+    @Test
+    void getRootCertificateByEnvironmentCrnTestIllegalStateException() {
+        getRootCertificateByEnvironmentCrnTestExceptionWithoutExtractionInternal(new IllegalStateException(ERROR_MSG));
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/rdsconfig/RedbeamsDbCertificateProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/rdsconfig/RedbeamsDbCertificateProviderTest.java
@@ -9,20 +9,18 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import com.sequenceiq.cloudbreak.TestUtil;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.dto.DatabaseSslDetails;
 import com.sequenceiq.cloudbreak.dto.StackDto;
-import com.sequenceiq.cloudbreak.service.rdsconfig.RedbeamsDbCertificateProvider.RedbeamsDbSslDetails;
 import com.sequenceiq.cloudbreak.service.sharedservice.DatalakeService;
 import com.sequenceiq.cloudbreak.view.StackView;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.SslMode;
@@ -33,8 +31,6 @@ import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.SslConfi
 @ExtendWith(MockitoExtension.class)
 class RedbeamsDbCertificateProviderTest {
 
-    private static final String SSL_CERTS_FILE_PATH = "/foo/bar.pem";
-
     @Mock
     private RedbeamsDbServerConfigurer dbServerConfigurer;
 
@@ -43,11 +39,6 @@ class RedbeamsDbCertificateProviderTest {
 
     @InjectMocks
     private RedbeamsDbCertificateProvider underTest;
-
-    @BeforeEach
-    void setUp() {
-        ReflectionTestUtils.setField(underTest, "certsPath", SSL_CERTS_FILE_PATH);
-    }
 
     @Test
     void getRelatedSslCertsWhenTheClusterSdxAndNoRdsConfiguredShouldReturnWithEmptyResult() {
@@ -59,7 +50,7 @@ class RedbeamsDbCertificateProviderTest {
         when(stack.getStack()).thenReturn(stackView);
         when(stackView.getType()).thenReturn(StackType.DATALAKE);
 
-        RedbeamsDbSslDetails result = underTest.getRelatedSslCerts(stack);
+        DatabaseSslDetails result = underTest.getRelatedSslCerts(stack);
 
         assertThat(result.getSslCerts()).isEmpty();
         assertThat(result.isSslEnabledForStack()).isFalse();
@@ -78,7 +69,7 @@ class RedbeamsDbCertificateProviderTest {
         when(dbServerConfigurer.isRemoteDatabaseRequested(dbServerCrn)).thenReturn(Boolean.TRUE);
         when(dbServerConfigurer.getDatabaseServer(dbServerCrn)).thenReturn(new DatabaseServerV4Response());
 
-        RedbeamsDbSslDetails result = underTest.getRelatedSslCerts(stack);
+        DatabaseSslDetails result = underTest.getRelatedSslCerts(stack);
 
         assertThat(result.getSslCerts()).isEmpty();
         assertThat(result.isSslEnabledForStack()).isFalse();
@@ -99,7 +90,7 @@ class RedbeamsDbCertificateProviderTest {
         databaseServerV4Response.setSslConfig(new SslConfigV4Response());
         when(dbServerConfigurer.getDatabaseServer(dbServerCrn)).thenReturn(databaseServerV4Response);
 
-        RedbeamsDbSslDetails result = underTest.getRelatedSslCerts(stack);
+        DatabaseSslDetails result = underTest.getRelatedSslCerts(stack);
 
         assertThat(result.getSslCerts()).isEmpty();
         assertThat(result.isSslEnabledForStack()).isFalse();
@@ -146,7 +137,7 @@ class RedbeamsDbCertificateProviderTest {
         databaseServerV4Response.setSslConfig(sslConfig);
         when(dbServerConfigurer.getDatabaseServer(dbServerCrn)).thenReturn(databaseServerV4Response);
 
-        RedbeamsDbSslDetails result = underTest.getRelatedSslCerts(stack);
+        DatabaseSslDetails result = underTest.getRelatedSslCerts(stack);
 
         Set<String> actual = result.getSslCerts();
         assertThat(actual).isNotEmpty();
@@ -170,7 +161,7 @@ class RedbeamsDbCertificateProviderTest {
         databaseServerV4Response.setSslConfig(getSslConfigV4ResponseWithCertificate(Set.of(certificateA)));
         when(dbServerConfigurer.getDatabaseServer(dbServerCrn)).thenReturn(databaseServerV4Response);
 
-        RedbeamsDbSslDetails result = underTest.getRelatedSslCerts(stack);
+        DatabaseSslDetails result = underTest.getRelatedSslCerts(stack);
 
         Set<String> actual = result.getSslCerts();
         assertThat(actual).isNotEmpty();
@@ -206,7 +197,7 @@ class RedbeamsDbCertificateProviderTest {
         databaseServerV4Response.setSslConfig(getSslConfigV4ResponseWithCertificate(Set.of(certificateA)));
         when(dbServerConfigurer.getDatabaseServer(dbServerCrn)).thenReturn(databaseServerV4Response);
 
-        RedbeamsDbSslDetails result = underTest.getRelatedSslCerts(stack);
+        DatabaseSslDetails result = underTest.getRelatedSslCerts(stack);
 
         Set<String> actual = result.getSslCerts();
         assertThat(actual).isNotEmpty();
@@ -242,7 +233,7 @@ class RedbeamsDbCertificateProviderTest {
         databaseServerV4ResponseB.setSslConfig(getSslConfigV4ResponseWithCertificate(Set.of(certificateB)));
         when(dbServerConfigurer.getDatabaseServer(dbServerCrnB)).thenReturn(databaseServerV4ResponseB);
 
-        RedbeamsDbSslDetails result = underTest.getRelatedSslCerts(stack);
+        DatabaseSslDetails result = underTest.getRelatedSslCerts(stack);
 
         Set<String> actual = result.getSslCerts();
         assertThat(actual).isNotEmpty();
@@ -283,7 +274,7 @@ class RedbeamsDbCertificateProviderTest {
         databaseServerV4ResponseB.setSslConfig(sslConfig);
         when(dbServerConfigurer.getDatabaseServer(dbServerCrnB)).thenReturn(databaseServerV4ResponseB);
 
-        RedbeamsDbSslDetails result = underTest.getRelatedSslCerts(stack);
+        DatabaseSslDetails result = underTest.getRelatedSslCerts(stack);
 
         Set<String> actual = result.getSslCerts();
         assertThat(actual).isNotEmpty();
@@ -323,17 +314,12 @@ class RedbeamsDbCertificateProviderTest {
         databaseServerV4ResponseB.setSslConfig(getSslConfigV4ResponseWithCertificate(Set.of(certificateB)));
         when(dbServerConfigurer.getDatabaseServer(dbServerCrnB)).thenReturn(databaseServerV4ResponseB);
 
-        RedbeamsDbSslDetails result = underTest.getRelatedSslCerts(stack);
+        DatabaseSslDetails result = underTest.getRelatedSslCerts(stack);
 
         Set<String> actual = result.getSslCerts();
         assertThat(actual).isNotEmpty();
         assertThat(actual).contains(certificateA, certificateB);
         assertThat(result.isSslEnabledForStack()).isTrue();
-    }
-
-    @Test
-    void getSslCertsFilePathTest() {
-        assertThat(underTest.getSslCertsFilePath()).isEqualTo(SSL_CERTS_FILE_PATH);
     }
 
     private SslConfigV4Response getSslConfigV4ResponseWithCertificate(Set<String> certs) {

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
@@ -167,7 +167,15 @@ public interface FreeIpaV1Endpoint {
     @Produces(MediaType.TEXT_PLAIN)
     @ApiOperation(value = FreeIpaOperationDescriptions.GET_ROOTCERTIFICATE_BY_ENVID, produces = MediaType.TEXT_PLAIN, notes = FreeIpaNotes.FREEIPA_NOTES,
             nickname = "getFreeIpaRootCertificateByEnvironmentV1")
-    String getRootCertificate(@QueryParam("environment") @NotEmpty String environmentCrn);
+    String getRootCertificate(@ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT) @QueryParam("environment") @NotEmpty String environmentCrn);
+
+    @GET
+    @Path("internal/ca.crt")
+    @Produces(MediaType.TEXT_PLAIN)
+    @ApiOperation(value = FreeIpaOperationDescriptions.INTERNAL_GET_ROOTCERTIFICATE_BY_ENVID_AND_ACCOUNTID, produces = MediaType.TEXT_PLAIN,
+            notes = FreeIpaNotes.FREEIPA_NOTES, nickname = "internalGetFreeIpaRootCertificateByEnvironmentV1")
+    String getRootCertificateInternal(@ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT) @QueryParam("environment") @NotEmpty String environmentCrn,
+            @QueryParam("accountId") @AccountId String accountId);
 
     @DELETE
     @Path("")

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaOperationDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaOperationDescriptions.java
@@ -13,6 +13,8 @@ public final class FreeIpaOperationDescriptions {
     public static final String LIST_BY_ACCOUNT = "List all FreeIPA stacks by account";
     public static final String INTERNAL_LIST_BY_ACCOUNT = "List all FreeIPA stacks by account using the internal actor";
     public static final String GET_ROOTCERTIFICATE_BY_ENVID = "Get FreeIPA root certificate by environment CRN";
+    public static final String INTERNAL_GET_ROOTCERTIFICATE_BY_ENVID_AND_ACCOUNTID =
+            "Get FreeIPA root certificate by environment CRN and account ID using the internal actor";
     public static final String DELETE_BY_ENVID = "Delete FreeIPA stack by environment CRN";
     public static final String CLEANUP = "Cleans out users, hosts and related DNS entries";
     public static final String INTERNAL_CLEANUP = "Cleans out users, hosts and related DNS entries using internal actor";

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaV1Controller.java
@@ -272,8 +272,19 @@ public class FreeIpaV1Controller implements FreeIpaV1Endpoint {
 
     @Override
     @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.DESCRIBE_ENVIRONMENT)
-    public String getRootCertificate(@ResourceCrn @TenantAwareParam String environmentCrn) {
+    public String getRootCertificate(@ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT) @ResourceCrn @NotEmpty @TenantAwareParam String environmentCrn) {
         String accountId = crnService.getCurrentAccountId();
+        try {
+            return freeIpaRootCertificateService.getRootCertificate(environmentCrn, accountId);
+        } catch (FreeIpaClientException e) {
+            throw new FreeIpaClientExceptionWrapper(e);
+        }
+    }
+
+    @Override
+    @InternalOnly
+    public String getRootCertificateInternal(@ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT) @ResourceCrn @NotEmpty String environmentCrn,
+            @AccountId String accountId) {
         try {
             return freeIpaRootCertificateService.getRootCertificate(environmentCrn, accountId);
         } catch (FreeIpaClientException e) {

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/controller/FreeIpaV1ControllerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/controller/FreeIpaV1ControllerTest.java
@@ -64,6 +64,8 @@ class FreeIpaV1ControllerTest {
 
     private static final String INITIATOR_USER_CRN = "initiatorUserCrn";
 
+    private static final String ROOT_CERTIFICATE = "rootCertificate";
+
     @InjectMocks
     private FreeIpaV1Controller underTest;
 
@@ -223,8 +225,18 @@ class FreeIpaV1ControllerTest {
 
     @Test
     void getRootCertificate() throws Exception {
-        underTest.getRootCertificate(ENVIRONMENT_CRN);
-        verify(rootCertificateService, times(1)).getRootCertificate(ENVIRONMENT_CRN, ACCOUNT_ID);
+        when(rootCertificateService.getRootCertificate(ENVIRONMENT_CRN, ACCOUNT_ID)).thenReturn(ROOT_CERTIFICATE);
+
+        assertThat(underTest.getRootCertificate(ENVIRONMENT_CRN)).isEqualTo(ROOT_CERTIFICATE);
+    }
+
+    @Test
+    void getRootCertificateInternal() throws Exception {
+        when(rootCertificateService.getRootCertificate(ENVIRONMENT_CRN, ACCOUNT_ID)).thenReturn(ROOT_CERTIFICATE);
+
+        assertThat(underTest.getRootCertificateInternal(ENVIRONMENT_CRN, ACCOUNT_ID)).isEqualTo(ROOT_CERTIFICATE);
+
+        verify(crnService, never()).getCurrentAccountId();
     }
 
     @Test

--- a/integration-test/scripts/check-results.sh
+++ b/integration-test/scripts/check-results.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #please don't add this property to Jenkins
-#this value changed 2022.11.24 from 4.5 to 4.6 (new test was added: DistroXUpgradeTests.testDistroXOsUpgradeByUpgradeSets)
-: ${INTEGRATIONTEST_MAX_PG_NETWORK_OUTPUT:="4.6GB"}
+#this value changed 2023.02.02 from 4.6 to 4.62 (additional FreeIPA creation in MockSdxBlueprintLoadTests, MockSdxResizeTests, MockSdxRetryTests, MockSdxTests)
+: ${INTEGRATIONTEST_MAX_PG_NETWORK_OUTPUT:="4.62GB"}
 
 status_code=0
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxBlueprintLoadTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxBlueprintLoadTests.java
@@ -20,10 +20,11 @@ public class MockSdxBlueprintLoadTests extends AbstractMockTest {
     @Inject
     private CloudbreakActor cloudbreakActor;
 
+    @Override
     protected void setupTest(TestContext testContext) {
         testContext.as(cloudbreakActor.create("sdxbploadtenant10", "sdxbpload@cloudera.com"));
         createDefaultCredential(testContext);
-        createDefaultEnvironment(testContext);
+        createEnvironmentWithFreeIpa(testContext);
         createDefaultImageCatalog(testContext);
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxResizeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxResizeTests.java
@@ -7,11 +7,14 @@ import javax.inject.Inject;
 import org.testng.annotations.Test;
 
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.it.cloudbreak.client.FreeIpaTestClient;
 import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.util.SdxUtil;
 import com.sequenceiq.it.cloudbreak.util.resize.SdxResizeTestValidator;
@@ -21,6 +24,9 @@ import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 public class MockSdxResizeTests extends AbstractMockTest {
 
     @Inject
+    private FreeIpaTestClient freeIpaTestClient;
+
+    @Inject
     private SdxTestClient sdxTestClient;
 
     @Inject
@@ -28,6 +34,7 @@ public class MockSdxResizeTests extends AbstractMockTest {
 
     private String sdxName;
 
+    @Override
     protected void setupTest(TestContext testContext) {
         sdxName = resourcePropertyProvider().getName();
 
@@ -43,6 +50,9 @@ public class MockSdxResizeTests extends AbstractMockTest {
                 .withBackup("mock://location/of/the/backup")
                 .when(getEnvironmentTestClient().create())
                 .await(EnvironmentStatus.AVAILABLE)
+                .given(FreeIpaTestDto.class)
+                .when(freeIpaTestClient.create())
+                .await(Status.AVAILABLE)
                 .given(sdxName, SdxInternalTestDto.class)
                 .when(sdxTestClient.createInternal(), key(sdxName))
                 .await(SdxClusterStatusResponse.RUNNING, key(sdxName))

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxRetryTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxRetryTests.java
@@ -5,6 +5,8 @@ import javax.inject.Inject;
 import org.testng.annotations.Test;
 
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.it.cloudbreak.client.FreeIpaTestClient;
 import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
@@ -18,8 +20,12 @@ import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 public class MockSdxRetryTests extends AbstractMockTest {
 
     @Inject
+    private FreeIpaTestClient freeIpaTestClient;
+
+    @Inject
     private SdxTestClient sdxTestClient;
 
+    @Override
     protected void setupTest(TestContext testContext) {
         createDefaultUser(testContext);
         createDefaultCredential(testContext);
@@ -40,6 +46,8 @@ public class MockSdxRetryTests extends AbstractMockTest {
                 .when(getEnvironmentTestClient().create())
                 .await(EnvironmentStatus.AVAILABLE)
                 .given(FreeIpaTestDto.class)
+                .when(freeIpaTestClient.create())
+                .await(Status.AVAILABLE)
                 .given(SdxInternalTestDto.class)
                 .when(sdxTestClient.createInternal())
                 .mockSpi().launch().post()

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxTests.java
@@ -47,6 +47,7 @@ public class MockSdxTests extends AbstractMockTest {
     @Inject
     private ImageCatalogTestClient imageCatalogTestClient;
 
+    @Override
     protected void setupTest(TestContext testContext) {
         createDefaultUser(testContext);
         createDefaultCredential(testContext);
@@ -69,6 +70,9 @@ public class MockSdxTests extends AbstractMockTest {
                 .withName(resourcePropertyProvider().getEnvironmentName())
                 .when(getEnvironmentTestClient().create())
                 .await(EnvironmentStatus.AVAILABLE)
+                .given(FreeIpaTestDto.class)
+                .when(freeIpaTestClient.create())
+                .await(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)
                 .given(sdxCustom, SdxCustomTestDto.class)
                 .withCustomInstanceGroup("master", "xlarge")
                 .when(sdxTestClient.createCustom(), key(sdxCustom))
@@ -95,6 +99,9 @@ public class MockSdxTests extends AbstractMockTest {
                 .withName(resourcePropertyProvider().getEnvironmentName())
                 .when(getEnvironmentTestClient().create())
                 .await(EnvironmentStatus.AVAILABLE)
+                .given(FreeIpaTestDto.class)
+                .when(freeIpaTestClient.create())
+                .await(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)
                 .given(sdxInternal, SdxInternalTestDto.class)
                 .when(sdxTestClient.createInternal(), key(sdxInternal))
                 .await(SdxClusterStatusResponse.RUNNING, key(sdxInternal))
@@ -120,6 +127,9 @@ public class MockSdxTests extends AbstractMockTest {
                 .withName(resourcePropertyProvider().getEnvironmentName())
                 .when(getEnvironmentTestClient().create())
                 .await(EnvironmentStatus.AVAILABLE)
+                .given(FreeIpaTestDto.class)
+                .when(freeIpaTestClient.create())
+                .await(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)
                 .given(sdxInternal, SdxInternalTestDto.class)
                 .withTemplate(jsonObject)
                 .when(sdxTestClient.createInternal(), key(sdxInternal))
@@ -131,7 +141,7 @@ public class MockSdxTests extends AbstractMockTest {
 
     @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
     @Description(
-            given = "there is a running CloudSdxInternalTestDtobreak",
+            given = "there is a running Cloudbreak",
             when = "start an sdx cluster with different CM and CDH versions",
             then = "versions should be correct"
     )
@@ -156,6 +166,9 @@ public class MockSdxTests extends AbstractMockTest {
                 .withName(resourcePropertyProvider().getEnvironmentName())
                 .when(getEnvironmentTestClient().create())
                 .await(EnvironmentStatus.AVAILABLE)
+                .given(FreeIpaTestDto.class)
+                .when(freeIpaTestClient.create())
+                .await(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)
                 .given(clouderaManager, ClouderaManagerTestDto.class)
                 .given(cluster, ClusterTestDto.class)
                 .withClouderaManager(clouderaManager)

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/conf_pgsql_ssl.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/conf_pgsql_ssl.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+CONFIG_FILE=$(psql -c "show config_file;" -t | xargs)
+echo "Config file: $CONFIG_FILE"
+
+set -e
+if grep -qR "^ssl =" $CONFIG_FILE; then
+    echo "Updating ssl config in the postgresql.conf"
+    sed -i.orig "/^ssl =/c\ssl = on" $CONFIG_FILE
+else
+    echo "Adding ssl config to the postgresql.conf"
+    echo "ssl = on" >> $CONFIG_FILE
+fi
+
+if grep -qR "^ssl_cert_file =" $CONFIG_FILE; then
+    echo "Updating ssl_cert_file config in the postgresql.conf"
+    sed -i.orig "/^ssl_cert_file =/c\ssl_cert_file = '{{ postgres_directory }}/certs/postgres.cert'" $CONFIG_FILE
+else
+    echo "Adding ssl_cert_file config to the postgresql.conf"
+    echo "ssl_cert_file = '{{ postgres_directory }}/certs/postgres.cert'" >> $CONFIG_FILE
+fi
+
+if grep -qR "^ssl_key_file =" $CONFIG_FILE; then
+    echo "Updating ssl_key_file config in the postgresql.conf"
+    sed -i.orig "/^ssl_key_file =/c\ssl_key_file = '{{ postgres_directory }}/certs/postgres.key'" $CONFIG_FILE
+else
+    echo "Adding ssl_key_file config to the postgresql.conf"
+    echo "ssl_key_file = '{{ postgres_directory }}/certs/postgres.key'" >> $CONFIG_FILE
+fi
+set +e

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/init_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/init_db.sh
@@ -4,6 +4,14 @@ set -e
 CONFIG_DIR=$(psql -c "show config_file;" -t | sed 's/\/postgresql.conf//g' | xargs)
 echo "CONFIG_DIR: $CONFIG_DIR"
 
+{%- from 'postgresql/settings.sls' import postgresql with context %}
+{% if postgresql.ssl_enabled == True %}
+export PGSSLROOTCERT="{{ postgresql.root_certs_file }}"
+export PGSSLMODE=verify-full
+
+sed -i 's/^host\([[:space:]]\+.*\)/hostssl\1/g' $CONFIG_DIR/pg_hba.conf
+{%- endif %}
+
 {% for service, values in pillar.get('postgres', {}).items()  %}
 
 {% if values['user'] is defined %}
@@ -15,12 +23,21 @@ echo "GRANT ALL PRIVILEGES ON DATABASE {{ values['database'] }} TO {{ values['us
 echo "ALTER SCHEMA public OWNER TO {{ values['user'] }};" | psql -U postgres -d {{ values['database'] }} -v "ON_ERROR_STOP=1"
 
 echo "Add access to pg_hba.conf"
+{% if postgresql.ssl_enabled == True %}
+sed -i '1ihostssl {{ values['database'] }} {{ values['user'] }} 0.0.0.0/0 md5' $CONFIG_DIR/pg_hba.conf
+{%- else %}
 sed -i '1ihost {{ values['database'] }} {{ values['user'] }} 0.0.0.0/0 md5' $CONFIG_DIR/pg_hba.conf
+{%- endif %}
 sed -i '1ilocal {{ values['database'] }} {{ values['user'] }} md5' $CONFIG_DIR/pg_hba.conf
 echo $(date +%Y-%m-%d:%H:%M:%S) >> $CONFIG_DIR/init_{{ service }}_db_executed
 
 {% endif %}
 
 {% endfor %}
+
+{% if postgresql.ssl_enabled == True %}
+sed -i '1ihostnossl all all ::0/0 reject' $CONFIG_DIR/pg_hba.conf
+sed -i '1ihostnossl all all 0.0.0.0/0 reject' $CONFIG_DIR/pg_hba.conf
+{%- endif %}
 
 set +e

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/upgrade/embedded.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/upgrade/embedded.sls
@@ -68,6 +68,18 @@ upgrade_postgresql_db:
     - require:
       - cmd: upgrade_postgresql_db
 
+{%- if postgresql.ssl_enabled == True %}
+
+{{ new_postgres_directory }}/certs:
+  file.copy:
+    - makedirs: True
+    - source: {{ original_postgres_directory}}/certs
+    - force: True
+    - require:
+      - cmd: upgrade_postgresql_db
+
+{%- endif %}
+
 remove_original_binaries:
   file.absent:
     - name: {{ original_postgres_binaries }}


### PR DESCRIPTION
* This is the embedded DB counterpart of [CB-5073](https://jira.cloudera.com/browse/CB-5073) / #9215 (DL external DB) & [CB-19725](https://jira.cloudera.com/browse/CB-19725) / #13881 (DH external DB).
* If applicable, configure the embedded DB with SSL enforcement.
  * Supported for both DL & DH clusters and irrespective of the cloud platform.
  * Prerequisites:
    * Cluster runtime >= 7.2.2. Like earlier, this is necessary to ensure the PostgreSQL JDBC driver is recent enough (>= 42.2.5, but effectively >= 42.2.14 as mentioned in [CB-8106](https://jira.cloudera.com/browse/CB-8106)).
    * Entitlement `CDP_CB_DATABASE_WIRE_ENCRYPTION` (see #9215; for DL) or `CDP_CB_DATABASE_WIRE_ENCRYPTION_DATAHUB` (see #13824; for DH) granted for the tenant.
    * Embedded DB kept on attached disk. This is to ensure the persistence of the PostgreSQL certificate & private key.
* The embedded DB PostgreSQL daemon is configured for SSL enforcement as follows:
  * Will accept only SSL / TLS connections via TCP (both IPv4 and IPv6).
  * Plaintext connections via TCP will always be rejected unconditionally.
  * Still permits local / Unix domain socket connections. This is required for the various CLI tooling used across CB. By their nature, Unix domain sockets expect plaintext traffic since there is no TCP layer involved (and hence no SSL / TLS either).
  * Uses the certificate & private key created in [CB-20174](https://jira.cloudera.com/browse/CB-20174) / #14029. The issuer of this certificate is always the FreeIPA CA, hence clients need only to trust the latter root certificate.
* When the embedded DB has SSL enforcement, configure the respective cluster services to require SSL connections. Like for the external DB, connections are initiated with `sslmode=verify-full`, i.e. using DB server certificate chain and host name verification.
  * Covers both CM Server and other cluster components.
* DB server root certificates are deployed to the cluster in the following cases:
  * Cluster is a DL and its DB (external or embedded) has SSL enforcement. The certificate bundle will contain the DL DB root certificates only.
  * Cluster is a DH having a DB (external or embedded) without SSL enforcement, but the parent DL has a DB (external or embedded) with SSL enforcement. The certificate bundle will contain the DL DB root certificates only.
  * Cluster is a DH having a DB (external or embedded) with SSL enforcement, and the parent DL also has a DB (external or embedded) with SSL enforcement. The certificate bundle will contain the union of the DL and DH DB root certificates (without repetitions).
* `PostgresConfigService.SSLSaltConfig`:
  * Add additional error handling, prohibiting `rootCertsBundle == null`. This has also been covered with a dedicated UT.
  * Fix Salt pillar types in `toMap()`.
* Extract common DB cert fetch logic from `PostgresConfigService` and `ClusterDbCertRotationHandler` into the new `DatabaseSslService`.
  * Move `RedbeamsDbCertificateProvider.getSslCertsFilePath()` over to `DatabaseSslService`.
* Move nested class `RedbeamsDbCertificateProvider.RedbeamsDbSslDetails` to top level as the new `DatabaseSslDetails`.
  * Extract the cert bundle string building logic from `ClusterService.updateDbSslCert()` into `DatabaseSslDetails.getSslCertBundle()`.
* Extend `EmbeddedDatabaseService` with the necessary validation logic for embedded DB SSL enforcement.
* New operation `FreeIpaV1Endpoint.getRootCertificateInternal()` for fetching the FreeIPA CA with the internal actor.
* Apply some code cleanup and fix typos.
* Testing:
  * Manual test of all DB SSL combinations with cluster creation and stop / start in a commercial AWS region.
  * Added new UT & adapted existing ones.
  * Fix failing mock IT. Whenever the test case depends on a running DL cluster, a FreeIPA is also created in order to ensure that "DL with embedded DB using SSL" scenarios can be verified.
