### PR TITLE
CB-20957 [API E2E] GOV E2E find MASTER InstanceIds is failing

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/FreeIpaInstanceUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/FreeIpaInstanceUtil.java
@@ -22,7 +22,7 @@ public class FreeIpaInstanceUtil {
                 .getFreeIpaV1Endpoint().describe(freeIpaTestDto.getRequest().getEnvironmentCrn());
         List<InstanceGroupResponse> instanceGroupResponses = describeFreeIpaResponse.getInstanceGroups();
         InstanceGroupResponse instanceGroupResponse = instanceGroupResponses.stream().filter(instanceGroup ->
-                instanceGroup.getName().equals(hostGroupName)).findFirst().orElse(null);
+                instanceGroup.getName().contains(hostGroupName)).findFirst().orElse(null);
         return Objects.requireNonNull(instanceGroupResponse).getMetaData()
                 .stream().map(InstanceMetaDataResponse::getInstanceId).collect(Collectors.toList());
     }


### PR DESCRIPTION
`testCreateDistroXWithEncryptedVolumes` is failing at the latest GOV API E2E with: `NullPointerException` at `FreeIpaInstanceUtil.getInstanceIds`, because of MASTER instance group contains 2 nodes with master0 name. So the related filter should be changed from `instanceGroup.getName().equals` to `instanceGroup.getName().contains`.