### PR TITLE
CB-20718 Outbound Load Balancer is created by default on new networks only

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/network/AzureNetworkV4Parameters.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/network/AzureNetworkV4Parameters.java
@@ -45,7 +45,7 @@ public class AzureNetworkV4Parameters extends MappableBase implements JsonEntity
     private String aksPrivateDnsZoneId;
 
     @ApiModelProperty
-    private boolean noOutboundLoadBalancer;
+    private Boolean noOutboundLoadBalancer;
 
     public Boolean getNoPublicIp() {
         return noPublicIp;
@@ -95,11 +95,11 @@ public class AzureNetworkV4Parameters extends MappableBase implements JsonEntity
         this.aksPrivateDnsZoneId = aksPrivateDnsZoneId;
     }
 
-    public boolean isNoOutboundLoadBalancer() {
+    public Boolean getNoOutboundLoadBalancer() {
         return noOutboundLoadBalancer;
     }
 
-    public void setNoOutboundLoadBalancer(boolean noOutboundLoadBalancer) {
+    public void setNoOutboundLoadBalancer(Boolean noOutboundLoadBalancer) {
         this.noOutboundLoadBalancer = noOutboundLoadBalancer;
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/AzureEnvironmentNetworkConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/AzureEnvironmentNetworkConverter.java
@@ -32,7 +32,7 @@ public class AzureEnvironmentNetworkConverter extends EnvironmentBaseNetworkConv
                 RESOURCE_GROUP_NAME, azure.getResourceGroupName(),
                 NO_PUBLIC_IP, azure.getNoPublicIp(),
                 DATABASE_PRIVATE_DNS_ZONE_ID, getDatabasePrivateDnsZoneId(azure),
-                NO_OUTBOUND_LOAD_BALANCER, azure.isNoOutboundLoadBalancer()
+                NO_OUTBOUND_LOAD_BALANCER, azure.getNoOutboundLoadBalancer()
         );
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/loadbalancer/LoadBalancerConfigService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/loadbalancer/LoadBalancerConfigService.java
@@ -272,8 +272,8 @@ public class LoadBalancerConfigService {
                 && LoadBalancerSku.STANDARD.equals(sku)
                 && !Optional.of(network)
                             .map(EnvironmentNetworkResponse::getAzure)
-                            .map(EnvironmentNetworkAzureParams::isNoOutboundLoadBalancer)
-                            .orElse(false);
+                            .map(EnvironmentNetworkAzureParams::getNoOutboundLoadBalancer)
+                            .orElse(network.isExistingNetwork());
     }
 
     private void setupLoadBalancer(boolean dryRun, Stack stack, Set<LoadBalancer> loadBalancers, TargetGroup targetGroup, LoadBalancerType type) {

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/NetworkV1ToNetworkV4Converter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/NetworkV1ToNetworkV4Converter.java
@@ -138,7 +138,7 @@ public class NetworkV1ToNetworkV4Converter {
             response.setResourceGroupName(networkAzureParams.getResourceGroupName());
             response.setDatabasePrivateDnsZoneId(networkAzureParams.getDatabasePrivateDnsZoneId());
             response.setAksPrivateDnsZoneId(networkAzureParams.getAksPrivateDnsZoneId());
-            response.setNoOutboundLoadBalancer(networkAzureParams.isNoOutboundLoadBalancer());
+            response.setNoOutboundLoadBalancer(networkAzureParams.getNoOutboundLoadBalancer());
             String subnetId = azureNetworkV1Parameters.getSubnetId();
             if (!Strings.isNullOrEmpty(subnetId)) {
                 response.setSubnetId(subnetId);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/AzureEnvironmentNetworkConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/AzureEnvironmentNetworkConverterTest.java
@@ -84,7 +84,7 @@ class AzureEnvironmentNetworkConverterTest {
         when(azure.getResourceGroupName()).thenReturn(RESOURCE_GROUP_NAME);
         when(azure.getNoPublicIp()).thenReturn(true);
         when(azure.getDatabasePrivateDnsZoneId()).thenReturn(DATABASE_PRIVATE_DNS_ZONE_ID);
-        when(azure.isNoOutboundLoadBalancer()).thenReturn(true);
+        when(azure.getNoOutboundLoadBalancer()).thenReturn(true);
 
         Map<String, Object> result = converter.getAttributesForLegacyNetwork(environmentNetworkResponse);
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/loadbalancer/LoadBalancerConfigServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/loadbalancer/LoadBalancerConfigServiceTest.java
@@ -143,7 +143,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
     void testCreateLoadBalancerForDataLakePrivateSubnets() {
         Stack stack = createAwsStack(StackType.DATALAKE, PRIVATE_ID_1);
         CloudSubnet subnet = getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1);
-        DetailedEnvironmentResponse environment = createEnvironment(subnet, false, "AWS");
+        DetailedEnvironmentResponse environment = createEnvironment(subnet, false, "AWS", true);
         StackV4Request request = new StackV4Request();
         request.setEnableLoadBalancer(false);
 
@@ -163,7 +163,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
     void testDisableLoadBalancer() {
         Stack stack = createAwsStack(StackType.DATALAKE, PUBLIC_ID_1);
         CloudSubnet subnet = getPublicCloudSubnet(PUBLIC_ID_1, AZ_1);
-        DetailedEnvironmentResponse environment = createEnvironment(subnet, false, "AWS");
+        DetailedEnvironmentResponse environment = createEnvironment(subnet, false, "AWS", true);
         environment.getNetwork().setLoadBalancerCreation(LoadBalancerCreation.DISABLED);
         StackV4Request request = new StackV4Request();
 
@@ -176,7 +176,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
     void testCreateLoadBalancerForDataLakePublicSubnets(boolean enablePublicEndpointGateway) {
         Stack stack = createAwsStack(StackType.DATALAKE, PUBLIC_ID_1);
         CloudSubnet subnet = getPublicCloudSubnet(PUBLIC_ID_1, AZ_1);
-        DetailedEnvironmentResponse environment = createEnvironment(subnet, enablePublicEndpointGateway, "AWS");
+        DetailedEnvironmentResponse environment = createEnvironment(subnet, enablePublicEndpointGateway, "AWS", true);
         StackV4Request request = new StackV4Request();
         request.setEnableLoadBalancer(false);
 
@@ -194,7 +194,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
     void testCreateLoadBalancerForYarn() {
         Stack stack = createYarnStack();
         CloudSubnet subnet = getPublicCloudSubnet(PUBLIC_ID_1, AZ_1);
-        DetailedEnvironmentResponse environment = createEnvironment(subnet, true, "YARN");
+        DetailedEnvironmentResponse environment = createEnvironment(subnet, true, "YARN", true);
         StackV4Request request = new StackV4Request();
         request.setEnableLoadBalancer(false);
 
@@ -209,7 +209,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
     @Test
     void testCreateLoadBalancerForDatahubPrivateSubnet() {
         Stack stack = createAwsStack(StackType.WORKLOAD, PRIVATE_ID_1);
-        DetailedEnvironmentResponse environment = createEnvironment(getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1), false, "AWS");
+        DetailedEnvironmentResponse environment = createEnvironment(getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1), false, "AWS", true);
         StackV4Request request = new StackV4Request();
         request.setEnableLoadBalancer(false);
         when(loadBalancerEnabler.isLoadBalancerEnabled(any(), any(), any(), anyBoolean())).thenReturn(false);
@@ -220,7 +220,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
     @Test
     void testCreateLoadBalancerForDataLakeEntitlementDisabled() {
         Stack stack = createAzureStack(StackType.DATALAKE, PRIVATE_ID_1, true);
-        DetailedEnvironmentResponse environment = createAzureEnvironment(getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1), false, false);
+        DetailedEnvironmentResponse environment = createAzureEnvironment(getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1), false, false, true);
         StackV4Request request = new StackV4Request();
         request.setEnableLoadBalancer(false);
 
@@ -232,7 +232,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
     void testCreateAWSLoadBalancerForDataLakeEntitlementDisabledPublicSubnets() {
         Stack stack = createAwsStack(StackType.DATALAKE, PUBLIC_ID_1);
         CloudSubnet subnet = getPublicCloudSubnet(PUBLIC_ID_1, AZ_1);
-        DetailedEnvironmentResponse environment = createEnvironment(subnet, true, "AWS");
+        DetailedEnvironmentResponse environment = createEnvironment(subnet, true, "AWS", true);
         environment.setCloudPlatform(CloudPlatform.AWS.name());
         StackV4Request request = new StackV4Request();
         request.setEnableLoadBalancer(false);
@@ -251,7 +251,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
     void testCreateAWSLoadBalancerForDataLakeEntitlementDisabledPrivateSubnets() {
         Stack stack = createAwsStack(StackType.DATALAKE, PRIVATE_ID_1);
         CloudSubnet subnet = getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1);
-        DetailedEnvironmentResponse environment = createEnvironment(subnet, false, "AWS");
+        DetailedEnvironmentResponse environment = createEnvironment(subnet, false, "AWS", true);
         environment.setCloudPlatform(CloudPlatform.AWS.name());
         StackV4Request request = new StackV4Request();
         request.setEnableLoadBalancer(false);
@@ -275,7 +275,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
     void testCreateLoadBalancersForEndpointGateway(StackType stackType) {
         Stack stack = createAwsStack(stackType, PRIVATE_ID_1);
         CloudSubnet subnet = getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1);
-        DetailedEnvironmentResponse environment = createEnvironment(subnet, true, "AWS");
+        DetailedEnvironmentResponse environment = createEnvironment(subnet, true, "AWS", true);
         StackV4Request request = new StackV4Request();
         request.setEnableLoadBalancer(false);
 
@@ -294,7 +294,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
     void testCreateLoadBalancersForDatahubWithPublicSubnet() {
         Stack stack = createAwsStack(StackType.WORKLOAD, PUBLIC_ID_1);
         CloudSubnet subnet = getPublicCloudSubnet(PUBLIC_ID_1, AZ_1);
-        DetailedEnvironmentResponse environment = createEnvironment(subnet, false, "AWS");
+        DetailedEnvironmentResponse environment = createEnvironment(subnet, false, "AWS", true);
         StackV4Request request = new StackV4Request();
         request.setEnableLoadBalancer(true);
 
@@ -312,7 +312,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
     void testCreateLoadBalancersForDatahubWithPrivateSubnet() {
         Stack stack = createAwsStack(StackType.WORKLOAD, PRIVATE_ID_1);
         CloudSubnet subnet = getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1);
-        DetailedEnvironmentResponse environment = createEnvironment(subnet, false, "AWS");
+        DetailedEnvironmentResponse environment = createEnvironment(subnet, false, "AWS", true);
         StackV4Request request = new StackV4Request();
         request.setEnableLoadBalancer(true);
 
@@ -330,7 +330,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
     void testCreateLoadBalancersForEndpointGatewayDatalakePublicSubnetsOnly() {
         Stack stack = createAwsStack(StackType.DATALAKE, PUBLIC_ID_1);
         CloudSubnet subnet = getPublicCloudSubnet(PUBLIC_ID_1, AZ_1);
-        DetailedEnvironmentResponse environment = createEnvironment(subnet, true, "AWS");
+        DetailedEnvironmentResponse environment = createEnvironment(subnet, true, "AWS", true);
         StackV4Request request = new StackV4Request();
         request.setEnableLoadBalancer(false);
 
@@ -347,7 +347,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
     @Test
     void testCreateLoadBalancersUnsupportedStackType() {
         Stack stack1 = createAwsStack(StackType.TEMPLATE, PRIVATE_ID_1);
-        DetailedEnvironmentResponse environment = createEnvironment(getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1), true, "AWS");
+        DetailedEnvironmentResponse environment = createEnvironment(getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1), true, "AWS", true);
         StackV4Request request = new StackV4Request();
         request.setEnableLoadBalancer(false);
 
@@ -373,7 +373,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
     @Test
     void testCreateLoadBalancersEndpointGatewayNullNetwork() {
         Stack stack = createAwsStack(StackType.DATALAKE, PUBLIC_ID_1);
-        DetailedEnvironmentResponse environment = createEnvironment(getPrivateCloudSubnet(PUBLIC_ID_1, AZ_1), true, "AWS");
+        DetailedEnvironmentResponse environment = createEnvironment(getPrivateCloudSubnet(PUBLIC_ID_1, AZ_1), true, "AWS", true);
         environment.setNetwork(null);
         StackV4Request request = new StackV4Request();
         request.setEnableLoadBalancer(false);
@@ -387,7 +387,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
         Stack stack = createAwsStack(StackType.DATALAKE, null);
         stack.setNetwork(null);
         CloudSubnet subnet = getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1);
-        DetailedEnvironmentResponse environment = createEnvironment(subnet, false, "AWS");
+        DetailedEnvironmentResponse environment = createEnvironment(subnet, false, "AWS", true);
         StackV4Request request = new StackV4Request();
         request.setEnableLoadBalancer(false);
 
@@ -400,7 +400,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
         Stack stack = createAwsStack(StackType.DATALAKE, null);
         stack.getNetwork().setAttributes(null);
         CloudSubnet subnet = getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1);
-        DetailedEnvironmentResponse environment = createEnvironment(subnet, false, "AWS");
+        DetailedEnvironmentResponse environment = createEnvironment(subnet, false, "AWS", true);
         StackV4Request request = new StackV4Request();
         request.setEnableLoadBalancer(false);
 
@@ -412,7 +412,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
     void testCreateLoadBalancerNoSubnetSpecified() {
         Stack stack = createAwsStack(StackType.DATALAKE, null);
         CloudSubnet subnet = getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1);
-        DetailedEnvironmentResponse environment = createEnvironment(subnet, false, "AWS");
+        DetailedEnvironmentResponse environment = createEnvironment(subnet, false, "AWS", true);
         StackV4Request request = new StackV4Request();
         request.setEnableLoadBalancer(false);
 
@@ -435,7 +435,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
         Stack stack = createAwsStack(StackType.DATALAKE, PRIVATE_ID_1);
         stack.setCloudPlatform(GCP);
         CloudSubnet subnet = getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1);
-        DetailedEnvironmentResponse environment = createEnvironment(subnet, false, "GCP");
+        DetailedEnvironmentResponse environment = createEnvironment(subnet, false, "GCP", true);
         StackV4Request request = new StackV4Request();
         request.setEnableLoadBalancer(false);
 
@@ -447,7 +447,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
     void testCreateLoadBalancerDryRun() {
         Stack stack = createAwsStack(StackType.DATALAKE, PRIVATE_ID_1);
         CloudSubnet subnet = getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1);
-        DetailedEnvironmentResponse environment = createEnvironment(subnet, false, "AWS");
+        DetailedEnvironmentResponse environment = createEnvironment(subnet, false, "AWS", true);
 
         when(subnetSelector.findSubnetById(any(), anyString())).thenReturn(Optional.of(subnet));
         when(knoxGroupDeterminer.getKnoxGatewayGroupNames(stack)).thenReturn(Set.of("master"));
@@ -463,7 +463,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
     void testCreateAzurePrivateLoadBalancer() {
         Stack stack = createAzureStack(StackType.DATALAKE, PRIVATE_ID_1, true);
         CloudSubnet subnet = getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1);
-        DetailedEnvironmentResponse environment = createAzureEnvironment(subnet, true, false);
+        DetailedEnvironmentResponse environment = createAzureEnvironment(subnet, true, false, true);
         StackV4Request request = new StackV4Request();
         request.setEnableLoadBalancer(false);
 
@@ -489,7 +489,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
     void testCreateAzurePublicLoadBalancer() {
         Stack stack = createAzureStack(StackType.DATALAKE, PUBLIC_ID_1, false);
         CloudSubnet subnet = getPublicCloudSubnet(PUBLIC_ID_1, AZ_1);
-        DetailedEnvironmentResponse environment = createAzureEnvironment(subnet, true, false);
+        DetailedEnvironmentResponse environment = createAzureEnvironment(subnet, true, false, true);
         StackV4Request request = new StackV4Request();
         request.setEnableLoadBalancer(false);
 
@@ -513,7 +513,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
     void testCreateAzurePrivateLoadBalancerWithOozieHA() {
         Stack stack = createAzureStack(StackType.DATALAKE, PRIVATE_ID_1, true);
         CloudSubnet subnet = getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1);
-        DetailedEnvironmentResponse environment = createAzureEnvironment(subnet, false, false);
+        DetailedEnvironmentResponse environment = createAzureEnvironment(subnet, false, false, true);
         StackV4Request request = new StackV4Request();
         request.setEnableLoadBalancer(false);
 
@@ -540,7 +540,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
     void testAzureLoadBalancerDisabledWithOozieHA() {
         Stack stack = createAzureStack(StackType.DATALAKE, PRIVATE_ID_1, true);
         CloudSubnet subnet = getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1);
-        DetailedEnvironmentResponse environment = createAzureEnvironment(subnet, false, false);
+        DetailedEnvironmentResponse environment = createAzureEnvironment(subnet, false, false, true);
         AzureStackV4Parameters azureParameters = new AzureStackV4Parameters();
         azureParameters.setLoadBalancerSku(LoadBalancerSku.NONE);
         StackV4Request request = new StackV4Request();
@@ -557,7 +557,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
     void testCreateAzureEndpointGateway() {
         Stack stack = createAzureStack(StackType.DATALAKE, PRIVATE_ID_1, true);
         CloudSubnet subnet = getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1);
-        DetailedEnvironmentResponse environment = createAzureEnvironment(subnet, true, false);
+        DetailedEnvironmentResponse environment = createAzureEnvironment(subnet, true, false, true);
         StackV4Request request = new StackV4Request();
         request.setEnableLoadBalancer(false);
 
@@ -579,7 +579,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
     void testCreateAzureLoadBalancerWithSkuSetToStandard() {
         Stack stack = createAzureStack(StackType.DATALAKE, PRIVATE_ID_1, true);
         CloudSubnet subnet = getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1);
-        DetailedEnvironmentResponse environment = createAzureEnvironment(subnet, false, false);
+        DetailedEnvironmentResponse environment = createAzureEnvironment(subnet, false, false, true);
         AzureStackV4Parameters azureParameters = new AzureStackV4Parameters();
         azureParameters.setLoadBalancerSku(LoadBalancerSku.STANDARD);
         StackV4Request request = new StackV4Request();
@@ -609,7 +609,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
     void testCreateAzureLoadBalancerWithSkuSetToBasic() {
         Stack stack = createAzureStack(StackType.DATALAKE, PRIVATE_ID_1, true);
         CloudSubnet subnet = getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1);
-        DetailedEnvironmentResponse environment = createAzureEnvironment(subnet, false, false);
+        DetailedEnvironmentResponse environment = createAzureEnvironment(subnet, false, false, true);
         AzureStackV4Parameters azureParameters = new AzureStackV4Parameters();
         azureParameters.setLoadBalancerSku(LoadBalancerSku.BASIC);
         StackV4Request request = new StackV4Request();
@@ -638,7 +638,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
     void testCreateAzureLoadBalancerSelectsDefaultWhenSkuIsNotSet() {
         Stack stack = createAzureStack(StackType.DATALAKE, PRIVATE_ID_1, true);
         CloudSubnet subnet = getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1);
-        DetailedEnvironmentResponse environment = createAzureEnvironment(subnet, false, false);
+        DetailedEnvironmentResponse environment = createAzureEnvironment(subnet, false, false, true);
         StackV4Request request = new StackV4Request();
         request.setEnableLoadBalancer(false);
 
@@ -670,7 +670,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
     void testAzureLoadBalancerDisabled() {
         Stack stack = createAzureStack(StackType.DATALAKE, PRIVATE_ID_1, true);
         CloudSubnet subnet = getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1);
-        DetailedEnvironmentResponse environment = createAzureEnvironment(subnet, false, false);
+        DetailedEnvironmentResponse environment = createAzureEnvironment(subnet, false, false, true);
         AzureStackV4Parameters azureParameters = new AzureStackV4Parameters();
         azureParameters.setLoadBalancerSku(LoadBalancerSku.NONE);
         StackV4Request request = new StackV4Request();
@@ -719,7 +719,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
     void testCreateAzureMultipleKnoxInstanceGroups() {
         Stack stack = createAzureStack(StackType.DATALAKE, PRIVATE_ID_1, true);
         CloudSubnet subnet = getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1);
-        DetailedEnvironmentResponse environment = createAzureEnvironment(subnet, false, false);
+        DetailedEnvironmentResponse environment = createAzureEnvironment(subnet, false, false, true);
         StackV4Request request = new StackV4Request();
         request.setEnableLoadBalancer(false);
 
@@ -734,7 +734,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
     void isDatalakeLoadBalancerEntitlementEnabled() {
         Stack azureStack = createAzureStack(StackType.DATALAKE, PRIVATE_ID_1, true);
         CloudSubnet subnet = getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1);
-        DetailedEnvironmentResponse environment = createAzureEnvironment(subnet, false, false);
+        DetailedEnvironmentResponse environment = createAzureEnvironment(subnet, false, false, true);
         Set<LoadBalancer> loadBalancers = underTest.setupLoadBalancers(azureStack, environment, false, true, LoadBalancerSku.BASIC);
         assertEquals(new HashSet<>(), loadBalancers);
     }
@@ -743,7 +743,7 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
     void testCreateAzureLoadBalancerWithoutOutboundLoadBalancer() {
         Stack stack = createAzureStack(StackType.DATALAKE, PRIVATE_ID_1, true);
         CloudSubnet subnet = getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1);
-        DetailedEnvironmentResponse environment = createAzureEnvironment(subnet, false, true);
+        DetailedEnvironmentResponse environment = createAzureEnvironment(subnet, false, true, true);
         AzureStackV4Parameters azureParameters = new AzureStackV4Parameters();
         azureParameters.setLoadBalancerSku(LoadBalancerSku.STANDARD);
         StackV4Request request = new StackV4Request();
@@ -766,6 +766,35 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
         assertEquals(1, masterInstanceGroup.getTargetGroups().size());
         assertTrue(loadBalancers.stream().allMatch(l -> LoadBalancerSku.STANDARD.equals(l.getSku())));
 
+        checkAvailabilitySetAttributes(loadBalancers);
+    }
+
+    @Test
+    void testWhenNewNetworkIsCreatedShouldEnableOutboundLoadBalancerByDefault() {
+        Stack stack = createAzureStack(StackType.DATALAKE, PRIVATE_ID_1, true);
+        CloudSubnet subnet = getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1);
+        DetailedEnvironmentResponse environment = createAzureEnvironment(subnet, false, null, false);
+        AzureStackV4Parameters azureParameters = new AzureStackV4Parameters();
+        azureParameters.setLoadBalancerSku(LoadBalancerSku.STANDARD);
+        StackV4Request request = new StackV4Request();
+        request.setAzure(azureParameters);
+
+        when(subnetSelector.findSubnetById(any(), anyString())).thenReturn(Optional.of(subnet));
+        when(availabilitySetNameService.generateName(any(), any())).thenReturn("");
+        when(knoxGroupDeterminer.getKnoxGatewayGroupNames(stack)).thenReturn(Set.of("master"));
+        when(loadBalancerEnabler.isLoadBalancerEnabled(any(), any(), any(), anyBoolean())).thenReturn(true);
+        when(loadBalancerEnabler.isEndpointGatewayEnabled(ACCOUNT_ID, environment.getNetwork())).thenReturn(false);
+
+        Set<LoadBalancer> loadBalancers = underTest.createLoadBalancers(stack, environment, request);
+
+        assertEquals(2, loadBalancers.size());
+        assertTrue(loadBalancers.stream().allMatch(l -> LoadBalancerSku.STANDARD.equals(l.getSku())));
+        assertTrue(loadBalancers.stream().anyMatch(l -> LoadBalancerType.PRIVATE.equals(l.getType())));
+        assertTrue(loadBalancers.stream().anyMatch(l -> LoadBalancerType.OUTBOUND.equals(l.getType())));
+        InstanceGroup masterInstanceGroup = stack.getInstanceGroups().stream()
+                .filter(ig -> "master".equals(ig.getGroupName()))
+                .findFirst().get();
+        assertEquals(1, masterInstanceGroup.getTargetGroups().size());
         checkAvailabilitySetAttributes(loadBalancers);
     }
 
@@ -880,9 +909,10 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
         return stack;
     }
 
-    private DetailedEnvironmentResponse createEnvironment(CloudSubnet subnet, boolean enableEndpointGateway, String cloudPlatform) {
+    private DetailedEnvironmentResponse createEnvironment(CloudSubnet subnet, boolean enableEndpointGateway, String cloudPlatform, boolean existingNetwork) {
         EnvironmentNetworkResponse network = new EnvironmentNetworkResponse();
         network.setSubnetMetas(Map.of("key", subnet));
+        network.setExistingNetwork(existingNetwork);
         if (enableEndpointGateway) {
             network.setPublicEndpointAccessGateway(PublicEndpointAccessGateway.ENABLED);
         }
@@ -893,8 +923,9 @@ class LoadBalancerConfigServiceTest extends SubnetTest {
         return environment;
     }
 
-    private DetailedEnvironmentResponse createAzureEnvironment(CloudSubnet subnet, boolean enableEndpointGateway, boolean noOutboundLoadBalancer) {
-        DetailedEnvironmentResponse environment = createEnvironment(subnet, enableEndpointGateway, AZURE);
+    private DetailedEnvironmentResponse createAzureEnvironment(CloudSubnet subnet, boolean enableEndpointGateway,
+            Boolean noOutboundLoadBalancer, boolean existingNetwork) {
+        DetailedEnvironmentResponse environment = createEnvironment(subnet, enableEndpointGateway, AZURE, existingNetwork);
         EnvironmentNetworkAzureParams azureParameters = EnvironmentNetworkAzureParams.EnvironmentNetworkAzureParamsBuilder
                 .anEnvironmentNetworkAzureParams()
                 .withNoOutboundLoadBalancer(noOutboundLoadBalancer)

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/NetworkV1ToNetworkV4ConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/NetworkV1ToNetworkV4ConverterTest.java
@@ -207,7 +207,7 @@ class NetworkV1ToNetworkV4ConverterTest {
         assertEquals(networkV4Request.createAzure().getNetworkId(), VPC_ID);
         assertEquals(networkV4Request.createAzure().getResourceGroupName(), GROUP_NAME);
         assertEquals(networkV4Request.createAzure().getSubnetId(), SUBNET_ID);
-        assertEquals(networkV4Request.createAzure().isNoOutboundLoadBalancer(), NO_OUTBOUND_LOAD_BALANCER);
+        assertEquals(networkV4Request.createAzure().getNoOutboundLoadBalancer(), NO_OUTBOUND_LOAD_BALANCER);
     }
 
     @Test
@@ -222,7 +222,7 @@ class NetworkV1ToNetworkV4ConverterTest {
         assertEquals(networkV4Request.createAzure().getNetworkId(), VPC_ID);
         assertEquals(networkV4Request.createAzure().getResourceGroupName(), GROUP_NAME);
         assertTrue(SUBNET_IDS.contains(networkV4Request.createAzure().getSubnetId()));
-        assertEquals(networkV4Request.createAzure().isNoOutboundLoadBalancer(), NO_OUTBOUND_LOAD_BALANCER);
+        assertEquals(networkV4Request.createAzure().getNoOutboundLoadBalancer(), NO_OUTBOUND_LOAD_BALANCER);
     }
 
     @Test

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/EnvironmentNetworkAzureParams.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/EnvironmentNetworkAzureParams.java
@@ -37,7 +37,7 @@ public class EnvironmentNetworkAzureParams {
     private Boolean noPublicIp;
 
     @ApiModelProperty(EnvironmentModelDescription.NO_OUTBOUND_LOAD_BALANCER)
-    private boolean noOutboundLoadBalancer;
+    private Boolean noOutboundLoadBalancer;
 
     public String getNetworkId() {
         return networkId;
@@ -79,11 +79,11 @@ public class EnvironmentNetworkAzureParams {
         this.aksPrivateDnsZoneId = aksPrivateDnsZoneId;
     }
 
-    public boolean isNoOutboundLoadBalancer() {
+    public Boolean getNoOutboundLoadBalancer() {
         return noOutboundLoadBalancer;
     }
 
-    public void setNoOutboundLoadBalancer(boolean noOutboundLoadBalancer) {
+    public void setNoOutboundLoadBalancer(Boolean noOutboundLoadBalancer) {
         this.noOutboundLoadBalancer = noOutboundLoadBalancer;
     }
 
@@ -110,7 +110,7 @@ public class EnvironmentNetworkAzureParams {
 
         private String aksPrivateDnsZoneId;
 
-        private boolean noOutboundLoadBalancer;
+        private Boolean noOutboundLoadBalancer;
 
         private EnvironmentNetworkAzureParamsBuilder() {
         }
@@ -144,7 +144,7 @@ public class EnvironmentNetworkAzureParams {
             return this;
         }
 
-        public EnvironmentNetworkAzureParamsBuilder withNoOutboundLoadBalancer(boolean noOutboundLoadBalancer) {
+        public EnvironmentNetworkAzureParamsBuilder withNoOutboundLoadBalancer(Boolean noOutboundLoadBalancer) {
             this.noOutboundLoadBalancer = noOutboundLoadBalancer;
             return this;
         }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/NetworkDtoToResponseConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/NetworkDtoToResponseConverter.java
@@ -62,7 +62,7 @@ public class NetworkDtoToResponseConverter {
                         .withNoPublicIp(p.isNoPublicIp())
                         .withDatabasePrivateDnsZoneId(p.getDatabasePrivateDnsZoneId())
                         .withAksPrivateDnsZoneId(p.getAksPrivateDnsZoneId())
-                        .withNoOutboundLoadBalancer(p.isNoOutboundLoadBalancer())
+                        .withNoOutboundLoadBalancer(p.getNoOutboundLoadBalancer())
                         .build()))
                 .withGcp(getIfNotNull(network.getGcp(), p -> EnvironmentNetworkGcpParams.EnvironmentNetworkGcpParamsBuilder
                         .anEnvironmentNetworkGcpParamsBuilder()

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/NetworkRequestToDtoConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/NetworkRequestToDtoConverter.java
@@ -47,7 +47,7 @@ public class NetworkRequestToDtoConverter {
                     .withResourceGroupName(network.getAzure().getResourceGroupName())
                     .withDatabasePrivateDnsZoneId(network.getAzure().getDatabasePrivateDnsZoneId())
                     .withAksPrivateDnsZoneId(network.getAzure().getAksPrivateDnsZoneId())
-                    .withNoOutboundLoadBalancer(network.getAzure().isNoOutboundLoadBalancer())
+                    .withNoOutboundLoadBalancer(network.getAzure().getNoOutboundLoadBalancer())
                     .build();
             builder.withAzure(azureParams);
             builder.withNetworkId(network.getAzure().getNetworkId());

--- a/environment/src/main/java/com/sequenceiq/environment/network/dao/domain/AzureNetwork.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/dao/domain/AzureNetwork.java
@@ -16,7 +16,7 @@ public class AzureNetwork extends BaseNetwork {
 
     private String aksPrivateDnsZoneId;
 
-    private boolean noOutboundLoadBalancer;
+    private Boolean noOutboundLoadBalancer;
 
     @Override
     public String getNetworkId() {
@@ -59,11 +59,11 @@ public class AzureNetwork extends BaseNetwork {
         this.aksPrivateDnsZoneId = aksPrivateDnsZoneId;
     }
 
-    public boolean isNoOutboundLoadBalancer() {
+    public Boolean getNoOutboundLoadBalancer() {
         return noOutboundLoadBalancer;
     }
 
-    public void setNoOutboundLoadBalancer(boolean noOutboundLoadBalancer) {
+    public void setNoOutboundLoadBalancer(Boolean noOutboundLoadBalancer) {
         this.noOutboundLoadBalancer = noOutboundLoadBalancer;
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/network/v1/converter/AzureEnvironmentNetworkConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/v1/converter/AzureEnvironmentNetworkConverter.java
@@ -49,7 +49,7 @@ public class AzureEnvironmentNetworkConverter extends EnvironmentBaseNetworkConv
             azureNetwork.setResourceGroupName(azureParams.getResourceGroupName());
             azureNetwork.setNoPublicIp(azureParams.isNoPublicIp());
             azureNetwork.setAksPrivateDnsZoneId(azureParams.getAksPrivateDnsZoneId());
-            azureNetwork.setNoOutboundLoadBalancer(azureParams.isNoOutboundLoadBalancer());
+            azureNetwork.setNoOutboundLoadBalancer(azureParams.getNoOutboundLoadBalancer());
             if (ServiceEndpointCreation.ENABLED_PRIVATE_ENDPOINT.equals(network.getServiceEndpointCreation())) {
                 azureNetwork.setDatabasePrivateDnsZoneId(azureParams.getDatabasePrivateDnsZoneId());
             }
@@ -104,7 +104,7 @@ public class AzureEnvironmentNetworkConverter extends EnvironmentBaseNetworkConv
                                 .withNoPublicIp(azureNetwork.getNoPublicIp())
                                 .withDatabasePrivateDnsZoneId(azureNetwork.getDatabasePrivateDnsZoneId())
                                 .withAksPrivateDnsZoneId(azureNetwork.getAksPrivateDnsZoneId())
-                                .withNoOutboundLoadBalancer(azureNetwork.isNoOutboundLoadBalancer())
+                                .withNoOutboundLoadBalancer(azureNetwork.getNoOutboundLoadBalancer())
                                 .build())
                 .build();
     }
@@ -137,7 +137,7 @@ public class AzureEnvironmentNetworkConverter extends EnvironmentBaseNetworkConv
         param.put(NETWORK_ID, azureNetwork.getNetworkId());
         param.put(DATABASE_PRIVATE_DNS_ZONE_ID, azureNetwork.getDatabasePrivateDnsZoneId());
         param.put(AKS_PRIVATE_DNS_ZONE_ID, azureNetwork.getAksPrivateDnsZoneId());
-        param.put(NO_OUTBOUND_LOAD_BALANCER, azureNetwork.isNoOutboundLoadBalancer());
+        param.put(NO_OUTBOUND_LOAD_BALANCER, azureNetwork.getNoOutboundLoadBalancer());
         return new Network(null, param);
     }
 }

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/NetworkDtoToResponseConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/NetworkDtoToResponseConverterTest.java
@@ -72,7 +72,7 @@ public class NetworkDtoToResponseConverterTest {
         assertEquals(network.getAzure().getResourceGroupName(), actual.getAzure().getResourceGroupName());
         assertEquals(network.getAzure().getDatabasePrivateDnsZoneId(), actual.getAzure().getDatabasePrivateDnsZoneId());
         assertEquals(network.getAzure().getAksPrivateDnsZoneId(), actual.getAzure().getAksPrivateDnsZoneId());
-        assertEquals(network.getAzure().isNoOutboundLoadBalancer(), actual.getAzure().isNoOutboundLoadBalancer());
+        assertEquals(network.getAzure().getNoOutboundLoadBalancer(), actual.getAzure().getNoOutboundLoadBalancer());
         assertNull(actual.getAws());
         assertNull(actual.getYarn());
         assertNull(actual.getMock());

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/NetworkRequestToDtoConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/NetworkRequestToDtoConverterTest.java
@@ -64,7 +64,7 @@ public class NetworkRequestToDtoConverterTest {
         assertEquals(network.getAzure().getNoPublicIp(), actual.getAzure().isNoPublicIp());
         assertEquals(network.getAzure().getDatabasePrivateDnsZoneId(), actual.getAzure().getDatabasePrivateDnsZoneId());
         assertEquals(network.getAzure().getAksPrivateDnsZoneId(), actual.getAzure().getAksPrivateDnsZoneId());
-        assertEquals(network.getAzure().isNoOutboundLoadBalancer(), actual.getAzure().isNoOutboundLoadBalancer());
+        assertEquals(network.getAzure().getNoOutboundLoadBalancer(), actual.getAzure().getNoOutboundLoadBalancer());
         assertCommonFields(network, actual);
     }
 

--- a/structuredevent-model/src/main/java/com/sequenceiq/environment/network/dto/AzureParams.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/environment/network/dto/AzureParams.java
@@ -16,7 +16,7 @@ public class AzureParams {
 
     private String aksPrivateDnsZoneId;
 
-    private boolean noOutboundLoadBalancer;
+    private Boolean noOutboundLoadBalancer;
 
     private AzureParams(Builder builder) {
         networkId = builder.networkId;
@@ -67,11 +67,11 @@ public class AzureParams {
         this.aksPrivateDnsZoneId = aksPrivateDnsZoneId;
     }
 
-    public boolean isNoOutboundLoadBalancer() {
+    public Boolean getNoOutboundLoadBalancer() {
         return noOutboundLoadBalancer;
     }
 
-    public void setNoOutboundLoadBalancer(boolean noOutboundLoadBalancer) {
+    public void setNoOutboundLoadBalancer(Boolean noOutboundLoadBalancer) {
         this.noOutboundLoadBalancer = noOutboundLoadBalancer;
     }
 
@@ -103,7 +103,7 @@ public class AzureParams {
 
         private String aksPrivateDnsZoneId;
 
-        private boolean noOutboundLoadBalancer;
+        private Boolean noOutboundLoadBalancer;
 
         private Builder() {
         }
@@ -133,7 +133,7 @@ public class AzureParams {
             return this;
         }
 
-        public Builder withNoOutboundLoadBalancer(boolean noOutboundLoadBalancer) {
+        public Builder withNoOutboundLoadBalancer(Boolean noOutboundLoadBalancer) {
             this.noOutboundLoadBalancer = noOutboundLoadBalancer;
             return this;
         }


### PR DESCRIPTION
Context: Azure outbound load balancer should be created by default if the network is new and shouldn't be created if the network already exists. In both cases, the user can change this behavior.

Test:
Create new environments and check with CLI describe-datalake the number and types of the load balancer created.

Request with existing network:
`{
	"name": "env-az-ex-net",
	"credentialName": "rod-local-cred",
	"regions": ["West US 2"],
	"location": {
		"name": "West US 2"
	},
	"network": {
		"subnetIds": ["sdx-daily.internal.0.westus2"],
		"serviceEndpointCreation": "ENABLED",
		"publicEndpointAccessGateway": "DISABLED",
		"azure": {
			"networkId": "sdx-daily",
			"resourceGroupName": "sdx-daily",
			"noPublicIp": true
		}
	},
	"telemetry": {
		"logging": {
			"storageLocation": "abfs://data@rodnewlocalsan.dfs.core.windows.net",
			"adlsGen2": {
				"managedIdentity": "/subscriptions/94359766-1315-49e2-b5da-7578f428b58b/resourcegroups/rod-new-local-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/loggerIdentity"
			}
		},
		"features": {}
	},
	"authentication": {
		"publicKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDEyHedSTmrdbtoh0ys0iNVK6M9tOQrzUk6F1GVVvBnz+9fGtEpy3Y4AJZOU/qWZzcktjHZl06tpRPLfRqs5fEYJVndsB7+nXOadsOL1XASlWDdTSEwYBuD4pQweoNuxVbE2INJsASLAL76wNnfHWz1sUPGXGkM7io9aPVjePQB7KaC+0f//6dtcsOY/1fBXXJhpc20/RvWQwzfN04rDKk5RF1zjbKpsuULO8xfiIqpjmPkHeVHK4OjExafGpN8BtjEWC8oVhrMpAj1L8N/mpJBCJKacTDBlgglSgGPc9W7Hf3Y1EeGGBMy5wHBCQ03t0ystOqBnsvDLqH5yf+OWuEp"
	},
	"freeIpa": {
		"create": true,
		"instanceCountByGroup": 2
	},
	"securityAccess": {
		"cidr": "0.0.0.0/0"
	},
	"tunnel": "DIRECT",
	"overrideTunnel": false,
	"azure": {
		"resourceGroup": {
			"name": "rod-default-rg",
			"resourceGroupUsage": "SINGLE"
		}
	},
	"tags": {
		"owner": "ralves",
        "project": "SDX"
	}
}`

Request with new network:
`{
	"name": "env-az-new-net-default",
	"credentialName": "rod-local-cred",
	"regions": ["West US 2"],
	"location": {
		"name": "West US 2"
	},
	"network": {
		"networkCidr": "10.10.0.0/16",
		"serviceEndpointCreation": "ENABLED",
		"publicEndpointAccessGateway": "DISABLED",
		"azure": {
			"noPublicIp": true
		}
	},
	"telemetry": {
		"logging": {
			"storageLocation": "abfs://data@roddefaultsan.dfs.core.windows.net",
			"adlsGen2": {
				"managedIdentity": "/subscriptions/94359766-1315-49e2-b5da-7578f428b58b/resourcegroups/rod-default-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/loggerIdentity"
			}
		},
		"features": {}
	},
	"authentication": {
		"publicKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDEyHedSTmrdbtoh0ys0iNVK6M9tOQrzUk6F1GVVvBnz+9fGtEpy3Y4AJZOU/qWZzcktjHZl06tpRPLfRqs5fEYJVndsB7+nXOadsOL1XASlWDdTSEwYBuD4pQweoNuxVbE2INJsASLAL76wNnfHWz1sUPGXGkM7io9aPVjePQB7KaC+0f//6dtcsOY/1fBXXJhpc20/RvWQwzfN04rDKk5RF1zjbKpsuULO8xfiIqpjmPkHeVHK4OjExafGpN8BtjEWC8oVhrMpAj1L8N/mpJBCJKacTDBlgglSgGPc9W7Hf3Y1EeGGBMy5wHBCQ03t0ystOqBnsvDLqH5yf+OWuEp"
	},
	"freeIpa": {
		"create": true,
		"instanceCountByGroup": 2
	},
	"securityAccess": {
		"cidr": "0.0.0.0/0"
	},
	"tunnel": "DIRECT",
	"overrideTunnel": false,
	"azure": {
		"resourceGroup": {
			"name": "rod-default-rg",
			"resourceGroupUsage": "SINGLE"
		}
	},
	"tags": {
		"owner": "ralves",
        "project": "SDX"
	}
}`
