### PR TITLE
CB-20678 Allow DNS request from different networks for FreeIPA on RH8

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/common-install.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/common-install.sls
@@ -111,3 +111,26 @@ restart_sssd_if_reconfigured:
     - failhard: True
     - watch:
       - file: /etc/sssd/sssd.conf
+
+{% if grains['os_family'] == 'RedHat' and grains['osmajorrelease'] | int == 8 %}
+  
+/etc/named/ipa-ext.conf:
+  file.managed:
+    - source: salt://freeipa/templates/ipa-ext.conf
+
+/etc/named/ipa-options-ext.conf:
+  file.append:
+    - text:
+        - allow-recursion { trusted_network; };
+        - allow-query-cache  { trusted_network; };
+    - require:
+        - file: /etc/named/ipa-ext.conf
+
+restart_named_if_reconfigured:
+  service.running:
+    - name: named-pkcs11
+    - failhard: True
+    - watch:
+        - file: /etc/named/ipa-options-ext.conf
+
+{% endif %}

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/templates/ipa-ext.conf
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/templates/ipa-ext.conf
@@ -1,0 +1,18 @@
+/* User customization for BIND named
+ *
+ * This file is included in /etc/named.conf and is not modified during IPA
+ * upgrades.
+ *
+ * "options" settings must be configured in /etc/named/ipa-options-ext.conf.
+ *
+ * Example: ACL for recursion access:
+ *
+ * acl "trusted_network" {
+ *   localnets;
+ *   localhost;
+ *   234.234.234.0/24;
+ *   2001::co:ffee:babe:1/48;
+ * };
+ */
+
+acl "trusted_network" { any; };


### PR DESCRIPTION
On RH8 we have newer FreeIPA which has a different behavior and forbids requests from different networks by default. Issue explained https://access.redhat.com/solutions/5753431 and in jira

Solution is to restore the previous behavior by the solution suggested by RedHat portal.

See detailed description in the commit message.