### PR TITLE
CB-20429 Call WIAM for usersync on environment start

### DIFF
--- a/environment/build.gradle
+++ b/environment/build.gradle
@@ -79,6 +79,7 @@ dependencies {
     implementation     project(':cluster-dns-connector')
     implementation     project(":sdx-connector")
     implementation     project(':usage-collection')
+    implementation     project(':wiam-connector')
 
     implementation     group: "org.yaml",                  name: "snakeyaml",                                version: snakeYamlVersion
     implementation     group: "com.google.code.gson",      name: "gson",                                     version: gsonVersion

--- a/environment/src/main/resources/application.yml
+++ b/environment/src/main/resources/application.yml
@@ -229,4 +229,7 @@ clusterdns:
   host: localhost
   port: 8982
 
-
+wiam:
+  host: localhost
+  port: 8982
+  grpc.timeout.sec: 60

--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -344,3 +344,4 @@ ccmRevertJob:
 wiam:
   host: localhost
   port: 8982
+  grpc.timeout.sec: 60

--- a/wiam-connector/src/main/java/com/sequenceiq/cloudbreak/wiam/client/GrpcWiamClient.java
+++ b/wiam-connector/src/main/java/com/sequenceiq/cloudbreak/wiam/client/GrpcWiamClient.java
@@ -8,6 +8,7 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.cloudera.thunderhead.service.workloadiam.WorkloadIamProto.SyncUsersResponse;
@@ -18,6 +19,9 @@ import com.sequenceiq.cloudbreak.grpc.ManagedChannelWrapper;
 public class GrpcWiamClient {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GrpcWiamClient.class);
+
+    @Value("${wiam.grpc.timeout.sec:60}")
+    private long grpcTimeoutSec;
 
     @Qualifier("wiamManagedChannelWrapper")
     @Inject
@@ -35,6 +39,6 @@ public class GrpcWiamClient {
     }
 
     private WiamClient createClient() {
-        return new WiamClient(channelWrapper.getChannel(), regionAwareInternalCrnGeneratorFactory.iam().getInternalCrnForServiceAsString());
+        return new WiamClient(channelWrapper.getChannel(), regionAwareInternalCrnGeneratorFactory.iam().getInternalCrnForServiceAsString(), grpcTimeoutSec);
     }
 }

--- a/wiam-connector/src/main/java/com/sequenceiq/cloudbreak/wiam/client/WiamClient.java
+++ b/wiam-connector/src/main/java/com/sequenceiq/cloudbreak/wiam/client/WiamClient.java
@@ -7,6 +7,7 @@ import com.cloudera.thunderhead.service.workloadiam.WorkloadIamGrpc;
 import com.cloudera.thunderhead.service.workloadiam.WorkloadIamGrpc.WorkloadIamBlockingStub;
 import com.cloudera.thunderhead.service.workloadiam.WorkloadIamProto.SyncUsersResponse;
 import com.sequenceiq.cloudbreak.grpc.altus.AltusMetadataInterceptor;
+import com.sequenceiq.cloudbreak.grpc.util.GrpcUtil;
 
 import io.grpc.ManagedChannel;
 
@@ -16,9 +17,12 @@ public class WiamClient {
 
     private final String actorCrn;
 
-    public WiamClient(ManagedChannel channel, String actorCrn) {
+    private final long grpcTimeoutSec;
+
+    public WiamClient(ManagedChannel channel, String actorCrn, long grpcTimeoutSec) {
         this.channel = channel;
         this.actorCrn = actorCrn;
+        this.grpcTimeoutSec = grpcTimeoutSec;
     }
 
     public SyncUsersResponse syncUsersInEnvironment(String accountId, String environmentCrn, String requestId) {
@@ -33,6 +37,8 @@ public class WiamClient {
     private WorkloadIamBlockingStub newStub(String requestId) {
         checkNotNull(requestId, "requestId should not be null.");
         return WorkloadIamGrpc.newBlockingStub(channel)
-                .withInterceptors(new AltusMetadataInterceptor(requestId, actorCrn));
+                .withInterceptors(
+                        GrpcUtil.getTimeoutInterceptor(grpcTimeoutSec),
+                        new AltusMetadataInterceptor(requestId, actorCrn));
     }
 }


### PR DESCRIPTION
- when `WORKLOAD_IAM_USERSYNC_ROUTING` entitlement is enabled the usersync would be initiated through a WIAM call
- added WIAM client to env service
- set grpc timeout for WIAM client

See detailed description in the commit message.