### PR TITLE
CB-20777 Change java.arg.7 property name to java.arg.tmp.dir in clust…

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.17/cdp-flow-management-small.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.17/cdp-flow-management-small.bp
@@ -162,7 +162,7 @@
                 "value": "-Xms8g"
               },
               {
-                "name": "java.arg.7",
+                "name": "java.arg.tmp.dir",
                 "value": "${nifi.working.directory}/tmp"
               },
               {

--- a/core/src/main/resources/defaults/blueprints/7.2.17/cdp-flow-management.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.17/cdp-flow-management.bp
@@ -138,7 +138,7 @@
                 "value": "-Xms8g"
               },
               {
-                "name": "java.arg.7",
+                "name": "java.arg.tmp.dir",
                 "value": "${nifi.working.directory}/tmp"
               },
               {


### PR DESCRIPTION
…er blueprint. In this jira we have changed name of property 'java.arg.7', which was added earlier, to 'java.arg.tmp.dir' because it was also changed in new related CFM release 2.2.7.0.

See detailed description in the commit message.