### PR TITLE
CDPSDX-3919 Convert disk blocks to bytes while checking disk

### DIFF
--- a/datalake-dr-connector/src/main/java/com/sequenceiq/cloudbreak/datalakedr/converter/DatalakeDataInfoJsonToObjectConverter.java
+++ b/datalake-dr-connector/src/main/java/com/sequenceiq/cloudbreak/datalakedr/converter/DatalakeDataInfoJsonToObjectConverter.java
@@ -9,6 +9,9 @@ import com.google.gson.JsonParser;
 
 @Service
 public class DatalakeDataInfoJsonToObjectConverter {
+
+    public static final int BYTES_IN_FILESYSTEM_BLOCK = 1024;
+
     public DatalakeDataInfoObject convert(String operationId, String inputJSON) {
         try {
             JsonObject json = JsonParser.parseString(inputJSON).getAsJsonObject();
@@ -20,7 +23,7 @@ public class DatalakeDataInfoJsonToObjectConverter {
             return DatalakeDataInfoObject.newBuilder()
                     .setOperationId(operationId)
                     .setDatabaseSizeInBytes(getTotalDatabaseSize(databaseJSON))
-                    .setDatabaseBackupNodeFreeSpaceInBytes(backupSpaceJSON.getAsLong())
+                    .setDatabaseBackupNodeFreeSpaceInBytes(backupSpaceJSON.getAsLong() * BYTES_IN_FILESYSTEM_BLOCK)
                     .setHbaseAtlasEntityAuditEventsTableSizeInBytes(hbaseJSON.get("atlas_entity_audit_events").getAsLong())
                     .setHbaseAtlasJanusTableSizeInBytes(hbaseJSON.get("atlas_janus").getAsLong())
                     .setSolrVertexIndexCollectionSizeInBytes(solrJSON.get("vertex_index").getAsLong())

--- a/datalake-dr-connector/src/test/java/com/sequenceiq/cloudbreak/datalakedr/converter/DatalakeDataInfoJsonToObjectConverterTest.java
+++ b/datalake-dr-connector/src/test/java/com/sequenceiq/cloudbreak/datalakedr/converter/DatalakeDataInfoJsonToObjectConverterTest.java
@@ -78,7 +78,7 @@ public class DatalakeDataInfoJsonToObjectConverterTest {
         assertEquals(out.getSolrFulltextIndexCollectionSizeInBytes(), FULLTEXT_SIZE);
         assertEquals(out.getSolrRangerAuditsCollectionSizeInBytes(), RANGER_AUDITS_SIZE);
         assertEquals(out.getSolrVertexIndexCollectionSizeInBytes(), VERTEX_SIZE);
-        assertEquals(out.getDatabaseBackupNodeFreeSpaceInBytes(), AVAILABLE_BACKUP_SIZE);
+        assertEquals(out.getDatabaseBackupNodeFreeSpaceInBytes(), AVAILABLE_BACKUP_SIZE * 1024);
     }
 
     @Test

--- a/orchestrator-salt/src/main/resources/salt/salt/datalake_metrics/get_free_space/get_free_space.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/datalake_metrics/get_free_space/get_free_space.sls
@@ -1,3 +1,3 @@
 get_free_space:
   cmd.run:
-    - name: /usr/bin/df --exclude-type=tmpfs  --exclude-type=devtmpfs -P -l|grep " /$"|sed 's/  */ /g'|cut -f 4 -d ' '|sed -E 's/(.*)/"freeSpace":\1/g'
+    - name: /usr/bin/df --block-size=1024 --exclude-type=tmpfs  --exclude-type=devtmpfs -P -l|grep " /$"|sed 's/  */ /g'|cut -f 4 -d ' '|sed -E 's/(.*)/"freeSpace":\1/g'

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
@@ -170,6 +170,9 @@ backup_database_for_service() {
     replace_ranger_group_before_export $RANGERGROUP $LOCAL_BACKUP
   fi
 
+  BACKUP_SIZE=$(du -h $LOCAL_BACKUP | cut -f 1)
+  doLog "INFO ${SERVICE} backup size is ${BACKUP_SIZE}"
+
   move_backup_to_cloud "$LOCAL_BACKUP"
 
   doLog "INFO Completed upload to ${BACKUP_LOCATION}"


### PR DESCRIPTION
value returned by Salt script is in 1024-byte blocks, we should convert it to bytes to match the property name meaning.

Testing:
- manual run on the AWS instance - from the salt command specification: `/usr/bin/df --block-size=1024 --exclude-type=tmpfs  --exclude-type=devtmpfs -P -l|grep " /$"|sed 's/  */ /g'|cut -f 4 -d ' '|sed -E 's/(.*)/"freeSpace":\1/g'`
- run as part of the backup flow