### PR TITLE
CDPSDX-3995 Throw errors when jobs.lookup_jid returns empty response

### DIFF
--- a/mock-infrastructure/src/main/java/com/sequenceiq/mock/salt/response/JobsLookupJidSaltResponse.java
+++ b/mock-infrastructure/src/main/java/com/sequenceiq/mock/salt/response/JobsLookupJidSaltResponse.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.ApplyResponse;
 import com.sequenceiq.mock.salt.SaltResponse;
 
@@ -14,8 +15,10 @@ public class JobsLookupJidSaltResponse implements SaltResponse {
 
     @Override
     public Object run(String mockUuid, Map<String, List<String>> params) throws Exception {
+        ObjectNode mockJson = new ObjectMapper().createObjectNode();
+        mockJson.put("mockField", "mockValue");
         ApplyResponse applyResponse = new ApplyResponse();
-        applyResponse.setResult(List.of(Map.of("data", new ObjectMapper().createObjectNode())));
+        applyResponse.setResult(List.of(Map.of("data", mockJson)));
         return applyResponse;
     }
 

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/SaltJobIdTracker.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/SaltJobIdTracker.java
@@ -19,6 +19,7 @@ import com.sequenceiq.cloudbreak.orchestrator.salt.client.SaltConnector;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.JobState;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.RunningJobsResponse;
 import com.sequenceiq.cloudbreak.orchestrator.salt.poller.checker.SaltJobFailedException;
+import com.sequenceiq.cloudbreak.orchestrator.salt.states.SaltEmptyResponseException;
 import com.sequenceiq.cloudbreak.orchestrator.salt.states.SaltStateService;
 
 public class SaltJobIdTracker implements OrchestratorBootstrap {
@@ -139,6 +140,9 @@ public class SaltJobIdTracker implements OrchestratorBootstrap {
                 LOGGER.debug("The job (jid: {}) completed successfully on every node.", jobId);
                 saltJobRunner.setJobState(JobState.FINISHED);
             }
+        } catch (SaltEmptyResponseException e) {
+            LOGGER.debug("Jid info is empty (jid: {}), this usually occurs due to salt not working properly", jobId, e);
+            saltJobRunner.setJobState(JobState.IN_PROGRESS);
         } catch (RuntimeException e) {
             LOGGER.debug("Fail while checking the result (jid: {}), this usually occurs due to concurrency", jobId, e);
             saltJobRunner.setJobState(JobState.AMBIGUOUS);

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltEmptyResponseException.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltEmptyResponseException.java
@@ -1,0 +1,7 @@
+package com.sequenceiq.cloudbreak.orchestrator.salt.states;
+
+public class SaltEmptyResponseException extends SaltExecutionWentWrongException {
+    public SaltEmptyResponseException(String message) {
+        super(message);
+    }
+}

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStateService.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStateService.java
@@ -159,6 +159,10 @@ public class SaltStateService {
 
     private Multimap<String, Map<String, String>> applyStateJidInfo(SaltConnector sc, String jid) {
         JidInfoResponse jidInfo = sc.run("jobs.lookup_jid", RUNNER, JidInfoResponse.class, "jid", jid);
+        if (jidInfo.isEmpty()) {
+            LOGGER.error("jobs.lookup_jid returns an empty response: {}", jidInfo);
+            throw new SaltEmptyResponseException("jobs.lookup_jid returns an empty response. Please check the salt log.");
+        }
         LOGGER.debug("Salt apply state jid info: {}", jidInfo);
         Map<String, List<RunnerInfo>> states = JidInfoResponseTransformer.getSimpleStates(jidInfo);
         return collectMissingTargets(states);
@@ -166,6 +170,10 @@ public class SaltStateService {
 
     private Multimap<String, Map<String, String>> highStateJidInfo(SaltConnector sc, String jid) {
         JidInfoResponse jidInfo = sc.run("jobs.lookup_jid", RUNNER, JidInfoResponse.class, "jid", jid, "missing", "True");
+        if (jidInfo.isEmpty()) {
+            LOGGER.error("jobs.lookup_jid returns an empty response: {}", jidInfo);
+            throw new SaltEmptyResponseException("jobs.lookup_jid returns an empty response. Please check the salt log.");
+        }
         Map<String, List<RunnerInfo>> states = JidInfoResponseTransformer.getHighStates(jidInfo);
         return collectMissingTargets(states);
     }

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStateServiceTest.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStateServiceTest.java
@@ -607,4 +607,24 @@ class SaltStateServiceTest {
         assertEquals("Salt run command failed", actionFailedException.getMessage());
     }
 
+    @Test
+    void testSaltJobsLookupJidReturnsEmptyResponseWithHighState() {
+        String jobId = "2";
+        JidInfoResponse emptyJidInfo = new JidInfoResponse();
+        when(saltConnector.run(eq("jobs.lookup_jid"), any(), any(), eq("jid"), any(), any(), any())).thenReturn(emptyJidInfo);
+        SaltEmptyResponseException saltEmptyResponseException = Assertions.assertThrows(
+                SaltEmptyResponseException.class, () -> underTest.jidInfo(saltConnector, jobId, StateType.HIGH));
+        assertTrue(saltEmptyResponseException.getMessage().contains("jobs.lookup_jid returns an empty response"));
+    }
+
+    @Test
+    void testSaltJobsLookupJidReturnsEmptyResponseWithSimpleState() {
+        String jobId = "2";
+        JidInfoResponse emptyJidInfo = new JidInfoResponse();
+        when(saltConnector.run(eq("jobs.lookup_jid"), any(), any(), eq("jid"), any())).thenReturn(emptyJidInfo);
+        SaltEmptyResponseException saltEmptyResponseException = Assertions.assertThrows(
+                SaltEmptyResponseException.class, () -> underTest.jidInfo(saltConnector, jobId, StateType.SIMPLE));
+        assertTrue(saltEmptyResponseException.getMessage().contains("jobs.lookup_jid returns an empty response"));
+    }
+
 }


### PR DESCRIPTION
**JIRA:** [CDPSDX-3995](https://jira.cloudera.com/browse/CDPSDX-3995) & [CDPD-50759](https://jira.cloudera.com/browse/CDPD-50759)

**ISSUE:** When we backup a large set of DB data, we dump those data to the local disk. When there's no space in the disk to store that data we should return the backup as failed but we get a successful status. This is caused by salt is not working well when there's no enough space and then it returns an empty response, since the response is empty, we assume there's no error, so we mark it as successful.

**SOLUTION:**  When jobs.lookup_jid  returns an empty response, throws an error, because jobs.lookup_jid should always return something. **[Latest Updates]** However, after we catch the jid empty response exception, we will just mark this job as in progress (using `OrchestratorInProgressException`) rather than failed (`OrchestratorInProgressException`), because salt will treat this job as in progress and continue running it. We will just wait jid info returns something again and continue the job.

**BEFORE:**
Backup is marked as successful even if the database is not backed up successfully.
![Screen Shot 2023-03-30 at 11 18 53 PM](https://user-images.githubusercontent.com/39275944/229014397-e1020be9-ff54-4f71-b4f2-b5de1ae89a8b.png)

**AFTER:**
Backup throws the expected errors. Test updated at 4/11 9:25PM EST:
![Screen Shot 2023-04-11 at 9 10 48 PM](https://user-images.githubusercontent.com/39275944/231323364-361a2fb8-59d4-48e1-b891-3d795626e9cc.png)

**Other tests**
If the program keeps getting empty jid info response it will finally timeout with errors as below (If we get jid info as empty, it means salt is not running properly. Since we set the job to be in progress when we get empty jid info, the program will keep retrying. If we are getting an empty response all the time, retry times out and throws the below error.)
<img width="1226" alt="Screen Shot 2023-04-12 at 11 51 04 AM" src="https://user-images.githubusercontent.com/39275944/231513206-03b412c2-8203-4cae-b50a-6093bb9aa69c.png">

