### PR TITLE
Revert "CB-21047 CB-21018 During freeipa downscale pillars are overwr…

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/pillar/freeipa/init.sls
+++ b/freeipa/src/main/resources/freeipa-salt/pillar/freeipa/init.sls
@@ -1,0 +1,19 @@
+freeipa:
+  domain: testdomain
+  password: pwpwpw
+  dnssecValidationEnabled: true
+  realm: testrealm
+  admin_user: admin
+  freeipa_to_replicate:
+  backup:
+    enabled: false
+    monthly_full_enabled: false
+    hourly_enabled: false
+    initial_full_enabled: false
+    platform:
+    location:
+    azure_instance_msi:
+    gcp_service_account:
+    http_proxy:
+    aws_region:
+    aws_endpoint:

--- a/orchestrator-salt/src/main/resources/salt-common/pillar/fluent/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/pillar/fluent/init.sls
@@ -1,0 +1,35 @@
+fluent:
+  enabled: false
+  user: root
+  group: root
+  serverLogFolderPrefix: /var/log
+  agentLogFolderPrefix: /var/log
+  serviceLogFolderPrefix: /var/log
+  platform:
+  region:
+  providerPrefix: "stdout"
+  partitionIntervalMin: 5
+  logFolderName: cluster-logs
+  clusterName:
+  clusterType: datahub
+  clusterCrn:
+  clusterOwner:
+  clusterVersion:
+  cloudStorageLoggingEnabled: false
+  cloudLoggingServiceEnabled: false
+  s3LogArchiveBucketName:
+  cloudwatchStreamKey: hostname
+  azureStorageAccount:
+  azureContainer:
+  azureInstanceMsi:
+  azureIdBrokerInstanceMsi:
+  azureStorageAccessKey:
+  dbusClusterLogsCollection: false
+  dbusClusterLogsCollectionDisableStop: false
+  dbusMeteringEnabled: false
+  dbusMeteringAppName:
+  dbusMeteringStreamName:
+  dbusMonitoringEnabled: false
+  dbusIncludeSaltLogs: false
+  anonymizationRules:
+

--- a/orchestrator-salt/src/main/resources/salt-common/pillar/telemetry/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/pillar/telemetry/init.sls
@@ -1,0 +1,7 @@
+telemetry:
+  clusterName:
+  clusterType: datahub
+  clusterCrn:
+  clusterOwner:
+  clusterVersion:
+


### PR DESCRIPTION
…itten with dummy data"

GCP env creation tests failed with: Specified SLS 'telemetry.init' in environment 'base' is not available on the salt master.

This reverts commit b1befe491121fc02b5eb66d63493a5b61fdd7734.

See detailed description in the commit message.