### PR TITLE
CDPD-43642, increase CM memory threshold on all host

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterModificationService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterModificationService.java
@@ -28,6 +28,8 @@ public interface ClusterModificationService {
 
     void deployConfigAndStartClusterServices() throws CloudbreakException;
 
+    void reconfigureCMMemory() throws CloudbreakException;
+
     Map<String, String> getComponentsByCategory(String blueprintName, String hostGroupName);
 
     String getStackRepositoryJson(StackRepoDetails repoDetails, String stackRepoId);

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
@@ -35,6 +35,7 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+import com.cloudera.api.swagger.AllHostsResourceApi;
 import com.cloudera.api.swagger.BatchResourceApi;
 import com.cloudera.api.swagger.ClouderaManagerResourceApi;
 import com.cloudera.api.swagger.ClustersResourceApi;
@@ -52,6 +53,8 @@ import com.cloudera.api.swagger.model.ApiBatchRequestElement;
 import com.cloudera.api.swagger.model.ApiBatchResponse;
 import com.cloudera.api.swagger.model.ApiCommand;
 import com.cloudera.api.swagger.model.ApiCommandList;
+import com.cloudera.api.swagger.model.ApiConfig;
+import com.cloudera.api.swagger.model.ApiConfigList;
 import com.cloudera.api.swagger.model.ApiConfigStalenessStatus;
 import com.cloudera.api.swagger.model.ApiEntityTag;
 import com.cloudera.api.swagger.model.ApiHost;
@@ -902,6 +905,27 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
             LOGGER.info("Couldn't start Cloudera Manager services", e);
             throw new ClouderaManagerOperationFailedException(e.getMessage(), e);
         }
+    }
+
+    @Override
+    public void reconfigureCMMemory() {
+        try {
+            LOGGER.info("configure CM memory settings.");
+            configureCMMemoryThreasholdOnAllHosts();
+        } catch (ApiException e) {
+            LOGGER.warn("Couldn't Configure CM memory settings", e);
+            throw new ClouderaManagerOperationFailedException(e.getMessage(), e);
+        }
+    }
+
+    private void configureCMMemoryThreasholdOnAllHosts() throws ApiException {
+        AllHostsResourceApi allHostsResourceApi = clouderaManagerApiFactory.getAllHostsResourceApi(apiClient);
+        ApiConfigList apiConfigList = new ApiConfigList();
+        ApiConfig apiConfig = new ApiConfig();
+        apiConfig.setName("memory_overcommit_threshold");
+        apiConfig.setValue("0.95");
+        apiConfigList.addItemsItem(apiConfig);
+        allHostsResourceApi.updateConfig(null, apiConfigList);
     }
 
     @Override

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterStartHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterStartHandlerTest.java
@@ -30,7 +30,6 @@ import com.sequenceiq.cloudbreak.util.StackUtil;
 
 @ExtendWith(MockitoExtension.class)
 class ClusterStartHandlerTest {
-
     @Mock
     private CmTemplateProcessor cmTemplateProcessor;
 
@@ -61,7 +60,6 @@ class ClusterStartHandlerTest {
 
         stack = new Stack();
         stack.setCloudPlatform("AWS");
-
         when(stackUtil.stopStartScalingEntitlementEnabled(any())).thenReturn(true);
         when(apiConnectors.getConnector(any(Stack.class))).thenReturn(connector);
         when(connector.clusterStatusService()).thenReturn(clusterStatusService);

--- a/sdx-connector/src/main/java/com/sequenceiq/cloudbreak/saas/sdx/PaasSdxService.java
+++ b/sdx-connector/src/main/java/com/sequenceiq/cloudbreak/saas/sdx/PaasSdxService.java
@@ -86,4 +86,9 @@ public class PaasSdxService extends AbstractSdxService<SdxClusterStatusResponse>
         }
     }
 
+    @Override
+    public SdxClusterResponse getSdxClusterByEnvironmentCrn(String environmentCrn) {
+        return sdxEndpoint.getByCrn(environmentCrn);
+    }
+
 }

--- a/sdx-connector/src/main/java/com/sequenceiq/cloudbreak/saas/sdx/SaasSdxService.java
+++ b/sdx-connector/src/main/java/com/sequenceiq/cloudbreak/saas/sdx/SaasSdxService.java
@@ -23,6 +23,7 @@ import com.sequenceiq.cloudbreak.saas.client.sdx.GrpcSdxSaasClient;
 import com.sequenceiq.cloudbreak.saas.client.sdx.GrpcServiceDiscoveryClient;
 import com.sequenceiq.cloudbreak.saas.sdx.polling.PollingResult;
 import com.sequenceiq.cloudbreak.saas.sdx.status.StatusCheckResult;
+import com.sequenceiq.sdx.api.model.SdxClusterResponse;
 
 @Service
 public class SaasSdxService extends AbstractSdxService<SDXSvcCommonProto.InstanceHighLevelStatus.Value> {
@@ -95,5 +96,10 @@ public class SaasSdxService extends AbstractSdxService<SDXSvcCommonProto.Instanc
     @Override
     public Optional<Entitlement> getEntitlement() {
         return Optional.of(CDP_SAAS_SDX_INTEGRATION);
+    }
+
+    @Override
+    public SdxClusterResponse getSdxClusterByEnvironmentCrn(String environmentCrn) {
+        throw new UnsupportedOperationException("This is not supported in case of SAAS");
     }
 }

--- a/sdx-connector/src/main/java/com/sequenceiq/cloudbreak/saas/sdx/SdxService.java
+++ b/sdx-connector/src/main/java/com/sequenceiq/cloudbreak/saas/sdx/SdxService.java
@@ -12,6 +12,7 @@ import com.sequenceiq.cloudbreak.auth.altus.model.Entitlement;
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.saas.sdx.polling.PollingResult;
 import com.sequenceiq.cloudbreak.saas.sdx.status.StatusCheckResult;
+import com.sequenceiq.sdx.api.model.SdxClusterResponse;
 
 public interface SdxService<S> {
 
@@ -52,4 +53,6 @@ public interface SdxService<S> {
     default boolean isPlatformEntitled(String accountId) {
         return getEntitlement().isEmpty() || getEntitlementService().isEntitledFor(accountId, getEntitlement().get());
     }
+
+    SdxClusterResponse getSdxClusterByEnvironmentCrn(String environmentCrn);
 }


### PR DESCRIPTION
CDPD-43642, increase CM memory threshold on all hosts to 95% in the case of Medium duty Datalake and the EDL.

Our current datalakes have warnings about the memory settings. The default CM memory threshold is 80%. This means if we allocate more than 80% of the available resource. We cannot handle the basic datalake resource. Therefore we pump up the memory threshold to 95%.
