### PR TITLE
CB-21065 Create hints for Multi AZ nodes placement

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/converter/StringSetConverter.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/converter/StringSetConverter.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.cloudbreak.converter;
+
+import java.util.Set;
+
+import javax.persistence.AttributeConverter;
+
+import org.springframework.stereotype.Component;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
+
+@Component
+public class StringSetConverter implements AttributeConverter<Set<String>, String> {
+
+    @Override
+    public String convertToDatabaseColumn(Set<String> set) {
+        return set == null || set.isEmpty() ?
+                null : Joiner.on(',').join(set);
+    }
+
+    @Override
+    public Set<String> convertToEntityAttribute(String joined) {
+        return Strings.isNullOrEmpty(joined) ? null : Set.of(joined.split(","));
+    }
+}

--- a/common/src/test/java/com/sequenceiq/cloudbreak/converter/StringSetConverterTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/converter/StringSetConverterTest.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.cloudbreak.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+public class StringSetConverterTest {
+
+    private final StringSetConverter underTest = new StringSetConverter();
+
+    @Test
+    public void shouldConvertStringToSetByComma() {
+        String input = "az1,az2,az3";
+        Set<String> expectedResult = Set.of("az1", "az2", "az3");
+
+        Set<String> result = underTest.convertToEntityAttribute(input);
+
+        assertEquals(3, result.size());
+        assertTrue(result.containsAll(expectedResult));
+    }
+
+    @Test
+    public void shouldConvertNullOrEmptyToNull() {
+        assertNull(underTest.convertToDatabaseColumn(null));
+        assertNull(underTest.convertToDatabaseColumn(Collections.emptySet()));
+        assertNull(underTest.convertToEntityAttribute(null));
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/InstanceGroupV4Base.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/InstanceGroupV4Base.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base;
 
+import java.util.Set;
+
 import javax.validation.Valid;
 import javax.validation.constraints.Digits;
 import javax.validation.constraints.Max;
@@ -67,6 +69,8 @@ public class InstanceGroupV4Base extends ProviderParametersBase implements JsonE
 
     @ApiModelProperty(value = HostGroupModelDescription.RECOVERY_MODE, allowableValues = "MANUAL,AUTO")
     private RecoveryMode recoveryMode = RecoveryMode.MANUAL;
+
+    private Set<String> hints;
 
     public int getNodeCount() {
         return nodeCount;
@@ -191,5 +195,13 @@ public class InstanceGroupV4Base extends ProviderParametersBase implements JsonE
 
     public void setScalabilityOption(ScalabilityOption scalabilityOption) {
         this.scalabilityOption = scalabilityOption;
+    }
+
+    public Set<String> getHints() {
+        return hints;
+    }
+
+    public void setHints(Set<String> hints) {
+        this.hints = hints;
     }
 }

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/instance/InstanceGroup.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/instance/InstanceGroup.java
@@ -31,6 +31,7 @@ import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.json.JsonToString;
 import com.sequenceiq.cloudbreak.converter.InstanceGroupTypeConverter;
 import com.sequenceiq.cloudbreak.converter.ScalabilityOptionConverter;
+import com.sequenceiq.cloudbreak.converter.StringSetConverter;
 import com.sequenceiq.cloudbreak.domain.ProvisionEntity;
 import com.sequenceiq.cloudbreak.domain.SecurityGroup;
 import com.sequenceiq.cloudbreak.domain.Template;
@@ -93,6 +94,9 @@ public class InstanceGroup implements ProvisionEntity, Comparable<InstanceGroup>
 
     @OneToOne(fetch = FetchType.LAZY, orphanRemoval = true)
     private InstanceGroupNetwork instanceGroupNetwork;
+
+    @Convert(converter = StringSetConverter.class)
+    private Set<String> hints;
 
     public String getGroupName() {
         return groupName;
@@ -304,6 +308,14 @@ public class InstanceGroup implements ProvisionEntity, Comparable<InstanceGroup>
 
     public void setInstanceGroupNetwork(InstanceGroupNetwork instanceGroupNetwork) {
         this.instanceGroupNetwork = instanceGroupNetwork;
+    }
+
+    public Set<String> getHints() {
+        return hints;
+    }
+
+    public void setHints(Set<String> hints) {
+        this.hints = hints;
     }
 
     @Override

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/view/InstanceGroupView.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/view/InstanceGroupView.java
@@ -4,6 +4,7 @@ import static com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup.IDEN
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -34,6 +35,8 @@ public interface InstanceGroupView {
     InstanceGroupNetwork getInstanceGroupNetwork();
 
     ScalabilityOption getScalabilityOption();
+
+    Set<String> getHints();
 
     default Optional<CloudIdentityType> getCloudIdentityType() {
         Json attributes = getAttributes();

--- a/core-model/src/test/java/com/sequenceiq/cloudbreak/TestUtil.java
+++ b/core-model/src/test/java/com/sequenceiq/cloudbreak/TestUtil.java
@@ -281,6 +281,7 @@ public class TestUtil {
         instanceGroup.setSecurityGroup(securityGroup(1L));
         instanceGroup.setInstanceGroupNetwork(instanceGroupNetwork());
         instanceGroup.setInstanceMetaData(generateInstanceMetaDatas(nodeCount, id, instanceGroup));
+        instanceGroup.setHints(Set.of("1", "2"));
         return instanceGroup;
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cli/InstanceGroupToInstanceGroupV4RequestConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cli/InstanceGroupToInstanceGroupV4RequestConverter.java
@@ -34,6 +34,7 @@ public class InstanceGroupToInstanceGroupV4RequestConverter {
                 .convert(source.getTemplate()));
         instanceGroupRequest.setSecurityGroup(securityGroupToSecurityGroupV4RequestConverter
                 .convert(source.getSecurityGroup()));
+        instanceGroupRequest.setHints(source.getHints());
         return instanceGroupRequest;
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/instancegroup/InstanceGroupToInstanceGroupV4ResponseConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/instancegroup/InstanceGroupToInstanceGroupV4ResponseConverter.java
@@ -65,6 +65,7 @@ public class InstanceGroupToInstanceGroupV4ResponseConverter {
         }
         instanceGroupResponse.setAvailabilityZones(source.getAvailabilityZones());
         instanceGroupResponse.setScalabilityOption(source.getScalabilityOption() == null ? ScalabilityOption.ALLOWED : source.getScalabilityOption());
+        instanceGroupResponse.setHints(source.getHints());
         return instanceGroupResponse;
     }
 
@@ -97,6 +98,7 @@ public class InstanceGroupToInstanceGroupV4ResponseConverter {
         }
         instanceGroupResponse.setAvailabilityZones(availabilityZonesByInstanceGroup);
         instanceGroupResponse.setScalabilityOption(source.getScalabilityOption() == null ? ScalabilityOption.ALLOWED : source.getScalabilityOption());
+        instanceGroupResponse.setHints(source.getHints());
         return instanceGroupResponse;
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/instancegroup/InstanceGroupV4RequestToInstanceGroupConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/instancegroup/InstanceGroupV4RequestToInstanceGroupConverter.java
@@ -50,6 +50,7 @@ public class InstanceGroupV4RequestToInstanceGroupConverter {
         instanceGroup.setInstanceGroupType(source.getType());
         instanceGroup.setInitialNodeCount(source.getNodeCount());
         instanceGroup.setScalabilityOption(getScalabilityOption(source));
+        instanceGroup.setHints(source.getHints());
         setNetwork(source, instanceGroup);
         if (source.getNodeCount() > 0) {
             addInstanceMetadatas(source, instanceGroup, variant);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/converter/InstanceGroupToInstanceGroupDetailsConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/converter/InstanceGroupToInstanceGroupDetailsConverter.java
@@ -19,6 +19,7 @@ public class InstanceGroupToInstanceGroupDetailsConverter {
         instanceGroupDetails.setGroupName(source.getGroupName());
         instanceGroupDetails.setGroupType(source.getInstanceGroupType().name());
         instanceGroupDetails.setNodeCount(nodeCount);
+        instanceGroupDetails.setHints(source.getHints());
         Template template = source.getTemplate();
         if (template != null) {
             instanceGroupDetails.setInstanceType(template.getInstanceType());

--- a/core/src/main/resources/schema/app/20230406082541_CB-21065_add_hints-for-multi-az-placement.sql
+++ b/core/src/main/resources/schema/app/20230406082541_CB-21065_add_hints-for-multi-az-placement.sql
@@ -1,0 +1,9 @@
+-- // CB-21065 Add hits for multi AZ placement.
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE instancegroup ADD COLUMN IF NOT EXISTS hints VARCHAR(30) NULL;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE instancegroup DROP COLUMN IF EXISTS hints;

--- a/core/src/test/resources/com/sequenceiq/cloudbreak/converter/stack/instance/instance-group.json
+++ b/core/src/test/resources/com/sequenceiq/cloudbreak/converter/stack/instance/instance-group.json
@@ -8,6 +8,7 @@
       "size": 10
     }
   },
+  "hints": ["1", "2"],
   "securityGroup": {
     "securityGroupIds": [
       "id"

--- a/datalake/src/main/resources/duties/7.2.17/aws/enterprise.json
+++ b/datalake/src/main/resources/duties/7.2.17/aws/enterprise.json
@@ -23,7 +23,8 @@
       "nodeCount": 2,
       "type": "CORE",
       "recoveryMode": "MANUAL",
-      "recipeNames": []
+      "recipeNames": [],
+      "hints": ["az1","az2"]
     },
     {
       "name": "gateway",
@@ -40,7 +41,8 @@
       "nodeCount": 2,
       "type": "GATEWAY",
       "recoveryMode": "MANUAL",
-      "recipeNames": []
+      "recipeNames": [],
+      "hints": ["az2","az3"]
     },
     {
       "name": "core",
@@ -57,7 +59,8 @@
       "nodeCount": 3,
       "type": "CORE",
       "recoveryMode": "MANUAL",
-      "recipeNames": []
+      "recipeNames": [],
+      "hints": ["az1","az2","az3"]
     },
     {
       "name": "auxiliary",
@@ -74,7 +77,8 @@
       "nodeCount": 1,
       "type": "CORE",
       "recoveryMode": "MANUAL",
-      "recipeNames": []
+      "recipeNames": [],
+      "hints": ["az1"]
     },
     {
       "name": "solrHG",
@@ -192,7 +196,8 @@
       "nodeCount": 2,
       "type": "CORE",
       "recoveryMode": "MANUAL",
-      "recipeNames": []
+      "recipeNames": [],
+      "hints": ["az1","az2"]
     }
   ]
 }

--- a/structuredevent-model/src/main/java/com/sequenceiq/cloudbreak/structuredevent/event/InstanceGroupDetails.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/cloudbreak/structuredevent/event/InstanceGroupDetails.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.structuredevent.event;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -25,6 +26,8 @@ public class InstanceGroupDetails implements Serializable {
     private Integer rootVolumeSize;
 
     private Map<String, Object> attributes;
+
+    private Set<String> hints;
 
     public String getGroupName() {
         return groupName;
@@ -88,5 +91,13 @@ public class InstanceGroupDetails implements Serializable {
 
     public void setAttributes(Map<String, Object> attributes) {
         this.attributes = attributes;
+    }
+
+    public Set<String> getHints() {
+        return hints;
+    }
+
+    public void setHints(Set<String> hints) {
+        this.hints = hints;
     }
 }


### PR DESCRIPTION
Context: Datalakes templates will have "hints" for multi-az node placement. This PR creates this property in the database, data model, and converters.

Part 2: https://github.com/hortonworks/cloudbreak/pull/14655

Test:
Created a datalake with a custom template and different hints. Checked database if the set of hints was converted to the right format in the database.