### PR TITLE
CB-21327 Temporary data is not removed if restore fails and exits w…

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
@@ -74,7 +74,7 @@ errorExit() {
   if [[ "$CLOSECONNECTIONS" == "true" ]]; then
     limit_incomming_connection $SERVICE -1
   fi
-  if [ -d "$DATE_DIR" ]; then
+  if [ -d "$DATE_DIR" ] && [[ $DATE_DIR == /var/tmp/* ]]; then
     rm -rf -v "$DATE_DIR" > >(tee -a $LOGFILE) 2> >(tee -a $LOGFILE >&2)
     doLog "Removed directory $DATE_DIR"
   fi

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/restore_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/restore_db.sh
@@ -65,6 +65,11 @@ export PGSSLMODE=verify-full
 {%- endif %}
 
 errorExit() {
+  limit_incomming_connection $SERVICE -1
+  if [ -d "$BACKUPS_DIR" ] && [[ $BACKUPS_DIR == /var/tmp/postgres_restore_staging* ]]; then
+      rm -rfv "$BACKUPS_DIR" > >(tee -a $LOGFILE) 2> >(tee -a $LOGFILE >&2)
+      doLog "Removed directory $BACKUPS_DIR"
+  fi
   doLog "ERROR $1"
   exit 1
 }


### PR DESCRIPTION
…ith 1

JIRA: [CB-21327](https://jira.cloudera.com/browse/CB-21327)

**ISSUE**: 
1. We download and copy data into the local disk first when we restore data into DL, but if the restore fails and exits with 1 during the process, those temp data is not cleaned up. 
2. Also, we set the connection to 0 before the restore and we should set it back to -1 if the restore fils and exits with error.

**SOLUTION**: Add code to clean up and reset connection in the error exit function rather than just removing those data at the end when restore gets successful. (Backup is also updated a little bit based on comments - to remove more cautiously)

Tested by forcing an error at `psql --host="$HOST" --port="$PORT" --dbname="postgres" --username="testuser" -c "create database`
<img width="737" alt="Screen Shot 2023-03-23 at 9 12 48 PM" src="https://user-images.githubusercontent.com/39275944/227400135-5d4ae7df-7f23-4550-a5c3-13e97398e1f6.png">

**BEFORE** (temp directory and data left in there and hive log is having exceptions):
<img width="812" alt="Screen Shot 2023-03-23 at 9 18 58 PM" src="https://user-images.githubusercontent.com/39275944/227400296-0d879760-8146-4fcf-bd70-cda84a3b24d9.png">
![rb9f3](https://user-images.githubusercontent.com/39275944/227668516-eeee6e16-4c5a-4d68-9b04-1d8e691aa1f0.png)

**AFTER** (temp directory and data removed, and no more exceptions in the hive log):
<img width="772" alt="Screen Shot 2023-03-23 at 9 15 24 PM" src="https://user-images.githubusercontent.com/39275944/227400148-52980844-27c5-42ed-b7f9-53ace434986e.png">

![tlMar](https://user-images.githubusercontent.com/39275944/227668568-4ebe4576-8159-4341-b592-6c2b57cb13df.png)

