### PR TITLE
CB-21204 Increase SSSD heartbeat timeout to support more users/groups

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/SssdConfigProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/SssdConfigProvider.java
@@ -26,6 +26,9 @@ public class SssdConfigProvider {
     @Value("${sssd.memcache.timeout}")
     private int memcacheTimeout;
 
+    @Value("${sssd.heartbeat.timeout}")
+    private int heartbeatTimeout;
+
     @Inject
     private FreeIpaConfigProvider freeIpaConfigProvider;
 
@@ -50,6 +53,7 @@ public class SssdConfigProvider {
             sssdConfig.put("enumerate", enumerate);
             sssdConfig.put("entryCacheTimeout", entryCacheTimeout);
             sssdConfig.put("memcacheTimeout", memcacheTimeout);
+            sssdConfig.put("heartbeatTimeout", heartbeatTimeout);
             Map<String, Object> freeIpaConfig = freeIpaConfigProvider.createFreeIpaConfig(environmentCrn);
             return Map.of("sssd-ipa", new SaltPillarProperties("/sssd/ipa.sls",
                     Map.of("sssd-ipa", sssdConfig, "freeipa", freeIpaConfig)));

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -911,6 +911,7 @@ clusterdns:
 sssd:
   entry.cache.timeout: 300
   memcache.timeout: 300
+  heartbeat.timeout: 60
 
 cdp:
   structuredevent:

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/SssdConfigProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/SssdConfigProviderTest.java
@@ -30,6 +30,8 @@ class SssdConfigProviderTest {
 
     private static final int MEMCACHE_TIMEOUT = 400;
 
+    private static final int HEARTBEAT_TIMEOUT = 60;
+
     private static final int DNS_TTL = 30;
 
     private static final String ENV_CRN = "envCrn";
@@ -47,6 +49,7 @@ class SssdConfigProviderTest {
     public void init() {
         ReflectionTestUtils.setField(underTest, "entryCacheTimeout", ENTRY_CACHE_TIMEOUT);
         ReflectionTestUtils.setField(underTest, "memcacheTimeout", MEMCACHE_TIMEOUT);
+        ReflectionTestUtils.setField(underTest, "heartbeatTimeout", HEARTBEAT_TIMEOUT);
     }
 
     @Test
@@ -115,6 +118,7 @@ class SssdConfigProviderTest {
         assertEquals(DNS_TTL, sssdConfig.get("dns_ttl"));
         assertEquals(ENTRY_CACHE_TIMEOUT, sssdConfig.get("entryCacheTimeout"));
         assertEquals(MEMCACHE_TIMEOUT, sssdConfig.get("memcacheTimeout"));
+        assertEquals(HEARTBEAT_TIMEOUT, sssdConfig.get("heartbeatTimeout"));
 
         Map<String, Object> freeIpaConfigResult = (Map<String, Object>) properties.get("freeipa");
         assertEquals(freeIpaConfig, freeIpaConfigResult);

--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/template/sssd-ipa.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/template/sssd-ipa.j2
@@ -25,3 +25,5 @@ ldap_tls_cacert = /etc/ipa/ca.crt
 ipa_hostname = {{ salt['grains.get']('fqdn') }}
 enumerate = {{ pillar['sssd-ipa']['enumerate'] }}
 entry_cache_timeout = {{ pillar['sssd-ipa']['entryCacheTimeout'] }}
+timeout = {{ pillar['sssd-ipa']['heartbeatTimeout'] | default(60, true) }}
+


### PR DESCRIPTION
SSSD enumeration takes more time as the number of users/groups increases. At some point the sssd watchdog will assume that enumeration is stuck and kill the process. Enumeration will begin again, but will consistently be killed by the watchdog. The new value will be 60sec.

```
   Options usable in SERVICE and DOMAIN sections
       timeout (integer)
           Timeout in seconds between heartbeats for this service. This is used to ensure that the process is alive and
           capable of answering requests. Note that after three missed heartbeats the process will terminate itself.

           Default: 10
```

See detailed description in the commit message.