### PR TITLE
CB-20941 Slow query LegacyPagingStructuredEventRepository. findByEven…

### DIFF
--- a/core/src/main/resources/schema/app/20230215095147_CB-20941_missing_index_findByEventTypeAndResourceTypeAndResourceId.sql
+++ b/core/src/main/resources/schema/app/20230215095147_CB-20941_missing_index_findByEventTypeAndResourceTypeAndResourceId.sql
@@ -1,0 +1,11 @@
+-- // CB-20941 Slow query LegacyPagingStructuredEventRepository. findByEventTypeAndResourceTypeAndResourceId, due to missing index
+-- Migration SQL that makes the change goes here.
+
+DROP INDEX IF EXISTS idx_structuredevent_userid_eventtype_resourcetype_resourceid;
+CREATE INDEX IF NOT EXISTS idx_structuredevent_eventtype_resourcetype_resourceid ON structuredevent (eventtype, resourcetype, resourceid);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+DROP INDEX IF EXISTS idx_structuredevent_eventtype_resourcetype_resourceid;
+CREATE INDEX idx_structuredevent_userid_eventtype_resourcetype_resourceid ON structuredevent (userid, eventtype, resourcetype, resourceid);


### PR DESCRIPTION
…tTypeAndResourceTypeAndResourceId, due incorrect index.

This repository query uses and index based on "eventtype, resourcetype, resourceid", however we have created the index based on "userid, eventtype, resourcetype, resourceid". Since we are not executing queries that uses the userid based index, we can just drop it.

See detailed description in the commit message.