### PR TITLE
CB-20813 Fix the double slashes issue for permission precheck failure message

### DIFF
--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/util/AwsIamService.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/util/AwsIamService.java
@@ -152,6 +152,10 @@ public class AwsIamService {
         if (replacedTemplate != null) {
             for (Entry<String, String> replacement : replacements.entrySet()) {
                 String replacementValue = replacement.getValue() != null ? replacement.getValue() : "";
+                // Remove the ending "/" of a backup location so path with "*" will not have duplicated "/".
+                if (replacement.getKey().equals("${BACKUP_LOCATION_BASE}") && replacementValue.endsWith("/")) {
+                    replacementValue = replacementValue.substring(0, replacementValue.length() - 1);
+                }
                 replacedTemplate = replacedTemplate.replace(replacement.getKey(), replacementValue);
             }
         }

--- a/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/util/AwsIamServiceTest.java
+++ b/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/util/AwsIamServiceTest.java
@@ -219,6 +219,19 @@ public class AwsIamServiceTest {
                 Map.entry("ghi", "jkl")
         );
         assertThat(awsIamService.handleTemplateReplacements("abc ghi", replacements)).isEqualTo("def jkl");
+
+        // Test for backup/restore having location with/without ending slash.
+        assertThat(awsIamService.handleTemplateReplacements("${BACKUP_LOCATION_BASE}/*",
+                Collections.singletonMap("${BACKUP_LOCATION_BASE}", "abc/"))).isEqualTo("abc/*");
+        assertThat(awsIamService.handleTemplateReplacements("${BACKUP_LOCATION_BASE}/",
+                Collections.singletonMap("${BACKUP_LOCATION_BASE}", "abc/"))).isEqualTo("abc/");
+        assertThat(awsIamService.handleTemplateReplacements("${BACKUP_LOCATION_BASE}",
+                Collections.singletonMap("${BACKUP_LOCATION_BASE}", "abc/"))).isEqualTo("abc");
+        assertThat(awsIamService.handleTemplateReplacements("${BACKUP_LOCATION_BASE}",
+                Collections.singletonMap("${BACKUP_LOCATION_BASE}", "abc"))).isEqualTo("abc");
+        // Non-backup/restore policy is not be impacted on if the ending slash will be removed or not.
+        assertThat(awsIamService.handleTemplateReplacements("${TEST}/*", Collections.singletonMap("${TEST}", "abc/")))
+                .isEqualTo("abc//*");
     }
 
     @Test


### PR DESCRIPTION
JIRA: [CB-20813](https://jira.cloudera.com/browse/CB-20813) 
**Root cause:** The location passed in already ended with "/" and the template has a "/" as well, resulting in double slashes. 
<img width="599" alt="Screen Shot 2023-02-03 at 8 40 49 PM" src="https://user-images.githubusercontent.com/39275944/216739712-37ee3492-2181-440b-9113-a04d6726b6e4.png">
**Solution:** For backup/restore, If the location passed in ends with "/", we will remove that "/". 
**Before:**
<img width="1711" alt="Screen Shot 2023-02-03 at 8 48 04 PM" src="https://user-images.githubusercontent.com/39275944/216741792-45606463-c4f5-4d51-a7c2-147643776e72.png">

**After:** (The new line formatting issue will be handled by [CDPSDX-3700](https://jira.cloudera.com/browse/CDPSDX-3700) since the fix is in TH.  
<img width="1709" alt="Screen Shot 2023-02-03 at 9 30 25 PM" src="https://user-images.githubusercontent.com/39275944/216741847-c3b68267-266d-48b2-b3df-59f7c62053a9.png">


