### PR TITLE
Merge remote-tracking branch 'origin/CB-2.68.0' into master

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/salt/rotatepassword/RotateSaltPasswordActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/salt/rotatepassword/RotateSaltPasswordActions.java
@@ -21,7 +21,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordFailureResponse;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordSuccessResponse;
-import com.sequenceiq.cloudbreak.service.RotateSaltPasswordService;
+import com.sequenceiq.cloudbreak.service.salt.RotateSaltPasswordService;
 
 @Configuration
 public class RotateSaltPasswordActions {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/RotateSaltPasswordHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/RotateSaltPasswordHandler.java
@@ -13,7 +13,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordFai
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordSuccessResponse;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordType;
-import com.sequenceiq.cloudbreak.service.RotateSaltPasswordService;
+import com.sequenceiq.cloudbreak.service.salt.RotateSaltPasswordService;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/salt/RotateSaltPasswordService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/salt/RotateSaltPasswordService.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.cloudbreak.service;
+package com.sequenceiq.cloudbreak.service.salt;
 
 import java.util.List;
 import java.util.Map;
@@ -16,24 +16,18 @@ import org.springframework.stereotype.Service;
 import com.cloudera.thunderhead.service.common.usage.UsageProto;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.SaltPasswordStatus;
 import com.sequenceiq.cloudbreak.api.model.RotateSaltPasswordReason;
-import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
-import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.orchestration.Node;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterBootstrapper;
-import com.sequenceiq.cloudbreak.core.bootstrap.service.SaltBootstrapVersionChecker;
-import com.sequenceiq.cloudbreak.core.flow2.service.ReactorFlowManager;
 import com.sequenceiq.cloudbreak.domain.SecurityConfig;
 import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
-import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordType;
+import com.sequenceiq.cloudbreak.service.GatewayConfigService;
 import com.sequenceiq.cloudbreak.service.securityconfig.SecurityConfigService;
 import com.sequenceiq.cloudbreak.usage.UsageReporter;
 import com.sequenceiq.cloudbreak.util.PasswordUtil;
-import com.sequenceiq.cloudbreak.view.InstanceMetadataView;
-import com.sequenceiq.flow.api.model.FlowIdentifier;
 
 @Service
 public class RotateSaltPasswordService {
@@ -49,9 +43,6 @@ public class RotateSaltPasswordService {
     private GatewayConfigService gatewayConfigService;
 
     @Inject
-    private SaltBootstrapVersionChecker saltBootstrapVersionChecker;
-
-    @Inject
     private SecurityConfigService securityConfigService;
 
     @Inject
@@ -61,51 +52,15 @@ public class RotateSaltPasswordService {
     private ClusterBootstrapper clusterBootstrapper;
 
     @Inject
-    private EntitlementService entitlementService;
-
-    @Inject
-    private ReactorFlowManager flowManager;
-
-    @Inject
     private SaltPasswordStatusService saltPasswordStatusService;
+
+    @Inject
+    private RotateSaltPasswordValidator rotateSaltPasswordValidator;
 
     private Supplier<String> passwordGenerator = PasswordUtil::generatePassword;
 
-    public void validateRotateSaltPassword(StackDto stack) {
-        if (stack.getStatus().isStopped()) {
-            throw new BadRequestException("Rotating SaltStack user password is not supported for stopped clusters");
-        }
-        if (!entitlementService.isSaltUserPasswordRotationEnabled(stack.getAccountId())) {
-            throw new BadRequestException("Rotating SaltStack user password is not supported in your account");
-        }
-        if (stack.getNotTerminatedAndNotZombieGatewayInstanceMetadata().isEmpty()) {
-            throw new IllegalStateException("Rotating SaltStack user password is not supported when there are no available gateway instances");
-        }
-        if (!isChangeSaltuserPasswordSupported(stack) && stack.getNotTerminatedInstanceMetaData().stream().anyMatch(im -> !im.isRunning())) {
-            // fallback implementation re-bootstraps all nodes, so they have to be running
-            throw new IllegalStateException("Rotating SaltStack user password is only supported when all instances are running");
-        }
-    }
-
-    private boolean isChangeSaltuserPasswordSupported(StackDto stack) {
-        return stack.getNotTerminatedAndNotZombieGatewayInstanceMetadata().stream()
-                .map(InstanceMetadataView::getImage)
-                .allMatch(image -> saltBootstrapVersionChecker.isChangeSaltuserPasswordSupported(image));
-    }
-
-    public FlowIdentifier triggerRotateSaltPassword(StackDto stack, RotateSaltPasswordReason reason) {
-        validateRotateSaltPassword(stack);
-        RotateSaltPasswordType rotateSaltPasswordType = getRotateSaltPasswordType(stack);
-        LOGGER.info("Triggering rotate salt password for stack {} with type {}", stack.getId(), rotateSaltPasswordType);
-        return flowManager.triggerRotateSaltPassword(stack.getId(), reason, rotateSaltPasswordType);
-    }
-
-    private RotateSaltPasswordType getRotateSaltPasswordType(StackDto stack) {
-        return isChangeSaltuserPasswordSupported(stack) ? RotateSaltPasswordType.SALT_BOOTSTRAP_ENDPOINT : RotateSaltPasswordType.FALLBACK;
-    }
-
     public void rotateSaltPassword(StackDto stack) throws CloudbreakOrchestratorException {
-        validateRotateSaltPassword(stack);
+        rotateSaltPasswordValidator.validateRotateSaltPassword(stack);
         SecurityConfig securityConfig = stack.getSecurityConfig();
         String oldPassword = securityConfig.getSaltSecurityConfig().getSaltPassword();
         String newPassword = passwordGenerator.get();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/salt/RotateSaltPasswordTriggerService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/salt/RotateSaltPasswordTriggerService.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.cloudbreak.service.salt;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.api.model.RotateSaltPasswordReason;
+import com.sequenceiq.cloudbreak.core.flow2.service.ReactorFlowManager;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordType;
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+
+@Service
+public class RotateSaltPasswordTriggerService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RotateSaltPasswordTriggerService.class);
+
+    @Inject
+    private ReactorFlowManager flowManager;
+
+    @Inject
+    private RotateSaltPasswordValidator rotateSaltPasswordValidator;
+
+    public FlowIdentifier triggerRotateSaltPassword(StackDto stack, RotateSaltPasswordReason reason) {
+        rotateSaltPasswordValidator.validateRotateSaltPassword(stack);
+        RotateSaltPasswordType rotateSaltPasswordType = getRotateSaltPasswordType(stack);
+        LOGGER.info("Triggering rotate salt password for stack {} with type {}", stack.getId(), rotateSaltPasswordType);
+        return flowManager.triggerRotateSaltPassword(stack.getId(), reason, rotateSaltPasswordType);
+    }
+
+    private RotateSaltPasswordType getRotateSaltPasswordType(StackDto stack) {
+        return rotateSaltPasswordValidator.isChangeSaltuserPasswordSupported(stack) ? RotateSaltPasswordType.SALT_BOOTSTRAP_ENDPOINT
+                : RotateSaltPasswordType.FALLBACK;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/salt/RotateSaltPasswordValidator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/salt/RotateSaltPasswordValidator.java
@@ -1,0 +1,43 @@
+package com.sequenceiq.cloudbreak.service.salt;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.SaltBootstrapVersionChecker;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.view.InstanceMetadataView;
+
+@Component
+public class RotateSaltPasswordValidator {
+
+    @Inject
+    private SaltBootstrapVersionChecker saltBootstrapVersionChecker;
+
+    @Inject
+    private EntitlementService entitlementService;
+
+    public void validateRotateSaltPassword(StackDto stack) {
+        if (stack.getStatus().isStopped()) {
+            throw new BadRequestException("Rotating SaltStack user password is not supported for stopped clusters");
+        }
+        if (!entitlementService.isSaltUserPasswordRotationEnabled(stack.getAccountId())) {
+            throw new BadRequestException("Rotating SaltStack user password is not supported in your account");
+        }
+        if (stack.getNotTerminatedAndNotZombieGatewayInstanceMetadata().isEmpty()) {
+            throw new IllegalStateException("Rotating SaltStack user password is not supported when there are no available gateway instances");
+        }
+        if (!isChangeSaltuserPasswordSupported(stack) && stack.getNotTerminatedInstanceMetaData().stream().anyMatch(im -> !im.isRunning())) {
+            // fallback implementation re-bootstraps all nodes, so they have to be running
+            throw new IllegalStateException("Rotating SaltStack user password is only supported when all instances are running");
+        }
+    }
+
+    public boolean isChangeSaltuserPasswordSupported(StackDto stack) {
+        return stack.getNotTerminatedAndNotZombieGatewayInstanceMetadata().stream()
+                .map(InstanceMetadataView::getImage)
+                .allMatch(image -> saltBootstrapVersionChecker.isChangeSaltuserPasswordSupported(image));
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/salt/SaltPasswordStatusService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/salt/SaltPasswordStatusService.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.cloudbreak.service;
+package com.sequenceiq.cloudbreak.service.salt;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
@@ -18,13 +18,14 @@ import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorEx
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.quartz.saltstatuschecker.SaltStatusCheckerConfig;
+import com.sequenceiq.cloudbreak.service.GatewayConfigService;
 
 @Service
 public class SaltPasswordStatusService {
 
-    protected static final String SALTUSER = "saltuser";
+    private static final String SALTUSER = "saltuser";
 
-    protected static final String UNAUTHORIZED_RESPONSE = "Status: 401 Unauthorized Response";
+    private static final String UNAUTHORIZED_RESPONSE = "Status: 401 Unauthorized Response";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SaltPasswordStatusService.class);
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
@@ -48,14 +48,15 @@ import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.domain.view.StackApiView;
 import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
-import com.sequenceiq.cloudbreak.service.RotateSaltPasswordService;
-import com.sequenceiq.cloudbreak.service.SaltPasswordStatusService;
 import com.sequenceiq.cloudbreak.service.StackUpdater;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
 import com.sequenceiq.cloudbreak.service.cluster.flow.ClusterOperationService;
 import com.sequenceiq.cloudbreak.service.datalake.DataLakeStatusCheckerService;
 import com.sequenceiq.cloudbreak.service.environment.EnvironmentService;
 import com.sequenceiq.cloudbreak.service.image.ImageChangeDto;
+import com.sequenceiq.cloudbreak.service.salt.RotateSaltPasswordTriggerService;
+import com.sequenceiq.cloudbreak.service.salt.RotateSaltPasswordValidator;
+import com.sequenceiq.cloudbreak.service.salt.SaltPasswordStatusService;
 import com.sequenceiq.cloudbreak.service.spot.SpotInstanceUsageCondition;
 import com.sequenceiq.cloudbreak.service.stack.StackApiViewService;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
@@ -117,7 +118,10 @@ public class StackOperationService {
     private TargetedUpscaleSupportService targetedUpscaleSupportService;
 
     @Inject
-    private RotateSaltPasswordService rotateSaltPasswordService;
+    private RotateSaltPasswordTriggerService rotateSaltPasswordTriggerService;
+
+    @Inject
+    private RotateSaltPasswordValidator rotateSaltPasswordValidator;
 
     @Inject
     private SaltPasswordStatusService saltPasswordStatusService;
@@ -459,8 +463,8 @@ public class StackOperationService {
     public FlowIdentifier rotateSaltPassword(@NotNull NameOrCrn nameOrCrn, String accountId, RotateSaltPasswordReason reason) {
         StackDto stack = stackDtoService.getByNameOrCrn(nameOrCrn, accountId);
         MDCBuilder.buildMdcContext(stack);
-        rotateSaltPasswordService.validateRotateSaltPassword(stack);
-        return rotateSaltPasswordService.triggerRotateSaltPassword(stack, reason);
+        rotateSaltPasswordValidator.validateRotateSaltPassword(stack);
+        return rotateSaltPasswordTriggerService.triggerRotateSaltPassword(stack, reason);
     }
 
     public SaltPasswordStatus getSaltPasswordStatus(@NotNull NameOrCrn nameOrCrn, String accountId) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/job/salt/StackSaltStatusCheckerJobTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/job/salt/StackSaltStatusCheckerJobTest.java
@@ -35,8 +35,10 @@ import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGenerator;
 import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
 import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.logger.MdcContextInfoProvider;
-import com.sequenceiq.cloudbreak.service.RotateSaltPasswordService;
-import com.sequenceiq.cloudbreak.service.SaltPasswordStatusService;
+import com.sequenceiq.cloudbreak.service.salt.RotateSaltPasswordService;
+import com.sequenceiq.cloudbreak.service.salt.RotateSaltPasswordTriggerService;
+import com.sequenceiq.cloudbreak.service.salt.RotateSaltPasswordValidator;
+import com.sequenceiq.cloudbreak.service.salt.SaltPasswordStatusService;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 import com.sequenceiq.cloudbreak.view.StackView;
 
@@ -71,6 +73,12 @@ class StackSaltStatusCheckerJobTest {
 
     @Mock
     private JobDetail jobDetail;
+
+    @Mock
+    private RotateSaltPasswordTriggerService rotateSaltPasswordTriggerService;
+
+    @Mock
+    private RotateSaltPasswordValidator rotateSaltPasswordValidator;
 
     private JobKey jobKey;
 
@@ -166,8 +174,8 @@ class StackSaltStatusCheckerJobTest {
             underTest.executeTracedJob(context);
 
             verify(saltPasswordStatusService).getSaltPasswordStatus(stackDto);
-            verify(rotateSaltPasswordService).validateRotateSaltPassword(stackDto);
-            verify(rotateSaltPasswordService, never()).triggerRotateSaltPassword(eq(stackDto), any());
+            verify(rotateSaltPasswordValidator).validateRotateSaltPassword(stackDto);
+            verify(rotateSaltPasswordTriggerService, never()).triggerRotateSaltPassword(eq(stackDto), any());
         }
 
         @Test
@@ -177,8 +185,8 @@ class StackSaltStatusCheckerJobTest {
             underTest.executeTracedJob(context);
 
             verify(saltPasswordStatusService).getSaltPasswordStatus(stackDto);
-            verify(rotateSaltPasswordService).validateRotateSaltPassword(stackDto);
-            verify(rotateSaltPasswordService, never()).triggerRotateSaltPassword(eq(stackDto), any());
+            verify(rotateSaltPasswordValidator).validateRotateSaltPassword(stackDto);
+            verify(rotateSaltPasswordTriggerService, never()).triggerRotateSaltPassword(eq(stackDto), any());
         }
 
         @Test
@@ -188,8 +196,8 @@ class StackSaltStatusCheckerJobTest {
             underTest.executeTracedJob(context);
 
             verify(saltPasswordStatusService).getSaltPasswordStatus(stackDto);
-            verify(rotateSaltPasswordService).validateRotateSaltPassword(stackDto);
-            verify(rotateSaltPasswordService).triggerRotateSaltPassword(stackDto, RotateSaltPasswordReason.EXPIRED);
+            verify(rotateSaltPasswordValidator).validateRotateSaltPassword(stackDto);
+            verify(rotateSaltPasswordTriggerService).triggerRotateSaltPassword(stackDto, RotateSaltPasswordReason.EXPIRED);
         }
 
         @Test
@@ -199,8 +207,8 @@ class StackSaltStatusCheckerJobTest {
             underTest.executeTracedJob(context);
 
             verify(saltPasswordStatusService).getSaltPasswordStatus(stackDto);
-            verify(rotateSaltPasswordService).validateRotateSaltPassword(stackDto);
-            verify(rotateSaltPasswordService).triggerRotateSaltPassword(stackDto, RotateSaltPasswordReason.UNAUTHORIZED);
+            verify(rotateSaltPasswordValidator).validateRotateSaltPassword(stackDto);
+            verify(rotateSaltPasswordTriggerService).triggerRotateSaltPassword(stackDto, RotateSaltPasswordReason.UNAUTHORIZED);
         }
 
         @Test
@@ -212,7 +220,7 @@ class StackSaltStatusCheckerJobTest {
             underTest.executeTracedJob(context);
 
             verify(saltPasswordStatusService).getSaltPasswordStatus(stackDto);
-            verify(rotateSaltPasswordService).validateRotateSaltPassword(stackDto);
+            verify(rotateSaltPasswordValidator).validateRotateSaltPassword(stackDto);
             verify(rotateSaltPasswordService).sendFailureUsageReport(stackDto.getResourceCrn(), RotateSaltPasswordReason.UNSET,
                     "Failed to get salt password status: " + cause.getMessage());
         }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/RotateSaltPasswordHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/RotateSaltPasswordHandlerTest.java
@@ -27,7 +27,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordFai
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordSuccessResponse;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordType;
-import com.sequenceiq.cloudbreak.service.RotateSaltPasswordService;
+import com.sequenceiq.cloudbreak.service.salt.RotateSaltPasswordService;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
 import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/RotateSaltPasswordServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/RotateSaltPasswordServiceTest.java
@@ -33,11 +33,8 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.SaltPasswordStatus;
 import com.sequenceiq.cloudbreak.api.model.RotateSaltPasswordReason;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
-import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.orchestration.Node;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterBootstrapper;
-import com.sequenceiq.cloudbreak.core.bootstrap.service.SaltBootstrapVersionChecker;
-import com.sequenceiq.cloudbreak.core.flow2.service.ReactorFlowManager;
 import com.sequenceiq.cloudbreak.domain.SaltSecurityConfig;
 import com.sequenceiq.cloudbreak.domain.SecurityConfig;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
@@ -45,7 +42,9 @@ import com.sequenceiq.cloudbreak.dto.StackDto;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
-import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordType;
+import com.sequenceiq.cloudbreak.service.salt.RotateSaltPasswordService;
+import com.sequenceiq.cloudbreak.service.salt.RotateSaltPasswordValidator;
+import com.sequenceiq.cloudbreak.service.salt.SaltPasswordStatusService;
 import com.sequenceiq.cloudbreak.service.securityconfig.SecurityConfigService;
 import com.sequenceiq.cloudbreak.usage.UsageReporter;
 import com.sequenceiq.cloudbreak.view.InstanceMetadataView;
@@ -76,9 +75,6 @@ class RotateSaltPasswordServiceTest {
     private SecurityConfigService securityConfigService;
 
     @Mock
-    private SaltBootstrapVersionChecker saltBootstrapVersionChecker;
-
-    @Mock
     private EntitlementService entitlementService;
 
     @Mock
@@ -91,10 +87,10 @@ class RotateSaltPasswordServiceTest {
     private StackDto stack;
 
     @Mock
-    private ReactorFlowManager flowManager;
+    private InstanceMetadataView instanceMetadataView;
 
     @Mock
-    private InstanceMetadataView instanceMetadataView;
+    private RotateSaltPasswordValidator rotateSaltPasswordValidator;
 
     @Captor
     private ArgumentCaptor<UsageProto.CDPSaltPasswordRotationEvent> eventArgumentCaptor;
@@ -162,49 +158,10 @@ class RotateSaltPasswordServiceTest {
     }
 
     @Test
-    public void testRotateSaltPasswordOnStoppedStack() {
-        when(stack.getStatus()).thenReturn(Status.STOPPED);
-
-        assertThatThrownBy(() -> underTest.rotateSaltPassword(stack))
-                .isInstanceOf(BadRequestException.class)
-                .hasMessage("Rotating SaltStack user password is not supported for stopped clusters");
-    }
-
-    @Test
-    public void testRotateSaltPasswordOnStackInAccountWithoutEntitlement() {
-        when(entitlementService.isSaltUserPasswordRotationEnabled(ACCOUNT_ID)).thenReturn(false);
-
-        Assertions.assertThatThrownBy(() -> underTest.rotateSaltPassword(stack))
-                .isInstanceOf(BadRequestException.class)
-                .hasMessage("Rotating SaltStack user password is not supported in your account");
-    }
-
-    @Test
-    public void testRotateSaltPasswordOnStackWithoutAvailableGateway() {
-        when(stack.getNotTerminatedAndNotZombieGatewayInstanceMetadata()).thenReturn(List.of());
-
-        Assertions.assertThatThrownBy(() -> underTest.rotateSaltPassword(stack))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Rotating SaltStack user password is not supported when there are no available gateway instances");
-    }
-
-    @Test
-    public void testRotateSaltPasswordOnStackWithNotRunningInstanceAndFallbackImplementation() {
-        InstanceMetaData instanceMetaData = new InstanceMetaData();
-        instanceMetaData.setInstanceStatus(InstanceStatus.STOPPED);
-        when(stack.getNotTerminatedInstanceMetaData()).thenReturn(List.of(instanceMetaData));
-
-        Assertions.assertThatThrownBy(() -> underTest.rotateSaltPassword(stack))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Rotating SaltStack user password is only supported when all instances are running");
-    }
-
-    @Test
     public void testRotateSaltPasswordOnStackWithNotRunningInstanceAndDefaultImplementation() {
         InstanceMetaData instanceMetaData = new InstanceMetaData();
         instanceMetaData.setInstanceStatus(InstanceStatus.STOPPED);
         lenient().when(stack.getNotTerminatedInstanceMetaData()).thenReturn(List.of(instanceMetaData));
-        when(saltBootstrapVersionChecker.isChangeSaltuserPasswordSupported(any())).thenReturn(true);
 
         Assertions.assertThatCode(() -> underTest.rotateSaltPassword(stack))
                 .doesNotThrowAnyException();
@@ -273,24 +230,6 @@ class RotateSaltPasswordServiceTest {
                         "If the saltuser password was changed manually, " +
                         "please remove the user manually with the command 'userdel saltuser' on node(s) [1.1.1.1, 1.1.1.2] and retry the operation.")
                 .hasCause(new CloudbreakOrchestratorFailedException("Salt password status check failed with status INVALID, please try the operation again"));
-    }
-
-    @Test
-    void getRotateSaltPasswordTypeFallback() {
-        when(saltBootstrapVersionChecker.isChangeSaltuserPasswordSupported(any())).thenReturn(false);
-
-        underTest.triggerRotateSaltPassword(stack, RotateSaltPasswordReason.MANUAL);
-
-        verify(flowManager).triggerRotateSaltPassword(stack.getId(), RotateSaltPasswordReason.MANUAL, RotateSaltPasswordType.FALLBACK);
-    }
-
-    @Test
-    void getRotateSaltPasswordTypeSaltBootstrapEndpoint() {
-        when(saltBootstrapVersionChecker.isChangeSaltuserPasswordSupported(any())).thenReturn(true);
-
-        underTest.triggerRotateSaltPassword(stack, RotateSaltPasswordReason.MANUAL);
-
-        verify(flowManager).triggerRotateSaltPassword(stack.getId(), RotateSaltPasswordReason.MANUAL, RotateSaltPasswordType.SALT_BOOTSTRAP_ENDPOINT);
     }
 
     @Test

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/SaltPasswordStatusServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/SaltPasswordStatusServiceTest.java
@@ -23,9 +23,14 @@ import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFa
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.quartz.saltstatuschecker.SaltStatusCheckerConfig;
+import com.sequenceiq.cloudbreak.service.salt.SaltPasswordStatusService;
 
 @ExtendWith(MockitoExtension.class)
 class SaltPasswordStatusServiceTest {
+
+    private static final String SALTUSER = "saltuser";
+
+    private static final String UNAUTHORIZED_RESPONSE = "Status: 401 Unauthorized Response";
 
     private static final String ACCOUNT_ID = "0";
 
@@ -64,7 +69,7 @@ class SaltPasswordStatusServiceTest {
         when(clock.getCurrentLocalDateTime()).thenReturn(LocalDateTime.now());
         when(saltStatusCheckerConfig.getPasswordExpiryThresholdInDays()).thenReturn(14);
         when(gatewayConfigService.getAllGatewayConfigs(stack)).thenReturn(gatewayConfigs);
-        when(hostOrchestrator.getPasswordExpiryDate(gatewayConfigs, SaltPasswordStatusService.SALTUSER)).thenReturn(LocalDate.now().minusMonths(2));
+        when(hostOrchestrator.getPasswordExpiryDate(gatewayConfigs, SALTUSER)).thenReturn(LocalDate.now().minusMonths(2));
 
         SaltPasswordStatus result = underTest.getSaltPasswordStatus(stack);
 
@@ -76,7 +81,7 @@ class SaltPasswordStatusServiceTest {
         when(clock.getCurrentLocalDateTime()).thenReturn(LocalDateTime.now());
         when(saltStatusCheckerConfig.getPasswordExpiryThresholdInDays()).thenReturn(14);
         when(gatewayConfigService.getAllGatewayConfigs(stack)).thenReturn(gatewayConfigs);
-        when(hostOrchestrator.getPasswordExpiryDate(gatewayConfigs, SaltPasswordStatusService.SALTUSER)).thenReturn(LocalDate.now().plusMonths(2));
+        when(hostOrchestrator.getPasswordExpiryDate(gatewayConfigs, SALTUSER)).thenReturn(LocalDate.now().plusMonths(2));
 
         SaltPasswordStatus result = underTest.getSaltPasswordStatus(stack);
 
@@ -86,10 +91,10 @@ class SaltPasswordStatusServiceTest {
     @Test
     void unauthorizedSaltPasswordRotationNeeded() throws Exception {
         when(gatewayConfigService.getAllGatewayConfigs(stack)).thenReturn(gatewayConfigs);
-        RuntimeException causeCause = new RuntimeException(SaltPasswordStatusService.UNAUTHORIZED_RESPONSE);
+        RuntimeException causeCause = new RuntimeException(UNAUTHORIZED_RESPONSE);
         RuntimeException cause = new RuntimeException("Ooops", causeCause);
         CloudbreakOrchestratorFailedException exception = new CloudbreakOrchestratorFailedException("Failed", cause);
-        when(hostOrchestrator.getPasswordExpiryDate(gatewayConfigs, SaltPasswordStatusService.SALTUSER)).thenThrow(exception);
+        when(hostOrchestrator.getPasswordExpiryDate(gatewayConfigs, SALTUSER)).thenThrow(exception);
 
         SaltPasswordStatus result = underTest.getSaltPasswordStatus(stack);
 
@@ -100,7 +105,7 @@ class SaltPasswordStatusServiceTest {
     void errorWhileSaltPasswordRotationNeeded() throws Exception {
         when(gatewayConfigService.getAllGatewayConfigs(stack)).thenReturn(gatewayConfigs);
         CloudbreakOrchestratorFailedException exception = new CloudbreakOrchestratorFailedException("Unexpected failure");
-        when(hostOrchestrator.getPasswordExpiryDate(gatewayConfigs, SaltPasswordStatusService.SALTUSER)).thenThrow(exception);
+        when(hostOrchestrator.getPasswordExpiryDate(gatewayConfigs, SALTUSER)).thenThrow(exception);
 
         SaltPasswordStatus result = underTest.getSaltPasswordStatus(stack);
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/salt/RotateSaltPasswordTriggerServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/salt/RotateSaltPasswordTriggerServiceTest.java
@@ -1,0 +1,58 @@
+package com.sequenceiq.cloudbreak.service.salt;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.model.RotateSaltPasswordReason;
+import com.sequenceiq.cloudbreak.core.flow2.service.ReactorFlowManager;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RotateSaltPasswordType;
+
+@ExtendWith(MockitoExtension.class)
+class RotateSaltPasswordTriggerServiceTest {
+
+    private static final long STACK_ID = 1L;
+
+    @Mock
+    private ReactorFlowManager flowManager;
+
+    @Mock
+    private RotateSaltPasswordValidator rotateSaltPasswordValidator;
+
+    @Mock
+    private StackDto stack;
+
+    @InjectMocks
+    private RotateSaltPasswordTriggerService underTest;
+
+    @BeforeEach
+    void init() {
+        when(stack.getId()).thenReturn(STACK_ID);
+    }
+
+    @Test
+    void getRotateSaltPasswordTypeFallback() {
+        when(rotateSaltPasswordValidator.isChangeSaltuserPasswordSupported(stack)).thenReturn(false);
+
+        underTest.triggerRotateSaltPassword(stack, RotateSaltPasswordReason.MANUAL);
+
+        verify(flowManager).triggerRotateSaltPassword(STACK_ID, RotateSaltPasswordReason.MANUAL, RotateSaltPasswordType.FALLBACK);
+    }
+
+    @Test
+    void getRotateSaltPasswordTypeSaltBootstrapEndpoint() {
+        when(rotateSaltPasswordValidator.isChangeSaltuserPasswordSupported(stack)).thenReturn(true);
+
+        underTest.triggerRotateSaltPassword(stack, RotateSaltPasswordReason.MANUAL);
+
+        verify(flowManager).triggerRotateSaltPassword(STACK_ID, RotateSaltPasswordReason.MANUAL, RotateSaltPasswordType.SALT_BOOTSTRAP_ENDPOINT);
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/salt/RotateSaltPasswordValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/salt/RotateSaltPasswordValidatorTest.java
@@ -1,0 +1,86 @@
+package com.sequenceiq.cloudbreak.service.salt;
+
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.SaltBootstrapVersionChecker;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.dto.StackDto;
+import com.sequenceiq.cloudbreak.view.InstanceMetadataView;
+
+@ExtendWith(MockitoExtension.class)
+class RotateSaltPasswordValidatorTest {
+
+    private static final String STACK_CRN = "crn:cdp:datalake:us-west-1:cloudera:datalake:33071a14-d605-4b2d-9a55-218c0dbc95e3";
+
+    private static final String ACCOUNT_ID = "0";
+
+    private static final String OLD_PASSWORD = "old-password";
+
+    @Mock
+    private SaltBootstrapVersionChecker saltBootstrapVersionChecker;
+
+    @Mock
+    private EntitlementService entitlementService;
+
+    @Mock
+    private StackDto stack;
+
+    @Mock
+    private InstanceMetadataView instanceMetadataView;
+
+    @InjectMocks
+    private RotateSaltPasswordValidator underTest;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(stack.isAvailable()).thenReturn(true);
+        lenient().when(stack.getAccountId()).thenReturn(ACCOUNT_ID);
+        lenient().when(stack.getStatus()).thenReturn(Status.AVAILABLE);
+        lenient().when(stack.getNotTerminatedAndNotZombieGatewayInstanceMetadata()).thenReturn(List.of(instanceMetadataView));
+        lenient().when(entitlementService.isSaltUserPasswordRotationEnabled(ACCOUNT_ID)).thenReturn(true);
+    }
+
+    @Test
+    public void testRotateSaltPasswordOnStackWithNotRunningInstanceAndFallbackImplementation() {
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+        instanceMetaData.setInstanceStatus(InstanceStatus.STOPPED);
+        when(stack.getNotTerminatedInstanceMetaData()).thenReturn(List.of(instanceMetaData));
+
+        Assertions.assertThatThrownBy(() -> underTest.validateRotateSaltPassword(stack))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Rotating SaltStack user password is only supported when all instances are running");
+    }
+
+    @Test
+    public void testRotateSaltPasswordOnStackInAccountWithoutEntitlement() {
+        when(entitlementService.isSaltUserPasswordRotationEnabled(ACCOUNT_ID)).thenReturn(false);
+
+        Assertions.assertThatThrownBy(() -> underTest.validateRotateSaltPassword(stack))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("Rotating SaltStack user password is not supported in your account");
+    }
+
+    @Test
+    public void testRotateSaltPasswordOnStackWithoutAvailableGateway() {
+        when(stack.getNotTerminatedAndNotZombieGatewayInstanceMetadata()).thenReturn(List.of());
+
+        Assertions.assertThatThrownBy(() -> underTest.validateRotateSaltPassword(stack))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Rotating SaltStack user password is not supported when there are no available gateway instances");
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationServiceTest.java
@@ -62,13 +62,14 @@ import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.dto.StackDto;
-import com.sequenceiq.cloudbreak.service.RotateSaltPasswordService;
-import com.sequenceiq.cloudbreak.service.SaltPasswordStatusService;
 import com.sequenceiq.cloudbreak.service.StackUpdater;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
 import com.sequenceiq.cloudbreak.service.cluster.flow.ClusterOperationService;
 import com.sequenceiq.cloudbreak.service.datalake.DataLakeStatusCheckerService;
 import com.sequenceiq.cloudbreak.service.environment.EnvironmentService;
+import com.sequenceiq.cloudbreak.service.salt.RotateSaltPasswordTriggerService;
+import com.sequenceiq.cloudbreak.service.salt.RotateSaltPasswordValidator;
+import com.sequenceiq.cloudbreak.service.salt.SaltPasswordStatusService;
 import com.sequenceiq.cloudbreak.service.spot.SpotInstanceUsageCondition;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.cloudbreak.service.stack.StackDtoService;
@@ -137,10 +138,13 @@ public class StackOperationServiceTest {
     private InstanceMetaDataService instanceMetaDataService;
 
     @Mock
-    private RotateSaltPasswordService rotateSaltPasswordService;
+    private SaltPasswordStatusService saltPasswordStatusService;
 
     @Mock
-    private SaltPasswordStatusService saltPasswordStatusService;
+    private RotateSaltPasswordTriggerService rotateSaltPasswordTriggerService;
+
+    @Mock
+    private RotateSaltPasswordValidator rotateSaltPasswordValidator;
 
     @Test
     public void testStartWhenStackAvailable() {
@@ -474,14 +478,14 @@ public class StackOperationServiceTest {
         StackDto stackDto = mock(StackDto.class);
         when(stackDtoService.getByNameOrCrn(nameOrCrn, ACCOUNT_ID)).thenReturn(stackDto);
         FlowIdentifier flowIdentifier = new FlowIdentifier(FlowType.FLOW, "pollableId");
-        when(rotateSaltPasswordService.triggerRotateSaltPassword(stackDto, REASON)).thenReturn(flowIdentifier);
+        when(rotateSaltPasswordTriggerService.triggerRotateSaltPassword(stackDto, REASON)).thenReturn(flowIdentifier);
 
         FlowIdentifier result = underTest.rotateSaltPassword(nameOrCrn, ACCOUNT_ID, REASON);
 
         assertEquals(flowIdentifier, result);
         verify(stackDtoService).getByNameOrCrn(nameOrCrn, ACCOUNT_ID);
-        verify(rotateSaltPasswordService).validateRotateSaltPassword(stackDto);
-        verify(rotateSaltPasswordService).triggerRotateSaltPassword(stackDto, REASON);
+        verify(rotateSaltPasswordValidator).validateRotateSaltPassword(stackDto);
+        verify(rotateSaltPasswordTriggerService).triggerRotateSaltPassword(stackDto, REASON);
     }
 
     @Test

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
@@ -52,6 +52,7 @@ import com.sequenceiq.datalake.configuration.CDPConfigService;
 import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.metric.MetricType;
 import com.sequenceiq.datalake.metric.SdxMetricService;
+import com.sequenceiq.datalake.service.SdxDeleteService;
 import com.sequenceiq.datalake.service.sdx.SdxImageCatalogService;
 import com.sequenceiq.datalake.service.sdx.SdxRecommendationService;
 import com.sequenceiq.datalake.service.sdx.SdxRepairService;
@@ -137,6 +138,9 @@ public class SdxController implements SdxEndpoint {
     @Inject
     private VerticalScaleService verticalScaleService;
 
+    @Inject
+    private SdxDeleteService sdxDeleteService;
+
     @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.CREATE_DATALAKE)
     public SdxClusterResponse create(@ValidStackNameFormat @ValidStackNameLength String name,
@@ -204,15 +208,13 @@ public class SdxController implements SdxEndpoint {
     @Override
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.DELETE_DATALAKE)
     public FlowIdentifier delete(@ResourceName String name, Boolean forced) {
-        String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
-        return sdxService.deleteSdx(userCrn, name, forced);
+        return sdxDeleteService.deleteSdx(ThreadBasedUserCrnProvider.getAccountId(), name, forced);
     }
 
     @Override
     @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.DELETE_DATALAKE)
     public FlowIdentifier deleteByCrn(@ResourceCrn String clusterCrn, Boolean forced) {
-        String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
-        return sdxService.deleteSdxByClusterCrn(userCrn, clusterCrn, forced);
+        return sdxDeleteService.deleteSdxByClusterCrn(ThreadBasedUserCrnProvider.getAccountId(), clusterCrn, forced);
     }
 
     @Override

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/SdxDeleteService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/SdxDeleteService.java
@@ -1,0 +1,87 @@
+package com.sequenceiq.datalake.service;
+
+import static com.sequenceiq.cloudbreak.common.exception.NotFoundException.notFound;
+import static com.sequenceiq.datalake.entity.DatalakeStatusEnum.PROVISIONING_FAILED;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Response;
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.datalake.entity.DatalakeStatusEnum;
+import com.sequenceiq.datalake.entity.SdxCluster;
+import com.sequenceiq.datalake.entity.SdxStatusEntity;
+import com.sequenceiq.datalake.flow.SdxReactorFlowManager;
+import com.sequenceiq.datalake.repository.SdxClusterRepository;
+import com.sequenceiq.datalake.service.sdx.DistroxService;
+import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+import com.sequenceiq.flow.service.FlowCancelService;
+
+@Service
+public class SdxDeleteService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxDeleteService.class);
+
+    @Inject
+    private FlowCancelService flowCancelService;
+
+    @Inject
+    private SdxClusterRepository sdxClusterRepository;
+
+    @Inject
+    private SdxStatusService sdxStatusService;
+
+    @Inject
+    private SdxReactorFlowManager sdxReactorFlowManager;
+
+    @Inject
+    private DistroxService distroxService;
+
+    public FlowIdentifier deleteSdxByClusterCrn(String accountId, String clusterCrn, boolean forced) {
+        LOGGER.info("Deleting SDX {}", clusterCrn);
+        return sdxClusterRepository.findByAccountIdAndCrnAndDeletedIsNull(accountId, clusterCrn)
+                .map(sdxCluster -> deleteSdxCluster(sdxCluster, forced))
+                .orElseThrow(() -> notFound("SDX cluster", clusterCrn).get());
+    }
+
+    public FlowIdentifier deleteSdx(String accountId, String name, boolean forced) {
+        LOGGER.info("Deleting SDX {}", name);
+        return sdxClusterRepository.findByAccountIdAndClusterNameAndDeletedIsNull(accountId, name)
+                .map(sdxCluster -> deleteSdxCluster(sdxCluster, forced))
+                .orElseThrow(() -> notFound("SDX cluster", name).get());
+    }
+
+    private FlowIdentifier deleteSdxCluster(SdxCluster sdxCluster, boolean forced) {
+        checkIfSdxIsDeletable(sdxCluster, forced);
+        MDCBuilder.buildMdcContext(sdxCluster);
+        sdxClusterRepository.save(sdxCluster);
+        sdxStatusService.setStatusForDatalakeAndNotify(DatalakeStatusEnum.DELETE_REQUESTED, "Datalake deletion requested", sdxCluster);
+        FlowIdentifier flowIdentifier = sdxReactorFlowManager.triggerSdxDeletion(sdxCluster, forced);
+        flowCancelService.cancelRunningFlows(sdxCluster.getId());
+        return flowIdentifier;
+    }
+
+    private void checkIfSdxIsDeletable(SdxCluster sdxCluster, boolean forced) {
+        SdxStatusEntity actualStatusForSdx = sdxStatusService.getActualStatusForSdx(sdxCluster);
+        if (!forced && actualStatusForSdx.getStatus() != PROVISIONING_FAILED &&
+                sdxCluster.hasExternalDatabase() && StringUtils.isEmpty(sdxCluster.getDatabaseCrn())) {
+            throw new BadRequestException(String.format("Can not find external database for Data Lake, but it was requested: %s. Please use force delete.",
+                    sdxCluster.getClusterName()));
+        }
+        Collection<StackViewV4Response> attachedDistroXClusters = distroxService.getAttachedDistroXClusters(sdxCluster.getEnvCrn());
+        if (!attachedDistroXClusters.isEmpty()) {
+            throw new BadRequestException(String.format("The following Data Hub(s) cluster(s) must be terminated " +
+                            "before deletion of SDX cluster: [%s].",
+                    attachedDistroXClusters.stream().map(StackViewV4Response::getName).collect(Collectors.joining(", "))));
+        }
+    }
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -5,7 +5,6 @@ import static com.sequenceiq.cloudbreak.common.exception.NotFoundException.notFo
 import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AWS;
 import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AZURE;
 import static com.sequenceiq.cloudbreak.util.Benchmark.measure;
-import static com.sequenceiq.datalake.entity.DatalakeStatusEnum.PROVISIONING_FAILED;
 import static com.sequenceiq.sdx.api.model.SdxClusterShape.CUSTOM;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
@@ -68,7 +67,6 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.recipe.DetachRec
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.recipe.UpdateRecipesV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.RangerRazEnabledV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.cluster.ClusterV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.cluster.clouderamanager.ClouderaManagerProductV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.cluster.clouderamanager.ClouderaManagerV4Response;
@@ -119,7 +117,6 @@ import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvi
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.flow.core.PayloadContextProvider;
 import com.sequenceiq.flow.core.ResourceIdProvider;
-import com.sequenceiq.flow.service.FlowCancelService;
 import com.sequenceiq.sdx.api.model.SdxAwsBase;
 import com.sequenceiq.sdx.api.model.SdxAwsSpotParameters;
 import com.sequenceiq.sdx.api.model.SdxAzureBase;
@@ -181,9 +178,6 @@ public class SdxService implements ResourceIdProvider, PayloadContextProvider, H
 
     @Inject
     private CDPConfigService cdpConfigService;
-
-    @Inject
-    private FlowCancelService flowCancelService;
 
     @Inject
     private OwnerAssignmentService ownerAssignmentService;
@@ -1145,22 +1139,6 @@ public class SdxService implements ResourceIdProvider, PayloadContextProvider, H
         }
     }
 
-    public FlowIdentifier deleteSdxByClusterCrn(String userCrn, String clusterCrn, boolean forced) {
-        LOGGER.info("Deleting SDX {}", clusterCrn);
-        String accountIdFromCrn = getAccountIdFromCrn(userCrn);
-        return sdxClusterRepository.findByAccountIdAndCrnAndDeletedIsNull(accountIdFromCrn, clusterCrn)
-                .map(sdxCluster -> deleteSdxCluster(sdxCluster, forced))
-                .orElseThrow(() -> notFound("SDX cluster", clusterCrn).get());
-    }
-
-    public FlowIdentifier deleteSdx(String userCrn, String name, boolean forced) {
-        LOGGER.info("Deleting SDX {}", name);
-        String accountIdFromCrn = getAccountIdFromCrn(userCrn);
-        return sdxClusterRepository.findByAccountIdAndClusterNameAndDeletedIsNull(accountIdFromCrn, name)
-                .map(sdxCluster -> deleteSdxCluster(sdxCluster, forced))
-                .orElseThrow(() -> notFound("SDX cluster", name).get());
-    }
-
     public Optional<String> updateRuntimeVersionFromStackResponse(SdxCluster sdxCluster, StackV4Response stackV4Response) {
         String clusterName = sdxCluster.getClusterName();
         Optional<String> cdpVersionOpt = getCdpVersion(stackV4Response);
@@ -1201,31 +1179,6 @@ public class SdxService implements ResourceIdProvider, PayloadContextProvider, H
             return Optional.of(StringUtils.substringBefore(cdpVersion, "-"));
         }
         return Optional.empty();
-    }
-
-    private FlowIdentifier deleteSdxCluster(SdxCluster sdxCluster, boolean forced) {
-        checkIfSdxIsDeletable(sdxCluster, forced);
-        MDCBuilder.buildMdcContext(sdxCluster);
-        sdxClusterRepository.save(sdxCluster);
-        sdxStatusService.setStatusForDatalakeAndNotify(DatalakeStatusEnum.DELETE_REQUESTED, "Datalake deletion requested", sdxCluster);
-        FlowIdentifier flowIdentifier = sdxReactorFlowManager.triggerSdxDeletion(sdxCluster, forced);
-        flowCancelService.cancelRunningFlows(sdxCluster.getId());
-        return flowIdentifier;
-    }
-
-    private void checkIfSdxIsDeletable(SdxCluster sdxCluster, boolean forced) {
-        SdxStatusEntity actualStatusForSdx = sdxStatusService.getActualStatusForSdx(sdxCluster);
-        if (!forced && actualStatusForSdx.getStatus() != PROVISIONING_FAILED &&
-                sdxCluster.hasExternalDatabase() && StringUtils.isEmpty(sdxCluster.getDatabaseCrn())) {
-            throw new BadRequestException(String.format("Can not find external database for Data Lake, but it was requested: %s. Please use force delete.",
-                    sdxCluster.getClusterName()));
-        }
-        Collection<StackViewV4Response> attachedDistroXClusters = distroxService.getAttachedDistroXClusters(sdxCluster.getEnvCrn());
-        if (!attachedDistroXClusters.isEmpty()) {
-            throw new BadRequestException(String.format("The following Data Hub(s) cluster(s) must be terminated " +
-                            "before deletion of SDX cluster: [%s].",
-                    attachedDistroXClusters.stream().map(StackViewV4Response::getName).collect(Collectors.joining(", "))));
-        }
     }
 
     private String createCrn(@Nonnull String accountId) {

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/SdxDeleteServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/SdxDeleteServiceTest.java
@@ -1,0 +1,162 @@
+package com.sequenceiq.datalake.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.google.common.collect.Sets;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Response;
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.datalake.entity.DatalakeStatusEnum;
+import com.sequenceiq.datalake.entity.SdxCluster;
+import com.sequenceiq.datalake.entity.SdxStatusEntity;
+import com.sequenceiq.datalake.flow.SdxReactorFlowManager;
+import com.sequenceiq.datalake.repository.SdxClusterRepository;
+import com.sequenceiq.datalake.service.sdx.DistroxService;
+import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+import com.sequenceiq.flow.api.model.FlowType;
+import com.sequenceiq.flow.service.FlowCancelService;
+import com.sequenceiq.sdx.api.model.SdxDatabaseAvailabilityType;
+
+@ExtendWith(MockitoExtension.class)
+class SdxDeleteServiceTest {
+
+    private static final String ACCOUNT_ID = "accId";
+
+    private static final String CLUSTER_NAME = "test-sdx-cluster";
+
+    private static final Long SDX_ID = 2L;
+
+    private static final String SDX_CRN = "crn";
+
+    private static final String ENVIRONMENT_CRN = "crn:cdp:environments:us-west-1:default:environment:e438a2db-d650-4132-ae62-242c5ba2f784";
+
+    @Mock
+    private FlowCancelService flowCancelService;
+
+    @Mock
+    private SdxClusterRepository sdxClusterRepository;
+
+    @Mock
+    private SdxStatusService sdxStatusService;
+
+    @Mock
+    private SdxReactorFlowManager sdxReactorFlowManager;
+
+    @Mock
+    private DistroxService distroxService;
+
+    @InjectMocks
+    private SdxDeleteService underTest;
+
+    @Test
+    void testDeleteSdxWhenNameIsProvidedAndClusterDoesNotExistShouldThrowNotFoundException() {
+        assertThrows(com.sequenceiq.cloudbreak.common.exception.NotFoundException.class,
+                () -> underTest.deleteSdx(ACCOUNT_ID, CLUSTER_NAME, false));
+        verify(sdxClusterRepository, times(1))
+                .findByAccountIdAndClusterNameAndDeletedIsNull(eq(ACCOUNT_ID), eq(CLUSTER_NAME));
+    }
+
+    @Test
+    void testDeleteSdxWhenNameIsProvidedShouldInitiateSdxDeletionFlow() {
+        SdxCluster sdxCluster = getSdxCluster();
+        when(sdxClusterRepository.findByAccountIdAndClusterNameAndDeletedIsNull(anyString(), anyString())).thenReturn(Optional.of(sdxCluster));
+        when(sdxReactorFlowManager.triggerSdxDeletion(any(SdxCluster.class), anyBoolean())).thenReturn(new FlowIdentifier(FlowType.FLOW, "FLOW_ID"));
+        mockCBCallForDistroXClusters(Sets.newHashSet());
+        underTest.deleteSdx(ACCOUNT_ID, "sdx-cluster-name", true);
+        verify(sdxReactorFlowManager, times(1)).triggerSdxDeletion(sdxCluster, true);
+        ArgumentCaptor<SdxCluster> captor = ArgumentCaptor.forClass(SdxCluster.class);
+        verify(sdxClusterRepository, times(1)).save(captor.capture());
+        verify(sdxStatusService, times(1))
+                .setStatusForDatalakeAndNotify(DatalakeStatusEnum.DELETE_REQUESTED, "Datalake deletion requested", sdxCluster);
+    }
+
+    @Test
+    void testDeleteSdxWhenSdxHasExternalDatabaseButCrnIsMissingShouldThrowNotFoundException() {
+        SdxCluster sdxCluster = getSdxCluster();
+        sdxCluster.setDatabaseAvailabilityType(SdxDatabaseAvailabilityType.HA);
+        sdxCluster.setDatabaseCrn(null);
+        when(sdxClusterRepository.findByAccountIdAndClusterNameAndDeletedIsNull(anyString(), anyString())).thenReturn(Optional.of(sdxCluster));
+        SdxStatusEntity sdxStatusEntity = new SdxStatusEntity();
+        sdxStatusEntity.setStatus(DatalakeStatusEnum.RUNNING);
+        when(sdxStatusService.getActualStatusForSdx(sdxCluster)).thenReturn(sdxStatusEntity);
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> underTest.deleteSdx(ACCOUNT_ID, "sdx-cluster-name", false));
+        assertEquals(String.format("Can not find external database for Data Lake, but it was requested: %s. Please use force delete.",
+                sdxCluster.getClusterName()), badRequestException.getMessage());
+    }
+
+    @Test
+    void testDeleteSdxWhenSdxHasExternalDatabaseButCrnIsMissingShouldNotThrowNotFoundException() {
+        SdxCluster sdxCluster = getSdxCluster();
+        sdxCluster.setDatabaseAvailabilityType(SdxDatabaseAvailabilityType.HA);
+        sdxCluster.setDatabaseCrn(null);
+        when(sdxClusterRepository.findByAccountIdAndClusterNameAndDeletedIsNull(anyString(), anyString())).thenReturn(Optional.of(sdxCluster));
+        SdxStatusEntity sdxStatusEntity = new SdxStatusEntity();
+        sdxStatusEntity.setStatus(DatalakeStatusEnum.PROVISIONING_FAILED);
+        when(sdxReactorFlowManager.triggerSdxDeletion(eq(sdxCluster), anyBoolean())).thenReturn(new FlowIdentifier(FlowType.FLOW, "id"));
+        when(sdxStatusService.getActualStatusForSdx(sdxCluster)).thenReturn(sdxStatusEntity);
+        underTest.deleteSdx(ACCOUNT_ID, "sdx-cluster-name", false);
+        verify(sdxClusterRepository, times(1)).save(sdxCluster);
+        verify(sdxStatusService, times(1))
+                .setStatusForDatalakeAndNotify(DatalakeStatusEnum.DELETE_REQUESTED, "Datalake deletion requested", sdxCluster);
+        verify(sdxReactorFlowManager, times(1)).triggerSdxDeletion(sdxCluster, false);
+        verify(flowCancelService, times(1)).cancelRunningFlows(SDX_ID);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Status.class, names = {"AVAILABLE", "BACKUP_IN_PROGRESS", "STOPPED", "BACKUP_FAILED"})
+    void testDeleteSdxWhenSdxHasAttachedDataHubsShouldThrowBadRequest(Status dhStatus) {
+        SdxCluster sdxCluster = getSdxCluster();
+        SdxStatusEntity sdxStatusEntity = new SdxStatusEntity();
+        sdxStatusEntity.setStatus(DatalakeStatusEnum.RUNNING);
+        StackViewV4Response stackViewV4Response = new StackViewV4Response();
+        stackViewV4Response.setName("existingDistroXCluster");
+        stackViewV4Response.setStatus(dhStatus);
+
+        mockCBCallForDistroXClusters(Sets.newHashSet(stackViewV4Response));
+        when(sdxClusterRepository.findByAccountIdAndClusterNameAndDeletedIsNull(anyString(), anyString())).thenReturn(Optional.of(sdxCluster));
+        when(sdxStatusService.getActualStatusForSdx(sdxCluster)).thenReturn(sdxStatusEntity);
+
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> underTest.deleteSdx(ACCOUNT_ID, "sdx-cluster-name", true));
+
+        assertEquals("The following Data Hub(s) cluster(s) must be terminated before deletion of SDX cluster: [existingDistroXCluster].",
+                badRequestException.getMessage());
+    }
+
+    private void mockCBCallForDistroXClusters(Set<StackViewV4Response> stackViews) {
+        when(distroxService.getAttachedDistroXClusters(anyString())).thenReturn(stackViews);
+    }
+
+    private SdxCluster getSdxCluster() {
+        SdxCluster sdxCluster = new SdxCluster();
+        sdxCluster.setId(SDX_ID);
+        sdxCluster.setCrn(SDX_CRN);
+        sdxCluster.setEnvCrn(ENVIRONMENT_CRN);
+        sdxCluster.setEnvName("envir");
+        sdxCluster.setClusterName("sdx-cluster-name");
+        return sdxCluster;
+    }
+
+}

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxServiceTest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -60,7 +59,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.google.common.collect.Sets;
 import com.sequenceiq.authorization.service.OwnerAssignmentService;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
@@ -78,7 +76,6 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.image.ImageSetti
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.InstanceGroupV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.RangerRazEnabledV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.cluster.ClusterV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.cluster.clouderamanager.ClouderaManagerProductV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.cluster.clouderamanager.ClouderaManagerV4Response;
@@ -121,7 +118,6 @@ import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvi
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.flow.api.model.FlowType;
-import com.sequenceiq.flow.service.FlowCancelService;
 import com.sequenceiq.sdx.api.model.SdxAwsRequest;
 import com.sequenceiq.sdx.api.model.SdxAwsSpotParameters;
 import com.sequenceiq.sdx.api.model.SdxCloudStorageRequest;
@@ -130,7 +126,6 @@ import com.sequenceiq.sdx.api.model.SdxClusterRequestBase;
 import com.sequenceiq.sdx.api.model.SdxClusterResizeRequest;
 import com.sequenceiq.sdx.api.model.SdxClusterShape;
 import com.sequenceiq.sdx.api.model.SdxCustomClusterRequest;
-import com.sequenceiq.sdx.api.model.SdxDatabaseAvailabilityType;
 import com.sequenceiq.sdx.api.model.SdxInstanceGroupRequest;
 import com.sequenceiq.sdx.api.model.SdxRecipe;
 
@@ -205,9 +200,6 @@ class SdxServiceTest {
 
     @Mock
     private CDPConfigService cdpConfigService;
-
-    @Mock
-    private FlowCancelService flowCancelService;
 
     @Mock
     private OwnerAssignmentService ownerAssignmentService;
@@ -724,61 +716,6 @@ class SdxServiceTest {
     }
 
     @Test
-    void testDeleteSdxWhenNameIsProvidedAndClusterDoesNotExistShouldThrowNotFoundException() {
-        assertThrows(com.sequenceiq.cloudbreak.common.exception.NotFoundException.class,
-                () -> underTest.deleteSdx(USER_CRN, CLUSTER_NAME, false));
-        verify(sdxClusterRepository, times(1))
-                .findByAccountIdAndClusterNameAndDeletedIsNull(eq("hortonworks"), eq(CLUSTER_NAME));
-    }
-
-    @Test
-    void testDeleteSdxWhenNameIsProvidedShouldInitiateSdxDeletionFlow() {
-        SdxCluster sdxCluster = getSdxCluster();
-        when(sdxClusterRepository.findByAccountIdAndClusterNameAndDeletedIsNull(anyString(), anyString())).thenReturn(Optional.of(sdxCluster));
-        when(sdxReactorFlowManager.triggerSdxDeletion(any(SdxCluster.class), anyBoolean())).thenReturn(new FlowIdentifier(FlowType.FLOW, "FLOW_ID"));
-        mockCBCallForDistroXClusters(Sets.newHashSet());
-        underTest.deleteSdx(USER_CRN, "sdx-cluster-name", true);
-        verify(sdxReactorFlowManager, times(1)).triggerSdxDeletion(sdxCluster, true);
-        ArgumentCaptor<SdxCluster> captor = ArgumentCaptor.forClass(SdxCluster.class);
-        verify(sdxClusterRepository, times(1)).save(captor.capture());
-        verify(sdxStatusService, times(1))
-                .setStatusForDatalakeAndNotify(DatalakeStatusEnum.DELETE_REQUESTED, "Datalake deletion requested", sdxCluster);
-    }
-
-    @Test
-    void testDeleteSdxWhenSdxHasExternalDatabaseButCrnIsMissingShouldThrowNotFoundException() {
-        SdxCluster sdxCluster = getSdxCluster();
-        sdxCluster.setDatabaseAvailabilityType(SdxDatabaseAvailabilityType.HA);
-        sdxCluster.setDatabaseCrn(null);
-        when(sdxClusterRepository.findByAccountIdAndClusterNameAndDeletedIsNull(anyString(), anyString())).thenReturn(Optional.of(sdxCluster));
-        SdxStatusEntity sdxStatusEntity = new SdxStatusEntity();
-        sdxStatusEntity.setStatus(DatalakeStatusEnum.RUNNING);
-        when(sdxStatusService.getActualStatusForSdx(sdxCluster)).thenReturn(sdxStatusEntity);
-        BadRequestException badRequestException = assertThrows(BadRequestException.class,
-                () -> underTest.deleteSdx(USER_CRN, "sdx-cluster-name", false));
-        assertEquals(String.format("Can not find external database for Data Lake, but it was requested: %s. Please use force delete.",
-                sdxCluster.getClusterName()), badRequestException.getMessage());
-    }
-
-    @Test
-    void testDeleteSdxWhenSdxHasExternalDatabaseButCrnIsMissingShouldNotThrowNotFoundException() {
-        SdxCluster sdxCluster = getSdxCluster();
-        sdxCluster.setDatabaseAvailabilityType(SdxDatabaseAvailabilityType.HA);
-        sdxCluster.setDatabaseCrn(null);
-        when(sdxClusterRepository.findByAccountIdAndClusterNameAndDeletedIsNull(anyString(), anyString())).thenReturn(Optional.of(sdxCluster));
-        SdxStatusEntity sdxStatusEntity = new SdxStatusEntity();
-        sdxStatusEntity.setStatus(DatalakeStatusEnum.PROVISIONING_FAILED);
-        when(sdxReactorFlowManager.triggerSdxDeletion(eq(sdxCluster), anyBoolean())).thenReturn(new FlowIdentifier(FlowType.FLOW, "id"));
-        when(sdxStatusService.getActualStatusForSdx(sdxCluster)).thenReturn(sdxStatusEntity);
-        underTest.deleteSdx(USER_CRN, "sdx-cluster-name", false);
-        verify(sdxClusterRepository, times(1)).save(sdxCluster);
-        verify(sdxStatusService, times(1))
-                .setStatusForDatalakeAndNotify(DatalakeStatusEnum.DELETE_REQUESTED, "Datalake deletion requested", sdxCluster);
-        verify(sdxReactorFlowManager, times(1)).triggerSdxDeletion(sdxCluster, false);
-        verify(flowCancelService, times(1)).cancelRunningFlows(SDX_ID);
-    }
-
-    @Test
     void testSyncSdxClusterWhenClusterNameSpecifiedShouldCallStackEndpointExactlyOnce() {
         SdxCluster sdxCluser = new SdxCluster();
         sdxCluser.setEnvName("env");
@@ -1109,10 +1046,6 @@ class SdxServiceTest {
         imageV4Response.setImageSetsByProvider(imageSetsByProvider);
         imageV4Response.setStackDetails(stackDetails);
         return imageV4Response;
-    }
-
-    private void mockCBCallForDistroXClusters(Set<StackViewV4Response> stackViews) {
-        when(distroxService.getAttachedDistroXClusters(anyString())).thenReturn(stackViews);
     }
 
     private void mockEnvironmentCall(SdxClusterResizeRequest sdxClusterResizeRequest, CloudPlatform cloudPlatform) {
@@ -1754,26 +1687,5 @@ class SdxServiceTest {
 
         verifyNoInteractions(sdxReactorFlowManager);
         assertEquals(String.format("SaltStack update cannot be initiated as datalake 'sdx-cluster-name' is currently in '%s' state.", status), ex.getMessage());
-    }
-
-    @ParameterizedTest
-    @EnumSource(value = Status.class, names = {"AVAILABLE", "BACKUP_IN_PROGRESS", "STOPPED", "BACKUP_FAILED"})
-    void testDeleteSdxWhenSdxHasAttachedDataHubsShouldThrowBadRequest(Status dhStatus) {
-        SdxCluster sdxCluster = getSdxCluster();
-        SdxStatusEntity sdxStatusEntity = new SdxStatusEntity();
-        sdxStatusEntity.setStatus(DatalakeStatusEnum.RUNNING);
-        StackViewV4Response stackViewV4Response = new StackViewV4Response();
-        stackViewV4Response.setName("existingDistroXCluster");
-        stackViewV4Response.setStatus(dhStatus);
-
-        mockCBCallForDistroXClusters(Sets.newHashSet(stackViewV4Response));
-        when(sdxClusterRepository.findByAccountIdAndClusterNameAndDeletedIsNull(anyString(), anyString())).thenReturn(Optional.of(sdxCluster));
-        when(sdxStatusService.getActualStatusForSdx(sdxCluster)).thenReturn(sdxStatusEntity);
-
-        BadRequestException badRequestException = assertThrows(BadRequestException.class,
-                () -> underTest.deleteSdx(USER_CRN, "sdx-cluster-name", true));
-
-        assertEquals("The following Data Hub(s) cluster(s) must be terminated before deletion of SDX cluster: [existingDistroXCluster].",
-                badRequestException.getMessage());
     }
 }


### PR DESCRIPTION
2 cases are handled:
```
lowLogsToListDiagnosticsCollectionResponseConverter (field private com.sequenceiq.flow.core.config.FlowProgressHolder com.sequenceiq.cloudbreak.converter.v4.diagnostics.FlowLogsToListDiagnosticsCollectionResponseConverter.flowProgressHolder)
┌─────┐
flowProgressHolder defined in URL [jar:file:/cloudbreak.jar!/BOOT-INF/lib/flow-2.67.0-b102.jar!/com/sequenceiq/flow/core/config/FlowProgressHolder.class]
↑ ↓
rotateSaltPasswordFlowConfig
↑ ↓
rotateSaltPasswordActions (field private com.sequenceiq.cloudbreak.service.RotateSaltPasswordService com.sequenceiq.cloudbreak.core.flow2.cluster.salt.rotatepassword.RotateSaltPasswordActions.rotateSaltPasswordService)
↑ ↓
rotateSaltPasswordService (field private com.sequenceiq.cloudbreak.core.flow2.service.ReactorFlowManager com.sequenceiq.cloudbreak.service.RotateSaltPasswordService.flowManager)
↑ ↓
reactorFlowManager (field private com.sequenceiq.cloudbreak.core.flow2.service.TerminationTriggerService com.sequenceiq.cloudbreak.core.flow2.service.ReactorFlowManager.terminationTriggerService)
↑ ↓
terminationTriggerService (field private com.sequenceiq.flow.service.FlowCancelService com.sequenceiq.cloudbreak.core.flow2.service.TerminationTriggerService.flowCancelService)
↑ ↓
flowCancelService (field private com.sequenceiq.flow.core.Flow2Handler com.sequenceiq.flow.service.FlowCancelService.flow2Handler)
↑ ↓
flow2Handler
↑ ↓
clusterCreationFlowConfig
↑ ↓
clusterCreationActions (field private com.sequenceiq.cloudbreak.job.stackpatcher.ExistingStackPatcherJobService com.sequenceiq.cloudbreak.core.flow2.cluster.provision.ClusterCreationActions.existingStackPatcherJobService)
↑ ↓
existingStackPatcherJobService (field private com.sequenceiq.cloudbreak.job.stackpatcher.ExistingStackPatcherServiceProvider com.sequenceiq.cloudbreak.job.stackpatcher.ExistingStackPatcherJobService.existingStackPatcherServiceProvider)
↑ ↓
existingStackPatcherServiceProvider (field private java.util.Collection com.sequenceiq.cloudbreak.job.stackpatcher.ExistingStackPatcherServiceProvider.existingStackPatchServices)
↑ ↓
unboundRestartPatchService (field private com.sequenceiq.flow.service.FlowService com.sequenceiq.cloudbreak.service.stackpatch.UnboundRestartPatchService.flowService)
↑ ↓
flowService (field private com.sequenceiq.flow.converter.FlowProgressResponseConverter com.sequenceiq.flow.service.FlowService.flowProgressResponseConverter)
↑ ↓
flowProgressResponseConverter defined in URL [jar:file:/cloudbreak.jar!/BOOT-INF/lib/flow-2.67.0-b102.jar!/com/sequenceiq/flow/converter/FlowProgressResponseConverter.class]
└─────┘
```
and
```
{"timestamp":"2023-01-26 14:18:03.443","level":"ERROR","thread":"main","logger":"org.springframework.boot.diagnostics.LoggingFailureAnalysisReporter","message":"2023-01-26 14:18:03,443 [main] report:40 ERROR o.s.b.d.LoggingFailureAnalysisReporter - [type:springLog] [crn:] [name:] [flow:] [requestid:] [tenant:] [userCrn:] [environment:] [traceId:] [spanId:] \n\n***************************\nAPPLICATION FAILED TO START\n***************************\n\nDescription:\n\nThe dependencies of some of the beans in the application context form a cycle:\n\n   progressController (field private com.sequenceiq.datalake.service.sdx.progress.ProgressService com.sequenceiq.datalake.controller.progress.ProgressController.progressService)\n      ↓\n   progressService (field private com.sequenceiq.flow.service.FlowService com.sequenceiq.datalake.service.sdx.progress.ProgressService.flowService)\n      ↓\n   flowService\n┌─────┐\n|  failHandledEvents defined in class path resource [com/sequenceiq/flow/core/config/Flow2Config.class]\n↑     ↓\n|  updateLoadBalancerDNSFlowConfig\n↑     ↓\n|  updateLoadBalancerDNSActions (field private com.sequenceiq.datalake.service.sdx.SdxService com.sequenceiq.datalake.flow.loadbalancer.dns.UpdateLoadBalancerDNSActions.sdxService)\n↑     ↓\n|  sdxService (field private com.sequenceiq.flow.service.FlowCancelService com.sequenceiq.datalake.service.sdx.SdxService.flowCancelService)\n↑     ↓\n|  flowCancelService (field private com.sequenceiq.flow.core.Flow2Handler com.sequenceiq.flow.service.FlowCancelService.flow2Handler)\n↑     ↓\n|  flow2Handler\n└─────┘\n\n\n"}
```See detailed description in the commit message.