### PR TITLE
CB-20899: Updating Yarn LB image to use new one with better timeout/connection handling. Updating version to fixed image.

### DIFF
--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/loadbalancer/service/component/YarnLoadBalancerComponentFactoryService.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/loadbalancer/service/component/YarnLoadBalancerComponentFactoryService.java
@@ -34,7 +34,7 @@ public class YarnLoadBalancerComponentFactoryService {
     /**
      * Must match an existing Docker image in the primary Cloudbreak repository.
      */
-    private final String loadBalancerImageName = "docker-sandbox.infra.cloudera.com/cloudbreak/yarn-loadbalancer:2021-03-23-12-02-09";
+    private final String loadBalancerImageName = "docker-private.infra.cloudera.com/cloudera_thirdparty/yarn-loadbalancer:v2.cldr.1";
 
     private final String loadBalancerImageNameForDEHA = "docker-sandbox.infra.cloudera.com/cloudbreak/yarn-loadbalancer:2021-11-24-16-14-09";
 


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-20899

This is the updated image which has already been manually tested on YCloud clusters by the QE team. Previously this was on 2.69 but was reverted due to issues with the YCloud docker version. For now I am pointing this at 2.70.