### PR TITLE
CB-21118 NPE in GcpAttachedDiskResourceBuilder

### DIFF
--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpAttachedDiskResourceBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpAttachedDiskResourceBuilder.java
@@ -106,6 +106,7 @@ public class GcpAttachedDiskResourceBuilder extends AbstractGcpComputeBuilder {
                 .withDeleteOnTermination(Boolean.TRUE)
                 .withVolumes(volumes).build()));
         return CloudResource.builder()
+                .withType(resourceType())
                 .withStatus(CommonStatus.REQUESTED)
                 .withName(resourceName)
                 .withGroup(groupName)


### PR DESCRIPTION
A .withType() call from a CloudResource builder was accidentally removed. This needs an immediate fix as no GCP environment can be created as of now.

