### PR TITLE
CB-20838 Fix embedded DB cert subject for long FQDNs

### DIFF
--- a/mock-thunderhead/src/main/resources/application.yml
+++ b/mock-thunderhead/src/main/resources/application.yml
@@ -54,7 +54,7 @@ auth:
       zdu.osupgrade.enable: true
       backup.restore.permission.checks.enabled: true
     differentdatahubversionthandatalake.enabled: true
-    database.wire.encryption.enable: false
+    database.wire.encryption.enable: true
     database.wire.encryption.datahub.enable: false
     datahub:
       runtime.upgrade.enable: true

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/create_embeddeddb_certificate.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/create_embeddeddb_certificate.sh
@@ -1,4 +1,5 @@
 {%- set postgres_fqdn = salt['grains.get']('fqdn') %}
+{%- set postgres_host = salt['grains.get']('host') %}
 {%- set cm_keytab = salt['pillar.get']('keytab:CM') %}
 #!/usr/bin/env bash
 set -e
@@ -13,12 +14,45 @@ CM_KEYTAB_FILE={{ cm_keytab.path }}
 CM_PRINCIPAL={{ cm_keytab.principal }}
 CERTS_DIR={{ postgres_directory }}/certs
 
-kinit -kt $CM_KEYTAB_FILE $CM_PRINCIPAL
+kinit -kt ${CM_KEYTAB_FILE} ${CM_PRINCIPAL}
 
 mkdir -p ${CERTS_DIR}
 
-openssl req -nodes -newkey rsa:2048 -days 365 -keyout ${CERTS_DIR}/postgres.key -out ${CERTS_DIR}/postgres.csr -subj "/CN={{postgres_fqdn}}"
-ipa cert-request ${CERTS_DIR}/postgres.csr --principal=postgres/{{ postgres_fqdn }} --add --certificate-out=${CERTS_DIR}/postgres.cert
+openssl req -nodes -newkey rsa:2048 -days 365 -keyout ${CERTS_DIR}/postgres.key -out ${CERTS_DIR}/postgres.csr -config <(
+cat <<-EOF
+[req]
+distinguished_name = req_distinguished_name
+req_extensions = v3_req
+prompt = no
+[req_distinguished_name]
+CN = {{postgres_host}}
+[v3_req]
+subjectAltName = DNS:{{postgres_fqdn}}
+EOF
+)
+
+PGSQL_PRINCIPAL=postgres/{{ postgres_fqdn }}
+PGSQL_PRINCIPAL_ALIAS=postgres/{{ postgres_host }}
+
+echo "Checking if PgSQL service principal \"${PGSQL_PRINCIPAL}\" exists."
+if ipa service-show ${PGSQL_PRINCIPAL} &> /dev/null
+then
+  echo "Found PgSQL service principal \"${PGSQL_PRINCIPAL}\"."
+else
+  echo "PgSQL service principal \"${PGSQL_PRINCIPAL}\" is absent. Attempting to create it."
+  ipa service-add ${PGSQL_PRINCIPAL}
+fi
+
+echo "Checking if PgSQL service principal alias \"${PGSQL_PRINCIPAL_ALIAS}\" exists."
+if ipa service-show ${PGSQL_PRINCIPAL} --raw | grep "krbprincipalname:" | grep -q "${PGSQL_PRINCIPAL_ALIAS}@"
+then
+  echo "Found PgSQL service principal alias \"${PGSQL_PRINCIPAL_ALIAS}\"."
+else
+  echo "PgSQL service principal alias \"${PGSQL_PRINCIPAL_ALIAS}\" is absent. Attempting to add it."
+  ipa service-add-principal ${PGSQL_PRINCIPAL} ${PGSQL_PRINCIPAL_ALIAS}
+fi
+
+ipa cert-request ${CERTS_DIR}/postgres.csr --principal=${PGSQL_PRINCIPAL} --certificate-out=${CERTS_DIR}/postgres.cert
 
 chown -R postgres:postgres ${CERTS_DIR}
 chmod 600 ${CERTS_DIR}/postgres.key


### PR DESCRIPTION
* The embedded DB cert CSR has been changed as follows:
  * The subject is the hostname.
  * The FQDN is added as a SAN.
* The above change implies that clients connecting to the embedded DB using SSL must be able to interpret & consider the SAN correctly.
* Undo #14276 in order to re-enable `auth.mock.database.wire.encryption.enable` in `mock-thunderhead`. This basically enables entitlement `CDP_CB_DATABASE_WIRE_ENCRYPTION` that controls SSL for the DL DB (external & embedded).
* Testing: Manual test of embedded DB on DH with multiple cluster templates and different cluster name lengths, including the case when the cluster name is of maximal length (40 chars long).
