### PR TITLE
CDPSDX-3900 Add logging to DB backup/restore for errors when wrong no…

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
@@ -27,16 +27,20 @@ doLog() {
   echo "$(date "+%Y-%m-%dT%H:%M:%SZ") $type_of_msg ""$msg" >>$LOGFILE
 }
 
-if [[ $# -lt 6 || $# -gt 10 || "$1" == "None" ]]; then
-  doLog "Invalid inputs provided"
+if [[ $# -lt 6 || $# -gt 10 || "$1" == "None" || -z "$1" ]]; then
+  doLog "ERROR: Invalid inputs provided"
+  doLog "Here are $# inputs in this run."
   doLog "Script accepts at least 6 and at most 7 inputs:"
   doLog "  1. Object Storage Service url to place backups."
-  doLog "  2. PostgreSQL host name."
-  doLog "  3. PostgreSQL port."
-  doLog "  4. PostgreSQL user name."
+  doLog "  2. PostgresSQL host name."
+  doLog "  3. PostgresSQL port."
+  doLog "  4. PostgresSQL user name."
   doLog "  5. Ranger admin group."
   doLog "  6. Whether or not to close connections for the database while it is being backed up."
   doLog "  7-10. (optional) Names of the databases to backup. If not given, will backup ranger and hive databases."
+  doLog "This is because there are missing values in /srv/pillar/postgresql/disaster_recovery.sls or PostgresSQL,
+  which might be caused by salt command is not running on the master Gateway node or there has never had a backup/restore
+  from the CDP CLI run."
   exit 1
 fi
 

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/restore_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/restore_db.sh
@@ -25,15 +25,19 @@ doLog() {
   echo "$(date "+%Y-%m-%dT%H:%M:%SZ") $type_of_msg ""$msg" >>$LOGFILE
 }
 
-if [[ $# -lt 5 || $# -gt 6 || "$1" == "None" ]]; then
-  doLog "Invalid inputs provided"
+if [[ $# -lt 5 || $# -gt 6 || "$1" == "None" || -z "$1" ]]; then
+  doLog "ERROR: Invalid inputs provided"
+  doLog "Here are $# inputs in this run."
   doLog "Script accepts at least 5 and at most 6 inputs:"
   doLog "  1. Object Storage Service url to retrieve backups."
-  doLog "  2. PostgreSQL host name."
-  doLog "  3. PostgreSQL port."
-  doLog "  4. PostgreSQL user name."
+  doLog "  2. PostgresSQL host name."
+  doLog "  3. PostgresSQL port."
+  doLog "  4. PostgresSQL user name."
   doLog "  5. Ranger admin group."
   doLog "  6. (optional) Name of the database to restore. If not given, will restore ranger and hive databases."
+  doLog "This is because there are missing values in /srv/pillar/postgresql/disaster_recovery.sls or PostgresSQL,
+  which might be caused by salt command is not running on the master Gateway node or there has never had a backup/restore
+  from the CDP CLI run."
   exit 1
 fi
 


### PR DESCRIPTION
…de is used

**JIRA**: [CDPSDX-3900](https://jira.cloudera.com/browse/CDPSDX-3900)
**ISSUE**: When a user ran the salt command to manually backup database on a wrong node the backup fails because it is missing values in the pillar file, as below:
<img width="912" alt="V9b9V" src="https://user-images.githubusercontent.com/39275944/218854743-b3f90d6a-1913-47df-8bf8-df36b7a0fe43.png">

**SOLUTION**: Add in logs when that value is missing. I added in "-z "$1" which means $1 is null and I didn't remove "$1" == "None" since Im not sure if that was a case I don't know where object_storage_url is "None".

**Before**:
<img width="1187" alt="Screen Shot 2023-02-13 at 4 41 16 PM" src="https://user-images.githubusercontent.com/39275944/218854504-b58e345b-e617-4df9-bb14-dc7a13d03bc4.png">

**After**:
Backup:
<img width="1179" alt="Screen Shot 2023-02-14 at 3 19 59 PM" src="https://user-images.githubusercontent.com/39275944/218855323-82b59c42-58a6-4d69-a803-0c7903080336.png">
Restore: 
<img width="1153" alt="Screen Shot 2023-02-14 at 3 20 32 PM" src="https://user-images.githubusercontent.com/39275944/218855336-70639de3-fd41-4c94-b1e2-b9e0d23ea2eb.png">


