### PR TITLE
CB-20500 Freeipa downscale failed from 4 nodes

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/AvailabilityInfo.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/AvailabilityInfo.java
@@ -1,0 +1,30 @@
+package com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common;
+
+public class AvailabilityInfo {
+
+    private final AvailabilityType availabilityType;
+
+    private final int actualNodeCount;
+
+    public AvailabilityInfo(int nodeCount) {
+        this.availabilityType = AvailabilityType.getByInstanceCount(nodeCount);
+        this.actualNodeCount = nodeCount;
+    }
+
+    public AvailabilityType getAvailabilityType() {
+        return availabilityType;
+    }
+
+    public int getActualNodeCount() {
+        return actualNodeCount;
+    }
+
+    @Override
+    public String toString() {
+        return "AvailabilityInfo{" +
+                "availabilityType=" + availabilityType +
+                ", actualNodeCount=" + actualNodeCount +
+                '}';
+    }
+
+}

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/AvailabilityType.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/AvailabilityType.java
@@ -4,6 +4,7 @@ import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 public enum AvailabilityType {
@@ -30,6 +31,7 @@ public enum AvailabilityType {
     }
 
     public static AvailabilityType getByInstanceCount(Integer instanceCount) {
-        return AVAILABILITY_TYPE_MAP_BY_INSTANCE_COUNT.get(instanceCount);
+        return Optional.ofNullable(AVAILABILITY_TYPE_MAP_BY_INSTANCE_COUNT.get(instanceCount))
+                .orElseGet(() -> instanceCount > HA.getInstanceCount() ? HA : NON_HA);
     }
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/operation/model/OperationType.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/operation/model/OperationType.java
@@ -15,6 +15,12 @@ public enum OperationType {
     UPGRADE_CCM,
     MODIFY_PROXY_CONFIG;
 
+    private final String lowerCaseName;
+
+    OperationType() {
+        lowerCaseName = name().toLowerCase();
+    }
+
     public static OperationType fromSyncOperationType(SyncOperationType syncOperationType) {
         switch (syncOperationType) {
             case USER_SYNC:
@@ -24,5 +30,9 @@ public enum OperationType {
             default:
                 throw new UnsupportedOperationException("SyncOperationType not mapped: " + syncOperationType);
         }
+    }
+
+    public String getLowerCaseName() {
+        return lowerCaseName;
     }
 }

--- a/freeipa-api/src/test/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/AvailabilityTypeTest.java
+++ b/freeipa-api/src/test/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/AvailabilityTypeTest.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class AvailabilityTypeTest {
+
+    @ParameterizedTest
+    @MethodSource(value = "nodeCountToAvailabilityType")
+    void testGetByInstanceCount(int nodeCount, AvailabilityType availabilityType) {
+        assertEquals(availabilityType, AvailabilityType.getByInstanceCount(nodeCount));
+    }
+
+    static Object[][] nodeCountToAvailabilityType() {
+        return new Object[][]{
+                {0, AvailabilityType.NON_HA },
+                {1, AvailabilityType.NON_HA },
+                {2, AvailabilityType.TWO_NODE_BASED },
+                {3, AvailabilityType.HA },
+                {4, AvailabilityType.HA },
+                {5, AvailabilityType.HA },
+        };
+    }
+
+}

--- a/freeipa-api/src/test/java/com/sequenceiq/freeipa/api/v1/operation/model/OperationTypeTest.java
+++ b/freeipa-api/src/test/java/com/sequenceiq/freeipa/api/v1/operation/model/OperationTypeTest.java
@@ -1,6 +1,10 @@
 package com.sequenceiq.freeipa.api.v1.operation.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SyncOperationType;
 
@@ -12,4 +16,11 @@ public class OperationTypeTest {
             OperationType.fromSyncOperationType(syncOperationType);
         }
     }
+
+    @ParameterizedTest
+    @EnumSource(value = OperationType.class)
+    void testLowerCaseName(OperationType operationType) {
+        assertEquals(operationType.name().toLowerCase(), operationType.getLowerCaseName());
+    }
+
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/action/FreeIpaUpscaleActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/action/FreeIpaUpscaleActions.java
@@ -177,6 +177,7 @@ public class FreeIpaUpscaleActions {
                 stackUpdater.updateStackStatus(stack.getId(), getInProgressStatus(variables), "Adding instances");
 
                 List<CloudInstance> newInstances = buildNewInstances(context.getStack(), getInstanceCountByGroup(variables));
+                LOGGER.debug("Freeipa upscale new instances: {}", newInstances);
                 if (newInstances.isEmpty()) {
                     skipAddingNewInstances(context, stack);
                 } else {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/RepairInstancesService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/RepairInstancesService.java
@@ -98,21 +98,20 @@ public class RepairInstancesService {
         LOGGER.debug("Validating repair for account {} and stack ID {}. Remaining good instances [{}]. Remaining bad instances [{}]. Instances to repair [{}].",
                 accountId, stack.getId(), remainingGoodInstances, remainingBadInstances, instancesToRepair);
         if (!entitlementService.freeIpaHaRepairEnabled(accountId)) {
-            throw new BadRequestException("The FreeIPA HA Repair capability is disabled.");
+            throwBadRequest("The FreeIPA HA Repair capability is disabled.");
         }
         if (instancesToRepair.isEmpty()) {
-            throw new NotFoundException("No unhealthy instances to repair.  Maybe use the force option.");
+            throwNotFoundException("No unhealthy instances to repair. You can try to use the force option to enforce the repair process.");
         }
         if (remainingGoodInstances.isEmpty()) {
-            throw new BadRequestException("At least one instance must remain running with a good status during a repair.");
+            throwBadRequest("At least one instance must remain running with a good status during a repair.");
         }
         if (!remainingBadInstances.isEmpty()) {
-            String errorMsg = "At least one remaining non-repaired instance has a bad status. All remaining instances must have a good status during a repair.";
-            LOGGER.error("{}. The following instances have a bad status: [{}]", errorMsg, remainingBadInstances);
-            throw new BadRequestException(errorMsg);
+            throwBadRequest(String.format("At least one remaining non-repaired instance(s) have a bad status: [%s]. " +
+                    "All remaining instances must have a good status during a repair.", remainingBadInstances));
         }
         if (stack.getInstanceGroups().isEmpty()) {
-            throw new BadRequestException("At least one instace group must be present for a repair.");
+            throwBadRequest("At least one instance group must be present for a repair.");
         }
     }
 
@@ -132,9 +131,7 @@ public class RepairInstancesService {
             if (validInstanceIds.size() != instanceIds.size()) {
                 String badIds = instanceIds.stream()
                         .filter(not(allInstances::contains)).collect(Collectors.joining(","));
-                String msg = MessageFormat.format("Invalid instanceIds in request {0}.", badIds);
-                LOGGER.error(msg);
-                throw new BadRequestException(msg);
+                throwBadRequest(MessageFormat.format("Invalid instanceIds in request {0}.", badIds));
             }
             return validInstanceIds;
         }
@@ -182,23 +179,29 @@ public class RepairInstancesService {
      */
     public OperationStatus repairInstances(String accountId, RepairInstancesRequest request) {
         Stack stack = stackService.getByEnvironmentCrnAndAccountIdWithListsAndMdcContext(request.getEnvironmentCrn(), accountId);
-
+        LOGGER.debug("Repairing freeipa instances, request: {}", request);
         if (request.isForceRepair() && CollectionUtils.isEmpty(request.getInstanceIds())) {
-            throw new UnsupportedOperationException("Force repair requires the instance IDs to be provided.");
+            String message = "Force repair requires the instance IDs to be provided.";
+            LOGGER.error(message);
+            throw new UnsupportedOperationException(message);
         }
 
         Map<String, InstanceStatus> healthMap = request.isForceRepair() ? Collections.emptyMap() : getInstanceHealthMap(accountId, request.getEnvironmentCrn());
         Map<String, InstanceMetaData> allInstancesByInstanceId = getAllInstancesFromStack(stack);
         Map<String, InstanceMetaData> instancesToRepair =
                 getInstancesToRepair(healthMap, allInstancesByInstanceId, request.getInstanceIds(), request.isForceRepair(), false);
+        LOGGER.debug("Freeipa repair, instances: healthmap: {}, all instances by instance id: {}, instances to repair: {}",
+                healthMap, allInstancesByInstanceId, instancesToRepair);
 
         Set<InstanceMetaData> remainingGoodInstances =
                 getRemainingGoodInstances(allInstancesByInstanceId, instancesToRepair, healthMap, request.isForceRepair());
         Set<InstanceMetaData> remainingBadInstances = getRemainingBadInstances(allInstancesByInstanceId, instancesToRepair, healthMap, request.isForceRepair());
+        LOGGER.debug("Freeipa repair, remaining good instances: {}, remaining bad instances: {}", remainingGoodInstances, remainingBadInstances);
         validate(accountId, stack, remainingGoodInstances, remainingBadInstances, instancesToRepair.values());
         int nodeCount = stack.getInstanceGroups().stream().findFirst().get().getNodeCount();
 
         List<String> additionalTerminatedInstanceIds = getAdditionalTerminatedInstanceIds(allInstancesByInstanceId.values(), request.getInstanceIds());
+        LOGGER.debug("Freeipa repair, terminated instances: {}, node count: {}", additionalTerminatedInstanceIds, nodeCount);
 
         Operation operation = operationService.startOperation(accountId, OperationType.REPAIR, Set.of(stack.getEnvironmentCrn()), Collections.emptySet());
         if (operation.getStatus() == OperationState.RUNNING) {
@@ -259,29 +262,27 @@ public class RepairInstancesService {
                 getInstancesToRepair(healthMap, allInstancesByInstanceId, request.getInstanceIds(), request.isForceReboot(), true);
 
         if (instancesToReboot.keySet().isEmpty()) {
-            throw new NotFoundException("No unhealthy instances to reboot.  Maybe use the force option.");
+            throwNotFoundException("No unhealthy instances to reboot. You can try to use the force option to enforce the repair process.");
         }
-
 
         Operation operation = operationService.startOperation(accountId, OperationType.REBOOT, Set.of(stack.getEnvironmentCrn()), Collections.emptySet());
         if (operation.getStatus() == OperationState.RUNNING) {
             stackUpdater.updateStackStatus(stack.getId(), DetailedStackStatus.REPAIR_REQUESTED, "Reboot requested");
             flowManager.notify(REBOOT_EVENT.event(), new RebootInstanceEvent(REBOOT_EVENT.event(), stack.getId(),
-                    instancesToReboot.keySet().stream().collect(Collectors.toList()), operation.getOperationId()));
+                    new ArrayList<>(instancesToReboot.keySet()), operation.getOperationId()));
         }
         return operationToOperationStatusConverter.convert(operation);
     }
 
     public DescribeFreeIpaResponse rebuild(String accountId, RebuildRequest rebuildRequest) {
         if (!entitlementService.isFreeIpaRebuildEnabled(accountId)) {
-            throw new BadRequestException("The FreeIPA rebuild capability is disabled.");
+            throwBadRequest("The FreeIPA rebuild capability is disabled.");
         }
         Stack stack = stackService.getByCrnAndAccountIdEvenIfTerminated(rebuildRequest.getEnvironmentCrn(), accountId, rebuildRequest.getSourceCrn());
+        LOGGER.debug("Freeipa rebuild request: {}", rebuildRequest);
         Optional<Stack> nonTerminatedStack = stackService.findByEnvironmentCrnAndAccountId(rebuildRequest.getEnvironmentCrn(), accountId);
         if (nonTerminatedStack.isPresent()) {
-            String error = "There is a stack which hasn't been terminated.";
-            LOGGER.error(error);
-            throw new BadRequestException(error);
+            throwBadRequest("There is a stack which hasn't been terminated.");
         }
         renameStackIfNeeded(stack);
         CreateFreeIpaRequest createFreeIpaRequest = stackToCreateFreeIpaRequestConverter.convert(stack);
@@ -291,7 +292,7 @@ public class RepairInstancesService {
 
     void renameStackIfNeeded(Stack stack) {
         if (!stack.isDeleteCompleted()) {
-            throw new BadRequestException(String.format("The stack %s has not been terminated", stack.getResourceCrn()));
+            throwBadRequest(String.format("The stack %s has not been terminated", stack.getResourceCrn()));
         }
         Long terminated = stack.getTerminated();
         String originalName = stack.getName();
@@ -301,4 +302,15 @@ public class RepairInstancesService {
             terminationService.finalizeTermination(stack.getId());
         }
     }
+
+    private void throwBadRequest(String error) {
+        LOGGER.error(error);
+        throw new BadRequestException(error);
+    }
+
+    private void throwNotFoundException(String message) {
+        LOGGER.error(message);
+        throw new NotFoundException(message);
+    }
+
 }

--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -143,6 +143,7 @@ freeipa:
       TWO_NODE_BASED:
         - HA
       HA:
+        - HA
         - TWO_NODE_BASED
   sudo:
     ruleName: cb-sudo-rule

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaScalingValidationServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaScalingValidationServiceTest.java
@@ -1,12 +1,15 @@
 package com.sequenceiq.freeipa.service.stack;
 
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityType.HA;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityType.NON_HA;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityType.TWO_NODE_BASED;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -14,6 +17,8 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -44,7 +49,16 @@ class FreeIpaScalingValidationServiceTest {
         Stack stack = mock(Stack.class);
 
         BadRequestException exception = assertThrows(BadRequestException.class,
-                () -> underTest.validateStackForUpscale(Set.of(), stack, null));
+                () -> underTest.validateStackForUpscale(Set.of(), stack, new ScalingPath(NON_HA, HA)));
+        assertEquals("There are no instances available for scaling!", exception.getMessage());
+    }
+
+    @Test
+    public void testDownscaleIfNoInstanceExistsThenValidationFails() {
+        Stack stack = mock(Stack.class);
+
+        BadRequestException exception = assertThrows(BadRequestException.class,
+                () -> underTest.validateStackForDownscale(Set.of(), stack, new ScalingPath(HA, NON_HA)));
         assertEquals("There are no instances available for scaling!", exception.getMessage());
     }
 
@@ -58,15 +72,6 @@ class FreeIpaScalingValidationServiceTest {
     }
 
     @Test
-    public void testUpscaleIfMoreInstancesExistsThenValidationFails() {
-        Stack stack = mock(Stack.class);
-
-        BadRequestException exception = assertThrows(BadRequestException.class,
-                () -> underTest.validateStackForUpscale(createValidImSet(4), stack, null));
-        assertEquals("Upscaling currently only available for FreeIPA installation with 1 or 2 instances", exception.getMessage());
-    }
-
-    @Test
     public void testUpscaleIfUnavailableInstanceExistsThenValidationFails() {
         Stack stack = mock(Stack.class);
         Set<InstanceMetaData> validImSet = createValidImSet(2);
@@ -75,7 +80,20 @@ class FreeIpaScalingValidationServiceTest {
         validImSet.add(pgw);
 
         BadRequestException exception = assertThrows(BadRequestException.class,
-                () -> underTest.validateStackForUpscale(validImSet, stack, null));
+                () -> underTest.validateStackForUpscale(validImSet, stack, new ScalingPath(NON_HA, HA)));
+        assertEquals("Some of the instances is not available. Please fix them first! Instances: [pgw]", exception.getMessage());
+    }
+
+    @Test
+    public void testDownscaleIfUnavailableInstanceExistsThenValidationFails() {
+        Stack stack = mock(Stack.class);
+        Set<InstanceMetaData> validImSet = createValidImSet(2);
+        validImSet.removeIf(instanceMetaData -> instanceMetaData.getInstanceMetadataType() == InstanceMetadataType.GATEWAY_PRIMARY);
+        InstanceMetaData pgw = createPrimaryGateway();
+        validImSet.add(pgw);
+
+        BadRequestException exception = assertThrows(BadRequestException.class,
+                () -> underTest.validateStackForDownscale(validImSet, stack, new ScalingPath(HA, NON_HA)));
         assertEquals("Some of the instances is not available. Please fix them first! Instances: [pgw]", exception.getMessage());
     }
 
@@ -87,8 +105,20 @@ class FreeIpaScalingValidationServiceTest {
         when(stack.getStackStatus()).thenReturn(createStackStatus(false));
 
         BadRequestException exception = assertThrows(BadRequestException.class,
-                () -> underTest.validateStackForUpscale(validImSet, stack, null));
+                () -> underTest.validateStackForUpscale(validImSet, stack, new ScalingPath(NON_HA, HA)));
         assertEquals("Stack is not in available state, refusing to upscale. Current state: UNHEALTHY", exception.getMessage());
+    }
+
+    @Test
+    public void testDownscaleIfStackIsUnavailableThenValidationFails() {
+        Stack stack = mock(Stack.class);
+        Set<InstanceMetaData> validImSet = createValidImSet(2);
+        when(stack.isAvailable()).thenReturn(false);
+        when(stack.getStackStatus()).thenReturn(createStackStatus(false));
+
+        BadRequestException exception = assertThrows(BadRequestException.class,
+                () -> underTest.validateStackForDownscale(validImSet, stack, new ScalingPath(HA, NON_HA)));
+        assertEquals("Stack is not in available state, refusing to downscale. Current state: UNHEALTHY", exception.getMessage());
     }
 
     @Test
@@ -96,45 +126,9 @@ class FreeIpaScalingValidationServiceTest {
         Stack stack = mock(Stack.class);
         Set<InstanceMetaData> validImSet = createValidImSet(2);
         when(stack.isAvailable()).thenReturn(true);
-        when(allowedScalingPaths.getPaths()).thenReturn(createAllowedScalingPaths());
+        when(allowedScalingPaths.getPaths()).thenReturn(Map.of(NON_HA, List.of(HA)));
 
-        assertDoesNotThrow(() -> underTest.validateStackForUpscale(validImSet, stack, createScalingPath(true)));
-    }
-
-    @Test
-    public void testUpscaleIfPathIsNotPermittedAndNoAlternativeThenValidationFails() {
-        Stack stack = mock(Stack.class);
-        Set<InstanceMetaData> validImSet = createValidImSet(2);
-        when(stack.isAvailable()).thenReturn(true);
-        when(allowedScalingPaths.getPaths()).thenReturn(createAllowedScalingPaths());
-
-        BadRequestException exception = assertThrows(BadRequestException.class,
-                () -> underTest.validateStackForUpscale(validImSet, stack, createScalingPath(false)));
-        assertEquals("Refusing upscale as scaling from 3 node to 1 is not supported.", exception.getMessage());
-    }
-
-    @Test
-    public void testUpscaleIfPathNotPermittedAndAlternativeExistsThenValidationFails() {
-        Stack stack = mock(Stack.class);
-        Set<InstanceMetaData> validImSet = createValidImSet(2);
-        when(stack.isAvailable()).thenReturn(true);
-        Map<AvailabilityType, List<AvailabilityType>> allowedScalingPaths = createAllowedScalingPaths();
-        allowedScalingPaths.put(AvailabilityType.HA, List.of(AvailabilityType.TWO_NODE_BASED));
-
-        when(this.allowedScalingPaths.getPaths()).thenReturn(allowedScalingPaths);
-
-        BadRequestException exception = assertThrows(BadRequestException.class,
-                () -> underTest.validateStackForUpscale(validImSet, stack, createScalingPath(false)));
-        assertEquals("Refusing upscale as scaling from 3 node to 1 is not supported. Supported upscale targets: [TWO_NODE_BASED]", exception.getMessage());
-    }
-
-    @Test
-    public void testDownscaleIfInvalidInstancesExistsThenValidationFails() {
-        Stack stack = mock(Stack.class);
-
-        BadRequestException exception = assertThrows(BadRequestException.class,
-                () -> underTest.validateStackForDownscale(createValidImSet(2), stack, null));
-        assertEquals("Downscaling currently only available for FreeIPA installation with 3 instances", exception.getMessage());
+        assertDoesNotThrow(() -> underTest.validateStackForUpscale(validImSet, stack, new ScalingPath(NON_HA, HA)));
     }
 
     @Test
@@ -142,9 +136,103 @@ class FreeIpaScalingValidationServiceTest {
         Stack stack = mock(Stack.class);
         Set<InstanceMetaData> validImSet = createValidImSet(3);
         when(stack.isAvailable()).thenReturn(true);
-        when(allowedScalingPaths.getPaths()).thenReturn(createAllowedScalingPaths());
+        when(allowedScalingPaths.getPaths()).thenReturn(Map.of(HA, List.of(TWO_NODE_BASED)));
 
-        assertDoesNotThrow(() -> underTest.validateStackForDownscale(validImSet, stack, createScalingPath(true)));
+        assertDoesNotThrow(() -> underTest.validateStackForDownscale(validImSet, stack, new ScalingPath(HA, TWO_NODE_BASED)));
+    }
+
+    @Test
+    public void testUpscaleIfTargetNodeCountSmallerThenValidationFails() {
+        Stack stack = mock(Stack.class);
+        Set<InstanceMetaData> validImSet = createValidImSet(3);
+
+        assertThatCode(() -> underTest.validateStackForUpscale(validImSet, stack, new ScalingPath(HA, TWO_NODE_BASED)))
+                .isExactlyInstanceOf(BadRequestException.class)
+                .hasMessage("Refusing upscale as target node count is smaller than current. Current node count: 3, target node count: 2.");
+    }
+
+    @Test
+    public void testDownscaleIfTargetNodeCountHigherThenValidationFails() {
+        Stack stack = mock(Stack.class);
+        Set<InstanceMetaData> validImSet = createValidImSet(2);
+
+        assertThatCode(() -> underTest.validateStackForDownscale(validImSet, stack, new ScalingPath(TWO_NODE_BASED, HA)))
+                .isExactlyInstanceOf(BadRequestException.class)
+                .hasMessage("Refusing downscale as target node count is higher than current. Current node count: 2, target node count: 3.");
+    }
+
+    @Test
+    public void testUpscaleIfPathIsNotPermittedAndNoAlternativeThenValidationFails() {
+        Stack stack = mock(Stack.class);
+        Set<InstanceMetaData> validImSet = createValidImSet(2);
+        when(stack.isAvailable()).thenReturn(true);
+        when(allowedScalingPaths.getPaths()).thenReturn(Map.of());
+
+        BadRequestException exception = assertThrows(BadRequestException.class,
+                () -> underTest.validateStackForUpscale(validImSet, stack, new ScalingPath(TWO_NODE_BASED, HA)));
+        assertEquals("Refusing upscale as scaling from 2 node to 3 is not supported.", exception.getMessage());
+    }
+
+    @Test
+    public void testDownscaleIfPathIsNotPermittedAndNoAlternativeThenValidationFails() {
+        Stack stack = mock(Stack.class);
+        Set<InstanceMetaData> validImSet = createValidImSet(2);
+        when(stack.isAvailable()).thenReturn(true);
+        when(allowedScalingPaths.getPaths()).thenReturn(Map.of());
+
+        BadRequestException exception = assertThrows(BadRequestException.class,
+                () -> underTest.validateStackForDownscale(validImSet, stack, new ScalingPath(HA, NON_HA)));
+        assertEquals("Refusing downscale as scaling from 3 node to 1 is not supported.", exception.getMessage());
+    }
+
+    @Test
+    public void testUpscaleIfPathNotPermittedAndAlternativeExistsThenValidationFails() {
+        Stack stack = mock(Stack.class);
+        Set<InstanceMetaData> validImSet = createValidImSet(2);
+        when(stack.isAvailable()).thenReturn(true);
+        when(this.allowedScalingPaths.getPaths()).thenReturn(Map.of(NON_HA, List.of(TWO_NODE_BASED)));
+
+        BadRequestException exception = assertThrows(BadRequestException.class,
+                () -> underTest.validateStackForUpscale(validImSet, stack, new ScalingPath(NON_HA, HA)));
+        assertEquals("Refusing upscale as scaling from 1 node to 3 is not supported. Supported upscale targets: [TWO_NODE_BASED]", exception.getMessage());
+    }
+
+    @Test
+    public void testDownscaleIfPathNotPermittedAndAlternativeExistsThenValidationFails() {
+        Stack stack = mock(Stack.class);
+        Set<InstanceMetaData> validImSet = createValidImSet(2);
+        when(stack.isAvailable()).thenReturn(true);
+        when(this.allowedScalingPaths.getPaths()).thenReturn(Map.of(HA, List.of(TWO_NODE_BASED)));
+
+        BadRequestException exception = assertThrows(BadRequestException.class,
+                () -> underTest.validateStackForDownscale(validImSet, stack, new ScalingPath(HA, NON_HA)));
+        assertEquals("Refusing downscale as scaling from 3 node to 1 is not supported. Supported downscale targets: [TWO_NODE_BASED]", exception.getMessage());
+    }
+
+    @Test
+    public void testUpscaleIfNodeCountWouldNotChangeThenValidationFails() {
+        Stack stack = mock(Stack.class);
+        Set<InstanceMetaData> validImSet = createValidImSet(2);
+        when(stack.isAvailable()).thenReturn(true);
+
+        assertThatCode(() -> underTest.validateStackForUpscale(validImSet, stack, new ScalingPath(TWO_NODE_BASED, TWO_NODE_BASED)))
+                .isExactlyInstanceOf(BadRequestException.class)
+                .hasMessage("Refusing UPSCALE as the current node count already matches the node count of the requested availability type. Current " +
+                        "node count: 2, target availability type: TWO_NODE_BASED and node count: 2.");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = AvailabilityType.class)
+    public void testDownscaleIfNodeCountWouldNotChangeThenValidationFails(AvailabilityType availabilityType) {
+        Stack stack = mock(Stack.class);
+        Set<InstanceMetaData> validImSet = createValidImSet(availabilityType.getInstanceCount());
+        when(stack.isAvailable()).thenReturn(true);
+
+        assertThatCode(() -> underTest.validateStackForDownscale(validImSet, stack, new ScalingPath(availabilityType, availabilityType)))
+                .isExactlyInstanceOf(BadRequestException.class)
+                .hasMessage(String.format("Refusing DOWNSCALE as the current node count already matches the node count of the requested availability type. " +
+                        "Current node count: %d, target availability type: %s and node count: %d.",
+                        availabilityType.getInstanceCount(), availabilityType.name(), availabilityType.getInstanceCount()));
     }
 
     private InstanceMetaData createPrimaryGateway() {
@@ -178,17 +266,4 @@ class FreeIpaScalingValidationServiceTest {
         return stackStatus;
     }
 
-    private Map<AvailabilityType, List<AvailabilityType>> createAllowedScalingPaths() {
-        Map<AvailabilityType, List<AvailabilityType>> allowedPaths = new HashMap<>();
-        allowedPaths.put(AvailabilityType.NON_HA, List.of(AvailabilityType.HA, AvailabilityType.TWO_NODE_BASED));
-        return allowedPaths;
-    }
-
-    private ScalingPath createScalingPath(boolean allowed) {
-        AvailabilityType originalAvailabilityType = AvailabilityType.NON_HA;
-        AvailabilityType targetAvailabilityType = AvailabilityType.HA;
-        return allowed
-                ? new ScalingPath(originalAvailabilityType, targetAvailabilityType)
-                : new ScalingPath(targetAvailabilityType, originalAvailabilityType);
-    }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/RepairInstancesServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/RepairInstancesServiceTest.java
@@ -284,7 +284,7 @@ class RepairInstancesServiceTest {
     }
 
     @Test
-    void testRepairForceWhenOnlyBadInstarncesRemain() {
+    void testRepairForceWhenOnlyBadInstancesRemain() {
         Stack stack = createStack(Status.UNREACHABLE, List.of(InstanceStatus.UNREACHABLE, InstanceStatus.UNREACHABLE));
         List<String> instanceIds = List.of("i-2");
         OperationStatus operationStatus = new OperationStatus();
@@ -394,7 +394,8 @@ class RepairInstancesServiceTest {
         Exception expected = assertThrows(NotFoundException.class, () -> {
             underTest.rebootInstances(ACCOUNT_ID, rebootInstancesRequest);
         });
-        Assert.assertTrue(expected.getLocalizedMessage().equals("No unhealthy instances to reboot.  Maybe use the force option."));
+        Assert.assertTrue(expected.getLocalizedMessage().equals("No unhealthy instances to reboot. You can try to use the force option to enforce " +
+                "the repair process."));
         ArgumentCaptor<InstanceEvent> terminationEventArgumentCaptor = ArgumentCaptor.forClass(InstanceEvent.class);
         verify(flowManager, times(0)).notify(eq(REBOOT_EVENT.event()), terminationEventArgumentCaptor.capture());
     }
@@ -474,6 +475,19 @@ class RepairInstancesServiceTest {
         when(stackService.getByCrnAndAccountIdEvenIfTerminated(ENVIRONMENT_ID1, ACCOUNT_ID, FREEIPA_CRN)).thenReturn(stack);
         when(stackService.findByEnvironmentCrnAndAccountId(ENVIRONMENT_ID1, ACCOUNT_ID)).thenReturn(Optional.of(stack));
         when(entitlementService.isFreeIpaRebuildEnabled(eq(ACCOUNT_ID))).thenReturn(true);
+
+        RebuildRequest rebuildRequest = new RebuildRequest();
+        rebuildRequest.setEnvironmentCrn(ENVIRONMENT_ID1);
+        rebuildRequest.setSourceCrn(FREEIPA_CRN);
+
+        assertThrows(BadRequestException.class, () -> underTest.rebuild(ACCOUNT_ID, rebuildRequest));
+    }
+
+    @Test
+    public void testRebuildThrowsWhenNoEntitlement() throws Exception {
+        Stack stack = createStack(Status.AVAILABLE, List.of(InstanceStatus.CREATED, InstanceStatus.CREATED), 2);
+
+        when(entitlementService.isFreeIpaRebuildEnabled(eq(ACCOUNT_ID))).thenReturn(false);
 
         RebuildRequest rebuildRequest = new RebuildRequest();
         rebuildRequest.setEnvironmentCrn(ENVIRONMENT_ID1);


### PR DESCRIPTION
During freeipa upgrade an error happened, because of which 4 nodes remained. Using downscale from 4 nodes was not possible, however, as mapping 4 nodes to AvailabilityType was not possible, as the 4 node state was meant to be temporary.

The present commit thus adds an error handling scenario: it introduces a new state, TEMPORARY_FOUR_NODE_BASED, for the case when the freeipa ends up having 4 nodes. It is now possible to downscale to HA. A downscale to TWO_NODE_BASED system is not allowed, as this is an error fixing scenario and let's allow only the smallests change to the system. Once the customer is back to HA, and also replication agreements are ok, he can separately decide to go downscale to 2 nodes.

The present commit also adds numerous log lines to repair.

See detailed description in the commit message.