### PR TITLE
CB-21342 Error occurred during salt minion tear down java.lang.IllegalStateException: Duplicate key 10.28.216.147

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/orchestration/OrchestratorAware.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/orchestration/OrchestratorAware.java
@@ -11,7 +11,7 @@ public interface OrchestratorAware {
         throw new NotImplementedException("Needs to be implemented for the default operation or override the `getAllNodes()`");
     }
 
-    default Set<Node> getAllNodes() {
+    default Set<Node> getAllFunctioningNodes() {
         return getAllNodesForOrchestration().stream().map(OrchestrationNode::getNode).collect(Collectors.toSet());
     }
 }

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/dto/StackDto.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/dto/StackDto.java
@@ -303,11 +303,11 @@ public class StackDto implements OrchestratorAware, StackDtoDelegate, MdcContext
         return gateway != null;
     }
 
-    public Set<Node> getAllNodes() {
+    public Set<Node> getAllFunctioningNodes() {
         Set<Node> ret = new HashSet<>();
         getInstanceGroupDtos().forEach(ig -> {
             InstanceGroupView instanceGroup = ig.getInstanceGroup();
-            ig.getInstanceMetadataViews().forEach(im -> {
+            ig.getNotDeletedAndNotZombieInstanceMetaData().forEach(im -> {
                 if (StringUtils.isNotBlank(im.getDiscoveryFQDN())) {
                     ret.add(new Node(im.getPrivateIp(), im.getPublicIp(), im.getInstanceId(),
                             instanceGroup.getTemplate().getInstanceType(), im.getDiscoveryFQDN(), instanceGroup.getGroupName()));

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cmdiagnostics/CmDiagnosticsFlowService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cmdiagnostics/CmDiagnosticsFlowService.java
@@ -60,7 +60,7 @@ public class CmDiagnosticsFlowService {
                 .includeHosts(hosts)
                 .exlcudeHosts(excludeHosts)
                 .build();
-        Set<Node> filteredNodes = filter.apply(stack.getAllNodes());
+        Set<Node> filteredNodes = filter.apply(stack.getAllFunctioningNodes());
         ClusterDeletionBasedExitCriteriaModel exitModel = new ClusterDeletionBasedExitCriteriaModel(stackId, stack.getCluster().getId());
         if (filteredNodes.isEmpty()) {
             LOGGER.debug("CM Diagnostics {} has been skipped. (no target minions)", operation);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/orchestrator/OrchestratorService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/orchestrator/OrchestratorService.java
@@ -47,7 +47,7 @@ public class OrchestratorService implements OrchestratorMetadataProvider {
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
         List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
         ClusterDeletionBasedExitCriteriaModel exitModel = new ClusterDeletionBasedExitCriteriaModel(stackId, stack.getCluster().getId());
-        return new OrchestratorMetadata(gatewayConfigs, stack.getAllNodes(), exitModel, stack);
+        return new OrchestratorMetadata(gatewayConfigs, stack.getAllFunctioningNodes(), exitModel, stack);
     }
 
     @Override

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cmdiagnostics/CmDiagnosticsFlowServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cmdiagnostics/CmDiagnosticsFlowServiceTest.java
@@ -61,7 +61,7 @@ public class CmDiagnosticsFlowServiceTest {
         Stack stack = mock(Stack.class);
         given(stackService.getByIdWithListsInTransaction(STACK_ID)).willReturn(stack);
         given(stack.getCluster()).willReturn(mock(Cluster.class));
-        given(stack.getAllNodes()).willReturn(nodes());
+        given(stack.getAllFunctioningNodes()).willReturn(nodes());
         given(gatewayConfigService.getAllGatewayConfigs(stack)).willReturn(new ArrayList<>());
         given(gatewayConfigService.getPrimaryGatewayIp(stack)).willReturn("hostA");
         doNothing().when(telemetryOrchestrator).initDiagnosticCollection(any(), anySet(), any(), any());
@@ -77,7 +77,7 @@ public class CmDiagnosticsFlowServiceTest {
         Stack stack = mock(Stack.class);
         given(stackService.getByIdWithListsInTransaction(STACK_ID)).willReturn(stack);
         given(stack.getCluster()).willReturn(mock(Cluster.class));
-        given(stack.getAllNodes()).willReturn(nodes());
+        given(stack.getAllFunctioningNodes()).willReturn(nodes());
         given(gatewayConfigService.getAllGatewayConfigs(stack)).willReturn(new ArrayList<>());
         given(gatewayConfigService.getPrimaryGatewayIp(stack)).willReturn("hostA");
         doThrow(new CloudbreakOrchestratorFailedException("ex")).when(telemetryOrchestrator).initDiagnosticCollection(any(), anySet(), any(), any());
@@ -94,7 +94,7 @@ public class CmDiagnosticsFlowServiceTest {
         Stack stack = mock(Stack.class);
         given(stackService.getByIdWithListsInTransaction(STACK_ID)).willReturn(stack);
         given(stack.getCluster()).willReturn(mock(Cluster.class));
-        given(stack.getAllNodes()).willReturn(Set.of());
+        given(stack.getAllFunctioningNodes()).willReturn(Set.of());
         given(gatewayConfigService.getAllGatewayConfigs(stack)).willReturn(new ArrayList<>());
         given(gatewayConfigService.getPrimaryGatewayIp(stack)).willReturn("hostA");
         // WHEN
@@ -109,7 +109,7 @@ public class CmDiagnosticsFlowServiceTest {
         Stack stack = mock(Stack.class);
         given(stackService.getByIdWithListsInTransaction(STACK_ID)).willReturn(stack);
         given(stack.getCluster()).willReturn(mock(Cluster.class));
-        given(stack.getAllNodes()).willReturn(nodes());
+        given(stack.getAllFunctioningNodes()).willReturn(nodes());
         given(gatewayConfigService.getAllGatewayConfigs(stack)).willReturn(new ArrayList<>());
         given(gatewayConfigService.getPrimaryGatewayIp(stack)).willReturn("hostA");
         doNothing().when(telemetryOrchestrator).uploadCollectedDiagnostics(any(), anySet(), any(), any());
@@ -125,7 +125,7 @@ public class CmDiagnosticsFlowServiceTest {
         Stack stack = mock(Stack.class);
         given(stackService.getByIdWithListsInTransaction(STACK_ID)).willReturn(stack);
         given(stack.getCluster()).willReturn(mock(Cluster.class));
-        given(stack.getAllNodes()).willReturn(nodes());
+        given(stack.getAllFunctioningNodes()).willReturn(nodes());
         given(gatewayConfigService.getAllGatewayConfigs(stack)).willReturn(new ArrayList<>());
         given(gatewayConfigService.getPrimaryGatewayIp(stack)).willReturn("hostA");
         doNothing().when(telemetryOrchestrator).cleanupCollectedDiagnostics(any(), anySet(), any(), any());

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/orchestrator/RotateSaltPasswordService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/orchestrator/RotateSaltPasswordService.java
@@ -137,7 +137,7 @@ public class RotateSaltPasswordService {
 
     private void tryRemoveSaltuserFromGateways(Stack stack, List<GatewayConfig> allGatewayConfig) {
         try {
-            Set<String> targets = stack.getAllNodes().stream().map(Node::getHostname).collect(Collectors.toSet());
+            Set<String> targets = stack.getAllFunctioningNodes().stream().map(Node::getHostname).collect(Collectors.toSet());
             Map<String, String> response = hostOrchestrator.runCommandOnHosts(allGatewayConfig, targets, SALTUSER_DELETE_COMMAND);
             LOGGER.debug("Saltuser delete command response: {}", response);
         } catch (CloudbreakOrchestratorException e) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/orchestrator/OrchestratorService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/orchestrator/OrchestratorService.java
@@ -33,7 +33,7 @@ public class OrchestratorService implements OrchestratorMetadataProvider {
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
         List<GatewayConfig> gatewayConfigs = gatewayConfigService.getNotDeletedGatewayConfigs(stack);
         StackBasedExitCriteriaModel exitCriteriaModel = new StackBasedExitCriteriaModel(stackId);
-        return new OrchestratorMetadata(gatewayConfigs, stack.getAllNodes(), exitCriteriaModel, stack);
+        return new OrchestratorMetadata(gatewayConfigs, stack.getAllFunctioningNodes(), exitCriteriaModel, stack);
     }
 
     @Override

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/orchestrator/RotateSaltPasswordServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/orchestrator/RotateSaltPasswordServiceTest.java
@@ -132,7 +132,7 @@ class RotateSaltPasswordServiceTest {
         lenient().when(stack.isStopped()).thenReturn(false);
         Node node = mock(Node.class);
         lenient().when(node.getHostname()).thenReturn(FQDN);
-        lenient().when(stack.getAllNodes()).thenReturn(Set.of(node));
+        lenient().when(stack.getAllFunctioningNodes()).thenReturn(Set.of(node));
 
         SaltSecurityConfig saltSecurityConfig = new SaltSecurityConfig();
         saltSecurityConfig.setSaltPassword(OLD_PASSWORD);

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
@@ -347,7 +347,7 @@ public class SaltOrchestrator implements HostOrchestrator {
 
     private void saveHostsPillar(OrchestratorAware stack, ExitCriteriaModel exitModel,
             Set<String> gatewayTargetIpAddresses, SaltConnector sc) throws Exception {
-        OrchestratorBootstrap hostSave = PillarSave.createHostsPillar(sc, gatewayTargetIpAddresses, stack.getAllNodes());
+        OrchestratorBootstrap hostSave = PillarSave.createHostsPillar(sc, gatewayTargetIpAddresses, stack.getAllFunctioningNodes());
         Callable<Boolean> saltPillarRunner = saltRunner.runnerWithConfiguredErrorCount(hostSave, exitCriteria, exitModel);
         saltPillarRunner.call();
     }

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestratorTest.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestratorTest.java
@@ -304,7 +304,7 @@ class SaltOrchestratorTest {
     void runServiceTest() throws Exception {
         SaltConfig saltConfig = new SaltConfig();
         OrchestratorAware orchestratorAware = mock(OrchestratorAware.class);
-        when(orchestratorAware.getAllNodes()).thenReturn(Set.of());
+        when(orchestratorAware.getAllFunctioningNodes()).thenReturn(Set.of());
         saltOrchestrator.initServiceRun(orchestratorAware, Collections.singletonList(gatewayConfig), targets, targets,
                 saltConfig, exitCriteriaModel, "testPlatform");
         saltOrchestrator.runService(Collections.singletonList(gatewayConfig), targets, saltConfig, exitCriteriaModel);
@@ -359,7 +359,7 @@ class SaltOrchestratorTest {
         when(remainingNode.getPrivateIp()).thenReturn("10.0.0.1");
         ExitCriteriaModel exitCriteriaModel = mock(ExitCriteriaModel.class);
         OrchestratorAware orchestratorAware = mock(OrchestratorAware.class);
-        when(orchestratorAware.getAllNodes()).thenReturn(Set.of());
+        when(orchestratorAware.getAllFunctioningNodes()).thenReturn(Set.of());
 
         saltOrchestrator.tearDown(orchestratorAware, Collections.singletonList(gatewayConfig), privateIpsByFQDN, Set.of(remainingNode), exitCriteriaModel);
 
@@ -466,7 +466,7 @@ class SaltOrchestratorTest {
         when(saltRunner.runnerWithCalculatedErrorCount(any(), any(), any(), anyInt())).thenReturn(mock(Callable.class));
 
         OrchestratorAware orchestratorAware = mock(OrchestratorAware.class);
-        when(orchestratorAware.getAllNodes()).thenReturn(allNodes);
+        when(orchestratorAware.getAllFunctioningNodes()).thenReturn(allNodes);
         saltOrchestrator.stopClusterManagerAgent(orchestratorAware, gatewayConfig, targets, downscaleTargets,
                 exitCriteriaModel, new CmAgentStopFlags(false, false, false));
 


### PR DESCRIPTION
Situation:

We have 2 terminated nodes:
hostname=ascend-dev-master1, instance_id=i-0e61aa448ef41d3bb, fqdn=ascend-dev-master1.ascend-d.a8du-8mgv.cloudera.site, domain=ascend-d.a8du-8mgv.cloudera.site, public_address=false, custom_domain=true, instance_type=m5.xlarge hostname=ascend-dev-idbroker1, instance_id=i-0d1d4a9eaba612185, fqdn=ascend-dev-idbroker1.ascend-d.a8du-8mgv.cloudera.site, domain=ascend-d.a8du-8mgv.cloudera.site, public_address=false, custom_domain=true, instance_type=t3.medium We try to repair ascend-dev-master1, but it got the same IP address from Azure as the previous ascend-dev-idbroker instance IP address.

Solution:
When collecting nodes for the orchestrator we will skip nodes which are deleted on provider, so we will not push these hosts' infos in pillar.