### PR TITLE
CB-20940 Modify and fix query to find deleting resources during heart…

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/repository/SdxStatusRepository.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/repository/SdxStatusRepository.java
@@ -3,7 +3,9 @@ package com.sequenceiq.datalake.repository;
 import java.util.Collection;
 import java.util.List;
 
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.sequenceiq.datalake.entity.DatalakeStatusEnum;
@@ -17,7 +19,10 @@ public interface SdxStatusRepository extends CrudRepository<SdxStatusEntity, Lon
 
     SdxStatusEntity findFirstByDatalakeIdIsOrderByIdDesc(Long id);
 
-    List<SdxStatusEntity> findDistinctFirstByStatusInAndDatalakeIdInOrderByIdDesc(Collection<DatalakeStatusEnum> datalakeStatusEnums,
-            Collection<Long> datalakeId);
+    @Query("SELECT sse FROM SdxStatusEntity sse WHERE sse.id IN " +
+            "( SELECT max(isse.id) FROM SdxStatusEntity isse WHERE isse.status IN :statuses and isse.datalake.id IN :datalakeIds " +
+            "GROUP BY (isse.datalake.id))")
+    List<SdxStatusEntity> findLatestSdxStatusesFilteredByStatusesAndDatalakeIds(@Param("statuses") Collection<DatalakeStatusEnum> statuses,
+            @Param("datalakeIds") Collection<Long> datalakeIds);
 
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -228,8 +228,8 @@ public class SdxService implements ResourceIdProvider, PayloadContextProvider, H
     }
 
     public Set<Long> findByResourceIdsAndStatuses(Set<Long> resourceIds, Set<DatalakeStatusEnum> statuses) {
-        LOGGER.info("Searching for SDX cluster by ids and statuses.");
-        List<SdxStatusEntity> sdxStatusEntities = sdxStatusService.findDistinctFirstByStatusInAndDatalakeIdOrderByIdDesc(statuses, resourceIds);
+        LOGGER.info("Searching for SDX cluster by ids: {} and statuses: {}", resourceIds, statuses);
+        List<SdxStatusEntity> sdxStatusEntities = sdxStatusService.findLatestSdxStatusesFilteredByStatusesAndDatalakeIds(statuses, resourceIds);
         return sdxStatusEntities.stream().map(sdxStatusEntity -> sdxStatusEntity.getDatalake().getId()).collect(Collectors.toSet());
     }
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/status/SdxStatusService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/status/SdxStatusService.java
@@ -7,8 +7,6 @@ import static com.sequenceiq.datalake.entity.DatalakeStatusEnum.DELETED_ON_PROVI
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -188,15 +186,9 @@ public class SdxStatusService {
         return true;
     }
 
-    public List<SdxStatusEntity> findDistinctFirstByStatusInAndDatalakeIdOrderByIdDesc(Collection<DatalakeStatusEnum> datalakeStatusEnums,
+    public List<SdxStatusEntity> findLatestSdxStatusesFilteredByStatusesAndDatalakeIds(Collection<DatalakeStatusEnum> datalakeStatusEnums,
             Collection<Long> datalakeIds) {
-        return sdxStatusRepository.findDistinctFirstByStatusInAndDatalakeIdInOrderByIdDesc(datalakeStatusEnums, datalakeIds);
-    }
-
-    public Optional<SdxStatusEntity> findLastStatusByIdAndStatuses(Long id, Set<DatalakeStatusEnum> statuses) {
-        LOGGER.debug("Searching for SDX cluster by id and statuses.");
-        List<SdxStatusEntity> sdxStatusEntities = findDistinctFirstByStatusInAndDatalakeIdOrderByIdDesc(statuses, Set.of(id));
-        return sdxStatusEntities.stream().findFirst();
+        return sdxStatusRepository.findLatestSdxStatusesFilteredByStatusesAndDatalakeIds(datalakeStatusEnums, datalakeIds);
     }
 
     public SdxStatusEntity getActualStatusForSdx(SdxCluster sdxCluster) {


### PR DESCRIPTION
…beats

```
select sdxstatuse0_.id as id1_7_, sdxstatuse0_.created as created2_7_, sdxstatuse0_.datalake as datalake5_7_, sdxstatuse0_.status as status3_7_, sdxstatuse0_.statusReason as statusre4_7_ from public.sdxstatus sdxstatuse0_ where sdxstatuse0_.id in (select max(sdxstatuse1_.id) from public.sdxstatus sdxstatuse1_ where (sdxstatuse1_.status in (? , ? , ? , ? , ?)) and (sdxstatuse1_.datalake in (? , ? , ?)) group by sdxstatuse1_.datalake)
```


See detailed description in the commit message.