### PR TITLE
CDPSDX-3939: Added more granularized version of salt update to determine datalake data sizes flow.

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/DetermineDatalakeDataSizesFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/DetermineDatalakeDataSizesFlowEventChainFactory.java
@@ -8,8 +8,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.common.event.Selectable;
-import com.sequenceiq.cloudbreak.core.flow2.cluster.salt.update.SaltUpdateEvent;
-import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.datalakemetrics.datasizes.DetermineDatalakeDataSizesBaseEvent;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
 import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
@@ -24,9 +22,9 @@ public class DetermineDatalakeDataSizesFlowEventChainFactory implements FlowEven
     @Override
     public FlowTriggerEventQueue createFlowTriggerEventQueue(DetermineDatalakeDataSizesBaseEvent event) {
         Queue<Selectable> flowEventChain = new ConcurrentLinkedQueue<>();
-        flowEventChain.add(new StackEvent(SaltUpdateEvent.SALT_UPDATE_EVENT.event(), event.getResourceId(), event.accepted()));
+//        flowEventChain.add(new StackEvent(SaltUpdateEvent.SALT_UPDATE_EVENT.event(), event.getResourceId(), event.accepted()));
         flowEventChain.add(new DetermineDatalakeDataSizesBaseEvent(
-                DETERMINE_DATALAKE_DATA_SIZES_EVENT.event(), event.getResourceId(), event.getOperationId()
+                DETERMINE_DATALAKE_DATA_SIZES_EVENT.event(), event.getResourceId(), event.getOperationId(), event.accepted()
         ));
         return new FlowTriggerEventQueue(getName(), event, flowEventChain);
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/datalakemetrics/datasizes/DetermineDatalakeDataSizesBaseEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/datalakemetrics/datasizes/DetermineDatalakeDataSizesBaseEvent.java
@@ -2,6 +2,9 @@ package com.sequenceiq.cloudbreak.reactor.api.event.cluster.datalakemetrics.data
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.common.event.AcceptResult;
+import com.sequenceiq.cloudbreak.common.json.JsonIgnoreDeserialization;
+import com.sequenceiq.cloudbreak.eventbus.Promise;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 
 public class DetermineDatalakeDataSizesBaseEvent extends StackEvent {
@@ -11,6 +14,13 @@ public class DetermineDatalakeDataSizesBaseEvent extends StackEvent {
     public DetermineDatalakeDataSizesBaseEvent(@JsonProperty("selector") String selector, @JsonProperty("resourceId") Long stackId,
             @JsonProperty("operationId") String operationId) {
         super(selector, stackId);
+        this.operationId = operationId;
+    }
+
+    @JsonCreator
+    public DetermineDatalakeDataSizesBaseEvent(@JsonProperty("selector") String selector, @JsonProperty("resourceId") Long stackId,
+            @JsonProperty("operationId") String operationId, @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
+        super(selector, stackId, accepted);
         this.operationId = operationId;
     }
 


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CDPSDX-3939

This is meant to serve purely as a small hacked demo of the proposed changes in https://docs.google.com/document/d/1nrz6eXQInu-PjDojf4Eih24pm7l2Z88y2fBq0s3u3Ag/edit#heading=h.loplhmoi987v

All this does is avoid the full salt update and instead update only the files for the determine datalake data size logic. 

Timing results:

**Old Salt Update Time to Get Datalake Data Sizes**
```
Average of 85.67 seconds
```

**New Salt Update Time to Get Datalake Data Sizes**
```
Average of 17.8 seconds
```

**Speedup of ~4.8x** 