### PR TITLE
CB-21126 - [E2E] Recovery test does not work with prod image catalog

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxUpgradeRecoveryTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxUpgradeRecoveryTests.java
@@ -34,6 +34,7 @@ public class SdxUpgradeRecoveryTests extends PreconditionSdxE2ETest {
 
     private static final String INJECT_UPGRADE_FAILURE_CMD =
             "sudo sh -c \"echo -e '"
+                    + "\\n127.0.0.1 archive.cloudera.com"
                     + "\\n127.0.0.1 cloudera-build-us-west-1.vpc.cloudera.com"
                     + "\\n127.0.0.1 build-cache-azure.kc.cloudera.com"
                     + "\\n127.0.0.1 cloudera-build-2-us-west-2.vpc.cloudera.com"


### PR DESCRIPTION
Added `archive.cloudera.com` to the faked repository urls to handle the prod image catalog based tests.

See detailed description in the commit message.