### PR TITLE
CB-20411 Remove more circular dependency

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/salt/rotatepassword/RotateSaltPasswordActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/salt/rotatepassword/RotateSaltPasswordActions.java
@@ -21,7 +21,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordFailureResponse;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordSuccessResponse;
-import com.sequenceiq.cloudbreak.service.RotateSaltPasswordService;
+import com.sequenceiq.cloudbreak.service.salt.RotateSaltPasswordService;
 
 @Configuration
 public class RotateSaltPasswordActions {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/salt/StackSaltStatusCheckerJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/salt/StackSaltStatusCheckerJob.java
@@ -24,8 +24,10 @@ import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.logger.MdcContextInfoProvider;
 import com.sequenceiq.cloudbreak.quartz.statuschecker.job.StatusCheckerJob;
-import com.sequenceiq.cloudbreak.service.RotateSaltPasswordService;
-import com.sequenceiq.cloudbreak.service.SaltPasswordStatusService;
+import com.sequenceiq.cloudbreak.service.salt.RotateSaltPasswordService;
+import com.sequenceiq.cloudbreak.service.salt.RotateSaltPasswordTriggerService;
+import com.sequenceiq.cloudbreak.service.salt.RotateSaltPasswordValidator;
+import com.sequenceiq.cloudbreak.service.salt.SaltPasswordStatusService;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 
 import io.opentracing.Tracer;
@@ -93,6 +95,12 @@ public class StackSaltStatusCheckerJob extends StatusCheckerJob {
     private RotateSaltPasswordService rotateSaltPasswordService;
 
     @Inject
+    private RotateSaltPasswordTriggerService rotateSaltPasswordTriggerService;
+
+    @Inject
+    private RotateSaltPasswordValidator rotateSaltPasswordValidator;
+
+    @Inject
     private SaltPasswordStatusService saltPasswordStatusService;
 
     public StackSaltStatusCheckerJob(Tracer tracer) {
@@ -121,7 +129,7 @@ public class StackSaltStatusCheckerJob extends StatusCheckerJob {
                     } else if (null == stackStatus || IGNORED_STATES.contains(stackStatus)) {
                         LOGGER.debug("Stack salt sync is skipped, stack state is {}", stackStatus);
                     } else if (SYNCABLE_STATES.contains(stackStatus)) {
-                        rotateSaltPasswordService.validateRotateSaltPassword(stack);
+                        rotateSaltPasswordValidator.validateRotateSaltPassword(stack);
                         RegionAwareInternalCrnGenerator dataHub = regionAwareInternalCrnGeneratorFactory.datahub();
                         ThreadBasedUserCrnProvider.doAs(dataHub.getInternalCrnForServiceAsString(), () -> rotateSaltPasswordIfNeeded(stack));
                     } else {
@@ -144,7 +152,7 @@ public class StackSaltStatusCheckerJob extends StatusCheckerJob {
             if (reasonOptional.isPresent()) {
                 RotateSaltPasswordReason reason = reasonOptional.get();
                 LOGGER.info("Triggering salt password rotation for status {} with reason {}", status, reason);
-                rotateSaltPasswordService.triggerRotateSaltPassword(stack, reason);
+                rotateSaltPasswordTriggerService.triggerRotateSaltPassword(stack, reason);
             } else {
                 LOGGER.debug("Salt password rotation is not needed for status {}", status);
             }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/RotateSaltPasswordHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/RotateSaltPasswordHandler.java
@@ -13,7 +13,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordFai
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordSuccessResponse;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordType;
-import com.sequenceiq.cloudbreak.service.RotateSaltPasswordService;
+import com.sequenceiq.cloudbreak.service.salt.RotateSaltPasswordService;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/salt/RotateSaltPasswordTriggerService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/salt/RotateSaltPasswordTriggerService.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.cloudbreak.service.salt;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.api.model.RotateSaltPasswordReason;
+import com.sequenceiq.cloudbreak.core.flow2.service.ReactorFlowManager;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordType;
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+
+@Service
+public class RotateSaltPasswordTriggerService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RotateSaltPasswordTriggerService.class);
+
+    @Inject
+    private ReactorFlowManager flowManager;
+
+    @Inject
+    private RotateSaltPasswordValidator rotateSaltPasswordValidator;
+
+    public FlowIdentifier triggerRotateSaltPassword(StackDto stack, RotateSaltPasswordReason reason) {
+        rotateSaltPasswordValidator.validateRotateSaltPassword(stack);
+        RotateSaltPasswordType rotateSaltPasswordType = getRotateSaltPasswordType(stack);
+        LOGGER.info("Triggering rotate salt password for stack {} with type {}", stack.getId(), rotateSaltPasswordType);
+        return flowManager.triggerRotateSaltPassword(stack.getId(), reason, rotateSaltPasswordType);
+    }
+
+    private RotateSaltPasswordType getRotateSaltPasswordType(StackDto stack) {
+        return rotateSaltPasswordValidator.isChangeSaltuserPasswordSupported(stack) ? RotateSaltPasswordType.SALT_BOOTSTRAP_ENDPOINT
+                : RotateSaltPasswordType.FALLBACK;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/salt/RotateSaltPasswordValidator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/salt/RotateSaltPasswordValidator.java
@@ -1,0 +1,43 @@
+package com.sequenceiq.cloudbreak.service.salt;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.SaltBootstrapVersionChecker;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.view.InstanceMetadataView;
+
+@Component
+public class RotateSaltPasswordValidator {
+
+    @Inject
+    private SaltBootstrapVersionChecker saltBootstrapVersionChecker;
+
+    @Inject
+    private EntitlementService entitlementService;
+
+    public void validateRotateSaltPassword(StackDto stack) {
+        if (stack.getStatus().isStopped()) {
+            throw new BadRequestException("Rotating SaltStack user password is not supported for stopped clusters");
+        }
+        if (!entitlementService.isSaltUserPasswordRotationEnabled(stack.getAccountId())) {
+            throw new BadRequestException("Rotating SaltStack user password is not supported in your account");
+        }
+        if (stack.getNotTerminatedAndNotZombieGatewayInstanceMetadata().isEmpty()) {
+            throw new IllegalStateException("Rotating SaltStack user password is not supported when there are no available gateway instances");
+        }
+        if (!isChangeSaltuserPasswordSupported(stack) && stack.getNotTerminatedInstanceMetaData().stream().anyMatch(im -> !im.isRunning())) {
+            // fallback implementation re-bootstraps all nodes, so they have to be running
+            throw new IllegalStateException("Rotating SaltStack user password is only supported when all instances are running");
+        }
+    }
+
+    public boolean isChangeSaltuserPasswordSupported(StackDto stack) {
+        return stack.getNotTerminatedAndNotZombieGatewayInstanceMetadata().stream()
+                .map(InstanceMetadataView::getImage)
+                .allMatch(image -> saltBootstrapVersionChecker.isChangeSaltuserPasswordSupported(image));
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/salt/SaltPasswordStatusService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/salt/SaltPasswordStatusService.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.cloudbreak.service;
+package com.sequenceiq.cloudbreak.service.salt;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
@@ -18,13 +18,14 @@ import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorEx
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.quartz.saltstatuschecker.SaltStatusCheckerConfig;
+import com.sequenceiq.cloudbreak.service.GatewayConfigService;
 
 @Service
 public class SaltPasswordStatusService {
 
-    protected static final String SALTUSER = "saltuser";
+    private static final String SALTUSER = "saltuser";
 
-    protected static final String UNAUTHORIZED_RESPONSE = "Status: 401 Unauthorized Response";
+    private static final String UNAUTHORIZED_RESPONSE = "Status: 401 Unauthorized Response";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SaltPasswordStatusService.class);
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
@@ -48,14 +48,15 @@ import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.domain.view.StackApiView;
 import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
-import com.sequenceiq.cloudbreak.service.RotateSaltPasswordService;
-import com.sequenceiq.cloudbreak.service.SaltPasswordStatusService;
 import com.sequenceiq.cloudbreak.service.StackUpdater;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
 import com.sequenceiq.cloudbreak.service.cluster.flow.ClusterOperationService;
 import com.sequenceiq.cloudbreak.service.datalake.DataLakeStatusCheckerService;
 import com.sequenceiq.cloudbreak.service.environment.EnvironmentService;
 import com.sequenceiq.cloudbreak.service.image.ImageChangeDto;
+import com.sequenceiq.cloudbreak.service.salt.RotateSaltPasswordTriggerService;
+import com.sequenceiq.cloudbreak.service.salt.RotateSaltPasswordValidator;
+import com.sequenceiq.cloudbreak.service.salt.SaltPasswordStatusService;
 import com.sequenceiq.cloudbreak.service.spot.SpotInstanceUsageCondition;
 import com.sequenceiq.cloudbreak.service.stack.StackApiViewService;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
@@ -117,7 +118,10 @@ public class StackOperationService {
     private TargetedUpscaleSupportService targetedUpscaleSupportService;
 
     @Inject
-    private RotateSaltPasswordService rotateSaltPasswordService;
+    private RotateSaltPasswordTriggerService rotateSaltPasswordTriggerService;
+
+    @Inject
+    private RotateSaltPasswordValidator rotateSaltPasswordValidator;
 
     @Inject
     private SaltPasswordStatusService saltPasswordStatusService;
@@ -459,8 +463,8 @@ public class StackOperationService {
     public FlowIdentifier rotateSaltPassword(@NotNull NameOrCrn nameOrCrn, String accountId, RotateSaltPasswordReason reason) {
         StackDto stack = stackDtoService.getByNameOrCrn(nameOrCrn, accountId);
         MDCBuilder.buildMdcContext(stack);
-        rotateSaltPasswordService.validateRotateSaltPassword(stack);
-        return rotateSaltPasswordService.triggerRotateSaltPassword(stack, reason);
+        rotateSaltPasswordValidator.validateRotateSaltPassword(stack);
+        return rotateSaltPasswordTriggerService.triggerRotateSaltPassword(stack, reason);
     }
 
     public SaltPasswordStatus getSaltPasswordStatus(@NotNull NameOrCrn nameOrCrn, String accountId) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/job/salt/StackSaltStatusCheckerJobTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/job/salt/StackSaltStatusCheckerJobTest.java
@@ -35,8 +35,10 @@ import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGenerator;
 import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
 import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.logger.MdcContextInfoProvider;
-import com.sequenceiq.cloudbreak.service.RotateSaltPasswordService;
-import com.sequenceiq.cloudbreak.service.SaltPasswordStatusService;
+import com.sequenceiq.cloudbreak.service.salt.RotateSaltPasswordService;
+import com.sequenceiq.cloudbreak.service.salt.RotateSaltPasswordTriggerService;
+import com.sequenceiq.cloudbreak.service.salt.RotateSaltPasswordValidator;
+import com.sequenceiq.cloudbreak.service.salt.SaltPasswordStatusService;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 import com.sequenceiq.cloudbreak.view.StackView;
 
@@ -76,6 +78,12 @@ class StackSaltStatusCheckerJobTest {
 
     @Mock
     private JobDetail jobDetail;
+
+    @Mock
+    private RotateSaltPasswordTriggerService rotateSaltPasswordTriggerService;
+
+    @Mock
+    private RotateSaltPasswordValidator rotateSaltPasswordValidator;
 
     private JobKey jobKey;
 
@@ -171,8 +179,8 @@ class StackSaltStatusCheckerJobTest {
             underTest.executeTracedJob(context);
 
             verify(saltPasswordStatusService).getSaltPasswordStatus(stackDto);
-            verify(rotateSaltPasswordService).validateRotateSaltPassword(stackDto);
-            verify(rotateSaltPasswordService, never()).triggerRotateSaltPassword(eq(stackDto), any());
+            verify(rotateSaltPasswordValidator).validateRotateSaltPassword(stackDto);
+            verify(rotateSaltPasswordTriggerService, never()).triggerRotateSaltPassword(eq(stackDto), any());
         }
 
         @Test
@@ -182,8 +190,8 @@ class StackSaltStatusCheckerJobTest {
             underTest.executeTracedJob(context);
 
             verify(saltPasswordStatusService).getSaltPasswordStatus(stackDto);
-            verify(rotateSaltPasswordService).validateRotateSaltPassword(stackDto);
-            verify(rotateSaltPasswordService, never()).triggerRotateSaltPassword(eq(stackDto), any());
+            verify(rotateSaltPasswordValidator).validateRotateSaltPassword(stackDto);
+            verify(rotateSaltPasswordTriggerService, never()).triggerRotateSaltPassword(eq(stackDto), any());
         }
 
         @Test
@@ -193,8 +201,8 @@ class StackSaltStatusCheckerJobTest {
             underTest.executeTracedJob(context);
 
             verify(saltPasswordStatusService).getSaltPasswordStatus(stackDto);
-            verify(rotateSaltPasswordService).validateRotateSaltPassword(stackDto);
-            verify(rotateSaltPasswordService).triggerRotateSaltPassword(stackDto, RotateSaltPasswordReason.EXPIRED);
+            verify(rotateSaltPasswordValidator).validateRotateSaltPassword(stackDto);
+            verify(rotateSaltPasswordTriggerService).triggerRotateSaltPassword(stackDto, RotateSaltPasswordReason.EXPIRED);
         }
 
         @Test
@@ -204,8 +212,8 @@ class StackSaltStatusCheckerJobTest {
             underTest.executeTracedJob(context);
 
             verify(saltPasswordStatusService).getSaltPasswordStatus(stackDto);
-            verify(rotateSaltPasswordService).validateRotateSaltPassword(stackDto);
-            verify(rotateSaltPasswordService).triggerRotateSaltPassword(stackDto, RotateSaltPasswordReason.UNAUTHORIZED);
+            verify(rotateSaltPasswordValidator).validateRotateSaltPassword(stackDto);
+            verify(rotateSaltPasswordTriggerService).triggerRotateSaltPassword(stackDto, RotateSaltPasswordReason.UNAUTHORIZED);
         }
 
         @Test
@@ -217,7 +225,7 @@ class StackSaltStatusCheckerJobTest {
             underTest.executeTracedJob(context);
 
             verify(saltPasswordStatusService).getSaltPasswordStatus(stackDto);
-            verify(rotateSaltPasswordService).validateRotateSaltPassword(stackDto);
+            verify(rotateSaltPasswordValidator).validateRotateSaltPassword(stackDto);
             verify(rotateSaltPasswordService).sendFailureUsageReport(stackDto.getResourceCrn(), RotateSaltPasswordReason.UNSET,
                     "Failed to get salt password status: " + cause.getMessage());
         }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/RotateSaltPasswordHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/RotateSaltPasswordHandlerTest.java
@@ -27,7 +27,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordFai
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordSuccessResponse;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordType;
-import com.sequenceiq.cloudbreak.service.RotateSaltPasswordService;
+import com.sequenceiq.cloudbreak.service.salt.RotateSaltPasswordService;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/SaltPasswordStatusServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/SaltPasswordStatusServiceTest.java
@@ -23,9 +23,14 @@ import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFa
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.quartz.saltstatuschecker.SaltStatusCheckerConfig;
+import com.sequenceiq.cloudbreak.service.salt.SaltPasswordStatusService;
 
 @ExtendWith(MockitoExtension.class)
 class SaltPasswordStatusServiceTest {
+
+    private static final String SALTUSER = "saltuser";
+
+    private static final String UNAUTHORIZED_RESPONSE = "Status: 401 Unauthorized Response";
 
     private static final String ACCOUNT_ID = "0";
 
@@ -64,7 +69,7 @@ class SaltPasswordStatusServiceTest {
         when(clock.getCurrentLocalDateTime()).thenReturn(LocalDateTime.now());
         when(saltStatusCheckerConfig.getPasswordExpiryThresholdInDays()).thenReturn(14);
         when(gatewayConfigService.getAllGatewayConfigs(stack)).thenReturn(gatewayConfigs);
-        when(hostOrchestrator.getPasswordExpiryDate(gatewayConfigs, SaltPasswordStatusService.SALTUSER)).thenReturn(LocalDate.now().minusMonths(2));
+        when(hostOrchestrator.getPasswordExpiryDate(gatewayConfigs, SALTUSER)).thenReturn(LocalDate.now().minusMonths(2));
 
         SaltPasswordStatus result = underTest.getSaltPasswordStatus(stack);
 
@@ -76,7 +81,7 @@ class SaltPasswordStatusServiceTest {
         when(clock.getCurrentLocalDateTime()).thenReturn(LocalDateTime.now());
         when(saltStatusCheckerConfig.getPasswordExpiryThresholdInDays()).thenReturn(14);
         when(gatewayConfigService.getAllGatewayConfigs(stack)).thenReturn(gatewayConfigs);
-        when(hostOrchestrator.getPasswordExpiryDate(gatewayConfigs, SaltPasswordStatusService.SALTUSER)).thenReturn(LocalDate.now().plusMonths(2));
+        when(hostOrchestrator.getPasswordExpiryDate(gatewayConfigs, SALTUSER)).thenReturn(LocalDate.now().plusMonths(2));
 
         SaltPasswordStatus result = underTest.getSaltPasswordStatus(stack);
 
@@ -86,10 +91,10 @@ class SaltPasswordStatusServiceTest {
     @Test
     void unauthorizedSaltPasswordRotationNeeded() throws Exception {
         when(gatewayConfigService.getAllGatewayConfigs(stack)).thenReturn(gatewayConfigs);
-        RuntimeException causeCause = new RuntimeException(SaltPasswordStatusService.UNAUTHORIZED_RESPONSE);
+        RuntimeException causeCause = new RuntimeException(UNAUTHORIZED_RESPONSE);
         RuntimeException cause = new RuntimeException("Ooops", causeCause);
         CloudbreakOrchestratorFailedException exception = new CloudbreakOrchestratorFailedException("Failed", cause);
-        when(hostOrchestrator.getPasswordExpiryDate(gatewayConfigs, SaltPasswordStatusService.SALTUSER)).thenThrow(exception);
+        when(hostOrchestrator.getPasswordExpiryDate(gatewayConfigs, SALTUSER)).thenThrow(exception);
 
         SaltPasswordStatus result = underTest.getSaltPasswordStatus(stack);
 
@@ -100,7 +105,7 @@ class SaltPasswordStatusServiceTest {
     void errorWhileSaltPasswordRotationNeeded() throws Exception {
         when(gatewayConfigService.getAllGatewayConfigs(stack)).thenReturn(gatewayConfigs);
         CloudbreakOrchestratorFailedException exception = new CloudbreakOrchestratorFailedException("Unexpected failure");
-        when(hostOrchestrator.getPasswordExpiryDate(gatewayConfigs, SaltPasswordStatusService.SALTUSER)).thenThrow(exception);
+        when(hostOrchestrator.getPasswordExpiryDate(gatewayConfigs, SALTUSER)).thenThrow(exception);
 
         SaltPasswordStatus result = underTest.getSaltPasswordStatus(stack);
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/salt/RotateSaltPasswordTriggerServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/salt/RotateSaltPasswordTriggerServiceTest.java
@@ -1,0 +1,58 @@
+package com.sequenceiq.cloudbreak.service.salt;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.model.RotateSaltPasswordReason;
+import com.sequenceiq.cloudbreak.core.flow2.service.ReactorFlowManager;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordType;
+
+@ExtendWith(MockitoExtension.class)
+class RotateSaltPasswordTriggerServiceTest {
+
+    private static final long STACK_ID = 1L;
+
+    @Mock
+    private ReactorFlowManager flowManager;
+
+    @Mock
+    private RotateSaltPasswordValidator rotateSaltPasswordValidator;
+
+    @Mock
+    private StackDto stack;
+
+    @InjectMocks
+    private RotateSaltPasswordTriggerService underTest;
+
+    @BeforeEach
+    void init() {
+        when(stack.getId()).thenReturn(STACK_ID);
+    }
+
+    @Test
+    void getRotateSaltPasswordTypeFallback() {
+        when(rotateSaltPasswordValidator.isChangeSaltuserPasswordSupported(stack)).thenReturn(false);
+
+        underTest.triggerRotateSaltPassword(stack, RotateSaltPasswordReason.MANUAL);
+
+        verify(flowManager).triggerRotateSaltPassword(STACK_ID, RotateSaltPasswordReason.MANUAL, RotateSaltPasswordType.FALLBACK);
+    }
+
+    @Test
+    void getRotateSaltPasswordTypeSaltBootstrapEndpoint() {
+        when(rotateSaltPasswordValidator.isChangeSaltuserPasswordSupported(stack)).thenReturn(true);
+
+        underTest.triggerRotateSaltPassword(stack, RotateSaltPasswordReason.MANUAL);
+
+        verify(flowManager).triggerRotateSaltPassword(STACK_ID, RotateSaltPasswordReason.MANUAL, RotateSaltPasswordType.SALT_BOOTSTRAP_ENDPOINT);
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/salt/RotateSaltPasswordValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/salt/RotateSaltPasswordValidatorTest.java
@@ -1,0 +1,86 @@
+package com.sequenceiq.cloudbreak.service.salt;
+
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.SaltBootstrapVersionChecker;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.view.InstanceMetadataView;
+
+@ExtendWith(MockitoExtension.class)
+class RotateSaltPasswordValidatorTest {
+
+    private static final String STACK_CRN = "crn:cdp:datalake:us-west-1:cloudera:datalake:33071a14-d605-4b2d-9a55-218c0dbc95e3";
+
+    private static final String ACCOUNT_ID = "0";
+
+    private static final String OLD_PASSWORD = "old-password";
+
+    @Mock
+    private SaltBootstrapVersionChecker saltBootstrapVersionChecker;
+
+    @Mock
+    private EntitlementService entitlementService;
+
+    @Mock
+    private StackDto stack;
+
+    @Mock
+    private InstanceMetadataView instanceMetadataView;
+
+    @InjectMocks
+    private RotateSaltPasswordValidator underTest;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(stack.isAvailable()).thenReturn(true);
+        lenient().when(stack.getAccountId()).thenReturn(ACCOUNT_ID);
+        lenient().when(stack.getStatus()).thenReturn(Status.AVAILABLE);
+        lenient().when(stack.getNotTerminatedAndNotZombieGatewayInstanceMetadata()).thenReturn(List.of(instanceMetadataView));
+        lenient().when(entitlementService.isSaltUserPasswordRotationEnabled(ACCOUNT_ID)).thenReturn(true);
+    }
+
+    @Test
+    public void testRotateSaltPasswordOnStackWithNotRunningInstanceAndFallbackImplementation() {
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+        instanceMetaData.setInstanceStatus(InstanceStatus.STOPPED);
+        when(stack.getNotTerminatedInstanceMetaData()).thenReturn(List.of(instanceMetaData));
+
+        Assertions.assertThatThrownBy(() -> underTest.validateRotateSaltPassword(stack))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Rotating SaltStack user password is only supported when all instances are running");
+    }
+
+    @Test
+    public void testRotateSaltPasswordOnStackInAccountWithoutEntitlement() {
+        when(entitlementService.isSaltUserPasswordRotationEnabled(ACCOUNT_ID)).thenReturn(false);
+
+        Assertions.assertThatThrownBy(() -> underTest.validateRotateSaltPassword(stack))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("Rotating SaltStack user password is not supported in your account");
+    }
+
+    @Test
+    public void testRotateSaltPasswordOnStackWithoutAvailableGateway() {
+        when(stack.getNotTerminatedAndNotZombieGatewayInstanceMetadata()).thenReturn(List.of());
+
+        Assertions.assertThatThrownBy(() -> underTest.validateRotateSaltPassword(stack))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Rotating SaltStack user password is not supported when there are no available gateway instances");
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationServiceTest.java
@@ -62,13 +62,14 @@ import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.dto.StackDto;
-import com.sequenceiq.cloudbreak.service.RotateSaltPasswordService;
-import com.sequenceiq.cloudbreak.service.SaltPasswordStatusService;
 import com.sequenceiq.cloudbreak.service.StackUpdater;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
 import com.sequenceiq.cloudbreak.service.cluster.flow.ClusterOperationService;
 import com.sequenceiq.cloudbreak.service.datalake.DataLakeStatusCheckerService;
 import com.sequenceiq.cloudbreak.service.environment.EnvironmentService;
+import com.sequenceiq.cloudbreak.service.salt.RotateSaltPasswordTriggerService;
+import com.sequenceiq.cloudbreak.service.salt.RotateSaltPasswordValidator;
+import com.sequenceiq.cloudbreak.service.salt.SaltPasswordStatusService;
 import com.sequenceiq.cloudbreak.service.spot.SpotInstanceUsageCondition;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
@@ -137,10 +138,13 @@ public class StackOperationServiceTest {
     private InstanceMetaDataService instanceMetaDataService;
 
     @Mock
-    private RotateSaltPasswordService rotateSaltPasswordService;
+    private SaltPasswordStatusService saltPasswordStatusService;
 
     @Mock
-    private SaltPasswordStatusService saltPasswordStatusService;
+    private RotateSaltPasswordTriggerService rotateSaltPasswordTriggerService;
+
+    @Mock
+    private RotateSaltPasswordValidator rotateSaltPasswordValidator;
 
     @Test
     public void testStartWhenStackAvailable() {
@@ -474,14 +478,14 @@ public class StackOperationServiceTest {
         StackDto stackDto = mock(StackDto.class);
         when(stackDtoService.getByNameOrCrn(nameOrCrn, ACCOUNT_ID)).thenReturn(stackDto);
         FlowIdentifier flowIdentifier = new FlowIdentifier(FlowType.FLOW, "pollableId");
-        when(rotateSaltPasswordService.triggerRotateSaltPassword(stackDto, REASON)).thenReturn(flowIdentifier);
+        when(rotateSaltPasswordTriggerService.triggerRotateSaltPassword(stackDto, REASON)).thenReturn(flowIdentifier);
 
         FlowIdentifier result = underTest.rotateSaltPassword(nameOrCrn, ACCOUNT_ID, REASON);
 
         assertEquals(flowIdentifier, result);
         verify(stackDtoService).getByNameOrCrn(nameOrCrn, ACCOUNT_ID);
-        verify(rotateSaltPasswordService).validateRotateSaltPassword(stackDto);
-        verify(rotateSaltPasswordService).triggerRotateSaltPassword(stackDto, REASON);
+        verify(rotateSaltPasswordValidator).validateRotateSaltPassword(stackDto);
+        verify(rotateSaltPasswordTriggerService).triggerRotateSaltPassword(stackDto, REASON);
     }
 
     @Test

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
@@ -52,6 +52,7 @@ import com.sequenceiq.datalake.configuration.CDPConfigService;
 import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.metric.MetricType;
 import com.sequenceiq.datalake.metric.SdxMetricService;
+import com.sequenceiq.datalake.service.SdxDeleteService;
 import com.sequenceiq.datalake.service.sdx.SdxImageCatalogService;
 import com.sequenceiq.datalake.service.sdx.SdxRecommendationService;
 import com.sequenceiq.datalake.service.sdx.SdxRepairService;
@@ -137,6 +138,9 @@ public class SdxController implements SdxEndpoint {
     @Inject
     private VerticalScaleService verticalScaleService;
 
+    @Inject
+    private SdxDeleteService sdxDeleteService;
+
     @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.CREATE_DATALAKE)
     public SdxClusterResponse create(@ValidStackNameFormat @ValidStackNameLength String name,
@@ -204,15 +208,13 @@ public class SdxController implements SdxEndpoint {
     @Override
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.DELETE_DATALAKE)
     public FlowIdentifier delete(@ResourceName String name, Boolean forced) {
-        String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
-        return sdxService.deleteSdx(userCrn, name, forced);
+        return sdxDeleteService.deleteSdx(ThreadBasedUserCrnProvider.getAccountId(), name, forced);
     }
 
     @Override
     @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.DELETE_DATALAKE)
     public FlowIdentifier deleteByCrn(@ResourceCrn String clusterCrn, Boolean forced) {
-        String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
-        return sdxService.deleteSdxByClusterCrn(userCrn, clusterCrn, forced);
+        return sdxDeleteService.deleteSdxByClusterCrn(ThreadBasedUserCrnProvider.getAccountId(), clusterCrn, forced);
     }
 
     @Override

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/SdxDeleteService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/SdxDeleteService.java
@@ -1,0 +1,87 @@
+package com.sequenceiq.datalake.service;
+
+import static com.sequenceiq.cloudbreak.common.exception.NotFoundException.notFound;
+import static com.sequenceiq.datalake.entity.DatalakeStatusEnum.PROVISIONING_FAILED;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Response;
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.datalake.entity.DatalakeStatusEnum;
+import com.sequenceiq.datalake.entity.SdxCluster;
+import com.sequenceiq.datalake.entity.SdxStatusEntity;
+import com.sequenceiq.datalake.flow.SdxReactorFlowManager;
+import com.sequenceiq.datalake.repository.SdxClusterRepository;
+import com.sequenceiq.datalake.service.sdx.DistroxService;
+import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+import com.sequenceiq.flow.service.FlowCancelService;
+
+@Service
+public class SdxDeleteService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxDeleteService.class);
+
+    @Inject
+    private FlowCancelService flowCancelService;
+
+    @Inject
+    private SdxClusterRepository sdxClusterRepository;
+
+    @Inject
+    private SdxStatusService sdxStatusService;
+
+    @Inject
+    private SdxReactorFlowManager sdxReactorFlowManager;
+
+    @Inject
+    private DistroxService distroxService;
+
+    public FlowIdentifier deleteSdxByClusterCrn(String accountId, String clusterCrn, boolean forced) {
+        LOGGER.info("Deleting SDX {}", clusterCrn);
+        return sdxClusterRepository.findByAccountIdAndCrnAndDeletedIsNull(accountId, clusterCrn)
+                .map(sdxCluster -> deleteSdxCluster(sdxCluster, forced))
+                .orElseThrow(() -> notFound("SDX cluster", clusterCrn).get());
+    }
+
+    public FlowIdentifier deleteSdx(String accountId, String name, boolean forced) {
+        LOGGER.info("Deleting SDX {}", name);
+        return sdxClusterRepository.findByAccountIdAndClusterNameAndDeletedIsNull(accountId, name)
+                .map(sdxCluster -> deleteSdxCluster(sdxCluster, forced))
+                .orElseThrow(() -> notFound("SDX cluster", name).get());
+    }
+
+    private FlowIdentifier deleteSdxCluster(SdxCluster sdxCluster, boolean forced) {
+        checkIfSdxIsDeletable(sdxCluster, forced);
+        MDCBuilder.buildMdcContext(sdxCluster);
+        sdxClusterRepository.save(sdxCluster);
+        sdxStatusService.setStatusForDatalakeAndNotify(DatalakeStatusEnum.DELETE_REQUESTED, "Datalake deletion requested", sdxCluster);
+        FlowIdentifier flowIdentifier = sdxReactorFlowManager.triggerSdxDeletion(sdxCluster, forced);
+        flowCancelService.cancelRunningFlows(sdxCluster.getId());
+        return flowIdentifier;
+    }
+
+    private void checkIfSdxIsDeletable(SdxCluster sdxCluster, boolean forced) {
+        SdxStatusEntity actualStatusForSdx = sdxStatusService.getActualStatusForSdx(sdxCluster);
+        if (!forced && actualStatusForSdx.getStatus() != PROVISIONING_FAILED &&
+                sdxCluster.hasExternalDatabase() && StringUtils.isEmpty(sdxCluster.getDatabaseCrn())) {
+            throw new BadRequestException(String.format("Can not find external database for Data Lake, but it was requested: %s. Please use force delete.",
+                    sdxCluster.getClusterName()));
+        }
+        Collection<StackViewV4Response> attachedDistroXClusters = distroxService.getAttachedDistroXClusters(sdxCluster.getEnvCrn());
+        if (!attachedDistroXClusters.isEmpty()) {
+            throw new BadRequestException(String.format("The following Data Hub(s) cluster(s) must be terminated " +
+                            "before deletion of SDX cluster: [%s].",
+                    attachedDistroXClusters.stream().map(StackViewV4Response::getName).collect(Collectors.joining(", "))));
+        }
+    }
+}

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/SdxDeleteServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/SdxDeleteServiceTest.java
@@ -1,0 +1,162 @@
+package com.sequenceiq.datalake.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.google.common.collect.Sets;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Response;
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.datalake.entity.DatalakeStatusEnum;
+import com.sequenceiq.datalake.entity.SdxCluster;
+import com.sequenceiq.datalake.entity.SdxStatusEntity;
+import com.sequenceiq.datalake.flow.SdxReactorFlowManager;
+import com.sequenceiq.datalake.repository.SdxClusterRepository;
+import com.sequenceiq.datalake.service.sdx.DistroxService;
+import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+import com.sequenceiq.flow.api.model.FlowType;
+import com.sequenceiq.flow.service.FlowCancelService;
+import com.sequenceiq.sdx.api.model.SdxDatabaseAvailabilityType;
+
+@ExtendWith(MockitoExtension.class)
+class SdxDeleteServiceTest {
+
+    private static final String ACCOUNT_ID = "accId";
+
+    private static final String CLUSTER_NAME = "test-sdx-cluster";
+
+    private static final Long SDX_ID = 2L;
+
+    private static final String SDX_CRN = "crn";
+
+    private static final String ENVIRONMENT_CRN = "crn:cdp:environments:us-west-1:default:environment:e438a2db-d650-4132-ae62-242c5ba2f784";
+
+    @Mock
+    private FlowCancelService flowCancelService;
+
+    @Mock
+    private SdxClusterRepository sdxClusterRepository;
+
+    @Mock
+    private SdxStatusService sdxStatusService;
+
+    @Mock
+    private SdxReactorFlowManager sdxReactorFlowManager;
+
+    @Mock
+    private DistroxService distroxService;
+
+    @InjectMocks
+    private SdxDeleteService underTest;
+
+    @Test
+    void testDeleteSdxWhenNameIsProvidedAndClusterDoesNotExistShouldThrowNotFoundException() {
+        assertThrows(com.sequenceiq.cloudbreak.common.exception.NotFoundException.class,
+                () -> underTest.deleteSdx(ACCOUNT_ID, CLUSTER_NAME, false));
+        verify(sdxClusterRepository, times(1))
+                .findByAccountIdAndClusterNameAndDeletedIsNull(eq(ACCOUNT_ID), eq(CLUSTER_NAME));
+    }
+
+    @Test
+    void testDeleteSdxWhenNameIsProvidedShouldInitiateSdxDeletionFlow() {
+        SdxCluster sdxCluster = getSdxCluster();
+        when(sdxClusterRepository.findByAccountIdAndClusterNameAndDeletedIsNull(anyString(), anyString())).thenReturn(Optional.of(sdxCluster));
+        when(sdxReactorFlowManager.triggerSdxDeletion(any(SdxCluster.class), anyBoolean())).thenReturn(new FlowIdentifier(FlowType.FLOW, "FLOW_ID"));
+        mockCBCallForDistroXClusters(Sets.newHashSet());
+        underTest.deleteSdx(ACCOUNT_ID, "sdx-cluster-name", true);
+        verify(sdxReactorFlowManager, times(1)).triggerSdxDeletion(sdxCluster, true);
+        ArgumentCaptor<SdxCluster> captor = ArgumentCaptor.forClass(SdxCluster.class);
+        verify(sdxClusterRepository, times(1)).save(captor.capture());
+        verify(sdxStatusService, times(1))
+                .setStatusForDatalakeAndNotify(DatalakeStatusEnum.DELETE_REQUESTED, "Datalake deletion requested", sdxCluster);
+    }
+
+    @Test
+    void testDeleteSdxWhenSdxHasExternalDatabaseButCrnIsMissingShouldThrowNotFoundException() {
+        SdxCluster sdxCluster = getSdxCluster();
+        sdxCluster.setDatabaseAvailabilityType(SdxDatabaseAvailabilityType.HA);
+        sdxCluster.setDatabaseCrn(null);
+        when(sdxClusterRepository.findByAccountIdAndClusterNameAndDeletedIsNull(anyString(), anyString())).thenReturn(Optional.of(sdxCluster));
+        SdxStatusEntity sdxStatusEntity = new SdxStatusEntity();
+        sdxStatusEntity.setStatus(DatalakeStatusEnum.RUNNING);
+        when(sdxStatusService.getActualStatusForSdx(sdxCluster)).thenReturn(sdxStatusEntity);
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> underTest.deleteSdx(ACCOUNT_ID, "sdx-cluster-name", false));
+        assertEquals(String.format("Can not find external database for Data Lake, but it was requested: %s. Please use force delete.",
+                sdxCluster.getClusterName()), badRequestException.getMessage());
+    }
+
+    @Test
+    void testDeleteSdxWhenSdxHasExternalDatabaseButCrnIsMissingShouldNotThrowNotFoundException() {
+        SdxCluster sdxCluster = getSdxCluster();
+        sdxCluster.setDatabaseAvailabilityType(SdxDatabaseAvailabilityType.HA);
+        sdxCluster.setDatabaseCrn(null);
+        when(sdxClusterRepository.findByAccountIdAndClusterNameAndDeletedIsNull(anyString(), anyString())).thenReturn(Optional.of(sdxCluster));
+        SdxStatusEntity sdxStatusEntity = new SdxStatusEntity();
+        sdxStatusEntity.setStatus(DatalakeStatusEnum.PROVISIONING_FAILED);
+        when(sdxReactorFlowManager.triggerSdxDeletion(eq(sdxCluster), anyBoolean())).thenReturn(new FlowIdentifier(FlowType.FLOW, "id"));
+        when(sdxStatusService.getActualStatusForSdx(sdxCluster)).thenReturn(sdxStatusEntity);
+        underTest.deleteSdx(ACCOUNT_ID, "sdx-cluster-name", false);
+        verify(sdxClusterRepository, times(1)).save(sdxCluster);
+        verify(sdxStatusService, times(1))
+                .setStatusForDatalakeAndNotify(DatalakeStatusEnum.DELETE_REQUESTED, "Datalake deletion requested", sdxCluster);
+        verify(sdxReactorFlowManager, times(1)).triggerSdxDeletion(sdxCluster, false);
+        verify(flowCancelService, times(1)).cancelRunningFlows(SDX_ID);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Status.class, names = {"AVAILABLE", "BACKUP_IN_PROGRESS", "STOPPED", "BACKUP_FAILED"})
+    void testDeleteSdxWhenSdxHasAttachedDataHubsShouldThrowBadRequest(Status dhStatus) {
+        SdxCluster sdxCluster = getSdxCluster();
+        SdxStatusEntity sdxStatusEntity = new SdxStatusEntity();
+        sdxStatusEntity.setStatus(DatalakeStatusEnum.RUNNING);
+        StackViewV4Response stackViewV4Response = new StackViewV4Response();
+        stackViewV4Response.setName("existingDistroXCluster");
+        stackViewV4Response.setStatus(dhStatus);
+
+        mockCBCallForDistroXClusters(Sets.newHashSet(stackViewV4Response));
+        when(sdxClusterRepository.findByAccountIdAndClusterNameAndDeletedIsNull(anyString(), anyString())).thenReturn(Optional.of(sdxCluster));
+        when(sdxStatusService.getActualStatusForSdx(sdxCluster)).thenReturn(sdxStatusEntity);
+
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> underTest.deleteSdx(ACCOUNT_ID, "sdx-cluster-name", true));
+
+        assertEquals("The following Data Hub(s) cluster(s) must be terminated before deletion of SDX cluster: [existingDistroXCluster].",
+                badRequestException.getMessage());
+    }
+
+    private void mockCBCallForDistroXClusters(Set<StackViewV4Response> stackViews) {
+        when(distroxService.getAttachedDistroXClusters(anyString())).thenReturn(stackViews);
+    }
+
+    private SdxCluster getSdxCluster() {
+        SdxCluster sdxCluster = new SdxCluster();
+        sdxCluster.setId(SDX_ID);
+        sdxCluster.setCrn(SDX_CRN);
+        sdxCluster.setEnvCrn(ENVIRONMENT_CRN);
+        sdxCluster.setEnvName("envir");
+        sdxCluster.setClusterName("sdx-cluster-name");
+        return sdxCluster;
+    }
+
+}


### PR DESCRIPTION
2 cases are handled:
```
lowLogsToListDiagnosticsCollectionResponseConverter (field private com.sequenceiq.flow.core.config.FlowProgressHolder com.sequenceiq.cloudbreak.converter.v4.diagnostics.FlowLogsToListDiagnosticsCollectionResponseConverter.flowProgressHolder)
┌─────┐
flowProgressHolder defined in URL [jar:file:/cloudbreak.jar!/BOOT-INF/lib/flow-2.67.0-b102.jar!/com/sequenceiq/flow/core/config/FlowProgressHolder.class]
↑ ↓
rotateSaltPasswordFlowConfig
↑ ↓
rotateSaltPasswordActions (field private com.sequenceiq.cloudbreak.service.RotateSaltPasswordService com.sequenceiq.cloudbreak.core.flow2.cluster.salt.rotatepassword.RotateSaltPasswordActions.rotateSaltPasswordService)
↑ ↓
rotateSaltPasswordService (field private com.sequenceiq.cloudbreak.core.flow2.service.ReactorFlowManager com.sequenceiq.cloudbreak.service.RotateSaltPasswordService.flowManager)
↑ ↓
reactorFlowManager (field private com.sequenceiq.cloudbreak.core.flow2.service.TerminationTriggerService com.sequenceiq.cloudbreak.core.flow2.service.ReactorFlowManager.terminationTriggerService)
↑ ↓
terminationTriggerService (field private com.sequenceiq.flow.service.FlowCancelService com.sequenceiq.cloudbreak.core.flow2.service.TerminationTriggerService.flowCancelService)
↑ ↓
flowCancelService (field private com.sequenceiq.flow.core.Flow2Handler com.sequenceiq.flow.service.FlowCancelService.flow2Handler)
↑ ↓
flow2Handler
↑ ↓
clusterCreationFlowConfig
↑ ↓
clusterCreationActions (field private com.sequenceiq.cloudbreak.job.stackpatcher.ExistingStackPatcherJobService com.sequenceiq.cloudbreak.core.flow2.cluster.provision.ClusterCreationActions.existingStackPatcherJobService)
↑ ↓
existingStackPatcherJobService (field private com.sequenceiq.cloudbreak.job.stackpatcher.ExistingStackPatcherServiceProvider com.sequenceiq.cloudbreak.job.stackpatcher.ExistingStackPatcherJobService.existingStackPatcherServiceProvider)
↑ ↓
existingStackPatcherServiceProvider (field private java.util.Collection com.sequenceiq.cloudbreak.job.stackpatcher.ExistingStackPatcherServiceProvider.existingStackPatchServices)
↑ ↓
unboundRestartPatchService (field private com.sequenceiq.flow.service.FlowService com.sequenceiq.cloudbreak.service.stackpatch.UnboundRestartPatchService.flowService)
↑ ↓
flowService (field private com.sequenceiq.flow.converter.FlowProgressResponseConverter com.sequenceiq.flow.service.FlowService.flowProgressResponseConverter)
↑ ↓
flowProgressResponseConverter defined in URL [jar:file:/cloudbreak.jar!/BOOT-INF/lib/flow-2.67.0-b102.jar!/com/sequenceiq/flow/converter/FlowProgressResponseConverter.class]
└─────┘
```
and
```
{"timestamp":"2023-01-26 14:18:03.443","level":"ERROR","thread":"main","logger":"org.springframework.boot.diagnostics.LoggingFailureAnalysisReporter","message":"2023-01-26 14:18:03,443 [main] report:40 ERROR o.s.b.d.LoggingFailureAnalysisReporter - [type:springLog] [crn:] [name:] [flow:] [requestid:] [tenant:] [userCrn:] [environment:] [traceId:] [spanId:] \n\n***************************\nAPPLICATION FAILED TO START\n***************************\n\nDescription:\n\nThe dependencies of some of the beans in the application context form a cycle:\n\n   progressController (field private com.sequenceiq.datalake.service.sdx.progress.ProgressService com.sequenceiq.datalake.controller.progress.ProgressController.progressService)\n      ↓\n   progressService (field private com.sequenceiq.flow.service.FlowService com.sequenceiq.datalake.service.sdx.progress.ProgressService.flowService)\n      ↓\n   flowService\n┌─────┐\n|  failHandledEvents defined in class path resource [com/sequenceiq/flow/core/config/Flow2Config.class]\n↑     ↓\n|  updateLoadBalancerDNSFlowConfig\n↑     ↓\n|  updateLoadBalancerDNSActions (field private com.sequenceiq.datalake.service.sdx.SdxService com.sequenceiq.datalake.flow.loadbalancer.dns.UpdateLoadBalancerDNSActions.sdxService)\n↑     ↓\n|  sdxService (field private com.sequenceiq.flow.service.FlowCancelService com.sequenceiq.datalake.service.sdx.SdxService.flowCancelService)\n↑     ↓\n|  flowCancelService (field private com.sequenceiq.flow.core.Flow2Handler com.sequenceiq.flow.service.FlowCancelService.flow2Handler)\n↑     ↓\n|  flow2Handler\n└─────┘\n\n\n"}
```

See detailed description in the commit message.