### PR TITLE
CB-20958 [API E2E] GOV E2E Pre Termination test recipe is failing at Cloud Storage Base Location

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/RecipeUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/RecipeUtil.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.it.cloudbreak.cloud.v4.CommonCloudProperties;
 import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.it.cloudbreak.util.aws.amazons3.client.S3Client;
 import com.sequenceiq.it.util.ResourceUtil;
 
 @Component
@@ -35,6 +36,9 @@ public class RecipeUtil {
 
     @Inject
     private CommonCloudProperties commonCloudProperties;
+
+    @Inject
+    private S3Client s3Client;
 
     public String generatePreDeploymentRecipeContent(ApplicationContext applicationContext) {
         try {
@@ -89,7 +93,7 @@ public class RecipeUtil {
         String cloudStorageCopy;
 
         if (StringUtils.equalsIgnoreCase(cloudProvider, CloudPlatform.AWS.name())) {
-            cloudStorageCopy = format("aws s3 cp /e2e-pre-termination s3://cloudbreak-test/pre-termination/%s/", preTerminationRecipeName);
+            cloudStorageCopy = format("aws s3 cp /e2e-pre-termination s3://%s/pre-termination/%s/", s3Client.getDefaultBucketName(), preTerminationRecipeName);
         } else if (StringUtils.equalsIgnoreCase(cloudProvider, CloudPlatform.GCP.name())) {
             cloudStorageCopy = format("gsutil cp /e2e-pre-termination gs://cloudbreak-dev/pre-termination/%s/", preTerminationRecipeName);
         } else {


### PR DESCRIPTION
`testCreateStopStartRepairFreeIpaWithTwoInstances` is failing at the latest GOV API E2E with: `The specified bucket does not exist`, because of the `cloudbreak-test` base location is for Cloudera AWS. However the Cloudera GOV AWS base location is: `cloudbreak-gov-dev-test`. So we should introduce `INTEGRATIONTEST_AWS_CLOUDSTORAGE_BASELOCATION` environment variable to the Pre Termination recipe script.