### PR TITLE
Revert "CB-20884 add a skip window for core statuschecker to avoid CM related issues"

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJob.java
@@ -9,9 +9,6 @@ import static com.sequenceiq.cloudbreak.cloud.model.HostName.hostName;
 import static com.sequenceiq.cloudbreak.util.Benchmark.measure;
 import static java.util.stream.Collectors.toSet;
 
-import java.time.Duration;
-import java.time.Instant;
-import java.time.ZoneOffset;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
@@ -27,7 +24,6 @@ import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -45,7 +41,6 @@ import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
 import com.sequenceiq.cloudbreak.cluster.status.ExtendedHostStatuses;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessorFactory;
-import com.sequenceiq.cloudbreak.common.service.Clock;
 import com.sequenceiq.cloudbreak.common.type.HealthCheck;
 import com.sequenceiq.cloudbreak.common.type.Versioned;
 import com.sequenceiq.cloudbreak.converter.spi.InstanceMetaDataToCloudInstanceConverter;
@@ -72,7 +67,6 @@ import com.sequenceiq.cloudbreak.util.StackUtil;
 import com.sequenceiq.cloudbreak.view.InstanceMetadataView;
 import com.sequenceiq.cloudbreak.view.StackView;
 import com.sequenceiq.flow.core.FlowLogService;
-import com.sequenceiq.flow.domain.FlowLog;
 
 @DisallowConcurrentExecution
 @Component
@@ -131,12 +125,6 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
     @Inject
     private ServiceStatusCheckerLogLocationDecorator serviceStatusCheckerLogLocationDecorator;
 
-    @Inject
-    private Clock clock;
-
-    @Value("${cb.statuschecker.skip.window.minutes:2}")
-    private Integer skipWindow;
-
     @Override
     protected Optional<MdcContextInfoProvider> getMdcContextConfigProvider() {
         return Optional.ofNullable(stackDtoService.getStackViewById(getStackId()));
@@ -144,8 +132,8 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
 
     @Override
     protected void executeTracedJob(JobExecutionContext context) throws JobExecutionException {
-        if (shouldSkipStatusCheck()) {
-            LOGGER.info("Status check skipped for stack {}", getStackId());
+        if (flowLogService.isOtherFlowRunning(getStackId())) {
+            LOGGER.debug("StackStatusCheckerJob cannot run, because flow is running for stack: {}", getStackId());
             return;
         }
         try {
@@ -176,26 +164,6 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
         } catch (Exception e) {
             LOGGER.info("Exception during cluster state check.", e);
         }
-    }
-
-    private boolean shouldSkipStatusCheck() {
-        if (flowLogService.isOtherFlowRunning(getStackId())) {
-            LOGGER.debug("StackStatusCheckerJob cannot run, because flow is running for stack: {}", getStackId());
-            return true;
-        }
-        Optional<FlowLog> lastFlowLog = flowLogService.getLastFlowLogWithEndTime(getStackId());
-        if (lastFlowLog.isPresent()) {
-            FlowLog flowLog = lastFlowLog.get();
-            Instant skipTimeInstant = clock.nowMinus(Duration.ofMinutes(skipWindow));
-            Instant lastFlowLogEndTimeInstant = Instant.ofEpochMilli(flowLog.getEndTime());
-            if (lastFlowLogEndTimeInstant.isAfter(skipTimeInstant)) {
-                LOGGER.debug("StackStatusCheckerJob skipped, because the last flow log was finished for stack {}. Skip window is {} minutes. " +
-                                "Last flow log endtime in UTC: {}. Skip time in UTC: {}.", getStackId(), skipWindow,
-                        lastFlowLogEndTimeInstant.atZone(ZoneOffset.UTC), skipTimeInstant.atZone(ZoneOffset.UTC));
-                return true;
-            }
-        }
-        return false;
     }
 
     private void switchToShortSyncIfNecessary(JobExecutionContext context, StackDto stackDto) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJobTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJobTest.java
@@ -1,7 +1,7 @@
 package com.sequenceiq.cloudbreak.job;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -14,9 +14,6 @@ import static org.mockito.Mockito.validateMockitoUsage;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.time.Duration;
-import java.time.Instant;
-import java.time.temporal.TemporalAmount;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
@@ -28,7 +25,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -37,7 +33,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import com.google.common.collect.Sets;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
@@ -53,7 +48,6 @@ import com.sequenceiq.cloudbreak.cluster.status.ClusterStatusResult;
 import com.sequenceiq.cloudbreak.cluster.status.ExtendedHostStatuses;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessorFactory;
-import com.sequenceiq.cloudbreak.common.service.Clock;
 import com.sequenceiq.cloudbreak.common.type.HealthCheck;
 import com.sequenceiq.cloudbreak.common.type.HealthCheckResult;
 import com.sequenceiq.cloudbreak.common.type.HealthCheckType;
@@ -80,7 +74,6 @@ import com.sequenceiq.cloudbreak.util.StackUtil;
 import com.sequenceiq.cloudbreak.workspace.model.User;
 import com.sequenceiq.cloudbreak.workspace.model.Workspace;
 import com.sequenceiq.flow.core.FlowLogService;
-import com.sequenceiq.flow.domain.FlowLog;
 
 @ExtendWith(MockitoExtension.class)
 public class StackStatusCheckerJobTest {
@@ -180,9 +173,6 @@ public class StackStatusCheckerJobTest {
     @Mock
     private ServiceStatusCheckerLogLocationDecorator serviceStatusCheckerLogLocationDecorator;
 
-    @Mock
-    private Clock clock;
-
     @BeforeEach
     public void init() {
         underTest = new StackStatusCheckerJob();
@@ -216,54 +206,6 @@ public class StackStatusCheckerJobTest {
     @AfterEach
     public void tearDown() {
         validateMockitoUsage();
-    }
-
-    @Test
-    public void testNotRunningIfFlowEndedIn2Minutes() throws JobExecutionException {
-        FlowLog lastFlowLog = new FlowLog();
-        lastFlowLog.setEndTime(1676030290000L);
-        when(flowLogService.getLastFlowLogWithEndTime(anyLong())).thenReturn(Optional.of(lastFlowLog));
-        ArgumentCaptor<TemporalAmount> temporalAmountArgumentCaptor = ArgumentCaptor.forClass(TemporalAmount.class);
-        Instant nowMinus2Minutes = Instant.ofEpochMilli(1676030245000L);
-        when(clock.nowMinus(temporalAmountArgumentCaptor.capture())).thenReturn(nowMinus2Minutes);
-        ReflectionTestUtils.setField(underTest, "skipWindow", 2);
-
-        underTest.executeTracedJob(jobExecutionContext);
-
-        assertEquals(120, ((Duration) temporalAmountArgumentCaptor.getValue()).getSeconds());
-        verify(stackDtoService, times(0)).getById(anyLong());
-    }
-
-    @Test
-    public void testNotRunningIfFlowEndedAtTheSameTime() throws JobExecutionException {
-        FlowLog lastFlowLog = new FlowLog();
-        lastFlowLog.setEndTime(1676030290000L);
-        when(flowLogService.getLastFlowLogWithEndTime(anyLong())).thenReturn(Optional.of(lastFlowLog));
-        ArgumentCaptor<TemporalAmount> temporalAmountArgumentCaptor = ArgumentCaptor.forClass(TemporalAmount.class);
-        Instant nowMinus2Minutes = Instant.ofEpochMilli(1676030290000L);
-        when(clock.nowMinus(temporalAmountArgumentCaptor.capture())).thenReturn(nowMinus2Minutes);
-        ReflectionTestUtils.setField(underTest, "skipWindow", 2);
-
-        underTest.executeTracedJob(jobExecutionContext);
-
-        assertEquals(120, ((Duration) temporalAmountArgumentCaptor.getValue()).getSeconds());
-        verify(stackDtoService, times(1)).getById(anyLong());
-    }
-
-    @Test
-    public void testNotRunningIfFlowEndedInTime() throws JobExecutionException {
-        FlowLog lastFlowLog = new FlowLog();
-        lastFlowLog.setEndTime(1676030290000L);
-        when(flowLogService.getLastFlowLogWithEndTime(anyLong())).thenReturn(Optional.of(lastFlowLog));
-        ArgumentCaptor<TemporalAmount> temporalAmountArgumentCaptor = ArgumentCaptor.forClass(TemporalAmount.class);
-        Instant nowMinus2Minutes = Instant.ofEpochMilli(1676030005000L);
-        when(clock.nowMinus(temporalAmountArgumentCaptor.capture())).thenReturn(nowMinus2Minutes);
-        ReflectionTestUtils.setField(underTest, "skipWindow", 2);
-
-        underTest.executeTracedJob(jobExecutionContext);
-
-        assertEquals(120, ((Duration) temporalAmountArgumentCaptor.getValue()).getSeconds());
-        verify(stackDtoService, times(0)).getById(anyLong());
     }
 
     @Test

--- a/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusIntegrationTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusIntegrationTest.java
@@ -53,7 +53,6 @@ import com.sequenceiq.cloudbreak.cluster.status.ClusterStatusResult;
 import com.sequenceiq.cloudbreak.cluster.status.ExtendedHostStatuses;
 import com.sequenceiq.cloudbreak.cluster.util.ResourceAttributeUtil;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessorFactory;
-import com.sequenceiq.cloudbreak.common.service.Clock;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
 import com.sequenceiq.cloudbreak.common.type.HealthCheck;
 import com.sequenceiq.cloudbreak.common.type.HealthCheckResult;
@@ -141,9 +140,6 @@ class StackStatusIntegrationTest {
 
     @MockBean
     private StackViewService stackViewService;
-
-    @MockBean
-    private Clock clock;
 
     @Mock
     private ClusterStatusService clusterStatusService;

--- a/environment/build.gradle
+++ b/environment/build.gradle
@@ -49,7 +49,7 @@ sonarqube {
 }
 
 dependencies {
-    implementation     project(':audit-connector')
+    implementation project(':audit-connector')
     implementation     project(":authorization-common")
     implementation     project(":common")
     implementation     project(':core-common')

--- a/flow/src/main/java/com/sequenceiq/flow/core/FlowLogService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/FlowLogService.java
@@ -64,8 +64,6 @@ public interface FlowLogService {
 
     Optional<FlowLog> getLastFlowLog(Long resourceId);
 
-    Optional<FlowLog> getLastFlowLogWithEndTime(Long resourceId);
-
     boolean isFlowConfigAlreadyRunning(Long id, Class<? extends FlowConfiguration<?>> flowConfiguration);
 
     List<FlowLog> findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(Long id);

--- a/flow/src/main/java/com/sequenceiq/flow/repository/FlowLogRepository.java
+++ b/flow/src/main/java/com/sequenceiq/flow/repository/FlowLogRepository.java
@@ -90,8 +90,6 @@ public interface FlowLogRepository extends CrudRepository<FlowLog, Long> {
 
     Optional<FlowLog> findFirstByResourceIdOrderByCreatedDesc(@Param("resourceId") Long resourceId);
 
-    Optional<FlowLog> findFirstByResourceIdAndEndTimeNotNullOrderByCreatedDesc(@Param("resourceId") Long resourceId);
-
     List<FlowLog> findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(Long resourceId);
 
     List<FlowLog> findAllByFlowIdOrderByCreatedDesc(String flowId);

--- a/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowLogDBService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowLogDBService.java
@@ -302,11 +302,6 @@ public class FlowLogDBService implements FlowLogService {
     }
 
     @Override
-    public Optional<FlowLog> getLastFlowLogWithEndTime(Long resourceId) {
-        return flowLogRepository.findFirstByResourceIdAndEndTimeNotNullOrderByCreatedDesc(resourceId);
-    }
-
-    @Override
     public List<FlowLog> findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(Long id) {
         return flowLogRepository.findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(id);
     }

--- a/integration-test/scripts/config-ums.sh
+++ b/integration-test/scripts/config-ums.sh
@@ -20,14 +20,16 @@ validate-ums-users() {
 
 prepare-cb-profile() {
     echo "Replacing UMS_HOST in profile file"
-    sed -i '/export UMS_HOST/d' ./integcb/Profile
-    sed -i '/export UMS_PORT/d' ./integcb/Profile
+    sed '/export UMS_HOST/d' ./integcb/Profile > ./integcb/Profile.tmp1
+    sed '/export UMS_PORT/d' ./integcb/Profile > ./integcb/Profile.tmp1
+    sed '/export CB_JAVA_OPTS/d' ./integcb/Profile.tmp1 > ./integcb/Profile.tmp
+    mv ./integcb/Profile.tmp ./integcb/Profile
 }
 
 update-cb-profile() {
     echo "export UMS_HOST=$INTEGRATIONTEST_UMS_HOST" >> integcb/Profile
     echo "export UMS_PORT=$INTEGRATIONTEST_UMS_PORT" >> integcb/Profile
-    sed -i '/^export CB_JAVA_OPTS/ s/$/ -Daltus.ums.rights.cache.seconds.ttl=5 -Drest.debug=true -Dmock.spi.endpoint=https\:\/\/test\:9443\//' Profile
+    echo 'export CB_JAVA_OPTS="-Daltus.ums.rights.cache.seconds.ttl=5 -Drest.debug=true -Dmock.spi.endpoint=https://test:9443"' >> integcb/Profile
     echo 'export REDBEAMS_JAVA_OPTS="-Daltus.ums.rights.cache.seconds.ttl=5"' >> integcb/Profile
     echo 'export DATALAKE_JAVA_OPTS="-Daltus.ums.rights.cache.seconds.ttl=5"' >> integcb/Profile
     echo 'export FREEIPA_JAVA_OPTS="-Daltus.ums.rights.cache.seconds.ttl=5"' >> integcb/Profile

--- a/integration-test/scripts/create-cloudbreak-context.sh
+++ b/integration-test/scripts/create-cloudbreak-context.sh
@@ -11,7 +11,6 @@ echo -e "\n" >> integcb/Profile
 echo "export VAULT_AUTO_UNSEAL=true" >> integcb/Profile
 echo "export VAULT_DB_SCHEMA=inet_vault_$(date +%s)" >> integcb/Profile
 echo "export CB_UI_MAX_WAIT=600" >> integcb/Profile
-echo "export CB_JAVA_OPTS=-Dcb.statuschecker.skip.window.minutes=0"
 if [[ "$AWS" == true ]]; then
     echo "export AWS_ACCESS_KEY_ID=${INTEGRATIONTEST_AWS_CREDENTIAL_ACCESSKEYID}" >> integcb/Profile
     echo "export AWS_SECRET_ACCESS_KEY=${INTEGRATIONTEST_AWS_CREDENTIAL_SECRETKEY}" >> integcb/Profile


### PR DESCRIPTION
Reverts hortonworks/cloudbreak#14291

failed real-ums-test


```Replacing UMS_HOST in profile file
+ sed -i '/export UMS_HOST/d' ./integcb/Profile
+ sed -i '/export UMS_PORT/d' ./integcb/Profile
+ update-cb-profile
+ echo 'export UMS_HOST=usermanagement-internal.eu-1.cdp.mow-dev.cloudera.com'
+ echo 'export UMS_PORT=80'
+ sed -i '/^export CB_JAVA_OPTS/ s/$/ -Daltus.ums.rights.cache.seconds.ttl=5 -Drest.debug=true -Dmock.spi.endpoint=https\:\/\/test\:9443\//' Profile
sed: can't read Profile: No such file or directory
make: *** [config-ums] Error 2
Build step 'Execute shell' marked build as failure```