### PR TITLE
CB-21036 Add `request_time` to nginx access logging

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/nginx/conf/ssl.conf
+++ b/freeipa/src/main/resources/freeipa-salt/salt/nginx/conf/ssl.conf
@@ -1,4 +1,10 @@
 #curl --verbose --key ./key.pem --cert ./cert.pem -k --user "user:password" -H "Accept: application/json" https://104.155.27.67:9443/saltboot/health
+
+log_format main '$remote_addr - $remote_user [$time_local] '
+                               '"$request" $status $bytes_sent '
+                               '"$http_referer" "$http_user_agent" "$request_id" $request_time';
+access_log /var/log/nginx/access.log main;
+
 server {
     add_header x-response-nginx true always;
 

--- a/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/clouderamanager-ssl-user-facing.conf
+++ b/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/clouderamanager-ssl-user-facing.conf
@@ -5,7 +5,7 @@ map $http_upgrade $connection_upgrade {
 
 log_format main '$remote_addr - $remote_user [$time_local] '
                                '"$request" $status $bytes_sent '
-                               '"$http_referer" "$http_user_agent" "$request_id"';
+                               '"$http_referer" "$http_user_agent" "$request_id" $request_time';
 access_log /var/log/nginx/access.log main;
 
 upstream knox {


### PR DESCRIPTION
In order to ease investigation of long requests, nginx should log how long did it take to process a request. Currently only the timestamp is logged when the response was sent to the client.

```
$request_time
    request processing time in seconds with a milliseconds resolution; time elapsed between the first bytes were read from the client and the log write after the last bytes were sent to the client
```
From: http://nginx.org/en/docs/http/ngx_http_log_module.html

See detailed description in the commit message.