### PR TITLE
CB-20412 [API E2E GOV] FreeIpa deployment requests are only allowed with at least '2' instance(s) by group

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
@@ -124,6 +124,11 @@ public class EnvironmentTestDto
         return this;
     }
 
+    public EnvironmentTestDto withFreeIpaNodes(int instanceCountByGroup) {
+        getRequest().getFreeIpa().setInstanceCountByGroup(instanceCountByGroup);
+        return this;
+    }
+
     public EnvironmentTestDto withCreateFreeIpa(Boolean create) {
         getRequest().getFreeIpa().setCreate(create);
         return this;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaTestDto.java
@@ -101,7 +101,7 @@ public class FreeIpaTestDto extends AbstractFreeIpaTestDto<CreateFreeIpaRequest,
         return withName(getResourcePropertyProvider().getName(getCloudPlatform()))
                 .withEnvironment(getTestContext().given(EnvironmentTestDto.class).withTunnel(getTestContext().getTunnel()))
                 .withPlacement(getTestContext().given(PlacementSettingsTestDto.class))
-                .withInstanceGroupsEntity(InstanceGroupTestDto.defaultHostGroup(getTestContext()), OptionalInt.empty(), OptionalInt.empty())
+                .withInstanceGroupsEntity()
                 .withNetwork(getTestContext().given(NetworkV4TestDto.class))
                 .withGatewayPort(getCloudProvider().gatewayPort(this))
                 .withAuthentication(getCloudProvider().stackAuthentication(given(StackAuthenticationTestDto.class)))
@@ -215,6 +215,20 @@ public class FreeIpaTestDto extends AbstractFreeIpaTestDto<CreateFreeIpaRequest,
         }
         getRequest().setInstanceGroups(instanceGroupRequests);
         return this;
+    }
+
+    private FreeIpaTestDto withInstanceGroupsEntity() {
+        OptionalInt instanceGroupCount;
+        OptionalInt instanceCountByGroup;
+        if (getCloudProvider().getGovCloud()) {
+            instanceGroupCount = OptionalInt.of(1);
+            instanceCountByGroup = OptionalInt.of(2);
+        } else {
+            instanceGroupCount = OptionalInt.empty();
+            instanceCountByGroup = OptionalInt.empty();
+        }
+        return withInstanceGroupsEntity(InstanceGroupTestDto.defaultHostGroup(getTestContext()), instanceGroupCount,
+                instanceCountByGroup);
     }
 
     private Function<InstanceGroupV4Request, InstanceGroupRequest> mapInstanceGroupRequest(OptionalInt instanceCountByGroup) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/AbstractIntegrationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/AbstractIntegrationTest.java
@@ -294,7 +294,7 @@ public abstract class AbstractIntegrationTest extends AbstractMinimalTest {
                     .withTelemetry("telemetry")
                     .withTunnel(testContext.getTunnel())
                     .withCreateFreeIpa(Boolean.TRUE)
-                    .withOneFreeIpaNode()
+                    .withFreeIpaNodes(getFreeIpaInstanceCountByProdiver(testContext))
                     .withFreeIpaImage(commonCloudProperties().getImageValidation().getFreeIpaImageCatalog(),
                             commonCloudProperties().getImageValidation().getFreeIpaImageUuid())
                 .when(environmentTestClient.create())
@@ -350,5 +350,13 @@ public abstract class AbstractIntegrationTest extends AbstractMinimalTest {
             throw new IllegalArgumentException("SDX Cloud Storage does not exist!");
         }
         return cloudStorage.getRequest();
+    }
+
+    protected int getFreeIpaInstanceCountByProdiver(TestContext testContext) {
+        if (testContext.getCloudProvider().getGovCloud()) {
+            return 2;
+        } else {
+            return 1;
+        }
     }
 }


### PR DESCRIPTION
Latest GOV-Dev API E2E tests are failing, because of FreeIpa deployment requests are only allowed with at least '2' instance(s) by group. The requested value was '1'. So we should assure GOV E2E tests are starting FreeIPA at least with 2 instances by group.