### PR TITLE
CRB-2402 updating mina-core because the current apacheds-kerberos-cod…

### DIFF
--- a/freeipa/build.gradle
+++ b/freeipa/build.gradle
@@ -51,6 +51,8 @@ dependencies {
   implementation     ('io.swagger:swagger-jersey2-jaxrs') {
     exclude group: 'org.yaml'
   }
+  // apacheds-kerberos-codec using a pretty old mina-core and that library was not update since 2020
+  implementation     group: 'org.apache.mina',           name: 'mina-core',                            version: '2.1.5'
   implementation     group: 'javax.activation',          name: 'activation',                           version: '1.1.1'
   implementation     group: 'org.glassfish.jersey.core', name: 'jersey-server'
   implementation     group: 'org.mybatis',               name: 'mybatis-migrations'
@@ -67,7 +69,9 @@ dependencies {
     exclude group: 'org.hibernate', module: 'hibernate-envers'
   }
   implementation     group: 'com.google.guava',          name: 'guava',                                version: guavaVersion
-  implementation     group: 'org.apache.directory.server', name: 'apacheds-kerberos-codec',            version: '2.0.0.AM26'
+  implementation     (group: 'org.apache.directory.server', name: 'apacheds-kerberos-codec',            version: '2.0.0.AM26') {
+    exclude group: 'org.apache.mina', module: 'mina-core'
+  }
 
   implementation     group: 'com.github.briandilley.jsonrpc4j', name: 'jsonrpc4j',                     version: '1.6'
   implementation     group: 'com.dyngr',                        name: 'polling',                       version: dyngrPollingVersion


### PR DESCRIPTION
…ec using a pretty old mina-core and that library was not update since 2020. Also updaing spring we starter for tomcat-embbedded websocker update

See detailed description in the commit message.