### PR TITLE
CB-20809 Add in more info for database backup/restore timeout; change…

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/handler/DatalakeDatabaseBackupWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/handler/DatalakeDatabaseBackupWaitHandler.java
@@ -55,7 +55,7 @@ public class DatalakeDatabaseBackupWaitHandler extends ExceptionCatcherEventHand
         String userId = request.getUserId();
         Selectable response;
         try {
-            LOGGER.info("Start polling datalake database backup  for id: {}", sdxId);
+            LOGGER.info("Start polling datalake database backup for id: {}", sdxId);
             PollingConfig pollingConfig = new PollingConfig(sleepTimeInSec, TimeUnit.SECONDS, durationInMinutes, TimeUnit.MINUTES);
             sdxBackupRestoreService.waitCloudbreakFlow(sdxId, pollingConfig, "Database backup");
             response = new DatalakeFullBackupInProgressEvent(sdxId, userId, request.getOperationId());
@@ -68,8 +68,9 @@ public class DatalakeDatabaseBackupWaitHandler extends ExceptionCatcherEventHand
             LOGGER.info("Database backup poller stopped for cluster: {}", sdxId);
             sdxBackupRestoreService.updateDatabaseStatusEntry(event.getData().getOperationId(),
                     SdxOperationStatus.FAILED, pollerStoppedException.getLocalizedMessage());
+            String errorStage = sdxBackupRestoreService.createDatabaseBackupRestoreErrorStage(sdxId);
             response = new DatalakeDatabaseBackupFailedEvent(sdxId, userId,
-                    new PollerStoppedException("Database backup timed out after " + durationInMinutes + " minutes"));
+                    new PollerStoppedException("Database backup timed out after " + durationInMinutes + " minutes" + errorStage));
         } catch (PollerException exception) {
             LOGGER.info("Database backup polling failed for cluster: {}", sdxId);
             sdxBackupRestoreService.updateDatabaseStatusEntry(event.getData().getOperationId(),

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/handler/DatalakeDatabaseRestoreWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/handler/DatalakeDatabaseRestoreWaitHandler.java
@@ -68,8 +68,9 @@ public class DatalakeDatabaseRestoreWaitHandler extends ExceptionCatcherEventHan
             LOGGER.info("Database restore poller stopped for cluster: {}", sdxId);
             sdxBackupRestoreService.updateDatabaseStatusEntry(event.getData().getOperationId(),
                     SdxOperationStatus.FAILED, pollerStoppedException.getLocalizedMessage());
+            String errorStage = sdxBackupRestoreService.createDatabaseBackupRestoreErrorStage(sdxId);
             response = new DatalakeDatabaseRestoreFailedEvent(sdxId, userId,
-                    new PollerStoppedException("Database restore timed out after " + durationInMinutes + " minutes"));
+                    new PollerStoppedException("Database restore timed out after " + durationInMinutes + " minutes" + errorStage));
         } catch (PollerException exception) {
             LOGGER.info("Database restore polling failed for cluster: {}", sdxId);
             sdxBackupRestoreService.updateDatabaseStatusEntry(event.getData().getOperationId(),

--- a/flow-api/src/main/java/com/sequenceiq/flow/api/model/FlowCheckResponse.java
+++ b/flow-api/src/main/java/com/sequenceiq/flow/api/model/FlowCheckResponse.java
@@ -15,6 +15,12 @@ public class FlowCheckResponse {
 
     private Long endTime;
 
+    private String currentState;
+
+    private String nextEvent;
+
+    private String flowType;
+
     public String getFlowId() {
         return flowId;
     }
@@ -53,5 +59,42 @@ public class FlowCheckResponse {
 
     public void setEndTime(Long endTime) {
         this.endTime = endTime;
+    }
+
+    public String getCurrentState() {
+        return currentState;
+    }
+
+    public void setCurrentState(String currentFailedState) {
+        this.currentState = currentFailedState;
+    }
+
+    public String getNextEvent() {
+        return nextEvent;
+    }
+
+    public void setNextEvent(String nextEvent) {
+        this.nextEvent = nextEvent;
+    }
+
+    public String getFlowType() {
+        return flowType;
+    }
+
+    public void setFlowType(String flowType) {
+        this.flowType = flowType;
+    }
+
+    public String toString() {
+        return "FlowCheckResponse{" +
+                "flowId='" + flowId + '\'' +
+                ", flowChainId='" + flowChainId + '\'' +
+                ", hasActiveFlow='" + hasActiveFlow + '\'' +
+                ", latestFlowFinalizedAndFailed='" + latestFlowFinalizedAndFailed + '\'' +
+                ", endTime='" + endTime + '\'' +
+                ", currentState='" + currentState + '\'' +
+                ", nextEvent=" + nextEvent + '\'' +
+                ", flowType=" + flowType + '\'' +
+                '}';
     }
 }

--- a/flow/src/main/java/com/sequenceiq/flow/core/FlowConstants.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/FlowConstants.java
@@ -1,7 +1,11 @@
 package com.sequenceiq.flow.core;
 
 public class FlowConstants {
+    public static final String FLOW = "FLOW";
+
     public static final String FLOW_ID = "FLOW_ID";
+
+    public static final String FLOW_CHAIN = "FLOW_CHAIN";
 
     public static final String FLOW_CHAIN_TYPE = "FLOW_CHAIN_TYPE";
 

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
@@ -208,7 +208,7 @@ public class SaltOrchestrator implements HostOrchestrator {
             Set<String> allTargets = targets.stream().map(Node::getPrivateIp).collect(Collectors.toSet());
             uploadSignKey(sc, primaryGateway, gatewayTargets, allTargets, exitModel);
             OrchestratorBootstrap saltBootstrap = saltBootstrapFactory.of(sc, saltConnectors, allGatewayConfigs, targets, params);
-            Callable<Boolean> saltBootstrapRunner = saltRunner.runner(saltBootstrap, exitCriteria, exitModel);
+            Callable<Boolean> saltBootstrapRunner = saltRunner.runnerWithConfiguredErrorCount(saltBootstrap, exitCriteria, exitModel);
             saltBootstrapRunner.call();
         } catch (Exception e) {
             LOGGER.info("Error occurred during the salt bootstrap", e);

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestratorTest.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestratorTest.java
@@ -196,8 +196,7 @@ class SaltOrchestratorTest {
 
         saltOrchestrator.bootstrap(allGatewayConfigs, targets, bootstrapParams, exitCriteriaModel);
 
-        verify(saltRunner, times(1)).runner(any(OrchestratorBootstrap.class), any(ExitCriteria.class), any(ExitCriteriaModel.class));
-        verify(saltRunner, times(3)).runnerWithConfiguredErrorCount(any(OrchestratorBootstrap.class), any(ExitCriteria.class), any(ExitCriteriaModel.class));
+        verify(saltRunner, times(4)).runnerWithConfiguredErrorCount(any(OrchestratorBootstrap.class), any(ExitCriteria.class), any(ExitCriteriaModel.class));
         // salt.zip, master_sign.pem, master_sign.pub
         verify(saltBootstrapFactory, times(1)).of(eq(saltConnector), eq(saltConnectors), eq(allGatewayConfigs), eq(targets),
                 eq(bootstrapParams));


### PR DESCRIPTION
… bootstrap maxError to be configured. 

**JIRA**: [CB-20809](https://jira.cloudera.com/browse/CB-20809)

**ISSUE**: 1. The salt bootstrap has a very large number of retry on error, making the retry happen for about 180 times with more than 90 min. 2. When DB backup/restore timeouts, we don't know at which stage it times out or fails.

**SOLUTION**: 1. Make the salt bootstrap to have a configured retry on error number, which is approved by the CB team (see comments in the jira). 2. Use `flowLog` to get the latest state and log it for error. Since `flowLog` only has state that has been finalized (has status of failed/successful etc), so the state that is being retry on and potentially failed is not in the `flowLog` table yet, therefore, we can only get the state that happens before the state that is failing. 

**Before:**
![image](https://user-images.githubusercontent.com/39275944/220236860-7d815050-77d0-4d1d-82f1-96819a794264.png)

**After:** (Tested by forcing timeout duration to be 1 min)
Backup - SaltJobIdTracker fails:
<img width="1568" alt="Screen Shot 2023-02-22 at 5 16 00 PM" src="https://user-images.githubusercontent.com/39275944/220773210-4f48d467-fdfa-47b5-ae77-09f89611dbcc.png">

Restore - SaltJobIdTracker fails:
<img width="1448" alt="Screen Shot 2023-02-22 at 5 19 17 PM" src="https://user-images.githubusercontent.com/39275944/220773241-3d54afd0-75ca-437e-9fd7-d34fd0375d34.png">







