### PR TITLE
CB-19533: Add scalable KRaft instance group to the Streams Messaging …

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.17/cdp-streaming-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.17/cdp-streaming-ha.bp
@@ -50,6 +50,11 @@
             "refName": "kafka-KAFKA_CONNECT-BASE",
             "roleType": "KAFKA_CONNECT",
             "base": true
+          },
+          {
+            "refName": "kafka-KAFKA_KRAFT-BASE",
+            "roleType": "KRAFT",
+            "base": true
           }
         ]
       },
@@ -160,6 +165,14 @@
         "roleConfigGroupsRefNames": [
           "kafka-GATEWAY-BASE",
           "kafka-KAFKA_CONNECT-BASE"
+        ]
+      },
+      {
+        "refName": "kraft",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "kafka-GATEWAY-BASE",
+          "kafka-KAFKA_KRAFT-BASE"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/blueprints/7.2.17/cdp-streaming-small.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.17/cdp-streaming-small.bp
@@ -50,6 +50,11 @@
             "refName": "kafka-KAFKA_CONNECT-BASE",
             "roleType": "KAFKA_CONNECT",
             "base": true
+          },
+          {
+            "refName": "kafka-KAFKA_KRAFT-BASE",
+            "roleType": "KRAFT",
+            "base": true
           }
         ]
       },
@@ -141,6 +146,14 @@
           "kafka-GATEWAY-BASE",
           "kafka-KAFKA_BROKER-BASE",
           "kafka-KAFKA_CONNECT-BASE"
+        ]
+      },
+      {
+        "refName": "kraft",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "kafka-GATEWAY-BASE",
+          "kafka-KAFKA_KRAFT-BASE"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/blueprints/7.2.17/cdp-streaming.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.17/cdp-streaming.bp
@@ -50,6 +50,11 @@
             "refName": "kafka-KAFKA_CONNECT-BASE",
             "roleType": "KAFKA_CONNECT",
             "base": true
+          },
+          {
+            "refName": "kafka-KAFKA_KRAFT-BASE",
+            "roleType": "KRAFT",
+            "base": true
           }
         ]
       },
@@ -169,6 +174,14 @@
         "roleConfigGroupsRefNames": [
           "kafka-GATEWAY-BASE",
           "kafka-KAFKA_CONNECT-BASE"
+        ]
+      },
+      {
+        "refName": "kraft",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "kafka-GATEWAY-BASE",
+          "kafka-KAFKA_KRAFT-BASE"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/clustertemplates/7.2.17/aws/streaming-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.17/aws/streaming-ha.json
@@ -124,6 +124,27 @@
         "nodeCount": 0,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "kraft",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "standard"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.17/aws/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.17/aws/streaming-small.json
@@ -62,6 +62,27 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "recipeNames": []
+      },
+      {
+        "name": "kraft",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "standard"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.17/aws/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.17/aws/streaming.json
@@ -149,6 +149,27 @@
         "nodeCount": 0,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "kraft",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "standard"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.17/aws_gov/streaming-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.17/aws_gov/streaming-ha.json
@@ -124,6 +124,27 @@
         "nodeCount": 0,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "kraft",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "standard"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.17/aws_gov/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.17/aws_gov/streaming-small.json
@@ -62,6 +62,27 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "recipeNames": []
+      },
+      {
+        "name": "kraft",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "standard"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.17/aws_gov/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.17/aws_gov/streaming.json
@@ -149,6 +149,27 @@
         "nodeCount": 0,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "kraft",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "standard"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.17/azure/streaming-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.17/azure/streaming-ha.json
@@ -118,6 +118,25 @@
         "nodeCount": 0,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "kraft",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "Standard_LRS"
+            }
+          ],
+          "azure": {
+            "manageDisk": true
+          },
+          "instanceType": "Standard_D8_v3"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.17/azure/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.17/azure/streaming-small.json
@@ -62,6 +62,25 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "recipeNames": []
+      },
+      {
+        "name": "kraft",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "Standard_LRS"
+            }
+          ],
+          "azure": {
+            "manageDisk": true
+          },
+          "instanceType": "Standard_D8_v3"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.17/azure/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.17/azure/streaming.json
@@ -140,6 +140,25 @@
         "nodeCount": 0,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "kraft",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "Standard_LRS"
+            }
+          ],
+          "azure": {
+            "manageDisk": true
+          },
+          "instanceType": "Standard_D8_v3"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.17/gcp/streaming-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.17/gcp/streaming-ha.json
@@ -110,6 +110,22 @@
         "nodeCount": 0,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "kraft",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "pd-standard"
+            }
+          ],
+          "instanceType": "e2-standard-8"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.17/gcp/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.17/gcp/streaming-small.json
@@ -62,6 +62,22 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "recipeNames": []
+      },
+      {
+        "name": "kraft",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "pd-standard"
+            }
+          ],
+          "instanceType": "e2-standard-8"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.17/gcp/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.17/gcp/streaming.json
@@ -128,6 +128,22 @@
         "nodeCount": 0,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "kraft",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "pd-standard"
+            }
+          ],
+          "instanceType": "e2-standard-8"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.17/yarn/streaming-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.17/yarn/streaming-ha.json
@@ -101,6 +101,21 @@
         "nodeCount": 0,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "kraft",
+        "template": {
+          "yarn": {
+            "cpus": 4,
+            "memory": 16384
+          },
+          "rootVolume": {
+            "size": 50
+          }
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.17/yarn/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.17/yarn/streaming-small.json
@@ -56,6 +56,21 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "recipeNames": []
+      },
+      {
+        "name": "kraft",
+        "template": {
+          "yarn": {
+            "cpus": 4,
+            "memory": 16384
+          },
+          "rootVolume": {
+            "size": 50
+          }
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.17/yarn/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.17/yarn/streaming.json
@@ -118,6 +118,21 @@
         "nodeCount": 0,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "kraft",
+        "template": {
+          "yarn": {
+            "cpus": 4,
+            "memory": 16384
+          },
+          "rootVolume": {
+            "size": 50
+          }
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
@@ -79,6 +79,8 @@ public class CMRepositoryVersionUtil {
 
     public static final Versioned CLOUDERA_STACK_VERSION_7_2_16 = () -> "7.2.16";
 
+    public static final Versioned CLOUDERA_STACK_VERSION_7_2_17 = () -> "7.2.17";
+
     public static final Versioned CFM_VERSION_2_0_0_0 = () -> "2.0.0.0";
 
     public static final Versioned CFM_VERSION_2_2_3_0 = () -> "2.2.3.0";

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaConfigs.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaConfigs.java
@@ -24,5 +24,7 @@ public class KafkaConfigs {
 
     static final String SASL_AUTH_METHOD = "sasl.plain.auth";
 
+    static final String METADATA_STORE = "metadata.store";
+
     private KafkaConfigs() { }
 }

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaKraftConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaKraftConfigProvider.java
@@ -1,0 +1,56 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERA_STACK_VERSION_7_2_17;
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaConfigProviderUtils.getCdhVersion;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.google.api.client.util.Lists;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRoleConfigProvider;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.cloudbreak.template.views.HostgroupView;
+
+@Component
+public class KafkaKraftConfigProvider extends AbstractRoleConfigProvider {
+
+    @Override
+    public List<ApiClusterTemplateConfig> getRoleConfigs(String roleType, TemplatePreparationObject source) {
+        ArrayList<ApiClusterTemplateConfig> configs = Lists.newArrayList();
+        String cdhVersion = getCdhVersion(source);
+
+        if (isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERA_STACK_VERSION_7_2_17)) {
+            Optional<HostgroupView> kraftHostGroup = source.getHostGroupsWithComponent(KafkaRoles.KAFKA_KRAFT).findFirst();
+            if (kraftHostGroup.isPresent() && kraftHostGroup.get().getNodeCount() > 0) {
+                configs.add(
+                        config(KafkaConfigs.METADATA_STORE, "KRaft")
+                );
+                return configs;
+            }
+        }
+        return List.of();
+    }
+
+    @Override
+    public String getServiceType() {
+        return KafkaRoles.KAFKA_SERVICE;
+    }
+
+    @Override
+    public List<String> getRoleTypes() {
+        return List.of(KafkaRoles.KAFKA_BROKER);
+    }
+
+    @Override
+    public boolean isConfigurationNeeded(CmTemplateProcessor cmTemplateProcessor, TemplatePreparationObject source) {
+        return StackType.WORKLOAD.equals(source.getStackType());
+    }
+}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaRoles.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaRoles.java
@@ -8,6 +8,8 @@ public class KafkaRoles {
 
     public static final String KAFKA_CONNECT = "KAFKA_CONNECT";
 
+    public static final String KAFKA_KRAFT = "KRAFT";
+
     private KafkaRoles() {
     }
 

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaDelegationTokenConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaDelegationTokenConfigProviderTest.java
@@ -1,6 +1,11 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka;
 
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -9,9 +14,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.dto.KerberosConfig;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.cloudbreak.template.views.HostgroupView;
+import com.sequenceiq.common.api.type.InstanceGroupType;
 
 @ExtendWith(MockitoExtension.class)
 class KafkaDelegationTokenConfigProviderTest {
@@ -63,5 +71,17 @@ class KafkaDelegationTokenConfigProviderTest {
         boolean result = underTest.isConfigurationNeeded(cmTemplateProcessor, templatePreparationObject);
 
         Assertions.assertTrue(result);
+    }
+
+    @Test
+    void testKRaftRoleIsPresent() {
+        TemplatePreparationObject templatePreparationObject = mock(TemplatePreparationObject.class);
+        HostgroupView kraft = new HostgroupView("kraft", 1, InstanceGroupType.CORE, 3);
+        when(templatePreparationObject.getHostGroupsWithComponent(KafkaRoles.KAFKA_KRAFT)).thenReturn(Stream.of(kraft));
+
+        List<ApiClusterTemplateConfig> result = underTest.getServiceConfigs(cmTemplateProcessor, templatePreparationObject);
+        List<ApiClusterTemplateConfig> expected = List.of(config(KafkaConfigs.DELEGATION_TOKEN_ENABLE, "false"));
+
+        Assertions.assertEquals(expected, result);
     }
 }

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaKraftConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaKraftConfigProviderTest.java
@@ -1,0 +1,95 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.cloudbreak.template.views.BlueprintView;
+import com.sequenceiq.cloudbreak.template.views.HostgroupView;
+import com.sequenceiq.common.api.type.InstanceGroupType;
+
+@ExtendWith(MockitoExtension.class)
+public class KafkaKraftConfigProviderTest {
+
+    private final KafkaKraftConfigProvider kraftConfigProvider = new KafkaKraftConfigProvider();
+
+    @Mock
+    private BlueprintView blueprintView;
+
+    @Mock
+    private CmTemplateProcessor processor;
+
+    @Test
+    public void testKraftConfigPresent() {
+        cdpMainVersionIs("7.2.17");
+        List<ApiClusterTemplateConfig> expectedConfig = List.of(config(KafkaConfigs.METADATA_STORE, "KRaft"));
+        List<ApiClusterTemplateConfig> actualConfig = kraftConfigProvider.getRoleConfigs(KafkaRoles.KAFKA_BROKER, sourceWithKraft(StackType.WORKLOAD));
+
+        assertEquals(expectedConfig, actualConfig);
+    }
+
+    @Test
+    public void testKraftConfigDefaultWithoutKRaft() {
+        cdpMainVersionIs("7.2.17");
+        List<ApiClusterTemplateConfig> actualConfig = kraftConfigProvider.getRoleConfigs(KafkaRoles.KAFKA_BROKER, sourceWithoutKraft(StackType.WORKLOAD));
+
+        assertEquals(List.of(), actualConfig);
+    }
+
+    @Test
+    public void testConfigDefaultWithOldVersion() {
+        cdpMainVersionIs("7.2.16");
+        List<ApiClusterTemplateConfig> actualConfig = kraftConfigProvider.getRoleConfigs(KafkaRoles.KAFKA_BROKER, sourceWithKraft(StackType.WORKLOAD));
+
+        assertEquals(List.of(), actualConfig);
+    }
+
+    @Test
+    public void testConfigDefaultOnDatalakeCluster() {
+        cdpMainVersionIs("7.2.16");
+        List<ApiClusterTemplateConfig> actualConfig = kraftConfigProvider.getRoleConfigs(KafkaRoles.KAFKA_BROKER, sourceWithKraft(StackType.DATALAKE));
+
+        assertEquals(List.of(), actualConfig);
+    }
+
+    private void cdpMainVersionIs(String version) {
+        when(blueprintView.getProcessor()).thenReturn(processor);
+        when(processor.getStackVersion()).thenReturn(version);
+    }
+
+    private TemplatePreparationObject sourceWithKraft(StackType stackType) {
+        HostgroupView kraft = new HostgroupView("kraft", 1, InstanceGroupType.CORE, 3);
+        TemplatePreparationObject source = mock(TemplatePreparationObject.class);
+
+        when(source.getBlueprintView()).thenReturn(blueprintView);
+        Mockito.lenient().when(source.getHostGroupsWithComponent(KafkaRoles.KAFKA_KRAFT)).thenReturn(Stream.of(kraft));
+        Mockito.lenient().when(source.getStackType()).thenReturn(stackType);
+
+        return source;
+    }
+
+    private TemplatePreparationObject sourceWithoutKraft(StackType stackType) {
+        HostgroupView kafka = new HostgroupView("kafka", 1, InstanceGroupType.CORE, 3);
+        TemplatePreparationObject source = mock(TemplatePreparationObject.class);
+
+        when(source.getBlueprintView()).thenReturn(blueprintView);
+        Mockito.lenient().when(source.getHostGroupsWithComponent(KafkaRoles.KAFKA_BROKER)).thenReturn(Stream.of(kafka));
+        Mockito.lenient().when(source.getStackType()).thenReturn(stackType);
+
+        return source;
+    }
+}


### PR DESCRIPTION
…templates

KRaft means we replace Zookeeper with Kafka's own Raft implementation, KRaft. This is practically a new controller quorum and in order to realize the changes we make in CM to add the new KRaft service, we'll need this in Cloudbreak templates as well.

Work done:

- Updated all Streams Messaging templates (Light, Heavy, HA) to have a new hostgroup called 'kraft' with initially 0 cardinality.
- Added a KraftConfigProvider that notices if the kraft hostgroup has been scaled up, and adds the metadata.store=KRaft configuration to Kafka.
- Modified the KafkaDelegationTokenConfigProvider to set the delegation token feature to false if KRaft is enabled, as it is not supported yet. (The default value is true)
- Unit tests for the config provider
-Manually provisioned clusters