### PR TITLE
CB-20459 set knox knoxsso.token.ttl to 1 hour because of the fisma re…

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/knoxsso.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/knoxsso.xml.j2
@@ -133,9 +133,9 @@
         </param>
         {% endif %}
         <param>
-            <!-- 24 hours in milliseconds = 86400000 -->
+            <!-- 1 hours in milliseconds = 3600000 -->
             <name>knoxsso.token.ttl</name>
-            <value>86400000</value>
+            <value>3600000</value>
         </param>
         <param>
            <name>knoxsso.redirect.whitelist.regex</name>


### PR DESCRIPTION
…quirement we need to set all idle timeout to 1 hour as a maximum.

See detailed description in the commit message.