### PR TITLE
CB-18949 Targeting Subnets for Load Balancers in Azure

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureLoadBalancerFrontend.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureLoadBalancerFrontend.java
@@ -1,0 +1,58 @@
+package com.sequenceiq.cloudbreak.cloud.azure;
+
+import java.util.Objects;
+
+import com.sequenceiq.common.api.type.LoadBalancerType;
+
+public class AzureLoadBalancerFrontend {
+
+    private final String name;
+
+    private final String ip;
+
+    private final LoadBalancerType loadBalancerType;
+
+    public AzureLoadBalancerFrontend(String name, String ip, LoadBalancerType loadBalancerType) {
+        this.name = name;
+        this.ip = ip;
+        this.loadBalancerType = loadBalancerType;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getIp() {
+        return ip;
+    }
+
+    public LoadBalancerType getLoadBalancerType() {
+        return loadBalancerType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof AzureLoadBalancerFrontend)) {
+            return false;
+        }
+        AzureLoadBalancerFrontend that = (AzureLoadBalancerFrontend) o;
+        return Objects.equals(name, that.name) && Objects.equals(ip, that.ip) && Objects.equals(loadBalancerType, that.loadBalancerType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, ip, loadBalancerType);
+    }
+
+    @Override
+    public String toString() {
+        return "AzureLoadBalancerFrontend{" +
+                "name='" + name + '\'' +
+                ", ip='" + ip + '\'' +
+                ", loadBalancerType=" + loadBalancerType +
+                '}';
+    }
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureLoadBalancerMetadataCollector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureLoadBalancerMetadataCollector.java
@@ -39,7 +39,10 @@ public class AzureLoadBalancerMetadataCollector {
         AzureClient azureClient = ac.getParameter(AzureClient.class);
         Map<String, LoadBalancingRule> rules = azureClient.getLoadBalancerRules(resourceGroup, loadBalancerName);
 
+        // rule name ending with special "gateway" suffix is happening _only_ in the case of requested GATEWAY_PRIVATE load balancer
+        // and in that case the second rule is basically the copy of the first one, only the name differs. See arm-v2.ftl
         Map<Integer, String> portToAsMapping = rules.values().stream()
+                .filter(r -> !r.name().endsWith("gateway"))
                 .collect(Collectors.toMap(LoadBalancingRule::backendPort, rule -> generateAvailabilitySetName(ac, rule.backend())));
         LOGGER.debug("Found port to availability set mapping [{}] for load balancer {}", portToAsMapping, loadBalancerName);
 

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilder.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilder.java
@@ -97,7 +97,7 @@ public class AzureTemplateBuilder {
 
             // needed for pre 1.16.5 templates and Load balancer setup on Medium duty datalakes.
             model.put("existingSubnetName", azureUtils.getCustomSubnetIds(network).stream().findFirst().orElse(""));
-
+            model.put("endpointGwSubnet", azureUtils.getCustomEndpointGatewaySubnetIds(network).stream().findFirst().orElse(""));
             model.put("usePartnerCenter", Objects.nonNull(azureMarketplaceImage));
             model.put("marketplaceImageDetails", azureMarketplaceImage);
             model.put("customImageId", customImageId);

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtils.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtils.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.cloud.azure;
 
+import static com.sequenceiq.cloudbreak.common.network.NetworkConstants.ENDPOINT_GATEWAY_SUBNET_ID;
 import static com.sequenceiq.cloudbreak.common.network.NetworkConstants.SUBNET_ID;
 import static com.sequenceiq.cloudbreak.constant.AzureConstants.DATABASE_PRIVATE_DNS_ZONE_ID;
 import static com.sequenceiq.cloudbreak.constant.AzureConstants.NETWORK_ID;
@@ -209,6 +210,14 @@ public class AzureUtils {
 
     public List<String> getCustomSubnetIds(Network network) {
         String subnetIds = network.getStringParameter(SUBNET_ID);
+        if (StringUtils.isBlank(subnetIds)) {
+            return new ArrayList<>();
+        }
+        return Arrays.asList(subnetIds.split(","));
+    }
+
+    public List<String> getCustomEndpointGatewaySubnetIds(Network network) {
+        String subnetIds = network.getStringParameter(ENDPOINT_GATEWAY_SUBNET_ID);
         if (StringUtils.isBlank(subnetIds)) {
             return new ArrayList<>();
         }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/EnvironmentBaseNetworkConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/EnvironmentBaseNetworkConverter.java
@@ -77,9 +77,12 @@ public abstract class EnvironmentBaseNetworkConverter implements EnvironmentNetw
     /**
      * Attach the subnet ID in which to place a public endpoint gateway.
      *
-     * The default implementation should be sufficient for GCP and AWS.
+     * The default implementation is sufficient for GCP.
      *
-     * For Azure, we do not need to attach the endpoint gateway to a public subnet, so this method must be overrridable.
+     * For Azure, as there are no Availability Zones, when targeting, we need to attach the endpoint gateway to the targeted private subnet.
+     * If there is no targeting then there is no need to attach to a public subnet.
+     * So this method must be overrridable.
+     *
      * @param source contains source information to retrieve subnets from
      * @param attributes a Map which we put the gateway subnet ID in
      */

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/loadbalancer/LoadBalancerFqdnUtil.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/loadbalancer/LoadBalancerFqdnUtil.java
@@ -33,6 +33,10 @@ public class LoadBalancerFqdnUtil {
                         .orElseGet(() -> findAnyLbNameOrNull(loadBalancers)));
     }
 
+    public Set<LoadBalancer> getLoadBalancersForStack(Long stackId) {
+        return loadBalancerPersistenceService.findByStackId(stackId);
+    }
+
     private Optional<String> findLbNameForType(Set<LoadBalancer> loadBalancers, LoadBalancerType loadBalancerType) {
         return loadBalancers.stream()
                 .filter(lb -> loadBalancerType.equals(lb.getType()))

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/loadbalancer/LoadBalancerFqdnUtilTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/loadbalancer/LoadBalancerFqdnUtilTest.java
@@ -1,7 +1,10 @@
 package com.sequenceiq.cloudbreak.service.loadbalancer;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.HashSet;
@@ -31,6 +34,8 @@ class LoadBalancerFqdnUtilTest {
     private static final String PRIVATE_FQDN = "private.fqdn";
 
     private static final String PRIVATE_IP = "private.ip";
+
+    private static final long STACK_ID = 123L;
 
     @Mock
     private LoadBalancerPersistenceService loadBalancerPersistenceService;
@@ -164,6 +169,17 @@ class LoadBalancerFqdnUtilTest {
 
         String fqdn = underTest.getLoadBalancerUserFacingFQDN(0L);
         assertNull(fqdn);
+    }
+
+    @Test
+    void testGetLoadBalancersForStack() {
+        LoadBalancer lb1 = mock(LoadBalancer.class);
+        LoadBalancer lb2 = mock(LoadBalancer.class);
+        Set<LoadBalancer> loadBalancers = Set.of(lb1, lb2);
+        when(loadBalancerPersistenceService.findByStackId(STACK_ID)).thenReturn(loadBalancers);
+        Set<LoadBalancer> result = underTest.getLoadBalancersForStack(STACK_ID);
+        verify(loadBalancerPersistenceService).findByStackId(STACK_ID);
+        assertThat(result).isEqualTo(loadBalancers);
     }
 
     private Set<LoadBalancer> createLoadBalancers(boolean createPrivate, boolean createPublic, boolean createOutbound) {

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/floating_ip_loadbalancer.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/floating_ip_loadbalancer.sls
@@ -1,0 +1,25 @@
+{% if salt['pillar.get']('platform') == 'AZURE' and salt['pillar.get']('gateway:loadbalancers:floatingIpEnabled', False) %}
+rename_original_ifcfg_lo:
+  file.rename:
+    - makedirs: True
+    - name: /etc/sysconfig/network-scripts/ifcfg-lo.orig
+    - source: /etc/sysconfig/network-scripts/ifcfg-lo
+    - unless: test -f /etc/sysconfig/network-scripts/ifcfg-lo.orig
+
+lo:
+  network.managed:
+    - name: lo
+    - type: eth
+    - onboot: yes
+    - userctl: no
+    - ipv6_autoconf: no
+    - enable_ipv6: false
+    - peerdns: no
+    - scope: global
+    - ipaddrs:
+{% for lb in salt['pillar.get']('gateway:loadbalancers:frontends') %}
+  {%- if lb['type'] == 'GATEWAY_PRIVATE' or lb['type'] == 'PRIVATE' %}
+      - {{ lb['ip'] }}/32
+  {%- endif %}
+{% endfor %}
+{% endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/top.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/top.sls
@@ -69,6 +69,7 @@ base:
     - gateway.knox
     - ccm
     - nginx.init
+    - gateway.floating_ip_loadbalancer
 
   'G@roles:knox':
     - match: compound


### PR DESCRIPTION
In the case of Azure, if a secondary load balancer would be needed, just create the first and only private but add a secondary frontend IP configuration, using the targeted subnet from the environment request, and set the load balancing rules for both the two frontend IP configurations to enable Floating IP, also using the same frontend-backend port pair, backend pool and health probe.

VM OS level configuration is also needed for the loopback net interface

See detailed description in the commit message.