### PR TITLE
CB-21382 Make retry number and timeout duration configurable for DB…

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
@@ -544,8 +544,9 @@ public interface StackV4Endpoint {
     BackupV4Response backupDatabaseByName(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name,
             @QueryParam("backupLocation") String backupLocation, @QueryParam("backupId") String backupId,
             @QueryParam("skipDatabaseNames") List<String> skipDatabaseNames,
-            @AccountId @QueryParam("accountId") String accountId);
+            @AccountId @QueryParam("accountId") String accountId, @QueryParam("databaseMaxDurationInMin") int databaseMaxDurationInMin);
 
+    @SuppressWarnings("ParameterNumber")
     @POST
     @Path("internal/{name}/database_backup")
     @Produces(MediaType.APPLICATION_JSON)
@@ -553,7 +554,8 @@ public interface StackV4Endpoint {
     BackupV4Response backupDatabaseByNameInternal(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name,
             @QueryParam("backupId") String backupId, @QueryParam("backupLocation") String backupLocation,
             @QueryParam("closeConnections") boolean closeConnections,
-            @QueryParam("skipDatabaseNames") List<String> skipDatabaseNames, @QueryParam("initiatorUserCrn") String initiatorUserCrn);
+            @QueryParam("skipDatabaseNames") List<String> skipDatabaseNames, @QueryParam("initiatorUserCrn") String initiatorUserCrn,
+            @QueryParam("databaseMaxDurationInMin") int databaseMaxDurationInMin);
 
     @POST
     @Path("{name}/database_restore")
@@ -561,7 +563,7 @@ public interface StackV4Endpoint {
     @ApiOperation(value = DATABASE_RESTORE, nickname = "databaseRestore")
     RestoreV4Response restoreDatabaseByName(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name,
             @QueryParam("backupLocation") String backupLocation, @QueryParam("backupId") String backupId,
-            @AccountId @QueryParam("accountId") String accountId);
+            @AccountId @QueryParam("accountId") String accountId, @QueryParam("databaseMaxDurationInMin") int databaseMaxDurationInMin);
 
     @POST
     @Path("internal/{name}/database_restore")
@@ -569,7 +571,7 @@ public interface StackV4Endpoint {
     @ApiOperation(value = DATABASE_RESTORE_INTERNAL, nickname = "databaseRestoreInternal")
     RestoreV4Response restoreDatabaseByNameInternal(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name,
             @QueryParam("backupLocation") String backupLocation, @QueryParam("backupId") String backupId,
-            @QueryParam("initiatorUserCrn") String initiatorUserCrn);
+            @QueryParam("initiatorUserCrn") String initiatorUserCrn, @QueryParam("databaseMaxDurationInMin") int databaseMaxDurationInMin);
 
     @POST
     @Path("internal/{name}/cluster_recover")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
@@ -462,36 +462,39 @@ public class StackV4Controller extends NotificationController implements StackV4
     @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.POWERUSER_ONLY)
     public BackupV4Response backupDatabaseByName(Long workspaceId, String name, String backupLocation, String backupId, List<String> skipDatabaseNames,
-            @AccountId String accountId) {
+            @AccountId String accountId, int databaseMaxDurationInMin) {
         FlowIdentifier flowIdentifier = stackOperations.backupClusterDatabase(NameOrCrn.ofName(name),
-                restRequestThreadLocalService.getRequestedWorkspaceId(), backupLocation, backupId, true, skipDatabaseNames);
+                restRequestThreadLocalService.getRequestedWorkspaceId(), backupLocation, backupId, true, skipDatabaseNames,
+                databaseMaxDurationInMin);
         return new BackupV4Response(flowIdentifier);
     }
 
     @Override
     @InternalOnly
+    @SuppressWarnings("ParameterNumber")
     public BackupV4Response backupDatabaseByNameInternal(Long workspaceId, String name, String backupId, String backupLocation,
-            boolean closeConnections, List<String> skipDatabaseNames, @InitiatorUserCrn String initiatorUserCrn) {
+            boolean closeConnections, List<String> skipDatabaseNames, @InitiatorUserCrn String initiatorUserCrn, int databaseMaxDurationInMin) {
         FlowIdentifier flowIdentifier = stackOperations.backupClusterDatabase(NameOrCrn.ofName(name),
-                restRequestThreadLocalService.getRequestedWorkspaceId(), backupLocation, backupId, closeConnections, skipDatabaseNames);
+                restRequestThreadLocalService.getRequestedWorkspaceId(), backupLocation, backupId, closeConnections, skipDatabaseNames,
+                databaseMaxDurationInMin);
         return new BackupV4Response(flowIdentifier);
     }
 
     @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.POWERUSER_ONLY)
     public RestoreV4Response restoreDatabaseByName(Long workspaceId, String name, String backupLocation, String backupId,
-            @AccountId String accountId) {
+            @AccountId String accountId, int databaseMaxDurationInMin) {
         FlowIdentifier flowIdentifier = stackOperations.restoreClusterDatabase(NameOrCrn.ofName(name),
-                restRequestThreadLocalService.getRequestedWorkspaceId(), backupLocation, backupId);
+                restRequestThreadLocalService.getRequestedWorkspaceId(), backupLocation, backupId, databaseMaxDurationInMin);
         return new RestoreV4Response(flowIdentifier);
     }
 
     @Override
     @InternalOnly
     public RestoreV4Response restoreDatabaseByNameInternal(Long workspaceId, String name, String backupLocation, String backupId,
-            @InitiatorUserCrn String initiatorUserCrn) {
+            @InitiatorUserCrn String initiatorUserCrn, int databaseMaxDurationInMin) {
         FlowIdentifier flowIdentifier = stackOperations.restoreClusterDatabase(NameOrCrn.ofName(name),
-                restRequestThreadLocalService.getRequestedWorkspaceId(), backupLocation, backupId);
+                restRequestThreadLocalService.getRequestedWorkspaceId(), backupLocation, backupId, databaseMaxDurationInMin);
         return new RestoreV4Response(flowIdentifier);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/BackupDatalakeDatabaseFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/BackupDatalakeDatabaseFlowEventChainFactory.java
@@ -52,7 +52,8 @@ public class BackupDatalakeDatabaseFlowEventChainFactory implements FlowEventCha
             LOGGER.info("Skipping salt update step in backup DL DB flow chain due to already being done as part of determine DL data sizes flow chain.");
         }
         flowEventChain.add(new DatabaseBackupTriggerEvent(DATABASE_BACKUP_EVENT.event(), event.getResourceId(), event.accepted(),
-                event.getBackupLocation(), event.getBackupId(), event.isCloseConnections(), event.getSkipDatabaseNames()));
+                event.getBackupLocation(), event.getBackupId(), event.isCloseConnections(), event.getSkipDatabaseNames(),
+                event.getDatabaseMaxDurationInMin()));
         return new FlowTriggerEventQueue(getName(), event, flowEventChain);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/AbstractBackupRestoreActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/AbstractBackupRestoreActions.java
@@ -22,7 +22,7 @@ public abstract class AbstractBackupRestoreActions<P extends BackupRestoreEvent>
     protected BackupRestoreContext createFlowContext(FlowParameters flowParameters, StateContext<FlowState, FlowEvent> stateContext,
         P payload) {
         return BackupRestoreContext.from(flowParameters, payload, payload.getBackupLocation(), payload.getBackupId(),
-                payload.isCloseConnections(), payload.getSkipDatabaseNames());
+                payload.isCloseConnections(), payload.getSkipDatabaseNames(), payload.getDatabaseMaxDurationInMin());
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/BackupRestoreContext.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/BackupRestoreContext.java
@@ -18,19 +18,22 @@ public class BackupRestoreContext extends CommonContext {
 
     private final List<String> skipDatabaseNames;
 
+    private final int databaseMaxDurationInMin;
+
     public BackupRestoreContext(FlowParameters flowParameters, StackEvent event, String backupLocation, String backupId,
-                                boolean closeConnections, List<String> skipDatabaseNames) {
+                                boolean closeConnections, List<String> skipDatabaseNames, int databaseMaxDurationInMin) {
         super(flowParameters);
         this.stackId = event.getResourceId();
         this.backupLocation = backupLocation;
         this.backupId = backupId;
         this.closeConnections = closeConnections;
         this.skipDatabaseNames = skipDatabaseNames;
+        this.databaseMaxDurationInMin = databaseMaxDurationInMin;
     }
 
     public static BackupRestoreContext from(FlowParameters flowParameters, StackEvent event, String backupLocation, String backupId,
-                                            boolean closeConnections, List<String> skipDatabaseNames) {
-        return new BackupRestoreContext(flowParameters, event, backupLocation, backupId, closeConnections, skipDatabaseNames);
+                                            boolean closeConnections, List<String> skipDatabaseNames, int databaseMaxDurationInMin) {
+        return new BackupRestoreContext(flowParameters, event, backupLocation, backupId, closeConnections, skipDatabaseNames, databaseMaxDurationInMin);
     }
 
     public Long getStackId() {
@@ -51,5 +54,9 @@ public class BackupRestoreContext extends CommonContext {
 
     public List<String> getSkipDatabaseNames() {
         return skipDatabaseNames;
+    }
+
+    public int getDatabaseMaxDurationInMin() {
+        return databaseMaxDurationInMin;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/backup/DatabaseBackupActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/backup/DatabaseBackupActions.java
@@ -46,7 +46,7 @@ public class DatabaseBackupActions {
             @Override
             protected Selectable createRequest(BackupRestoreContext context) {
                 return new DatabaseBackupRequest(context.getStackId(), context.getBackupLocation(), context.getBackupId(),
-                        context.getCloseConnections(), context.getSkipDatabaseNames());
+                        context.getCloseConnections(), context.getSkipDatabaseNames(), context.getDatabaseMaxDurationInMin());
             }
 
             @Override
@@ -82,7 +82,8 @@ public class DatabaseBackupActions {
                 DatabaseBackupFailedEvent payload) {
                 Flow flow = getFlow(flowParameters.getFlowId());
                 flow.setFlowFailed(payload.getException());
-                return BackupRestoreContext.from(flowParameters, payload, null, null, true, payload.getSkipDatabaseNames());
+                return BackupRestoreContext.from(flowParameters, payload, null, null, true, payload.getSkipDatabaseNames(),
+                        payload.getDatabaseMaxDurationInMin());
             }
 
             @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/restore/DatabaseRestoreActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/restore/DatabaseRestoreActions.java
@@ -45,7 +45,8 @@ public class DatabaseRestoreActions {
 
             @Override
             protected Selectable createRequest(BackupRestoreContext context) {
-                return new DatabaseRestoreRequest(context.getStackId(), context.getBackupLocation(), context.getBackupId());
+                return new DatabaseRestoreRequest(context.getStackId(), context.getBackupLocation(), context.getBackupId(),
+                        context.getDatabaseMaxDurationInMin());
             }
 
             @Override
@@ -81,7 +82,8 @@ public class DatabaseRestoreActions {
                 DatabaseRestoreFailedEvent payload) {
                 Flow flow = getFlow(flowParameters.getFlowId());
                 flow.setFlowFailed(payload.getException());
-                return BackupRestoreContext.from(flowParameters, payload, null, null, true, payload.getSkipDatabaseNames());
+                return BackupRestoreContext.from(flowParameters, payload, null, null, true, payload.getSkipDatabaseNames(),
+                        payload.getDatabaseMaxDurationInMin());
             }
 
             @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/DatabaseBackupTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/DatabaseBackupTriggerEvent.java
@@ -14,8 +14,8 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.dr.BackupRestoreEvent
 public class DatabaseBackupTriggerEvent extends BackupRestoreEvent {
 
     public DatabaseBackupTriggerEvent(String selector, Long stackId, String backupLocation, String backupId,
-        boolean closeConnections, List<String> skipDatabaseNames) {
-        super(selector, stackId, backupLocation, backupId, closeConnections, skipDatabaseNames);
+        boolean closeConnections, List<String> skipDatabaseNames, int databaseMaxDurationInMin) {
+        super(selector, stackId, backupLocation, backupId, closeConnections, skipDatabaseNames, databaseMaxDurationInMin);
     }
 
     @JsonCreator
@@ -26,8 +26,9 @@ public class DatabaseBackupTriggerEvent extends BackupRestoreEvent {
             @JsonProperty("backupLocation") String backupLocation,
             @JsonProperty("backupId") String backupId,
             @JsonProperty("closeConnections") boolean closeConnections,
-            @JsonProperty("skipDatabaseNames") List<String> skipDatabaseNames) {
-        super(event, resourceId, accepted, backupLocation, backupId, closeConnections, skipDatabaseNames);
+            @JsonProperty("skipDatabaseNames") List<String> skipDatabaseNames,
+            @JsonProperty("databaseMaxDurationInMin") int databaseMaxDurationInMin) {
+        super(event, resourceId, accepted, backupLocation, backupId, closeConnections, skipDatabaseNames, databaseMaxDurationInMin);
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/DatabaseRestoreTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/DatabaseRestoreTriggerEvent.java
@@ -12,8 +12,8 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.dr.BackupRestoreEvent
 
 public class DatabaseRestoreTriggerEvent extends BackupRestoreEvent {
 
-    public DatabaseRestoreTriggerEvent(String selector, Long stackId, String backupLocation, String backupId) {
-        super(selector, stackId, backupLocation, backupId);
+    public DatabaseRestoreTriggerEvent(String selector, Long stackId, String backupLocation, String backupId, int databaseMaxDurationInMin) {
+        super(selector, stackId, backupLocation, backupId, databaseMaxDurationInMin);
     }
 
     @JsonCreator
@@ -22,8 +22,9 @@ public class DatabaseRestoreTriggerEvent extends BackupRestoreEvent {
             @JsonProperty("resourceId") Long resourceId,
             @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted,
             @JsonProperty("backupLocation") String backupLocation,
-            @JsonProperty("backupId") String backupId) {
-        super(event, resourceId, accepted, backupLocation, backupId, true);
+            @JsonProperty("backupId") String backupId,
+            @JsonProperty("databaseMaxDurationInMin") int databaseMaxDurationInMin) {
+        super(event, resourceId, accepted, backupLocation, backupId, true, databaseMaxDurationInMin);
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
@@ -414,15 +414,15 @@ public class ReactorFlowManager {
     }
 
     public FlowIdentifier triggerDatalakeDatabaseBackup(Long stackId, String location, String backupId,
-            boolean closeConnections, List<String> skipDatabaseNames) {
+            boolean closeConnections, List<String> skipDatabaseNames, int databaseMaxDurationInMin) {
         String selector = FlowChainTriggers.DATALAKE_DATABASE_BACKUP_CHAIN_TRIGGER_EVENT;
         return reactorNotifier.notify(stackId, selector, new DatabaseBackupTriggerEvent(selector, stackId,
-                location, backupId, closeConnections, skipDatabaseNames));
+                location, backupId, closeConnections, skipDatabaseNames, databaseMaxDurationInMin));
     }
 
-    public FlowIdentifier triggerDatalakeDatabaseRestore(Long stackId, String location, String backupId) {
+    public FlowIdentifier triggerDatalakeDatabaseRestore(Long stackId, String location, String backupId, int databaseMaxDurationInMin) {
         String selector = DATABASE_RESTORE_EVENT.event();
-        return reactorNotifier.notify(stackId, selector, new DatabaseRestoreTriggerEvent(selector, stackId, location, backupId));
+        return reactorNotifier.notify(stackId, selector, new DatabaseRestoreTriggerEvent(selector, stackId, location, backupId, databaseMaxDurationInMin));
     }
 
     public FlowIdentifier triggerAutoTlsCertificatesRotation(Long stackId, CertificatesRotationV4Request certificatesRotationV4Request) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/dr/BackupRestoreEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/dr/BackupRestoreEvent.java
@@ -20,8 +20,14 @@ public class BackupRestoreEvent extends StackEvent {
 
     private final List<String> skipDatabaseNames;
 
+    private final int databaseMaxDurationInMin;
+
     public BackupRestoreEvent(Long stackId, String backupLocation, String backupId) {
         this (null, stackId, backupLocation, backupId);
+    }
+
+    public BackupRestoreEvent(Long stackId, String backupLocation, String backupId, int databaseMaxDurationInMin) {
+        this (null, stackId, backupLocation, backupId, databaseMaxDurationInMin);
     }
 
     public BackupRestoreEvent(String selector, Long stackId, String backupLocation, String backupId) {
@@ -30,22 +36,36 @@ public class BackupRestoreEvent extends StackEvent {
         this.backupId = backupId;
         this.closeConnections = true;
         this.skipDatabaseNames = Collections.emptyList();
+        this.databaseMaxDurationInMin = 0;
     }
 
-    public BackupRestoreEvent(String selector, Long stackId, String backupLocation, String backupId, boolean closeConnections, List<String> skipDatabaseNames) {
+    public BackupRestoreEvent(String selector, Long stackId, String backupLocation, String backupId, int databaseMaxDurationInMin) {
+        super(selector, stackId);
+        this.backupLocation = backupLocation;
+        this.backupId = backupId;
+        this.closeConnections = true;
+        this.skipDatabaseNames = Collections.emptyList();
+        this.databaseMaxDurationInMin = databaseMaxDurationInMin;
+    }
+
+    public BackupRestoreEvent(String selector, Long stackId, String backupLocation, String backupId, boolean closeConnections, List<String> skipDatabaseNames,
+            int databaseMaxDurationInMin) {
         super(selector, stackId);
         this.backupLocation = backupLocation;
         this.backupId = backupId;
         this.closeConnections = closeConnections;
         this.skipDatabaseNames = skipDatabaseNames;
+        this.databaseMaxDurationInMin = databaseMaxDurationInMin;
     }
 
-    public BackupRestoreEvent(String selector, Long stackId, Promise<AcceptResult> accepted, String backupLocation, String backupId, boolean closeConnections) {
+    public BackupRestoreEvent(String selector, Long stackId, Promise<AcceptResult> accepted, String backupLocation, String backupId, boolean closeConnections,
+            int databaseMaxDurationInMin) {
         super(selector, stackId, accepted);
         this.backupLocation = backupLocation;
         this.backupId = backupId;
         this.closeConnections = closeConnections;
         this.skipDatabaseNames = Collections.emptyList();
+        this.databaseMaxDurationInMin = databaseMaxDurationInMin;
     }
 
     @JsonCreator
@@ -56,12 +76,14 @@ public class BackupRestoreEvent extends StackEvent {
             @JsonProperty("backupLocation") String backupLocation,
             @JsonProperty("backupId") String backupId,
             @JsonProperty("closeConnections") boolean closeConnections,
-            @JsonProperty("skipDatabaseNames") List<String> skipDatabaseNames) {
+            @JsonProperty("skipDatabaseNames") List<String> skipDatabaseNames,
+            @JsonProperty("databaseMaxDurationInMin") int databaseMaxDurationInMin) {
         super(selector, stackId, accepted);
         this.backupLocation = backupLocation;
         this.backupId = backupId;
         this.closeConnections = closeConnections;
         this.skipDatabaseNames = skipDatabaseNames;
+        this.databaseMaxDurationInMin = databaseMaxDurationInMin;
     }
 
     public String getBackupLocation() {
@@ -78,5 +100,9 @@ public class BackupRestoreEvent extends StackEvent {
 
     public List<String> getSkipDatabaseNames() {
         return skipDatabaseNames;
+    }
+
+    public int getDatabaseMaxDurationInMin() {
+        return databaseMaxDurationInMin;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/dr/backup/DatabaseBackupRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/dr/backup/DatabaseBackupRequest.java
@@ -14,7 +14,8 @@ public class DatabaseBackupRequest extends BackupRestoreEvent {
             @JsonProperty("backupLocation") String backupLocation,
             @JsonProperty("backupId") String backupId,
             @JsonProperty("closeConnections") boolean closeConnections,
-            @JsonProperty("skipDatabaseNames") List<String> skipDatabaseNames) {
-        super(null, stackId, backupLocation, backupId, closeConnections, skipDatabaseNames);
+            @JsonProperty("skipDatabaseNames") List<String> skipDatabaseNames,
+            @JsonProperty("databaseMaxDurationInMin") int databaseMaxDurationInMin) {
+        super(null, stackId, backupLocation, backupId, closeConnections, skipDatabaseNames, databaseMaxDurationInMin);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/dr/restore/DatabaseRestoreRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/dr/restore/DatabaseRestoreRequest.java
@@ -10,7 +10,8 @@ public class DatabaseRestoreRequest extends BackupRestoreEvent {
     public DatabaseRestoreRequest(
             @JsonProperty("resourceId") Long stackId,
             @JsonProperty("backupLocation") String backupLocation,
-            @JsonProperty("backupId") String backupId) {
-        super(stackId, backupLocation, backupId);
+            @JsonProperty("backupId") String backupId,
+            @JsonProperty("databaseMaxDurationInMin") int databaseMaxDurationInMin) {
+        super(stackId, backupLocation, backupId, databaseMaxDurationInMin);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/backup/DatabaseBackupHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/backup/DatabaseBackupHandler.java
@@ -78,7 +78,7 @@ public class DatabaseBackupHandler extends ExceptionCatcherEventHandler<Database
             String rangerAdminGroup = rangerVirtualGroupService.getRangerVirtualGroup(stack);
             SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(request.getBackupLocation(), request.getBackupId(), rangerAdminGroup,
                     request.isCloseConnections(), request.getSkipDatabaseNames(), stack);
-            hostOrchestrator.backupDatabase(gatewayConfig, gatewayFQDN, saltConfig, exitModel);
+            hostOrchestrator.backupDatabase(gatewayConfig, gatewayFQDN, saltConfig, exitModel, request.getDatabaseMaxDurationInMin());
 
             result = new DatabaseBackupSuccess(stackId);
         } catch (Exception e) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/restore/DatabaseRestoreHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/restore/DatabaseRestoreHandler.java
@@ -78,7 +78,7 @@ public class DatabaseRestoreHandler extends ExceptionCatcherEventHandler<Databas
             String rangerAdminGroup = rangerVirtualGroupService.getRangerVirtualGroup(stack);
             SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(request.getBackupLocation(), request.getBackupId(), rangerAdminGroup,
                     true, Collections.emptyList(), stack);
-            hostOrchestrator.restoreDatabase(gatewayConfig, gatewayFQDN, saltConfig, exitModel);
+            hostOrchestrator.restoreDatabase(gatewayConfig, gatewayFQDN, saltConfig, exitModel, request.getDatabaseMaxDurationInMin());
 
             result = new DatabaseRestoreSuccess(stackId);
         } catch (Exception e) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/DatabaseBackupRestoreService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/DatabaseBackupRestoreService.java
@@ -45,17 +45,17 @@ public class DatabaseBackupRestoreService {
     }
 
     public FlowIdentifier backupDatabase(Long workspaceId, NameOrCrn nameOrCrn, String location, String backupId,
-            boolean closeConnections, List<String> skipDatabaseNames) {
+            boolean closeConnections, List<String> skipDatabaseNames, int databaseMaxDurationInMin) {
         Stack stack = stackService.getByNameOrCrnInWorkspace(nameOrCrn, workspaceId);
         MDCBuilder.buildMdcContext(stack);
         LOGGER.info("Initiating database backup flow for stack {}", stack.getId());
-        return flowManager.triggerDatalakeDatabaseBackup(stack.getId(), location, backupId, closeConnections, skipDatabaseNames);
+        return flowManager.triggerDatalakeDatabaseBackup(stack.getId(), location, backupId, closeConnections, skipDatabaseNames, databaseMaxDurationInMin);
     }
 
-    public FlowIdentifier restoreDatabase(Long workspaceId, NameOrCrn nameOrCrn, String location, String backupId) {
+    public FlowIdentifier restoreDatabase(Long workspaceId, NameOrCrn nameOrCrn, String location, String backupId, int databaseMaxDurationInMin) {
         Stack stack = stackService.getByNameOrCrnInWorkspace(nameOrCrn, workspaceId);
         MDCBuilder.buildMdcContext(stack);
         LOGGER.info("Initiating database restore flow for stack {}", stack.getId());
-        return flowManager.triggerDatalakeDatabaseRestore(stack.getId(), location, backupId);
+        return flowManager.triggerDatalakeDatabaseRestore(stack.getId(), location, backupId, databaseMaxDurationInMin);
     }
 }

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
@@ -409,16 +409,18 @@ public class StackOperations implements HierarchyAuthResourcePropertyProvider {
     }
 
     public FlowIdentifier backupClusterDatabase(@NotNull NameOrCrn nameOrCrn, Long workspaceId, String location, String backupId,
-                                                boolean closeConnections, List<String> skipDatabaseNames) {
+                                                boolean closeConnections, List<String> skipDatabaseNames, int databaseMaxDurationInMin) {
         databaseBackupRestoreService.validate(workspaceId, nameOrCrn, location, backupId);
         LOGGER.debug("Starting cluster database backup: " + nameOrCrn);
-        return databaseBackupRestoreService.backupDatabase(workspaceId, nameOrCrn, location, backupId, closeConnections, skipDatabaseNames);
+        return databaseBackupRestoreService.backupDatabase(workspaceId, nameOrCrn, location, backupId, closeConnections, skipDatabaseNames,
+                databaseMaxDurationInMin);
     }
 
-    public FlowIdentifier restoreClusterDatabase(@NotNull NameOrCrn nameOrCrn, Long workspaceId, String location, String backupId) {
+    public FlowIdentifier restoreClusterDatabase(@NotNull NameOrCrn nameOrCrn, Long workspaceId, String location, String backupId,
+            int databaseMaxDurationInMin) {
         databaseBackupRestoreService.validate(workspaceId, nameOrCrn, location, backupId);
         LOGGER.debug("Starting cluster database restore: " + nameOrCrn);
-        return databaseBackupRestoreService.restoreDatabase(workspaceId, nameOrCrn, location, backupId);
+        return databaseBackupRestoreService.restoreDatabase(workspaceId, nameOrCrn, location, backupId, databaseMaxDurationInMin);
     }
 
     @Override

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/chain/BackupDatalakeDatabaseFlowEventChainFactoryTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/chain/BackupDatalakeDatabaseFlowEventChainFactoryTest.java
@@ -33,11 +33,13 @@ public class BackupDatalakeDatabaseFlowEventChainFactoryTest {
 
     private static final Boolean CLOSE_CONNECTIONS = false;
 
+    private static final Integer DATABASE_MAX_DURATION_IN_MIN = 0;
+
     private static final List<String> SKIP_DB_NAMES = Collections.singletonList("atlas");
 
     private static final DatabaseBackupTriggerEvent TRIGGER_EVENT = new DatabaseBackupTriggerEvent(
             FlowChainTriggers.DATALAKE_DATABASE_BACKUP_CHAIN_TRIGGER_EVENT, STACK_ID,
-            BACKUP_LOCATION, BACKUP_ID, CLOSE_CONNECTIONS, SKIP_DB_NAMES
+            BACKUP_LOCATION, BACKUP_ID, CLOSE_CONNECTIONS, SKIP_DB_NAMES, DATABASE_MAX_DURATION_IN_MIN
     );
 
     @Mock

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/DatabaseBackupRestoreServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/DatabaseBackupRestoreServiceTest.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.service;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
@@ -91,9 +92,9 @@ public class DatabaseBackupRestoreServiceTest {
         when(stackService.findStackByNameAndWorkspaceId(any(), anyLong())).thenReturn(Optional.of(stack));
         when(stackService.getByNameOrCrnInWorkspace(any(), anyLong())).thenReturn(stack);
         when(flowLogService.findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(1L)).thenReturn(Collections.EMPTY_LIST);
-        when(flowManager.triggerDatalakeDatabaseBackup(anyLong(), any(), any(), anyBoolean(), any())).thenReturn(FlowIdentifier.notTriggered());
+        when(flowManager.triggerDatalakeDatabaseBackup(anyLong(), any(), any(), anyBoolean(), any(), eq(0))).thenReturn(FlowIdentifier.notTriggered());
 
-        service.backupDatabase(WORKSPACE_ID, ofName, null, null, true, Collections.emptyList());
+        service.backupDatabase(WORKSPACE_ID, ofName, null, null, true, Collections.emptyList(), 0);
     }
 
     @Test
@@ -103,9 +104,9 @@ public class DatabaseBackupRestoreServiceTest {
         when(stackService.findStackByNameAndWorkspaceId(any(), anyLong())).thenReturn(Optional.of(stack));
         when(stackService.getByNameOrCrnInWorkspace(any(), anyLong())).thenReturn(stack);
         when(flowLogService.findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(1L)).thenReturn(Collections.EMPTY_LIST);
-        when(flowManager.triggerDatalakeDatabaseRestore(anyLong(), any(), any())).thenReturn(FlowIdentifier.notTriggered());
+        when(flowManager.triggerDatalakeDatabaseRestore(anyLong(), any(), any(), eq(0))).thenReturn(FlowIdentifier.notTriggered());
 
-        service.restoreDatabase(WORKSPACE_ID, ofName, null, null);
+        service.restoreDatabase(WORKSPACE_ID, ofName, null, null, 0);
     }
 
     @Test
@@ -131,6 +132,34 @@ public class DatabaseBackupRestoreServiceTest {
         expectedException.expectMessage(MISSING_PARAM_EXCEPTION_MESSAGE);
 
         service.validate(WORKSPACE_ID, ofName, null, null);
+    }
+
+    @Test
+    public void testSuccessfulDatabaseBackupWithCustomizedMaxDurationInMin() {
+        int databaseMaxDurationInMin = 20;
+        Stack stack = getStack();
+
+        when(stackService.findStackByNameAndWorkspaceId(any(), anyLong())).thenReturn(Optional.of(stack));
+        when(stackService.getByNameOrCrnInWorkspace(any(), anyLong())).thenReturn(stack);
+        when(flowLogService.findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(1L)).thenReturn(Collections.EMPTY_LIST);
+        when(flowManager.triggerDatalakeDatabaseBackup(anyLong(), any(), any(), anyBoolean(), any(), eq(0))).thenReturn(FlowIdentifier.notTriggered());
+
+        service.backupDatabase(WORKSPACE_ID, ofName, null, null, true, Collections.emptyList(), databaseMaxDurationInMin);
+
+    }
+
+    @Test
+    public void testSuccessfulDatabaseRestoreWithCustomizedMaxDurationInMin() {
+        int databaseMaxDurationInMin = 20;
+        Stack stack = getStack();
+
+        when(stackService.findStackByNameAndWorkspaceId(any(), anyLong())).thenReturn(Optional.of(stack));
+        when(stackService.getByNameOrCrnInWorkspace(any(), anyLong())).thenReturn(stack);
+        when(flowLogService.findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(1L)).thenReturn(Collections.EMPTY_LIST);
+        when(flowManager.triggerDatalakeDatabaseRestore(anyLong(), any(), any(), eq(0))).thenReturn(FlowIdentifier.notTriggered());
+
+        service.backupDatabase(WORKSPACE_ID, ofName, null, null, true, Collections.emptyList(), databaseMaxDurationInMin);
+
     }
 
     private Stack getStack() {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxBackupEndpoint.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxBackupEndpoint.java
@@ -35,13 +35,15 @@ public interface SdxBackupEndpoint {
     @Path("{name}/backupDatalake")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "backup the datalake ", produces = MediaType.APPLICATION_JSON, nickname = "backupDatalake")
+    @SuppressWarnings("ParameterNumber")
     SdxBackupResponse backupDatalakeByName(@PathParam("name") String name,
             @QueryParam("backupLocation") String backupLocation,
             @QueryParam("backupName") String backupName,
             @QueryParam("skipValidation") boolean skipValidation,
             @QueryParam("skipAtlasMetadata") boolean skipAtlasMetadata,
             @QueryParam("skipRangerAudits") boolean skipRangerAudits,
-            @QueryParam("skipRangerMetadata") boolean skipRangerMetadata);
+            @QueryParam("skipRangerMetadata") boolean skipRangerMetadata,
+            @QueryParam("fullDrMaxDurationInMin") int fullDrMaxDurationInMin);
 
     @POST
     @Path("{name}/backupDatalakeStatus")

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxRestoreEndpoint.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxRestoreEndpoint.java
@@ -32,13 +32,15 @@ public interface SdxRestoreEndpoint {
     @Path("{name}/restoreDatalake")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "restore the datalake ", produces = MediaType.APPLICATION_JSON, nickname = "restoreDatalake")
+    @SuppressWarnings("ParameterNumber")
     SdxRestoreResponse restoreDatalakeByName(@PathParam("name") String name,
             @QueryParam("backupId") String backupId,
             @QueryParam("backupLocationOverride") String backupLocationOverride,
             @QueryParam("skipValidation") boolean skipValidation,
             @QueryParam("skipAtlasMetadata") boolean skipAtlasMetadata,
             @QueryParam("skipRangerAudits") boolean skipRangerAudits,
-            @QueryParam("skipRangerMetadata") boolean skipRangerMetadata);
+            @QueryParam("skipRangerMetadata") boolean skipRangerMetadata,
+            @QueryParam("fullDrMaxDurationInMin") int fullDrMaxDurationInMin);
 
     @POST
     @Path("{name}/restoreDatalakeStatus")
@@ -69,7 +71,7 @@ public interface SdxRestoreEndpoint {
     @ApiOperation(value = "restore the database backing datalake ", produces = MediaType.APPLICATION_JSON, nickname = "restoreDatabase")
     SdxDatabaseRestoreResponse restoreDatabaseByName(@PathParam("name") String name,
             @QueryParam("backupId") String backupId, @QueryParam("restoreId") String restoreId,
-            @QueryParam("backupLocation") String backupLocation);
+            @QueryParam("backupLocation") String backupLocation, @QueryParam("databaseMaxDurationInMin") int databaseMaxDurationInMin);
 
     @GET
     @Path("{name}/restoreDatabaseStatus")

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/ModelDescriptions.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/ModelDescriptions.java
@@ -206,6 +206,8 @@ public class ModelDescriptions {
 
     public static final String JAVA_VERSION = "Java version to be forced on virtual machines";
 
+    public static final String DATABASE_BACKUP_RESTORE_MAX_DURATION = "The maximum duration allowed for a backup or restore";
+
     private ModelDescriptions() {
     }
 }

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxDatabaseBackupRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxDatabaseBackupRequest.java
@@ -30,6 +30,9 @@ public class SdxDatabaseBackupRequest {
     @ApiModelProperty(value = ModelDescriptions.SKIP_DATABASE_NAMES, required = false)
     private List<String> skipDatabaseNames;
 
+    @ApiModelProperty(value = ModelDescriptions.DATABASE_BACKUP_RESTORE_MAX_DURATION, required = false)
+    private int databaseMaxDurationInMin;
+
     public String getBackupId() {
         return backupId;
     }
@@ -62,6 +65,14 @@ public class SdxDatabaseBackupRequest {
         this.skipDatabaseNames = skipDatabaseNames;
     }
 
+    public int getDatabaseMaxDurationInMin() {
+        return databaseMaxDurationInMin;
+    }
+
+    public void setDatabaseMaxDurationInMin(int databaseMaxDurationInMin) {
+        this.databaseMaxDurationInMin = databaseMaxDurationInMin;
+    }
+
     @Override
     public String toString() {
         return "SdxDatabaseBackupRequest{" +
@@ -69,6 +80,7 @@ public class SdxDatabaseBackupRequest {
                 ", backupLocation='" + backupLocation + '\'' +
                 ", closeConnections=" + closeConnections +
                 ", skipDatabaseNames='" + skipDatabaseNames + '\'' +
+                ", databaseMaxDurationInMin='" + databaseMaxDurationInMin + '\'' +
                 '}';
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxBackupController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxBackupController.java
@@ -66,13 +66,15 @@ public class SdxBackupController implements SdxBackupEndpoint {
         }
     }
 
+    @SuppressWarnings("ParameterNumber")
     @Override
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.BACKUP_DATALAKE)
     public SdxBackupResponse backupDatalakeByName(@ResourceName String name, String backupLocation,
-            String backupName, boolean skipValidation, boolean skipAtlasMetadata, boolean skipRangerAudits, boolean skipRangerMetadata) {
+            String backupName, boolean skipValidation, boolean skipAtlasMetadata, boolean skipRangerAudits, boolean skipRangerMetadata,
+            int fullDrMaxDurationInMin) {
         SdxCluster sdxCluster = getSdxClusterByName(name);
         return sdxBackupRestoreService.triggerDatalakeBackup(sdxCluster, backupLocation, backupName,
-                new DatalakeDrSkipOptions(skipValidation, skipAtlasMetadata, skipRangerAudits, skipRangerMetadata));
+                new DatalakeDrSkipOptions(skipValidation, skipAtlasMetadata, skipRangerAudits, skipRangerMetadata), fullDrMaxDurationInMin);
     }
 
     @Override

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxRestoreController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxRestoreController.java
@@ -32,7 +32,7 @@ public class SdxRestoreController implements SdxRestoreEndpoint {
     @Override
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.RESTORE_DATALAKE)
     public SdxDatabaseRestoreResponse restoreDatabaseByName(@ResourceName String name, String backupId,
-            String restoreId, String backupLocation) {
+            String restoreId, String backupLocation, int databaseMaxDurationInMin) {
         SdxCluster sdxCluster = getSdxClusterByName(name);
         try {
             sdxBackupRestoreService.getDatabaseRestoreStatus(sdxCluster, restoreId);
@@ -40,18 +40,19 @@ public class SdxRestoreController implements SdxRestoreEndpoint {
             sdxDatabaseRestoreResponse.setOperationId(restoreId);
             return sdxDatabaseRestoreResponse;
         } catch (NotFoundException notFoundException) {
-            return sdxBackupRestoreService.triggerDatabaseRestore(sdxCluster, backupId, restoreId, backupLocation);
+            return sdxBackupRestoreService.triggerDatabaseRestore(sdxCluster, backupId, restoreId, backupLocation, databaseMaxDurationInMin);
         }
     }
 
+    @SuppressWarnings("ParameterNumber")
     @Override
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.RESTORE_DATALAKE)
     public SdxRestoreResponse restoreDatalakeByName(@ResourceName String name, String backupId, String backupLocationOverride,
                                                     boolean skipValidation, boolean skipAtlasMetadata, boolean skipRangerAudits,
-                                                    boolean skipRangerMetadata) {
+                                                    boolean skipRangerMetadata, int fullDrMaxDurationInMin) {
         SdxCluster sdxCluster = getSdxClusterByName(name);
         return sdxBackupRestoreService.triggerDatalakeRestore(sdxCluster, name, backupId, backupLocationOverride,
-                new DatalakeDrSkipOptions(skipValidation, skipAtlasMetadata, skipRangerAudits, skipRangerMetadata));
+                new DatalakeDrSkipOptions(skipValidation, skipAtlasMetadata, skipRangerAudits, skipRangerMetadata), fullDrMaxDurationInMin);
     }
 
     @Override

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/chain/DatalakeResizeFlowEventChainFactory.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/chain/DatalakeResizeFlowEventChainFactory.java
@@ -47,7 +47,7 @@ public class DatalakeResizeFlowEventChainFactory implements FlowEventChainFactor
             chain.add(new DatalakeTriggerBackupEvent(DATALAKE_TRIGGER_BACKUP_EVENT.event(),
                     event.getResourceId(), event.getUserId(), event.getBackupLocation(), "resize" + System.currentTimeMillis(),
                     event.getSkipOptions(),
-                    DatalakeBackupFailureReason.BACKUP_ON_RESIZE, Collections.emptyList(), event.accepted()));
+                    DatalakeBackupFailureReason.BACKUP_ON_RESIZE, Collections.emptyList(), 0, event.accepted()));
             // Stop datalake
             chain.add(new SdxStartStopEvent(SDX_STOP_EVENT.event(), event.getResourceId(), event.getUserId(), STOP_DATAHUBS));
         } else {
@@ -64,7 +64,8 @@ public class DatalakeResizeFlowEventChainFactory implements FlowEventChainFactor
         if (event.shouldPerformRestore()) {
             //restore the new cluster
             chain.add(new DatalakeTriggerRestoreEvent(DATALAKE_TRIGGER_RESTORE_EVENT.event(), event.getResourceId(), event.getSdxCluster().getClusterName(),
-                    event.getUserId(), null, event.getBackupLocation(), null, event.getSkipOptions(), DatalakeRestoreFailureReason.RESTORE_ON_RESIZE));
+                    event.getUserId(), null, event.getBackupLocation(), null, event.getSkipOptions(), DatalakeRestoreFailureReason.RESTORE_ON_RESIZE,
+                    0));
         }
 
         // Delete the detached Sdx

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/chain/DatalakeUpgradeFlowEventChainFactory.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/chain/DatalakeUpgradeFlowEventChainFactory.java
@@ -31,7 +31,7 @@ public class DatalakeUpgradeFlowEventChainFactory implements FlowEventChainFacto
         chain.add(new DatalakeTriggerBackupEvent(DATALAKE_TRIGGER_BACKUP_EVENT.event(),
                 event.getResourceId(), event.getUserId(), event.getBackupLocation(), "",
                 event.getSkipOptions(),
-                DatalakeBackupFailureReason.BACKUP_ON_UPGRADE, List.of(DatabaseType.HIVE.toString().toLowerCase()), event.accepted()));
+                DatalakeBackupFailureReason.BACKUP_ON_UPGRADE, List.of(DatabaseType.HIVE.toString().toLowerCase()), 0, event.accepted()));
         chain.add(new DatalakeUpgradeStartEvent(DATALAKE_UPGRADE_EVENT.event(), event.getResourceId(), event.getUserId(),
                 event.getImageId(), event.isReplaceVms(), event.isRollingUpgradeEnabled(), event.isKeepVariant()));
         return new FlowTriggerEventQueue(getName(), event, chain);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeDatabaseBackupStartEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeDatabaseBackupStartEvent.java
@@ -28,24 +28,27 @@ public class DatalakeDatabaseBackupStartEvent extends DatalakeDatabaseDrStartBas
         this.backupRequest = backupRequest;
     }
 
+    @SuppressWarnings("checkstyle:ExecutableStatementCount")
     public DatalakeDatabaseBackupStartEvent(String selector, SdxOperation drStatus, String userId,
-                                            String backupId, String backupLocation, List<String> skipDatabaseNames) {
+                                            String backupId, String backupLocation, List<String> skipDatabaseNames, int databaseMaxDurationInMin) {
         super(selector, drStatus.getSdxClusterId(), userId, drStatus, skipDatabaseNames);
         backupRequest = new SdxDatabaseBackupRequest();
         backupRequest.setBackupId(backupId);
         backupRequest.setBackupLocation(backupLocation);
         backupRequest.setCloseConnections(true);
         backupRequest.setSkipDatabaseNames(skipDatabaseNames);
+        backupRequest.setDatabaseMaxDurationInMin(databaseMaxDurationInMin);
     }
 
-    public static DatalakeDatabaseBackupStartEvent from(DatalakeTriggerBackupEvent trigggerBackupEvent,
+    public static DatalakeDatabaseBackupStartEvent from(DatalakeTriggerBackupEvent triggerBackupEvent,
                                                         String backupId) {
         return  new DatalakeDatabaseBackupStartEvent(DATALAKE_DATABASE_BACKUP_EVENT.event(),
-                trigggerBackupEvent.getDrStatus(),
-                trigggerBackupEvent.getUserId(),
+                triggerBackupEvent.getDrStatus(),
+                triggerBackupEvent.getUserId(),
                 backupId,
-                trigggerBackupEvent.getBackupLocation(),
-                trigggerBackupEvent.getSkipDatabaseNames());
+                triggerBackupEvent.getBackupLocation(),
+                triggerBackupEvent.getSkipDatabaseNames(),
+                0);
     }
 
     public SdxDatabaseBackupRequest getBackupRequest() {

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeDatabaseBackupWaitRequest.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeDatabaseBackupWaitRequest.java
@@ -9,21 +9,28 @@ public class DatalakeDatabaseBackupWaitRequest extends SdxEvent {
 
     private final String operationId;
 
+    private final int databaseMaxDurationInMin;
+
     @JsonCreator
     public DatalakeDatabaseBackupWaitRequest(
             @JsonProperty("resourceId") Long sdxId,
             @JsonProperty("userId") String userId,
-            @JsonProperty("operationId") String operationId) {
+            @JsonProperty("operationId") String operationId,
+            @JsonProperty("databaseMaxDurationInMin") int databaseMaxDurationInMin) {
         super(sdxId, userId);
         this.operationId = operationId;
+        this.databaseMaxDurationInMin = databaseMaxDurationInMin;
     }
 
-    public static DatalakeDatabaseBackupWaitRequest from(SdxContext context, String operationId) {
-        return new DatalakeDatabaseBackupWaitRequest(context.getSdxId(), context.getUserId(), operationId);
+    public static DatalakeDatabaseBackupWaitRequest from(SdxContext context, String operationId, int databaseMaxDurationInMin) {
+        return new DatalakeDatabaseBackupWaitRequest(context.getSdxId(), context.getUserId(), operationId, databaseMaxDurationInMin);
     }
 
     public String getOperationId() {
         return operationId;
     }
 
+    public int getDatabaseMaxDurationInMin() {
+        return databaseMaxDurationInMin;
+    }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeFullBackupWaitRequest.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeFullBackupWaitRequest.java
@@ -9,21 +9,28 @@ public class DatalakeFullBackupWaitRequest extends SdxEvent {
 
     private final String operationId;
 
+    private final int fullDrMaxDurationInMin;
+
     @JsonCreator
     public DatalakeFullBackupWaitRequest(
             @JsonProperty("resourceId") Long sdxId,
             @JsonProperty("userId") String userId,
-            @JsonProperty("operationId") String operationId) {
+            @JsonProperty("operationId") String operationId,
+            @JsonProperty("fullDrMaxDurationInMin") int fullDrMaxDurationInMin) {
         super(sdxId, userId);
         this.operationId = operationId;
+        this.fullDrMaxDurationInMin = fullDrMaxDurationInMin;
     }
 
-    public static DatalakeFullBackupWaitRequest from(SdxContext context, String operationId) {
-        return new DatalakeFullBackupWaitRequest(context.getSdxId(), context.getUserId(), operationId);
+    public static DatalakeFullBackupWaitRequest from(SdxContext context, String operationId, int fullDrMaxDurationInMin) {
+        return new DatalakeFullBackupWaitRequest(context.getSdxId(), context.getUserId(), operationId, fullDrMaxDurationInMin);
     }
 
     public String getOperationId() {
         return operationId;
     }
 
+    public int getFullDrMaxDurationInMin() {
+        return fullDrMaxDurationInMin;
+    }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeTriggerBackupEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeTriggerBackupEvent.java
@@ -24,6 +24,8 @@ public class DatalakeTriggerBackupEvent extends DatalakeDatabaseDrStartBaseEvent
 
     private final DatalakeDrSkipOptions skipOptions;
 
+    private final int fullDrMaxDurationInMin;
+
     @JsonCreator
     public DatalakeTriggerBackupEvent(
             @JsonProperty("selector") String selector,
@@ -34,21 +36,25 @@ public class DatalakeTriggerBackupEvent extends DatalakeDatabaseDrStartBaseEvent
             @JsonProperty("skipOptions") DatalakeDrSkipOptions skipOptions,
             @JsonProperty("reason") DatalakeBackupFailureReason reason,
             @JsonProperty("skipDatabaseNames") List<String> skipDatabaseNames,
+            @JsonProperty("fullDrMaxDurationInMin") int fullDrMaxDurationInMin,
             @JsonIgnoreDeserialization @JsonProperty("accepted") Promise<AcceptResult> accepted) {
         super(selector, sdxId, userId, SdxOperationType.BACKUP, skipDatabaseNames, accepted);
         this.backupLocation = backupLocation;
         this.backupName = backupName;
         this.skipOptions = skipOptions;
         this.reason = reason;
+        this.fullDrMaxDurationInMin = fullDrMaxDurationInMin;
     }
 
     public DatalakeTriggerBackupEvent(String selector, Long sdxId, String userId, String backupLocation, String backupName,
-            DatalakeBackupFailureReason reason, DatalakeDrSkipOptions skipOptions, List<String> skipDatabaseNames) {
+            DatalakeBackupFailureReason reason, DatalakeDrSkipOptions skipOptions, List<String> skipDatabaseNames,
+            int fullDrMaxDurationInMin) {
         super(selector, sdxId, userId, SdxOperationType.BACKUP, skipDatabaseNames);
         this.backupLocation = backupLocation;
         this.backupName = backupName;
         this.reason = reason;
         this.skipOptions = skipOptions;
+        this.fullDrMaxDurationInMin = fullDrMaxDurationInMin;
     }
 
     public String getBackupLocation() {
@@ -65,6 +71,10 @@ public class DatalakeTriggerBackupEvent extends DatalakeDatabaseDrStartBaseEvent
 
     public DatalakeDrSkipOptions getSkipOptions() {
         return skipOptions;
+    }
+
+    public int getFullDrMaxDurationInMin() {
+        return fullDrMaxDurationInMin;
     }
 
     @Override

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/handler/DatalakeDatabaseBackupWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/handler/DatalakeDatabaseBackupWaitHandler.java
@@ -53,10 +53,11 @@ public class DatalakeDatabaseBackupWaitHandler extends ExceptionCatcherEventHand
         DatalakeDatabaseBackupWaitRequest request = event.getData();
         Long sdxId = request.getResourceId();
         String userId = request.getUserId();
+        int duration = request.getDatabaseMaxDurationInMin() == 0 ? durationInMinutes : request.getDatabaseMaxDurationInMin();
         Selectable response;
         try {
-            LOGGER.info("Start polling datalake database backup for id: {}", sdxId);
-            PollingConfig pollingConfig = new PollingConfig(sleepTimeInSec, TimeUnit.SECONDS, durationInMinutes, TimeUnit.MINUTES);
+            LOGGER.info("Start polling datalake database backup for id: {} with timeout duration: {}", sdxId, duration);
+            PollingConfig pollingConfig = new PollingConfig(sleepTimeInSec, TimeUnit.SECONDS, duration, TimeUnit.MINUTES);
             sdxBackupRestoreService.waitCloudbreakFlow(sdxId, pollingConfig, "Database backup");
             response = new DatalakeFullBackupInProgressEvent(sdxId, userId, request.getOperationId());
         } catch (UserBreakException userBreakException) {

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/handler/DatalakeFullBackupWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/handler/DatalakeFullBackupWaitHandler.java
@@ -64,10 +64,15 @@ public class DatalakeFullBackupWaitHandler extends ExceptionCatcherEventHandler<
         Long sdxId = request.getResourceId();
         String userId = request.getUserId();
         Selectable response;
-        int duration = entitlementService.isLongTimeBackupEnabled(ThreadBasedUserCrnProvider.getAccountId())
-                ? longDurationInMinutes : durationInMinutes;
+        int duration;
+        if (request.getFullDrMaxDurationInMin() != 0) {
+            duration = request.getFullDrMaxDurationInMin();
+        } else {
+            duration = entitlementService.isLongTimeBackupEnabled(ThreadBasedUserCrnProvider.getAccountId())
+                    ? longDurationInMinutes : durationInMinutes;
+        }
         try {
-            LOGGER.info("Start polling datalake full backup status for id: {}", sdxId);
+            LOGGER.info("Start polling datalake full backup status for id: {} with timeout duration: {}", sdxId, duration);
             PollingConfig pollingConfig = new PollingConfig(sleepTimeInSec, TimeUnit.SECONDS, duration,
                     TimeUnit.MINUTES);
             DatalakeBackupStatusResponse backupStatusResponse = sdxBackupRestoreService.waitForDatalakeDrBackupToComplete(

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/event/DatalakeDatabaseRestoreStartEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/event/DatalakeDatabaseRestoreStartEvent.java
@@ -19,12 +19,15 @@ public class DatalakeDatabaseRestoreStartEvent extends DatalakeDatabaseDrStartBa
 
     private final String backupLocation;
 
+    private final int databaseMaxDurationInMin;
+
     public DatalakeDatabaseRestoreStartEvent(String selector, Long sdxId, String userId,
-            String backupId, String restoreId, String backupLocation) {
+            String backupId, String restoreId, String backupLocation, int databaseMaxDurationInMin) {
         super(selector, sdxId, userId, SdxOperationType.RESTORE, Collections.emptyList());
         this.backupId = backupId;
         this.restoreId = restoreId;
         this.backupLocation = backupLocation;
+        this.databaseMaxDurationInMin = databaseMaxDurationInMin;
     }
 
     @JsonCreator
@@ -35,22 +38,25 @@ public class DatalakeDatabaseRestoreStartEvent extends DatalakeDatabaseDrStartBa
             @JsonProperty("userId") String userId,
             @JsonProperty("backupId") String backupId,
             @JsonProperty("restoreId") String restoreId,
-            @JsonProperty("backupLocation") String backupLocation) {
+            @JsonProperty("backupLocation") String backupLocation,
+            @JsonProperty("databaseMaxDurationInMin") int databaseMaxDurationInMin) {
         super(selector, sdxId, userId, drStatus, Collections.emptyList());
         this.backupId = backupId;
         this.restoreId = restoreId;
         this.backupLocation = backupLocation;
+        this.databaseMaxDurationInMin = databaseMaxDurationInMin;
     }
 
-    public static DatalakeDatabaseRestoreStartEvent from(DatalakeTriggerRestoreEvent trigggerRestoreEvent, Long sdxId,
+    public static DatalakeDatabaseRestoreStartEvent from(DatalakeTriggerRestoreEvent triggerRestoreEvent, Long sdxId,
             String backupId, String restoreId) {
         return new DatalakeDatabaseRestoreStartEvent(DATALAKE_DATABASE_RESTORE_EVENT.event(),
                 sdxId,
-                trigggerRestoreEvent.getDrStatus(),
-                trigggerRestoreEvent.getUserId(),
+                triggerRestoreEvent.getDrStatus(),
+                triggerRestoreEvent.getUserId(),
                 backupId,
                 restoreId,
-                trigggerRestoreEvent.getBackupLocation());
+                triggerRestoreEvent.getBackupLocation(),
+                0);
     }
 
     public String getBackupId() {
@@ -63,6 +69,10 @@ public class DatalakeDatabaseRestoreStartEvent extends DatalakeDatabaseDrStartBa
 
     public String getBackupLocation() {
         return backupLocation;
+    }
+
+    public int getDatabaseMaxDurationInMin() {
+        return databaseMaxDurationInMin;
     }
 
     @Override

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/event/DatalakeDatabaseRestoreWaitRequest.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/event/DatalakeDatabaseRestoreWaitRequest.java
@@ -9,20 +9,28 @@ public class DatalakeDatabaseRestoreWaitRequest extends SdxEvent {
 
     private final String operationId;
 
+    private final int databaseMaxDurationInMin;
+
     @JsonCreator
     public DatalakeDatabaseRestoreWaitRequest(
             @JsonProperty("resourceId") Long sdxId,
             @JsonProperty("userId") String userId,
-            @JsonProperty("operationId") String operationId) {
+            @JsonProperty("operationId") String operationId,
+            @JsonProperty("databaseMaxDurationInMin") int databaseMaxDurationInMin) {
         super(sdxId, userId);
         this.operationId = operationId;
+        this.databaseMaxDurationInMin = databaseMaxDurationInMin;
     }
 
-    public static DatalakeDatabaseRestoreWaitRequest from(SdxContext context, String operationId) {
-        return new DatalakeDatabaseRestoreWaitRequest(context.getSdxId(), context.getUserId(), operationId);
+    public static DatalakeDatabaseRestoreWaitRequest from(SdxContext context, String operationId, int databaseMaxDurationInMin) {
+        return new DatalakeDatabaseRestoreWaitRequest(context.getSdxId(), context.getUserId(), operationId, databaseMaxDurationInMin);
     }
 
     public String getOperationId() {
         return operationId;
+    }
+
+    public int getDatabaseMaxDurationInMin() {
+        return databaseMaxDurationInMin;
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/event/DatalakeFullRestoreWaitRequest.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/event/DatalakeFullRestoreWaitRequest.java
@@ -9,21 +9,28 @@ public class DatalakeFullRestoreWaitRequest extends SdxEvent {
 
     private final String operationId;
 
+    private final int fullDrMaxDurationInMin;
+
     @JsonCreator
     public DatalakeFullRestoreWaitRequest(
             @JsonProperty("resourceId") Long sdxId,
             @JsonProperty("userId") String userId,
-            @JsonProperty("operationId") String operationId) {
+            @JsonProperty("operationId") String operationId,
+            @JsonProperty("fullDrMaxDurationInMin") int fullDrMaxDurationInMin) {
         super(sdxId, userId);
         this.operationId = operationId;
+        this.fullDrMaxDurationInMin = fullDrMaxDurationInMin;
     }
 
-    public static DatalakeFullRestoreWaitRequest from(SdxContext context, String operationId) {
-        return new DatalakeFullRestoreWaitRequest(context.getSdxId(), context.getUserId(), operationId);
+    public static DatalakeFullRestoreWaitRequest from(SdxContext context, String operationId, int fullDrMaxDurationInMin) {
+        return new DatalakeFullRestoreWaitRequest(context.getSdxId(), context.getUserId(), operationId, fullDrMaxDurationInMin);
     }
 
     public String getOperationId() {
         return operationId;
     }
 
+    public int getFullDrMaxDurationInMin() {
+        return fullDrMaxDurationInMin;
+    }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/event/DatalakeTriggerRestoreEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/event/DatalakeTriggerRestoreEvent.java
@@ -22,6 +22,9 @@ public class DatalakeTriggerRestoreEvent extends DatalakeDatabaseDrStartBaseEven
 
     private final DatalakeDrSkipOptions skipOptions;
 
+    private final int fullDrMaxDurationInMin;
+
+    @SuppressWarnings("checkstyle:ExecutableStatementCount")
     @JsonCreator
     public DatalakeTriggerRestoreEvent(
             @JsonProperty("selector") String selector,
@@ -32,13 +35,15 @@ public class DatalakeTriggerRestoreEvent extends DatalakeDatabaseDrStartBaseEven
             @JsonProperty("backupLocation") String backupLocation,
             @JsonProperty("backupLocationOverride") String backupLocationOverride,
             @JsonProperty("skipOptions") DatalakeDrSkipOptions skipOptions,
-            @JsonProperty("reason") DatalakeRestoreFailureReason reason) {
+            @JsonProperty("reason") DatalakeRestoreFailureReason reason,
+            @JsonProperty("fullDrMaxDurationInMin") int fullDrMaxDurationInMin) {
         super(selector, sdxId, sdxName, userId, SdxOperationType.RESTORE);
         this.backupId = backupId;
         this.backupLocation = backupLocation;
         this.backupLocationOverride = backupLocationOverride;
         this.skipOptions = skipOptions;
         this.reason = reason;
+        this.fullDrMaxDurationInMin = fullDrMaxDurationInMin;
     }
 
     public String getBackupId() {
@@ -59,6 +64,10 @@ public class DatalakeTriggerRestoreEvent extends DatalakeDatabaseDrStartBaseEven
 
     public DatalakeRestoreFailureReason getReason() {
         return reason;
+    }
+
+    public int getFullDrMaxDurationInMin() {
+        return fullDrMaxDurationInMin;
     }
 
     @Override

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/handler/DatalakeDatabaseRestoreWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/handler/DatalakeDatabaseRestoreWaitHandler.java
@@ -53,10 +53,11 @@ public class DatalakeDatabaseRestoreWaitHandler extends ExceptionCatcherEventHan
         DatalakeDatabaseRestoreWaitRequest request = event.getData();
         Long sdxId = request.getResourceId();
         String userId = request.getUserId();
+        int duration = request.getDatabaseMaxDurationInMin() == 0 ? durationInMinutes : request.getDatabaseMaxDurationInMin();
         Selectable response;
         try {
-            LOGGER.info("Start polling datalake database restore for id: {}", sdxId);
-            PollingConfig pollingConfig = new PollingConfig(sleepTimeInSec, TimeUnit.SECONDS, durationInMinutes, TimeUnit.MINUTES);
+            LOGGER.info("Start polling datalake database restore for id: {} with timeout duration: {}", sdxId, duration);
+            PollingConfig pollingConfig = new PollingConfig(sleepTimeInSec, TimeUnit.SECONDS, duration, TimeUnit.MINUTES);
             sdxBackupRestoreService.waitCloudbreakFlow(sdxId, pollingConfig, "Database restore");
             response = new DatalakeFullRestoreInProgressEvent(sdxId, userId, request.getOperationId());
         } catch (UserBreakException userBreakException) {

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/handler/DatalakeFullRestoreWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/handler/DatalakeFullRestoreWaitHandler.java
@@ -54,9 +54,10 @@ public class DatalakeFullRestoreWaitHandler extends ExceptionCatcherEventHandler
         Long sdxId = request.getResourceId();
         String userId = request.getUserId();
         Selectable response;
+        int duration = request.getFullDrMaxDurationInMin() == 0 ? durationInMinutes : request.getFullDrMaxDurationInMin();
         try {
-            LOGGER.info("Start polling datalake full restore status for id: {}", sdxId);
-            PollingConfig pollingConfig = new PollingConfig(sleepTimeInSec, TimeUnit.SECONDS, durationInMinutes,
+            LOGGER.info("Start polling datalake full restore status for id: {} with timeout duration: {}", sdxId, duration);
+            PollingConfig pollingConfig = new PollingConfig(sleepTimeInSec, TimeUnit.SECONDS, duration,
                 TimeUnit.MINUTES);
             sdxBackupRestoreService.waitForDatalakeDrRestoreToComplete(sdxId, request.getOperationId(), request.getUserId(),
                 pollingConfig, "Full restore");

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/dr/SdxBackupRestoreServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/dr/SdxBackupRestoreServiceTest.java
@@ -177,7 +177,7 @@ public class SdxBackupRestoreServiceTest {
     public void triggerDatabaseRestoreSuccess() {
         when(sdxReactorFlowManager.triggerDatalakeDatabaseRestoreFlow(any(DatalakeDatabaseRestoreStartEvent.class), anyString())).thenReturn(FLOW_IDENTIFIER);
         SdxDatabaseRestoreResponse restoreResponse = ThreadBasedUserCrnProvider.doAs(USER_CRN,
-                () -> sdxBackupRestoreService.triggerDatabaseRestore(sdxCluster, BACKUP_ID, RESTORE_ID, BACKUP_LOCATION));
+                () -> sdxBackupRestoreService.triggerDatabaseRestore(sdxCluster, BACKUP_ID, RESTORE_ID, BACKUP_LOCATION, 0));
         assertEquals(FLOW_IDENTIFIER, restoreResponse.getFlowIdentifier());
         ArgumentCaptor<DatalakeDatabaseRestoreStartEvent> eventArgumentCaptor = ArgumentCaptor.forClass(DatalakeDatabaseRestoreStartEvent.class);
         verify(sdxReactorFlowManager, times(1)).triggerDatalakeDatabaseRestoreFlow(eventArgumentCaptor.capture(), anyString());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxBackupAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxBackupAction.java
@@ -40,7 +40,8 @@ public class SdxBackupAction implements Action<SdxTestDto, SdxClient> {
         LOGGER.info(format(" SDX '%s' backup has been started to '%s' by name '%s'... ", sdxName, backupLocation, backupName));
         SdxBackupResponse sdxBackupResponse = client.getDefaultClient()
                 .sdxBackupEndpoint()
-                .backupDatalakeByName(sdxName, backupLocation, backupName, false, false, false, false);
+                .backupDatalakeByName(sdxName, backupLocation, backupName, false, false, false, false,
+                        0);
         testDto.setFlow("SDX backup", sdxBackupResponse.getFlowIdentifier());
         SdxClusterDetailResponse detailedResponse = client.getDefaultClient()
                 .sdxEndpoint()

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxBackupInternalAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxBackupInternalAction.java
@@ -40,7 +40,8 @@ public class SdxBackupInternalAction implements Action<SdxInternalTestDto, SdxCl
         LOGGER.info(format(" Internal SDX '%s' backup has been started to '%s' by name '%s'... ", sdxName, backupLocation, backupName));
         SdxBackupResponse sdxBackupResponse = client.getDefaultClient()
                 .sdxBackupEndpoint()
-                .backupDatalakeByName(sdxName, backupLocation, backupName, false, false, false, false);
+                .backupDatalakeByName(sdxName, backupLocation, backupName, false, false, false, false,
+                        0);
         testDto.setFlow("SDX backup", sdxBackupResponse.getFlowIdentifier());
         SdxClusterDetailResponse detailedResponse = client.getDefaultClient()
                 .sdxEndpoint()

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRestoreAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRestoreAction.java
@@ -37,7 +37,8 @@ public class SdxRestoreAction implements Action<SdxTestDto, SdxClient> {
         LOGGER.info(format(" SDX '%s' restore has been started to '%s'... ", sdxName, backupLocation));
         SdxRestoreResponse sdxRestoreResponse = client.getDefaultClient()
                 .sdxRestoreEndpoint()
-                .restoreDatalakeByName(sdxName, backupId, backupLocation, false, false, false, false);
+                .restoreDatalakeByName(sdxName, backupId, backupLocation, false, false, false, false,
+                        0);
         testDto.setFlow("SDX restore", sdxRestoreResponse.getFlowIdentifier());
 
         SdxClusterDetailResponse detailedResponse = client.getDefaultClient()

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRestoreInternalAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRestoreInternalAction.java
@@ -40,7 +40,8 @@ public class SdxRestoreInternalAction implements Action<SdxInternalTestDto, SdxC
         LOGGER.info(format(" Internal SDX '%s' restore has been started to '%s'... ", sdxName, backupLocation));
         SdxRestoreResponse sdxRestoreResponse = client.getDefaultClient()
                 .sdxRestoreEndpoint()
-                .restoreDatalakeByName(sdxName, backupId, backupLocation, false, false, false, false);
+                .restoreDatalakeByName(sdxName, backupId, backupLocation, false, false, false, false,
+                        0);
         testDto.setFlow("SDX restore", sdxRestoreResponse.getFlowIdentifier());
         SdxClusterDetailResponse detailedResponse = client.getDefaultClient()
                 .sdxEndpoint()

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
@@ -125,10 +125,10 @@ public interface HostOrchestrator extends HostRecipeExecutor {
     Map<String, Map<String, String>> formatAndMountDisksOnNodesLegacy(List<GatewayConfig> gatewayConfigs, Set<Node> targets, Set<Node> allNodes,
             ExitCriteriaModel exitCriteriaModel, String platformVariant) throws CloudbreakOrchestratorFailedException;
 
-    void backupDatabase(GatewayConfig primaryGateway, Set<String> target, SaltConfig saltConfig, ExitCriteriaModel exitModel)
+    void backupDatabase(GatewayConfig primaryGateway, Set<String> target, SaltConfig saltConfig, ExitCriteriaModel exitModel, int databaseMaxDurationInMin)
             throws CloudbreakOrchestratorFailedException;
 
-    void restoreDatabase(GatewayConfig primaryGateway, Set<String> target, SaltConfig saltConfig, ExitCriteriaModel exitModel)
+    void restoreDatabase(GatewayConfig primaryGateway, Set<String> target, SaltConfig saltConfig, ExitCriteriaModel exitModel, int databaseMaxDurationInMin)
             throws CloudbreakOrchestratorFailedException;
 
     void applyDiagnosticsState(List<GatewayConfig> gatewayConfigs, String state, Map<String, Object> parameters,


### PR DESCRIPTION
… backup/restore

**JIRA:** [CB-21382](https://jira.cloudera.com/browse/CB-21382)

**ISSUE:** Backup/restore has orchestrator timeout when the data size is big because we only allow 300 numbers of retries and the time needed to restore the big size of data exceeds 300 retries.
**SOLUTION:** 
1. Make the database backup/restore retry number configurable so we can adjust how many retries we want. The retry number is calculated based on each retry taking about 10 seconds (it's a rough number based on logs when running backup/restore), so the retry number will be `duration * 60 /10`. 
2. We also make the database backup/restore timeout duration configurable. 
The above two numbers will be controlled by the newly-passed in value `databaseMaxDurationInMin`. If `databaseMaxDurationInMin` is not passed in (default to be 0 in java), the default hardcoded values will be used (90 min for timeout and 300 retry numbers). 
3. We also make the full datalake backup/restore timeout duration configurable. The newly-passed in value `fullDrMaxDurationInMin` will control this. Same as above, if it's not configured, it will default to the hardcoded number 240 min. 
**NOTICE:** Currently this change is just internal so we can only pass in the values calling the API, we will make changes in TH in the future to make this option public.

**BEFORE:** Got a salt timeout error with big size restore. (The restore gets completed in the end though but we got this error message before it gets completed.)

![Screen Shot 2023-04-03 at 11 06 55 PM](https://user-images.githubusercontent.com/39275944/229676825-e363a368-0b34-434f-a4c0-341e5a588ab1.png)
`"database": {
            "database": {
                "status": "FAILED",
                "failureReason": "Failed: Orchestrator component went failed in 50 min(s), message: Target: [gracezhu-aws-env-master0.gracezhu.xcu2-8y8x.wl.cloudera.site]",
                "durationInMinutes": "61"
            }
        }
    },
    "failureReason": "[DATABASE: Failed: Orchestrator component went failed in 50 min(s), message: Target: [gracezhu-aws-env-master0.gracezhu.xcu2-8y8x.wl.cloudera.site]]",
    "runtimeVersion": "7.2.17"`

**AFTER**: No error messages (The test size is about 40GB and I increased the duration to 100 min)
![Screen Shot 2023-04-03 at 11 06 39 PM](https://user-images.githubusercontent.com/39275944/229676884-41ca20a3-a330-4e37-a3f4-15fe733370e3.png)


**Overall manual tests**
1. DB Backup without passing in the databaseMaxDurationInMin. The two numbers be default numbers.
![Screen Shot 2023-04-03 at 5 29 59 PM](https://user-images.githubusercontent.com/39275944/229662485-be046a66-b836-4c2e-9674-ef504072fe9b.png)
![Screen Shot 2023-04-03 at 5 29 26 PM](https://user-images.githubusercontent.com/39275944/229822170-f5157260-9032-4316-b771-8fda40c3e04c.png)
![Screen Shot 2023-04-03 at 5 29 45 PM](https://user-images.githubusercontent.com/39275944/229822211-a833265d-2373-4acc-9dda-417e8791a647.png)

2. DB Backup with passing in databaseMaxDurationInMin value. 
![Screen Shot 2023-04-03 at 5 31 28 PM](https://user-images.githubusercontent.com/39275944/229662009-ce356659-62ee-45e5-a241-6ee3041a6948.png)
![Screen Shot 2023-04-03 at 5 31 34 PM](https://user-images.githubusercontent.com/39275944/229662026-b0fea429-6db2-497c-9c9a-57d78399f636.png)
![Screen Shot 2023-04-03 at 5 32 19 PM](https://user-images.githubusercontent.com/39275944/229662043-473a0636-0027-485d-98b3-25b3784b7ffb.png)

3. DB Restore without passing in the databaseMaxDurationInMin value.
![Screen Shot 2023-04-03 at 6 00 47 PM](https://user-images.githubusercontent.com/39275944/229821901-9c4d9c92-1cd4-4639-a164-410efc10c5d7.png)
![Screen Shot 2023-04-03 at 5 59 32 PM](https://user-images.githubusercontent.com/39275944/229822028-729bbe21-9e4d-418b-a8ed-6d31648239b8.png)
![Screen Shot 2023-04-03 at 6 00 18 PM](https://user-images.githubusercontent.com/39275944/229822042-5fce2cbb-97b2-4a49-b8dd-fd812a791b68.png)

4. DB Restore with passing in databaseMaxDurationInMin value. 
![Screen Shot 2023-04-03 at 9 24 42 
![Screen Shot 2023-04-03 at 6 00 18 PM](https://user-images.githubusercontent.com/39275944/229821689-2c052c07-b029-439e-b820-32f0ac76c5a5.png)
PM](https://user-images.githubusercontent.com/39275944/229662271-52667d30-05c0-4282-8672-886a36a949e0.png)
![Screen Shot 2023-04-03 at 9 09 59 PM](https://user-images.githubusercontent.com/39275944/229662327-8235f538-65ad-4f6f-8016-fe85ed0414f1.png)
![Screen Shot 2023-04-03 at 9 09 31 PM](https://user-images.githubusercontent.com/39275944/229662329-c95561f0-ec77-413b-9974-da9698bfde0c.png)

5. Resize & upgrade (configurable number is not applied to resize or upgrade yet. We can do that in the future.)
<img width="347" alt="Screen Shot 2023-04-09 at 10 02 59 PM" src="https://user-images.githubusercontent.com/39275944/230811865-6d4f2199-a960-43aa-8746-5af9be2f4cc1.png">

![Screen Shot 2023-04-09 at 9 40 02 PM](https://user-images.githubusercontent.com/39275944/230811857-2cdd781a-857c-47c0-8bc2-7adee5fe53c9.png)

6. Full backup without passing in fullDrMaxDurationInMin value. (Default to 240min)
<img width="967" alt="defaultFullBackupAPI" src="https://user-images.githubusercontent.com/39275944/230811145-5ff0fdea-96ff-4f43-96b8-04c13abdad67.png">

<img width="1087" alt="defaultFullBackup" src="https://user-images.githubusercontent.com/39275944/230811141-0cc4a63b-06b2-4ed6-ab60-b08d6d70a4e2.png">

7. Full backup passing in fullDrMaxDurationInMin value with 100 min.
![customizedFullBackup](https://user-images.githubusercontent.com/39275944/230811170-bc954fea-4ea9-415a-9dc5-a318be254327.png)

8. Full restore passing in fullDrMaxDurationInMin value with 20 min.

![Screen Shot 2023-04-12 at 4 20 33 PM](https://user-images.githubusercontent.com/39275944/231575599-fe597909-756d-477d-bde9-2bf5d4ab05c4.png)
<img width="1008" alt="Screen Shot 2023-04-12 at 4 20 26 PM" src="https://user-images.githubusercontent.com/39275944/231575602-5b73343d-b8e3-445f-9a1b-7aa039f9d8e1.png">

9.[New] Full backup for longTimeBackupEntitlement without passing in value (default to 840):
![Screen Shot 2023-04-17 at 3 02 30 PM](https://user-images.githubusercontent.com/39275944/232585675-868a58c2-f0c4-4a43-b218-448f9a080736.png)

10. [New] Full backup for longTimeBackupEntitlement with passed in value 300:
![Screen Shot 2023-04-17 at 3 04 10 PM](https://user-images.githubusercontent.com/39275944/232585933-c54213f4-c831-4d36-b807-7cd9f7c817e7.png)




