### PR TITLE
CB-21019 After freeipa downscale the cipa output still contains the d…

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/templates/checkipaconsistency.j2
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/templates/checkipaconsistency.j2
@@ -1,5 +1,4 @@
 [IPA]
 domain = {{ salt['pillar.get']('freeipa:domain') }}
-hosts = {{ salt['pillar.get']('freeipa:hosts')|map(attribute='fqdn')|join(', ')}}
 binddn = cn=Directory Manager
 bindpw = {{ salt['pillar.get']('freeipa:password') }}


### PR DESCRIPTION
…eleted server's name

The salt state to generate the ipaconsistency config contained all the hosts making up the ipa cluster. During downscale, the hosts pillar is not refreshed, and there is no highstate, either. However, as it turns out, there is no need to specify hosts as ipaconsistency tool is going to query the ipa node running on the very host where the tool is executed for the list of other nodes. By not specifying the hosts, cipa will always return info about nodes it knows about. Freeipa has the setup of replication agreements, so based on that it is possible for ipa to "know" about the hosts. If all replication agreements were to be missing, then, however, there would possibly be no missing nodes. However, latter case is a failure in upgrade, that will put freeipa in a failure state (for a brief time). Tests executed:
- after a downscale only active nodes were shown
- ipa is down on the host where cipa is executed: no answer, even if nodes are specified
- ipa is down on another node, that is part of the cluster: the node is shown missing, even if hosts are not specified in the config file
- another node is stopped on the cloud provider: even without specifying hosts cipa contaiend the missing node.

See detailed description in the commit message.