### PR TITLE
CB-21323: Remove unnecessary response objects from PlatformSecurityGroupResponse

### DIFF
--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/AwsPlatformResources.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/AwsPlatformResources.java
@@ -526,9 +526,6 @@ public class AwsPlatformResources implements PlatformResources {
         for (SecurityGroup securityGroup : fetchSecurityGroups(ec2Client, describeSecurityGroupsRequestBuilder.build())) {
             Map<String, Object> properties = new HashMap<>();
             properties.put("vpcId", securityGroup.vpcId());
-            properties.put("description", securityGroup.description());
-            properties.put("ipPermissions", securityGroup.ipPermissions());
-            properties.put("ipPermissionsEgress", securityGroup.ipPermissionsEgress());
             cloudSecurityGroups.add(new CloudSecurityGroup(securityGroup.groupName(), securityGroup.groupId(), properties));
         }
         result.put(region.value(), cloudSecurityGroups);


### PR DESCRIPTION
In this commit I've removed the following objects from the PlatformSecurityGroupResponse
- description
- ipPermissions
- ipPermissionsEgress

The ipPermissions and ipPermissionsEgress are using a non-serializable Class from AWS SDK v2. Then I removed them from the response because we're not using these properties anywhere.