### PR TITLE
CB-20884 add a skip window for core statuschecker to avoid CM related issues

### DIFF
--- a/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusIntegrationTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusIntegrationTest.java
@@ -53,6 +53,7 @@ import com.sequenceiq.cloudbreak.cluster.status.ClusterStatusResult;
 import com.sequenceiq.cloudbreak.cluster.status.ExtendedHostStatuses;
 import com.sequenceiq.cloudbreak.cluster.util.ResourceAttributeUtil;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessorFactory;
+import com.sequenceiq.cloudbreak.common.service.Clock;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
 import com.sequenceiq.cloudbreak.common.type.HealthCheck;
 import com.sequenceiq.cloudbreak.common.type.HealthCheckResult;
@@ -140,6 +141,9 @@ class StackStatusIntegrationTest {
 
     @MockBean
     private StackViewService stackViewService;
+
+    @MockBean
+    private Clock clock;
 
     @Mock
     private ClusterStatusService clusterStatusService;

--- a/environment/build.gradle
+++ b/environment/build.gradle
@@ -49,7 +49,7 @@ sonarqube {
 }
 
 dependencies {
-    implementation project(':audit-connector')
+    implementation     project(':audit-connector')
     implementation     project(":authorization-common")
     implementation     project(":common")
     implementation     project(':core-common')

--- a/flow/src/main/java/com/sequenceiq/flow/core/FlowLogService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/FlowLogService.java
@@ -64,6 +64,8 @@ public interface FlowLogService {
 
     Optional<FlowLog> getLastFlowLog(Long resourceId);
 
+    Optional<FlowLog> getLastFlowLogWithEndTime(Long resourceId);
+
     boolean isFlowConfigAlreadyRunning(Long id, Class<? extends FlowConfiguration<?>> flowConfiguration);
 
     List<FlowLog> findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(Long id);

--- a/flow/src/main/java/com/sequenceiq/flow/repository/FlowLogRepository.java
+++ b/flow/src/main/java/com/sequenceiq/flow/repository/FlowLogRepository.java
@@ -90,6 +90,8 @@ public interface FlowLogRepository extends CrudRepository<FlowLog, Long> {
 
     Optional<FlowLog> findFirstByResourceIdOrderByCreatedDesc(@Param("resourceId") Long resourceId);
 
+    Optional<FlowLog> findFirstByResourceIdAndEndTimeNotNullOrderByCreatedDesc(@Param("resourceId") Long resourceId);
+
     List<FlowLog> findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(Long resourceId);
 
     List<FlowLog> findAllByFlowIdOrderByCreatedDesc(String flowId);

--- a/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowLogDBService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowLogDBService.java
@@ -302,6 +302,11 @@ public class FlowLogDBService implements FlowLogService {
     }
 
     @Override
+    public Optional<FlowLog> getLastFlowLogWithEndTime(Long resourceId) {
+        return flowLogRepository.findFirstByResourceIdAndEndTimeNotNullOrderByCreatedDesc(resourceId);
+    }
+
+    @Override
     public List<FlowLog> findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(Long id) {
         return flowLogRepository.findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(id);
     }

--- a/integration-test/scripts/config-ums.sh
+++ b/integration-test/scripts/config-ums.sh
@@ -20,16 +20,14 @@ validate-ums-users() {
 
 prepare-cb-profile() {
     echo "Replacing UMS_HOST in profile file"
-    sed '/export UMS_HOST/d' ./integcb/Profile > ./integcb/Profile.tmp1
-    sed '/export UMS_PORT/d' ./integcb/Profile > ./integcb/Profile.tmp1
-    sed '/export CB_JAVA_OPTS/d' ./integcb/Profile.tmp1 > ./integcb/Profile.tmp
-    mv ./integcb/Profile.tmp ./integcb/Profile
+    sed -i '/export UMS_HOST/d' ./integcb/Profile
+    sed -i '/export UMS_PORT/d' ./integcb/Profile
 }
 
 update-cb-profile() {
     echo "export UMS_HOST=$INTEGRATIONTEST_UMS_HOST" >> integcb/Profile
     echo "export UMS_PORT=$INTEGRATIONTEST_UMS_PORT" >> integcb/Profile
-    echo 'export CB_JAVA_OPTS="-Daltus.ums.rights.cache.seconds.ttl=5 -Drest.debug=true -Dmock.spi.endpoint=https://test:9443"' >> integcb/Profile
+    sed -i '/^export CB_JAVA_OPTS/ s/$/ -Daltus.ums.rights.cache.seconds.ttl=5 -Drest.debug=true -Dmock.spi.endpoint=https\:\/\/test\:9443\//' Profile
     echo 'export REDBEAMS_JAVA_OPTS="-Daltus.ums.rights.cache.seconds.ttl=5"' >> integcb/Profile
     echo 'export DATALAKE_JAVA_OPTS="-Daltus.ums.rights.cache.seconds.ttl=5"' >> integcb/Profile
     echo 'export FREEIPA_JAVA_OPTS="-Daltus.ums.rights.cache.seconds.ttl=5"' >> integcb/Profile

--- a/integration-test/scripts/create-cloudbreak-context.sh
+++ b/integration-test/scripts/create-cloudbreak-context.sh
@@ -11,6 +11,7 @@ echo -e "\n" >> integcb/Profile
 echo "export VAULT_AUTO_UNSEAL=true" >> integcb/Profile
 echo "export VAULT_DB_SCHEMA=inet_vault_$(date +%s)" >> integcb/Profile
 echo "export CB_UI_MAX_WAIT=600" >> integcb/Profile
+echo "export CB_JAVA_OPTS=-Dcb.statuschecker.skip.window.minutes=0"
 if [[ "$AWS" == true ]]; then
     echo "export AWS_ACCESS_KEY_ID=${INTEGRATIONTEST_AWS_CREDENTIAL_ACCESSKEYID}" >> integcb/Profile
     echo "export AWS_SECRET_ACCESS_KEY=${INTEGRATIONTEST_AWS_CREDENTIAL_SECRETKEY}" >> integcb/Profile


### PR DESCRIPTION
When we do a status check, we will query the latest flow log end time, and if it is not older than 2 minutes, we will skip the status check. It will help in cases like the following: we did a CM management restart service, and the CM operation finished, but the services not properly started, and they need a few more seconds to start properly.