### PR TITLE
CB-20852: Create all Spark3 datahub cluster templates which are necessary for Spark2 deprecation

### DIFF
--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -533,9 +533,11 @@ cb:
           7.2.16 - SDX Medium Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas, Profiler Manager=cdp-sdx-medium-ha-profiler;
           7.2.16 - Data Engineering: Apache Spark, Apache Hive, Apache Oozie=cdp-data-engineering;
           7.2.16 - Data Engineering: HA: Apache Spark, Apache Hive, Apache Oozie=cdp-data-engineering-ha;
+          7.2.16 - Data Engineering: HA: Apache Spark3, Apache Hive, Apache Oozie=cdp-data-engineering-spark3-ha;
           7.2.16 - Data Engineering: Apache Spark3=cdp-data-engineering-spark3;
           7.2.16 - Data Mart: Apache Impala, Hue=cdp-data-mart;
           7.2.16 - Real-time Data Mart: Apache Impala, Hue, Apache Kudu, Apache Spark=cdp-rt-data-mart;
+          7.2.16 - Real-time Data Mart: Apache Impala, Hue, Apache Kudu, Apache Spark3=cdp-rt-data-mart-spark3;
           7.2.16 - Streams Messaging High Availability: Apache Kafka, Schema Registry, Streams Messaging Manager, Streams Replication Manager, Cruise Control=cdp-streaming-ha;
           7.2.16 - Streams Messaging Heavy Duty: Apache Kafka, Schema Registry, Streams Messaging Manager, Streams Replication Manager, Cruise Control=cdp-streaming;
           7.2.16 - Streams Messaging Light Duty: Apache Kafka, Schema Registry, Streams Messaging Manager, Streams Replication Manager, Cruise Control=cdp-streaming-small;
@@ -553,9 +555,11 @@ cb:
           7.2.17 - SDX Medium Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas, Profiler Manager=cdp-sdx-medium-ha-profiler;
           7.2.17 - Data Engineering: Apache Spark, Apache Hive, Apache Oozie=cdp-data-engineering;
           7.2.17 - Data Engineering: HA: Apache Spark, Apache Hive, Apache Oozie=cdp-data-engineering-ha;
+          7.2.17 - Data Engineering: HA: Apache Spark3, Apache Hive, Apache Oozie=cdp-data-engineering-spark3-ha;
           7.2.17 - Data Engineering: Apache Spark3=cdp-data-engineering-spark3;
           7.2.17 - Data Mart: Apache Impala, Hue=cdp-data-mart;
           7.2.17 - Real-time Data Mart: Apache Impala, Hue, Apache Kudu, Apache Spark=cdp-rt-data-mart;
+          7.2.17 - Real-time Data Mart: Apache Impala, Hue, Apache Kudu, Apache Spark3=cdp-rt-data-mart-spark3;
           7.2.17 - Streams Messaging High Availability: Apache Kafka, Schema Registry, Streams Messaging Manager, Streams Replication Manager, Cruise Control=cdp-streaming-ha;
           7.2.17 - Streams Messaging Heavy Duty: Apache Kafka, Schema Registry, Streams Messaging Manager, Streams Replication Manager, Cruise Control=cdp-streaming;
           7.2.17 - Streams Messaging Light Duty: Apache Kafka, Schema Registry, Streams Messaging Manager, Streams Replication Manager, Cruise Control=cdp-streaming-small;

--- a/core/src/main/resources/defaults/blueprints/7.2.16/cdp-data-engineering-spark3-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.16/cdp-data-engineering-spark3-ha.bp
@@ -1,19 +1,13 @@
 {
-  "description": "7.2.16 - Data Engineering Spark3",
+  "description": "7.2.16 - Data Engineering - Spark3 HA",
   "blueprint": {
     "cdhVersion": "7.2.16",
-    "displayName": "dataengineering_spark3",
+    "displayName": "dataengineering_spark3_ha",
     "blueprintUpgradeOption": "GA",
     "services": [
       {
         "refName": "zookeeper",
         "serviceType": "ZOOKEEPER",
-        "serviceConfigs": [
-          {
-            "name": "service_config_suppression_server_count_validator",
-            "value": "true"
-          }
-        ],
         "roleConfigGroups": [
           {
             "refName": "zookeeper-SERVER-BASE",
@@ -27,8 +21,16 @@
         "serviceType": "HDFS",
         "serviceConfigs": [
           {
+            "name": "zookeeper_service",
+            "ref": "zookeeper"
+          },
+          {
             "name": "hdfs_verify_ec_with_topology_enabled",
             "value": false
+          },
+          {
+            "name": "dfs_replication",
+            "value": 2
           },
           {
             "name": "core_site_safety_valve",
@@ -64,13 +66,29 @@
             ]
           },
           {
-            "refName": "hdfs-SECONDARYNAMENODE-BASE",
-            "roleType": "SECONDARYNAMENODE",
+            "refName": "hdfs-FAILOVERCONTROLLER-BASE",
+            "roleType": "FAILOVERCONTROLLER",
+            "base": true
+          },
+          {
+            "refName": "hdfs-JOURNALNODE-BASE",
+            "roleType": "JOURNALNODE",
             "base": true
           },
           {
             "refName": "hdfs-DATANODE-BASE",
             "roleType": "DATANODE",
+            "base": true
+          },
+          {
+            "refName": "hdfs-SECONDARYNAMENODE-BASE",
+            "roleType": "SECONDARYNAMENODE",
+            "configs": [
+              {
+                "name": "fs_checkpoint_dir_list",
+                "value": "/should_not_be_required_in_HA_setup"
+              }
+            ],
             "base": true
           },
           {
@@ -96,6 +114,150 @@
                 "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
               }
             ]
+          },
+          {
+            "refName": "hdfs-HTTPFS-BASE",
+            "roleType": "HTTPFS",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "hms",
+        "serviceType": "HIVE",
+        "displayName": "Hive Metastore",
+        "roleConfigGroups": [
+          {
+            "refName": "hms-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          },
+          {
+            "refName": "hms-HIVEMETASTORE-BASE",
+            "roleType": "HIVEMETASTORE",
+            "base": true,
+            "configs": [
+              {
+                "name": "hive_metastore_config_safety_valve",
+                "value": "<property><name>hive.metastore.try.direct.sql.ddl</name><value>true</value></property>"
+              },
+              {
+                "name": "hive_compactor_initiator_on",
+                "value": "false"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "refName": "hive",
+        "serviceType": "HIVE_ON_TEZ",
+        "displayName": "Hive",
+        "serviceConfigs": [
+          {
+            "name": "tez_auto_reducer_parallelism",
+            "value": "false"
+          },
+          {
+            "name": "hive_service_config_safety_valve",
+            "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property><property><name>hive.server2.tez.session.lifetime</name><value>30m</value></property><property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property><property><name>hive.orc.splits.include.fileid</name><value>false</value></property><property><name>hive.hook.proto.events.clean.freq</name><value>1h</value></property><property><name>hive.metastore.try.direct.sql.ddl</name><value>true</value></property><property><name>parquet.compression</name><value>SNAPPY</value></property><property><name>hive.privilege.synchronizer</name><value>false</value></property>"
+          }
+        ],
+        "roleConfigGroups": [
+          {
+            "refName": "hive-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          },
+          {
+            "refName": "hive-HIVESERVER2-BASE",
+            "roleType": "HIVESERVER2",
+            "base": true,
+            "configs": [
+              {
+                "name": "hive_server2_transport_mode",
+                "value": "http"
+              },
+              {
+                "name": "hiveserver2_mv_files_thread",
+                "value": 20
+              },
+              {
+                "name": "hiveserver2_load_dynamic_partitions_thread_count",
+                "value": 20
+              },
+              {
+                "name": "hiveserver2_idle_session_timeout",
+                "value": 14400000
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "refName": "hue",
+        "serviceType": "HUE",
+        "serviceConfigs": [
+          {
+            "name": "hue_service_safety_valve",
+            "value": "[desktop]\napp_blacklist=spark,zookeeper,hbase,impala,search,sqoop,security,pig"
+          }
+        ],
+        "roleConfigGroups": [
+          {
+            "refName": "hue-HUE_SERVER-BASE",
+            "roleType": "HUE_SERVER",
+            "base": true
+          },
+          {
+            "refName": "hue-HUE_LOAD_BALANCER-BASE",
+            "roleType": "HUE_LOAD_BALANCER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "livy_for_spark3",
+        "serviceType": "LIVY_FOR_SPARK3",
+        "roleConfigGroups": [
+          {
+            "refName": "livy_for_spark3-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          },
+          {
+            "refName": "livy_for_spark3-LIVY_SERVER-BASE",
+            "roleType": "LIVY_SERVER_FOR_SPARK3",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "oozie",
+        "serviceType": "OOZIE",
+        "roleConfigGroups": [
+          {
+            "refName": "oozie-OOZIE_SERVER-BASE",
+            "roleType": "OOZIE_SERVER",
+            "configs": [
+              {
+                "name": "oozie_config_safety_valve",
+                "value": "<property><name>oozie.service.HadoopAccessorService.nameNode.whitelist</name><value></value></property>"
+              }
+            ],
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "sqoop",
+        "serviceType": "SQOOP_CLIENT",
+        "roleConfigGroups": [
+          {
+            "refName": "sqoop-SQOOP_CLIENT-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "configs": [ ],
+            "base": true
           }
         ]
       },
@@ -230,138 +392,23 @@
             "base": true,
             "configs": [
               {
-                 "name": "tez-conf/tez-site.xml_client_config_safety_valve",
-                 "value": "<property><name>tez.runtime.pipelined.sorter.lazy-allocate.memory</name><value>true</value></property>"
+                "name": "tez-conf/tez-site.xml_client_config_safety_valve",
+                "value": "<property><name>tez.runtime.pipelined.sorter.lazy-allocate.memory</name><value>true</value></property>"
               }
             ]
           }
         ]
       },
       {
-        "refName": "hms",
-        "serviceType": "HIVE",
-        "displayName": "Hive Metastore",
+        "refName": "knox",
         "roleConfigGroups": [
           {
-            "refName": "hms-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "base": true
-          },
-          {
-            "refName": "hms-HIVEMETASTORE-BASE",
-            "roleType": "HIVEMETASTORE",
             "base": true,
-            "configs": [
-              {
-                "name": "hive_metastore_config_safety_valve",
-                "value": "<property><name>hive.metastore.try.direct.sql.ddl</name><value>true</value></property>"
-              },
-              {
-                "name": "hive_compactor_initiator_on",
-                "value": "false"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "refName": "hive_on_tez",
-        "serviceType": "HIVE_ON_TEZ",
-        "displayName": "Hive",
-        "serviceConfigs": [
-          {
-            "name": "hms_connector",
-            "ref": "hms"
-          },
-          {
-            "name": "tez_service",
-            "ref": "tez"
-          },
-          {
-            "name": "zookeeper_service",
-            "ref": "zookeeper"
-          },
-          {
-            "name": "mapreduce_yarn_service",
-            "ref": "yarn"
-          },
-          {
-            "name": "tez_auto_reducer_parallelism",
-            "value": "false"
-          },
-          {
-            "name": "hive_service_config_safety_valve",
-            "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property><property><name>hive.server2.tez.session.lifetime</name><value>30m</value></property><property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property><property><name>hive.orc.splits.include.fileid</name><value>false</value></property><property><name>hive.hook.proto.events.clean.freq</name><value>1h</value></property><property><name>hive.metastore.try.direct.sql.ddl</name><value>true</value></property><property><name>parquet.compression</name><value>SNAPPY</value></property><property><name>hive.privilege.synchronizer</name><value>false</value></property>"
+            "refName": "knox-KNOX_GATEWAY-BASE",
+            "roleType": "KNOX_GATEWAY"
           }
         ],
-        "roleConfigGroups": [
-          {
-            "refName": "hive_on_tez-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "base": true
-          },
-          {
-            "refName": "hive_on_tez-HIVESERVER2-BASE",
-            "roleType": "HIVESERVER2",
-            "base": true,
-            "configs": [
-              {
-                "name": "hive_server2_transport_mode",
-                "value": "http"
-              },
-              {
-                "name": "hiveserver2_mv_files_thread",
-                "value": 20
-              },
-              {
-                "name": "hiveserver2_load_dynamic_partitions_thread_count",
-                "value": 20
-              },
-              {
-                "name": "hiveserver2_idle_session_timeout",
-                "value": 14400000
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "refName": "hue",
-        "serviceType": "HUE",
-        "serviceConfigs": [
-          {
-            "name": "hue_service_safety_valve",
-            "value": "[desktop]\napp_blacklist=spark,zookeeper,hbase,impala,search,sqoop,security,pig"
-          }
-        ],
-        "roleConfigGroups": [
-          {
-            "refName": "hue-HUE_SERVER-BASE",
-            "roleType": "HUE_SERVER",
-            "base": true
-          },
-          {
-            "refName": "hue-HUE_LOAD_BALANCER-BASE",
-            "roleType": "HUE_LOAD_BALANCER",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "livy_for_spark3",
-        "serviceType": "LIVY_FOR_SPARK3",
-        "roleConfigGroups": [
-          {
-            "refName": "livy_for_spark3-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "base": true
-          },
-          {
-            "refName": "livy_for_spark3-LIVY_SERVER-BASE",
-            "roleType": "LIVY_SERVER_FOR_SPARK3",
-            "base": true
-          }
-        ]
+        "serviceType": "KNOX"
       },
       {
         "refName": "zeppelin",
@@ -384,35 +431,6 @@
           {
             "refName": "zeppelin-ZEPPELIN_SERVER-BASE",
             "roleType": "ZEPPELIN_SERVER",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "oozie",
-        "serviceType": "OOZIE",
-        "roleConfigGroups": [
-          {
-            "refName": "oozie-OOZIE_SERVER-BASE",
-            "roleType": "OOZIE_SERVER",
-            "configs": [
-              {
-                "name": "oozie_config_safety_valve",
-                "value": "<property><name>oozie.service.HadoopAccessorService.nameNode.whitelist</name><value></value></property>"
-              }
-            ],
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "sqoop",
-        "serviceType": "SQOOP_CLIENT",
-        "roleConfigGroups": [
-          {
-            "refName": "sqoop-SQOOP_CLIENT-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "configs": [ ],
             "base": true
           }
         ]
@@ -442,29 +460,60 @@
     ],
     "hostTemplates": [
       {
+        "refName": "gateway",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "hdfs-GATEWAY-BASE",
+          "hive-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
+          "livy_for_spark3-GATEWAY-BASE",
+          "spark3_on_yarn-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
+          "yarn-GATEWAY-BASE",
+          "sqoop-SQOOP_CLIENT-GATEWAY-BASE"
+        ]
+      },
+      {
         "refName": "master",
+        "cardinality": 2,
+        "roleConfigGroupsRefNames": [
+          "hdfs-FAILOVERCONTROLLER-BASE",
+          "hdfs-NAMENODE-BASE",
+          "hdfs-GATEWAY-BASE",
+          "hdfs-HTTPFS-BASE",
+          "hive-GATEWAY-BASE",
+          "hive-HIVESERVER2-BASE",
+          "hms-GATEWAY-BASE",
+          "hms-HIVEMETASTORE-BASE",
+          "livy_for_spark3-GATEWAY-BASE",
+          "livy_for_spark3-LIVY_SERVER-BASE",
+          "spark3_on_yarn-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
+          "yarn-RESOURCEMANAGER-BASE",
+          "hdfs-JOURNALNODE-BASE",
+          "zookeeper-SERVER-BASE",
+          "yarn-GATEWAY-BASE",
+          "sqoop-SQOOP_CLIENT-GATEWAY-BASE",
+          "hue-HUE_LOAD_BALANCER-BASE",
+          "hue-HUE_SERVER-BASE"
+        ]
+      },
+      {
+        "refName": "masterx",
         "cardinality": 1,
         "roleConfigGroupsRefNames": [
           "hdfs-BALANCER-BASE",
-          "hdfs-NAMENODE-BASE",
-          "hdfs-SECONDARYNAMENODE-BASE",
           "hdfs-GATEWAY-BASE",
+          "hive-GATEWAY-BASE",
           "hms-GATEWAY-BASE",
-          "hms-HIVEMETASTORE-BASE",
-          "hive_on_tez-HIVESERVER2-BASE",
-          "hive_on_tez-GATEWAY-BASE",
-          "hue-HUE_LOAD_BALANCER-BASE",
-          "hue-HUE_SERVER-BASE",
-          "tez-GATEWAY-BASE",
+          "livy_for_spark3-GATEWAY-BASE",
           "spark3_on_yarn-GATEWAY-BASE",
           "spark3_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
-          "livy_for_spark3-GATEWAY-BASE",
-          "livy_for_spark3-LIVY_SERVER-BASE",
-          "zeppelin-ZEPPELIN_SERVER-BASE",
-          "oozie-OOZIE_SERVER-BASE",
-          "sqoop-SQOOP_CLIENT-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
           "yarn-JOBHISTORY-BASE",
-          "yarn-RESOURCEMANAGER-BASE",
+          "sqoop-SQOOP_CLIENT-GATEWAY-BASE",
+          "zeppelin-ZEPPELIN_SERVER-BASE",
+          "hdfs-JOURNALNODE-BASE",
           "zookeeper-SERVER-BASE",
           "yarn-QUEUEMANAGER_WEBAPP-BASE",
           "yarn-QUEUEMANAGER_STORE-BASE",
@@ -476,42 +525,30 @@
         "cardinality": 3,
         "roleConfigGroupsRefNames": [
           "hdfs-DATANODE-BASE",
-          "hdfs-GATEWAY-BASE",
-          "hms-GATEWAY-BASE",
-          "tez-GATEWAY-BASE",
-          "hive_on_tez-GATEWAY-BASE",
-          "spark3_on_yarn-GATEWAY-BASE",
-          "livy_for_spark3-GATEWAY-BASE",
-          "yarn-NODEMANAGER-WORKER",
-          "yarn-GATEWAY-BASE"
+          "yarn-NODEMANAGER-WORKER"
         ]
       },
       {
         "refName": "compute",
         "cardinality": 0,
         "roleConfigGroupsRefNames": [
-          "hdfs-GATEWAY-BASE",
-          "hms-GATEWAY-BASE",
-          "tez-GATEWAY-BASE",
-          "hive_on_tez-GATEWAY-BASE",
-          "spark3_on_yarn-GATEWAY-BASE",
-          "livy_for_spark3-GATEWAY-BASE",
-          "yarn-NODEMANAGER-COMPUTE",
-          "yarn-GATEWAY-BASE"
+          "yarn-NODEMANAGER-COMPUTE"
         ]
       },
       {
-        "refName": "gateway",
-        "cardinality": 0,
+        "refName": "manager",
+        "cardinality": 2,
         "roleConfigGroupsRefNames": [
-          "hdfs-GATEWAY-BASE",
+          "knox-KNOX_GATEWAY-BASE",
+          "oozie-OOZIE_SERVER-BASE",
+          "hive-GATEWAY-BASE",
           "hms-GATEWAY-BASE",
-          "hive_on_tez-GATEWAY-BASE",
-          "tez-GATEWAY-BASE",
-          "spark3_on_yarn-GATEWAY-BASE",
           "livy_for_spark3-GATEWAY-BASE",
+          "hdfs-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
           "yarn-GATEWAY-BASE",
-          "sqoop-SQOOP_CLIENT-GATEWAY-BASE"
+          "sqoop-SQOOP_CLIENT-GATEWAY-BASE",
+          "spark3_on_yarn-GATEWAY-BASE"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/blueprints/7.2.16/cdp-rt-data-mart-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.16/cdp-rt-data-mart-spark3.bp
@@ -1,0 +1,218 @@
+{
+  "description": "7.2.16 - Real-time Data Mart: Apache Impala, Hue, Apache Kudu, Apache Spark3",
+  "blueprint": {
+    "cdhVersion": "7.2.16",
+    "displayName": "rt-datamarts-spark3",
+    "blueprintUpgradeOption": "GA",
+    "services": [
+      {
+        "refName": "hdfs",
+        "serviceType": "HDFS",
+        "roleConfigGroups": [
+          {
+            "refName": "hdfs-NAMENODE-BASE",
+            "roleType": "NAMENODE",
+            "base": true
+          },
+          {
+            "refName": "hdfs-SECONDARYNAMENODE-BASE",
+            "roleType": "SECONDARYNAMENODE",
+            "base": true
+          },
+          {
+            "refName": "hdfs-DATANODE-BASE",
+            "roleType": "DATANODE",
+            "configs" : [ {
+              "name" : "dfs_datanode_max_locked_memory",
+              "value" : "0",
+              "autoConfig" : false
+            } ],
+            "base": true
+          },
+          {
+            "refName": "hdfs-BALANCER-BASE",
+            "roleType": "BALANCER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "kudu",
+        "serviceType": "KUDU",
+        "roleConfigGroups": [
+          {
+            "refName": "kudu-MASTER-BASE",
+            "roleType": "KUDU_MASTER",
+            "base": true
+          },
+          {
+            "refName": "kudu-TSERVER-BASE",
+            "roleType": "KUDU_TSERVER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "yarn",
+        "serviceType": "YARN",
+        "roleConfigGroups": [
+          {
+            "refName": "yarn-RESOURCEMANAGER-BASE",
+            "roleType": "RESOURCEMANAGER",
+            "base": true
+          },
+          {
+            "refName": "yarn-NODEMANAGER-BASE",
+            "roleType": "NODEMANAGER",
+            "base": true
+          },
+          {
+            "refName": "yarn-JOBHISTORY-BASE",
+            "roleType": "JOBHISTORY",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "spark3_on_yarn",
+        "serviceType": "SPARK3_ON_YARN",
+        "roleConfigGroups": [
+          {
+            "refName": "spark3_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+            "roleType": "SPARK3_YARN_HISTORY_SERVER",
+            "base": true
+          },
+          {
+            "refName": "spark3_on_yarn-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true,
+            "configs": [
+              {
+                "name": "spark3-conf/spark-defaults.conf_client_config_safety_valve",
+                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl\nspark.hadoop.mapreduce.fileoutputcommitter.algorithm.version=1"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "refName": "impala",
+        "serviceType": "IMPALA",
+        "serviceConfigs" : [ {
+          "name" : "impala_cmd_args_safety_valve",
+          "value" : "--cache_s3_file_handles=true"
+        } ],
+        "roleConfigGroups": [
+          {
+            "refName": "impala-IMPALAD-COORDINATOR",
+            "roleType": "IMPALAD",
+            "configs" : [ {
+              "name" : "impalad_specialization",
+              "value" : "COORDINATOR_ONLY"
+            }, {
+              "name" : "impala_hdfs_site_conf_safety_valve",
+              "value" : "<property><name>fs.s3a.experimental.input.fadvise</name><value>RANDOM</value></property><property><name>fs.s3a.fast.upload</name><value>true</value></property>"
+            }, {
+              "name" : "impala_graceful_shutdown_deadline",
+              "value" : "60"
+            } ],
+            "base": false
+          },
+          {
+            "refName": "impala-IMPALAD-EXECUTOR",
+            "roleType": "IMPALAD",
+            "configs" : [ {
+              "name" : "impalad_specialization",
+              "value" : "EXECUTOR_ONLY"
+            }, {
+              "name" : "impala_hdfs_site_conf_safety_valve",
+              "value" : "<property><name>fs.s3a.experimental.input.fadvise</name><value>RANDOM</value></property><property><name>fs.s3a.fast.upload</name><value>true</value></property>"
+            }, {
+              "name" : "impala_graceful_shutdown_deadline",
+              "value" : "60"
+            } ],
+            "base": false
+          },
+          {
+            "refName": "impala-STATESTORE-BASE",
+            "roleType": "STATESTORE",
+            "base": true
+          },
+          {
+            "refName": "impala-CATALOGSERVER-BASE",
+            "roleType": "CATALOGSERVER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "hue",
+        "serviceType": "HUE",
+        "roleConfigGroups": [
+          {
+            "refName": "hue-HUE_SERVER-BASE",
+            "roleType": "HUE_SERVER",
+            "base": true
+          },
+          {
+            "refName": "hue-HUE_LOAD_BALANCER-BASE",
+            "roleType": "HUE_LOAD_BALANCER",
+            "base": true
+          }
+        ]
+      }
+    ],
+    "hostTemplates": [
+      {
+        "refName": "master1",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "hdfs-BALANCER-BASE",
+          "kudu-MASTER-BASE"
+        ]
+      },
+      {
+        "refName": "master2",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "hue-HUE_LOAD_BALANCER-BASE",
+          "hue-HUE_SERVER-BASE",
+          "impala-CATALOGSERVER-BASE",
+          "impala-STATESTORE-BASE",
+          "kudu-MASTER-BASE"
+        ]
+      },
+      {
+        "refName": "master3",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "spark3_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+          "yarn-JOBHISTORY-BASE",
+          "yarn-RESOURCEMANAGER-BASE",
+          "hdfs-NAMENODE-BASE",
+          "hdfs-SECONDARYNAMENODE-BASE",
+          "kudu-MASTER-BASE"
+        ]
+      },
+      {
+        "refName": "coordinator",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "spark3_on_yarn-GATEWAY-BASE",
+          "impala-IMPALAD-COORDINATOR"
+        ]
+      },
+      {
+        "refName": "executor",
+        "cardinality": 3,
+        "roleConfigGroupsRefNames": [
+          "hdfs-DATANODE-BASE",
+          "spark3_on_yarn-GATEWAY-BASE",
+          "yarn-NODEMANAGER-BASE",
+          "impala-IMPALAD-EXECUTOR",
+          "kudu-TSERVER-BASE"
+        ]
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/blueprints/7.2.17/cdp-data-engineering-spark3-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.17/cdp-data-engineering-spark3-ha.bp
@@ -1,19 +1,13 @@
 {
-  "description": "7.2.16 - Data Engineering Spark3",
+  "description": "7.2.17 - Data Engineering - Spark3 HA",
   "blueprint": {
-    "cdhVersion": "7.2.16",
-    "displayName": "dataengineering_spark3",
+    "cdhVersion": "7.2.17",
+    "displayName": "dataengineering_spark3_ha",
     "blueprintUpgradeOption": "GA",
     "services": [
       {
         "refName": "zookeeper",
         "serviceType": "ZOOKEEPER",
-        "serviceConfigs": [
-          {
-            "name": "service_config_suppression_server_count_validator",
-            "value": "true"
-          }
-        ],
         "roleConfigGroups": [
           {
             "refName": "zookeeper-SERVER-BASE",
@@ -27,8 +21,16 @@
         "serviceType": "HDFS",
         "serviceConfigs": [
           {
+            "name": "zookeeper_service",
+            "ref": "zookeeper"
+          },
+          {
             "name": "hdfs_verify_ec_with_topology_enabled",
             "value": false
+          },
+          {
+            "name": "dfs_replication",
+            "value": 2
           },
           {
             "name": "core_site_safety_valve",
@@ -64,13 +66,29 @@
             ]
           },
           {
-            "refName": "hdfs-SECONDARYNAMENODE-BASE",
-            "roleType": "SECONDARYNAMENODE",
+            "refName": "hdfs-FAILOVERCONTROLLER-BASE",
+            "roleType": "FAILOVERCONTROLLER",
+            "base": true
+          },
+          {
+            "refName": "hdfs-JOURNALNODE-BASE",
+            "roleType": "JOURNALNODE",
             "base": true
           },
           {
             "refName": "hdfs-DATANODE-BASE",
             "roleType": "DATANODE",
+            "base": true
+          },
+          {
+            "refName": "hdfs-SECONDARYNAMENODE-BASE",
+            "roleType": "SECONDARYNAMENODE",
+            "configs": [
+              {
+                "name": "fs_checkpoint_dir_list",
+                "value": "/should_not_be_required_in_HA_setup"
+              }
+            ],
             "base": true
           },
           {
@@ -96,6 +114,150 @@
                 "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
               }
             ]
+          },
+          {
+            "refName": "hdfs-HTTPFS-BASE",
+            "roleType": "HTTPFS",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "hms",
+        "serviceType": "HIVE",
+        "displayName": "Hive Metastore",
+        "roleConfigGroups": [
+          {
+            "refName": "hms-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          },
+          {
+            "refName": "hms-HIVEMETASTORE-BASE",
+            "roleType": "HIVEMETASTORE",
+            "base": true,
+            "configs": [
+              {
+                "name": "hive_metastore_config_safety_valve",
+                "value": "<property><name>hive.metastore.try.direct.sql.ddl</name><value>true</value></property>"
+              },
+              {
+                "name": "hive_compactor_initiator_on",
+                "value": "false"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "refName": "hive",
+        "serviceType": "HIVE_ON_TEZ",
+        "displayName": "Hive",
+        "serviceConfigs": [
+          {
+            "name": "tez_auto_reducer_parallelism",
+            "value": "false"
+          },
+          {
+            "name": "hive_service_config_safety_valve",
+            "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property><property><name>hive.server2.tez.session.lifetime</name><value>30m</value></property><property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property><property><name>hive.orc.splits.include.fileid</name><value>false</value></property><property><name>hive.hook.proto.events.clean.freq</name><value>1h</value></property><property><name>hive.metastore.try.direct.sql.ddl</name><value>true</value></property><property><name>parquet.compression</name><value>SNAPPY</value></property><property><name>hive.privilege.synchronizer</name><value>false</value></property>"
+          }
+        ],
+        "roleConfigGroups": [
+          {
+            "refName": "hive-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          },
+          {
+            "refName": "hive-HIVESERVER2-BASE",
+            "roleType": "HIVESERVER2",
+            "base": true,
+            "configs": [
+              {
+                "name": "hive_server2_transport_mode",
+                "value": "http"
+              },
+              {
+                "name": "hiveserver2_mv_files_thread",
+                "value": 20
+              },
+              {
+                "name": "hiveserver2_load_dynamic_partitions_thread_count",
+                "value": 20
+              },
+              {
+                "name": "hiveserver2_idle_session_timeout",
+                "value": 14400000
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "refName": "hue",
+        "serviceType": "HUE",
+        "serviceConfigs": [
+          {
+            "name": "hue_service_safety_valve",
+            "value": "[desktop]\napp_blacklist=spark,zookeeper,hbase,impala,search,sqoop,security,pig"
+          }
+        ],
+        "roleConfigGroups": [
+          {
+            "refName": "hue-HUE_SERVER-BASE",
+            "roleType": "HUE_SERVER",
+            "base": true
+          },
+          {
+            "refName": "hue-HUE_LOAD_BALANCER-BASE",
+            "roleType": "HUE_LOAD_BALANCER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "livy_for_spark3",
+        "serviceType": "LIVY_FOR_SPARK3",
+        "roleConfigGroups": [
+          {
+            "refName": "livy_for_spark3-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          },
+          {
+            "refName": "livy_for_spark3-LIVY_SERVER-BASE",
+            "roleType": "LIVY_SERVER_FOR_SPARK3",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "oozie",
+        "serviceType": "OOZIE",
+        "roleConfigGroups": [
+          {
+            "refName": "oozie-OOZIE_SERVER-BASE",
+            "roleType": "OOZIE_SERVER",
+            "configs": [
+              {
+                "name": "oozie_config_safety_valve",
+                "value": "<property><name>oozie.service.HadoopAccessorService.nameNode.whitelist</name><value></value></property>"
+              }
+            ],
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "sqoop",
+        "serviceType": "SQOOP_CLIENT",
+        "roleConfigGroups": [
+          {
+            "refName": "sqoop-SQOOP_CLIENT-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "configs": [ ],
+            "base": true
           }
         ]
       },
@@ -230,138 +392,23 @@
             "base": true,
             "configs": [
               {
-                 "name": "tez-conf/tez-site.xml_client_config_safety_valve",
-                 "value": "<property><name>tez.runtime.pipelined.sorter.lazy-allocate.memory</name><value>true</value></property>"
+                "name": "tez-conf/tez-site.xml_client_config_safety_valve",
+                "value": "<property><name>tez.runtime.pipelined.sorter.lazy-allocate.memory</name><value>true</value></property>"
               }
             ]
           }
         ]
       },
       {
-        "refName": "hms",
-        "serviceType": "HIVE",
-        "displayName": "Hive Metastore",
+        "refName": "knox",
         "roleConfigGroups": [
           {
-            "refName": "hms-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "base": true
-          },
-          {
-            "refName": "hms-HIVEMETASTORE-BASE",
-            "roleType": "HIVEMETASTORE",
             "base": true,
-            "configs": [
-              {
-                "name": "hive_metastore_config_safety_valve",
-                "value": "<property><name>hive.metastore.try.direct.sql.ddl</name><value>true</value></property>"
-              },
-              {
-                "name": "hive_compactor_initiator_on",
-                "value": "false"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "refName": "hive_on_tez",
-        "serviceType": "HIVE_ON_TEZ",
-        "displayName": "Hive",
-        "serviceConfigs": [
-          {
-            "name": "hms_connector",
-            "ref": "hms"
-          },
-          {
-            "name": "tez_service",
-            "ref": "tez"
-          },
-          {
-            "name": "zookeeper_service",
-            "ref": "zookeeper"
-          },
-          {
-            "name": "mapreduce_yarn_service",
-            "ref": "yarn"
-          },
-          {
-            "name": "tez_auto_reducer_parallelism",
-            "value": "false"
-          },
-          {
-            "name": "hive_service_config_safety_valve",
-            "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property><property><name>hive.server2.tez.session.lifetime</name><value>30m</value></property><property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property><property><name>hive.orc.splits.include.fileid</name><value>false</value></property><property><name>hive.hook.proto.events.clean.freq</name><value>1h</value></property><property><name>hive.metastore.try.direct.sql.ddl</name><value>true</value></property><property><name>parquet.compression</name><value>SNAPPY</value></property><property><name>hive.privilege.synchronizer</name><value>false</value></property>"
+            "refName": "knox-KNOX_GATEWAY-BASE",
+            "roleType": "KNOX_GATEWAY"
           }
         ],
-        "roleConfigGroups": [
-          {
-            "refName": "hive_on_tez-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "base": true
-          },
-          {
-            "refName": "hive_on_tez-HIVESERVER2-BASE",
-            "roleType": "HIVESERVER2",
-            "base": true,
-            "configs": [
-              {
-                "name": "hive_server2_transport_mode",
-                "value": "http"
-              },
-              {
-                "name": "hiveserver2_mv_files_thread",
-                "value": 20
-              },
-              {
-                "name": "hiveserver2_load_dynamic_partitions_thread_count",
-                "value": 20
-              },
-              {
-                "name": "hiveserver2_idle_session_timeout",
-                "value": 14400000
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "refName": "hue",
-        "serviceType": "HUE",
-        "serviceConfigs": [
-          {
-            "name": "hue_service_safety_valve",
-            "value": "[desktop]\napp_blacklist=spark,zookeeper,hbase,impala,search,sqoop,security,pig"
-          }
-        ],
-        "roleConfigGroups": [
-          {
-            "refName": "hue-HUE_SERVER-BASE",
-            "roleType": "HUE_SERVER",
-            "base": true
-          },
-          {
-            "refName": "hue-HUE_LOAD_BALANCER-BASE",
-            "roleType": "HUE_LOAD_BALANCER",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "livy_for_spark3",
-        "serviceType": "LIVY_FOR_SPARK3",
-        "roleConfigGroups": [
-          {
-            "refName": "livy_for_spark3-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "base": true
-          },
-          {
-            "refName": "livy_for_spark3-LIVY_SERVER-BASE",
-            "roleType": "LIVY_SERVER_FOR_SPARK3",
-            "base": true
-          }
-        ]
+        "serviceType": "KNOX"
       },
       {
         "refName": "zeppelin",
@@ -384,35 +431,6 @@
           {
             "refName": "zeppelin-ZEPPELIN_SERVER-BASE",
             "roleType": "ZEPPELIN_SERVER",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "oozie",
-        "serviceType": "OOZIE",
-        "roleConfigGroups": [
-          {
-            "refName": "oozie-OOZIE_SERVER-BASE",
-            "roleType": "OOZIE_SERVER",
-            "configs": [
-              {
-                "name": "oozie_config_safety_valve",
-                "value": "<property><name>oozie.service.HadoopAccessorService.nameNode.whitelist</name><value></value></property>"
-              }
-            ],
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "sqoop",
-        "serviceType": "SQOOP_CLIENT",
-        "roleConfigGroups": [
-          {
-            "refName": "sqoop-SQOOP_CLIENT-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "configs": [ ],
             "base": true
           }
         ]
@@ -442,29 +460,60 @@
     ],
     "hostTemplates": [
       {
+        "refName": "gateway",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "hdfs-GATEWAY-BASE",
+          "hive-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
+          "livy_for_spark3-GATEWAY-BASE",
+          "spark3_on_yarn-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
+          "yarn-GATEWAY-BASE",
+          "sqoop-SQOOP_CLIENT-GATEWAY-BASE"
+        ]
+      },
+      {
         "refName": "master",
+        "cardinality": 2,
+        "roleConfigGroupsRefNames": [
+          "hdfs-FAILOVERCONTROLLER-BASE",
+          "hdfs-NAMENODE-BASE",
+          "hdfs-GATEWAY-BASE",
+          "hdfs-HTTPFS-BASE",
+          "hive-GATEWAY-BASE",
+          "hive-HIVESERVER2-BASE",
+          "hms-GATEWAY-BASE",
+          "hms-HIVEMETASTORE-BASE",
+          "livy_for_spark3-GATEWAY-BASE",
+          "livy_for_spark3-LIVY_SERVER-BASE",
+          "spark3_on_yarn-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
+          "yarn-RESOURCEMANAGER-BASE",
+          "hdfs-JOURNALNODE-BASE",
+          "zookeeper-SERVER-BASE",
+          "yarn-GATEWAY-BASE",
+          "sqoop-SQOOP_CLIENT-GATEWAY-BASE",
+          "hue-HUE_LOAD_BALANCER-BASE",
+          "hue-HUE_SERVER-BASE"
+        ]
+      },
+      {
+        "refName": "masterx",
         "cardinality": 1,
         "roleConfigGroupsRefNames": [
           "hdfs-BALANCER-BASE",
-          "hdfs-NAMENODE-BASE",
-          "hdfs-SECONDARYNAMENODE-BASE",
           "hdfs-GATEWAY-BASE",
+          "hive-GATEWAY-BASE",
           "hms-GATEWAY-BASE",
-          "hms-HIVEMETASTORE-BASE",
-          "hive_on_tez-HIVESERVER2-BASE",
-          "hive_on_tez-GATEWAY-BASE",
-          "hue-HUE_LOAD_BALANCER-BASE",
-          "hue-HUE_SERVER-BASE",
-          "tez-GATEWAY-BASE",
+          "livy_for_spark3-GATEWAY-BASE",
           "spark3_on_yarn-GATEWAY-BASE",
           "spark3_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
-          "livy_for_spark3-GATEWAY-BASE",
-          "livy_for_spark3-LIVY_SERVER-BASE",
-          "zeppelin-ZEPPELIN_SERVER-BASE",
-          "oozie-OOZIE_SERVER-BASE",
-          "sqoop-SQOOP_CLIENT-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
           "yarn-JOBHISTORY-BASE",
-          "yarn-RESOURCEMANAGER-BASE",
+          "sqoop-SQOOP_CLIENT-GATEWAY-BASE",
+          "zeppelin-ZEPPELIN_SERVER-BASE",
+          "hdfs-JOURNALNODE-BASE",
           "zookeeper-SERVER-BASE",
           "yarn-QUEUEMANAGER_WEBAPP-BASE",
           "yarn-QUEUEMANAGER_STORE-BASE",
@@ -476,42 +525,30 @@
         "cardinality": 3,
         "roleConfigGroupsRefNames": [
           "hdfs-DATANODE-BASE",
-          "hdfs-GATEWAY-BASE",
-          "hms-GATEWAY-BASE",
-          "tez-GATEWAY-BASE",
-          "hive_on_tez-GATEWAY-BASE",
-          "spark3_on_yarn-GATEWAY-BASE",
-          "livy_for_spark3-GATEWAY-BASE",
-          "yarn-NODEMANAGER-WORKER",
-          "yarn-GATEWAY-BASE"
+          "yarn-NODEMANAGER-WORKER"
         ]
       },
       {
         "refName": "compute",
         "cardinality": 0,
         "roleConfigGroupsRefNames": [
-          "hdfs-GATEWAY-BASE",
-          "hms-GATEWAY-BASE",
-          "tez-GATEWAY-BASE",
-          "hive_on_tez-GATEWAY-BASE",
-          "spark3_on_yarn-GATEWAY-BASE",
-          "livy_for_spark3-GATEWAY-BASE",
-          "yarn-NODEMANAGER-COMPUTE",
-          "yarn-GATEWAY-BASE"
+          "yarn-NODEMANAGER-COMPUTE"
         ]
       },
       {
-        "refName": "gateway",
-        "cardinality": 0,
+        "refName": "manager",
+        "cardinality": 2,
         "roleConfigGroupsRefNames": [
-          "hdfs-GATEWAY-BASE",
+          "knox-KNOX_GATEWAY-BASE",
+          "oozie-OOZIE_SERVER-BASE",
+          "hive-GATEWAY-BASE",
           "hms-GATEWAY-BASE",
-          "hive_on_tez-GATEWAY-BASE",
-          "tez-GATEWAY-BASE",
-          "spark3_on_yarn-GATEWAY-BASE",
           "livy_for_spark3-GATEWAY-BASE",
+          "hdfs-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
           "yarn-GATEWAY-BASE",
-          "sqoop-SQOOP_CLIENT-GATEWAY-BASE"
+          "sqoop-SQOOP_CLIENT-GATEWAY-BASE",
+          "spark3_on_yarn-GATEWAY-BASE"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/blueprints/7.2.17/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.17/cdp-data-engineering-spark3.bp
@@ -8,6 +8,12 @@
       {
         "refName": "zookeeper",
         "serviceType": "ZOOKEEPER",
+        "serviceConfigs": [
+          {
+            "name": "service_config_suppression_server_count_validator",
+            "value": "true"
+          }
+        ],
         "roleConfigGroups": [
           {
             "refName": "zookeeper-SERVER-BASE",
@@ -126,7 +132,7 @@
               },
               {
                 "name": "resourcemanager_capacity_scheduler_configuration",
-                "value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property><property><name>yarn.scheduler.capacity.per-node-heartbeat.maximum-offswitch-assignments</name><value>4</value></property></configuration>"
+                "value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property></configuration>"
               }
             ]
           },
@@ -181,47 +187,6 @@
         ]
       },
       {
-        "refName": "livy_for_spark3",
-        "serviceType": "LIVY_FOR_SPARK3",
-        "roleConfigGroups": [
-          {
-            "refName": "livy_for_spark3-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "base": true
-          },
-          {
-            "refName": "livy_for_spark3-LIVY_SERVER-BASE",
-            "roleType": "LIVY_SERVER_FOR_SPARK3",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "zeppelin",
-        "serviceType": "ZEPPELIN",
-        "serviceConfigs": [
-          {
-            "name": "yarn_service",
-            "ref": "yarn"
-          },
-          {
-            "name": "hdfs_service",
-            "ref": "hdfs"
-          },
-          {
-            "name": "spark3_on_yarn_service",
-            "ref": "spark3_on_yarn"
-          }
-        ],
-        "roleConfigGroups": [
-          {
-            "refName": "zeppelin-ZEPPELIN_SERVER-BASE",
-            "roleType": "ZEPPELIN_SERVER",
-            "base": true
-          }
-        ]
-      },
-      {
         "refName": "tez",
         "serviceType": "TEZ",
         "serviceConfigs": [
@@ -265,8 +230,8 @@
             "base": true,
             "configs": [
               {
-                "name": "tez-conf/tez-site.xml_client_config_safety_valve",
-                "value": "<property><name>tez.runtime.pipelined.sorter.lazy-allocate.memory</name><value>true</value></property>"
+                 "name": "tez-conf/tez-site.xml_client_config_safety_valve",
+                 "value": "<property><name>tez.runtime.pipelined.sorter.lazy-allocate.memory</name><value>true</value></property>"
               }
             ]
           }
@@ -300,28 +265,6 @@
         ]
       },
       {
-        "refName": "hue",
-        "serviceType": "HUE",
-        "serviceConfigs": [
-          {
-            "name": "hue_service_safety_valve",
-            "value": "[desktop]\napp_blacklist=zookeeper,hbase,impala,search,sqoop,security,pig"
-          }
-        ],
-        "roleConfigGroups": [
-          {
-            "refName": "hue-HUE_SERVER-BASE",
-            "roleType": "HUE_SERVER",
-            "base": true
-          },
-          {
-            "refName": "hue-HUE_LOAD_BALANCER-BASE",
-            "roleType": "HUE_LOAD_BALANCER",
-            "base": true
-          }
-        ]
-      },
-      {
         "refName": "hive_on_tez",
         "serviceType": "HIVE_ON_TEZ",
         "displayName": "Hive",
@@ -348,9 +291,7 @@
           },
           {
             "name": "hive_service_config_safety_valve",
-            "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property>
-                        <property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property><property><name>hive.orc.splits.include.fileid</name><value>false</value></property><property><name>hive.hook.proto.events.clean.freq</name><value>1h</value></property>
-                        <property><name>hive.metastore.try.direct.sql.ddl</name><value>true</value></property><property><name>parquet.compression</name><value>SNAPPY</value></property><property><name>hive.privilege.synchronizer</name><value>false</value></property>"
+            "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property><property><name>hive.server2.tez.session.lifetime</name><value>30m</value></property><property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property><property><name>hive.orc.splits.include.fileid</name><value>false</value></property><property><name>hive.hook.proto.events.clean.freq</name><value>1h</value></property><property><name>hive.metastore.try.direct.sql.ddl</name><value>true</value></property><property><name>parquet.compression</name><value>SNAPPY</value></property><property><name>hive.privilege.synchronizer</name><value>false</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -381,6 +322,98 @@
                 "value": 14400000
               }
             ]
+          }
+        ]
+      },
+      {
+        "refName": "hue",
+        "serviceType": "HUE",
+        "serviceConfigs": [
+          {
+            "name": "hue_service_safety_valve",
+            "value": "[desktop]\napp_blacklist=spark,zookeeper,hbase,impala,search,sqoop,security,pig"
+          }
+        ],
+        "roleConfigGroups": [
+          {
+            "refName": "hue-HUE_SERVER-BASE",
+            "roleType": "HUE_SERVER",
+            "base": true
+          },
+          {
+            "refName": "hue-HUE_LOAD_BALANCER-BASE",
+            "roleType": "HUE_LOAD_BALANCER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "livy_for_spark3",
+        "serviceType": "LIVY_FOR_SPARK3",
+        "roleConfigGroups": [
+          {
+            "refName": "livy_for_spark3-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          },
+          {
+            "refName": "livy_for_spark3-LIVY_SERVER-BASE",
+            "roleType": "LIVY_SERVER_FOR_SPARK3",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "zeppelin",
+        "serviceType": "ZEPPELIN",
+        "serviceConfigs": [
+          {
+            "name": "yarn_service",
+            "ref": "yarn"
+          },
+          {
+            "name": "hdfs_service",
+            "ref": "hdfs"
+          },
+          {
+            "name": "spark3_on_yarn_service",
+            "ref": "spark3_on_yarn"
+          }
+        ],
+        "roleConfigGroups": [
+          {
+            "refName": "zeppelin-ZEPPELIN_SERVER-BASE",
+            "roleType": "ZEPPELIN_SERVER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "oozie",
+        "serviceType": "OOZIE",
+        "roleConfigGroups": [
+          {
+            "refName": "oozie-OOZIE_SERVER-BASE",
+            "roleType": "OOZIE_SERVER",
+            "configs": [
+              {
+                "name": "oozie_config_safety_valve",
+                "value": "<property><name>oozie.service.HadoopAccessorService.nameNode.whitelist</name><value></value></property>"
+              }
+            ],
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "sqoop",
+        "serviceType": "SQOOP_CLIENT",
+        "roleConfigGroups": [
+          {
+            "refName": "sqoop-SQOOP_CLIENT-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "configs": [ ],
+            "base": true
           }
         ]
       },
@@ -417,20 +450,22 @@
           "hdfs-SECONDARYNAMENODE-BASE",
           "hdfs-GATEWAY-BASE",
           "hms-GATEWAY-BASE",
-          "tez-GATEWAY-BASE",
           "hms-HIVEMETASTORE-BASE",
           "hive_on_tez-HIVESERVER2-BASE",
           "hive_on_tez-GATEWAY-BASE",
           "hue-HUE_LOAD_BALANCER-BASE",
           "hue-HUE_SERVER-BASE",
+          "tez-GATEWAY-BASE",
           "spark3_on_yarn-GATEWAY-BASE",
           "spark3_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
           "livy_for_spark3-GATEWAY-BASE",
           "livy_for_spark3-LIVY_SERVER-BASE",
           "zeppelin-ZEPPELIN_SERVER-BASE",
-          "zookeeper-SERVER-BASE",
+          "oozie-OOZIE_SERVER-BASE",
+          "sqoop-SQOOP_CLIENT-GATEWAY-BASE",
           "yarn-JOBHISTORY-BASE",
           "yarn-RESOURCEMANAGER-BASE",
+          "zookeeper-SERVER-BASE",
           "yarn-QUEUEMANAGER_WEBAPP-BASE",
           "yarn-QUEUEMANAGER_STORE-BASE",
           "yarn-GATEWAY-BASE"
@@ -471,11 +506,12 @@
         "roleConfigGroupsRefNames": [
           "hdfs-GATEWAY-BASE",
           "hms-GATEWAY-BASE",
-          "tez-GATEWAY-BASE",
           "hive_on_tez-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
           "spark3_on_yarn-GATEWAY-BASE",
           "livy_for_spark3-GATEWAY-BASE",
-          "yarn-GATEWAY-BASE"
+          "yarn-GATEWAY-BASE",
+          "sqoop-SQOOP_CLIENT-GATEWAY-BASE"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/blueprints/7.2.17/cdp-rt-data-mart-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.17/cdp-rt-data-mart-spark3.bp
@@ -1,0 +1,218 @@
+{
+  "description": "7.2.17 - Real-time Data Mart: Apache Impala, Hue, Apache Kudu, Apache Spark3",
+  "blueprint": {
+    "cdhVersion": "7.2.17",
+    "displayName": "rt-datamarts-spark3",
+    "blueprintUpgradeOption": "GA",
+    "services": [
+      {
+        "refName": "hdfs",
+        "serviceType": "HDFS",
+        "roleConfigGroups": [
+          {
+            "refName": "hdfs-NAMENODE-BASE",
+            "roleType": "NAMENODE",
+            "base": true
+          },
+          {
+            "refName": "hdfs-SECONDARYNAMENODE-BASE",
+            "roleType": "SECONDARYNAMENODE",
+            "base": true
+          },
+          {
+            "refName": "hdfs-DATANODE-BASE",
+            "roleType": "DATANODE",
+            "configs" : [ {
+              "name" : "dfs_datanode_max_locked_memory",
+              "value" : "0",
+              "autoConfig" : false
+            } ],
+            "base": true
+          },
+          {
+            "refName": "hdfs-BALANCER-BASE",
+            "roleType": "BALANCER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "kudu",
+        "serviceType": "KUDU",
+        "roleConfigGroups": [
+          {
+            "refName": "kudu-MASTER-BASE",
+            "roleType": "KUDU_MASTER",
+            "base": true
+          },
+          {
+            "refName": "kudu-TSERVER-BASE",
+            "roleType": "KUDU_TSERVER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "yarn",
+        "serviceType": "YARN",
+        "roleConfigGroups": [
+          {
+            "refName": "yarn-RESOURCEMANAGER-BASE",
+            "roleType": "RESOURCEMANAGER",
+            "base": true
+          },
+          {
+            "refName": "yarn-NODEMANAGER-BASE",
+            "roleType": "NODEMANAGER",
+            "base": true
+          },
+          {
+            "refName": "yarn-JOBHISTORY-BASE",
+            "roleType": "JOBHISTORY",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "spark3_on_yarn",
+        "serviceType": "SPARK3_ON_YARN",
+        "roleConfigGroups": [
+          {
+            "refName": "spark3_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+            "roleType": "SPARK3_YARN_HISTORY_SERVER",
+            "base": true
+          },
+          {
+            "refName": "spark3_on_yarn-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true,
+            "configs": [
+              {
+                "name": "spark3-conf/spark-defaults.conf_client_config_safety_valve",
+                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl\nspark.hadoop.mapreduce.fileoutputcommitter.algorithm.version=1"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "refName": "impala",
+        "serviceType": "IMPALA",
+        "serviceConfigs" : [ {
+          "name" : "impala_cmd_args_safety_valve",
+          "value" : "--cache_s3_file_handles=true"
+        } ],
+        "roleConfigGroups": [
+          {
+            "refName": "impala-IMPALAD-COORDINATOR",
+            "roleType": "IMPALAD",
+            "configs" : [ {
+              "name" : "impalad_specialization",
+              "value" : "COORDINATOR_ONLY"
+            }, {
+              "name" : "impala_hdfs_site_conf_safety_valve",
+              "value" : "<property><name>fs.s3a.experimental.input.fadvise</name><value>RANDOM</value></property><property><name>fs.s3a.fast.upload</name><value>true</value></property>"
+            }, {
+              "name" : "impala_graceful_shutdown_deadline",
+              "value" : "60"
+            } ],
+            "base": false
+          },
+          {
+            "refName": "impala-IMPALAD-EXECUTOR",
+            "roleType": "IMPALAD",
+            "configs" : [ {
+              "name" : "impalad_specialization",
+              "value" : "EXECUTOR_ONLY"
+            }, {
+              "name" : "impala_hdfs_site_conf_safety_valve",
+              "value" : "<property><name>fs.s3a.experimental.input.fadvise</name><value>RANDOM</value></property><property><name>fs.s3a.fast.upload</name><value>true</value></property>"
+            }, {
+              "name" : "impala_graceful_shutdown_deadline",
+              "value" : "60"
+            } ],
+            "base": false
+          },
+          {
+            "refName": "impala-STATESTORE-BASE",
+            "roleType": "STATESTORE",
+            "base": true
+          },
+          {
+            "refName": "impala-CATALOGSERVER-BASE",
+            "roleType": "CATALOGSERVER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "hue",
+        "serviceType": "HUE",
+        "roleConfigGroups": [
+          {
+            "refName": "hue-HUE_SERVER-BASE",
+            "roleType": "HUE_SERVER",
+            "base": true
+          },
+          {
+            "refName": "hue-HUE_LOAD_BALANCER-BASE",
+            "roleType": "HUE_LOAD_BALANCER",
+            "base": true
+          }
+        ]
+      }
+    ],
+    "hostTemplates": [
+      {
+        "refName": "master1",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "hdfs-BALANCER-BASE",
+          "kudu-MASTER-BASE"
+        ]
+      },
+      {
+        "refName": "master2",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "hue-HUE_LOAD_BALANCER-BASE",
+          "hue-HUE_SERVER-BASE",
+          "impala-CATALOGSERVER-BASE",
+          "impala-STATESTORE-BASE",
+          "kudu-MASTER-BASE"
+        ]
+      },
+      {
+        "refName": "master3",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "spark3_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+          "yarn-JOBHISTORY-BASE",
+          "yarn-RESOURCEMANAGER-BASE",
+          "hdfs-NAMENODE-BASE",
+          "hdfs-SECONDARYNAMENODE-BASE",
+          "kudu-MASTER-BASE"
+        ]
+      },
+      {
+        "refName": "coordinator",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "spark3_on_yarn-GATEWAY-BASE",
+          "impala-IMPALAD-COORDINATOR"
+        ]
+      },
+      {
+        "refName": "executor",
+        "cardinality": 3,
+        "roleConfigGroupsRefNames": [
+          "hdfs-DATANODE-BASE",
+          "spark3_on_yarn-GATEWAY-BASE",
+          "yarn-NODEMANAGER-BASE",
+          "impala-IMPALAD-EXECUTOR",
+          "kudu-TSERVER-BASE"
+        ]
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.16/aws/dataengineering-spark3-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.16/aws/dataengineering-spark3-ha.json
@@ -1,0 +1,155 @@
+{
+  "name": "7.2.16 - Data Engineering HA - Spark3 for AWS",
+  "description": "",
+  "type": "DATAENGINEERING",
+  "featureState": "RELEASED",
+  "cloudPlatform": "AWS",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.16 - Data Engineering: HA: Apache Spark3, Apache Hive, Apache Oozie"
+    },
+    "externalDatabase": {
+      "availabilityType": "HA"
+    },
+    "enableLoadBalancer": true,
+    "instanceGroups": [{
+      "nodeCount": 2,
+      "name": "manager",
+      "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "template": {
+        "aws": {
+          "placementGroup" : {
+            "strategy" : "PARTITION"
+          }
+        },
+        "instanceType": "m5.4xlarge",
+        "rootVolume": {
+          "size": 150
+        },
+        "attachedVolumes": [{
+          "size": 150,
+          "count": 1,
+          "type": "gp2"
+        }],
+        "cloudPlatform": "AWS"
+      },
+      "recipeNames": []
+    },
+      {
+        "nodeCount": 1,
+        "name": "compute",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "aws": {},
+          "instanceType": "r5d.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [{
+            "size": 300,
+            "count": 2,
+            "type": "ephemeral"
+          }],
+          "cloudPlatform": "AWS"
+        },
+        "recipeNames": []
+      },
+      {
+        "nodeCount": 0,
+        "name": "gateway",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "aws": {},
+          "instanceType": "m5.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [{
+            "size": 150,
+            "count": 1,
+            "type": "gp2"
+          }],
+          "cloudPlatform": "AWS"
+        },
+        "recipeNames": []
+      },
+      {
+        "nodeCount": 3,
+        "name": "worker",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "aws": {
+            "placementGroup" : {
+              "strategy" : "PARTITION"
+            }
+          },
+          "instanceType": "r5d.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [{
+            "size": 500,
+            "count": 1,
+            "type": "gp2"
+          }],
+          "cloudPlatform": "AWS"
+        },
+        "recipeNames": []
+      },
+      {
+        "nodeCount": 2,
+        "minimumNodeCount": 2,
+        "name": "master",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "aws": {
+            "placementGroup" : {
+              "strategy" : "PARTITION"
+            }
+          },
+          "instanceType": "m5.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [{
+            "size": 150,
+            "count": 1,
+            "type": "gp2"
+          }],
+          "cloudPlatform": "AWS"
+        },
+        "recipeNames": []
+      },
+      {
+        "nodeCount": 1,
+        "minimumNodeCount": 1,
+        "name": "masterx",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "aws": {
+            "placementGroup" : {
+              "strategy" : "PARTITION"
+            }
+          },
+          "instanceType": "m5.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [{
+            "size": 150,
+            "count": 1,
+            "type": "gp2"
+          }],
+          "cloudPlatform": "AWS"
+        },
+        "recipeNames": []
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.16/aws/rt-datamart-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.16/aws/rt-datamart-spark3.json
@@ -1,0 +1,119 @@
+{
+  "name": "7.2.16 - Real-time Data Mart - Spark3 for AWS",
+  "description": "",
+  "type": "DATAMART",
+  "featureState": "RELEASED",
+  "cloudPlatform": "AWS",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.16 - Real-time Data Mart: Apache Impala, Hue, Apache Kudu, Apache Spark3"
+    },
+    "instanceGroups": [
+      {
+        "name": "master1",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "gp2"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "nodeCount": 1,
+        "type": "GATEWAY",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "master2",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "gp2"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "master3",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "gp2"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "coordinator",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 2,
+              "size": 300,
+              "type": "ephemeral"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "r5d.4xlarge"
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "executor",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 5,
+              "size": 500,
+              "type": "gp2"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "r5d.4xlarge"
+        },
+        "nodeCount": 3,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.16/aws_gov/dataengineering-spark3-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.16/aws_gov/dataengineering-spark3-ha.json
@@ -1,0 +1,155 @@
+{
+  "name": "7.2.16 - Data Engineering HA - Spark3 for AWS",
+  "description": "",
+  "type": "DATAENGINEERING",
+  "featureState": "RELEASED",
+  "cloudPlatform": "AWS",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.16 - Data Engineering: HA: Apache Spark3, Apache Hive, Apache Oozie"
+    },
+    "externalDatabase": {
+      "availabilityType": "HA"
+    },
+    "enableLoadBalancer": true,
+    "instanceGroups": [{
+      "nodeCount": 2,
+      "name": "manager",
+      "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "template": {
+        "aws": {
+          "placementGroup" : {
+            "strategy" : "PARTITION"
+          }
+        },
+        "instanceType": "m5.4xlarge",
+        "rootVolume": {
+          "size": 150
+        },
+        "attachedVolumes": [{
+          "size": 150,
+          "count": 1,
+          "type": "gp2"
+        }],
+        "cloudPlatform": "AWS"
+      },
+      "recipeNames": []
+    },
+      {
+        "nodeCount": 1,
+        "name": "compute",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "aws": {},
+          "instanceType": "r5d.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [{
+            "size": 300,
+            "count": 2,
+            "type": "ephemeral"
+          }],
+          "cloudPlatform": "AWS"
+        },
+        "recipeNames": []
+      },
+      {
+        "nodeCount": 0,
+        "name": "gateway",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "aws": {},
+          "instanceType": "m5.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [{
+            "size": 150,
+            "count": 1,
+            "type": "gp2"
+          }],
+          "cloudPlatform": "AWS"
+        },
+        "recipeNames": []
+      },
+      {
+        "nodeCount": 3,
+        "name": "worker",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "aws": {
+            "placementGroup" : {
+              "strategy" : "PARTITION"
+            }
+          },
+          "instanceType": "r5d.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [{
+            "size": 500,
+            "count": 1,
+            "type": "gp2"
+          }],
+          "cloudPlatform": "AWS"
+        },
+        "recipeNames": []
+      },
+      {
+        "nodeCount": 2,
+        "minimumNodeCount": 2,
+        "name": "master",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "aws": {
+            "placementGroup" : {
+              "strategy" : "PARTITION"
+            }
+          },
+          "instanceType": "m5.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [{
+            "size": 150,
+            "count": 1,
+            "type": "gp2"
+          }],
+          "cloudPlatform": "AWS"
+        },
+        "recipeNames": []
+      },
+      {
+        "nodeCount": 1,
+        "minimumNodeCount": 1,
+        "name": "masterx",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "aws": {
+            "placementGroup" : {
+              "strategy" : "PARTITION"
+            }
+          },
+          "instanceType": "m5.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [{
+            "size": 150,
+            "count": 1,
+            "type": "gp2"
+          }],
+          "cloudPlatform": "AWS"
+        },
+        "recipeNames": []
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.16/aws_gov/rt-datamart-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.16/aws_gov/rt-datamart-spark3.json
@@ -1,0 +1,119 @@
+{
+  "name": "7.2.16 - Real-time Data Mart - Spark3 for AWS",
+  "description": "",
+  "type": "DATAMART",
+  "featureState": "RELEASED",
+  "cloudPlatform": "AWS",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.16 - Real-time Data Mart: Apache Impala, Hue, Apache Kudu, Apache Spark3"
+    },
+    "instanceGroups": [
+      {
+        "name": "master1",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "gp2"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "nodeCount": 1,
+        "type": "GATEWAY",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "master2",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "gp2"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "master3",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "gp2"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "coordinator",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 2,
+              "size": 300,
+              "type": "ephemeral"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "r5d.4xlarge"
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "executor",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 5,
+              "size": 500,
+              "type": "gp2"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "r5d.4xlarge"
+        },
+        "nodeCount": 3,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.16/azure/dataengineering-spark3-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.16/azure/dataengineering-spark3-ha.json
@@ -1,0 +1,187 @@
+{
+  "name": "7.2.16 - Data Engineering HA - Spark3 for Azure",
+  "description": "",
+  "type": "DATAENGINEERING",
+  "featureState": "RELEASED",
+  "cloudPlatform": "AZURE",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.16 - Data Engineering: HA: Apache Spark3, Apache Hive, Apache Oozie"
+    },
+    "externalDatabase": {
+      "availabilityType": "HA"
+    },
+    "enableLoadBalancer": true,
+    "instanceGroups": [
+      {
+        "nodeCount": 2,
+        "name": "manager",
+        "type": "GATEWAY",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D16_v3",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [
+            {
+              "size": 150,
+              "count": 1,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "cloudPlatform": "AZURE"
+        },
+        "recipeNames": [],
+        "cloudPlatform": "AZURE"
+      },
+      {
+        "nodeCount": 1,
+        "name": "compute",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "azure": {},
+          "instanceType": "Standard_D5_v2",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [
+            {
+              "size": 500,
+              "count": 0,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "cloudPlatform": "AZURE"
+        },
+        "recipeNames": [],
+        "cloudPlatform": "AZURE"
+      },
+      {
+        "nodeCount": 3,
+        "name": "worker",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D5_v2",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [
+            {
+              "size": 500,
+              "count": 1,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "cloudPlatform": "AZURE"
+        },
+        "recipeNames": [],
+        "cloudPlatform": "AZURE"
+      },
+      {
+        "nodeCount": 2,
+        "minimumNodeCount": 2,
+        "name": "master",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D16_v3",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [
+            {
+              "size": 150,
+              "count": 1,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "cloudPlatform": "AZURE"
+        },
+        "recipeNames": [],
+        "cloudPlatform": "AZURE"
+      },
+      {
+        "nodeCount": 0,
+        "name": "gateway",
+        "type": "CORE",
+        "template": {
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D16_v3",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [
+            {
+              "size": 150,
+              "count": 1,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "cloudPlatform": "AZURE"
+        },
+        "recipeNames": [],
+        "cloudPlatform": "AZURE"
+      },
+      {
+        "nodeCount": 1,
+        "minimumNodeCount": 1,
+        "name": "masterx",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D16_v3",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [
+            {
+              "size": 150,
+              "count": 1,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "cloudPlatform": "AZURE"
+        },
+        "recipeNames": [],
+        "cloudPlatform": "AZURE"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.16/azure/rt-datamart-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.16/azure/rt-datamart-spark3.json
@@ -1,0 +1,129 @@
+{
+  "name": "7.2.16 - Real-time Data Mart - Spark3 for Azure",
+  "description": "",
+  "type": "DATAMART",
+  "featureState": "RELEASED",
+  "cloudPlatform": "AZURE",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.16 - Real-time Data Mart: Apache Impala, Hue, Apache Kudu, Apache Spark3"
+    },
+    "instanceGroups": [
+      {
+        "name": "master1",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D8_v3"
+        },
+        "nodeCount": 1,
+        "type": "GATEWAY",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "master2",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D8_v3"
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "master3",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D8_v3"
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "coordinator",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 0,
+              "size": 300,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_E16ds_v4"
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "executor",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 5,
+              "size": 500,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_E16ds_v4"
+        },
+        "nodeCount": 3,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.16/gcp/dataengineering-spark3-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.16/gcp/dataengineering-spark3-ha.json
@@ -1,0 +1,134 @@
+{
+  "name": "7.2.16 - Data Engineering HA - Spark3 for Google Cloud",
+  "description": "",
+  "type": "DATAENGINEERING",
+  "featureState": "PREVIEW",
+  "cloudPlatform": "GCP",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.16 - Data Engineering: HA: Apache Spark3, Apache Hive, Apache Oozie"
+    },
+    "externalDatabase": {
+      "availabilityType": "HA"
+    },
+    "enableLoadBalancer": true,
+    "instanceGroups": [
+      {
+        "name": "manager",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 150,
+              "type": "pd-ssd"
+            }
+          ],
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
+        },
+        "nodeCount": 2,
+        "type": "GATEWAY",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "master",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 150,
+              "type": "pd-ssd"
+            }
+          ],
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
+        },
+        "nodeCount": 2,
+        "minimumNodeCount": 2,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "compute",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 500,
+              "type": "pd-ssd"
+            }
+          ],
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "worker",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 500,
+              "type": "pd-ssd"
+            }
+          ],
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
+        },
+        "nodeCount": 3,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "gateway",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 150,
+              "type": "pd-ssd"
+            }
+          ],
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "masterx",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 150,
+              "type": "pd-ssd"
+            }
+          ],
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
+        },
+        "nodeCount": 1,
+        "minimumNodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.16/gcp/rt-datamart-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.16/gcp/rt-datamart-spark3.json
@@ -1,0 +1,94 @@
+{
+  "name": "7.2.16 - Real-time Data Mart - Spark3 for Google Cloud",
+  "description": "",
+  "type": "DATAMART",
+  "featureState": "PREVIEW",
+  "cloudPlatform": "GCP",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.16 - Real-time Data Mart: Apache Impala, Hue, Apache Kudu, Apache Spark3"
+    },
+    "instanceGroups": [
+      {
+        "name": "master1",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "pd-ssd"
+            }
+          ],
+          "instanceType": "e2-standard-8"
+        },
+        "nodeCount": 1,
+        "type": "GATEWAY",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "master2",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "pd-ssd"
+            }
+          ],
+          "instanceType": "e2-standard-8"
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "master3",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "pd-ssd"
+            }
+          ],
+          "instanceType": "e2-standard-8"
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "coordinator",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "pd-ssd"
+            }
+          ],
+          "instanceType": "e2-highmem-16"
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "executor",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 5,
+              "size": 500,
+              "type": "pd-ssd"
+            }
+          ],
+          "instanceType": "e2-highmem-16"
+        },
+        "nodeCount": 3,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.16/yarn/dataengineering-spark3-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.16/yarn/dataengineering-spark3-ha.json
@@ -1,0 +1,112 @@
+{
+  "name": "7.2.16 - Data Engineering HA - Spark3 for YCloud",
+  "description": "",
+  "type": "DATAENGINEERING",
+  "featureState": "PREVIEW",
+  "cloudPlatform": "YARN",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.16 - Data Engineering: HA: Apache Spark3, Apache Hive, Apache Oozie"
+    },
+    "externalDatabase": {
+      "availabilityType": "HA"
+    },
+    "instanceGroups": [
+      {
+        "nodeCount": 1,
+        "name": "manager",
+        "type": "GATEWAY",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 8192
+          }
+        },
+        "recipeNames": []
+      },
+      {
+        "nodeCount": 0,
+        "name": "compute",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 8192
+          }
+        },
+        "recipeNames": []
+      },
+      {
+        "nodeCount": 3,
+        "name": "worker",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 8192
+          }
+        },
+        "recipeNames": []
+      },
+      {
+        "nodeCount": 2,
+        "name": "master",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 32768
+          }
+        },
+        "recipeNames": []
+      },
+      {
+        "nodeCount": 0,
+        "name": "gateway",
+        "type": "CORE",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 8192
+          }
+        },
+        "recipeNames": []
+      },
+      {
+        "nodeCount": 1,
+        "name": "masterx",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 32768
+          }
+        },
+        "recipeNames": []
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.16/yarn/rt-datamart-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.16/yarn/rt-datamart-spark3.json
@@ -1,0 +1,89 @@
+{
+  "name": "7.2.16 - Real-time Data Mart - Spark3 for YCloud",
+  "description": "",
+  "type": "DATAMART",
+  "featureState": "RELEASED",
+  "cloudPlatform": "YARN",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.16 - Real-time Data Mart: Apache Impala, Hue, Apache Kudu, Apache Spark3"
+    },
+    "instanceGroups": [
+      {
+        "name": "master1",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 32768
+          }
+        },
+        "nodeCount": 1,
+        "type": "GATEWAY",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "master2",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 32768
+          }
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "master3",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 32768
+          }
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "coordinator",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 8192
+          }
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "executor",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 8192
+          }
+        },
+        "nodeCount": 3,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.17/aws/dataengineering-spark3-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.17/aws/dataengineering-spark3-ha.json
@@ -1,0 +1,155 @@
+{
+  "name": "7.2.17 - Data Engineering HA - Spark3 for AWS",
+  "description": "",
+  "type": "DATAENGINEERING",
+  "featureState": "RELEASED",
+  "cloudPlatform": "AWS",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.17 - Data Engineering: HA: Apache Spark3, Apache Hive, Apache Oozie"
+    },
+    "externalDatabase": {
+      "availabilityType": "HA"
+    },
+    "enableLoadBalancer": true,
+    "instanceGroups": [{
+      "nodeCount": 2,
+      "name": "manager",
+      "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "template": {
+        "aws": {
+          "placementGroup" : {
+            "strategy" : "PARTITION"
+          }
+        },
+        "instanceType": "m5.4xlarge",
+        "rootVolume": {
+          "size": 150
+        },
+        "attachedVolumes": [{
+          "size": 150,
+          "count": 1,
+          "type": "gp2"
+        }],
+        "cloudPlatform": "AWS"
+      },
+      "recipeNames": []
+    },
+      {
+        "nodeCount": 1,
+        "name": "compute",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "aws": {},
+          "instanceType": "r5d.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [{
+            "size": 300,
+            "count": 2,
+            "type": "ephemeral"
+          }],
+          "cloudPlatform": "AWS"
+        },
+        "recipeNames": []
+      },
+      {
+        "nodeCount": 0,
+        "name": "gateway",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "aws": {},
+          "instanceType": "m5.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [{
+            "size": 150,
+            "count": 1,
+            "type": "gp2"
+          }],
+          "cloudPlatform": "AWS"
+        },
+        "recipeNames": []
+      },
+      {
+        "nodeCount": 3,
+        "name": "worker",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "aws": {
+            "placementGroup" : {
+              "strategy" : "PARTITION"
+            }
+          },
+          "instanceType": "r5d.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [{
+            "size": 500,
+            "count": 1,
+            "type": "gp2"
+          }],
+          "cloudPlatform": "AWS"
+        },
+        "recipeNames": []
+      },
+      {
+        "nodeCount": 2,
+        "minimumNodeCount": 2,
+        "name": "master",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "aws": {
+            "placementGroup" : {
+              "strategy" : "PARTITION"
+            }
+          },
+          "instanceType": "m5.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [{
+            "size": 150,
+            "count": 1,
+            "type": "gp2"
+          }],
+          "cloudPlatform": "AWS"
+        },
+        "recipeNames": []
+      },
+      {
+        "nodeCount": 1,
+        "minimumNodeCount": 1,
+        "name": "masterx",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "aws": {
+            "placementGroup" : {
+              "strategy" : "PARTITION"
+            }
+          },
+          "instanceType": "m5.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [{
+            "size": 150,
+            "count": 1,
+            "type": "gp2"
+          }],
+          "cloudPlatform": "AWS"
+        },
+        "recipeNames": []
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.17/aws/rt-datamart-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.17/aws/rt-datamart-spark3.json
@@ -1,0 +1,119 @@
+{
+  "name": "7.2.17 - Real-time Data Mart - Spark3 for AWS",
+  "description": "",
+  "type": "DATAMART",
+  "featureState": "RELEASED",
+  "cloudPlatform": "AWS",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.17 - Real-time Data Mart: Apache Impala, Hue, Apache Kudu, Apache Spark3"
+    },
+    "instanceGroups": [
+      {
+        "name": "master1",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "gp2"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "nodeCount": 1,
+        "type": "GATEWAY",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "master2",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "gp2"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "master3",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "gp2"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "coordinator",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 2,
+              "size": 300,
+              "type": "ephemeral"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "r5d.4xlarge"
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "executor",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 5,
+              "size": 500,
+              "type": "gp2"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "r5d.4xlarge"
+        },
+        "nodeCount": 3,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.17/aws_gov/dataengineering-spark3-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.17/aws_gov/dataengineering-spark3-ha.json
@@ -1,0 +1,155 @@
+{
+  "name": "7.2.17 - Data Engineering HA - Spark3 for AWS",
+  "description": "",
+  "type": "DATAENGINEERING",
+  "featureState": "RELEASED",
+  "cloudPlatform": "AWS",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.17 - Data Engineering: HA: Apache Spark3, Apache Hive, Apache Oozie"
+    },
+    "externalDatabase": {
+      "availabilityType": "HA"
+    },
+    "enableLoadBalancer": true,
+    "instanceGroups": [{
+      "nodeCount": 2,
+      "name": "manager",
+      "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "template": {
+        "aws": {
+          "placementGroup" : {
+            "strategy" : "PARTITION"
+          }
+        },
+        "instanceType": "m5.4xlarge",
+        "rootVolume": {
+          "size": 150
+        },
+        "attachedVolumes": [{
+          "size": 150,
+          "count": 1,
+          "type": "gp2"
+        }],
+        "cloudPlatform": "AWS"
+      },
+      "recipeNames": []
+    },
+      {
+        "nodeCount": 1,
+        "name": "compute",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "aws": {},
+          "instanceType": "r5d.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [{
+            "size": 300,
+            "count": 2,
+            "type": "ephemeral"
+          }],
+          "cloudPlatform": "AWS"
+        },
+        "recipeNames": []
+      },
+      {
+        "nodeCount": 0,
+        "name": "gateway",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "aws": {},
+          "instanceType": "m5.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [{
+            "size": 150,
+            "count": 1,
+            "type": "gp2"
+          }],
+          "cloudPlatform": "AWS"
+        },
+        "recipeNames": []
+      },
+      {
+        "nodeCount": 3,
+        "name": "worker",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "aws": {
+            "placementGroup" : {
+              "strategy" : "PARTITION"
+            }
+          },
+          "instanceType": "r5d.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [{
+            "size": 500,
+            "count": 1,
+            "type": "gp2"
+          }],
+          "cloudPlatform": "AWS"
+        },
+        "recipeNames": []
+      },
+      {
+        "nodeCount": 2,
+        "minimumNodeCount": 2,
+        "name": "master",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "aws": {
+            "placementGroup" : {
+              "strategy" : "PARTITION"
+            }
+          },
+          "instanceType": "m5.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [{
+            "size": 150,
+            "count": 1,
+            "type": "gp2"
+          }],
+          "cloudPlatform": "AWS"
+        },
+        "recipeNames": []
+      },
+      {
+        "nodeCount": 1,
+        "minimumNodeCount": 1,
+        "name": "masterx",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "aws": {
+            "placementGroup" : {
+              "strategy" : "PARTITION"
+            }
+          },
+          "instanceType": "m5.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [{
+            "size": 150,
+            "count": 1,
+            "type": "gp2"
+          }],
+          "cloudPlatform": "AWS"
+        },
+        "recipeNames": []
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.17/aws_gov/rt-datamart-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.17/aws_gov/rt-datamart-spark3.json
@@ -1,0 +1,119 @@
+{
+  "name": "7.2.17 - Real-time Data Mart - Spark3 for AWS",
+  "description": "",
+  "type": "DATAMART",
+  "featureState": "RELEASED",
+  "cloudPlatform": "AWS",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.17 - Real-time Data Mart: Apache Impala, Hue, Apache Kudu, Apache Spark3"
+    },
+    "instanceGroups": [
+      {
+        "name": "master1",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "gp2"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "nodeCount": 1,
+        "type": "GATEWAY",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "master2",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "gp2"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "master3",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "gp2"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "coordinator",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 2,
+              "size": 300,
+              "type": "ephemeral"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "r5d.4xlarge"
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "executor",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 5,
+              "size": 500,
+              "type": "gp2"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "r5d.4xlarge"
+        },
+        "nodeCount": 3,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.17/azure/dataengineering-spark3-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.17/azure/dataengineering-spark3-ha.json
@@ -1,0 +1,187 @@
+{
+  "name": "7.2.17 - Data Engineering HA - Spark3 for Azure",
+  "description": "",
+  "type": "DATAENGINEERING",
+  "featureState": "RELEASED",
+  "cloudPlatform": "AZURE",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.17 - Data Engineering: HA: Apache Spark3, Apache Hive, Apache Oozie"
+    },
+    "externalDatabase": {
+      "availabilityType": "HA"
+    },
+    "enableLoadBalancer": true,
+    "instanceGroups": [
+      {
+        "nodeCount": 2,
+        "name": "manager",
+        "type": "GATEWAY",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D16_v3",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [
+            {
+              "size": 150,
+              "count": 1,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "cloudPlatform": "AZURE"
+        },
+        "recipeNames": [],
+        "cloudPlatform": "AZURE"
+      },
+      {
+        "nodeCount": 1,
+        "name": "compute",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "azure": {},
+          "instanceType": "Standard_D5_v2",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [
+            {
+              "size": 500,
+              "count": 0,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "cloudPlatform": "AZURE"
+        },
+        "recipeNames": [],
+        "cloudPlatform": "AZURE"
+      },
+      {
+        "nodeCount": 3,
+        "name": "worker",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D5_v2",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [
+            {
+              "size": 500,
+              "count": 1,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "cloudPlatform": "AZURE"
+        },
+        "recipeNames": [],
+        "cloudPlatform": "AZURE"
+      },
+      {
+        "nodeCount": 2,
+        "minimumNodeCount": 2,
+        "name": "master",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D16_v3",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [
+            {
+              "size": 150,
+              "count": 1,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "cloudPlatform": "AZURE"
+        },
+        "recipeNames": [],
+        "cloudPlatform": "AZURE"
+      },
+      {
+        "nodeCount": 0,
+        "name": "gateway",
+        "type": "CORE",
+        "template": {
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D16_v3",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [
+            {
+              "size": 150,
+              "count": 1,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "cloudPlatform": "AZURE"
+        },
+        "recipeNames": [],
+        "cloudPlatform": "AZURE"
+      },
+      {
+        "nodeCount": 1,
+        "minimumNodeCount": 1,
+        "name": "masterx",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D16_v3",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [
+            {
+              "size": 150,
+              "count": 1,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "cloudPlatform": "AZURE"
+        },
+        "recipeNames": [],
+        "cloudPlatform": "AZURE"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.17/azure/rt-datamart-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.17/azure/rt-datamart-spark3.json
@@ -1,0 +1,129 @@
+{
+  "name": "7.2.17 - Real-time Data Mart - Spark3 for Azure",
+  "description": "",
+  "type": "DATAMART",
+  "featureState": "RELEASED",
+  "cloudPlatform": "AZURE",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.17 - Real-time Data Mart: Apache Impala, Hue, Apache Kudu, Apache Spark3"
+    },
+    "instanceGroups": [
+      {
+        "name": "master1",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D8_v3"
+        },
+        "nodeCount": 1,
+        "type": "GATEWAY",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "master2",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D8_v3"
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "master3",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D8_v3"
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "coordinator",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 0,
+              "size": 300,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_E16ds_v4"
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "executor",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 5,
+              "size": 500,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_E16ds_v4"
+        },
+        "nodeCount": 3,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.17/gcp/dataengineering-spark3-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.17/gcp/dataengineering-spark3-ha.json
@@ -1,0 +1,134 @@
+{
+  "name": "7.2.17 - Data Engineering HA - Spark3 for Google Cloud",
+  "description": "",
+  "type": "DATAENGINEERING",
+  "featureState": "PREVIEW",
+  "cloudPlatform": "GCP",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.17 - Data Engineering: HA: Apache Spark3, Apache Hive, Apache Oozie"
+    },
+    "externalDatabase": {
+      "availabilityType": "HA"
+    },
+    "enableLoadBalancer": true,
+    "instanceGroups": [
+      {
+        "name": "manager",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 150,
+              "type": "pd-ssd"
+            }
+          ],
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
+        },
+        "nodeCount": 2,
+        "type": "GATEWAY",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "master",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 150,
+              "type": "pd-ssd"
+            }
+          ],
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
+        },
+        "nodeCount": 2,
+        "minimumNodeCount": 2,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "compute",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 500,
+              "type": "pd-ssd"
+            }
+          ],
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "worker",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 500,
+              "type": "pd-ssd"
+            }
+          ],
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
+        },
+        "nodeCount": 3,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "gateway",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 150,
+              "type": "pd-ssd"
+            }
+          ],
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
+        },
+        "nodeCount": 0,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "masterx",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 150,
+              "type": "pd-ssd"
+            }
+          ],
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
+        },
+        "nodeCount": 1,
+        "minimumNodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.17/gcp/rt-datamart-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.17/gcp/rt-datamart-spark3.json
@@ -1,0 +1,94 @@
+{
+  "name": "7.2.17 - Real-time Data Mart - Spark3 for Google Cloud",
+  "description": "",
+  "type": "DATAMART",
+  "featureState": "PREVIEW",
+  "cloudPlatform": "GCP",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.17 - Real-time Data Mart: Apache Impala, Hue, Apache Kudu, Apache Spark3"
+    },
+    "instanceGroups": [
+      {
+        "name": "master1",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "pd-ssd"
+            }
+          ],
+          "instanceType": "e2-standard-8"
+        },
+        "nodeCount": 1,
+        "type": "GATEWAY",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "master2",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "pd-ssd"
+            }
+          ],
+          "instanceType": "e2-standard-8"
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "master3",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "pd-ssd"
+            }
+          ],
+          "instanceType": "e2-standard-8"
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "coordinator",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "pd-ssd"
+            }
+          ],
+          "instanceType": "e2-highmem-16"
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "executor",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 5,
+              "size": 500,
+              "type": "pd-ssd"
+            }
+          ],
+          "instanceType": "e2-highmem-16"
+        },
+        "nodeCount": 3,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.17/yarn/dataengineering-spark3-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.17/yarn/dataengineering-spark3-ha.json
@@ -1,0 +1,112 @@
+{
+  "name": "7.2.17 - Data Engineering HA - Spark3 for YCloud",
+  "description": "",
+  "type": "DATAENGINEERING",
+  "featureState": "PREVIEW",
+  "cloudPlatform": "YARN",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.17 - Data Engineering: HA: Apache Spark3, Apache Hive, Apache Oozie"
+    },
+    "externalDatabase": {
+      "availabilityType": "HA"
+    },
+    "instanceGroups": [
+      {
+        "nodeCount": 1,
+        "name": "manager",
+        "type": "GATEWAY",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 8192
+          }
+        },
+        "recipeNames": []
+      },
+      {
+        "nodeCount": 0,
+        "name": "compute",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 8192
+          }
+        },
+        "recipeNames": []
+      },
+      {
+        "nodeCount": 3,
+        "name": "worker",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 8192
+          }
+        },
+        "recipeNames": []
+      },
+      {
+        "nodeCount": 2,
+        "name": "master",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 32768
+          }
+        },
+        "recipeNames": []
+      },
+      {
+        "nodeCount": 0,
+        "name": "gateway",
+        "type": "CORE",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 8192
+          }
+        },
+        "recipeNames": []
+      },
+      {
+        "nodeCount": 1,
+        "name": "masterx",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 32768
+          }
+        },
+        "recipeNames": []
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.17/yarn/rt-datamart-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.17/yarn/rt-datamart-spark3.json
@@ -1,0 +1,89 @@
+{
+  "name": "7.2.17 - Real-time Data Mart - Spark3 for YCloud",
+  "description": "",
+  "type": "DATAMART",
+  "featureState": "RELEASED",
+  "cloudPlatform": "YARN",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.17 - Real-time Data Mart: Apache Impala, Hue, Apache Kudu, Apache Spark3"
+    },
+    "instanceGroups": [
+      {
+        "name": "master1",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 32768
+          }
+        },
+        "nodeCount": 1,
+        "type": "GATEWAY",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "master2",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 32768
+          }
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "master3",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 32768
+          }
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "coordinator",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 8192
+          }
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "executor",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 8192
+          }
+        },
+        "nodeCount": 3,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      }
+    ]
+  }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
@@ -367,7 +367,7 @@ public class ClusterTemplateTest extends AbstractMockTest {
             assertNotNull(entity);
             assertNotNull(entity.getResponses());
             long defaultCount = entity.getResponses().stream().filter(template -> ResourceStatus.DEFAULT.equals(template.getStatus())).count();
-            long expectedCount = 660;
+            long expectedCount = 676;
             assertEquals("Should have " + expectedCount + " of default cluster templates.", expectedCount, defaultCount);
         } catch (Exception e) {
             throw new TestFailException(String.format("Failed to validate default count of cluster templates: %s", e.getMessage()), e);


### PR DESCRIPTION
    Spark2 templates will be marked as deprecated in 7.2.17, all Spark3
    templates have to be in sync with the Spark2 ones
    
    Main changes:
    
    Added these new templates:
    
    7.2.17 - Data Engineering: HA: Apache Spark3, Apache Hive, Apache Oozie
    7.2.17 - Real-time Data Mart: Apache Impala, Hue, Apache Kudu, Apache Spark3
    7.2.16 - Data Engineering: HA: Apache Spark3, Apache Hive, Apache Oozie
    7.2.16 - Real-time Data Mart: Apache Impala, Hue, Apache Kudu, Apache Spark3
    
    Synced these templates:
    
    7.2.17:  cdp-data-engineering-spark3.bp vs. cdp-data-engineering.bp (7.2.17 - Data Engineering Spark3)
    7.2.16:  cdp-data-engineering-spark3.bp vs. cdp-data-engineering.bp (7.2.16 - Data Engineering Spark3)