### PR TITLE
CB-20455 Separate application and quartz db connection pool. With the…

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/config/DatabaseConfig.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/config/DatabaseConfig.java
@@ -8,7 +8,6 @@ import java.sql.SQLException;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.persistence.EntityManagerFactory;
-import javax.sql.DataSource;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -27,6 +26,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 import com.sequenceiq.cloudbreak.common.database.BatchProperties;
 import com.sequenceiq.cloudbreak.common.database.JpaPropertiesFacory;
 import com.sequenceiq.cloudbreak.common.tx.CircuitBreakerType;
+import com.sequenceiq.cloudbreak.database.MultiDataSourceConfig;
 import com.sequenceiq.cloudbreak.util.DatabaseUtil;
 import com.sequenceiq.periscope.service.ha.PeriscopeNodeConfig;
 import com.zaxxer.hikari.HikariConfig;
@@ -35,7 +35,7 @@ import com.zaxxer.hikari.HikariDataSource;
 @Configuration
 @EnableTransactionManagement
 @ConditionalOnProperty(name = "periscope.db.enabled", havingValue = "true", matchIfMissing = true)
-public class DatabaseConfig {
+public class DatabaseConfig extends MultiDataSourceConfig {
 
     @Value("${periscope.db.env.user:postgres}")
     private String dbUser;
@@ -89,10 +89,10 @@ public class DatabaseConfig {
     @Inject
     private Environment environment;
 
-    @Bean
-    public DataSource dataSource() throws SQLException {
+    protected HikariDataSource getDataSource(String poolName) throws SQLException {
         DatabaseUtil.createSchemaIfNeeded("postgresql", databaseAddress, dbName, dbUser, dbPassword, dbSchemaName);
         HikariConfig config = new HikariConfig();
+        config.setPoolName(poolName);
         if (ssl) {
             config.addDataSourceProperty("ssl", "true");
             config.addDataSourceProperty("sslfactory", "org.postgresql.ssl.DefaultJavaSSLFactory");

--- a/cloud-consumption/src/main/java/com/sequenceiq/consumption/configuration/DatabaseConfig.java
+++ b/cloud-consumption/src/main/java/com/sequenceiq/consumption/configuration/DatabaseConfig.java
@@ -10,7 +10,6 @@ import java.sql.Statement;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.persistence.EntityManagerFactory;
-import javax.sql.DataSource;
 
 import org.postgresql.Driver;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,6 +30,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 import com.sequenceiq.cloudbreak.common.database.BatchProperties;
 import com.sequenceiq.cloudbreak.common.database.JpaPropertiesFacory;
 import com.sequenceiq.cloudbreak.common.tx.CircuitBreakerType;
+import com.sequenceiq.cloudbreak.database.MultiDataSourceConfig;
 import com.sequenceiq.flow.ha.NodeConfig;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
@@ -38,7 +38,7 @@ import com.zaxxer.hikari.HikariDataSource;
 @Configuration
 @EnableTransactionManagement
 @ConditionalOnProperty(name = "consumption.db.enabled", havingValue = "true", matchIfMissing = true)
-public class DatabaseConfig {
+public class DatabaseConfig extends MultiDataSourceConfig {
 
     private static final String DEFAULT_SCHEMA_NAME = "public";
 
@@ -94,10 +94,10 @@ public class DatabaseConfig {
     @Inject
     private Environment environment;
 
-    @Bean
-    public DataSource dataSource() throws SQLException {
+    protected HikariDataSource getDataSource(String poolName) throws SQLException {
         createSchemaIfNeeded("postgresql", databaseAddress, dbName, dbUser, dbPassword, dbSchemaName);
         HikariConfig config = new HikariConfig();
+        config.setPoolName(poolName);
         if (ssl) {
             config.addDataSourceProperty("ssl", "true");
             config.addDataSourceProperty("sslfactory", "org.postgresql.ssl.DefaultJavaSSLFactory");

--- a/common/src/main/java/com/sequenceiq/cloudbreak/database/MultiDataSourceConfig.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/database/MultiDataSourceConfig.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.cloudbreak.database;
+
+import java.sql.SQLException;
+
+import javax.sql.DataSource;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+import com.zaxxer.hikari.HikariDataSource;
+
+public abstract class MultiDataSourceConfig {
+
+    @Bean(name = "defaultDataSource")
+    public DataSource defaultDataSource() throws SQLException {
+        return getDataSource("hikari-app-pool");
+    }
+
+    @Bean(name = "quartzDataSource")
+    public DataSource quartzDataSource() throws SQLException {
+        return getDataSource("hikari-quartz-pool");
+    }
+
+    @Primary
+    @Bean(name = "dataSource")
+    public DataSource dataSource() {
+        return new RoutingDataSource();
+    }
+
+    protected abstract HikariDataSource getDataSource(String poolName) throws SQLException;
+
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/database/RoutingDataSource.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/database/RoutingDataSource.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.cloudbreak.conf;
+package com.sequenceiq.cloudbreak.database;
 
 import java.util.Map;
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/conf/DatabaseConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/conf/DatabaseConfig.java
@@ -7,13 +7,11 @@ import java.sql.SQLException;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-import javax.sql.DataSource;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
-import org.springframework.context.annotation.Primary;
 import org.springframework.core.env.Environment;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.JpaVendorAdapter;
@@ -26,6 +24,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 import com.sequenceiq.cloudbreak.common.database.BatchProperties;
 import com.sequenceiq.cloudbreak.common.database.JpaPropertiesFacory;
 import com.sequenceiq.cloudbreak.common.tx.CircuitBreakerType;
+import com.sequenceiq.cloudbreak.database.MultiDataSourceConfig;
 import com.sequenceiq.cloudbreak.util.DatabaseUtil;
 import com.sequenceiq.flow.ha.NodeConfig;
 import com.zaxxer.hikari.HikariConfig;
@@ -33,7 +32,7 @@ import com.zaxxer.hikari.HikariDataSource;
 
 @Configuration
 @EnableTransactionManagement
-public class DatabaseConfig {
+public class DatabaseConfig extends MultiDataSourceConfig {
 
     @Value("${cb.db.env.user:}")
     private String dbUser;
@@ -87,23 +86,7 @@ public class DatabaseConfig {
     @Inject
     private Environment environment;
 
-    @Bean(name = "defaultDataSource")
-    public DataSource defaultDataSource() throws SQLException {
-        return getDataSource("hikari-app-pool");
-    }
-
-    @Bean(name = "quartzDataSource")
-    public DataSource quartzDataSource() throws SQLException {
-        return getDataSource("hikari-quartz-pool");
-    }
-
-    @Primary
-    @Bean(name = "dataSource")
-    public DataSource dataSource() {
-        return new RoutingDataSource();
-    }
-
-    private HikariDataSource getDataSource(String poolName) throws SQLException {
+    protected HikariDataSource getDataSource(String poolName) throws SQLException {
         DatabaseUtil.createSchemaIfNeeded("postgresql", databaseAddress, dbName, dbUser, dbPassword, dbSchemaName);
         HikariConfig config = new HikariConfig();
         config.setPoolName(poolName);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/database/RoutingDataSourceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/database/RoutingDataSourceTest.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.cloudbreak.conf;
+package com.sequenceiq.cloudbreak.database;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.lenient;

--- a/datalake/src/main/java/com/sequenceiq/datalake/configuration/DatabaseConfig.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/configuration/DatabaseConfig.java
@@ -8,7 +8,6 @@ import java.sql.SQLException;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.persistence.EntityManagerFactory;
-import javax.sql.DataSource;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -26,6 +25,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 import com.sequenceiq.cloudbreak.common.database.BatchProperties;
 import com.sequenceiq.cloudbreak.common.database.JpaPropertiesFacory;
 import com.sequenceiq.cloudbreak.common.tx.CircuitBreakerType;
+import com.sequenceiq.cloudbreak.database.MultiDataSourceConfig;
 import com.sequenceiq.cloudbreak.util.DatabaseUtil;
 import com.sequenceiq.flow.ha.NodeConfig;
 import com.zaxxer.hikari.HikariConfig;
@@ -33,7 +33,7 @@ import com.zaxxer.hikari.HikariDataSource;
 
 @Configuration
 @EnableTransactionManagement
-public class DatabaseConfig {
+public class DatabaseConfig extends MultiDataSourceConfig {
 
     @Value("${datalake.db.env.user:}")
     private String dbUser;
@@ -87,10 +87,10 @@ public class DatabaseConfig {
     @Inject
     private Environment environment;
 
-    @Bean
-    public DataSource dataSource() throws SQLException {
+    protected HikariDataSource getDataSource(String poolName) throws SQLException {
         DatabaseUtil.createSchemaIfNeeded("postgresql", databaseAddress, dbName, dbUser, dbPassword, dbSchemaName);
         HikariConfig config = new HikariConfig();
+        config.setPoolName(poolName);
         if (ssl) {
             config.addDataSourceProperty("ssl", "true");
             config.addDataSourceProperty("sslfactory", "org.postgresql.ssl.DefaultJavaSSLFactory");

--- a/environment/src/main/java/com/sequenceiq/environment/configuration/DatabaseConfig.java
+++ b/environment/src/main/java/com/sequenceiq/environment/configuration/DatabaseConfig.java
@@ -10,7 +10,6 @@ import java.sql.Statement;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.persistence.EntityManagerFactory;
-import javax.sql.DataSource;
 
 import org.postgresql.Driver;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,6 +30,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 import com.sequenceiq.cloudbreak.common.database.BatchProperties;
 import com.sequenceiq.cloudbreak.common.database.JpaPropertiesFacory;
 import com.sequenceiq.cloudbreak.common.tx.CircuitBreakerType;
+import com.sequenceiq.cloudbreak.database.MultiDataSourceConfig;
 import com.sequenceiq.flow.ha.NodeConfig;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
@@ -38,7 +38,7 @@ import com.zaxxer.hikari.HikariDataSource;
 @Configuration
 @EnableTransactionManagement
 @ConditionalOnProperty(name = "environment.db.enabled", havingValue = "true", matchIfMissing = true)
-public class DatabaseConfig {
+public class DatabaseConfig extends MultiDataSourceConfig {
 
     private static final String DEFAULT_SCHEMA_NAME = "public";
 
@@ -94,10 +94,10 @@ public class DatabaseConfig {
     @Inject
     private Environment environment;
 
-    @Bean
-    public DataSource dataSource() throws SQLException {
+    protected HikariDataSource getDataSource(String poolName) throws SQLException {
         createSchemaIfNeeded("postgresql", databaseAddress, dbName, dbUser, dbPassword, dbSchemaName);
         HikariConfig config = new HikariConfig();
+        config.setPoolName(poolName);
         if (ssl) {
             config.addDataSourceProperty("ssl", "true");
             config.addDataSourceProperty("sslfactory", "org.postgresql.ssl.DefaultJavaSSLFactory");

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/DatabaseConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/DatabaseConfig.java
@@ -8,7 +8,6 @@ import java.sql.SQLException;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.persistence.EntityManagerFactory;
-import javax.sql.DataSource;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -26,6 +25,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 import com.sequenceiq.cloudbreak.common.database.BatchProperties;
 import com.sequenceiq.cloudbreak.common.database.JpaPropertiesFacory;
 import com.sequenceiq.cloudbreak.common.tx.CircuitBreakerType;
+import com.sequenceiq.cloudbreak.database.MultiDataSourceConfig;
 import com.sequenceiq.cloudbreak.util.DatabaseUtil;
 import com.sequenceiq.flow.ha.NodeConfig;
 import com.zaxxer.hikari.HikariConfig;
@@ -33,7 +33,7 @@ import com.zaxxer.hikari.HikariDataSource;
 
 @Configuration
 @EnableTransactionManagement
-public class DatabaseConfig {
+public class DatabaseConfig extends MultiDataSourceConfig {
 
     @Value("${freeipa.db.env.user:}")
     private String dbUser;
@@ -87,10 +87,10 @@ public class DatabaseConfig {
     @Inject
     private Environment environment;
 
-    @Bean
-    public DataSource dataSource() throws SQLException {
+    protected HikariDataSource getDataSource(String poolName) throws SQLException {
         DatabaseUtil.createSchemaIfNeeded("postgresql", databaseAddress, dbName, dbUser, dbPassword, dbSchemaName);
         HikariConfig config = new HikariConfig();
+        config.setPoolName(poolName);
         if (ssl) {
             config.addDataSourceProperty("ssl", "true");
             config.addDataSourceProperty("sslfactory", "org.postgresql.ssl.DefaultJavaSSLFactory");

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/DatabaseConfig.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/DatabaseConfig.java
@@ -8,7 +8,6 @@ import java.sql.SQLException;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.persistence.EntityManagerFactory;
-import javax.sql.DataSource;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -26,6 +25,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 import com.sequenceiq.cloudbreak.common.database.BatchProperties;
 import com.sequenceiq.cloudbreak.common.database.JpaPropertiesFacory;
 import com.sequenceiq.cloudbreak.common.tx.CircuitBreakerType;
+import com.sequenceiq.cloudbreak.database.MultiDataSourceConfig;
 import com.sequenceiq.cloudbreak.util.DatabaseUtil;
 import com.sequenceiq.flow.ha.NodeConfig;
 import com.zaxxer.hikari.HikariConfig;
@@ -33,7 +33,7 @@ import com.zaxxer.hikari.HikariDataSource;
 
 @Configuration
 @EnableTransactionManagement
-public class DatabaseConfig {
+public class DatabaseConfig extends MultiDataSourceConfig {
 
     @Value("${redbeams.db.env.user:}")
     private String dbUser;
@@ -87,10 +87,10 @@ public class DatabaseConfig {
     @Inject
     private Environment environment;
 
-    @Bean
-    public DataSource dataSource() throws SQLException {
+    protected HikariDataSource getDataSource(String poolName) throws SQLException {
         DatabaseUtil.createSchemaIfNeeded("postgresql", databaseAddress, dbName, dbUser, dbPassword, dbSchemaName);
         HikariConfig config = new HikariConfig();
+        config.setPoolName(poolName);
         if (ssl) {
             config.addDataSourceProperty("ssl", "true");
             config.addDataSourceProperty("sslfactory", "org.postgresql.ssl.DefaultJavaSSLFactory");


### PR DESCRIPTION
… separation of the db connection pool used by quartz the application itself we can minimize the impact on the application caused by If we separate the connection pool used by quartz and the connection pool used by the application itself, then we can minimize the impact caused by misbehaving quartz.

In order to keep the implementation simple we will go with the same default for the new connection pool that we have for the application pool. This means that in certain conditions the maximum connections to the database can be doubled, which is acceptable.

It is not trivial to create an assertion on what pool was used, but based on the logs it seems when quartzExecutor- thread is used then I saw activity in Hikari pool

```
2023-02-10 17:03:59,106 [quartzExecutor-2] lambda$checkStatus$1:40 INFO  c.s.f.s.FreeipaChecker - [type:STACK] [crn:crn:cdp:freeipa:us-west-1:cloudera:freeipa:.....-...] [name:akanto-aws-maz1-freeipa] [flow:] [requestid:e56fa6de-3bd0-....-2b152b2a3084] [tenant:cloudera] [userCrn:crn:cdp:iam:us-west-1:altus:user:__internal__actor__] [environment:crn:cdp:environments:us-west-1:cloudera:environment:....8270a3a7206d] [traceId:] [spanId:] [operationId:] Checking FreeIPA status for instance IDs [....]
...
2023-02-10 17:04:20,951 [hikari-app-pool housekeeper] logPoolState:421 DEBUG c.z.h.p.HikariPool - [type:springLog] [crn:] [name:] [flow:] [requestid:] [tenant:] [userCrn:] [environment:] [traceId:] [spanId:] [operationId:] hikari-app-pool - After cleanup  stats (total=3, active=1, idle=2, waiting=0)
```

