### PR TITLE
CB-20887 Azure SDK upgrade: Virtual network link listing throws when …

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
@@ -133,15 +133,18 @@ public class AzureClient {
 
     private final AzureExceptionHandler azureExceptionHandler;
 
+    private final AzureListResultFactory azureListResultFactory;
+
     private final ComputeManager computeManager;
 
-    public AzureClient(AzureClientFactory azureClientCredentials, AzureExceptionHandler azureExceptionHandler) {
+    public AzureClient(AzureClientFactory azureClientCredentials, AzureExceptionHandler azureExceptionHandler, AzureListResultFactory azureListResultFactory) {
         this.azureClientFactory = azureClientCredentials;
         azure = azureClientCredentials.getAzureResourceManager();
         privateDnsZoneManager = azureClientCredentials.getPrivateDnsManager();
         marketplaceOrderingManager = azureClientCredentials.getMarketplaceOrderingManager();
         computeManager = azureClientCredentials.getComputeManager();
         this.azureExceptionHandler = azureExceptionHandler;
+        this.azureListResultFactory = azureListResultFactory;
     }
 
     public AzureResourceManager getAzure() {
@@ -157,7 +160,7 @@ public class AzureClient {
     }
 
     public AzureListResult<Network> getNetworks() {
-        return handleException(() -> new AzureListResult<>(azure.networks().list()));
+        return handleException(() -> azureListResultFactory.create(azure.networks().list()));
     }
 
     public boolean resourceGroupExists(String name) {
@@ -322,7 +325,7 @@ public class AzureClient {
     }
 
     public AzureListResult<Disk> listDisksByResourceGroup(String resourceGroupName) {
-        return AzureListResult.listByResourceGroup(azure.disks(), resourceGroupName);
+        return azureListResultFactory.listByResourceGroup(azure.disks(), resourceGroupName);
     }
 
     public Disk getDiskById(String id) {
@@ -431,7 +434,7 @@ public class AzureClient {
 
     public List<BlobItem> listBlobInStorage(String resourceGroup, String storageName, String containerName) {
         try {
-            return new AzureListResult<>(getBlobContainerClient(resourceGroup, storageName, containerName).listBlobs()).getAll();
+            return azureListResultFactory.create(getBlobContainerClient(resourceGroup, storageName, containerName).listBlobs()).getAll();
         } catch (Exception e) {
             LOGGER.warn("Failed to list blobs in storage: {}.", storageName);
             throw new CloudConnectorException(e);
@@ -468,7 +471,7 @@ public class AzureClient {
     }
 
     public AzureListResult<VirtualMachine> getVirtualMachines(String resourceGroup) {
-        return handleException(() -> AzureListResult.listByResourceGroup(azure.virtualMachines(), resourceGroup));
+        return handleException(() -> azureListResultFactory.listByResourceGroup(azure.virtualMachines(), resourceGroup));
     }
 
     public VirtualMachine getVirtualMachineByResourceGroup(String resourceGroup, String vmName) {
@@ -531,7 +534,7 @@ public class AzureClient {
     }
 
     public AzureListResult<PublicIpAddress> getPublicIpAddresses(String resourceGroup) {
-        return handleException(() -> AzureListResult.listByResourceGroup(azure.publicIpAddresses(), resourceGroup));
+        return handleException(() -> azureListResultFactory.listByResourceGroup(azure.publicIpAddresses(), resourceGroup));
     }
 
     public Mono<Void> deleteNetworkInterfaceAsync(String resourceGroup, String networkInterfaceName) {
@@ -539,7 +542,7 @@ public class AzureClient {
     }
 
     public AzureListResult<NetworkInterface> getNetworkInterfaces(String resourceGroup) {
-        return handleException(() -> AzureListResult.listByResourceGroup(azure.networkInterfaces(), resourceGroup));
+        return handleException(() -> azureListResultFactory.listByResourceGroup(azure.networkInterfaces(), resourceGroup));
     }
 
     public List<NetworkInterface> getNetworkInterfaceListByNames(String resourceGroup, Collection<String> attachedNetworkInterfaces) {
@@ -597,10 +600,10 @@ public class AzureClient {
             Set<VirtualMachineSize> resultList = new HashSet<>();
             if (region == null) {
                 for (Region tmpRegion : Region.values()) {
-                    resultList.addAll(AzureListResult.listByRegion(azure.virtualMachines().sizes(), tmpRegion.label()).getAll());
+                    resultList.addAll(azureListResultFactory.listByRegion(azure.virtualMachines().sizes(), tmpRegion.label()).getAll());
                 }
             } else {
-                resultList.addAll(AzureListResult.listByRegion(azure.virtualMachines().sizes(), region).getAll());
+                resultList.addAll(azureListResultFactory.listByRegion(azure.virtualMachines().sizes(), region).getAll());
             }
             return resultList;
         });
@@ -684,7 +687,7 @@ public class AzureClient {
     }
 
     public AzureListResult<Identity> listIdentities() {
-        return handleException(() -> AzureListResult.list(azure.identities()));
+        return handleException(() -> azureListResultFactory.list(azure.identities()));
     }
 
     public List<Identity> listIdentitiesByRegion(String region) {
@@ -709,7 +712,7 @@ public class AzureClient {
     }
 
     public AzureListResult<RoleAssignment> listRoleAssignmentsByScope(String scope) {
-        return handleException(() -> new AzureListResult<>(getRoleAssignments().listByScope(scope)));
+        return handleException(() -> azureListResultFactory.create(getRoleAssignments().listByScope(scope)));
     }
 
     public List<RoleAssignmentInner> listRoleAssignmentsByScopeInner(String scope) {
@@ -720,7 +723,7 @@ public class AzureClient {
     }
 
     public AzureListResult<RoleAssignmentInner> listRoleAssignments() {
-        return new AzureListResult<>(listRoleAssignmentsBySubscription(getCurrentSubscription().subscriptionId()));
+        return azureListResultFactory.create(listRoleAssignmentsBySubscription(getCurrentSubscription().subscriptionId()));
     }
 
     public PagedIterable<RoleAssignmentInner> listRoleAssignmentsBySubscription(String subscriptionId) {
@@ -736,7 +739,7 @@ public class AzureClient {
     }
 
     public AzureListResult<Subscription> listSubscriptions() {
-        return AzureListResult.list(azure.subscriptions());
+        return azureListResultFactory.list(azure.subscriptions());
     }
 
     public void deleteGenericResourceById(String id) {
@@ -752,11 +755,11 @@ public class AzureClient {
     }
 
     public AzureListResult<PrivateDnsZone> getPrivateDnsZoneList() {
-        return AzureListResult.list(privateDnsZoneManager.privateZones());
+        return azureListResultFactory.list(privateDnsZoneManager.privateZones());
     }
 
     public AzureListResult<PrivateDnsZone> getPrivateDnsZonesByResourceGroup(String subscriptionId, String resourceGroupName) {
-        return AzureListResult.listByResourceGroup(
+        return azureListResultFactory.listByResourceGroup(
                 azureClientFactory.getPrivateDnsManagerWithAnotherSubscription(subscriptionId).privateZones(),
                 resourceGroupName);
     }
@@ -771,19 +774,19 @@ public class AzureClient {
     }
 
     private AzureListResult<PrivateDnsZone> getPrivateDnsZones(String subscriptionId) {
-        return AzureListResult.list(azureClientFactory.getPrivateDnsManagerWithAnotherSubscription(subscriptionId).privateZones());
+        return azureListResultFactory.list(azureClientFactory.getPrivateDnsManagerWithAnotherSubscription(subscriptionId).privateZones());
     }
 
     public AzureListResult<PrivateDnsZone> listPrivateDnsZonesByResourceGroup(String resourceGroupName) {
-        return AzureListResult.listByResourceGroup(privateDnsZoneManager.privateZones(), resourceGroupName);
+        return azureListResultFactory.listByResourceGroup(privateDnsZoneManager.privateZones(), resourceGroupName);
     }
 
     public AzureListResult<VirtualNetworkLinkInner> listNetworkLinksByPrivateDnsZoneName(String resourceGroupName, String dnsZoneName) {
-        return new AzureListResult<>(privateDnsZoneManager.serviceClient().getVirtualNetworkLinks().list(resourceGroupName, dnsZoneName));
+        return azureListResultFactory.create(privateDnsZoneManager.serviceClient().getVirtualNetworkLinks().list(resourceGroupName, dnsZoneName));
     }
 
     public AzureListResult<VirtualNetworkLinkInner> listNetworkLinksByPrivateDnsZoneName(String subscriptionId, String resourceGroupName, String dnsZoneName) {
-        return new AzureListResult<>(azureClientFactory.getPrivateDnsManagerWithAnotherSubscription(subscriptionId)
+        return azureListResultFactory.create(azureClientFactory.getPrivateDnsManagerWithAnotherSubscription(subscriptionId)
                 .serviceClient()
                 .getVirtualNetworkLinks()
                 .list(resourceGroupName, dnsZoneName));

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClientService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClientService.java
@@ -25,6 +25,9 @@ public class AzureClientService {
     private AzureHttpClientConfigurer azureHttpClientConfigurer;
 
     @Inject
+    private AzureListResultFactory azureListResultFactory;
+
+    @Inject
     @Qualifier("azureClientThreadPool")
     private ExecutorService mdcCopyingThreadPoolExecutor;
 
@@ -49,7 +52,7 @@ public class AzureClientService {
     private AzureClient getClient(CloudContext cloudContext, AzureCredentialView credentialView) {
         AzureClientFactory azureClientFactory = new AzureClientFactory(cloudContext, credentialView, mdcCopyingThreadPoolExecutor,
                 azureHttpClientConfigurer);
-        return new AzureClient(azureClientFactory, azureExceptionHandler);
+        return new AzureClient(azureClientFactory, azureExceptionHandler, azureListResultFactory);
     }
 
     private boolean credentialIsInKeyGeneratedStatus(AzureCredentialView credentialView) {

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureListResultFactory.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureListResultFactory.java
@@ -1,0 +1,41 @@
+package com.sequenceiq.cloudbreak.cloud.azure.client;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.azure.core.http.rest.PagedIterable;
+import com.azure.core.management.Region;
+import com.azure.resourcemanager.resources.fluentcore.arm.collection.SupportsListingByResourceGroup;
+import com.azure.resourcemanager.resources.fluentcore.collection.SupportsListing;
+import com.azure.resourcemanager.resources.fluentcore.collection.SupportsListingByRegion;
+import com.sequenceiq.cloudbreak.cloud.azure.util.AzureExceptionHandler;
+import com.sequenceiq.cloudbreak.cloud.azure.util.RegionUtil;
+
+@Component
+public class AzureListResultFactory {
+
+    @Inject
+    private AzureExceptionHandler azureExceptionHandler;
+
+    public <T> AzureListResult<T> create(PagedIterable<T> pagedIterable) {
+        return new AzureListResult<>(pagedIterable, azureExceptionHandler);
+    }
+
+    public <T> AzureListResult<T> list(SupportsListing<T> supportsListing) {
+        return create(supportsListing.list());
+    }
+
+    public <T> AzureListResult<T> listByRegion(SupportsListingByRegion<T> supportsListingByRegion, Region region) {
+        return create(supportsListingByRegion.listByRegion(region));
+    }
+
+    public <T> AzureListResult<T> listByRegion(SupportsListingByRegion<T> supportsListingByRegion, String region) {
+        return create(supportsListingByRegion.listByRegion(RegionUtil.findByLabelOrName(region)));
+    }
+
+    public <T> AzureListResult<T> listByResourceGroup(SupportsListingByResourceGroup<T> supportsListingByResourceGroup, String resourceGroup) {
+        return create(supportsListingByResourceGroup.listByResourceGroup(resourceGroup));
+    }
+
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/util/AzureExceptionHandlerParameters.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/util/AzureExceptionHandlerParameters.java
@@ -1,0 +1,77 @@
+package com.sequenceiq.cloudbreak.cloud.azure.util;
+
+public class AzureExceptionHandlerParameters {
+
+    private final boolean handleNotFound;
+
+    private final boolean handleAllExceptions;
+
+    public AzureExceptionHandlerParameters(boolean handleNotFound, boolean handleAllExceptions) {
+        this.handleNotFound = handleNotFound;
+        this.handleAllExceptions = handleAllExceptions;
+    }
+
+    public boolean isHandleNotFound() {
+        return handleNotFound;
+    }
+
+    public boolean isHandleAllExceptions() {
+        return handleAllExceptions;
+    }
+
+    @Override
+    public String toString() {
+        return "AzureExceptionHandlerParameters{" +
+                "handleNotFound=" + handleNotFound +
+                ", handleAllExceptions=" + handleAllExceptions +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AzureExceptionHandlerParameters that = (AzureExceptionHandlerParameters) o;
+
+        if (isHandleNotFound() != that.isHandleNotFound()) {
+            return false;
+        }
+        return isHandleAllExceptions() == that.isHandleAllExceptions();
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (isHandleNotFound() ? 1 : 0);
+        result = 31 * result + (isHandleAllExceptions() ? 1 : 0);
+        return result;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private boolean handleNotFound;
+
+        private boolean handleAllExceptions;
+
+        public Builder withHandleNotFound(boolean handleNotFound) {
+            this.handleNotFound = handleNotFound;
+            return this;
+        }
+
+        public Builder withHandleAllExceptions(boolean handleAllExceptions) {
+            this.handleAllExceptions = handleAllExceptions;
+            return this;
+        }
+
+        public AzureExceptionHandlerParameters build() {
+            return new AzureExceptionHandlerParameters(handleNotFound, handleAllExceptions);
+        }
+    }
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/AzureIDBrokerObjectStorageValidator.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/AzureIDBrokerObjectStorageValidator.java
@@ -38,7 +38,7 @@ import com.gs.collections.impl.factory.Sets;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureStorage;
 import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
-import com.sequenceiq.cloudbreak.cloud.azure.client.AzureListResult;
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureListResultFactory;
 import com.sequenceiq.cloudbreak.cloud.model.SpiFileSystem;
 import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudAdlsGen2View;
 import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudFileSystemView;
@@ -65,6 +65,9 @@ public class AzureIDBrokerObjectStorageValidator {
 
     @Inject
     private EntitlementService entitlementService;
+
+    @Inject
+    private AzureListResultFactory azureListResultFactory;
 
     @SuppressWarnings("checkstyle:CyclomaticComplexity")
     public ValidationResult validateObjectStorage(AzureClient client, String accountId,
@@ -233,7 +236,7 @@ public class AzureIDBrokerObjectStorageValidator {
             return roleAssignmentsOfCurrentSubscription;
         }
 
-        return new AzureListResult<>(client.listRoleAssignmentsBySubscription(targetSubscriptionId)).getAll();
+        return azureListResultFactory.create(client.listRoleAssignmentsBySubscription(targetSubscriptionId)).getAll();
     }
 
     private Set<Identity> validateAllMappedIdentities(AzureClient client, CloudFileSystemView cloudFileSystemView,

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClientTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClientTest.java
@@ -89,6 +89,9 @@ class AzureClientTest {
     private IndexableRefreshableWrapperImpl withCreateIndexableRefreshableWrapperImpl;
 
     @Mock
+    private AzureListResultFactory azureListResultFactory;
+
+    @Mock
     private DiskInner diskInner;
 
     @Captor
@@ -99,7 +102,7 @@ class AzureClientTest {
         lenient().when(azureClientCredentials.getAzureResourceManager()).thenReturn(azureResourceManager);
         lenient().when(azureExceptionHandler.handleException(any(Supplier.class))).thenCallRealMethod();
 
-        underTest = new AzureClient(azureClientCredentials, azureExceptionHandler);
+        underTest = new AzureClient(azureClientCredentials, azureExceptionHandler, azureListResultFactory);
     }
 
     static Object[][] setupDiskEncryptionWithDesIfNeededTestWhenDesAbsentDataProvider() {

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureListResultTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureListResultTest.java
@@ -1,0 +1,57 @@
+package com.sequenceiq.cloudbreak.cloud.azure.client;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.azure.core.http.rest.PagedIterable;
+import com.sequenceiq.cloudbreak.cloud.azure.util.AzureExceptionHandler;
+import com.sequenceiq.cloudbreak.cloud.azure.util.AzureExceptionHandlerParameters;
+
+@ExtendWith(MockitoExtension.class)
+public class AzureListResultTest {
+
+    @Mock
+    private AzureExceptionHandler azureExceptionHandler;
+
+    @Mock
+    private PagedIterable<String> pagedIterable;
+
+    @Test
+    void testWhenGetStreamThenExceptionHandlerIsCalled() {
+        AzureListResult<String> azureListResult = new AzureListResult<>(pagedIterable, azureExceptionHandler);
+
+        azureListResult.getStream();
+
+        verify(azureExceptionHandler).handleException(any(), any(Stream.class));
+    }
+
+    @Test
+    void testWhenGetStreamWithExceptionHandlerParametersThenExceptionHandlerWithParametersIsCalled() {
+        AzureListResult<String> azureListResult = new AzureListResult<>(pagedIterable, azureExceptionHandler);
+        AzureExceptionHandlerParameters azureExceptionHandlerParameters = AzureExceptionHandlerParameters.builder().build();
+
+        azureListResult.getStream(azureExceptionHandlerParameters);
+
+        verify(azureExceptionHandler).handleException(any(), any(Stream.class), eq(azureExceptionHandlerParameters));
+    }
+
+    @Test
+    void testGetAll() {
+        AzureListResult<String> azureListResult = new AzureListResult<>(pagedIterable, azureExceptionHandler);
+        when(azureExceptionHandler.handleException(any(), any(Stream.class))).thenReturn(Stream.of());
+
+        azureListResult.getAll();
+
+        verify(azureExceptionHandler).handleException(any(), any(Stream.class));
+    }
+
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/util/AzureExceptionHandlerTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/util/AzureExceptionHandlerTest.java
@@ -1,0 +1,164 @@
+package com.sequenceiq.cloudbreak.cloud.azure.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Supplier;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import com.azure.core.http.HttpResponse;
+import com.azure.core.management.exception.ManagementException;
+import com.microsoft.aad.msal4j.MsalServiceException;
+import com.sequenceiq.cloudbreak.client.ProviderAuthenticationFailedException;
+
+@ExtendWith(MockitoExtension.class)
+public class AzureExceptionHandlerTest {
+
+    private static final AzureExceptionHandlerParameters HANDLE_ALL_EXCEPTIONS =
+            AzureExceptionHandlerParameters.builder().withHandleAllExceptions(true).build();
+
+    private static final AzureExceptionHandlerParameters HANDLE_NOT_FOUND_EXCEPTIONS =
+            AzureExceptionHandlerParameters.builder().withHandleNotFound(true).build();
+
+    AzureExceptionHandler underTest = new AzureExceptionHandler();
+
+    @Test
+    void handleException() {
+        Supplier<String> stringSupplier = () -> "This works";
+
+        String result = underTest.handleException(stringSupplier);
+
+        assertEquals("This works", result);
+    }
+
+    @Test
+    void handleExceptionWhenNotFoundThenReturnsNull() {
+        Supplier<String> stringSupplier = () -> {
+            throw getManagementException(HttpStatus.NOT_FOUND);
+        };
+
+        String result = underTest.handleException(stringSupplier);
+
+        assertNull(result);
+    }
+
+    @Test
+    void handleExceptionWhenManagementExceptionNotHandledThenThrowsOriginalException() {
+        Supplier<String> stringSupplier = () -> {
+            throw getManagementException(HttpStatus.FORBIDDEN);
+        };
+
+        Assertions.assertThatThrownBy(() -> underTest.handleException(stringSupplier))
+                .isExactlyInstanceOf(ManagementException.class);
+    }
+
+    @Test
+    void handleExceptionWhenMsalUnauthorizedThenThrowsProviderAuthenticationFailedException() {
+        Supplier<String> stringSupplier = () -> {
+            throw getMsalServiceException(HttpStatus.UNAUTHORIZED);
+        };
+
+        Assertions.assertThatThrownBy(() -> underTest.handleException(stringSupplier))
+                .isExactlyInstanceOf(ProviderAuthenticationFailedException.class);
+
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = HttpStatus.class, names = {"UNAUTHORIZED"}, mode = EnumSource.Mode.EXCLUDE)
+    void handleExceptionWhenOtherThanMsalExceptionUnauthorizedThenThrowsOriginalException(HttpStatus httpStatus) {
+        Supplier<String> stringSupplier = () -> {
+            throw getMsalServiceException(httpStatus);
+        };
+
+        Assertions.assertThatThrownBy(() -> underTest.handleException(stringSupplier))
+                .isExactlyInstanceOf(MsalServiceException.class);
+    }
+
+    @Test
+    void handleExceptionWithDefaultWhenNotFoundThenReturnsDefault() {
+        Supplier<String> stringSupplier = () -> {
+            throw getManagementException(HttpStatus.NOT_FOUND);
+        };
+
+        String result = underTest.handleException(stringSupplier, "default");
+
+        assertEquals("default", result);
+    }
+
+    @Test
+    void handleExceptionWithDefaultWhenManagementExceptionNotHandledThenThrowsOriginalException() {
+        Supplier<String> stringSupplier = () -> {
+            throw getManagementException(HttpStatus.FORBIDDEN);
+        };
+
+        Assertions.assertThatThrownBy(() -> underTest.handleException(stringSupplier, "default"))
+                .isExactlyInstanceOf(ManagementException.class);
+    }
+
+    @Test
+    void handleExceptionWithDefaultAndHandleAllExceptionsWhenManagementExceptionThenReturnsDefault() {
+        Supplier<String> stringSupplier = () -> {
+            throw new ManagementException("", null);
+        };
+
+        String result = underTest.handleException(stringSupplier, "default", HANDLE_ALL_EXCEPTIONS);
+
+        assertEquals("default", result);
+    }
+
+    @Test
+    void handleExceptionWithDefaultAndHandleAllExceptionsWhenNotManagementExceptionThenThrowsOriginalException() {
+        Supplier<String> stringSupplier = () -> {
+            throw new RuntimeException("my Exception");
+        };
+
+        Assertions.assertThatThrownBy(() -> underTest.handleException(stringSupplier, "default", HANDLE_ALL_EXCEPTIONS))
+                .isExactlyInstanceOf(RuntimeException.class)
+                .hasMessage("my Exception");
+    }
+
+    @Test
+    void handleExceptionWithDefaultAndHandleNotFoundExceptionsWhenNotFoundThenReturnsDefault() {
+        Supplier<String> stringSupplier = () -> {
+            throw getManagementException(HttpStatus.NOT_FOUND);
+        };
+
+        String result = underTest.handleException(stringSupplier, "default", HANDLE_NOT_FOUND_EXCEPTIONS);
+
+        assertEquals("default", result);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = HttpStatus.class, names = {"NOT_FOUND"}, mode = EnumSource.Mode.EXCLUDE)
+    void handleExceptionWithDefaultAndHandleNotFoundWhenOtherThanNotFoundThenThrowsOriginalException(HttpStatus httpStatus) {
+        Supplier<String> stringSupplier = () -> {
+            throw getManagementException(httpStatus);
+        };
+
+        Assertions.assertThatThrownBy(() -> underTest.handleException(stringSupplier, "default", HANDLE_NOT_FOUND_EXCEPTIONS))
+                .isExactlyInstanceOf(ManagementException.class);
+    }
+
+    private ManagementException getManagementException(HttpStatus httpStatus) {
+        HttpResponse httpResponse = mock(HttpResponse.class);
+        when(httpResponse.getStatusCode()).thenReturn(httpStatus.value());
+        return new ManagementException("", httpResponse);
+    }
+
+    private MsalServiceException getMsalServiceException(HttpStatus httpStatus) {
+        MsalServiceException msalServiceException = mock(MsalServiceException.class);
+        when(msalServiceException.statusCode()).thenReturn(httpStatus.value());
+        when(msalServiceException.getSuppressed()).thenReturn(new Throwable[]{});
+        return msalServiceException;
+    }
+
+}


### PR DESCRIPTION
…DNS zone not found

Cloudbreak has been changed to use the new Azure SDKs. The corresponding method calls seem to behave differently: if the underlying entity against which the query is executed, is not found, then instead of returning a null as previously, it now throws a ManagementException with status code 404. A previous commit already prepared the code for handling not found exceptions. However, the getStream method can also throw if the underlying entity is not found, and that case was not handled previously. Tricky enough, it is not only 404 that can come from Azure SDK: if e.g. a RG name is misspelled, and the permissions are granted only for the RG with the correct name, then an unauthorized exception is thrown instead of not found.

Usually, exceptions from the Azure SDK should be forwarded to the customer (maybe after some polishing for readability). In case of validations, however, the goal is to present all different errors within one message if possible. Not handling exception disrupts this behavior, so there has to be a way to suppress throwing exceptions when returning a validation error and continuing with the rest of validations is the desired behavior.

The present commit introduces parametrization of the AzureExceptionHandler used in the AzureListResult:
- per default only the not found exceptions are handled (as before)
- from validations parameters are set to instruct the exception handler to catch all ManagementExceptions
- an overload will return a default value instead of null
- exceptions other than ManagementExceptions from Azure SDK will be rethrown as previously

See detailed description in the commit message.