### PR TITLE
CB-20935 Enable hibernate/jpa metrics in order to help debug DB relat…

### DIFF
--- a/autoscale/src/main/resources/application-test.yml
+++ b/autoscale/src/main/resources/application-test.yml
@@ -70,9 +70,6 @@ cert:
   ignorePreValidation: false
 
 spring:
-  cloud:
-    consul:
-      host: consul.service.consul
   freemarker:
     template-loader-path: classpath:/
     prefer-file-system-access: false

--- a/autoscale/src/main/resources/application.yml
+++ b/autoscale/src/main/resources/application.yml
@@ -97,14 +97,19 @@ cert:
 spring:
   application:
     name: Periscope
-  cloud:
-    consul:
-      host: consul.service.consul
   freemarker:
     template-loader-path: classpath:/
     prefer-file-system-access: false
   datasource:
       maxActive: 30
+  jpa:
+    properties:
+      hibernate:
+        generate_statistics: true
+        jdbc:
+          batch_size: 400
+        order_inserts: true
+        order_updates: true
   lifecycle:
     timeout-per-shutdown-phase: 60s
 

--- a/cloud-consumption/src/main/resources/application.yml
+++ b/cloud-consumption/src/main/resources/application.yml
@@ -80,6 +80,14 @@ spring:
   freemarker:
     template-loader-path: file:/etc/consumption,classpath:/
     prefer-file-system-access: false
+  jpa:
+    properties:
+      hibernate:
+        generate_statistics: true
+        jdbc:
+          batch_size: 400
+        order_inserts: true
+        order_updates: true
   lifecycle:
     timeout-per-shutdown-phase: 60s
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -61,6 +61,7 @@ dependencies {
   api group: 'org.springframework.data',         name: 'spring-data-jpa',                version: springDataJpaFrameworkVersion
   api group: 'org.springframework',                         name: 'spring-jdbc',                    version: springFrameworkVersion
   api group: 'org.hibernate',                               name: 'hibernate-core',                 version: hibernateCoreVersion
+  api group: 'org.hibernate',                               name: 'hibernate-micrometer',           version: hibernateCoreVersion
   api group: 'org.springframework',                         name: 'spring-web',                     version: springFrameworkVersion
   api group: 'org.springframework.boot',                    name: 'spring-boot-starter-quartz',     version: springBootVersion
   api group: 'org.springframework.retry',                   name: 'spring-retry',                   version: '1.3.4'

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -48,10 +48,9 @@ spring:
   datasource:
     maxActive: 30
   jpa:
-    show-sql: false
     properties:
       hibernate:
-        format_sql: false
+        generate_statistics: true
         jdbc:
           batch_size: 400
         order_inserts: true

--- a/datalake/src/main/resources/application.yml
+++ b/datalake/src/main/resources/application.yml
@@ -9,6 +9,14 @@ server:
 spring:
   application:
     name: DatalakeService
+  jpa:
+    properties:
+      hibernate:
+        generate_statistics: true
+        jdbc:
+          batch_size: 400
+        order_inserts: true
+        order_updates: true
   lifecycle:
     timeout-per-shutdown-phase: 60s
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -72,7 +72,7 @@ ext {
   grpcVersion = '1.42.1'
 
   // Database
-  hibernateCoreVersion = '5.4.25.Final'
+  hibernateCoreVersion = '5.6.15.Final'
   h2databaseVersion = '1.3.148'
   mybatisMigrationVersion = '3.3.9'
   postgreSQLVersion = '42.3.7'

--- a/environment/src/main/resources/application.yml
+++ b/environment/src/main/resources/application.yml
@@ -215,6 +215,14 @@ spring:
     prefer-file-system-access: false
   datasource:
     maxActive: 30
+  jpa:
+    properties:
+      hibernate:
+        generate_statistics: true
+        jdbc:
+          batch_size: 400
+        order_inserts: true
+        order_updates: true
   lifecycle:
     timeout-per-shutdown-phase: 60s
 

--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -173,6 +173,14 @@ spring:
     prefer-file-system-access: false
   datasource:
     maxActive: 30
+  jpa:
+    properties:
+      hibernate:
+        generate_statistics: true
+        jdbc:
+          batch_size: 400
+        order_inserts: true
+        order_updates: true
   lifecycle:
     timeout-per-shutdown-phase: 60s
 

--- a/redbeams/src/main/resources/application.yml
+++ b/redbeams/src/main/resources/application.yml
@@ -79,6 +79,14 @@ spring:
   freemarker:
     template-loader-path: file:/etc/redbeams,classpath:/
     prefer-file-system-access: false
+  jpa:
+    properties:
+      hibernate:
+        generate_statistics: true
+        jdbc:
+          batch_size: 400
+        order_inserts: true
+        order_updates: true
   lifecycle:
     timeout-per-shutdown-phase: 60s
 


### PR DESCRIPTION
…ed issues. This statistic prints  the max elapsed time for each query, the sum and also the count on the /metrics endpoint.

```
# HELP spring_data_repository_invocations_seconds_max
# TYPE spring_data_repository_invocations_seconds_max gauge
spring_data_repository_invocations_seconds_max{exception="None",method="findComponentsByClusterIdAndInComponentType",repository="ClusterComponentViewRepository",state="SUCCESS",} 0.00868183

# HELP spring_data_repository_invocations_seconds
# TYPE spring_data_repository_invocations_seconds summary
spring_data_repository_invocations_seconds_count{exception="None",method="findComponentsByClusterIdAndInComponentType",repository="ClusterComponentViewRepository",state="SUCCESS",} 15.0
spring_data_repository_invocations_seconds_sum{exception="None",method="findComponentsByClusterIdAndInComponentType",repository="ClusterComponentViewRepository",state="SUCCESS",} 0.03322875
spring_data_repository_invocations_seconds_count{exception="None",method="findAvailabilityZonesByStackId",repository="InstanceGroupRepository",state="SUCCESS",} 15.0
spring_data_repository_invocations_seconds_sum{exception="None",method="findAvailabilityZonesByStackId",repository="InstanceGroupRepository",state="SUCCESS",} 0.025264332
```

See detailed description in the commit message.