### PR TITLE
CB-21242: Sdx external database configuration provider should use the internal database request as well

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -60,6 +60,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.RotateSaltPasswordRequest;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.customdomain.CustomDomainSettingsV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseRequest;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.image.ImageSettingsV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.InstanceGroupV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.securitygroup.SecurityGroupV4Request;
@@ -467,7 +468,8 @@ public class SdxService implements ResourceIdProvider, PayloadContextProvider, H
             throw new BadRequestException("Cloud storage parameter is required.");
         }
 
-        externalDatabaseConfigurer.configure(cloudPlatform, sdxClusterRequest.getExternalDatabase(), sdxCluster);
+        DatabaseRequest internalDatabaseRequest = Optional.ofNullable(internalStackV4Request).map(StackV4Request::getExternalDatabase).orElse(null);
+        externalDatabaseConfigurer.configure(cloudPlatform, internalDatabaseRequest, sdxClusterRequest.getExternalDatabase(), sdxCluster);
         updateStackV4RequestWithEnvironmentCrnIfNotExistsOnIt(internalStackV4Request, environment.getCrn());
         StackV4Request stackRequest = getStackRequest(sdxClusterRequest.getClusterShape(), sdxClusterRequest.isEnableRangerRaz(),
                 internalStackV4Request, cloudPlatform, runtimeVersion, imageSettingsV4Request, sdxClusterRequest.getJavaVersion());

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxExternalDatabaseConfigurerTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxExternalDatabaseConfigurerTest.java
@@ -1,6 +1,9 @@
 package com.sequenceiq.datalake.service.sdx;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Assertions;
@@ -10,6 +13,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseAvailabilityType;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseRequest;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.service.database.DatabaseDefaultVersionProvider;
@@ -38,9 +43,9 @@ public class SdxExternalDatabaseConfigurerTest {
         when(databaseDefaultVersionProvider.calculateDbVersionBasedOnRuntimeIfMissing(null, null)).thenReturn("11");
         SdxCluster sdxCluster = new SdxCluster();
 
-        underTest.configure(cloudPlatform, null, sdxCluster);
+        underTest.configure(cloudPlatform, null, null, sdxCluster);
 
-        assertEquals(true, sdxCluster.isCreateDatabase());
+        assertTrue(sdxCluster.isCreateDatabase());
         assertEquals(SdxDatabaseAvailabilityType.HA, sdxCluster.getDatabaseAvailabilityType());
         assertEquals("11", sdxCluster.getDatabaseEngineVersion());
     }
@@ -53,9 +58,9 @@ public class SdxExternalDatabaseConfigurerTest {
         SdxCluster sdxCluster = new SdxCluster();
         when(databaseDefaultVersionProvider.calculateDbVersionBasedOnRuntimeIfMissing(null, null)).thenReturn("11");
 
-        underTest.configure(cloudPlatform, dbRequest, sdxCluster);
+        underTest.configure(cloudPlatform, null, dbRequest, sdxCluster);
 
-        assertEquals(false, sdxCluster.isCreateDatabase());
+        assertFalse(sdxCluster.isCreateDatabase());
         assertEquals(SdxDatabaseAvailabilityType.NONE, sdxCluster.getDatabaseAvailabilityType());
         assertEquals("11", sdxCluster.getDatabaseEngineVersion());
     }
@@ -69,9 +74,9 @@ public class SdxExternalDatabaseConfigurerTest {
         SdxCluster sdxCluster = new SdxCluster();
         when(databaseDefaultVersionProvider.calculateDbVersionBasedOnRuntimeIfMissing(null, null)).thenReturn("11");
 
-        underTest.configure(cloudPlatform, dbRequest, sdxCluster);
+        underTest.configure(cloudPlatform, null, dbRequest, sdxCluster);
 
-        assertEquals(true, sdxCluster.isCreateDatabase());
+        assertTrue(sdxCluster.isCreateDatabase());
         assertEquals(SdxDatabaseAvailabilityType.HA, sdxCluster.getDatabaseAvailabilityType());
         assertEquals("11", sdxCluster.getDatabaseEngineVersion());
     }
@@ -86,9 +91,9 @@ public class SdxExternalDatabaseConfigurerTest {
         sdxCluster.setClusterName("clusterName");
         when(databaseDefaultVersionProvider.calculateDbVersionBasedOnRuntimeIfMissing(null, null)).thenReturn("11");
 
-        underTest.configure(cloudPlatform, dbRequest, sdxCluster);
+        underTest.configure(cloudPlatform, null, dbRequest, sdxCluster);
 
-        assertEquals(true, sdxCluster.isCreateDatabase());
+        assertTrue(sdxCluster.isCreateDatabase());
         assertEquals(SdxDatabaseAvailabilityType.HA, sdxCluster.getDatabaseAvailabilityType());
         assertEquals("11", sdxCluster.getDatabaseEngineVersion());
     }
@@ -102,9 +107,9 @@ public class SdxExternalDatabaseConfigurerTest {
         sdxCluster.setClusterName("clusterName");
         when(databaseDefaultVersionProvider.calculateDbVersionBasedOnRuntimeIfMissing(null, null)).thenReturn("11");
 
-        underTest.configure(cloudPlatform, dbRequest, sdxCluster);
+        underTest.configure(cloudPlatform, null, dbRequest, sdxCluster);
 
-        assertEquals(false, sdxCluster.isCreateDatabase());
+        assertFalse(sdxCluster.isCreateDatabase());
         assertEquals(SdxDatabaseAvailabilityType.NONE, sdxCluster.getDatabaseAvailabilityType());
         assertEquals("11", sdxCluster.getDatabaseEngineVersion());
     }
@@ -120,9 +125,9 @@ public class SdxExternalDatabaseConfigurerTest {
         when(databaseDefaultVersionProvider.calculateDbVersionBasedOnRuntimeIfMissing(sdxCluster.getRuntime(), null)).thenReturn("11");
 
 
-        underTest.configure(cloudPlatform, dbRequest, sdxCluster);
+        underTest.configure(cloudPlatform, null, dbRequest, sdxCluster);
 
-        assertEquals(false, sdxCluster.isCreateDatabase());
+        assertFalse(sdxCluster.isCreateDatabase());
         assertEquals(SdxDatabaseAvailabilityType.NONE, sdxCluster.getDatabaseAvailabilityType());
         assertEquals("11", sdxCluster.getDatabaseEngineVersion());
     }
@@ -138,9 +143,9 @@ public class SdxExternalDatabaseConfigurerTest {
         sdxCluster.setRuntime("7.1.0");
         when(databaseDefaultVersionProvider.calculateDbVersionBasedOnRuntimeIfMissing(sdxCluster.getRuntime(), null)).thenReturn("11");
 
-        underTest.configure(cloudPlatform, dbRequest, sdxCluster);
+        underTest.configure(cloudPlatform, null, dbRequest, sdxCluster);
 
-        assertEquals(true, sdxCluster.isCreateDatabase());
+        assertTrue(sdxCluster.isCreateDatabase());
         assertEquals(SdxDatabaseAvailabilityType.HA, sdxCluster.getDatabaseAvailabilityType());
         assertEquals("11", sdxCluster.getDatabaseEngineVersion());
     }
@@ -156,9 +161,9 @@ public class SdxExternalDatabaseConfigurerTest {
         sdxCluster.setRuntime("7.2.0");
         when(databaseDefaultVersionProvider.calculateDbVersionBasedOnRuntimeIfMissing(sdxCluster.getRuntime(), null)).thenReturn("11");
 
-        underTest.configure(cloudPlatform, dbRequest, sdxCluster);
+        underTest.configure(cloudPlatform, null, dbRequest, sdxCluster);
 
-        assertEquals(true, sdxCluster.isCreateDatabase());
+        assertTrue(sdxCluster.isCreateDatabase());
         assertEquals(SdxDatabaseAvailabilityType.HA, sdxCluster.getDatabaseAvailabilityType());
         assertEquals("11", sdxCluster.getDatabaseEngineVersion());
     }
@@ -172,10 +177,78 @@ public class SdxExternalDatabaseConfigurerTest {
         SdxCluster sdxCluster = new SdxCluster();
         when(databaseDefaultVersionProvider.calculateDbVersionBasedOnRuntimeIfMissing(null, null)).thenReturn("11");
 
-        Assertions.assertThrows(BadRequestException.class, () -> underTest.configure(cloudPlatform, dbRequest, sdxCluster));
+        Assertions.assertThrows(BadRequestException.class, () -> underTest.configure(cloudPlatform, null, dbRequest, sdxCluster));
 
-        assertEquals(true, sdxCluster.isCreateDatabase());
+        assertTrue(sdxCluster.isCreateDatabase());
         assertEquals(SdxDatabaseAvailabilityType.HA, sdxCluster.getDatabaseAvailabilityType());
         assertEquals("11", sdxCluster.getDatabaseEngineVersion());
+    }
+
+    @Test
+    public void whenPlatformIsAwsWithInternalRequestAndRuntimeVersionIsPresentAndAvailabilityTypeIsNonHa() {
+        CloudPlatform cloudPlatform = CloudPlatform.AWS;
+        DatabaseRequest databaseRequest = new DatabaseRequest();
+        String databaseEngineVersion = "11";
+        databaseRequest.setDatabaseEngineVersion(databaseEngineVersion);
+        databaseRequest.setAvailabilityType(DatabaseAvailabilityType.NON_HA);
+        SdxCluster sdxCluster = new SdxCluster();
+        when(platformConfig.isExternalDatabaseSupportedOrExperimental(cloudPlatform)).thenReturn(true);
+        when(databaseDefaultVersionProvider.calculateDbVersionBasedOnRuntimeIfMissing(null, databaseEngineVersion)).thenReturn(databaseEngineVersion);
+
+        underTest.configure(cloudPlatform, databaseRequest, null, sdxCluster);
+
+        assertTrue(sdxCluster.isCreateDatabase());
+        assertEquals(SdxDatabaseAvailabilityType.NON_HA, sdxCluster.getDatabaseAvailabilityType());
+        assertEquals(databaseEngineVersion, sdxCluster.getDatabaseEngineVersion());
+    }
+
+    @Test
+    public void whenPlatformIsAwsWithInternalRequestAndRuntimeVersionIsPresentAndAvailabilityTypeIsHa() {
+        CloudPlatform cloudPlatform = CloudPlatform.AWS;
+        DatabaseRequest databaseRequest = new DatabaseRequest();
+        String databaseEngineVersion = "11";
+        databaseRequest.setDatabaseEngineVersion(databaseEngineVersion);
+        databaseRequest.setAvailabilityType(DatabaseAvailabilityType.HA);
+        SdxCluster sdxCluster = new SdxCluster();
+        when(platformConfig.isExternalDatabaseSupportedOrExperimental(cloudPlatform)).thenReturn(true);
+        when(databaseDefaultVersionProvider.calculateDbVersionBasedOnRuntimeIfMissing(null, databaseEngineVersion)).thenReturn(databaseEngineVersion);
+
+        underTest.configure(cloudPlatform, databaseRequest, null, sdxCluster);
+
+        assertTrue(sdxCluster.isCreateDatabase());
+        assertEquals(SdxDatabaseAvailabilityType.HA, sdxCluster.getDatabaseAvailabilityType());
+        assertEquals(databaseEngineVersion, sdxCluster.getDatabaseEngineVersion());
+    }
+
+    @Test
+    public void whenPlatformIsAwsWithInternalRequestAndRuntimeVersionIsNotPresentAndAvailabilityTypeIsHa() {
+        CloudPlatform cloudPlatform = CloudPlatform.AWS;
+        DatabaseRequest databaseRequest = new DatabaseRequest();
+        databaseRequest.setAvailabilityType(DatabaseAvailabilityType.HA);
+        SdxCluster sdxCluster = new SdxCluster();
+        when(platformConfig.isExternalDatabaseSupportedOrExperimental(cloudPlatform)).thenReturn(true);
+        when(databaseDefaultVersionProvider.calculateDbVersionBasedOnRuntimeIfMissing(null, null)).thenReturn(null);
+
+        underTest.configure(cloudPlatform, databaseRequest, null, sdxCluster);
+
+        assertTrue(sdxCluster.isCreateDatabase());
+        assertEquals(SdxDatabaseAvailabilityType.HA, sdxCluster.getDatabaseAvailabilityType());
+        assertNull(sdxCluster.getDatabaseEngineVersion());
+    }
+
+    @Test
+    public void whenPlatformIsAwsWithInternalRequestAndRuntimeVersionIsPresentAndAvailabilityTypeIsNull() {
+        CloudPlatform cloudPlatform = CloudPlatform.AWS;
+        DatabaseRequest databaseRequest = new DatabaseRequest();
+        String databaseEngineVersion = "11";
+        databaseRequest.setDatabaseEngineVersion(databaseEngineVersion);
+        SdxCluster sdxCluster = new SdxCluster();
+        when(databaseDefaultVersionProvider.calculateDbVersionBasedOnRuntimeIfMissing(null, databaseEngineVersion)).thenReturn(databaseEngineVersion);
+
+        underTest.configure(cloudPlatform, databaseRequest, null, sdxCluster);
+
+        assertFalse(sdxCluster.isCreateDatabase());
+        assertEquals(SdxDatabaseAvailabilityType.NONE, sdxCluster.getDatabaseAvailabilityType());
+        assertEquals(databaseEngineVersion, sdxCluster.getDatabaseEngineVersion());
     }
 }

--- a/redbeams/src/main/resources/application.yml
+++ b/redbeams/src/main/resources/application.yml
@@ -53,7 +53,7 @@ redbeams:
       ssl: false
     postgres:
       major:
-        version: 10
+        version: 11
   threadpool:
     core.size: 40
     capacity.size: 4000


### PR DESCRIPTION
In this commit I set the default database engine version to 11 and modified the database config provider to use the database engine version and the availability type from the internal database request if present