### PR TITLE
CB-21293 - Better error reporting in CM package version sync

### DIFF
--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/common/model/PackageInfo.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/common/model/PackageInfo.java
@@ -72,6 +72,10 @@ public class PackageInfo {
         }
     }
 
+    public boolean isInvalid() {
+        return "false".equals(version) || "null".equals(buildNumber);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/common/model/PackageInfoValidationResult.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/common/model/PackageInfoValidationResult.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.cloudbreak.common.model;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PackageInfoValidationResult {
+
+    private final Map<String, List<PackageInfo>> cmPackageVersionsFromAllHostsFiltered;
+
+    private final Set<String> hostsWithInvalidResponse;
+
+    public PackageInfoValidationResult(Map<String, List<PackageInfo>> cmPackageVersionsFromAllHostsFiltered, Set<String> hostsWithInvalidResponse) {
+        this.cmPackageVersionsFromAllHostsFiltered = cmPackageVersionsFromAllHostsFiltered;
+        this.hostsWithInvalidResponse = hostsWithInvalidResponse;
+    }
+
+    public Map<String, List<PackageInfo>> getCmPackageVersionsFromAllHostsFiltered() {
+        return cmPackageVersionsFromAllHostsFiltered;
+    }
+
+    public Set<String> getHostsWithInvalidResponse() {
+        return hostsWithInvalidResponse;
+    }
+
+    @Override
+    public String toString() {
+        return "PackageInfoValidationResult{" +
+                "cmPackageVersionsFromAllHostsFiltered=" + cmPackageVersionsFromAllHostsFiltered +
+                ", hostsWithInvalidResponse=" + hostsWithInvalidResponse +
+                '}';
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
@@ -211,6 +211,7 @@ public enum ResourceEvent {
     STACK_SYNC_INSTANCE_DELETED_BY_PROVIDER_CBMETADATA("stack.sync.instance.deletedbyprovider.cbmetadata"),
     STACK_SYNC_VERSIONS_FROM_CM_TO_DB_SUCCESS("stack.sync.versions.from.cm.to.db.succeeded"),
     STACK_SYNC_VERSIONS_FROM_CM_TO_DB_FAILED("stack.sync.versions.from.cm.to.db.failed"),
+    STACK_SYNC_VERSIONS_FROM_CM_MISSING_VERSIONS("stack.sync.versions.from.cm.to.db.missing.versions"),
     STACK_DELETE_IN_PROGRESS("stack.delete.in.progress"),
     STACK_ADDING_INSTANCES("stack.adding.instances"),
     STACK_METADATA_EXTEND_WITH_COUNT("stack.metadata.extend.with.count"),

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -330,6 +330,7 @@ stack.sync.instance.deleted.cbmetadata=Deleted instance {0} from Cloudbreak meta
 stack.sync.instance.deletedbyprovider.cbmetadata=Deleted instance {0} from Cloudbreak metadata because it was deleted by the cloud provider.
 stack.sync.versions.from.cm.to.db.succeeded=Reading CM and active parcel versions from CM server succeeded: {0}
 stack.sync.versions.from.cm.to.db.failed=Reading CM and active parcel versions from CM server has failure(s): {0}
+stack.sync.versions.from.cm.to.db.missing.versions=Please check the following node(s) as they could not report CM version: {0}
 stack.sync.instance.updated=Updated metadata of instance {0} to {1} as the cloud provider reported it as {1}.
 stack.sync.instance.failed=Updated metadata of instance {0} to failed, because update was in progress, but instance isn''t member of the cluster.
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmServerQueryService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmServerQueryService.java
@@ -43,7 +43,7 @@ public class CmServerQueryService {
      * TODO: the call is blocking for some time. Check if it is possible to block for shorter period of time.
      *
      * @param stack The stack, to get the coordinates of the CM to query
-     * @return List of parcels found in the CM
+     * @return Set of parcels found in the CM
      */
     public Set<ParcelInfo> queryActiveParcels(Stack stack) {
         Set<ParcelInfo> activeParcels = apiConnectors.getConnector(stack).gatherInstalledParcels(stack.getName());
@@ -59,7 +59,7 @@ public class CmServerQueryService {
     public Optional<String> queryCmVersion(StackDtoDelegate stack) {
         try {
             Map<String, List<PackageInfo>> packageVersions = cmVersionQueryService.queryCmPackageInfo(stack);
-            PackageInfo cmPackageInfo = cmVersionQueryService.checkCmPackageInfoConsistency(packageVersions);
+            PackageInfo cmPackageInfo = cmVersionQueryService.checkCmPackageInfoConsistency(packageVersions, stack.getId());
             String version = cmPackageInfo.getFullVersionPrettyPrinted();
             LOGGER.debug("Reading CM version info, found version: {}", version);
             return Optional.of(version);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmVersionQueryService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmVersionQueryService.java
@@ -1,10 +1,15 @@
 package com.sequenceiq.cloudbreak.service.upgrade.sync.component;
 
+import static com.sequenceiq.cloudbreak.event.ResourceEvent.STACK_SYNC_VERSIONS_FROM_CM_MISSING_VERSIONS;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.UPDATE_IN_PROGRESS;
+
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -21,6 +26,7 @@ import com.google.common.collect.Multimaps;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.ImagePackageVersion;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.model.PackageInfo;
+import com.sequenceiq.cloudbreak.common.model.PackageInfoValidationResult;
 import com.sequenceiq.cloudbreak.dto.StackDtoDelegate;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
@@ -28,6 +34,7 @@ import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.service.GatewayConfigService;
 import com.sequenceiq.cloudbreak.service.cluster.Package;
 import com.sequenceiq.cloudbreak.service.cluster.PackageName;
+import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 import com.sequenceiq.cloudbreak.util.VersionComparator;
 
 @Component
@@ -44,6 +51,9 @@ public class CmVersionQueryService {
     @Inject
     private GatewayConfigService gatewayConfigService;
 
+    @Inject
+    private CloudbreakEventService eventService;
+
     public List<Package> getPackages() {
         return packages;
     }
@@ -57,7 +67,7 @@ public class CmVersionQueryService {
      * <p>
      *
      * @param stack The stack, with metadata to be able to build the client to query package versions
-     * @return List of package info found in each host (map key is host fqdn)
+     * @return Map of package info found in each host (map key is host fqdn)
      */
     public Map<String, List<PackageInfo>> queryCmPackageInfo(StackDtoDelegate stack) throws CloudbreakOrchestratorFailedException {
         GatewayConfig gatewayConfig = gatewayConfigService.getPrimaryGatewayConfig(stack);
@@ -70,15 +80,54 @@ public class CmVersionQueryService {
         return fullPackageVersionsFromAllHosts;
     }
 
-    public PackageInfo checkCmPackageInfoConsistency(Map<String, List<PackageInfo>> cmPackageVersionsFromAllHosts) {
-        Multimap<String, PackageInfo> pkgVersionsMMap = HashMultimap.create();
-        cmPackageVersionsFromAllHosts.values()
-                .forEach(packageInfoList -> packageInfoList.forEach(
-                        packageInfo -> pkgVersionsMMap.put(packageInfo.getName(), packageInfo)));
+    public PackageInfo checkCmPackageInfoConsistency(Map<String, List<PackageInfo>> cmPackageVersionsFromAllHosts, Long stackId) {
+        Map<String, List<PackageInfo>> validPackageInfoList = reportAndRemoveMissingPackageInfo(cmPackageVersionsFromAllHosts, stackId);
+        Multimap<String, PackageInfo> pkgVersionsMMap = collectPackageInfoByPackageName(validPackageInfoList);
         validatePackageHasMultipleVersions(pkgVersionsMMap);
         Set<PackageInfo> distinctPackageInfos = new HashSet<>(pkgVersionsMMap.values());
         validatePackageInfoExists(distinctPackageInfos);
         return getPackageInfoWithLatestVersion(distinctPackageInfos);
+    }
+
+    private Map<String, List<PackageInfo>> reportAndRemoveMissingPackageInfo(Map<String, List<PackageInfo>> cmPackageVersionsFromAllHosts, Long stackId) {
+        PackageInfoValidationResult result = collectInvalidPackageInfos(cmPackageVersionsFromAllHosts);
+        Set<String> hostsWithInvalidResponse = result.getHostsWithInvalidResponse();
+        if (!hostsWithInvalidResponse.isEmpty()) {
+            String hostList = String.join(", ", hostsWithInvalidResponse);
+            LOGGER.info("The following node(s) could not report CM version: {}", hostList);
+            eventService.fireCloudbreakEvent(stackId, UPDATE_IN_PROGRESS.name(), STACK_SYNC_VERSIONS_FROM_CM_MISSING_VERSIONS, List.of(hostList));
+        }
+        return result.getCmPackageVersionsFromAllHostsFiltered();
+    }
+
+    private PackageInfoValidationResult collectInvalidPackageInfos(Map<String, List<PackageInfo>> cmPackageVersionsFromAllHosts) {
+        Set<String> hostsWithInvalidResponse = new HashSet<>();
+        Map<String, List<PackageInfo>> cmPackageVersionsFromAllHostsFiltered = new HashMap<>();
+
+        cmPackageVersionsFromAllHosts.forEach((host, packageInfoList) -> {
+            List<PackageInfo> validPackageInfoList = packageInfoList
+                    .stream()
+                    .filter(Predicate.not(PackageInfo::isInvalid))
+                    .collect(Collectors.toList());
+            if (validPackageInfoList.size() == packageInfoList.size()) {
+                cmPackageVersionsFromAllHostsFiltered.put(host, packageInfoList);
+            } else {
+                LOGGER.info("Invalid package info found for host {}: {}", host, packageInfoList.stream()
+                        .filter(PackageInfo::isInvalid)
+                        .collect(Collectors.toList()));
+                cmPackageVersionsFromAllHostsFiltered.put(host, validPackageInfoList);
+                hostsWithInvalidResponse.add(host);
+            }
+        });
+        return new PackageInfoValidationResult(cmPackageVersionsFromAllHostsFiltered, hostsWithInvalidResponse);
+    }
+
+    private Multimap<String, PackageInfo> collectPackageInfoByPackageName(Map<String, List<PackageInfo>> cmPackageVersionsFromAllHosts) {
+        Multimap<String, PackageInfo> pkgVersionsMMap = HashMultimap.create();
+        cmPackageVersionsFromAllHosts.values()
+                .forEach(packageInfoList -> packageInfoList.forEach(
+                        packageInfo -> pkgVersionsMMap.put(packageInfo.getName(), packageInfo)));
+        return pkgVersionsMMap;
     }
 
     private PackageInfo getPackageInfoWithLatestVersion(Set<PackageInfo> distinctPackageInfos) {


### PR DESCRIPTION
This commit contains the following CM package version sync enhancements:
- indicating the unreachable nodes in the event history
- removing the invalid package versions from the result set

<img width="1357" alt="image" src="https://user-images.githubusercontent.com/19725708/228367736-a01268b5-0dca-4b6e-96db-36bd28820fa4.png">
