### PR TITLE
CB-20451 Add accountid-timestamp index to cdp_structured_event table

### DIFF
--- a/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/conf/StructuredEventSchemaLocationProvider.java
+++ b/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/conf/StructuredEventSchemaLocationProvider.java
@@ -1,0 +1,16 @@
+package com.sequenceiq.cloudbreak.structuredevent.conf;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.dbmigration.SchemaLocationProvider;
+
+@Component
+public class StructuredEventSchemaLocationProvider implements SchemaLocationProvider {
+
+    @Override
+    public Optional<String> pendingSubfolder() {
+        return Optional.of("structuredevent");
+    }
+}

--- a/structuredevent-service-cdp/src/main/resources/schema/structuredevent/20230124110711_CB-20451_add_index_to_cdp_structered_event.sql
+++ b/structuredevent-service-cdp/src/main/resources/schema/structuredevent/20230124110711_CB-20451_add_index_to_cdp_structered_event.sql
@@ -1,0 +1,10 @@
+-- // CB-20451 Add index to cdp_structured_event for accountid, timestamp
+-- Migration SQL that makes the change goes here.
+
+CREATE INDEX IF NOT EXISTS idx_cdp_structured_event_accountid_timestamp ON cdp_structured_event (accountid, timestamp);
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+DROP INDEX IF EXISTS idx_cdp_structured_event_accountid_timestamp;


### PR DESCRIPTION
Cleanup from this table takes a long time as index was missing for the query. The SQL has been added to the module itself, to avoid copying it over to other services.

See detailed description in the commit message.