### PR TITLE
CB-21175 Extend e2e tests with SafeLogic installation validation

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/safelogic/SafeLogicAssertions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/safelogic/SafeLogicAssertions.java
@@ -1,0 +1,73 @@
+package com.sequenceiq.it.cloudbreak.assertion.safelogic;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
+import com.sequenceiq.common.api.type.InstanceGroupType;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.it.cloudbreak.util.ssh.action.SshSafeLogicActions;
+
+@Component
+public class SafeLogicAssertions {
+
+    @Inject
+    private SshSafeLogicActions sshSafeLogicActions;
+
+    public void validate(TestContext testContext) {
+        SdxTestDto sdxTestDto = testContext.given(SdxTestDto.class);
+        if (sdxTestDto.getResponse() != null) {
+            validate(testContext, getSdxIpAddresses(sdxTestDto));
+        }
+        SdxInternalTestDto sdxInternalTestDto = testContext.given(SdxInternalTestDto.class);
+        if (sdxInternalTestDto.getResponse() != null) {
+            validate(testContext, getSdxIpAddresses(sdxInternalTestDto));
+        }
+        DistroXTestDto distroXTestDto = testContext.given(DistroXTestDto.class);
+        if (distroXTestDto.getResponse() != null) {
+            validate(testContext, getDistroXIpAddresses(distroXTestDto));
+        }
+    }
+
+    private void validate(TestContext testContext, Set<String> ipAddresses) {
+        boolean govCloud = testContext.getCloudProvider().getGovCloud();
+        if (govCloud != sshSafeLogicActions.hasSafeLogicBinaries(ipAddresses)) {
+            throw new TestFailException(govCloud ? "Expected SafeLogic binaries but not found all of them!" : "Expected no SafeLogic binaries but found them!");
+        }
+        if (govCloud != sshSafeLogicActions.hasCryptoComplyForJavaSecurityProvider(ipAddresses)) {
+            throw new TestFailException(govCloud ? "Expected CryptoComplyForJava to be configured" : "Expected CryptoComplyForJava to not be configured");
+        }
+        if (govCloud) {
+            sshSafeLogicActions.validateMaxAESKeyLength(ipAddresses);
+        }
+    }
+
+    private static Set<String> getSdxIpAddresses(SdxInternalTestDto testDto) {
+        return getStackIpAddresses(testDto.getResponse().getStackV4Response());
+    }
+
+    private static Set<String> getSdxIpAddresses(SdxTestDto testDto) {
+        return getStackIpAddresses(testDto.getResponse().getStackV4Response());
+    }
+
+    private static Set<String> getDistroXIpAddresses(DistroXTestDto testDto) {
+        return getStackIpAddresses(testDto.getResponse());
+    }
+
+    private static Set<String> getStackIpAddresses(StackV4Response stack) {
+        return stack.getInstanceGroups().stream()
+                .filter(ig -> ig.getType().equals(InstanceGroupType.GATEWAY))
+                .flatMap(ig -> ig.getMetadata().stream())
+                .map(InstanceMetaDataV4Response::getPrivateIp)
+                .collect(Collectors.toSet());
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXEncryptedVolumeTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXEncryptedVolumeTest.java
@@ -119,7 +119,7 @@ public class DistroXEncryptedVolumeTest extends AbstractE2ETest {
         createDefaultCredential(testContext);
     }
 
-    @AfterMethod(onlyForGroups = "azure_singlerg", dependsOnMethods = { "tearDown", "tearDownSpotValidateTags" })
+    @AfterMethod(onlyForGroups = "azure_singlerg", dependsOnMethods = { "tearDown", "tearDownAbstract"})
     public void singleResourceGroupTearDown(Object[] data) {
         LOGGER.info("Delete the '{}' resource group after test has been done!", resourceGroupForTest);
         deleteResourceGroupCreatedForEnvironment(resourceGroupForTest);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/action/SshSafeLogicActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/action/SshSafeLogicActions.java
@@ -1,0 +1,99 @@
+package com.sequenceiq.it.cloudbreak.util.ssh.action;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.it.cloudbreak.util.ssh.client.SshJClient;
+
+@Component
+public class SshSafeLogicActions extends SshJClient {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SshSafeLogicActions.class);
+
+    private static final String LIST_JRE_EXTENSIONS_COMMAND = "sudo ls ${JAVA_HOME}/jre/lib/ext/";
+
+    private static final Set<String> SAFELOGIC_BINARIES = Set.of("bctls.jar", "ccj.jar");
+
+    private static final String LIST_JAVA_SECURITY_PROVIDERS_COMMAND = "${JAVA_HOME}/bin/jrunscript -e " +
+            "\"providers = java.security.Security.getProviders(); for (p in providers) print(providers[p])\"";
+
+    private static final String CCJ_VERSION_PREFIX = "CCJ version";
+
+    private static final String GET_MAX_AES_KEY_LENGTH_COMMAND = "${JAVA_HOME}/bin/jrunscript -Dcom.safelogic.cryptocomply.fips.approved_only=true -e " +
+            "\"print(javax.crypto.Cipher.getMaxAllowedKeyLength(\\\"AES/CBC/PKCS5Padding\\\"));\"";
+
+    private static final String EXPECTED_MAX_AES_KEY_LENGTH = "2147483647";
+
+    public boolean hasSafeLogicBinaries(Set<String> ipAddresses) {
+        LOGGER.info("Getting SafeLogic binaries on instances {}", ipAddresses);
+        Map<String, Pair<Integer, String>> results = executeCommands(ipAddresses, LIST_JRE_EXTENSIONS_COMMAND);
+        LOGGER.info("List JRE extensions output on instances: {}", results);
+        Boolean result = null;
+
+        for (String ip : ipAddresses) {
+            if (!results.containsKey(ip) || results.get(ip).getKey() != 0) {
+                throw new TestFailException("Failed to list SafeLogic binaries on instance " + ip);
+            }
+            String commandResult = results.get(ip).getValue();
+            LOGGER.debug("Found JRE extensions on node {}: {}", ip, commandResult);
+            boolean allSafeLogicBinariesInstalled = Set.of(commandResult.split("\\s+")).containsAll(SAFELOGIC_BINARIES);
+            if (result != null && result != allSafeLogicBinariesInstalled) {
+                throw new TestFailException("SafeLogic binary installation is not matching on all instances");
+            }
+            result = allSafeLogicBinariesInstalled;
+        }
+
+        return Boolean.TRUE.equals(result);
+    }
+
+    public boolean hasCryptoComplyForJavaSecurityProvider(Set<String> ipAddresses) {
+        LOGGER.info("Getting Java security providers on instances {}", ipAddresses);
+        Map<String, Pair<Integer, String>> results = executeCommands(ipAddresses, LIST_JAVA_SECURITY_PROVIDERS_COMMAND);
+        LOGGER.info("List Java security providers output on instances: {}", results);
+        Boolean result = null;
+
+        for (String ip : ipAddresses) {
+            if (!results.containsKey(ip) || results.get(ip).getKey() != 0) {
+                throw new TestFailException("Failed to list Java security providers on instance " + ip);
+            }
+            String commandResult = results.get(ip).getValue();
+            LOGGER.debug("Found Java security providers on node {}: {}", ip, commandResult);
+            boolean cryptoComplyForJavaConfigured = commandResult.startsWith(CCJ_VERSION_PREFIX);
+            if (result != null && result != cryptoComplyForJavaConfigured) {
+                throw new TestFailException("CryptoComply configuration is not matching on all instances");
+            }
+            result = cryptoComplyForJavaConfigured;
+        }
+
+        return Boolean.TRUE.equals(result);
+    }
+
+    public void validateMaxAESKeyLength(Set<String> ipAddresses) {
+        LOGGER.info("Getting max AES key length on instances {}", ipAddresses);
+        Map<String, Pair<Integer, String>> results = executeCommands(ipAddresses, GET_MAX_AES_KEY_LENGTH_COMMAND);
+        LOGGER.info("Get max AES key length output on instances: {}", results);
+        String result = null;
+
+        for (String ip : ipAddresses) {
+            if (!results.containsKey(ip) || results.get(ip).getKey() != 0) {
+                throw new TestFailException("Failed to get max AES key length on instance " + ip);
+            }
+            String commandResult = results.get(ip).getValue().trim();
+            LOGGER.debug("Max AES key length on node {}: {}", ip, commandResult);
+            if (result != null && !result.equals(commandResult)) {
+                throw new TestFailException("Max AES key length is not matching on all instances");
+            }
+            result = commandResult;
+        }
+
+        if (!EXPECTED_MAX_AES_KEY_LENGTH.equals(result)) {
+            throw new TestFailException(String.format("Max AES key length %s not matching expected value %s", result, EXPECTED_MAX_AES_KEY_LENGTH));
+        }
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/action/SshSaltPasswordActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/action/SshSaltPasswordActions.java
@@ -2,7 +2,6 @@ package com.sequenceiq.it.cloudbreak.util.ssh.action;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -57,11 +56,5 @@ public class SshSaltPasswordActions extends SshJClient {
                 .map(result -> LocalDate.parse(result.getValue().trim(), CHAGE_DATE_PATTERN))
                 .min(LocalDate::compareTo)
                 .orElseThrow(() -> new TestFailException("Failed to get password expiry date on nodes " + ipAddresses));
-    }
-
-    private Map<String, Pair<Integer, String>> executeCommands(Set<String> ipAddresses, String command) {
-        Map<String, Pair<Integer, String>> results = new HashMap<>();
-        ipAddresses.forEach(ipAddress -> results.put(ipAddress, executeCommand(ipAddress, command)));
-        return results;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/client/SshJClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/client/SshJClient.java
@@ -6,6 +6,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.PostConstruct;
@@ -118,6 +121,12 @@ public class SshJClient {
             LOGGER.error("SSH fail on [{}] while executing command [{}]. {}", instanceIP, command, e.getMessage());
             throw new TestFailException(" SSH fail on [" + instanceIP + "] while executing command [" + command + "].", e);
         }
+    }
+
+    protected Map<String, Pair<Integer, String>> executeCommands(Set<String> ipAddresses, String command) {
+        Map<String, Pair<Integer, String>> results = new HashMap<>();
+        ipAddresses.forEach(ipAddress -> results.put(ipAddress, executeCommand(ipAddress, command)));
+        return results;
     }
 
     private Session startSshSession(SSHClient ssh) throws ConnectionException, TransportException {


### PR DESCRIPTION
After tests have run, Datalake and Datahub resources are checked for SafeLogic installation. They must be on gov clusters, but must not be on commercial clusters.

Depends on https://github.com/hortonworks/cloudbreak/pull/14402 