### PR TITLE
CB-20921 - [Knox] Update samesite=lax for hadoop-jwt cookie

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/knoxsso.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/knoxsso.xml.j2
@@ -138,6 +138,10 @@
             <value>86400000</value>
         </param>
         <param>
+             <name>knoxsso.cookie.samesite</name>
+             <value>Lax</value>
+        </param>
+        <param>
            <name>knoxsso.redirect.whitelist.regex</name>
            {% if salt['pillar.get']('gateway:userfacingdomain') is defined and salt['pillar.get']('gateway:userfacingdomain')|length > 1 %}
            <value>^\/.*$;^https?:\/\/(.+\.{{ salt['pillar.get']('gateway:userfacingdomain') }})(?::[0-9]+)?(?:\/.*)?$</value>


### PR DESCRIPTION
**Problem:**
Due to some changes in how Knox cookies are handled Public cloud UI have stopped working (7.2.17). This is the JIRA that contains the details [CB-20921](https://jira.cloudera.com/browse/CB-20921). In a nutshell `hadoop-jwt` cookie samesite property was changed from `None` to `Strict` to prevent Cross-Site Script Inclusion attacks [ENGESC-16602](https://jira.cloudera.com/browse/ENGESC-16602). This change breaks the SSO flow. 

**What is fixed:**
Here we are updating knoxsso topology to change the samesite property to `Lax`  using configuration `knoxsso.cookie.samesite`.

**How as this tested:**
This change was tested on a public cloud cluster. Runtime: 7.2.17-1.cdh7.2.17.p0.37723226  CB: 2.68.0-b108

// Edit to see if this triggers tests