### PR TITLE
CB-19956 Implement SSL for Streaming SQL Engine DB

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
@@ -81,6 +81,8 @@ public class CMRepositoryVersionUtil {
 
     public static final Versioned CFM_VERSION_2_2_3_0 = () -> "2.2.3.0";
 
+    public static final Versioned FLINK_VERSION_1_15_1 = () -> "1.15.1";
+
     public static final Versioned CDPD_VERSION_7_2_11 = () -> "7.2.11";
 
     public static final Map<CloudPlatform, Versioned> MIN_CM_VERSION_FOR_RAZ = new HashMap<>() {
@@ -125,7 +127,7 @@ public class CMRepositoryVersionUtil {
     }
 
     public static boolean isIgnorePropertyValidationSupportedViaBlueprint(ClouderaManagerRepo clouderaManagerRepoDetails) {
-        LOGGER.info("ClouderaManagerRepo is compared for ignore porperty validation support");
+        LOGGER.info("ClouderaManagerRepo is compared for ignore property validation support");
         return isVersionNewerOrEqualThanLimited(clouderaManagerRepoDetails::getVersion, CLOUDERAMANAGER_VERSION_7_1_0);
     }
 

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ssb/SqlStreamBuilderAdminDatabaseConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ssb/SqlStreamBuilderAdminDatabaseConfigProvider.java
@@ -1,15 +1,22 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.ssb;
 
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.FLINK_VERSION_1_15_1;
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.schemaregistry.StreamingAppRdsRoleConfigProviderUtil.dataBaseTypeForCM;
 import static java.util.Collections.emptyList;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.views.RdsView;
@@ -29,6 +36,12 @@ public class SqlStreamBuilderAdminDatabaseConfigProvider extends SqlStreamBuilde
 
     static final String DATABASE_PASSWORD = "database_password";
 
+    static final String DATABASE_JDBC_URL_OVERRIDE = "database_jdbc_url_override";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SqlStreamBuilderAdminDatabaseConfigProvider.class);
+
+    private static final String FLINK_PRODUCT = "FLINK";
+
     @Override
     public String getServiceType() {
         return SqlStreamBuilderRoles.SQL_STREAM_BUILDER;
@@ -43,14 +56,43 @@ public class SqlStreamBuilderAdminDatabaseConfigProvider extends SqlStreamBuilde
     public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject source) {
         RdsView ssbRdsView = getRdsView(source);
 
-        return List.of(
-                config(DATABASE_TYPE, dataBaseTypeForCM(ssbRdsView.getDatabaseVendor())),
-                config(DATABASE_HOST, ssbRdsView.getHost()),
-                config(DATABASE_PORT, ssbRdsView.getPort()),
-                config(DATABASE_SCHEMA, ssbRdsView.getDatabaseName()),
-                config(DATABASE_USER, ssbRdsView.getConnectionUserName()),
-                config(DATABASE_PASSWORD, ssbRdsView.getConnectionPassword())
-        );
+        List<ApiClusterTemplateConfig> configList = new ArrayList<>();
+        addDbConfigs(ssbRdsView, configList);
+        addDbSslConfigsIfNeeded(ssbRdsView, configList, getFlinkProduct(source.getProductDetailsView().getProducts()));
+        return configList;
+    }
+
+    private void addDbConfigs(RdsView ssbRdsView, List<ApiClusterTemplateConfig> configList) {
+        configList.add(config(DATABASE_TYPE, dataBaseTypeForCM(ssbRdsView.getDatabaseVendor())));
+        configList.add(config(DATABASE_HOST, ssbRdsView.getHost()));
+        configList.add(config(DATABASE_PORT, ssbRdsView.getPort()));
+        configList.add(config(DATABASE_SCHEMA, ssbRdsView.getDatabaseName()));
+        configList.add(config(DATABASE_USER, ssbRdsView.getConnectionUserName()));
+        configList.add(config(DATABASE_PASSWORD, ssbRdsView.getConnectionPassword()));
+    }
+
+    private Optional<ClouderaManagerProduct> getFlinkProduct(List<ClouderaManagerProduct> products) {
+        Optional<ClouderaManagerProduct> flinkProductOptional = products
+                .stream()
+                .filter(e -> e.getName().equalsIgnoreCase(FLINK_PRODUCT))
+                .findFirst();
+        if (flinkProductOptional.isEmpty()) {
+            LOGGER.warn("FLINK product not found!");
+        }
+        return flinkProductOptional;
+    }
+
+    private void addDbSslConfigsIfNeeded(RdsView ssbRdsView, List<ApiClusterTemplateConfig> configList, Optional<ClouderaManagerProduct> flinkProductOptional) {
+        flinkProductOptional.ifPresent(flinkProduct -> {
+            if (isVersionNewerOrEqualThanLimited(getFlinkVersion(flinkProduct), FLINK_VERSION_1_15_1) && ssbRdsView.isUseSsl()) {
+                configList.add(config(DATABASE_JDBC_URL_OVERRIDE, ssbRdsView.getConnectionURL()));
+            }
+        });
+    }
+
+    private String getFlinkVersion(ClouderaManagerProduct flinkProduct) {
+        // 1.15.1-csadh1.9.0.1-cdh7.2.16.0-254-37351973 -> 1.15.1
+        return flinkProduct.getVersion().split("-")[0];
     }
 
     @Override
@@ -62,4 +104,5 @@ public class SqlStreamBuilderAdminDatabaseConfigProvider extends SqlStreamBuilde
     protected DatabaseType dbType() {
         return DatabaseType.SQL_STREAM_BUILDER_ADMIN;
     }
+
 }

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ssb/SqlStreamBuilderAdminDatabaseConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ssb/SqlStreamBuilderAdminDatabaseConfigProviderTest.java
@@ -1,23 +1,33 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.ssb;
 
-import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
+import com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigTestUtil;
+import com.sequenceiq.cloudbreak.common.type.Versioned;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.views.BlueprintView;
 import com.sequenceiq.cloudbreak.template.views.HostgroupView;
@@ -25,8 +35,13 @@ import com.sequenceiq.cloudbreak.template.views.RdsView;
 import com.sequenceiq.cloudbreak.util.FileReaderUtils;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class SqlStreamBuilderAdminDatabaseConfigProviderTest {
+
+    private static final String CONNECTION_URL = "jdbc:postgresql://cluster-master0.bar.com:5432/ssb_admin";
+
+    private static final String CONNECTION_URL_WITH_SSL = "jdbc:postgresql://cluster-master0.bar.com:5432/ssb_admin" +
+            "?sslmode=verify-full&sslrootcert=/foo/cert.pem";
 
     private final SqlStreamBuilderAdminDatabaseConfigProvider underTest = new SqlStreamBuilderAdminDatabaseConfigProvider();
 
@@ -51,17 +66,62 @@ public class SqlStreamBuilderAdminDatabaseConfigProviderTest {
         CmTemplateProcessor cmTemplateProcessor = initTemplateProcessor("7.2.11");
         TemplatePreparationObject preparationObject = initTemplatePreparationObject(cmTemplateProcessor);
 
-        List<ApiClusterTemplateConfig> roleConfigs = underTest.getServiceConfigs(cmTemplateProcessor, preparationObject);
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(cmTemplateProcessor, preparationObject);
 
-        assertThat(roleConfigs).hasSameElementsAs(
-                List.of(
-                        config(SqlStreamBuilderAdminDatabaseConfigProvider.DATABASE_TYPE, "postgresql"),
-                        config(SqlStreamBuilderAdminDatabaseConfigProvider.DATABASE_HOST, "testhost"),
-                        config(SqlStreamBuilderAdminDatabaseConfigProvider.DATABASE_PORT, "5432"),
-                        config(SqlStreamBuilderAdminDatabaseConfigProvider.DATABASE_SCHEMA, "ssb_admin"),
-                        config(SqlStreamBuilderAdminDatabaseConfigProvider.DATABASE_USER, "ssb_test_user"),
-                        config(SqlStreamBuilderAdminDatabaseConfigProvider.DATABASE_PASSWORD, "ssb_test_pw")
-                ));
+        validateServiceConfigsNoDbSsl(serviceConfigs);
+    }
+
+    private void validateServiceConfigsNoDbSsl(List<ApiClusterTemplateConfig> serviceConfigs) {
+        Map<String, String> configToValue = ConfigTestUtil.getConfigNameToValueMap(serviceConfigs);
+        assertThat(configToValue).containsOnly(
+                entry(SqlStreamBuilderAdminDatabaseConfigProvider.DATABASE_TYPE, "postgresql"),
+                entry(SqlStreamBuilderAdminDatabaseConfigProvider.DATABASE_HOST, "testhost"),
+                entry(SqlStreamBuilderAdminDatabaseConfigProvider.DATABASE_PORT, "5432"),
+                entry(SqlStreamBuilderAdminDatabaseConfigProvider.DATABASE_SCHEMA, "ssb_admin"),
+                entry(SqlStreamBuilderAdminDatabaseConfigProvider.DATABASE_USER, "ssb_test_user"),
+                entry(SqlStreamBuilderAdminDatabaseConfigProvider.DATABASE_PASSWORD, "ssb_test_pw")
+        );
+    }
+
+    @Test
+    public void getServiceConfigsWhenGoodFlinkVersionButDbSslIsNotRequested() {
+        CmTemplateProcessor cmTemplateProcessor = initTemplateProcessor("7.2.11");
+        TemplatePreparationObject preparationObject = initTemplatePreparationObject(cmTemplateProcessor, true, CMRepositoryVersionUtil.FLINK_VERSION_1_15_1,
+                false);
+
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(cmTemplateProcessor, preparationObject);
+
+        validateServiceConfigsNoDbSsl(serviceConfigs);
+    }
+
+    @Test
+    public void getServiceConfigsWhenDbSslIsRequestedButBadFlinkVersion() {
+        CmTemplateProcessor cmTemplateProcessor = initTemplateProcessor("7.2.11");
+        TemplatePreparationObject preparationObject = initTemplatePreparationObject(cmTemplateProcessor, true, () -> "1.14.0", true);
+
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(cmTemplateProcessor, preparationObject);
+
+        validateServiceConfigsNoDbSsl(serviceConfigs);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(strings = {"1.15.1", "1.15.1-csadh1.9.0.1-cdh7.2.16.0-254-37351973", "1.15.2", "1.16.0"})
+    public void getServiceConfigsWhenDbSsl(String flinkVersion) {
+        CmTemplateProcessor cmTemplateProcessor = initTemplateProcessor("7.2.11");
+        TemplatePreparationObject preparationObject = initTemplatePreparationObject(cmTemplateProcessor, true, () -> flinkVersion, true);
+
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(cmTemplateProcessor, preparationObject);
+
+        Map<String, String> configToValue = ConfigTestUtil.getConfigNameToValueMap(serviceConfigs);
+        assertThat(configToValue).containsOnly(
+                entry(SqlStreamBuilderAdminDatabaseConfigProvider.DATABASE_TYPE, "postgresql"),
+                entry(SqlStreamBuilderAdminDatabaseConfigProvider.DATABASE_HOST, "testhost"),
+                entry(SqlStreamBuilderAdminDatabaseConfigProvider.DATABASE_PORT, "5432"),
+                entry(SqlStreamBuilderAdminDatabaseConfigProvider.DATABASE_SCHEMA, "ssb_admin"),
+                entry(SqlStreamBuilderAdminDatabaseConfigProvider.DATABASE_USER, "ssb_test_user"),
+                entry(SqlStreamBuilderAdminDatabaseConfigProvider.DATABASE_PASSWORD, "ssb_test_pw"),
+                entry(SqlStreamBuilderAdminDatabaseConfigProvider.DATABASE_JDBC_URL_OVERRIDE, CONNECTION_URL_WITH_SSL)
+        );
     }
 
     private CmTemplateProcessor initTemplateProcessor(String cdhVersion) {
@@ -72,6 +132,11 @@ public class SqlStreamBuilderAdminDatabaseConfigProviderTest {
     }
 
     private TemplatePreparationObject initTemplatePreparationObject(CmTemplateProcessor cmTemplateProcessor) {
+        return initTemplatePreparationObject(cmTemplateProcessor, false, CMRepositoryVersionUtil.FLINK_VERSION_1_15_1, false);
+    }
+
+    private TemplatePreparationObject initTemplatePreparationObject(CmTemplateProcessor cmTemplateProcessor, boolean flinkProductPresent,
+            Versioned flinkVersion, boolean useDbSsl) {
         HostgroupView manager = new HostgroupView("manager", 1, InstanceGroupType.GATEWAY, 1);
         HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.CORE, 2);
         HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, 3);
@@ -79,17 +144,40 @@ public class SqlStreamBuilderAdminDatabaseConfigProviderTest {
 
         RdsView rdsConfig = mock(RdsView.class);
         when(rdsConfig.getType()).thenReturn(DatabaseType.SQL_STREAM_BUILDER_ADMIN.toString());
-        when(rdsConfig.getDatabaseVendor()).thenReturn(DatabaseVendor.POSTGRES);
-        when(rdsConfig.getHost()).thenReturn("testhost");
-        when(rdsConfig.getPort()).thenReturn("5432");
-        when(rdsConfig.getDatabaseName()).thenReturn("ssb_admin");
-        when(rdsConfig.getConnectionUserName()).thenReturn("ssb_test_user");
-        when(rdsConfig.getConnectionPassword()).thenReturn("ssb_test_pw");
+        lenient().when(rdsConfig.getDatabaseVendor()).thenReturn(DatabaseVendor.POSTGRES);
+        lenient().when(rdsConfig.getHost()).thenReturn("testhost");
+        lenient().when(rdsConfig.getPort()).thenReturn("5432");
+        lenient().when(rdsConfig.getDatabaseName()).thenReturn("ssb_admin");
+        lenient().when(rdsConfig.getConnectionUserName()).thenReturn("ssb_test_user");
+        lenient().when(rdsConfig.getConnectionPassword()).thenReturn("ssb_test_pw");
+        lenient().when(rdsConfig.isUseSsl()).thenReturn(useDbSsl);
+        lenient().when(rdsConfig.getConnectionURL()).thenReturn(useDbSsl ? CONNECTION_URL_WITH_SSL : CONNECTION_URL);
 
         return TemplatePreparationObject.Builder.builder()
                 .withBlueprintView(blueprintView)
                 .withHostgroupViews(Set.of(manager, master, worker))
                 .withRdsViews(Set.of(rdsConfig))
+                .withProductDetails(generateCmRepo(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_2), generateProducts(flinkProductPresent, flinkVersion))
                 .build();
     }
+
+    private ClouderaManagerRepo generateCmRepo(Versioned version) {
+        return new ClouderaManagerRepo()
+                .withBaseUrl("baseurl")
+                .withGpgKeyUrl("gpgurl")
+                .withPredefined(true)
+                .withVersion(version.getVersion());
+    }
+
+    private List<ClouderaManagerProduct> generateProducts(boolean flinkProductPresent, Versioned flinkVersion) {
+        List<ClouderaManagerProduct> products = new ArrayList<>();
+        if (flinkProductPresent) {
+            ClouderaManagerProduct flinkProduct = new ClouderaManagerProduct()
+                    .withName("FLINK")
+                    .withVersion(flinkVersion.getVersion());
+            products.add(flinkProduct);
+        }
+        return products;
+    }
+
 }


### PR DESCRIPTION
* Add DB SSL configs to SQL Stream Builder Streaming SQL Engine (SSE / Sqlio / Admin) service configs if needed.
  * Prerequisite: FLINK parcel >= 1.15.1. The earliest build with the changes was 1.15.1-csadh1.9.0.0-cdh7.2.16.0-254-36094986.
* Fix various typos and other code clean-up.
* Testing:
  * Manual test with a Streaming Analytics Light Duty DH in a commercial AWS region.
  * Added new UT & adapted existing ones.
