### PR TITLE
CB-21068 FreeIPA repair should return with HTTP 400 instead of 500 if…

### DIFF
--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/RepairInstancesServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/RepairInstancesServiceTest.java
@@ -278,7 +278,7 @@ class RepairInstancesServiceTest {
         RepairInstancesRequest request = new RepairInstancesRequest();
         request.setForceRepair(true);
         request.setEnvironmentCrn(ENVIRONMENT_ID1);
-        assertThrows(UnsupportedOperationException.class, () -> {
+        assertThrows(BadRequestException.class, () -> {
             underTest.repairInstances(ACCOUNT_ID, request);
         });
     }


### PR DESCRIPTION
… the request is invalid

Switching from `UnsupportedOperationException` to `BadRequestException`

See detailed description in the commit message.