### PR TITLE
CB-21290 Introduce skip logic for SafeLogic Validation in the E2E tests

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxDeleteAction.java
@@ -19,6 +19,7 @@ public class SdxDeleteAction implements Action<SdxTestDto, SdxClient> {
 
     @Override
     public SdxTestDto action(TestContext testContext, SdxTestDto testDto, SdxClient client) throws Exception {
+        testContext.skipSafeLogicValidation();
         Log.when(LOGGER, " SDX endpoint: %s" + client.getDefaultClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
         Log.whenJson(LOGGER, " SDX delete request: ", testDto.getRequest());
         FlowIdentifier flowIdentifier = client.getDefaultClient()

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxDeleteCustomAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxDeleteCustomAction.java
@@ -19,6 +19,7 @@ public class SdxDeleteCustomAction implements Action<SdxCustomTestDto, SdxClient
 
     @Override
     public SdxCustomTestDto action(TestContext testContext, SdxCustomTestDto testDto, SdxClient client) throws Exception {
+        testContext.skipSafeLogicValidation();
         Log.when(LOGGER, " SDX endpoint: %s" + client.getDefaultClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
         Log.whenJson(LOGGER, " SDX custom delete request: ", testDto.getRequest());
         FlowIdentifier flowIdentifier = client.getDefaultClient()

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxDeleteInternalAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxDeleteInternalAction.java
@@ -19,6 +19,7 @@ public class SdxDeleteInternalAction implements Action<SdxInternalTestDto, SdxCl
 
     @Override
     public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
+        testContext.skipSafeLogicValidation();
         Log.when(LOGGER, " SDX endpoint: %s" + client.getDefaultClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
         Log.whenJson(LOGGER, " SDX Internal delete request: ", testDto.getRequest());
         FlowIdentifier flowIdentifier = client.getDefaultClient()

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXDeleteAction.java
@@ -15,6 +15,7 @@ public class DistroXDeleteAction implements Action<DistroXTestDto, CloudbreakCli
 
     @Override
     public DistroXTestDto action(TestContext testContext, DistroXTestDto testDto, CloudbreakClient client) throws Exception {
+        testContext.skipSafeLogicValidation();
         client.getDefaultClient()
                 .distroXV1Endpoint()
                 .deleteByName(testDto.getName(), false);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/MeasuredTestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/MeasuredTestContext.java
@@ -304,6 +304,16 @@ public class MeasuredTestContext extends MockedTestContext {
     }
 
     @Override
+    public void skipSafeLogicValidation() {
+        wrappedTestContext.skipSafeLogicValidation();
+    }
+
+    @Override
+    public String getSafeLogicValidation() {
+        return wrappedTestContext.getSafeLogicValidation();
+    }
+
+    @Override
     public void checkNonEmpty(String name, String value) {
         wrappedTestContext.checkNonEmpty(name, value);
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
@@ -21,6 +21,7 @@ import javax.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
@@ -1321,6 +1322,26 @@ public abstract class TestContext implements ApplicationContextAware {
             throw new NullPointerException(format("Following variable must be set whether as environment variables or (test) application.yaml: %s",
                     name.replaceAll("\\.", "_").toUpperCase()));
         }
+    }
+
+    /**
+     * The SafeLogic CryptoComply for Java should be installed on Cloudbreak images.
+     * This is validated on VM instances by default, it has been invoked in the E2E tearDown
+     * (after the execution of each E2E test method).
+     *
+     * If the JAVA has been forced (re)installed or SDX, DistroX have been deleted during test execution,
+     * the SafeLogic validation should be disabled for the test tearDown.
+     */
+    public void skipSafeLogicValidation() {
+        MDC.put("safeLogicValidation", "false");
+    }
+
+    /**
+     *
+     * @return SafeLogic Validation value (true or false)
+     */
+    public String getSafeLogicValidation() {
+        return MDC.get("safeLogicValidation");
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/AbstractE2ETest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/AbstractE2ETest.java
@@ -10,6 +10,7 @@ import javax.annotation.Nonnull;
 import javax.inject.Inject;
 
 import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.ITestResult;
@@ -73,9 +74,11 @@ public abstract class AbstractE2ETest extends AbstractIntegrationTest {
         if (MapUtils.isEmpty(testContext.getExceptionMap())) {
             LOGGER.info("Validating default tags on the created and tagged test resources...");
             testContext.getResourceNames().values().forEach(value -> tagsUtil.verifyTags(value, testContext));
-
-            LOGGER.info("Validating SafeLogic installation of created resources...");
-            safeLogicAssertions.validate(testContext);
+            if (StringUtils.isBlank(testContext.getSafeLogicValidation())
+                    || !StringUtils.equalsIgnoreCase(testContext.getSafeLogicValidation(), "false")) {
+                LOGGER.info("Validating SafeLogic installation of created resources...");
+                safeLogicAssertions.validate(testContext);
+            }
         }
         spotUtil.setUseSpotInstances(Boolean.FALSE);
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/java/ForceJavaVersionE2ETest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/java/ForceJavaVersionE2ETest.java
@@ -27,6 +27,10 @@ public class ForceJavaVersionE2ETest extends AbstractE2ETest {
 
     @Override
     protected void setupTest(TestContext testContext) {
+        // The SafeLogic CryptoComply for Java should be installed on Cloudbreak images. This is validated by default in this test project.
+        // So the SafeLogic validation should be disabled for this test suite.
+        testContext.skipSafeLogicValidation();
+
         createDefaultUser(testContext);
         createDefaultCredential(testContext);
         initializeDefaultBlueprints(testContext);


### PR DESCRIPTION
We have a [new validation](https://github.com/hortonworks/cloudbreak/commit/ac48224caeb53c929cac032bdb442c0be18b900f) in our API E2E test project for SafeLogic installation of created resources by [CB-21175](https://jira.cloudera.com/browse/CB-21175).

Unfortunately this test does not take in account some cases where:
1. testCreateDistroXWithEncryptedVolumes where DistroX Delete is part of the test (in case of AWS and GCP)
2. testClusterProvisionWithForcedJavaVersion (test presents only for AWS) `/usr/lib/jvm/java/jre/lib/ext/: No such file or directory`

The validation should be enhanced or skipped for these cases, because of the E2E 2.70.0-b73 is failing. So this is a quick fix for the issue.