### PR TITLE
CB-20332 Remove bouncycastle as security provider

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/PeriscopeApplication.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/PeriscopeApplication.java
@@ -9,7 +9,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 
-import com.sequenceiq.cloudbreak.util.FipsOpenSSLLoaderUtil;
+import com.sequenceiq.cloudbreak.util.OpenSSLLoaderUtil;
 
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
@@ -21,7 +21,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 public class PeriscopeApplication {
 
     public static void main(String[] args) {
-        FipsOpenSSLLoaderUtil.registerOpenSSLJniProvider();
+        OpenSSLLoaderUtil.registerOpenSSLJniProvider();
         if (!versionedApplication().showVersionInfo(args)) {
             if (args.length == 0) {
                 SpringApplication.run(PeriscopeApplication.class);

--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/ConsumptionApplication.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/ConsumptionApplication.java
@@ -6,7 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-import com.sequenceiq.cloudbreak.util.FipsOpenSSLLoaderUtil;
+import com.sequenceiq.cloudbreak.util.OpenSSLLoaderUtil;
 
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
@@ -17,7 +17,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 public class ConsumptionApplication {
 
     public static void main(String[] args) {
-        FipsOpenSSLLoaderUtil.registerOpenSSLJniProvider();
+        OpenSSLLoaderUtil.registerOpenSSLJniProvider();
         SpringApplication.run(ConsumptionApplication.class, args);
     }
 

--- a/common/src/main/java/com/sequenceiq/cloudbreak/certificate/PkiUtil.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/certificate/PkiUtil.java
@@ -16,7 +16,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.SecureRandom;
-import java.security.Security;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPublicKey;
@@ -53,7 +52,6 @@ import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
 import org.bouncycastle.crypto.params.RSAKeyParameters;
 import org.bouncycastle.crypto.signers.PSSSigner;
 import org.bouncycastle.crypto.util.PrivateKeyFactory;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.PEMKeyPair;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
@@ -235,14 +233,13 @@ public class PkiUtil {
 
     public static KeyPair fromPrivateKeyPem(String privateKeyContent) {
         BufferedReader br = new BufferedReader(new StringReader(privateKeyContent));
-        Security.addProvider(new BouncyCastleProvider());
         try (PEMParser pp = new PEMParser(br)) {
             PEMKeyPair pemKeyPair = (PEMKeyPair) pp.readObject();
             return new JcaPEMKeyConverter().getKeyPair(pemKeyPair);
         } catch (IOException e) {
             LOGGER.info("Cannot parse KeyPair from private key PEM content, skip it. {}", e.getMessage(), e);
+            return null;
         }
-        return null;
     }
 
     public static X509Certificate fromCertificatePem(String certPem) {

--- a/common/src/main/java/com/sequenceiq/cloudbreak/util/OpenSSLLoaderUtil.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/util/OpenSSLLoaderUtil.java
@@ -8,8 +8,8 @@ import org.slf4j.LoggerFactory;
 
 import com.cloudera.crypto.provider.OpenSSLJniProvider;
 
-public class FipsOpenSSLLoaderUtil {
-    private static final Logger LOGGER = LoggerFactory.getLogger(FipsOpenSSLLoaderUtil.class);
+public class OpenSSLLoaderUtil {
+    private static final Logger LOGGER = LoggerFactory.getLogger(OpenSSLLoaderUtil.class);
 
     // CHECKSTYLE:OFF
     /**
@@ -19,7 +19,7 @@ public class FipsOpenSSLLoaderUtil {
     // CHECKSTYLE:ON
     private static final String SUN_PKCS_11_NSS_FIPS_PROVIDER_NAME = "SunPKCS11-NSS-FIPS";
 
-    private FipsOpenSSLLoaderUtil() {
+    private OpenSSLLoaderUtil() {
     }
 
     public static void registerOpenSSLJniProvider() {
@@ -27,8 +27,16 @@ public class FipsOpenSSLLoaderUtil {
         if (sunNSSFipsProvider != null) {
             LOGGER.info("Registering OpenSSLJniProvider, because FIPS related security provider '{}' is available.", SUN_PKCS_11_NSS_FIPS_PROVIDER_NAME);
             OpenSSLJniProvider.register();
+            LOGGER.info("Registered OpenSSLJniProvider for FIPS.");
         } else {
-            LOGGER.info("OpenSSLJniProvider doesn't need to be registered because '{}' is NOT available.", SUN_PKCS_11_NSS_FIPS_PROVIDER_NAME);
+            LOGGER.info("OpenSSLJniProvider doesn't need to be registered because '{}' is NOT available. Let's try it anyway",
+                    SUN_PKCS_11_NSS_FIPS_PROVIDER_NAME);
+            try {
+                OpenSSLJniProvider.register();
+                LOGGER.info("Registered OpenSSLJniProvider for non FIPS env.");
+            } catch (Throwable e) {
+                LOGGER.warn("Couldn't register OpenSSLJniProvider. Using default implementation.", e);
+            }
         }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/CloudbreakApplication.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/CloudbreakApplication.java
@@ -14,7 +14,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 import com.sequenceiq.cloudbreak.structuredevent.service.CDPFlowStructuredEventHandler;
-import com.sequenceiq.cloudbreak.util.FipsOpenSSLLoaderUtil;
+import com.sequenceiq.cloudbreak.util.OpenSSLLoaderUtil;
 
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
@@ -29,7 +29,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 @EnableAutoConfiguration(exclude = WebMvcMetricsAutoConfiguration.class)
 public class CloudbreakApplication {
     public static void main(String[] args) {
-        FipsOpenSSLLoaderUtil.registerOpenSSLJniProvider();
+        OpenSSLLoaderUtil.registerOpenSSLJniProvider();
         if (!versionedApplication().showVersionInfo(args)) {
             if (args.length == 0) {
                 SpringApplication.run(CloudbreakApplication.class);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/conf/AppConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/conf/AppConfig.java
@@ -4,7 +4,6 @@ import static com.sequenceiq.cloudbreak.service.executor.DelayedExecutorService.
 
 import java.io.File;
 import java.io.IOException;
-import java.security.Security;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumMap;
@@ -139,8 +138,6 @@ public class AppConfig implements ResourceLoaderAware {
 
     @PostConstruct
     public void init() throws IOException {
-        Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
-
         ResourcePatternResolver patternResolver = new PathMatchingResourcePatternResolver();
         PropertySourceLoader load = new YamlPropertySourceLoader();
         for (Resource resource : patternResolver.getResources("classpath*:*-images.yml")) {

--- a/datalake/src/main/java/com/sequenceiq/datalake/DatalakeApplication.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/DatalakeApplication.java
@@ -5,7 +5,7 @@ import org.springframework.boot.actuate.autoconfigure.metrics.web.servlet.WebMvc
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
-import com.sequenceiq.cloudbreak.util.FipsOpenSSLLoaderUtil;
+import com.sequenceiq.cloudbreak.util.OpenSSLLoaderUtil;
 
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
@@ -15,7 +15,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 public class DatalakeApplication {
 
     public static void main(String[] args) {
-        FipsOpenSSLLoaderUtil.registerOpenSSLJniProvider();
+        OpenSSLLoaderUtil.registerOpenSSLJniProvider();
         SpringApplication.run(DatalakeApplication.class, args);
     }
 

--- a/docker-autoscale/Dockerfile
+++ b/docker-autoscale/Dockerfile
@@ -35,4 +35,9 @@ RUN JAVA_SECURITY_POLICY_FILE=$JAVA_HOME/conf/security/java.security \
 && N=$(grep -m 1 -n "^fips\.provider\.[[:digit:]]=" $JAVA_SECURITY_POLICY_FILE | cut -d: -f1) \
 && sed -i "$N i fips.provider.1=OpenSSL" $JAVA_SECURITY_POLICY_FILE
 
+RUN JAVA_SECURITY_POLICY_FILE=$JAVA_HOME/conf/security/java.security \
+&& for I in {20..1}; do J=$((I+1)); sed -i "s/security.provider.$I=/security.provider.$J=/" $JAVA_SECURITY_POLICY_FILE; done \
+&& N=$(grep -m 1 -n "^security\.provider\.[[:digit:]]=" $JAVA_SECURITY_POLICY_FILE | cut -d: -f1) \
+&& sed -i "$N i security.provider.1=OpenSSL" $JAVA_SECURITY_POLICY_FILE
+
 ENTRYPOINT ["/start_autoscale_app.sh"]

--- a/docker-cloudbreak/Dockerfile
+++ b/docker-cloudbreak/Dockerfile
@@ -35,4 +35,9 @@ RUN JAVA_SECURITY_POLICY_FILE=$JAVA_HOME/conf/security/java.security \
 && N=$(grep -m 1 -n "^fips\.provider\.[[:digit:]]=" $JAVA_SECURITY_POLICY_FILE | cut -d: -f1) \
 && sed -i "$N i fips.provider.1=OpenSSL" $JAVA_SECURITY_POLICY_FILE
 
+RUN JAVA_SECURITY_POLICY_FILE=$JAVA_HOME/conf/security/java.security \
+&& for I in {20..1}; do J=$((I+1)); sed -i "s/security.provider.$I=/security.provider.$J=/" $JAVA_SECURITY_POLICY_FILE; done \
+&& N=$(grep -m 1 -n "^security\.provider\.[[:digit:]]=" $JAVA_SECURITY_POLICY_FILE | cut -d: -f1) \
+&& sed -i "$N i security.provider.1=OpenSSL" $JAVA_SECURITY_POLICY_FILE
+
 ENTRYPOINT ["/start_cloudbreak_app.sh"]

--- a/docker-consumption/Dockerfile
+++ b/docker-consumption/Dockerfile
@@ -35,4 +35,9 @@ RUN JAVA_SECURITY_POLICY_FILE=$JAVA_HOME/conf/security/java.security \
 && N=$(grep -m 1 -n "^fips\.provider\.[[:digit:]]=" $JAVA_SECURITY_POLICY_FILE | cut -d: -f1) \
 && sed -i "$N i fips.provider.1=OpenSSL" $JAVA_SECURITY_POLICY_FILE
 
+RUN JAVA_SECURITY_POLICY_FILE=$JAVA_HOME/conf/security/java.security \
+&& for I in {20..1}; do J=$((I+1)); sed -i "s/security.provider.$I=/security.provider.$J=/" $JAVA_SECURITY_POLICY_FILE; done \
+&& N=$(grep -m 1 -n "^security\.provider\.[[:digit:]]=" $JAVA_SECURITY_POLICY_FILE | cut -d: -f1) \
+&& sed -i "$N i security.provider.1=OpenSSL" $JAVA_SECURITY_POLICY_FILE
+
 ENTRYPOINT ["/start_consumption_app.sh"]

--- a/docker-datalake/Dockerfile
+++ b/docker-datalake/Dockerfile
@@ -35,4 +35,9 @@ RUN JAVA_SECURITY_POLICY_FILE=$JAVA_HOME/conf/security/java.security \
 && N=$(grep -m 1 -n "^fips\.provider\.[[:digit:]]=" $JAVA_SECURITY_POLICY_FILE | cut -d: -f1) \
 && sed -i "$N i fips.provider.1=OpenSSL" $JAVA_SECURITY_POLICY_FILE
 
+RUN JAVA_SECURITY_POLICY_FILE=$JAVA_HOME/conf/security/java.security \
+&& for I in {20..1}; do J=$((I+1)); sed -i "s/security.provider.$I=/security.provider.$J=/" $JAVA_SECURITY_POLICY_FILE; done \
+&& N=$(grep -m 1 -n "^security\.provider\.[[:digit:]]=" $JAVA_SECURITY_POLICY_FILE | cut -d: -f1) \
+&& sed -i "$N i security.provider.1=OpenSSL" $JAVA_SECURITY_POLICY_FILE
+
 ENTRYPOINT ["/start_datalake_app.sh"]

--- a/docker-environment/Dockerfile
+++ b/docker-environment/Dockerfile
@@ -35,4 +35,9 @@ RUN JAVA_SECURITY_POLICY_FILE=$JAVA_HOME/conf/security/java.security \
 && N=$(grep -m 1 -n "^fips\.provider\.[[:digit:]]=" $JAVA_SECURITY_POLICY_FILE | cut -d: -f1) \
 && sed -i "$N i fips.provider.1=OpenSSL" $JAVA_SECURITY_POLICY_FILE
 
+RUN JAVA_SECURITY_POLICY_FILE=$JAVA_HOME/conf/security/java.security \
+&& for I in {20..1}; do J=$((I+1)); sed -i "s/security.provider.$I=/security.provider.$J=/" $JAVA_SECURITY_POLICY_FILE; done \
+&& N=$(grep -m 1 -n "^security\.provider\.[[:digit:]]=" $JAVA_SECURITY_POLICY_FILE | cut -d: -f1) \
+&& sed -i "$N i security.provider.1=OpenSSL" $JAVA_SECURITY_POLICY_FILE
+
 ENTRYPOINT ["/start_environment_app.sh"]

--- a/docker-freeipa/Dockerfile
+++ b/docker-freeipa/Dockerfile
@@ -35,4 +35,9 @@ RUN JAVA_SECURITY_POLICY_FILE=$JAVA_HOME/conf/security/java.security \
 && N=$(grep -m 1 -n "^fips\.provider\.[[:digit:]]=" $JAVA_SECURITY_POLICY_FILE | cut -d: -f1) \
 && sed -i "$N i fips.provider.1=OpenSSL" $JAVA_SECURITY_POLICY_FILE
 
+RUN JAVA_SECURITY_POLICY_FILE=$JAVA_HOME/conf/security/java.security \
+&& for I in {20..1}; do J=$((I+1)); sed -i "s/security.provider.$I=/security.provider.$J=/" $JAVA_SECURITY_POLICY_FILE; done \
+&& N=$(grep -m 1 -n "^security\.provider\.[[:digit:]]=" $JAVA_SECURITY_POLICY_FILE | cut -d: -f1) \
+&& sed -i "$N i security.provider.1=OpenSSL" $JAVA_SECURITY_POLICY_FILE
+
 ENTRYPOINT ["/start_freeipa_app.sh"]

--- a/docker-redbeams/Dockerfile
+++ b/docker-redbeams/Dockerfile
@@ -35,4 +35,9 @@ RUN JAVA_SECURITY_POLICY_FILE=$JAVA_HOME/conf/security/java.security \
 && N=$(grep -m 1 -n "^fips\.provider\.[[:digit:]]=" $JAVA_SECURITY_POLICY_FILE | cut -d: -f1) \
 && sed -i "$N i fips.provider.1=OpenSSL" $JAVA_SECURITY_POLICY_FILE
 
+RUN JAVA_SECURITY_POLICY_FILE=$JAVA_HOME/conf/security/java.security \
+&& for I in {20..1}; do J=$((I+1)); sed -i "s/security.provider.$I=/security.provider.$J=/" $JAVA_SECURITY_POLICY_FILE; done \
+&& N=$(grep -m 1 -n "^security\.provider\.[[:digit:]]=" $JAVA_SECURITY_POLICY_FILE | cut -d: -f1) \
+&& sed -i "$N i security.provider.1=OpenSSL" $JAVA_SECURITY_POLICY_FILE
+
 ENTRYPOINT ["/start_redbeams_app.sh"]

--- a/environment/src/main/java/com/sequenceiq/environment/EnvironmentApplication.java
+++ b/environment/src/main/java/com/sequenceiq/environment/EnvironmentApplication.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-import com.sequenceiq.cloudbreak.util.FipsOpenSSLLoaderUtil;
+import com.sequenceiq.cloudbreak.util.OpenSSLLoaderUtil;
 
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
@@ -19,7 +19,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 public class EnvironmentApplication {
 
     public static void main(String[] args) {
-        FipsOpenSSLLoaderUtil.registerOpenSSLJniProvider();
+        OpenSSLLoaderUtil.registerOpenSSLJniProvider();
         SpringApplication.run(EnvironmentApplication.class, args);
     }
 

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/KeystoreUtils.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/KeystoreUtils.java
@@ -43,7 +43,7 @@ public class KeystoreUtils {
         StringReader reader = new StringReader(serverCert);
         try (PEMParser pemParser = new PEMParser(reader)) {
             X509CertificateHolder certificateHolder = (X509CertificateHolder) pemParser.readObject();
-            Certificate caCertificate = new JcaX509CertificateConverter().setProvider("BC").getCertificate(certificateHolder);
+            Certificate caCertificate = new JcaX509CertificateConverter().getCertificate(certificateHolder);
 
             KeyStore trustStore = KeyStore.getInstance("JKS");
             trustStore.load(null);
@@ -57,7 +57,7 @@ public class KeystoreUtils {
 
         try (PEMParser pemParser = new PEMParser(reader)) {
             X509CertificateHolder certificateHolder = (X509CertificateHolder) pemParser.readObject();
-            return new JcaX509CertificateConverter().setProvider("BC").getCertificate(certificateHolder);
+            return new JcaX509CertificateConverter().getCertificate(certificateHolder);
         }
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/FreeIpaApplication.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/FreeIpaApplication.java
@@ -5,7 +5,7 @@ import org.springframework.boot.actuate.autoconfigure.metrics.web.servlet.WebMvc
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
-import com.sequenceiq.cloudbreak.util.FipsOpenSSLLoaderUtil;
+import com.sequenceiq.cloudbreak.util.OpenSSLLoaderUtil;
 
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
@@ -15,7 +15,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 public class FreeIpaApplication {
 
     public static void main(String[] args) {
-        FipsOpenSSLLoaderUtil.registerOpenSSLJniProvider();
+        OpenSSLLoaderUtil.registerOpenSSLJniProvider();
         SpringApplication.run(FreeIpaApplication.class, args);
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientBuilder.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientBuilder.java
@@ -7,7 +7,6 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.security.Security;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -37,7 +36,6 @@ import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.ssl.SSLContexts;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -215,8 +213,8 @@ public class FreeIpaClientBuilder {
 
                 throw FreeIpaClientExceptionUtil.convertToRetryableIfNeeded(new FreeIpaClientException(String.format(
                         "Encountered unexpected response from FreeIPA; details:%n%n"
-                        + "code: %s%n"
-                        + "headers: %s", response.getStatusLine().getStatusCode(), anonymize(Arrays.toString(response.getAllHeaders()))),
+                                + "code: %s%n"
+                                + "headers: %s", response.getStatusLine().getStatusCode(), anonymize(Arrays.toString(response.getAllHeaders()))),
                         response.getStatusLine().getStatusCode()));
             }
         }
@@ -232,8 +230,8 @@ public class FreeIpaClientBuilder {
             throw new FreeIpaClientException("Unable to obtain FreeIPA session cookie");
         } else if (sortedCookies.size() > 1) {
             List<String> cookieDetails = sortedCookies.stream()
-                            .map(this::cookieString)
-                            .collect(Collectors.toList());
+                    .map(this::cookieString)
+                    .collect(Collectors.toList());
             LOGGER.debug("Found multiple cookies [{}]", cookieDetails);
         }
         return sortedCookies.get(0);
@@ -249,17 +247,14 @@ public class FreeIpaClientBuilder {
     }
 
     private SSLContext setupSSLContext(String clientCert, String clientKey, String serverCert) throws Exception {
-        Security.addProvider(new BouncyCastleProvider());
-        SSLContext context;
         if (StringUtils.isNoneBlank(clientCert, clientKey, serverCert)) {
-            context = SSLContexts.custom()
+            return SSLContexts.custom()
                     .loadTrustMaterial(KeystoreUtils.createTrustStore(serverCert), null)
                     .loadKeyMaterial(KeystoreUtils.createKeyStore(clientCert, clientKey), "consul".toCharArray())
                     .build();
         } else {
-            context = CertificateTrustManager.sslContext();
+            return CertificateTrustManager.sslContext();
         }
-        return context;
     }
 
     private URL getIpaUrl(String apiAddress, int port, String basePath, String context) throws MalformedURLException {

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/RedbeamsApplication.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/RedbeamsApplication.java
@@ -6,7 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-import com.sequenceiq.cloudbreak.util.FipsOpenSSLLoaderUtil;
+import com.sequenceiq.cloudbreak.util.OpenSSLLoaderUtil;
 
 @EnableScheduling
 @EnableJpaRepositories(basePackages = "com.sequenceiq")
@@ -14,7 +14,7 @@ import com.sequenceiq.cloudbreak.util.FipsOpenSSLLoaderUtil;
 public class RedbeamsApplication {
 
     public static void main(String[] args) {
-        FipsOpenSSLLoaderUtil.registerOpenSSLJniProvider();
+        OpenSSLLoaderUtil.registerOpenSSLJniProvider();
         SpringApplication.run(RedbeamsApplication.class, args);
     }
 

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/AppConfig.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/AppConfig.java
@@ -2,11 +2,8 @@ package com.sequenceiq.redbeams.configuration;
 
 import static com.sequenceiq.cloudbreak.service.executor.DelayedExecutorService.DELAYED_TASK_EXECUTOR;
 
-import java.io.IOException;
-import java.security.Security;
 import java.util.concurrent.ScheduledExecutorService;
 
-import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
@@ -74,11 +71,6 @@ public class AppConfig implements ResourceLoaderAware {
     private MeterRegistry meterRegistry;
 
     private ResourceLoader resourceLoader;
-
-    @PostConstruct
-    public void init() throws IOException {
-        Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
-    }
 
     @Bean
     public AsyncTaskExecutor intermediateBuilderExecutor() {


### PR DESCRIPTION
Move to OpenSSL provider on non gov/fips environment so our code and operation can behave the same.

On FIPS enabled envs OpenSSL is enforced, and the apps wouldn't start if cannot be loaded. On other envs if OpenSSL is not available then falling back to default JDK provider.

See detailed description in the commit message.