### PR TITLE
CDPSDX-3878 Reset connection to -1 when error happens in DB backup

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
@@ -60,6 +60,9 @@ export PGSSLMODE=verify-full
 {%- endif %}
 
 errorExit() {
+  if [[ "$CLOSECONNECTIONS" == "true" ]]; then
+        limit_incomming_connection $SERVICE -1
+  fi
   if [ -d "$DATE_DIR" ]; then
     rm -rf -v "$DATE_DIR" > >(tee -a $LOGFILE) 2> >(tee -a $LOGFILE >&2)
     doLog "Removed directory $DATE_DIR"


### PR DESCRIPTION
JIRA: [CDPSDX-3878](https://jira.cloudera.com/browse/CDPSDX-3878) 

Issue: Connection is supposed to set back to -1 after DB backup completes, but if an error happens at `pg_dump` the program will not process to the step where we set it to -1. 
Fix: Add that setting in the `exitError` function, similar approach as we did to remove the temporary folders in the past.

Before (I tested this by forcing `pg_dump` to fail): connection not set back to -1 after it was set to 0:
<img width="1160" alt="Screen Shot 2023-01-26 at 7 35 41 PM" src="https://user-images.githubusercontent.com/39275944/214982075-8047269f-f52b-4c90-ba54-87031c8e10bc.png">

After (tested with both aws and azure, backup and backup before upgrade): connection set to -1 when `pg_dump` fails.
<img width="579" alt="Screen Shot 2023-01-26 at 3 34 03 PM" src="https://user-images.githubusercontent.com/39275944/214982813-7386c037-1178-46ba-8ace-5739deca4551.png">


