### PR TITLE
CB-20679 Periscope can end up executing a scale operation against the

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/load/YarnLoadEvaluator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/load/YarnLoadEvaluator.java
@@ -131,7 +131,7 @@ public class YarnLoadEvaluator extends EvaluatorExecutor {
                 }
             }
         } catch (Exception ex) {
-            LOGGER.info("Failed to process load alert for Cluster '{}', exception '{}'", stackCrn, ex);
+            LOGGER.info("Failed to process load alert for Cluster '{}', userCrn: {}, exception: ", stackCrn, pollingUserCrn, ex);
             eventPublisher.publishEvent(new UpdateFailedEvent(clusterId, ex, Instant.now().toEpochMilli(),
                     pollingUserCrn != null && pollingUserCrn.equals(cluster.getMachineUserCrn())));
         } finally {

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/LoadAlertPolicyHostGroupInstanceInfo.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/LoadAlertPolicyHostGroupInstanceInfo.java
@@ -1,0 +1,48 @@
+package com.sequenceiq.periscope.service;
+
+import java.util.List;
+import java.util.Map;
+
+import com.sequenceiq.periscope.domain.LoadAlert;
+
+public class LoadAlertPolicyHostGroupInstanceInfo {
+
+    private final LoadAlert loadAlert;
+
+    private final String policyHostGroup;
+
+    private final Map<String, String> hostFqdnsToInstanceId;
+
+    private final List<String> servicesHealthyInstanceIds;
+
+    private final List<String> stoppedHostInstanceIds;
+
+    public LoadAlertPolicyHostGroupInstanceInfo(LoadAlert loadAlert, String policyHostGroup, Map<String, String> hostFqdnsToInstanceId,
+            List<String> servicesHealthyInstanceIds, List<String> stoppedHostInstanceIds) {
+        this.loadAlert = loadAlert;
+        this.policyHostGroup = policyHostGroup;
+        this.hostFqdnsToInstanceId = hostFqdnsToInstanceId;
+        this.servicesHealthyInstanceIds = servicesHealthyInstanceIds;
+        this.stoppedHostInstanceIds = stoppedHostInstanceIds;
+    }
+
+    public LoadAlert getLoadAlert() {
+        return loadAlert;
+    }
+
+    public String getPolicyHostGroup() {
+        return policyHostGroup;
+    }
+
+    public Map<String, String> getHostFqdnsToInstanceId() {
+        return hostFqdnsToInstanceId;
+    }
+
+    public List<String> getServicesHealthyInstanceIds() {
+        return servicesHealthyInstanceIds;
+    }
+
+    public List<String> getStoppedHostInstanceIds() {
+        return stoppedHostInstanceIds;
+    }
+}


### PR DESCRIPTION
wrong cluster (Load Based Scaling).

Changes the various LoadBasedAdjustmentServices to not use instance variables, which otherwise get clobbered by multiple threads dealing with different clusters.

See detailed description in the commit message.