### PR TITLE
CB-21089 Configure salt master worker threads

### DIFF
--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/model/BootstrapParams.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/model/BootstrapParams.java
@@ -1,6 +1,11 @@
 package com.sequenceiq.cloudbreak.orchestrator.model;
 
 public class BootstrapParams {
+
+    public static final int DEFAULT_WORKER_THREADS = 5;
+
+    public static final int WORKER_THREAD_REDUCTION_COUNT = 4;
+
     private String cloud;
 
     private String os;
@@ -10,6 +15,8 @@ public class BootstrapParams {
     private boolean restartNeededFlagSupported;
 
     private boolean restartNeeded;
+
+    private int masterWorkerThreads = DEFAULT_WORKER_THREADS;
 
     public String getCloud() {
         return cloud;
@@ -51,12 +58,23 @@ public class BootstrapParams {
         this.restartNeeded = restartNeeded;
     }
 
+    public int getMasterWorkerThreads() {
+        return masterWorkerThreads;
+    }
+
+    public void setMasterWorkerThreads(int masterWorkerThreads) {
+        this.masterWorkerThreads = masterWorkerThreads;
+    }
+
     @Override
     public String toString() {
         return "BootstrapParams{" +
                 "cloud='" + cloud + '\'' +
                 ", os='" + os + '\'' +
                 ", saltBootstrapFpSupported=" + saltBootstrapFpSupported +
+                ", restartNeededFlagSupported=" + restartNeededFlagSupported +
+                ", restartNeeded=" + restartNeeded +
+                ", masterWorkerThreads=" + masterWorkerThreads +
                 '}';
     }
 }

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestratorTest.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestratorTest.java
@@ -189,14 +189,14 @@ class SaltOrchestratorTest {
 
     @Test
     void bootstrapTest() throws Exception {
-        when(compressUtil.generateCompressedOutputFromFolders("salt-common", "salt")).thenReturn(new byte[]{});
+        when(compressUtil.generateCompressedOutputFromFolders("salt-common", "salt")).thenReturn(new byte[] {});
 
         BootstrapParams bootstrapParams = mock(BootstrapParams.class);
         List<GatewayConfig> allGatewayConfigs = Collections.singletonList(gatewayConfig);
 
         saltOrchestrator.bootstrap(allGatewayConfigs, targets, bootstrapParams, exitCriteriaModel);
 
-        verify(saltRunner, times(4)).runnerWithConfiguredErrorCount(any(OrchestratorBootstrap.class), any(ExitCriteria.class), any(ExitCriteriaModel.class));
+        verify(saltRunner, times(5)).runnerWithConfiguredErrorCount(any(OrchestratorBootstrap.class), any(ExitCriteria.class), any(ExitCriteriaModel.class));
         // salt.zip, master_sign.pem, master_sign.pub
         verify(saltBootstrapFactory, times(1)).of(eq(saltConnector), eq(saltConnectors), eq(allGatewayConfigs), eq(targets),
                 eq(bootstrapParams));
@@ -266,12 +266,12 @@ class SaltOrchestratorTest {
     @Test
     void bootstrapNewNodesTest() throws Exception {
         BootstrapParams bootstrapParams = mock(BootstrapParams.class);
-        when(compressUtil.generateCompressedOutputFromFolders("salt-common", "salt")).thenReturn(new byte[]{});
+        when(compressUtil.generateCompressedOutputFromFolders("salt-common", "salt")).thenReturn(new byte[] {});
 
         saltOrchestrator.bootstrapNewNodes(Collections.singletonList(gatewayConfig), targets, targets, null, bootstrapParams, exitCriteriaModel);
 
         verify(saltRunner, times(1)).runner(any(OrchestratorBootstrap.class), any(ExitCriteria.class), any(ExitCriteriaModel.class));
-        verify(saltRunner, times(3)).runnerWithConfiguredErrorCount(any(OrchestratorBootstrap.class), any(ExitCriteria.class), any(ExitCriteriaModel.class));
+        verify(saltRunner, times(4)).runnerWithConfiguredErrorCount(any(OrchestratorBootstrap.class), any(ExitCriteria.class), any(ExitCriteriaModel.class));
         verify(saltBootstrapFactory, times(1))
                 .of(eq(saltConnector), eq(saltConnectors), eq(Collections.singletonList(gatewayConfig)), eq(targets), eq(bootstrapParams));
     }


### PR DESCRIPTION
Configure salt master worker threads during. The motivation is to add more threads to salt master for better performance on bigger instances. This takes effect during cluster creation or during node repair when the user repairs the node where salt master is running.