### PR TITLE
CB-20494 Create metrics without service specific prefixes

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/PeriscopeMetricService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/PeriscopeMetricService.java
@@ -1,14 +1,17 @@
 package com.sequenceiq.periscope.service;
 
 import java.util.Arrays;
+import java.util.Optional;
 
 import javax.annotation.PostConstruct;
 
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.common.metrics.AbstractMetricService;
 import com.sequenceiq.periscope.domain.MetricType;
 
+@Primary
 @Service("MetricService")
 public class PeriscopeMetricService extends AbstractMetricService {
 
@@ -26,7 +29,7 @@ public class PeriscopeMetricService extends AbstractMetricService {
     }
 
     @Override
-    protected String getMetricPrefix() {
-        return METRIC_PREFIX;
+    protected Optional<String> getMetricPrefix() {
+        return Optional.of(METRIC_PREFIX);
     }
 }

--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/configuration/metrics/ConsumptionMetricService.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/configuration/metrics/ConsumptionMetricService.java
@@ -1,17 +1,21 @@
 package com.sequenceiq.consumption.configuration.metrics;
 
+import java.util.Optional;
+
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.common.metrics.AbstractMetricService;
 
+@Primary
 @Service
 public class ConsumptionMetricService extends AbstractMetricService {
 
     private static final String METRIC_PREFIX = "consumption";
 
     @Override
-    protected String getMetricPrefix() {
-        return METRIC_PREFIX;
+    protected Optional<String> getMetricPrefix() {
+        return Optional.of(METRIC_PREFIX);
     }
 
 }

--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/job/storage/StorageConsumptionJobService.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/job/storage/StorageConsumptionJobService.java
@@ -26,12 +26,13 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.common.mappable.StorageType;
+import com.sequenceiq.cloudbreak.quartz.JobSchedulerService;
 import com.sequenceiq.consumption.api.v1.consumption.model.common.ConsumptionType;
 import com.sequenceiq.consumption.domain.Consumption;
 import com.sequenceiq.consumption.service.ConsumptionService;
 
 @Service
-public class StorageConsumptionJobService {
+public class StorageConsumptionJobService implements JobSchedulerService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StorageConsumptionJobService.class);
 
@@ -203,5 +204,10 @@ public class StorageConsumptionJobService {
     private Date delayedFirstStart() {
         int delayInSeconds = RANDOM.nextInt((int) TimeUnit.MINUTES.toSeconds(storageConsumptionConfig.getIntervalInMinutes()));
         return Date.from(ZonedDateTime.now().toInstant().plus(Duration.ofSeconds(delayInSeconds)));
+    }
+
+    @Override
+    public String getJobGroup() {
+        return JOB_GROUP;
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/metrics/AbstractMetricService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/metrics/AbstractMetricService.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -82,7 +83,11 @@ public abstract class AbstractMetricService implements MetricService {
     }
 
     private String getMetricName(Metric metric) {
-        return getMetricPrefix() + '.' + metric.getMetricName().toLowerCase();
+        if (getMetricPrefix().isPresent()) {
+            return getMetricPrefix().get() + '.' + metric.getMetricName().toLowerCase();
+        } else {
+            return metric.getMetricName().toLowerCase();
+        }
     }
 
     @Override
@@ -108,5 +113,5 @@ public abstract class AbstractMetricService implements MetricService {
         recordTimer(duration, MetricType.DB_TRANSACTION_ID);
     }
 
-    protected abstract String getMetricPrefix();
+    protected abstract Optional<String> getMetricPrefix();
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/metrics/CommonMetricService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/metrics/CommonMetricService.java
@@ -1,0 +1,14 @@
+package com.sequenceiq.cloudbreak.common.metrics;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+@Service("CommonMetricService")
+public class CommonMetricService extends AbstractMetricService {
+
+    @Override
+    protected Optional<String> getMetricPrefix() {
+        return Optional.empty();
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/quartz/JobSchedulerService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/quartz/JobSchedulerService.java
@@ -1,0 +1,6 @@
+package com.sequenceiq.cloudbreak.quartz;
+
+public interface JobSchedulerService {
+
+    String getJobGroup();
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/quartz/cleanup/service/UMSCleanupJobService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/quartz/cleanup/service/UMSCleanupJobService.java
@@ -14,10 +14,11 @@ import org.quartz.TriggerBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.sequenceiq.cloudbreak.quartz.JobSchedulerService;
 import com.sequenceiq.cloudbreak.quartz.cleanup.UMSCleanupConfig;
 import com.sequenceiq.cloudbreak.quartz.cleanup.job.UMSCleanupJob;
 
-public abstract class UMSCleanupJobService<T extends UMSCleanupJob> {
+public abstract class UMSCleanupJobService<T extends UMSCleanupJob> implements JobSchedulerService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UMSCleanupJobService.class);
 
@@ -76,5 +77,10 @@ public abstract class UMSCleanupJobService<T extends UMSCleanupJob> {
         } catch (SchedulerException e) {
             LOGGER.error(String.format("Error during unscheduling quartz job: %s", jobKey), e);
         }
+    }
+
+    @Override
+    public String getJobGroup() {
+        return JOB_GROUP;
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/quartz/metric/JobMetricsListener.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/quartz/metric/JobMetricsListener.java
@@ -4,6 +4,7 @@ import static com.sequenceiq.cloudbreak.quartz.metric.QuartzMetricTag.JOB_GROUP;
 import static com.sequenceiq.cloudbreak.quartz.metric.QuartzMetricTag.PROVIDER;
 
 import java.time.Duration;
+import java.util.List;
 
 import javax.inject.Inject;
 
@@ -26,7 +27,7 @@ public class JobMetricsListener extends JobListenerSupport {
     private static final int MILLI_SECONDS_30000 = 30000;
 
     @Inject
-    private MetricService metricService;
+    private List<MetricService> metricServices;
 
     @Override
     public String getName() {
@@ -38,9 +39,9 @@ public class JobMetricsListener extends JobListenerSupport {
         JobKey jobKey = context.getJobDetail().getKey();
         getLog().trace("Job will be executed with group: {}, name: {}, class: {}",
                 jobKey.getGroup(), jobKey.getName(), context.getJobDetail().getJobClass().getName());
-        metricService.incrementMetricCounter(QuartzMetricType.JOB_TRIGGERED,
+        metricServices.forEach(metricService -> metricService.incrementMetricCounter(QuartzMetricType.JOB_TRIGGERED,
                 JOB_GROUP.name(), jobKey.getGroup(),
-                PROVIDER.name(), QuartzMetricUtil.getProvider(context.getJobDetail().getJobDataMap()));
+                PROVIDER.name(), QuartzMetricUtil.getProvider(context.getJobDetail().getJobDataMap())));
     }
 
     @Override
@@ -52,9 +53,9 @@ public class JobMetricsListener extends JobListenerSupport {
         QuartzMetricType metricType = jobException == null ? QuartzMetricType.JOB_FINISHED : QuartzMetricType.JOB_FAILED;
         Duration jobRunTime = Duration.ofMillis(context.getJobRunTime());
         logJobDurationIfCritical(context);
-        metricService.recordTimerMetric(metricType, jobRunTime,
+        metricServices.forEach(metricService -> metricService.recordTimerMetric(metricType, jobRunTime,
                 JOB_GROUP.name(), jobKey.getGroup(),
-                PROVIDER.name(), QuartzMetricUtil.getProvider(context.getJobDetail().getJobDataMap()));
+                PROVIDER.name(), QuartzMetricUtil.getProvider(context.getJobDetail().getJobDataMap())));
     }
 
     private void logJobDurationIfCritical(JobExecutionContext context) {

--- a/common/src/main/java/com/sequenceiq/cloudbreak/quartz/metric/SchedulerMetricsListener.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/quartz/metric/SchedulerMetricsListener.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.quartz.metric;
 
+import java.util.List;
+
 import javax.inject.Inject;
 
 import org.quartz.SchedulerException;
@@ -12,12 +14,12 @@ import com.sequenceiq.cloudbreak.common.metrics.MetricService;
 public class SchedulerMetricsListener extends SchedulerListenerSupport {
 
     @Inject
-    private MetricService metricService;
+    private List<MetricService> metricServices;
 
     @Override
     public void schedulerError(String msg, SchedulerException cause) {
         getLog().warn("Scheduler error occured: {}", msg, cause);
-        metricService.incrementMetricCounter(QuartzMetricType.SCHEDULER_ERROR);
+        metricServices.forEach(metricService -> metricService.incrementMetricCounter(QuartzMetricType.SCHEDULER_ERROR));
     }
 
     @Override

--- a/common/src/main/java/com/sequenceiq/cloudbreak/quartz/metric/TriggerMetricsListener.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/quartz/metric/TriggerMetricsListener.java
@@ -6,6 +6,7 @@ import static com.sequenceiq.cloudbreak.quartz.metric.QuartzMetricTag.TRIGGER_GR
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
+import java.util.List;
 
 import javax.inject.Inject;
 
@@ -22,7 +23,7 @@ import com.sequenceiq.cloudbreak.common.metrics.MetricService;
 public class TriggerMetricsListener extends TriggerListenerSupport {
 
     @Inject
-    private MetricService metricService;
+    private List<MetricService> metricServices;
 
     @Override
     public String getName() {
@@ -35,22 +36,22 @@ public class TriggerMetricsListener extends TriggerListenerSupport {
         Date triggerTime = trigger.getPreviousFireTime() == null ? trigger.getStartTime() : trigger.getPreviousFireTime();
         Duration triggerDelay = Duration.between(triggerTime.toInstant(), Instant.now());
         getLog().debug("Trigger fired with group: {}, name: {}, delay: {} ms", triggerKey.getGroup(), triggerKey.getName(), triggerDelay.toMillis());
-        metricService.incrementMetricCounter(QuartzMetricType.TRIGGER_FIRED,
+        metricServices.forEach(metricService -> metricService.incrementMetricCounter(QuartzMetricType.TRIGGER_FIRED,
                 TRIGGER_GROUP.name(), triggerKey.getGroup(),
-                PROVIDER.name(), QuartzMetricUtil.getProvider(context.getJobDetail().getJobDataMap()));
+                PROVIDER.name(), QuartzMetricUtil.getProvider(context.getJobDetail().getJobDataMap())));
 
-        metricService.recordTimerMetric(QuartzMetricType.TRIGGER_DELAYED, triggerDelay,
+        metricServices.forEach(metricService -> metricService.recordTimerMetric(QuartzMetricType.TRIGGER_DELAYED, triggerDelay,
                 TRIGGER_GROUP.name(), triggerKey.getGroup(),
-                PROVIDER.name(), QuartzMetricUtil.getProvider(context.getJobDetail().getJobDataMap()));
+                PROVIDER.name(), QuartzMetricUtil.getProvider(context.getJobDetail().getJobDataMap())));
     }
 
     @Override
     public void triggerMisfired(Trigger trigger) {
         TriggerKey triggerKey = trigger.getKey();
         getLog().warn("Trigger misfired with group: {}, name: {}", triggerKey.getGroup(), triggerKey.getName());
-        metricService.incrementMetricCounter(QuartzMetricType.TRIGGER_MISFIRED,
+        metricServices.forEach(metricService -> metricService.incrementMetricCounter(QuartzMetricType.TRIGGER_MISFIRED,
                 TRIGGER_GROUP.name(), triggerKey.getGroup(),
-                PROVIDER.name(), QuartzMetricUtil.getProvider(trigger.getJobDataMap()));
+                PROVIDER.name(), QuartzMetricUtil.getProvider(trigger.getJobDataMap())));
     }
 
     @Override
@@ -58,8 +59,8 @@ public class TriggerMetricsListener extends TriggerListenerSupport {
         TriggerKey triggerKey = trigger.getKey();
         getLog().debug("Trigger completed with group: {}, name: {}, triggerInstructionCode: {}",
                 triggerKey.getGroup(), triggerKey.getName(), triggerInstructionCode);
-        metricService.incrementMetricCounter(QuartzMetricType.TRIGGER_COMPLETED,
+        metricServices.forEach(metricService -> metricService.incrementMetricCounter(QuartzMetricType.TRIGGER_COMPLETED,
                 TRIGGER_GROUP.name(), triggerKey.getGroup(),
-                PROVIDER.name(), QuartzMetricUtil.getProvider(trigger.getJobDataMap()));
+                PROVIDER.name(), QuartzMetricUtil.getProvider(trigger.getJobDataMap())));
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/quartz/saltstatuschecker/SaltStatusCheckerJobService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/quartz/saltstatuschecker/SaltStatusCheckerJobService.java
@@ -19,10 +19,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sequenceiq.cloudbreak.quartz.JobDataMapProvider;
+import com.sequenceiq.cloudbreak.quartz.JobSchedulerService;
 import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
 import com.sequenceiq.cloudbreak.util.RandomUtil;
 
-public abstract class SaltStatusCheckerJobService<T extends JobResourceAdapter<?>> {
+public abstract class SaltStatusCheckerJobService<T extends JobResourceAdapter<?>> implements JobSchedulerService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SaltStatusCheckerJobService.class);
 
@@ -90,5 +91,10 @@ public abstract class SaltStatusCheckerJobService<T extends JobResourceAdapter<?
     private Date delayedStart() {
         int intervalInSeconds = (int) TimeUnit.MINUTES.toSeconds(saltStatusCheckerConfig.getIntervalInMinutes());
         return Date.from(ZonedDateTime.now().toInstant().plus(Duration.ofSeconds(RandomUtil.getInt(intervalInSeconds))));
+    }
+
+    @Override
+    public String getJobGroup() {
+        return JOB_GROUP;
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/quartz/statuschecker/service/StatusCheckerJobService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/quartz/statuschecker/service/StatusCheckerJobService.java
@@ -24,13 +24,14 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
+import com.sequenceiq.cloudbreak.quartz.JobSchedulerService;
 import com.sequenceiq.cloudbreak.quartz.model.JobResource;
 import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
 import com.sequenceiq.cloudbreak.quartz.statuschecker.StatusCheckerConfig;
 import com.sequenceiq.cloudbreak.util.RandomUtil;
 
 @Service
-public class StatusCheckerJobService {
+public class StatusCheckerJobService implements JobSchedulerService {
 
     public static final String SYNC_JOB_TYPE = "syncJobType";
 
@@ -169,5 +170,10 @@ public class StatusCheckerJobService {
 
     private Date delayedStart(int delayInSeconds) {
         return Date.from(ZonedDateTime.now().toInstant().plus(Duration.ofSeconds(delayInSeconds)));
+    }
+
+    @Override
+    public String getJobGroup() {
+        return JOB_GROUP;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/instancemetadata/ArchiveInstanceMetaDataJobService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/instancemetadata/ArchiveInstanceMetaDataJobService.java
@@ -21,10 +21,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.quartz.JobSchedulerService;
 import com.sequenceiq.cloudbreak.util.RandomUtil;
 
 @Service
-public class ArchiveInstanceMetaDataJobService {
+public class ArchiveInstanceMetaDataJobService implements JobSchedulerService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ArchiveInstanceMetaDataJobService.class);
 
@@ -117,5 +118,10 @@ public class ArchiveInstanceMetaDataJobService {
     private Date delayedFirstStart() {
         int delayInMinutes = RandomUtil.getInt((int) TimeUnit.HOURS.toMinutes(properties.getIntervalInHours()));
         return Date.from(ZonedDateTime.now().toInstant().plus(Duration.ofMinutes(delayInMinutes)));
+    }
+
+    @Override
+    public String getJobGroup() {
+        return JOB_GROUP;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/nodestatus/NodeStatusCheckerJobService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/nodestatus/NodeStatusCheckerJobService.java
@@ -22,11 +22,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.quartz.JobSchedulerService;
 import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
 import com.sequenceiq.cloudbreak.util.RandomUtil;
 
 @Service
-public class NodeStatusCheckerJobService {
+public class NodeStatusCheckerJobService implements JobSchedulerService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NodeStatusCheckerJobService.class);
 
@@ -125,4 +126,8 @@ public class NodeStatusCheckerJobService {
         return Date.from(ZonedDateTime.now().toInstant().plus(Duration.ofSeconds(delayInSeconds)));
     }
 
+    @Override
+    public String getJobGroup() {
+        return JOB_GROUP;
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJobService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJobService.java
@@ -17,12 +17,13 @@ import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.domain.stack.StackPatchType;
 import com.sequenceiq.cloudbreak.quartz.JobDataMapProvider;
+import com.sequenceiq.cloudbreak.quartz.JobSchedulerService;
 import com.sequenceiq.cloudbreak.quartz.model.JobResource;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.service.stackpatch.ExistingStackPatchService;
 
 @Service
-public class ExistingStackPatcherJobService {
+public class ExistingStackPatcherJobService implements JobSchedulerService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ExistingStackPatcherJobService.class);
 
@@ -101,5 +102,10 @@ public class ExistingStackPatcherJobService {
                         .withMisfireHandlingInstructionNextWithExistingCount())
                 .startAt(existingStackPatchService.getFirstStart())
                 .build();
+    }
+
+    @Override
+    public String getJobGroup() {
+        return JOB_GROUP;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/metrics/CloudbreakMetricService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/metrics/CloudbreakMetricService.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.common.metrics.AbstractMetricService;
@@ -13,6 +14,7 @@ import com.sequenceiq.cloudbreak.dto.StackDtoDelegate;
 import com.sequenceiq.cloudbreak.view.StackView;
 import com.sequenceiq.cloudbreak.workspace.model.Tenant;
 
+@Primary
 @Service("MetricService")
 public class CloudbreakMetricService extends AbstractMetricService {
 
@@ -38,8 +40,8 @@ public class CloudbreakMetricService extends AbstractMetricService {
     }
 
     @Override
-    protected String getMetricPrefix() {
-        return METRIC_PREFIX;
+    protected Optional<String> getMetricPrefix() {
+        return Optional.of(METRIC_PREFIX);
     }
 
     private String[] nullableValueTags(String... tags) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/job/StructuredSynchronizerJobService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/job/StructuredSynchronizerJobService.java
@@ -21,11 +21,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.quartz.JobSchedulerService;
 import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
 import com.sequenceiq.cloudbreak.util.RandomUtil;
 
 @Service
-public class StructuredSynchronizerJobService {
+public class StructuredSynchronizerJobService implements JobSchedulerService {
 
     private static final String JOB_GROUP = "structured-synchronizer-jobs";
 
@@ -125,5 +126,10 @@ public class StructuredSynchronizerJobService {
     private Date delayedStart() {
         return Date.from(ZonedDateTime.now().toInstant().plus(
                 Duration.ofSeconds(RandomUtil.getInt(structuredSynchronizerConfig.getIntervalInHours() * SECONDS_IN_HOUR))));
+    }
+
+    @Override
+    public String getJobGroup() {
+        return JOB_GROUP;
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/metric/SdxMetricService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/metric/SdxMetricService.java
@@ -1,18 +1,22 @@
 package com.sequenceiq.datalake.metric;
 
+import java.util.Optional;
+
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.common.metrics.AbstractMetricService;
 import com.sequenceiq.datalake.entity.SdxCluster;
 
+@Primary
 @Service
 public class SdxMetricService extends AbstractMetricService {
 
     private static final String METRIC_PREFIX = "sdx";
 
     @Override
-    protected String getMetricPrefix() {
-        return METRIC_PREFIX;
+    protected Optional<String> getMetricPrefix() {
+        return Optional.of(METRIC_PREFIX);
     }
 
     public void incrementMetricCounter(MetricType metricType, SdxCluster sdxCluster) {

--- a/environment/src/main/java/com/sequenceiq/environment/metrics/EnvironmentMetricService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/metrics/EnvironmentMetricService.java
@@ -1,5 +1,8 @@
 package com.sequenceiq.environment.metrics;
 
+import java.util.Optional;
+
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.common.metrics.AbstractMetricService;
@@ -7,14 +10,15 @@ import com.sequenceiq.cloudbreak.common.metrics.type.MetricTag;
 import com.sequenceiq.environment.environment.domain.Environment;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
 
+@Primary
 @Service
 public class EnvironmentMetricService extends AbstractMetricService {
 
     private static final String METRIC_PREFIX = "environment";
 
     @Override
-    protected String getMetricPrefix() {
-        return METRIC_PREFIX;
+    protected Optional<String> getMetricPrefix() {
+        return Optional.of(METRIC_PREFIX);
     }
 
     public void incrementMetricCounter(MetricType metricType, EnvironmentDto environment) {

--- a/environment/src/test/java/com/sequenceiq/environment/service/integration/CredentialExperienceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/service/integration/CredentialExperienceTest.java
@@ -20,11 +20,9 @@ import org.mockito.Mock;
 import org.quartz.Scheduler;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Primary;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.sequenceiq.authorization.service.OwnerAssignmentService;
@@ -44,7 +42,6 @@ import com.sequenceiq.cloudbreak.cloud.response.AwsCredentialPrerequisites;
 import com.sequenceiq.cloudbreak.cloud.response.AzureCredentialPrerequisites;
 import com.sequenceiq.cloudbreak.cloud.response.CredentialPrerequisitesResponse;
 import com.sequenceiq.cloudbreak.cloud.response.GcpCredentialPrerequisites;
-import com.sequenceiq.cloudbreak.common.metrics.MetricService;
 import com.sequenceiq.cloudbreak.common.service.Clock;
 import com.sequenceiq.cloudbreak.common.service.TransactionMetricsService;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
@@ -341,12 +338,6 @@ public class CredentialExperienceTest {
 
         @MockBean
         private EditCredentialRequestToCredentialConverter editCredentialRequestToCredentialConverter;
-
-        @Bean
-        @Primary
-        MetricService metricService() {
-            return new EnvironmentMetricService();
-        }
 
     }
 

--- a/flow/src/main/java/com/sequenceiq/flow/cleanup/FlowCleanupJobService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/cleanup/FlowCleanupJobService.java
@@ -19,10 +19,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.quartz.JobSchedulerService;
 import com.sequenceiq.cloudbreak.util.RandomUtil;
 
 @Service
-public class FlowCleanupJobService {
+public class FlowCleanupJobService implements JobSchedulerService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FlowCleanupJobService.class);
 
@@ -88,5 +89,10 @@ public class FlowCleanupJobService {
 
     private Date delayedFirstStart() {
         return Date.from(ZonedDateTime.now().toInstant().plus(Duration.ofHours(RandomUtil.getInt(flowCleanupConfig.getIntervalInHours()))));
+    }
+
+    @Override
+    public String getJobGroup() {
+        return JOB_GROUP;
     }
 }

--- a/flow/src/test/java/com/sequenceiq/flow/reactor/ContextClosedEventHandlerTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/reactor/ContextClosedEventHandlerTest.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.flow.reactor;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.TestComponent;
@@ -36,8 +38,8 @@ class ContextClosedEventHandlerTest {
     static class TestMetricService extends AbstractMetricService {
 
         @Override
-        protected String getMetricPrefix() {
-            return "test";
+        protected Optional<String> getMetricPrefix() {
+            return Optional.of("test");
         }
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/metrics/FreeIpaMetricService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/metrics/FreeIpaMetricService.java
@@ -1,11 +1,15 @@
 package com.sequenceiq.freeipa.metrics;
 
+import java.util.Optional;
+
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.common.metrics.AbstractMetricService;
 import com.sequenceiq.cloudbreak.common.metrics.type.MetricTag;
 import com.sequenceiq.freeipa.entity.Stack;
 
+@Primary
 @Service
 public class FreeIpaMetricService extends AbstractMetricService {
 
@@ -31,7 +35,7 @@ public class FreeIpaMetricService extends AbstractMetricService {
     }
 
     @Override
-    protected String getMetricPrefix() {
-        return METRIC_PREFIX;
+    protected Optional<String> getMetricPrefix() {
+        return Optional.of(METRIC_PREFIX);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/nodestatus/NodeStatusJobService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/nodestatus/NodeStatusJobService.java
@@ -22,12 +22,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.quartz.JobSchedulerService;
 import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
 import com.sequenceiq.cloudbreak.util.RandomUtil;
 import com.sequenceiq.freeipa.entity.Stack;
 
 @Component
-public class NodeStatusJobService {
+public class NodeStatusJobService implements JobSchedulerService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NodeStatusJobService.class);
 
@@ -118,5 +119,10 @@ public class NodeStatusJobService {
 
     private Class<? extends Job> getJobClass() {
         return NodeStatusJob.class;
+    }
+
+    @Override
+    public String getJobGroup() {
+        return JOB_GROUP;
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/metrics/RedbeamsMetricService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/metrics/RedbeamsMetricService.java
@@ -2,19 +2,21 @@ package com.sequenceiq.redbeams.metrics;
 
 import java.util.Optional;
 
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.common.metrics.AbstractMetricService;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
 
+@Primary
 @Service
 public class RedbeamsMetricService extends AbstractMetricService {
 
     private static final String METRIC_PREFIX = "redbeams";
 
     @Override
-    protected String getMetricPrefix() {
-        return METRIC_PREFIX;
+    protected Optional<String> getMetricPrefix() {
+        return Optional.of(METRIC_PREFIX);
     }
 
     public void incrementMetricCounter(MetricType metricType, Optional<DBStack> dbStack) {


### PR DESCRIPTION
The use of service specific prefixes makes it very cumbersome to handle metrics in Prometheus and Datadog.
- Common metric service added
- Prefixed metric services marked as @Primary to preserve the original behavior
- Quartz related metrics are handled by both  (prefixed and non-prefixed) metric services on a temporary basis until Prometheus rules and Datadog dashboards/monitors use the new metrics
- Fixed the quartz_job_count metric initalization

See detailed description in the commit message.