### PR TITLE
CDPSDX-3900 Add logging to DB backup/restore for errors when wrong no…

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
@@ -27,13 +27,25 @@ doLog() {
   echo "$(date "+%Y-%m-%dT%H:%M:%SZ") $type_of_msg ""$msg" >>$LOGFILE
 }
 
-if [[ $# -lt 6 || $# -gt 10 || "$1" == "None" ]]; then
-  doLog "Invalid inputs provided"
+if [[ $# -lt 6 || $# -gt 10 || "$1" == "None" || -z "$1" ]]; then
+  doLog "ERROR: Invalid inputs provided"
+  doLog "A total of $# inputs were provided."
+  if [[ $# -gt 0 ]]; then
+    doLog "Below are the inputs passed in. If some of them are empty, it could be incorrect:"
+    COUNTER=1
+    for input in "$@"
+    do
+      echo "  $COUNTER. $input"
+      let COUNTER++
+    done
+  fi
+  doLog "There might be missing values in /srv/pillar/postgresql/disaster_recovery.sls or /srv/pillar/postgresql/postgre.sls."
+  doLog "This might be caused by the command not being run on the Primary Gateway node or due to never having run a backup/restore via the CDP CLI before."
   doLog "Script accepts at least 6 and at most 7 inputs:"
   doLog "  1. Object Storage Service url to place backups."
-  doLog "  2. PostgreSQL host name."
-  doLog "  3. PostgreSQL port."
-  doLog "  4. PostgreSQL user name."
+  doLog "  2. PostgresSQL host name."
+  doLog "  3. PostgresSQL port."
+  doLog "  4. PostgresSQL user name."
   doLog "  5. Ranger admin group."
   doLog "  6. Whether or not to close connections for the database while it is being backed up."
   doLog "  7-10. (optional) Names of the databases to backup. If not given, will backup ranger and hive databases."

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/restore_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/restore_db.sh
@@ -25,13 +25,25 @@ doLog() {
   echo "$(date "+%Y-%m-%dT%H:%M:%SZ") $type_of_msg ""$msg" >>$LOGFILE
 }
 
-if [[ $# -lt 5 || $# -gt 6 || "$1" == "None" ]]; then
-  doLog "Invalid inputs provided"
+if [[ $# -lt 5 || $# -gt 6 || "$1" == "None" || -z "$1" ]]; then
+  doLog "ERROR: Invalid inputs provided"
+  doLog "A total of $# inputs were provided."
+  if [[ $# -gt 0 ]]; then
+    doLog "Below are the inputs passed in. If some of them are empty, it could be incorrect:"
+    COUNTER=1
+    for input in "$@"
+    do
+      echo "  $COUNTER. $input"
+      let COUNTER++
+    done
+  fi
+  doLog "There might be missing values in /srv/pillar/postgresql/disaster_recovery.sls or /srv/pillar/postgresql/postgre.sls."
+  doLog "This might be caused by the command not being run on the Primary Gateway node or due to never having run a backup/restore via the CDP CLI before."
   doLog "Script accepts at least 5 and at most 6 inputs:"
   doLog "  1. Object Storage Service url to retrieve backups."
-  doLog "  2. PostgreSQL host name."
-  doLog "  3. PostgreSQL port."
-  doLog "  4. PostgreSQL user name."
+  doLog "  2. PostgresSQL host name."
+  doLog "  3. PostgresSQL port."
+  doLog "  4. PostgresSQL user name."
   doLog "  5. Ranger admin group."
   doLog "  6. (optional) Name of the database to restore. If not given, will restore ranger and hive databases."
   exit 1


### PR DESCRIPTION
…de is used

*I gave up [the old PR](https://github.com/hortonworks/cloudbreak/pull/14325) which `getOpts` is used. So please review this one with simpler changes. Sorry for the back and forth!

**JIRA:** [CDPSDX-3900](https://jira.cloudera.com/browse/CDPSDX-3900)
**ISSUE:** When a user ran the salt command to manually backup/restore database on a wrong node the backup/restore fails because it is missing values in the pillar file or in postgres. 

**BEFORE (the log):**
![image](https://user-images.githubusercontent.com/39275944/221427284-1f75fcf7-d8a4-406d-9a97-2f3ca8491e0c.png)

**AFTER (the log):** 
<img width="1209" alt="Screen Shot 2023-02-27 at 1 04 03 PM" src="https://user-images.githubusercontent.com/39275944/221646546-24af28f4-3373-4636-810a-be61dd9694de.png">
