### PR TITLE
CB-19948,CB-19955 Implement SSL for DAS and Query Processor DB

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
@@ -63,6 +63,8 @@ public class CMRepositoryVersionUtil {
 
     public static final Versioned CLOUDERAMANAGER_VERSION_7_9_0 = () -> "7.9.0";
 
+    public static final Versioned CLOUDERAMANAGER_VERSION_7_9_2 = () -> "7.9.2";
+
     public static final Versioned CLOUDERA_STACK_VERSION_7_2_7 = () -> "7.2.7";
 
     public static final Versioned CLOUDERA_STACK_VERSION_7_2_9 = () -> "7.2.9";

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/views/RdsView.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/views/RdsView.java
@@ -1,10 +1,16 @@
 package com.sequenceiq.cloudbreak.template.views;
 
+import java.util.Objects;
+
+import javax.annotation.Nonnull;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
 import com.sequenceiq.cloudbreak.template.views.dialect.RdsViewDialect;
 
 public class RdsView {
+
+    private static final String CONNECTION_URL_OPTIONS_DELIMITER = "?";
 
     private String connectionURL;
 
@@ -104,6 +110,13 @@ public class RdsView {
 
     public String getConnectionURL() {
         return connectionURL;
+    }
+
+    @Nonnull
+    public String getConnectionURLOptions() {
+        return Objects.requireNonNullElse(connectionURL, "").contains(CONNECTION_URL_OPTIONS_DELIMITER) ?
+                connectionURL.substring(connectionURL.indexOf(CONNECTION_URL_OPTIONS_DELIMITER)) :
+                "";
     }
 
     public boolean isUseSsl() {

--- a/template-manager-core/src/test/java/com/sequenceiq/cloudbreak/template/views/RdsViewTest.java
+++ b/template-manager-core/src/test/java/com/sequenceiq/cloudbreak/template/views/RdsViewTest.java
@@ -1,0 +1,30 @@
+package com.sequenceiq.cloudbreak.template.views;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class RdsViewTest {
+
+    static Object[][] getConnectionURLOptionsDataProvider() {
+        return new Object[][]{
+                // connectionURL, resultExpected
+                {null, ""},
+                {"", ""},
+                {"foo", ""},
+                {"jdbc:postgresql://cluster-master0.bar.com:5432/hive", ""},
+                {"jdbc:postgresql://cluster-master0.bar.com:5432/hive?option1=value1&option2=value2", "?option1=value1&option2=value2"},
+        };
+    }
+
+    @ParameterizedTest(name = "connectionURL={0}")
+    @MethodSource("getConnectionURLOptionsDataProvider")
+    void getConnectionURLOptionsTest(String connectionURL, String resultExpected) {
+        RdsView underTest = new RdsView();
+        underTest.setConnectionURL(connectionURL);
+
+        assertThat(underTest.getConnectionURLOptions()).isEqualTo(resultExpected);
+    }
+
+}


### PR DESCRIPTION
* Add DB SSL configs to DAS and Query Processor service configs if needed.
  * Prerequisite: CM >= 7.9.2.
* Fix various typos and other code clean-up.
* Testing:
  * Manual test with a Data Engineering DH in a commercial AWS region.
  * Added new UT & adapted existing ones.
