### PR TITLE
CB-21051 Freeipa should upscale with 1 node at a time

### DIFF
--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
@@ -381,10 +381,10 @@ public class SaltOrchestrator implements HostOrchestrator {
     private void uploadMountScriptsAndMakeThemExecutable(Set<Node> nodes, ExitCriteriaModel exitModel, Set<String> allTargets, Target<String> allHosts,
             SaltConnector sc) throws IOException {
         Map.of(
-                DISK_INITIALIZE, readFileFromClasspath(DISK_SCRIPT_PATH + DISK_INITIALIZE).getBytes(),
-                DISK_COMMON, readFileFromClasspath(DISK_SCRIPT_PATH + DISK_COMMON).getBytes(),
-                DISK_FORMAT, readFileFromClasspath(DISK_SCRIPT_PATH + DISK_FORMAT).getBytes(),
-                DISK_MOUNT, readFileFromClasspath(DISK_SCRIPT_PATH + DISK_MOUNT).getBytes())
+                        DISK_INITIALIZE, readFileFromClasspath(DISK_SCRIPT_PATH + DISK_INITIALIZE).getBytes(),
+                        DISK_COMMON, readFileFromClasspath(DISK_SCRIPT_PATH + DISK_COMMON).getBytes(),
+                        DISK_FORMAT, readFileFromClasspath(DISK_SCRIPT_PATH + DISK_FORMAT).getBytes(),
+                        DISK_MOUNT, readFileFromClasspath(DISK_SCRIPT_PATH + DISK_MOUNT).getBytes())
                 .entrySet()
                 .stream()
                 .map(script -> {
@@ -701,11 +701,13 @@ public class SaltOrchestrator implements HostOrchestrator {
 
     private void installFreeIpaReplicas(SaltConnector sc, Set<String> newFreeIpaReplicaHostnames, Set<Node> allNodes, ExitCriteriaModel exitCriteriaModel)
             throws Exception {
-        LOGGER.debug("New Replica FreeIPAs: [{}]", newFreeIpaReplicaHostnames);
-        if (!newFreeIpaReplicaHostnames.isEmpty()) {
+        LOGGER.debug("New Replica FreeIPAs: {}", newFreeIpaReplicaHostnames);
+        for (String newFreeIpaReplicaHostname : newFreeIpaReplicaHostnames) {
+            LOGGER.debug("New Replica FreeIPA: [{}]", newFreeIpaReplicaHostname);
             saltCommandRunner.runModifyGrainCommand(sc,
-                    new GrainAddRunner(saltStateService, newFreeIpaReplicaHostnames, allNodes, FREEIPA_REPLICA_ROLE), exitCriteriaModel, exitCriteria);
-            runNewService(sc, new HighStateRunner(saltStateService, newFreeIpaReplicaHostnames, allNodes), exitCriteriaModel);
+                    new GrainAddRunner(saltStateService, Set.of(newFreeIpaReplicaHostname), allNodes, FREEIPA_REPLICA_ROLE), exitCriteriaModel, exitCriteria);
+            runNewService(sc, new HighStateRunner(saltStateService, Set.of(newFreeIpaReplicaHostname), allNodes), exitCriteriaModel);
+            LOGGER.debug("New Replica FreeIPA installation finished for: [{}]", newFreeIpaReplicaHostname);
         }
     }
 

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestratorTest.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestratorTest.java
@@ -189,7 +189,7 @@ class SaltOrchestratorTest {
 
     @Test
     void bootstrapTest() throws Exception {
-        when(compressUtil.generateCompressedOutputFromFolders("salt-common", "salt")).thenReturn(new byte[] {});
+        when(compressUtil.generateCompressedOutputFromFolders("salt-common", "salt")).thenReturn(new byte[]{});
 
         BootstrapParams bootstrapParams = mock(BootstrapParams.class);
         List<GatewayConfig> allGatewayConfigs = Collections.singletonList(gatewayConfig);
@@ -267,7 +267,7 @@ class SaltOrchestratorTest {
     @Test
     void bootstrapNewNodesTest() throws Exception {
         BootstrapParams bootstrapParams = mock(BootstrapParams.class);
-        when(compressUtil.generateCompressedOutputFromFolders("salt-common", "salt")).thenReturn(new byte[] {});
+        when(compressUtil.generateCompressedOutputFromFolders("salt-common", "salt")).thenReturn(new byte[]{});
 
         saltOrchestrator.bootstrapNewNodes(Collections.singletonList(gatewayConfig), targets, targets, null, bootstrapParams, exitCriteriaModel);
 
@@ -380,7 +380,7 @@ class SaltOrchestratorTest {
         doThrow(new NullPointerException("message")).when(saltStateService).stopMinions(eq(saltConnector), eq(privateIps));
 
         assertThatThrownBy(() ->
-            saltOrchestrator.tearDown(null, Collections.singletonList(gatewayConfig), privateIpsByFQDN, Set.of(), null))
+                saltOrchestrator.tearDown(null, Collections.singletonList(gatewayConfig), privateIpsByFQDN, Set.of(), null))
                 .hasMessage("message")
                 .isInstanceOf(CloudbreakOrchestratorFailedException.class)
                 .hasCauseInstanceOf(NullPointerException.class);
@@ -555,10 +555,11 @@ class SaltOrchestratorTest {
         saltOrchestrator.installFreeIpa(primaryGateway, List.of(primaryGateway, replica1Config, replica2Config),
                 Set.of(primaryNode, replica1Node, replica2Node), exitCriteriaModel);
 
-        verify(saltRunner, times(2)).runnerWithCalculatedErrorCount(saltJobIdTrackerArgumentCaptor.capture(), any(), any(), anyInt());
+        verify(saltRunner, times(3)).runnerWithCalculatedErrorCount(saltJobIdTrackerArgumentCaptor.capture(), any(), any(), anyInt());
         List<SaltJobIdTracker> jobIdTrackers = saltJobIdTrackerArgumentCaptor.getAllValues();
         assertEquals(Set.of("primary.example.com"), jobIdTrackers.get(0).getSaltJobRunner().getTargetHostnames());
-        assertEquals(Set.of("replica1.example.com", "replica2.example.com"), jobIdTrackers.get(1).getSaltJobRunner().getTargetHostnames());
+        assertEquals(Set.of("replica1.example.com"), jobIdTrackers.get(1).getSaltJobRunner().getTargetHostnames());
+        assertEquals(Set.of("replica2.example.com"), jobIdTrackers.get(2).getSaltJobRunner().getTargetHostnames());
     }
 
     @Test
@@ -616,10 +617,11 @@ class SaltOrchestratorTest {
         saltOrchestrator.installFreeIpa(primaryGateway, List.of(primaryGateway, newReplica1Config, newReplica2Config),
                 Set.of(primaryNode, newReplica1Node, newReplica2Node), exitCriteriaModel);
 
-        verify(saltRunner, times(2)).runnerWithCalculatedErrorCount(saltJobIdTrackerArgumentCaptor.capture(), any(), any(), anyInt());
+        verify(saltRunner, times(3)).runnerWithCalculatedErrorCount(saltJobIdTrackerArgumentCaptor.capture(), any(), any(), anyInt());
         List<SaltJobIdTracker> jobIdTrackers = saltJobIdTrackerArgumentCaptor.getAllValues();
         assertEquals(Set.of("primary.example.com"), jobIdTrackers.get(0).getSaltJobRunner().getTargetHostnames());
-        assertEquals(Set.of("new_replica1.example.com", "new_replica2.example.com"), jobIdTrackers.get(1).getSaltJobRunner().getTargetHostnames());
+        assertEquals(Set.of("new_replica2.example.com"), jobIdTrackers.get(1).getSaltJobRunner().getTargetHostnames());
+        assertEquals(Set.of("new_replica1.example.com"), jobIdTrackers.get(2).getSaltJobRunner().getTargetHostnames());
         Target<String> hostRoleAndTarget1 =
                 new HostAndRoleTarget("freeipa_primary", Set.of("new_replica2.example.com", "primary.example.com", "new_replica1.example.com"));
         Target<String> hostRoleAndTarget2 =


### PR DESCRIPTION
During upscale and repair when provisioning replicas, only a single instance should be installing freeipa replica. This is how it works during provisioning, so it makes sense to work the same way during repair and upscale. Also we have seen an issue where salt retry mechanism couldn't detect the failure of one instance as the other was still doing the installation for a long time.

See detailed description in the commit message.