### PR TITLE
CB-20404 Improving type safety in EDH use case mapping for flows and …

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/BackupDatalakeDatabaseFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/BackupDatalakeDatabaseFlowEventChainFactory.java
@@ -1,5 +1,9 @@
 package com.sequenceiq.cloudbreak.core.flow2.chain;
 
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.BACKUP_FAILED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.BACKUP_FINISHED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.BACKUP_STARTED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.UNSET;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.dr.backup.DatabaseBackupEvent.DATABASE_BACKUP_EVENT;
 
 import java.util.Queue;
@@ -7,15 +11,19 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.springframework.stereotype.Component;
 
+import com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.dr.backup.DatabaseBackupState;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.salt.update.SaltUpdateEvent;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.salt.update.SaltUpdateState;
 import com.sequenceiq.cloudbreak.core.flow2.event.DatabaseBackupTriggerEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+import com.sequenceiq.cloudbreak.structuredevent.service.telemetry.mapper.ClusterUseCaseAware;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
 import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 @Component
-public class BackupDatalakeDatabaseFlowEventChainFactory implements FlowEventChainFactory<DatabaseBackupTriggerEvent> {
+public class BackupDatalakeDatabaseFlowEventChainFactory implements FlowEventChainFactory<DatabaseBackupTriggerEvent>, ClusterUseCaseAware {
     @Override
     public String initEvent() {
         return FlowChainTriggers.DATALAKE_DATABASE_BACKUP_CHAIN_TRIGGER_EVENT;
@@ -28,5 +36,18 @@ public class BackupDatalakeDatabaseFlowEventChainFactory implements FlowEventCha
         flowEventChain.add(new DatabaseBackupTriggerEvent(DATABASE_BACKUP_EVENT.event(), event.getResourceId(),
                 event.getBackupLocation(), event.getBackupId(), event.isCloseConnections(), event.getSkipDatabaseNames()));
         return new FlowTriggerEventQueue(getName(), event, flowEventChain);
+    }
+
+    @Override
+    public Value getUseCaseForFlowState(Enum flowState) {
+        if (SaltUpdateState.INIT_STATE.equals(flowState)) {
+            return BACKUP_STARTED;
+        } else if (DatabaseBackupState.DATABASE_BACKUP_FINISHED_STATE.equals(flowState)) {
+            return BACKUP_FINISHED;
+        } else if (flowState.toString().endsWith("FAILED_STATE")) {
+            return BACKUP_FAILED;
+        } else {
+            return UNSET;
+        }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/DownscaleFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/DownscaleFlowEventChainFactory.java
@@ -1,5 +1,9 @@
 package com.sequenceiq.cloudbreak.core.flow2.chain;
 
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.DOWNSCALE_FAILED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.DOWNSCALE_FINISHED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.DOWNSCALE_STARTED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.UNSET;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.downscale.ClusterDownscaleEvent.DECOMMISSION_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.downscale.StackDownscaleEvent.STACK_DOWNSCALE_EVENT;
 
@@ -10,20 +14,24 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
+import com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.common.type.ScalingType;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.downscale.ClusterDownscaleState;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterAndStackDownscaleTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterDownscaleTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterScaleTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.StackDownscaleTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.StackScaleTriggerEvent;
+import com.sequenceiq.cloudbreak.core.flow2.stack.downscale.StackDownscaleState;
 import com.sequenceiq.cloudbreak.domain.view.StackView;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.structuredevent.service.telemetry.mapper.ClusterUseCaseAware;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
 import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 @Component
-public class DownscaleFlowEventChainFactory implements FlowEventChainFactory<ClusterAndStackDownscaleTriggerEvent> {
+public class DownscaleFlowEventChainFactory implements FlowEventChainFactory<ClusterAndStackDownscaleTriggerEvent>, ClusterUseCaseAware {
     @Inject
     private StackService stackService;
 
@@ -49,5 +57,20 @@ public class DownscaleFlowEventChainFactory implements FlowEventChainFactory<Clu
             flowEventChain.add(sste);
         }
         return new FlowTriggerEventQueue(getName(), event, flowEventChain);
+    }
+
+    @Override
+    public Value getUseCaseForFlowState(Enum flowState) {
+        if (ClusterDownscaleState.INIT_STATE.equals(flowState)) {
+            return DOWNSCALE_STARTED;
+        } else if (StackDownscaleState.DOWNSCALE_FINISHED_STATE.equals(flowState)) {
+            return DOWNSCALE_FINISHED;
+        } else if (flowState.toString().endsWith("FAILED_STATE") &&
+                !ClusterDownscaleState.DECOMISSION_FAILED_STATE.equals(flowState) &&
+                !ClusterDownscaleState.REMOVE_HOSTS_FROM_ORCHESTRATION_FAILED_STATE.equals(flowState)) {
+            return DOWNSCALE_FAILED;
+        } else {
+            return UNSET;
+        }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/MultiHostgroupDownscaleFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/MultiHostgroupDownscaleFlowEventChainFactory.java
@@ -1,5 +1,9 @@
 package com.sequenceiq.cloudbreak.core.flow2.chain;
 
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.DOWNSCALE_FAILED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.DOWNSCALE_FINISHED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.DOWNSCALE_STARTED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.UNSET;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.downscale.ClusterDownscaleEvent.DECOMMISSION_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.downscale.StackDownscaleEvent.STACK_DOWNSCALE_EVENT;
 
@@ -11,22 +15,28 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
+import com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value;
 import com.sequenceiq.cloudbreak.cloud.model.CloudPlatformVariant;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.common.type.ScalingType;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.downscale.ClusterDownscaleState;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterDownscaleTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterScaleTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.MultiHostgroupClusterAndStackDownscaleTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.StackDownscaleTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.StackScaleTriggerEvent;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.structuredevent.service.telemetry.mapper.ClusterUseCaseAware;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
 import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
+import com.sequenceiq.flow.core.chain.finalize.config.FlowChainFinalizeState;
 import com.sequenceiq.flow.core.chain.finalize.flowevents.FlowChainFinalizePayload;
+import com.sequenceiq.flow.core.chain.init.config.FlowChainInitState;
 import com.sequenceiq.flow.core.chain.init.flowevents.FlowChainInitPayload;
 
 @Component
-public class MultiHostgroupDownscaleFlowEventChainFactory implements FlowEventChainFactory<MultiHostgroupClusterAndStackDownscaleTriggerEvent> {
+public class MultiHostgroupDownscaleFlowEventChainFactory implements FlowEventChainFactory<MultiHostgroupClusterAndStackDownscaleTriggerEvent>,
+        ClusterUseCaseAware {
 
     @Inject
     private StackService stackService;
@@ -51,5 +61,20 @@ public class MultiHostgroupDownscaleFlowEventChainFactory implements FlowEventCh
         }
         flowEventChain.add(new FlowChainFinalizePayload(getName(), event.getResourceId(), event.accepted()));
         return new FlowTriggerEventQueue(getName(), event, flowEventChain);
+    }
+
+    @Override
+    public Value getUseCaseForFlowState(Enum flowState) {
+        if (FlowChainInitState.INIT_STATE.equals(flowState)) {
+            return DOWNSCALE_STARTED;
+        } else if (FlowChainFinalizeState.FLOWCHAIN_FINALIZE_FINISHED_STATE.equals(flowState)) {
+            return DOWNSCALE_FINISHED;
+        } else if (flowState.toString().endsWith("FAILED_STATE") &&
+                !ClusterDownscaleState.DECOMISSION_FAILED_STATE.equals(flowState) &&
+                !ClusterDownscaleState.REMOVE_HOSTS_FROM_ORCHESTRATION_FAILED_STATE.equals(flowState)) {
+            return DOWNSCALE_FAILED;
+        } else {
+            return UNSET;
+        }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/PrepareClusterUpgradeFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/PrepareClusterUpgradeFlowEventChainFactory.java
@@ -1,5 +1,10 @@
 package com.sequenceiq.cloudbreak.core.flow2.chain;
 
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.UNSET;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.UPGRADE_PREPARE_FAILED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.UPGRADE_PREPARE_FINISHED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.UPGRADE_PREPARE_STARTED;
+
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
@@ -7,15 +12,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.preparation.ClusterUpgradePreparationState;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.preparation.event.ClusterUpgradePreparationTriggerEvent;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.ClusterUpgradeValidationState;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.UpgradePreparationChainTriggerEvent;
+import com.sequenceiq.cloudbreak.structuredevent.service.telemetry.mapper.ClusterUseCaseAware;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
 import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 @Component
-public class PrepareClusterUpgradeFlowEventChainFactory implements FlowEventChainFactory<UpgradePreparationChainTriggerEvent> {
+public class PrepareClusterUpgradeFlowEventChainFactory implements FlowEventChainFactory<UpgradePreparationChainTriggerEvent>, ClusterUseCaseAware {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PrepareClusterUpgradeFlowEventChainFactory.class);
 
@@ -31,6 +40,19 @@ public class PrepareClusterUpgradeFlowEventChainFactory implements FlowEventChai
         flowEventChain.add(createUpgradeValidationTriggerEvent(event));
         flowEventChain.add(createClusterUpgradePreparationTriggerEvent(event));
         return new FlowTriggerEventQueue(getName(), event, flowEventChain);
+    }
+
+    @Override
+    public Value getUseCaseForFlowState(Enum flowState) {
+        if (ClusterUpgradeValidationState.INIT_STATE.equals(flowState)) {
+            return UPGRADE_PREPARE_STARTED;
+        } else if (ClusterUpgradePreparationState.CLUSTER_UPGRADE_PREPARATION_FINISHED_STATE.equals(flowState)) {
+            return UPGRADE_PREPARE_FINISHED;
+        } else if (flowState.toString().endsWith("FAILED_STATE")) {
+            return UPGRADE_PREPARE_FAILED;
+        } else {
+            return UNSET;
+        }
     }
 
     private ClusterUpgradeValidationTriggerEvent createUpgradeValidationTriggerEvent(UpgradePreparationChainTriggerEvent event) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ProperTerminationFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ProperTerminationFlowEventChainFactory.java
@@ -1,5 +1,9 @@
 package com.sequenceiq.cloudbreak.core.flow2.chain;
 
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.DELETE_FAILED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.DELETE_FINISHED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.DELETE_STARTED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.UNSET;
 import static com.sequenceiq.cloudbreak.core.flow2.externaldatabase.terminate.config.ExternalDatabaseTerminationEvent.START_EXTERNAL_DATABASE_TERMINATION_EVENT;
 
 import java.util.Queue;
@@ -7,15 +11,19 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.springframework.stereotype.Component;
 
+import com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.termination.ClusterTerminationEvent;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.termination.ClusterTerminationState;
 import com.sequenceiq.cloudbreak.core.flow2.stack.termination.StackTerminationEvent;
+import com.sequenceiq.cloudbreak.core.flow2.stack.termination.StackTerminationState;
 import com.sequenceiq.cloudbreak.reactor.api.event.stack.TerminationEvent;
+import com.sequenceiq.cloudbreak.structuredevent.service.telemetry.mapper.ClusterUseCaseAware;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
 import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 @Component
-public class ProperTerminationFlowEventChainFactory implements FlowEventChainFactory<TerminationEvent> {
+public class ProperTerminationFlowEventChainFactory implements FlowEventChainFactory<TerminationEvent>, ClusterUseCaseAware {
     @Override
     public String initEvent() {
         return FlowChainTriggers.PROPER_TERMINATION_TRIGGER_EVENT;
@@ -29,5 +37,18 @@ public class ProperTerminationFlowEventChainFactory implements FlowEventChainFac
         flowEventChain.add(new TerminationEvent(StackTerminationEvent.TERMINATION_EVENT.event(), event.getResourceId(), event.getTerminationType(),
                 event.accepted()));
         return new FlowTriggerEventQueue(getName(), event, flowEventChain);
+    }
+
+    @Override
+    public Value getUseCaseForFlowState(Enum flowState) {
+        if (ClusterTerminationState.INIT_STATE.equals(flowState)) {
+            return DELETE_STARTED;
+        } else if (StackTerminationState.TERMINATION_FINISHED_STATE.equals(flowState)) {
+            return DELETE_FINISHED;
+        } else if (flowState.toString().endsWith("FAILED_STATE")) {
+            return DELETE_FAILED;
+        } else {
+            return UNSET;
+        }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/StartFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/StartFlowEventChainFactory.java
@@ -1,5 +1,9 @@
 package com.sequenceiq.cloudbreak.core.flow2.chain;
 
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.RESUME_FAILED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.RESUME_FINISHED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.RESUME_STARTED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.UNSET;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.start.ClusterStartEvent.CLUSTER_START_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.externaldatabase.start.config.ExternalDatabaseStartEvent.EXTERNAL_DATABASE_COMMENCE_START_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.start.StackStartEvent.STACK_START_EVENT;
@@ -9,13 +13,17 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.springframework.stereotype.Component;
 
+import com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.start.ClusterStartState;
+import com.sequenceiq.cloudbreak.core.flow2.stack.start.StackStartState;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+import com.sequenceiq.cloudbreak.structuredevent.service.telemetry.mapper.ClusterUseCaseAware;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
 import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 @Component
-public class StartFlowEventChainFactory implements FlowEventChainFactory<StackEvent> {
+public class StartFlowEventChainFactory implements FlowEventChainFactory<StackEvent>, ClusterUseCaseAware {
 
     @Override
     public String initEvent() {
@@ -29,5 +37,18 @@ public class StartFlowEventChainFactory implements FlowEventChainFactory<StackEv
         flowEventChain.add(new StackEvent(STACK_START_EVENT.event(), event.getResourceId()));
         flowEventChain.add(new StackEvent(CLUSTER_START_EVENT.event(), event.getResourceId()));
         return new FlowTriggerEventQueue(getName(), event, flowEventChain);
+    }
+
+    @Override
+    public Value getUseCaseForFlowState(Enum flowState) {
+        if (StackStartState.INIT_STATE.equals(flowState)) {
+            return RESUME_STARTED;
+        } else if (ClusterStartState.CLUSTER_START_FINISHED_STATE.equals(flowState)) {
+            return RESUME_FINISHED;
+        } else if (flowState.toString().endsWith("FAILED_STATE")) {
+            return RESUME_FAILED;
+        } else {
+            return UNSET;
+        }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/StopFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/StopFlowEventChainFactory.java
@@ -1,5 +1,9 @@
 package com.sequenceiq.cloudbreak.core.flow2.chain;
 
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.SUSPEND_FAILED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.SUSPEND_FINISHED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.SUSPEND_STARTED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.UNSET;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.stop.ClusterStopEvent.CLUSTER_STOP_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.externaldatabase.stop.config.ExternalDatabaseStopEvent.EXTERNAL_DATABASE_COMMENCE_STOP_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.stop.StackStopEvent.STACK_STOP_EVENT;
@@ -9,13 +13,17 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.springframework.stereotype.Component;
 
+import com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.stop.ClusterStopState;
+import com.sequenceiq.cloudbreak.core.flow2.externaldatabase.stop.config.ExternalDatabaseStopState;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+import com.sequenceiq.cloudbreak.structuredevent.service.telemetry.mapper.ClusterUseCaseAware;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
 import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 @Component
-public class StopFlowEventChainFactory implements FlowEventChainFactory<StackEvent> {
+public class StopFlowEventChainFactory implements FlowEventChainFactory<StackEvent>, ClusterUseCaseAware {
     @Override
     public String initEvent() {
         return FlowChainTriggers.FULL_STOP_TRIGGER_EVENT;
@@ -28,5 +36,18 @@ public class StopFlowEventChainFactory implements FlowEventChainFactory<StackEve
         flowEventChain.add(new StackEvent(STACK_STOP_EVENT.event(), event.getResourceId()));
         flowEventChain.add(new StackEvent(EXTERNAL_DATABASE_COMMENCE_STOP_EVENT.event(), event.getResourceId()));
         return new FlowTriggerEventQueue(getName(), event, flowEventChain);
+    }
+
+    @Override
+    public Value getUseCaseForFlowState(Enum flowState) {
+        if (ClusterStopState.INIT_STATE.equals(flowState)) {
+            return SUSPEND_STARTED;
+        } else if (ExternalDatabaseStopState.EXTERNAL_DATABASE_STOP_FINISHED_STATE.equals(flowState)) {
+            return SUSPEND_FINISHED;
+        } else if (flowState.toString().endsWith("FAILED_STATE")) {
+            return SUSPEND_FAILED;
+        } else {
+            return UNSET;
+        }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/TerminationFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/TerminationFlowEventChainFactory.java
@@ -1,5 +1,9 @@
 package com.sequenceiq.cloudbreak.core.flow2.chain;
 
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.DELETE_FAILED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.DELETE_FINISHED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.DELETE_STARTED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.UNSET;
 import static com.sequenceiq.cloudbreak.core.flow2.externaldatabase.terminate.config.ExternalDatabaseTerminationEvent.START_EXTERNAL_DATABASE_TERMINATION_EVENT;
 
 import java.util.Queue;
@@ -7,16 +11,20 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.springframework.stereotype.Component;
 
+import com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.termination.ClusterTerminationEvent;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.termination.ClusterTerminationState;
 import com.sequenceiq.cloudbreak.core.flow2.stack.termination.StackTerminationEvent;
+import com.sequenceiq.cloudbreak.core.flow2.stack.termination.StackTerminationState;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.stack.TerminationEvent;
+import com.sequenceiq.cloudbreak.structuredevent.service.telemetry.mapper.ClusterUseCaseAware;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
 import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 @Component
-public class TerminationFlowEventChainFactory implements FlowEventChainFactory<TerminationEvent> {
+public class TerminationFlowEventChainFactory implements FlowEventChainFactory<TerminationEvent>, ClusterUseCaseAware {
     @Override
     public String initEvent() {
         return FlowChainTriggers.TERMINATION_TRIGGER_EVENT;
@@ -31,5 +39,18 @@ public class TerminationFlowEventChainFactory implements FlowEventChainFactory<T
         flowEventChain.add(new TerminationEvent(StackTerminationEvent.TERMINATION_EVENT.event(), event.getResourceId(), event.getTerminationType(),
                 event.accepted()));
         return new FlowTriggerEventQueue(getName(), event, flowEventChain);
+    }
+
+    @Override
+    public Value getUseCaseForFlowState(Enum flowState) {
+        if (ClusterTerminationState.INIT_STATE.equals(flowState)) {
+            return DELETE_STARTED;
+        } else if (StackTerminationState.TERMINATION_FINISHED_STATE.equals(flowState)) {
+            return DELETE_FINISHED;
+        } else if (flowState.toString().endsWith("FAILED_STATE")) {
+            return DELETE_FAILED;
+        } else {
+            return UNSET;
+        }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpgradeCcmFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpgradeCcmFlowEventChainFactory.java
@@ -1,5 +1,9 @@
 package com.sequenceiq.cloudbreak.core.flow2.chain;
 
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.CCM_UPGRADE_FAILED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.CCM_UPGRADE_FINISHED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.CCM_UPGRADE_STARTED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.UNSET;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.ccm.upgrade.UpgradeCcmEvent.UPGRADE_CCM_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.update.userdata.UpdateUserDataEvents.UPDATE_USERDATA_TRIGGER_EVENT;
 
@@ -8,17 +12,21 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.springframework.stereotype.Component;
 
+import com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.ccm.upgrade.UpgradeCcmState;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.salt.update.SaltUpdateEvent;
+import com.sequenceiq.cloudbreak.core.flow2.stack.update.userdata.UpdateUserDataState;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmFlowChainTriggerEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ccm.UpgradeCcmTriggerRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.stack.userdata.UserDataUpdateRequest;
+import com.sequenceiq.cloudbreak.structuredevent.service.telemetry.mapper.ClusterUseCaseAware;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
 import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 @Component
-public class UpgradeCcmFlowEventChainFactory implements FlowEventChainFactory<UpgradeCcmFlowChainTriggerEvent> {
+public class UpgradeCcmFlowEventChainFactory implements FlowEventChainFactory<UpgradeCcmFlowChainTriggerEvent>, ClusterUseCaseAware {
 
     @Override
     public String initEvent() {
@@ -37,5 +45,18 @@ public class UpgradeCcmFlowEventChainFactory implements FlowEventChainFactory<Up
                 .withOldTunnel(event.getOldTunnel())
                 .build());
         return new FlowTriggerEventQueue(getName(), event, flowEventChain);
+    }
+
+    @Override
+    public Value getUseCaseForFlowState(Enum flowState) {
+        if (UpgradeCcmState.INIT_STATE.equals(flowState)) {
+            return CCM_UPGRADE_STARTED;
+        } else if (UpdateUserDataState.UPDATE_USERDATA_FINISHED_STATE.equals(flowState)) {
+            return CCM_UPGRADE_FINISHED;
+        } else if (flowState.toString().endsWith("FAILED_STATE")) {
+            return CCM_UPGRADE_FAILED;
+        } else {
+            return UNSET;
+        }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpgradeDatalakeFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpgradeDatalakeFlowEventChainFactory.java
@@ -1,5 +1,9 @@
 package com.sequenceiq.cloudbreak.core.flow2.chain;
 
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.UNSET;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.UPGRADE_FAILED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.UPGRADE_FINISHED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.UPGRADE_STARTED;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.ClusterUpgradeEvent.CLUSTER_UPGRADE_INIT_EVENT;
 
 import java.util.Queue;
@@ -10,19 +14,23 @@ import javax.inject.Inject;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.ClusterUpgradeState;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.salt.update.SaltUpdateEvent;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.salt.update.SaltUpdateState;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterUpgradeTriggerEvent;
 import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 import com.sequenceiq.cloudbreak.service.upgrade.image.locked.LockedComponentService;
+import com.sequenceiq.cloudbreak.structuredevent.service.telemetry.mapper.ClusterUseCaseAware;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
 import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 @Component
-public class UpgradeDatalakeFlowEventChainFactory implements FlowEventChainFactory<ClusterUpgradeTriggerEvent> {
+public class UpgradeDatalakeFlowEventChainFactory implements FlowEventChainFactory<ClusterUpgradeTriggerEvent>, ClusterUseCaseAware {
 
     @Value("${cb.upgrade.validation.sdx.enabled}")
     private boolean upgradeValidationEnabled;
@@ -46,6 +54,19 @@ public class UpgradeDatalakeFlowEventChainFactory implements FlowEventChainFacto
         flowEventChain.add(new ClusterUpgradeTriggerEvent(CLUSTER_UPGRADE_INIT_EVENT.event(), event.getResourceId(),
                 event.accepted(), event.getImageId(), event.isRollingUpgradeEnabled()));
         return new FlowTriggerEventQueue(getName(), event, flowEventChain);
+    }
+
+    @Override
+    public CDPClusterStatus.Value getUseCaseForFlowState(Enum flowState) {
+        if (SaltUpdateState.INIT_STATE.equals(flowState)) {
+            return UPGRADE_STARTED;
+        } else if (ClusterUpgradeState.CLUSTER_UPGRADE_FINISHED_STATE.equals(flowState)) {
+            return UPGRADE_FINISHED;
+        } else if (flowState.toString().endsWith("FAILED_STATE")) {
+            return UPGRADE_FAILED;
+        } else {
+            return UNSET;
+        }
     }
 
     private void addUpgradeValidationToChain(ClusterUpgradeTriggerEvent event, Queue<Selectable> flowEventChain) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpgradeRdsFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpgradeRdsFlowEventChainFactory.java
@@ -1,5 +1,10 @@
 package com.sequenceiq.cloudbreak.core.flow2.chain;
 
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.DATABASE_UPGRADE_FAILED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.DATABASE_UPGRADE_FINISHED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.DATABASE_UPGRADE_STARTED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.UNSET;
+
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
@@ -7,19 +12,23 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.rds.upgrade.UpgradeRdsEvent;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.rds.upgrade.UpgradeRdsState;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.rds.upgrade.validation.ValidateRdsUpgradeEvent;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.salt.update.SaltUpdateEvent;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.salt.update.SaltUpdateState;
 import com.sequenceiq.cloudbreak.core.flow2.event.RdsUpgradeChainTriggerEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.rds.UpgradeRdsTriggerRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.rds.validation.ValidateRdsUpgradeTriggerRequest;
+import com.sequenceiq.cloudbreak.structuredevent.service.telemetry.mapper.ClusterUseCaseAware;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
 import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 @Component
-public class UpgradeRdsFlowEventChainFactory implements FlowEventChainFactory<RdsUpgradeChainTriggerEvent> {
+public class UpgradeRdsFlowEventChainFactory implements FlowEventChainFactory<RdsUpgradeChainTriggerEvent>, ClusterUseCaseAware {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UpgradeRdsFlowEventChainFactory.class);
 
@@ -38,5 +47,18 @@ public class UpgradeRdsFlowEventChainFactory implements FlowEventChainFactory<Rd
         flowEventChain.add(new UpgradeRdsTriggerRequest(UpgradeRdsEvent.UPGRADE_RDS_EVENT.event(),
                 event.getResourceId(), event.getVersion(), event.getBackupLocation(), event.getBackupInstanceProfile()));
         return new FlowTriggerEventQueue(getName(), event, flowEventChain);
+    }
+
+    @Override
+    public Value getUseCaseForFlowState(Enum flowState) {
+        if (SaltUpdateState.INIT_STATE.equals(flowState)) {
+            return DATABASE_UPGRADE_STARTED;
+        } else if (UpgradeRdsState.UPGRADE_RDS_FINISHED_STATE.equals(flowState)) {
+            return DATABASE_UPGRADE_FINISHED;
+        } else if (flowState.toString().endsWith("FAILED_STATE")) {
+            return DATABASE_UPGRADE_FAILED;
+        } else {
+            return UNSET;
+        }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpscaleFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpscaleFlowEventChainFactory.java
@@ -1,5 +1,9 @@
 package com.sequenceiq.cloudbreak.core.flow2.chain;
 
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.UNSET;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.UPSCALE_FAILED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.UPSCALE_FINISHED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.UPSCALE_STARTED;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.downscale.ClusterDownscaleEvent.DECOMMISSION_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.upscale.ClusterUpscaleEvent.CLUSTER_UPSCALE_TRIGGER_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.downscale.StackDownscaleEvent.STACK_DOWNSCALE_EVENT;
@@ -18,8 +22,10 @@ import org.apache.commons.collections4.MapUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.common.type.ScalingType;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.upscale.ClusterUpscaleState;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterDownscaleDetails;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterDownscaleTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterScaleTriggerEvent;
@@ -27,14 +33,16 @@ import com.sequenceiq.cloudbreak.core.flow2.event.StackAndClusterUpscaleTriggerE
 import com.sequenceiq.cloudbreak.core.flow2.event.StackDownscaleTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.StackScaleTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.StackSyncTriggerEvent;
+import com.sequenceiq.cloudbreak.core.flow2.stack.upscale.StackUpscaleState;
 import com.sequenceiq.cloudbreak.domain.view.ClusterView;
 import com.sequenceiq.cloudbreak.domain.view.StackView;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.structuredevent.service.telemetry.mapper.ClusterUseCaseAware;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
 import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 @Component
-public class UpscaleFlowEventChainFactory implements FlowEventChainFactory<StackAndClusterUpscaleTriggerEvent> {
+public class UpscaleFlowEventChainFactory implements FlowEventChainFactory<StackAndClusterUpscaleTriggerEvent>, ClusterUseCaseAware {
 
     @Inject
     private StackService stackService;
@@ -60,6 +68,19 @@ public class UpscaleFlowEventChainFactory implements FlowEventChainFactory<Stack
             addStackDownscaleTriggerEventForZombieNodes(event, flowEventChain, stackView);
         }
         return new FlowTriggerEventQueue(getName(), event, flowEventChain);
+    }
+
+    @Override
+    public CDPClusterStatus.Value getUseCaseForFlowState(Enum flowState) {
+        if (StackUpscaleState.INIT_STATE.equals(flowState)) {
+            return UPSCALE_STARTED;
+        } else if (ClusterUpscaleState.FINALIZE_UPSCALE_STATE.equals(flowState)) {
+            return UPSCALE_FINISHED;
+        } else if (flowState.toString().endsWith("FAILED_STATE")) {
+            return UPSCALE_FAILED;
+        } else {
+            return UNSET;
+        }
     }
 
     private void addStackSyncTriggerEvent(StackAndClusterUpscaleTriggerEvent event, Queue<Selectable> flowEventChain) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/downscale/ClusterDownscaleState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/downscale/ClusterDownscaleState.java
@@ -4,7 +4,7 @@ import com.sequenceiq.cloudbreak.core.flow2.restart.FillInMemoryStateStoreRestar
 import com.sequenceiq.flow.core.FlowState;
 import com.sequenceiq.flow.core.RestartAction;
 
-enum ClusterDownscaleState implements FlowState {
+public enum ClusterDownscaleState implements FlowState {
     INIT_STATE,
     COLLECT_CANDIDATES_STATE,
     DECOMMISSION_STATE,

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/salt/update/SaltUpdateFlowConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/salt/update/SaltUpdateFlowConfig.java
@@ -1,5 +1,9 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.salt.update;
 
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.SALT_UPDATE_FAILED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.SALT_UPDATE_FINISHED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.SALT_UPDATE_STARTED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.UNSET;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.salt.update.SaltUpdateEvent.BOOTSTRAP_MACHINES_FAILED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.salt.update.SaltUpdateEvent.BOOTSTRAP_MACHINES_FINISHED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.salt.update.SaltUpdateEvent.CONFIGURE_KEYTABS_FAILED_EVENT;
@@ -25,11 +29,14 @@ import java.util.List;
 
 import org.springframework.stereotype.Component;
 
+import com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value;
 import com.sequenceiq.cloudbreak.core.flow2.StackStatusFinalizerAbstractFlowConfig;
+import com.sequenceiq.cloudbreak.structuredevent.service.telemetry.mapper.ClusterUseCaseAware;
+import com.sequenceiq.flow.core.FlowState;
 import com.sequenceiq.flow.core.config.AbstractFlowConfiguration.Transition.Builder;
 
 @Component
-public class SaltUpdateFlowConfig extends StackStatusFinalizerAbstractFlowConfig<SaltUpdateState, SaltUpdateEvent> {
+public class SaltUpdateFlowConfig extends StackStatusFinalizerAbstractFlowConfig<SaltUpdateState, SaltUpdateEvent> implements ClusterUseCaseAware {
 
     private static final List<Transition<SaltUpdateState, SaltUpdateEvent>> TRANSITIONS =
             new Builder<SaltUpdateState, SaltUpdateEvent>().defaultFailureEvent(SALT_UPDATE_FAILED_EVENT)
@@ -72,5 +79,18 @@ public class SaltUpdateFlowConfig extends StackStatusFinalizerAbstractFlowConfig
     @Override
     public String getDisplayName() {
         return "Salt update";
+    }
+
+    @Override
+    public Value getUseCaseForFlowState(Enum<? extends FlowState> flowState) {
+        if (INIT_STATE.equals(flowState)) {
+            return SALT_UPDATE_STARTED;
+        } else if (SALT_UPDATE_FINISHED_STATE.equals(flowState)) {
+            return SALT_UPDATE_FINISHED;
+        } else if (flowState.toString().endsWith("FAILED_STATE")) {
+            return SALT_UPDATE_FAILED;
+        } else {
+            return UNSET;
+        }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartds/StopStartDownscaleState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartds/StopStartDownscaleState.java
@@ -4,7 +4,7 @@ import com.sequenceiq.cloudbreak.core.flow2.restart.FillInMemoryStateStoreRestar
 import com.sequenceiq.flow.core.FlowState;
 import com.sequenceiq.flow.core.RestartAction;
 
-enum StopStartDownscaleState implements FlowState {
+public enum StopStartDownscaleState implements FlowState {
 
     INIT_STATE,
     STOPSTART_DOWNSCALE_GET_RECOVERY_CANDIDATES_STATE,

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartus/StopStartUpscaleState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stopstartus/StopStartUpscaleState.java
@@ -4,7 +4,7 @@ import com.sequenceiq.cloudbreak.core.flow2.restart.FillInMemoryStateStoreRestar
 import com.sequenceiq.flow.core.FlowState;
 import com.sequenceiq.flow.core.RestartAction;
 
-enum StopStartUpscaleState implements FlowState {
+public enum StopStartUpscaleState implements FlowState {
 
     INIT_STATE,
     STOPSTART_UPSCALE_GET_RECOVERY_CANDIDATES_STATE,

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/upscale/ClusterUpscaleState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/upscale/ClusterUpscaleState.java
@@ -4,7 +4,7 @@ import com.sequenceiq.cloudbreak.core.flow2.restart.FillInMemoryStateStoreRestar
 import com.sequenceiq.flow.core.FlowState;
 import com.sequenceiq.flow.core.RestartAction;
 
-enum ClusterUpscaleState implements FlowState {
+public enum ClusterUpscaleState implements FlowState {
     INIT_STATE,
     UPLOAD_UPSCALE_RECIPES_STATE,
     CHECK_HOST_METADATA_STATE,

--- a/flow/src/main/java/com/sequenceiq/flow/core/config/AbstractFlowConfiguration.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/config/AbstractFlowConfiguration.java
@@ -189,6 +189,10 @@ public abstract class AbstractFlowConfiguration<S extends FlowState, E extends F
         }
     }
 
+    public Class<S> getStateType() {
+        return stateType;
+    }
+
     static class MachineConfiguration<S, E> {
         private final StateMachineConfigurationBuilder<S, E> configurationBuilder;
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/ProvisionFlowEventChainFactory.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/ProvisionFlowEventChainFactory.java
@@ -1,20 +1,30 @@
 package com.sequenceiq.freeipa.flow.chain;
 
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value.CREATE_FAILED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value.CREATE_FINISHED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value.CREATE_STARTED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value.UNSET;
+
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.springframework.stereotype.Component;
 
+import com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.structuredevent.service.telemetry.mapper.FreeIpaUseCaseAware;
 import com.sequenceiq.flow.api.model.operation.OperationType;
+import com.sequenceiq.flow.core.FlowState;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
 import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 import com.sequenceiq.freeipa.flow.freeipa.provision.FreeIpaProvisionEvent;
+import com.sequenceiq.freeipa.flow.freeipa.provision.FreeIpaProvisionState;
 import com.sequenceiq.freeipa.flow.stack.StackEvent;
 import com.sequenceiq.freeipa.flow.stack.provision.StackProvisionEvent;
+import com.sequenceiq.freeipa.flow.stack.provision.StackProvisionState;
 
 @Component
-public class ProvisionFlowEventChainFactory implements FlowEventChainFactory<StackEvent> {
+public class ProvisionFlowEventChainFactory implements FlowEventChainFactory<StackEvent>, FreeIpaUseCaseAware {
     @Override
     public String initEvent() {
         return FlowChainTriggers.PROVISION_TRIGGER_EVENT;
@@ -32,5 +42,18 @@ public class ProvisionFlowEventChainFactory implements FlowEventChainFactory<Sta
     @Override
     public OperationType getFlowOperationType() {
         return OperationType.PROVISION;
+    }
+
+    @Override
+    public Value getUseCaseForFlowState(Enum<? extends FlowState> flowState) {
+        if (StackProvisionState.INIT_STATE.equals(flowState)) {
+            return CREATE_STARTED;
+        } else if (FreeIpaProvisionState.FREEIPA_PROVISION_FINISHED_STATE.equals(flowState)) {
+            return CREATE_FINISHED;
+        } else if (flowState.toString().endsWith("FAILED_STATE")) {
+            return CREATE_FAILED;
+        } else {
+            return UNSET;
+        }
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/UpgradeCcmFlowEventChainFactory.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/UpgradeCcmFlowEventChainFactory.java
@@ -1,21 +1,31 @@
 package com.sequenceiq.freeipa.flow.chain;
 
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value.CCM_UPGRADE_FAILED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value.CCM_UPGRADE_FINISHED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value.CCM_UPGRADE_STARTED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value.UNSET;
+
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.springframework.stereotype.Component;
 
+import com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.structuredevent.service.telemetry.mapper.FreeIpaUseCaseAware;
+import com.sequenceiq.flow.core.FlowState;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
 import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 import com.sequenceiq.freeipa.flow.stack.update.UpdateUserDataEvents;
+import com.sequenceiq.freeipa.flow.stack.update.UpdateUserDataState;
 import com.sequenceiq.freeipa.flow.stack.update.event.UserDataUpdateRequest;
+import com.sequenceiq.freeipa.flow.stack.upgrade.ccm.UpgradeCcmState;
 import com.sequenceiq.freeipa.flow.stack.upgrade.ccm.event.UpgradeCcmFlowChainTriggerEvent;
 import com.sequenceiq.freeipa.flow.stack.upgrade.ccm.event.UpgradeCcmTriggerEvent;
 import com.sequenceiq.freeipa.flow.stack.upgrade.ccm.selector.UpgradeCcmStateSelector;
 
 @Component
-public class UpgradeCcmFlowEventChainFactory implements FlowEventChainFactory<UpgradeCcmFlowChainTriggerEvent> {
+public class UpgradeCcmFlowEventChainFactory implements FlowEventChainFactory<UpgradeCcmFlowChainTriggerEvent>, FreeIpaUseCaseAware {
 
     @Override
     public String initEvent() {
@@ -39,5 +49,18 @@ public class UpgradeCcmFlowEventChainFactory implements FlowEventChainFactory<Up
                         .withFinalFlow(true)
                         .build());
         return new FlowTriggerEventQueue(getName(), event, flowEventChain);
+    }
+
+    @Override
+    public Value getUseCaseForFlowState(Enum<? extends FlowState> flowState) {
+        if (UpgradeCcmState.INIT_STATE.equals(flowState)) {
+            return CCM_UPGRADE_STARTED;
+        } else if (UpdateUserDataState.UPDATE_USERDATA_FINISHED_STATE.equals(flowState)) {
+            return CCM_UPGRADE_FINISHED;
+        } else if (flowState.toString().contains("_FAIL")) {
+            return CCM_UPGRADE_FAILED;
+        } else {
+            return UNSET;
+        }
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/verticalscale/FreeIpaVerticalScaleFlowConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/verticalscale/FreeIpaVerticalScaleFlowConfig.java
@@ -1,5 +1,9 @@
 package com.sequenceiq.freeipa.flow.freeipa.verticalscale;
 
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value.UNSET;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value.VERTICAL_SCALE_FAILED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value.VERTICAL_SCALE_FINISHED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value.VERTICAL_SCALE_STARTED;
 import static com.sequenceiq.freeipa.flow.freeipa.verticalscale.FreeIpaVerticalScaleState.FINAL_STATE;
 import static com.sequenceiq.freeipa.flow.freeipa.verticalscale.FreeIpaVerticalScaleState.INIT_STATE;
 import static com.sequenceiq.freeipa.flow.freeipa.verticalscale.FreeIpaVerticalScaleState.STACK_VERTICALSCALE_FAILED_STATE;
@@ -16,12 +20,16 @@ import java.util.List;
 
 import org.springframework.stereotype.Component;
 
+import com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value;
+import com.sequenceiq.cloudbreak.structuredevent.service.telemetry.mapper.FreeIpaUseCaseAware;
+import com.sequenceiq.flow.core.FlowState;
 import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
 import com.sequenceiq.flow.core.config.AbstractFlowConfiguration.Transition.Builder;
 import com.sequenceiq.freeipa.flow.freeipa.verticalscale.event.FreeIpaVerticalScaleEvent;
 
 @Component
-public class FreeIpaVerticalScaleFlowConfig extends AbstractFlowConfiguration<FreeIpaVerticalScaleState, FreeIpaVerticalScaleEvent> {
+public class FreeIpaVerticalScaleFlowConfig extends AbstractFlowConfiguration<FreeIpaVerticalScaleState, FreeIpaVerticalScaleEvent>
+        implements FreeIpaUseCaseAware {
     private static final List<Transition<FreeIpaVerticalScaleState, FreeIpaVerticalScaleEvent>> TRANSITIONS =
             new Builder<FreeIpaVerticalScaleState, FreeIpaVerticalScaleEvent>()
                     .defaultFailureEvent(FAILURE_EVENT)
@@ -78,6 +86,19 @@ public class FreeIpaVerticalScaleFlowConfig extends AbstractFlowConfiguration<Fr
     @Override
     public String getDisplayName() {
         return "Vertical scaling on the FreeIPA";
+    }
+
+    @Override
+    public Value getUseCaseForFlowState(Enum<? extends FlowState> flowState) {
+        if (INIT_STATE.equals(flowState)) {
+            return VERTICAL_SCALE_STARTED;
+        } else if (STACK_VERTICALSCALE_FINISHED_STATE.equals(flowState)) {
+            return VERTICAL_SCALE_FINISHED;
+        } else if (STACK_VERTICALSCALE_FAILED_STATE.equals(flowState)) {
+            return VERTICAL_SCALE_FAILED;
+        } else {
+            return UNSET;
+        }
     }
 
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/start/StackStartFlowConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/start/StackStartFlowConfig.java
@@ -1,5 +1,9 @@
 package com.sequenceiq.freeipa.flow.stack.start;
 
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value.RESUME_FAILED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value.RESUME_FINISHED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value.RESUME_STARTED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value.UNSET;
 import static com.sequenceiq.freeipa.flow.stack.start.StackStartEvent.COLLECT_METADATA_FAILED_EVENT;
 import static com.sequenceiq.freeipa.flow.stack.start.StackStartEvent.COLLECT_METADATA_FINISHED_EVENT;
 import static com.sequenceiq.freeipa.flow.stack.start.StackStartEvent.STACK_START_EVENT;
@@ -23,11 +27,14 @@ import java.util.List;
 
 import org.springframework.stereotype.Component;
 
+import com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value;
+import com.sequenceiq.cloudbreak.structuredevent.service.telemetry.mapper.FreeIpaUseCaseAware;
+import com.sequenceiq.flow.core.FlowState;
 import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
 import com.sequenceiq.flow.core.config.AbstractFlowConfiguration.Transition.Builder;
 
 @Component
-public class StackStartFlowConfig extends AbstractFlowConfiguration<StackStartState, StackStartEvent> {
+public class StackStartFlowConfig extends AbstractFlowConfiguration<StackStartState, StackStartEvent> implements FreeIpaUseCaseAware {
 
     private static final List<Transition<StackStartState, StackStartEvent>> TRANSITIONS = new Builder<StackStartState, StackStartEvent>()
             .defaultFailureEvent(START_FAILURE_EVENT)
@@ -72,5 +79,18 @@ public class StackStartFlowConfig extends AbstractFlowConfiguration<StackStartSt
     @Override
     protected FlowEdgeConfig<StackStartState, StackStartEvent> getEdgeConfig() {
         return EDGE_CONFIG;
+    }
+
+    @Override
+    public Value getUseCaseForFlowState(Enum<? extends FlowState> flowState) {
+        if (INIT_STATE.equals(flowState)) {
+            return RESUME_STARTED;
+        } else if (START_FINISHED_STATE.equals(flowState)) {
+            return RESUME_FINISHED;
+        } else if (START_FAILED_STATE.equals(flowState)) {
+            return RESUME_FAILED;
+        } else {
+            return UNSET;
+        }
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/StackTerminationFlowConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/StackTerminationFlowConfig.java
@@ -1,5 +1,9 @@
 package com.sequenceiq.freeipa.flow.stack.termination;
 
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value.DELETE_FAILED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value.DELETE_FINISHED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value.DELETE_STARTED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value.UNSET;
 import static com.sequenceiq.freeipa.flow.stack.termination.StackTerminationEvent.CCM_KEY_DEREGISTRATION_FINISHED_EVENT;
 import static com.sequenceiq.freeipa.flow.stack.termination.StackTerminationEvent.CLUSTER_PROXY_DEREGISTRATION_FINISHED_EVENT;
 import static com.sequenceiq.freeipa.flow.stack.termination.StackTerminationEvent.EXECUTE_PRE_TERMINATION_RECIPES_FINISHED_EVENT;
@@ -25,11 +29,14 @@ import java.util.List;
 
 import org.springframework.stereotype.Component;
 
+import com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value;
+import com.sequenceiq.cloudbreak.structuredevent.service.telemetry.mapper.FreeIpaUseCaseAware;
+import com.sequenceiq.flow.core.FlowState;
 import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
 import com.sequenceiq.flow.core.config.AbstractFlowConfiguration.Transition.Builder;
 
 @Component
-public class StackTerminationFlowConfig extends AbstractFlowConfiguration<StackTerminationState, StackTerminationEvent> {
+public class StackTerminationFlowConfig extends AbstractFlowConfiguration<StackTerminationState, StackTerminationEvent> implements FreeIpaUseCaseAware {
 
     private static final List<Transition<StackTerminationState, StackTerminationEvent>> TRANSITIONS =
             new Builder<StackTerminationState, StackTerminationEvent>()
@@ -75,5 +82,18 @@ public class StackTerminationFlowConfig extends AbstractFlowConfiguration<StackT
     @Override
     public String getDisplayName() {
         return "Terminate stack";
+    }
+
+    @Override
+    public Value getUseCaseForFlowState(Enum<? extends FlowState> flowState) {
+        if (INIT_STATE.equals(flowState)) {
+            return DELETE_STARTED;
+        } else if (TERMINATION_FINISHED_STATE.equals(flowState)) {
+            return DELETE_FINISHED;
+        } else if (TERMINATION_FAILED_STATE.equals(flowState)) {
+            return DELETE_FAILED;
+        } else {
+            return UNSET;
+        }
     }
 }

--- a/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/log/environment/CDPEnvironmentLogger.java
+++ b/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/log/environment/CDPEnvironmentLogger.java
@@ -6,8 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.cloudera.thunderhead.service.common.usage.UsageProto;
-import com.sequenceiq.cloudbreak.structuredevent.event.FlowDetails;
+import com.cloudera.thunderhead.service.common.usage.UsageProto.CDPEnvironmentStatus.Value;
 import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPStructuredFlowEvent;
 import com.sequenceiq.cloudbreak.structuredevent.event.cdp.environment.CDPEnvironmentStructuredFlowEvent;
 import com.sequenceiq.cloudbreak.structuredevent.service.telemetry.converter.CDPEnvironmentStructuredFlowEventToCDPEnvironmentRequestedConverter;
@@ -35,18 +34,15 @@ public class CDPEnvironmentLogger implements CDPTelemetryEventLogger {
 
     @Override
     public void log(CDPStructuredFlowEvent cdpStructuredFlowEvent) {
-
-        FlowDetails flow = cdpStructuredFlowEvent.getFlow();
-        UsageProto.CDPEnvironmentStatus.Value useCase = environmentUseCaseMapper.useCase(flow);
-        LOGGER.debug("Telemetry use case: {}", useCase);
-
-        if (cdpStructuredFlowEvent instanceof CDPEnvironmentStructuredFlowEvent &&
-                useCase != UsageProto.CDPEnvironmentStatus.Value.UNSET) {
-            LOGGER.debug("Sending usage report for {}", cdpStructuredFlowEvent.getOperation().getResourceType());
-            usageReporter.cdpEnvironmentRequested(
-                    environmentRequestedConverter.convert((CDPEnvironmentStructuredFlowEvent) cdpStructuredFlowEvent));
-            usageReporter.cdpEnvironmentStatusChanged(
-                    statusChangedConverter.convert((CDPEnvironmentStructuredFlowEvent) cdpStructuredFlowEvent, useCase));
+        if (cdpStructuredFlowEvent instanceof CDPEnvironmentStructuredFlowEvent) {
+            Value useCase = environmentUseCaseMapper.useCase(cdpStructuredFlowEvent.getFlow());
+            if (useCase != Value.UNSET) {
+                LOGGER.debug("Sending usage report for {}", cdpStructuredFlowEvent.getOperation().getResourceType());
+                usageReporter.cdpEnvironmentRequested(
+                        environmentRequestedConverter.convert((CDPEnvironmentStructuredFlowEvent) cdpStructuredFlowEvent));
+                usageReporter.cdpEnvironmentStatusChanged(
+                        statusChangedConverter.convert((CDPEnvironmentStructuredFlowEvent) cdpStructuredFlowEvent, useCase));
+            }
         }
     }
 }

--- a/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/log/environment/CDPFreeIpaLogger.java
+++ b/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/log/environment/CDPFreeIpaLogger.java
@@ -6,8 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.cloudera.thunderhead.service.common.usage.UsageProto;
-import com.sequenceiq.cloudbreak.structuredevent.event.FlowDetails;
+import com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value;
 import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPStructuredFlowEvent;
 import com.sequenceiq.cloudbreak.structuredevent.event.cdp.freeipa.CDPFreeIpaStructuredFlowEvent;
 import com.sequenceiq.cloudbreak.structuredevent.service.telemetry.converter.CDPFreeIpaStructuredFlowEventToCDPFreeIpaStatusChangedConverter;
@@ -31,16 +30,13 @@ public class CDPFreeIpaLogger implements CDPTelemetryEventLogger {
 
     @Override
     public void log(CDPStructuredFlowEvent cdpStructuredFlowEvent) {
-
-        FlowDetails flow = cdpStructuredFlowEvent.getFlow();
-        UsageProto.CDPFreeIPAStatus.Value useCase = freeIpaUseCaseMapper.useCase(flow);
-        LOGGER.debug("Telemetry use case: {}", useCase);
-
-        if (cdpStructuredFlowEvent instanceof CDPFreeIpaStructuredFlowEvent &&
-                useCase != UsageProto.CDPFreeIPAStatus.Value.UNSET) {
-            LOGGER.debug("Sending usage report for {}", cdpStructuredFlowEvent.getOperation().getResourceType());
-            usageReporter.cdpFreeIpaStatusChanged(
-                    statusChangedConverter.convert((CDPFreeIpaStructuredFlowEvent) cdpStructuredFlowEvent, useCase));
+        if (cdpStructuredFlowEvent instanceof CDPFreeIpaStructuredFlowEvent) {
+            Value useCase = freeIpaUseCaseMapper.useCase(cdpStructuredFlowEvent.getFlow());
+            if (useCase != Value.UNSET) {
+                LOGGER.debug("Sending usage report for {}", cdpStructuredFlowEvent.getOperation().getResourceType());
+                usageReporter.cdpFreeIpaStatusChanged(
+                        statusChangedConverter.convert((CDPFreeIpaStructuredFlowEvent) cdpStructuredFlowEvent, useCase));
+            }
         }
     }
 }

--- a/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/mapper/EnvironmentUseCaseAware.java
+++ b/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/mapper/EnvironmentUseCaseAware.java
@@ -1,0 +1,6 @@
+package com.sequenceiq.cloudbreak.structuredevent.service.telemetry.mapper;
+
+import com.cloudera.thunderhead.service.common.usage.UsageProto.CDPEnvironmentStatus.Value;
+
+public interface EnvironmentUseCaseAware extends UseCaseAware<Value> {
+}

--- a/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/mapper/FreeIpaUseCaseAware.java
+++ b/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/mapper/FreeIpaUseCaseAware.java
@@ -1,0 +1,6 @@
+package com.sequenceiq.cloudbreak.structuredevent.service.telemetry.mapper;
+
+import com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value;
+
+public interface FreeIpaUseCaseAware extends UseCaseAware<Value> {
+}

--- a/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/mapper/UseCaseAware.java
+++ b/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/mapper/UseCaseAware.java
@@ -1,0 +1,8 @@
+package com.sequenceiq.cloudbreak.structuredevent.service.telemetry.mapper;
+
+import com.sequenceiq.flow.core.FlowState;
+
+public interface UseCaseAware<E> {
+
+    E getUseCaseForFlowState(Enum<? extends FlowState> flowState);
+}

--- a/structuredevent-service-cdp/src/test/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/mapper/EnvironmentUseCaseMapperTest.java
+++ b/structuredevent-service-cdp/src/test/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/mapper/EnvironmentUseCaseMapperTest.java
@@ -1,105 +1,181 @@
 package com.sequenceiq.cloudbreak.structuredevent.service.telemetry.mapper;
 
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPEnvironmentStatus.Value.CREATE_FAILED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPEnvironmentStatus.Value.CREATE_FINISHED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPEnvironmentStatus.Value.CREATE_STARTED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPEnvironmentStatus.Value.UNSET;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.test.util.ReflectionTestUtils;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.cloudera.thunderhead.service.common.usage.UsageProto;
+import com.cloudera.thunderhead.service.common.usage.UsageProto.CDPEnvironmentStatus.Value;
 import com.sequenceiq.cloudbreak.structuredevent.event.FlowDetails;
+import com.sequenceiq.flow.core.FlowEvent;
+import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
+import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
 
+@ExtendWith(MockitoExtension.class)
 class EnvironmentUseCaseMapperTest {
 
+    @Spy
+    private List<AbstractFlowConfiguration> flowConfigurations = new ArrayList<>();
+
+    @Spy
+    private CDPRequestProcessingStepMapper cdpRequestProcessingStepMapper;
+
+    @InjectMocks
     private EnvironmentUseCaseMapper underTest;
 
     @BeforeEach()
     void setUp() {
-        underTest = new EnvironmentUseCaseMapper();
-        ReflectionTestUtils.setField(underTest, "cdpRequestProcessingStepMapper", new CDPRequestProcessingStepMapper());
+        flowConfigurations.add(new TestFlowConfig(TestFlowState.class, TestEvent.class));
+        underTest.init();
     }
 
     @Test
     void testNullFlowDetailsMappedToUnset() {
-        Assertions.assertEquals(UsageProto.CDPEnvironmentStatus.Value.UNSET, underTest.useCase(null));
+        Assertions.assertEquals(UNSET, underTest.useCase(null));
     }
 
     @Test
     void testEmptyFlowDetailsMappedToUnset() {
-        Assertions.assertEquals(UsageProto.CDPEnvironmentStatus.Value.UNSET, underTest.useCase(new FlowDetails()));
+        Assertions.assertEquals(UNSET, underTest.useCase(new FlowDetails()));
     }
 
     @Test
-    void testOtherNextFlowStateMappedToUnsetUseCase() {
-        Assertions.assertEquals(UsageProto.CDPEnvironmentStatus.Value.UNSET,
-                mapFlowDetailsToUseCase("SOME_STATE"));
-        Assertions.assertEquals(UsageProto.CDPEnvironmentStatus.Value.UNSET,
-                mapFlowDetailsWithFlowTypeToUseCase("SOME_STATE", "SomeOtherFlowConfig"));
+    void testFlowChainTypeIsIgnored() {
+        Assertions.assertEquals(CREATE_STARTED,
+                mapFlowDetailsToUseCase("INIT_STATE", "TestFlowConfig", ""));
+        Assertions.assertEquals(CREATE_STARTED,
+                mapFlowDetailsToUseCase("INIT_STATE", "TestFlowConfig", "TestFlowChain"));
     }
 
     @Test
-    void testInitNextFlowStatesMappedToStartedUseCases() {
-        Assertions.assertEquals(UsageProto.CDPEnvironmentStatus.Value.CREATE_STARTED,
-                mapFlowDetailsWithFlowTypeToUseCase("INIT_STATE", "EnvCreationFlowConfig"));
-        Assertions.assertEquals(UsageProto.CDPEnvironmentStatus.Value.DELETE_STARTED,
-                mapFlowDetailsWithFlowTypeToUseCase("INIT_STATE", "EnvDeleteFlowConfig"));
-        Assertions.assertEquals(UsageProto.CDPEnvironmentStatus.Value.RESUME_STARTED,
-                mapFlowDetailsWithFlowTypeToUseCase("INIT_STATE", "EnvStartFlowConfig"));
-        Assertions.assertEquals(UsageProto.CDPEnvironmentStatus.Value.SUSPEND_STARTED,
-                mapFlowDetailsWithFlowTypeToUseCase("INIT_STATE", "EnvStopFlowConfig"));
+    void testCorrectNextFlowStatesMappedCorrectly() {
+        Assertions.assertEquals(CREATE_STARTED,
+                mapFlowDetailsToUseCase("INIT_STATE", "TestFlowConfig"));
+        Assertions.assertEquals(CREATE_FINISHED,
+                mapFlowDetailsToUseCase("FINISHED_STATE", "TestFlowConfig"));
+        Assertions.assertEquals(CREATE_FAILED,
+                mapFlowDetailsToUseCase("FAILED_STATE", "TestFlowConfig"));
+        Assertions.assertEquals(UNSET,
+                mapFlowDetailsToUseCase("TEMP_STATE", "TestFlowConfig"));
+        Assertions.assertEquals(UNSET,
+                mapFlowDetailsToUseCase("NOT_THE_LATEST_FAILED_STATE", "TestFlowConfig"));
+        Assertions.assertEquals(UNSET,
+                mapFlowDetailsToUseCase("FINAL_STATE", "TestFlowConfig"));
     }
 
     @Test
-    void testInitNextFlowStateWithIncorrectFlowTypeMappedToUnsetUseCase() {
-        Assertions.assertEquals(UsageProto.CDPEnvironmentStatus.Value.UNSET,
-                mapFlowDetailsToUseCase("INIT_STATE"));
-        Assertions.assertEquals(UsageProto.CDPEnvironmentStatus.Value.UNSET,
-                mapFlowDetailsWithFlowTypeToUseCase("INIT_STATE", "SomeOtherFlowConfig"));
+    void testIncorrectNextFlowStatesMappedToUnsetUseCase() {
+        Assertions.assertEquals(UNSET,
+                mapFlowDetailsToUseCase("OTHER_STATE", "TestFlowConfig"));
+        Assertions.assertEquals(UNSET,
+                mapFlowDetailsToUseCase(null, "TestFlowConfig"));
+        Assertions.assertEquals(UNSET,
+                mapFlowDetailsToUseCase("", "TestFlowConfig"));
     }
 
     @Test
-    void testCorrectFinishedAndFailedNextFlowStatesMappedCorrectly() {
-        Assertions.assertEquals(UsageProto.CDPEnvironmentStatus.Value.CREATE_FINISHED,
-                mapFlowDetailsToUseCase("ENV_CREATION_FINISHED_STATE"));
-        Assertions.assertEquals(UsageProto.CDPEnvironmentStatus.Value.CREATE_FAILED,
-                mapFlowDetailsToUseCase("ENV_CREATION_FAILED_STATE"));
-        Assertions.assertEquals(UsageProto.CDPEnvironmentStatus.Value.DELETE_FINISHED,
-                mapFlowDetailsToUseCase("ENV_DELETE_FINISHED_STATE"));
-        Assertions.assertEquals(UsageProto.CDPEnvironmentStatus.Value.DELETE_FAILED,
-                mapFlowDetailsToUseCase("ENV_DELETE_FAILED_STATE"));
-        Assertions.assertEquals(UsageProto.CDPEnvironmentStatus.Value.RESUME_FINISHED,
-                mapFlowDetailsToUseCase("ENV_START_FINISHED_STATE"));
-        Assertions.assertEquals(UsageProto.CDPEnvironmentStatus.Value.RESUME_FAILED,
-                mapFlowDetailsToUseCase("ENV_START_FAILED_STATE"));
-        Assertions.assertEquals(UsageProto.CDPEnvironmentStatus.Value.SUSPEND_FINISHED,
-                mapFlowDetailsToUseCase("ENV_STOP_FINISHED_STATE"));
-        Assertions.assertEquals(UsageProto.CDPEnvironmentStatus.Value.SUSPEND_FAILED,
-                mapFlowDetailsToUseCase("ENV_STOP_FAILED_STATE"));
+    void testIncorrectFlowConfigMappedToUnsetUseCase() {
+        Assertions.assertEquals(UNSET,
+                mapFlowDetailsToUseCase("INIT_STATE", "OtherFlowConfig"));
+        Assertions.assertEquals(UNSET,
+                mapFlowDetailsToUseCase("INIT_STATE", null));
+        Assertions.assertEquals(UNSET,
+                mapFlowDetailsToUseCase("INIT_STATE", ""));
     }
 
-    @Test
-    void testOtherFinishedAndFailedNextFlowStatesMappedToUnsetUseCase() {
-        Assertions.assertEquals(UsageProto.CDPEnvironmentStatus.Value.UNSET,
-                mapFlowDetailsToUseCase("SOME_OTHER_FINISHED_STATE"));
-        Assertions.assertEquals(UsageProto.CDPEnvironmentStatus.Value.UNSET,
-                mapFlowDetailsToUseCase("SOME_OTHER_FAILED_STATE"));
-        Assertions.assertEquals(UsageProto.CDPEnvironmentStatus.Value.UNSET,
-                mapFlowDetailsToUseCase("_FINISHED_STATE"));
-        Assertions.assertEquals(UsageProto.CDPEnvironmentStatus.Value.UNSET,
-                mapFlowDetailsToUseCase("_FAILED_STATE"));
+    private Value mapFlowDetailsToUseCase(String nextFlowState, String flowType) {
+        return mapFlowDetailsToUseCase(nextFlowState, flowType, null);
     }
 
-    private UsageProto.CDPEnvironmentStatus.Value mapFlowDetailsWithFlowTypeToUseCase(String nextFlowState, String flowType) {
+    private Value mapFlowDetailsToUseCase(String nextFlowState, String flowType, String flowChainType) {
         FlowDetails flowDetails = new FlowDetails();
         flowDetails.setNextFlowState(nextFlowState);
         flowDetails.setFlowType(flowType);
-
+        flowDetails.setFlowChainType(flowChainType);
         return underTest.useCase(flowDetails);
     }
 
-    private UsageProto.CDPEnvironmentStatus.Value mapFlowDetailsToUseCase(String nextFlowState) {
-        FlowDetails flowDetails = new FlowDetails();
-        flowDetails.setNextFlowState(nextFlowState);
+    private class TestFlowConfig extends AbstractFlowConfiguration<TestFlowState, TestEvent> implements EnvironmentUseCaseAware {
 
-        return underTest.useCase(flowDetails);
+        protected TestFlowConfig(Class stateType, Class eventType) {
+            super(stateType, eventType);
+        }
+
+        @Override
+        public Value getUseCaseForFlowState(Enum<? extends FlowState> flowState) {
+            if (flowState.equals(TestFlowState.INIT_STATE)) {
+                return CREATE_STARTED;
+            } else if (flowState.toString().endsWith("FAILED_STATE")
+                    && !flowState.equals(TestFlowState.NOT_THE_LATEST_FAILED_STATE)) {
+                return CREATE_FAILED;
+            } else if (flowState.equals(TestFlowState.FINISHED_STATE)) {
+                return CREATE_FINISHED;
+            }
+            return UNSET;
+        }
+
+        @Override
+        protected List<Transition<TestFlowState, TestEvent>> getTransitions() {
+            return null;
+        }
+
+        @Override
+        protected FlowEdgeConfig getEdgeConfig() {
+            return null;
+        }
+
+        @Override
+        public TestEvent[] getEvents() {
+            return new TestEvent[0];
+        }
+
+        @Override
+        public TestEvent[] getInitEvents() {
+            return new TestEvent[0];
+        }
+
+        @Override
+        public String getDisplayName() {
+            return null;
+        }
+    }
+
+    private enum TestFlowState implements FlowState {
+        INIT_STATE,
+        TEMP_STATE,
+        NOT_THE_LATEST_FAILED_STATE,
+        FAILED_STATE,
+        FINISHED_STATE,
+        FINAL_STATE;
+
+        @Override
+        public Class<? extends RestartAction> restartAction() {
+            return null;
+        }
+    }
+
+    private class TestEvent implements FlowEvent {
+
+        @Override
+        public String name() {
+            return null;
+        }
+
+        @Override
+        public String event() {
+            return null;
+        }
     }
 }

--- a/structuredevent-service-cdp/src/test/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/mapper/FreeIpaUseCaseMapperTest.java
+++ b/structuredevent-service-cdp/src/test/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/mapper/FreeIpaUseCaseMapperTest.java
@@ -1,133 +1,251 @@
 package com.sequenceiq.cloudbreak.structuredevent.service.telemetry.mapper;
 
-import org.junit.jupiter.api.Assertions;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value.CREATE_FAILED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value.CREATE_FINISHED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value.CREATE_STARTED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value.UNSET;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value.UPSCALE_FAILED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value.UPSCALE_FINISHED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value.UPSCALE_STARTED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.test.util.ReflectionTestUtils;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.cloudera.thunderhead.service.common.usage.UsageProto;
+import com.cloudera.thunderhead.service.common.usage.UsageProto.CDPFreeIPAStatus.Value;
+import com.sequenceiq.cloudbreak.common.event.Payload;
 import com.sequenceiq.cloudbreak.structuredevent.event.FlowDetails;
+import com.sequenceiq.flow.core.FlowEvent;
+import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
+import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
+import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
 
+@ExtendWith(MockitoExtension.class)
 class FreeIpaUseCaseMapperTest {
 
-    private static final String UPSCALEFLOWCONFIG = "UpscaleFlowConfig";
+    @Spy
+    private List<AbstractFlowConfiguration> flowConfigurations = new ArrayList<>();
 
-    private static final String OTHERFLOWEVENTCHAINFACTORY = "OtherFlowEventChainFactory";
+    @Spy
+    private List<FlowEventChainFactory> flowEventChainFactories = new ArrayList<>();
 
-    private static final String UPSCALE_FINISHED_STATE = "UPSCALE_FINISHED_STATE";
+    @Spy
+    private CDPRequestProcessingStepMapper cdpRequestProcessingStepMapper;
 
-    private static final String SOMETHING_FAILED_STATE = "SOMETHING_FAILED_STATE";
-
-    private static final String INIT_STATE = "INIT_STATE";
-
+    @InjectMocks
     private FreeIpaUseCaseMapper underTest;
 
     @BeforeEach()
     void setUp() {
-        underTest = new FreeIpaUseCaseMapper();
-        ReflectionTestUtils.setField(underTest, "cdpRequestProcessingStepMapper", new CDPRequestProcessingStepMapper());
-        underTest.initUseCaseMaps();
+        flowConfigurations.add(new TestFlowConfig(TestFlowState.class, TestEvent.class));
+        flowEventChainFactories.add(new TestFlowEventChainFactory());
+        underTest.init();
     }
 
     @Test
     void testNullFlowDetailsMappedToUnset() {
-        Assertions.assertEquals(UsageProto.CDPFreeIPAStatus.Value.UNSET, underTest.useCase(null));
+        assertEquals(UNSET, underTest.useCase(null));
     }
 
     @Test
     void testEmptyFlowDetailsMappedToUnset() {
-        Assertions.assertEquals(UsageProto.CDPFreeIPAStatus.Value.UNSET, underTest.useCase(new FlowDetails()));
+        assertEquals(UNSET, underTest.useCase(new FlowDetails()));
     }
 
     @Test
-    void testOtherNextFlowStateMappedToUnsetUseCase() {
-        Assertions.assertEquals(UsageProto.CDPFreeIPAStatus.Value.UNSET,
-                mapFlowDetailsToUseCase(null, UPSCALEFLOWCONFIG, "SOME_STATE"));
+    void testCorrectNextFlowStatesMappedCorrectly() {
+        assertEquals(CREATE_STARTED,
+                mapFlowDetailsToUseCase("INIT_STATE", "TestFlowConfig"));
+        assertEquals(CREATE_FINISHED,
+                mapFlowDetailsToUseCase("FINISHED_STATE", "TestFlowConfig"));
+        assertEquals(CREATE_FAILED,
+                mapFlowDetailsToUseCase("FAILED_STATE", "TestFlowConfig"));
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("TEMP_STATE", "TestFlowConfig"));
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("NOT_THE_LATEST_FAILED_STATE", "TestFlowConfig"));
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("FINAL_STATE", "TestFlowConfig"));
     }
 
     @Test
-    void testInitNextFlowStateWithCorrectFlowChainAndFlowTypeMappedToCorrectUseCase() {
-        Assertions.assertEquals(UsageProto.CDPFreeIPAStatus.Value.UPSCALE_STARTED,
-                mapFlowDetailsToUseCase(null, UPSCALEFLOWCONFIG, INIT_STATE));
-        Assertions.assertEquals(UsageProto.CDPFreeIPAStatus.Value.CREATE_STARTED,
-                mapFlowDetailsToUseCase("ProvisionFlowEventChainFactory", "StackProvisionFlowConfig", INIT_STATE));
-        Assertions.assertEquals(UsageProto.CDPFreeIPAStatus.Value.DELETE_STARTED,
-                mapFlowDetailsToUseCase(null, "StackTerminationFlowConfig", INIT_STATE));
-        Assertions.assertEquals(UsageProto.CDPFreeIPAStatus.Value.SUSPEND_STARTED,
-                mapFlowDetailsToUseCase(null, "StackStopFlowConfig", INIT_STATE));
-        Assertions.assertEquals(UsageProto.CDPFreeIPAStatus.Value.RESUME_STARTED,
-                mapFlowDetailsToUseCase(null, "StackStartFlowConfig", INIT_STATE));
-
+    void testCorrectNextFlowStatesInFlowChainMappedCorrectly() {
+        assertEquals(UPSCALE_STARTED,
+                mapFlowDetailsToUseCase("INIT_STATE", "TestFlowConfig", "TestFlowEventChainFactory"));
+        assertEquals(UPSCALE_FINISHED,
+                mapFlowDetailsToUseCase("FINISHED_STATE", "TestFlowConfig", "TestFlowEventChainFactory"));
+        assertEquals(UPSCALE_FAILED,
+                mapFlowDetailsToUseCase("FAILED_STATE", "TestFlowConfig", "TestFlowEventChainFactory"));
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("TEMP_STATE", "TestFlowConfig", "TestFlowEventChainFactory"));
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("NOT_THE_LATEST_FAILED_STATE", "TestFlowConfig", "TestFlowEventChainFactory"));
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("FINAL_STATE", "TestFlowConfig", "TestFlowEventChainFactory"));
     }
 
     @Test
-    void testInitNextFlowStateWithIncorrectFlowChainAndFlowTypeMappedToUnsetUseCase() {
-        Assertions.assertEquals(UsageProto.CDPFreeIPAStatus.Value.UNSET,
-                mapFlowDetailsToUseCase(OTHERFLOWEVENTCHAINFACTORY, UPSCALEFLOWCONFIG, INIT_STATE));
-        Assertions.assertEquals(UsageProto.CDPFreeIPAStatus.Value.UNSET,
-                mapFlowDetailsToUseCase(OTHERFLOWEVENTCHAINFACTORY, "OtherFlowConfig", INIT_STATE));
-        Assertions.assertEquals(UsageProto.CDPFreeIPAStatus.Value.UNSET,
-                mapFlowDetailsToUseCase(OTHERFLOWEVENTCHAINFACTORY, null, INIT_STATE));
-        Assertions.assertEquals(UsageProto.CDPFreeIPAStatus.Value.UNSET,
-                mapFlowDetailsToUseCase(null, null, INIT_STATE));
+    void testIncorrectNextFlowStatesMappedToUnsetUseCase() {
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("OTHER_STATE", "TestFlowConfig"));
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase(null, "TestFlowConfig"));
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("", "TestFlowConfig"));
     }
 
     @Test
-    void testCorrectFinishedAndFailedNextFlowStatesWithCorrectFlowChainMappedToCorrectUseCase() {
-        Assertions.assertEquals(UsageProto.CDPFreeIPAStatus.Value.UPSCALE_FINISHED,
-                mapFlowDetailsToUseCase(null, UPSCALEFLOWCONFIG, UPSCALE_FINISHED_STATE));
-        Assertions.assertEquals(UsageProto.CDPFreeIPAStatus.Value.UPSCALE_FAILED,
-                mapFlowDetailsToUseCase(null, UPSCALEFLOWCONFIG, SOMETHING_FAILED_STATE));
-        Assertions.assertEquals(UsageProto.CDPFreeIPAStatus.Value.UPSCALE_FAILED,
-                mapFlowDetailsToUseCase(null, UPSCALEFLOWCONFIG, "SOME_FAIL_STATE"));
-
-        Assertions.assertEquals(UsageProto.CDPFreeIPAStatus.Value.CREATE_FINISHED,
-                mapFlowDetailsToUseCase("ProvisionFlowEventChainFactory", "FreeIpaProvisionFlowConfig", "FREEIPA_PROVISION_FINISHED_STATE"));
-        Assertions.assertEquals(UsageProto.CDPFreeIPAStatus.Value.CREATE_FAILED,
-                mapFlowDetailsToUseCase("ProvisionFlowEventChainFactory", "StackProvisionFlowConfig", SOMETHING_FAILED_STATE));
-        Assertions.assertEquals(UsageProto.CDPFreeIPAStatus.Value.CREATE_FAILED,
-                mapFlowDetailsToUseCase("ProvisionFlowEventChainFactory", "FreeIpaProvisionFlowConfig", SOMETHING_FAILED_STATE));
-
-        Assertions.assertEquals(UsageProto.CDPFreeIPAStatus.Value.DELETE_FINISHED,
-                mapFlowDetailsToUseCase(null, "StackTerminationFlowConfig", "TERMINATION_FINISHED_STATE"));
-        Assertions.assertEquals(UsageProto.CDPFreeIPAStatus.Value.DELETE_FAILED,
-                mapFlowDetailsToUseCase(null, "StackTerminationFlowConfig", SOMETHING_FAILED_STATE));
-
-        Assertions.assertEquals(UsageProto.CDPFreeIPAStatus.Value.SUSPEND_FINISHED,
-                mapFlowDetailsToUseCase(null, "StackStopFlowConfig", "STOP_FINISHED_STATE"));
-        Assertions.assertEquals(UsageProto.CDPFreeIPAStatus.Value.SUSPEND_FAILED,
-                mapFlowDetailsToUseCase(null, "StackStopFlowConfig", SOMETHING_FAILED_STATE));
-
-        Assertions.assertEquals(UsageProto.CDPFreeIPAStatus.Value.RESUME_FINISHED,
-                mapFlowDetailsToUseCase(null, "StackStartFlowConfig", "START_FINISHED_STATE"));
-        Assertions.assertEquals(UsageProto.CDPFreeIPAStatus.Value.RESUME_FAILED,
-                mapFlowDetailsToUseCase(null, "StackStartFlowConfig", SOMETHING_FAILED_STATE));
+    void testIncorrectNextFlowStatesInFlowChainMappedToUnsetUseCase() {
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("OTHER_STATE", "TestFlowConfig", "TestFlowEventChainFactory"));
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase(null, "TestFlowConfig", "TestFlowEventChainFactory"));
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("", "TestFlowConfig", "TestFlowEventChainFactory"));
     }
 
     @Test
-    void testCorrectFinishedAndFailedNextFlowStatesWithIncorrectFlowChainMappedToUnsetUseCase() {
-        Assertions.assertEquals(UsageProto.CDPFreeIPAStatus.Value.UNSET,
-                mapFlowDetailsToUseCase(OTHERFLOWEVENTCHAINFACTORY, UPSCALEFLOWCONFIG, UPSCALE_FINISHED_STATE));
-        Assertions.assertEquals(UsageProto.CDPFreeIPAStatus.Value.UNSET,
-                mapFlowDetailsToUseCase(null, null, UPSCALE_FINISHED_STATE));
-        Assertions.assertEquals(UsageProto.CDPFreeIPAStatus.Value.UNSET,
-                mapFlowDetailsToUseCase(OTHERFLOWEVENTCHAINFACTORY, null, SOMETHING_FAILED_STATE));
-        Assertions.assertEquals(UsageProto.CDPFreeIPAStatus.Value.UNSET,
-                mapFlowDetailsToUseCase(null, null, SOMETHING_FAILED_STATE));
+    void testIncorrectFlowConfigMappedToUnsetUseCase() {
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("INIT_STATE", "OtherFlowConfig"));
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("INIT_STATE", null));
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("INIT_STATE", ""));
     }
 
     @Test
-    void testIncorrectFinishedNextFlowStatesWithCorrectFlowMappedToUnsetUseCase() {
-        Assertions.assertEquals(UsageProto.CDPFreeIPAStatus.Value.UNSET,
-                mapFlowDetailsToUseCase(null, UPSCALEFLOWCONFIG, "OTHER_FINISHED_STATE"));
+    void testIncorrectFlowConfigInFlowChainMappedToUnsetUseCase() {
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("INIT_STATE", "OtherFlowConfig", "TestFlowEventChainFactory"));
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("INIT_STATE", null, "TestFlowEventChainFactory"));
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("INIT_STATE", "", "TestFlowEventChainFactory"));
     }
 
-    private UsageProto.CDPFreeIPAStatus.Value mapFlowDetailsToUseCase(String flowChainType, String flowType, String nextFlowState) {
+    @Test
+    void testIncorrectFlowChainInFlowChainMappedToUnsetUseCase() {
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("INIT_STATE", "TestFlowConfig", "OtherFlowEventChainFactory"));
+    }
+
+    private Value mapFlowDetailsToUseCase(String nextFlowState, String flowType) {
+        return mapFlowDetailsToUseCase(nextFlowState, flowType, null);
+    }
+
+    private Value mapFlowDetailsToUseCase(String nextFlowState, String flowType, String flowChainType) {
         FlowDetails flowDetails = new FlowDetails();
-        flowDetails.setFlowChainType(flowChainType);
-        flowDetails.setFlowType(flowType);
         flowDetails.setNextFlowState(nextFlowState);
-
+        flowDetails.setFlowType(flowType);
+        flowDetails.setFlowChainType(flowChainType);
         return underTest.useCase(flowDetails);
+    }
+
+    private class TestFlowEventChainFactory implements FlowEventChainFactory, FreeIpaUseCaseAware {
+
+        @Override
+        public String initEvent() {
+            return null;
+        }
+
+        @Override
+        public FlowTriggerEventQueue createFlowTriggerEventQueue(Payload event) {
+            return null;
+        }
+
+        @Override
+        public Value getUseCaseForFlowState(Enum flowState) {
+            if (flowState.equals(TestFlowState.INIT_STATE)) {
+                return UPSCALE_STARTED;
+            } else if (flowState.toString().endsWith("FAILED_STATE")
+                    && !flowState.equals(TestFlowState.NOT_THE_LATEST_FAILED_STATE)) {
+                return UPSCALE_FAILED;
+            } else if (flowState.equals(TestFlowState.FINISHED_STATE)) {
+                return UPSCALE_FINISHED;
+            }
+            return UNSET;
+        }
+    }
+
+    private class TestFlowConfig extends AbstractFlowConfiguration<TestFlowState, TestEvent> implements FreeIpaUseCaseAware {
+
+        protected TestFlowConfig(Class stateType, Class eventType) {
+            super(stateType, eventType);
+        }
+
+        @Override
+        public Value getUseCaseForFlowState(Enum<? extends FlowState> flowState) {
+            if (flowState.equals(TestFlowState.INIT_STATE)) {
+                return CREATE_STARTED;
+            } else if (flowState.toString().endsWith("FAILED_STATE")
+                    && !flowState.equals(TestFlowState.NOT_THE_LATEST_FAILED_STATE)) {
+                return CREATE_FAILED;
+            } else if (flowState.equals(TestFlowState.FINISHED_STATE)) {
+                return CREATE_FINISHED;
+            }
+            return UNSET;
+        }
+
+        @Override
+        protected List<Transition<TestFlowState, TestEvent>> getTransitions() {
+            return null;
+        }
+
+        @Override
+        protected FlowEdgeConfig getEdgeConfig() {
+            return null;
+        }
+
+        @Override
+        public TestEvent[] getEvents() {
+            return new TestEvent[0];
+        }
+
+        @Override
+        public TestEvent[] getInitEvents() {
+            return new TestEvent[0];
+        }
+
+        @Override
+        public String getDisplayName() {
+            return null;
+        }
+    }
+
+    private enum TestFlowState implements FlowState {
+        INIT_STATE,
+        TEMP_STATE,
+        NOT_THE_LATEST_FAILED_STATE,
+        FAILED_STATE,
+        FINISHED_STATE,
+        FINAL_STATE;
+
+        @Override
+        public Class<? extends RestartAction> restartAction() {
+            return null;
+        }
+    }
+
+    private class TestEvent implements FlowEvent {
+
+        @Override
+        public String name() {
+            return null;
+        }
+
+        @Override
+        public String event() {
+            return null;
+        }
     }
 }

--- a/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/log/cluster/ClusterLogger.java
+++ b/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/log/cluster/ClusterLogger.java
@@ -6,8 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.cloudera.thunderhead.service.common.usage.UsageProto;
-import com.sequenceiq.cloudbreak.structuredevent.event.FlowDetails;
+import com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value;
 import com.sequenceiq.cloudbreak.structuredevent.event.StructuredFlowEvent;
 import com.sequenceiq.cloudbreak.structuredevent.service.telemetry.converter.StructuredFlowEventToCDPDatahubRequestedConverter;
 import com.sequenceiq.cloudbreak.structuredevent.service.telemetry.converter.StructuredFlowEventToCDPDatahubStatusChangedConverter;
@@ -42,12 +41,8 @@ public class ClusterLogger implements LegacyTelemetryEventLogger {
 
     @Override
     public void log(StructuredFlowEvent structuredFlowEvent) {
-
-        FlowDetails flow = structuredFlowEvent.getFlow();
-        UsageProto.CDPClusterStatus.Value useCase = clusterUseCaseMapper.useCase(flow);
-        LOGGER.debug("Telemetry use case: {}", useCase);
-
-        if (useCase != UsageProto.CDPClusterStatus.Value.UNSET) {
+        Value useCase = clusterUseCaseMapper.useCase(structuredFlowEvent.getFlow());
+        if (useCase != Value.UNSET) {
             String resourceType = structuredFlowEvent.getOperation().getResourceType();
             if (resourceType != null) {
                 switch (resourceType) {

--- a/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/mapper/ClusterUseCaseAware.java
+++ b/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/mapper/ClusterUseCaseAware.java
@@ -1,0 +1,9 @@
+package com.sequenceiq.cloudbreak.structuredevent.service.telemetry.mapper;
+
+import com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value;
+import com.sequenceiq.flow.core.FlowState;
+
+public interface ClusterUseCaseAware {
+
+    Value getUseCaseForFlowState(Enum<? extends FlowState> flowState);
+}

--- a/structuredevent-service-legacy/src/test/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/mapper/ClusterUseCaseMapperTest.java
+++ b/structuredevent-service-legacy/src/test/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/mapper/ClusterUseCaseMapperTest.java
@@ -1,101 +1,251 @@
 package com.sequenceiq.cloudbreak.structuredevent.service.telemetry.mapper;
 
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.CREATE_FAILED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.CREATE_FINISHED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.CREATE_STARTED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.UNSET;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.UPSCALE_FAILED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.UPSCALE_FINISHED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.UPSCALE_STARTED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.test.util.ReflectionTestUtils;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.cloudera.thunderhead.service.common.usage.UsageProto;
+import com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value;
+import com.sequenceiq.cloudbreak.common.event.Payload;
 import com.sequenceiq.cloudbreak.structuredevent.event.FlowDetails;
+import com.sequenceiq.flow.core.FlowEvent;
+import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
+import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
+import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
 
+@ExtendWith(MockitoExtension.class)
 class ClusterUseCaseMapperTest {
 
+    @Spy
+    private ClusterRequestProcessingStepMapper clusterRequestProcessingStepMapper;
+
+    @Spy
+    private List<AbstractFlowConfiguration> flowConfigurations = new ArrayList<>();
+
+    @Spy
+    private List<FlowEventChainFactory> flowEventChainFactories = new ArrayList<>();
+
+    @InjectMocks
     private ClusterUseCaseMapper underTest;
 
     @BeforeEach
     void setUp() {
-        underTest = new ClusterUseCaseMapper();
-        ReflectionTestUtils.setField(underTest, "clusterRequestProcessingStepMapper", new ClusterRequestProcessingStepMapper());
-        underTest.initUseCaseMaps();
+        flowConfigurations.add(new TestFlowConfig(TestFlowState.class, TestEvent.class));
+        flowEventChainFactories.add(new TestFlowEventChainFactory());
+        underTest.init();
     }
 
     @Test
     void testNullFlowDetailsMappedToUnset() {
-        assertEquals(UsageProto.CDPClusterStatus.Value.UNSET, underTest.useCase(null));
+        assertEquals(UNSET, underTest.useCase(null));
     }
 
     @Test
     void testEmptyFlowDetailsMappedToUnset() {
-        assertEquals(UsageProto.CDPClusterStatus.Value.UNSET, underTest.useCase(new FlowDetails()));
+        assertEquals(UNSET, underTest.useCase(new FlowDetails()));
     }
 
     @Test
-    void testOtherNextFlowStateMappedToUnsetUseCase() {
-        assertEquals(UsageProto.CDPClusterStatus.Value.UNSET,
-                mapFlowDetailsToUseCase("ProvisionFlowEventChainFactory", "CloudConfigValidationFlowConfig", "SOME_STATE"));
+    void testCorrectNextFlowStatesMappedCorrectly() {
+        assertEquals(CREATE_STARTED,
+                mapFlowDetailsToUseCase("INIT_STATE", "TestFlowConfig"));
+        assertEquals(CREATE_FINISHED,
+                mapFlowDetailsToUseCase("FINISHED_STATE", "TestFlowConfig"));
+        assertEquals(CREATE_FAILED,
+                mapFlowDetailsToUseCase("FAILED_STATE", "TestFlowConfig"));
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("TEMP_STATE", "TestFlowConfig"));
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("NOT_THE_LATEST_FAILED_STATE", "TestFlowConfig"));
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("FINAL_STATE", "TestFlowConfig"));
     }
 
     @Test
-    void testInitNextFlowStateWithCorrectFlowChainAndFlowTypeMappedToCorrectUseCase() {
-        assertEquals(UsageProto.CDPClusterStatus.Value.CREATE_STARTED,
-                mapFlowDetailsToUseCase("ProvisionFlowEventChainFactory", "CloudConfigValidationFlowConfig", "INIT_STATE"));
+    void testCorrectNextFlowStatesInFlowChainMappedCorrectly() {
+        assertEquals(UPSCALE_STARTED,
+                mapFlowDetailsToUseCase("INIT_STATE", "TestFlowConfig", "TestFlowEventChainFactory"));
+        assertEquals(UPSCALE_FINISHED,
+                mapFlowDetailsToUseCase("FINISHED_STATE", "TestFlowConfig", "TestFlowEventChainFactory"));
+        assertEquals(UPSCALE_FAILED,
+                mapFlowDetailsToUseCase("FAILED_STATE", "TestFlowConfig", "TestFlowEventChainFactory"));
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("TEMP_STATE", "TestFlowConfig", "TestFlowEventChainFactory"));
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("NOT_THE_LATEST_FAILED_STATE", "TestFlowConfig", "TestFlowEventChainFactory"));
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("FINAL_STATE", "TestFlowConfig", "TestFlowEventChainFactory"));
     }
 
     @Test
-    void testInitNextFlowStateWithIncorrectFlowChainAndFlowTypeMappedToUnsetUseCase() {
-        assertEquals(UsageProto.CDPClusterStatus.Value.UNSET,
-                mapFlowDetailsToUseCase("ProvisionFlowEventChainFactory", "OtherFlowConfig", "INIT_STATE"));
-        assertEquals(UsageProto.CDPClusterStatus.Value.UNSET,
-                mapFlowDetailsToUseCase("ProvisionFlowEventChainFactory", null, "INIT_STATE"));
-        assertEquals(UsageProto.CDPClusterStatus.Value.UNSET,
-                mapFlowDetailsToUseCase("OtherFlowEventChainFactory", "CloudConfigValidationFlowConfig", "INIT_STATE"));
-        assertEquals(UsageProto.CDPClusterStatus.Value.UNSET,
-                mapFlowDetailsToUseCase(null, "CloudConfigValidationFlowConfig", "INIT_STATE"));
-        assertEquals(UsageProto.CDPClusterStatus.Value.UNSET,
-                mapFlowDetailsToUseCase("OtherFlowEventChainFactory", "OtherFlowConfig", "INIT_STATE"));
-        assertEquals(UsageProto.CDPClusterStatus.Value.UNSET,
-                mapFlowDetailsToUseCase(null, null, "INIT_STATE"));
+    void testIncorrectNextFlowStatesMappedToUnsetUseCase() {
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("OTHER_STATE", "TestFlowConfig"));
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase(null, "TestFlowConfig"));
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("", "TestFlowConfig"));
     }
 
     @Test
-    void testCorrectFinishedAndFailedNextFlowStatesWithCorrectFlowChainMappedToCorrectUseCase() {
-        assertEquals(UsageProto.CDPClusterStatus.Value.CREATE_FINISHED,
-                mapFlowDetailsToUseCase("ProvisionFlowEventChainFactory", null, "CLUSTER_CREATION_FINISHED_STATE"));
-        assertEquals(UsageProto.CDPClusterStatus.Value.CREATE_FAILED,
-                mapFlowDetailsToUseCase("ProvisionFlowEventChainFactory", null, "SOMETHING_FAILED_STATE"));
-        assertEquals(UsageProto.CDPClusterStatus.Value.CREATE_FAILED,
-                mapFlowDetailsToUseCase("ProvisionFlowEventChainFactory", null, "SOME_FAILURE_STATE"));
+    void testIncorrectNextFlowStatesInFlowChainMappedToUnsetUseCase() {
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("OTHER_STATE", "TestFlowConfig", "TestFlowEventChainFactory"));
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase(null, "TestFlowConfig", "TestFlowEventChainFactory"));
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("", "TestFlowConfig", "TestFlowEventChainFactory"));
     }
 
     @Test
-    void testCorrectFinishedAndFailedNextFlowStatesWithIncorrectFlowChainMappedToUnsetUseCase() {
-        assertEquals(UsageProto.CDPClusterStatus.Value.UNSET,
-                mapFlowDetailsToUseCase("OtherFlowEventChainFactory", null, "CLUSTER_CREATION_FINISHED_STATE"));
-        assertEquals(UsageProto.CDPClusterStatus.Value.UNSET,
-                mapFlowDetailsToUseCase(null, null, "CLUSTER_CREATION_FINISHED_STATE"));
-        assertEquals(UsageProto.CDPClusterStatus.Value.UNSET,
-                mapFlowDetailsToUseCase("OtherFlowEventChainFactory", null, "SOMETHING_FAILED_STATE"));
-        assertEquals(UsageProto.CDPClusterStatus.Value.UNSET,
-                mapFlowDetailsToUseCase(null, null, "SOMETHING_FAILED_STATE"));
+    void testIncorrectFlowConfigMappedToUnsetUseCase() {
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("INIT_STATE", "OtherFlowConfig"));
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("INIT_STATE", null));
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("INIT_STATE", ""));
     }
 
     @Test
-    void testIncorrectFinishedAndFailedNextFlowStatesWithCorrectFlowChainMappedToUnsetUseCase() {
-        assertEquals(UsageProto.CDPClusterStatus.Value.UNSET,
-                mapFlowDetailsToUseCase("ProvisionFlowEventChainFactory", null, "OTHER_FINISHED_STATE"));
-        assertEquals(UsageProto.CDPClusterStatus.Value.UNSET,
-                mapFlowDetailsToUseCase("UpscaleFlowEventChainFactory", null, "FINALIZE_OTHER_STATE"));
-        assertEquals(UsageProto.CDPClusterStatus.Value.UNSET,
-                mapFlowDetailsToUseCase("ProvisionFlowEventChainFactory", null, "OTHER_STATE"));
+    void testIncorrectFlowConfigInFlowChainMappedToUnsetUseCase() {
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("INIT_STATE", "OtherFlowConfig", "TestFlowEventChainFactory"));
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("INIT_STATE", null, "TestFlowEventChainFactory"));
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("INIT_STATE", "", "TestFlowEventChainFactory"));
     }
 
-    private UsageProto.CDPClusterStatus.Value mapFlowDetailsToUseCase(String flowChainType, String flowType, String nextFlowState) {
+    @Test
+    void testIncorrectFlowChainInFlowChainMappedToUnsetUseCase() {
+        assertEquals(UNSET,
+                mapFlowDetailsToUseCase("INIT_STATE", "TestFlowConfig", "OtherFlowEventChainFactory"));
+    }
+
+    private Value mapFlowDetailsToUseCase(String nextFlowState, String flowType) {
+        return mapFlowDetailsToUseCase(nextFlowState, flowType, null);
+    }
+
+    private Value mapFlowDetailsToUseCase(String nextFlowState, String flowType, String flowChainType) {
         FlowDetails flowDetails = new FlowDetails();
-        flowDetails.setFlowChainType(flowChainType);
-        flowDetails.setFlowType(flowType);
         flowDetails.setNextFlowState(nextFlowState);
-
+        flowDetails.setFlowType(flowType);
+        flowDetails.setFlowChainType(flowChainType);
         return underTest.useCase(flowDetails);
+    }
+
+    private class TestFlowEventChainFactory implements FlowEventChainFactory, ClusterUseCaseAware {
+
+        @Override
+        public String initEvent() {
+            return null;
+        }
+
+        @Override
+        public FlowTriggerEventQueue createFlowTriggerEventQueue(Payload event) {
+            return null;
+        }
+
+        @Override
+        public Value getUseCaseForFlowState(Enum flowState) {
+            if (flowState.equals(TestFlowState.INIT_STATE)) {
+                return UPSCALE_STARTED;
+            } else if (flowState.toString().endsWith("FAILED_STATE")
+                    && !flowState.equals(TestFlowState.NOT_THE_LATEST_FAILED_STATE)) {
+                return UPSCALE_FAILED;
+            } else if (flowState.equals(TestFlowState.FINISHED_STATE)) {
+                return UPSCALE_FINISHED;
+            }
+            return UNSET;
+        }
+    }
+
+    private class TestFlowConfig extends AbstractFlowConfiguration<TestFlowState, TestEvent> implements ClusterUseCaseAware {
+
+        protected TestFlowConfig(Class stateType, Class eventType) {
+            super(stateType, eventType);
+        }
+
+        @Override
+        public Value getUseCaseForFlowState(Enum<? extends FlowState> flowState) {
+            if (flowState.equals(TestFlowState.INIT_STATE)) {
+                return CREATE_STARTED;
+            } else if (flowState.toString().endsWith("FAILED_STATE")
+                    && !flowState.equals(TestFlowState.NOT_THE_LATEST_FAILED_STATE)) {
+                return CREATE_FAILED;
+            } else if (flowState.equals(TestFlowState.FINISHED_STATE)) {
+                return CREATE_FINISHED;
+            }
+            return UNSET;
+        }
+
+        @Override
+        protected List<Transition<TestFlowState, TestEvent>> getTransitions() {
+            return null;
+        }
+
+        @Override
+        protected FlowEdgeConfig getEdgeConfig() {
+            return null;
+        }
+
+        @Override
+        public TestEvent[] getEvents() {
+            return new TestEvent[0];
+        }
+
+        @Override
+        public TestEvent[] getInitEvents() {
+            return new TestEvent[0];
+        }
+
+        @Override
+        public String getDisplayName() {
+            return null;
+        }
+    }
+
+    private enum TestFlowState implements FlowState {
+        INIT_STATE,
+        TEMP_STATE,
+        NOT_THE_LATEST_FAILED_STATE,
+        FAILED_STATE,
+        FINISHED_STATE,
+        FINAL_STATE;
+
+        @Override
+        public Class<? extends RestartAction> restartAction() {
+            return null;
+        }
+    }
+
+    private class TestEvent implements FlowEvent {
+
+        @Override
+        public String name() {
+            return null;
+        }
+
+        @Override
+        public String event() {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
…flow chains

- Moved the use-case mappings into the related flow and flowchain configs.
- Removed configurations related to datalake-only use-cases that never worked before(CertRotationFlowConfig, DatalakeResizeFlowEventChainFactory)
- Fixed mapping for StopFlowEventChainFactory because the order of the flows has changed

See detailed description in the commit message.