### PR TITLE
CB-20441 [FEDRAMP] FreeIpa creation is failing with V3 format keys: I…

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/databus/DatabusConfigService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/databus/DatabusConfigService.java
@@ -16,7 +16,7 @@ public class DatabusConfigService implements TelemetryPillarConfigGenerator<Data
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DatabusConfigService.class);
 
-    private static final String ED25519 = "Ed25519";
+    private static final String DEFAULT_ACCESS_KEY_TYPE = "Ed25519";
 
     private static final String SALT_STATE = "databus";
 
@@ -24,7 +24,7 @@ public class DatabusConfigService implements TelemetryPillarConfigGenerator<Data
     public DatabusConfigView createConfigs(TelemetryContext context) {
         final DatabusContext databusContext = context.getDatabusContext();
         final DataBusCredential dataBusCredential = databusContext.getCredential();
-        String accessKeySecretAlgorithm = StringUtils.defaultIfBlank(dataBusCredential.getAccessKeyType(), ED25519);
+        String accessKeySecretAlgorithm = StringUtils.defaultIfBlank(dataBusCredential.getAccessKeyType(), DEFAULT_ACCESS_KEY_TYPE);
         return new DatabusConfigView.Builder()
                 .withEnabled(databusContext.isEnabled())
                 .withEndpoint(databusContext.getEndpoint())

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfigService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfigService.java
@@ -15,7 +15,7 @@ public class MonitoringConfigService implements TelemetryPillarConfigGenerator<M
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MonitoringConfigService.class);
 
-    private static final String ED25519 = "Ed25519";
+    private static final String DEFAULT_ACCESS_KEY_TYPE = "Ed25519";
 
     private static final String SALT_STATE = "monitoring";
 
@@ -49,7 +49,7 @@ public class MonitoringConfigService implements TelemetryPillarConfigGenerator<M
         builder.withMinBackoff(monitoringConfiguration.getAgent().getMinBackoff());
         builder.withMaxBackoff(monitoringConfiguration.getAgent().getMaxBackoff());
         if (monitoringContext.getCredential() != null) {
-            String accessKeyType = StringUtils.defaultIfBlank(monitoringContext.getCredential().getAccessKeyType(), ED25519);
+            String accessKeyType = StringUtils.defaultIfBlank(monitoringContext.getCredential().getAccessKeyType(), DEFAULT_ACCESS_KEY_TYPE);
             builder.withAccessKeyId(monitoringContext.getCredential().getAccessKey())
                     .withPrivateKey(UMSSecretKeyFormatter.formatSecretKey(accessKeyType, monitoringContext.getCredential().getPrivateKey()).toCharArray())
                     .withAccessKeyType(accessKeyType);

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/TelemetryFeatureServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/TelemetryFeatureServiceTest.java
@@ -1,0 +1,54 @@
+package com.sequenceiq.cloudbreak.telemetry;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TelemetryFeatureServiceTest {
+
+    @InjectMocks
+    private TelemetryFeatureService undertest;
+
+    @Test
+    void testIsECDSAAccessKeyTypeSupported() {
+        boolean result = undertest.isECDSAAccessKeyTypeSupported(generatePackageVersions());
+        assertTrue(result);
+    }
+
+    @Test
+    void testIsECDSAAccessKeyTypeSupportedNull() {
+        boolean result = undertest.isECDSAAccessKeyTypeSupported(null);
+        assertFalse(result);
+    }
+
+    @Test
+    void testIsECDSAAccessKeyTypeSupportedBadVersion() {
+        Map<String, String> packages = new HashMap(generatePackageVersions());
+        packages.put("cdp-logging-agent", "0.3.2");
+        boolean result = undertest.isECDSAAccessKeyTypeSupported(packages);
+        assertFalse(result);
+    }
+
+    @Test
+    void testIsECDSAAccessKeyTypeSupportedMissingPackage() {
+        Map<String, String> packages = new HashMap(generatePackageVersions());
+        packages.remove("cdp-logging-agent");
+        boolean result = undertest.isECDSAAccessKeyTypeSupported(packages);
+        assertFalse(result);
+    }
+
+    private Map<String, String> generatePackageVersions() {
+        return Map.of("cdp-logging-agent", "0.3.3",
+                "cdp-request-signer", "0.2.3",
+                "cdp-telemetry", "0.4.30");
+    }
+
+}


### PR DESCRIPTION
…NVALID_ARGUMENT: Invalid access key type ED25519 for this region

Cleanup for readability and added unit tests for locking the feature.
