### PR TITLE
CB-16136:Add cloud provider type to cm settings

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.core.bootstrap.service.host;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_0_2;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_0;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_1;
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_6_2;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
 import static com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterDeletionBasedExitCriteriaModel.clusterDeletionBasedModel;
 import static com.sequenceiq.cloudbreak.util.NullUtil.throwIfNull;
@@ -67,6 +68,7 @@ import com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.common.orchestration.Node;
 import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterDeletionBasedExitCriteriaModel;
@@ -662,10 +664,16 @@ public class ClusterHostServiceRunner {
                                 "gov_cloud", govCluster(stackDto.getPlatformVariant()),
                                 "disable_auto_bundle_collection", disableAutoBundleCollection,
                                 "set_cdp_env", isVersionNewerOrEqualThanLimited(cmVersion, CLOUDERAMANAGER_VERSION_7_0_2),
+                                "cloud_provider_setup_supported", isCloudProviderSetupSupported(stackDto, cmVersion),
                                 "deterministic_uid_gid", isVersionNewerOrEqualThanLimited(cmVersion, CLOUDERAMANAGER_VERSION_7_2_1),
                                 "cloudera_scm_sudo_access", CMRepositoryVersionUtil.isSudoAccessNeededForHostCertRotation(clouderaManagerRepo)),
                         "mgmt_service_directories", serviceLocations.getAllVolumePath(),
                         "address", primaryGatewayConfig.getPrivateAddress()))));
+    }
+
+    private boolean isCloudProviderSetupSupported(StackDto stackDto, String cmVersion) {
+        List<String> supportedCloudProviders = List.of(CloudPlatform.AWS.name(), CloudPlatform.GCP.name(), CloudPlatform.AZURE.name());
+        return supportedCloudProviders.contains(stackDto.getCloudPlatform()) && isVersionNewerOrEqualThanLimited(cmVersion, CLOUDERAMANAGER_VERSION_7_6_2);
     }
 
     private boolean govCluster(String platformVariant) {

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/init.sls
@@ -44,7 +44,10 @@ add_settings_file_to_cfm_server_args:
   file.replace:
     - name: /etc/default/cloudera-scm-server
     - pattern: "CMF_SERVER_ARGS=.*"
-{% if salt['pillar.get']('cloudera-manager:settings:set_cdp_env') == True %}
+{% if salt['pillar.get']('cloudera-manager:settings:cloud_provider_setup_supported') == True %}
+    - repl: CMF_SERVER_ARGS="-i /etc/cloudera-scm-server/cm.settings -cp {{ salt['pillar.get']('platform') }} -env PUBLIC_CLOUD"
+    - unless: grep "CMF_SERVER_ARGS=\"-i /etc/cloudera-scm-server/cm.settings -cp {{ salt['pillar.get']('platform') }}\"" /etc/default/cloudera-scm-server
+{% elif salt['pillar.get']('cloudera-manager:settings:set_cdp_env') == True %}
     - repl: CMF_SERVER_ARGS="-i /etc/cloudera-scm-server/cm.settings -env PUBLIC_CLOUD"
     - unless: grep "CMF_SERVER_ARGS=\"-i /etc/cloudera-scm-server/cm.settings -env PUBLIC_CLOUD\"" /etc/default/cloudera-scm-server
 {% else %}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
@@ -59,6 +59,8 @@ public class CMRepositoryVersionUtil {
 
     public static final Versioned CLOUDERAMANAGER_VERSION_7_6_0 = () -> "7.6.0";
 
+    public static final Versioned CLOUDERAMANAGER_VERSION_7_6_2 = () -> "7.6.2";
+
     public static final Versioned CLOUDERAMANAGER_VERSION_7_7_1 = () -> "7.7.1";
 
     public static final Versioned CLOUDERAMANAGER_VERSION_7_9_0 = () -> "7.9.0";


### PR DESCRIPTION
Added the -cp option to indicate the cloud provider to CM server file.

The screenshot shared below is from the file /etc/default/cloudera-scm-server file
Before the change:
![image](https://user-images.githubusercontent.com/7271603/217839994-9e253239-0bdf-4718-b7c5-619f28bc7ce4.png)




After the change :

`CMF_SERVER_ARGS="-i /etc/cloudera-scm-server/cm.settings -cp  AWS -env PUBLIC_CLOUD"`