### PR TITLE
CB-21173 - Setting knox read only topologies property

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
@@ -67,6 +67,8 @@ public class CMRepositoryVersionUtil {
 
     public static final Versioned CLOUDERAMANAGER_VERSION_7_9_2 = () -> "7.9.2";
 
+    public static final Versioned CLOUDERAMANAGER_VERSION_7_10_0 = () -> "7.10.0";
+
     public static final Versioned CLOUDERA_STACK_VERSION_7_2_7 = () -> "7.2.7";
 
     public static final Versioned CLOUDERA_STACK_VERSION_7_2_9 = () -> "7.2.9";
@@ -173,6 +175,19 @@ public class CMRepositoryVersionUtil {
             }
         }
         LOGGER.info("The current cdh and cm version is supported={}", supported);
+        return supported;
+    }
+
+    public static boolean isKnoxCustomTopologyManagementSupported(ClouderaManagerRepo clouderaManagerRepoDetails,
+                                                            Optional<ClouderaManagerProduct> cdhProduct) {
+        LOGGER.info("ClouderaManagerRepo is compared for knox custom topology management support");
+        boolean supported = cdhProduct.map(product -> {
+            String cdhVersion = cdhProduct.get().getVersion().split("-")[0];
+            LOGGER.info("The cdhVersion is {}. CM version is {}", cdhVersion, clouderaManagerRepoDetails.getVersion());
+            return isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERA_STACK_VERSION_7_2_17)
+                    && isVersionNewerOrEqualThanLimited(clouderaManagerRepoDetails::getVersion, CLOUDERAMANAGER_VERSION_7_10_0);
+        }).orElse(false);
+        LOGGER.info("The current cdh and cm version supports Knox custom topology management: {}", supported);
         return supported;
     }
 

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxGatewayConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxGatewayConfigProvider.java
@@ -118,7 +118,8 @@ public class KnoxGatewayConfigProvider extends AbstractRoleConfigProvider {
                 config.add(config(KNOX_MASTER_SECRET, masterSecret));
                 config.add(config(GATEWAY_DEFAULT_TOPOLOGY_NAME, topologyName));
                 config.add(config(GATEWAY_ADMIN_GROUPS, adminGroup));
-                if (isKnoxCustomTopologyManagementSupported(source.getProductDetailsView().getCm(), getCdhProduct(source))) {
+                if (source.getProductDetailsView() != null
+                        && isKnoxCustomTopologyManagementSupported(source.getProductDetailsView().getCm(), getCdhProduct(source))) {
                     config.add(config(GATEWAY_READ_ONLY_TOPOLOGIES, String.join(",", CLOUDBREAK_MANAGED_TOPOLOGIES)));
                 } else {
                     config.add(config(GATEWAY_CM_AUTO_DISCOVERY_ENABLED, "false"));

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxGatewayConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxGatewayConfigProvider.java
@@ -118,12 +118,7 @@ public class KnoxGatewayConfigProvider extends AbstractRoleConfigProvider {
                 config.add(config(KNOX_MASTER_SECRET, masterSecret));
                 config.add(config(GATEWAY_DEFAULT_TOPOLOGY_NAME, topologyName));
                 config.add(config(GATEWAY_ADMIN_GROUPS, adminGroup));
-                if (source.getProductDetailsView() != null
-                        && isKnoxCustomTopologyManagementSupported(source.getProductDetailsView().getCm(), getCdhProduct(source))) {
-                    config.add(config(GATEWAY_READ_ONLY_TOPOLOGIES, String.join(",", CLOUDBREAK_MANAGED_TOPOLOGIES)));
-                } else {
-                    config.add(config(GATEWAY_CM_AUTO_DISCOVERY_ENABLED, "false"));
-                }
+                setReadOnlyTopologies(source, config);
                 if (gateway != null) {
                     config.add(config(GATEWAY_PATH, gateway.getPath()));
                     config.add(config(GATEWAY_SIGNING_KEYSTORE_NAME, SIGNING_JKS));
@@ -148,6 +143,15 @@ public class KnoxGatewayConfigProvider extends AbstractRoleConfigProvider {
                 );
             default:
                 return List.of();
+        }
+    }
+
+    private void setReadOnlyTopologies(TemplatePreparationObject source, List<ApiClusterTemplateConfig> config) {
+        if (source.getProductDetailsView() != null
+                && isKnoxCustomTopologyManagementSupported(source.getProductDetailsView().getCm(), getCdhProduct(source))) {
+            config.add(config(GATEWAY_READ_ONLY_TOPOLOGIES, String.join(",", CLOUDBREAK_MANAGED_TOPOLOGIES)));
+        } else {
+            config.add(config(GATEWAY_CM_AUTO_DISCOVERY_ENABLED, "false"));
         }
     }
 

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxGatewayConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxGatewayConfigProviderTest.java
@@ -271,6 +271,133 @@ public class KnoxGatewayConfigProviderTest {
     }
 
     @Test
+    public void cloudbreakManagedTopologiesAreSet() {
+        GatewayTopology topology = new GatewayTopology();
+        topology.setTopologyName("my-topology");
+        topology.setExposedServices(Json.silent(new ExposedServices()));
+
+        Gateway gateway = new Gateway();
+        gateway.setTopologies(Set.of(topology));
+
+        GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
+        generalClusterConfigs.setAccountId(Optional.of("1234"));
+
+        TemplatePreparationObject source = Builder.builder()
+                .withGateway(gateway, "key", new HashSet<>())
+                .withGeneralClusterConfigs(generalClusterConfigs)
+                .withVirtualGroupView(new VirtualGroupRequest(TestConstants.CRN, ""))
+                .withProductDetails(new ClouderaManagerRepo().withVersion("7.10.0"), List.of(new ClouderaManagerProduct()
+                        .withVersion("7.2.17")
+                        .withName("CDH")))
+                .build();
+        when(virtualGroupService.createOrGetVirtualGroup(source.getVirtualGroupRequest(), UmsVirtualGroupRight.KNOX_ADMIN)).thenReturn("");
+
+        assertEquals(
+                List.of(
+                        config("gateway_master_secret", gateway.getKnoxMaster()),
+                        config("gateway_default_topology_name",
+                                gateway.getTopologies().iterator().next().getTopologyName()),
+                        config("gateway_knox_admin_groups", ""),
+                        config("gateway.read.only.override.topologies",
+                                "admin,cdp-proxy-api,cdp-proxy-token,cdp-proxy,cdp-token,knoxsso,manager"),
+                        config("gateway_path", gateway.getPath()),
+                        config("gateway_signing_keystore_name", "signing.jks"),
+                        config("gateway_signing_keystore_type", "JKS"),
+                        config("gateway_signing_key_alias", "signing-identity"),
+                        config("gateway_dispatch_whitelist", "^*.*$"),
+                        config("gateway_token_generation_enable_lifespan_input", "true"),
+                        config("gateway_token_generation_knox_token_ttl", "86400000"),
+                        config("gateway_service_tokenstate_impl", "org.apache.knox.gateway.services.token.impl.JDBCTokenStateService")
+                ),
+                ThreadBasedUserCrnProvider.doAs(TEST_USER_CRN, () -> underTest.getRoleConfigs(KnoxRoles.KNOX_GATEWAY, source))
+        );
+    }
+
+    @Test
+    public void cloudbreakManagedTopologiesAreNotSetDueToCmVersion() {
+        GatewayTopology topology = new GatewayTopology();
+        topology.setTopologyName("my-topology");
+        topology.setExposedServices(Json.silent(new ExposedServices()));
+
+        Gateway gateway = new Gateway();
+        gateway.setTopologies(Set.of(topology));
+
+        GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
+        generalClusterConfigs.setAccountId(Optional.of("1234"));
+
+        TemplatePreparationObject source = Builder.builder()
+                .withGateway(gateway, "key", new HashSet<>())
+                .withGeneralClusterConfigs(generalClusterConfigs)
+                .withVirtualGroupView(new VirtualGroupRequest(TestConstants.CRN, ""))
+                .withProductDetails(new ClouderaManagerRepo().withVersion("7.9.0"), List.of(new ClouderaManagerProduct()
+                        .withVersion("7.2.17")
+                        .withName("CDH")))
+                .build();
+        when(virtualGroupService.createOrGetVirtualGroup(source.getVirtualGroupRequest(), UmsVirtualGroupRight.KNOX_ADMIN)).thenReturn("");
+
+        assertEquals(
+                List.of(
+                        config("gateway_master_secret", gateway.getKnoxMaster()),
+                        config("gateway_default_topology_name",
+                                gateway.getTopologies().iterator().next().getTopologyName()),
+                        config("gateway_knox_admin_groups", ""),
+                        config("gateway_auto_discovery_enabled", "false"),
+                        config("gateway_path", gateway.getPath()),
+                        config("gateway_signing_keystore_name", "signing.jks"),
+                        config("gateway_signing_keystore_type", "JKS"),
+                        config("gateway_signing_key_alias", "signing-identity"),
+                        config("gateway_dispatch_whitelist", "^*.*$"),
+                        config("gateway_token_generation_enable_lifespan_input", "true"),
+                        config("gateway_token_generation_knox_token_ttl", "86400000"),
+                        config("gateway_service_tokenstate_impl", "org.apache.knox.gateway.services.token.impl.JDBCTokenStateService")
+                ),
+                ThreadBasedUserCrnProvider.doAs(TEST_USER_CRN, () -> underTest.getRoleConfigs(KnoxRoles.KNOX_GATEWAY, source))
+        );
+    }
+
+    @Test
+    public void cloudbreakManagedTopologiesAreNotSetDueToCdhVersion() {
+        GatewayTopology topology = new GatewayTopology();
+        topology.setTopologyName("my-topology");
+        topology.setExposedServices(Json.silent(new ExposedServices()));
+
+        Gateway gateway = new Gateway();
+        gateway.setTopologies(Set.of(topology));
+
+        GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
+        generalClusterConfigs.setAccountId(Optional.of("1234"));
+
+        TemplatePreparationObject source = Builder.builder()
+                .withGateway(gateway, "key", new HashSet<>())
+                .withGeneralClusterConfigs(generalClusterConfigs)
+                .withVirtualGroupView(new VirtualGroupRequest(TestConstants.CRN, ""))
+                .withProductDetails(new ClouderaManagerRepo().withVersion("7.10.0"), List.of(new ClouderaManagerProduct()
+                        .withVersion("7.2.16")
+                        .withName("CDH")))
+                .build();
+        when(virtualGroupService.createOrGetVirtualGroup(source.getVirtualGroupRequest(), UmsVirtualGroupRight.KNOX_ADMIN)).thenReturn("");
+        assertEquals(
+                List.of(
+                        config("gateway_master_secret", gateway.getKnoxMaster()),
+                        config("gateway_default_topology_name",
+                                gateway.getTopologies().iterator().next().getTopologyName()),
+                        config("gateway_knox_admin_groups", ""),
+                        config("gateway_auto_discovery_enabled", "false"),
+                        config("gateway_path", gateway.getPath()),
+                        config("gateway_signing_keystore_name", "signing.jks"),
+                        config("gateway_signing_keystore_type", "JKS"),
+                        config("gateway_signing_key_alias", "signing-identity"),
+                        config("gateway_dispatch_whitelist", "^*.*$"),
+                        config("gateway_token_generation_enable_lifespan_input", "true"),
+                        config("gateway_token_generation_knox_token_ttl", "86400000"),
+                        config("gateway_service_tokenstate_impl", "org.apache.knox.gateway.services.token.impl.JDBCTokenStateService")
+                ),
+                ThreadBasedUserCrnProvider.doAs(TEST_USER_CRN, () -> underTest.getRoleConfigs(KnoxRoles.KNOX_GATEWAY, source))
+        );
+    }
+
+
+    @Test
     public void roleConfigsWithoutGateway() {
         GeneralClusterConfigs gcc = new GeneralClusterConfigs();
         gcc.setPassword("secret");

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxGatewayConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxGatewayConfigProviderTest.java
@@ -396,7 +396,6 @@ public class KnoxGatewayConfigProviderTest {
         );
     }
 
-
     @Test
     public void roleConfigsWithoutGateway() {
         GeneralClusterConfigs gcc = new GeneralClusterConfigs();


### PR DESCRIPTION
We are giving the ability for users to create new Knox topologies (descriptors + shared providers) via Cloudera Manager UI / simplified topology management (Knox Gateway Advanced Configuration Snippet (Safety Valve) for conf/cdp-resources.xml), on public cloud.

However we want to be make sure that topologies which are created by cloudbreak (cdp-proxy, cdp-proxy-api, etc) cannot be overwritten by the user.

Every topology names should added to "gateway.read.only.override.topologies" to prevent them from being overwritten by the user.

Additionally setting the `gateway_auto_discovery_enabled = false` should be removed.