### PR TITLE
CB-21266 Fix NPE in EnvironmentBaseNetworkConverter

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/network/v1/converter/EnvironmentBaseNetworkConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/v1/converter/EnvironmentBaseNetworkConverter.java
@@ -98,9 +98,11 @@ public abstract class EnvironmentBaseNetworkConverter implements EnvironmentNetw
     }
 
     private Map<String, CloudSubnet> setDefaultDeploymentRestrictionsForEndpointAccessGateway(Map<String, CloudSubnet> endpointGatewaySubnetMetas) {
-        endpointGatewaySubnetMetas.entrySet().stream()
-                .filter(m -> CollectionUtils.isEmpty(m.getValue().getDeploymentRestrictions()))
-                .forEach(m -> m.getValue().setDeploymentRestrictions(DeploymentRestriction.ENDPOINT_ACCESS_GATEWAYS));
+        if (endpointGatewaySubnetMetas != null) {
+            endpointGatewaySubnetMetas.entrySet().stream()
+                    .filter(m -> CollectionUtils.isEmpty(m.getValue().getDeploymentRestrictions()))
+                    .forEach(m -> m.getValue().setDeploymentRestrictions(DeploymentRestriction.ENDPOINT_ACCESS_GATEWAYS));
+        }
         return endpointGatewaySubnetMetas;
     }
 


### PR DESCRIPTION
setDefaultDeploymentRestrictionsForEndpointAccessGateway got a `null` value which has the root cause: the `endpointgatewaysubnetmeta` column in `environment_network` table contains the literal string "null" for older environments that is converted to a `null` map instead of an empty map.

This is a forward merge PR towards master. Please apply merge instead of rebase.