### PR TITLE
CB-18490 Modify proxy config e2e test

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxDescribeInternalAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxDescribeInternalAction.java
@@ -19,7 +19,7 @@ public class SdxDescribeInternalAction implements Action<SdxInternalTestDto, Sdx
 
     @Override
     public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
-        if (testDto.getCrn() != null) {
+        if (testDto.getResponse() != null) {
             Log.when(LOGGER, format(" SDX Crn: %s ", testDto.getCrn()));
         }
         Log.whenJson(LOGGER, " SDX describe internal request: ", testDto.getRequest());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentModifyProxyConfigAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentModifyProxyConfigAction.java
@@ -1,0 +1,40 @@
+package com.sequenceiq.it.cloudbreak.action.v4.environment;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentEditRequest;
+import com.sequenceiq.environment.api.v1.proxy.model.request.ProxyRequest;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+import com.sequenceiq.it.cloudbreak.microservice.EnvironmentClient;
+
+public class EnvironmentModifyProxyConfigAction extends AbstractEnvironmentAction {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EnvironmentModifyProxyConfigAction.class);
+
+    private final String proxyConfigName;
+
+    public EnvironmentModifyProxyConfigAction(String proxyConfigName) {
+        this.proxyConfigName = proxyConfigName;
+    }
+
+    @Override
+    protected EnvironmentTestDto environmentAction(TestContext testContext, EnvironmentTestDto testDto, EnvironmentClient client) throws Exception {
+        EnvironmentEditRequest request = createEditRequest();
+        client.getDefaultClient()
+                .environmentV1Endpoint()
+                .editByCrn(testDto.getResponse().getCrn(), request);
+        Log.when(LOGGER, "Environment modify proxy config action posted");
+        return testDto;
+    }
+
+    private EnvironmentEditRequest createEditRequest() {
+        EnvironmentEditRequest request = new EnvironmentEditRequest();
+        ProxyRequest proxyRequest = new ProxyRequest();
+        proxyRequest.setName(proxyConfigName);
+        request.setProxy(proxyRequest);
+        return request;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/CBAssertion.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/CBAssertion.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.it.cloudbreak.assertion;
 
 import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.it.cloudbreak.microservice.MicroserviceClient;
 
 public class CBAssertion {
 
@@ -44,5 +45,14 @@ public class CBAssertion {
 
     private static TestFailException getException(String message) {
         return new TestFailException(message);
+    }
+
+    public static <T, U extends MicroserviceClient> Assertion<T, U> multiAssert(Assertion<T, U>... assertions) {
+        return (testContext, testDto, client) -> {
+            for (Assertion<T, U> assertion : assertions) {
+                assertion.doAssertion(testContext, testDto, client);
+            }
+            return testDto;
+        };
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/proxy/ProxyConfigAssertions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/proxy/ProxyConfigAssertions.java
@@ -1,0 +1,75 @@
+package com.sequenceiq.it.cloudbreak.assertion.proxy;
+
+import static com.sequenceiq.it.cloudbreak.assertion.CBAssertion.multiAssert;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.it.cloudbreak.assertion.Assertion;
+import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
+import com.sequenceiq.it.cloudbreak.dto.proxy.ProxyTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.microservice.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.microservice.FreeIpaClient;
+import com.sequenceiq.it.cloudbreak.microservice.SdxClient;
+
+@Component
+public class ProxyConfigAssertions {
+
+    @Inject
+    private ProxyConfigFileAssertions proxyConfigFileAssertions;
+
+    @Inject
+    private ProxyConfigUserDataAssertions proxyConfigUserDataAssertions;
+
+    @Inject
+    private ProxyConfigCmAssertions proxyConfigCmAssertions;
+
+    public Assertion<FreeIpaTestDto, FreeIpaClient> validateFreeIpaNoProxyConfig() {
+        return multiAssert(
+                proxyConfigFileAssertions.validateFreeIpaNoProxyConfigFile(),
+                proxyConfigUserDataAssertions.validateFreeIpaUserDataNoProxySettings()
+        );
+    }
+
+    public Assertion<FreeIpaTestDto, FreeIpaClient> validateFreeIpaProxyConfig(ProxyTestDto proxy) {
+        return multiAssert(
+                proxyConfigFileAssertions.validateFreeIpaProxyConfigFile(proxy),
+                proxyConfigUserDataAssertions.validateFreeIpaUserDataProxySettings(proxy)
+        );
+    }
+
+    public Assertion<SdxInternalTestDto, SdxClient> validateDatalakeNoProxyConfig() {
+        return multiAssert(
+                proxyConfigFileAssertions.validateDatalakeNoProxyConfigFile(),
+                proxyConfigUserDataAssertions.validateDatalakeUserDataNoProxySettings(),
+                proxyConfigCmAssertions.validateDatalakeCmNoProxySettings()
+        );
+    }
+
+    public Assertion<SdxInternalTestDto, SdxClient> validateDatalakeProxyConfig(ProxyTestDto proxy) {
+        return multiAssert(
+                proxyConfigFileAssertions.validateDatalakeProxyConfigFile(proxy),
+                proxyConfigUserDataAssertions.validateDatalakeUserDataProxySettings(proxy),
+                proxyConfigCmAssertions.validateDatalakeCmProxySettings(proxy)
+        );
+    }
+
+    public Assertion<DistroXTestDto, CloudbreakClient> validateDatahubNoProxyConfig() {
+        return multiAssert(
+                proxyConfigFileAssertions.validateDatahubNoProxyConfigFile(),
+                proxyConfigUserDataAssertions.validateDatahubUserDataNoProxySettings(),
+                proxyConfigCmAssertions.validateDatahubCmNoProxySettings()
+        );
+    }
+
+    public Assertion<DistroXTestDto, CloudbreakClient> validateDatahubProxyConfig(ProxyTestDto proxy) {
+        return multiAssert(
+                proxyConfigFileAssertions.validateDatahubProxyConfigFile(proxy),
+                proxyConfigUserDataAssertions.validateDatahubUserDataProxySettings(proxy),
+                proxyConfigCmAssertions.validateDatahubCmProxySettings(proxy)
+        );
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/proxy/ProxyConfigCmAssertions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/proxy/ProxyConfigCmAssertions.java
@@ -1,0 +1,101 @@
+package com.sequenceiq.it.cloudbreak.assertion.proxy;
+
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.util.SanitizerUtil;
+import com.sequenceiq.environment.api.v1.proxy.model.request.ProxyRequest;
+import com.sequenceiq.it.cloudbreak.assertion.Assertion;
+import com.sequenceiq.it.cloudbreak.config.ProxyConfigProperties;
+import com.sequenceiq.it.cloudbreak.dto.AbstractTestDto;
+import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
+import com.sequenceiq.it.cloudbreak.dto.proxy.ProxyTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.microservice.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.microservice.SdxClient;
+import com.sequenceiq.it.cloudbreak.testcase.e2e.proxy.ModifyProxyConfigE2ETest;
+import com.sequenceiq.it.cloudbreak.util.clouderamanager.ClouderaManagerUtil;
+
+@Component
+class ProxyConfigCmAssertions {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ModifyProxyConfigE2ETest.class);
+
+    private static final String MOCK_UMS_PASSWORD = "Password123!";
+
+    @Inject
+    private ProxyConfigProperties proxyConfigProperties;
+
+    @Inject
+    private ClouderaManagerUtil clouderaManagerUtil;
+
+    public Assertion<SdxInternalTestDto, SdxClient> validateDatalakeCmNoProxySettings() {
+        return (testContext, testDto, client) -> {
+            LOGGER.info("Validating {} datalake's CM has no proxy settings", testDto.getCrn());
+            String sanitizedUserName = getSanitizedUserName(testDto);
+            Map<String, String> expectedConfig = getEmptyExpectedConfig();
+            clouderaManagerUtil.checkConfig(testDto, sanitizedUserName, MOCK_UMS_PASSWORD, expectedConfig);
+            return testDto;
+        };
+    }
+
+    public Assertion<DistroXTestDto, CloudbreakClient> validateDatahubCmNoProxySettings() {
+        return (testContext, testDto, client) -> {
+            LOGGER.info("Validating {} datahub's CM has no proxy settings", testDto.getCrn());
+            String sanitizedUserName = getSanitizedUserName(testDto);
+            Map<String, String> expectedConfig = getEmptyExpectedConfig();
+            clouderaManagerUtil.checkConfig(testDto, sanitizedUserName, MOCK_UMS_PASSWORD, expectedConfig);
+            return testDto;
+        };
+    }
+
+    public Assertion<SdxInternalTestDto, SdxClient> validateDatalakeCmProxySettings(ProxyTestDto proxy) {
+        return (testContext, testDto, client) -> {
+            LOGGER.info("Validating {} datalake's CM has correct proxy settings {}", testDto.getCrn(), proxy.getName());
+            String sanitizedUserName = getSanitizedUserName(testDto);
+            Map<String, String> expectedConfig = getExpectedConfig(proxy);
+            clouderaManagerUtil.checkConfig(testDto, sanitizedUserName, MOCK_UMS_PASSWORD, expectedConfig);
+            return testDto;
+        };
+    }
+
+    public Assertion<DistroXTestDto, CloudbreakClient> validateDatahubCmProxySettings(ProxyTestDto proxy) {
+        return (testContext, testDto, client) -> {
+            LOGGER.info("Validating {} datahub's CM has correct proxy settings {}", testDto.getCrn(), proxy.getName());
+            String sanitizedUserName = getSanitizedUserName(testDto);
+            Map<String, String> expectedConfig = getExpectedConfig(proxy);
+            clouderaManagerUtil.checkConfig(testDto, sanitizedUserName, MOCK_UMS_PASSWORD, expectedConfig);
+            return testDto;
+        };
+    }
+
+    private static String getSanitizedUserName(AbstractTestDto testDto) {
+        String username = testDto.getTestContext().getActingUserCrn().getResource();
+        return SanitizerUtil.sanitizeWorkloadUsername(username);
+    }
+
+    private static Map<String, String> getEmptyExpectedConfig() {
+        return getExpectedConfig("", "", "", "", "");
+    }
+
+    private static Map<String, String> getExpectedConfig(ProxyTestDto proxy) {
+        ProxyRequest proxyRequest = proxy.getRequest();
+        return getExpectedConfig(proxyRequest.getHost(), proxyRequest.getPort().toString(), proxyRequest.getProtocol().toUpperCase(),
+                proxyRequest.getUserName(), proxyRequest.getNoProxyHosts());
+    }
+
+    private static Map<String, String> getExpectedConfig(String host, String port, String protocol, String user, String noProxy) {
+        return Map.of(
+                "parcel_proxy_server", host,
+                "parcel_proxy_port", port,
+                "parcel_proxy_protocol", protocol,
+                "parcel_proxy_user", user,
+                "parcel_no_proxy_list", noProxy
+        );
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/proxy/ProxyConfigFileAssertions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/proxy/ProxyConfigFileAssertions.java
@@ -1,0 +1,112 @@
+package com.sequenceiq.it.cloudbreak.assertion.proxy;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
+import com.sequenceiq.common.api.type.InstanceGroupType;
+import com.sequenceiq.environment.api.v1.proxy.model.request.ProxyRequest;
+import com.sequenceiq.it.cloudbreak.assertion.Assertion;
+import com.sequenceiq.it.cloudbreak.dto.AbstractTestDto;
+import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
+import com.sequenceiq.it.cloudbreak.dto.proxy.ProxyTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.it.cloudbreak.microservice.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.microservice.FreeIpaClient;
+import com.sequenceiq.it.cloudbreak.microservice.SdxClient;
+import com.sequenceiq.it.cloudbreak.util.ssh.action.SshProxyActions;
+
+@Component
+class ProxyConfigFileAssertions {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProxyConfigFileAssertions.class);
+
+    private static final String PROXY_PASSWORD_PATTERN = "(https_proxy=.*//[^:]*:)(.*)(@.*)";
+
+    private static final String PROXY_PASSWORD_REPLACED_VALUE = "$1<password>$3";
+
+    @Inject
+    private SshProxyActions sshProxyActions;
+
+    public Assertion<FreeIpaTestDto, FreeIpaClient> validateFreeIpaNoProxyConfigFile() {
+        return (testContext, testDto, client) -> validateNoProxyConfigFile(testDto, getFreeipaIpAddresses(testDto));
+    }
+
+    public Assertion<SdxInternalTestDto, SdxClient> validateDatalakeNoProxyConfigFile() {
+        return (testContext, testDto, client) -> validateNoProxyConfigFile(testDto, getSdxIpAddresses(testDto));
+    }
+
+    public Assertion<DistroXTestDto, CloudbreakClient> validateDatahubNoProxyConfigFile() {
+        return (testContext, testDto, client) -> validateNoProxyConfigFile(testDto, getDistroXIpAddresses(testDto));
+    }
+
+    private <T extends AbstractTestDto<?, ?, ?, ?>> T validateNoProxyConfigFile(T testDto, Set<String> ipAddresses) {
+        LOGGER.info("Validating {} has no proxy config file on node(s) {}", testDto.getCrn(), ipAddresses);
+        Optional<String> proxySettings = sshProxyActions.getProxySettings(ipAddresses);
+        if (proxySettings.isPresent()) {
+            throw new TestFailException(String.format("Expected no proxy settings but found %s", sanitizeCcmProxySettings(proxySettings.get())));
+        }
+        return testDto;
+    }
+
+    public Assertion<FreeIpaTestDto, FreeIpaClient> validateFreeIpaProxyConfigFile(ProxyTestDto proxy) {
+        return (testContext, testDto, client) -> validateProxyConfigFile(testDto, getFreeipaIpAddresses(testDto), proxy);
+    }
+
+    public Assertion<SdxInternalTestDto, SdxClient> validateDatalakeProxyConfigFile(ProxyTestDto proxy) {
+        return (testContext, testDto, client) -> validateProxyConfigFile(testDto, getSdxIpAddresses(testDto), proxy);
+    }
+
+    public Assertion<DistroXTestDto, CloudbreakClient> validateDatahubProxyConfigFile(ProxyTestDto proxy) {
+        return (testContext, testDto, client) -> validateProxyConfigFile(testDto, getDistroXIpAddresses(testDto), proxy);
+    }
+
+    private <T extends AbstractTestDto<?, ?, ?, ?>> T validateProxyConfigFile(T testDto, Set<String> ipAddresses, ProxyTestDto proxy) {
+        LOGGER.info("Validating {} has {} proxy config file on node(s) {}", testDto.getCrn(), proxy.getName(), ipAddresses);
+        String proxySettings = sshProxyActions.getProxySettings(ipAddresses)
+                .orElseThrow(() -> new TestFailException("Expected proxy settings but found none"));
+        ProxyRequest proxyRequest = proxy.getRequest();
+        String expectedProxySettings = String.format("https_proxy=%s://%s:%s@%s:%s\r\nno_proxy=%s\r\n",
+                proxyRequest.getProtocol(), proxyRequest.getUserName(), proxyRequest.getPassword(),
+                proxyRequest.getHost(), proxyRequest.getPort(), proxyRequest.getNoProxyHosts());
+        if (!proxySettings.equals(expectedProxySettings)) {
+            throw new TestFailException(String.format("Proxy settings does not match! Expected: '%s', Received: '%s'",
+                    sanitizeCcmProxySettings(expectedProxySettings), sanitizeCcmProxySettings(proxySettings)));
+        }
+        return testDto;
+    }
+
+    private static String sanitizeCcmProxySettings(String proxySettings) {
+        return proxySettings.replaceAll(PROXY_PASSWORD_PATTERN, PROXY_PASSWORD_REPLACED_VALUE);
+    }
+
+    private static Set<String> getFreeipaIpAddresses(FreeIpaTestDto testDto) {
+        return testDto.getResponse().getFreeIpa().getServerIp();
+    }
+
+    private static Set<String> getSdxIpAddresses(SdxInternalTestDto testDto) {
+        return getStackIpAddresses(testDto.getResponse().getStackV4Response());
+    }
+
+    private static Set<String> getDistroXIpAddresses(DistroXTestDto testDto) {
+        return getStackIpAddresses(testDto.getResponse());
+    }
+
+    private static Set<String> getStackIpAddresses(StackV4Response stack) {
+        return stack.getInstanceGroups().stream()
+                .filter(ig -> ig.getType().equals(InstanceGroupType.GATEWAY))
+                .flatMap(ig -> ig.getMetadata().stream())
+                .map(InstanceMetaDataV4Response::getPrivateIp)
+                .collect(Collectors.toSet());
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/proxy/ProxyConfigUserDataAssertions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/proxy/ProxyConfigUserDataAssertions.java
@@ -1,0 +1,142 @@
+package com.sequenceiq.it.cloudbreak.assertion.proxy;
+
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.environment.api.v1.proxy.model.request.ProxyRequest;
+import com.sequenceiq.it.cloudbreak.assertion.Assertion;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
+import com.sequenceiq.it.cloudbreak.dto.proxy.ProxyTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.it.cloudbreak.microservice.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.microservice.FreeIpaClient;
+import com.sequenceiq.it.cloudbreak.microservice.SdxClient;
+import com.sequenceiq.it.cloudbreak.util.CloudFunctionality;
+
+@Component
+class ProxyConfigUserDataAssertions {
+
+    private static final String EXPORT_FORMAT = "export %s=%s";
+
+    private static final String EXPORT_QUOTED_FORMAT = "export %s=\"%s\"";
+
+    public Assertion<FreeIpaTestDto, FreeIpaClient> validateFreeIpaUserDataProxySettings(ProxyTestDto proxy) {
+        return (testContext, testDto, client) -> {
+            String stackNamePrefix = getFreeipaStackNamePrefix(testContext);
+            validateUserDataProxySettings(testContext, stackNamePrefix, proxy);
+            return testDto;
+        };
+    }
+
+    public Assertion<SdxInternalTestDto, SdxClient> validateDatalakeUserDataProxySettings(ProxyTestDto proxy) {
+        return (testContext, testDto, client) -> {
+            validateUserDataProxySettings(testContext, testDto.getName(), proxy);
+            return testDto;
+        };
+    }
+
+    public Assertion<DistroXTestDto, CloudbreakClient> validateDatahubUserDataProxySettings(ProxyTestDto proxy) {
+        return (testContext, testDto, client) -> {
+            validateUserDataProxySettings(testContext, testDto.getName(), proxy);
+            return testDto;
+        };
+    }
+
+    private void validateUserDataProxySettings(TestContext testContext, String stackNamePrefix, ProxyTestDto proxy) {
+        CloudFunctionality cloudFunctionality = testContext.getCloudProvider().getCloudFunctionality();
+        Map<String, String> launchTemplateUserData = cloudFunctionality.getLaunchTemplateUserData(stackNamePrefix);
+        if (launchTemplateUserData != null) {
+            launchTemplateUserData.forEach((launchTemplateId, userData) -> {
+                if (userData.contains("IS_GATEWAY=false")) {
+                    // only gateway instance groups should have proxy settings
+                    checkUserDataContains(launchTemplateId, userData, "IS_PROXY_ENABLED", "false");
+                } else {
+                    ProxyRequest proxyRequest = proxy.getRequest();
+                    checkUserDataContains(launchTemplateId, userData, "IS_PROXY_ENABLED", "true");
+                    checkUserDataContains(launchTemplateId, userData, "PROXY_HOST", proxyRequest.getHost());
+                    checkUserDataContains(launchTemplateId, userData, "PROXY_PORT", proxyRequest.getPort().toString());
+                    checkUserDataContains(launchTemplateId, userData, "PROXY_PROTOCOL", proxyRequest.getProtocol());
+                    checkUserDataContainsQuoted(launchTemplateId, userData, "PROXY_USER", proxyRequest.getUserName());
+                    checkUserDataContainsQuoted(launchTemplateId, userData, "PROXY_PASSWORD", proxyRequest.getPassword());
+                    checkUserDataContainsQuoted(launchTemplateId, userData, "PROXY_NO_PROXY_HOSTS", proxyRequest.getNoProxyHosts());
+                }
+            });
+        }
+    }
+
+    public Assertion<FreeIpaTestDto, FreeIpaClient> validateFreeIpaUserDataNoProxySettings() {
+        return (testContext, testDto, client) -> {
+            String stackNamePrefix = getFreeipaStackNamePrefix(testContext);
+            validateUserDataNoProxySettings(testContext, stackNamePrefix);
+            return testDto;
+        };
+    }
+
+    public Assertion<SdxInternalTestDto, SdxClient> validateDatalakeUserDataNoProxySettings() {
+        return (testContext, testDto, client) -> {
+            validateUserDataNoProxySettings(testContext, testDto.getName());
+            return testDto;
+        };
+    }
+
+    public Assertion<DistroXTestDto, CloudbreakClient> validateDatahubUserDataNoProxySettings() {
+        return (testContext, testDto, client) -> {
+            validateUserDataNoProxySettings(testContext, testDto.getName());
+            return testDto;
+        };
+    }
+
+    private void validateUserDataNoProxySettings(TestContext testContext, String stackNamePrefix) {
+        CloudFunctionality cloudFunctionality = testContext.getCloudProvider().getCloudFunctionality();
+        Map<String, String> launchTemplateUserData = cloudFunctionality.getLaunchTemplateUserData(stackNamePrefix);
+        if (launchTemplateUserData != null) {
+            launchTemplateUserData.forEach((launchTemplateId, userData) -> {
+                if (userData.contains("IS_GATEWAY=false")) {
+                    // only gateway instance groups should have proxy settings
+                    checkUserDataContains(launchTemplateId, userData, "IS_PROXY_ENABLED", "false");
+                } else {
+                    checkUserDataContains(launchTemplateId, userData, "IS_PROXY_ENABLED", "false");
+                    checkUserDataDoesNotContain(launchTemplateId, userData, "PROXY_HOST");
+                    checkUserDataDoesNotContain(launchTemplateId, userData, "PROXY_PORT");
+                    checkUserDataDoesNotContain(launchTemplateId, userData, "PROXY_PROTOCOL");
+                    checkUserDataDoesNotContain(launchTemplateId, userData, "PROXY_USER");
+                    checkUserDataDoesNotContain(launchTemplateId, userData, "PROXY_PASSWORD");
+                    checkUserDataDoesNotContain(launchTemplateId, userData, "PROXY_NO_PROXY_HOSTS");
+                }
+            });
+        }
+    }
+
+    private void checkUserDataContains(String launchTemplateId, String userData, String exportKey, String exportValue) {
+        String export = String.format(EXPORT_FORMAT, exportKey, exportValue);
+        checkUserDataContains(launchTemplateId, userData, export);
+    }
+
+    private void checkUserDataContainsQuoted(String launchTemplateId, String userData, String exportKey, String exportValue) {
+        String export = String.format(EXPORT_QUOTED_FORMAT, exportKey, exportValue);
+        checkUserDataContains(launchTemplateId, userData, export);
+    }
+
+    private static void checkUserDataContains(String launchTemplateId, String userData, String export) {
+        if (!userData.contains(export)) {
+            String sanitizedExport = export.contains("PASSWORD") ? "<password>" : export;
+            throw new TestFailException(String.format("Userdata for launch template %s does not contain %s", launchTemplateId, sanitizedExport));
+        }
+    }
+
+    private void checkUserDataDoesNotContain(String launchTemplateId, String userData, String exportKey) {
+        String export = String.format(EXPORT_FORMAT, exportKey, null);
+        if (userData.contains(exportKey)) {
+            throw new TestFailException(String.format("Userdata for launch template %s must not contain %s", launchTemplateId, export));
+        }
+    }
+
+    private static String getFreeipaStackNamePrefix(TestContext testContext) {
+        return testContext.given(EnvironmentTestDto.class).getName() + "-freeipa";
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/EnvironmentTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/EnvironmentTestClient.java
@@ -19,6 +19,7 @@ import com.sequenceiq.it.cloudbreak.action.v4.environment.EnvironmentGetAction;
 import com.sequenceiq.it.cloudbreak.action.v4.environment.EnvironmentGetByCrnAction;
 import com.sequenceiq.it.cloudbreak.action.v4.environment.EnvironmentInternalGetAction;
 import com.sequenceiq.it.cloudbreak.action.v4.environment.EnvironmentListAction;
+import com.sequenceiq.it.cloudbreak.action.v4.environment.EnvironmentModifyProxyConfigAction;
 import com.sequenceiq.it.cloudbreak.action.v4.environment.EnvironmentRefreshAction;
 import com.sequenceiq.it.cloudbreak.action.v4.environment.EnvironmentStartAction;
 import com.sequenceiq.it.cloudbreak.action.v4.environment.EnvironmentStopAction;
@@ -103,5 +104,9 @@ public class EnvironmentTestClient {
 
     public Action<EnvironmentTestDto, EnvironmentClient> upgradeCcm() {
         return new EnvironmentCcmUpgrade();
+    }
+
+    public Action<EnvironmentTestDto, EnvironmentClient> modifyProxyConfig(String proxyConfigName) {
+        return new EnvironmentModifyProxyConfigAction(proxyConfigName);
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/config/ProxyConfigProperties.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/config/ProxyConfigProperties.java
@@ -1,0 +1,96 @@
+package com.sequenceiq.it.cloudbreak.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProxyConfigProperties {
+
+    @Value("${integrationtest.proxy.protocol:http}")
+    private String proxyProtocol;
+
+    @Value("${integrationtest.proxy.host:1.2.3.4}")
+    private String proxyHost;
+
+    @Value("${integrationtest.proxy.port:9}")
+    private Integer proxyPort;
+
+    @Value("${integrationtest.proxy.noproxyhosts:noproxy.com}")
+    private String proxyNoProxyHosts;
+
+    @Value("${integrationtest.proxy.user:mock}")
+    private String proxyUser;
+
+    @Value("${integrationtest.proxy.password:akarmi}")
+    private String proxyPassword;
+
+    @Value("${integrationtest.proxy.user2:mock2}")
+    private String proxyUser2;
+
+    @Value("${integrationtest.proxy.password2:akarmi2}")
+    private String proxyPassword2;
+
+    public String getProxyProtocol() {
+        return proxyProtocol;
+    }
+
+    public void setProxyProtocol(String proxyProtocol) {
+        this.proxyProtocol = proxyProtocol;
+    }
+
+    public String getProxyHost() {
+        return proxyHost;
+    }
+
+    public void setProxyHost(String proxyHost) {
+        this.proxyHost = proxyHost;
+    }
+
+    public Integer getProxyPort() {
+        return proxyPort;
+    }
+
+    public void setProxyPort(Integer proxyPort) {
+        this.proxyPort = proxyPort;
+    }
+
+    public String getProxyNoProxyHosts() {
+        return proxyNoProxyHosts;
+    }
+
+    public void setProxyNoProxyHosts(String proxyNoProxyHosts) {
+        this.proxyNoProxyHosts = proxyNoProxyHosts;
+    }
+
+    public String getProxyUser() {
+        return proxyUser;
+    }
+
+    public void setProxyUser(String proxyUser) {
+        this.proxyUser = proxyUser;
+    }
+
+    public String getProxyPassword() {
+        return proxyPassword;
+    }
+
+    public void setProxyPassword(String proxyPassword) {
+        this.proxyPassword = proxyPassword;
+    }
+
+    public String getProxyUser2() {
+        return proxyUser2;
+    }
+
+    public void setProxyUser2(String proxyUser2) {
+        this.proxyUser2 = proxyUser2;
+    }
+
+    public String getProxyPassword2() {
+        return proxyPassword2;
+    }
+
+    public void setProxyPassword2(String proxyPassword2) {
+        this.proxyPassword2 = proxyPassword2;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/proxy/ProxyTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/proxy/ProxyTestDto.java
@@ -1,8 +1,12 @@
 package com.sequenceiq.it.cloudbreak.dto.proxy;
 
+import javax.inject.Inject;
+
+import com.sequenceiq.environment.api.v1.proxy.endpoint.ProxyEndpoint;
 import com.sequenceiq.environment.api.v1.proxy.model.request.ProxyRequest;
 import com.sequenceiq.environment.api.v1.proxy.model.response.ProxyResponse;
 import com.sequenceiq.it.cloudbreak.Prototype;
+import com.sequenceiq.it.cloudbreak.config.ProxyConfigProperties;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.AbstractEnvironmentTestDto;
 
@@ -10,6 +14,9 @@ import com.sequenceiq.it.cloudbreak.dto.AbstractEnvironmentTestDto;
 public class ProxyTestDto extends AbstractEnvironmentTestDto<ProxyRequest, ProxyResponse, ProxyTestDto> {
 
     private static final String PROXYCONFIG_RESOURCE_NAME = "proxyName";
+
+    @Inject
+    private ProxyConfigProperties proxyConfigProperties;
 
     public ProxyTestDto(TestContext testContext) {
         super(new ProxyRequest(), testContext);
@@ -23,12 +30,12 @@ public class ProxyTestDto extends AbstractEnvironmentTestDto<ProxyRequest, Proxy
     public ProxyTestDto valid() {
         return withName(getResourcePropertyProvider().getName(getCloudPlatform()))
                 .withDescription(getResourcePropertyProvider().getDescription("proxy"))
-                .withServerHost("1.2.3.4")
-                .withServerUser("mock")
-                .withPassword("akarmi")
-                .withServerPort(9)
-                .withProtocol("http")
-                .withNoProxyHosts("noproxy.com");
+                .withProtocol(proxyConfigProperties.getProxyProtocol())
+                .withServerHost(proxyConfigProperties.getProxyHost())
+                .withServerPort(proxyConfigProperties.getProxyPort())
+                .withServerUser(proxyConfigProperties.getProxyUser())
+                .withPassword(proxyConfigProperties.getProxyPassword())
+                .withNoProxyHosts(proxyConfigProperties.getProxyNoProxyHosts());
     }
 
     public ProxyTestDto withName(String name) {
@@ -92,5 +99,11 @@ public class ProxyTestDto extends AbstractEnvironmentTestDto<ProxyRequest, Proxy
     @Override
     public int order() {
         return 500;
+    }
+
+    @Override
+    public void deleteForCleanup() {
+        ProxyEndpoint proxyEndpoint = getClientForCleanup().getDefaultClient().proxyV1Endpoint();
+        proxyEndpoint.deleteByCrn(getCrn());
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/AbstractIntegrationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/AbstractIntegrationTest.java
@@ -24,6 +24,7 @@ import com.sequenceiq.it.cloudbreak.client.FreeIpaTestClient;
 import com.sequenceiq.it.cloudbreak.client.ImageCatalogTestClient;
 import com.sequenceiq.it.cloudbreak.client.KerberosTestClient;
 import com.sequenceiq.it.cloudbreak.client.LdapTestClient;
+import com.sequenceiq.it.cloudbreak.client.ProxyTestClient;
 import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.blueprint.BlueprintTestDto;
@@ -31,11 +32,13 @@ import com.sequenceiq.it.cloudbreak.dto.credential.CredentialTestDto;
 import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
 import com.sequenceiq.it.cloudbreak.dto.distrox.instancegroup.DistroXInstanceGroupsBuilder;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaUserSyncTestDto;
 import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
 import com.sequenceiq.it.cloudbreak.dto.kerberos.ActiveDirectoryKerberosDescriptorTestDto;
 import com.sequenceiq.it.cloudbreak.dto.kerberos.KerberosTestDto;
 import com.sequenceiq.it.cloudbreak.dto.ldap.LdapTestDto;
+import com.sequenceiq.it.cloudbreak.dto.proxy.ProxyTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCloudStorageTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.dto.telemetry.TelemetryTestDto;
@@ -81,6 +84,9 @@ public abstract class AbstractIntegrationTest extends AbstractMinimalTest {
 
     @Inject
     private FreeIpaTestClient freeIpaTestClient;
+
+    @Inject
+    private ProxyTestClient proxyTestClient;
 
     @BeforeMethod
     public final void minimalSetupForClusterCreation(Object[] data, ITestResult testResult) {
@@ -275,12 +281,20 @@ public abstract class AbstractIntegrationTest extends AbstractMinimalTest {
         initiateEnvironmentCreation(testContext);
         waitForEnvironmentCreation(testContext);
         waitForUserSync(testContext);
+        setFreeIpaResponse(testContext);
     }
 
     protected void waitForUserSync(TestContext testContext) {
         testContext.given(FreeIpaUserSyncTestDto.class)
                 .when(freeIpaTestClient.getLastSyncOperationStatus())
                 .await(OperationState.COMPLETED)
+                .validate();
+    }
+
+    private void setFreeIpaResponse(TestContext testContext) {
+        testContext
+                .given(FreeIpaTestDto.class)
+                .when(freeIpaTestClient.describe())
                 .validate();
     }
 
@@ -358,5 +372,52 @@ public abstract class AbstractIntegrationTest extends AbstractMinimalTest {
         } else {
             return 1;
         }
+    }
+
+    protected void createProxyConfig(TestContext testContext) {
+        testContext
+                .given(ProxyTestDto.class)
+                .when(proxyTestClient.createIfNotExist())
+                .validate();
+    }
+
+    /**
+     * Helper method to speed up local testing. Could be invoked to re-use an already existing environment with the given name
+     */
+    protected void useExistingEnvironment(TestContext testContext, String environmentName) {
+        testContext
+                .given(EnvironmentTestDto.class)
+                    .withName(environmentName)
+                .when(environmentTestClient.describe())
+                .validate();
+    }
+
+    /**
+     * Helper method to speed up local testing. Could be invoked to re-use an already existing environment and FreeIpa with the given name
+     */
+    protected void useExistingEnvironmentWithFreeipa(TestContext testContext, String environmentName) {
+        useExistingEnvironment(testContext, environmentName);
+        setFreeIpaResponse(testContext);
+    }
+
+    /**
+     * Helper method to speed up local testing. Could be invoked to re-use an already existing datalake with the given name
+     */
+    protected void useExistingDatalake(TestContext testContext, String datalakeName) {
+        testContext
+                .given(SdxInternalTestDto.class)
+                    .withName(datalakeName)
+                .when(sdxTestClient.describeInternal());
+    }
+
+    /**
+     * Helper method to speed up local testing. Could be invoked to re-use an already existing datahub with the given name
+     */
+    protected void useExistingDatahub(TestContext testContext, String datahubName) {
+        testContext
+                .given(DistroXTestDto.class)
+                    .withName(datahubName)
+                .when(distroXTestClient.get())
+                .validate();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/DatalakeCcmUpgradeTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/DatalakeCcmUpgradeTest.java
@@ -101,12 +101,12 @@ public class DatalakeCcmUpgradeTest extends AbstractE2ETest {
                 boolean result = m.find();
                 if (!result) {
                     Log.then(LOGGER,
-                            format("the {} launch template user data does not contain {} ", ud.getKey(), EXPORT_IS_CCM_V_2_JUMPGATE_ENABLED_TRUE));
+                            format("the %s launch template user data does not contain %s ", ud.getKey(), EXPORT_IS_CCM_V_2_JUMPGATE_ENABLED_TRUE));
                 }
                 return result;
             });
             if (!ccmV2Enabled) {
-                throw new TestFailException(format("user data is not updated by ", EXPORT_IS_CCM_V_2_JUMPGATE_ENABLED_TRUE));
+                throw new TestFailException(format("user data is not updated by %s", EXPORT_IS_CCM_V_2_JUMPGATE_ENABLED_TRUE));
             }
 
             return sdxInternalTestDto;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/proxy/ModifyProxyConfigE2ETest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/proxy/ModifyProxyConfigE2ETest.java
@@ -1,0 +1,131 @@
+package com.sequenceiq.it.cloudbreak.testcase.e2e.proxy;
+
+import javax.inject.Inject;
+
+import org.testng.annotations.Test;
+
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
+import com.sequenceiq.it.cloudbreak.assertion.proxy.ProxyConfigAssertions;
+import com.sequenceiq.it.cloudbreak.client.EnvironmentTestClient;
+import com.sequenceiq.it.cloudbreak.client.ProxyTestClient;
+import com.sequenceiq.it.cloudbreak.config.ProxyConfigProperties;
+import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
+import com.sequenceiq.it.cloudbreak.dto.proxy.ProxyTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
+import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
+
+public class ModifyProxyConfigE2ETest extends AbstractE2ETest {
+
+    private static final String PROXY2 = "proxy2";
+
+    @Inject
+    private ProxyConfigProperties proxyConfigProperties;
+
+    @Inject
+    private ProxyTestClient proxyTestClient;
+
+    @Inject
+    private EnvironmentTestClient environmentTestClient;
+
+    @Inject
+    private ProxyConfigAssertions proxyConfigAssertions;
+
+    @Override
+    protected void setupTest(TestContext testContext) {
+        createDefaultUser(testContext);
+        createDefaultCredential(testContext);
+        initializeDefaultBlueprints(testContext);
+        createProxyConfig(testContext);
+        createProxyConfig2(testContext);
+        createEnvironmentWithFreeIpa(testContext);
+    }
+
+    private void createProxyConfig2(TestContext testContext) {
+        testContext
+                .given(PROXY2, ProxyTestDto.class)
+                    .withServerUser(proxyConfigProperties.getProxyUser2())
+                    .withPassword(proxyConfigProperties.getProxyPassword2())
+                .when(proxyTestClient.createIfNotExist())
+                .validate();
+    }
+
+    @Test(dataProvider = TEST_CONTEXT)
+    @UseSpotInstances
+    @Description(
+            given = "there is a running FreeIpa/Datalake/Datahub ",
+            when = "adding/modifying/removing proxy config ",
+            then = "all existing and newly created nodes should have the new proxy config settings "
+    )
+    public void testModifyProxyConfig(TestContext testContext) {
+        ProxyTestDto proxy = testContext.given(ProxyTestDto.class);
+        ProxyTestDto proxy2 = testContext.given(PROXY2, ProxyTestDto.class);
+
+        addAndValidateProxy(testContext, proxy);
+        createDatalakeWithoutDatabase(testContext);
+        validateDatalakeProxy(testContext, proxy);
+
+        changeAndValidateProxy(testContext, proxy2);
+        createDefaultDatahubForExistingDatalake(testContext);
+        validateDatahubProxy(testContext, proxy2);
+
+        removeAndValidateProxy(testContext);
+    }
+
+    private void addAndValidateProxy(TestContext testContext, ProxyTestDto proxy) {
+        testContext
+                .given(EnvironmentTestDto.class)
+                .when(environmentTestClient.modifyProxyConfig(proxy.getName()))
+                .await(EnvironmentStatus.PROXY_CONFIG_MODIFICATION_ON_FREEIPA_IN_PROGRESS)
+                .await(EnvironmentStatus.AVAILABLE)
+                .given(FreeIpaTestDto.class)
+                .then(proxyConfigAssertions.validateFreeIpaProxyConfig(proxy))
+                .validate();
+    }
+
+    private void validateDatalakeProxy(TestContext testContext, ProxyTestDto proxy) {
+        testContext
+                .given(SdxInternalTestDto.class)
+                .then(proxyConfigAssertions.validateDatalakeProxyConfig(proxy))
+                .validate();
+    }
+
+    private void changeAndValidateProxy(TestContext testContext, ProxyTestDto proxy2) {
+        testContext
+                .given(EnvironmentTestDto.class)
+                .when(environmentTestClient.modifyProxyConfig(proxy2.getName()))
+                .await(EnvironmentStatus.PROXY_CONFIG_MODIFICATION_ON_DATALAKE_IN_PROGRESS)
+                .await(EnvironmentStatus.AVAILABLE)
+                .given(FreeIpaTestDto.class)
+                .then(proxyConfigAssertions.validateFreeIpaProxyConfig(proxy2))
+                .given(SdxInternalTestDto.class)
+                .then(proxyConfigAssertions.validateDatalakeProxyConfig(proxy2))
+                .validate();
+    }
+
+    private void validateDatahubProxy(TestContext testContext, ProxyTestDto proxy2) {
+        testContext
+                .given(DistroXTestDto.class)
+                .then(proxyConfigAssertions.validateDatahubProxyConfig(proxy2))
+                .validate();
+    }
+
+    private void removeAndValidateProxy(TestContext testContext) {
+        testContext
+                .given(EnvironmentTestDto.class)
+                .when(environmentTestClient.modifyProxyConfig(null))
+                .await(EnvironmentStatus.PROXY_CONFIG_MODIFICATION_ON_DATAHUBS_IN_PROGRESS)
+                .await(EnvironmentStatus.AVAILABLE)
+                .given(FreeIpaTestDto.class)
+                .then(proxyConfigAssertions.validateFreeIpaNoProxyConfig())
+                .given(SdxInternalTestDto.class)
+                .then(proxyConfigAssertions.validateDatalakeNoProxyConfig())
+                .given(DistroXTestDto.class)
+                .then(proxyConfigAssertions.validateDatahubNoProxyConfig())
+                .validate();
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazoncf/action/CfClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazoncf/action/CfClientActions.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.it.cloudbreak.util.aws.amazoncf.action;
 
+import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -9,13 +11,15 @@ import javax.inject.Inject;
 import org.springframework.stereotype.Component;
 
 import com.amazonaws.services.cloudformation.AmazonCloudFormation;
-import com.amazonaws.services.cloudformation.model.DescribeStacksRequest;
-import com.amazonaws.services.cloudformation.model.DescribeStacksResult;
 import com.amazonaws.services.cloudformation.model.ListStackResourcesRequest;
 import com.amazonaws.services.cloudformation.model.ListStackResourcesResult;
+import com.amazonaws.services.cloudformation.model.ListStacksRequest;
+import com.amazonaws.services.cloudformation.model.ListStacksResult;
 import com.amazonaws.services.cloudformation.model.Stack;
 import com.amazonaws.services.cloudformation.model.StackResourceSummary;
+import com.amazonaws.services.cloudformation.model.StackStatus;
 import com.amazonaws.services.cloudformation.model.StackSummary;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
 import com.sequenceiq.it.cloudbreak.util.aws.amazoncf.client.CfClient;
 
 @Component
@@ -24,16 +28,32 @@ public class CfClientActions {
 
     private static final String CLOUDERA_ENVIRONMENT_RESOURCE_NAME = "Cloudera-Environment-Resource-Name";
 
-    private static final Set DO_NOT_LIST_CLOUDFORMATIONS_STATUSES = Set.of("DELETE_COMPLETE", "DELETE_IN_PROGRESS");
+    private static final Set<StackStatus> DO_NOT_LIST_CLOUDFORMATION_STATUSES = Set.of(StackStatus.DELETE_COMPLETE, StackStatus.DELETE_IN_PROGRESS);
+
+    private static final Set<String> LIST_CLOUDFORMATION_STATUSES = Arrays.stream(StackStatus.values())
+            .filter(stackStatus -> !DO_NOT_LIST_CLOUDFORMATION_STATUSES.contains(stackStatus))
+            .map(Enum::name)
+            .collect(Collectors.toSet());
 
     @Inject
     private CfClient cfClient;
 
     public List<StackSummary> listCfStacksByName(String name) {
         AmazonCloudFormation client = cfClient.buildCfClient();
-        return client.listStacks().getStackSummaries()
-                .stream().filter(stack -> stack.getStackName().startsWith(name)
-                        && !DO_NOT_LIST_CLOUDFORMATIONS_STATUSES.contains(stack.getStackStatus())).collect(Collectors.toList());
+        String nextToken = null;
+        List<StackSummary> stacks = new LinkedList<>();
+        do {
+            ListStacksRequest request = new ListStacksRequest()
+                    .withStackStatusFilters(LIST_CLOUDFORMATION_STATUSES)
+                    .withNextToken(nextToken);
+            ListStacksResult listStacksResult = client.listStacks(request);
+            nextToken = listStacksResult.getNextToken();
+            List<StackSummary> stackSummaryList = listStacksResult.getStackSummaries().stream()
+                    .filter(stack -> stack.getStackName().startsWith(name))
+                    .collect(Collectors.toList());
+            stacks.addAll(stackSummaryList);
+        } while (nextToken != null);
+        return stacks;
     }
 
     public List<Stack> listCfStacksByTagsEnvironmentCrn(String crn) {
@@ -41,21 +61,21 @@ public class CfClientActions {
         return client.describeStacks().getStacks().stream().filter(
                 stack ->
                         stack.getTags().stream().anyMatch(tag -> tag.getKey().equals(CLOUDERA_ENVIRONMENT_RESOURCE_NAME) && tag.getValue().equals(crn)
-                        && !DO_NOT_LIST_CLOUDFORMATIONS_STATUSES.contains(stack.getStackStatus()))
+                        && LIST_CLOUDFORMATION_STATUSES.contains(stack.getStackStatus()))
         ).collect(Collectors.toList());
     }
 
     public List<StackResourceSummary> getLaunchTemplatesToStack(String name) {
-        AmazonCloudFormation client = cfClient.buildCfClient();
         List<StackSummary> list = listCfStacksByName(name);
-        if (list.size() == 0) {
-            return null;
+        if (list.size() != 1) {
+            Set<String> stackNames = list.stream().map(StackSummary::getStackName).collect(Collectors.toSet());
+            throw new TestFailException(String.format("Expected exactly one CF stack by name %s but found %s", name, stackNames));
         }
-        DescribeStacksResult desc = client.describeStacks(new DescribeStacksRequest().withStackName(list.get(0).getStackName()));
-
-        ListStackResourcesResult resources = client.listStackResources(new ListStackResourcesRequest()
-                .withStackName(desc.getStacks().get(0).getStackName()));
+        String stackName = list.get(0).getStackName();
+        AmazonCloudFormation client = cfClient.buildCfClient();
+        ListStackResourcesResult resources = client.listStackResources(new ListStackResourcesRequest().withStackName(stackName));
         return resources.getStackResourceSummaries().stream()
-                .filter(resource -> AWS_EC_2_LAUNCH_TEMPLATE.equals(resource.getResourceType())).collect(Collectors.toList());
+                .filter(resource -> AWS_EC_2_LAUNCH_TEMPLATE.equals(resource.getResourceType()))
+                .collect(Collectors.toList());
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazonec2/action/EC2ClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazonec2/action/EC2ClientActions.java
@@ -34,6 +34,8 @@ import com.amazonaws.services.ec2.model.EbsInstanceBlockDevice;
 import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.InstanceBlockDeviceMapping;
 import com.amazonaws.services.ec2.model.InstanceState;
+import com.amazonaws.services.ec2.model.LaunchTemplate;
+import com.amazonaws.services.ec2.model.LaunchTemplateVersion;
 import com.amazonaws.services.ec2.model.Reservation;
 import com.amazonaws.services.ec2.model.StopInstancesRequest;
 import com.amazonaws.services.ec2.model.StopInstancesResult;
@@ -223,23 +225,22 @@ public class EC2ClientActions extends EC2Client {
     }
 
     public Map<String, String> listLaunchTemplatesUserData(String stack) {
-        List<StackResourceSummary> launchTemplateList;
-        try {
-            launchTemplateList = cfClientActions.getLaunchTemplatesToStack(stack);
-        } catch (Exception e) {
-            launchTemplateList = List.of();
-        }
+        List<StackResourceSummary> launchTemplateList = cfClientActions.getLaunchTemplatesToStack(stack);
         AmazonEC2 client = buildEC2Client();
+        List<String> launchTemplateIds = launchTemplateList.stream()
+                .map(StackResourceSummary::getPhysicalResourceId)
+                .collect(Collectors.toList());
+        DescribeLaunchTemplatesResult launchTemplates = client.describeLaunchTemplates(
+                new DescribeLaunchTemplatesRequest().withLaunchTemplateIds(launchTemplateIds));
 
         Map<String, String> result = new HashMap<>();
-        DescribeLaunchTemplatesResult launchTemplates = client.describeLaunchTemplates(new DescribeLaunchTemplatesRequest()
-                .withLaunchTemplateIds(launchTemplateList.stream().map(lt -> lt.getPhysicalResourceId()).collect(Collectors.toList())));
-        for (int i = 0; i < launchTemplateList.size(); i++) {
+        for (LaunchTemplate launchTemplate : launchTemplates.getLaunchTemplates()) {
             DescribeLaunchTemplateVersionsResult ver = client.describeLaunchTemplateVersions(new DescribeLaunchTemplateVersionsRequest()
-                    .withLaunchTemplateId(launchTemplates.getLaunchTemplates().get(i).getLaunchTemplateId())
-                    .withVersions(String.valueOf(launchTemplates.getLaunchTemplates().get(i).getLatestVersionNumber())));
-            String userData = new String(Base64.getDecoder().decode(ver.getLaunchTemplateVersions().get(0).getLaunchTemplateData().getUserData()));
-            result.put(launchTemplates.getLaunchTemplates().get(i).getLaunchTemplateId(), userData);
+                    .withLaunchTemplateId(launchTemplate.getLaunchTemplateId())
+                    .withVersions(String.valueOf(launchTemplate.getLatestVersionNumber())));
+            LaunchTemplateVersion launchTemplateVersion = ver.getLaunchTemplateVersions().get(0);
+            String userData = new String(Base64.getDecoder().decode(launchTemplateVersion.getLaunchTemplateData().getUserData()));
+            result.put(launchTemplate.getLaunchTemplateId(), userData);
         }
 
         return result;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/clouderamanager/ClouderaManagerUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/clouderamanager/ClouderaManagerUtil.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.it.cloudbreak.util.clouderamanager;
 
+import java.util.Map;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -21,6 +22,14 @@ public class ClouderaManagerUtil {
 
     public SdxInternalTestDto checkClouderaManagerKnoxIDBrokerRoleConfigGroups(SdxInternalTestDto testDto, String user, String password) {
         return clouderaManagerClientActions.checkCmKnoxIDBrokerRoleConfigGroups(testDto, user, password);
+    }
+
+    public SdxInternalTestDto checkConfig(SdxInternalTestDto testDto, String user, String password, Map<String, String> expectedConfig) {
+        return clouderaManagerClientActions.checkConfig(testDto, user, password, expectedConfig);
+    }
+
+    public DistroXTestDto checkConfig(DistroXTestDto testDto, String user, String password, Map<String, String> expectedConfig) {
+        return clouderaManagerClientActions.checkConfig(testDto, user, password, expectedConfig);
     }
 
     public DistroXTestDto checkClouderaManagerYarnNodemanagerRoleConfigGroups(DistroXTestDto testDto, String user, String password) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/clouderamanager/action/ClouderaManagerClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/clouderamanager/action/ClouderaManagerClientActions.java
@@ -4,6 +4,8 @@ import static java.lang.String.format;
 import static org.apache.commons.collections4.ListUtils.emptyIfNull;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -12,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import com.cloudera.api.swagger.ClouderaManagerResourceApi;
 import com.cloudera.api.swagger.HostsResourceApi;
 import com.cloudera.api.swagger.RoleConfigGroupsResourceApi;
 import com.cloudera.api.swagger.client.ApiClient;
@@ -38,6 +41,46 @@ public class ClouderaManagerClientActions extends ClouderaManagerClient {
 
     @Value("${integrationtest.cloudProvider:}")
     private String cloudProvider;
+
+    public SdxInternalTestDto checkConfig(SdxInternalTestDto testDto, String user, String password, Map<String, String> expectedConfig) {
+        String serverIp = testDto.getResponse().getStackV4Response().getCluster().getServerIp();
+        checkConfig(serverIp, testDto.getName(), user, password, expectedConfig);
+        return testDto;
+    }
+
+    public DistroXTestDto checkConfig(DistroXTestDto testDto, String user, String password, Map<String, String> expectedConfig) {
+        String serverIp = testDto.getResponse().getCluster().getServerIp();
+        checkConfig(serverIp, testDto.getName(), user, password, expectedConfig);
+        return testDto;
+    }
+
+    private void checkConfig(String serverIp, String name, String user, String password, Map<String, String> expectedConfig) {
+        ApiClient apiClient = getCmApiClient(serverIp, name, V_43, user, password);
+        // CHECKSTYLE:OFF
+        ClouderaManagerResourceApi clouderaManagerResourceApi = new ClouderaManagerResourceApi(apiClient);
+        // CHECKSTYLE:ON
+        try {
+            ApiConfigList configList = clouderaManagerResourceApi.getConfig("full");
+            expectedConfig.forEach((configKey, expectedConfigValue) -> {
+                String actualConfigValue = configList.getItems().stream()
+                        .filter(apiConfig -> apiConfig.getName().equalsIgnoreCase(configKey))
+                        .findFirst()
+                        .orElseThrow(() -> new TestFailException("Config not found with key " + configKey))
+                        .getValue();
+                if (!Objects.equals(expectedConfigValue, actualConfigValue)) {
+                    String message = configKey.toLowerCase().contains("password")
+                            ? String.format("Expected '%s' config value does not match found password", configKey)
+                            : String.format("Expected '%s' config value to be '%s' but found '%s'", configKey, expectedConfigValue, actualConfigValue);
+                    throw new TestFailException(message);
+                }
+            });
+        } catch (ApiException e) {
+            String message = format("Exception when calling ClouderaManagerResourceApi#getConfig at %s. Response: %s",
+                    apiClient.getBasePath(), e.getResponseBody());
+            LOGGER.error(message, e);
+            throw new TestFailException(message, e);
+        }
+    }
 
     public SdxInternalTestDto checkCmKnoxIDBrokerRoleConfigGroups(SdxInternalTestDto testDto, String user, String password) {
         String serverFqdn = testDto.getResponse().getStackV4Response().getCluster().getServerFqdn();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/action/SshProxyActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/action/SshProxyActions.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.it.cloudbreak.util.ssh.action;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.it.cloudbreak.util.ssh.client.SshJClient;
+
+@Component
+public class SshProxyActions extends SshJClient {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SshProxyActions.class);
+
+    private static final String PROXY_SETTINGS_COMMAND = "sudo cat /etc/cdp/proxy.env";
+
+    public Optional<String> getProxySettings(Set<String> ipAddresses) {
+        LOGGER.info("Getting proxy settings on instances {}", ipAddresses);
+        Map<String, Pair<Integer, String>> results = executeCommands(ipAddresses, PROXY_SETTINGS_COMMAND);
+        LOGGER.info("Proxy settings output on instances: {}", results);
+        Set<String> proxySettings = results.values().stream()
+                .filter(result -> result.getKey() == 0)
+                .map(Pair::getValue)
+                .collect(Collectors.toSet());
+        if (proxySettings.size() > 1) {
+            String message = String.format("Found different proxy settings on instances: %s", proxySettings);
+            LOGGER.error(message);
+            throw new TestFailException(message);
+        }
+        return proxySettings.stream().findFirst();
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/action/SshSaltPasswordActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/action/SshSaltPasswordActions.java
@@ -2,7 +2,6 @@ package com.sequenceiq.it.cloudbreak.util.ssh.action;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -57,11 +56,5 @@ public class SshSaltPasswordActions extends SshJClient {
                 .map(result -> LocalDate.parse(result.getValue().trim(), CHAGE_DATE_PATTERN))
                 .min(LocalDate::compareTo)
                 .orElseThrow(() -> new TestFailException("Failed to get password expiry date on nodes " + ipAddresses));
-    }
-
-    private Map<String, Pair<Integer, String>> executeCommands(Set<String> ipAddresses, String command) {
-        Map<String, Pair<Integer, String>> results = new HashMap<>();
-        ipAddresses.forEach(ipAddress -> results.put(ipAddress, executeCommand(ipAddress, command)));
-        return results;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/client/SshJClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/client/SshJClient.java
@@ -6,6 +6,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.PostConstruct;
@@ -107,6 +110,12 @@ public class SshJClient {
             cmd.join(10L, TimeUnit.SECONDS);
             return Pair.of(cmd.getExitStatus(), os.toString());
         }
+    }
+
+    protected Map<String, Pair<Integer, String>> executeCommands(Set<String> ipAddresses, String command) {
+        Map<String, Pair<Integer, String>> results = new HashMap<>();
+        ipAddresses.forEach(ipAddress -> results.put(ipAddress, executeCommand(ipAddress, command)));
+        return results;
     }
 
     protected Pair<Integer, String> executeCommand(String instanceIP, String command) {

--- a/integration-test/src/main/resources/testsuites/e2e/aws-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/aws-e2e-tests.yaml
@@ -18,3 +18,4 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRangerRazEnabledTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.InternalSdxRepairWithRecipeTest
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.saltpassword.RotateSaltPasswordE2ETest
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.proxy.ModifyProxyConfigE2ETest

--- a/integration-test/src/main/resources/testsuites/e2e/azure-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/azure-e2e-tests.yaml
@@ -14,3 +14,5 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxImagesTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.AzureMarketplaceImageTest
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.InternalSdxRepairWithRecipeTest
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.saltpassword.RotateSaltPasswordE2ETest
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.proxy.ModifyProxyConfigE2ETest

--- a/integration-test/src/main/resources/testsuites/e2e/gcp-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/gcp-e2e-tests.yaml
@@ -11,3 +11,5 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXRepairTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXScaleTest
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxImagesTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.saltpassword.RotateSaltPasswordE2ETest
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.proxy.ModifyProxyConfigE2ETest

--- a/integration-test/src/main/resources/testsuites/e2e/salt-password-rotation-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/salt-password-rotation-tests.yaml
@@ -1,5 +1,0 @@
-name: "salt-password-rotation-tests"
-tests:
-  - name: "salt_password_rotation_tests"
-    classes:
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.saltpassword.RotateSaltPasswordE2ETest


### PR DESCRIPTION
The test is ran as part of aws, azure and gcp testsuites. Test steps:
- Create an environment without proxy
- Add proxy
- Check proxy settings of FreeIpa nodes
- Create a Datalake
- Check proxy settings of Datalake nodes
- Modify to another proxy
- Check proxy settings of FreeIpa and Datalake nodes
- Create a Datahub
- Check proxy settings on Datahub
- Remove proxy
- Check proxy settings on Freeipa, Datalake and Datahub nodes

Proxy setting check steps:
- Check contents of /etc/cdp/proxy.env file on nodes
- Check proxy config in userdata in AWS CF stacks
- In case of Datalake/Datahub, check CM proxy settings

Additional changes:
- Helper methods to re-use existing clusters while testing locally to speed up development
- Unification of proxy and rotate salt password test suites

See detailed description in the commit message.