### PR TITLE
CB-20071: Use the Rolling OS API in case of Rolling Upgrade

### DIFF
--- a/common-model/src/main/java/com/sequenceiq/common/api/type/InstanceGroupName.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/type/InstanceGroupName.java
@@ -1,0 +1,20 @@
+package com.sequenceiq.common.api.type;
+
+public enum InstanceGroupName {
+    MASTER("master"),
+    WORKER("worker"),
+    IDBROKER("idbroker"),
+    GATEWAY("gateway"),
+    AUXILIARY("auxiliary"),
+    CORE("core");
+
+    private final String name;
+
+    InstanceGroupName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
@@ -60,6 +60,7 @@ import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescrip
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescription.UPDATE_LOAD_BALANCERS;
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescription.UPDATE_LOAD_BALANCER_DNS_IN_WORKSPACE;
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescription.UPGRADE_CLUSTER_IN_WORKSPACE;
+import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescription.UPGRADE_OS_IN_WORKSPACE;
 import static com.sequenceiq.distrox.api.v1.distrox.doc.DistroXOpDescription.DETERMINE_DATALAKE_DATA_SIZES;
 import static com.sequenceiq.distrox.api.v1.distrox.doc.DistroXOpDescription.VERTICAL_SCALE_BY_NAME;
 
@@ -94,6 +95,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackVerticalSca
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.UpdateClusterV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.UserNamePasswordV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.cluster.cm.ClouderaManagerSyncV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.osupgrade.OrderedOSUpgradeSetRequest;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.recipe.AttachRecipeV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.recipe.DetachRecipeV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.recipe.UpdateRecipesV4Request;
@@ -317,6 +319,12 @@ public interface StackV4Endpoint {
             nickname = "upgradeOsInWorkspaceV4")
     FlowIdentifier upgradeOs(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name,
             @AccountId @QueryParam("accountId") String accountId, @QueryParam("keepVariant") Boolean keepVariant);
+
+    @POST
+    @Path("internal/{crn}/os_upgrade_by_upgrade_sets")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = UPGRADE_OS_IN_WORKSPACE, nickname = "osUpgradeByUpgradeSetsInternal")
+    FlowIdentifier upgradeOsByUpgradeSetsInternal(@PathParam("crn") String crn, OrderedOSUpgradeSetRequest orderedOsUpgradeSetRequest);
 
     @POST
     @Path("internal/{name}/upgrade")

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
@@ -51,6 +51,7 @@ public class OperationDescriptions {
         public static final String REPAIR_CLUSTER_IN_WORKSPACE = "repairs the stack by name in workspace";
         public static final String REPAIR_CLUSTER_IN_WORKSPACE_INTERNAL = "repairs the stack by name in workspace, internal only";
         public static final String UPGRADE_CLUSTER_IN_WORKSPACE = "upgrades the stack by name in workspace";
+        public static final String UPGRADE_OS_IN_WORKSPACE = "Upgrades the cluster OS by name and upgrades sets internal";
         public static final String UPGRADE_CLUSTER_IN_WORKSPACE_INTERNAL = "upgrades the stack by name in workspace, internal only";
         public static final String RECOVER_CLUSTER_IN_WORKSPACE_INTERNAL = "recovers the stack by name in workspace, internal only";
         public static final String REFRESH_RECIPES_IN_WORKSPACE = "refresh recipes on the cluster by name in workspace";

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Controller;
 import com.sequenceiq.authorization.annotation.CheckPermissionByAccount;
 import com.sequenceiq.authorization.annotation.CheckPermissionByResourceName;
 import com.sequenceiq.authorization.annotation.InternalOnly;
+import com.sequenceiq.authorization.annotation.ResourceCrn;
 import com.sequenceiq.authorization.annotation.ResourceName;
 import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
@@ -33,6 +34,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackVerticalSca
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.UpdateClusterV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.UserNamePasswordV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.cluster.cm.ClouderaManagerSyncV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.osupgrade.OrderedOSUpgradeSetRequest;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.recipe.AttachRecipeV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.recipe.DetachRecipeV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.recipe.UpdateRecipesV4Request;
@@ -267,6 +269,13 @@ public class StackV4Controller extends NotificationController implements StackV4
     @CheckPermissionByAccount(action = AuthorizationResourceAction.POWERUSER_ONLY)
     public FlowIdentifier upgradeOs(Long workspaceId, String name, @AccountId String accountId, Boolean keepVariant) {
         return stackUpgradeOperations.upgradeOs(NameOrCrn.ofName(name), restRequestThreadLocalService.getAccountId(), Boolean.TRUE.equals(keepVariant));
+    }
+
+    @InternalOnly
+    public FlowIdentifier upgradeOsByUpgradeSetsInternal(@TenantAwareParam @ResourceCrn String crn, OrderedOSUpgradeSetRequest orderedOsUpgradeSetRequest) {
+        Long workspaceId = restRequestThreadLocalService.getRequestedWorkspaceId();
+        return stackUpgradeOperations.upgradeOsByUpgradeSets(NameOrCrn.ofCrn(crn), workspaceId, orderedOsUpgradeSetRequest.getImageId(),
+                orderedOsUpgradeSetRequest.getOrderedOsUpgradeSets());
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackUpgradeOperations.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackUpgradeOperations.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.InternalUpgradeSettings;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.osupgrade.OrderedOSUpgradeSet;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.tags.upgrade.UpgradeV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.upgrade.UpgradeOptionV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.upgrade.UpgradeV4Response;
@@ -78,6 +79,12 @@ public class StackUpgradeOperations {
     public FlowIdentifier upgradeOs(@NotNull NameOrCrn nameOrCrn, String accountId, boolean keepVariant) {
         LOGGER.debug("Starting to upgrade OS: " + nameOrCrn);
         return upgradeService.upgradeOs(accountId, nameOrCrn, keepVariant);
+    }
+
+    public FlowIdentifier upgradeOsByUpgradeSets(@NotNull NameOrCrn nameOrCrn, Long workspaceId, String imageId, List<OrderedOSUpgradeSet> upgradeSets) {
+        LOGGER.debug("Starting to upgrade OS: " + nameOrCrn);
+        Stack stack = stackService.getByNameOrCrnInWorkspace(nameOrCrn, workspaceId);
+        return upgradeService.upgradeOsByUpgradeSets(stack, imageId, upgradeSets);
     }
 
     public FlowIdentifier upgradeCluster(@NotNull NameOrCrn nameOrCrn, String accountId, String imageId, Boolean rollingUpgradeEnabled) {

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/service/upgrade/DistroXUpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/service/upgrade/DistroXUpgradeService.java
@@ -96,7 +96,7 @@ public class DistroXUpgradeService {
         Stack stack = stackService.getByNameOrCrnInWorkspace(nameOrCrn, workspaceId);
         Crn crn = Crn.safeFromString(stack.getResourceCrn());
         ImageChangeDto imageChangeDto = deteremineImageChangeDto(nameOrCrn, imageId, stack, crn.getAccountId());
-        return upgradeService.osUpgradeByUpgradeSets(stack, imageChangeDto, upgradeSets);
+        return upgradeService.upgradeOsByUpgradeSets(stack, imageChangeDto, upgradeSets);
     }
 
     private ImageChangeDto deteremineImageChangeDto(NameOrCrn nameOrCrn, String imageId, Stack stack, String accountId) {

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/service/upgrade/DistroXUpgradeServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/service/upgrade/DistroXUpgradeServiceTest.java
@@ -366,7 +366,7 @@ class DistroXUpgradeServiceTest {
                 internalUpgradeSettingsArgumentCaptor.capture(), eq(true));
         assertFalse(internalUpgradeSettingsArgumentCaptor.getValue().isSkipValidations());
         ArgumentCaptor<ImageChangeDto> imageChangeDtoCaptor = ArgumentCaptor.forClass(ImageChangeDto.class);
-        verify(upgradeService, times(1)).osUpgradeByUpgradeSets(eq(stack), imageChangeDtoCaptor.capture(), eq(upgradeSets));
+        verify(upgradeService, times(1)).upgradeOsByUpgradeSets(eq(stack), imageChangeDtoCaptor.capture(), eq(upgradeSets));
         assertEquals("imageID", imageChangeDtoCaptor.getValue().getImageId());
         assertEquals("imageID", imageChangeRequestArgumentCaptor.getValue().getImageId());
     }

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/DatalakeUpgradeActions.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/DatalakeUpgradeActions.java
@@ -51,6 +51,8 @@ public class DatalakeUpgradeActions {
 
     private static final String REPLACE_VMS_AFTER_UPGRADE = "REPAIR_AFTER_UPGRADE";
 
+    private static final String ROLLING_UPGRADE_ENABLED = "ROLLING_UPGRADE_ENABLED";
+
     private static final String KEEP_VARIANT = "KEEP_VARIANT";
 
     @Inject
@@ -73,6 +75,7 @@ public class DatalakeUpgradeActions {
                 super.prepareExecution(payload, variables);
                 variables.put(TARGET_IMAGE, payload.getImageId());
                 variables.put(REPLACE_VMS_AFTER_UPGRADE, payload.isReplaceVms());
+                variables.put(ROLLING_UPGRADE_ENABLED, payload.isRollingUpgradeEnabled());
                 variables.put(KEEP_VARIANT, payload.isKeepVariant());
             }
 
@@ -176,8 +179,11 @@ public class DatalakeUpgradeActions {
             @Override
             protected void doExecute(SdxContext context, DatalakeVmReplaceEvent payload, Map<Object, Object> variables) {
                 if ((boolean) variables.get(REPLACE_VMS_AFTER_UPGRADE)) {
-                    LOGGER.info("Start Datalake upgrade vm replacement for {} ", payload.getResourceId());
-                    sdxUpgradeService.upgradeOs(payload.getResourceId(), Boolean.TRUE.equals(variables.get(KEEP_VARIANT)));
+                    boolean rollingUpgradeEnabled = Boolean.TRUE.equals(variables.get(ROLLING_UPGRADE_ENABLED));
+                    boolean keepVariant = Boolean.TRUE.equals(variables.get(KEEP_VARIANT));
+                    LOGGER.info("Start Datalake upgrade vm replacement for {} rolling upgrade enabled: {}, keepVariant: {}",
+                            payload.getResourceId(), rollingUpgradeEnabled, keepVariant);
+                    sdxUpgradeService.upgradeOs(payload.getResourceId(), rollingUpgradeEnabled, keepVariant);
                     sendEvent(context, new SdxEvent(DATALAKE_VM_REPLACE_IN_PROGRESS_EVENT.event(), context));
                 } else {
                     LOGGER.info("Vm replacement is not required for {} ", payload.getResourceId());

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/OrderedOSUpgradeRequestProvider.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/OrderedOSUpgradeRequestProvider.java
@@ -1,0 +1,98 @@
+package com.sequenceiq.datalake.service.upgrade;
+
+import static com.sequenceiq.common.api.type.InstanceGroupName.AUXILIARY;
+import static com.sequenceiq.common.api.type.InstanceGroupName.CORE;
+import static com.sequenceiq.common.api.type.InstanceGroupName.GATEWAY;
+import static com.sequenceiq.common.api.type.InstanceGroupName.IDBROKER;
+import static com.sequenceiq.common.api.type.InstanceGroupName.MASTER;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.osupgrade.OrderedOSUpgradeSet;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.osupgrade.OrderedOSUpgradeSetRequest;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.common.api.type.InstanceGroupName;
+
+@Component
+public class OrderedOSUpgradeRequestProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OrderedOSUpgradeRequestProvider.class);
+
+    public OrderedOSUpgradeSetRequest createMediumDutyOrderedOSUpgradeSetRequest(StackV4Response stackV4Response) {
+        LOGGER.debug("Creating OrderedOSUpgradeSetRequest for rolling OS upgrade");
+        Map<String, List<InstanceMetaDataV4Response>> instanceMetaDataByInstanceGroup = getInstanceMetaDataByInstanceGroup(stackV4Response);
+        Map<String, List<String>> instanceIdsByInstanceGroup = getInstanceIdsByInstanceGroup(instanceMetaDataByInstanceGroup);
+        LOGGER.debug("Instance ids by instance group: {}", instanceIdsByInstanceGroup);
+
+        List<OrderedOSUpgradeSet> osUpgradeByUpgradeSets = new ArrayList<>();
+        osUpgradeByUpgradeSets.add(new OrderedOSUpgradeSet(0, Set.of(
+                getInstanceId(instanceIdsByInstanceGroup, MASTER),
+                getInstanceId(instanceIdsByInstanceGroup, CORE),
+                getInstanceId(instanceIdsByInstanceGroup, AUXILIARY),
+                getInstanceId(instanceIdsByInstanceGroup, IDBROKER)
+        )));
+        osUpgradeByUpgradeSets.add(new OrderedOSUpgradeSet(1, Set.of(
+                getInstanceId(instanceIdsByInstanceGroup, MASTER),
+                getInstanceId(instanceIdsByInstanceGroup, CORE),
+                getInstanceId(instanceIdsByInstanceGroup, GATEWAY),
+                getInstanceId(instanceIdsByInstanceGroup, IDBROKER)
+        )));
+        osUpgradeByUpgradeSets.add(new OrderedOSUpgradeSet(2, Set.of(
+                getInstanceId(instanceIdsByInstanceGroup, CORE),
+                getInstanceId(instanceIdsByInstanceGroup, GATEWAY)
+        )));
+        validateThatEveryInstanceIsPresentInTheConfig(instanceIdsByInstanceGroup);
+        OrderedOSUpgradeSetRequest request = new OrderedOSUpgradeSetRequest();
+        request.setOrderedOsUpgradeSets(osUpgradeByUpgradeSets);
+        LOGGER.debug("Request created for rolling OS upgrade: {}", request);
+        return request;
+    }
+
+    private Map<String, List<InstanceMetaDataV4Response>> getInstanceMetaDataByInstanceGroup(StackV4Response stackV4Response) {
+        return stackV4Response.getInstanceGroups().stream()
+                .flatMap(instanceGroup -> instanceGroup.getMetadata().stream().sorted(Comparator.comparing(InstanceMetaDataV4Response::getDiscoveryFQDN)))
+                .collect(Collectors.groupingBy(InstanceMetaDataV4Response::getInstanceGroup));
+    }
+
+    private Map<String, List<String>> getInstanceIdsByInstanceGroup(Map<String, List<InstanceMetaDataV4Response>> instanceMetaDataByInstanceGroup) {
+        return instanceMetaDataByInstanceGroup.entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        entry -> entry.getValue().stream()
+                                .map(InstanceMetaDataV4Response::getInstanceId)
+                                .collect(Collectors.toList())));
+    }
+
+    private String getInstanceId(Map<String, List<String>> instanceIdsByInstanceGroup, InstanceGroupName instanceGroup) {
+        try {
+            return instanceIdsByInstanceGroup.get(instanceGroup.getName()).remove(0);
+        } catch (Exception e) {
+            String message = String.format("There are no instances left in the %s group. "
+                    + "Please make sure your cluster template have enough instances for rolling os upgrade. "
+                    + "Remaining instances in instance groups: %s", instanceGroup, instanceIdsByInstanceGroup);
+            LOGGER.error(message, e);
+            throw new CloudbreakServiceException(message, e);
+        }
+    }
+
+    private void validateThatEveryInstanceIsPresentInTheConfig(Map<String, List<String>> instanceIdsByInstanceGroup) {
+        Set<String> instancesFromInstanceGroups = instanceIdsByInstanceGroup.entrySet().stream()
+                .flatMap(entry -> entry.getValue().stream())
+                .collect(Collectors.toSet());
+        if (!instancesFromInstanceGroups.isEmpty()) {
+            throw new CloudbreakServiceException(
+                    String.format("The following instances are missing from the ordered OS upgrade request: %s", instancesFromInstanceGroups));
+        }
+    }
+}

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/upgrade/OrderedOSUpgradeRequestProviderTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/upgrade/OrderedOSUpgradeRequestProviderTest.java
@@ -1,0 +1,144 @@
+package com.sequenceiq.datalake.service.upgrade;
+
+import static com.sequenceiq.common.api.type.InstanceGroupName.AUXILIARY;
+import static com.sequenceiq.common.api.type.InstanceGroupName.CORE;
+import static com.sequenceiq.common.api.type.InstanceGroupName.GATEWAY;
+import static com.sequenceiq.common.api.type.InstanceGroupName.IDBROKER;
+import static com.sequenceiq.common.api.type.InstanceGroupName.MASTER;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.osupgrade.OrderedOSUpgradeSetRequest;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.common.api.type.InstanceGroupName;
+
+@ExtendWith(MockitoExtension.class)
+class OrderedOSUpgradeRequestProviderTest {
+
+    @InjectMocks
+    private OrderedOSUpgradeRequestProvider underTest;
+
+    @Test
+    void testCreateOrderedOSUpgradeSetRequest() {
+        List<InstanceGroupV4Response> instanceGroups = new ArrayList<>();
+        instanceGroups.add(createInstanceGroup(Set.of(
+                createInstanceMetadata(CORE, 0),
+                createInstanceMetadata(CORE, 1),
+                createInstanceMetadata(CORE, 2)
+        )));
+        instanceGroups.add(createInstanceGroup(Set.of(
+                createInstanceMetadata(MASTER, 0),
+                createInstanceMetadata(MASTER, 1)
+        )));
+        instanceGroups.add(createInstanceGroup(Set.of(
+                createInstanceMetadata(IDBROKER, 0),
+                createInstanceMetadata(IDBROKER, 1)
+        )));
+        instanceGroups.add(createInstanceGroup(Set.of(
+                createInstanceMetadata(GATEWAY, 0),
+                createInstanceMetadata(GATEWAY, 1)
+        )));
+        instanceGroups.add(createInstanceGroup(Set.of(createInstanceMetadata(AUXILIARY, 0))));
+
+        OrderedOSUpgradeSetRequest actual = underTest.createMediumDutyOrderedOSUpgradeSetRequest(createStackV4Response(instanceGroups));
+
+        assertEquals(0, actual.getOrderedOsUpgradeSets().get(0).getOrder());
+        assertEquals(1, actual.getOrderedOsUpgradeSets().get(1).getOrder());
+        assertEquals(2, actual.getOrderedOsUpgradeSets().get(2).getOrder());
+        assertThat(actual.getOrderedOsUpgradeSets().get(0).getInstanceIds(),
+                containsInAnyOrder(Arrays.asList("i-master0", "i-core0", "i-auxiliary0", "i-idbroker0").toArray()));
+        assertThat(actual.getOrderedOsUpgradeSets().get(1).getInstanceIds(),
+                containsInAnyOrder(Set.of("i-master1", "i-core1", "i-gateway0", "i-idbroker1").toArray()));
+        assertThat(actual.getOrderedOsUpgradeSets().get(2).getInstanceIds(),
+                containsInAnyOrder(Set.of("i-core2", "i-gateway1").toArray()));
+    }
+
+    @Test
+    void testCreateOrderedOSUpgradeSetRequestShouldThrowExceptionWhenThereAreMissingInstancesFromTheRequest() {
+        List<InstanceGroupV4Response> instanceGroups = new ArrayList<>();
+        instanceGroups.add(createInstanceGroup(Set.of(
+                createInstanceMetadata(CORE, 0),
+                createInstanceMetadata(CORE, 1),
+                createInstanceMetadata(CORE, 2)
+        )));
+        instanceGroups.add(createInstanceGroup(Set.of(
+                createInstanceMetadata(MASTER, 0),
+                createInstanceMetadata(MASTER, 1)
+        )));
+        instanceGroups.add(createInstanceGroup(Set.of(
+                createInstanceMetadata(IDBROKER, 0),
+                createInstanceMetadata(IDBROKER, 1)
+        )));
+        instanceGroups.add(createInstanceGroup(Set.of(
+                createInstanceMetadata(GATEWAY, 2),
+                createInstanceMetadata(GATEWAY, 0),
+                createInstanceMetadata(GATEWAY, 1)
+        )));
+        instanceGroups.add(createInstanceGroup(Set.of(createInstanceMetadata(AUXILIARY, 0))));
+
+        Exception exception = assertThrows(CloudbreakServiceException.class,
+                () -> underTest.createMediumDutyOrderedOSUpgradeSetRequest(createStackV4Response(instanceGroups)));
+
+        assertEquals("The following instances are missing from the ordered OS upgrade request: [i-gateway2]", exception.getMessage());
+    }
+
+    @Test
+    void testCreateOrderedOSUpgradeSetRequestShouldThrowExceptionWhenThereAreMissingInstances() {
+        List<InstanceGroupV4Response> instanceGroups = new ArrayList<>();
+        instanceGroups.add(createInstanceGroup(Set.of(
+                createInstanceMetadata(CORE, 0),
+                createInstanceMetadata(CORE, 2)
+        )));
+        instanceGroups.add(createInstanceGroup(Set.of(
+                createInstanceMetadata(MASTER, 0),
+                createInstanceMetadata(MASTER, 1)
+        )));
+        instanceGroups.add(createInstanceGroup(Set.of(
+                createInstanceMetadata(IDBROKER, 0),
+                createInstanceMetadata(IDBROKER, 1)
+        )));
+        instanceGroups.add(createInstanceGroup(Set.of(
+                createInstanceMetadata(GATEWAY, 0),
+                createInstanceMetadata(GATEWAY, 1)
+        )));
+        instanceGroups.add(createInstanceGroup(Set.of(createInstanceMetadata(AUXILIARY, 0))));
+
+        assertThrows(CloudbreakServiceException.class, () -> underTest.createMediumDutyOrderedOSUpgradeSetRequest(createStackV4Response(instanceGroups)));
+    }
+
+    private InstanceGroupV4Response createInstanceGroup(Set<InstanceMetaDataV4Response> instanceMetaDataV4Responses) {
+        InstanceGroupV4Response instanceGroupV4Response = new InstanceGroupV4Response();
+        instanceGroupV4Response.setName(instanceMetaDataV4Responses.iterator().next().getInstanceGroup());
+        instanceGroupV4Response.setMetadata(instanceMetaDataV4Responses);
+        return instanceGroupV4Response;
+    }
+
+    private InstanceMetaDataV4Response createInstanceMetadata(InstanceGroupName instanceGroup, int order) {
+        InstanceMetaDataV4Response instanceMetaDataV4Response = new InstanceMetaDataV4Response();
+        instanceMetaDataV4Response.setInstanceGroup(instanceGroup.getName());
+        instanceMetaDataV4Response.setInstanceId("i-" + instanceGroup.getName() + order);
+        instanceMetaDataV4Response.setDiscoveryFQDN("test-dl-" + instanceGroup.getName() + order + ".test-env.cloudera.site");
+        return instanceMetaDataV4Response;
+    }
+
+    private StackV4Response createStackV4Response(List<InstanceGroupV4Response> instanceGroups) {
+        StackV4Response stackV4Response = new StackV4Response();
+        stackV4Response.setInstanceGroups(instanceGroups);
+        return stackV4Response;
+    }
+}


### PR DESCRIPTION
There is a new API where you have to tell the order of the instances to be replaced with a new OS. In case of Rolling Upgrade