### PR TITLE
CB-17750 ; Change the dfs_replication count to 2 in case of medium duty data lake. Tested locally with different run times, the expected replication count was set in the CM config.

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-sdx-medium-ha.bp
@@ -355,7 +355,7 @@
           },
           {
             "name": "dfs_replication",
-            "value": "3"
+            "value": "2"
           },
           {
             "name": "service_config_suppression_datanode_count_validator",

--- a/core/src/main/resources/defaults/blueprints/7.2.11/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.11/cdp-sdx-medium-ha.bp
@@ -355,7 +355,7 @@
           },
           {
             "name": "dfs_replication",
-            "value": "3"
+            "value": "2"
           },
           {
             "name": "service_config_suppression_datanode_count_validator",

--- a/core/src/main/resources/defaults/blueprints/7.2.12/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.12/cdp-sdx-medium-ha.bp
@@ -355,7 +355,7 @@
           },
           {
             "name": "dfs_replication",
-            "value": "3"
+            "value": "2"
           },
           {
             "name": "service_config_suppression_datanode_count_validator",

--- a/core/src/main/resources/defaults/blueprints/7.2.14/cdp-sdx-medium-ha-profiler.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.14/cdp-sdx-medium-ha-profiler.bp
@@ -359,7 +359,7 @@
           },
           {
             "name": "dfs_replication",
-            "value": "3"
+            "value": "2"
           },
           {
             "name": "service_config_suppression_datanode_count_validator",

--- a/core/src/main/resources/defaults/blueprints/7.2.14/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.14/cdp-sdx-medium-ha.bp
@@ -355,7 +355,7 @@
           },
           {
             "name": "dfs_replication",
-            "value": "3"
+            "value": "2"
           },
           {
             "name": "service_config_suppression_datanode_count_validator",

--- a/core/src/main/resources/defaults/blueprints/7.2.15/cdp-sdx-medium-ha-profiler.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.15/cdp-sdx-medium-ha-profiler.bp
@@ -359,7 +359,7 @@
           },
           {
             "name": "dfs_replication",
-            "value": "3"
+            "value": "2"
           },
           {
             "name": "service_config_suppression_datanode_count_validator",

--- a/core/src/main/resources/defaults/blueprints/7.2.15/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.15/cdp-sdx-medium-ha.bp
@@ -355,7 +355,7 @@
           },
           {
             "name": "dfs_replication",
-            "value": "3"
+            "value": "2"
           },
           {
             "name": "service_config_suppression_datanode_count_validator",

--- a/core/src/main/resources/defaults/blueprints/7.2.16/cdp-sdx-medium-ha-profiler.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.16/cdp-sdx-medium-ha-profiler.bp
@@ -359,7 +359,7 @@
           },
           {
             "name": "dfs_replication",
-            "value": "3"
+            "value": "2"
           },
           {
             "name": "service_config_suppression_datanode_count_validator",

--- a/core/src/main/resources/defaults/blueprints/7.2.16/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.16/cdp-sdx-medium-ha.bp
@@ -355,7 +355,7 @@
           },
           {
             "name": "dfs_replication",
-            "value": "3"
+            "value": "2"
           },
           {
             "name": "service_config_suppression_datanode_count_validator",

--- a/core/src/main/resources/defaults/blueprints/7.2.17/cdp-sdx-medium-ha-profiler.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.17/cdp-sdx-medium-ha-profiler.bp
@@ -359,7 +359,7 @@
           },
           {
             "name": "dfs_replication",
-            "value": "3"
+            "value": "2"
           },
           {
             "name": "service_config_suppression_datanode_count_validator",

--- a/core/src/main/resources/defaults/blueprints/7.2.17/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.17/cdp-sdx-medium-ha.bp
@@ -355,7 +355,7 @@
           },
           {
             "name": "dfs_replication",
-            "value": "3"
+            "value": "2"
           },
           {
             "name": "service_config_suppression_datanode_count_validator",

--- a/core/src/main/resources/defaults/blueprints/7.2.7/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.7/cdp-sdx-medium-ha.bp
@@ -355,7 +355,7 @@
           },
           {
             "name": "dfs_replication",
-            "value": "3"
+            "value": "2"
           },
           {
             "name": "service_config_suppression_datanode_count_validator",

--- a/core/src/main/resources/defaults/blueprints/7.2.8/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.8/cdp-sdx-medium-ha.bp
@@ -355,7 +355,7 @@
           },
           {
             "name": "dfs_replication",
-            "value": "3"
+            "value": "2"
           },
           {
             "name": "service_config_suppression_datanode_count_validator",

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-sdx-medium-ha.bp
@@ -359,7 +359,7 @@
           },
           {
             "name": "dfs_replication",
-            "value": "3"
+            "value": "2"
           },
           {
             "name": "service_config_suppression_datanode_count_validator",

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hdfs/HdfsRoleConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hdfs/HdfsRoleConfigProvider.java
@@ -28,10 +28,6 @@ public class HdfsRoleConfigProvider extends AbstractRoleConfigProvider {
 
     private static final Integer NUM_FAILED_VOLUMES_TOLERATED = 0;
 
-    private static final String DFS_REPLICATION = "dfs_replication";
-
-    private static final Integer DFS_REPLICATION_VALUE = 2;
-
     private static final String DFS_ENCRYPT_DATA_TRANSFER = "dfs_encrypt_data_transfer";
 
     private static final String DFS_DATA_TRANSFER_PROTECTION = "dfs_data_transfer_protection";
@@ -62,6 +58,11 @@ public class HdfsRoleConfigProvider extends AbstractRoleConfigProvider {
                 configs.add(
                         config(FAILED_VOLUMES_TOLERATED, NUM_FAILED_VOLUMES_TOLERATED.toString())
                 );
+                if (isSDXOptimizationEnabled(source)) {
+                    configs.add(
+                            config(DFS_ENCRYPT_DATA_TRANSFER, "true")
+                    );
+                }
                 return configs;
             case HdfsRoles.NAMENODE:
                 if (isNamenodeHA(source)) {
@@ -91,9 +92,6 @@ public class HdfsRoleConfigProvider extends AbstractRoleConfigProvider {
     public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject source) {
         List<ApiClusterTemplateConfig> configs = new ArrayList<>();
         if (isSDXOptimizationEnabled(source)) {
-            if (isNamenodeHA(source)) {
-                configs.add(config(DFS_REPLICATION, DFS_REPLICATION_VALUE.toString()));
-            }
             configs.add(config(DFS_ENCRYPT_DATA_TRANSFER, "true"));
             configs.add(config(DFS_DATA_TRANSFER_PROTECTION, "privacy"));
             configs.add(config(HADOOP_RPC_PROTECTION, "privacy"));

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hdfs/HdfsRoleConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hdfs/HdfsRoleConfigProviderTest.java
@@ -30,7 +30,7 @@ class HdfsRoleConfigProviderTest {
 
     private static final String TEST_USER_CRN = "crn:cdp:iam:us-west-1:accid:user:mockuser@cloudera.com";
 
-    private EntitlementService entitlementService = mock(EntitlementService.class);
+    private final EntitlementService entitlementService = mock(EntitlementService.class);
 
     private final HdfsRoleConfigProvider subject = new HdfsRoleConfigProvider(entitlementService);
 
@@ -102,8 +102,9 @@ class HdfsRoleConfigProviderTest {
             Map<String, ApiClusterTemplateConfig> configMap = cmTemplateProcessor.mapByName(namenodeConfigs);
             assertEquals(NN_HA_PROPERTIES, configMap.keySet());
             assertEquals("true", configMap.get("autofailover_enabled").getValue());
-            assertEquals(
-                    List.of(config("dfs_datanode_failed_volumes_tolerated", "0")),
+            assertEquals(List.of(
+                            config("dfs_datanode_failed_volumes_tolerated", "0"),
+                            config("dfs_encrypt_data_transfer", "true")),
                     roleConfigs.get("hdfs-DATANODE-BASE"));
 
         });
@@ -129,15 +130,10 @@ class HdfsRoleConfigProviderTest {
             List<ApiClusterTemplateConfig> serviceConfigs = subject.getServiceConfigs(cmTemplateProcessor, preparationObject);
 
             Map<String, ApiClusterTemplateConfig> configMap = cmTemplateProcessor.mapByName(serviceConfigs);
-            assertEquals(4, serviceConfigs.size());
-            assertEquals("dfs_replication", serviceConfigs.get(0).getName());
-            assertEquals("2", serviceConfigs.get(0).getValue());
-            assertEquals("dfs_encrypt_data_transfer", serviceConfigs.get(1).getName());
-            assertEquals("true", serviceConfigs.get(1).getValue());
-            assertEquals("dfs_data_transfer_protection", serviceConfigs.get(2).getName());
-            assertEquals("privacy", serviceConfigs.get(2).getValue());
-            assertEquals("hadoop_rpc_protection", serviceConfigs.get(3).getName());
-            assertEquals("privacy", serviceConfigs.get(3).getValue());
+            assertEquals(3, serviceConfigs.size());
+            assertEquals("true", configMap.get("dfs_encrypt_data_transfer").getValue());
+            assertEquals("privacy", configMap.get("dfs_data_transfer_protection").getValue());
+            assertEquals("privacy", configMap.get("hadoop_rpc_protection").getValue());
         });
     }
 
@@ -164,7 +160,9 @@ class HdfsRoleConfigProviderTest {
             Map<String, ApiClusterTemplateConfig> configMap = cmTemplateProcessor.mapByName(namenodeConfigs);
             assertEquals(NN_HA_PROPERTIES, configMap.keySet());
             assertEquals("true", configMap.get("autofailover_enabled").getValue());
-            assertEquals(List.of(config("dfs_datanode_failed_volumes_tolerated", "0")),
+            assertEquals(List.of(
+                            config("dfs_datanode_failed_volumes_tolerated", "0"),
+                            config("dfs_encrypt_data_transfer", "true")),
                     roleConfigs.get("hdfs-DATANODE-BASE"));
 
         });


### PR DESCRIPTION
[CB-17750](https://jira.cloudera.com/browse/CB-17750) ; Change the dfs_replication count to 2 in case of medium duty data lake. Tested locally with different run times, the expected replication count was set in the CM config.

The actual ConfigProvider behavior does not allow us to override a template value. Therefore I removed the ConfigProvider part and updated only the template values.