### PR TITLE
CB-21091 Salt state cm-server-restart-root-cert-changed in the state …

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/root-certs.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/root-certs.sls
@@ -10,7 +10,7 @@ create-root-certs-file:
     - group: root
     - mode: 644
 
-{% if postgresql.ssl_restart_required == True %}
+{% if postgresql.ssl_restart_required == True and postgresql.ssl_enabled == True and "manager_server" in grains.get('roles', []) %}
 cm-server-restart-root-cert-changed:
   service.running:
     - name: cloudera-scm-server


### PR DESCRIPTION
…file postgresql.root-certs starts CM on every node during an upscale

See detailed description in the commit message.