### PR TITLE
CB-20135:Turn off KMS validations / allows keys in remote AWS account

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/validators/EncryptionKeyArnValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/validators/EncryptionKeyArnValidator.java
@@ -104,9 +104,11 @@ public class EncryptionKeyArnValidator {
                     platformResources().encryptionKeys(extendedCloudCredential, region, Collections.emptyMap()));
             List<String> keyArns = encryptionKeys.getCloudEncryptionKeys().stream().map(CloudEncryptionKey::getName).collect(Collectors.toList());
             if (keyArns.stream().noneMatch(s -> s.equals(encryptionKeyArn))) {
-                validationResultBuilder.error("Following encryption keys are retrieved from the cloud " + keyArns +
+                validationResultBuilder.warning("Following encryption keys are retrieved from the cloud " + keyArns +
                                 " . The provided encryption key " + encryptionKeyArn +
-                        " does not exist in the given region's encryption key list for this credential.");
+                        " does not exist in the given region's encryption key list for this credential." +
+                        " This is possible if the key is present in a different AWS Account." +
+                        " Please ensure that the Key is present" + "and have valid permissions otherwise would result to failures in EBS volume creation");
 
             }
         } catch (Exception e) {

--- a/environment/src/test/java/com/sequenceiq/environment/environment/validation/validators/EncryptionKeyArnValidatorTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/validation/validators/EncryptionKeyArnValidatorTest.java
@@ -106,14 +106,15 @@ class EncryptionKeyArnValidatorTest {
         testInput1.setName("arn:aws:kms:eu-west-2:123456789012:key/1a2b3c4d-5e6f-jjjj-9i0j-1k2l3m4n5o6p");
         CloudEncryptionKeys cloudEncryptionKeys = new CloudEncryptionKeys(Set.of(testInput, testInput1));
         when(retryService.testWith2SecDelayMax15Times(any(Supplier.class))).thenReturn(cloudEncryptionKeys);
-
         ValidationResult validationResult = underTest.validate(environmentValidationDto);
-        assertTrue(validationResult.hasError());
-        assertEquals(String.format("Following encryption keys are retrieved from the cloud " +
-                        cloudEncryptionKeys.getCloudEncryptionKeys().stream().map(CloudEncryptionKey::getName).collect(Collectors.toList()) +
-                        " . The provided encryption key " + invalidKey +
-                        " does not exist in the given region's encryption key list for this credential."),
-                validationResult.getFormattedErrors());
+        assertTrue(validationResult.hasWarning());
+        assertEquals(String.format("Following encryption keys are retrieved from the cloud "
+                        + cloudEncryptionKeys.getCloudEncryptionKeys().stream().map(CloudEncryptionKey::getName).collect(Collectors.toList()) +
+                                " . The provided encryption key " + invalidKey +
+                                " does not exist in the given region's encryption key list for this credential." +
+                                " This is possible if the key is present in a different AWS Account." +
+                        " Please ensure that the Key is present" + "and have valid permissions otherwise would result to failures in EBS volume creation"),
+                validationResult.getFormattedWarnings());
     }
 
     @Test


### PR DESCRIPTION
Changed the key validation to throw Warnings instead of errors to allow KMS keys from other AWS accounts from which  we cannot list the keys.