### PR TITLE
CB-21347 json-smart upgrade from 2.4.5 to 2.4.9 (Aquasec cve) 

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -58,7 +58,7 @@ ext {
   gsonVersion = '2.8.9'
   jacksonVersion = '2.13.4'
   jacksonDatabindVersion = '2.13.5'
-  jsonSmartVersion = '2.4.5'
+  jsonSmartVersion = '2.4.9'
   snakeYamlVersion = '1.33'
   xerces = '2.12.0'
 


### PR DESCRIPTION
See detailed description in the commit message.