### PR TITLE
CB-20442: Fixed SDX status checker job status update issues.

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxNotificationService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxNotificationService.java
@@ -26,15 +26,17 @@ public class SdxNotificationService {
     @Inject
     private SdxClusterConverter sdxClusterConverter;
 
-    public void send(ResourceEvent resourceEvent, Collection<?> messageArgs, SdxCluster sdx) {
-        LOGGER.info("SDX Notification has been sent: {}", resourceEvent);
-        notificationService.send(resourceEvent, messageArgs, sdxClusterConverter.sdxClusterToResponse(sdx),
-                ThreadBasedUserCrnProvider.getUserCrn());
+    public void send(ResourceEvent resourceEvent, SdxCluster sdx) {
+        send(resourceEvent, Collections.singleton(sdx.getClusterName()), sdx);
     }
 
-    public void send(ResourceEvent resourceEvent, SdxCluster sdx) {
+    public void send(ResourceEvent resourceEvent, Collection<?> messageArgs, SdxCluster sdx) {
+        notificationService.send(resourceEvent, messageArgs, sdxClusterConverter.sdxClusterToResponse(sdx),
+                getAccountIdFromSdx(sdx));
         LOGGER.info("SDX Notification has been sent: {}", resourceEvent);
-        notificationService.send(resourceEvent, Collections.singleton(sdx.getClusterName()), sdxClusterConverter.sdxClusterToResponse(sdx),
-                ThreadBasedUserCrnProvider.getUserCrn());
+    }
+
+    private String getAccountIdFromSdx(SdxCluster sdx) {
+        return (sdx.getAccountId() != null) ? sdx.getAccountId() : ThreadBasedUserCrnProvider.getUserCrn();
     }
 }


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-20442

Simply modified the logic within the status checker job to use the SDX cluster's account ID for the status updates.

Note that this is not an issue our team introduced especially not in any period in the last few months. Seems to me like either something in CB changed or we modified how we track these exceptions making them more present. Note also that the basic functionality of the status checker job is still correct even with this issue. This is just ensuring that we do not throw an exception every time the updates are called.

Testing:

- Verify that issue exists without this fix by stopping a DL's nodes on the cloud provider so as to make the status checker job set it to unreachable
- Verify that the issue no longer exists with this fix by doing the same as above and ensuring no exceptions are present