### PR TITLE
CDPSDX-3900 Add Logging to DB Backup/Restore for Errors where Wrong N…

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/restore.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/restore.sls
@@ -3,10 +3,20 @@
 include:
   - postgresql.disaster_recovery
 
+{% set storage = salt['pillar.get']('disaster_recovery:object_storage_url') %}
+{% set host = salt['pillar.get']('postgres:clouderamanager:remote_db_url') %}
+{% set port = salt['pillar.get']('postgres:clouderamanager:remote_db_port') %}
+{% set username = salt['pillar.get']('postgres:clouderamanager:remote_admin') %}
+{% set group = salt['pillar.get']('disaster_recovery:ranger_admin_group') %}
+{% set dbname = salt['pillar.get']('disaster_recovery:database_name') %}
+{% if dbname %}
+{% set dbname_list = dbname.split(' ') %}
+{% endif %}
+
 {% if 'None' != configure_remote_db %}
 restore_postgresql_db:
   cmd.run:
-    - name: /opt/salt/scripts/restore_db.sh {{salt['pillar.get']('disaster_recovery:object_storage_url')}} {{salt['pillar.get']('postgres:clouderamanager:remote_db_url')}} {{salt['pillar.get']('postgres:clouderamanager:remote_db_port')}} {{salt['pillar.get']('postgres:clouderamanager:remote_admin')}} {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}} {{salt['pillar.get']('disaster_recovery:database_name') or ''}}
+    - name: /opt/salt/scripts/restore_db.sh{% if storage %} -s {{storage}}{% endif %}{% if host %} -h {{host}}{% endif %}{% if port %} -p {{port}}{% endif %}{% if username %} -u {{username}}{% endif %}{% if group %} -g {{group}}{% endif %}{% if dbname %}{% for item in dbname_list %} -n {{item}}{% endfor %}{% endif %}
     - require:
         - sls: postgresql.disaster_recovery
 
@@ -23,7 +33,7 @@ add_root_role_to_database:
 
 restore_postgresql_db:
   cmd.run:
-    - name: /opt/salt/scripts/restore_db.sh {{salt['pillar.get']('disaster_recovery:object_storage_url')}} "" "" "" {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}} {{salt['pillar.get']('disaster_recovery:database_name') or ''}}
+    - name: /opt/salt/scripts/restore_db.sh{% if storage %} -s {{storage}}{% endif %} -h "" -p "" -u ""{% if group %} -g {{group}}{% endif %}{% if dbname %}{% for item in dbname_list %} -n {{item}}{% endfor %}{% endif %}
     - require:
         - cmd: add_root_role_to_database
 {% endif %}


### PR DESCRIPTION
…ode is Used

*Restore will be updated after we determine we want to make the logging this detailed. 

**JIRA**: JIRA: [CDPSDX-3900](https://jira.cloudera.com/browse/CDPSDX-3900)
**ISSUE**: When a user ran the salt command to manually backup database on a wrong node the backup fails because it is missing values in the pillar file or in postgres.

**SOLUTION**: To make the logging more precise, I added in options when running the bash command and use `getopts` to get the argument of each option.

**BEFORE** (the log):
![image](https://user-images.githubusercontent.com/39275944/220231052-a928d7b8-d7dc-482f-bf33-fcfcfe2ae3cf.png)

**AFTER** (the log):
Tested with a successful backup:


Tested with a successful backup with database names defined:
<img width="1524" alt="Screen Shot 2023-02-21 at 3 45 16 PM" src="https://user-images.githubusercontent.com/39275944/220503762-c947f8d0-4de8-459d-a389-5709b239c4ab.png">

Tested with backup on the wrong node:
<img width="1318" alt="Screen Shot 2023-02-23 at 9 05 11 PM" src="https://user-images.githubusercontent.com/39275944/221074920-8f2af189-f374-4335-bcd6-64c60d17aa7a.png">

Tested with a successful restore (the restore log has some decoding issues which we may need to fix in the future):
<img width="634" alt="Screen Shot 2023-02-21 at 9 18 28 PM" src="https://user-images.githubusercontent.com/39275944/220504009-3a816305-0a07-4339-8457-1dfb8ffbc511.png">

Tested with restore on the wrong node:
<img width="1230" alt="Screen Shot 2023-02-23 at 9 06 50 PM" src="https://user-images.githubusercontent.com/39275944/221074884-5ea43c9a-01da-41dc-8088-75506d36b0b4.png">

Also tested by setting up configure_remote_db to be "None" so it will call another command in the jinjia file. 
