### PR TITLE
CB-20669 Added upgrade validation for Flink

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
@@ -141,6 +141,10 @@ public interface ClusterApi {
         return clusterModificationService().getRoleConfigValueByServiceType(clusterName, roleConfigGroup, serviceType, configName);
     }
 
+    default boolean isRolePresent(String clusterName, String roleConfigGroup, String serviceType) {
+        return clusterModificationService().isRolePresent(clusterName, roleConfigGroup, serviceType);
+    }
+
     default void rotateHostCertificates(String sshUser, KeyPair sshKeyPair, String subAltName) throws CloudbreakException {
         clusterSecurityService().rotateHostCertificates(sshUser, sshKeyPair, subAltName);
     }

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterModificationService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterModificationService.java
@@ -56,6 +56,8 @@ public interface ClusterModificationService {
     ParcelOperationStatus removeUnusedParcels(Set<ClusterComponentView> usedParcelComponents, Set<String> parcelNamesFromImage)
             throws CloudbreakException;
 
+    boolean isRolePresent(String clusterName, String roleConfigGroup, String serviceType);
+
     boolean isServicePresent(String clusterName, String serviceType);
 
     default void stopComponents(Map<String, String> components, String hostname) {

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerConfigService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerConfigService.java
@@ -173,7 +173,24 @@ public class ClouderaManagerConfigService {
 
     private String getServiceNameValue(String clusterName, String serviceType, ServicesResourceApi servicesResourceApi) {
         return getServiceName(clusterName, serviceType, servicesResourceApi).orElseThrow(
-                () -> new NotFoundException(String.format("No service found with %s service type", serviceType)));
+                () -> new NotFoundException(String.format("No service name found with %s service type", serviceType)));
+    }
+
+    public boolean isRolePresent(ApiClient apiClient, String clusterName, String roleType, String serviceType) {
+        LOGGER.debug("Looking for role name for cluster {}, roleType {}, and serviceType {}", clusterName, roleType, serviceType);
+        RoleConfigGroupsResourceApi roleConfigGroupsResourceApi = clouderaManagerApiFactory.getRoleConfigGroupsResourceApi(apiClient);
+        ServicesResourceApi servicesResourceApi = clouderaManagerApiFactory.getServicesResourceApi(apiClient);
+        try {
+            String serviceName = getServiceNameValue(clusterName, serviceType, servicesResourceApi);
+            getRoleConfigGroupNameByTypeAndServiceName(roleType, clusterName, serviceName, roleConfigGroupsResourceApi);
+            return true;
+        } catch (NotFoundException e) {
+            LOGGER.debug("Role not found for cluster {}, roleType {}, and serviceType {}", clusterName, roleType, serviceType, e);
+            return false;
+        } catch (ApiException e) {
+            LOGGER.debug("Failed to get role name for cluster {}, roleType {}, and serviceType {}", clusterName, roleType, serviceType, e);
+            throw new ClouderaManagerOperationFailedException(e.getMessage(), e);
+        }
     }
 
     private String getRoleConfigGroupNameByTypeAndServiceName(String roleType, String clusterName, String serviceName,

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
@@ -1029,6 +1029,11 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
     }
 
     @Override
+    public boolean isRolePresent(String clusterName, String roleConfigGroup, String serviceType) {
+        return configService.isRolePresent(apiClient, clusterName, roleConfigGroup, serviceType);
+    }
+
+    @Override
     public boolean isServicePresent(String clusterName, String serviceType) {
         boolean servicePresent = false;
         try {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/ClusterUpgradeValidationActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/ClusterUpgradeValidationActions.java
@@ -82,6 +82,8 @@ public class ClusterUpgradeValidationActions {
 
     private static final String UPGRADE_IMAGE_INFO = "upgradeImageInfo";
 
+    private static final String TARGET_RUNTIME = "targetRuntime";
+
     @Inject
     private StackService stackService;
 
@@ -144,6 +146,7 @@ public class ClusterUpgradeValidationActions {
                 variables.put(TARGET_IMAGE, targetImage);
                 variables.put(UPGRADE_IMAGE_INFO, upgradeImageInfo);
                 String targetVersion = targetImage.getPackageVersions().getOrDefault(ImagePackageVersion.STACK.getDisplayName(), "");
+                variables.put(TARGET_RUNTIME, targetVersion);
                 if (CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited(targetVersion, CMRepositoryVersionUtil.CLOUDERA_STACK_VERSION_7_2_16)) {
                     ClusterUpgradeS3guardValidationEvent event = new ClusterUpgradeS3guardValidationEvent(payload.getResourceId(),
                             payload.getImageId());
@@ -277,7 +280,8 @@ public class ClusterUpgradeValidationActions {
             protected void doExecute(StackContext context, ClusterUpgradeFreeIpaStatusValidationFinishedEvent payload, Map<Object, Object> variables) {
                 LOGGER.info("Starting to validate services.");
                 boolean lockComponents = (Boolean) variables.get(LOCK_COMPONENTS);
-                ClusterUpgradeServiceValidationEvent event = new ClusterUpgradeServiceValidationEvent(payload.getResourceId(), lockComponents);
+                String targetRuntime = (String) variables.get(TARGET_RUNTIME);
+                ClusterUpgradeServiceValidationEvent event = new ClusterUpgradeServiceValidationEvent(payload.getResourceId(), lockComponents, targetRuntime);
                 sendEvent(context, event.selector(), event);
             }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/event/ClusterUpgradeServiceValidationEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/event/ClusterUpgradeServiceValidationEvent.java
@@ -8,22 +8,31 @@ public class ClusterUpgradeServiceValidationEvent extends StackEvent {
 
     private final boolean lockComponents;
 
+    private final String targetRuntime;
+
     @JsonCreator
     public ClusterUpgradeServiceValidationEvent(
             @JsonProperty("resourceId") Long resourceId,
-            @JsonProperty("lockComponents") boolean lockComponents) {
+            @JsonProperty("lockComponents") boolean lockComponents,
+            @JsonProperty("targetRuntime") String targetRuntime) {
         super(ClusterUpgradeValidationHandlerSelectors.VALIDATE_SERVICES_EVENT.name(), resourceId);
         this.lockComponents = lockComponents;
+        this.targetRuntime = targetRuntime;
     }
 
     public boolean isLockComponents() {
         return lockComponents;
     }
 
+    public String getTargetRuntime() {
+        return targetRuntime;
+    }
+
     @Override
     public String toString() {
         return "ClusterUpgradeServiceValidationEvent{" +
                 "lockComponents=" + lockComponents +
+                "targetRuntime=" + targetRuntime +
                 "} " + super.toString();
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/handler/ClusterUpgradeServiceValidationHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/handler/ClusterUpgradeServiceValidationHandler.java
@@ -41,7 +41,9 @@ public class ClusterUpgradeServiceValidationHandler extends ExceptionCatcherEven
         Long stackId = request.getResourceId();
         try {
             Stack stack = getStack(stackId);
-            serviceUpgradeValidators.forEach(validator -> validator.validate(new ServiceUpgradeValidationRequest(stack, request.isLockComponents())));
+            ServiceUpgradeValidationRequest validationRequest =
+                    new ServiceUpgradeValidationRequest(stack, request.isLockComponents(), request.getTargetRuntime());
+            serviceUpgradeValidators.forEach(validator -> validator.validate(validationRequest));
             return new ClusterUpgradeValidationFinishedEvent(stackId);
         } catch (UpgradeValidationFailedException e) {
             LOGGER.warn("Cluster upgrade service validation failed", e);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/service/FlinkUpgradeValidator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/service/FlinkUpgradeValidator.java
@@ -1,0 +1,60 @@
+package com.sequenceiq.cloudbreak.service.upgrade.validation.service;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.StringUtils;
+
+import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
+import com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateService;
+import com.sequenceiq.cloudbreak.common.exception.UpgradeValidationFailedException;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
+
+public class FlinkUpgradeValidator implements ServiceUpgradeValidator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FlinkUpgradeValidator.class);
+
+    private static final String FLINK_SERVICE_TYPE = "FLINK";
+
+    private static final String ROLE_TYPE = "STREAMING_SQL_CONSOLE";
+
+    @Inject
+    private CmTemplateService cmTemplateService;
+
+    @Inject
+    private ClusterApiConnectors clusterApiConnectors;
+
+    @Override
+    public void validate(ServiceUpgradeValidationRequest validationRequest) {
+        String targetRuntime = validationRequest.getTargetRuntime();
+        Stack stack = validationRequest.getStack();
+        if (!StringUtils.hasText(targetRuntime)) {
+            LOGGER.debug("Skipping Flink service validation due to missing or invalid: target runtime version: [{}]", targetRuntime);
+        } else if (!CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited(targetRuntime, CMRepositoryVersionUtil.CLOUDERA_STACK_VERSION_7_2_16)) {
+            LOGGER.debug("Skipping Flink service validation, because target runtime ({}) is lower than 7.2.16", targetRuntime);
+        } else if (!isFLinkServicePresent(stack)) {
+            LOGGER.debug("Skipping Flink service validation, because Flink service not found in blueprint");
+        } else {
+            ClusterApi connector = clusterApiConnectors.getConnector(stack);
+            LOGGER.debug("Validating Flink service role : {}", ROLE_TYPE);
+            if (!connector.isRolePresent(stack.getCluster().getName(), ROLE_TYPE, FLINK_SERVICE_TYPE)) {
+                LOGGER.debug("Flink upgrade validation was successful");
+            } else {
+                throw new UpgradeValidationFailedException(
+                        String.format("Version change to CDH %s would lose access to role STREAMING_SQL_CONSOLE. " +
+                                "To continue, remove this role and any dependent services.", targetRuntime));
+            }
+        }
+    }
+
+    private boolean isFLinkServicePresent(Stack stack) {
+        return cmTemplateService.isServiceTypePresent(FLINK_SERVICE_TYPE, getBlueprintText(stack));
+    }
+
+    private String getBlueprintText(Stack stack) {
+        return stack.getCluster().getBlueprint().getBlueprintText();
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/service/ServiceUpgradeValidationRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/service/ServiceUpgradeValidationRequest.java
@@ -8,9 +8,12 @@ public class ServiceUpgradeValidationRequest {
 
     private final boolean lockComponents;
 
-    public ServiceUpgradeValidationRequest(Stack stack, boolean lockComponents) {
+    private final String targetRuntime;
+
+    public ServiceUpgradeValidationRequest(Stack stack, boolean lockComponents, String targetRuntime) {
         this.stack = stack;
         this.lockComponents = lockComponents;
+        this.targetRuntime = targetRuntime;
     }
 
     public Stack getStack() {
@@ -19,5 +22,9 @@ public class ServiceUpgradeValidationRequest {
 
     public boolean isLockComponents() {
         return lockComponents;
+    }
+
+    public String getTargetRuntime() {
+        return targetRuntime;
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/validation/service/ActiveCommandsValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/validation/service/ActiveCommandsValidatorTest.java
@@ -57,7 +57,7 @@ public class ActiveCommandsValidatorTest {
         when(clusterApiConnectors.getConnector(stack)).thenReturn(connector);
         when(connector.clusterStatusService()).thenReturn(clusterStatusService);
         // WHEN
-        underTest.validate(new ServiceUpgradeValidationRequest(stack, true));
+        underTest.validate(new ServiceUpgradeValidationRequest(stack, true, ""));
         // THEN no exception is thrown
     }
 
@@ -68,7 +68,7 @@ public class ActiveCommandsValidatorTest {
         when(connector.clusterStatusService()).thenReturn(clusterStatusService);
         when(clusterStatusService.getActiveCommandsList()).thenReturn(null);
         // WHEN
-        underTest.validate(new ServiceUpgradeValidationRequest(stack, true));
+        underTest.validate(new ServiceUpgradeValidationRequest(stack, true, ""));
         // THEN no exception is thrown
     }
 
@@ -80,7 +80,7 @@ public class ActiveCommandsValidatorTest {
         initGlobalPrivateFields();
         when(clusterStatusService.getActiveCommandsList()).thenReturn(List.of(createCommand(INTERRUPTABLE_COMMAND_1), createCommand(INTERRUPTABLE_COMMAND_2)));
         // WHEN
-        underTest.validate(new ServiceUpgradeValidationRequest(stack, true));
+        underTest.validate(new ServiceUpgradeValidationRequest(stack, true, ""));
         // THEN no exception is thrown
     }
 
@@ -94,7 +94,7 @@ public class ActiveCommandsValidatorTest {
                 List.of(createCommand(NON_INTERRUPTABLE_COMMAND_1), createCommand(NON_INTERRUPTABLE_COMMAND_2)));
         // WHEN
         UpgradeValidationFailedException ex = Assertions.assertThrows(UpgradeValidationFailedException.class,
-                () -> underTest.validate(new ServiceUpgradeValidationRequest(stack, true)));
+                () -> underTest.validate(new ServiceUpgradeValidationRequest(stack, true, "")));
         // THEN exception is thrown
         assertEquals("There are active commands running on CM that are not interruptable, upgrade is not possible. " +
                 "Active commands: [ClusterManagerCommand{id=1, name='non-interruptable-1', startTime='start-time', endTime='null', active=null, " +
@@ -112,7 +112,7 @@ public class ActiveCommandsValidatorTest {
                 List.of(createCommand(INTERRUPTABLE_COMMAND_1), createCommand(NON_INTERRUPTABLE_COMMAND_1)));
         // WHEN
         UpgradeValidationFailedException ex = Assertions.assertThrows(UpgradeValidationFailedException.class,
-                () -> underTest.validate(new ServiceUpgradeValidationRequest(stack, true)));
+                () -> underTest.validate(new ServiceUpgradeValidationRequest(stack, true, "")));
         // THEN exception is thrown
         assertEquals("There are active commands running on CM that are not interruptable, upgrade is not possible. " +
                 "Active commands: [ClusterManagerCommand{id=1, name='non-interruptable-1', startTime='start-time', endTime='null', active=null, " +

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/validation/service/FlinkUpgradeValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/validation/service/FlinkUpgradeValidatorTest.java
@@ -1,0 +1,127 @@
+package com.sequenceiq.cloudbreak.service.upgrade.validation.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
+import com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateService;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.common.exception.UpgradeValidationFailedException;
+import com.sequenceiq.cloudbreak.domain.Blueprint;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
+
+@ExtendWith(MockitoExtension.class)
+public class FlinkUpgradeValidatorTest {
+
+    private static final String BLUEPRINT_TEXT = "{blueprint}";
+
+    private static final String CLUSTER_NAME = "clusterName";
+
+    @InjectMocks
+    private FlinkUpgradeValidator underTest;
+
+    private Stack stack;
+
+    @Mock
+    private CmTemplateService cmTemplateService;
+
+    @Mock
+    private ClusterApiConnectors clusterApiConnectors;
+
+    @Mock
+    private ClusterApi clusterApi;
+
+    @BeforeEach
+    public void before() {
+        Blueprint blueprint = new Blueprint();
+        blueprint.setBlueprintText(BLUEPRINT_TEXT);
+
+        Cluster cluster = new Cluster();
+        cluster.setName(CLUSTER_NAME);
+        cluster.setBlueprint(blueprint);
+
+        stack = new Stack();
+        stack.setCluster(cluster);
+    }
+
+    @Test
+    void validateNoRuntimeVersion() {
+        ServiceUpgradeValidationRequest request =
+                new ServiceUpgradeValidationRequest(stack, false, null);
+        underTest.validate(request);
+        verifyNoInteractions(cmTemplateService);
+        verifyNoInteractions(clusterApiConnectors);
+    }
+
+    @Test
+    void validateNotAffectedRuntime() {
+        ServiceUpgradeValidationRequest request =
+                new ServiceUpgradeValidationRequest(stack, false, CMRepositoryVersionUtil.CLOUDERA_STACK_VERSION_7_2_14.getVersion());
+        underTest.validate(request);
+        verifyNoInteractions(cmTemplateService);
+        verifyNoInteractions(clusterApiConnectors);
+    }
+
+    @Test
+    void validateNoFlinkSevice() {
+        when(cmTemplateService.isServiceTypePresent("FLINK", BLUEPRINT_TEXT)).thenReturn(false);
+        ServiceUpgradeValidationRequest request =
+                new ServiceUpgradeValidationRequest(stack, false, CMRepositoryVersionUtil.CLOUDERA_STACK_VERSION_7_2_16.getVersion());
+        underTest.validate(request);
+
+        verifyNoInteractions(clusterApiConnectors);
+    }
+
+    @Test
+    void validateNoRole() {
+        when(cmTemplateService.isServiceTypePresent("FLINK", BLUEPRINT_TEXT)).thenReturn(true);
+        when(clusterApiConnectors.getConnector(stack)).thenReturn(clusterApi);
+        when(clusterApi.isRolePresent(CLUSTER_NAME, "STREAMING_SQL_CONSOLE", "FLINK")).thenReturn(false);
+        ServiceUpgradeValidationRequest request =
+                new ServiceUpgradeValidationRequest(stack, false, CMRepositoryVersionUtil.CLOUDERA_STACK_VERSION_7_2_16.getVersion());
+        underTest.validate(request);
+    }
+
+    @Test
+    void validateApiException() {
+        when(cmTemplateService.isServiceTypePresent("FLINK", BLUEPRINT_TEXT)).thenReturn(true);
+        when(clusterApiConnectors.getConnector(stack)).thenReturn(clusterApi);
+        when(clusterApi.isRolePresent(CLUSTER_NAME, "STREAMING_SQL_CONSOLE", "FLINK"))
+                .thenThrow(new CloudbreakServiceException("Api exception"));
+
+        ServiceUpgradeValidationRequest request =
+                new ServiceUpgradeValidationRequest(stack, false, CMRepositoryVersionUtil.CLOUDERA_STACK_VERSION_7_2_16.getVersion());
+
+        CloudbreakServiceException exception = assertThrows(CloudbreakServiceException.class, () -> underTest.validate(request));
+
+        assertEquals("Api exception", exception.getMessage());
+    }
+
+    @Test
+    void validateRoleExistsValidationFails() {
+        when(cmTemplateService.isServiceTypePresent("FLINK", BLUEPRINT_TEXT)).thenReturn(true);
+        when(clusterApiConnectors.getConnector(stack)).thenReturn(clusterApi);
+        when(clusterApi.isRolePresent(CLUSTER_NAME, "STREAMING_SQL_CONSOLE", "FLINK")).thenReturn(true);
+
+        ServiceUpgradeValidationRequest request =
+                new ServiceUpgradeValidationRequest(stack, false, CMRepositoryVersionUtil.CLOUDERA_STACK_VERSION_7_2_16.getVersion());
+
+        UpgradeValidationFailedException exception = assertThrows(UpgradeValidationFailedException.class, () -> underTest.validate(request));
+
+        String expected =
+                "Version change to CDH 7.2.16 would lose access to role STREAMING_SQL_CONSOLE. To continue, remove this role and any dependent services.";
+        assertEquals(expected, exception.getMessage());
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/validation/service/NifiUpgradeValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/validation/service/NifiUpgradeValidatorTest.java
@@ -59,7 +59,7 @@ public class NifiUpgradeValidatorTest {
 
     @Test
     public void testValidateShouldNotThrowExceptionWhenLockComponentsIsFalse() {
-        underTest.validate(new ServiceUpgradeValidationRequest(null, false));
+        underTest.validate(new ServiceUpgradeValidationRequest(null, false, ""));
 
         verifyNoInteractions(cmTemplateService);
         verifyNoInteractions(clusterApiConnectors);
@@ -69,7 +69,7 @@ public class NifiUpgradeValidatorTest {
     public void testValidateShouldNotThrowExceptionWhenLockComponentsTrueAndTheNifiServiceIsNotPresent() {
         when(cmTemplateService.isServiceTypePresent(SERVICE_TYPE, BLUEPRINT_TEXT)).thenReturn(false);
 
-        underTest.validate(new ServiceUpgradeValidationRequest(stack, true));
+        underTest.validate(new ServiceUpgradeValidationRequest(stack, true, ""));
 
         verifyNoInteractions(clusterApiConnectors);
     }
@@ -80,7 +80,7 @@ public class NifiUpgradeValidatorTest {
         when(clusterApiConnectors.getConnector(stack)).thenReturn(connector);
         when(connector.getRoleConfigValueByServiceType(CLUSTER_NAME, ROLE_TYPE, SERVICE_TYPE, CONFIG)).thenReturn(Optional.of(VolumeUtils.VOLUME_PREFIX));
 
-        underTest.validate(new ServiceUpgradeValidationRequest(stack, true));
+        underTest.validate(new ServiceUpgradeValidationRequest(stack, true, ""));
         verify(cmTemplateService).isServiceTypePresent(SERVICE_TYPE, BLUEPRINT_TEXT);
         verify(clusterApiConnectors).getConnector(stack);
         verify(connector).getRoleConfigValueByServiceType(CLUSTER_NAME, ROLE_TYPE, SERVICE_TYPE, CONFIG);
@@ -92,7 +92,7 @@ public class NifiUpgradeValidatorTest {
         when(clusterApiConnectors.getConnector(stack)).thenReturn(connector);
         when(connector.getRoleConfigValueByServiceType(CLUSTER_NAME, ROLE_TYPE, SERVICE_TYPE, CONFIG)).thenReturn(Optional.of("/var/etc"));
 
-        Exception actual = assertThrows(UpgradeValidationFailedException.class, () -> underTest.validate(new ServiceUpgradeValidationRequest(stack, true)));
+        Exception actual = assertThrows(UpgradeValidationFailedException.class, () -> underTest.validate(new ServiceUpgradeValidationRequest(stack, true, "")));
 
         assertEquals("Nifi working directory validation failed. The current directory /var/etc is not eligible for upgrade because it is located on the "
                 + "root disk. The Nifi working directory should be under the /hadoopfs/fs path. During upgrade or repair the Nifi directory would get deleted "


### PR DESCRIPTION
In 7.2.16, there is no longer a STREAMING_SQL_CONSOLE role, its functionality is included in STREAMING_SQL_ENGINE. This role needs to be removed manually when upgrading a cluster with the Flink service to 7.2.16

