### PR TITLE
CB-11269 SSL for CM schema creation

### DIFF
--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/container/postgres/PostgresConfigServiceSSLSaltConfigTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/container/postgres/PostgresConfigServiceSSLSaltConfigTest.java
@@ -17,6 +17,7 @@ public class PostgresConfigServiceSSLSaltConfigTest {
         assertThat(underTest.getRootCertsBundle()).isEqualTo("");
         assertThat(underTest.isSslEnabled()).isFalse();
         assertThat(underTest.isRestartRequired()).isFalse();
+        assertThat(underTest.isSslForCmDbNativelySupported()).isFalse();
     }
 
     @Test
@@ -33,7 +34,8 @@ public class PostgresConfigServiceSSLSaltConfigTest {
         Map<String, Object> result = underTest.toMap();
 
         assertThat(result).isNotNull();
-        assertThat(result).isEqualTo(Map.ofEntries(entry("ssl_certs", ""), entry("ssl_restart_required", "false"), entry("ssl_enabled", "false")));
+        assertThat(result).isEqualTo(Map.ofEntries(entry("ssl_certs", ""), entry("ssl_restart_required", "false"), entry("ssl_enabled", "false"),
+                entry("ssl_for_cm_db_natively_supported", "false")));
     }
 
     @Test
@@ -41,12 +43,14 @@ public class PostgresConfigServiceSSLSaltConfigTest {
         PostgresConfigService.SSLSaltConfig underTest = new PostgresConfigService.SSLSaltConfig();
         underTest.setRestartRequired(false);
         underTest.setSslEnabled(true);
+        underTest.setSslForCmDbNativelySupported(false);
         underTest.setRootCertsBundle("myCert");
 
         Map<String, Object> result = underTest.toMap();
 
         assertThat(result).isNotNull();
-        assertThat(result).isEqualTo(Map.ofEntries(entry("ssl_certs", "myCert"), entry("ssl_restart_required", "false"), entry("ssl_enabled", "true")));
+        assertThat(result).isEqualTo(Map.ofEntries(entry("ssl_certs", "myCert"), entry("ssl_restart_required", "false"), entry("ssl_enabled", "true"),
+                entry("ssl_for_cm_db_natively_supported", "false")));
     }
 
     @Test
@@ -54,12 +58,29 @@ public class PostgresConfigServiceSSLSaltConfigTest {
         PostgresConfigService.SSLSaltConfig underTest = new PostgresConfigService.SSLSaltConfig();
         underTest.setRestartRequired(true);
         underTest.setSslEnabled(true);
+        underTest.setSslForCmDbNativelySupported(false);
         underTest.setRootCertsBundle("myCert");
 
         Map<String, Object> result = underTest.toMap();
 
         assertThat(result).isNotNull();
-        assertThat(result).isEqualTo(Map.ofEntries(entry("ssl_certs", "myCert"), entry("ssl_restart_required", "true"), entry("ssl_enabled", "true")));
+        assertThat(result).isEqualTo(Map.ofEntries(entry("ssl_certs", "myCert"), entry("ssl_restart_required", "true"), entry("ssl_enabled", "true"),
+                entry("ssl_for_cm_db_natively_supported", "false")));
+    }
+
+    @Test
+    void toMapTestWhenSslWithCmDbNativeSupport() {
+        PostgresConfigService.SSLSaltConfig underTest = new PostgresConfigService.SSLSaltConfig();
+        underTest.setRestartRequired(false);
+        underTest.setSslEnabled(true);
+        underTest.setSslForCmDbNativelySupported(true);
+        underTest.setRootCertsBundle("myCert");
+
+        Map<String, Object> result = underTest.toMap();
+
+        assertThat(result).isNotNull();
+        assertThat(result).isEqualTo(Map.ofEntries(entry("ssl_certs", "myCert"), entry("ssl_restart_required", "false"), entry("ssl_enabled", "true"),
+                entry("ssl_for_cm_db_natively_supported", "true")));
     }
 
 }

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/settings.sls
@@ -3,6 +3,7 @@
 {% set root_certs_file = salt['pillar.get']('postgres_root_certs:ssl_certs_file_path') %}
 {% set ssl_enabled = salt['pillar.get']('postgres_root_certs:ssl_enabled', 'False') == 'true' %}
 {% set ssl_restart_required = salt['pillar.get']('postgres_root_certs:ssl_restart_required', 'False') == 'true' %}
+{% set ssl_for_cm_db_natively_supported = salt['pillar.get']('postgres_root_certs:ssl_for_cm_db_natively_supported', 'False') == 'true' %}
 
 {% set postgresql = {} %}
 {% do postgresql.update({
@@ -10,5 +11,6 @@
     'root_certs': root_certs,
     'root_certs_file': root_certs_file,
     'root_certs_enabled': root_certs_enabled,
-    'ssl_restart_required': ssl_restart_required
+    'ssl_restart_required': ssl_restart_required,
+    'ssl_for_cm_db_natively_supported': ssl_for_cm_db_natively_supported
 }) %}


### PR DESCRIPTION
* When having a DB with SSL enforcement (embedded or external DB), use SSL JDBC options when creating CM DB schema in Salt.
  * Prerequisites: CM >= 7.9.2 (specifically, at least 7.9.2-b98 / GBN 37940714 as stated in [OPSAPS-54579](https://jira.cloudera.com/browse/OPSAPS-54579)).
  * When prerequisites are met, `scm_prepare_database.sh` will be invoked with 2 extra options: `-s` and `-j`. The latter will include the complete JDBC connection string including explicit SSL options. At the moment, this means `sslmode=verify-full` (i.e. DB server cert and host name verification) and `sslrootcert=/hadoopfs/fs1/database-cacerts/certs.pem` .
  * Otherwise, `scm_prepare_database.sh` will be invoked as before, and `/etc/cloudera-scm-server/db.properties` will be still updated manually with the Hibernate JDBC connection string override. In other words, no change in behavior for earlier CM versions.
* Testing:
  * Manual test with DL and DH clusters, using CM versions 7.6.2 (with CDH 7.2.15) and 7.9.2 (with CDH 7.2.16.1), SSL enforcement disabled and enabled, and two AWS regions (`eu-central-1` and `us-gov-west-1`).
  * Added new UT & adapted existing ones.
