### PR TITLE
CB-20836: Datalake rolling upgrade should skip the DataHub validation

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/InternalUpgradeSettings.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/InternalUpgradeSettings.java
@@ -33,7 +33,7 @@ public class InternalUpgradeSettings {
         this.dataHubRuntimeUpgradeEntitled = dataHubRuntimeUpgradeEntitled;
         this.dataHubOsUpgradeEntitled = dataHubOsUpgradeEntitled;
         this.rollingUpgradeEnabled = rollingUpgradeEnabled;
-        upgradePreparation = false;
+        this.upgradePreparation = false;
     }
 
     @JsonCreator

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackUpgradeOperations.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackUpgradeOperations.java
@@ -170,9 +170,14 @@ public class StackUpgradeOperations {
             if (!entitlementService.datahubRuntimeUpgradeEnabled(accountId)) {
                 upgradeResponse.appendReason(upgradePreconditionService.checkForNonUpgradeableAttachedClusters(datahubsInEnvironment));
             }
+            boolean rollingUpgradeEnabled = isRollingUpgradeEnabled(request);
             upgradeResponse.appendReason(upgradePreconditionService.checkForRunningAttachedClusters(datahubsInEnvironment, request.
-                    isSkipDataHubValidation(), accountId));
+                    isSkipDataHubValidation(), rollingUpgradeEnabled, accountId));
         }
+    }
+
+    private boolean isRollingUpgradeEnabled(UpgradeV4Request request) {
+        return Optional.ofNullable(request.getInternalUpgradeSettings()).map(InternalUpgradeSettings::isRollingUpgradeEnabled).orElse(false);
     }
 
     private boolean determineReplaceVmsParameter(Stack stack, Boolean replaceVms) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/UpgradePreconditionServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/UpgradePreconditionServiceTest.java
@@ -51,7 +51,7 @@ public class UpgradePreconditionServiceTest {
         StackDtoDelegate dataHubStack3 = createStackDtoDelegate(Status.STOPPED, "stack-3", "stack-crn-2", BlueprintUpgradeOption.GA, ResourceStatus.DEFAULT);
         List<StackDtoDelegate> datahubs = List.of(dataHubStack1, dataHubStack2, dataHubStack3);
 
-        String actualRunning = underTest.checkForRunningAttachedClusters(datahubs, null, ACCOUNT_ID);
+        String actualRunning = underTest.checkForRunningAttachedClusters(datahubs, null, false, ACCOUNT_ID);
         String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(datahubs);
 
         assertEquals("There are attached Data Hub clusters in incorrect state: stack-1. Please stop those to be able to perform the upgrade.",
@@ -71,13 +71,49 @@ public class UpgradePreconditionServiceTest {
         StackDtoDelegate dataHubStack3 = createStackDtoDelegate(Status.STOPPED, "stack-3", "stack-crn-2", BlueprintUpgradeOption.GA, ResourceStatus.DEFAULT);
         List<StackDtoDelegate> datahubs = List.of(dataHubStack1, dataHubStack2, dataHubStack3);
 
-        String actual = underTest.checkForRunningAttachedClusters(datahubs, null, ACCOUNT_ID);
+        String actual = underTest.checkForRunningAttachedClusters(datahubs, null, false, ACCOUNT_ID);
         String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(datahubs);
 
         assertEquals("", actual);
         assertEquals("", actualNonUpgradeable);
 
         verify(spotInstanceUsageCondition).isStackRunsOnSpotInstances(dataHubStack1);
+    }
+
+    @Test
+    public void testCheckForRunningAttachedClustersShouldNotReturnErrorMessageWhenSkipDataHubValidationParameterIsTrue() {
+        StackDtoDelegate dataHubStack1 = createStackDtoDelegate(Status.AVAILABLE, "stack-1", "stack-crn-1", BlueprintUpgradeOption.GA, ResourceStatus.DEFAULT);
+        StackDtoDelegate dataHubStack2 = createStackDtoDelegate(Status.DELETE_COMPLETED, "stack-2", "stack-crn-2",
+                BlueprintUpgradeOption.GA, ResourceStatus.DEFAULT);
+        StackDtoDelegate dataHubStack3 = createStackDtoDelegate(Status.STOPPED, "stack-3", "stack-crn-2", BlueprintUpgradeOption.GA, ResourceStatus.DEFAULT);
+        List<StackDtoDelegate> datahubs = List.of(dataHubStack1, dataHubStack2, dataHubStack3);
+
+        String actual = underTest.checkForRunningAttachedClusters(datahubs, Boolean.TRUE, false, ACCOUNT_ID);
+        String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(datahubs);
+
+        assertEquals("", actual);
+        assertEquals("", actualNonUpgradeable);
+
+        verify(spotInstanceUsageCondition).isStackRunsOnSpotInstances(dataHubStack1);
+        verifyNoInteractions(entitlementService);
+    }
+
+    @Test
+    public void testCheckForRunningAttachedClustersShouldNotReturnErrorMessageWhenRollingUpgradeIsEnabled() {
+        StackDtoDelegate dataHubStack1 = createStackDtoDelegate(Status.AVAILABLE, "stack-1", "stack-crn-1", BlueprintUpgradeOption.GA, ResourceStatus.DEFAULT);
+        StackDtoDelegate dataHubStack2 = createStackDtoDelegate(Status.DELETE_COMPLETED, "stack-2", "stack-crn-2",
+                BlueprintUpgradeOption.GA, ResourceStatus.DEFAULT);
+        StackDtoDelegate dataHubStack3 = createStackDtoDelegate(Status.STOPPED, "stack-3", "stack-crn-2", BlueprintUpgradeOption.GA, ResourceStatus.DEFAULT);
+        List<StackDtoDelegate> datahubs = List.of(dataHubStack1, dataHubStack2, dataHubStack3);
+
+        String actual = underTest.checkForRunningAttachedClusters(datahubs, Boolean.FALSE, true, ACCOUNT_ID);
+        String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(datahubs);
+
+        assertEquals("", actual);
+        assertEquals("", actualNonUpgradeable);
+
+        verify(spotInstanceUsageCondition).isStackRunsOnSpotInstances(dataHubStack1);
+        verifyNoInteractions(entitlementService);
     }
 
     @Test
@@ -90,7 +126,7 @@ public class UpgradePreconditionServiceTest {
         List<StackDtoDelegate> datahubs = List.of(dataHubStack1, dataHubStack2, dataHubStack3);
         when(stackStopRestrictionService.isInfrastructureStoppable(any())).thenReturn(StopRestrictionReason.EPHEMERAL_VOLUMES);
 
-        String actual = underTest.checkForRunningAttachedClusters(datahubs, Boolean.FALSE, ACCOUNT_ID);
+        String actual = underTest.checkForRunningAttachedClusters(datahubs, Boolean.FALSE, false, ACCOUNT_ID);
         String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(datahubs);
 
         assertEquals("", actual);
@@ -109,7 +145,7 @@ public class UpgradePreconditionServiceTest {
         when(stackStopRestrictionService.isInfrastructureStoppable(any())).thenReturn(StopRestrictionReason.NONE);
         when(spotInstanceUsageCondition.isStackRunsOnSpotInstances(dataHubStack1)).thenReturn(true);
 
-        String actualRunning = underTest.checkForRunningAttachedClusters(datahubs, Boolean.FALSE, ACCOUNT_ID);
+        String actualRunning = underTest.checkForRunningAttachedClusters(datahubs, Boolean.FALSE, false, ACCOUNT_ID);
         String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(datahubs);
 
         assertEquals("", actualRunning);
@@ -125,7 +161,7 @@ public class UpgradePreconditionServiceTest {
                 "stack-crn-2", BlueprintUpgradeOption.DISABLED, ResourceStatus.DEFAULT);
         List<StackDtoDelegate> datahubs = List.of(dataHubStack1, dataHubStack2);
 
-        String actualRunning = underTest.checkForRunningAttachedClusters(datahubs, Boolean.FALSE, ACCOUNT_ID);
+        String actualRunning = underTest.checkForRunningAttachedClusters(datahubs, Boolean.FALSE, false, ACCOUNT_ID);
         String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(datahubs);
 
         assertEquals("There are attached Data Hub clusters that are non-upgradeable: stack-2. Please delete those to be able to perform the upgrade.",
@@ -141,7 +177,7 @@ public class UpgradePreconditionServiceTest {
         StackDtoDelegate dataHubStack3 = createStackDtoDelegate(Status.STOPPED, "stack-3", "stack-crn-3", BlueprintUpgradeOption.GA, ResourceStatus.DEFAULT);
         List<StackDtoDelegate> datahubs = List.of(dataHubStack1, dataHubStack2, dataHubStack3);
 
-        String actual = underTest.checkForRunningAttachedClusters(datahubs, Boolean.FALSE, ACCOUNT_ID);
+        String actual = underTest.checkForRunningAttachedClusters(datahubs, Boolean.FALSE, false, ACCOUNT_ID);
         String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(datahubs);
 
         assertEquals("", actual);
@@ -158,7 +194,7 @@ public class UpgradePreconditionServiceTest {
         StackDtoDelegate dataHubStack3 = createStackDtoDelegate(Status.STOPPED, "stack-3", "stack-crn-3", BlueprintUpgradeOption.GA, ResourceStatus.DEFAULT);
         List<StackDtoDelegate> datahubs = List.of(dataHubStack1, dataHubStack2, dataHubStack3);
 
-        String actualRunning = underTest.checkForRunningAttachedClusters(datahubs, Boolean.FALSE, ACCOUNT_ID);
+        String actualRunning = underTest.checkForRunningAttachedClusters(datahubs, Boolean.FALSE, false, ACCOUNT_ID);
         String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(datahubs);
 
         assertEquals("There are attached Data Hub clusters in incorrect state: stack-1. Please stop those to be able to perform the upgrade.",
@@ -177,7 +213,7 @@ public class UpgradePreconditionServiceTest {
         StackDtoDelegate dataHubStack3 = createStackDtoDelegate(Status.STOPPED, "stack-3", "stack-crn-3", null, ResourceStatus.USER_MANAGED);
         List<StackDtoDelegate> datahubs = List.of(dataHubStack1, dataHubStack2, dataHubStack3);
 
-        String actualRunning = underTest.checkForRunningAttachedClusters(datahubs, Boolean.FALSE, ACCOUNT_ID);
+        String actualRunning = underTest.checkForRunningAttachedClusters(datahubs, Boolean.FALSE, false, ACCOUNT_ID);
         String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(datahubs);
 
         assertEquals("There are attached Data Hub clusters in incorrect state: stack-1. Please stop those to be able to perform the upgrade.",
@@ -191,7 +227,7 @@ public class UpgradePreconditionServiceTest {
     public void testDataHubsNotAttached() {
         List<StackDtoDelegate> datahubs = List.of();
 
-        String actual = underTest.checkForRunningAttachedClusters(datahubs, Boolean.FALSE, ACCOUNT_ID);
+        String actual = underTest.checkForRunningAttachedClusters(datahubs, Boolean.FALSE, false, ACCOUNT_ID);
         String actualNonUpgradeable = underTest.checkForNonUpgradeableAttachedClusters(datahubs);
 
         assertEquals("", actual);

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/StackUpgradeOperationsTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/StackUpgradeOperationsTest.java
@@ -3,6 +3,7 @@ package com.sequenceiq.distrox.v1.distrox;
 import static com.sequenceiq.cloudbreak.util.TestConstants.DO_NOT_KEEP_VARIANT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -264,7 +265,7 @@ class StackUpgradeOperationsTest {
                 .checkForUpgradesByName(stack, false, true, request.getInternalUpgradeSettings(), false);
         verify(clusterUpgradeAvailabilityService).filterUpgradeOptions(ACCOUNT_ID, upgradeResponse, request, true);
         verify(entitlementService).runtimeUpgradeEnabled(ACCOUNT_ID);
-        verify(upgradePreconditionService).checkForRunningAttachedClusters(List.of(stackDto), request.isSkipDataHubValidation(), ACCOUNT_ID);
+        verify(upgradePreconditionService).checkForRunningAttachedClusters(List.of(stackDto), request.isSkipDataHubValidation(), false, ACCOUNT_ID);
         verify(upgradePreconditionService).checkForNonUpgradeableAttachedClusters(List.of(stackDto));
         verifyNoInteractions(clusterDBValidationService);
     }
@@ -320,7 +321,7 @@ class StackUpgradeOperationsTest {
                 .checkForUpgradesByName(stack, false, true, request.getInternalUpgradeSettings(), false))
                 .thenReturn(upgradeResponseToReturn);
         when(entitlementService.runtimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(true);
-        when(upgradePreconditionService.checkForRunningAttachedClusters(List.of(stackDto), request.isSkipDataHubValidation(), ACCOUNT_ID))
+        when(upgradePreconditionService.checkForRunningAttachedClusters(List.of(stackDto), request.isSkipDataHubValidation(), false, ACCOUNT_ID))
                 .thenReturn("There are attached Data Hub clusters in incorrect state");
         when(upgradePreconditionService.checkForNonUpgradeableAttachedClusters(List.of(stackDto)))
                 .thenReturn("There are attached Data Hub clusters that are non-upgradeable");
@@ -337,7 +338,7 @@ class StackUpgradeOperationsTest {
                 .checkForUpgradesByName(stack, false, true, request.getInternalUpgradeSettings(), false);
         verify(clusterUpgradeAvailabilityService).filterUpgradeOptions(ACCOUNT_ID, upgradeResponseToReturn, request, true);
         verify(entitlementService).runtimeUpgradeEnabled(ACCOUNT_ID);
-        verify(upgradePreconditionService).checkForRunningAttachedClusters(List.of(stackDto), request.isSkipDataHubValidation(), ACCOUNT_ID);
+        verify(upgradePreconditionService).checkForRunningAttachedClusters(List.of(stackDto), request.isSkipDataHubValidation(), false, ACCOUNT_ID);
         verify(upgradePreconditionService).checkForNonUpgradeableAttachedClusters(List.of(stackDto));
         verifyNoInteractions(clusterDBValidationService);
     }
@@ -362,7 +363,7 @@ class StackUpgradeOperationsTest {
                 .thenReturn(upgradeResponseToReturn);
         when(entitlementService.runtimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(true);
         when(entitlementService.datahubRuntimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(true);
-        when(upgradePreconditionService.checkForRunningAttachedClusters(List.of(stackDto), request.isSkipDataHubValidation(), ACCOUNT_ID))
+        when(upgradePreconditionService.checkForRunningAttachedClusters(List.of(stackDto), request.isSkipDataHubValidation(), false, ACCOUNT_ID))
                 .thenReturn("There are attached Data Hub clusters in incorrect state");
         when(stackDtoService.findAllByEnvironmentCrnAndStackType(ENVIRONMENT_CRN, List.of(StackType.WORKLOAD))).thenReturn(List.of(stackDto));
 
@@ -377,7 +378,7 @@ class StackUpgradeOperationsTest {
                 .checkForUpgradesByName(stack, false, true, request.getInternalUpgradeSettings(), false);
         verify(clusterUpgradeAvailabilityService).filterUpgradeOptions(ACCOUNT_ID, upgradeResponseToReturn, request, true);
         verify(entitlementService).runtimeUpgradeEnabled(ACCOUNT_ID);
-        verify(upgradePreconditionService).checkForRunningAttachedClusters(List.of(stackDto), request.isSkipDataHubValidation(), ACCOUNT_ID);
+        verify(upgradePreconditionService).checkForRunningAttachedClusters(List.of(stackDto), request.isSkipDataHubValidation(), false, ACCOUNT_ID);
         verify(upgradePreconditionService, times(0)).checkForNonUpgradeableAttachedClusters(List.of(stackDto));
         verifyNoInteractions(clusterDBValidationService);
     }
@@ -396,7 +397,7 @@ class StackUpgradeOperationsTest {
                 ComponentType.CLUSTER_UPGRADE_PREPARED_IMAGES.name());
         UpgradeV4Response upgradeResponse = new UpgradeV4Response();
         upgradeResponse.setUpgradeCandidates(List.of(new ImageInfoV4Response()));
-        upgradeResponse.getUpgradeCandidates().stream().forEach(imageInfoV4Response -> imageInfoV4Response.setImageId(IMAGE_ID));
+        upgradeResponse.getUpgradeCandidates().forEach(imageInfoV4Response -> imageInfoV4Response.setImageId(IMAGE_ID));
         when(instanceGroupService.getByStackAndFetchTemplates(STACK_ID)).thenReturn(Collections.emptySet());
         when(upgradeService.isOsUpgrade(request)).thenReturn(false);
         when(upgradePreconditionService.notUsingEphemeralVolume(stack)).thenReturn(false);
@@ -408,7 +409,7 @@ class StackUpgradeOperationsTest {
         UpgradeV4Response actual = underTest.checkForClusterUpgrade(ACCOUNT_ID, stack, request);
 
         assertEquals(upgradeResponse, actual);
-        assertEquals(true, upgradeResponse.getUpgradeCandidates().get(0).isPrepared());
+        assertTrue(upgradeResponse.getUpgradeCandidates().get(0).isPrepared());
         verify(instanceGroupService).getByStackAndFetchTemplates(STACK_ID);
         verify(upgradeService).isOsUpgrade(request);
         verify(upgradePreconditionService).notUsingEphemeralVolume(stack);


### PR DESCRIPTION
When we initiate a rolling upgrade it should skip the Data Hub validation. This means that we don't need to stop the Data Hub clusters to upgrade the Data Lake.
