### PR TITLE
CB-21074 Add timestamp to the hashed part of the volume name generation on Azure

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureVolumeResourceBuilder.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureVolumeResourceBuilder.java
@@ -111,11 +111,12 @@ public class AzureVolumeResourceBuilder extends AbstractAzureComputeBuilder {
             CloudContext cloudContext = auth.getCloudContext();
             String stackName = cloudContext.getName();
             String availabilityZone = getAvailabilityZone(auth, vm);
+            String hashableString = stackCrn + System.currentTimeMillis();
 
             return new Builder()
                     .withPersistent(true)
                     .withType(resourceType())
-                    .withName(resourceNameService.resourceName(resourceType(), stackName, groupName, privateId, stackCrn))
+                    .withName(resourceNameService.resourceName(resourceType(), stackName, groupName, privateId, hashableString))
                     .withGroup(group.getName())
                     .withStatus(CommonStatus.REQUESTED)
                     .withParameters(Map.of(CloudResource.ATTRIBUTES, new VolumeSetAttributes.Builder()
@@ -125,7 +126,7 @@ public class AzureVolumeResourceBuilder extends AbstractAzureComputeBuilder {
                                     template.getVolumes().stream()
                                             .map(volume -> new VolumeSetAttributes.Volume(
                                                     resourceNameService.resourceName(ResourceType.AZURE_DISK, stackName, groupName, privateId,
-                                                            template.getVolumes().indexOf(volume), stackCrn),
+                                                            template.getVolumes().indexOf(volume), hashableString),
                                                     null, volume.getSize(), volume.getType(), volume.getVolumeUsageType()))
                                             .collect(toList()))
                             .build()))

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureVolumeResourceBuilderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureVolumeResourceBuilderTest.java
@@ -169,7 +169,7 @@ public class AzureVolumeResourceBuilderTest {
         when(auth.getCloudContext()).thenReturn(cloudContext);
         when(auth.getParameter(AzureClient.class)).thenReturn(azureClient);
 
-        when(resourceNameService.resourceName(eq(ResourceType.AZURE_VOLUMESET), any(), any(), eq(PRIVATE_ID), eq(STACK_CRN))).thenReturn("someResourceName");
+        when(resourceNameService.resourceName(eq(ResourceType.AZURE_VOLUMESET), any(), any(), eq(PRIVATE_ID), any())).thenReturn("someResourceName");
 
         Region region = Region.region(REGION);
         Location location = Location.location(region);


### PR DESCRIPTION
There is a serious issue on Azure. Bence Hegyi  found us today, and he noticed during an upscale that we randomly detached a disk from another machine in the group. At first, I looked at it incredulously, but I found the cause, and unfortunately, it's a real problem. Situation: someone starts a cluster with 5 workers. The following machines come up: stackname-w-0, stackname-w-1, stackname-w-2, stackname-w-3, stackname-w-4, and the following volume sets come up: stackname-w-3, stackname-w-1, stackname-w-4, stackname-w-0, stackname-w-2. I wrote this order because even though the private ID is in the disk name, we don't care what it is because we randomly attach it to the machines and then push the FQDN to the disk. So the stack is created, a week goes by, and the customer says they only need 3 workers instead of 5, so they downscale by two. We select the stackname-w-3, stackname-w-4 instance and delete it along with the disk, so we bring the stackname-w-0, stackname-w-2 disks. A month goes by, and our instance metadata archiver job kicks in, removing w-3 and w-4 from the instance metadata. Another month goes by, and the customer realizes they need +1 worker after all. And here's the problem: the code that generates private IDs uses the instance metadata table to generate private IDs, so in this case, since we deleted the last two, it will generate a new one, which means the generated volume name will be stackname-w-3. It sees in the database that there is already a resource with that name, so the code doesn't save it and moves on. During the upscale, the following runs on Azure: https://github.com/hortonworks/cloudbreak/blob/cafc3f5918a91b4ea06e25ecfcfb907af0f2db93/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureAttachmentResourceBuilder.java#L71-L79 , which detaches the disk from the machine it's attached to (which is stackname-w-0, in this case) and attaches it to the new machine, so we basically break the cluster.
