### PR TITLE
CB-21062 ;  Move Ranger UserSync to the Gateway Host group

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.17/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.17/cdp-sdx-medium-ha.bp
@@ -29,6 +29,7 @@
           "atlas-ATLAS_SERVER-BASE",
           "ranger-RANGER_ADMIN-BASE",
           "zookeeper-SERVER-BASE",
+          "ranger-RANGER_USERSYNC-BASE",
           "knox-KNOX_GATEWAY-BASE",
           "solr-GATEWAY-BASE",
           "hdfs-GATEWAY-BASE",
@@ -58,7 +59,6 @@
         "cardinality": 1,
         "refName": "auxiliary",
         "roleConfigGroupsRefNames": [
-          "ranger-RANGER_USERSYNC-BASE",
           "ranger-RANGER_TAGSYNC-BASE",
           "zookeeper-SERVER-BASE"
         ]


### PR DESCRIPTION
[CB-21062](https://jira.cloudera.com/browse/CB-21062);  Move Ranger UserSync to the Gateway Host group to increase the instance count. This modification makes the Ranger UserSync to HA. This modification requires a template modification to ensure the CM will not refuse the multi-instance of the Ranger UserSync.

Result:
![Screenshot from 2023-03-02 14-22-28](https://user-images.githubusercontent.com/17518249/222441904-e60d31ec-da63-4d4c-b07c-7e9f38560bc2.png)


