### PR TITLE
CB-20713 Skip ORG policy decisions rule(AWS) for datalake backup

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/objectstorage/ObjectStorageValidateRequest.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/objectstorage/ObjectStorageValidateRequest.java
@@ -29,6 +29,8 @@ public class ObjectStorageValidateRequest implements CloudPlatformAware {
 
     private BackupOperationType backupOperationType;
 
+    private boolean skipOrgPolicyDecisions;
+
     private AzureParameters azure;
 
     private MockAccountMappingSettings mockAccountMappingSettings;
@@ -44,6 +46,7 @@ public class ObjectStorageValidateRequest implements CloudPlatformAware {
         this.logsLocationBase = builder.logsLocationBase;
         this.backupLocationBase = builder.backupLocationBase;
         this.backupOperationType = builder.backupOperationType;
+        this.skipOrgPolicyDecisions = builder.skipOrgPolicyDecisions;
         this.mockAccountMappingSettings = builder.mockAccountMappingSettings;
         this.azure = builder.azure;
     }
@@ -108,6 +111,14 @@ public class ObjectStorageValidateRequest implements CloudPlatformAware {
         this.backupOperationType = backupOperationType;
     }
 
+    public void setSkipOrgPolicyDecisions(boolean skipOrgPolicyDecisions) {
+        this.skipOrgPolicyDecisions = skipOrgPolicyDecisions;
+    }
+
+    public boolean isSkipOrgPolicyDecisions() {
+        return skipOrgPolicyDecisions;
+    }
+
     public MockAccountMappingSettings getMockAccountMappingSettings() {
         return mockAccountMappingSettings;
     }
@@ -141,12 +152,13 @@ public class ObjectStorageValidateRequest implements CloudPlatformAware {
                 Objects.equals(logsLocationBase, request.logsLocationBase) &&
                 Objects.equals(backupLocationBase, request.backupLocationBase) &&
                 Objects.equals(backupOperationType, request.backupOperationType) &&
+                Objects.equals(skipOrgPolicyDecisions, request.skipOrgPolicyDecisions) &&
                 Objects.equals(azure, request.azure);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(credential, cloudPlatform, cloudStorageRequest, spiFileSystem, logsLocationBase, azure);
+        return Objects.hash(credential, cloudPlatform, cloudStorageRequest, spiFileSystem, logsLocationBase, skipOrgPolicyDecisions, azure);
     }
 
     @Override
@@ -158,6 +170,7 @@ public class ObjectStorageValidateRequest implements CloudPlatformAware {
                 ", logsLocationBase='" + logsLocationBase + '\'' +
                 ", backupLocationBase='" + backupLocationBase + '\'' +
                 ", backupOperationType='" + backupOperationType + '\'' +
+                ", skipOrgPolicyDecisions='" + skipOrgPolicyDecisions + '\'' +
                 '}';
     }
 
@@ -186,6 +199,8 @@ public class ObjectStorageValidateRequest implements CloudPlatformAware {
         private String backupLocationBase;
 
         private BackupOperationType backupOperationType;
+
+        private boolean skipOrgPolicyDecisions;
 
         private MockAccountMappingSettings mockAccountMappingSettings;
 
@@ -227,6 +242,11 @@ public class ObjectStorageValidateRequest implements CloudPlatformAware {
             } else {
                 this.backupOperationType = BackupOperationType.ANY;
             }
+            return this;
+        }
+
+        public Builder withSkipOrgPolicyDecisions() {
+            this.skipOrgPolicyDecisions = true;
             return this;
         }
 

--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/validator/AwsIDBrokerObjectStorageValidator.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/validator/AwsIDBrokerObjectStorageValidator.java
@@ -67,7 +67,7 @@ public class AwsIDBrokerObjectStorageValidator {
                     cloudFileSystem.getCloudIdentityType(), resultBuilder);
             if (instanceProfile != null) {
                 CloudIdentityType cloudIdentityType = cloudFileSystem.getCloudIdentityType();
-                boolean skipOrgPolicyDecisions = validationRequest.getCredential().getCredentialSettings().isSkipOrgPolicyDecisions();
+                boolean skipOrgPolicyDecisions = skipOrgPolicyDecisions(validationRequest);
                 if (CloudIdentityType.ID_BROKER.equals(cloudIdentityType)) {
                     validateIDBroker(validationRequest, iam, instanceProfile, cloudFileSystem, accountId, skipOrgPolicyDecisions, resultBuilder);
                 } else if (CloudIdentityType.LOG.equals(cloudIdentityType)) {
@@ -76,6 +76,11 @@ public class AwsIDBrokerObjectStorageValidator {
             }
         }
         return resultBuilder.build();
+    }
+
+    private boolean skipOrgPolicyDecisions(ObjectStorageValidateRequest validationRequest) {
+        return validationRequest.getCredential().getCredentialSettings().isSkipOrgPolicyDecisions()
+                || validationRequest.isSkipOrgPolicyDecisions();
     }
 
     private void validateIDBroker(ObjectStorageValidateRequest validationRequest, AmazonIdentityManagementClient iam, InstanceProfile instanceProfile,

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/validation/cloudstorage/CloudStorageValidator.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/validation/cloudstorage/CloudStorageValidator.java
@@ -162,6 +162,7 @@ public class CloudStorageValidator {
                 .withCloudStorageRequest(cloudStorageRequest)
                 .withBackupLocationBase(backupLocation)
                 .withBackupOperationType(backupOperationType)
+                .withSkipOrgPolicyDecisions()
                 .withAzureParameters(getSingleResourceGroupName(environment));
         if (environment.getIdBrokerMappingSource() == MOCK) {
             result.withMockSettings(environment.getLocation().getName(), environment.getAdminGroupName());


### PR DESCRIPTION
Context: Org policy decisions should always be skipped for datalake backup.

Test:
Added a custom result for the simultate policy (com.sequenceiq.cloudbreak.cloud.aws.common.util.AwsIamService#simulatePrincipalPolicy) with a 'denied by organization rules' and then checked if it was ignored and the precheckStoragePermission step in datalake backup was successful.