### PR TITLE
CDPD-50804 Increase total time for DB backup/restore

### DIFF
--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
@@ -160,7 +160,7 @@ public class SaltOrchestrator implements HostOrchestrator {
     @Value("${cb.max.salt.recipe.execution.retry.forced:2}")
     private int maxRetryRecipeForced;
 
-    @Value("${cb.max.salt.database.dr.retry:300}")
+    @Value("${cb.max.salt.database.dr.retry:550}")
     private int maxDatabaseDrRetry;
 
     @Value("${cb.max.salt.database.dr.retry.onerror:5}")


### PR DESCRIPTION
[CDPD-50804](https://jira.cloudera.com/browse/CDPD-50804) 
ISSUE: Backup/restore has orchestrator timeout when the data size is big. 
SOLUTION (short-term): Increase the retry number so we have enough time to backup/restore the big size data.
FUTURE: Need to have a dynamic retry number based on data size. JIRA for this: [CDPSDX-4015](https://jira.cloudera.com/browse/CDPSDX-4015) 