### PR TITLE
CB-21280: Added tags to cloudwatch alarms when they're provisioned.

### DIFF
--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsLaunchService.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsLaunchService.java
@@ -158,7 +158,7 @@ public class AwsLaunchService {
 
         awsTaggingService.tagRootVolumes(ac, amazonEC2Client, instances, stack.getTags());
 
-        awsCloudWatchService.addCloudWatchAlarmsForSystemFailures(instances, regionName, credentialView);
+        awsCloudWatchService.addCloudWatchAlarmsForSystemFailures(instances, regionName, credentialView, stack.getTags());
 
         return awsResourceConnector.check(ac, instances);
     }

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsUpscaleService.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsUpscaleService.java
@@ -140,7 +140,7 @@ public class AwsUpscaleService {
                 throw new RuntimeException("Additional resource creation failed: " + failedResources);
             }
             awsTaggingService.tagRootVolumes(ac, amazonEC2Client, instances, stack.getTags());
-            awsCloudWatchService.addCloudWatchAlarmsForSystemFailures(instances, regionName, credentialView);
+            awsCloudWatchService.addCloudWatchAlarmsForSystemFailures(instances, regionName, credentialView, stack.getTags());
 
             for (CloudLoadBalancer loadBalancer : stack.getLoadBalancers()) {
                 cfStackUtil.addLoadBalancerTargets(ac, loadBalancer, newInstances);

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsCloudWatchServiceTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsCloudWatchServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -23,6 +24,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.sequenceiq.cloudbreak.cloud.aws.AwsCloudFormationClient;
+import com.sequenceiq.cloudbreak.cloud.aws.common.AwsTaggingService;
 import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonCloudWatchClient;
 import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsCredentialView;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
@@ -50,6 +52,9 @@ class AwsCloudWatchServiceTest {
     @Mock
     private AwsCloudFormationClient awsClient;
 
+    @Mock
+    private AwsTaggingService awsTaggingService;
+
     @InjectMocks
     private AwsCloudWatchService underTest;
 
@@ -69,7 +74,7 @@ class AwsCloudWatchServiceTest {
 
         AmazonCloudWatchClient cloudWatchClient = mock(AmazonCloudWatchClient.class);
         when(awsClient.createCloudWatchClient(eq(credentialView), eq(REGION))).thenReturn(cloudWatchClient);
-        underTest.addCloudWatchAlarmsForSystemFailures(List.of(firstInst, secondInst), REGION, credentialView);
+        underTest.addCloudWatchAlarmsForSystemFailures(List.of(firstInst, secondInst), REGION, credentialView, Collections.emptyMap());
 
         ArgumentCaptor<PutMetricAlarmRequest> captorPut = ArgumentCaptor.forClass(PutMetricAlarmRequest.class);
         verify(cloudWatchClient, times(2)).putMetricAlarm(captorPut.capture());
@@ -89,7 +94,7 @@ class AwsCloudWatchServiceTest {
 
         AmazonCloudWatchClient cloudWatchClient = mock(AmazonCloudWatchClient.class);
         when(awsClient.createCloudWatchClient(eq(credentialView), eq(REGION))).thenReturn(cloudWatchClient);
-        underTest.addCloudWatchAlarmsForSystemFailures(List.of(firstInst, secondInst), REGION, credentialView);
+        underTest.addCloudWatchAlarmsForSystemFailures(List.of(firstInst, secondInst), REGION, credentialView, Collections.emptyMap());
 
         ArgumentCaptor<PutMetricAlarmRequest> captorPut = ArgumentCaptor.forClass(PutMetricAlarmRequest.class);
         verify(cloudWatchClient, times(1)).putMetricAlarm(captorPut.capture());

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsUpscaleServiceTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsUpscaleServiceTest.java
@@ -184,7 +184,7 @@ class AwsUpscaleServiceTest {
                         eq(adjustmentTypeWithThreshold));
         verify(awsTaggingService, times(1)).tagRootVolumes(eq(authenticatedContext), any(AmazonEc2Client.class), eq(allInstances), eq(tags));
         verify(awsCloudWatchService, times(1)).addCloudWatchAlarmsForSystemFailures(any(), eq("eu-west-1"),
-                any(AwsCredentialView.class));
+                any(AwsCredentialView.class), any());
         List<CloudResource> newInstances = captor.getValue();
         assertEquals("Two new instances should be created", 2, newInstances.size());
         assertThat(newInstances, hasItem(workerInstance4));

--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/AwsTaggingService.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/AwsTaggingService.java
@@ -44,6 +44,12 @@ public class AwsTaggingService {
                 .collect(Collectors.toList());
     }
 
+    public Collection<software.amazon.awssdk.services.cloudwatch.model.Tag> prepareCloudWatchTags(Map<String, String> userDefinedTags) {
+        return userDefinedTags.entrySet().stream()
+                .map(entry -> prepareCloudWatchTag(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toList());
+    }
+
     public Collection<software.amazon.awssdk.services.elasticloadbalancingv2.model.Tag> prepareElasticLoadBalancingTags(Map<String, String> userDefinedTags) {
         return userDefinedTags.entrySet().stream()
                 .map(entry -> prepareElasticLoadBalancingTag(entry.getKey(), entry.getValue()))
@@ -104,6 +110,10 @@ public class AwsTaggingService {
 
     private software.amazon.awssdk.services.ec2.model.Tag prepareEc2Tag(String key, String value) {
         return software.amazon.awssdk.services.ec2.model.Tag.builder().key(key).value(value).build();
+    }
+
+    private software.amazon.awssdk.services.cloudwatch.model.Tag prepareCloudWatchTag(String key, String value) {
+        return software.amazon.awssdk.services.cloudwatch.model.Tag.builder().key(key).value(value).build();
     }
 
     private software.amazon.awssdk.services.efs.model.Tag prepareEfsTag(String key, String value) {


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-21280

Objective: We want to add all user-defined tags, which are already added to other AWS resources, to the Cloudwatch alarms generated. This will enable us to manage and maintain all of our resources.

I simply added the tags to the cloudwatch generation request.

I was unable to test this locally due to issues with generating environments in master, however the change is very simple. I figured it would be okay to move forward with the PR and we can figure out testing later.