### PR TITLE
CB-18055 Implement start/StopWithLimitedRetry for Azure

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
@@ -9,6 +9,7 @@ import static com.sequenceiq.cloudbreak.util.Benchmark.measure;
 import static java.util.Collections.emptyMap;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -509,16 +510,22 @@ public class AzureClient {
         return handleException(() -> azure.availabilitySets().deleteByResourceGroupAsync(resourceGroup, asName));
     }
 
-    public Mono<Void> deallocateVirtualMachineAsync(String resourceGroup, String vmName) {
-        return handleException(() -> azure.virtualMachines().deallocateAsync(resourceGroup, vmName));
+    public Mono<Void> deallocateVirtualMachineAsync(String resourceGroup, String vmName, Long timeboundInMs) {
+        if (timeboundInMs == null) {
+            return handleException(() -> azure.virtualMachines().deallocateAsync(resourceGroup, vmName));
+        }
+        return handleException(() -> azure.virtualMachines().deallocateAsync(resourceGroup, vmName).timeout(Duration.ofMillis(timeboundInMs)));
     }
 
     public Mono<Void> deleteVirtualMachine(String resourceGroup, String vmName) {
         return handleException(() -> azure.virtualMachines().deleteByResourceGroupAsync(resourceGroup, vmName));
     }
 
-    public Mono<Void> startVirtualMachineAsync(String resourceGroup, String vmName) {
-        return handleException(() -> azure.virtualMachines().startAsync(resourceGroup, vmName));
+    public Mono<Void> startVirtualMachineAsync(String resourceGroup, String vmName, Long timeboundInMs) {
+        if (timeboundInMs == null) {
+            return handleException(() -> azure.virtualMachines().startAsync(resourceGroup, vmName));
+        }
+        return handleException(() -> azure.virtualMachines().startAsync(resourceGroup, vmName).timeout(Duration.ofMillis(timeboundInMs)));
     }
 
     public Mono<Void> stopVirtualMachineAsync(String resourceGroup, String vmName) {

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtilsTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtilsTest.java
@@ -176,12 +176,12 @@ public class AzureUtilsTest {
         AuthenticatedContext ac = Mockito.mock(AuthenticatedContext.class);
         AzureClient azureClient = Mockito.mock(AzureClient.class);
         when(ac.getParameter(AzureClient.class)).thenReturn(azureClient);
-        when(azureClient.deallocateVirtualMachineAsync(anyString(), anyString())).thenReturn(Mono.empty());
+        when(azureClient.deallocateVirtualMachineAsync(anyString(), anyString(), any())).thenReturn(Mono.empty());
 
         List<CloudVmInstanceStatus> statusesAfterDeallocate = underTest.deallocateInstances(ac,
                 List.of(createCloudInstance("instance1"), createCloudInstance("instance2")));
 
-        verify(azureClient, times(2)).deallocateVirtualMachineAsync(anyString(), anyString());
+        verify(azureClient, times(2)).deallocateVirtualMachineAsync(anyString(), anyString(), any());
         assertEquals(2, statusesAfterDeallocate.size());
         statusesAfterDeallocate.forEach(status -> assertEquals(InstanceStatus.STOPPED, status.getStatus()));
     }
@@ -197,12 +197,12 @@ public class AzureUtilsTest {
         AuthenticatedContext ac = Mockito.mock(AuthenticatedContext.class);
         AzureClient azureClient = Mockito.mock(AzureClient.class);
         when(ac.getParameter(AzureClient.class)).thenReturn(azureClient);
-        when(azureClient.deallocateVirtualMachineAsync(anyString(), anyString())).thenReturn(Mono.empty());
+        when(azureClient.deallocateVirtualMachineAsync(anyString(), anyString(), any())).thenReturn(Mono.empty());
 
         List<CloudVmInstanceStatus> statusesAfterDeallocate = underTest.deallocateInstances(ac,
                 List.of(createCloudInstance("instance1"), createCloudInstance("instance2")));
 
-        verify(azureClient, times(1)).deallocateVirtualMachineAsync(anyString(), anyString());
+        verify(azureClient, times(1)).deallocateVirtualMachineAsync(anyString(), anyString(), any());
         assertEquals(2, statusesAfterDeallocate.size());
         statusesAfterDeallocate.forEach(status -> assertEquals(InstanceStatus.STOPPED, status.getStatus()));
     }
@@ -219,9 +219,9 @@ public class AzureUtilsTest {
         AuthenticatedContext ac = Mockito.mock(AuthenticatedContext.class);
         AzureClient azureClient = Mockito.mock(AzureClient.class);
         when(ac.getParameter(AzureClient.class)).thenReturn(azureClient);
-        when(azureClient.deallocateVirtualMachineAsync(anyString(), eq("instance1"))).thenReturn(Mono.empty());
-        when(azureClient.deallocateVirtualMachineAsync(anyString(), eq("instance2"))).thenReturn(Mono.error(new RuntimeException("failed1")));
-        when(azureClient.deallocateVirtualMachineAsync(anyString(), eq("instance3"))).thenReturn(Mono.error(new RuntimeException("failed2")));
+        when(azureClient.deallocateVirtualMachineAsync(anyString(), eq("instance1"), any())).thenReturn(Mono.empty());
+        when(azureClient.deallocateVirtualMachineAsync(anyString(), eq("instance2"), any())).thenReturn(Mono.error(new RuntimeException("failed1")));
+        when(azureClient.deallocateVirtualMachineAsync(anyString(), eq("instance3"), any())).thenReturn(Mono.error(new RuntimeException("failed2")));
 
         assertThrows(
                 CloudbreakServiceException.class,
@@ -229,7 +229,7 @@ public class AzureUtilsTest {
                         List.of(createCloudInstance("instance1"), createCloudInstance("instance2"),
                                 createCloudInstance("instance3"))));
 
-        verify(azureClient, times(3)).deallocateVirtualMachineAsync(anyString(), anyString());
+        verify(azureClient, times(3)).deallocateVirtualMachineAsync(anyString(), anyString(), any());
     }
 
     @Test

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXStopStartScaleTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXStopStartScaleTest.java
@@ -30,10 +30,9 @@ public class DistroXStopStartScaleTest extends AbstractE2ETest {
 
     @Override
     protected void setupTest(TestContext testContext) {
-        // Azure and GCP are not supported right now.
+        // GCP are not supported right now.
         // - GCP does not support stopping instances with ephemeral storage.
-        // - Azure starting/stopping nodes consume almost same time as adding/deleting nodes.
-        assertSupportedCloudPlatform(CloudPlatform.AWS);
+        assertNotSupportedCloudPlatform(CloudPlatform.GCP);
         testContext.getCloudProvider().getCloudFunctionality().cloudStorageInitialize();
         createDefaultUser(testContext);
         createDefaultCredential(testContext);


### PR DESCRIPTION
- start/stopWithLimitedRetry are versions of instance start/stop where it limits the retries that the operation may perform normally.
- If the instances are not started/stopped in the given time than we update the instance state as unknown.