### PR TITLE
CB-20513 Create metrics for provider API calls - AWS

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/ClusterService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/ClusterService.java
@@ -313,9 +313,9 @@ public class ClusterService {
     }
 
     private void calculateClusterStateMetrics() {
-        periscopeMetricService.submit(MetricType.CLUSTER_STATE_ACTIVE,
+        periscopeMetricService.gauge(MetricType.CLUSTER_STATE_ACTIVE,
                 clusterRepository.countByStateAndAutoscalingEnabledAndPeriscopeNodeId(RUNNING, true, periscopeNodeConfig.getId()));
-        periscopeMetricService.submit(MetricType.CLUSTER_STATE_SUSPENDED,
+        periscopeMetricService.gauge(MetricType.CLUSTER_STATE_SUSPENDED,
                 clusterRepository.countByStateAndAutoscalingEnabledAndPeriscopeNodeId(SUSPENDED, true, periscopeNodeConfig.getId()));
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/PeriscopeMetricService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/PeriscopeMetricService.java
@@ -25,7 +25,7 @@ public class PeriscopeMetricService extends AbstractMetricService {
 
         Arrays.stream(MetricType.values())
                 .filter(this::gaugeMetric)
-                .forEach(m -> submit(m, 0));
+                .forEach(m -> gauge(m, 0));
     }
 
     @Override

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/ha/LeaderElectionService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/ha/LeaderElectionService.java
@@ -88,7 +88,7 @@ public class LeaderElectionService {
         if (periscopeNodeConfig.isNodeIdSpecified()) {
             long leaders = periscopeNodeRepository.countByLeaderIsTrueAndLastUpdatedIsGreaterThan(clock.getCurrentTimeMillis() - heartbeatThresholdRate);
             if (leaders == 0L) {
-                metricService.submit(MetricType.LEADER, 0);
+                metricService.gauge(MetricType.LEADER, 0);
                 LOGGER.info("There is no active leader available");
                 resetTimer();
                 try {
@@ -104,7 +104,7 @@ public class LeaderElectionService {
                     LOGGER.error("Failed to select node as leader, something went wrong. Message: {}", e.getMessage());
                     return;
                 }
-                metricService.submit(MetricType.LEADER, 1);
+                metricService.gauge(MetricType.LEADER, 1);
                 LOGGER.info("Selected {} as leader", periscopeNodeConfig.getId());
                 timer.schedule(new TimerTask() {
                     @Override

--- a/autoscale/src/main/java/com/sequenceiq/periscope/utils/MetricUtils.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/utils/MetricUtils.java
@@ -22,9 +22,9 @@ public class MetricUtils {
 
     public void submitThreadPoolExecutorParameters(ExecutorService executorService) {
         MDCCleanerScheduledExecutor threadPoolExecutor = (MDCCleanerScheduledExecutor) executorService;
-        metricService.submit(THREADPOOL_THREADS_TOTAL, threadPoolExecutor.getCorePoolSize());
-        metricService.submit(THREADPOOL_QUEUE_SIZE, threadPoolExecutor.getQueue().size());
-        metricService.submit(THREADPOOL_TASKS_COMPLETED, threadPoolExecutor.getCompletedTaskCount());
-        metricService.submit(THREADPOOL_ACTIVE_THREADS, threadPoolExecutor.getActiveCount());
+        metricService.gauge(THREADPOOL_THREADS_TOTAL, threadPoolExecutor.getCorePoolSize());
+        metricService.gauge(THREADPOOL_QUEUE_SIZE, threadPoolExecutor.getQueue().size());
+        metricService.gauge(THREADPOOL_TASKS_COMPLETED, threadPoolExecutor.getCompletedTaskCount());
+        metricService.gauge(THREADPOOL_ACTIVE_THREADS, threadPoolExecutor.getActiveCount());
     }
 }

--- a/autoscale/src/test/java/com/sequenceiq/periscope/component/MetricTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/component/MetricTest.java
@@ -241,8 +241,8 @@ public class MetricTest {
 
     @Test
     public void testMetricsWhenSuspendActiveCluster() {
-        metricService.submit(MetricType.CLUSTER_STATE_ACTIVE, 1);
-        metricService.submit(MetricType.CLUSTER_STATE_SUSPENDED, 0);
+        metricService.gauge(MetricType.CLUSTER_STATE_ACTIVE, 1);
+        metricService.gauge(MetricType.CLUSTER_STATE_SUSPENDED, 0);
         when(clusterRepository.findByStackId(STACK_ID)).thenReturn(getACluster(ClusterState.RUNNING));
         when(clusterRepository.findById(CLUSTER_ID)).thenReturn(Optional.of(getACluster(ClusterState.RUNNING)));
         when(clusterRepository.save(any())).thenAnswer(this::saveCluster);
@@ -265,7 +265,7 @@ public class MetricTest {
 
     @Test
     public void testMetricsWhenRunSuspendedCluster() {
-        metricService.submit(MetricType.CLUSTER_STATE_SUSPENDED, 1);
+        metricService.gauge(MetricType.CLUSTER_STATE_SUSPENDED, 1);
         when(clusterRepository.findByStackId(STACK_ID)).thenReturn(getACluster(ClusterState.SUSPENDED));
         when(clusterRepository.findById(CLUSTER_ID)).thenReturn(Optional.of(getACluster(ClusterState.SUSPENDED)));
         when(clusterRepository.save(any())).thenAnswer(this::saveCluster);
@@ -288,7 +288,7 @@ public class MetricTest {
 
     @Test
     public void testMetricsWhenAutofailSuspendsCluster() {
-        metricService.submit(MetricType.CLUSTER_STATE_ACTIVE, 2);
+        metricService.gauge(MetricType.CLUSTER_STATE_ACTIVE, 2);
         when(clusterRepository.findById(CLUSTER_ID)).thenReturn(Optional.of(getACluster(ClusterState.RUNNING)));
         when(clusterRepository.save(any())).thenAnswer(this::saveCluster);
         when(clusterRepository.countByStateAndAutoscalingEnabledAndPeriscopeNodeId(eq(ClusterState.RUNNING), eq(true), anyString()))
@@ -318,7 +318,7 @@ public class MetricTest {
 
     @Test
     public void testDeleteActiveCluster() {
-        metricService.submit(MetricType.CLUSTER_STATE_ACTIVE, 1);
+        metricService.gauge(MetricType.CLUSTER_STATE_ACTIVE, 1);
         when(clusterRepository.findByStackId(STACK_ID)).thenReturn(getACluster(ClusterState.RUNNING));
         when(clusterRepository.findById(CLUSTER_ID)).thenReturn(Optional.of(getACluster(ClusterState.RUNNING)));
         when(clusterRepository.save(any())).thenAnswer(this::saveCluster);
@@ -341,7 +341,7 @@ public class MetricTest {
 
     @Test
     public void testLeaderElection() {
-        metricService.submit(MetricType.LEADER, 0);
+        metricService.gauge(MetricType.LEADER, 0);
         PeriscopeNode periscopeNode = new PeriscopeNode();
         when(periscopeNodeRepository.findById(periscopeNodeConfig.getId())).thenReturn(Optional.of(periscopeNode));
 

--- a/autoscale/src/test/java/com/sequenceiq/periscope/utils/MetricUtilsTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/utils/MetricUtilsTest.java
@@ -42,10 +42,10 @@ public class MetricUtilsTest {
 
         underTest.submitThreadPoolExecutorParameters(threadPoolExecutor);
 
-        verify(metricService).submit(MetricType.THREADPOOL_ACTIVE_THREADS, 8);
-        verify(metricService).submit(MetricType.THREADPOOL_TASKS_COMPLETED, 7L);
-        verify(metricService).submit(MetricType.THREADPOOL_QUEUE_SIZE, 6);
-        verify(metricService).submit(MetricType.THREADPOOL_THREADS_TOTAL, 5);
+        verify(metricService).gauge(MetricType.THREADPOOL_ACTIVE_THREADS, 8);
+        verify(metricService).gauge(MetricType.THREADPOOL_TASKS_COMPLETED, 7L);
+        verify(metricService).gauge(MetricType.THREADPOOL_QUEUE_SIZE, 6);
+        verify(metricService).gauge(MetricType.THREADPOOL_THREADS_TOTAL, 5);
     }
 
 }

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsValidatorsTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsValidatorsTest.java
@@ -52,6 +52,7 @@ import com.sequenceiq.cloudbreak.cloud.aws.common.endpoint.AwsRegionEndpointProv
 import com.sequenceiq.cloudbreak.cloud.aws.common.endpoint.AwsServiceEndpointProvider;
 import com.sequenceiq.cloudbreak.cloud.aws.common.loadbalancer.LoadBalancerTypeConverter;
 import com.sequenceiq.cloudbreak.cloud.aws.common.mapper.SdkClientExceptionMapper;
+import com.sequenceiq.cloudbreak.cloud.aws.common.metrics.AwsMetricPublisher;
 import com.sequenceiq.cloudbreak.cloud.aws.common.subnetselector.SubnetFilterStrategyMultiplePreferPrivate;
 import com.sequenceiq.cloudbreak.cloud.aws.common.subnetselector.SubnetFilterStrategyMultiplePreferPublic;
 import com.sequenceiq.cloudbreak.cloud.aws.common.subnetselector.SubnetSelectorService;
@@ -110,6 +111,9 @@ class AwsValidatorsTest {
 
     @MockBean
     private AwsPageCollector awsPageCollector;
+
+    @MockBean
+    private AwsMetricPublisher awsMetricPublisher;
 
     private AuthenticatedContext authenticatedContext;
 

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/AwsLaunchTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/AwsLaunchTest.java
@@ -34,6 +34,7 @@ import com.sequenceiq.cloudbreak.cloud.aws.common.CommonAwsClient;
 import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonCloudWatchClient;
 import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonEc2Client;
 import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonEfsClient;
+import com.sequenceiq.cloudbreak.cloud.aws.common.metrics.AwsMetricPublisher;
 import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.AwsResourceConnector;
 import com.sequenceiq.cloudbreak.cloud.aws.scheduler.CustomAmazonWaiterProvider;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
@@ -196,6 +197,9 @@ public class AwsLaunchTest {
 
     @MockBean
     private ResourceRetriever resourceRetriever;
+
+    @MockBean
+    private AwsMetricPublisher awsMetricPublisher;
 
     @Inject
     private ResourceBuilders resourceBuilders;

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/AwsRepairTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/AwsRepairTest.java
@@ -48,6 +48,7 @@ import com.sequenceiq.cloudbreak.cloud.aws.common.CommonAwsClient;
 import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonCloudWatchClient;
 import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonEc2Client;
 import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonEfsClient;
+import com.sequenceiq.cloudbreak.cloud.aws.common.metrics.AwsMetricPublisher;
 import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.AwsResourceConnector;
 import com.sequenceiq.cloudbreak.cloud.aws.scheduler.CustomAmazonWaiterProvider;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
@@ -212,6 +213,9 @@ public class AwsRepairTest {
 
     @MockBean
     private AwsMetadataCollector awsMetadataCollector;
+
+    @MockBean
+    private AwsMetricPublisher awsMetricPublisher;
 
     @Test
     public void repairStack() throws Exception {

--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/metrics/AwsMetricPublisher.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/metrics/AwsMetricPublisher.java
@@ -1,0 +1,97 @@
+package com.sequenceiq.cloudbreak.cloud.aws.common.metrics;
+
+import static com.sequenceiq.cloudbreak.cloud.aws.common.metrics.AwsMetricTag.OPERATION_NAME;
+import static com.sequenceiq.cloudbreak.cloud.aws.common.metrics.AwsMetricTag.SERVICE_ID;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import com.google.common.base.CaseFormat;
+import com.sequenceiq.cloudbreak.common.metrics.MetricService;
+
+import software.amazon.awssdk.core.metrics.CoreMetric;
+import software.amazon.awssdk.http.HttpMetric;
+import software.amazon.awssdk.metrics.MetricCollection;
+import software.amazon.awssdk.metrics.MetricPublisher;
+import software.amazon.awssdk.metrics.SdkMetric;
+
+@Component
+public class AwsMetricPublisher implements MetricPublisher {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsMetricPublisher.class);
+
+    private static final Set<SdkMetric<?>> ALLOWED_METRICS = Set.of(CoreMetric.API_CALL_DURATION, CoreMetric.API_CALL_SUCCESSFUL,
+            CoreMetric.SERVICE_CALL_DURATION, CoreMetric.RETRY_COUNT, HttpMetric.MAX_CONCURRENCY, HttpMetric.LEASED_CONCURRENCY,
+            HttpMetric.PENDING_CONCURRENCY_ACQUIRES);
+
+    private static final String AWS_METRIC_PREFIX = "aws_";
+
+    private static final String API_CALL_FAILED_METRIC_NAME = "aws_api_call_failed_total";
+
+    @Qualifier("CommonMetricService")
+    @Inject
+    private MetricService metricService;
+
+    @Override
+    public void publish(MetricCollection metricCollection) {
+        try {
+            Optional<String> serviceId = metricCollection.metricValues(CoreMetric.SERVICE_ID).stream().filter(Objects::nonNull).findFirst();
+            Optional<String> operationName = metricCollection.metricValues(CoreMetric.OPERATION_NAME).stream().filter(Objects::nonNull).findFirst();
+            if (serviceId.isEmpty() || operationName.isEmpty()) {
+                LOGGER.warn("ServiceId or OperationName is empty for AWS MetricCollection: {}", metricCollection);
+                return;
+            }
+
+            publishMetrics(metricCollection, serviceId.get(), operationName.get());
+        } catch (Exception e) {
+            LOGGER.warn("Publishing AWS metrics failed", e);
+        }
+    }
+
+    private void publishMetrics(MetricCollection metricCollection, String serviceId, String operationName) {
+        metricCollection.stream()
+                .filter(metricRecord -> metricRecord.metric() != null && metricRecord.value() != null)
+                .filter(metricRecord -> ALLOWED_METRICS.contains(metricRecord.metric()))
+                .forEach(metricRecord -> {
+            String metricName = convertMetricName(metricRecord.metric().name());
+            Class<?> metricValueClass = metricRecord.metric().valueClass();
+            String[] tags = tags(serviceId, operationName);
+
+            if (CoreMetric.API_CALL_SUCCESSFUL.equals(metricRecord.metric())) {
+                Boolean success = (Boolean) metricRecord.value();
+                if (Boolean.FALSE.equals(success)) {
+                    metricService.incrementMetricCounter(API_CALL_FAILED_METRIC_NAME, tags);
+                }
+            } else if (Duration.class.isAssignableFrom(metricValueClass)) {
+                Duration duration = (Duration) metricRecord.value();
+                metricService.recordTimerMetric(metricName, duration, tags);
+            } else if (Number.class.isAssignableFrom(metricValueClass)) {
+                Double amount = Double.valueOf(metricRecord.value().toString());
+                metricService.incrementMetricCounter(metricName, amount, tags);
+            }
+        });
+
+        metricCollection.children().forEach(child -> publishMetrics(child, serviceId, operationName));
+    }
+
+    @Override
+    public void close() {
+    }
+
+    private String convertMetricName(String metricName) {
+        return AWS_METRIC_PREFIX + CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, metricName);
+    }
+
+    private String[] tags(String serviceId, String operationName) {
+        return new String[] { SERVICE_ID.name(), serviceId, OPERATION_NAME.name(), operationName };
+    }
+}

--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/metrics/AwsMetricTag.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/metrics/AwsMetricTag.java
@@ -1,0 +1,7 @@
+package com.sequenceiq.cloudbreak.cloud.aws.common.metrics;
+
+public enum AwsMetricTag {
+
+    SERVICE_ID,
+    OPERATION_NAME
+}

--- a/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/AwsAuthenticatorTest.java
+++ b/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/AwsAuthenticatorTest.java
@@ -31,6 +31,7 @@ import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonEc2Client;
 import com.sequenceiq.cloudbreak.cloud.aws.common.endpoint.AwsRegionEndpointProvider;
 import com.sequenceiq.cloudbreak.cloud.aws.common.endpoint.AwsServiceEndpointProvider;
 import com.sequenceiq.cloudbreak.cloud.aws.common.mapper.SdkClientExceptionMapper;
+import com.sequenceiq.cloudbreak.cloud.aws.common.metrics.AwsMetricPublisher;
 import com.sequenceiq.cloudbreak.cloud.aws.common.util.AwsPageCollector;
 import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsCredentialView;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
@@ -63,6 +64,9 @@ class AwsAuthenticatorTest {
 
     @MockBean
     private AwsPageCollector awsPageCollector;
+
+    @MockBean
+    private AwsMetricPublisher awsMetricPublisher;
 
     @BeforeEach
     void awsClientSetup() {

--- a/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/AwsInstanceConnectorTest.java
+++ b/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/AwsInstanceConnectorTest.java
@@ -47,6 +47,7 @@ import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonEc2Client;
 import com.sequenceiq.cloudbreak.cloud.aws.common.endpoint.AwsRegionEndpointProvider;
 import com.sequenceiq.cloudbreak.cloud.aws.common.endpoint.AwsServiceEndpointProvider;
 import com.sequenceiq.cloudbreak.cloud.aws.common.mapper.SdkClientExceptionMapper;
+import com.sequenceiq.cloudbreak.cloud.aws.common.metrics.AwsMetricPublisher;
 import com.sequenceiq.cloudbreak.cloud.aws.common.poller.PollerUtil;
 import com.sequenceiq.cloudbreak.cloud.aws.common.util.AwsInstanceStatusMapper;
 import com.sequenceiq.cloudbreak.cloud.aws.common.util.AwsPageCollector;
@@ -109,6 +110,9 @@ class AwsInstanceConnectorTest {
 
     @MockBean
     private AwsPageCollector awsPageCollector;
+
+    @MockBean
+    private AwsMetricPublisher awsMetricPublisher;
 
     private AuthenticatedContext authenticatedContext;
 

--- a/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/metrics/AwsMetricPublisherTest.java
+++ b/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/metrics/AwsMetricPublisherTest.java
@@ -1,0 +1,176 @@
+package com.sequenceiq.cloudbreak.cloud.aws.common.metrics;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.metrics.MetricService;
+
+import software.amazon.awssdk.core.metrics.CoreMetric;
+import software.amazon.awssdk.metrics.MetricCollection;
+import software.amazon.awssdk.metrics.MetricRecord;
+import software.amazon.awssdk.metrics.SdkMetric;
+import software.amazon.awssdk.metrics.internal.DefaultMetricCollection;
+import software.amazon.awssdk.metrics.internal.DefaultMetricRecord;
+
+@ExtendWith(MockitoExtension.class)
+class AwsMetricPublisherTest {
+
+    @Mock
+    private MetricService metricService;
+
+    @InjectMocks
+    private AwsMetricPublisher underTest;
+
+    @Test
+    void publishShouldReturnWhenMetricsIsEmpty() {
+        underTest.publish(metricCollection(new HashMap<>()));
+        verifyNoInteractions(metricService);
+    }
+
+    @Test
+    void publishShouldReturnWhenServiceIdMissing() {
+        underTest.publish(metricCollection(Map.of(CoreMetric.OPERATION_NAME, List.of(new DefaultMetricRecord<>(CoreMetric.OPERATION_NAME, "operationName")))));
+        verifyNoInteractions(metricService);
+    }
+
+    @Test
+    void publishShouldReturnWhenOperationNameMissing() {
+        underTest.publish(metricCollection(Map.of(CoreMetric.SERVICE_ID, List.of(new DefaultMetricRecord<>(CoreMetric.SERVICE_ID, "serviceId")))));
+        verifyNoInteractions(metricService);
+    }
+
+    @Test
+    void publishShouldReturnWhenOperationNameIsNull() {
+        underTest.publish(metricCollection(Map.of(CoreMetric.OPERATION_NAME, List.of(new DefaultMetricRecord<>(CoreMetric.OPERATION_NAME, null)))));
+        verifyNoInteractions(metricService);
+    }
+
+    @Test
+    void publishShouldReturnWhenServiceIdIsNull() {
+        underTest.publish(metricCollection(Map.of(CoreMetric.SERVICE_ID, List.of(new DefaultMetricRecord<>(CoreMetric.SERVICE_ID, null)))));
+        verifyNoInteractions(metricService);
+    }
+
+    @Test
+    void publishShouldReturnWhenNoMetricWithExistingValuePresents() {
+        Map<SdkMetric<?>, List<MetricRecord<?>>> metrics = defaultMetrics();
+        metrics.put(CoreMetric.API_CALL_DURATION, List.of(new DefaultMetricRecord<>(CoreMetric.API_CALL_DURATION, null)));
+        underTest.publish(metricCollection(metrics));
+        verifyNoInteractions(metricService);
+    }
+
+    @Test
+    void publishShouldReturnWhenNoMetricWithMetricValuePresents() {
+        Map<SdkMetric<?>, List<MetricRecord<?>>> metrics = defaultMetrics();
+        metrics.put(CoreMetric.API_CALL_DURATION, List.of(new DefaultMetricRecord<>(null, "value")));
+        underTest.publish(metricCollection(metrics));
+        verifyNoInteractions(metricService);
+    }
+
+    @Test
+    void publishShouldReturnWhenNoKnownMetricPresents() {
+        Map<SdkMetric<?>, List<MetricRecord<?>>> metrics = defaultMetrics();
+        metrics.put(CoreMetric.MARSHALLING_DURATION, List.of(new DefaultMetricRecord<>(CoreMetric.MARSHALLING_DURATION, Duration.ofMinutes(1))));
+        underTest.publish(metricCollection(metrics));
+        verifyNoInteractions(metricService);
+    }
+
+    @Test
+    void publishShouldReturnWhenApiCallSuccessfulMetricSucceeds() {
+        Map<SdkMetric<?>, List<MetricRecord<?>>> metrics = defaultMetrics();
+        metrics.put(CoreMetric.API_CALL_SUCCESSFUL, List.of(new DefaultMetricRecord<>(CoreMetric.API_CALL_SUCCESSFUL, Boolean.TRUE)));
+        underTest.publish(metricCollection(metrics));
+        verifyNoInteractions(metricService);
+    }
+
+    @Test
+    void publishShouldReturnWhenRecordingMetricFails() {
+        Mockito.doThrow(new RuntimeException("failed")).when(metricService).incrementMetricCounter(anyString(), any());
+        Map<SdkMetric<?>, List<MetricRecord<?>>> metrics = defaultMetrics();
+        metrics.put(CoreMetric.API_CALL_SUCCESSFUL, List.of(new DefaultMetricRecord<>(CoreMetric.API_CALL_SUCCESSFUL, Boolean.FALSE)));
+        metrics.put(CoreMetric.API_CALL_DURATION, List.of(new DefaultMetricRecord<>(CoreMetric.API_CALL_DURATION, Duration.ofMinutes(1))));
+        underTest.publish(metricCollection(metrics));
+        verify(metricService, times(1)).incrementMetricCounter(eq("aws_api_call_failed_total"), any());
+        verifyNoMoreInteractions(metricService);
+    }
+
+    @Test
+    void publishShouldRecordApiCallFailedWhenApiCallSuccessfulMetricFailed() {
+        Map<SdkMetric<?>, List<MetricRecord<?>>> metrics = defaultMetrics();
+        metrics.put(CoreMetric.API_CALL_SUCCESSFUL, List.of(new DefaultMetricRecord<>(CoreMetric.API_CALL_SUCCESSFUL, Boolean.FALSE)));
+        underTest.publish(metricCollection(metrics));
+        verify(metricService, only()).incrementMetricCounter(eq("aws_api_call_failed_total"), any());
+    }
+
+    @Test
+    void publishShouldRecordKnownDurationTypeMetric() {
+        Map<SdkMetric<?>, List<MetricRecord<?>>> metrics = defaultMetrics();
+        metrics.put(CoreMetric.API_CALL_DURATION, List.of(new DefaultMetricRecord<>(CoreMetric.API_CALL_DURATION, Duration.ofMinutes(1))));
+        underTest.publish(metricCollection(metrics));
+        verify(metricService, only()).recordTimerMetric(eq("aws_api_call_duration"), eq(Duration.ofMinutes(1)), any());
+    }
+
+    @Test
+    void publishShouldRecordKnownNumberTypeMetric() {
+        Map<SdkMetric<?>, List<MetricRecord<?>>> metrics = defaultMetrics();
+        metrics.put(CoreMetric.RETRY_COUNT, List.of(new DefaultMetricRecord<>(CoreMetric.RETRY_COUNT, Integer.valueOf(10))));
+        underTest.publish(metricCollection(metrics));
+        verify(metricService, only()).incrementMetricCounter(eq("aws_retry_count"), eq(10.0), any());
+    }
+
+    @Test
+    void publishShouldRecordKnownChildrenMetric() {
+        Map<SdkMetric<?>, List<MetricRecord<?>>> metrics = defaultMetrics();
+        underTest.publish(metricCollection(metrics,
+                List.of(metricCollection(Map.of(CoreMetric.RETRY_COUNT, List.of(new DefaultMetricRecord<>(CoreMetric.RETRY_COUNT, Integer.valueOf(10))))))));
+        verify(metricService, only()).incrementMetricCounter(eq("aws_retry_count"), eq(10.0), any());
+    }
+
+    @Test
+    void publishShouldRecordAllKnownMetrics() {
+        Map<SdkMetric<?>, List<MetricRecord<?>>> metrics = defaultMetrics();
+        metrics.put(CoreMetric.API_CALL_DURATION, List.of(new DefaultMetricRecord<>(CoreMetric.API_CALL_DURATION, Duration.ofMinutes(1))));
+        metrics.put(CoreMetric.API_CALL_SUCCESSFUL, List.of(new DefaultMetricRecord<>(CoreMetric.API_CALL_SUCCESSFUL, Boolean.FALSE)));
+        metrics.put(CoreMetric.MARSHALLING_DURATION, List.of(new DefaultMetricRecord<>(CoreMetric.MARSHALLING_DURATION, Duration.ofMinutes(1))));
+        underTest.publish(metricCollection(metrics,
+                List.of(metricCollection(Map.of(CoreMetric.RETRY_COUNT, List.of(new DefaultMetricRecord<>(CoreMetric.RETRY_COUNT, Integer.valueOf(10))))))));
+        verify(metricService, times(1)).recordTimerMetric(eq("aws_api_call_duration"), eq(Duration.ofMinutes(1)), any());
+        verify(metricService, times(1)).incrementMetricCounter(eq("aws_api_call_failed_total"), any());
+        verify(metricService, times(1)).incrementMetricCounter(eq("aws_retry_count"), eq(10.0), any());
+        verifyNoMoreInteractions(metricService);
+    }
+
+    private Map<SdkMetric<?>, List<MetricRecord<?>>> defaultMetrics() {
+        Map<SdkMetric<?>, List<MetricRecord<?>>> defaultMetrics = new HashMap<>();
+        defaultMetrics.put(CoreMetric.OPERATION_NAME, List.of(new DefaultMetricRecord<>(CoreMetric.OPERATION_NAME, "operationName")));
+        defaultMetrics.put(CoreMetric.SERVICE_ID, List.of(new DefaultMetricRecord<>(CoreMetric.SERVICE_ID, "serviceId")));
+        return defaultMetrics;
+    }
+
+    private MetricCollection metricCollection(Map<SdkMetric<?>, List<MetricRecord<?>>> metrics) {
+        return metricCollection(metrics, null);
+    }
+
+    private MetricCollection metricCollection(Map<SdkMetric<?>, List<MetricRecord<?>>> metrics, List<MetricCollection> children) {
+        return new DefaultMetricCollection("metricCollection", metrics, children);
+    }
+
+}

--- a/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/validator/AwsStorageValidatorsTest.java
+++ b/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/validator/AwsStorageValidatorsTest.java
@@ -47,6 +47,7 @@ import com.sequenceiq.cloudbreak.cloud.aws.common.endpoint.AwsRegionEndpointProv
 import com.sequenceiq.cloudbreak.cloud.aws.common.endpoint.AwsServiceEndpointProvider;
 import com.sequenceiq.cloudbreak.cloud.aws.common.loadbalancer.LoadBalancerTypeConverter;
 import com.sequenceiq.cloudbreak.cloud.aws.common.mapper.SdkClientExceptionMapper;
+import com.sequenceiq.cloudbreak.cloud.aws.common.metrics.AwsMetricPublisher;
 import com.sequenceiq.cloudbreak.cloud.aws.common.subnetselector.SubnetFilterStrategyMultiplePreferPrivate;
 import com.sequenceiq.cloudbreak.cloud.aws.common.subnetselector.SubnetFilterStrategyMultiplePreferPublic;
 import com.sequenceiq.cloudbreak.cloud.aws.common.subnetselector.SubnetSelectorService;
@@ -100,6 +101,9 @@ public class AwsStorageValidatorsTest {
 
     @MockBean
     private EntitlementService entitlementService;
+
+    @MockBean
+    private AwsMetricPublisher awsMetricPublisher;
 
     private AuthenticatedContext authenticatedContext;
 

--- a/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsNativeMetadataCollectorApiIntegrationTest.java
+++ b/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsNativeMetadataCollectorApiIntegrationTest.java
@@ -35,6 +35,7 @@ import com.sequenceiq.cloudbreak.cloud.aws.common.endpoint.AwsRegionEndpointProv
 import com.sequenceiq.cloudbreak.cloud.aws.common.endpoint.AwsServiceEndpointProvider;
 import com.sequenceiq.cloudbreak.cloud.aws.common.loadbalancer.LoadBalancerTypeConverter;
 import com.sequenceiq.cloudbreak.cloud.aws.common.mapper.SdkClientExceptionMapper;
+import com.sequenceiq.cloudbreak.cloud.aws.common.metrics.AwsMetricPublisher;
 import com.sequenceiq.cloudbreak.cloud.aws.common.subnetselector.SubnetFilterStrategyMultiplePreferPrivate;
 import com.sequenceiq.cloudbreak.cloud.aws.common.subnetselector.SubnetFilterStrategyMultiplePreferPublic;
 import com.sequenceiq.cloudbreak.cloud.aws.common.subnetselector.SubnetSelectorService;
@@ -87,6 +88,9 @@ class AwsNativeMetadataCollectorApiIntegrationTest {
 
     @MockBean
     private EntitlementService entitlementService;
+
+    @MockBean
+    private AwsMetricPublisher awsMetricPublisher;
 
     @Inject
     private AwsAuthenticator awsAuthenticator;

--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/metrics/MetricService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/metrics/MetricService.java
@@ -8,17 +8,23 @@ import com.sequenceiq.cloudbreak.common.metrics.type.Metric;
 import com.sequenceiq.cloudbreak.common.service.TransactionMetricsContext;
 
 public interface MetricService {
-    void submit(Metric metric, double value);
+    void gauge(Metric metric, double value);
 
-    void submit(Metric metric, double value, Map<String, String> labels);
+    void gauge(Metric metric, double value, Map<String, String> tags);
 
     void initMicrometerMetricCounter(Metric metric);
 
     void incrementMetricCounter(Metric metric, String... tags);
 
+    void incrementMetricCounter(String metric, String... tags);
+
+    void incrementMetricCounter(String metric, double amount, String... tags);
+
     <T, U> Map<T, U> gaugeMapSize(Metric metric, Map<T, U> map);
 
     void recordTimerMetric(Metric metric, Duration duration, String... tags);
+
+    void recordTimerMetric(String metric, Duration duration, String... tags);
 
     <T> void registerGaugeMetric(Metric metric, T object, ToDoubleFunction<T> valueFunction, Map<String, String> tags);
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/StackCreatorService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/StackCreatorService.java
@@ -294,7 +294,7 @@ public class StackCreatorService {
 
         recipeService.sendClusterCreationUsageReport(savedStack);
 
-        metricService.submit(STACK_PREPARATION, System.currentTimeMillis() - start);
+        metricService.gauge(STACK_PREPARATION, System.currentTimeMillis() - start);
 
         return response;
     }

--- a/flow/src/main/java/com/sequenceiq/flow/core/AbstractAction.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/AbstractAction.java
@@ -99,7 +99,7 @@ public abstract class AbstractAction<S extends FlowState, E extends FlowEvent, C
             String resourceId = getResourceId(payload, flowStateName);
             LOGGER.debug("Resource ID: {}, flow state: {}, phase: {}, execution time {} sec", resourceId,
                     flowStateName, execElapsed > flowElapsed ? "doExec" : "service", executionTime);
-            metricService.submit(FlowMetricType.FLOW_STEP, executionTime, Map.of("name", flowStateName.toLowerCase()));
+            metricService.gauge(FlowMetricType.FLOW_STEP, executionTime, Map.of("name", flowStateName.toLowerCase()));
         }
         variables.put(FLOW_STATE_NAME, context.getStateMachine().getState().getId());
         variables.put(FLOW_START_EXEC_TIME, System.currentTimeMillis());

--- a/flow/src/main/java/com/sequenceiq/flow/core/FlowRegister.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/FlowRegister.java
@@ -50,7 +50,7 @@ public class FlowRegister {
     public Flow remove(String flowId) {
         LOGGER.info("Remove flow {} from running flows", flowId);
         Pair<Flow, String> pair = runningFlows.remove(flowId);
-        metricService.submit(FlowMetricType.ACTIVE_FLOWS, runningFlows.size());
+        metricService.gauge(FlowMetricType.ACTIVE_FLOWS, runningFlows.size());
         LOGGER.info("Running flows after removal: {}", runningFlows.keySet());
         return pair == null ? null : pair.getLeft();
     }

--- a/secret-engine/src/main/java/com/sequenceiq/cloudbreak/service/secret/service/SecretService.java
+++ b/secret-engine/src/main/java/com/sequenceiq/cloudbreak/service/secret/service/SecretService.java
@@ -68,7 +68,7 @@ public class SecretService {
         long start = System.currentTimeMillis();
         boolean exists = vaultRetryService.tryReadingVault(() -> persistentEngine.exists(key));
         long duration = System.currentTimeMillis() - start;
-        metricService.submit(MetricType.VAULT_READ, duration);
+        metricService.gauge(MetricType.VAULT_READ, duration);
         LOGGER.trace("Secret read took {} ms", duration);
         if (exists) {
             throw new InvalidKeyException(format("Key: %s already exists!", key));
@@ -76,7 +76,7 @@ public class SecretService {
         start = System.currentTimeMillis();
         String secret = vaultRetryService.tryWritingVault(() -> persistentEngine.put(key, value));
         duration = System.currentTimeMillis() - start;
-        metricService.submit(MetricType.VAULT_WRITE, duration);
+        metricService.gauge(MetricType.VAULT_WRITE, duration);
         LOGGER.trace("Secret write took {} ms", duration);
         metricService.incrementMetricCounter(() -> "secret.write." + convertSecretToMetric(secret));
         return secret;
@@ -103,7 +103,7 @@ public class SecretService {
                     .orElse(null);
         });
         long duration = System.currentTimeMillis() - start;
-        metricService.submit(MetricType.VAULT_READ, duration);
+        metricService.gauge(MetricType.VAULT_READ, duration);
         LOGGER.trace("Secret read took {} ms", duration);
         return "null".equals(response) ? null : response;
     }
@@ -142,7 +142,7 @@ public class SecretService {
                 .filter(e -> e.isSecret(secret))
                 .forEach(e -> e.delete(secret));
         long duration = System.currentTimeMillis() - start;
-        metricService.submit(MetricType.VAULT_WRITE, duration);
+        metricService.gauge(MetricType.VAULT_WRITE, duration);
         LOGGER.trace("Secret delete took {} ms", duration);
     }
 
@@ -155,7 +155,7 @@ public class SecretService {
         long start = System.currentTimeMillis();
         persistentEngine.cleanup(pathPrefix);
         long duration = System.currentTimeMillis() - start;
-        metricService.submit(MetricType.VAULT_WRITE, duration);
+        metricService.gauge(MetricType.VAULT_WRITE, duration);
         LOGGER.trace("Secret cleanup took {} ms", duration);
     }
 

--- a/secret-engine/src/test/java/com/sequenceiq/cloudbreak/service/secret/service/SecretServiceTest.java
+++ b/secret-engine/src/test/java/com/sequenceiq/cloudbreak/service/secret/service/SecretServiceTest.java
@@ -70,7 +70,7 @@ public class SecretServiceTest {
         try {
             underTest.put("key", "value");
         } catch (InvalidKeyException e) {
-            verify(metricService, times(1)).submit(eq(MetricType.VAULT_READ), anyDouble());
+            verify(metricService, times(1)).gauge(eq(MetricType.VAULT_READ), anyDouble());
             throw e;
         }
     }
@@ -82,9 +82,9 @@ public class SecretServiceTest {
 
         String result = underTest.put("key", "value");
 
-        verify(metricService, times(1)).submit(eq(MetricType.VAULT_READ), anyDouble());
+        verify(metricService, times(1)).gauge(eq(MetricType.VAULT_READ), anyDouble());
         verify(persistentEngine, times(1)).put(eq("key"), eq("value"));
-        verify(metricService, times(1)).submit(eq(MetricType.VAULT_WRITE), anyDouble());
+        verify(metricService, times(1)).gauge(eq(MetricType.VAULT_WRITE), anyDouble());
         verify(metricService, times(1)).incrementMetricCounter(any(Metric.class));
 
         Assert.assertEquals("secret", result);
@@ -103,7 +103,7 @@ public class SecretServiceTest {
 
         verify(metricService, times(1)).incrementMetricCounter(any(Metric.class));
         verify(persistentEngine, times(1)).isSecret(anyString());
-        verify(metricService, times(1)).submit(eq(MetricType.VAULT_READ), anyDouble());
+        verify(metricService, times(1)).gauge(eq(MetricType.VAULT_READ), anyDouble());
 
         Assert.assertNull(result);
     }
@@ -126,7 +126,7 @@ public class SecretServiceTest {
         verify(metricService, times(1)).incrementMetricCounter(any(Metric.class));
         verify(persistentEngine, times(1)).isSecret(any());
         verify(persistentEngine, times(0)).delete(anyString());
-        verify(metricService, times(1)).submit(eq(MetricType.VAULT_WRITE), anyDouble());
+        verify(metricService, times(1)).gauge(eq(MetricType.VAULT_WRITE), anyDouble());
     }
 
     @Test
@@ -136,6 +136,6 @@ public class SecretServiceTest {
         verify(metricService, times(1)).incrementMetricCounter(any(Metric.class));
         verify(persistentEngine, times(1)).isSecret(anyString());
         verify(persistentEngine, times(1)).delete(anyString());
-        verify(metricService, times(1)).submit(eq(MetricType.VAULT_WRITE), anyDouble());
+        verify(metricService, times(1)).gauge(eq(MetricType.VAULT_WRITE), anyDouble());
     }
 }


### PR DESCRIPTION
Metrics: aws_api_call_duration_,aws_service_call_duration_, aws_api_call_failed_total, aws_retry_count_total, aws_max_concurrency_total, aws_leased_concurrency_total, aws_pending_concurrency_acquires_total

See detailed description in the commit message.