### PR TITLE
CB-20824 eliminate unnecessary DTO conversions from HeartbeatService related Environment service's calls

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/EnvironmentHaApplication.java
+++ b/environment/src/main/java/com/sequenceiq/environment/EnvironmentHaApplication.java
@@ -9,7 +9,6 @@ import static com.sequenceiq.environment.environment.EnvironmentStatus.RDBMS_DEL
 
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,7 +18,6 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
 import com.sequenceiq.cloudbreak.service.ha.HaApplication;
 import com.sequenceiq.environment.environment.EnvironmentStatus;
-import com.sequenceiq.environment.environment.dto.EnvironmentDto;
 import com.sequenceiq.environment.environment.service.EnvironmentService;
 import com.sequenceiq.environment.store.EnvironmentInMemoryStateStore;
 import com.sequenceiq.flow.core.FlowRegister;
@@ -48,15 +46,13 @@ public class EnvironmentHaApplication implements HaApplication {
 
     @Override
     public Set<Long> getDeletingResources(Set<Long> resourceIds) {
-        List<EnvironmentDto> environments = environmentService.findAllByIdInAndStatusIn(resourceIds, DELETION_STATUSES);
-        return environments.stream().map(EnvironmentDto::getId).collect(Collectors.toSet());
+        return environmentService.findAllIdByIdInAndStatusIn(resourceIds, DELETION_STATUSES);
     }
 
     @Override
     public Set<Long> getAllDeletingResources() {
         Set<Long> envIds = EnvironmentInMemoryStateStore.getAll();
-        List<EnvironmentDto> environments = environmentService.findAllByIdInAndStatusIn(envIds, DELETION_STATUSES);
-        return environments.stream().map(EnvironmentDto::getId).collect(Collectors.toSet());
+        return environmentService.findAllIdByIdInAndStatusIn(envIds, DELETION_STATUSES);
     }
 
     @Override
@@ -66,10 +62,8 @@ public class EnvironmentHaApplication implements HaApplication {
 
     @Override
     public void cancelRunningFlow(Long resourceId) {
-        environmentService.findById(resourceId).ifPresentOrElse(environmentDto -> {
-            EnvironmentInMemoryStateStore.put(resourceId, PollGroup.CANCELLED);
-            flowCancelService.cancelRunningFlows(resourceId);
-        }, () -> LOGGER.error("Cannot cancel the flow, because the environment does not exist: {}", resourceId));
+        EnvironmentInMemoryStateStore.put(resourceId, PollGroup.CANCELLED);
+        flowCancelService.cancelRunningFlows(resourceId);
     }
 
     @Override

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeIpaCreationHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeIpaCreationHandler.java
@@ -4,7 +4,6 @@ import static com.sequenceiq.cloudbreak.cloud.model.Platform.platform;
 import static com.sequenceiq.cloudbreak.util.SecurityGroupSeparator.getSecurityGroupIds;
 import static com.sequenceiq.environment.environment.flow.creation.event.EnvCreationHandlerSelectors.CREATE_FREEIPA_EVENT;
 import static com.sequenceiq.environment.environment.flow.creation.event.EnvCreationStateSelectors.FINISH_ENV_CREATION_EVENT;
-import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.CREATE_IN_PROGRESS;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -184,9 +183,7 @@ public class FreeIpaCreationHandler extends EventSenderAwareHandler<EnvironmentD
             }
         } else {
             LOGGER.info("FreeIpa for environmentCrn '{}' already exists. Using this one.", environmentDto.getResourceCrn());
-            if (CREATE_IN_PROGRESS == freeIpa.get().getStatus()) {
-                awaitFreeIpaCreation(environmentDtoEvent, environmentDto);
-            }
+            awaitFreeIpaCreation(environmentDtoEvent, environmentDto);
         }
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/environment/repository/EnvironmentRepository.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/repository/EnvironmentRepository.java
@@ -91,9 +91,11 @@ public interface EnvironmentRepository extends AccountAwareResourceRepository<En
     @Query("SELECT COUNT(e)>0 FROM Environment e WHERE e.name = :name AND e.accountId = :accountId AND e.archived = false")
     boolean existsWithNameAndAccountAndArchivedIsFalse(@Param("name") String name, @Param("accountId") String accountId);
 
-    List<Environment> findAllByIdInAndStatusInAndArchivedIsFalse(Collection<Long> ids, Collection<EnvironmentStatus> statuses);
-
-    List<Environment> findAllByStatusInAndArchivedIsFalse(Collection<EnvironmentStatus> statuses);
+    @Query("SELECT e.id FROM Environment e " +
+            "WHERE e.id in (:ids) " +
+            "AND e.status in (:statuses) " +
+            "AND e.archived = false")
+    Set<Long> findAllIdByIdInAndStatusInAndArchivedIsFalse(@Param("ids") Collection<Long> ids, @Param("statuses") Collection<EnvironmentStatus> statuses);
 
     @Query("SELECT e.resourceCrn FROM Environment e WHERE e.name = :name AND e.accountId = :accountId")
     Optional<String> findResourceCrnByNameAndAccountId(@Param("name") String name, @Param("accountId") String accountId);

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentService.java
@@ -304,16 +304,8 @@ public class EnvironmentService extends AbstractAccountAwareResourceService<Envi
         return environmentRepository.existsWithNameAndAccountAndArchivedIsFalse(name, accountId);
     }
 
-    public List<EnvironmentDto> findAllByIdInAndStatusIn(Collection<Long> resourceIds, Collection<EnvironmentStatus> environmentStatuses) {
-        List<Environment> environments = environmentRepository
-                .findAllByIdInAndStatusInAndArchivedIsFalse(resourceIds, environmentStatuses);
-        return environments.stream().map(environmentDtoConverter::environmentToDto).collect(Collectors.toList());
-    }
-
-    public List<EnvironmentDto> findAllByStatusIn(Collection<EnvironmentStatus> environmentStatuses) {
-        List<Environment> environments = environmentRepository
-                .findAllByStatusInAndArchivedIsFalse(environmentStatuses);
-        return environments.stream().map(environmentDtoConverter::environmentToDto).collect(Collectors.toList());
+    public Set<Long> findAllIdByIdInAndStatusIn(Collection<Long> resourceIds, Collection<EnvironmentStatus> environmentStatuses) {
+        return environmentRepository.findAllIdByIdInAndStatusInAndArchivedIsFalse(resourceIds, environmentStatuses);
     }
 
     Optional<Environment> findByNameAndAccountIdAndArchivedIsFalse(String name, String accountId) {

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentServiceTest.java
@@ -17,7 +17,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -215,23 +214,12 @@ class EnvironmentServiceTest {
     void findAllByIdInAndStatusIn() {
         Set<Long> resourceIds = Set.of(1L, 2L);
         Set<EnvironmentStatus> statuses = Set.of(EnvironmentStatus.AVAILABLE, EnvironmentStatus.CREATION_INITIATED);
-        List<Environment> qresult = List.of(environment);
-        when(environmentDtoConverter.environmentToDto(eq(environment))).thenReturn(environmentDto);
+        Set<Long> expectedResourceIds = Set.of(1L);
         when(environmentRepository
-                .findAllByIdInAndStatusInAndArchivedIsFalse(eq(resourceIds), eq(statuses))).thenReturn(qresult);
-        assertEquals(List.of(environmentDto), environmentServiceUnderTest.findAllByIdInAndStatusIn(resourceIds,
+                .findAllIdByIdInAndStatusInAndArchivedIsFalse(eq(resourceIds), eq(statuses))).thenReturn(expectedResourceIds);
+
+        assertEquals(expectedResourceIds, environmentServiceUnderTest.findAllIdByIdInAndStatusIn(resourceIds,
                 statuses));
-    }
-
-    @Test
-    void findAllByStatusIn() {
-        when(environmentDtoConverter.environmentToDto(eq(environment))).thenReturn(environmentDto);
-        when(environmentRepository
-                .findAllByStatusInAndArchivedIsFalse(eq(Set.of(EnvironmentStatus.AVAILABLE, EnvironmentStatus.CREATION_INITIATED))))
-                .thenReturn(List.of(environment));
-        assertEquals(List.of(environmentDto), environmentServiceUnderTest
-                .findAllByStatusIn(Set.of(EnvironmentStatus.AVAILABLE, EnvironmentStatus.CREATION_INITIATED)));
-
     }
 
     @Test


### PR DESCRIPTION
With the changes Environment service was able to pick up an abandoned flow:
```
select 
	fl.id,
	fl.finalized, 
	fl.cloudbreaknodeid, 
	fl.statestatus,
	fl.currentstate,
	fl.endtime,
 	fl.created
from flowlog fl where fl.flowid = 'bd43a6d4-93ac-41f5-8a2f-dbc4956f1a7e'
order by fl.created;

 id  | finalized | cloudbreaknodeid | statestatus |                         currentstate                         |    endtime    |    created    
-----+-----------+------------------+-------------+--------------------------------------------------------------+---------------+---------------
 204 | t         | 18e6237b-node1   | SUCCESSFUL  | INIT_STATE                                                   | 1676382403047 | 1676382402165
 205 | t         | 18e6237b-node1   | SUCCESSFUL  | ENVIRONMENT_INITIALIZATION_STATE                             | 1676382403494 | 1676382403048
 206 | t         | 18e6237b-node1   | SUCCESSFUL  | ENVIRONMENT_CREATION_VALIDATION_STATE                        | 1676382403523 | 1676382403495
 207 | t         | 18e6237b-node1   | SUCCESSFUL  | STORAGE_CONSUMPTION_COLLECTION_SCHEDULING_STARTED_STATE      | 1676382403928 | 1676382403524
 208 | t         | 18e6237b-node1   | SUCCESSFUL  | NETWORK_CREATION_STARTED_STATE                               | 1676382404436 | 1676382403929
 209 | t         | 18e6237b-node1   | SUCCESSFUL  | PUBLICKEY_CREATION_STARTED_STATE                             | 1676382404468 | 1676382404437
 210 | t         | 18e6237b-node2   | SUCCESSFUL  | ENVIRONMENT_RESOURCE_ENCRYPTION_INITIALIZATION_STARTED_STATE | 1676382483105 | 1676382404469
 211 | t         | 18e6237b-node2   | SUCCESSFUL  | FREEIPA_CREATION_STARTED_STATE                               | 1676382483155 | 1676382483106
 212 | t         | 18e6237b-node2   | SUCCESSFUL  | ENV_CREATION_FINISHED_STATE                                  | 1676382483172 | 1676382483156
 213 | t         | 18e6237b-node2   | SUCCESSFUL  | FINISHED                                                     |               | 1676382483173
(10 rows)

