### PR TITLE
CB-21302 Azure Outbound Load Balancer created by default for e2e tests

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
@@ -276,6 +276,7 @@ public class AzureCloudProvider extends AbstractCloudProvider {
         environmentNetworkAzureParams.setNoPublicIp(network.getNoPublicIp());
         environmentNetworkAzureParams.setResourceGroupName(network.getResourceGroupName());
         environmentNetworkAzureParams.setDatabasePrivateDnsZoneId(network.getDatabasePrivateDnsZoneId());
+        environmentNetworkAzureParams.setNoOutboundLoadBalancer(false);
         return environmentNetworkAzureParams;
     }
 


### PR DESCRIPTION
Context: e2e test for Azure doesn't work without the outbound load balancer. The default for an existing network will be not to create the outbound load balancer and most of the tests are using an existing network. The purpose of this change is to create the outbound LB for default in e2e tests.

Tests:
Run the com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxImagesTests#testSDXWithPrewarmedImageCanBeCreatedSuccessfully for Azure provider.
com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxUpgradeTests#testSDXHAUpgrade
com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxUpgradeTests#testSDXUpgrade

The nooutboundloadbalancer from the environment_network table should be false.
The `cdp datalake describe-datalake --datalake-name` should return the outbound LB.