### PR TITLE
CB-20808 Improve log messages for unknown status and update failed

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/dr/SdxBackupRestoreService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/dr/SdxBackupRestoreService.java
@@ -318,16 +318,15 @@ public class SdxBackupRestoreService {
         } else if (isStackOrClusterStatusFailed(stackV4Response.getStatus())) {
             LOGGER.info("{} failed for Stack {} with status {}", pollingMessage, stackV4Response.getName(), stackV4Response.getStatus());
             return sdxDrFailed(sdxCluster, stackV4Response.getStatusReason(), pollingMessage);
-        } else if (isStackOrClusterStatusFailed(stackV4Response.getCluster().getStatus())) {
-            LOGGER.info("{} failed for Cluster {} status {}", pollingMessage, stackV4Response.getCluster().getName(),
-                    stackV4Response.getCluster().getStatus());
-            return sdxDrFailed(sdxCluster, stackV4Response.getCluster().getStatusReason(), pollingMessage);
+        } else if (isStackOrClusterStatusFailed(cluster.getStatus())) {
+            LOGGER.info("{} failed for Cluster {} status {}", pollingMessage, cluster.getName(), cluster.getStatus());
+            return sdxDrFailed(sdxCluster, cluster.getStatusReason(), pollingMessage);
         } else if (FINISHED.equals(flowState)) {
             LOGGER.info("Flow finished, but Backup/Restore is not complete: {}", sdxCluster.getClusterName());
             return sdxDrFailed(sdxCluster, "stack is in improper state", pollingMessage);
         } else {
-            LOGGER.info("Flow is unknown state");
-            return sdxDrFailed(sdxCluster, "Flow is unknown state", pollingMessage);
+            LOGGER.info("{} for Stack {} failed with unhandled status: {}", pollingMessage, stackV4Response.getName(), stackV4Response.getStatus());
+            return sdxDrFailed(sdxCluster, stackV4Response.getStatusReason(), pollingMessage);
         }
     }
 
@@ -339,7 +338,8 @@ public class SdxBackupRestoreService {
      */
     private boolean isStackOrClusterStatusFailed(Status status) {
         return Status.BACKUP_FAILED.equals(status) ||
-                Status.RESTORE_FAILED.equals(status);
+                Status.RESTORE_FAILED.equals(status) ||
+                Status.UPDATE_FAILED.equals(status);
     }
 
     private AttemptResult<StackV4Response> sdxDrFailed(SdxCluster sdxCluster, String statusReason, String pollingMessage) {


### PR DESCRIPTION
Context: Permission denied on files were displayed and logged as "Flow is unknown state".

Tests:
Removed the `/etc/sssd/sssd.conf` file from CM master and turned the folder immutable (chattr +i /etc/sssd/s).
Start a datalake backup `cdp datalake backup-datalake --datalake-name rod-dl-aws-1`.