### PR TITLE
CB-20942 Optimized last flow log sql query to filter flow logs by res…

### DIFF
--- a/flow/src/main/java/com/sequenceiq/flow/repository/FlowLogRepository.java
+++ b/flow/src/main/java/com/sequenceiq/flow/repository/FlowLogRepository.java
@@ -65,8 +65,10 @@ public interface FlowLogRepository extends CrudRepository<FlowLog, Long> {
     @Query("SELECT fl FROM FlowLog fl WHERE fl.flowType = :flowType AND fl.resourceId = :resourceId ORDER BY fl.created DESC")
     List<FlowLog> findAllFlowByType(@Param("resourceId") Long resourceId, @Param("flowType") ClassValue classValue);
 
-    @Query("SELECT fl FROM FlowLog fl WHERE fl.created IN " +
-            "( SELECT max(fls.created) from FlowLog fls WHERE fls.flowType = :flowType and fls.resourceId = :resourceId " +
+    @Query("SELECT fl FROM FlowLog fl " +
+            "WHERE fl.resourceId = :resourceId " +
+            "AND fl.created IN " +
+            "( SELECT max(fls.created) FROM FlowLog fls WHERE fls.flowType = :flowType AND fls.resourceId = :resourceId " +
             "AND fls.currentState <> 'FINISHED' " +
             "GROUP BY (fls.flowId, fls.resourceId)) " +
             "ORDER BY fl.created DESC ")


### PR DESCRIPTION
Optimized last flow log sql query to filter flow logs by resource id in outer query.

Query analysis from local test:

__Old query:__

```
Sort  (cost=18.36..18.36 rows=1 width=5781) (actual time=0.101..0.102 rows=2 loops=1)
  Sort Key: flowlog0_.created DESC
  Sort Method: quicksort  Memory: 27kB
  ->  Hash Semi Join  (cost=8.21..18.35 rows=1 width=5781) (actual time=0.078..0.081 rows=2 loops=1)
        Hash Cond: (flowlog0_.created = "ANY_subquery".max)
        ->  Seq Scan on flowlog flowlog0_  (cost=0.00..10.10 rows=10 width=5781) (actual time=0.005..0.007 rows=5 loops=1)
        ->  Hash  (cost=8.20..8.20 rows=1 width=8) (actual time=0.062..0.062 rows=2 loops=1)
              Buckets: 1024  Batches: 1  Memory Usage: 9kB
              ->  Subquery Scan on "ANY_subquery"  (cost=8.17..8.20 rows=1 width=8) (actual time=0.056..0.057 rows=2 loops=1)
                    ->  GroupAggregate  (cost=8.17..8.19 rows=1 width=532) (actual time=0.056..0.057 rows=2 loops=1)
                          Group Key: flowlog1_.flowid, flowlog1_.resourceid
                          ->  Sort  (cost=8.17..8.17 rows=1 width=532) (actual time=0.051..0.051 rows=4 loops=1)
                                Sort Key: flowlog1_.flowid
                                Sort Method: quicksort  Memory: 25kB
                                ->  Index Scan using idx_flowlog_resourceid_resourcetype on flowlog flowlog1_  (cost=0.14..8.16 rows=1 width=532) (actual time=0.015..0.017 rows=4 loops=1)
                                      Index Cond: (resourceid = 1)
                                      Filter: (((currentstate)::text <> 'FINISHED'::text) AND ((flowtype)::text = 'com.sequenceiq.flow.component.sleep.SleepFlowConfig'::text))
                                      Rows Removed by Filter: 1
```

__New query:__

```
Sort Method: quicksort  Memory: 27kB
->  Nested Loop Semi Join  (cost=8.30..16.37 rows=1 width=5781) (actual time=0.058..0.061 rows=2 loops=1)
      Join Filter: (flowlog0_.created = (max(flowlog1_.created)))
      Rows Removed by Join Filter: 7
      ->  Index Scan using idx_flowlog_resourceid_resourcetype on flowlog flowlog0_  (cost=0.14..8.15 rows=1 width=5781) (actual time=0.020..0.021 rows=5 loops=1)
            Index Cond: (resourceid = 1)
      ->  GroupAggregate  (cost=8.17..8.19 rows=1 width=532) (actual time=0.007..0.007 rows=2 loops=5)
            Group Key: flowlog1_.flowid, flowlog1_.resourceid
            ->  Sort  (cost=8.17..8.17 rows=1 width=532) (actual time=0.006..0.006 rows=4 loops=5)
                  Sort Key: flowlog1_.flowid
                  Sort Method: quicksort  Memory: 25kB
                  ->  Index Scan using idx_flowlog_resourceid_resourcetype on flowlog flowlog1_  (cost=0.14..8.16 rows=1 width=532) (actual time=0.005..0.006 rows=4 loops=1)
                        Index Cond: (resourceid = 1)
                        Filter: (((currentstate)::text <> 'FINISHED'::text) AND ((flowtype)::text = 'com.sequenceiq.flow.component.sleep.SleepFlowConfig'::text))
                        Rows Removed by Filter: 1
```