### PR TITLE
CB-20479:Change the deployment name "addaccesspolicy" to unique name

### DIFF
--- a/cloud-azure/src/main/resources/templates/arm-dbstack.ftl
+++ b/cloud-azure/src/main/resources/templates/arm-dbstack.ftl
@@ -315,7 +315,7 @@
         {
           "type": "Microsoft.Resources/deployments",
           "apiVersion": "2019-05-01",
-          "name": "addAccessPolicy",
+          "name": "[concat(parameters('dbServerName'), '-', 'addAccessPolicy')]",
           "resourceGroup": "[parameters('keyVaultResourceGroupName')]",
           "dependsOn": [
             "[resourceId('Microsoft.DBforPostgreSQL/servers', parameters('dbServerName'))]"
@@ -355,7 +355,7 @@
           "type": "Microsoft.DBforPostgreSQL/servers/keys",
           "apiVersion": "2020-01-01-preview",
           "dependsOn": [
-            "addAccessPolicy",
+            "[concat(parameters('dbServerName'), '-', 'addAccessPolicy')]",
             "[resourceId('Microsoft.DBforPostgreSQL/servers', parameters('dbServerName'))]"
           ],
           "properties": {


### PR DESCRIPTION
We are seeing test case failures due to hard coded deployment name for "addAccessPolicy". Changed that to contain the dbservername so that every deployment will have a unique name and does not conflict when multiple environments were triggered at the same time. Screenwhot from azure console below:

<img width="559" alt="Screenshot 2023-02-10 at 9 00 00 AM" src="https://user-images.githubusercontent.com/7271603/217993909-072db785-ffb4-4767-92dc-51fdf5c16af4.png">
