### PR TITLE
CB-20838 Disable DB SSL entitlement in mock-thunderhead temporarily

### DIFF
--- a/mock-thunderhead/src/main/resources/application.yml
+++ b/mock-thunderhead/src/main/resources/application.yml
@@ -54,7 +54,7 @@ auth:
       zdu.osupgrade.enable: true
       backup.restore.permission.checks.enabled: true
     differentdatahubversionthandatalake.enabled: true
-    database.wire.encryption.enable: true
+    database.wire.encryption.enable: false
     database.wire.encryption.datahub.enable: false
     datahub:
       runtime.upgrade.enable: true


### PR DESCRIPTION
This is to unblock E2E tests until the proper fix can be found for [CB-20838](https://jira.cloudera.com/browse/CB-20838).
