### PR TITLE
CB-20662 Downscale should be able to take exact instance id

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaOperationDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaOperationDescriptions.java
@@ -34,7 +34,8 @@ public final class FreeIpaOperationDescriptions {
     public static final String UPGRADE_FREEIPA = "Upgrades FreeIPA to the latest or defined image";
     public static final String UPGRADE_OPTIONS = "Get available images for FreeIPA upgrade. If catalog is defined use the catalog as image source.";
     public static final String UPSCALE_FREEIPA = "Upscales FreeIPA instances";
-    public static final String DOWNSCALE_FREEIPA = "Downscales FreeIPA instances";
+    public static final String DOWNSCALE_FREEIPA = "Downscales FreeIPA instances, either by providing a target AvailabilityType, or specifying a list of " +
+            "nodes to delete";
     public static final String RETRY = "Retries the latest failed operation";
     public static final String LIST_RETRYABLE_FLOWS = "List retryable failed flows";
     public static final String CHANGE_IMAGE_CATALOG = "Changes the image catalog used for creating instances";

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/AvailabilityInfo.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/AvailabilityInfo.java
@@ -27,4 +27,28 @@ public class AvailabilityInfo {
                 '}';
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AvailabilityInfo that = (AvailabilityInfo) o;
+
+        if (getActualNodeCount() != that.getActualNodeCount()) {
+            return false;
+        }
+        return getAvailabilityType() == that.getAvailabilityType();
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getAvailabilityType().hashCode();
+        result = 31 * result + getActualNodeCount();
+        return result;
+    }
+
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/scale/DownscaleRequest.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/scale/DownscaleRequest.java
@@ -1,17 +1,50 @@
 package com.sequenceiq.freeipa.api.v1.freeipa.stack.model.scale;
 
+import java.util.Set;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.sequenceiq.cloudbreak.validation.MutuallyExclusiveNotNull;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityType;
+import com.sequenceiq.service.api.doc.ModelDescriptions;
 
 import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 
 @ApiModel("FreeIpaDownscaleV1Request")
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@MutuallyExclusiveNotNull(fieldGroups = {"targetAvailabilityType", "instanceIds"}, message = "Either targetAvailabilityType or instanceIds should be " +
+        "provided but not both.")
 public class DownscaleRequest extends ScaleRequestBase {
+
+    @ApiModelProperty(value = ModelDescriptions.AVAILABILITY_TYPE)
+    private AvailabilityType targetAvailabilityType;
+
+    @ApiModelProperty(ModelDescriptions.INSTANCE_ID)
+    private Set<String> instanceIds;
+
+    public AvailabilityType getTargetAvailabilityType() {
+        return targetAvailabilityType;
+    }
+
+    public void setTargetAvailabilityType(AvailabilityType targetAvailabilityType) {
+        this.targetAvailabilityType = targetAvailabilityType;
+    }
+
+    public Set<String> getInstanceIds() {
+        return instanceIds;
+    }
+
+    public void setInstanceIds(Set<String> instanceIds) {
+        this.instanceIds = instanceIds;
+    }
 
     @Override
     public String toString() {
-        return "DownscaleRequest{} " + super.toString();
+        return "DownscaleRequest{" +
+                "targetAvailabilityType=" + targetAvailabilityType +
+                ", instanceIds=" + instanceIds +
+                "} " + super.toString();
     }
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/scale/ScaleRequestBase.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/scale/ScaleRequestBase.java
@@ -1,11 +1,9 @@
 package com.sequenceiq.freeipa.api.v1.freeipa.stack.model.scale;
 
 import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.NotNull;
 
 import com.sequenceiq.cloudbreak.auth.crn.CrnResourceDescriptor;
 import com.sequenceiq.cloudbreak.validation.ValidCrn;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityType;
 import com.sequenceiq.service.api.doc.ModelDescriptions;
 
 import io.swagger.annotations.ApiModelProperty;
@@ -17,10 +15,6 @@ public abstract class ScaleRequestBase {
     @ApiModelProperty(value = ModelDescriptions.ENVIRONMENT_CRN, required = true)
     private String environmentCrn;
 
-    @NotNull
-    @ApiModelProperty(value = ModelDescriptions.AVAILABILITY_TYPE, required = true)
-    private AvailabilityType targetAvailabilityType;
-
     public String getEnvironmentCrn() {
         return environmentCrn;
     }
@@ -29,19 +23,10 @@ public abstract class ScaleRequestBase {
         this.environmentCrn = environmentCrn;
     }
 
-    public AvailabilityType getTargetAvailabilityType() {
-        return targetAvailabilityType;
-    }
-
-    public void setTargetAvailabilityType(AvailabilityType targetAvailabilityType) {
-        this.targetAvailabilityType = targetAvailabilityType;
-    }
-
     @Override
     public String toString() {
-        return "ScaleRequest{" +
+        return "ScaleRequestBase{" +
                 "environmentCrn='" + environmentCrn + '\'' +
-                ", targetAvailabilityType=" + targetAvailabilityType +
                 '}';
     }
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/scale/UpscaleRequest.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/scale/UpscaleRequest.java
@@ -1,17 +1,36 @@
 package com.sequenceiq.freeipa.api.v1.freeipa.stack.model.scale;
 
+import javax.validation.constraints.NotNull;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityType;
+import com.sequenceiq.service.api.doc.ModelDescriptions;
 
 import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 
 @ApiModel("FreeIpaUpscaleV1Request")
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class UpscaleRequest extends ScaleRequestBase {
 
+    @NotNull
+    @ApiModelProperty(value = ModelDescriptions.AVAILABILITY_TYPE, required = true)
+    private AvailabilityType targetAvailabilityType;
+
+    public AvailabilityType getTargetAvailabilityType() {
+        return targetAvailabilityType;
+    }
+
+    public void setTargetAvailabilityType(AvailabilityType targetAvailabilityType) {
+        this.targetAvailabilityType = targetAvailabilityType;
+    }
+
     @Override
     public String toString() {
-        return "UpscaleRequest{} " + super.toString();
+        return "UpscaleRequest{" +
+                "targetAvailabilityType=" + targetAvailabilityType +
+                "} " + super.toString();
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeipaDownscaleNodeCalculatorService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeipaDownscaleNodeCalculatorService.java
@@ -1,0 +1,52 @@
+package com.sequenceiq.freeipa.service.stack;
+
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityInfo;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityType;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceMetadataType;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.scale.DownscaleRequest;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
+import com.sequenceiq.freeipa.entity.Stack;
+
+@Service
+public class FreeipaDownscaleNodeCalculatorService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FreeipaDownscaleNodeCalculatorService.class);
+
+    public ArrayList<String> calculateDownscaleCandidates(Stack stack, AvailabilityInfo originalAvailabilityInfo, AvailabilityType targetAvailabilityType,
+            Set<String> instanceIdsToDelete) {
+        ArrayList<String> downscaleCandidates = instanceIdsToDelete.isEmpty()
+                ? calculateDownscaleCandidates(stack, originalAvailabilityInfo, targetAvailabilityType)
+                : new ArrayList<>(instanceIdsToDelete);
+        LOGGER.debug("Freeipa downscale candidates are: {}", downscaleCandidates);
+        return downscaleCandidates;
+    }
+
+    private ArrayList<String> calculateDownscaleCandidates(Stack stack, AvailabilityInfo originalAvailabilityInfo, AvailabilityType targetAvailabilityType) {
+        int instancesToRemove = originalAvailabilityInfo.getActualNodeCount() - targetAvailabilityType.getInstanceCount();
+        Set<InstanceMetaData> notDeletedInstanceMetadataSet = stack.getNotDeletedInstanceMetaDataSet();
+        LOGGER.debug("Calculating nodes to remove during freeipa downscale. Number of nodes to remove: {}, not deleted instanceMetaData: {}",
+                instancesToRemove, notDeletedInstanceMetadataSet);
+        return notDeletedInstanceMetadataSet.stream()
+                .filter(imd -> imd.getInstanceMetadataType() != InstanceMetadataType.GATEWAY_PRIMARY)
+                .limit(instancesToRemove)
+                .map(InstanceMetaData::getInstanceId)
+                .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    public AvailabilityType calculateTargetAvailabilityType(DownscaleRequest request, int currentNodeCount) {
+        AvailabilityType calculatedAvailabilityType = request.getTargetAvailabilityType() != null
+                ? request.getTargetAvailabilityType()
+                : AvailabilityType.getByInstanceCount(currentNodeCount - request.getInstanceIds().size());
+        LOGGER.debug("Calculated target availability type for freeipa downscale: {}", calculatedAvailabilityType);
+        return calculatedAvailabilityType;
+    }
+
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaScalingServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaScalingServiceTest.java
@@ -1,19 +1,27 @@
 package com.sequenceiq.freeipa.service.stack;
 
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityType.HA;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityType.NON_HA;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityType.TWO_NODE_BASED;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -21,7 +29,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.flow.api.model.FlowType;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityType;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityInfo;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceMetadataType;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceTemplateRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.scale.DownscaleRequest;
@@ -35,6 +43,7 @@ import com.sequenceiq.freeipa.api.v1.operation.model.OperationType;
 import com.sequenceiq.freeipa.entity.InstanceMetaData;
 import com.sequenceiq.freeipa.entity.Operation;
 import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.flow.freeipa.downscale.event.DownscaleEvent;
 import com.sequenceiq.freeipa.service.freeipa.flow.FreeIpaFlowManager;
 import com.sequenceiq.freeipa.service.operation.OperationService;
 
@@ -63,6 +72,9 @@ class FreeIpaScalingServiceTest {
     @Mock
     private FreeIpaScalingValidationService validationService;
 
+    @Mock
+    private FreeipaDownscaleNodeCalculatorService freeipaDownscaleNodeCalculatorService;
+
     @InjectMocks
     private FreeIpaScalingService underTest;
 
@@ -75,7 +87,7 @@ class FreeIpaScalingServiceTest {
         when(stack.getNotDeletedInstanceMetaDataSet()).thenReturn(allInstances);
         UpscaleRequest request = createUpscaleRequest();
         doThrow(new BadRequestException("validation failed")).when(validationService).validateStackForUpscale(allInstances, stack,
-                new ScalingPath(AvailabilityType.TWO_NODE_BASED, AvailabilityType.HA));
+                new ScalingPath(TWO_NODE_BASED, HA));
 
         BadRequestException exception = Assertions.assertThrows(BadRequestException.class, () -> underTest.upscale(ACCOUNT_ID, request));
 
@@ -113,8 +125,8 @@ class FreeIpaScalingServiceTest {
         UpscaleResponse response = underTest.upscale(ACCOUNT_ID, request);
 
         assertEquals(response.getOperationId(), OPERATION_ID);
-        assertEquals(response.getOriginalAvailabilityType(), AvailabilityType.TWO_NODE_BASED);
-        assertEquals(response.getTargetAvailabilityType(), AvailabilityType.HA);
+        assertEquals(response.getOriginalAvailabilityType(), TWO_NODE_BASED);
+        assertEquals(response.getTargetAvailabilityType(), HA);
         assertEquals(response.getFlowIdentifier(), flowIdentifier);
     }
 
@@ -139,12 +151,12 @@ class FreeIpaScalingServiceTest {
     public void testDownscaleIfValidationFailsThenErrorThrown() {
         Stack stack = mock(Stack.class);
         Set<InstanceMetaData> allInstances = createValidImSet();
-
         when(stackService.getByEnvironmentCrnAndAccountIdWithListsAndMdcContext(ENV_CRN, ACCOUNT_ID)).thenReturn(stack);
         when(stack.getNotDeletedInstanceMetaDataSet()).thenReturn(allInstances);
         DownscaleRequest request = createDownscaleRequest();
+        when(freeipaDownscaleNodeCalculatorService.calculateTargetAvailabilityType(request, allInstances.size())).thenReturn(NON_HA);
         doThrow(new BadRequestException("validation failed")).when(validationService).validateStackForDownscale(allInstances, stack,
-                new ScalingPath(AvailabilityType.TWO_NODE_BASED, AvailabilityType.NON_HA));
+                new ScalingPath(TWO_NODE_BASED, NON_HA), null);
 
         BadRequestException exception = Assertions.assertThrows(BadRequestException.class, () -> underTest.downscale(ACCOUNT_ID, request));
 
@@ -164,13 +176,46 @@ class FreeIpaScalingServiceTest {
         FlowIdentifier flowIdentifier = new FlowIdentifier(FlowType.FLOW, POLLABLE_ID);
         when(flowManager.notify(anyString(), any())).thenReturn(flowIdentifier);
         DownscaleRequest request = createDownscaleRequest();
+        when(freeipaDownscaleNodeCalculatorService.calculateTargetAvailabilityType(request, allInstances.size())).thenCallRealMethod();
 
         DownscaleResponse response = underTest.downscale(ACCOUNT_ID, request);
 
         assertEquals(response.getOperationId(), OPERATION_ID);
-        assertEquals(response.getOriginalAvailabilityType(), AvailabilityType.TWO_NODE_BASED);
-        assertEquals(response.getTargetAvailabilityType(), AvailabilityType.NON_HA);
+        assertEquals(response.getOriginalAvailabilityType(), TWO_NODE_BASED);
+        assertEquals(response.getTargetAvailabilityType(), NON_HA);
         assertEquals(response.getFlowIdentifier(), flowIdentifier);
+    }
+
+    @Test
+    public void testDownscaleWithInstanceIdsIfValidationPassesAndOperationRunningThenSucceed() {
+        Stack stack = mock(Stack.class);
+        Set<InstanceMetaData> allInstances = createValidImSet();
+        AvailabilityInfo originalAvailabilityInfo = new AvailabilityInfo(allInstances.size());
+        Operation operation = createOperation(true);
+
+        when(stack.getAccountId()).thenReturn(ACCOUNT_ID);
+        when(stackService.getByEnvironmentCrnAndAccountIdWithListsAndMdcContext(ENV_CRN, ACCOUNT_ID)).thenReturn(stack);
+        when(operationService.startOperation(ACCOUNT_ID, OperationType.DOWNSCALE, List.of(ENV_CRN), List.of())).thenReturn(operation);
+        when(stack.getNotDeletedInstanceMetaDataSet()).thenReturn(allInstances);
+        FlowIdentifier flowIdentifier = new FlowIdentifier(FlowType.FLOW, POLLABLE_ID);
+        when(flowManager.notify(anyString(), any())).thenReturn(flowIdentifier);
+        Set<String> instanceIdsToDelete = Set.of("im2");
+        DownscaleRequest request = createDownscaleRequest(instanceIdsToDelete);
+        when(freeipaDownscaleNodeCalculatorService.calculateTargetAvailabilityType(request, allInstances.size())).thenCallRealMethod();
+        when(freeipaDownscaleNodeCalculatorService.calculateDownscaleCandidates(stack, originalAvailabilityInfo, request.getTargetAvailabilityType(),
+                instanceIdsToDelete)).thenReturn(new ArrayList<>(instanceIdsToDelete));
+
+        DownscaleResponse response = underTest.downscale(ACCOUNT_ID, request);
+
+        assertEquals(response.getOperationId(), OPERATION_ID);
+        assertEquals(response.getOriginalAvailabilityType(), TWO_NODE_BASED);
+        assertEquals(response.getTargetAvailabilityType(), NON_HA);
+        assertEquals(response.getFlowIdentifier(), flowIdentifier);
+
+        ArgumentCaptor<DownscaleEvent> downscaleEventArgumentCaptor = ArgumentCaptor.forClass(DownscaleEvent.class);
+        verify(flowManager).notify(eq("DOWNSCALE_EVENT"), downscaleEventArgumentCaptor.capture());
+        DownscaleEvent downscaleEvent = downscaleEventArgumentCaptor.getValue();
+        assertThat(downscaleEvent.getInstanceIds()).asList().hasSize(1).hasSameElementsAs(Set.of("im2"));
     }
 
     @Test
@@ -191,16 +236,24 @@ class FreeIpaScalingServiceTest {
     }
 
     private DownscaleRequest createDownscaleRequest() {
+        return createDownscaleRequest(Set.of());
+    }
+
+    private DownscaleRequest createDownscaleRequest(Set<String> instanceIds) {
         DownscaleRequest request = new DownscaleRequest();
         request.setEnvironmentCrn(ENV_CRN);
-        request.setTargetAvailabilityType(AvailabilityType.NON_HA);
+        if (instanceIds.isEmpty()) {
+            request.setTargetAvailabilityType(NON_HA);
+        } else {
+            request.setInstanceIds(instanceIds);
+        }
         return request;
     }
 
     private UpscaleRequest createUpscaleRequest() {
         UpscaleRequest request = new UpscaleRequest();
         request.setEnvironmentCrn(ENV_CRN);
-        request.setTargetAvailabilityType(AvailabilityType.HA);
+        request.setTargetAvailabilityType(HA);
         return request;
     }
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeipaDownscaleNodeCalculatorServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeipaDownscaleNodeCalculatorServiceTest.java
@@ -1,0 +1,107 @@
+package com.sequenceiq.freeipa.service.stack;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityInfo;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityType;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceMetadataType;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.scale.DownscaleRequest;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
+import com.sequenceiq.freeipa.entity.Stack;
+
+public class FreeipaDownscaleNodeCalculatorServiceTest {
+
+    private final FreeipaDownscaleNodeCalculatorService underTest = new FreeipaDownscaleNodeCalculatorService();
+
+    @Test
+    void testCalculateDownscaleCandidatesWhenInstanceIdsToDeleteNotProvided() {
+        Stack stack = mock(Stack.class);
+        when(stack.getNotDeletedInstanceMetaDataSet()).thenReturn(getNotDeletedInstanceMetadataSet(3));
+        AvailabilityInfo availabilityInfo = new AvailabilityInfo(3);
+        Set<String> instanceIdsToDelete = Set.of();
+
+        ArrayList<String> downscaleCandidates = underTest.calculateDownscaleCandidates(stack, availabilityInfo, AvailabilityType.TWO_NODE_BASED,
+                instanceIdsToDelete);
+
+        assertThat(downscaleCandidates).asList()
+                .hasSize(1);
+    }
+
+    @Test
+    void testCalculateDownscaleCandidatesWhenInstanceIdIsProvided() {
+        Stack stack = mock(Stack.class);
+        when(stack.getNotDeletedInstanceMetaDataSet()).thenReturn(getNotDeletedInstanceMetadataSet(3));
+        AvailabilityInfo availabilityInfo = new AvailabilityInfo(3);
+        Set<String> instanceIdsToDelete = Set.of("im_0");
+
+        ArrayList<String> downscaleCandidates = underTest.calculateDownscaleCandidates(stack, availabilityInfo, null, instanceIdsToDelete);
+
+        assertThat(downscaleCandidates).asList()
+                .hasSize(1)
+                .hasSameElementsAs(Set.of("im_0"));
+    }
+
+    @Test
+    void testCalculateTargetAvailabilityTypeWhenAvailabilityTypeSpecified() {
+        DownscaleRequest downscaleRequest = new DownscaleRequest();
+        downscaleRequest.setTargetAvailabilityType(AvailabilityType.TWO_NODE_BASED);
+
+        AvailabilityType targetAvailabilityType = underTest.calculateTargetAvailabilityType(downscaleRequest, 3);
+
+        assertEquals(AvailabilityType.TWO_NODE_BASED, targetAvailabilityType);
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "createDeleteNodeCountToAvailabilityTypeMapping")
+    void testCalculateTargetAvailabilityTypeWhenInstanceIdsSpecified(int instanceIdCount, AvailabilityType expectedTargetAvailabilityType) {
+        DownscaleRequest downscaleRequest = new DownscaleRequest();
+        downscaleRequest.setInstanceIds(getInstanceIds(instanceIdCount));
+
+        AvailabilityType targetAvailabilityType = underTest.calculateTargetAvailabilityType(downscaleRequest, 3);
+
+        assertEquals(expectedTargetAvailabilityType, targetAvailabilityType);
+    }
+
+    static Object [][] createDeleteNodeCountToAvailabilityTypeMapping() {
+        return new Object[][] {
+                {1, AvailabilityType.TWO_NODE_BASED},
+                {2, AvailabilityType.NON_HA}
+        };
+    }
+
+    private Set<String> getInstanceIds(int instanceIdCount) {
+        return IntStream.range(0, instanceIdCount)
+                .mapToObj(this::generateInstanceMetadataName)
+                .collect(Collectors.toSet());
+    }
+
+    private Set<InstanceMetaData> getNotDeletedInstanceMetadataSet(int nodeCount) {
+        return getInstanceIds(nodeCount).stream()
+                .map(this::createInstanceMetadata)
+                .collect(Collectors.toSet());
+    }
+
+    private InstanceMetaData createInstanceMetadata(String id) {
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+        instanceMetaData.setInstanceId(id);
+        instanceMetaData.setInstanceMetadataType(InstanceMetadataType.GATEWAY);
+        return instanceMetaData;
+    }
+
+    private String generateInstanceMetadataName(int id) {
+        return "im_" + id;
+    }
+
+}


### PR DESCRIPTION
Currently freeipa resize takes an AVAILABILITY_TYPE as argument. Downscale will then arbitrarily choose a node id. However, sometimes, in troublehooting scenarios it would be great if the user could choose the node to downscale.

The present commit thus adds support to remove exactly the nodes specified in a request.

See detailed description in the commit message.