### PR TITLE
CB-21196: Optimize FreeIPA StackRepository.findByAccountId query

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/PasswordService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/PasswordService.java
@@ -24,6 +24,7 @@ import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.auth.crn.RegionAwareInternalCrnGeneratorFactory;
 import com.sequenceiq.cloudbreak.cloud.event.model.EventStatus;
+import com.sequenceiq.cloudbreak.common.dal.ResourceBasicView;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.common.service.Clock;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
@@ -34,7 +35,6 @@ import com.sequenceiq.freeipa.api.v1.operation.model.OperationState;
 import com.sequenceiq.freeipa.api.v1.operation.model.OperationType;
 import com.sequenceiq.freeipa.configuration.UsersyncConfig;
 import com.sequenceiq.freeipa.entity.Operation;
-import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.flow.freeipa.user.event.SetPasswordRequest;
 import com.sequenceiq.freeipa.flow.freeipa.user.event.SetPasswordResult;
 import com.sequenceiq.freeipa.service.freeipa.flow.FreeIpaFlowManager;
@@ -77,21 +77,16 @@ public class PasswordService {
     @Inject
     private RegionAwareInternalCrnGeneratorFactory regionAwareInternalCrnGeneratorFactory;
 
-    public Operation setPassword(String accountId, String userCrn, String password, Set<String> environmentCrnFilter) {
-        List<Stack> stacks = getStacksForSetPassword(accountId, userCrn, password, environmentCrnFilter);
-        return setPasswordForStacks(accountId, userCrn, password, environmentCrnFilter, stacks);
-    }
-
     public Operation setPasswordWithCustomPermissionCheck(String accountId, String userCrn,
             String password, Set<String> environmentCrnFilter, AuthorizationResourceAction action) {
-        List<Stack> stacks = getStacksForSetPassword(accountId, userCrn, password, environmentCrnFilter);
-        List<String> relatedEnvironmentCrns = stacks.stream().map(Stack::getEnvironmentCrn).collect(Collectors.toList());
+        List<ResourceBasicView> stacks = getStacksForSetPassword(accountId, userCrn, password, environmentCrnFilter);
+        List<String> relatedEnvironmentCrns = stacks.stream().map(ResourceBasicView::getEnvironmentCrn).collect(Collectors.toList());
         customCheckUtil.run(userCrn, () -> commonPermissionCheckingUtils.checkPermissionForUserOnResources(action, userCrn, relatedEnvironmentCrns));
         return setPasswordForStacks(accountId, userCrn, password, environmentCrnFilter, stacks);
     }
 
-    private Operation setPasswordForStacks(String accountId, String userCrn, String password,
-            Set<String> environmentCrnFilter, List<Stack> stacks) {
+    private Operation setPasswordForStacks(String accountId, String userCrn, String password, Set<String> environmentCrnFilter,
+            List<ResourceBasicView> stacks) {
         Operation operation = operationService.startOperation(accountId, OperationType.SET_PASSWORD,
                 environmentCrnFilter, List.of(userCrn));
         if (operation.getStatus() == OperationState.RUNNING) {
@@ -100,10 +95,12 @@ public class PasswordService {
         return operation;
     }
 
-    private List<Stack> getStacksForSetPassword(String accountId, String userCrn, String password, Set<String> environmentCrnFilter) {
+    private List<ResourceBasicView> getStacksForSetPassword(String accountId, String userCrn, String password, Set<String> environmentCrnFilter) {
         LOGGER.debug("setting password for user {} in account {}", userCrn, accountId);
         freeIpaPasswordValidator.validate(password);
-        List<Stack> stacks = stackService.getMultipleByEnvironmentCrnOrChildEnvironmantCrnAndAccountId(environmentCrnFilter, accountId);
+        List<ResourceBasicView> stacks = environmentCrnFilter.isEmpty() ?
+                stackService.findAllResourceBasicViewByAccountId(accountId) :
+                stackService.findAllResourceBasicViewByEnvironmentAccountId(environmentCrnFilter, accountId);
         if (stacks.isEmpty()) {
             LOGGER.warn("No stacks found for accountId {}", accountId);
             throw new NotFoundException("No matching FreeIPA stacks found for accountId " + accountId);
@@ -112,7 +109,7 @@ public class PasswordService {
         return stacks;
     }
 
-    private void asyncSetPasswords(String operationId, String accountId, String userCrn, String password, List<Stack> stacks) {
+    private void asyncSetPasswords(String operationId, String accountId, String userCrn, String password, List<ResourceBasicView> stacks) {
         try {
             MDCBuilder.addOperationId(operationId);
             usersyncExternalTaskExecutor.submit(() -> internalSetPasswords(operationId, accountId, userCrn, password, stacks));
@@ -121,14 +118,14 @@ public class PasswordService {
         }
     }
 
-    private void internalSetPasswords(String operationId, String accountId, String userCrn, String password, List<Stack> stacks) {
+    private void internalSetPasswords(String operationId, String accountId, String userCrn, String password, List<ResourceBasicView> stacks) {
         try {
             String userId = getUserIdFromUserCrn(userCrn);
 
             Optional<Instant> expirationInstant = calculateExpirationTime(userCrn, accountId);
 
             List<SetPasswordRequest> requests = new ArrayList<>();
-            for (Stack stack : stacks) {
+            for (ResourceBasicView stack : stacks) {
                 requests.add(triggerSetPassword(stack, stack.getEnvironmentCrn(), userId, userCrn, password, expirationInstant));
             }
 
@@ -179,33 +176,33 @@ public class PasswordService {
     private Optional<UserManagementProto.WorkloadPasswordPolicy> getPasswordPolicyForUser(UserManagementProto.Account account, String userCrn) {
         Crn crn = Crn.safeFromString(userCrn);
         switch (crn.getResourceType()) {
-            case USER:
-                return account.hasGlobalPasswordPolicy() ? Optional.of(account.getGlobalPasswordPolicy()) : Optional.empty();
-            case MACHINE_USER:
-                if (account.hasMachineUserPasswordPolicy()) {
-                    return Optional.of(account.getMachineUserPasswordPolicy());
-                }
-                return account.hasGlobalPasswordPolicy() ? Optional.of(account.getGlobalPasswordPolicy()) : Optional.empty();
-            default:
-                throw new IllegalArgumentException(String.format("UserCrn %s is not of resource type USER or MACHINE_USER", userCrn));
+        case USER:
+            return account.hasGlobalPasswordPolicy() ? Optional.of(account.getGlobalPasswordPolicy()) : Optional.empty();
+        case MACHINE_USER:
+            if (account.hasMachineUserPasswordPolicy()) {
+                return Optional.of(account.getMachineUserPasswordPolicy());
+            }
+            return account.hasGlobalPasswordPolicy() ? Optional.of(account.getGlobalPasswordPolicy()) : Optional.empty();
+        default:
+            throw new IllegalArgumentException(String.format("UserCrn %s is not of resource type USER or MACHINE_USER", userCrn));
         }
     }
 
     private String getUserIdFromUserCrn(String userCrn) {
         Crn crn = Crn.safeFromString(userCrn);
         switch (crn.getResourceType()) {
-            case USER:
-                return umsClient.getUserDetails(userCrn, regionAwareInternalCrnGeneratorFactory).getWorkloadUsername();
-            case MACHINE_USER:
-                return umsClient.getMachineUserDetails(userCrn,
-                        Crn.fromString(userCrn).getAccountId(),
-                        regionAwareInternalCrnGeneratorFactory).getWorkloadUsername();
-            default:
-                throw new IllegalArgumentException(String.format("UserCrn %s is not of resource type USER or MACHINE_USER", userCrn));
+        case USER:
+            return umsClient.getUserDetails(userCrn, regionAwareInternalCrnGeneratorFactory).getWorkloadUsername();
+        case MACHINE_USER:
+            return umsClient.getMachineUserDetails(userCrn,
+                    Crn.fromString(userCrn).getAccountId(),
+                    regionAwareInternalCrnGeneratorFactory).getWorkloadUsername();
+        default:
+            throw new IllegalArgumentException(String.format("UserCrn %s is not of resource type USER or MACHINE_USER", userCrn));
         }
     }
 
-    private SetPasswordRequest triggerSetPassword(Stack stack, String environment, String username, String userCrn,
+    private SetPasswordRequest triggerSetPassword(ResourceBasicView stack, String environment, String username, String userCrn,
             String password, Optional<Instant> expirationInstant) {
         SetPasswordRequest request = new SetPasswordRequest(stack.getId(), environment, username, userCrn, password, expirationInstant);
         freeIpaFlowManager.notifyNonFlowEvent(request);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncService.java
@@ -176,7 +176,7 @@ public class UserSyncService {
         userSyncRequestValidator.validateParameters(accountId, actorCrn, environmentCrnFilter, userSyncRequestFilter);
         LOGGER.debug("Synchronizing users in account {} for environmentCrns {}, user sync filter {}", accountId, environmentCrnFilter, userSyncRequestFilter);
 
-        List<Stack> stacks = stackService.getMultipleByEnvironmentCrnOrChildEnvironmantCrnAndAccountId(environmentCrnFilter, accountId);
+        List<Stack> stacks = stackService.getMultipleByEnvironmentCrnOrChildEnvironmentCrnAndAccountId(environmentCrnFilter, accountId);
         if (stacks.isEmpty()) {
             throw new NotFoundException(String.format("No matching FreeIPA stacks found for account %s with environment crn filter %s",
                     accountId, environmentCrnFilter));

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
@@ -39,7 +39,6 @@ import com.sequenceiq.common.api.telemetry.model.Telemetry;
 import com.sequenceiq.common.api.type.Tunnel;
 import com.sequenceiq.flow.core.PayloadContextProvider;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.dto.StackIdWithStatus;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.repository.StackRepository;
@@ -141,16 +140,12 @@ public class StackService implements EnvironmentPropertyProvider, PayloadContext
         return stacks;
     }
 
-    public List<Stack> getMultipleByEnvironmentCrnOrChildEnvironmantCrnAndAccountId(Collection<String> environmentCrns, String accountId) {
+    public List<Stack> getMultipleByEnvironmentCrnOrChildEnvironmentCrnAndAccountId(Collection<String> environmentCrns, String accountId) {
         if (environmentCrns.isEmpty()) {
             return Lists.newArrayList(getAllByAccountId(accountId));
         } else {
             return stackRepository.findMultipleByEnvironmentCrnOrChildEnvironmentCrnAndAccountId(environmentCrns, accountId);
         }
-    }
-
-    public List<Stack> getMultipleDistinctByEnvironmentCrnsAndAccountIdWithList(Collection<String> environmentCrns, String accountId) {
-        return stackRepository.findMultipleDistinctByEnvironmentCrnsAndAccountIdWithList(environmentCrns, accountId);
     }
 
     public List<Stack> getByEnvironmentCrnsAndCloudPlatforms(Collection<String> environmentCrns, Collection<CloudPlatform> cloudPlatforms) {
@@ -160,21 +155,6 @@ public class StackService implements EnvironmentPropertyProvider, PayloadContext
 
     public List<Stack> findAllByEnvironmentCrnAndAccountId(String environmentCrn, String accountId) {
         return stackRepository.findAllByEnvironmentCrnAndAccountId(environmentCrn, accountId);
-    }
-
-    public List<Long> findAllIdByEnvironmentCrnAndAccountId(String environmentCrn, String accountId) {
-        return stackRepository.findAllIdByEnvironmentCrnAndAccountId(environmentCrn, accountId);
-    }
-
-    public Long getIdByEnvironmentCrnAndAccountId(String environmentCrn, String accountId) {
-        List<Long> ids = stackRepository.findAllIdByEnvironmentCrnAndAccountId(environmentCrn, accountId);
-        if (ids.isEmpty()) {
-            throw new NotFoundException(String.format("FreeIPA stack by environment [%s] not found", environmentCrn));
-        } else if (ids.size() > 1) {
-            throw new BadRequestException(String.format("Multiple FreeIPA stack by environment [%s] found", environmentCrn));
-        } else {
-            return ids.get(0);
-        }
     }
 
     public ResourceBasicView getResourceBasicViewByEnvironmentCrnAndAccountId(String environmentCrn, String accountId) {
@@ -203,28 +183,21 @@ public class StackService implements EnvironmentPropertyProvider, PayloadContext
         return stackRepository.findByAccountId(accountId);
     }
 
+    public List<ResourceBasicView> findAllResourceBasicViewByAccountId(String accountId) {
+        return stackRepository.findAllResourceBasicViewByAccountId(accountId);
+    }
+
+    public List<ResourceBasicView> findAllResourceBasicViewByEnvironmentAccountId(Collection<String> environmentCrns,
+            String accountId) {
+        return stackRepository.findMultipleResourceBasicViewByEnvironmentCrnOrChildEnvironmentCrnAndAccountId(environmentCrns, accountId);
+    }
+
     public List<StackIdWithStatus> getStatuses(Set<Long> stackIds) {
         return stackRepository.findStackStatusesWithoutAuth(stackIds);
     }
 
-    public List<Stack> findAllWithStatuses(Collection<Status> statuses) {
-        return stackRepository.findAllWithStatuses(statuses);
-    }
-
     public List<Stack> findAllWithDetailedStackStatuses(Collection<DetailedStackStatus> detailedStackStatuses) {
         return stackRepository.findAllWithDetailedStackStatuses(detailedStackStatuses);
-    }
-
-    public List<Stack> findAllByAccountIdWithStatuses(String accountId, Collection<Status> statuses) {
-        return stackRepository.findByAccountIdWithStatuses(accountId, statuses);
-    }
-
-    public List<Stack> findMultipleByEnvironmentCrnAndAccountIdWithStatuses(Collection<String> environmentCrns, String accountId, Collection<Status> statuses) {
-        if (environmentCrns.isEmpty()) {
-            return findAllByAccountIdWithStatuses(accountId, statuses);
-        } else {
-            return stackRepository.findMultipleByEnvironmentCrnAndAccountIdWithStatuses(environmentCrns, accountId, statuses);
-        }
     }
 
     @Override

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncServiceTest.java
@@ -109,7 +109,7 @@ public class UserSyncServiceTest {
     public void testSyncUsers() {
         Stack stack = mock(Stack.class);
         when(stack.getEnvironmentCrn()).thenReturn(ENV_CRN);
-        when(stackService.getMultipleByEnvironmentCrnOrChildEnvironmantCrnAndAccountId(Set.of(), ACCOUNT_ID)).thenReturn(List.of(stack));
+        when(stackService.getMultipleByEnvironmentCrnOrChildEnvironmentCrnAndAccountId(Set.of(), ACCOUNT_ID)).thenReturn(List.of(stack));
         Operation operation = createRunningOperation();
         when(operationService.startOperation(anyString(), any(OperationType.class), anyCollection(), anyCollection()))
                 .thenReturn(operation);
@@ -160,7 +160,7 @@ public class UserSyncServiceTest {
         Stack stack2 = mock(Stack.class);
         when(stack.getEnvironmentCrn()).thenReturn(ENV_CRN);
         when(stack2.getEnvironmentCrn()).thenReturn(ENV_CRN_2);
-        when(stackService.getMultipleByEnvironmentCrnOrChildEnvironmantCrnAndAccountId(Set.of(ENV_CRN, ENV_CRN_2), ACCOUNT_ID))
+        when(stackService.getMultipleByEnvironmentCrnOrChildEnvironmentCrnAndAccountId(Set.of(ENV_CRN, ENV_CRN_2), ACCOUNT_ID))
                 .thenReturn(List.of(stack, stack2));
         Operation operation = createRunningOperation();
         when(operationService.startOperation(anyString(), any(OperationType.class), anyCollection(), anyCollection()))
@@ -209,7 +209,7 @@ public class UserSyncServiceTest {
     public void testSyncUsersWithCustomPermissionCheck() {
         Stack stack = mock(Stack.class);
         when(stack.getEnvironmentCrn()).thenReturn(ENV_CRN);
-        when(stackService.getMultipleByEnvironmentCrnOrChildEnvironmantCrnAndAccountId(Set.of(), ACCOUNT_ID)).thenReturn(List.of(stack));
+        when(stackService.getMultipleByEnvironmentCrnOrChildEnvironmentCrnAndAccountId(Set.of(), ACCOUNT_ID)).thenReturn(List.of(stack));
         Operation operation = createRunningOperation();
         when(operationService.startOperation(anyString(), any(OperationType.class), anyCollection(), anyCollection()))
                 .thenReturn(operation);
@@ -265,7 +265,7 @@ public class UserSyncServiceTest {
     public void testSyncUsersWithTimeoutCheckTaskFinished() {
         Stack stack = mock(Stack.class);
         when(stack.getEnvironmentCrn()).thenReturn(ENV_CRN);
-        when(stackService.getMultipleByEnvironmentCrnOrChildEnvironmantCrnAndAccountId(Set.of(), ACCOUNT_ID)).thenReturn(List.of(stack));
+        when(stackService.getMultipleByEnvironmentCrnOrChildEnvironmentCrnAndAccountId(Set.of(), ACCOUNT_ID)).thenReturn(List.of(stack));
         Operation operation = createRunningOperation();
         when(operationService.startOperation(anyString(), any(OperationType.class), anyCollection(), anyCollection()))
                 .thenReturn(operation);
@@ -315,7 +315,7 @@ public class UserSyncServiceTest {
     public void testSyncUsersWithTimeoutCheckTaskRunnable() {
         Stack stack = mock(Stack.class);
         when(stack.getEnvironmentCrn()).thenReturn(ENV_CRN);
-        when(stackService.getMultipleByEnvironmentCrnOrChildEnvironmantCrnAndAccountId(Set.of(), ACCOUNT_ID)).thenReturn(List.of(stack));
+        when(stackService.getMultipleByEnvironmentCrnOrChildEnvironmentCrnAndAccountId(Set.of(), ACCOUNT_ID)).thenReturn(List.of(stack));
         Operation operation = createRunningOperation();
         when(operationService.startOperation(anyString(), any(OperationType.class), anyCollection(), anyCollection()))
                 .thenReturn(operation);


### PR DESCRIPTION
In this commit, I introduced some changes to improve the performance of the StackRepository.findByAccountId query.

- I've created a new query for the PasswordService because it does not necessary to retrieve the whole Stack table.
- I've removed the joining of the instanceGroups and instanceMetaData table from the original query.
- Removed some unused queries from the StackRepository