### PR TITLE
CDPSDX-3978 Mark flow as failed when cancel datalake backup during re…

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/DatalakeBackupActions.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/DatalakeBackupActions.java
@@ -288,6 +288,8 @@ public class DatalakeBackupActions {
                 SdxCluster sdxCluster = sdxStatusService.setStatusForDatalakeAndNotify(DatalakeStatusEnum.RUNNING,
                         ResourceEvent.DATALAKE_BACKUP_CANCELLED,
                         "Datalake backup cancelled", payload.getResourceId());
+                Flow flow = getFlow(context.getFlowParameters().getFlowId());
+                flow.setFlowFailed(new Exception("Datalake backup cancelled"));
             }
 
             @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxResizeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxResizeTests.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.it.cloudbreak.testcase.mock;
 
+import static com.sequenceiq.it.cloudbreak.assertion.CBAssertion.assertEquals;
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
 
 import javax.inject.Inject;
@@ -18,6 +19,7 @@ import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.util.SdxUtil;
 import com.sequenceiq.it.cloudbreak.util.resize.SdxResizeTestValidator;
+import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
 import com.sequenceiq.sdx.api.model.SdxClusterShape;
 import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 
@@ -32,16 +34,22 @@ public class MockSdxResizeTests extends AbstractMockTest {
     @Inject
     private SdxUtil sdxUtil;
 
-    private String sdxName;
-
     @Override
     protected void setupTest(TestContext testContext) {
-        sdxName = resourcePropertyProvider().getName();
-
         createDefaultUser(testContext);
         createDefaultCredential(testContext);
         createDefaultImageCatalog(testContext);
+    }
 
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
+    @Description(
+            given = "there is a running Cloudbreak",
+            when = "a valid SDX Resize request is sent",
+            then = "Resized SDX should be available AND deletable"
+    )
+    public void testDefaultSDXResizeSuccessfully(MockedTestContext testContext) {
+        String sdxName = resourcePropertyProvider().getName();
+        SdxResizeTestValidator resizeTestValidator = new SdxResizeTestValidator(SdxClusterShape.LIGHT_DUTY);
         testContext
                 .given(EnvironmentTestDto.class)
                 .withNetwork()
@@ -56,18 +64,6 @@ public class MockSdxResizeTests extends AbstractMockTest {
                 .given(sdxName, SdxInternalTestDto.class)
                 .when(sdxTestClient.createInternal(), key(sdxName))
                 .await(SdxClusterStatusResponse.RUNNING, key(sdxName))
-                .validate();
-    }
-
-    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
-    @Description(
-            given = "there is a running Cloudbreak",
-            when = "a valid SDX Resize request is sent",
-            then = "Resized SDX should be available AND deletable"
-    )
-    public void testDefaultSDXResizeSuccessfully(MockedTestContext testContext) {
-        SdxResizeTestValidator resizeTestValidator = new SdxResizeTestValidator(SdxClusterShape.LIGHT_DUTY);
-        testContext
                 .given(sdxName, SdxInternalTestDto.class)
                 .then((tc, testDto, client) -> {
                     resizeTestValidator.setExpectedCrn(sdxUtil.getCrn(testDto, client));
@@ -82,6 +78,47 @@ public class MockSdxResizeTests extends AbstractMockTest {
                 .await(SdxClusterStatusResponse.DATALAKE_RESTORE_INPROGRESS, key(sdxName).withWaitForFlow(Boolean.FALSE))
                 .await(SdxClusterStatusResponse.RUNNING, key(sdxName).withWaitForFlow(Boolean.FALSE))
                 .then((tc, dto, client) -> resizeTestValidator.validateResizedCluster(dto))
+                .validate();
+    }
+
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
+    @Description(
+            given = "there is a running Cloudbreak",
+            when = "a valid SDX Resize request is sent but cancel datalake backup is called during the backup process",
+            then = "stack status reason should be datalake cancelled when stack turns back to be RUNNING"
+    )
+    public void testFailedSDXResizeWithBackupCancelled(MockedTestContext testContext) {
+        String sdxName = resourcePropertyProvider().getName();
+        SdxResizeTestValidator resizeTestValidator = new SdxResizeTestValidator(SdxClusterShape.LIGHT_DUTY);
+        testContext
+                .given(EnvironmentTestDto.class)
+                .withNetwork()
+                .withCreateFreeIpa(Boolean.FALSE)
+                .withName(resourcePropertyProvider().getEnvironmentName())
+                .withBackup("mock://location/of/the/backup/cancel")
+                .when(getEnvironmentTestClient().create())
+                .await(EnvironmentStatus.AVAILABLE)
+                .given(FreeIpaTestDto.class)
+                .when(freeIpaTestClient.create())
+                .await(Status.AVAILABLE)
+                .given(sdxName, SdxInternalTestDto.class)
+                .when(sdxTestClient.createInternal(), key(sdxName))
+                .await(SdxClusterStatusResponse.RUNNING, key(sdxName))
+                .given(sdxName, SdxInternalTestDto.class)
+                .then((tc, testDto, client) -> {
+                    resizeTestValidator.setExpectedCrn(sdxUtil.getCrn(testDto, client));
+                    resizeTestValidator.setExpectedName(testDto.getName());
+                    resizeTestValidator.setExpectedRuntime(sdxUtil.getRuntime(testDto, client));
+                    return testDto;
+                })
+                .when(sdxTestClient.resize(), key(sdxName))
+                .await(SdxClusterStatusResponse.DATALAKE_BACKUP_INPROGRESS, key(sdxName).withWaitForFlow(Boolean.FALSE))
+                .await(SdxClusterStatusResponse.RUNNING, key(sdxName).withWaitForFlow(Boolean.FALSE))
+                .then((tc, testDto, client) -> {
+                    SdxClusterDetailResponse sdx = testDto.getResponse();
+                    assertEquals(sdx.getStatusReason(), "Datalake backup cancelled");
+                    return testDto;
+                })
                 .validate();
     }
 }

--- a/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/datalakedr/MockDatalakeDrService.java
+++ b/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/datalakedr/MockDatalakeDrService.java
@@ -37,12 +37,21 @@ public class MockDatalakeDrService extends datalakeDRGrpc.datalakeDRImplBase {
     @Override
     public void backupDatalake(datalakeDRProto.BackupDatalakeRequest request, StreamObserver<datalakeDRProto.BackupDatalakeResponse> responseObserver) {
         LOGGER.info("Backing up for {}", request.getBackupName());
+        String backupLocaiton = request.getBackupLocation();
         UUID id = UUID.randomUUID();
-        mockStatusDatabase.put(id.toString(), DatalakeOperationStatus.State.STARTED);
-        responseObserver.onNext(datalakeDRProto.BackupDatalakeResponse.newBuilder()
-                .setBackupName(request.getBackupName())
-                .setBackupId(id.toString())
-                .setOverallState(DatalakeOperationStatus.State.STARTED.name()).build());
+        if (!backupLocaiton.contains("/cancel")) {
+            mockStatusDatabase.put(id.toString(), DatalakeOperationStatus.State.STARTED);
+            responseObserver.onNext(datalakeDRProto.BackupDatalakeResponse.newBuilder()
+                    .setBackupName(request.getBackupName())
+                    .setBackupId(id.toString())
+                    .setOverallState(DatalakeOperationStatus.State.STARTED.name()).build());
+        } else {
+            mockStatusDatabase.put(id.toString(), DatalakeOperationStatus.State.CANCELLED);
+            responseObserver.onNext(datalakeDRProto.BackupDatalakeResponse.newBuilder()
+                    .setBackupName(request.getBackupName())
+                    .setBackupId(id.toString())
+                    .setOverallState(DatalakeOperationStatus.State.CANCELLED.name()).build());
+        }
         responseObserver.onCompleted();
     }
 

--- a/mock-thunderhead/src/main/resources/application.yml
+++ b/mock-thunderhead/src/main/resources/application.yml
@@ -43,7 +43,7 @@ auth:
       efs.enable: false
       customimage.enable: true
       loadbalancer.enable: true
-      backup.on.upgrade.enable: false
+      backup.on.upgrade.enable: true
       backup.on.resize.enable: true
       light.to.medium.migration.enable: true
       recovery.resize.enable: true


### PR DESCRIPTION
…size/upgrade process

JIRA: https://jira.cloudera.com/browse/CDPSDX-3978

ISSUE: Resize/upgrade continues even if backup for resize/upgrade is cancelled.
SOLUTION: Mark the backup flow as failed when it gets cancelled.

*Cancel restore is not implemented yet so this change is not applied to restore. 

**Manual test:**
Before: resize continues even if backup gets cancelled.
![ResizeBeforeCancelState](https://user-images.githubusercontent.com/39275944/225482003-9ac153a1-748b-41e5-a6de-24bbf4186269.png)

After: resize flowchain didn't continue when backup gets cancelled. 
![resizeAfterCancelfailed](https://user-images.githubusercontent.com/39275944/225481974-ef96bbe5-368d-4ab7-b651-1bd3314148fd.png)

backup floachain didn't continue when backup gets cancelled.
![Screen Shot 2023-04-02 at 10 03 59 PM](https://user-images.githubusercontent.com/39275944/229395363-e2ce1662-e24f-4d32-8090-4df6c774ae97.png)
![Screen Shot 2023-04-02 at 10 03 17 PM](https://user-images.githubusercontent.com/39275944/229395376-cdf6cee6-f0e8-4518-8a9d-b2f6505bef62.png)


