### PR TITLE
CDPSDX-3878 Reset incomming connection to -1 when error happens in DB…

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
@@ -60,6 +60,9 @@ export PGSSLMODE=verify-full
 {%- endif %}
 
 errorExit() {
+  if [[ "$CLOSECONNECTIONS" == "true" ]]; then
+    limit_incomming_connection $SERVICE -1
+  fi
   if [ -d "$DATE_DIR" ]; then
     rm -rf -v "$DATE_DIR" > >(tee -a $LOGFILE) 2> >(tee -a $LOGFILE >&2)
     doLog "Removed directory $DATE_DIR"
@@ -130,7 +133,7 @@ close_existing_connections() {
 limit_incomming_connection() {
   SERVICE=$1
   COUNT=$2
-  doLog "INFO limit existing connections to ${COUNT}"
+  doLog "INFO limit existing connections to ${COUNT} on ${SERVICE}"
   psql --host="$HOST" --port="$PORT" --dbname="postgres" --username="$USERNAME" -c "alter user ${SERVICE} connection limit ${COUNT};" > >(tee -a $LOGFILE) 2> >(tee -a $LOGFILE >&2) || errorExit "Unable to limit connections to ${SERVICE}"
 }
 


### PR DESCRIPTION
JIRA: [CDPSDX-3878](https://jira.cloudera.com/browse/CDPSDX-3878)

Issue: Connection is supposed to set back to -1 after DB backup completes, but if an error happens at pg_dump the program will not process to the step where we set it to -1.
Fix: Add that setting in the exitError function, similar approach as we did to remove the temporary folders in the past.

Before (I tested this by forcing pg_dump to fail): connection not set back to -1 after it was set to 0:
<img width="1160" alt="214982075-8047269f-f52b-4c90-ba54-87031c8e10bc (1)" src="https://user-images.githubusercontent.com/39275944/214985949-32b190ac-edbb-4ef4-bbea-29d036da204f.png">

After (tested with both aws and azure, backup and backup before upgrade:
<img width="777" alt="Screen Shot 2023-01-27 at 12 09 31 PM" src="https://user-images.githubusercontent.com/39275944/215190231-6912e9c1-bc4d-4e7d-b4c3-351d118b2874.png">

Before (Hive log) - throws exception:
<img width="1642" alt="Screen Shot 2023-01-27 at 3 14 48 PM" src="https://user-images.githubusercontent.com/39275944/215190310-c9094294-7cb5-421c-b663-1fa2db83224b.png">

After (Hive log) - no more exception:
<img width="1673" alt="Screen Shot 2023-01-27 at 3 23 50 PM" src="https://user-images.githubusercontent.com/39275944/215190359-1048d897-95bd-4643-9928-161117edf781.png">



