### PR TITLE
CB-20899: Updating Yarn LB image to use new one with better timeout/connection handling.

### DIFF
--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/loadbalancer/service/component/YarnLoadBalancerComponentFactoryService.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/loadbalancer/service/component/YarnLoadBalancerComponentFactoryService.java
@@ -34,7 +34,7 @@ public class YarnLoadBalancerComponentFactoryService {
     /**
      * Must match an existing Docker image in the primary Cloudbreak repository.
      */
-    private final String loadBalancerImageName = "docker-sandbox.infra.cloudera.com/cloudbreak/yarn-loadbalancer:2021-03-23-12-02-09";
+    private final String loadBalancerImageName = "docker-private.infra.cloudera.com/cloudera_thirdparty/yarn-loadbalancer:v1.cldr.1";
 
     private final String loadBalancerImageNameForDEHA = "docker-sandbox.infra.cloudera.com/cloudbreak/yarn-loadbalancer:2021-11-24-16-14-09";
 


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-20899

Simply updates the image used for the Yarn LB. The old image for DEHA is fine as is for now, we are moreso focused on the DL. This is specifically to update it with recent changes I made to the image configuration to increase its timeouts and max connections.

We want this on 2.69 as that is where the current testing is being done and failing. This is of high priority for the QE team.

Let me know if any more info is needed.