### PR TITLE
CB-21149 Change FreeIPA `nsslapd-db-deadlock-policy`

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/templates/initial-ldap-conf.ldif
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/templates/initial-ldap-conf.ldif
@@ -4,6 +4,12 @@ replace: nsslapd-db-locks
 nsslapd-db-locks: 200000
 
 
+dn: cn=config,cn=ldbm database,cn=plugins,cn=config
+changetype: modify
+replace: nsslapd-db-deadlock-policy
+nsslapd-db-deadlock-policy: 6
+
+
 dn: cn=config
 changetype: modify
 replace: nsslapd-sizelimit


### PR DESCRIPTION
Changing `nsslapd-db-deadlock-policy` to `6` which prefers writes against reads. We expect to see a more stable replication, as repliaction requires great number of writes. Config values available here: https://github.com/berkeleydb/libdb/blob/5b7b02ae052442626af54c176335b67ecc613a30/src/dbinc/db.in#L287-L300 
Default value is `9`

See detailed description in the commit message.